### PR TITLE
docs(sandbox): add sandbox documentation

### DIFF
--- a/packages/sandbox/docs/.navigation.yml
+++ b/packages/sandbox/docs/.navigation.yml
@@ -1,0 +1,2 @@
+title: Sandbox
+icon: i-lucide-box

--- a/packages/sandbox/docs/guides/reuse-a-sandbox.md
+++ b/packages/sandbox/docs/guides/reuse-a-sandbox.md
@@ -1,0 +1,76 @@
+---
+title: Reuse a sandbox
+description: Control sandbox identity with sandboxId when the provider supports sandbox reuse.
+navigation.title: Reuse a sandbox
+navigation.group: Guides
+---
+
+Some Sandbox providers can reuse the same underlying runtime identity across calls. Use `sandboxId` when repeated runs should attach to the same provider-managed sandbox instead of creating a fresh one.
+
+## Set a stable sandbox id in config
+
+Use top-level `sandbox.sandboxId` when most executions for that app should reuse the same identity.
+
+::fw{#vite}
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import { hubSandbox } from '@vitehub/sandbox/vite'
+
+export default defineConfig({
+  plugins: [hubSandbox()],
+  sandbox: {
+    provider: 'cloudflare',
+    sandboxId: 'release-notes',
+  },
+})
+```
+::
+
+::fw{#nitro #nuxt}
+```ts [nitro.config.ts]
+import { defineNitroConfig } from 'nitro/config'
+
+export default defineNitroConfig({
+  modules: ['@vitehub/sandbox/nitro'],
+  sandbox: {
+    provider: 'cloudflare',
+    sandboxId: 'release-notes',
+  },
+})
+```
+::
+
+## Override sandbox identity per run
+
+Use `runSandbox(..., { sandboxId })` when only one execution path should reuse an existing runtime.
+
+```ts
+import { runSandbox } from '@vitehub/sandbox'
+
+await runSandbox('release-notes', {
+  notes: '- Added weekly digest',
+}, {
+  sandboxId: 'repo-acme-docs',
+})
+```
+
+## When to use reuse
+
+Reach for `sandboxId` when:
+
+- the provider should preserve runtime identity between requests
+- repeated calls should hit the same provider-managed sandbox
+- the work benefits from provider-side warm reuse
+
+Avoid it when every execution should stay ephemeral and isolated from previous runs.
+
+## Provider notes
+
+- Cloudflare Durable Objects can reuse sandbox identity with `sandboxId`.
+- Vercel may model reuse differently depending on the sandbox runtime.
+
+## Related pages
+
+- [Run a sandbox](./run-a-sandbox)
+- [Cloudflare](../providers/cloudflare)
+- [Vercel](../providers/vercel)

--- a/packages/sandbox/docs/guides/run-a-sandbox.md
+++ b/packages/sandbox/docs/guides/run-a-sandbox.md
@@ -1,0 +1,77 @@
+---
+title: Run a sandbox
+description: Execute a named sandbox and handle the returned result safely.
+navigation.title: Run a sandbox
+navigation.group: Guides
+---
+
+Use `runSandbox()` when you want to execute one named sandbox from a route, task, or server helper.
+
+## Run the common payload-first form
+
+`runSandbox()` takes the discovered sandbox name and an optional payload.
+
+```ts
+import { runSandbox } from '@vitehub/sandbox'
+
+const result = await runSandbox('release-notes', {
+  notes: '- Added weekly digest',
+})
+```
+
+The sandbox name comes from the file path, so `release-notes.ts` becomes `release-notes`.
+
+## Handle the result safely
+
+`runSandbox()` returns a result object, so check it before reading the value.
+
+```ts
+import { createError } from 'h3'
+import { runSandbox } from '@vitehub/sandbox'
+
+const result = await runSandbox('release-notes', {
+  notes: '- Added weekly digest',
+})
+
+if (result.isErr()) {
+  throw createError({
+    statusCode: 500,
+    statusMessage: result.error.message,
+  })
+}
+
+return result.value
+```
+
+## Pass per-run context
+
+Use the third argument when the handler needs extra caller-scoped context.
+
+```ts
+await runSandbox('release-notes', {
+  notes: '- Added weekly digest',
+}, {
+  context: {
+    requestId: 'req_123',
+    actor: 'docs-bot',
+  },
+})
+```
+
+The `context` object is separate from the payload. Use it for execution metadata that should not become part of the sandbox input contract.
+
+## Know what stays stable
+
+These parts do not change when you switch providers:
+
+- the discovered sandbox name
+- the `runSandbox(name, payload, options?)` call site
+- the result-checking pattern with `isOk()` and `isErr()`
+
+Provider-specific runtime behavior still changes. Use the provider pages when you need bindings, credentials, or platform limits.
+
+## Related pages
+
+- [Quickstart](../quickstart)
+- [Runtime API](../runtime-api)
+- [Reuse a sandbox](./reuse-a-sandbox)

--- a/packages/sandbox/docs/guides/validate-payloads.md
+++ b/packages/sandbox/docs/guides/validate-payloads.md
@@ -1,0 +1,97 @@
+---
+title: Validate sandbox payloads
+description: Validate and normalize payloads before you execute a sandbox.
+navigation.title: Validate payloads
+navigation.group: Guides
+---
+
+Validate payloads before you execute a sandbox so the isolated runtime only sees normalized input.
+
+## Validate input before execution
+
+Use `readValidatedBody(event, validate)` for H3 request bodies. Use `validatePayload(payload, validate)` or `readValidatedPayload(payload, validate)` when the input is already plain data.
+
+::fw{#vite}
+```ts [src/run-release-notes.ts]
+import { createError, defineEventHandler, readValidatedBody } from 'h3'
+import { runSandbox } from '@vitehub/sandbox'
+
+export default defineEventHandler(async (event) => {
+  const { notes } = await readValidatedBody(event, (input) => {
+    if (!input || typeof input !== 'object' || typeof input.notes !== 'string' || !input.notes.trim()) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'Enter release notes before running the sandbox.',
+      })
+    }
+
+    return {
+      notes: input.notes.trim(),
+    }
+  })
+  const result = await runSandbox('release-notes', { notes })
+
+  if (result.isErr()) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: result.error.message,
+      data: {
+        code: result.error.code,
+        provider: result.error.provider,
+      },
+    })
+  }
+
+  return { result: result.value }
+})
+```
+::
+
+::fw{#nitro #nuxt}
+```ts [server/api/sandboxes/release-notes.post.ts]
+import { createError, defineEventHandler } from 'h3'
+import { readRequestPayload, readValidatedPayload, runSandbox } from '@vitehub/sandbox'
+
+export default defineEventHandler(async (event) => {
+  const { notes } = await readValidatedPayload(await readRequestPayload(event), (input) => {
+    if (!input || typeof input !== 'object' || typeof input.notes !== 'string' || !input.notes.trim()) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'Enter release notes before running the sandbox.',
+      })
+    }
+
+    return {
+      notes: input.notes.trim(),
+    }
+  })
+  const result = await runSandbox('release-notes', { notes })
+
+  if (result.isErr()) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: result.error.message,
+      data: {
+        code: result.error.code,
+        provider: result.error.provider,
+      },
+    })
+  }
+
+  return { result: result.value }
+})
+```
+::
+
+## Normalize once at the edge
+
+Use the validator to:
+
+- reject invalid user input
+- trim or coerce values into the shape the sandbox expects
+- keep provider-specific execution errors separate from caller-side input errors
+
+## Related pages
+
+- [Run a sandbox](./run-a-sandbox)
+- [Runtime API](../runtime-api)

--- a/packages/sandbox/docs/index.md
+++ b/packages/sandbox/docs/index.md
@@ -1,0 +1,127 @@
+---
+title: Sandbox
+description: Run named sandbox handlers on Cloudflare Durable Objects or Vercel Sandbox.
+navigation.title: Overview
+---
+
+Use Sandbox to run one named handler inside an isolated runtime. Define the sandbox once, execute it with `runSandbox()`, and keep provider setup at the application boundary.
+
+::fw{#vite}
+- Put sandbox definitions in `src/**/*.sandbox.ts`.
+- Default-export `defineSandbox(handler, options?)`.
+- Execute the generated name with `runSandbox()`.
+::
+
+::fw{#nitro #nuxt}
+- Put sandbox definitions in `server/sandboxes/**`.
+- Default-export `defineSandbox(handler, options?)`.
+- Execute the generated name with `runSandbox()`.
+::
+
+## What Sandbox is
+
+Sandbox gives you one portable API for isolated work that still returns a value to the current request. Version 1 supports Cloudflare Durable Object sandboxes and Vercel Sandbox.
+
+## When Sandbox fits
+
+Sandbox is a good fit when you want to:
+
+- run untrusted or isolated code without introducing a queue
+- keep filesystem, process, or network isolation explicit
+- target Cloudflare or Vercel without changing call sites
+- return a result from isolated work inside the same request flow
+
+Use [When to use Sandbox](./when-to-use) when you need to choose between Sandbox, Queue, Workflow, and inline execution.
+
+## What stays portable
+
+These parts stay the same when you switch providers:
+
+- the definition API: `defineSandbox()`
+- the execution API: `runSandbox()`
+- the sandbox name derived from the file path
+- the portable definition options: `timeout`, `env`, and `runtime`
+
+Provider-specific setup, credentials, bindings, and native runtime limits live on the provider pages.
+
+## Where to go next
+
+::u-page-grid{class="pb-2"}
+  :::u-page-card
+  ---
+  title: Quickstart
+  description: Get a first Cloudflare or Vercel sandbox wired into an app.
+  to: ./quickstart
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Runtime API
+  description: Look up defineSandbox, runSandbox, and the core Sandbox types.
+  to: ./runtime-api
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: When to use Sandbox
+  description: Decide when Sandbox is better than Queue, Workflow, or inline execution.
+  to: ./when-to-use
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Run a sandbox
+  description: Execute a named sandbox and handle the returned result safely.
+  to: ./guides/run-a-sandbox
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Validate payloads
+  description: Normalize sandbox input before execution.
+  to: ./guides/validate-payloads
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Reuse a sandbox
+  description: Control sandbox identity with sandboxId when the provider supports reuse.
+  to: ./guides/reuse-a-sandbox
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Troubleshooting
+  description: Diagnose discovery, provider, and runtime result issues.
+  to: ./troubleshooting
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Runtime playground
+  description: Inspect the existing Sandbox playground apps and the files they use.
+  to: ./playground
+  ---
+  :::
+::
+
+## Providers
+
+::u-page-grid{class="pb-2"}
+  :::u-page-card
+  ---
+  title: Cloudflare
+  description: Run isolated sandboxes on Durable Objects close to the rest of a Cloudflare stack.
+  to: ./providers/cloudflare
+  icon: i-simple-icons-cloudflare
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Vercel
+  description: Use Vercel-hosted isolated execution without changing the public Sandbox API.
+  to: ./providers/vercel
+  icon: i-simple-icons-vercel
+  ---
+  :::
+::

--- a/packages/sandbox/docs/playground.md
+++ b/packages/sandbox/docs/playground.md
@@ -1,0 +1,53 @@
+---
+title: Sandbox playground
+description: Explore the existing Sandbox playground app and the files that show the end-to-end runtime flow.
+navigation.title: Playground
+---
+
+The Sandbox playground is intentionally small. It shows one discovered sandbox and one API route that executes it.
+
+## Start here
+
+Inspect these files first:
+
+::fw{#vite}
+- `packages/sandbox/playground/vite/src/release-notes.sandbox.ts`
+- `packages/sandbox/playground/vite/src/run-release-notes.ts`
+::
+
+::fw{#nitro}
+- `packages/sandbox/playground/nitro/server/sandboxes/release-notes.ts`
+- `packages/sandbox/playground/nitro/server/api/sandboxes/release-notes.post.ts`
+::
+
+::fw{#nuxt}
+- `packages/sandbox/playground/nuxt/server/sandboxes/release-notes.ts`
+- `packages/sandbox/playground/nuxt/server/api/sandboxes/release-notes.post.ts`
+::
+
+## Run the playground
+
+```bash [Terminal]
+SANDBOX_PROVIDER=cloudflare pnpm -C packages/sandbox/playground/nitro dev
+```
+
+## Trigger one sandbox run
+
+```bash [Terminal]
+curl -X POST http://localhost:3000/api/sandboxes/release-notes \
+  -H 'content-type: application/json' \
+  -d '{"notes":"- Added weekly digest\n- Fixed invite flow\n- Tightened signup copy"}'
+```
+
+## What to look for
+
+- the sandbox file becomes the sandbox name `release-notes`
+- the API route calls `runSandbox('release-notes', body)`
+- the route checks `result.isErr()` before returning `result.value`
+- changing the provider changes the runtime backend without changing the call site
+
+## Useful follow-ups
+
+- Use [Quickstart](./quickstart) if you want the smallest provider setup.
+- Use [Run a sandbox](./guides/run-a-sandbox) if you want the normal production call pattern.
+- Use [Reuse a sandbox](./guides/reuse-a-sandbox) if you want stable provider identity.

--- a/packages/sandbox/docs/providers/cloudflare.md
+++ b/packages/sandbox/docs/providers/cloudflare.md
@@ -1,0 +1,112 @@
+---
+title: Cloudflare Sandbox
+description: Configure Cloudflare Sandbox on top of Durable Objects.
+icon: i-simple-icons-cloudflare
+navigation.title: Cloudflare
+---
+
+Use Cloudflare Sandbox when isolated runs should stay close to the rest of a Cloudflare-based stack. ViteHub handles the Durable Object integration and keeps the Cloudflare-specific settings in the top-level `sandbox` config.
+
+## Before you start
+
+Install the Cloudflare SDK alongside `@vitehub/sandbox`.
+
+```bash [Terminal]
+pnpm add https://pkg.pr.new/vite-hub/vitehub/@vitehub/sandbox@main @cloudflare/sandbox
+```
+
+You also need a Cloudflare deployment so ViteHub can provision the sandbox runtime.
+
+## Configure Cloudflare
+
+::fw{#vite}
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import { hubSandbox } from '@vitehub/sandbox/vite'
+
+export default defineConfig({
+  plugins: [hubSandbox()],
+})
+```
+::
+::fw{#nitro}
+```ts [nitro.config.ts]
+import { defineNitroConfig } from 'nitro/config'
+
+export default defineNitroConfig({
+  modules: ['@vitehub/sandbox/nitro'],
+})
+```
+::
+::fw{#nuxt}
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@vitehub/sandbox/nuxt'],
+})
+```
+::
+
+On Cloudflare hosting, ViteHub uses the Durable Object sandbox provider automatically. Set `binding` only when you need to override the default Durable Object binding name.
+
+The shipped sandbox examples also support `SANDBOX_PROVIDER=cloudflare` when you want to force the Cloudflare provider locally before deploying.
+
+## Cloudflare-specific options
+
+Set Cloudflare-specific options such as `sandboxId`, `keepAlive`, `sleepAfter`, and `normalizeId` in the top-level `sandbox` config. These are provider settings, not definition options.
+
+::fw{#vite}
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import { hubSandbox } from '@vitehub/sandbox/vite'
+
+export default defineConfig({
+  plugins: [hubSandbox()],
+  sandbox: {
+    sandboxId: 'release-notes',
+    keepAlive: true,
+    sleepAfter: '10m',
+  },
+})
+```
+::
+
+::fw{#nitro}
+```ts [nitro.config.ts]
+import { defineNitroConfig } from 'nitro/config'
+
+export default defineNitroConfig({
+  modules: ['@vitehub/sandbox/nitro'],
+  sandbox: {
+    sandboxId: 'release-notes',
+    keepAlive: true,
+    sleepAfter: '10m',
+  },
+})
+```
+::
+
+::fw{#nuxt}
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@vitehub/sandbox/nuxt'],
+  sandbox: {
+    sandboxId: 'release-notes',
+    keepAlive: true,
+    sleepAfter: '10m',
+  },
+})
+```
+::
+
+## What changes on Cloudflare
+
+| Concern | Behavior |
+| --- | --- |
+| Sandbox identity | Use `sandboxId` when repeated calls should reuse the same Cloudflare sandbox identity. |
+| Binding resolution | ViteHub resolves the Durable Object binding from `sandbox.binding` or falls back to the default Cloudflare binding. |
+| Provider options | Use `keepAlive`, `sleepAfter`, and `normalizeId` in the top-level `sandbox` config. |
+
+## Related pages
+
+- [Quickstart](../quickstart)
+- [Reuse a sandbox](../guides/reuse-a-sandbox)

--- a/packages/sandbox/docs/providers/vercel.md
+++ b/packages/sandbox/docs/providers/vercel.md
@@ -1,0 +1,83 @@
+---
+title: Vercel Sandbox
+description: Configure Vercel Sandbox and run isolated sandboxes on Vercel.
+icon: i-simple-icons-vercel
+navigation.title: Vercel
+---
+
+Vercel Sandbox fits Vercel-hosted apps that want isolated execution without adding a second platform. ViteHub keeps the public sandbox API stable and forwards runtime settings to Vercel where they matter.
+
+## Before you start
+
+Install the Vercel SDK alongside `@vitehub/sandbox`.
+
+```bash [Terminal]
+pnpm add https://pkg.pr.new/vite-hub/vitehub/@vitehub/sandbox@main @vercel/sandbox
+```
+
+Set Vercel sandbox credentials in the runtime environment when the provider cannot inherit them automatically.
+
+```bash [.env]
+VERCEL_TOKEN=your-token
+VERCEL_TEAM_ID=your-team-id
+VERCEL_PROJECT_ID=your-project-id
+```
+
+ViteHub reads these values from `process.env`. Vite also accepts `VITE_SANDBOX_TOKEN`, `VITE_SANDBOX_TEAM_ID`, and `VITE_SANDBOX_PROJECT_ID`. Nitro and Nuxt also accept `NITRO_SANDBOX_TOKEN`, `NITRO_SANDBOX_TEAM_ID`, `NITRO_SANDBOX_PROJECT_ID`, `NUXT_SANDBOX_TOKEN`, `NUXT_SANDBOX_TEAM_ID`, and `NUXT_SANDBOX_PROJECT_ID`. Nuxt, Nitro, Vite, or your process manager must load `.env` before startup.
+
+## Configure Vercel
+
+::fw{#vite}
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import { hubSandbox } from '@vitehub/sandbox/vite'
+
+export default defineConfig({
+  plugins: [hubSandbox()],
+  sandbox: {
+    runtime: 'node22',
+  },
+})
+```
+::
+::fw{#nitro}
+```ts [nitro.config.ts]
+import { defineNitroConfig } from 'nitro/config'
+
+export default defineNitroConfig({
+  modules: ['@vitehub/sandbox/nitro'],
+  sandbox: {
+    runtime: 'node22',
+  },
+})
+```
+::
+::fw{#nuxt}
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@vitehub/sandbox/nuxt'],
+  sandbox: {
+    runtime: 'node22',
+  },
+})
+```
+::
+
+On Vercel hosting, ViteHub uses the Vercel sandbox provider automatically. Set app-wide defaults in top-level `sandbox` config.
+
+If you use the shipped sandbox examples, they also accept `SANDBOX_PROVIDER=vercel` so you can switch providers without editing the example config.
+
+## What changes on Vercel
+
+| Concern | Behavior |
+| --- | --- |
+| Runtime defaults | Configure app-wide defaults such as `runtime`, `timeout`, `cpu`, and `ports` in top-level `sandbox` config. |
+| Provider options | Set `cpu`, `ports`, `source`, and `networkPolicy` in the top-level `sandbox` config, not in the definition file. Keep top-level provider config separate from definition-level options. |
+| Credentials | ViteHub resolves credentials in this order: explicit config, Nitro/Nuxt alias env vars, generic `VERCEL_*`, then automatic platform inheritance when available. |
+| Execution model | ViteHub resolves the named sandbox and asks Vercel to run it inside Vercel's sandbox runtime. |
+
+## Related pages
+
+- [Quickstart](../quickstart)
+- [Run a sandbox](../guides/run-a-sandbox)
+- [Troubleshooting](../troubleshooting)

--- a/packages/sandbox/docs/quickstart.md
+++ b/packages/sandbox/docs/quickstart.md
@@ -1,0 +1,192 @@
+---
+title: Sandbox quickstart
+description: Get a first Cloudflare or Vercel sandbox wired into an app.
+navigation.title: Quickstart
+---
+
+This quickstart wires a `release-notes` sandbox and a route that executes it. Pick Cloudflare or Vercel in app config; local and Docker providers are not part of Sandbox v1.
+
+## Install the package
+
+```bash [Terminal]
+pnpm add https://pkg.pr.new/vite-hub/vitehub/@vitehub/sandbox@main
+```
+
+Install the provider SDK you use at runtime:
+
+```bash [Terminal]
+pnpm add @cloudflare/sandbox
+```
+
+```bash [Terminal]
+pnpm add @vercel/sandbox
+```
+
+## Configure Sandbox
+
+::fw{#vite}
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import { hubSandbox } from '@vitehub/sandbox/vite'
+
+export default defineConfig({
+  plugins: [hubSandbox()],
+  sandbox: {
+    provider: 'cloudflare',
+  },
+})
+```
+::
+
+::fw{#nitro}
+```ts [nitro.config.ts]
+import { defineNitroConfig } from 'nitro/config'
+
+export default defineNitroConfig({
+  modules: ['@vitehub/sandbox/nitro'],
+  sandbox: {
+    provider: 'cloudflare',
+  },
+})
+```
+::
+
+::fw{#nuxt}
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@vitehub/sandbox/nuxt'],
+  sandbox: {
+    provider: 'cloudflare',
+  },
+})
+```
+::
+
+Use `provider: 'vercel'` instead when the app runs on Vercel. Vercel can resolve credentials from explicit config or `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, and `VERCEL_PROJECT_ID`.
+
+## Define a sandbox
+
+::fw{#vite}
+```ts [src/release-notes.sandbox.ts]
+import { defineSandbox } from '@vitehub/sandbox'
+
+export default defineSandbox(async (payload?: { notes?: string }) => {
+  const notes = typeof payload?.notes === 'string' ? payload.notes.trim() : ''
+  const items = notes
+    .split(/\n+/)
+    .map(line => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean)
+
+  return {
+    summary: items[0] || 'No notes provided.',
+    items: items.slice(0, 3),
+  }
+})
+```
+::
+
+::fw{#nitro #nuxt}
+```ts [server/sandboxes/release-notes.ts]
+import { defineSandbox } from '@vitehub/sandbox'
+
+export default defineSandbox(async (payload?: { notes?: string }) => {
+  const notes = typeof payload?.notes === 'string' ? payload.notes.trim() : ''
+  const items = notes
+    .split(/\n+/)
+    .map(line => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean)
+
+  return {
+    summary: items[0] || 'No notes provided.',
+    items: items.slice(0, 3),
+  }
+})
+```
+::
+
+## Run the sandbox from a route
+
+`runSandbox()` returns a result object, so check for errors before you read the value.
+
+::fw{#vite}
+```ts [src/run-release-notes.ts]
+import { createError, defineEventHandler, readBody } from 'h3'
+import { runSandbox } from '@vitehub/sandbox'
+
+export default defineEventHandler(async (event) => {
+  const payload = await readBody<{ notes: string }>(event)
+  const result = await runSandbox('release-notes', payload)
+
+  if (result.isErr()) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: result.error.message,
+      data: {
+        code: result.error.code,
+        provider: result.error.provider,
+      },
+    })
+  }
+
+  return { result: result.value }
+})
+```
+::
+
+::fw{#nitro #nuxt}
+```ts [server/api/sandboxes/release-notes.post.ts]
+import { createError, defineEventHandler, readBody } from 'h3'
+import { runSandbox } from '@vitehub/sandbox'
+
+export default defineEventHandler(async (event) => {
+  const payload = await readBody<{ notes: string }>(event)
+  const result = await runSandbox('release-notes', payload)
+
+  if (result.isErr()) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: result.error.message,
+      data: {
+        code: result.error.code,
+        provider: result.error.provider,
+      },
+    })
+  }
+
+  return { result: result.value }
+})
+```
+::
+
+## Verify that it worked
+
+Deploy or run the app with a configured provider, then send one request:
+
+```bash [Terminal]
+curl -X POST https://your-app.example.com/api/sandboxes/release-notes \
+  -H 'content-type: application/json' \
+  -d '{"notes":"- Added weekly digest\n- Tightened signup copy"}'
+```
+
+You should see a JSON response with the computed sandbox result:
+
+```json
+{
+  "result": {
+    "summary": "Added weekly digest",
+    "items": [
+      "Added weekly digest",
+      "Tightened signup copy"
+    ]
+  }
+}
+```
+
+That response confirms the sandbox file was discovered by name, `runSandbox('release-notes', ...)` resolved the right definition, and the provider returned the normalized `{ result: ... }` contract.
+
+## Next steps
+
+- Use [Run a sandbox](./guides/run-a-sandbox) for the normal execution pattern.
+- Use [Validate payloads](./guides/validate-payloads) if this route accepts untrusted input.
+- Use [Reuse a sandbox](./guides/reuse-a-sandbox) when the provider should keep identity between runs.
+- Use [Cloudflare](./providers/cloudflare) or [Vercel](./providers/vercel) for provider-specific setup.

--- a/packages/sandbox/docs/runtime-api.md
+++ b/packages/sandbox/docs/runtime-api.md
@@ -1,0 +1,117 @@
+---
+title: Sandbox runtime API
+description: Reference for defineSandbox, runSandbox, readRequestPayload, readValidatedPayload, and the core Sandbox types.
+navigation.title: Runtime API
+---
+
+Use this page when you need the Sandbox surface area, signatures, or option names. For a guided first run, start with [Quickstart](./quickstart).
+
+## Definition API
+
+### `defineSandbox(handler, options?)`
+
+Each sandbox definition default-exports `defineSandbox()`.
+
+::fw{#vite}
+Sandbox definitions live in `src/**/*.sandbox.ts`. The name comes from the relative path with `.sandbox` stripped, so `src/release-notes.sandbox.ts` becomes `release-notes`.
+::
+
+::fw{#nitro #nuxt}
+Sandbox definitions live in `server/sandboxes/**`. The name comes from the relative path inside that directory.
+::
+
+```ts
+import { defineSandbox } from '@vitehub/sandbox'
+
+export default defineSandbox(async (payload?: { notes?: string }) => {
+  return {
+    notes: payload?.notes || '',
+  }
+}, {
+  timeout: 30_000,
+})
+```
+
+## Execution API
+
+### `runSandbox(name, payload?, options?)`
+
+Use `runSandbox()` to execute one named sandbox.
+
+```ts
+import { runSandbox } from '@vitehub/sandbox'
+
+const result = await runSandbox('release-notes', {
+  notes: '- Added weekly digest',
+})
+
+if (result.isOk()) {
+  console.log(result.value.summary)
+}
+```
+
+`runSandbox()` returns a result object instead of throwing for provider/runtime execution failures.
+
+### `SandboxExecutionOptions`
+
+These options are available as the third argument to `runSandbox()`:
+
+| Option | Description |
+| --- | --- |
+| `context` | Pass request-scoped or caller-scoped data into the sandbox handler. |
+| `sandboxId` | Request a stable sandbox identity when the provider supports sandbox reuse. |
+
+## Validation helpers
+
+Sandbox also exports validation helpers for caller input:
+
+| Helper | Use it for |
+| --- | --- |
+| `readRequestPayload()` | Read a JSON payload from an H3 request event once, with Cloudflare-safe fallback handling. |
+| `readValidatedPayload()` | Validate and normalize input before you execute the sandbox. |
+| `validatePayload()` | Alias of `readValidatedPayload()` for explicit imports. |
+
+Use [Validate payloads](./guides/validate-payloads) for examples.
+
+## Result API
+
+### `SandboxRunResult<T>`
+
+`runSandbox()` returns `SandboxRunResult<T>`, which is a result wrapper around the sandbox return value or a `SandboxError`.
+
+| Method / Field | Type | Description |
+| --- | --- | --- |
+| `isOk()` | `boolean` | `true` when execution succeeded. |
+| `isErr()` | `boolean` | `true` when execution failed. |
+| `value` | `T` | The sandbox return value. Only safe after `isOk()`. |
+| `error` | `SandboxError` | Error details with `message`, `code`, `provider`, and `details`. |
+
+## Core types
+
+### `SandboxDefinitionOptions`
+
+Portable definition options that work across Sandbox providers:
+
+| Option | Description |
+| --- | --- |
+| `timeout` | Maximum execution time in milliseconds. |
+| `env` | Environment variables passed into the sandbox runtime. |
+| `runtime` | Override the runtime command with `{ command, args? }`. |
+
+### `SandboxError`
+
+Sandbox failures surface through `result.error` rather than thrown exceptions from `runSandbox()`.
+
+| Field | Description |
+| --- | --- |
+| `message` | Human-readable failure message. |
+| `code` | Provider or runtime error code when available. |
+| `provider` | Active sandbox provider. |
+| `details` | Extra provider-specific failure data when available. |
+
+## Related pages
+
+- [Quickstart](./quickstart)
+- [Run a sandbox](./guides/run-a-sandbox)
+- [Validate payloads](./guides/validate-payloads)
+- [Reuse a sandbox](./guides/reuse-a-sandbox)

--- a/packages/sandbox/docs/troubleshooting.md
+++ b/packages/sandbox/docs/troubleshooting.md
@@ -1,0 +1,44 @@
+---
+title: Sandbox troubleshooting
+description: Diagnose common Sandbox setup and runtime problems across Cloudflare and Vercel providers.
+navigation.title: Troubleshooting
+---
+
+Use this page when Sandbox is wired up but the definition, provider, or returned result is not behaving the way you expect.
+
+## The sandbox name is not found
+
+| Likely cause | Fix |
+| --- | --- |
+| The sandbox file is not in the discovery directory. | Put the file in `src/**/*.sandbox.ts` for Vite or `server/sandboxes/**` for Nitro and Nuxt. |
+| The name in `runSandbox()` does not match the file path. | Check the derived sandbox name and use that exact string. |
+| The build output is stale. | Restart the dev server after adding or renaming sandbox files. |
+
+## The sandbox returns an error result
+
+| Likely cause | Fix |
+| --- | --- |
+| The isolated runtime failed to start or execute. | Check `result.error.message`, `result.error.code`, and the active provider before you wrap the value into your route response. |
+| The provider needs extra setup. | Re-read the provider page for bindings, tokens, or runtime limits. |
+| The payload shape is wrong. | Validate input before execution with `readValidatedPayload()`. |
+
+## Provider inference does not match production
+
+| Likely cause | Fix |
+| --- | --- |
+| No provider was inferred outside Cloudflare or Vercel. | Set `sandbox.provider` explicitly. |
+| The hosted provider exposes different runtime capabilities. | Check the provider page for file, process, network, or public URL limitations. |
+| The examples run against the wrong provider. | Force the examples with `SANDBOX_PROVIDER=cloudflare` or `SANDBOX_PROVIDER=vercel`. |
+
+## Provider-specific setup fails
+
+| Symptom | Fix |
+| --- | --- |
+| Cloudflare binding or container setup fails. | Check the configured binding name, deployment target, and account access. |
+| Vercel sandbox execution fails before the run starts. | Check `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, and `VERCEL_PROJECT_ID`, or the Nitro/Nuxt alias env vars, when automatic credentials are unavailable. |
+
+## Still stuck
+
+- Re-run the flow with [Quickstart](./quickstart) and an explicit Cloudflare or Vercel provider first.
+- Compare your setup with the [Playground](./playground).
+- Re-read the provider page for the backend you are using.

--- a/packages/sandbox/docs/when-to-use.md
+++ b/packages/sandbox/docs/when-to-use.md
@@ -1,0 +1,69 @@
+---
+title: When to use Sandbox
+description: Decide when Sandbox is the right primitive compared with Queue, Workflow, or inline execution.
+navigation.title: When to use Sandbox
+---
+
+Use Sandbox when the important part is the isolated runtime, not delayed delivery or durable orchestration.
+
+## Choose Sandbox when
+
+Sandbox is usually the right tool when:
+
+- the code should run in an isolated process, container, or managed runtime
+- the caller can wait for the isolated result in the same request flow
+- filesystem, process, or network controls matter more than retry queues
+- you want one named sandbox definition while swapping between Cloudflare and Vercel providers
+
+Examples:
+
+- evaluate generated code in an isolated runtime
+- run release-note formatting in a separate execution environment
+- inspect repositories or files with sandboxed process access
+- execute provider-managed code where Cloudflare and Vercel runtimes should share the same call site
+
+## Sandbox vs Queue
+
+Choose Sandbox when you need isolated execution and a result from that execution.
+
+Choose Queue when you need background delivery and the current request should return immediately.
+
+If the job sounds like "run this code safely somewhere else and give me the result," Sandbox is usually the better fit. If it sounds like "hand this work off and let another system process it later," Queue is the better primitive.
+
+## Sandbox vs Workflow
+
+Choose Sandbox when one isolated run is enough.
+
+Choose Workflow when you need:
+
+- multi-step orchestration
+- durable progress between steps
+- run lookup later by id
+- retries, sleeps, or resumable state across a longer process
+
+Sandbox is about where code runs. Workflow is about how a process progresses over time.
+
+## Sandbox vs inline execution
+
+Choose Sandbox when inline execution would be risky or too coupled to the current server runtime.
+
+Stay inline when:
+
+- the code is already safe to run in the current request
+- there is no need for isolation
+- introducing a second runtime adds more complexity than value
+
+## When Sandbox is not the right primitive
+
+Sandbox is usually the wrong choice when:
+
+- the caller should not wait for the work at all
+- the task needs durable orchestration across several steps
+- the work is tiny and safe enough to run inline
+- scheduling or retries are the main requirement
+
+## Related pages
+
+- [Quickstart](./quickstart)
+- [Runtime API](./runtime-api)
+- [Troubleshooting](./troubleshooting)


### PR DESCRIPTION
## Summary

- add sandbox docs, guides, provider pages, and runtime API docs
- update the showcase test for the Nitro sandbox example
