### PR TITLE
feat(env): add nuxt module

### DIFF
--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -31,6 +31,10 @@
       "types": "./dist/nitro.d.ts",
       "import": "./dist/nitro.js"
     },
+    "./nuxt": {
+      "types": "./dist/nuxt.d.ts",
+      "import": "./dist/nuxt.js"
+    },
     "./runtime/server": {
       "types": "./dist/runtime/server.d.ts",
       "import": "./dist/runtime/server.js"
@@ -59,6 +63,9 @@
     "typecheck": "tsc --noEmit -p ./tsconfig.json",
     "test": "pnpm --filter @vitehub/env build && vitest run"
   },
+  "dependencies": {
+    "@nuxt/kit": "catalog:"
+  },
   "peerDependencies": {
     "nitro": "^3.0.0-0",
     "vite": ">=6.0.0"
@@ -72,6 +79,7 @@
     }
   },
   "devDependencies": {
+    "@nuxt/schema": "catalog:",
     "@vitehub/internal": "workspace:*",
     "nitro": "catalog:",
     "publint": "^0.3.15",

--- a/packages/env/src/core/resolve.ts
+++ b/packages/env/src/core/resolve.ts
@@ -28,9 +28,6 @@ export function validateEnvConfigShape(config: EnvNitroConfigOptions | EnvViteCo
 
   if (target === "nitro") {
     const nitroConfig = config as EnvNitroConfigOptions
-    if ("public" in nitroConfig) {
-      throw new EnvError("`env.public` is not available in Nitro env config. Nitro env is private runtime config; expose public values through an explicit endpoint.")
-    }
     if ("server" in nitroConfig) {
       throw new EnvError("`env.server` is not available in Nitro env config. Put private runtime declarations directly under `env`.")
     }
@@ -228,12 +225,24 @@ async function resolveSourceValue(source: EnvSource, context: EnvSourceContext):
 function validateNitroDeclarations(declarations: EnvNitroConfigOptions, path: string): void {
   for (const [key, value] of Object.entries(declarations)) {
     const valuePath = `${path}.${key}`
+    if (path === "env" && key === "public") {
+      if (!isPlainRecord(value) || isEnvVariableDeclaration(value)) {
+        throw new EnvError("Invalid declaration at env.public. Use a nested object of public envVariable() declarations.")
+      }
+      validateNitroDeclarations(value as EnvNitroConfigOptions, valuePath)
+      continue
+    }
     if (isEnvVariableDeclaration(value)) {
       if (value.mode !== "runtime") {
         throw new EnvError(`${valuePath} must use runtime mode.`)
       }
       if (value.source && value.source.kind !== "env") {
         throw new EnvError(`${valuePath} must use an env source in runtime mode for v1. Custom, package, and git sources are build-only.`)
+      }
+      if (path === "env.public" || path.startsWith("env.public.")) {
+        if (value.secret) {
+          throw new EnvError(`${valuePath} cannot be marked secret because public runtime config is exposed to the client.`)
+        }
       }
       continue
     }

--- a/packages/env/src/nitro/module.ts
+++ b/packages/env/src/nitro/module.ts
@@ -13,6 +13,12 @@ import type { Nitro, NitroModule } from "nitro/types"
 
 export { envSource, envVariable }
 
+const VITE_PLUGIN_NAME = "@vitehub/env/vite"
+
+type EnvVitePluginConfig = {
+  plugins?: unknown
+}
+
 function resolveEntry(srcRelative: string, packageSubpath: string): string {
   return resolveRuntimeEntry(srcRelative, packageSubpath, import.meta.url)
 }
@@ -90,10 +96,26 @@ function resolveTypeName(entry: EnvRegistryEntry): string {
   return entry.required || typeof entry.default !== "undefined" ? "string" : "string | undefined"
 }
 
+function hasEnvVitePlugin(plugin: unknown): boolean {
+  if (Array.isArray(plugin)) {
+    return plugin.some(hasEnvVitePlugin)
+  }
+  return typeof plugin === "object" && plugin !== null && "name" in plugin && plugin.name === VITE_PLUGIN_NAME
+}
+
+function assertNoEnvVitePlugin(nitro: Nitro): void {
+  const options = nitro.options as typeof nitro.options & { vite?: EnvVitePluginConfig }
+  if (hasEnvVitePlugin(options.vite?.plugins)) {
+    throw new Error("[vitehub] Do not configure @vitehub/env/vite when using @vitehub/env/nitro.")
+  }
+}
+
 export function envNitro(options: EnvIntegrationOptions = {}): NitroModule {
   return {
     name: "@vitehub/env",
     async setup(nitro) {
+      assertNoEnvVitePlugin(nitro)
+
       const config = (nitro.options as typeof nitro.options & EnvNitroUserConfig).env
       validateEnvConfigShape(config, "nitro")
       const registry = createRuntimeRegistry(config, { prefix: options.prefix })
@@ -182,8 +204,11 @@ function describeRuntimeEntries(
     const source = resolveEnvSource(value, valuePath, prefix)
     const hasRuntimeValue = source.kind === "env" && typeof process.env[source.name] !== "undefined"
     const hasDefault = typeof value.default !== "undefined"
+    const exposure = valuePath === "env.public" || valuePath.startsWith("env.public.")
+      ? "public runtime transport"
+      : "server only"
     return {
-      exposed: value.secret ? "server only, masked" : "server only",
+      exposed: value.secret ? `${exposure}, masked` : exposure,
       key: valuePath,
       masked: value.secret,
       mode: "runtime",

--- a/packages/env/src/nuxt.ts
+++ b/packages/env/src/nuxt.ts
@@ -1,0 +1,2 @@
+export * from "./nuxt/module.ts"
+export { default } from "./nuxt/module.ts"

--- a/packages/env/src/nuxt/module.ts
+++ b/packages/env/src/nuxt/module.ts
@@ -1,0 +1,104 @@
+import { addServerImports, defineNuxtModule } from "@nuxt/kit"
+import { envNitro } from "../nitro/module.ts"
+import type { NitroConfig, NitroModule, NitroModuleInput } from "nitro/types"
+import type { NuxtModule } from "@nuxt/schema"
+
+import type { EnvIntegrationOptions, EnvNitroConfigOptions } from "../types.ts"
+
+const NITRO_MODULE_ID = "@vitehub/env/nitro"
+const NITRO_MODULE_NAME = "@vitehub/env"
+const VITE_PLUGIN_NAME = "@vitehub/env/vite"
+
+type EnvNitroConfig = NitroConfig & {
+  env?: EnvNitroConfigOptions
+  modules?: NitroModuleInput[]
+}
+
+type EnvVitePluginConfig = {
+  plugins?: unknown
+}
+
+function hasEnvNitroModule(entry: NitroModuleInput): boolean {
+  if (entry === NITRO_MODULE_ID) {
+    return true
+  }
+  if (typeof entry !== "object" || entry === null) {
+    return false
+  }
+  const module = "nitro" in entry ? entry.nitro : entry
+  return (module as Partial<NitroModule>).name === NITRO_MODULE_NAME
+}
+
+function hasEnvVitePlugin(plugin: unknown): boolean {
+  if (Array.isArray(plugin)) {
+    return plugin.some(hasEnvVitePlugin)
+  }
+  return typeof plugin === "object" && plugin !== null && "name" in plugin && plugin.name === VITE_PLUGIN_NAME
+}
+
+function createEnvNitroModuleEntry(options: EnvIntegrationOptions): NitroModuleInput {
+  return Object.keys(options).length === 0 ? NITRO_MODULE_ID : envNitro(options)
+}
+
+function assertNoEnvNitroModule(nitro: EnvNitroConfig): void {
+  if (nitro.modules?.some(hasEnvNitroModule)) {
+    throw new Error("[vitehub] Do not configure @vitehub/env/nitro when using @vitehub/env/nuxt.")
+  }
+}
+
+function assertNoEnvVitePlugin(vite: EnvVitePluginConfig | undefined): void {
+  if (hasEnvVitePlugin(vite?.plugins)) {
+    throw new Error("[vitehub] Do not configure @vitehub/env/vite when using @vitehub/env/nuxt.")
+  }
+}
+
+function installEnvNitroModule(nitro: EnvNitroConfig, env: EnvNitroConfigOptions | undefined, options: EnvIntegrationOptions): void {
+  nitro.modules ||= []
+  if (!nitro.modules.some(hasEnvNitroModule)) {
+    nitro.modules.push(createEnvNitroModuleEntry(options))
+  }
+  if (env !== undefined) {
+    nitro.env = env
+  }
+}
+
+const envNuxtModule: NuxtModule<EnvIntegrationOptions, EnvIntegrationOptions, false> = defineNuxtModule<EnvIntegrationOptions>({
+  meta: { name: "@vitehub/env/nuxt" },
+  setup(inlineOptions = {}, nuxt) {
+    if (nuxt.options.env === false) {
+      return
+    }
+
+    const nitro = (nuxt.options.nitro ||= {}) as EnvNitroConfig
+    assertNoEnvVitePlugin(nuxt.options.vite as EnvVitePluginConfig | undefined)
+    assertNoEnvNitroModule(nitro)
+    installEnvNitroModule(nitro, nuxt.options.env, inlineOptions)
+    nuxt.hook("nitro:config", (config) => {
+      const env = nuxt.options.env
+      if (env !== false) {
+        installEnvNitroModule(config as EnvNitroConfig, env, inlineOptions)
+      }
+    })
+
+    addServerImports({
+      from: "#vitehub/env/server",
+      name: "useSafeRuntimeConfig",
+    })
+  },
+})
+
+export default envNuxtModule
+
+declare module "@nuxt/schema" {
+  interface NuxtConfig {
+    env?: EnvNitroConfigOptions | false
+    nitro?: NitroConfig
+  }
+  interface NuxtOptions {
+    env?: EnvNitroConfigOptions | false
+    nitro?: NitroConfig
+  }
+  interface NuxtHooks {
+    "nitro:config": (config: NitroConfig) => void | Promise<void>
+  }
+}

--- a/packages/env/test/declarations.test.ts
+++ b/packages/env/test/declarations.test.ts
@@ -84,17 +84,23 @@ describe("env declarations", () => {
     }, "vite")).toThrow("Invalid declaration")
   })
 
-  it("rejects nested Nitro server and public buckets", () => {
+  it("rejects nested Nitro server buckets", () => {
     expect(() => validateEnvConfigShape({
       server: envVariable(),
     }, "nitro")).toThrow("`env.server` is not available")
-    expect(() => validateEnvConfigShape({
-      public: envVariable(),
-    }, "nitro")).toThrow("`env.public` is not available")
   })
 
-  it("accepts nested Nitro runtime declaration groups", () => {
+  it("rejects scalar Nitro public runtime declarations", () => {
     expect(() => validateEnvConfigShape({
+      public: envVariable(),
+    }, "nitro")).toThrow("Invalid declaration at env.public")
+  })
+
+  it("accepts nested Nitro runtime declaration groups and public runtime transport", () => {
+    expect(() => validateEnvConfigShape({
+      public: {
+        apiBase: envVariable(),
+      },
       telegram: {
         botToken: envVariable({ secret: true }),
       },
@@ -102,6 +108,14 @@ describe("env declarations", () => {
         model: envVariable({ default: "gemini-3.1-pro-preview-customtools" }),
       },
     }, "nitro")).not.toThrow()
+  })
+
+  it("rejects secret Nitro public runtime declarations", () => {
+    expect(() => validateEnvConfigShape({
+      public: {
+        apiBase: envVariable({ secret: true }),
+      },
+    }, "nitro")).toThrow("env.public.apiBase cannot be marked secret")
   })
 
   it("creates a runtime registry with inferred nested env sources", () => {

--- a/packages/env/test/nitro.test.ts
+++ b/packages/env/test/nitro.test.ts
@@ -26,6 +26,9 @@ interface NitroStub {
     plugins?: string[]
     preset?: string
     rootDir: string
+    vite?: {
+      plugins?: unknown
+    }
   }
 }
 
@@ -40,6 +43,7 @@ describe("Nitro module", () => {
   it("writes runtime files, installs aliases, and describes runtime env", async () => {
     process.env.AUTH_SECRET = "a".repeat(32)
     process.env.DATABASE_URL = "https://db.example.com"
+    process.env.PUBLIC_API_BASE = "https://api.example.com"
     process.env.TELEGRAM_BOT_TOKEN = "telegram-secret"
 
     const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
@@ -59,6 +63,9 @@ describe("Nitro module", () => {
           authSecret: envVariable({ secret: true }),
           databaseUrl: envVariable(),
           optionalApiBase: envVariable({ optional: true, source: envSource.env("PUBLIC_API_BASE") }),
+          public: {
+            apiBase: envVariable({ source: envSource.env("PUBLIC_API_BASE") }),
+          },
           telegram: {
             apiBaseUrl: envVariable({ optional: true }),
             botToken: envVariable({ secret: true }),
@@ -79,6 +86,8 @@ describe("Nitro module", () => {
     expect(nitro.options.handlers).toBeUndefined()
     expect(nitro.options.cloudflare?.wrangler?.secrets?.required).toEqual(["EXISTING_SECRET", "AUTH_SECRET", "TELEGRAM_BOT_TOKEN"])
     expect(nitro.logger.info).toHaveBeenCalledWith(expect.stringContaining("env.databaseUrl"))
+    expect(nitro.logger.info).toHaveBeenCalledWith(expect.stringContaining("env.public.apiBase"))
+    expect(nitro.logger.info).toHaveBeenCalledWith(expect.stringContaining("public runtime transport"))
     expect(nitro.logger.info).toHaveBeenCalledWith(expect.stringContaining("env.telegram.botToken"))
 
     const typesHook = nitro.hooks.hook.mock.calls.find(([name]) => name === "types:extend")?.[1]
@@ -88,6 +97,8 @@ describe("Nitro module", () => {
     expect(types).toContain("export interface SafeRuntimeConfig")
     expect(types).toContain("\"databaseUrl\": string")
     expect(types).toContain("\"optionalApiBase\": string | undefined")
+    expect(types).toContain("\"public\": {")
+    expect(types).toContain("\"apiBase\": string")
     expect(types).toContain("\"telegram\": {")
     expect(types).toContain("\"apiBaseUrl\": string | undefined")
     expect(types).toContain("\"botToken\": string")
@@ -104,6 +115,7 @@ describe("Nitro module", () => {
 
     const registry = await readFile(join(root, ".vitehub/nitro-runtime/env/registry.mjs"), "utf8")
     expect(registry).toContain("DATABASE_URL")
+    expect(registry).toContain("PUBLIC_API_BASE")
     expect(registry).toContain("TELEGRAM_BOT_TOKEN")
     expect(registry).toContain("\"required\": false")
     expect(registry).not.toContain("aaaaaaaa")
@@ -134,11 +146,41 @@ describe("Nitro module", () => {
     expect(registry).toContain("VITEHUB_TELEGRAM_BOT_TOKEN")
   })
 
+  it("rejects direct Vite plugin configuration with the Nitro module", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
+    const nitro: NitroStub = {
+      hooks: { hook: vi.fn() },
+      logger: { info: vi.fn() },
+      options: {
+        buildDir: join(root, ".nitro"),
+        env: {
+          authSecret: envVariable({ secret: true }),
+        },
+        rootDir: root,
+        vite: {
+          plugins: [{ name: "@vitehub/env/vite" }],
+        },
+      },
+    }
+
+    await expect(envNitro().setup(nitro as never)).rejects.toThrow(
+      "Do not configure @vitehub/env/vite when using @vitehub/env/nitro",
+    )
+  })
+
   it("resolves nested runtime config objects", async () => {
     const { applyEnvRegistryToRuntimeConfig, setEnvRegistry, useSafeRuntimeConfig } = await import("../src/runtime/server.ts")
+    process.env.PUBLIC_API_BASE = "https://api.example.com"
     process.env.TELEGRAM_BOT_TOKEN = "telegram-secret"
 
     setEnvRegistry({
+      public: {
+        apiBase: {
+          required: true,
+          secret: false,
+          source: { kind: "env", label: "env:PUBLIC_API_BASE", name: "PUBLIC_API_BASE", serializable: true },
+        },
+      },
       telegram: {
         apiBaseUrl: {
           required: false,
@@ -162,18 +204,21 @@ describe("Nitro module", () => {
     })
 
     const config = useSafeRuntimeConfig(undefined) as {
+      public: { apiBase: string }
       telegram: { apiBaseUrl?: string, botToken: string }
       vertex: { model: string }
     }
 
     expect(config.telegram.botToken).toBe("telegram-secret")
     expect(config.telegram.apiBaseUrl).toBeUndefined()
+    expect(config.public.apiBase).toBe("https://api.example.com")
     expect(config.vertex.model).toBe("gemini-3.1-pro-preview-customtools")
 
-    const runtimeConfig = { chat: { enabled: true } } as Record<string, unknown>
+    const runtimeConfig = { chat: { enabled: true }, public: { existing: "keep" } } as Record<string, unknown>
     applyEnvRegistryToRuntimeConfig(runtimeConfig)
     expect(runtimeConfig).toMatchObject({
       chat: { enabled: true },
+      public: { apiBase: "https://api.example.com", existing: "keep" },
       telegram: { botToken: "telegram-secret" },
       vertex: { model: "gemini-3.1-pro-preview-customtools" },
     })

--- a/packages/env/test/nuxt.test.ts
+++ b/packages/env/test/nuxt.test.ts
@@ -1,0 +1,294 @@
+import { mkdtemp, readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { envVariable } from "../src/index.ts"
+
+interface NitroHarnessOptions {
+  env?: unknown
+  imports?: boolean
+  modules?: Array<string | { name?: string, setup?: unknown }>
+  runtimeConfig?: Record<string, unknown>
+}
+
+interface NuxtHarnessOptions {
+  env?: unknown
+  nitro?: NitroHarnessOptions
+  vite?: {
+    plugins?: unknown
+  }
+}
+
+interface NuxtModuleDefinitionLike {
+  setup: (inlineOptions: unknown, nuxt: unknown) => void | Promise<void>
+}
+
+interface NitroModuleLike {
+  name?: string
+  setup: (nitro: unknown) => void | Promise<void>
+}
+
+const addServerImports = vi.fn()
+const defineNuxtModule = vi.fn((definition: NuxtModuleDefinitionLike) => {
+  return async (inlineOptions: unknown, nuxt: unknown) => {
+    await definition.setup(inlineOptions, nuxt)
+  }
+})
+
+vi.mock("@nuxt/kit", () => ({
+  addServerImports,
+  defineNuxtModule,
+}))
+
+function createNuxtHarness(options: NuxtHarnessOptions = {}) {
+  const hooks = new Map<string, ((payload: unknown) => void | Promise<void>)[]>()
+
+  return {
+    hook(name: string, fn: (payload: unknown) => void | Promise<void>) {
+      hooks.set(name, [...(hooks.get(name) || []), fn])
+    },
+    async runHook(name: string, payload: unknown) {
+      for (const fn of hooks.get(name) || []) {
+        await fn(payload)
+      }
+    },
+    options,
+  }
+}
+
+describe("Nuxt module", () => {
+  beforeEach(() => {
+    addServerImports.mockClear()
+    defineNuxtModule.mockClear()
+  })
+
+  it("short-circuits disabled config", async () => {
+    const module = (await import("../src/nuxt/module.ts")).default as (
+      inlineOptions: unknown,
+      nuxt: unknown,
+    ) => Promise<void>
+    const nuxt = createNuxtHarness({ env: false })
+
+    await module({ diagnostics: "trace" }, nuxt as never)
+
+    expect(nuxt.options.nitro).toBeUndefined()
+    expect(addServerImports).not.toHaveBeenCalled()
+  })
+
+  it("installs the Nitro module once and forwards top-level env config", async () => {
+    const module = (await import("../src/nuxt/module.ts")).default as (
+      inlineOptions: unknown,
+      nuxt: unknown,
+    ) => Promise<void>
+    const env = {
+      authSecret: envVariable({ secret: true }),
+      databaseUrl: envVariable(),
+    }
+    const inlineOptions = { diagnostics: "trace" as const, prefix: "VITEHUB_" }
+    const nuxt = createNuxtHarness({
+      env,
+      nitro: {
+        imports: false,
+        modules: [],
+      },
+    })
+
+    await module(inlineOptions, nuxt as never)
+
+    expect(nuxt.options.nitro!.modules).toHaveLength(1)
+    expect(nuxt.options.nitro!.modules![0]).toMatchObject({
+      name: "@vitehub/env",
+      setup: expect.any(Function),
+    })
+    expect(nuxt.options.nitro!.imports).toBe(false)
+    expect(nuxt.options.nitro!.env).toBe(env)
+
+    const nitroConfig: NitroHarnessOptions = {
+      imports: false,
+      modules: [],
+    }
+
+    await nuxt.runHook("nitro:config", nitroConfig)
+
+    expect(nitroConfig.modules).toHaveLength(1)
+    expect(nitroConfig.modules![0]).toMatchObject({
+      name: "@vitehub/env",
+      setup: expect.any(Function),
+    })
+    expect(nitroConfig.imports).toBe(false)
+    expect(nitroConfig.env).toBe(env)
+
+    const root = await mkdtemp(join(tmpdir(), "vitehub-env-nuxt-"))
+    await (nuxt.options.nitro!.modules![0] as NitroModuleLike).setup({
+      hooks: { hook: vi.fn() },
+      logger: { info: vi.fn() },
+      options: {
+        buildDir: join(root, ".nitro"),
+        env,
+        rootDir: root,
+      },
+    })
+    const registry = await readFile(join(root, ".vitehub/nitro-runtime/env/registry.mjs"), "utf8")
+    expect(registry).toContain("VITEHUB_AUTH_SECRET")
+  })
+
+  it("forwards public declarations for Nuxt runtimeConfig.public transport", async () => {
+    const module = (await import("../src/nuxt/module.ts")).default as (
+      inlineOptions: unknown,
+      nuxt: unknown,
+    ) => Promise<void>
+    const env = {
+      authSecret: envVariable({ secret: true }),
+      public: {
+        apiBase: envVariable(),
+      },
+    }
+    const nuxt = createNuxtHarness({
+      env,
+      nitro: {
+        modules: [],
+        runtimeConfig: {
+          public: {
+            existing: "keep",
+          },
+        },
+      },
+    })
+
+    await module(undefined, nuxt as never)
+
+    expect(nuxt.options.nitro!.modules).toEqual(["@vitehub/env/nitro"])
+    expect(nuxt.options.nitro!.env).toBe(env)
+    expect(nuxt.options.nitro!.runtimeConfig).toEqual({
+      public: {
+        existing: "keep",
+      },
+    })
+  })
+
+  it("reads top-level env declarations when Nitro config is created", async () => {
+    const module = (await import("../src/nuxt/module.ts")).default as (
+      inlineOptions: unknown,
+      nuxt: unknown,
+    ) => Promise<void>
+    const initialEnv = {
+      authSecret: envVariable({ secret: true }),
+    }
+    const updatedEnv = {
+      authSecret: envVariable({ secret: true }),
+      databaseUrl: envVariable(),
+    }
+    const nuxt = createNuxtHarness({
+      env: initialEnv,
+      nitro: {
+        modules: [],
+      },
+    })
+
+    await module(undefined, nuxt as never)
+
+    nuxt.options.env = updatedEnv
+
+    const nitroConfig: NitroHarnessOptions = {
+      modules: [],
+    }
+
+    await nuxt.runHook("nitro:config", nitroConfig)
+
+    expect(nitroConfig.env).toBe(updatedEnv)
+  })
+
+  it("installs the Nitro module without forcing env config", async () => {
+    const module = (await import("../src/nuxt/module.ts")).default as (
+      inlineOptions: unknown,
+      nuxt: unknown,
+    ) => Promise<void>
+    const nuxt = createNuxtHarness({
+      nitro: {
+        modules: [],
+      },
+    })
+
+    await module(undefined, nuxt as never)
+
+    expect(nuxt.options.nitro!.modules).toEqual(["@vitehub/env/nitro"])
+    expect(nuxt.options.nitro!.env).toBeUndefined()
+  })
+
+  it("rejects direct Nitro module configuration with the Nuxt module", async () => {
+    const module = (await import("../src/nuxt/module.ts")).default as (
+      inlineOptions: unknown,
+      nuxt: unknown,
+    ) => Promise<void>
+    const env = {
+      authSecret: envVariable({ secret: true }),
+    }
+    const nuxt = createNuxtHarness({
+      env,
+      nitro: {
+        modules: ["@vitehub/env/nitro"],
+      },
+    })
+
+    await expect(module(undefined, nuxt as never)).rejects.toThrow(
+      "Do not configure @vitehub/env/nitro when using @vitehub/env/nuxt",
+    )
+  })
+
+  it("rejects direct Nitro module objects with the Nuxt module", async () => {
+    const module = (await import("../src/nuxt/module.ts")).default as (
+      inlineOptions: unknown,
+      nuxt: unknown,
+    ) => Promise<void>
+    const env = {
+      authSecret: envVariable({ secret: true }),
+    }
+    const existingModule = { name: "@vitehub/env", setup: vi.fn() }
+    const nuxt = createNuxtHarness({
+      env,
+      nitro: {
+        modules: [existingModule],
+      },
+    })
+
+    await expect(module({ prefix: "VITEHUB_" }, nuxt as never)).rejects.toThrow(
+      "Do not configure @vitehub/env/nitro when using @vitehub/env/nuxt",
+    )
+  })
+
+  it("rejects direct Vite plugin configuration with the Nuxt module", async () => {
+    const module = (await import("../src/nuxt/module.ts")).default as (
+      inlineOptions: unknown,
+      nuxt: unknown,
+    ) => Promise<void>
+    const nuxt = createNuxtHarness({
+      env: {
+        authSecret: envVariable({ secret: true }),
+      },
+      vite: {
+        plugins: [{ name: "@vitehub/env/vite" }],
+      },
+    })
+
+    await expect(module(undefined, nuxt as never)).rejects.toThrow(
+      "Do not configure @vitehub/env/vite when using @vitehub/env/nuxt",
+    )
+  })
+
+  it("registers useSafeRuntimeConfig as a server import", async () => {
+    const module = (await import("../src/nuxt/module.ts")).default as (
+      inlineOptions: unknown,
+      nuxt: unknown,
+    ) => Promise<void>
+    const nuxt = createNuxtHarness()
+
+    await module(undefined, nuxt as never)
+
+    expect(addServerImports).toHaveBeenCalledWith({
+      from: "#vitehub/env/server",
+      name: "useSafeRuntimeConfig",
+    })
+  })
+})

--- a/packages/env/tsdown.config.ts
+++ b/packages/env/tsdown.config.ts
@@ -7,11 +7,13 @@ export default defineConfig({
   ],
   deps: {
     alwaysBundle: [/^@vitehub\/internal/],
+    onlyBundle: false,
   },
   dts: true,
   entry: [
     "src/index.ts",
     "src/nitro.ts",
+    "src/nuxt.ts",
     "src/runtime/server.ts",
     "src/schema.ts",
     "src/virtual.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,7 +375,14 @@ importers:
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/env:
+    dependencies:
+      '@nuxt/kit':
+        specifier: 'catalog:'
+        version: 4.4.2(magicast@0.5.2)
     devDependencies:
+      '@nuxt/schema':
+        specifier: 'catalog:'
+        version: 4.4.2
       '@vitehub/internal':
         specifier: workspace:*
         version: link:../internal


### PR DESCRIPTION
Adds `@vitehub/env/nuxt` as the Nuxt runtime-env entrypoint for `@vitehub/env`.

This module:
- forwards top-level Nuxt `env` declarations into Nitro
- supports `env.public` for Nuxt client runtime config transport
- rejects secret declarations under `env.public`
- preserves inline integration options for the Nitro module
- supports `env: false` as an opt-out
- registers server-only `useSafeRuntimeConfig` from `#vitehub/env/server`

Client exposure is limited to non-secret declarations nested under `env.public`; private and secret declarations stay in server runtime config.

Checked locally with:
- `pnpm --filter @vitehub/env test`
- `pnpm --filter @vitehub/env typecheck`