### PR TITLE
docs(sandbox): add framework examples

### DIFF
--- a/packages/sandbox/examples/nitro/.gitignore
+++ b/packages/sandbox/examples/nitro/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local

--- a/packages/sandbox/examples/nitro/.gitignore
+++ b/packages/sandbox/examples/nitro/.gitignore
@@ -1,2 +1,5 @@
 .vercel
+.vitehub
+.nitro
+.output
 .env*.local

--- a/packages/sandbox/examples/nitro/nitro.config.ts
+++ b/packages/sandbox/examples/nitro/nitro.config.ts
@@ -1,42 +1,16 @@
-import { resolve } from 'node:path'
 import { defineNitroConfig } from 'nitro/config'
-import type { AgentSandboxConfig } from '@vitehub/sandbox'
-
-declare module 'nitro/types' {
-  interface NitroConfig {
-    sandbox?: false | AgentSandboxConfig
-  }
-}
 
 function resolveSandboxConfig() {
-  switch (process.env.SANDBOX_PROVIDER) {
-    case 'cloudflare':
-      return { provider: 'cloudflare' as const }
-    case 'vercel':
-      return { provider: 'vercel' as const }
-    default:
-      if ((process.env.NITRO_PRESET || '').includes('cloudflare'))
-        return { provider: 'cloudflare' as const }
-      if ((process.env.NITRO_PRESET || '').includes('vercel'))
-        return { provider: 'vercel' as const }
-      return { provider: 'cloudflare' as const }
-  }
+  const preset = process.env.NITRO_PRESET || ''
+  const explicit = process.env.SANDBOX_PROVIDER
+  if (explicit === 'cloudflare' || explicit === 'vercel')
+    return { provider: explicit as 'cloudflare' | 'vercel' }
+  if (preset.includes('vercel'))
+    return { provider: 'vercel' as const }
+  return { provider: 'cloudflare' as const }
 }
 
 export default defineNitroConfig({
-  serverDir: 'server',
-  handlers: [
-    {
-      route: '/api/sandboxes/release-notes',
-      method: 'post',
-      handler: resolve(import.meta.dirname, 'server/api/sandboxes/release-notes.post.ts'),
-    },
-    {
-      route: '/api/tests/probe',
-      method: 'get',
-      handler: resolve(import.meta.dirname, 'server/api/tests/probe.get.ts'),
-    },
-  ],
   modules: ['@vitehub/sandbox/nitro'],
   sandbox: resolveSandboxConfig(),
 })

--- a/packages/sandbox/examples/nitro/nitro.config.ts
+++ b/packages/sandbox/examples/nitro/nitro.config.ts
@@ -1,0 +1,42 @@
+import { resolve } from 'node:path'
+import { defineNitroConfig } from 'nitro/config'
+import type { AgentSandboxConfig } from '@vitehub/sandbox'
+
+declare module 'nitro/types' {
+  interface NitroConfig {
+    sandbox?: false | AgentSandboxConfig
+  }
+}
+
+function resolveSandboxConfig() {
+  switch (process.env.SANDBOX_PROVIDER) {
+    case 'cloudflare':
+      return { provider: 'cloudflare' as const }
+    case 'vercel':
+      return { provider: 'vercel' as const }
+    default:
+      if ((process.env.NITRO_PRESET || '').includes('cloudflare'))
+        return { provider: 'cloudflare' as const }
+      if ((process.env.NITRO_PRESET || '').includes('vercel'))
+        return { provider: 'vercel' as const }
+      return { provider: 'cloudflare' as const }
+  }
+}
+
+export default defineNitroConfig({
+  serverDir: 'server',
+  handlers: [
+    {
+      route: '/api/sandboxes/release-notes',
+      method: 'post',
+      handler: resolve(import.meta.dirname, 'server/api/sandboxes/release-notes.post.ts'),
+    },
+    {
+      route: '/api/tests/probe',
+      method: 'get',
+      handler: resolve(import.meta.dirname, 'server/api/tests/probe.get.ts'),
+    },
+  ],
+  modules: ['@vitehub/sandbox/nitro'],
+  sandbox: resolveSandboxConfig(),
+})

