### PR TITLE
fix(ci): cover workspace typecheck and docs checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,16 @@ jobs:
         run: pnpm lint
 
       - name: Typecheck
-        run: pnpm -r --filter './packages/*' --if-present run typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Docs Test
+        run: pnpm --dir docs test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Docs Build
+        run: pnpm docs:build

--- a/docs/app/app.vue
+++ b/docs/app/app.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useHead, useSeoMeta } from "#app/composables/head";
+
 useHead({
   titleTemplate: title => !title || title === "ViteHub" ? "ViteHub" : `${title} · ViteHub`,
   meta: [

--- a/docs/app/components/AppHeader.vue
+++ b/docs/app/components/AppHeader.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { useRoute } from "#app/composables/router";
+import { computed } from "vue";
+import { useFrameworkPreference } from "../composables/useFrameworkPreference";
 import { docsManifest, getDocsPath } from "~~/modules/vitehub-docs/runtime/utils/docs";
 import { normalizeSitePath } from "~~/modules/vitehub-docs/runtime/utils/docs-routes";
 

--- a/docs/app/components/DocsAsideLeftBody.vue
+++ b/docs/app/components/DocsAsideLeftBody.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { useDocsNavigation } from "../composables/useDocsNavigation";
+import { useFrameworkPreference } from "../composables/useFrameworkPreference";
+
 const { sidebarNavigation } = useDocsNavigation();
 const { current } = useFrameworkPreference();
 </script>

--- a/docs/app/components/DocsAsideMobileBar.vue
+++ b/docs/app/components/DocsAsideMobileBar.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+import { useAppConfig } from "#app/config";
 import { ref } from "vue";
+import { useDocsNavigation } from "../composables/useDocsNavigation";
+import { useFrameworkPreference } from "../composables/useFrameworkPreference";
 
 type ContentTocLink = {
   id: string;

--- a/docs/app/components/ExamplePathBrowser.vue
+++ b/docs/app/components/ExamplePathBrowser.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { useHighlightedCode } from "../composables/useHighlightedCode";
+import { useShowcaseExamples } from "../composables/useShowcaseExamples";
 import { showcasePhaseIds, type ExampleFile, type ShowcasePhaseId } from "~~/modules/vitehub-docs/runtime/utils/showcase";
 
 const props = defineProps<{

--- a/docs/app/components/FrameworkSelector.vue
+++ b/docs/app/components/FrameworkSelector.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { ref } from "vue";
+import { useFrameworkPreference } from "../composables/useFrameworkPreference";
 import {
   frameworkColorIcons,
   frameworkDescriptions,

--- a/docs/app/components/Fw.vue
+++ b/docs/app/components/Fw.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { computed, inject, useAttrs } from "vue";
+import { useDocsRenderMode } from "../composables/useDocsRenderMode";
+import { useFrameworkPreference } from "../composables/useFrameworkPreference";
+import { useUsageModePreference } from "../composables/useUsageModePreference";
 import {
   createFwVariant,
   fwGroupContextKey,

--- a/docs/app/components/FwGroup.vue
+++ b/docs/app/components/FwGroup.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { Fragment, computed, provide, ref, watch, type VNode } from "vue";
-import type { AstNode } from "~~/modules/vitehub-docs/runtime/utils/framework-content";
+import { useFrameworkPreference } from "../composables/useFrameworkPreference";
+import { useUsageModePreference } from "../composables/useUsageModePreference";
+import type {
+  AstNode,
+  FrameworkGroupBody,
+} from "~~/modules/vitehub-docs/runtime/utils/framework-content";
 import {
   fwGroupContextKey,
   getFwVariantTabScore,
@@ -15,19 +20,13 @@ import {
 type FrameworkTabItem = {
   id: string;
   variants: ReturnType<typeof parseFwVariants>;
-  body?: {
-    type: "root";
-    children: AstNode[];
-  };
+  body?: FrameworkGroupBody;
 };
 
 const props = defineProps<{
   items?: Array<{
     id: string;
-    body?: {
-      type: "root";
-      children: AstNode[];
-    };
+    body?: FrameworkGroupBody;
   }>;
 }>();
 

--- a/docs/app/components/LandingHero.vue
+++ b/docs/app/components/LandingHero.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { useFramework } from "../composables/useFrameworkPreference";
+import { useHighlightedCode } from "../composables/useHighlightedCode";
 import { frameworkColorIcons, frameworkLabels, type Framework } from "~~/modules/vitehub-docs/runtime/utils/frameworks";
 import { getShowcaseExamples, getShowcaseFiles, getShowcasePhasePaths, type ExampleFile, type ShowcasePhaseId } from "~~/modules/vitehub-docs/runtime/utils/showcase";
 

--- a/docs/app/composables/useDocsNavigation.ts
+++ b/docs/app/composables/useDocsNavigation.ts
@@ -1,3 +1,4 @@
+import { useRoute } from "#app/composables/router";
 import { computed } from "vue";
 import type { ContentNavigationItem } from "@nuxt/content";
 import { useFrameworkPreference } from "./useFrameworkPreference";

--- a/docs/app/composables/useDocsPage.ts
+++ b/docs/app/composables/useDocsPage.ts
@@ -1,8 +1,9 @@
+import { useSeoMeta } from "#app/composables/head";
 import { computed, type ComputedRef, type Ref } from "vue";
 import { useDocsRenderMode } from "./useDocsRenderMode";
 import { useFrameworkPreference } from "./useFrameworkPreference";
 import { useUsageModePreference } from "./useUsageModePreference";
-import { normalizeFrameworkPage, type NormalizedPage } from "~~/modules/vitehub-docs/runtime/utils/framework-content";
+import { normalizeFrameworkPage, toMdcRootBody, type NormalizedPage } from "~~/modules/vitehub-docs/runtime/utils/framework-content";
 
 export type ContentPage = NormalizedPage & {
   data?: Record<string, unknown>;
@@ -12,7 +13,7 @@ export type ContentPage = NormalizedPage & {
   toc?: unknown;
 };
 
-export function useDocsPage(sourcePath: string | ComputedRef<string>, rawDoc: Ref<Record<string, any> | null>, fallback: { title: string; sourceTitle: string | null; description: string | null }) {
+export function useDocsPage(sourcePath: string | ComputedRef<string>, rawDoc: Ref<Record<string, any> | null | undefined>, fallback: { title: string; sourceTitle: string | null; description: string | null }) {
   const { current: framework } = useFrameworkPreference();
   const { current: mode } = useUsageModePreference();
   const { renderMode } = useDocsRenderMode();
@@ -29,7 +30,7 @@ export function useDocsPage(sourcePath: string | ComputedRef<string>, rawDoc: Re
       description,
       seo: { title: doc?.seo?.title || title, description: doc?.seo?.description || description },
       data: doc?.meta || {},
-      body: doc?.body ? { ...doc.body, toc: doc.body?.toc || null } : null,
+      body: doc?.body ? toMdcRootBody({ ...doc.body, toc: doc.body?.toc || null }) : null,
     };
   });
 

--- a/docs/app/composables/useDocsRenderMode.ts
+++ b/docs/app/composables/useDocsRenderMode.ts
@@ -1,3 +1,4 @@
+import { useRoute } from "#app/composables/router";
 import { computed } from "vue";
 import type { DocsRenderOptions } from "~~/modules/vitehub-docs/runtime/utils/framework-content";
 

--- a/docs/app/composables/useFrameworkPreference.ts
+++ b/docs/app/composables/useFrameworkPreference.ts
@@ -1,3 +1,5 @@
+import { useCookie } from "#app/composables/cookie";
+import { navigateTo, useRoute } from "#app/composables/router";
 import { computed, nextTick } from "vue";
 import { normalizeSitePath, resolveFrameworkSwitchPath } from "~~/modules/vitehub-docs/runtime/utils/docs-routes";
 import { defaultFramework, frameworks, type Framework } from "~~/modules/vitehub-docs/runtime/utils/frameworks";

--- a/docs/app/composables/useHighlightedCode.ts
+++ b/docs/app/composables/useHighlightedCode.ts
@@ -1,3 +1,4 @@
+import { useAsyncData } from "#app/composables/asyncData";
 import { computed, toValue, type MaybeRefOrGetter } from "vue";
 import { codeToHtml } from "shiki";
 import { getCodeLanguage } from "~~/modules/vitehub-docs/runtime/utils/showcase";

--- a/docs/app/composables/useUsageModePreference.ts
+++ b/docs/app/composables/useUsageModePreference.ts
@@ -1,3 +1,4 @@
+import { useCookie } from "#app/composables/cookie";
 import { computed, nextTick } from "vue";
 import {
   defaultUsageMode,

--- a/docs/app/pages/docs/[framework]/[...slug].vue
+++ b/docs/app/pages/docs/[framework]/[...slug].vue
@@ -1,4 +1,11 @@
 <script setup lang="ts">
+import { useAsyncData } from "#app/composables/asyncData";
+import { createError } from "#app/composables/error";
+import { definePageMeta } from "#app/composables/pages";
+import { useRoute } from "#app/composables/router";
+import { computed } from "vue";
+import { useDocsPage } from "../../../composables/useDocsPage";
+import type { FrameworkGroupBody } from "~~/modules/vitehub-docs/runtime/utils/framework-content";
 import { getDocsPage, getDocsPath, getDocsPathMeta } from "~~/modules/vitehub-docs/runtime/utils/docs";
 import type { Framework } from "~~/modules/vitehub-docs/runtime/utils/frameworks";
 
@@ -29,6 +36,12 @@ const { page } = useDocsPage(
   rawDoc,
   { title: docsPage.title, sourceTitle: docsPage.sourceTitle, description: docsPage.description },
 );
+
+const rendererBody = computed<FrameworkGroupBody | null>(() => {
+  return page.value?.body && Array.isArray(page.value.body.children)
+    ? page.value.body as FrameworkGroupBody
+    : null;
+});
 </script>
 
 <template>
@@ -40,7 +53,7 @@ const { page } = useDocsPage(
     </UPageHeader>
 
     <UPageBody prose class="docs-content pb-0">
-      <MDCRenderer v-if="page.body" :body="page.body" :data="page.data || {}" />
+      <MDCRenderer v-if="rendererBody" :body="rendererBody" :data="page.data || {}" />
     </UPageBody>
   </UPage>
 </template>

--- a/docs/app/pages/docs/index.vue
+++ b/docs/app/pages/docs/index.vue
@@ -1,4 +1,11 @@
 <script setup lang="ts">
+import { useAsyncData } from "#app/composables/asyncData";
+import { createError } from "#app/composables/error";
+import { definePageMeta } from "#app/composables/pages";
+import { computed } from "vue";
+import { useDocsPage } from "../../composables/useDocsPage";
+import { useFrameworkPreference } from "../../composables/useFrameworkPreference";
+import type { FrameworkGroupBody } from "~~/modules/vitehub-docs/runtime/utils/framework-content";
 import { getDocsPage, getDocsPath } from "~~/modules/vitehub-docs/runtime/utils/docs";
 
 definePageMeta({
@@ -24,6 +31,12 @@ const { page } = useDocsPage(
   rawDoc,
   { title: docsPage.title, sourceTitle: docsPage.sourceTitle, description: docsPage.description },
 );
+
+const rendererBody = computed<FrameworkGroupBody | null>(() => {
+  return page.value?.body && Array.isArray(page.value.body.children)
+    ? page.value.body as FrameworkGroupBody
+    : null;
+});
 </script>
 
 <template>
@@ -35,7 +48,7 @@ const { page } = useDocsPage(
     </UPageHeader>
 
     <UPageBody prose class="docs-content docs-root-content pb-0">
-      <MDCRenderer v-if="page.body" :body="page.body" :data="page.data || {}" />
+      <MDCRenderer v-if="rendererBody" :body="rendererBody" :data="page.data || {}" />
     </UPageBody>
   </UPage>
 </template>

--- a/docs/app/pages/index.vue
+++ b/docs/app/pages/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useHead, useSeoMeta } from "#app/composables/head";
+
 useHead({ titleTemplate: () => "ViteHub" });
 
 useSeoMeta({

--- a/docs/content/docs/providers/.navigation.yml
+++ b/docs/content/docs/providers/.navigation.yml
@@ -1,0 +1,2 @@
+title: Providers
+description: Deploy ViteHub packages on the host that matches your runtime, scaling, and platform needs.

--- a/docs/content/docs/providers/index.md
+++ b/docs/content/docs/providers/index.md
@@ -1,0 +1,23 @@
+---
+title: Providers
+description: Compare supported deployment providers and choose the runtime that fits each ViteHub package.
+icon: i-lucide-cloud
+---
+
+# Providers
+
+ViteHub packages target the same high-level API surface across different hosts, but each provider exposes a different runtime model, deployment shape, and platform-specific capabilities.
+
+Use these guides to choose the provider that matches your deployment target and to see the configuration expected for each framework integration.
+
+## Available Providers
+
+- Cloudflare for edge-first Workers and Pages deployments.
+- Netlify for serverless and edge function deployments.
+- Vercel for serverless and edge function deployments with platform integrations.
+
+## What To Compare
+
+- Runtime constraints such as edge versus server execution.
+- Platform-specific bindings, adapters, or runtime flags.
+- How each provider maps platform resources to ViteHub package configuration.

--- a/docs/modules/vitehub-docs/index.ts
+++ b/docs/modules/vitehub-docs/index.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { defineNuxtModule } from "nuxt/kit";
+import type { NitroConfig } from "nitropack/types";
 import { readDocsArtifactsManifest, writeDocsArtifacts } from "./artifacts";
 
 const frameworkIds = ["vite", "nitro", "nuxt"] as const;
@@ -28,10 +29,10 @@ export default defineNuxtModule({
         }
       }
     }
-    nuxt.options.nitro ||= {};
-    nuxt.options.nitro.prerender ||= {};
-    nuxt.options.nitro.prerender.routes = [...new Set([
-      ...(nuxt.options.nitro.prerender.routes || []),
+    const nitroOptions = ((nuxt.options as typeof nuxt.options & { nitro?: NitroConfig }).nitro ??= {});
+    nitroOptions.prerender ??= {};
+    nitroOptions.prerender.routes = [...new Set([
+      ...(nitroOptions.prerender.routes || []),
       ...prerenderRoutes,
     ])];
 

--- a/docs/modules/vitehub-docs/runtime/utils/framework-content.ts
+++ b/docs/modules/vitehub-docs/runtime/utils/framework-content.ts
@@ -5,17 +5,24 @@ import {
   matchesFwVariant,
   type UsageMode,
 } from "./fw-variants";
+import type { MDCComment, MDCElement, MDCNode, MDCRoot, MDCText } from "@nuxtjs/mdc";
 import { frameworkPattern, type Framework } from "./frameworks";
 
 export type NodeProps = Record<string, unknown>;
 export type ContentNode = string | [string, NodeProps?, ...ContentNode[]];
-export type AstTextNode = { type: "text"; value: string };
-export type AstElementNode = { type: "element"; tag: string; props?: NodeProps; children?: AstNode[] };
-export type AstNode = AstTextNode | AstElementNode;
+export type AstTextNode = MDCText;
+export type AstCommentNode = MDCComment;
+export type AstElementNode = MDCElement;
+export type AstNode = MDCNode;
+export type MdcAstTextNode = MDCText;
+export type MdcAstCommentNode = MDCComment;
+export type MdcAstElementNode = MDCElement;
+export type MdcAstNode = MDCNode;
+export type FrameworkGroupBody = MDCRoot;
 
 export type TocLink = { id: string; depth: number; text: string; children?: TocLink[] };
 export type BodyToc = { depth?: number; links?: TocLink[]; searchDepth?: number; title?: string; [key: string]: unknown };
-export type PageBody = { toc?: BodyToc; type?: string; value?: ContentNode[]; children?: AstNode[]; [key: string]: unknown };
+export type PageBody = { toc?: BodyToc; type: "root"; value?: ContentNode[]; children?: MdcAstNode[]; [key: string]: unknown };
 export type NormalizedPage = { path: string; body: PageBody | null; [key: string]: unknown };
 export type DocsRenderOptions = { framework: Framework; mode: UsageMode; renderMode: "single" | "all"; tocMode: "current-selection" };
 
@@ -87,6 +94,35 @@ function isAstText(node: unknown): node is AstTextNode {
     && typeof (node as AstTextNode).value === "string";
 }
 
+function toMdcAstNode(node: AstNode): MdcAstNode {
+  if (isAstText(node) || node.type === "comment") {
+    return node;
+  }
+
+  return {
+    ...node,
+    props: node.props || {},
+    children: node.children?.map(toMdcAstNode) || [],
+  };
+}
+
+export function toFrameworkGroupBody(children: AstNode[]): FrameworkGroupBody {
+  return {
+    type: "root",
+    children: children.map(toMdcAstNode),
+  };
+}
+
+export function toMdcRootBody(body: Omit<PageBody, "children"> & { children?: AstNode[] | MdcAstNode[] }): PageBody {
+  const children = body.children?.map(node => toMdcAstNode(node as AstNode));
+
+  return {
+    ...body,
+    type: "root",
+    ...(children ? { children } : {}),
+  };
+}
+
 const astAccessor: NodeAccessor<AstNode> = {
   isText: (node) => isAstText(node),
   isElement: (node) => isAstElement(node),
@@ -104,7 +140,7 @@ const astAccessor: NodeAccessor<AstNode> = {
       tag: "fw-group",
       props: {
         items: items
-          .filter((item): item is { id: string; body: { type: "root"; children: AstNode[] } } => Boolean(item?.id)),
+          .filter((item): item is { id: string; body: FrameworkGroupBody } => Boolean(item?.id)),
       },
       children: [],
     } as AstNode;
@@ -128,7 +164,7 @@ function flushGroup<N>(buffer: N[], output: N[], acc: NodeAccessor<N>) {
         if (!id) return null;
         // For AST nodes, include body for MDCRenderer
         if (acc === astAccessor as unknown) {
-          return { id, body: { type: "root" as const, children: acc.getChildren(node) } };
+          return { id, body: toFrameworkGroupBody(acc.getChildren(node) as AstNode[]) };
         }
         return { id };
       })
@@ -246,13 +282,13 @@ export function normalizeFrameworkPage(page: NormalizedPage | null, options?: Do
 
     return {
       ...page,
-      body: {
+      body: toMdcRootBody({
         ...page.body,
         value,
         toc: page.body.toc
           ? { ...page.body.toc, links: buildTocTree(collectHeadings(tocNodes, tupleAccessor)) }
           : page.body.toc,
-      },
+      }),
     };
   }
 
@@ -265,12 +301,12 @@ export function normalizeFrameworkPage(page: NormalizedPage | null, options?: Do
 
   return {
     ...page,
-    body: {
+    body: toMdcRootBody({
       ...page.body,
       children,
       toc: page.body.toc
         ? { ...page.body.toc, links: buildTocTree(collectHeadings(tocNodes, astAccessor)) }
         : page.body.toc,
-    },
+    }),
   };
 }

--- a/docs/test/docs-routes.test.ts
+++ b/docs/test/docs-routes.test.ts
@@ -9,4 +9,8 @@ describe("resolveFrameworkSwitchPath", () => {
   it("falls back to the section overview when the target page is unsupported", () => {
     expect(resolveFrameworkSwitchPath("/docs/nuxt/dummy/missing-page", "vite")).toBe("/docs/vite/dummy");
   });
+
+  it("keeps section landing pages when switching frameworks", () => {
+    expect(resolveFrameworkSwitchPath("/docs/nuxt/providers", "vite")).toBe("/docs/vite/providers");
+  });
 });

--- a/docs/test/showcase.test.ts
+++ b/docs/test/showcase.test.ts
@@ -26,4 +26,10 @@ describe("showcase examples", () => {
     const files = getShowcaseFiles(dummy!, "vite", "build");
     expect(files.slice(0, 2).map(file => file.path)).toEqual(["vite.config.ts", "src/build.ts"]);
   });
+
+  it("includes a providers overview page in the docs manifest", () => {
+    const providers = docsManifest.sections.find(section => section.id === "providers");
+
+    expect(providers?.pages.some(page => page.id === "index")).toBe(true);
+  });
 });

--- a/docs/tsconfig.typecheck.json
+++ b/docs/tsconfig.typecheck.json
@@ -5,6 +5,7 @@
     "noImplicitAny": false
   },
   "include": [
+    ".nuxt/content/types.d.ts",
     "app/**/*.ts",
     "app/**/*.vue",
     "modules/**/*.ts",
@@ -16,7 +17,6 @@
   ],
   "exclude": [
     "node_modules",
-    ".output",
-    "../node_modules/.pnpm/docus*/node_modules/docus/app/composables/**/*"
+    ".output"
   ]
 }

--- a/docs/types/query-collection.global.d.ts
+++ b/docs/types/query-collection.global.d.ts
@@ -1,0 +1,7 @@
+import type { Collections, CollectionQueryBuilder } from "@nuxt/content";
+
+declare global {
+  const queryCollection: <T extends keyof Collections>(collection: T) => CollectionQueryBuilder<Collections[T]>;
+}
+
+export {};

--- a/docs/types/typecheck-shims.d.ts
+++ b/docs/types/typecheck-shims.d.ts
@@ -1,0 +1,33 @@
+declare module "@nuxtjs/mdc" {
+  export type NodePosition = {
+    start: number;
+    end: number;
+  };
+
+  export type MDCText = {
+    type: "text";
+    value: string;
+    position?: NodePosition;
+  };
+
+  export type MDCComment = {
+    type: "comment";
+    value: string;
+    position?: NodePosition;
+  };
+
+  export type MDCElement = {
+    type: "element";
+    tag: string;
+    props: Record<string, any> | undefined;
+    children: Array<MDCElement | MDCText | MDCComment>;
+    position?: NodePosition;
+  };
+
+  export type MDCNode = MDCElement | MDCText | MDCComment;
+
+  export type MDCRoot = {
+    type: "root";
+    children: Array<MDCNode>;
+  };
+}


### PR DESCRIPTION

- expand CI to run lint, full workspace typecheck, package tests, docs tests, package builds, and docs production build
- fix the docs typecheck path without broadening it to the full generated Nuxt surface
- add the missing providers landing page so docs prerender succeeds for `/docs/:framework/providers`
