### PR TITLE
test(sandbox): add package coverage

### DIFF
--- a/packages/sandbox/test/frameworks.test.ts
+++ b/packages/sandbox/test/frameworks.test.ts
@@ -1,0 +1,195 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+interface NuxtModuleDefinitionLike {
+  setup: (inlineOptions: unknown, nuxt: unknown) => void | Promise<void>
+}
+
+const defineNuxtModule = vi.fn((definition: NuxtModuleDefinitionLike) => {
+  return async (inlineOptions: unknown, nuxt: unknown) => {
+    await definition.setup(inlineOptions, nuxt)
+  }
+})
+
+vi.mock("@nuxt/kit", () => ({
+  defineNuxtModule,
+}))
+
+const tempDirs: string[] = []
+
+async function createFixtureRoot() {
+  const rootDir = await mkdtemp(join(tmpdir(), "vitehub-sandbox-"))
+  tempDirs.push(rootDir)
+
+  await writeFile(join(rootDir, "package.json"), JSON.stringify({
+    name: "vitehub-sandbox-fixture",
+    private: true,
+    type: "module",
+    dependencies: {
+      "@cloudflare/sandbox": "0.8.11",
+      "@vercel/sandbox": "1.10.0",
+    },
+  }, null, 2))
+  await mkdir(join(rootDir, "server/sandboxes"), { recursive: true })
+  await writeFile(join(rootDir, "server/sandboxes/release-notes.ts"), [
+    `import { defineSandbox } from "@vitehub/sandbox"`,
+    ``,
+    `export default defineSandbox(async (payload?: { notes?: string }) => ({`,
+    `  summary: payload?.notes || "empty",`,
+    `}), {`,
+    `  timeout: 10_000,`,
+    `  runtime: { command: "node", args: ["--enable-source-maps"] },`,
+    `})`,
+    ``,
+  ].join("\n"))
+
+  return rootDir
+}
+
+function createNitroStub(rootDir: string, options: Record<string, unknown> = {}) {
+  const hooks = new Map<string, ((payload?: any) => void | Promise<void>)[]>()
+
+  return {
+    options: {
+      rootDir,
+      srcDir: "server",
+      buildDir: join(rootDir, ".nitro"),
+      alias: {},
+      plugins: [],
+      imports: { presets: [] },
+      handlers: [],
+      runtimeConfig: {},
+      ...options,
+    },
+    hooks: {
+      hook(name: string, fn: (payload?: any) => void | Promise<void>) {
+        hooks.set(name, [...(hooks.get(name) || []), fn])
+      },
+    },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    _hooks: hooks,
+  }
+}
+
+function createNuxtHarness(options: Record<string, any> = {}) {
+  const hooks = new Map<string, ((payload: unknown) => void | Promise<void>)[]>()
+
+  return {
+    hook(name: string, fn: (payload: unknown) => void | Promise<void>) {
+      hooks.set(name, [...(hooks.get(name) || []), fn])
+    },
+    async runHook(name: string, payload: unknown) {
+      for (const fn of hooks.get(name) || []) {
+        await fn(payload)
+      }
+    },
+    options,
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(root => rm(root, { recursive: true, force: true })))
+  defineNuxtModule.mockClear()
+})
+
+describe("sandbox public api", () => {
+  it("exposes defineSandbox without the inline factory api", async () => {
+    const sandboxPackage = await import("../src/index.ts")
+    const definition = sandboxPackage.defineSandbox(async (payload?: { value?: string }) => payload?.value, {
+      env: { FOO: "bar" },
+      runtime: { command: "node", args: ["--trace-warnings"] },
+      timeout: 1000,
+    })
+
+    expect("createSandbox" in sandboxPackage).toBe(false)
+    expect(definition.options).toEqual({
+      env: { FOO: "bar" },
+      runtime: { command: "node", args: ["--trace-warnings"] },
+      timeout: 1000,
+    })
+  })
+
+  it("returns a result wrapper instead of throwing", async () => {
+    const { runSandbox } = await import("../src/index.ts")
+    const result = await runSandbox("missing")
+
+    expect(result.isErr()).toBe(true)
+    expect(result.isOk()).toBe(false)
+    if (result.isErr()) {
+      expect(result.error!.message).toContain("missing")
+    }
+  })
+})
+
+describe("sandbox framework modules", () => {
+  it("installs Nitro artifacts from server/sandboxes discovery", async () => {
+    const rootDir = await createFixtureRoot()
+    const nitro = createNitroStub(rootDir, {
+      preset: "cloudflare-module",
+      sandbox: {
+        provider: "cloudflare",
+      },
+    })
+    const module = (await import("../src/nitro/module.ts")).default
+
+    await module.setup(nitro as never)
+
+    const alias = nitro.options.alias as Record<string, string>
+    expect(alias["@vitehub/sandbox"]).toContain("/packages/sandbox/src/index")
+    expect(alias["#vitehub-sandbox-registry"]).toContain("sandbox-registry.mjs")
+    expect(alias["#vitehub-sandbox-provider-loader"]).toContain("sandbox-provider-loader.mjs")
+    expect(nitro.options.plugins).toHaveLength(1)
+    expect(nitro.options.runtimeConfig).toMatchObject({
+      hosting: "cloudflare-module",
+      sandbox: {
+        provider: "cloudflare",
+      },
+    })
+  })
+
+  it("seeds Vercel credential placeholders", async () => {
+    const rootDir = await createFixtureRoot()
+    const nitro = createNitroStub(rootDir, {
+      preset: "vercel",
+      sandbox: {
+        provider: "vercel",
+      },
+    })
+    const module = (await import("../src/nitro/module.ts")).default
+
+    await module.setup(nitro as never)
+
+    expect(nitro.options.runtimeConfig).toMatchObject({
+      sandbox: {
+        provider: "vercel",
+        projectId: "",
+        teamId: "",
+        token: "",
+      },
+    })
+  })
+
+  it("installs the Nitro module from Nuxt and respects sandbox false", async () => {
+    const sandboxModule = (await import("../src/nuxt/module.ts")).default
+    const disabled = createNuxtHarness({ sandbox: false })
+
+    await sandboxModule(undefined as never, disabled as never)
+    expect(disabled.options.nitro).toBeUndefined()
+
+    const enabled = createNuxtHarness({
+      sandbox: { provider: "vercel" },
+      nitro: { modules: [] },
+    })
+    await sandboxModule(undefined as never, enabled as never)
+
+    expect(enabled.options.nitro.modules).toEqual(["@vitehub/sandbox/nitro"])
+    expect(enabled.options.nitro.sandbox).toEqual({ provider: "vercel" })
+  })
+})