--- a/packages/sandbox/examples/nitro/package.json
+++ b/packages/sandbox/examples/nitro/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "vitehub-sandbox-nitro-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nitro build",
+    "dev": "nitro dev",
+    "preview": "nitro preview"
+  },
+  "dependencies": {
+    "@cloudflare/sandbox": "catalog:",
+    "@vercel/sandbox": "catalog:",
+    "@vitehub/sandbox": "workspace:*",
+    "nitro": "catalog:"
+  }
+}

--- a/packages/sandbox/examples/nitro/server/api/sandboxes/release-notes.post.ts
+++ b/packages/sandbox/examples/nitro/server/api/sandboxes/release-notes.post.ts
@@ -1,0 +1,21 @@
+import { createError, defineEventHandler } from 'h3'
+import { readRequestPayload, readValidatedPayload, runSandbox } from '@vitehub/sandbox'
+import { validateReleaseNotesPayload } from '../../sandbox-example'
+
+export default defineEventHandler(async (event) => {
+  const payload = await readValidatedPayload(await readRequestPayload(event), validateReleaseNotesPayload)
+  const result = await runSandbox('release-notes', payload)
+
+  if (result.isErr()) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: result.error.message,
+      data: {
+        code: result.error.code,
+        provider: result.error.provider,
+      },
+    })
+  }
+
+  return { result: result.value }
+})

--- a/packages/sandbox/examples/nitro/server/api/tests/probe.get.ts
+++ b/packages/sandbox/examples/nitro/server/api/tests/probe.get.ts
@@ -1,0 +1,32 @@
+import { defineEventHandler } from 'h3'
+import { useRuntimeConfig } from 'nitro/runtime-config'
+
+export default defineEventHandler((event) => {
+  const runtimeConfig = useRuntimeConfig() as {
+    hosting?: string
+    sandbox?: {
+      provider?: string
+    }
+  }
+  const preset = process.env.NITRO_PRESET || null
+  const isCloudflare = event.req.runtime?.name === 'cloudflare'
+    || !!event.context.cloudflare?.env
+    || !!event.context._platform?.cloudflare?.env
+  const provider = runtimeConfig.sandbox?.provider
+    || process.env.SANDBOX_PROVIDER
+    || (isCloudflare ? 'cloudflare' : null)
+    || (process.env.VERCEL || process.env.VERCEL_URL ? 'vercel' : null)
+  const hosting = runtimeConfig.hosting
+    || preset
+    || (isCloudflare ? 'cloudflare-module' : null)
+    || (process.env.VERCEL || process.env.VERCEL_URL ? 'vercel' : null)
+
+  return {
+    ok: true,
+    feature: 'sandbox',
+    hosting,
+    provider,
+    runtime: event.req.runtime?.name || null,
+    hasWaitUntil: typeof event.req.waitUntil === 'function',
+  }
+})

--- a/packages/sandbox/examples/nitro/server/sandbox-example.ts
+++ b/packages/sandbox/examples/nitro/server/sandbox-example.ts
@@ -1,0 +1,27 @@
+import { createError } from 'h3'
+
+export type ReleaseNotesPayload = {
+  notes: string
+}
+
+export function validateReleaseNotesPayload(input: unknown): ReleaseNotesPayload {
+  if (!input || typeof input !== 'object') {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Enter release notes before running the sandbox.',
+    })
+  }
+
+  const notes = typeof (input as { notes?: unknown }).notes === 'string'
+    ? (input as { notes: string }).notes.trim()
+    : ''
+
+  if (!notes) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Enter release notes before running the sandbox.',
+    })
+  }
+
+  return { notes }
+}

