### PR TITLE
docs(blob): add framework examples

### DIFF
--- a/packages/blob/examples/nitro/nitro.config.ts
+++ b/packages/blob/examples/nitro/nitro.config.ts
@@ -1,0 +1,5 @@
+import { defineNitroConfig } from "nitro/config"
+
+export default defineNitroConfig({
+  modules: ["@vitehub/blob/nitro"],
+})

--- a/packages/blob/examples/nitro/package.json
+++ b/packages/blob/examples/nitro/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nitro build",
+    "dev": "nitro dev"
+  },
+  "dependencies": {
+    "@vitehub/blob": "workspace:*",
+    "nitro": "catalog:"
+  }
+}

--- a/packages/blob/examples/nitro/server/api/files.post.ts
+++ b/packages/blob/examples/nitro/server/api/files.post.ts
@@ -1,0 +1,8 @@
+import { defineEventHandler } from "h3"
+import { blob } from "@vitehub/blob"
+
+export default defineEventHandler(async () => {
+  return await blob.put("avatars/user-1.txt", "hello blob", {
+    contentType: "text/plain",
+  })
+})

--- a/packages/blob/examples/nitro/server/api/files/[...pathname].get.ts
+++ b/packages/blob/examples/nitro/server/api/files/[...pathname].get.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler, getRouterParam } from "h3"
+import { blob } from "@vitehub/blob"
+
+export default defineEventHandler(async (event) => {
+  const pathname = getRouterParam(event, "pathname") || ""
+  return await blob.serve(event, pathname)
+})

--- a/packages/blob/examples/nuxt/nuxt.config.ts
+++ b/packages/blob/examples/nuxt/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  modules: ["@vitehub/blob/nuxt"],
+})

--- a/packages/blob/examples/nuxt/package.json
+++ b/packages/blob/examples/nuxt/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nuxi build",
+    "dev": "nuxi dev"
+  },
+  "dependencies": {
+    "@vitehub/blob": "workspace:*",
+    "nuxt": "catalog:"
+  }
+}

--- a/packages/blob/examples/nuxt/server/api/files.post.ts
+++ b/packages/blob/examples/nuxt/server/api/files.post.ts
@@ -1,0 +1,7 @@
+import { blob } from "@vitehub/blob"
+
+export default defineEventHandler(async () => {
+  return await blob.put("avatars/user-1.txt", "hello blob", {
+    contentType: "text/plain",
+  })
+})

--- a/packages/blob/examples/nuxt/server/api/files/[...pathname].get.ts
+++ b/packages/blob/examples/nuxt/server/api/files/[...pathname].get.ts
@@ -1,0 +1,6 @@
+import { blob } from "@vitehub/blob"
+
+export default defineEventHandler(async (event) => {
+  const pathname = getRouterParam(event, "pathname") || ""
+  return await blob.serve(event, pathname)
+})