--- a/packages/sandbox/test/types.test-d.ts
+++ b/packages/sandbox/test/types.test-d.ts
@@ -1,0 +1,38 @@
+import type { UserConfig } from "vite"
+
+import { describe, expectTypeOf, it } from "vitest"
+
+import {
+  defineSandbox,
+  runSandbox,
+  type AgentSandboxConfig,
+  type SandboxDefinition,
+  type SandboxRunResult,
+} from "../src/index.ts"
+import { hubSandbox } from "../src/vite.ts"
+
+describe("types", () => {
+  it("augments Vite user config with sandbox options", () => {
+    const config: UserConfig = {
+      sandbox: {
+        provider: "cloudflare",
+        binding: "SANDBOX",
+      },
+    }
+
+    expectTypeOf(config.sandbox).toMatchTypeOf<AgentSandboxConfig | false | undefined>()
+  })
+
+  it("types sandbox definitions and run results", () => {
+    const definition = defineSandbox(async (payload?: { value: string }) => ({ value: payload?.value || "" }))
+
+    expectTypeOf(definition).toMatchTypeOf<SandboxDefinition<{ value: string } | undefined, { value: string }>>()
+    expectTypeOf(runSandbox("release-notes", { value: "ok" })).resolves.toMatchTypeOf<SandboxRunResult>()
+  })
+
+  it("returns a Vite plugin with an attached Nitro module", () => {
+    const plugin = hubSandbox()
+
+    expectTypeOf(plugin).toMatchTypeOf<{ nitro?: { name?: string } }>()
+  })
+})

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -1,0 +1,71 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+const tempDirs: string[] = []
+
+async function createViteRoot() {
+  const rootDir = await mkdtemp(join(tmpdir(), "vitehub-sandbox-vite-"))
+  tempDirs.push(rootDir)
+  await writeFile(join(rootDir, "package.json"), JSON.stringify({
+    name: "vitehub-sandbox-vite-fixture",
+    private: true,
+    type: "module",
+  }, null, 2))
+  await mkdir(join(rootDir, "src/tools"), { recursive: true })
+  await writeFile(join(rootDir, "src/tools/release-notes.sandbox.ts"), [
+    `import { defineSandbox } from "@vitehub/sandbox"`,
+    ``,
+    `export default defineSandbox(async () => ({ ok: true }))`,
+    ``,
+  ].join("\n"))
+  return rootDir
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(root => rm(root, { recursive: true, force: true })))
+})
+
+describe("hubSandbox", () => {
+  it("exposes Vite feature state and attaches a Nitro bridge", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox()
+    const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const resolveId = plugin.resolveId as (id: string) => string | undefined | Promise<string | undefined>
+    const load = plugin.load as (id: string) => string | undefined | Promise<string | undefined>
+
+    const configResult = await configHook({
+      root: rootDir,
+      sandbox: {
+        provider: "vercel",
+      },
+    }, {
+      command: "serve",
+      mode: "development",
+    })
+
+    const resolvedId = await resolveId("virtual:vitehub/sandbox")
+    const code = await load(resolvedId as string)
+
+    expect(plugin.nitro?.name).toBe("@vitehub/sandbox")
+    expect(code).toContain('"feature": "sandbox"')
+    expect(code).toContain('"provider": "vercel"')
+    expect(configResult).toEqual({})
+  })
+
+  it("adds server-environment markers through the Environment API", async () => {
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox()
+    const configEnvironment = plugin.configEnvironment as (name: string, environment: { consumer: "client" | "server" }) => unknown
+
+    expect(configEnvironment("rsc", { consumer: "server" })).toEqual({
+      define: {
+        __VITEHUB_ENVIRONMENT_SANDBOX__: "\"rsc\"",
+      },
+    })
+    expect(configEnvironment("client", { consumer: "client" })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary\n- restore sandbox package unit and type coverage on top of the core integration stack\n- cover Vite discovery, Nitro/Nuxt wiring, and public typing\n- keep e2e and workflow changes for the upper stack PRs\n