### PR TITLE
fix(docs): improve hero file icons

### DIFF
--- a/docs/app/assets/main.css
+++ b/docs/app/assets/main.css
@@ -83,12 +83,7 @@
 
 .code-block-wrapper .shiki {
   min-height: 100%;
-  line-height: 1.35;
   background-color: transparent !important;
-}
-
-.code-block-wrapper .shiki .line {
-  display: block;
 }
 
 :is(.dark) .code-block-wrapper .shiki {

--- a/docs/app/assets/main.css
+++ b/docs/app/assets/main.css
@@ -83,13 +83,8 @@
 
 .code-block-wrapper .shiki {
   min-height: 100%;
+  line-height: 1.35;
   background-color: transparent !important;
-}
-
-.code-block-wrapper .shiki,
-.code-block-wrapper .shiki code,
-.code-block-wrapper .shiki .line {
-  line-height: 1.45;
 }
 
 .code-block-wrapper .shiki .line {

--- a/docs/app/components/LandingHero.vue
+++ b/docs/app/components/LandingHero.vue
@@ -48,8 +48,27 @@ watch(activeFiles, () => {
 });
 
 function fileIcon(path: string) {
-  if (path.endsWith(".json")) return "i-lucide-file-json";
-  if (path === "env.example") return "i-lucide-file-key";
+  const fileName = path.split("/").pop()?.toLowerCase() || path.toLowerCase();
+
+  if (fileName === "nuxt.config.ts") return "i-vscode-icons-file-type-nuxt";
+  if (fileName === "nitro.config.ts") return "i-brand-nitro";
+  if (fileName === "vite.config.ts") return "i-vscode-icons-file-type-vite";
+  if (fileName === "package.json") return "i-vscode-icons-file-type-package";
+  if (fileName === "tsconfig.json" || fileName.startsWith("tsconfig.")) return "i-vscode-icons-file-type-tsconfig-official";
+  if (fileName === "pnpm-lock.yaml" || fileName === "pnpm-workspace.yaml") return "i-vscode-icons-file-type-pnpm";
+  if (fileName === "package-lock.json") return "i-vscode-icons-file-type-npm";
+  if (fileName === "env.example" || fileName === ".env" || fileName.startsWith(".env.")) return "i-vscode-icons-file-type-dotenv";
+  if (fileName === "readme.md") return "i-vscode-icons-file-type-markdown";
+
+  if (fileName.endsWith(".ts") || fileName.endsWith(".tsx")) return "i-vscode-icons-file-type-typescript-official";
+  if (fileName.endsWith(".js") || fileName.endsWith(".jsx") || fileName.endsWith(".mjs") || fileName.endsWith(".cjs")) return "i-vscode-icons-file-type-js-official";
+  if (fileName.endsWith(".vue")) return "i-vscode-icons-file-type-vue";
+  if (fileName.endsWith(".json")) return "i-vscode-icons-file-type-json-official";
+  if (fileName.endsWith(".md") || fileName.endsWith(".mdx")) return "i-vscode-icons-file-type-markdown";
+  if (fileName.endsWith(".yaml") || fileName.endsWith(".yml")) return "i-vscode-icons-file-type-yaml-official";
+  if (fileName.endsWith(".toml")) return "i-vscode-icons-file-type-toml";
+  if (fileName.endsWith(".html")) return "i-vscode-icons-file-type-html";
+
   return "i-lucide-file-code";
 }
 

--- a/docs/app/components/LandingHero.vue
+++ b/docs/app/components/LandingHero.vue
@@ -18,40 +18,23 @@ const activePhasePaths = computed(() => getShowcasePhasePaths(activeExample.valu
 const activeFiles = computed(() => getShowcaseFiles(activeExample.value, current.value, activeProvider.value));
 const activeFile = computed(() => activeFiles.value.find(f => f.path === activeFilePath.value) || activeFiles.value[0]);
 
-const exactFileIcons = new Map<string, string>([
-  ["nuxt.config.ts", "i-vscode-icons-file-type-nuxt"],
-  ["nitro.config.ts", "i-brand-nitro"],
-  ["vite.config.ts", "i-vscode-icons-file-type-vite"],
-  ["package.json", "i-vscode-icons-file-type-package"],
-  ["tsconfig.json", "i-vscode-icons-file-type-tsconfig-official"],
-  ["pnpm-lock.yaml", "i-vscode-icons-file-type-pnpm"],
-  ["pnpm-workspace.yaml", "i-vscode-icons-file-type-pnpm"],
-  ["package-lock.json", "i-vscode-icons-file-type-npm"],
-  ["env.example", "i-vscode-icons-file-type-dotenv"],
-  [".env", "i-vscode-icons-file-type-dotenv"],
-  ["readme.md", "i-vscode-icons-file-type-markdown"],
-]);
-
-const prefixFileIcons = new Map<string, string>([
-  ["tsconfig.", "i-vscode-icons-file-type-tsconfig-official"],
-  [".env.", "i-vscode-icons-file-type-dotenv"],
-]);
-
-const suffixFileIcons = new Map<string, string>([
-  [".ts", "i-vscode-icons-file-type-typescript-official"],
-  [".tsx", "i-vscode-icons-file-type-typescript-official"],
-  [".js", "i-vscode-icons-file-type-js-official"],
-  [".jsx", "i-vscode-icons-file-type-js-official"],
-  [".mjs", "i-vscode-icons-file-type-js-official"],
-  [".cjs", "i-vscode-icons-file-type-js-official"],
-  [".vue", "i-vscode-icons-file-type-vue"],
-  [".json", "i-vscode-icons-file-type-json-official"],
-  [".md", "i-vscode-icons-file-type-markdown"],
-  [".mdx", "i-vscode-icons-file-type-markdown"],
-  [".yaml", "i-vscode-icons-file-type-yaml-official"],
-  [".yml", "i-vscode-icons-file-type-yaml-official"],
-  [".toml", "i-vscode-icons-file-type-toml"],
-  [".html", "i-vscode-icons-file-type-html"],
+const fileIconMatchers = new Map<string, RegExp[]>([
+  ["i-vscode-icons-file-type-nuxt", [/^nuxt\.config\.ts$/]],
+  ["i-brand-nitro", [/^nitro\.config\.ts$/]],
+  ["i-vscode-icons-file-type-vite", [/^vite\.config\.ts$/]],
+  ["i-vscode-icons-file-type-package", [/^package\.json$/]],
+  ["i-vscode-icons-file-type-tsconfig-official", [/^tsconfig\.json$/, /^tsconfig\..+/]],
+  ["i-vscode-icons-file-type-pnpm", [/^pnpm-lock\.yaml$/, /^pnpm-workspace\.yaml$/]],
+  ["i-vscode-icons-file-type-npm", [/^package-lock\.json$/]],
+  ["i-vscode-icons-file-type-dotenv", [/^env\.example$/, /^\.env$/, /^\.env\..+/]],
+  ["i-vscode-icons-file-type-markdown", [/^readme\.md$/, /\.mdx?$/]],
+  ["i-vscode-icons-file-type-typescript-official", [/\.tsx?$/]],
+  ["i-vscode-icons-file-type-js-official", [/\.(?:[cm]?js|jsx)$/]],
+  ["i-vscode-icons-file-type-vue", [/\.vue$/]],
+  ["i-vscode-icons-file-type-json-official", [/\.json$/]],
+  ["i-vscode-icons-file-type-yaml-official", [/\.ya?ml$/]],
+  ["i-vscode-icons-file-type-toml", [/\.toml$/]],
+  ["i-vscode-icons-file-type-html", [/\.html$/]],
 ]);
 
 function applyFrameworkSelection(framework: Framework, options: { phase?: ShowcasePhaseId; provider?: string } = {}) {
@@ -85,15 +68,8 @@ watch(activeFiles, () => {
 
 function fileIcon(path: string) {
   const fileName = path.split("/").pop()?.toLowerCase() || path.toLowerCase();
-  const exactMatch = exactFileIcons.get(fileName);
-  if (exactMatch) return exactMatch;
-
-  for (const [prefix, icon] of prefixFileIcons) {
-    if (fileName.startsWith(prefix)) return icon;
-  }
-
-  for (const [suffix, icon] of suffixFileIcons) {
-    if (fileName.endsWith(suffix)) return icon;
+  for (const [icon, patterns] of fileIconMatchers) {
+    if (patterns.some(pattern => pattern.test(fileName))) return icon;
   }
 
   return "i-lucide-file-code";

--- a/docs/app/components/LandingHero.vue
+++ b/docs/app/components/LandingHero.vue
@@ -18,6 +18,42 @@ const activePhasePaths = computed(() => getShowcasePhasePaths(activeExample.valu
 const activeFiles = computed(() => getShowcaseFiles(activeExample.value, current.value, activeProvider.value));
 const activeFile = computed(() => activeFiles.value.find(f => f.path === activeFilePath.value) || activeFiles.value[0]);
 
+const exactFileIcons = new Map<string, string>([
+  ["nuxt.config.ts", "i-vscode-icons-file-type-nuxt"],
+  ["nitro.config.ts", "i-brand-nitro"],
+  ["vite.config.ts", "i-vscode-icons-file-type-vite"],
+  ["package.json", "i-vscode-icons-file-type-package"],
+  ["tsconfig.json", "i-vscode-icons-file-type-tsconfig-official"],
+  ["pnpm-lock.yaml", "i-vscode-icons-file-type-pnpm"],
+  ["pnpm-workspace.yaml", "i-vscode-icons-file-type-pnpm"],
+  ["package-lock.json", "i-vscode-icons-file-type-npm"],
+  ["env.example", "i-vscode-icons-file-type-dotenv"],
+  [".env", "i-vscode-icons-file-type-dotenv"],
+  ["readme.md", "i-vscode-icons-file-type-markdown"],
+]);
+
+const prefixFileIcons = new Map<string, string>([
+  ["tsconfig.", "i-vscode-icons-file-type-tsconfig-official"],
+  [".env.", "i-vscode-icons-file-type-dotenv"],
+]);
+
+const suffixFileIcons = new Map<string, string>([
+  [".ts", "i-vscode-icons-file-type-typescript-official"],
+  [".tsx", "i-vscode-icons-file-type-typescript-official"],
+  [".js", "i-vscode-icons-file-type-js-official"],
+  [".jsx", "i-vscode-icons-file-type-js-official"],
+  [".mjs", "i-vscode-icons-file-type-js-official"],
+  [".cjs", "i-vscode-icons-file-type-js-official"],
+  [".vue", "i-vscode-icons-file-type-vue"],
+  [".json", "i-vscode-icons-file-type-json-official"],
+  [".md", "i-vscode-icons-file-type-markdown"],
+  [".mdx", "i-vscode-icons-file-type-markdown"],
+  [".yaml", "i-vscode-icons-file-type-yaml-official"],
+  [".yml", "i-vscode-icons-file-type-yaml-official"],
+  [".toml", "i-vscode-icons-file-type-toml"],
+  [".html", "i-vscode-icons-file-type-html"],
+]);
+
 function applyFrameworkSelection(framework: Framework, options: { phase?: ShowcasePhaseId; provider?: string } = {}) {
   const provider = options.provider && activeExample.value.providers.some(p => p.id === options.provider)
     ? options.provider
@@ -49,25 +85,16 @@ watch(activeFiles, () => {
 
 function fileIcon(path: string) {
   const fileName = path.split("/").pop()?.toLowerCase() || path.toLowerCase();
+  const exactMatch = exactFileIcons.get(fileName);
+  if (exactMatch) return exactMatch;
 
-  if (fileName === "nuxt.config.ts") return "i-vscode-icons-file-type-nuxt";
-  if (fileName === "nitro.config.ts") return "i-brand-nitro";
-  if (fileName === "vite.config.ts") return "i-vscode-icons-file-type-vite";
-  if (fileName === "package.json") return "i-vscode-icons-file-type-package";
-  if (fileName === "tsconfig.json" || fileName.startsWith("tsconfig.")) return "i-vscode-icons-file-type-tsconfig-official";
-  if (fileName === "pnpm-lock.yaml" || fileName === "pnpm-workspace.yaml") return "i-vscode-icons-file-type-pnpm";
-  if (fileName === "package-lock.json") return "i-vscode-icons-file-type-npm";
-  if (fileName === "env.example" || fileName === ".env" || fileName.startsWith(".env.")) return "i-vscode-icons-file-type-dotenv";
-  if (fileName === "readme.md") return "i-vscode-icons-file-type-markdown";
+  for (const [prefix, icon] of prefixFileIcons) {
+    if (fileName.startsWith(prefix)) return icon;
+  }
 
-  if (fileName.endsWith(".ts") || fileName.endsWith(".tsx")) return "i-vscode-icons-file-type-typescript-official";
-  if (fileName.endsWith(".js") || fileName.endsWith(".jsx") || fileName.endsWith(".mjs") || fileName.endsWith(".cjs")) return "i-vscode-icons-file-type-js-official";
-  if (fileName.endsWith(".vue")) return "i-vscode-icons-file-type-vue";
-  if (fileName.endsWith(".json")) return "i-vscode-icons-file-type-json-official";
-  if (fileName.endsWith(".md") || fileName.endsWith(".mdx")) return "i-vscode-icons-file-type-markdown";
-  if (fileName.endsWith(".yaml") || fileName.endsWith(".yml")) return "i-vscode-icons-file-type-yaml-official";
-  if (fileName.endsWith(".toml")) return "i-vscode-icons-file-type-toml";
-  if (fileName.endsWith(".html")) return "i-vscode-icons-file-type-html";
+  for (const [suffix, icon] of suffixFileIcons) {
+    if (fileName.endsWith(suffix)) return icon;
+  }
 
   return "i-lucide-file-code";
 }


### PR DESCRIPTION
## Summary
- tighten the hero code block line-height by applying it only to the Shiki container
- add filename-aware file icons for common config and manifest files in the hero tree
- use TypeScript, Nuxt, Nitro, Vite, dotenv, package, tsconfig, pnpm, npm, JSON, YAML, TOML, Markdown, Vue, JS, and HTML icons where applicable

## Testing
- pnpm --dir docs exec nuxi prepare
- pnpm --dir docs typecheck *(fails due to pre-existing Nuxt auto-import/type errors unrelated to this change)*