--- a/packages/blob/examples/showcase.json
+++ b/packages/blob/examples/showcase.json
@@ -1,0 +1,92 @@
+{
+  "label": "Blob",
+  "icon": "i-lucide-file-archive",
+  "order": 1,
+  "providers": [
+    {
+      "id": "cloudflare-r2",
+      "label": "Cloudflare",
+      "icon": "i-simple-icons-cloudflare",
+      "configOverride": "  blob: {\n    driver: 'cloudflare-r2',\n    binding: 'BLOB',\n    bucketName: '<r2-bucket-name>',\n  },"
+    },
+    {
+      "id": "vercel-blob",
+      "label": "Vercel",
+      "icon": "i-simple-icons-vercel",
+      "configOverride": "  blob: {\n    driver: 'vercel-blob',\n  },",
+      "envOverride": "BLOB_READ_WRITE_TOKEN=<vercel-blob-read-write-token>"
+    }
+  ],
+  "frameworks": {
+    "vite": {
+      "modes": {
+        "dev": {
+          "phases": {
+            "configure": "vite.config.ts",
+            "run": "src/main.ts"
+          },
+          "supplementalFiles": [
+            "package.json"
+          ]
+        },
+        "build": {
+          "phases": {
+            "configure": "vite.config.ts",
+            "run": "src/main.ts"
+          },
+          "supplementalFiles": [
+            "package.json"
+          ]
+        }
+      }
+    },
+    "nitro": {
+      "modes": {
+        "dev": {
+          "phases": {
+            "configure": "nitro.config.ts",
+            "run": "server/api/files.post.ts"
+          },
+          "supplementalFiles": [
+            "server/api/files/[...pathname].get.ts",
+            "package.json"
+          ]
+        },
+        "build": {
+          "phases": {
+            "configure": "nitro.config.ts",
+            "run": "server/api/files.post.ts"
+          },
+          "supplementalFiles": [
+            "server/api/files/[...pathname].get.ts",
+            "package.json"
+          ]
+        }
+      }
+    },
+    "nuxt": {
+      "modes": {
+        "dev": {
+          "phases": {
+            "configure": "nuxt.config.ts",
+            "run": "server/api/files.post.ts"
+          },
+          "supplementalFiles": [
+            "server/api/files/[...pathname].get.ts",
+            "package.json"
+          ]
+        },
+        "build": {
+          "phases": {
+            "configure": "nuxt.config.ts",
+            "run": "server/api/files.post.ts"
+          },
+          "supplementalFiles": [
+            "server/api/files/[...pathname].get.ts",
+            "package.json"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/packages/blob/examples/vite/package.json
+++ b/packages/blob/examples/vite/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@vitehub/blob": "workspace:*",
+    "h3": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/packages/blob/examples/vite/src/main.ts
+++ b/packages/blob/examples/vite/src/main.ts
@@ -1,5 +1,8 @@
 import { H3, serve } from "h3"
 import { blob } from "@vitehub/blob"
+import blobConfig from "virtual:@vitehub/blob/config"
+
+;(globalThis as typeof globalThis & { __vitehubBlobConfig?: typeof blobConfig.blob }).__vitehubBlobConfig = blobConfig.blob
 
 const app = new H3()
   .post("/files", async () => {

--- a/packages/blob/examples/vite/src/main.ts
+++ b/packages/blob/examples/vite/src/main.ts
@@ -1,0 +1,14 @@
+import { H3, serve } from "h3"
+import { blob } from "@vitehub/blob"
+
+const app = new H3()
+  .post("/files", async () => {
+    return await blob.put("avatars/user-1.txt", "hello blob", {
+      contentType: "text/plain",
+    })
+  })
+  .get("/files/:pathname", async (event) => {
+    return await blob.serve(event, event.context.params.pathname)
+  })
+
+serve(app)

--- a/packages/blob/examples/vite/src/main.ts
+++ b/packages/blob/examples/vite/src/main.ts
@@ -7,7 +7,7 @@ const app = new H3()
       contentType: "text/plain",
     })
   })
-  .get("/files/:pathname", async (event) => {
+  .get("/files/**:pathname", async (event) => {
     return await blob.serve(event, event.context.params.pathname)
   })
 

--- a/packages/blob/examples/vite/vite.config.ts
+++ b/packages/blob/examples/vite/vite.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from "vite"
 import { hubBlob } from "@vitehub/blob/vite"
 
 export default defineConfig({
+  blob: { driver: "vercel-blob" },
   plugins: [hubBlob()],
-  server: {
-    port: 5173,
-  },
+  server: { port: 5173 },
 })

--- a/packages/blob/examples/vite/vite.config.ts
+++ b/packages/blob/examples/vite/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite"
+import { hubBlob } from "@vitehub/blob/vite"
+
+export default defineConfig({
+  plugins: [hubBlob()],
+  server: {
+    port: 5173,
+  },
+})

--- a/packages/blob/playground/_shared/api/files/[...pathname].get.ts
+++ b/packages/blob/playground/_shared/api/files/[...pathname].get.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler, getRouterParam } from "h3"
+import { blob } from "@vitehub/blob"
+
+export default defineEventHandler(async (event) => {
+  const pathname = getRouterParam(event, "pathname") || ""
+  return await blob.serve(event, pathname)
+})

--- a/packages/blob/playground/_shared/api/tests/blob.post.ts
+++ b/packages/blob/playground/_shared/api/tests/blob.post.ts
@@ -1,0 +1,22 @@
+import { defineEventHandler } from "h3"
+import { blob } from "@vitehub/blob"
+
+export default defineEventHandler(async () => {
+  const pathname = `smoke/hello-${Date.now()}.txt`
+
+  const uploaded = await blob.put(pathname, "hello blob", {
+    contentType: "text/plain",
+    customMetadata: { source: "smoke" },
+  })
+  const head = await blob.head(pathname)
+  const body = await blob.get(pathname)
+  const listed = await blob.list({ prefix: "smoke/" })
+
+  return {
+    head,
+    listed: listed.blobs.map(item => item.pathname),
+    ok: true,
+    text: await body?.text(),
+    uploaded,
+  }
+})

--- a/packages/blob/playground/_shared/api/tests/probe.get.ts
+++ b/packages/blob/playground/_shared/api/tests/probe.get.ts
@@ -1,0 +1,25 @@
+import { defineEventHandler } from "h3"
+import { useRuntimeConfig } from "nitro/runtime"
+
+export default defineEventHandler((event) => {
+  const config = useRuntimeConfig(event) as {
+    blob?: {
+      provider?: {
+        driver?: string
+      }
+    }
+    hosting?: string
+  }
+  const runtime = config.hosting === "cloudflare-module" || event.context?.cloudflare || event.context?._platform?.cloudflare
+    ? "cloudflare"
+    : process.env.VERCEL ? "vercel" : "node"
+
+  return {
+    feature: "blob",
+    hasWaitUntil: typeof event.waitUntil === "function",
+    hosting: config.hosting,
+    ok: true,
+    provider: config.blob?.provider?.driver,
+    runtime,
+  }
+})

--- a/packages/blob/playground/_shared/api/tests/probe.get.ts
+++ b/packages/blob/playground/_shared/api/tests/probe.get.ts
@@ -2,24 +2,22 @@ import { defineEventHandler } from "h3"
 import { useRuntimeConfig } from "nitro/runtime"
 
 export default defineEventHandler((event) => {
-  const config = useRuntimeConfig(event) as {
-    blob?: {
-      provider?: {
-        driver?: string
-      }
-    }
+  const { blob, hosting } = useRuntimeConfig(event) as {
+    blob?: { provider?: { driver?: string } }
     hosting?: string
   }
-  const runtime = config.hosting === "cloudflare-module" || event.context?.cloudflare || event.context?._platform?.cloudflare
-    ? "cloudflare"
-    : process.env.VERCEL ? "vercel" : "node"
+
+  const isCloudflare = hosting === "cloudflare-module" || event.context?.cloudflare || event.context?._platform?.cloudflare
+  let runtime = "node"
+  if (isCloudflare) runtime = "cloudflare"
+  else if (process.env.VERCEL) runtime = "vercel"
 
   return {
     feature: "blob",
     hasWaitUntil: typeof event.waitUntil === "function",
-    hosting: config.hosting,
+    hosting,
     ok: true,
-    provider: config.blob?.provider?.driver,
+    provider: blob?.provider?.driver,
     runtime,
   }
 })

--- a/packages/blob/playground/_shared/api/upload.post.ts
+++ b/packages/blob/playground/_shared/api/upload.post.ts
@@ -1,0 +1,9 @@
+import { defineEventHandler } from "h3"
+import { blob } from "@vitehub/blob"
+
+export default defineEventHandler(async (event) => {
+  return await blob.handleUpload(event, {
+    formKey: "files",
+    multiple: true,
+  })
+})

--- a/packages/blob/playground/_shared/wrangler.template.jsonc
+++ b/packages/blob/playground/_shared/wrangler.template.jsonc
@@ -1,0 +1,12 @@
+{
+  "name": "vitehub-blob-${APP_NAME}",
+  "compatibility_date": "2025-01-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "./server/index.mjs",
+  "r2_buckets": [
+    {
+      "binding": "BLOB",
+      "bucket_name": "${BLOB_BUCKET_NAME}"
+    }
+  ]
+}

--- a/packages/blob/playground/nitro/.gitignore
+++ b/packages/blob/playground/nitro/.gitignore
@@ -1,0 +1,5 @@
+.vercel
+.wrangler
+.output
+.nitro
+.nuxt

--- a/packages/blob/playground/nitro/nitro.config.ts
+++ b/packages/blob/playground/nitro/nitro.config.ts
@@ -1,0 +1,4 @@
+export default {
+  srcDir: "server",
+  modules: ["../../src/nitro/module.ts"],
+}

--- a/packages/blob/playground/nitro/package.json
+++ b/packages/blob/playground/nitro/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "playground-blob-nitro",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nitro build",
+    "dev": "nitro dev"
+  },
+  "dependencies": {
+    "@vitehub/blob": "workspace:*",
+    "nitro": "catalog:"
+  }
+}

--- a/packages/blob/playground/nitro/server/api/files/[...pathname].get.ts
+++ b/packages/blob/playground/nitro/server/api/files/[...pathname].get.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../../_shared/api/files/[...pathname].get.ts"

--- a/packages/blob/playground/nitro/server/api/tests/blob.post.ts
+++ b/packages/blob/playground/nitro/server/api/tests/blob.post.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../../_shared/api/tests/blob.post.ts"

--- a/packages/blob/playground/nitro/server/api/tests/probe.get.ts
+++ b/packages/blob/playground/nitro/server/api/tests/probe.get.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../../_shared/api/tests/probe.get.ts"

--- a/packages/blob/playground/nitro/server/api/upload.post.ts
+++ b/packages/blob/playground/nitro/server/api/upload.post.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../_shared/api/upload.post.ts"

--- a/packages/blob/playground/nuxt/.gitignore
+++ b/packages/blob/playground/nuxt/.gitignore
@@ -1,0 +1,5 @@
+.vercel
+.wrangler
+.output
+.nitro
+.nuxt

--- a/packages/blob/playground/nuxt/nuxt.config.ts
+++ b/packages/blob/playground/nuxt/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  modules: ["../../src/nuxt/module.ts"],
+})

--- a/packages/blob/playground/nuxt/package.json
+++ b/packages/blob/playground/nuxt/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "playground-blob-nuxt",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nuxi build",
+    "dev": "nuxi dev"
+  },
+  "dependencies": {
+    "@vitehub/blob": "workspace:*",
+    "nuxt": "catalog:"
+  }
+}

