### PR TITLE
fix(docs): filter framework blocks from raw docs

### DIFF
--- a/docs/app/app.config.ts
+++ b/docs/app/app.config.ts
@@ -1,0 +1,7 @@
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: "yellow",
+    },
+  },
+});

--- a/docs/app/components/PackageSelector.vue
+++ b/docs/app/components/PackageSelector.vue
@@ -50,30 +50,30 @@ const activePackage = computed(() => {
 });
 
 const items = computed(() => [
-  packageLinks.value.map(link => ({
-    label: link.label,
-    icon: link.icon,
-    to: link.to,
-    type: "checkbox" as const,
-    checked: link.active,
-  })),
+  {
+    label: activePackage.value?.label || "Packages",
+    icon: activePackage.value?.icon || "i-lucide-box",
+    value: "packages",
+    children: packageLinks.value.map(link => ({
+      label: link.label,
+      icon: link.icon,
+      to: link.to,
+      active: link.active,
+    })),
+  },
 ]);
 </script>
 
 <template>
-  <UDropdownMenu
+  <UNavigationMenu
     v-if="isDocsRoute && packageLinks.length"
     :items="items"
-    :content="{ align: 'start', sideOffset: 8 }"
-    :ui="{ content: 'min-w-56' }"
-  >
-    <UButton
-      color="neutral"
-      variant="ghost"
-      :icon="activePackage?.icon || 'i-lucide-box'"
-      :label="activePackage?.label || 'Packages'"
-      trailing-icon="i-lucide-chevron-down"
-      class="hidden lg:inline-flex"
-    />
-  </UDropdownMenu>
+    disable-hover-trigger
+    class="hidden lg:flex"
+    :ui="{
+      content: 'min-w-56 w-max',
+      childLink: 'min-w-full w-max whitespace-nowrap',
+      childLinkLabel: 'overflow-visible text-clip whitespace-nowrap',
+    }"
+  />
 </template>

--- a/docs/modules/vitehub-docs/artifacts.ts
+++ b/docs/modules/vitehub-docs/artifacts.ts
@@ -107,6 +107,60 @@ function getSupportedFrameworks(meta: Record<string, unknown>) {
     : [...frameworkIds];
 }
 
+function fwBlockMatchesFramework(meta: string | undefined, framework: Framework) {
+  if (!meta) {
+    return false;
+  }
+
+  const id = meta.match(/\bid\s*=\s*["']([^"']*)/)?.[1] || meta;
+
+  return id
+    .split(/[\s,]+/)
+    .filter(Boolean)
+    .some(item => {
+      const token = item.replace(/^:/, "");
+      return token === framework || token.startsWith(`${framework}:`);
+    });
+}
+
+export function filterFwBlocksForFramework(source: string, framework: Framework) {
+  const lines = source.split("\n");
+  const output: string[] = [];
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index]!;
+    const match = line.match(/^\s*::fw(?:\{([^}]*)\})?\s*$/);
+
+    if (!match) {
+      output.push(line);
+      continue;
+    }
+
+    const body: string[] = [];
+    let closed = false;
+
+    for (index++; index < lines.length; index++) {
+      if (/^\s*::\s*$/.test(lines[index]!)) {
+        closed = true;
+        break;
+      }
+
+      body.push(lines[index]!);
+    }
+
+    if (!closed) {
+      output.push(line, ...body);
+      break;
+    }
+
+    if (fwBlockMatchesFramework(match[1], framework)) {
+      output.push(...body);
+    }
+  }
+
+  return output.join("\n");
+}
+
 function getPhasePriority(modeConfig: { phases: Partial<Record<typeof phaseOrder[number], string>>; supplementalFiles?: string[] }, path: string) {
   const index = phaseOrder.findIndex(phaseId => modeConfig.phases[phaseId] === path);
   return index === -1 ? Number.POSITIVE_INFINITY : index;
@@ -326,7 +380,10 @@ export function writeDocsArtifacts({ docsRoot, repoRoot, outputDir }: DocsArtifa
 
           for (const page of pages) {
             for (const framework of page.frameworks) {
-              generatedPages.push({ filename: `docs-content/${framework}/${sectionId}/${page.relativeFile}`, contents: page.source });
+              generatedPages.push({
+                filename: `docs-content/${framework}/${sectionId}/${page.relativeFile}`,
+                contents: filterFwBlocksForFramework(page.source, framework),
+              });
             }
           }
 
@@ -362,7 +419,10 @@ export function writeDocsArtifacts({ docsRoot, repoRoot, outputDir }: DocsArtifa
 
         for (const page of pages) {
           for (const framework of page.frameworks) {
-            generatedPages.push({ filename: `docs-content/${framework}/${sectionId}/${page.relativeFile}`, contents: page.source });
+            generatedPages.push({
+              filename: `docs-content/${framework}/${sectionId}/${page.relativeFile}`,
+              contents: filterFwBlocksForFramework(page.source, framework),
+            });
           }
         }
 

--- a/docs/test/docs-artifacts.test.ts
+++ b/docs/test/docs-artifacts.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { filterFwBlocksForFramework } from "../modules/vitehub-docs/artifacts";
+
+describe("filterFwBlocksForFramework", () => {
+  it("keeps only matching explicit id blocks", () => {
+    const source = [
+      "# Getting started",
+      "",
+      "::fw{id=\"vite:dev vite:build\"}",
+      "Vite setup",
+      "::",
+      "",
+      "::fw{id=\"nitro:dev nitro:build\"}",
+      "Nitro setup",
+      "::",
+      "",
+      "::fw{id=\"nuxt:dev nuxt:build\"}",
+      "Nuxt app",
+      "::",
+    ].join("\n");
+
+    const filtered = filterFwBlocksForFramework(source, "nitro");
+
+    expect(filtered).toContain("# Getting started");
+    expect(filtered).toContain("Nitro setup");
+    expect(filtered).not.toContain("::fw");
+    expect(filtered).not.toContain("Vite setup");
+    expect(filtered).not.toContain("Nuxt app");
+  });
+
+  it("keeps matching shorthand framework blocks", () => {
+    const source = [
+      "::fw{nitro nuxt}",
+      "Server platforms",
+      "::",
+      "",
+      "::fw{vite}",
+      "Vite only",
+      "::",
+    ].join("\n");
+
+    expect(filterFwBlocksForFramework(source, "nitro")).toContain("Server platforms");
+    expect(filterFwBlocksForFramework(source, "nitro")).not.toContain("Vite only");
+    expect(filterFwBlocksForFramework(source, "vite")).toContain("Vite only");
+    expect(filterFwBlocksForFramework(source, "vite")).not.toContain("Server platforms");
+  });
+
+  it("preserves frontmatter and non-fw markdown", () => {
+    const source = [
+      "---",
+      "title: Providers",
+      "---",
+      "",
+      "# Providers",
+      "",
+      "Regular paragraph.",
+    ].join("\n");
+
+    expect(filterFwBlocksForFramework(source, "nuxt")).toBe(source);
+  });
+
+  it("preserves malformed fw blocks", () => {
+    const source = [
+      "# Broken",
+      "",
+      "::fw{nitro}",
+      "Unclosed body",
+    ].join("\n");
+
+    expect(filterFwBlocksForFramework(source, "nitro")).toBe(source);
+  });
+});


### PR DESCRIPTION
## Summary

- filters generated framework docs content so raw docs only include the requested framework
- removes `fw` wrapper artifacts from raw markdown output
- keeps the yellow primary theme configured through Nuxt UI app config instead of CSS token overrides

## Validation

- pnpm --dir docs test
- pnpm --dir docs typecheck
- pnpm --dir docs generate