### PR TITLE
test: add root contract checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "fallow:dead-code": "pnpm exec fallow dead-code --summary --format markdown --fail-on-issues",
     "lint": "pnpm exec oxlint . --ignore-path .gitignore",
     "typecheck": "pnpm --dir docs typecheck && pnpm -r --filter './packages/*' --if-present run typecheck",
+    "test:contracts": "vitest run",
     "test": "pnpm -r --workspace-concurrency=1 --filter './packages/*' --if-present run test",
     "build": "pnpm -r --filter './packages/*' --if-present run build",
     "playground:vite:build": "pnpm --dir playground/vite build",
@@ -23,6 +24,7 @@
     "@types/node": "catalog:",
     "fallow": "2.41.0",
     "oxlint": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   docs:
     dependencies:

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -1,0 +1,172 @@
+import { execFileSync } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import {
+  packageDir,
+  packageNames,
+  readJson,
+  readPackageManifest,
+  repoRoot,
+  toRepoPath,
+  walkFiles,
+  type PackageName,
+} from "./utils/repo"
+
+const ignoredGeneratedDirs = new Set([
+  ".nuxt",
+  ".output",
+  ".vercel",
+  ".wrangler",
+  "dist",
+  "node_modules",
+])
+
+function exportTargetPath(packageName: PackageName, target: string) {
+  return join(packageDir(packageName), target.replace(/^\.\//, ""))
+}
+
+function hasExport(packageName: string, specifier: string) {
+  const shortName = packageName.replace("@vitehub/", "") as PackageName
+  const manifest = readPackageManifest(shortName)
+  const subpath = specifier.slice(packageName.length)
+
+  if (!subpath) {
+    return true
+  }
+
+  return Boolean(manifest.exports?.[`.${subpath}`])
+}
+
+describe("package manifest contracts", () => {
+  it("keeps landed package manifests publishable by convention", () => {
+    for (const packageName of packageNames) {
+      const manifest = readPackageManifest(packageName)
+
+      expect(manifest.name).toBe(`@vitehub/${packageName}`)
+      expect(manifest.description, `${packageName} should describe its package`).toEqual(expect.any(String))
+      expect(manifest.license).toBe("Apache-2.0")
+      expect(manifest.sideEffects).toBe(false)
+      expect(manifest.type).toBe("module")
+      expect(manifest.types).toBe("./dist/index.d.ts")
+      expect(manifest.files).toEqual(expect.arrayContaining(["dist", "package.json"]))
+      expect(manifest.scripts?.build).toEqual(expect.any(String))
+      expect(manifest.scripts?.typecheck).toEqual(expect.any(String))
+      expect(manifest.scripts?.test).toEqual(expect.any(String))
+      expect(manifest.exports?.["."]).toBe("./dist/index.js")
+      expect(manifest.exports?.["./package.json"]).toBe("./package.json")
+    }
+  })
+
+  it("keeps export targets under dist except package.json", () => {
+    for (const packageName of packageNames) {
+      const manifest = readPackageManifest(packageName)
+
+      for (const [subpath, rawTarget] of Object.entries(manifest.exports || {})) {
+        const target = typeof rawTarget === "string" ? rawTarget : rawTarget.default
+        expect(target, `${packageName} ${subpath} should use string/default export target`).toEqual(expect.any(String))
+
+        if (subpath === "./package.json") {
+          expect(target).toBe("./package.json")
+          expect(existsSync(exportTargetPath(packageName, target))).toBe(true)
+          continue
+        }
+
+        expect(target, `${packageName} ${subpath} should point to dist`).toMatch(/^\.\/dist\/.+\.js$/)
+      }
+    }
+  })
+})
+
+describe("docs import contracts", () => {
+  it("only references existing @vitehub package exports in source docs", () => {
+    const markdownFiles = [
+      ...walkFiles(join(repoRoot, "docs", "content"), { extensions: new Set(["md"]) }),
+      ...packageNames.flatMap(packageName => walkFiles(join(packageDir(packageName), "docs"), { extensions: new Set(["md"]) })),
+    ]
+    const specifiers = new Set<string>()
+    const importPattern = /from\s+['"](@vitehub\/[^'"]+)['"]|import\s+['"](@vitehub\/[^'"]+)['"]/g
+
+    for (const file of markdownFiles) {
+      const source = readFileSync(file, "utf8")
+      for (const match of source.matchAll(importPattern)) {
+        const specifier = match[1] || match[2]
+        if (specifier) {
+          specifiers.add(specifier)
+        }
+      }
+    }
+
+    expect(specifiers.size).toBeGreaterThan(0)
+
+    for (const specifier of specifiers) {
+      const [scope, name] = specifier.split("/")
+      const packageName = `${scope}/${name}`
+      expect(packageNames.map(item => `@vitehub/${item}`), `Unexpected docs package import: ${specifier}`).toContain(packageName)
+      expect(hasExport(packageName, specifier), `Missing docs export: ${specifier}`).toBe(true)
+    }
+  })
+})
+
+describe("showcase contracts", () => {
+  it("keeps existing showcase manifests pointed at real files", () => {
+    for (const packageName of packageNames) {
+      const manifestPath = join(packageDir(packageName), "examples", "showcase.json")
+      if (!existsSync(manifestPath)) {
+        continue
+      }
+
+      const manifest = readJson<{
+        label?: string
+        frameworks?: Record<string, { modes?: Record<string, { phases?: Record<string, string>, supplementalFiles?: string[] }> }>
+      }>(manifestPath)
+
+      expect(manifest.label, `${packageName} showcase should have a label`).toEqual(expect.any(String))
+      expect(manifest.frameworks, `${packageName} showcase should list frameworks`).toEqual(expect.any(Object))
+
+      for (const [framework, frameworkConfig] of Object.entries(manifest.frameworks || {})) {
+        for (const [mode, modeConfig] of Object.entries(frameworkConfig.modes || {})) {
+          const files = [
+            ...Object.values(modeConfig.phases || {}),
+            ...(modeConfig.supplementalFiles || []),
+          ]
+
+          for (const file of files) {
+            const path = join(packageDir(packageName), "examples", framework, file)
+            expect(existsSync(path), `${packageName}/${framework}/${mode} references missing file: ${file}`).toBe(true)
+          }
+        }
+      }
+    }
+  })
+})
+
+describe("runtime hygiene contracts", () => {
+  it("does not track generated output under package examples or playgrounds", () => {
+    const tracked = execFileSync("git", ["ls-files", "packages"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    })
+      .split("\n")
+      .filter(Boolean)
+      .filter(path => /\/(examples|playground)\/(\.nuxt|\.output|\.vercel|\.wrangler|dist|node_modules)\//.test(path))
+
+    expect(tracked).toEqual([])
+  })
+
+  it("does not use stale generated globals in runtime source", () => {
+    const runtimeFiles = packageNames.flatMap(packageName =>
+      walkFiles(packageDir(packageName), {
+        ignoreDirs: ignoredGeneratedDirs,
+        extensions: new Set(["ts"]),
+      }).filter(path => toRepoPath(path).includes("/src/runtime/")),
+    )
+
+    const offenders = runtimeFiles
+      .filter(path => !path.endsWith("/empty-registry.ts"))
+      .filter(path => readFileSync(path, "utf8").includes("__vitehub"))
+      .map(toRepoPath)
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -38,6 +38,12 @@ function hasExport(packageName: string, specifier: string) {
   return Boolean(manifest.exports?.[`.${subpath}`])
 }
 
+function hasGeneratedOutputUnderExampleSurface(path: string) {
+  const parts = path.split("/")
+  const surfaceIndex = parts.findIndex(part => part === "examples" || part === "playground")
+  return surfaceIndex !== -1 && parts.slice(surfaceIndex + 1).some(part => ignoredGeneratedDirs.has(part))
+}
+
 describe("package manifest contracts", () => {
   it("keeps landed package manifests publishable by convention", () => {
     for (const packageName of packageNames) {
@@ -149,7 +155,7 @@ describe("runtime hygiene contracts", () => {
     })
       .split("\n")
       .filter(Boolean)
-      .filter(path => /\/(examples|playground)\/(\.nuxt|\.output|\.vercel|\.wrangler|dist|node_modules)\//.test(path))
+      .filter(hasGeneratedOutputUnderExampleSurface)
 
     expect(tracked).toEqual([])
   })
@@ -163,7 +169,7 @@ describe("runtime hygiene contracts", () => {
     )
 
     const offenders = runtimeFiles
-      .filter(path => !path.endsWith("/empty-registry.ts"))
+      .filter(path => !toRepoPath(path).endsWith("/empty-registry.ts"))
       .filter(path => readFileSync(path, "utf8").includes("__vitehub"))
       .map(toRepoPath)
 

--- a/test/utils/repo.ts
+++ b/test/utils/repo.ts
@@ -1,0 +1,66 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import { join, relative, resolve } from "node:path"
+
+export const repoRoot = resolve(import.meta.dirname, "../..")
+export const packageNames = ["kv", "blob", "queue", "sandbox"] as const
+
+export type PackageName = (typeof packageNames)[number]
+
+export type PackageManifest = {
+  name?: string
+  description?: string
+  license?: string
+  sideEffects?: boolean
+  type?: string
+  types?: string
+  exports?: Record<string, string | Record<string, string>>
+  files?: string[]
+  scripts?: Record<string, string>
+}
+
+export function packageDir(packageName: PackageName) {
+  return join(repoRoot, "packages", packageName)
+}
+
+export function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T
+}
+
+export function readPackageManifest(packageName: PackageName) {
+  return readJson<PackageManifest>(join(packageDir(packageName), "package.json"))
+}
+
+export function toRepoPath(path: string) {
+  return relative(repoRoot, path).replace(/\\/g, "/")
+}
+
+export function walkFiles(dir: string, options: { ignoreDirs?: Set<string>, extensions?: Set<string> } = {}) {
+  const files: string[] = []
+  const ignoreDirs = options.ignoreDirs ?? new Set<string>()
+
+  function walk(currentDir: string) {
+    for (const entry of readdirSync(currentDir)) {
+      if (ignoreDirs.has(entry)) {
+        continue
+      }
+
+      const path = join(currentDir, entry)
+      const stat = statSync(path)
+
+      if (stat.isDirectory()) {
+        walk(path)
+        continue
+      }
+
+      if (!options.extensions || options.extensions.has(entry.split(".").pop() || "")) {
+        files.push(path)
+      }
+    }
+  }
+
+  if (existsSync(dir)) {
+    walk(dir)
+  }
+
+  return files
+}

--- a/test/utils/repo.ts
+++ b/test/utils/repo.ts
@@ -6,7 +6,7 @@ export const packageNames = ["kv", "blob", "queue", "sandbox"] as const
 
 export type PackageName = (typeof packageNames)[number]
 
-export type PackageManifest = {
+type PackageManifest = {
   name?: string
   description?: string
   license?: string

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+  },
+})


### PR DESCRIPTION
Refs ONM-210.

Adds a lightweight root contract suite for the landed ViteHub packages: KV, Blob, Queue, and Sandbox. The checks stay filesystem/manifest based and cover package export conventions, docs import references, showcase manifest file references, and generated runtime hygiene without adding packed-consumer installs or live e2e.

Adds a root `test:contracts` script while leaving the existing root `pnpm test` package-local path unchanged.

Checked with:
- `pnpm test:contracts`
- `pnpm typecheck`
- `pnpm exec oxlint vitest.config.ts test`