--- a/packages/sandbox/examples/nitro/server/sandboxes/release-notes.ts
+++ b/packages/sandbox/examples/nitro/server/sandboxes/release-notes.ts
@@ -1,0 +1,14 @@
+import { defineSandbox } from '@vitehub/sandbox'
+
+export default defineSandbox(async (payload?: { notes?: string }) => {
+  const notes = typeof payload?.notes === 'string' ? payload.notes.trim() : ''
+  const items = notes
+    .split(/\n+/)
+    .map(line => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean)
+
+  return {
+    summary: items[0] || 'No notes provided.',
+    items: items.slice(0, 3),
+  }
+})

--- a/packages/sandbox/examples/nitro/vercel.json
+++ b/packages/sandbox/examples/nitro/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nitro",
+  "buildCommand": "npm run build",
+  "installCommand": "npm install"
+}

--- a/packages/sandbox/examples/nitro/wrangler.jsonc
+++ b/packages/sandbox/examples/nitro/wrangler.jsonc
@@ -1,0 +1,46 @@
+{
+  "name": "vitehub-sandbox-nitro",
+  "main": ".output/server/index.mjs",
+  "compatibility_date": "2025-07-15",
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "assets": {
+    "directory": ".output/public",
+    "binding": "ASSETS"
+  },
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./.output/server/Dockerfile",
+      "instance_type": "lite",
+      "max_instances": 12
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "SANDBOX",
+        "class_name": "Sandbox"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": [
+        "Sandbox"
+      ]
+    }
+  ],
+  "no_bundle": true,
+  "rules": [
+    {
+      "type": "ESModule",
+      "globs": [
+        "**/*.mjs",
+        "**/*.js"
+      ]
+    }
+  ]
+}

--- a/packages/sandbox/examples/nuxt/.gitignore
+++ b/packages/sandbox/examples/nuxt/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local

--- a/packages/sandbox/examples/nuxt/.gitignore
+++ b/packages/sandbox/examples/nuxt/.gitignore
@@ -1,2 +1,5 @@
 .vercel
+.vitehub
+.nuxt
+.output
 .env*.local

--- a/packages/sandbox/examples/nuxt/nuxt.config.ts
+++ b/packages/sandbox/examples/nuxt/nuxt.config.ts
@@ -1,0 +1,35 @@
+import { resolve } from 'node:path'
+
+function resolveSandboxConfig() {
+  switch (process.env.SANDBOX_PROVIDER) {
+    case 'cloudflare':
+      return { provider: 'cloudflare' as const }
+    case 'vercel':
+      return { provider: 'vercel' as const }
+    default:
+      if ((process.env.NITRO_PRESET || '').includes('cloudflare'))
+        return { provider: 'cloudflare' as const }
+      if ((process.env.NITRO_PRESET || '').includes('vercel'))
+        return { provider: 'vercel' as const }
+      return { provider: 'cloudflare' as const }
+  }
+}
+
+export default defineNuxtConfig({
+  modules: ['@vitehub/sandbox/nuxt'],
+  nitro: {
+    handlers: [
+      {
+        route: '/api/sandboxes/release-notes',
+        method: 'post',
+        handler: resolve(import.meta.dirname, 'server/api/sandboxes/release-notes.post.ts'),
+      },
+      {
+        route: '/api/tests/probe',
+        method: 'get',
+        handler: resolve(import.meta.dirname, 'server/api/tests/probe.get.ts'),
+      },
+    ],
+  },
+  sandbox: resolveSandboxConfig(),
+})

