### PR TITLE
docs(workflow): align guide examples across frameworks

### DIFF
--- a/packages/workflow/docs/guides/observe-a-run.md
+++ b/packages/workflow/docs/guides/observe-a-run.md
@@ -2,7 +2,8 @@
 title: Observe a workflow run
 description: Read normalized workflow status and result metadata from a route.
 navigation.title: Observe a Run
-navigation.order: 1
+navigation.group: Guides
+navigation.order: 31
 icon: i-lucide-search-check
 frameworks: [vite, nitro]
 ---
@@ -15,6 +16,38 @@ const run = await getWorkflowRun('welcome', id)
 
 ## Add a status route
 
+Every status route follows the same shape:
+
+1. Read the workflow run id from the request path.
+2. Return `getWorkflowRun(name, id)`.
+3. Map missing ids to the framework's normal error response.
+
+::fw{id="vite:dev vite:build"}
+```ts [src/server.ts]
+import { H3, readBody } from 'h3'
+import { getWorkflowRun } from '@vitehub/workflow'
+import { runWorkflow } from '@vitehub/workflow'
+import type { WelcomePayload } from './welcome.workflow'
+
+const app = new H3()
+
+app.post('/api/welcome', async (event) => {
+  const payload = await readBody<WelcomePayload>(event)
+  const run = await runWorkflow('welcome', payload)
+
+  return { ok: true, payload, run }
+})
+
+app.get('/api/workflow/:id', async (event) => {
+  const id = event.context.params?.id
+  return id ? await getWorkflowRun('welcome', id) : { status: 'unknown' }
+})
+
+export default app
+```
+::
+
+::fw{id="nitro:dev nitro:build"}
 ```ts [server/api/workflow/[id].get.ts]
 import { getWorkflowRun } from '@vitehub/workflow'
 
@@ -30,6 +63,7 @@ export default defineEventHandler(async (event) => {
   return await getWorkflowRun('welcome', id)
 })
 ```
+::
 
 ## Handle status values
 

--- a/packages/workflow/docs/guides/observe-a-run.md
+++ b/packages/workflow/docs/guides/observe-a-run.md
@@ -24,23 +24,21 @@ Every status route follows the same shape:
 
 ::fw{id="vite:dev vite:build"}
 ```ts [src/server.ts]
-import { H3, readBody } from 'h3'
+import { createError, H3 } from 'h3'
 import { getWorkflowRun } from '@vitehub/workflow'
-import { runWorkflow } from '@vitehub/workflow'
-import type { WelcomePayload } from './welcome.workflow'
 
 const app = new H3()
 
-app.post('/api/welcome', async (event) => {
-  const payload = await readBody<WelcomePayload>(event)
-  const run = await runWorkflow('welcome', payload)
-
-  return { ok: true, payload, run }
-})
-
 app.get('/api/workflow/:id', async (event) => {
   const id = event.context.params?.id
-  return id ? await getWorkflowRun('welcome', id) : { status: 'unknown' }
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing workflow run id.',
+    })
+  }
+
+  return await getWorkflowRun('welcome', id)
 })
 
 export default app

--- a/packages/workflow/docs/guides/start-a-workflow.md
+++ b/packages/workflow/docs/guides/start-a-workflow.md
@@ -2,16 +2,20 @@
 title: Start a workflow
 description: Start a named workflow with a payload, stable id, and provider-neutral route code.
 navigation.title: Start a Workflow
-navigation.order: 0
+navigation.group: Guides
+navigation.order: 30
 icon: i-lucide-play
 frameworks: [vite, nitro]
 ---
 
-Use `runWorkflow()` when the route should wait until the provider accepts the workflow start.
+This guide defines a `welcome` workflow, then starts it from a server route. It assumes Workflow is already registered in Vite or Nitro config.
 
 ## Define the workflow
 
-```ts [server/workflows/welcome.ts]
+Use `runWorkflow()` when the route should wait until the provider accepts the workflow start.
+
+::fw{id="vite:dev vite:build"}
+```ts [src/welcome.workflow.ts]
 import { defineWorkflow } from '@vitehub/workflow'
 
 export type WelcomePayload = {
@@ -28,8 +32,39 @@ export default defineWorkflow<WelcomePayload>(async ({ id, payload, provider }) 
   }
 })
 ```
