### PR TITLE
feat(workflow): add Nitro playground live e2e coverage

### DIFF
--- a/.github/workflows/manual-live-e2e.yml
+++ b/.github/workflows/manual-live-e2e.yml
@@ -184,8 +184,7 @@ jobs:
       - name: Sandbox Live E2E (${{ matrix.provider }} × ${{ matrix.framework }})
         run: pnpm --dir packages/sandbox test:e2e --mode live --provider ${{ matrix.provider }} --framework ${{ matrix.framework }} --url "${{ steps.url.outputs.url }}"
 
-      - name: Workflow Live E2E (${{ matrix.provider }} × vite)
-        if: matrix.framework == 'vite'
+      - name: Workflow Live E2E (${{ matrix.provider }} × ${{ matrix.framework }})
         timeout-minutes: 5
         run: node packages/workflow/test/e2e-live.mjs --framework "${{ matrix.framework }}" --provider "${{ matrix.provider }}" --url "${{ steps.url.outputs.url }}"
 

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -42,7 +42,7 @@
     "build": "tsdown --tsconfig tsconfig.build.json",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit -p ./tsconfig.json",
-    "test": "pnpm --filter @vitehub/blob build && pnpm --filter @vitehub/kv build && pnpm --filter @vitehub/queue build && pnpm --filter @vitehub/sandbox build && vitest run"
+    "test": "pnpm --filter @vitehub/blob build && pnpm --filter @vitehub/kv build && pnpm --filter @vitehub/queue build && pnpm --filter @vitehub/sandbox build && pnpm --filter @vitehub/workflow build && vitest run"
   },
   "dependencies": {
     "@vercel/functions": "catalog:",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -54,7 +54,7 @@
     "build": "tsdown --tsconfig tsconfig.build.json",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit -p ./tsconfig.json",
-    "test": "pnpm --filter @vitehub/blob build && pnpm --filter @vitehub/kv build && pnpm --filter @vitehub/queue build && pnpm --filter @vitehub/sandbox build && vitest run",
+    "test": "pnpm --filter @vitehub/blob build && pnpm --filter @vitehub/kv build && pnpm --filter @vitehub/queue build && pnpm --filter @vitehub/sandbox build && pnpm --filter @vitehub/workflow build && vitest run",
     "test:e2e": "tsx ./test/e2e.ts"
   },
   "dependencies": {

--- a/playground/nitro/nitro.config.ts
+++ b/playground/nitro/nitro.config.ts
@@ -1,9 +1,16 @@
 import { defineNitroConfig } from "nitro/config"
 
 export default defineNitroConfig({
-  modules: ["@vitehub/queue/nitro", "@vitehub/kv/nitro", "@vitehub/blob/nitro", "@vitehub/sandbox/nitro"],
+  modules: [
+    "@vitehub/queue/nitro",
+    "@vitehub/kv/nitro",
+    "@vitehub/blob/nitro",
+    "@vitehub/sandbox/nitro",
+    "@vitehub/workflow/nitro",
+  ],
   blob: {},
   queue: {},
   sandbox: {},
   serverDir: "./server",
+  workflow: {},
 })

--- a/playground/nitro/package.json
+++ b/playground/nitro/package.json
@@ -11,6 +11,7 @@
     "@vitehub/kv": "workspace:*",
     "@vitehub/queue": "workspace:*",
     "@vitehub/sandbox": "workspace:*",
+    "@vitehub/workflow": "workspace:*",
     "h3": "catalog:",
     "nitro": "catalog:",
     "valibot": "catalog:"

--- a/playground/nitro/server/api/workflows/welcome-defer.post.ts
+++ b/playground/nitro/server/api/workflows/welcome-defer.post.ts
@@ -1,0 +1,20 @@
+import { defineEventHandler, readValidatedBody } from "h3"
+import * as v from "valibot"
+import { deferWorkflow } from "@vitehub/workflow"
+
+const workflowName = "welcome"
+const workflowBody = v.optional(v.object({
+  email: v.optional(v.string()),
+  id: v.optional(v.string()),
+  marker: v.optional(v.string()),
+}), {})
+
+export default defineEventHandler(async (event) => {
+  const body = await readValidatedBody(event, workflowBody)
+  const marker = typeof body?.marker === "string" ? body.marker : event.headers.get("x-vitehub-e2e-marker") || undefined
+  const id = body?.id || marker
+  return {
+    ok: true,
+    result: await deferWorkflow(workflowName, { email: body?.email || "ava@example.com", marker }, { id }),
+  }
+})

--- a/playground/nitro/server/api/workflows/welcome.post.ts
+++ b/playground/nitro/server/api/workflows/welcome.post.ts
@@ -1,0 +1,20 @@
+import { defineEventHandler, readValidatedBody } from "h3"
+import * as v from "valibot"
+import { runWorkflow } from "@vitehub/workflow"
+
+const workflowName = "welcome"
+const workflowBody = v.optional(v.object({
+  email: v.optional(v.string()),
+  id: v.optional(v.string()),
+  marker: v.optional(v.string()),
+}), {})
+
+export default defineEventHandler(async (event) => {
+  const body = await readValidatedBody(event, workflowBody)
+  const marker = typeof body?.marker === "string" ? body.marker : event.headers.get("x-vitehub-e2e-marker") || undefined
+  const id = body?.id || marker
+  return {
+    ok: true,
+    result: await runWorkflow(workflowName, { email: body?.email || "ava@example.com", marker }, { id }),
+  }
+})

--- a/playground/nitro/server/api/workflows/welcome/[id].get.ts
+++ b/playground/nitro/server/api/workflows/welcome/[id].get.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler } from "h3"
+import { getWorkflowRun } from "@vitehub/workflow"
+
+export default defineEventHandler(async (event) => {
+  const id = event.context.params?.id
+  return id ? await getWorkflowRun("welcome", id) : { status: "unknown" }
+})

--- a/playground/nitro/server/routes/index.ts
+++ b/playground/nitro/server/routes/index.ts
@@ -3,4 +3,5 @@ import { defineEventHandler } from "h3"
 export default defineEventHandler(() => ({
   ok: true,
   queue: "welcome",
+  workflow: "welcome",
 }))

--- a/playground/nitro/server/workflows/welcome.ts
+++ b/playground/nitro/server/workflows/welcome.ts
@@ -1,0 +1,11 @@
+import { defineWorkflow } from "@vitehub/workflow"
+
+export default defineWorkflow(async ({ payload }) => {
+  const body = payload as { email?: string, marker?: string } | undefined
+
+  return {
+    email: body?.email || "ava@example.com",
+    marker: body?.marker,
+    ok: true,
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,6 +597,9 @@ importers:
       '@vitehub/sandbox':
         specifier: workspace:*
         version: link:../../packages/sandbox
+      '@vitehub/workflow':
+        specifier: workspace:*
+        version: link:../../packages/workflow
       h3:
         specifier: 'catalog:'
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))


### PR DESCRIPTION
Adds the shared Nitro workflow playground routes and wiring so the existing workflow live-e2e flow runs against Nitro as well as Vite. It also updates the manual live-e2e workflow to execute the workflow check for both frameworks.

Ref: ONM-228
Live e2e run: https://github.com/vite-hub/vitehub/actions/runs/25034220523