--- a/packages/sandbox/examples/nuxt/nuxt.config.ts
+++ b/packages/sandbox/examples/nuxt/nuxt.config.ts
@@ -1,35 +1,14 @@
-import { resolve } from 'node:path'
-
 function resolveSandboxConfig() {
-  switch (process.env.SANDBOX_PROVIDER) {
-    case 'cloudflare':
-      return { provider: 'cloudflare' as const }
-    case 'vercel':
-      return { provider: 'vercel' as const }
-    default:
-      if ((process.env.NITRO_PRESET || '').includes('cloudflare'))
-        return { provider: 'cloudflare' as const }
-      if ((process.env.NITRO_PRESET || '').includes('vercel'))
-        return { provider: 'vercel' as const }
-      return { provider: 'cloudflare' as const }
-  }
+  const preset = process.env.NITRO_PRESET || ''
+  const explicit = process.env.SANDBOX_PROVIDER
+  if (explicit === 'cloudflare' || explicit === 'vercel')
+    return { provider: explicit as 'cloudflare' | 'vercel' }
+  if (preset.includes('vercel'))
+    return { provider: 'vercel' as const }
+  return { provider: 'cloudflare' as const }
 }
 
 export default defineNuxtConfig({
   modules: ['@vitehub/sandbox/nuxt'],
-  nitro: {
-    handlers: [
-      {
-        route: '/api/sandboxes/release-notes',
-        method: 'post',
-        handler: resolve(import.meta.dirname, 'server/api/sandboxes/release-notes.post.ts'),
-      },
-      {
-        route: '/api/tests/probe',
-        method: 'get',
-        handler: resolve(import.meta.dirname, 'server/api/tests/probe.get.ts'),
-      },
-    ],
-  },
   sandbox: resolveSandboxConfig(),
 })

--- a/packages/sandbox/examples/nuxt/package.json
+++ b/packages/sandbox/examples/nuxt/package.json
@@ -10,6 +10,6 @@
     "@cloudflare/sandbox": "catalog:",
     "@vercel/sandbox": "catalog:",
     "@vitehub/sandbox": "workspace:*",
-    "nuxt": "catalog:"
+    "nuxt": "catalog:nuxt-nightly"
   }
 }

--- a/packages/sandbox/examples/nuxt/package.json
+++ b/packages/sandbox/examples/nuxt/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "preview": "nuxt preview"
+  },
+  "dependencies": {
+    "@cloudflare/sandbox": "catalog:",
+    "@vercel/sandbox": "catalog:",
+    "@vitehub/sandbox": "workspace:*",
+    "nuxt": "catalog:"
+  }
+}

--- a/packages/sandbox/examples/nuxt/server/api/sandboxes/release-notes.post.ts
+++ b/packages/sandbox/examples/nuxt/server/api/sandboxes/release-notes.post.ts
@@ -1,0 +1,21 @@
+import { createError, defineEventHandler } from 'h3'
+import { readRequestPayload, readValidatedPayload, runSandbox } from '@vitehub/sandbox'
+import { validateReleaseNotesPayload } from '../../sandbox-example'
+
+export default defineEventHandler(async (event) => {
+  const payload = await readValidatedPayload(await readRequestPayload(event), validateReleaseNotesPayload)
+  const result = await runSandbox('release-notes', payload)
+
+  if (result.isErr()) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: result.error.message,
+      data: {
+        code: result.error.code,
+        provider: result.error.provider,
+      },
+    })
+  }
+
+  return { result: result.value }
+})

--- a/packages/sandbox/examples/nuxt/server/api/tests/probe.get.ts
+++ b/packages/sandbox/examples/nuxt/server/api/tests/probe.get.ts
@@ -1,0 +1,32 @@
+import { defineEventHandler } from 'h3'
+import { useRuntimeConfig } from 'nitro/runtime-config'
+
+export default defineEventHandler((event) => {
+  const runtimeConfig = useRuntimeConfig() as {
+    hosting?: string
+    sandbox?: {
+      provider?: string
+    }
+  }
+  const preset = process.env.NITRO_PRESET || null
+  const isCloudflare = event.req.runtime?.name === 'cloudflare'
+    || !!event.context.cloudflare?.env
+    || !!event.context._platform?.cloudflare?.env
+  const provider = runtimeConfig.sandbox?.provider
+    || process.env.SANDBOX_PROVIDER
+    || (isCloudflare ? 'cloudflare' : null)
+    || (process.env.VERCEL || process.env.VERCEL_URL ? 'vercel' : null)
+  const hosting = runtimeConfig.hosting
+    || preset
+    || (isCloudflare ? 'cloudflare-module' : null)
+    || (process.env.VERCEL || process.env.VERCEL_URL ? 'vercel' : null)
+
+  return {
+    ok: true,
+    feature: 'sandbox',
+    hosting,
+    provider,
+    runtime: event.req.runtime?.name || null,
+    hasWaitUntil: typeof event.req.waitUntil === 'function',
+  }
+})