--- a/packages/blob/playground/nuxt/server/api/files/[...pathname].get.ts
+++ b/packages/blob/playground/nuxt/server/api/files/[...pathname].get.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../../_shared/api/files/[...pathname].get.ts"

--- a/packages/blob/playground/nuxt/server/api/tests/blob.post.ts
+++ b/packages/blob/playground/nuxt/server/api/tests/blob.post.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../../_shared/api/tests/blob.post.ts"

--- a/packages/blob/playground/nuxt/server/api/tests/probe.get.ts
+++ b/packages/blob/playground/nuxt/server/api/tests/probe.get.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../../_shared/api/tests/probe.get.ts"

--- a/packages/blob/playground/nuxt/server/api/upload.post.ts
+++ b/packages/blob/playground/nuxt/server/api/upload.post.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../_shared/api/upload.post.ts"

--- a/packages/blob/playground/vite/.gitignore
+++ b/packages/blob/playground/vite/.gitignore
@@ -1,0 +1,5 @@
+.vercel
+.wrangler
+.output
+.nitro
+.nuxt

--- a/packages/blob/playground/vite/nitro.config.ts
+++ b/packages/blob/playground/vite/nitro.config.ts
@@ -1,0 +1,4 @@
+export default {
+  srcDir: "server",
+  modules: ["../../src/nitro/module.ts"],
+}

