### PR TITLE
feat(chat): infer Nitro runtime config types

### DIFF
--- a/packages/chat/src/nitro/module.ts
+++ b/packages/chat/src/nitro/module.ts
@@ -335,6 +335,28 @@ function installExternals(nitro: Nitro): void {
   }
 }
 
+async function writeNitroTypes(nitro: Nitro): Promise<string> {
+  const dtsPath = resolve(nitro.options.rootDir, nitro.options.buildDir, "types", "vitehub-chat.d.ts")
+  await writeFileIfChanged(dtsPath, [
+    `import "@vitehub/chat/nitro"`,
+    "",
+    "export {}",
+    "",
+  ].join("\n"))
+  return dtsPath
+}
+
+async function installNitroTypes(nitro: Nitro): Promise<void> {
+  await writeNitroTypes(nitro)
+  nitro.hooks.hook("types:extend", async (types: { tsConfig?: { include?: string[] } }) => {
+    const dtsPath = await writeNitroTypes(nitro)
+    if (types.tsConfig) {
+      types.tsConfig.include ||= []
+      types.tsConfig.include.push(dtsPath)
+    }
+  })
+}
+
 function installRoute(nitro: Nitro, options: ResolvedChatModuleOptions, routeFile: string | undefined): void {
   if (!routeFile || !options.webhook) {
     return
@@ -412,6 +434,7 @@ const chatNitroModule: NitroModule = {
     installAliases(nitro)
     installNitroPlugin(nitro)
     installExternals(nitro)
+    await installNitroTypes(nitro)
 
     const importsExplicitlyDisabled = nitro.options._config?.imports === false || (resolved && !resolved.imports)
     if (!importsExplicitlyDisabled) {

--- a/packages/chat/test/nitro.test.ts
+++ b/packages/chat/test/nitro.test.ts
@@ -451,6 +451,13 @@ describe("Nitro module", () => {
     await nitro.testHooks["build:before"]?.[0]?.()
     expect(nitro.options.rollupConfig.plugins?.filter(plugin => typeof plugin === "object" && plugin !== null && "name" in plugin && plugin.name === "vitehub-chat-cloudflare-exports:ChatStateDO")).toHaveLength(1)
 
+    const typesHook = nitro.testHooks["types:extend"]?.[0]
+    const tsConfig = { include: [] as string[] }
+    await typesHook?.({ tsConfig })
+    const types = await readFile(join(rootDir, ".nitro/types/vitehub-chat.d.ts"), "utf8")
+    expect(types).toContain(`import "@vitehub/chat/nitro"`)
+    expect(tsConfig.include).toContain(join(rootDir, ".nitro/types/vitehub-chat.d.ts"))
+
     const routeFile = nitro.options.handlers[0]!.handler
     const routeContents = await readFile(routeFile, "utf8")
     expect(routeContents).toContain("defineChatWebhookHandler(chat")

--- a/packages/env/src/core/declarations.ts
+++ b/packages/env/src/core/declarations.ts
@@ -1,16 +1,24 @@
 import type { EnvSource, EnvSourceResolver, EnvVariableDeclaration, EnvVariableOptions } from "../types.ts"
 
 interface DefaultStringSchema {
+  __vitehubDefaultRuntimeSchema: string
   safeParse: (input: unknown) => { data: string, success: true } | { error: Error, success: false }
 }
 
-export const defaultStringSchema: DefaultStringSchema = {
+const defaultStringSchema: DefaultStringSchema = {
+  __vitehubDefaultRuntimeSchema: getDefaultStringSchemaToken(),
   safeParse(input: unknown): { data: string, success: true } | { error: Error, success: false } {
     return typeof input === "string"
       ? { data: input, success: true as const }
       : { error: new Error("Expected string"), success: false as const }
   },
 }
+
+const defaultStringSchemaProperty = "__vitehubDefaultRuntimeSchema"
+const defaultStringSchemaToken = defaultStringSchema.__vitehubDefaultRuntimeSchema
+const defaultStringSchemas = new WeakMap<EnvVariableDeclaration, DefaultStringSchema>()
+const defaultStringSchemaParsers = new WeakSet<DefaultStringSchema["safeParse"]>()
+defaultStringSchemaParsers.add(defaultStringSchema.safeParse)
 
 export const envSource = {
   custom(label: string, resolver: EnvSourceResolver): EnvSource {
@@ -68,14 +76,49 @@ export function envVariable(options: EnvVariableOptions = {}): EnvVariableDeclar
     ? envSource.custom("custom", options.source)
     : options.source
 
-  return {
+  const schema = options.schema ?? defaultStringSchema
+  const declaration: EnvVariableDeclaration = {
     default: options.default,
     kind: "env-variable",
     mode: options.mode ?? "runtime",
     required,
-    schema: options.schema ?? defaultStringSchema,
+    schema,
     secret: options.secret ?? false,
     source,
     type: options.type,
   }
+
+  if (typeof options.schema === "undefined") {
+    defaultStringSchemas.set(declaration, defaultStringSchema)
+    Object.defineProperty(declaration, defaultStringSchemaProperty, {
+      enumerable: true,
+      value: defaultStringSchemaToken,
+    })
+  }
+
+  return declaration
+}
+
+export function isDefaultStringEnvVariable(declaration: EnvVariableDeclaration): boolean {
+  return defaultStringSchemas.get(declaration) === declaration.schema
+    || (
+      (declaration as unknown as Record<string, unknown>)[defaultStringSchemaProperty] === defaultStringSchemaToken
+      && typeof declaration.schema === "object"
+      && declaration.schema !== null
+      && (declaration.schema as Record<string, unknown>)[defaultStringSchemaProperty] === defaultStringSchemaToken
+      && hasDefaultStringSchemaParser(declaration.schema)
+    )
+}
+
+function getDefaultStringSchemaToken(): string {
+  const tokenKey = Symbol.for("vitehub.env.defaultRuntimeSchemaToken")
+  const globalScope = globalThis as typeof globalThis & Record<symbol, string | undefined>
+  globalScope[tokenKey] ??= `string:${Math.random().toString(36).slice(2)}`
+  return globalScope[tokenKey]
+}
+
+function hasDefaultStringSchemaParser(schema: object): boolean {
+  const candidate = schema as { safeParse?: unknown }
+  return typeof candidate.safeParse === "function"
+    && defaultStringSchemaParsers.has(candidate.safeParse as DefaultStringSchema["safeParse"])
 }

--- a/packages/env/src/core/resolve.ts
+++ b/packages/env/src/core/resolve.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path"
 import { promisify } from "node:util"
 
 import { parseSchema } from "../schema.ts"
-import { defaultStringSchema } from "./declarations.ts"
+import { isDefaultStringEnvVariable } from "./declarations.ts"
 import { EnvError } from "./errors.ts"
 
 import type {
@@ -169,7 +169,7 @@ function buildRegistry(declarations: EnvNitroConfigOptions | undefined, path: st
     if (source.kind !== "env") {
       throw new EnvError(`Runtime declaration ${valuePath} must use envSource.env() in v1.`)
     }
-    if (value.schema !== defaultStringSchema) {
+    if (!isDefaultStringEnvVariable(value)) {
       throw new EnvError(`Runtime declaration ${valuePath} uses a custom schema, but Nitro runtime schemas cannot be serialized in v1.`)
     }
     if (value.type && value.type !== "string") {

--- a/packages/env/src/nitro/module.ts
+++ b/packages/env/src/nitro/module.ts
@@ -37,10 +37,16 @@ function createPluginContents(file: string, registryFile: string): string {
   ].join("\n")
 }
 
-function installNitroTypes(nitro: Nitro, registry: EnvRuntimeRegistry): void {
+async function writeNitroTypes(nitro: Nitro, registry: EnvRuntimeRegistry): Promise<string> {
+  const dtsPath = resolve(nitro.options.buildDir, "types", "vitehub-env.d.ts")
+  await writeFileIfChanged(dtsPath, createNitroTypes(registry))
+  return dtsPath
+}
+
+async function installNitroTypes(nitro: Nitro, registry: EnvRuntimeRegistry): Promise<void> {
+  await writeNitroTypes(nitro, registry)
   nitro.hooks.hook("types:extend", async (types: { tsConfig?: { include?: string[] } }) => {
-    const dtsPath = resolve(nitro.options.buildDir, "types", "vitehub-env.d.ts")
-    await writeFileIfChanged(dtsPath, createNitroTypes(registry))
+    const dtsPath = await writeNitroTypes(nitro, registry)
     if (types.tsConfig) {
       types.tsConfig.include ||= []
       types.tsConfig.include.push(dtsPath)
@@ -120,7 +126,7 @@ export function envNitro(options: EnvIntegrationOptions = {}): NitroModule {
         nitro.options.plugins.push(pluginFile)
       }
 
-      installNitroTypes(nitro, registry)
+      await installNitroTypes(nitro, registry)
     },
   }
 }

--- a/packages/env/test/nitro.test.ts
+++ b/packages/env/test/nitro.test.ts
@@ -234,6 +234,127 @@ describe("Nitro module", () => {
     await expect(envNitro().setup(nitro as never)).rejects.toThrow("custom schema")
   })
 
+  it("rejects runtime schemas that spoof default schema metadata", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
+    const nitro: NitroStub = {
+      hooks: { hook: vi.fn() },
+      logger: { info: vi.fn() },
+      options: {
+        buildDir: join(root, ".nitro"),
+        env: {
+          apiKey: envVariable({
+            schema: {
+              __vitehubDefaultRuntimeSchema: "string",
+              safeParse(input: unknown) {
+                return { data: String(input), success: true as const }
+              },
+            },
+          }),
+        },
+        rootDir: root,
+      },
+    }
+
+    await expect(envNitro().setup(nitro as never)).rejects.toThrow("custom schema")
+  })
+
+  it("rejects default runtime declarations that are mutated to custom schemas", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
+    const apiKey = envVariable()
+    apiKey.schema = stringSchema()
+
+    const nitro: NitroStub = {
+      hooks: { hook: vi.fn() },
+      logger: { info: vi.fn() },
+      options: {
+        buildDir: join(root, ".nitro"),
+        env: { apiKey },
+        rootDir: root,
+      },
+    }
+
+    await expect(envNitro().setup(nitro as never)).rejects.toThrow("custom schema")
+  })
+
+  it("rejects custom runtime schemas that copy default runtime markers", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
+    const defaultDeclaration = envVariable()
+    const marker = (defaultDeclaration as unknown as Record<string, unknown>).__vitehubDefaultRuntimeSchema
+    const schema = stringSchema() as ReturnType<typeof stringSchema> & { __vitehubDefaultRuntimeSchema?: unknown }
+    schema.__vitehubDefaultRuntimeSchema = marker
+    const apiKey = envVariable({ schema })
+    const apiKeyRecord = apiKey as unknown as Record<string, unknown>
+    apiKeyRecord.__vitehubDefaultRuntimeSchema = marker
+
+    const nitro: NitroStub = {
+      hooks: { hook: vi.fn() },
+      logger: { info: vi.fn() },
+      options: {
+        buildDir: join(root, ".nitro"),
+        env: { apiKey },
+        rootDir: root,
+      },
+    }
+
+    await expect(envNitro().setup(nitro as never)).rejects.toThrow("custom schema")
+  })
+
+  it("rejects custom runtime schemas that spoof the default parser source", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
+    const defaultDeclaration = envVariable()
+    const marker = (defaultDeclaration as unknown as Record<string, unknown>).__vitehubDefaultRuntimeSchema
+    const defaultSchema = defaultDeclaration.schema as { safeParse: (input: unknown) => unknown }
+    const schema = stringSchema() as ReturnType<typeof stringSchema> & { __vitehubDefaultRuntimeSchema?: unknown }
+    schema.__vitehubDefaultRuntimeSchema = marker
+    schema.safeParse.toString = () => defaultSchema.safeParse.toString()
+    const apiKey = envVariable({ schema })
+    const apiKeyRecord = apiKey as unknown as Record<string, unknown>
+    apiKeyRecord.__vitehubDefaultRuntimeSchema = marker
+
+    const nitro: NitroStub = {
+      hooks: { hook: vi.fn() },
+      logger: { info: vi.fn() },
+      options: {
+        buildDir: join(root, ".nitro"),
+        env: { apiKey },
+        rootDir: root,
+      },
+    }
+
+    await expect(envNitro().setup(nitro as never)).rejects.toThrow("custom schema")
+  })
+
+  it("rejects custom runtime schemas registered through a forged global parser allowlist", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
+    const defaultDeclaration = envVariable()
+    const marker = (defaultDeclaration as unknown as Record<string, unknown>).__vitehubDefaultRuntimeSchema
+    const schema = stringSchema() as ReturnType<typeof stringSchema> & { __vitehubDefaultRuntimeSchema?: unknown }
+    schema.__vitehubDefaultRuntimeSchema = marker
+    const parsersKey = Symbol.for("vitehub.env.defaultRuntimeSchemaParsers")
+    const forgedGlobal = globalThis as typeof globalThis & Record<symbol, WeakSet<typeof schema.safeParse> | undefined>
+    forgedGlobal[parsersKey] = new WeakSet([schema.safeParse])
+    const apiKey = envVariable({ schema })
+    const apiKeyRecord = apiKey as unknown as Record<string, unknown>
+    apiKeyRecord.__vitehubDefaultRuntimeSchema = marker
+
+    const nitro: NitroStub = {
+      hooks: { hook: vi.fn() },
+      logger: { info: vi.fn() },
+      options: {
+        buildDir: join(root, ".nitro"),
+        env: { apiKey },
+        rootDir: root,
+      },
+    }
+
+    try {
+      await expect(envNitro().setup(nitro as never)).rejects.toThrow("custom schema")
+    }
+    finally {
+      delete forgedGlobal[parsersKey]
+    }
+  })
+
   it("rejects custom runtime sources", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
     const nitro: NitroStub = {


### PR DESCRIPTION
This makes Nitro chat runtime config typing automatic for apps using `@vitehub/chat/nitro` with generated `@vitehub/env` runtime config types. The chat Nitro module now emits a small generated type file that imports `@vitehub/chat/nitro`, so `defineChat()` sees the Nitro `RuntimeConfig` augmentation without a user-defined generic.

The env Nitro module now writes its generated runtime config types during module setup as well as through `types:extend`, because the real Vite/Nitro path used by the chat app does not call that hook before `tsc` reads `node_modules/.nitro/types`. I also replaced built-package default schema identity checks with an internal marker so packaged `@vitehub/env` keeps accepting default string env variables after bundling.

Checked with `pnpm --filter @vitehub/chat typecheck`, `pnpm --filter @vitehub/chat test`, `pnpm --filter @vitehub/env typecheck`, `pnpm --filter @vitehub/env test`, and a temporary copy of `~/vitehub/chat` with the manual `RuntimeConfig`/`defineChat<RuntimeConfig>` removed.