--- a/packages/sandbox/examples/nuxt/server/sandbox-example.ts
+++ b/packages/sandbox/examples/nuxt/server/sandbox-example.ts
@@ -1,0 +1,27 @@
+import { createError } from 'h3'
+
+export type ReleaseNotesPayload = {
+  notes: string
+}
+
+export function validateReleaseNotesPayload(input: unknown): ReleaseNotesPayload {
+  if (!input || typeof input !== 'object') {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Enter release notes before running the sandbox.',
+    })
+  }
+
+  const notes = typeof (input as { notes?: unknown }).notes === 'string'
+    ? (input as { notes: string }).notes.trim()
+    : ''
+
+  if (!notes) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Enter release notes before running the sandbox.',
+    })
+  }
+
+  return { notes }
+}

--- a/packages/sandbox/examples/nuxt/server/sandboxes/release-notes.ts
+++ b/packages/sandbox/examples/nuxt/server/sandboxes/release-notes.ts
@@ -1,0 +1,14 @@
+import { defineSandbox } from '@vitehub/sandbox'
+
+export default defineSandbox(async (payload?: { notes?: string }) => {
+  const notes = typeof payload?.notes === 'string' ? payload.notes.trim() : ''
+  const items = notes
+    .split(/\n+/)
+    .map(line => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean)
+
+  return {
+    summary: items[0] || 'No notes provided.',
+    items: items.slice(0, 3),
+  }
+})

--- a/packages/sandbox/examples/nuxt/vercel.json
+++ b/packages/sandbox/examples/nuxt/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nuxtjs",
+  "buildCommand": "npm run build",
+  "installCommand": "npm install"
+}

--- a/packages/sandbox/examples/nuxt/wrangler.jsonc
+++ b/packages/sandbox/examples/nuxt/wrangler.jsonc
@@ -1,0 +1,46 @@
+{
+  "name": "vitehub-sandbox-nuxt",
+  "main": ".output/server/index.mjs",
+  "compatibility_date": "2025-07-15",
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "assets": {
+    "directory": ".output/public",
+    "binding": "ASSETS"
+  },
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./.output/server/Dockerfile",
+      "instance_type": "lite",
+      "max_instances": 12
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "SANDBOX",
+        "class_name": "Sandbox"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": [
+        "Sandbox"
+      ]
+    }
+  ],
+  "no_bundle": true,
+  "rules": [
+    {
+      "type": "ESModule",
+      "globs": [
+        "**/*.mjs",
+        "**/*.js"
+      ]
+    }
+  ]
+}

--- a/packages/sandbox/examples/showcase.json
+++ b/packages/sandbox/examples/showcase.json
@@ -1,0 +1,53 @@
+{
+  "label": "Sandbox",
+  "icon": "i-lucide-box",
+  "docsPath": "sandbox",
+  "order": 90,
+  "defaultPhase": "run",
+  "providers": [
+    {
+      "id": "cloudflare",
+      "label": "Cloudflare",
+      "icon": "i-simple-icons-cloudflare",
+      "configOverride": "  sandbox: {\n    provider: 'cloudflare',\n  },"
+    },
+    {
+      "id": "vercel",
+      "label": "Vercel",
+      "icon": "i-simple-icons-vercel",
+      "configOverride": "  sandbox: {\n    provider: 'vercel',\n    runtime: 'node22',\n  },"
+    }
+  ],
+  "frameworks": {
+    "nuxt": {
+      "phases": {
+        "configure": "nuxt.config.ts",
+        "define": "server/sandboxes/release-notes.ts",
+        "run": "server/api/sandboxes/release-notes.post.ts"
+      },
+      "supplementalFiles": [
+        "package.json"
+      ]
+    },
+    "nitro": {
+      "phases": {
+        "configure": "nitro.config.ts",
+        "define": "server/sandboxes/release-notes.ts",
+        "run": "server/api/sandboxes/release-notes.post.ts"
+      },
+      "supplementalFiles": [
+        "package.json"
+      ]
+    },
+    "vite": {
+      "phases": {
+        "configure": "vite.config.ts",
+        "define": "src/release-notes.sandbox.ts",
+        "run": "src/run-release-notes.ts"
+      },
+      "supplementalFiles": [
+        "package.json"
+      ]
+    }
+  }
+}

