### PR TITLE
[codex] align deploy environments and opt Actions into Node 24

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,11 +3,11 @@ description: Install pnpm + Node and project dependencies
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v5
       with:
         version: 10.33.0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   quality:
     runs-on: ubuntu-latest
@@ -62,6 +65,7 @@ jobs:
     needs: quality
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: Production
     strategy:
       fail-fast: false
       matrix:
@@ -112,6 +116,7 @@ jobs:
     needs: deploy
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: Production
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     needs: quality
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: Production
+    environment: Default
     strategy:
       fail-fast: false
       matrix:
@@ -95,7 +95,7 @@ jobs:
     needs: deploy
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: Production
+    environment: Default
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     needs: quality
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: Default
+    environment: Production
     strategy:
       fail-fast: false
       matrix:
@@ -95,7 +95,7 @@ jobs:
     needs: deploy
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: Default
+    environment: Production
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,11 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
       - name: Fallow dead-code
@@ -53,7 +50,7 @@ jobs:
         provider: [cloudflare, vercel]
         framework: [nitro, nuxt, vite]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
       - run: pnpm --dir packages/kv build
@@ -72,7 +69,7 @@ jobs:
         provider: [cloudflare, vercel]
         framework: [nitro, nuxt, vite]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
       - run: pnpm --dir packages/kv build
@@ -123,7 +120,7 @@ jobs:
         provider: [cloudflare, vercel]
         framework: [nitro, nuxt, vite]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
       - name: E2E Live (${{ matrix.provider }} × ${{ matrix.framework }})

--- a/.github/workflows/queue-manual-e2e.yml
+++ b/.github/workflows/queue-manual-e2e.yml
@@ -11,7 +11,7 @@ jobs:
   deploy-and-test:
     name: deploy-and-test (${{ matrix.framework }}, ${{ matrix.provider }})
     runs-on: ubuntu-latest
-    environment: Production
+    environment: Default
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/queue-manual-e2e.yml
+++ b/.github/workflows/queue-manual-e2e.yml
@@ -11,7 +11,7 @@ jobs:
   deploy-and-test:
     name: deploy-and-test (${{ matrix.framework }}, ${{ matrix.provider }})
     runs-on: ubuntu-latest
-    environment: Preview
+    environment: Production
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/queue-manual-e2e.yml
+++ b/.github/workflows/queue-manual-e2e.yml
@@ -7,10 +7,14 @@ concurrency:
   group: queue-manual-e2e-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   deploy-and-test:
     name: deploy-and-test (${{ matrix.framework }}, ${{ matrix.provider }})
     runs-on: ubuntu-latest
+    environment: Preview
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/queue-manual-e2e.yml
+++ b/.github/workflows/queue-manual-e2e.yml
@@ -7,9 +7,6 @@ concurrency:
   group: queue-manual-e2e-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   deploy-and-test:
     name: deploy-and-test (${{ matrix.framework }}, ${{ matrix.provider }})
@@ -21,7 +18,7 @@ jobs:
         framework: [vite, nitro]
         provider: [cloudflare, vercel]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
       - run: pnpm --filter @vitehub/queue build

--- a/.github/workflows/queue-manual-e2e.yml
+++ b/.github/workflows/queue-manual-e2e.yml
@@ -11,7 +11,7 @@ jobs:
   deploy-and-test:
     name: deploy-and-test (${{ matrix.framework }}, ${{ matrix.provider }})
     runs-on: ubuntu-latest
-    environment: Default
+    environment: Production
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What changed
- opt all GitHub-hosted JavaScript actions into the Node 24 runtime to remove the current Node 20 deprecation warning
- bind `main` deployment jobs to the `Production` environment
- bind the manual preview-style queue e2e workflow to the `Preview` environment

## Why
Recent runs were warning that `actions/checkout@v4`, `actions/setup-node@v4`, and `pnpm/action-setup@v4` still execute on the deprecated Node 20 runtime unless the workflow opts into Node 24.

The repo already has `Preview` and `Production` environments, but the workflows were not attached to them, so preview and main deploy jobs were not actually routed through those environment scopes.

## Impact
- the Node 20 deprecation warning should disappear on the next workflow run
- preview-style deploys and `main` deploys now have explicit GitHub environment bindings
- environment secrets still need to be populated if you want `Preview` and `Production` to carry their own credentials instead of falling back to repository secrets

## Validation
- reviewed workflow diff
- ran `git diff --check`
