### PR TITLE
docs(queue): add framework examples

### DIFF
--- a/packages/queue/examples/nitro/nitro.config.ts
+++ b/packages/queue/examples/nitro/nitro.config.ts
@@ -1,0 +1,8 @@
+import { defineNitroConfig } from "nitro/config"
+
+export default defineNitroConfig({
+  modules: ["@vitehub/queue/nitro"],
+  queue: {
+    provider: "memory",
+  },
+})

--- a/packages/queue/examples/nitro/package.json
+++ b/packages/queue/examples/nitro/package.json
@@ -1,0 +1,11 @@
+{
+  "type": "module",
+  "scripts": {
+    "dev": "nitro dev",
+    "build": "nitro build"
+  },
+  "dependencies": {
+    "@vitehub/queue": "workspace:*",
+    "nitro": "catalog:"
+  }
+}

--- a/packages/queue/examples/nitro/server/api/queues/welcome-defer.post.ts
+++ b/packages/queue/examples/nitro/server/api/queues/welcome-defer.post.ts
@@ -1,0 +1,9 @@
+import { deferQueue } from "@vitehub/queue"
+
+export default defineEventHandler(() => {
+  deferQueue("welcome-email", {
+    email: "ava@example.com",
+  })
+
+  return { ok: true }
+})

--- a/packages/queue/examples/nitro/server/api/queues/welcome.post.ts
+++ b/packages/queue/examples/nitro/server/api/queues/welcome.post.ts
@@ -1,0 +1,9 @@
+import { runQueue } from "@vitehub/queue"
+
+export default defineEventHandler(async () => {
+  return await runQueue("welcome-email", {
+    id: "welcome-ava",
+    payload: { email: "ava@example.com" },
+    delaySeconds: 5,
+  })
+})

--- a/packages/queue/examples/nitro/server/queues/welcome-email.ts
+++ b/packages/queue/examples/nitro/server/queues/welcome-email.ts
@@ -1,0 +1,5 @@
+import { defineQueue } from "@vitehub/queue"
+
+export default defineQueue<{ email: string }>(async (job) => {
+  console.log(`Queued welcome email for ${job.payload.email}`)
+})

--- a/packages/queue/examples/nuxt/nuxt.config.ts
+++ b/packages/queue/examples/nuxt/nuxt.config.ts
@@ -1,0 +1,6 @@
+export default defineNuxtConfig({
+  modules: ["@vitehub/queue/nuxt"],
+  queue: {
+    provider: "memory",
+  },
+})

--- a/packages/queue/examples/nuxt/package.json
+++ b/packages/queue/examples/nuxt/package.json
@@ -1,0 +1,11 @@
+{
+  "type": "module",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "@vitehub/queue": "workspace:*",
+    "nuxt": "catalog:"
+  }
+}

--- a/packages/queue/examples/nuxt/server/api/queues/welcome-defer.post.ts
+++ b/packages/queue/examples/nuxt/server/api/queues/welcome-defer.post.ts
@@ -1,0 +1,9 @@
+import { deferQueue } from "@vitehub/queue"
+
+export default defineEventHandler(() => {
+  deferQueue("welcome-email", {
+    email: "ava@example.com",
+  })
+
+  return { ok: true }
+})

--- a/packages/queue/examples/nuxt/server/api/queues/welcome.post.ts
+++ b/packages/queue/examples/nuxt/server/api/queues/welcome.post.ts
@@ -1,0 +1,9 @@
+import { runQueue } from "@vitehub/queue"
+
+export default defineEventHandler(async () => {
+  return await runQueue("welcome-email", {
+    id: "welcome-ava",
+    payload: { email: "ava@example.com" },
+    delaySeconds: 5,
+  })
+})

--- a/packages/queue/examples/nuxt/server/queues/welcome-email.ts
+++ b/packages/queue/examples/nuxt/server/queues/welcome-email.ts
@@ -1,0 +1,5 @@
+import { defineQueue } from "@vitehub/queue"
+
+export default defineQueue<{ email: string }>(async (job) => {
+  console.log(`Queued welcome email for ${job.payload.email}`)
+})

