### PR TITLE
docs(blob): add nitro example

### DIFF
--- a/docs/test/showcase.test.ts
+++ b/docs/test/showcase.test.ts
@@ -100,6 +100,16 @@ describe("showcase examples", () => {
     expect(queue?.frameworks.nuxt).toBeFalsy();
   });
 
+  it("loads the blob example for vite and nitro only", () => {
+    const blob = getShowcaseExamples().find(example => example.docsPath === "blob");
+    expect(blob).toBeTruthy();
+
+    expect(blob?.label).toBe("Blob");
+    expect(blob?.frameworks.vite).toBeTruthy();
+    expect(blob?.frameworks.nitro).toBeTruthy();
+    expect(blob?.frameworks.nuxt).toBeFalsy();
+  });
+
   it("returns queue phase paths for supported frameworks", () => {
     const queue = getShowcaseExamples().find(example => example.docsPath === "queue");
     expect(queue).toBeTruthy();
@@ -113,6 +123,20 @@ describe("showcase examples", () => {
       configure: "nitro.config.ts",
       define: "server/queues/welcome-email.ts",
       run: "server/api/welcome.post.ts",
+    });
+  });
+
+  it("returns blob phase paths for supported frameworks", () => {
+    const blob = getShowcaseExamples().find(example => example.docsPath === "blob");
+    expect(blob).toBeTruthy();
+
+    expect(getShowcasePhasePaths(blob!, "vite", "build")).toEqual({
+      configure: "vite.config.ts",
+      run: "src/server.ts",
+    });
+    expect(getShowcasePhasePaths(blob!, "nitro", "build")).toEqual({
+      configure: "nitro.config.ts",
+      run: "server/api/blob.get.ts",
     });
   });
 
@@ -132,6 +156,24 @@ describe("showcase examples", () => {
       "nitro.config.ts",
       "server/queues/welcome-email.ts",
       "server/api/welcome.post.ts",
+      "package.json",
+    ]);
+  });
+
+  it("keeps blob showcase files ordered by phase and supplemental files", () => {
+    const blob = getShowcaseExamples().find(example => example.docsPath === "blob");
+    expect(blob).toBeTruthy();
+
+    expect(getShowcaseFiles(blob!, "vite", "build").slice(0, 3).map(file => file.path)).toEqual([
+      "vite.config.ts",
+      "src/server.ts",
+      "package.json",
+    ]);
+
+    expect(getShowcaseFiles(blob!, "nitro", "build").slice(0, 4).map(file => file.path)).toEqual([
+      "nitro.config.ts",
+      "server/api/blob.get.ts",
+      "server/api/blob.put.ts",
       "package.json",
     ]);
   });

--- a/fallow.toml
+++ b/fallow.toml
@@ -14,6 +14,8 @@ dynamicallyLoaded = [
   "packages/queue/examples/**/src/**/*.queue.ts",
   "packages/blob/test/helpers/*.ts",
   "packages/blob/test/**/*.test-d.ts",
+  "packages/blob/examples/**/nitro.config.ts",
+  "packages/blob/examples/**/server/**",
   "packages/blob/examples/**/src/server.ts",
   "playground/nitro/nitro.config.ts",
   "playground/nitro/server/**",

--- a/packages/blob/examples/nitro/nitro.config.ts
+++ b/packages/blob/examples/nitro/nitro.config.ts
@@ -1,0 +1,5 @@
+import { defineNitroConfig } from "nitro/config"
+
+export default defineNitroConfig({
+  modules: ["@vitehub/blob/nitro"],
+})

--- a/packages/blob/examples/nitro/package.json
+++ b/packages/blob/examples/nitro/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "nitro build",
+    "dev": "nitro dev",
+    "preview": "nitro preview"
+  },
+  "dependencies": {
+    "@vitehub/blob": "workspace:*",
+    "nitro": "catalog:"
+  }
+}

--- a/packages/blob/examples/nitro/server/api/blob.get.ts
+++ b/packages/blob/examples/nitro/server/api/blob.get.ts
@@ -1,0 +1,5 @@
+import { defineEventHandler } from "h3"
+
+import { blob } from "@vitehub/blob"
+
+export default defineEventHandler(async () => await blob.list({ limit: 10 }))

--- a/packages/blob/examples/nitro/server/api/blob.put.ts
+++ b/packages/blob/examples/nitro/server/api/blob.put.ts
@@ -1,0 +1,8 @@
+import { defineEventHandler, readBody } from "h3"
+
+import { blob } from "@vitehub/blob"
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ pathname?: string, value?: string }>(event)
+  return await blob.put(body?.pathname || "notes/example.txt", body?.value || "hello world")
+})

--- a/packages/blob/examples/showcase.json
+++ b/packages/blob/examples/showcase.json
@@ -41,6 +41,30 @@
           ]
         }
       }
+    },
+    "nitro": {
+      "modes": {
+        "dev": {
+          "phases": {
+            "configure": "nitro.config.ts",
+            "run": "server/api/blob.get.ts"
+          },
+          "supplementalFiles": [
+            "server/api/blob.put.ts",
+            "package.json"
+          ]
+        },
+        "build": {
+          "phases": {
+            "configure": "nitro.config.ts",
+            "run": "server/api/blob.get.ts"
+          },
+          "supplementalFiles": [
+            "server/api/blob.put.ts",
+            "package.json"
+          ]
+        }
+      }
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,15 @@ importers:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/blob/examples/nitro:
+    dependencies:
+      '@vitehub/blob':
+        specifier: workspace:*
+        version: link:../..
+      nitro:
+        specifier: 'catalog:'
+        version: 3.0.260311-beta(@upstash/redis@1.37.0)(@vercel/blob@1.1.1)(@vercel/functions@3.4.3)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(miniflare@4.20260415.0)(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/blob/examples/vite:
     dependencies:
       '@vitehub/blob':


### PR DESCRIPTION
Adds a minimal Nitro blob example and updates the showcase coverage so the docs manifest exposes Blob for both Vite and Nitro.

Refs ONM-214.