--- a/packages/blob/playground/vite/package.json
+++ b/packages/blob/playground/vite/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "playground-blob-vite",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nitro build",
+    "dev": "nitro dev"
+  },
+  "dependencies": {
+    "@vitehub/blob": "workspace:*",
+    "nitro": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/packages/blob/playground/vite/server/api/files/[...pathname].get.ts
+++ b/packages/blob/playground/vite/server/api/files/[...pathname].get.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../../_shared/api/files/[...pathname].get.ts"

--- a/packages/blob/playground/vite/server/api/tests/blob.post.ts
+++ b/packages/blob/playground/vite/server/api/tests/blob.post.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../../_shared/api/tests/blob.post.ts"

--- a/packages/blob/playground/vite/server/api/tests/probe.get.ts
+++ b/packages/blob/playground/vite/server/api/tests/probe.get.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../../_shared/api/tests/probe.get.ts"

--- a/packages/blob/playground/vite/server/api/upload.post.ts
+++ b/packages/blob/playground/vite/server/api/upload.post.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../_shared/api/upload.post.ts"

--- a/packages/blob/playground/vite/vite.config.ts
+++ b/packages/blob/playground/vite/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite"
+import { hubBlob } from "../../src/vite.ts"
+
+export default defineConfig({
+  plugins: [hubBlob()],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,13 +164,10 @@ importers:
         version: 1.0.8
       h3:
         specifier: 'catalog:'
-        version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.8.16))
+        version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       mime:
         specifier: 'catalog:'
         version: 4.1.0
-      nitro:
-        specifier: ^3.0.0-0
-        version: 3.0.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.0.0-rc.16)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -181,6 +178,9 @@ importers:
       '@vercel/blob':
         specifier: 'catalog:'
         version: 2.3.3