--- a/packages/sandbox/examples/vite/.gitignore
+++ b/packages/sandbox/examples/vite/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local

--- a/packages/sandbox/examples/vite/.gitignore
+++ b/packages/sandbox/examples/vite/.gitignore
@@ -1,2 +1,5 @@
 .vercel
+.vitehub
+.output
+dist
 .env*.local

--- a/packages/sandbox/examples/vite/index.html
+++ b/packages/sandbox/examples/vite/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sandbox Vite Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+  </html>

--- a/packages/sandbox/examples/vite/package.json
+++ b/packages/sandbox/examples/vite/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite dev",
+    "preview": "node .output/server/index.mjs"
+  },
+  "dependencies": {
+    "@cloudflare/sandbox": "catalog:",
+    "@vercel/sandbox": "catalog:",
+    "@vitehub/sandbox": "workspace:*",
+    "h3": "catalog:",
+    "nitro": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/packages/sandbox/examples/vite/src/main.ts
+++ b/packages/sandbox/examples/vite/src/main.ts
@@ -1,0 +1,65 @@
+type SandboxResponse = {
+  result?: {
+    items?: string[]
+    summary?: string
+  }
+}
+
+const app = document.querySelector<HTMLElement>('#app')
+
+if (!app)
+  throw new Error('Missing app root.')
+
+app.innerHTML = `
+  <section style="font-family: ui-sans-serif, system-ui, sans-serif; max-width: 720px; margin: 48px auto; padding: 24px;">
+    <h1 style="font-size: 2rem; line-height: 1.1; margin: 0 0 12px;">Sandbox Vite Example</h1>
+    <p style="margin: 0 0 24px; color: #555;">POST to <code>/api/sandboxes/release-notes</code> to summarize release notes inside an isolated sandbox.</p>
+
+    <form id="sandbox-form" style="display: grid; gap: 12px; margin-bottom: 24px;">
+      <label style="display: grid; gap: 6px;">
+        <span>Release notes</span>
+        <textarea name="notes" rows="6" style="padding: 12px 14px; border: 1px solid #ccc; border-radius: 10px;">- Added weekly digest
+- Tightened signup copy
+- Fixed failed billing retries</textarea>
+      </label>
+      <button type="submit" style="padding: 12px 16px; border: 0; border-radius: 10px; background: #111; color: #fff; font-weight: 600;">Run sandbox</button>
+    </form>
+
+    <section>
+      <h2 style="font-size: 1rem; margin: 0 0 8px;">Sandbox response</h2>
+      <pre id="sandbox-output" style="margin: 0; padding: 16px; border-radius: 12px; background: #f6f6f6; overflow: auto;">Waiting for a request.</pre>
+    </section>
+  </section>
+`
+
+const form = document.querySelector<HTMLFormElement>('#sandbox-form')
+const output = document.querySelector<HTMLElement>('#sandbox-output')
+
+function renderJson(value: unknown) {
+  if (!output)
+    return
+  output.textContent = JSON.stringify(value, null, 2)
+}
+
+form?.addEventListener('submit', async (event) => {
+  event.preventDefault()
+
+  const formData = new FormData(form)
+  const notes = String(formData.get('notes') || '')
+
+  renderJson({ loading: true })
+
+  const response = await fetch('/api/sandboxes/release-notes', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ notes }),
+  })
+
+  const body = response.ok
+    ? await response.json() as SandboxResponse
+    : { status: response.status, statusText: response.statusText, body: await response.text() }
+
+  renderJson(body)
+})

