### PR TITLE
docs(queue): add queue documentation

### DIFF
--- a/docs/content/docs/getting-started/index.md
+++ b/docs/content/docs/getting-started/index.md
@@ -1,13 +1,13 @@
 ---
 title: Getting started
-description: Set up your first ViteHub package and continue with the KV quickstart.
+description: Set up your first ViteHub package and continue with package quickstarts.
 navigation.title: Getting started
 icon: i-lucide-rocket
 ---
 
-ViteHub currently ships [`@vitehub/kv`](/docs/nuxt/kv), a Nitro-backed key-value API with Nitro and Nuxt runtime usage plus a Vite bridge entrypoint.
+ViteHub currently ships [`@vitehub/kv`](/docs/nuxt/kv), a Nitro-backed key-value API, and [`@vitehub/queue`](/docs/nuxt/queue), a discovered background job API for Memory, Cloudflare, and Vercel queues.
 
-This page gives you the first framework-specific setup step, then points you to the KV docs where the full examples live.
+This page gives you the first framework-specific setup step, then points you to package docs where the full examples live.
 
 ## Start with KV
 
@@ -83,16 +83,30 @@ After that, continue with the [KV quickstart](/docs/nuxt/kv/quickstart).
   :::
   :::u-page-card
   ---
+  title: Queue overview
+  description: Understand discovered queue handlers and provider resolution.
+  to: /docs/nuxt/queue
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Queue quickstart
+  description: Define and enqueue a first queue job locally.
+  to: /docs/nuxt/queue/quickstart
+  ---
+  :::
+  :::u-page-card
+  ---
   title: Cloudflare provider
-  description: Configure the Cloudflare KV path.
-  to: /docs/nuxt/kv/providers/cloudflare
+  description: Configure Cloudflare-backed package paths.
+  to: /docs/nuxt/providers/cloudflare
   ---
   :::
   :::u-page-card
   ---
   title: Vercel provider
-  description: Configure the Upstash-backed Vercel path.
-  to: /docs/nuxt/kv/providers/vercel
+  description: Configure Vercel-backed package paths.
+  to: /docs/nuxt/providers/vercel
   ---
   :::
 ::

--- a/docs/content/docs/providers/cloudflare.md
+++ b/docs/content/docs/providers/cloudflare.md
@@ -17,6 +17,13 @@ Use this page to find package-specific Cloudflare guidance in ViteHub.
 - Setup overview: [KV overview](../kv)
 - Provider details: [KV on Cloudflare](../kv/providers/cloudflare)
 
+### Queue
+
+`@vitehub/queue` supports Cloudflare Queues through discovered queue definitions and Wrangler queue bindings.
+
+- Setup overview: [Queue overview](../queue)
+- Provider details: [Queue on Cloudflare](../queue/providers/cloudflare)
+
 ## What stays package-specific
 
-Bindings, namespace IDs, and exact config examples live with the package docs. Use this section as a routing page, not as the source of truth for package setup.
+Bindings, namespace IDs, queue names, and exact config examples live with the package docs. Use this section as a routing page, not as the source of truth for package setup.

--- a/docs/content/docs/providers/vercel.md
+++ b/docs/content/docs/providers/vercel.md
@@ -17,6 +17,13 @@ Use this page to find package-specific Vercel guidance in ViteHub.
 - Setup overview: [KV overview](../kv)
 - Provider details: [KV on Vercel](../kv/providers/vercel)
 
+### Queue
+
+`@vitehub/queue` supports Vercel Queues through discovered queue definitions and generated Vercel callback functions.
+
+- Setup overview: [Queue overview](../queue)
+- Provider details: [Queue on Vercel](../queue/providers/vercel)
+
 ## What stays package-specific
 
-Environment variables, fallback behavior, and exact config examples live with the package docs. Use this section as a routing page, not as the source of truth for package setup.
+Environment variables, callback behavior, fallback behavior, and exact config examples live with the package docs. Use this section as a routing page, not as the source of truth for package setup.

