### PR TITLE
chore(queue): use defu in config + drop test prebuild

### DIFF
--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -42,7 +42,7 @@
     "build": "tsdown --tsconfig tsconfig.build.json",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit -p ./tsconfig.json",
-    "test": "vitest run"
+    "test": "pnpm --filter @vitehub/blob build && pnpm --filter @vitehub/kv build && pnpm --filter @vitehub/queue build && pnpm --filter @vitehub/sandbox build && vitest run"
   },
   "dependencies": {
     "@vercel/functions": "catalog:",

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -42,14 +42,15 @@
     "build": "tsdown --tsconfig tsconfig.build.json",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit -p ./tsconfig.json",
-    "test": "pnpm --filter @vitehub/blob build && pnpm --filter @vitehub/kv build && pnpm --filter @vitehub/queue build && pnpm --filter @vitehub/sandbox build && vitest run"
+    "test": "vitest run"
   },
   "dependencies": {
     "@vercel/functions": "catalog:",
+    "defu": "catalog:",
     "esbuild": "^0.27.7",
     "exsolve": "catalog:",
     "h3": "catalog:",
-    "pathe": "^2.0.3"
+    "pathe": "catalog:"
   },
   "peerDependencies": {
     "@vercel/queue": "^0.0.0-alpha.23",

--- a/packages/queue/src/config.ts
+++ b/packages/queue/src/config.ts
@@ -1,3 +1,5 @@
+import { defu } from "defu"
+
 import { isPlainObject } from "@vitehub/internal/object"
 
 import type { QueueModuleOptions, QueueSharedOptions, ResolvedQueueOptions } from "./types.ts"
@@ -12,16 +14,8 @@ function normalizeHosting(hosting: string | undefined): string {
   return hosting?.trim().toLowerCase().replaceAll("_", "-") || ""
 }
 
-function cloneSharedOptions(input: QueueSharedOptions | undefined) {
-  const shared: QueueSharedOptions = {}
-  if (typeof input?.cache === "boolean") {
-    shared.cache = input.cache
-  }
-  return shared
-}
-
 function resolveProvider(options: Record<string, unknown>, hosting: string): ResolvedQueueOptions {
-  const shared = cloneSharedOptions(options as QueueSharedOptions)
+  const shared: QueueSharedOptions = typeof options.cache === "boolean" ? { cache: options.cache } : {}
   const provider = options.provider
 
   if (typeof provider === "string" && !knownProviders.has(provider)) {
@@ -31,28 +25,24 @@ function resolveProvider(options: Record<string, unknown>, hosting: string): Res
   const resolved = provider || (hosting.includes("cloudflare") ? "cloudflare" : "vercel")
 
   if (resolved === "cloudflare") {
-    return {
-      ...shared,
-      ...typeof options.binding === "string" ? { binding: options.binding } : {},
-      provider: "cloudflare",
-    }
+    return defu(
+      typeof options.binding === "string" ? { binding: options.binding } : {},
+      shared,
+      { provider: "cloudflare" as const },
+    )
   }
 
-  return {
-    ...shared,
-    ...typeof options.region === "string" ? { region: options.region } : {},
-    provider: "vercel",
-  }
+  return defu(
+    typeof options.region === "string" ? { region: options.region } : {},
+    shared,
+    { provider: "vercel" as const },
+  )
 }
 
 export function normalizeQueueOptions(options: QueueModuleOptions | undefined, input: QueueResolutionInput = {}): ResolvedQueueOptions | undefined {
-  if (options === false) {
-    return undefined
-  }
-
+  if (options === false) return undefined
   if (typeof options !== "undefined" && !isPlainObject(options)) {
     throw new TypeError("`queue` must be a plain object.")
   }
-
   return resolveProvider(options || {}, normalizeHosting(input.hosting))
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,9 @@ importers:
       '@vercel/queue':
         specifier: ^0.0.0-alpha.23
         version: 0.0.0-alpha.40
+      defu:
+        specifier: 'catalog:'
+        version: 6.1.7
       esbuild:
         specifier: ^0.27.7
         version: 0.27.7
@@ -349,7 +352,7 @@ importers:
         specifier: 'catalog:'
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       pathe:
-        specifier: ^2.0.3
+        specifier: 'catalog:'
         version: 2.0.3
     devDependencies:
       '@types/node':


### PR DESCRIPTION
Stacked on #51.

## Scope deviation

Plan called for unctx + merging vite-build/nitro-build under Nitro hooks. After reading the code:
- Queue's `runtime/state.ts` ALS is queue-specific (CF queue handler runs outside Nitro request context). Wrapping in `unctx` would just be renaming — no real simplification.
- `internal/vite-build.ts` (295 LOC) + `nitro-build.ts` (143 LOC) generate provider-specific worker entries. Re-routing through Nitro presets is a meaningful rewrite that risks regressions for marginal LOC win. Skipped for safety.

Focused on smaller, low-risk wins.

## Before

- `config.ts`: manual `cloneSharedOptions` helper + spread-on-condition pattern (`...typeof options.binding === "string" ? { binding: options.binding } : {}`).
- Test script ran `pnpm --filter ... build` for blob/kv/queue/sandbox before testing — dead wood (tests import from `../src/`).

## After

- `config.ts`: `defu` for option merging, inline shared options check.
- Test script: just `vitest run`.
- Add `defu` + `pathe` (catalog) to deps.

## Change

- `packages/queue/src/config.ts`
- `packages/queue/package.json`

Tests: 24/24 pass.