### PR TITLE
fix(docs): sidebar nav and frontmatter order

### DIFF
--- a/docs/app/composables/useDocsNavigation.ts
+++ b/docs/app/composables/useDocsNavigation.ts
@@ -66,10 +66,12 @@ function buildDocsIndexSidebarNavigation(sections: DocsSection[], framework: Fra
 
 function buildSectionSidebarNavigation(section: DocsSection, framework: Framework, currentPath: string) {
   const pages = getSupportedPages(section, framework);
-  const overviewItem = toNavigationItem({ title: "Overview", path: getDocsPath(section.id, framework), icon: section.icon }, currentPath);
-  const guides = pages
-    .filter(page => page.id !== "index" && !page.group)
-    .map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath));
+  const rootItems = [
+    toNavigationItem({ title: "Overview", path: getDocsPath(section.id, framework), icon: section.icon }, currentPath),
+    ...pages
+      .filter(page => page.id !== "index" && !page.group)
+      .map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath)),
+  ];
   const groupedPages = new Map<string, DocsPage[]>();
 
   for (const page of pages) {
@@ -78,12 +80,13 @@ function buildSectionSidebarNavigation(section: DocsSection, framework: Framewor
   }
 
   const groups = [
-    createNavigationGroup("Start Here", [overviewItem]),
-    createNavigationGroup("Guides", guides),
-    ...[...groupedPages.entries()].map(([group, items]) => createNavigationGroup(
-      group,
-      items.map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath)),
-    )),
+    ...rootItems,
+    ...[...groupedPages.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([group, items]) => createNavigationGroup(
+        group,
+        items.map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath)),
+      )),
   ];
 
   return groups.filter(Boolean) as ContentNavigationItem[];

--- a/docs/modules/vitehub-docs/artifacts.ts
+++ b/docs/modules/vitehub-docs/artifacts.ts
@@ -44,6 +44,7 @@ function parseScalar(value: string) {
     return trimmed.slice(1, -1);
   if (trimmed === "true") return true;
   if (trimmed === "false") return false;
+  if (/^-?\d+$/.test(trimmed)) return Number(trimmed);
   // Handle arrays: [a, b] or bare comma-separated values
   const inner = trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed.includes(",") ? trimmed : null;
   if (inner !== null)
@@ -287,6 +288,7 @@ function collectPages(rootDir: string) {
       description: typeof meta.description === "string" ? meta.description : null,
       icon: typeof meta.icon === "string" ? meta.icon : null,
       group: typeof meta["navigation.group"] === "string" ? meta["navigation.group"] : null,
+      order: typeof meta["navigation.order"] === "number" ? meta["navigation.order"] : Number.MAX_SAFE_INTEGER,
       frameworks: getSupportedFrameworks(meta),
     };
   }).sort((left, right) => {
@@ -296,6 +298,10 @@ function collectPages(rootDir: string) {
 
     if (right.pageId === "index") {
       return 1;
+    }
+
+    if (left.order !== right.order) {
+      return left.order - right.order;
     }
 
     return left.pageId.localeCompare(right.pageId);


### PR DESCRIPTION
## Summary
- Flatten sidebar groups (remove "Start Here"/"Guides" wrappers), sort nav groups alphabetically
- Parse `navigation.order` from frontmatter, sort pages by order
- Broaden tsconfig include to `.nuxt/**/*.d.ts`

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` in docs workspace passes
- [ ] Sidebar renders correctly in `pnpm docs:dev`