+::
+
+::fw{id="nitro:dev nitro:build"}
+```ts [server/workflows/welcome.ts]
+import { defineWorkflow } from '@vitehub/workflow'
+
+export type WelcomePayload = {
+  email: string
+  marker?: string
+}
+
+export default defineWorkflow<WelcomePayload>(async ({ id, payload, provider }) => {
+  return {
+    id,
+    marker: payload.marker,
+    message: `Welcome ${payload.email}`,
+    provider,
+  }
+})
+```
+::
+
+## Call pattern
+
+Every producer follows the same shape:
+
+1. Read or build a payload.
+2. Call `runWorkflow(name, payload)`.
+3. Return the normalized run metadata.
 
 ## Start with generated id
+
+Pass the payload directly when the provider can generate the run id:
 
 ```ts
 const run = await runWorkflow('welcome', {
@@ -46,8 +81,28 @@ Use a stable id when the caller needs to poll the run later:
 const run = await runWorkflow('welcome', { email: 'ava@example.com', marker: 'signup-42' }, { id: 'welcome-signup-42' })
 ```
 
-## Return the run
+## Return the run from a route
 
+::fw{id="vite:dev vite:build"}
+```ts [src/server.ts]
+import { H3, readBody } from 'h3'
+import { runWorkflow } from '@vitehub/workflow'
+import type { WelcomePayload } from './welcome.workflow'
+
+const app = new H3()
+
+app.post('/api/welcome', async (event) => {
+  const payload = await readBody<WelcomePayload>(event)
+  const run = await runWorkflow('welcome', payload)
+
+  return { ok: true, payload, run }
+})
+
+export default app
+```
+::
+
+::fw{id="nitro:dev nitro:build"}
 ```ts [server/api/welcome.post.ts]
 import { runWorkflow } from '@vitehub/workflow'
 import type { WelcomePayload } from '../workflows/welcome'
@@ -56,8 +111,9 @@ export default defineEventHandler(async (event) => {
   const payload = await readBody<WelcomePayload>(event)
   const run = await runWorkflow('welcome', payload)
 
-  return { ok: true, run }
+  return { ok: true, payload, run }
 })
 ```
+::
 
 The returned `id` is the value to store when the user needs a status page, receipt, or polling endpoint.

