### PR TITLE
test(sandbox): add source and provider tests

### DIFF
--- a/packages/sandbox/src/internal/shared/cloudflare-retry.ts
+++ b/packages/sandbox/src/internal/shared/cloudflare-retry.ts
@@ -1,3 +1,61 @@
-export const CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS = [1000, 2000, 5000, 10000, 15000]
+import { SandboxError } from '../../sandbox/errors'
 
+export const CLOUDFLARE_RETRY_DELAYS_MS = [1000, 2000, 5000, 10000, 15000]
+export const CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS = CLOUDFLARE_RETRY_DELAYS_MS
 export const CLOUDFLARE_RETRIABLE_STARTUP_ERROR_RE = /container is starting|currently provisioning|retry in a moment|network connection lost|not listening in the tcp address|durable object reset|code was updated|aborterror|aborted|maximum number of running container instances exceeded|there is no container instance that can be provided to this durable object/i
+
+type CloudflareRetryMetadata = {
+  code?: string
+  provider?: string
+  cause?: unknown
+}
+
+function readCloudflareRetryMetadata(error: unknown): CloudflareRetryMetadata | undefined {
+  if (!error || typeof error !== 'object')
+    return undefined
+
+  const metadata = error as {
+    code?: unknown
+    provider?: unknown
+    cause?: unknown
+  }
+
+  return {
+    code: typeof metadata.code === 'string' ? metadata.code : undefined,
+    provider: typeof metadata.provider === 'string' ? metadata.provider : undefined,
+    cause: metadata.cause,
+  }
+}
+
+function collectCloudflareRetryMessages(error: unknown): string {
+  const sandboxError = error instanceof SandboxError ? error : undefined
+  const metadata = readCloudflareRetryMetadata(error)
+
+  return [
+    error instanceof Error ? error.message : String(error),
+    error instanceof Error && error.cause instanceof Error ? error.cause.message : '',
+    sandboxError?.cause instanceof Error ? sandboxError.cause.message : '',
+    metadata?.cause instanceof Error ? metadata.cause.message : '',
+  ].filter(Boolean).join('\n')
+}
+
+export function isRetriableCloudflareError(
+  error: unknown,
+  options: {
+    allowedCodes?: string[]
+  } = {},
+): boolean {
+  const sandboxError = error instanceof SandboxError ? error : undefined
+  const metadata = readCloudflareRetryMetadata(error)
+  const provider = sandboxError?.provider || metadata?.provider
+
+  if (provider && provider !== 'cloudflare')
+    return false
+
+  const allowedCodes = new Set(options.allowedCodes || ['TIMEOUT'])
+  const code = sandboxError?.code || metadata?.code
+  if (code && allowedCodes.has(code))
+    return true
+
+  return CLOUDFLARE_RETRIABLE_STARTUP_ERROR_RE.test(collectCloudflareRetryMessages(error))
+}