--- a/packages/queue/examples/showcase.json
+++ b/packages/queue/examples/showcase.json
@@ -1,0 +1,101 @@
+{
+  "label": "Queue",
+  "icon": "i-lucide-list-restart",
+  "order": 1,
+  "providers": [
+    {
+      "id": "cloudflare",
+      "label": "Cloudflare",
+      "icon": "i-simple-icons-cloudflare",
+      "configOverride": "  queue: {\n    provider: 'cloudflare',\n  },"
+    },
+    {
+      "id": "vercel",
+      "label": "Vercel",
+      "icon": "i-simple-icons-vercel",
+      "configOverride": "  queue: {\n    provider: 'vercel',\n  },"
+    },
+    {
+      "id": "memory",
+      "label": "Memory",
+      "icon": "i-lucide-memory-stick",
+      "configOverride": "  queue: {\n    provider: 'memory',\n  },"
+    }
+  ],
+  "frameworks": {
+    "vite": {
+      "modes": {
+        "dev": {
+          "phases": {
+            "configure": "vite.config.ts",
+            "define": "src/welcome-email.queue.ts"
+          },
+          "supplementalFiles": [
+            "package.json"
+          ]
+        },
+        "build": {
+          "phases": {
+            "configure": "vite.config.ts",
+            "define": "src/welcome-email.queue.ts"
+          },
+          "supplementalFiles": [
+            "package.json"
+          ]
+        }
+      }
+    },
+    "nitro": {
+      "modes": {
+        "dev": {
+          "phases": {
+            "configure": "nitro.config.ts",
+            "define": "server/queues/welcome-email.ts",
+            "run": "server/api/queues/welcome.post.ts"
+          },
+          "supplementalFiles": [
+            "server/api/queues/welcome-defer.post.ts",
+            "package.json"
+          ]
+        },
+        "build": {
+          "phases": {
+            "configure": "nitro.config.ts",
+            "define": "server/queues/welcome-email.ts",
+            "run": "server/api/queues/welcome.post.ts"
+          },
+          "supplementalFiles": [
+            "server/api/queues/welcome-defer.post.ts",
+            "package.json"
+          ]
+        }
+      }
+    },
+    "nuxt": {
+      "modes": {
+        "dev": {
+          "phases": {
+            "configure": "nuxt.config.ts",
+            "define": "server/queues/welcome-email.ts",
+            "run": "server/api/queues/welcome.post.ts"
+          },
+          "supplementalFiles": [
+            "server/api/queues/welcome-defer.post.ts",
+            "package.json"
+          ]
+        },
+        "build": {
+          "phases": {
+            "configure": "nuxt.config.ts",
+            "define": "server/queues/welcome-email.ts",
+            "run": "server/api/queues/welcome.post.ts"
+          },
+          "supplementalFiles": [
+            "server/api/queues/welcome-defer.post.ts",
+            "package.json"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/packages/queue/examples/vite/package.json
+++ b/packages/queue/examples/vite/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@vitehub/queue": "workspace:*",
+    "vite": "catalog:"
+  }
+}

--- a/packages/queue/examples/vite/src/welcome-email.queue.ts
+++ b/packages/queue/examples/vite/src/welcome-email.queue.ts
@@ -1,0 +1,5 @@
+import { defineQueue } from "@vitehub/queue"
+
+export default defineQueue<{ email: string }>(async (job) => {
+  console.log(`Queued welcome email for ${job.payload.email}`)
+})

--- a/packages/queue/examples/vite/vite.config.ts
+++ b/packages/queue/examples/vite/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite"
+import { hubQueue } from "@vitehub/queue/vite"
+
+export default defineConfig({
+  plugins: [hubQueue()],
+  queue: {
+    provider: "memory",
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,33 @@ importers:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/queue/examples/nitro:
+    dependencies:
+      '@vitehub/queue':
+        specifier: workspace:*
+        version: link:../..
+      nitro:
+        specifier: 'catalog:'
+        version: 3.0.260311-beta(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(miniflare@4.20260415.0)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/queue/examples/nuxt:
+    dependencies:
+      '@vitehub/queue':
+        specifier: workspace:*
+        version: link:../..
+      nuxt:
+        specifier: 'catalog:'
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@parcel/watcher@2.5.6)(@types/node@25.6.0)(@upstash/redis@1.37.0)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.0(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+
+  packages/queue/examples/vite:
+    dependencies:
+      '@vitehub/queue':
+        specifier: workspace:*
+        version: link:../..
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
 packages:
 
   '@ai-sdk/gateway@3.0.83':


### PR DESCRIPTION
## Summary

- Add Nitro, Nuxt, and Vite examples for `@vitehub/queue`.
- Include enqueue, defer, probe, and discovered queue handler examples for server-capable frameworks.
- Keep the Vite example bridge-only so it does not bundle server queue runtime into browser code.

## Stack

Base stack:
- #10
- #11 umbrella
- #12 source + tests

This PR is part 2 of the queue stack:
1. Source + tests
2. Examples
3. Docs
4. E2E tests

## Tests

- `pnpm --filter @vitehub/queue build`
- `pnpm --filter ./packages/queue/examples/nitro build`
- `pnpm --filter ./packages/queue/examples/nuxt build`
- `pnpm --filter ./packages/queue/examples/vite build`

## Linear
- ONM-225