--- a/packages/sandbox/examples/vite/src/release-notes-example.ts
+++ b/packages/sandbox/examples/vite/src/release-notes-example.ts
@@ -1,0 +1,45 @@
+import { createError } from 'h3'
+
+export type ReleaseNotesPayload = {
+  notes: string
+}
+
+export type SandboxProbeData = {
+  hasWaitUntil: boolean
+  hosting: string | null
+  provider: string | null
+  runtime: string | null
+}
+
+export function validateReleaseNotesPayload(input: unknown): ReleaseNotesPayload {
+  if (!input || typeof input !== 'object') {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Enter release notes before running the sandbox.',
+    })
+  }
+
+  const notes = typeof (input as { notes?: unknown }).notes === 'string'
+    ? (input as { notes: string }).notes.trim()
+    : ''
+
+  if (!notes) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Enter release notes before running the sandbox.',
+    })
+  }
+
+  return { notes }
+}
+
+export function getSandboxProbeData(input: SandboxProbeData) {
+  return {
+    ok: true,
+    feature: 'sandbox',
+    hasWaitUntil: input.hasWaitUntil,
+    hosting: input.hosting,
+    provider: input.provider,
+    runtime: input.runtime,
+  }
+}

--- a/packages/sandbox/examples/vite/src/release-notes.sandbox.ts
+++ b/packages/sandbox/examples/vite/src/release-notes.sandbox.ts
@@ -1,0 +1,14 @@
+import { defineSandbox } from '@vitehub/sandbox'
+
+export default defineSandbox(async (payload?: { notes?: string }) => {
+  const notes = typeof payload?.notes === 'string' ? payload.notes.trim() : ''
+  const items = notes
+    .split(/\n+/)
+    .map(line => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean)
+
+  return {
+    summary: items[0] || 'No notes provided.',
+    items: items.slice(0, 3),
+  }
+})

--- a/packages/sandbox/examples/vite/src/run-release-notes.ts
+++ b/packages/sandbox/examples/vite/src/run-release-notes.ts
@@ -1,0 +1,21 @@
+import { createError, defineEventHandler } from 'h3'
+import { readRequestPayload, readValidatedPayload, runSandbox } from '@vitehub/sandbox'
+import { validateReleaseNotesPayload } from './release-notes-example'
+
+export default defineEventHandler(async (event) => {
+  const payload = await readValidatedPayload(await readRequestPayload(event), validateReleaseNotesPayload)
+  const result = await runSandbox('release-notes', payload)
+
+  if (result.isErr()) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: result.error.message,
+      data: {
+        code: result.error.code,
+        provider: result.error.provider,
+      },
+    })
+  }
+
+  return { result: result.value }
+})

--- a/packages/sandbox/examples/vite/src/sandbox-probe.ts
+++ b/packages/sandbox/examples/vite/src/sandbox-probe.ts
@@ -1,0 +1,31 @@
+import { defineEventHandler } from 'h3'
+import { useRuntimeConfig } from 'nitro/runtime-config'
+import { getSandboxProbeData } from './release-notes-example'
+
+export default defineEventHandler((event) => {
+  const runtimeConfig = useRuntimeConfig() as {
+    hosting?: string
+    sandbox?: {
+      provider?: string
+    }
+  }
+  const preset = process.env.NITRO_PRESET || null
+  const isCloudflare = event.req.runtime?.name === 'cloudflare'
+    || !!event.context.cloudflare?.env
+    || !!event.context._platform?.cloudflare?.env
+  const provider = runtimeConfig.sandbox?.provider
+    || process.env.SANDBOX_PROVIDER
+    || (isCloudflare ? 'cloudflare' : null)
+    || (process.env.VERCEL || process.env.VERCEL_URL ? 'vercel' : null)
+  const hosting = runtimeConfig.hosting
+    || preset
+    || (isCloudflare ? 'cloudflare-module' : null)
+    || (process.env.VERCEL || process.env.VERCEL_URL ? 'vercel' : null)
+
+  return getSandboxProbeData({
+    hasWaitUntil: typeof event.req.waitUntil === 'function',
+    hosting,
+    provider,
+    runtime: event.req.runtime?.name || null,
+  })
+})