--- a/packages/workflow/docs/guides/start-a-workflow.md
+++ b/packages/workflow/docs/guides/start-a-workflow.md
@@ -26,9 +26,9 @@ export type WelcomePayload = {
 export default defineWorkflow<WelcomePayload>(async ({ id, payload, provider }) => {
   return {
     id,
-    provider,
-    message: `Welcome ${payload.email}`,
     marker: payload.marker,
+    message: `Welcome ${payload.email}`,
+    provider,
   }
 })
 ```
@@ -117,3 +117,28 @@ export default defineEventHandler(async (event) => {
 ::
 
 The returned `id` is the value to store when the user needs a status page, receipt, or polling endpoint.
+
+## Verify the route
+
+```bash
+curl -X POST http://localhost:3000/api/welcome \
+  -H 'content-type: application/json' \
+  -d '{"email":"ava@example.com","marker":"signup-42"}'
+```
+
+Expected response:
+
+```json
+{
+  "ok": true,
+  "payload": {
+    "email": "ava@example.com",
+    "marker": "signup-42"
+  },
+  "run": {
+    "id": "wrun_lvn4hx4f_x8k2p9s1",
+    "provider": "vercel",
+    "status": "queued"
+  }
+}
+```

--- a/packages/workflow/docs/guides/validate-payloads.md
+++ b/packages/workflow/docs/guides/validate-payloads.md
@@ -2,7 +2,8 @@
 title: Validate workflow payloads
 description: Parse and validate request payloads before starting a workflow.
 navigation.title: Validate Payloads
-navigation.order: 2
+navigation.group: Guides
+navigation.order: 32
 icon: i-lucide-badge-check
 frameworks: [vite, nitro]
 ---
@@ -48,7 +49,7 @@ export default {
 
 ## Validate inside framework routes
 
-Framework helpers are still a good fit when they already expose validated body parsing:
+Framework helpers are still a good fit when they already expose validated body parsing.
 
 ```ts
 import { runWorkflow, validatePayload } from '@vitehub/workflow'
@@ -64,5 +65,52 @@ export default defineEventHandler(async (event) => {
   }
 })
 ```
+
+## Full route examples
+
+::fw{id="vite:dev vite:build"}
+```ts [src/server.ts]
+import { H3, readBody } from 'h3'
+import { runWorkflow, validatePayload } from '@vitehub/workflow'
+import { z } from 'zod'
+
+const welcomePayload = z.object({
+  email: z.string().email(),
+  marker: z.string().optional(),
+})
+
+const app = new H3()
+
+app.post('/api/welcome', async (event) => {
+  const rawPayload = await readBody(event)
+  const payload = await validatePayload(rawPayload, welcomePayload)
+  const run = await runWorkflow('welcome', payload)
+
+  return { ok: true, run }
+})
+
+export default app
+```
+::
+
+::fw{id="nitro:dev nitro:build"}
+```ts [server/api/welcome.post.ts]
+import { runWorkflow, validatePayload } from '@vitehub/workflow'
+import { z } from 'zod'
+
+const welcomePayload = z.object({
+  email: z.string().email(),
+  marker: z.string().optional(),
+})
+
+export default defineEventHandler(async (event) => {
+  const rawPayload = await readBody(event)
+  const payload = await validatePayload(rawPayload, welcomePayload)
+  const run = await runWorkflow('welcome', payload)
+
+  return { ok: true, run }
+})
+```
+::
 
 The validation helpers throw the parser or schema error directly so the route can map it to the framework's normal error response.

--- a/packages/workflow/docs/guides/validate-payloads.md
+++ b/packages/workflow/docs/guides/validate-payloads.md
@@ -29,7 +29,7 @@ const payload = await validatePayload(rawPayload, (value) => {
 `validatePayload()` and `readValidatedPayload()` accept schema objects with `parse()` or `safeParse()`.
 
 ```ts
-import { readValidatedPayload, runWorkflow } from '@vitehub/workflow'
+import { validatePayload } from '@vitehub/workflow'
 import { z } from 'zod'
 
 const welcomePayload = z.object({
@@ -37,34 +37,12 @@ const welcomePayload = z.object({
   marker: z.string().optional(),
 })
 
-export default {
-  async fetch(request: Request) {
-    const payload = await readValidatedPayload(request, welcomePayload)
-    const run = await runWorkflow('welcome', payload)
-
-    return Response.json({ ok: true, run })
-  },
-}
+const payload = await validatePayload(rawPayload, welcomePayload)
 ```
 
 ## Validate inside framework routes
 
-Framework helpers are still a good fit when they already expose validated body parsing.
-
-```ts
-import { runWorkflow, validatePayload } from '@vitehub/workflow'
-import { readBody } from 'h3'
-
-export default defineEventHandler(async (event) => {
-  const rawPayload = await readBody(event)
-  const payload = await validatePayload(rawPayload, welcomePayload)
-
-  return {
-    ok: true,
-    run: await runWorkflow('welcome', payload),
-  }
-})
-```
+Framework helpers are still a good fit when they already expose body parsing. Read the request body with the framework helper, validate the parsed value, then call `runWorkflow()`.
 
 ## Full route examples
 


### PR DESCRIPTION
This updates the Workflow guide pages to match the example pattern already used by Queue and Sandbox. The start, observe, and validate guides now render framework-specific Vite and Nitro snippets using the real example paths, and the guide frontmatter is grouped and ordered consistently in the docs navigation.

Verified with `pnpm --dir docs test` and `pnpm docs:build`.