--- a/packages/sandbox/src/internal/shared/discovered-definition-typescript.ts
+++ b/packages/sandbox/src/internal/shared/discovered-definition-typescript.ts
@@ -1,0 +1,209 @@
+import { createRequire } from 'node:module'
+import type { Import } from 'unimport'
+import type ts from 'typescript'
+
+const require = createRequire(import.meta.url)
+const typescript = require('typescript') as typeof import('typescript')
+
+function resolveImportLocalName(entry: Import) {
+  return entry.as || entry.name
+}
+
+function getScriptKind(id: string) {
+  const scriptKind = typescript.ScriptKind as typeof typescript.ScriptKind & {
+    MTS?: typeof typescript.ScriptKind.TS
+    CTS?: typeof typescript.ScriptKind.TS
+  }
+  if (id.endsWith('.tsx'))
+    return typescript.ScriptKind.TSX
+  if (id.endsWith('.jsx'))
+    return typescript.ScriptKind.JSX
+  if (id.endsWith('.mts'))
+    return scriptKind.MTS ?? typescript.ScriptKind.TS
+  if (id.endsWith('.cts'))
+    return scriptKind.CTS ?? typescript.ScriptKind.TS
+  if (id.endsWith('.mjs'))
+    return typescript.ScriptKind.JS
+  if (id.endsWith('.cjs'))
+    return typescript.ScriptKind.JS
+  if (id.endsWith('.js'))
+    return typescript.ScriptKind.JS
+  return typescript.ScriptKind.TS
+}
+
+function createSourceFile(id: string, source: string) {
+  return typescript.createSourceFile(id, source, typescript.ScriptTarget.Latest, true, getScriptKind(id))
+}
+
+function collectExplicitImportNames(sourceFile: ts.SourceFile) {
+  const names = new Set<string>()
+
+  for (const statement of sourceFile.statements) {
+    if (!typescript.isImportDeclaration(statement))
+      continue
+
+    const clause = statement.importClause
+    if (!clause)
+      continue
+
+    if (clause.name)
+      names.add(clause.name.text)
+
+    const bindings = clause.namedBindings
+    if (!bindings)
+      continue
+
+    if (typescript.isNamespaceImport(bindings)) {
+      names.add(bindings.name.text)
+      continue
+    }
+
+    for (const element of bindings.elements)
+      names.add(element.name.text)
+  }
+
+  return names
+}
+
+function collectDeclaredTypeNames(sourceFile: ts.SourceFile) {
+  const names = new Set<string>()
+
+  function visit(node: ts.Node) {
+    if (
+      (typescript.isInterfaceDeclaration(node)
+        || typescript.isTypeAliasDeclaration(node)
+        || typescript.isClassDeclaration(node)
+        || typescript.isEnumDeclaration(node))
+      && node.name
+    ) {
+      names.add(node.name.text)
+    }
+
+    if (
+      (typescript.isFunctionDeclaration(node)
+        || typescript.isClassDeclaration(node)
+        || typescript.isInterfaceDeclaration(node)
+        || typescript.isMethodDeclaration(node)
+        || typescript.isArrowFunction(node)
+        || typescript.isFunctionExpression(node)
+        || typescript.isTypeAliasDeclaration(node))
+      && node.typeParameters
+    ) {
+      for (const parameter of node.typeParameters)
+        names.add(parameter.name.text)
+    }
+
+    typescript.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return names
+}
+
+function collectTypeReferenceNames(sourceFile: ts.SourceFile) {
+  const names = new Set<string>()
+
+  function addEntityName(name: ts.EntityName) {
+    if (typescript.isIdentifier(name))
+      names.add(name.text)
+  }
+
+  function visit(node: ts.Node) {
+    if (typescript.isImportTypeNode(node) || typescript.isTypeQueryNode(node))
+      return
+
+    if (typescript.isTypeReferenceNode(node)) {
+      addEntityName(node.typeName)
+      node.typeArguments?.forEach(argument => visit(argument))
+      return
+    }
+
+    if (typescript.isExpressionWithTypeArguments(node)) {
+      if (typescript.isIdentifier(node.expression))
+        names.add(node.expression.text)
+      node.typeArguments?.forEach(argument => visit(argument))
+      return
+    }
+
+    typescript.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return names
+}
+
+function groupTypeImports(imports: Import[]) {
+  const grouped = new Map<string, Import[]>()
+
+  for (const entry of imports) {
+    const from = entry.typeFrom || entry.from
+    const entries = grouped.get(from)
+    if (entries) {
+      entries.push(entry)
+      continue
+    }
+    grouped.set(from, [entry])
+  }
+
+  return grouped
+}
+
+function stringifyTypeImport(entry: Import) {
+  const localName = resolveImportLocalName(entry)
+  if (localName === entry.name)
+    return entry.name
+  return `${entry.name} as ${localName}`
+}
+
+function injectTypeImports(source: string, imports: Import[], id: string) {
+  if (!imports.length)
+    return source
+
+  const sourceFile = createSourceFile(id, source)
+  const importStatements = sourceFile.statements.filter(typescript.isImportDeclaration)
+  const groupedImports = groupTypeImports(imports)
+  const block = Array.from(groupedImports.entries()).map(([from, entries]) =>
+    `import type { ${entries.map(stringifyTypeImport).join(', ')} } from ${JSON.stringify(from)}`
+  ).join('\n')
+
+  if (!block)
+    return source
+
+  const insertAt = importStatements.at(-1)?.end ?? (source.startsWith('#!')
+    ? (source.indexOf('\n') + 1)
+    : 0)
+  const prefix = source.slice(0, insertAt)
+  const suffix = source.slice(insertAt)
+  const needsLeadingNewline = insertAt > 0 && !prefix.endsWith('\n')
+  const needsTrailingNewline = suffix.length > 0 && !suffix.startsWith('\n')
+
+  return `${prefix}${needsLeadingNewline ? '\n' : ''}${block}${needsTrailingNewline ? '\n' : ''}${suffix}`
+}
+
+export async function injectTypeImportsFromImports(
+  source: string,
+  id: string,
+  imports: Import[],
+) {
+  const sourceFile = createSourceFile(id, source)
+  const explicitImports = collectExplicitImportNames(sourceFile)
+  const declaredTypes = collectDeclaredTypeNames(sourceFile)
+  const usedTypes = collectTypeReferenceNames(sourceFile)
+  const pendingImports: Import[] = []
+
+  for (const entry of imports) {
+    if (!entry.type || entry.disabled)
+      continue
+
+    const localName = resolveImportLocalName(entry)
+    if (!usedTypes.has(localName))
+      continue
+    if (explicitImports.has(localName) || declaredTypes.has(localName))
+      continue
+
+    pendingImports.push(entry)
+    explicitImports.add(localName)
+  }
+
+  return injectTypeImports(source, pendingImports, id)
+}

--- a/packages/sandbox/src/internal/shared/sleep.ts
+++ b/packages/sandbox/src/internal/shared/sleep.ts
@@ -1,0 +1,3 @@
+export async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/packages/sandbox/src/runtime/execute-cloudflare.ts
+++ b/packages/sandbox/src/runtime/execute-cloudflare.ts
@@ -1,0 +1,130 @@
+import { isRetriableCloudflareError } from '../internal/shared/cloudflare-retry'
+import { sleep } from '../internal/shared/sleep'
+import type { SandboxClient } from '../sandbox/types'
+import {
+  createHandlerError,
+  extractSandboxOutputFromExecution,
+  getErrorDiagnostics,
+  getErrorMessage,
+  getExecutionDiagnostics,
+  tryParseSandboxOutput,
+} from './execute-output'
+
+const MIN_EXEC_OUTPUT_RECOVERY_TIMEOUT_MS = 20_000
+const DEFAULT_EXEC_OUTPUT_RECOVERY_TIMEOUT_MS = 60_000
+const MAX_EXEC_OUTPUT_RECOVERY_TIMEOUT_MS = 120_000
+const EXEC_OUTPUT_RECOVERY_POLL_MS = 1_000
+
+export function resolveExecOutputRecoveryTimeout(timeout?: number) {
+  if (!timeout || timeout <= 0)
+    return DEFAULT_EXEC_OUTPUT_RECOVERY_TIMEOUT_MS
+
+  return Math.min(
+    MAX_EXEC_OUTPUT_RECOVERY_TIMEOUT_MS,
+    Math.max(MIN_EXEC_OUTPUT_RECOVERY_TIMEOUT_MS, Math.floor(timeout * 0.1)),
+  )
+}
+
+function isRecoverableCloudflareExecError(error: unknown) {
+  return isRetriableCloudflareError(error, {
+    allowedCodes: ['TIMEOUT', 'SANDBOX_TRANSPORT_ERROR'],
+  })
+}
+
+export async function recoverExecOutput(
+  sandbox: SandboxClient,
+  outputPath: string,
+  error: unknown,
+  timeout?: number,
+  execution?: { stdout?: string, stderr?: string, code?: number | null },
+) {
+  if (sandbox.provider !== 'cloudflare' || !isRecoverableCloudflareExecError(error))
+    return null
+
+  const recoveryTimeout = resolveExecOutputRecoveryTimeout(timeout)
+  const deadline = Date.now() + recoveryTimeout
+  let lastError: unknown
+
+  while (Date.now() < deadline) {
+    try {
+      return await sandbox.readFile(outputPath)
+    }
+    catch (readError) {
+      lastError = readError
+      await sleep(EXEC_OUTPUT_RECOVERY_POLL_MS)
+    }
+  }
+
+  throw createHandlerError('Sandbox definition execution failed before producing an output file.', sandbox.provider, {
+    outputPath,
+    cause: getErrorMessage(error),
+    lastReadError: getErrorMessage(lastError),
+    recoveryTimeout,
+    ...getErrorDiagnostics(error),
+    ...getExecutionDiagnostics(execution),
+  })
+}
+
+async function waitForCloudflareOutput(
+  sandbox: SandboxClient,
+  outputPath: string,
+  error: unknown,
+  timeout?: number,
+  execution?: { stdout?: string, stderr?: string, code?: number | null },
+) {
+  if (sandbox.provider !== 'cloudflare')
+    throw error
+
+  const recoveryTimeout = resolveExecOutputRecoveryTimeout(timeout)
+  const deadline = Date.now() + recoveryTimeout
+  let lastError: unknown = error
+  let lastOutput = ''
+
+  while (Date.now() < deadline) {
+    try {
+      const output = await sandbox.readFile(outputPath)
+      if (tryParseSandboxOutput(output))
+        return output
+      lastOutput = output
+    }
+    catch (readError) {
+      lastError = readError
+    }
+
+    await sleep(EXEC_OUTPUT_RECOVERY_POLL_MS)
+  }
+
+  throw createHandlerError('Sandbox definition execution failed before producing an output file.', sandbox.provider, {
+    outputPath,
+    cause: getErrorMessage(error),
+    lastReadError: getErrorMessage(lastError),
+    recoveryTimeout,
+    outputPreview: lastOutput.slice(0, 500),
+    ...getErrorDiagnostics(error),
+    ...getExecutionDiagnostics(execution),
+  })
+}
+
+export async function readExecOutputWithRecovery(
+  sandbox: SandboxClient,
+  outputPath: string,
+  error: unknown,
+  timeout?: number,
+  execution?: { stdout?: string, stderr?: string, code?: number | null },
+) {
+  const executionOutput = extractSandboxOutputFromExecution(execution)
+    || extractSandboxOutputFromExecution(error as { stdout?: string, stderr?: string } | undefined)
+  if (executionOutput)
+    return executionOutput
+
+  try {
+    const output = await sandbox.readFile(outputPath)
+    if (tryParseSandboxOutput(output))
+      return output
+  }
+  catch {
+    return await waitForCloudflareOutput(sandbox, outputPath, error, timeout, execution)
+  }
+
+  return await waitForCloudflareOutput(sandbox, outputPath, error, timeout, execution)
+}

--- a/packages/sandbox/src/runtime/execute-output.ts
+++ b/packages/sandbox/src/runtime/execute-output.ts
@@ -1,0 +1,110 @@
+import { SandboxError } from '../sandbox/errors'
+
+export const EXEC_STDIO_OUTPUT_MARKER = '__VITEHUB_OUTPUT__'
+
+export function createHandlerError(message: string, provider: string, details?: Record<string, unknown>) {
+  return new SandboxError(message, {
+    code: 'SANDBOX_HANDLER_ERROR',
+    provider,
+    details,
+  })
+}
+
+export function createTimeoutError(provider: string, timeout: number) {
+  return new SandboxError(`Sandbox definition timed out after ${timeout}ms.`, {
+    code: 'TIMEOUT',
+    provider,
+    details: { timeout },
+  })
+}
+
+export function getErrorMessage(error: unknown) {
+  if (error instanceof Error)
+    return error.message
+
+  if (error && typeof error === 'object') {
+    const candidate = error as { message?: unknown, stderr?: unknown, stdout?: unknown }
+
+    if (typeof candidate.message === 'string' && candidate.message)
+      return candidate.message
+    if (typeof candidate.stderr === 'string' && candidate.stderr)
+      return candidate.stderr
+    if (typeof candidate.stdout === 'string' && candidate.stdout)
+      return candidate.stdout
+  }
+
+  if (error === undefined)
+    return undefined
+
+  return String(error)
+}
+
+export function tryParseSandboxOutput<TResult>(outputRaw: string) {
+  if (!outputRaw.trim())
+    return null
+
+  try {
+    return JSON.parse(outputRaw) as {
+      ok?: boolean
+      result?: TResult
+      error?: { message?: string, name?: string, stack?: string, cause?: string }
+    }
+  }
+  catch {
+    return null
+  }
+}
+
+export function extractSandboxOutputFromExecution(execution?: { stdout?: string, stderr?: string }) {
+  const streams = [execution?.stdout, execution?.stderr].filter(Boolean) as string[]
+
+  for (const stream of streams) {
+    for (const line of stream.split('\n').reverse()) {
+      const markerIndex = line.indexOf(EXEC_STDIO_OUTPUT_MARKER)
+      if (markerIndex < 0)
+        continue
+
+      return line.slice(markerIndex + EXEC_STDIO_OUTPUT_MARKER.length)
+    }
+  }
+
+  return null
+}
+
+function previewExecutionStream(stream?: string) {
+  if (!stream)
+    return undefined
+
+  return stream.slice(0, 500)
+}
+
+export function getExecutionDiagnostics(execution?: { stdout?: string, stderr?: string, code?: number | null, meta?: Record<string, unknown> }) {
+  return {
+    args: Array.isArray(execution?.meta?.args) ? execution?.meta?.args : undefined,
+    command: typeof execution?.meta?.command === 'string' ? execution.meta.command : undefined,
+    cwd: typeof execution?.meta?.cwd === 'string' ? execution.meta.cwd : undefined,
+    exitCode: typeof execution?.code === 'undefined' ? undefined : execution.code,
+    stderrPreview: previewExecutionStream(execution?.stderr),
+    stdoutPreview: previewExecutionStream(execution?.stdout),
+  }
+}
+
+export function getErrorDiagnostics(error: unknown) {
+  if (!error || typeof error !== 'object' || !('details' in error))
+    return {}
+
+  const details = (error as { details?: Record<string, unknown> }).details
+  if (!details || typeof details !== 'object')
+    return {}
+
+  return {
+    args: Array.isArray(details.args) ? details.args : undefined,
+    command: typeof details.command === 'string' ? details.command : undefined,
+    cwd: typeof details.cwd === 'string' ? details.cwd : undefined,
+    exitCode: typeof details.exitCode === 'number' || details.exitCode === null ? details.exitCode : undefined,
+    spawnErrorCode: typeof details.spawnErrorCode === 'string' ? details.spawnErrorCode : undefined,
+    spawnErrorMessage: typeof details.spawnErrorMessage === 'string' ? details.spawnErrorMessage : undefined,
+    stderrPreview: typeof details.stderrPreview === 'string' ? details.stderrPreview : undefined,
+    stdoutPreview: typeof details.stdoutPreview === 'string' ? details.stdoutPreview : undefined,
+  }
+}

--- a/packages/sandbox/src/runtime/runtime-provider.ts
+++ b/packages/sandbox/src/runtime/runtime-provider.ts
@@ -1,0 +1,94 @@
+import { getCloudflareEnv } from '../internal/shared/provider-detection'
+import type {
+  AgentSandboxConfig,
+  SandboxDefinitionOptions,
+  SandboxDefinitionProviderOptions,
+} from '../module-types'
+import { getSandboxFeatureProvider } from '../module-types'
+import { SandboxError } from '../sandbox/errors'
+import { detectSandbox } from '../sandbox/providers/shared'
+import type { SandboxClient, SandboxProvider, SandboxProviderOptions } from '../sandbox/types'
+import { validateSandboxConfig } from '../sandbox/validation'
+import { loadSandboxRuntimeProvider } from 'virtual:vitehub-sandbox-provider-loader'
+
+export type SandboxEvent = {
+  context?: {
+    cloudflare?: { env?: Record<string, unknown> }
+    _platform?: { cloudflare?: { env?: Record<string, unknown> } }
+  }
+}
+
+const allowedDefinitionKeys = new Set(['timeout', 'env', 'runtime'])
+
+export function assertSandboxDefinitionOptions(local: SandboxDefinitionOptions) {
+  const invalidKeys = Object.keys(local).filter(key => !allowedDefinitionKeys.has(key))
+  if (invalidKeys.length > 0)
+    throw new TypeError(`[vitehub] Sandbox definition options only support timeout, env, runtime. Unsupported: ${invalidKeys.join(', ')}`)
+}
+
+export function resolveRuntimeProvider(provider?: SandboxDefinitionProviderOptions, event?: SandboxEvent) {
+  if (provider?.provider)
+    return provider.provider
+
+  const envProvider = process.env.SANDBOX_PROVIDER
+  if (envProvider === 'cloudflare' || envProvider === 'vercel')
+    return envProvider
+
+  if (getCloudflareEnv(event))
+    return 'cloudflare'
+
+  const detected = detectSandbox()
+  if (detected.type === 'cloudflare' || detected.type === 'vercel')
+    return detected.type
+
+  throw new SandboxError('Sandbox provider could not be inferred. Configure `sandbox.provider` as `cloudflare` or `vercel`.', {
+    code: 'SANDBOX_PROVIDER_REQUIRED',
+  })
+}
+
+export async function resolveSandboxProviderConfig(
+  provider: SandboxProvider,
+  providerOptions: SandboxDefinitionProviderOptions & { provider: SandboxProvider },
+  local: SandboxDefinitionOptions,
+  context: { event?: SandboxEvent },
+): Promise<{
+  createSandboxClient: (provider: SandboxProviderOptions) => Promise<SandboxClient>
+  resolvedProvider: SandboxProviderOptions
+}> {
+  const runtimeProvider = await loadSandboxRuntimeProvider(provider)
+  const resolvedProvider = await runtimeProvider.resolveSandboxProvider({
+    local,
+    provider: providerOptions,
+  }, context) as SandboxProviderOptions
+
+  return {
+    createSandboxClient: runtimeProvider.createSandboxClient,
+    resolvedProvider,
+  }
+}
+
+export async function loadSandboxClientFactory(provider: SandboxProvider) {
+  return (await loadSandboxRuntimeProvider(provider)).createSandboxClient
+}
+
+export async function createSandboxWithConfig(
+  config: AgentSandboxConfig,
+  local: SandboxDefinitionOptions = {},
+  context: { event?: SandboxEvent } = {},
+) {
+  assertSandboxDefinitionOptions(local)
+  const resolvedProviderConfig = getSandboxFeatureProvider(config)
+  const provider = resolveRuntimeProvider(resolvedProviderConfig, context.event)
+  const { createSandboxClient, resolvedProvider } = await resolveSandboxProviderConfig(provider, {
+    ...(resolvedProviderConfig || {}),
+    provider,
+  } as SandboxDefinitionProviderOptions & { provider: SandboxProvider }, local, context)
+
+  const validation = validateSandboxConfig(resolvedProvider)
+  if (!validation.ok) {
+    const firstIssue = validation.issues.find(issue => issue.severity === 'error') || validation.issues[0]
+    throw new SandboxError(firstIssue?.message || `[${provider}] invalid sandbox config`)
+  }
+
+  return await createSandboxClient(resolvedProvider)
+}

--- a/packages/sandbox/test/cloudflare-retry.test.ts
+++ b/packages/sandbox/test/cloudflare-retry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { isRetriableCloudflareError } from '../src/internal/shared/cloudflare-retry'
+import { SandboxError } from '../src/sandbox/errors'
+
+describe('isRetriableCloudflareError', () => {
+  it('retries timeout-style Cloudflare sandbox errors', () => {
+    const error = new SandboxError('request timed out', {
+      code: 'TIMEOUT',
+      provider: 'cloudflare',
+    })
+
+    expect(isRetriableCloudflareError(error)).toBe(true)
+  })
+
+  it('retries known Cloudflare startup failures by message', () => {
+    expect(isRetriableCloudflareError(new Error('Container is starting, retry in a moment'))).toBe(true)
+  })
+
+  it('does not treat non-Cloudflare provider errors as retriable', () => {
+    const error = new SandboxError('request timed out', {
+      code: 'TIMEOUT',
+      provider: 'vercel',
+    })
+
+    expect(isRetriableCloudflareError(error)).toBe(false)
+  })
+
+  it('rejects unrelated generic failures', () => {
+    expect(isRetriableCloudflareError(new Error('permission denied'))).toBe(false)
+  })
+})

--- a/packages/sandbox/test/discovered-definition.test.ts
+++ b/packages/sandbox/test/discovered-definition.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { injectTypeImportsFromImports } from '../src/internal/shared/discovered-definition-typescript'
+
+describe('discovered definition type imports', () => {
+  it('injects only missing type imports that are actually referenced', async () => {
+    const source = [
+      'export type Result = PromiseData<string>',
+      '',
+      'export const ok = true',
+    ].join('\n')
+
+    const injected = await injectTypeImportsFromImports(source, 'fixture.ts', [
+      { from: '#imports', name: 'PromiseData', type: true },
+      { from: '#imports', name: 'unusedValue' },
+    ])
+
+    expect(injected).toContain('import type { PromiseData } from "#imports"')
+    expect(injected).not.toContain('unusedValue')
+  })
+})

--- a/packages/sandbox/test/runtime-execute.test.ts
+++ b/packages/sandbox/test/runtime-execute.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { readExecOutputWithRecovery } from '../src/runtime/execute-cloudflare'
+import { EXEC_STDIO_OUTPUT_MARKER, extractSandboxOutputFromExecution, tryParseSandboxOutput } from '../src/runtime/execute-output'
+import { SandboxError } from '../src/sandbox/errors'
+
+describe('sandbox runtime execution helpers', () => {
+  it('extracts marked stdout payloads', () => {
+    const output = extractSandboxOutputFromExecution({
+      stdout: `log line\n${EXEC_STDIO_OUTPUT_MARKER}{"ok":true,"result":{"id":1}}\n`,
+    })
+
+    expect(tryParseSandboxOutput<{ id: number }>(output || '')).toEqual({
+      ok: true,
+      result: { id: 1 },
+    })
+  })
+
+  it('falls back to reading the Cloudflare output file when exec output is missing', async () => {
+    const sandbox = {
+      provider: 'cloudflare',
+      readFile: vi.fn()
+        .mockRejectedValueOnce(new Error('not ready'))
+        .mockResolvedValueOnce('{"ok":true,"result":{"status":"recovered"}}'),
+    }
+
+    await expect(readExecOutputWithRecovery(
+      sandbox as never,
+      '/tmp/output.json',
+      new SandboxError('Cloudflare sandbox exec timed out.', {
+        code: 'TIMEOUT',
+        provider: 'cloudflare',
+      }),
+      25_000,
+      { stdout: '', stderr: '', code: 1 },
+    )).resolves.toBe('{"ok":true,"result":{"status":"recovered"}}')
+
+    expect(sandbox.readFile).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/sandbox/test/runtime-provider.test.ts
+++ b/packages/sandbox/test/runtime-provider.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { assertSandboxDefinitionOptions, resolveRuntimeProvider } from '../src/runtime/runtime-provider'
+
+const originalSandboxProvider = process.env.SANDBOX_PROVIDER
+
+afterEach(() => {
+  if (originalSandboxProvider === undefined)
+    delete process.env.SANDBOX_PROVIDER
+  else
+    process.env.SANDBOX_PROVIDER = originalSandboxProvider
+})
+
+describe('sandbox runtime provider helpers', () => {
+  it('prefers explicit config over environment inference', () => {
+    process.env.SANDBOX_PROVIDER = 'cloudflare'
+
+    expect(resolveRuntimeProvider({ provider: 'vercel' })).toBe('vercel')
+  })
+
+  it('uses SANDBOX_PROVIDER when present', () => {
+    process.env.SANDBOX_PROVIDER = 'vercel'
+
+    expect(resolveRuntimeProvider()).toBe('vercel')
+  })
+
+  it('rejects unsupported per-definition options', () => {
+    expect(() => assertSandboxDefinitionOptions({
+      timeout: 1000,
+      runtime: { command: 'node' },
+      extra: true,
+    } as never)).toThrow(/Unsupported: extra/)
+  })
+})


### PR DESCRIPTION
## Summary

- add framework, runtime, and type coverage for `@vitehub/sandbox`
- cover the extracted retry, execution recovery, provider resolution, and discovered-definition helpers

## Validation

- `pnpm --filter @vitehub/sandbox build`
- `pnpm --filter @vitehub/sandbox typecheck`
- `pnpm --filter @vitehub/sandbox test`