+      nitro:
+        specifier: 'catalog:'
+        version: 3.0.260311-beta(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(miniflare@4.20260415.0)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       publint:
         specifier: ^0.3.15
         version: 0.3.18
@@ -270,7 +270,7 @@ importers:
         version: 1.0.8
       nitro:
         specifier: ^3.0.0-0
-        version: 3.0.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.0.0-rc.16)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.0.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(ioredis@5.10.1)(lru-cache@11.3.5)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unstorage:
         specifier: 'catalog:'
         version: 2.0.0-alpha.7(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(chokidar@4.0.3)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1)
@@ -12773,13 +12773,6 @@ snapshots:
     optionalDependencies:
       crossws: 0.4.5(srvx@0.11.15)
 
-  h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.8.16)):
-    dependencies:
-      rou3: 0.8.1
-      srvx: 0.11.15
-    optionalDependencies:
-      crossws: 0.4.5(srvx@0.8.16)
-
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -13847,7 +13840,7 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro@3.0.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.0.0-rc.16)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  nitro@3.0.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(ioredis@5.10.1)(lru-cache@11.3.5)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       consola: 3.4.2
       cookie-es: 2.0.1
@@ -13867,7 +13860,6 @@ snapshots:
       unenv: 2.0.0-rc.21
       unstorage: 2.0.0-alpha.3(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(chokidar@4.0.3)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1)
     optionalDependencies:
-      rolldown: 1.0.0-rc.16
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,10 +164,13 @@ importers:
         version: 1.0.8
       h3:
         specifier: 'catalog:'
-        version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
+        version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.8.16))
       mime:
         specifier: 'catalog:'
         version: 4.1.0
+      nitro:
+        specifier: ^3.0.0-0
+        version: 3.0.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.0.0-rc.16)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -178,9 +181,6 @@ importers:
       '@vercel/blob':
         specifier: 'catalog:'
         version: 2.3.3