--- a/docs/modules/vitehub-docs/artifacts.ts
+++ b/docs/modules/vitehub-docs/artifacts.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join, relative, resolve } from "node:path";
+import { join, posix, relative, resolve } from "node:path";
 
 const frameworkIds = ["vite", "nitro", "nuxt"] as const;
 const usageModes = ["dev", "build"] as const;
@@ -165,6 +165,37 @@ export function filterFwBlocksForFramework(source: string, framework: Framework)
   }
 
   return output.join("\n");
+}
+
+function splitUrlSuffix(target: string) {
+  const suffixIndex = target.search(/[?#]/);
+  return suffixIndex === -1
+    ? { pathname: target, suffix: "" }
+    : { pathname: target.slice(0, suffixIndex), suffix: target.slice(suffixIndex) };
+}
+
+function normalizeGeneratedDocLink(target: string, framework: Framework, sectionId: string, relativeFile: string) {
+  if (!target.startsWith("./") && !target.startsWith("../")) return target;
+
+  const currentDir = posix.dirname(posix.join(sectionId, relativeFile.replace(/\.md$/, "")));
+  const { pathname, suffix } = splitUrlSuffix(target);
+  let resolved = posix.normalize(posix.join(currentDir, pathname));
+
+  if (resolved === ".") resolved = sectionId;
+  if (resolved.endsWith("/index")) resolved = resolved.slice(0, -"/index".length);
+
+  return `/docs/${framework}/${resolved}${suffix}`;
+}
+
+function rewriteGeneratedDocLinks(source: string, framework: Framework, sectionId: string, relativeFile: string) {
+  return source
+    .replace(/(!?\[[^\]]+\]\()((?:\.\.?\/)[^)]+)(\))/g, (match, prefix: string, target: string, suffix: string) => {
+      if (prefix.startsWith("![")) return match;
+      return `${prefix}${normalizeGeneratedDocLink(target, framework, sectionId, relativeFile)}${suffix}`;
+    })
+    .replace(/^(\s*to:\s*)(['"]?)(\.\.?\/[^'"\s]+)(\2)\s*$/gm, (_, prefix: string, quote: string, target: string) => {
+      return `${prefix}${quote}${normalizeGeneratedDocLink(target, framework, sectionId, relativeFile)}${quote}`;
+    });
 }
 
 function getPhasePriority(modeConfig: { phases: Partial<Record<typeof phaseOrder[number], string>>; supplementalFiles?: string[] }, path: string) {
@@ -485,9 +516,10 @@ export function writeDocsArtifacts({ docsRoot, repoRoot, outputDir }: DocsArtifa
 
           for (const page of pages) {
             for (const framework of page.frameworks) {
+              const source = filterFwBlocksForFramework(page.source, framework);
               generatedPages.push({
                 filename: `docs-content/${framework}/${sectionId}/${page.relativeFile}`,
-                contents: filterFwBlocksForFramework(page.source, framework),
+                contents: rewriteGeneratedDocLinks(source, framework, sectionId, page.relativeFile),
               });
             }
           }
@@ -524,9 +556,10 @@ export function writeDocsArtifacts({ docsRoot, repoRoot, outputDir }: DocsArtifa
 
         for (const page of pages) {
           for (const framework of page.frameworks) {
+            const source = filterFwBlocksForFramework(page.source, framework);
             generatedPages.push({
               filename: `docs-content/${framework}/${sectionId}/${page.relativeFile}`,
-              contents: filterFwBlocksForFramework(page.source, framework),
+              contents: rewriteGeneratedDocLinks(source, framework, sectionId, page.relativeFile),
             });
           }
         }

--- a/packages/queue/docs/index.md
+++ b/packages/queue/docs/index.md
@@ -1,0 +1,100 @@
+---
+title: Queue
+description: Send background jobs through one shared queue API.
+navigation.title: Overview
+icon: i-lucide-list-restart
+---
+
+`@vitehub/queue` discovers named queue definitions and sends jobs through the active provider. The first supported providers are Memory, Cloudflare Queues, and Vercel Queues.
+
+## Getting started
+
+Start with [Quickstart](./quickstart) to define one queue and enqueue one job. The default local provider is Memory, so you can test the API before choosing a hosted provider.
+
+## Automatic configuration
+
+ViteHub resolves the queue provider in this order:
+
+1. `queue: false` disables queues.
+2. Explicit `queue.provider` config wins.
+3. Cloudflare hosting defaults to `cloudflare`.
+4. Vercel hosting defaults to `vercel`.
+5. Everything else falls back to `memory`.
+
+This mirrors the `normalizeQueueOptions` runtime logic.
+
+## Supported provider paths
+
+### Cloudflare
+
+Use this path when queue producers and consumers should run on Cloudflare Workers. ViteHub registers Wrangler queue producer and consumer bindings for discovered queue names.
+
+Read [Cloudflare](./providers/cloudflare) for binding names and queue behavior.
+
+### Vercel
+
+Use this path when queue publishing and callbacks should stay inside the Vercel deployment model. ViteHub emits hidden Vercel queue callback functions during Vercel builds.
+
+Read [Vercel](./providers/vercel) for topics, callback routes, and SDK behavior.
+
+### Memory
+
+Use this path for local development and tests. Jobs are stored in process memory and handlers run after enqueue.
+
+Read [Memory](./providers/memory) for local behavior and limits.
+
+## What stays portable
+
+These pieces stay stable when you change providers:
+
+- the top-level `queue` config key
+- discovered queue definition files
+- `defineQueue()`
+- `runQueue()`, `deferQueue()`, and `getQueue()`
+
+## Next steps
+
+::u-page-grid{class="pb-2"}
+  :::u-page-card
+  ---
+  title: Quickstart
+  description: Define and run your first queue.
+  to: ./quickstart
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Usage
+  description: Send jobs and defer work after a response.
+  to: ./usage
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Runtime API
+  description: Review exports, options, and types.
+  to: ./runtime-api
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Cloudflare
+  description: Configure Cloudflare Queues.
+  to: ./providers/cloudflare
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Vercel
+  description: Configure Vercel Queues.
+  to: ./providers/vercel
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Memory
+  description: Use the local provider.
+  to: ./providers/memory
+  ---
+  :::
+::

--- a/packages/queue/docs/providers/.navigation.yml
+++ b/packages/queue/docs/providers/.navigation.yml
@@ -1,0 +1,2 @@
+title: Providers
+icon: i-lucide-cloud

--- a/packages/queue/docs/providers/cloudflare.md
+++ b/packages/queue/docs/providers/cloudflare.md
@@ -1,0 +1,83 @@
+---
+title: Cloudflare Queue
+description: Configure @vitehub/queue for Cloudflare Queues.
+navigation.title: Cloudflare
+navigation.group: Providers
+navigation.order: 10
+icon: i-simple-icons-cloudflare
+---
+
+Use Cloudflare Queue when producers and consumers should run on Cloudflare Workers.
+
+## Configuration
+
+::fw{id="vite:dev vite:build"}
+The Vite entrypoint registers bridge config. Use Nitro or Nuxt for discovered runtime queue handlers.
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import { hubQueue } from '@vitehub/queue/vite'
+
+export default defineConfig({
+  plugins: [hubQueue()],
+  queue: {
+    provider: 'cloudflare',
+  },
+})
+```
+::
+
+::fw{id="nitro:dev nitro:build"}
+```ts [nitro.config.ts]
+import { defineNitroConfig } from 'nitro/config'
+
+export default defineNitroConfig({
+  modules: ['@vitehub/queue/nitro'],
+  queue: {
+    provider: 'cloudflare',
+  },
+})
+```
+::
+
+::fw{id="nuxt:dev nuxt:build"}
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@vitehub/queue/nuxt'],
+  queue: {
+    provider: 'cloudflare',
+  },
+})
+```
+::
+
+On Cloudflare hosting, ViteHub can infer this provider when `queue.provider` is omitted.
+
+## Bindings
+
+ViteHub derives one queue binding per discovered queue by hex-encoding the queue name. For `server/queues/welcome-email.ts`, the queue name is `welcome-email` and the generated binding is `QUEUE_77656C636F6D652D656D61696C`.
+
+The Nitro module registers Wrangler queue producers and consumers:
+
+```json
+{
+  "queues": {
+    "producers": [{ "binding": "QUEUE_77656C636F6D652D656D61696C", "queue": "welcome-email" }],
+    "consumers": [{ "queue": "welcome-email" }]
+  }
+}
+```
+
+Set `queue.binding` only when you have a single queue and need a specific binding name.
+
+## Handler behavior
+
+Cloudflare sends batches to the Worker queue handler. ViteHub maps each Cloudflare message to a `QueueJob`, calls the discovered queue handler, and acknowledges the message when the handler succeeds.
+
+If the handler throws, ViteHub retries the message unless `onError` returns `ack`, `retry`, or `{ retry }`.
+
+## Related
+
+- [Overview](../index)
+- [Quickstart](../quickstart)
+- [Runtime API](../runtime-api)

--- a/packages/queue/docs/providers/memory.md
+++ b/packages/queue/docs/providers/memory.md
@@ -1,0 +1,62 @@
+---
+title: Memory Queue
+description: Use the local in-process queue provider.
+navigation.title: Memory
+navigation.group: Providers
+navigation.order: 12
+icon: i-lucide-memory-stick
+---
+
+Memory is the default local provider. It stores messages in process memory and runs discovered handlers after enqueue.
+
+## Configuration
+
+::fw{id="vite:dev vite:build"}
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import { hubQueue } from '@vitehub/queue/vite'
+
+export default defineConfig({
+  plugins: [hubQueue()],
+  queue: {
+    provider: 'memory',
+  },
+})
+```
+::
+
+::fw{id="nitro:dev nitro:build"}
+```ts [nitro.config.ts]
+import { defineNitroConfig } from 'nitro/config'
+
+export default defineNitroConfig({
+  modules: ['@vitehub/queue/nitro'],
+  queue: {
+    provider: 'memory',
+  },
+})
+```
+::
+
+::fw{id="nuxt:dev nuxt:build"}
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@vitehub/queue/nuxt'],
+  queue: {
+    provider: 'memory',
+  },
+})
+```
+::
+
+## Behavior
+
+Memory is useful for local development and tests. It is not durable and does not share jobs across processes.
+
+Use Cloudflare or Vercel when you need hosted delivery, retry, and platform-managed execution.
+
+## Related
+
+- [Overview](../index)
+- [Quickstart](../quickstart)
+- [Usage](../usage)

--- a/packages/queue/docs/providers/vercel.md
+++ b/packages/queue/docs/providers/vercel.md
@@ -63,7 +63,9 @@ On Vercel hosting, ViteHub can infer this provider when `queue.provider` is omit
 
 ## Topics and callbacks
 
-The discovered queue name becomes the Vercel topic. For `server/queues/welcome-email.ts`, ViteHub sends to the topic `welcome-email`.
+The discovered queue name becomes the Vercel topic when it contains only letters, numbers, `_`, or `-`. For `server/queues/welcome-email.ts`, ViteHub sends to the topic `welcome-email`.
+
+Queue names with other characters are hex-encoded as `queue__<hex>` so they are safe Vercel topics. For `server/queues/email/welcome.ts`, ViteHub sends to the topic `queue__656d61696c2f77656c636f6d65`. Topic names matching `queue__<hex>` are reserved by `@vitehub/queue`.
 
 During Vercel builds, ViteHub generates hidden queue consumer functions in `.vercel/output/functions/api/vitehub/queues/vercel/**` and adds the `queue/v2beta` trigger metadata.
 

--- a/packages/queue/docs/providers/vercel.md
+++ b/packages/queue/docs/providers/vercel.md
@@ -1,0 +1,78 @@
+---
+title: Vercel Queue
+description: Configure @vitehub/queue for Vercel Queues.
+navigation.title: Vercel
+navigation.group: Providers
+navigation.order: 11
+icon: i-simple-icons-vercel
+---
+
+Use Vercel Queue when queue publishing and consumption should stay inside the Vercel deployment model.
+
+## Install the SDK
+
+Install `@vercel/queue` with `@vitehub/queue`.
+
+```bash [Terminal]
+pnpm add @vitehub/queue @vercel/queue
+```
+
+## Configuration
+
+::fw{id="vite:dev vite:build"}
+The Vite entrypoint registers bridge config. Use Nitro or Nuxt for discovered runtime queue handlers.
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import { hubQueue } from '@vitehub/queue/vite'
+
+export default defineConfig({
+  plugins: [hubQueue()],
+  queue: {
+    provider: 'vercel',
+  },
+})
+```
+::
+
+::fw{id="nitro:dev nitro:build"}
+```ts [nitro.config.ts]
+import { defineNitroConfig } from 'nitro/config'
+
+export default defineNitroConfig({
+  modules: ['@vitehub/queue/nitro'],
+  queue: {
+    provider: 'vercel',
+  },
+})
+```
+::
+
+::fw{id="nuxt:dev nuxt:build"}
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@vitehub/queue/nuxt'],
+  queue: {
+    provider: 'vercel',
+  },
+})
+```
+::
+
+On Vercel hosting, ViteHub can infer this provider when `queue.provider` is omitted.
+
+## Topics and callbacks
+
+The discovered queue name becomes the Vercel topic. For `server/queues/welcome-email.ts`, ViteHub sends to the topic `welcome-email`.
+
+During Vercel builds, ViteHub generates hidden queue consumer functions in `.vercel/output/functions/api/vitehub/queues/vercel/**` and adds the `queue/v2beta` trigger metadata.
+
+## Local development
+
+ViteHub does not manage a local Vercel queue emulator. Use `queue.provider = 'memory'` for local contract testing, then deploy with the Vercel provider.
+
+## Related
+
+- [Overview](../index)
+- [Quickstart](../quickstart)
+- [Runtime API](../runtime-api)

--- a/packages/queue/docs/quickstart.md
+++ b/packages/queue/docs/quickstart.md
@@ -1,0 +1,105 @@
+---
+title: Queue quickstart
+description: Define and enqueue a first queue job.
+navigation.title: Quickstart
+navigation.order: 1
+icon: i-lucide-rocket
+---
+
+This quickstart uses the Memory provider so you can verify the queue flow locally with minimal setup.
+
+## Configure Queue
+
+::fw{id="vite:dev vite:build"}
+The Vite entrypoint registers the Queue bridge for ViteHub environments. Runtime queue discovery and handlers currently require Nitro or Nuxt.
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import { hubQueue } from '@vitehub/queue/vite'
+
+export default defineConfig({
+  plugins: [hubQueue()],
+  queue: {
+    provider: 'memory',
+  },
+})
+```
+::
+
+::fw{id="nitro:dev nitro:build"}
+```ts [nitro.config.ts]
+import { defineNitroConfig } from 'nitro/config'
+
+export default defineNitroConfig({
+  modules: ['@vitehub/queue/nitro'],
+  queue: {
+    provider: 'memory',
+  },
+})
+```
+::
+
+::fw{id="nuxt:dev nuxt:build"}
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@vitehub/queue/nuxt'],
+  queue: {
+    provider: 'memory',
+  },
+})
+```
+::
+
+## Define a queue
+
+::fw{id="vite:dev vite:build"}
+Plain Vite processes do not discover queue handlers by themselves in this release. Use Nitro or Nuxt when you need runtime queue handlers.
+::
+
+::fw{id="nitro:dev nitro:build nuxt:dev nuxt:build"}
+Create a queue definition under `server/queues`.
+
+```ts [server/queues/welcome-email.ts]
+import { defineQueue } from '@vitehub/queue'
+
+export default defineQueue<{ email: string }>(async (job) => {
+  console.log(`Queued welcome email for ${job.payload.email}`)
+})
+```
+::
+
+## Send a job
+
+::fw{id="vite:dev vite:build"}
+Use the Nitro or Nuxt setup when you need the runtime `runQueue()` path.
+::
+
+::fw{id="nitro:dev nitro:build nuxt:dev nuxt:build"}
+```ts [server/api/queues/welcome.post.ts]
+import { runQueue } from '@vitehub/queue'
+
+export default defineEventHandler(async () => {
+  return await runQueue('welcome-email', {
+    id: 'welcome-ava',
+    payload: { email: 'ava@example.com' },
+    delaySeconds: 5,
+  })
+})
+```
+::
+
+## Verify the result
+
+Start the app and send one request:
+
+```bash [Terminal]
+curl -X POST http://localhost:3000/api/queues/welcome
+```
+
+With the Memory provider, the route returns a queued result and the handler logs the email payload.
+
+## Next steps
+
+- Use [Usage](./usage) for `runQueue()` and `deferQueue()` patterns.
+- Use [Runtime API](./runtime-api) for the complete public surface.
+- Move to [Cloudflare](./providers/cloudflare) or [Vercel](./providers/vercel) for hosted queues.

--- a/packages/queue/docs/runtime-api.md
+++ b/packages/queue/docs/runtime-api.md
@@ -1,0 +1,92 @@
+---
+title: Queue runtime API
+description: Reference for Queue exports, options, and core types.
+navigation.title: Runtime API
+navigation.order: 3
+icon: i-lucide-braces
+---
+
+Use this page when you need the Queue surface area, signatures, or option names.
+
+## Definition API
+
+### `defineQueue(handler, options?)`
+
+Define a queue handler.
+
+```ts [server/queues/welcome-email.ts]
+import { defineQueue } from '@vitehub/queue'
+
+export default defineQueue<{ email: string }>(async (job) => {
+  return { email: job.payload.email }
+})
+```
+
+## Enqueue APIs
+
+### `runQueue(name, input)`
+
+Use `runQueue()` for the normal enqueue path.
+
+```ts
+await runQueue('welcome-email', {
+  email: 'ava@example.com',
+})
+```
+
+### `deferQueue(name, input)`
+
+Use `deferQueue()` when the send should happen after the current response.
+
+```ts
+deferQueue('welcome-email', {
+  email: 'ava@example.com',
+})
+```
+
+### `getQueue(name)`
+
+Use `getQueue()` when you need the active provider handle.
+
+```ts
+const queue = await getQueue('welcome-email')
+console.log(queue.provider)
+```
+
+## Config type
+
+```ts
+type QueueProvider = 'cloudflare' | 'vercel' | 'memory'
+```
+
+```ts
+type QueueModuleOptions =
+  | false
+  | { provider?: undefined, cache?: boolean }
+  | { provider: 'memory', cache?: boolean }
+  | { provider: 'cloudflare', binding?: string, cache?: boolean }
+  | { provider: 'vercel', region?: string, cache?: boolean }
+```
+
+## Queue job
+
+Handlers receive a `QueueJob`.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Message identifier. |
+| `payload` | `TPayload` | Payload passed to `runQueue()`. |
+| `attempts` | `number` | Current delivery attempt. |
+| `signal` | `AbortSignal` | Abort signal for handler work. |
+| `metadata` | `unknown` | Provider-specific metadata. |
+
+## Enqueue options
+
+| Option | Description |
+| --- | --- |
+| `payload` | The message payload. |
+| `id` | Optional message identifier. |
+| `delaySeconds` | Delay delivery by a number of seconds. |
+| `idempotencyKey` | Deduplicate sends when the provider supports it. |
+| `retentionSeconds` | Keep the queued message for a limited time when the provider supports it. |
+| `contentType` | Set Cloudflare message content type. |

--- a/packages/queue/docs/usage.md
+++ b/packages/queue/docs/usage.md
@@ -1,0 +1,80 @@
+---
+title: Queue usage
+description: Define queue handlers and send jobs from runtime code.
+navigation.title: Usage
+navigation.order: 2
+icon: i-lucide-play
+---
+
+Queue usage has two parts: define a named queue and send jobs to that name.
+
+## Define a handler
+
+::fw{id="vite:dev vite:build"}
+Plain Vite runtime handler discovery is out of scope for this release. Use Nitro or Nuxt for discovered queue handlers.
+::
+
+::fw{id="nitro:dev nitro:build nuxt:dev nuxt:build"}
+Queue definitions live in `server/queues/**`. The queue name comes from the file path below that directory.
+
+```ts [server/queues/welcome-email.ts]
+import { defineQueue } from '@vitehub/queue'
+
+export default defineQueue<{ email: string }>(async (job) => {
+  await sendWelcomeEmail(job.payload.email)
+})
+```
+
+This file resolves to the queue name `welcome-email`.
+::
+
+## Send a payload
+
+Use a bare payload for the common path.
+
+```ts
+await runQueue('welcome-email', {
+  email: 'ava@example.com',
+})
+```
+
+Use an input object when you need delivery options.
+
+```ts
+await runQueue('welcome-email', {
+  id: 'welcome-ava',
+  payload: { email: 'ava@example.com' },
+  delaySeconds: 30,
+})
+```
+
+## Defer after the response
+
+Use `deferQueue()` when the enqueue call should happen after the current response is committed.
+
+```ts [server/api/signup.post.ts]
+import { deferQueue } from '@vitehub/queue'
+
+export default defineEventHandler(() => {
+  deferQueue('welcome-email', {
+    email: 'ava@example.com',
+  })
+
+  return { ok: true }
+})
+```
+
+`deferQueue()` uses the active Nitro request `waitUntil()` hook when the runtime provides one.
+
+## Provider-specific options
+
+Portable options are intentionally small.
+
+| Option | Memory | Cloudflare | Vercel |
+| --- | --- | --- | --- |
+| `delaySeconds` | accepted | supported | supported |
+| `contentType` | accepted | supported | unsupported |
+| `idempotencyKey` | accepted | unsupported | supported |
+| `retentionSeconds` | accepted | unsupported | supported |
+
+Unsupported hosted-provider options throw `QueueError`.

--- a/packages/queue/docs/when-to-use.md
+++ b/packages/queue/docs/when-to-use.md
@@ -1,0 +1,34 @@
+---
+title: When to use Queue
+description: Decide when Queue is the right primitive for background work.
+navigation.title: When to use Queue
+navigation.order: 4
+icon: i-lucide-route
+---
+
+Use Queue when a request can return now and the work can happen later.
+
+## Good fits
+
+- send emails, webhooks, or notifications
+- retry work that can fail transiently
+- delay delivery
+- smooth spikes in downstream load
+- keep one app-level API while moving between Memory, Cloudflare, and Vercel
+
+## Poor fits
+
+- work that must complete before the response
+- multi-step durable workflows with checkpoints
+- recurring scheduled tasks
+- low-latency in-process work that does not need retry or delivery semantics
+
+## Choose a provider
+
+| Need | Provider |
+| --- | --- |
+| Local development and tests | Memory |
+| Worker-native batch delivery | Cloudflare |
+| Vercel deployment-integrated callbacks | Vercel |
+
+Use provider pages for setup details and platform-specific behavior.


### PR DESCRIPTION
## Summary

- Add package docs for `@vitehub/queue`, including quickstart, usage, runtime API, when-to-use, and provider pages.
- Link Queue from the global getting-started and provider routing docs.
- Normalize generated framework doc links so package docs use absolute `/docs/{framework}/...` targets after generation.

## Stack

Base stack:
- #10
- #11 umbrella
- #12 source + tests
- #13 examples

This PR is part 3 of the queue stack:
1. Source + tests
2. Examples
3. Docs
4. E2E tests

## Tests

- `pnpm --dir docs test`
- `pnpm docs:build`
- `pnpm lint`

## Linear
- ONM-225
- ONM-275
- ONM-276
- ONM-265
