### PR TITLE
[codex] remove local e2e job from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,24 +40,6 @@ jobs:
       - run: pnpm build
       - run: pnpm docs:build
 
-  e2e-local:
-    needs: quality
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        provider: [cloudflare, vercel]
-        framework: [nitro, nuxt, vite]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup
-
-      - run: pnpm --dir packages/kv build
-
-      - name: E2E (${{ matrix.provider }} × ${{ matrix.framework }})
-        run: pnpm --dir packages/kv test:e2e --provider ${{ matrix.provider }} --framework ${{ matrix.framework }}
-
   deploy:
     needs: quality
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## What changed
- removed the `e2e-local` pull request job from `.github/workflows/ci.yml`

## Why
The local PR matrix is redundant with the quality checks and separate live deploy workflow, and it adds CI time without providing useful signal.

## Impact
- pull request CI becomes shorter and simpler
- `main` deploy and `e2e-live` remain unchanged
- manual live deploy testing remains available through `queue manual e2e`

## Validation
- reviewed workflow diff
- ran `git diff --check`