-      nitro:
-        specifier: 'catalog:'
-        version: 3.0.260311-beta(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(miniflare@4.20260415.0)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       publint:
         specifier: ^0.3.15
         version: 0.3.18
@@ -197,6 +197,66 @@ importers:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/blob/examples/nitro:
+    dependencies:
+      '@vitehub/blob':
+        specifier: workspace:*
+        version: link:../..
+      nitro:
+        specifier: 'catalog:'
+        version: 3.0.260311-beta(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(miniflare@4.20260415.0)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/blob/examples/nuxt:
+    dependencies:
+      '@vitehub/blob':
+        specifier: workspace:*
+        version: link:../..
+      nuxt:
+        specifier: 'catalog:'
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@parcel/watcher@2.5.6)(@types/node@25.6.0)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.0(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+
+  packages/blob/examples/vite:
+    dependencies:
+      '@vitehub/blob':
+        specifier: workspace:*
+        version: link:../..
+      h3:
+        specifier: 'catalog:'
+        version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/blob/playground/nitro:
+    dependencies:
+      '@vitehub/blob':
+        specifier: workspace:*
+        version: link:../..
+      nitro:
+        specifier: 'catalog:'
+        version: 3.0.260311-beta(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(miniflare@4.20260415.0)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/blob/playground/nuxt:
+    dependencies:
+      '@vitehub/blob':
+        specifier: workspace:*
+        version: link:../..
+      nuxt:
+        specifier: 'catalog:'
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@parcel/watcher@2.5.6)(@types/node@25.6.0)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@10.2.0(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+
+  packages/blob/playground/vite:
+    dependencies:
+      '@vitehub/blob':
+        specifier: workspace:*
+        version: link:../..
+      nitro:
+        specifier: 'catalog:'
+        version: 3.0.260311-beta(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(miniflare@4.20260415.0)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/kv:
     dependencies:
       '@nuxt/kit':
@@ -210,7 +270,7 @@ importers:
         version: 1.0.8
       nitro:
         specifier: ^3.0.0-0
-        version: 3.0.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(ioredis@5.10.1)(lru-cache@11.3.5)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.0.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.0.0-rc.16)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       unstorage:
         specifier: 'catalog:'
         version: 2.0.0-alpha.7(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(chokidar@4.0.3)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1)
@@ -12713,6 +12773,13 @@ snapshots:
     optionalDependencies:
       crossws: 0.4.5(srvx@0.11.15)
 
+  h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.8.16)):
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.15
+    optionalDependencies:
+      crossws: 0.4.5(srvx@0.8.16)
+
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -13780,7 +13847,7 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro@3.0.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(ioredis@5.10.1)(lru-cache@11.3.5)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  nitro@3.0.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(better-sqlite3@12.9.0)(chokidar@4.0.3)(ioredis@5.10.1)(lru-cache@11.3.5)(rolldown@1.0.0-rc.16)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       consola: 3.4.2
       cookie-es: 2.0.1
@@ -13800,6 +13867,7 @@ snapshots:
       unenv: 2.0.0-rc.21
       unstorage: 2.0.0-alpha.3(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(chokidar@4.0.3)(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1)
     optionalDependencies:
+      rolldown: 1.0.0-rc.16
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'


### PR DESCRIPTION
## Summary
- adds server-side Blob examples for Nitro, Nuxt, and Vite
- adds Blob playground routes for direct storage, upload, serve, and probe flows
- keeps Vite usage server-only with no browser/client imports

Part of the ONM-198 blob stack.

## Tests
- pnpm --filter ./packages/blob/examples/nitro build
- pnpm --filter ./packages/blob/examples/nuxt build
- pnpm --filter ./packages/blob/playground/nitro build
- pnpm --filter ./packages/blob/playground/nuxt build
- pnpm --filter ./packages/blob/playground/vite build
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm --dir docs test
- pnpm docs:build