### PR TITLE
fix(workspace): improve runtime dx

### DIFF
--- a/packages/workspace/src/build-assets.ts
+++ b/packages/workspace/src/build-assets.ts
@@ -1,16 +1,21 @@
 import { createHash } from "node:crypto"
-import { mkdir, rm, writeFile } from "node:fs/promises"
-import { dirname, join } from "node:path"
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { dirname, join, relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { createImportPath } from "@vitehub/internal/build/paths"
+import { listMatchingFiles } from "@vitehub/internal/definition-catalog"
 import { resolveRuntimeEntry } from "@vitehub/internal/nitro"
 
+import { syncWorkspaceDefinition } from "./lifecycle.ts"
 import { normalizeSafeWorkspacePath } from "./path.ts"
+import { createMemoryWorkspaceStore } from "./stores/memory.ts"
 import { createWorkspace } from "./workspace.ts"
+import { isWorkspaceAssetFile, workspaceConfigFileNames } from "./workspace-config.ts"
 
 import type { DiscoveredWorkspaceDefinition } from "./discovery.ts"
-import type { ResolvedWorkspaceModuleOptions, Workspace, WorkspaceContent, WorkspaceDefinitionInput } from "./types.ts"
+import type { ResolvedWorkspaceModuleOptions, Workspace, WorkspaceContent, WorkspaceDefinitionInput, WorkspaceStore } from "./types.ts"
 
 export interface WorkspaceAssetFile {
   content: WorkspaceContent
@@ -82,6 +87,70 @@ export async function collectWorkspaceAssetBundle(workspace: Workspace): Promise
 
 export async function collectWorkspaceAssetBundles(workspaces: Workspace[]): Promise<WorkspaceAssetBundle[]> {
   return await Promise.all(workspaces.map(workspace => collectWorkspaceAssetBundle(workspace)))
+}
+
+export async function collectWorkspaceStoreAssetBundle(name: string, store: WorkspaceStore): Promise<WorkspaceAssetBundle> {
+  const entries = (await store.glob("**/*")).filter(entry => entry.type === "file")
+  const files: WorkspaceAssetFile[] = []
+  for (const entry of entries) {
+    const path = normalizeSafeWorkspacePath(entry.path)
+    const file = await store.readFile(path)
+    if (file) {
+      files.push({ content: file.content, mediaType: file.mediaType, path })
+    }
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path))
+  return { files, name }
+}
+
+export async function syncDiscoveredWorkspaceAssetBundles(
+  definitions: DiscoveredWorkspaceDefinition[],
+  rootDir: string,
+  options: false | ResolvedWorkspaceModuleOptions,
+): Promise<WorkspaceAssetBundle[]> {
+  if (!options) return []
+
+  const bundles: WorkspaceAssetBundle[] = []
+  for (const definition of definitions) {
+    if (!shouldSyncWorkspace(options.syncOnBuild, definition.name)) continue
+
+    const mod = await import(pathToFileURL(definition.path).href) as { default?: WorkspaceDefinitionInput }
+    if (!mod.default) throw new TypeError(`[vitehub] Workspace definition "${definition.name}" has no default export.`)
+
+    const store = createMemoryWorkspaceStore()
+    await syncWorkspaceDefinition({
+      ...mod.default,
+      name: definition.name,
+      rootDir: mod.default.rootDir || rootDir,
+      store,
+    }, store)
+    bundles.push(await collectWorkspaceStoreAssetBundle(definition.name, store))
+  }
+
+  return bundles
+}
+
+export async function collectDirectoryWorkspaceAssetBundles(
+  definitions: DiscoveredWorkspaceDefinition[],
+  rootDir: string,
+): Promise<WorkspaceAssetBundle[]> {
+  const bundles: WorkspaceAssetBundle[] = []
+  for (const definition of definitions) {
+    const directory = definition.path ? dirname(definition.path) : resolve(rootDir, "server", "workspaces", ...definition.name.split("/"))
+    if (!workspaceConfigFileNames.some(file => existsSync(resolve(directory, file)))) continue
+
+    const files = await Promise.all(listMatchingFiles(directory, isWorkspaceAssetFile).map(async (file) => {
+      const path = normalizeSafeWorkspacePath(relative(directory, file))
+      return {
+        content: await readFile(file),
+        path,
+      }
+    }))
+    files.sort((a, b) => a.path.localeCompare(b.path))
+    bundles.push({ files, name: definition.name })
+  }
+  return bundles
 }
 
 export async function writeWorkspaceAssetsRegistry(registryFile: string, bundles: WorkspaceAssetBundle[]): Promise<string> {

--- a/packages/workspace/src/build-integration.ts
+++ b/packages/workspace/src/build-integration.ts
@@ -5,8 +5,8 @@ import { dirname, resolve } from "node:path"
 import { writeFileIfChanged } from "@vitehub/internal/definition-catalog"
 
 import {
-  collectWorkspaceAssetBundles,
-  syncDiscoveredWorkspaces,
+  collectDirectoryWorkspaceAssetBundles,
+  syncDiscoveredWorkspaceAssetBundles,
   writeWorkspaceAssetsRegistry,
 } from "./build-assets.ts"
 import {
@@ -53,8 +53,12 @@ export async function writeWorkspaceRuntimeRegistry(registryFile: string, defini
   return registryFile
 }
 
-export async function initializeWorkspaceAssetRegistry(assetsRegistryFile: string): Promise<void> {
-  await writeWorkspaceAssetsRegistry(assetsRegistryFile, [])
+export async function initializeWorkspaceAssetRegistry(
+  assetsRegistryFile: string,
+  definitions: DiscoveredWorkspaceDefinition[] = [],
+  rootDir = process.cwd(),
+): Promise<void> {
+  await writeWorkspaceAssetsRegistry(assetsRegistryFile, await collectDirectoryWorkspaceAssetBundles(definitions, rootDir))
 }
 
 export async function syncWorkspaceBuildAssets(
@@ -63,6 +67,9 @@ export async function syncWorkspaceBuildAssets(
   options: false | ResolvedWorkspaceModuleOptions,
   assetsRegistryFile: string,
 ): Promise<void> {
-  const workspaces = await syncDiscoveredWorkspaces(definitions, rootDir, options)
-  await writeWorkspaceAssetsRegistry(assetsRegistryFile, await collectWorkspaceAssetBundles(workspaces))
+  const syncedBundles = await syncDiscoveredWorkspaceAssetBundles(definitions, rootDir, options)
+  const syncedNames = new Set(syncedBundles.map(bundle => bundle.name))
+  const directoryBundles = (await collectDirectoryWorkspaceAssetBundles(definitions, rootDir))
+    .filter(bundle => !syncedNames.has(bundle.name))
+  await writeWorkspaceAssetsRegistry(assetsRegistryFile, [...directoryBundles, ...syncedBundles])
 }

--- a/packages/workspace/src/nitro/module.ts
+++ b/packages/workspace/src/nitro/module.ts
@@ -181,7 +181,7 @@ const workspaceNitroModule: NitroModule = {
     let definitions = discoverNitroWorkspaceDefinitions(nitro.options.rootDir)
     const registryFile = await writeWorkspaceRuntimeRegistry(registryPath(nitro), definitions)
     const assetsRegistryFile = assetsRegistryPath(nitro)
-    await initializeWorkspaceAssetRegistry(assetsRegistryFile)
+    await initializeWorkspaceAssetRegistry(assetsRegistryFile, definitions, nitro.options.rootDir)
     const plugin = await writePlugin(nitro, registryFile, assetsRegistryFile, resolved)
     nitro.options.alias["#vitehub-workspace-registry"] = registryFile
     nitro.options.alias["#vitehub-workspace-assets-registry"] = assetsRegistryFile

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -1,6 +1,8 @@
 import { Buffer } from "node:buffer"
 import { gunzipSync } from "node:zlib"
 
+import { getActiveCloudflareBinding } from "@vitehub/internal/runtime/cloudflare-env"
+
 import { WorkspaceError } from "../errors.ts"
 import { matchesAny, normalizeWorkspacePath } from "../path.ts"
 import type { WorkspaceSource } from "../types.ts"
@@ -48,14 +50,30 @@ interface GitHubArchiveFile {
 export function github(options: GitHubSourceOptions): WorkspaceSource {
   const ref = options.ref || "main"
   const root = normalizeWorkspacePath(options.root || "")
+  let auth: string | undefined
   let filesPromise: Promise<GitHubFile[]> | undefined
   const contentPromises = new Map<string, Promise<Uint8Array>>()
 
-  async function request<T>(url: string): Promise<T> {
+  function resolveAuth(): string | undefined {
+    const token = options.auth || getActiveCloudflareBinding<string>("GITHUB_TOKEN") || process.env.GITHUB_TOKEN
+    return typeof token === "string" && token.length > 0 ? token : undefined
+  }
+
+  function refreshAuth(): string | undefined {
+    const nextAuth = resolveAuth()
+    if (nextAuth !== auth) {
+      auth = nextAuth
+      filesPromise = undefined
+      contentPromises.clear()
+    }
+    return auth
+  }
+
+  async function request<T>(url: string, token = auth): Promise<T> {
     const response = await fetch(url, {
       headers: {
         accept: "application/vnd.github+json",
-        ...(options.auth ? { authorization: `Bearer ${options.auth}` } : {}),
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
         "user-agent": "vitehub-workspace",
         "x-github-api-version": "2022-11-28",
       },
@@ -135,8 +153,8 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
       .filter((file): file is GitHubFile => Boolean(file))
   }
 
-  async function loadFiles() {
-    if (options.auth) return await loadTreeFiles()
+  async function loadFiles(token: string | undefined) {
+    if (token) return await loadTreeFiles()
 
     try {
       return await loadTreeFiles()
@@ -150,7 +168,8 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
   }
 
   function getFiles() {
-    if (!filesPromise) filesPromise = loadFiles()
+    const token = refreshAuth()
+    if (!filesPromise) filesPromise = loadFiles(token)
     return filesPromise
   }
 
@@ -163,11 +182,13 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
 
     const repoPath = repoPathForKey(key)
     const encodedPath = encodeURIComponent(repoPath).replaceAll("%2F", "/")
-    if (!options.auth) {
+    const token = refreshAuth()
+    if (!token) {
       return fetchRawContent(repoPath, encodedPath)
     }
     return request<GitHubContentResponse>(
       `https://api.github.com/repos/${options.repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`,
+      token,
     ).then((file) => {
       if (file.encoding !== "base64" || typeof file.content !== "string") {
         throw new WorkspaceError(`[vitehub] source.github(${JSON.stringify(options.repo)}) received unsupported content for ${JSON.stringify(repoPath)}.`)

--- a/packages/workspace/src/use.ts
+++ b/packages/workspace/src/use.ts
@@ -7,6 +7,7 @@ import {
   type WorkspaceWriteToolMap,
 } from "./ai.ts"
 import { useWorkspaceAssets } from "./asset-registry.ts"
+import { WorkspaceNotFoundError } from "./errors.ts"
 import { appendWorkspaceFile, copyWorkspacePath } from "./fs-ops.ts"
 import { normalizeSafeWorkspacePath, normalizeSafeWorkspacePattern } from "./path.ts"
 import { useRegisteredWorkspace } from "./registry.ts"
@@ -222,6 +223,94 @@ function createWritableFs<Name extends WorkspaceName>(workspace: Workspace): Wri
   }
 }
 
+function useOptionalWorkspaceAssets<Name extends WorkspaceName>(name: Name): WorkspaceAssets<WorkspaceAssetPath<Name>> | undefined {
+  try {
+    return useWorkspaceAssets(name)
+  }
+  catch (error) {
+    if (error instanceof WorkspaceNotFoundError) return undefined
+    throw error
+  }
+}
+
+async function ignoreMissingWorkspace<T>(operation: () => Promise<T>): Promise<T | undefined> {
+  try {
+    return await operation()
+  }
+  catch (error) {
+    if (error instanceof WorkspaceNotFoundError) return undefined
+    throw error
+  }
+}
+
+function mergeEntries(primary: WorkspaceEntry[] = [], fallback: WorkspaceEntry[] = []) {
+  const entries = new Map<string, WorkspaceEntry>()
+  for (const entry of fallback) entries.set(entry.path, entry)
+  for (const entry of primary) entries.set(entry.path, entry)
+  return [...entries.values()].sort((left, right) => left.path.localeCompare(right.path))
+}
+
+function mergeSearchHits(primary: WorkspaceSearchHit[] = [], fallback: WorkspaceSearchHit[] = []) {
+  const seen = new Set<string>()
+  return [...primary, ...fallback].filter((hit) => {
+    const key = `${hit.path}:${hit.line}:${hit.column}:${hit.text}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function createReadonlyFs<Name extends WorkspaceName>(
+  name: Name,
+  workspace: Workspace,
+): ReadonlyWorkspaceFs<Name> {
+  const assets = useOptionalWorkspaceAssets(name)
+
+  return {
+    readFile: async (path, options) => {
+      const normalized = normalizePath(path)
+      if (assets && await assets.exists(normalized as WorkspaceAssetPath<Name>)) {
+        return await assets.readFile(normalized as WorkspaceAssetPath<Name>, options as never)
+      }
+      return await workspace.readFile(normalized, options as never)
+    },
+    stat: async (path) => {
+      const normalized = normalizePath(path)
+      if (assets && await assets.exists(normalized as WorkspaceAssetPath<Name>)) {
+        return await assets.stat(normalized as WorkspaceAssetPath<Name>)
+      }
+      return await workspace.stat(normalized)
+    },
+    exists: async (path) => {
+      const normalized = normalizePath(path)
+      if (assets && await assets.exists(normalized as WorkspaceAssetPath<Name>)) return true
+      return await ignoreMissingWorkspace(() => workspace.exists(normalized)) ?? false
+    },
+    list: async (path, options) => {
+      const normalized = path ? normalizeListPath(path) : ""
+      const assetEntries = assets ? await assets.list(normalized as WorkspaceAssetPath<Name>, options) : []
+      const workspaceEntries = await ignoreMissingWorkspace(() => workspace.list(normalized, options)) ?? []
+      return mergeEntries(assetEntries, workspaceEntries)
+    },
+    glob: async (pattern, options) => {
+      const normalized = normalizePattern(pattern as string | string[])
+      const assetEntries = assets ? await assets.glob(normalized as WorkspaceAssetPath<Name>, options) : []
+      const workspaceEntries = await ignoreMissingWorkspace(() => workspace.glob(normalized, options)) ?? []
+      return mergeEntries(assetEntries, workspaceEntries)
+    },
+    search: async (query) => {
+      const normalized = {
+        ...query,
+        cwd: query.cwd ? normalizeListPath(query.cwd) : query.cwd,
+        paths: query.paths?.map(path => normalizeListPath(path)),
+      }
+      const assetHits = assets ? await assets.search(normalized) : []
+      const workspaceHits = await ignoreMissingWorkspace(() => workspace.search(normalized)) ?? []
+      return mergeSearchHits(assetHits, workspaceHits)
+    },
+  }
+}
+
 function toReadOperations(options: WorkspaceFacadeToolOptions | undefined): WorkspaceReadOperations {
   return { list: options?.list, read: options?.read, search: options?.search }
 }
@@ -266,7 +355,7 @@ export function useWorkspace<Name extends WorkspaceName>(name: Name, options?: U
     }
   }
 
-  const fs = useWorkspaceAssets(name)
+  const fs = createReadonlyFs(name, createLazyWorkspace(name))
   const createTools = (opts?: WorkspaceFacadeToolOptions) => createWorkspaceTools(fs, {
     cwd: opts?.cwd,
     maxOutputLength: opts?.maxOutputLength,

--- a/packages/workspace/test/nitro-output.test.ts
+++ b/packages/workspace/test/nitro-output.test.ts
@@ -68,6 +68,7 @@ beforeAll(async () => {
     await execFileAsync("pnpm", ["--filter", `@vitehub/${name}`, "build"], {
       cwd: repoRoot,
       env: process.env,
+      maxBuffer: 1024 * 1024 * 16,
     })
   }
 }, 120_000)

--- a/packages/workspace/test/public-api.test.ts
+++ b/packages/workspace/test/public-api.test.ts
@@ -77,6 +77,38 @@ describe("workspace public API", () => {
     await expect(workspace.fs.stat("README.md")).resolves.toMatchObject({ path: "README.md", type: "file" })
   })
 
+  it("merges bundled assets with lazy runtime sources in the read-only facade", async () => {
+    setWorkspaceRuntimeAssetsRegistry({
+      docs: createWorkspaceAssets({
+        "AGENTS.md": { load: async () => "# Instructions\n" },
+      }),
+    })
+    setWorkspaceRegistry({
+      docs: async () => ({ default: defineWorkspace({
+        store: { provider: "memory" },
+        sources: {
+          repo: source.file({
+            content: "# Repo\n",
+            materialize: "lazy",
+            mount: "repo",
+            workspacePath: "README.md",
+          }),
+        },
+      }) }),
+    })
+
+    const workspace = useWorkspace("docs")
+
+    await expect(workspace.fs.readFile("AGENTS.md")).resolves.toBe("# Instructions\n")
+    await expect(workspace.fs.readFile("repo/README.md")).resolves.toBe("# Repo\n")
+    await expect(workspace.fs.exists("repo/README.md")).resolves.toBe(true)
+    await expect(workspace.fs.list("", { recursive: true })).resolves.toEqual([
+      expect.objectContaining({ path: "AGENTS.md", type: "file" }),
+      expect.objectContaining({ path: "repo", type: "directory" }),
+      expect.objectContaining({ path: "repo/README.md", type: "file" }),
+    ])
+  })
+
   it("uses runtime workspace root for default local stores", async () => {
     const root = await createRoot()
     const configuredRoot = join(root, "runtime-workspaces")

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -8,6 +8,7 @@ import { gzipSync } from "node:zlib"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { collectWorkspaceAssetBundle, writeWorkspaceAssetsRegistry } from "../src/build-assets.ts"
+import { initializeWorkspaceAssetRegistry, syncWorkspaceBuildAssets } from "../src/build-integration.ts"
 import { defineWorkspace, loader, publish, registerWorkspace, useWorkspace } from "../src/index.ts"
 import { useRegisteredWorkspace } from "../src/registry.ts"
 import * as source from "../src/source.ts"
@@ -22,6 +23,8 @@ async function createRoot() {
 }
 
 afterEach(async () => {
+  delete process.env.GITHUB_TOKEN
+  delete (globalThis as { __env__?: Record<string, unknown> }).__env__
   vi.unstubAllGlobals()
   await Promise.all(tempDirs.splice(0).map(path => rm(path, { recursive: true, force: true })))
 })
@@ -145,6 +148,39 @@ describe("sources, loaders, and publishers", () => {
     ])
   })
 
+  it("resolves GitHub auth lazily from runtime env", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+    process.env.GITHUB_TOKEN = "first-token"
+
+    const githubSource = source.github({ repo: "acme/private" })
+
+    await expect(githubSource.getKeys({ rootDir: "", workspace: "github-auth" })).resolves.toEqual(["docs/README.md"])
+    process.env.GITHUB_TOKEN = "second-token"
+    await expect(githubSource.getKeys({ rootDir: "", workspace: "github-auth" })).resolves.toEqual(["docs/README.md"])
+
+    const treeCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).includes("/git/trees/"))
+    expect(treeCalls.map(([, init]) => (init?.headers as Record<string, string>).authorization)).toEqual([
+      "Bearer first-token",
+      "Bearer second-token",
+    ])
+  })
+
+  it("prefers explicit GitHub auth over Cloudflare runtime env", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+    ;(globalThis as { __env__?: Record<string, unknown> }).__env__ = { GITHUB_TOKEN: "cloudflare-token" }
+
+    const githubSource = source.github({ auth: "explicit-token", repo: "acme/private" })
+
+    await githubSource.getKeys({ rootDir: "", workspace: "github-auth" })
+
+    const treeCall = vi.mocked(fetch).mock.calls.find(([url]) => String(url).includes("/git/trees/"))
+    expect((treeCall?.[1]?.headers as Record<string, string>).authorization).toBe("Bearer explicit-token")
+  })
+
   it("falls back to GitHub archives when the public tree API is rate limited", async () => {
     stubGitHubSource({
       "dbt/models/marts/orders.sql": "select 1\n",
@@ -185,6 +221,90 @@ describe("sources, loaders, and publishers", () => {
     const workspace = useWorkspace("github-loader", { allowWrite: true })
 
     await expect(workspace.fs.readFile("docs/models/marts/orders.sql")).resolves.toBe("select 1\n")
+  })
+
+  it("initializes directory workspace assets for Nitro dev", async () => {
+    const root = await createRoot()
+    const directory = join(root, "server", "workspaces", "docs")
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, ".config.ts"), "export default {}\n")
+    await writeFile(join(directory, "AGENTS.md"), "# Instructions\n")
+    await writeFile(join(directory, "README.md"), "# Docs\n")
+    const registryFile = join(root, ".vitehub", "nitro-runtime", "workspace", "assets", "registry.mjs")
+
+    await initializeWorkspaceAssetRegistry(registryFile, [{
+      handler: join(directory, ".config.ts"),
+      name: "docs",
+      path: join(directory, ".config.ts"),
+      source: "test",
+    }], root)
+
+    const registry = (await import(`${pathToFileURL(registryFile).href}?t=${Date.now()}`)).default
+    await expect(registry.docs.readFile("AGENTS.md")).resolves.toBe("# Instructions\n")
+    await expect(registry.docs.glob("**/*.md")).resolves.toHaveLength(2)
+  })
+
+  it("keeps one asset bundle when directory workspaces are synced on build", async () => {
+    const root = await createRoot()
+    const directory = join(root, "server", "workspaces", "docs")
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, ".config.mjs"), "export default {}\n")
+    await writeFile(join(directory, "AGENTS.md"), "# Instructions\n")
+    const registryFile = join(root, ".vitehub", "nitro-runtime", "workspace", "assets", "registry.mjs")
+
+    await syncWorkspaceBuildAssets([{
+      handler: join(directory, ".config.mjs"),
+      name: "docs",
+      path: join(directory, ".config.mjs"),
+      source: "test",
+    }], root, {
+      root: join(root, ".vitehub", "workspaces"),
+      store: { provider: "memory" },
+      syncOnBuild: true,
+    }, registryFile)
+
+    const contents = await readFile(registryFile, "utf8")
+    expect(contents.match(/"docs": createWorkspaceAssets/g)).toHaveLength(1)
+    expect(contents.match(/"AGENTS.md"/g)).toHaveLength(1)
+  })
+
+  it("does not fetch lazy sources while syncing build assets", async () => {
+    const root = await createRoot()
+    const directory = join(root, "server", "workspaces", "docs")
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, ".config.mjs"), [
+      "export default {",
+      "  sources: {",
+      "    docs: {",
+      "      materialize: 'lazy',",
+      "      name: 'lazy-test',",
+      "      async getKeys() { throw new Error('lazy source should not be fetched') },",
+      "      async getItem() { throw new Error('lazy source should not be fetched') },",
+      "    },",
+      "  },",
+      "}",
+      "",
+    ].join("\n"))
+    await writeFile(join(directory, "AGENTS.md"), "# Instructions\n")
+    const registryFile = join(root, ".vitehub", "nitro-runtime", "workspace", "assets", "registry.mjs")
+    vi.stubGlobal("fetch", vi.fn(() => {
+      throw new Error("lazy source should not be fetched")
+    }))
+
+    await syncWorkspaceBuildAssets([{
+      handler: join(directory, ".config.mjs"),
+      name: "docs",
+      path: join(directory, ".config.mjs"),
+      source: "test",
+    }], root, {
+      root: join(root, ".vitehub", "workspaces"),
+      store: { provider: "memory" },
+      syncOnBuild: true,
+    }, registryFile)
+
+    expect(fetch).not.toHaveBeenCalled()
+    const registry = (await import(`${pathToFileURL(registryFile).href}?t=${Date.now()}`)).default
+    await expect(registry.docs.readFile("AGENTS.md")).resolves.toBe("# Instructions\n")
   })
 
   it("reports inaccessible GitHub repositories with a source-specific error", async () => {


### PR DESCRIPTION
This removes application-level workspace workarounds by making GitHub sources pick up `GITHUB_TOKEN` lazily at runtime and by bundling directory workspace assets during Nitro init as well as build sync.

Directory-config workspaces now expose files like `AGENTS.md` immediately in Nitro dev/build output, synced bundles avoid duplicate entries, and the Nitro output test can handle package build stderr without overflowing Node buffers.

Checks run: `pnpm --filter @vitehub/workspace test`.