--- a/packages/sandbox/examples/vite/vercel.json
+++ b/packages/sandbox/examples/vite/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nitro",
+  "buildCommand": "npm run build",
+  "installCommand": "npm install"
+}

--- a/packages/sandbox/examples/vite/vite.config.ts
+++ b/packages/sandbox/examples/vite/vite.config.ts
@@ -1,0 +1,37 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+import { hubSandbox } from '@vitehub/sandbox/vite'
+
+function resolveSandboxConfig() {
+  switch (process.env.SANDBOX_PROVIDER) {
+    case 'cloudflare':
+      return { provider: 'cloudflare' as const }
+    case 'vercel':
+      return { provider: 'vercel' as const }
+    default:
+      if ((process.env.NITRO_PRESET || '').includes('cloudflare'))
+        return { provider: 'cloudflare' as const }
+      if ((process.env.NITRO_PRESET || '').includes('vercel'))
+        return { provider: 'vercel' as const }
+      return { provider: 'cloudflare' as const }
+  }
+}
+
+export default defineConfig({
+  plugins: [hubSandbox()],
+  nitro: {
+    handlers: [
+      {
+        route: '/api/sandboxes/release-notes',
+        method: 'post',
+        handler: resolve(import.meta.dirname, 'src/run-release-notes.ts'),
+      },
+      {
+        route: '/api/tests/probe',
+        method: 'get',
+        handler: resolve(import.meta.dirname, 'src/sandbox-probe.ts'),
+      },
+    ],
+  },
+  sandbox: resolveSandboxConfig(),
+})

--- a/packages/sandbox/examples/vite/vite.config.ts
+++ b/packages/sandbox/examples/vite/vite.config.ts
@@ -3,18 +3,13 @@ import { defineConfig } from 'vite'
 import { hubSandbox } from '@vitehub/sandbox/vite'
 
 function resolveSandboxConfig() {
-  switch (process.env.SANDBOX_PROVIDER) {
-    case 'cloudflare':
-      return { provider: 'cloudflare' as const }
-    case 'vercel':
-      return { provider: 'vercel' as const }
-    default:
-      if ((process.env.NITRO_PRESET || '').includes('cloudflare'))
-        return { provider: 'cloudflare' as const }
-      if ((process.env.NITRO_PRESET || '').includes('vercel'))
-        return { provider: 'vercel' as const }
-      return { provider: 'cloudflare' as const }
-  }
+  const preset = process.env.NITRO_PRESET || ''
+  const explicit = process.env.SANDBOX_PROVIDER
+  if (explicit === 'cloudflare' || explicit === 'vercel')
+    return { provider: explicit as 'cloudflare' | 'vercel' }
+  if (preset.includes('vercel'))
+    return { provider: 'vercel' as const }
+  return { provider: 'cloudflare' as const }
 }
 
 export default defineConfig({

--- a/packages/sandbox/examples/vite/wrangler.jsonc
+++ b/packages/sandbox/examples/vite/wrangler.jsonc
@@ -1,0 +1,46 @@
+{
+  "name": "vitehub-sandbox-vite",
+  "main": ".output/server/index.mjs",
+  "compatibility_date": "2025-07-15",
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "assets": {
+    "directory": ".output/public",
+    "binding": "ASSETS"
+  },
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./.output/server/Dockerfile",
+      "instance_type": "lite",
+      "max_instances": 12
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "SANDBOX",
+        "class_name": "Sandbox"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": [
+        "Sandbox"
+      ]
+    }
+  ],
+  "no_bundle": true,
+  "rules": [
+    {
+      "type": "ESModule",
+      "globs": [
+        "**/*.mjs",
+        "**/*.js"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add Vite, Nitro, and Nuxt sandbox examples
- reduce framework duplication by moving shared example logic into `packages/sandbox/examples/_shared`
