### PR TITLE
fix: reject mixed vitehub integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "pnpm --dir docs typecheck && pnpm -r --filter './packages/*' --if-present run typecheck",
     "test:contracts": "vitest run",
     "test": "pnpm -r --workspace-concurrency=1 --filter './packages/*' --if-present run test",
-    "build": "pnpm -r --filter './packages/*' --if-present run build",
+    "build": "pnpm -r --workspace-concurrency=1 --filter './packages/*' --if-present run build",
     "playground:vite:build": "pnpm --dir playground/vite build",
     "docs:dev": "pnpm --dir docs dev",
     "docs:build": "pnpm --dir docs build"

--- a/packages/blob/src/nitro/module.ts
+++ b/packages/blob/src/nitro/module.ts
@@ -1,4 +1,4 @@
-import { resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
+import { assertNoVitePluginInNitro, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 import type { NitroModule, NitroRuntimeConfig } from "nitro/types"
 
 import { normalizeBlobOptions, warnVercelBlobFallback } from "../config.ts"
@@ -6,13 +6,17 @@ import { configureCloudflareR2 } from "../integrations/cloudflare.ts"
 
 import type { BlobModuleOptions, ResolvedBlobModuleOptions } from "../types.ts"
 
+const BLOB_VITE_PLUGIN_NAME = "@vitehub/blob/vite"
+
 function resolveRuntimeEntry(srcRelative: string, packageSubpath: string): string {
   return resolveEntry(srcRelative, packageSubpath, import.meta.url)
 }
 
 const blobNitroModule: NitroModule = {
   name: "@vitehub/blob",
-  setup(nitro) {
+  async setup(nitro) {
+    await assertNoVitePluginInNitro(nitro, BLOB_VITE_PLUGIN_NAME, "@vitehub/blob/nitro")
+
     const resolved = normalizeBlobOptions(nitro.options.blob, {
       env: process.env,
       hosting: nitro.options.preset,

--- a/packages/chat/src/nitro/module.ts
+++ b/packages/chat/src/nitro/module.ts
@@ -1,6 +1,6 @@
 import { createImportPath } from "@vitehub/internal/build/paths"
 import { createGeneratedDefinitionPath, createRuntimeRegistryContents, writeFileIfChanged } from "@vitehub/internal/definition-catalog"
-import { mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
+import { assertNoVitePluginInNitro, mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 
@@ -15,6 +15,7 @@ const CHAT_NITRO_IMPORTS_PRESET = {
   from: "@vitehub/chat",
   imports: ["defineChat"],
 }
+const CHAT_VITE_PLUGIN_NAME = "@vitehub/chat/vite"
 const chatCloudflareExportsModulePrefix = "virtual:vitehub-chat-cloudflare-exports"
 
 interface RollupPluginLike {
@@ -426,6 +427,8 @@ async function installCloudflareStateConfig(
 const chatNitroModule: NitroModule = {
   name: "@vitehub/chat",
   async setup(nitro) {
+    await assertNoVitePluginInNitro(nitro, CHAT_VITE_PLUGIN_NAME, "@vitehub/chat/nitro")
+
     const resolved = normalizeChatOptions((nitro.options as typeof nitro.options & { chat?: false | ChatModuleOptions }).chat)
     const runtimeConfig = (nitro.options.runtimeConfig ||= {} as NitroRuntimeConfig)
     if (nitro.options.preset) runtimeConfig.hosting ||= nitro.options.preset

--- a/packages/env/src/nitro/module.ts
+++ b/packages/env/src/nitro/module.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path"
 
 import { createImportPath } from "@vitehub/internal/build/paths"
 import { writeFileIfChanged } from "@vitehub/internal/definition-catalog"
-import { resolveRuntimeEntry } from "@vitehub/internal/nitro"
+import { assertNoVitePluginInNitro, resolveRuntimeEntry } from "@vitehub/internal/nitro"
 
 import { formatDiagnostics } from "../core/diagnostics.ts"
 import { envSource, envVariable } from "../core/declarations.ts"
@@ -13,11 +13,7 @@ import type { Nitro, NitroModule } from "nitro/types"
 
 export { envSource, envVariable }
 
-const VITE_PLUGIN_NAME = "@vitehub/env/vite"
-
-type EnvVitePluginConfig = {
-  plugins?: unknown
-}
+const ENV_VITE_PLUGIN_NAME = "@vitehub/env/vite"
 
 function resolveEntry(srcRelative: string, packageSubpath: string): string {
   return resolveRuntimeEntry(srcRelative, packageSubpath, import.meta.url)
@@ -108,25 +104,11 @@ function resolveTypeName(entry: EnvRegistryEntry): string {
   return entry.required || typeof entry.default !== "undefined" ? "string" : "string | undefined"
 }
 
-function hasEnvVitePlugin(plugin: unknown): boolean {
-  if (Array.isArray(plugin)) {
-    return plugin.some(hasEnvVitePlugin)
-  }
-  return typeof plugin === "object" && plugin !== null && "name" in plugin && plugin.name === VITE_PLUGIN_NAME
-}
-
-function assertNoEnvVitePlugin(nitro: Nitro): void {
-  const options = nitro.options as typeof nitro.options & { vite?: EnvVitePluginConfig }
-  if (hasEnvVitePlugin(options.vite?.plugins)) {
-    throw new Error("[vitehub] Do not configure @vitehub/env/vite when using @vitehub/env/nitro.")
-  }
-}
-
 export function envNitro(options: EnvIntegrationOptions = {}): NitroModule {
   return {
     name: "@vitehub/env",
     async setup(nitro) {
-      assertNoEnvVitePlugin(nitro)
+      await assertNoVitePluginInNitro(nitro, ENV_VITE_PLUGIN_NAME, "@vitehub/env/nitro")
 
       const config = (nitro.options as typeof nitro.options & EnvNitroUserConfig).env
       validateEnvConfigShape(config, "nitro")

--- a/packages/env/src/nuxt/module.ts
+++ b/packages/env/src/nuxt/module.ts
@@ -1,12 +1,14 @@
 import { addServerImports, defineNuxtModule } from "@nuxt/kit"
+import { assertNoNitroModule, assertNoVitePlugin, hasNitroModule } from "@vitehub/internal/nitro"
 import { envNitro } from "../nitro/module.ts"
-import type { NitroConfig, NitroModule, NitroModuleInput } from "nitro/types"
+import type { NitroConfig, NitroModuleInput } from "nitro/types"
 import type { NuxtModule } from "@nuxt/schema"
 
 import type { EnvIntegrationOptions, EnvNitroConfigOptions } from "../types.ts"
 
 const NITRO_MODULE_ID = "@vitehub/env/nitro"
 const NITRO_MODULE_NAME = "@vitehub/env"
+const NUXT_MODULE_ID = "@vitehub/env/nuxt"
 const VITE_PLUGIN_NAME = "@vitehub/env/vite"
 
 type EnvNitroConfig = NitroConfig & {
@@ -19,37 +21,11 @@ type EnvVitePluginConfig = {
 }
 
 function hasEnvNitroModule(entry: NitroModuleInput): boolean {
-  if (entry === NITRO_MODULE_ID) {
-    return true
-  }
-  if (typeof entry !== "object" || entry === null) {
-    return false
-  }
-  const module = "nitro" in entry ? entry.nitro : entry
-  return (module as Partial<NitroModule>).name === NITRO_MODULE_NAME
-}
-
-function hasEnvVitePlugin(plugin: unknown): boolean {
-  if (Array.isArray(plugin)) {
-    return plugin.some(hasEnvVitePlugin)
-  }
-  return typeof plugin === "object" && plugin !== null && "name" in plugin && plugin.name === VITE_PLUGIN_NAME
+  return hasNitroModule(entry, NITRO_MODULE_ID, NITRO_MODULE_NAME)
 }
 
 function createEnvNitroModuleEntry(options: EnvIntegrationOptions): NitroModuleInput {
   return Object.keys(options).length === 0 ? NITRO_MODULE_ID : envNitro(options)
-}
-
-function assertNoEnvNitroModule(nitro: EnvNitroConfig): void {
-  if (nitro.modules?.some(hasEnvNitroModule)) {
-    throw new Error("[vitehub] Do not configure @vitehub/env/nitro when using @vitehub/env/nuxt.")
-  }
-}
-
-function assertNoEnvVitePlugin(vite: EnvVitePluginConfig | undefined): void {
-  if (hasEnvVitePlugin(vite?.plugins)) {
-    throw new Error("[vitehub] Do not configure @vitehub/env/vite when using @vitehub/env/nuxt.")
-  }
 }
 
 function installEnvNitroModule(nitro: EnvNitroConfig, env: EnvNitroConfigOptions | undefined, options: EnvIntegrationOptions): void {
@@ -63,15 +39,15 @@ function installEnvNitroModule(nitro: EnvNitroConfig, env: EnvNitroConfigOptions
 }
 
 const envNuxtModule: NuxtModule<EnvIntegrationOptions, EnvIntegrationOptions, false> = defineNuxtModule<EnvIntegrationOptions>({
-  meta: { name: "@vitehub/env/nuxt" },
-  setup(inlineOptions = {}, nuxt) {
+  meta: { name: NUXT_MODULE_ID },
+  async setup(inlineOptions = {}, nuxt) {
     if (nuxt.options.env === false) {
       return
     }
 
     const nitro = (nuxt.options.nitro ||= {}) as EnvNitroConfig
-    assertNoEnvVitePlugin(nuxt.options.vite as EnvVitePluginConfig | undefined)
-    assertNoEnvNitroModule(nitro)
+    await assertNoVitePlugin(nuxt.options.vite as EnvVitePluginConfig | undefined, VITE_PLUGIN_NAME, NUXT_MODULE_ID)
+    assertNoNitroModule(nitro, NITRO_MODULE_ID, NITRO_MODULE_NAME, NUXT_MODULE_ID)
     installEnvNitroModule(nitro, nuxt.options.env, inlineOptions)
     nuxt.hook("nitro:config", (config) => {
       const env = nuxt.options.env

--- a/packages/internal/src/nitro.ts
+++ b/packages/internal/src/nitro.ts
@@ -18,6 +18,59 @@ export function resolveRuntimeEntry(
 
 export interface NitroImportPreset { from?: string, imports?: string[] }
 export interface NitroImportsLike { presets?: unknown[] }
+export interface NitroModulesLike { modules?: unknown[] }
+export interface NitroWithVitePlugins { options: object }
+export interface VitePluginsLike { plugins?: unknown }
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return typeof value === "object" && value !== null && "then" in value && typeof value.then === "function"
+}
+
+export async function hasNamedVitePlugin(plugin: unknown, name: string): Promise<boolean> {
+  if (isPromiseLike(plugin)) {
+    return hasNamedVitePlugin(await plugin, name)
+  }
+
+  if (Array.isArray(plugin)) {
+    for (const entry of plugin) {
+      if (await hasNamedVitePlugin(entry, name)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  return typeof plugin === "object" && plugin !== null && "name" in plugin && plugin.name === name
+}
+
+export function hasNitroModule(entry: unknown, moduleId: string, moduleName: string): boolean {
+  if (entry === moduleId) {
+    return true
+  }
+
+  if (typeof entry !== "object" || entry === null) {
+    return false
+  }
+
+  const module = "nitro" in entry ? entry.nitro : entry
+  return typeof module === "object" && module !== null && "name" in module && module.name === moduleName
+}
+
+export async function assertNoVitePlugin(vite: VitePluginsLike | undefined, vitePluginName: string, integrationName: string): Promise<void> {
+  if (await hasNamedVitePlugin(vite?.plugins, vitePluginName)) {
+    throw new Error(`[vitehub] Do not configure ${vitePluginName} when using ${integrationName}.`)
+  }
+}
+
+export async function assertNoVitePluginInNitro(nitro: NitroWithVitePlugins, vitePluginName: string, integrationName: string): Promise<void> {
+  await assertNoVitePlugin((nitro.options as { vite?: VitePluginsLike }).vite, vitePluginName, integrationName)
+}
+
+export function assertNoNitroModule(nitro: NitroModulesLike, moduleId: string, moduleName: string, integrationName: string): void {
+  if (nitro.modules?.some(entry => hasNitroModule(entry, moduleId, moduleName))) {
+    throw new Error(`[vitehub] Do not configure ${moduleId} when using ${integrationName}.`)
+  }
+}
 
 export function mergeNitroImportsPreset<T extends NitroImportsLike | false | undefined>(
   current: T,

--- a/packages/internal/test/nitro.test.ts
+++ b/packages/internal/test/nitro.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+
+import { assertNoNitroModule, assertNoVitePlugin, assertNoVitePluginInNitro, hasNamedVitePlugin, hasNitroModule } from "../src/nitro.ts"
+
+describe("integration boundary helpers", () => {
+  it("finds named Vite plugins in nested plugin arrays", async () => {
+    await expect(hasNamedVitePlugin([
+      { name: "other" },
+      [{ name: "@vitehub/kv/vite" }],
+    ], "@vitehub/kv/vite")).resolves.toBe(true)
+  })
+
+  it("finds named Vite plugins behind plugin promises", async () => {
+    await expect(hasNamedVitePlugin([
+      Promise.resolve({ name: "other" }),
+      Promise.resolve([{ name: "@vitehub/kv/vite" }]),
+    ], "@vitehub/kv/vite")).resolves.toBe(true)
+  })
+
+  it("finds Nitro modules by id, module object, and Vite bridge object", () => {
+    expect(hasNitroModule("@vitehub/kv/nitro", "@vitehub/kv/nitro", "@vitehub/kv")).toBe(true)
+    expect(hasNitroModule({ name: "@vitehub/kv" }, "@vitehub/kv/nitro", "@vitehub/kv")).toBe(true)
+    expect(hasNitroModule({ nitro: { name: "@vitehub/kv" } }, "@vitehub/kv/nitro", "@vitehub/kv")).toBe(true)
+  })
+
+  it("rejects direct Vite plugins when a framework integration owns setup", async () => {
+    await expect(assertNoVitePlugin({
+      plugins: [{ name: "@vitehub/kv/vite" }],
+    }, "@vitehub/kv/vite", "@vitehub/kv/nuxt")).rejects.toThrow(
+      "[vitehub] Do not configure @vitehub/kv/vite when using @vitehub/kv/nuxt.",
+    )
+  })
+
+  it("rejects promised Vite plugins when a framework integration owns setup", async () => {
+    await expect(assertNoVitePlugin({
+      plugins: [Promise.resolve({ name: "@vitehub/kv/vite" })],
+    }, "@vitehub/kv/vite", "@vitehub/kv/nuxt")).rejects.toThrow(
+      "[vitehub] Do not configure @vitehub/kv/vite when using @vitehub/kv/nuxt.",
+    )
+  })
+
+  it("rejects direct Vite plugins from Nitro options", async () => {
+    await expect(assertNoVitePluginInNitro({
+      options: {
+        vite: {
+          plugins: [{ name: "@vitehub/kv/vite" }],
+        },
+      },
+    }, "@vitehub/kv/vite", "@vitehub/kv/nitro")).rejects.toThrow(
+      "[vitehub] Do not configure @vitehub/kv/vite when using @vitehub/kv/nitro.",
+    )
+  })
+
+  it("rejects direct Nitro modules when Nuxt owns setup", () => {
+    expect(() => assertNoNitroModule({
+      modules: ["@vitehub/kv/nitro"],
+    }, "@vitehub/kv/nitro", "@vitehub/kv", "@vitehub/kv/nuxt")).toThrow(
+      "[vitehub] Do not configure @vitehub/kv/nitro when using @vitehub/kv/nuxt.",
+    )
+  })
+})

--- a/packages/kv/src/nitro/module.ts
+++ b/packages/kv/src/nitro/module.ts
@@ -1,9 +1,9 @@
-import { resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
+import { assertNoVitePluginInNitro, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 import type { NitroModule, NitroRuntimeConfig } from "nitro/types"
 
 import { warnVercelKVFallback } from "../config.ts"
 import { configureCloudflareKV } from "../integrations/cloudflare.ts"
-import { resolveKVViteConfig } from "../vite-config.ts"
+import { KV_VITE_PLUGIN_NAME, resolveKVViteConfig } from "../vite-config.ts"
 import type { KVModuleOptions, ResolvedKVModuleOptions } from "../types.ts"
 
 function resolveRuntimeEntry(srcRelative: string, packageSubpath: string): string {
@@ -12,7 +12,9 @@ function resolveRuntimeEntry(srcRelative: string, packageSubpath: string): strin
 
 const kvNitroModule: NitroModule = {
   name: "@vitehub/kv",
-  setup(nitro) {
+  async setup(nitro) {
+    await assertNoVitePluginInNitro(nitro, KV_VITE_PLUGIN_NAME, "@vitehub/kv/nitro")
+
     const viteConfig = resolveKVViteConfig(nitro.options.kv, {
       env: process.env,
       hosting: nitro.options.preset,

--- a/packages/kv/src/nuxt/module.ts
+++ b/packages/kv/src/nuxt/module.ts
@@ -1,10 +1,19 @@
 import { defineNuxtModule } from "@nuxt/kit"
+import { assertNoNitroModule, assertNoVitePlugin } from "@vitehub/internal/nitro"
 import type { NitroConfig } from "nitro/types"
 import type { NuxtModule } from "@nuxt/schema"
 
 import type { KVModuleOptions, KVStoreConfig } from "../types.ts"
 
 const NITRO_MODULE_ID = "@vitehub/kv/nitro"
+const NITRO_MODULE_NAME = "@vitehub/kv"
+const NUXT_MODULE_ID = "@vitehub/kv/nuxt"
+const VITE_PLUGIN_NAME = "@vitehub/kv/vite"
+const installedNitroConfigs = new WeakSet<object>()
+
+type ViteConfig = {
+  plugins?: unknown
+}
 
 function installKVNitroModule(nitro: NitroConfig, kv: KVModuleOptions | undefined) {
   nitro.modules ||= []
@@ -14,11 +23,12 @@ function installKVNitroModule(nitro: NitroConfig, kv: KVModuleOptions | undefine
   if (kv !== undefined) {
     nitro.kv = kv
   }
+  installedNitroConfigs.add(nitro)
 }
 
 const kvNuxtModule: NuxtModule<KVStoreConfig, KVStoreConfig, false> = defineNuxtModule<KVStoreConfig>({
-  meta: { configKey: "kv", name: "@vitehub/kv/nuxt" },
-  setup(inlineOptions, nuxt) {
+  meta: { configKey: "kv", name: NUXT_MODULE_ID },
+  async setup(inlineOptions, nuxt) {
     const topLevel = nuxt.options.kv
     if (topLevel === false) {
       return
@@ -26,6 +36,10 @@ const kvNuxtModule: NuxtModule<KVStoreConfig, KVStoreConfig, false> = defineNuxt
 
     const kv = topLevel ?? inlineOptions
     nuxt.options.nitro ||= {}
+    await assertNoVitePlugin(nuxt.options.vite as ViteConfig | undefined, VITE_PLUGIN_NAME, NUXT_MODULE_ID)
+    if (!installedNitroConfigs.has(nuxt.options.nitro)) {
+      assertNoNitroModule(nuxt.options.nitro, NITRO_MODULE_ID, NITRO_MODULE_NAME, NUXT_MODULE_ID)
+    }
     installKVNitroModule(nuxt.options.nitro, kv)
     nuxt.hook("nitro:config", config => installKVNitroModule(config, kv))
   },

--- a/packages/kv/test/frameworks.test.ts
+++ b/packages/kv/test/frameworks.test.ts
@@ -3,12 +3,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 interface NitroHarnessOptions {
   imports?: boolean
   kv?: unknown
-  modules?: string[]
+  modules?: unknown[]
+  vite?: {
+    plugins?: unknown
+  }
 }
 
 interface NuxtHarnessOptions {
   kv?: unknown
   nitro?: NitroHarnessOptions
+  vite?: {
+    plugins?: unknown
+  }
 }
 
 interface NuxtModuleDefinitionLike {
@@ -31,6 +37,9 @@ interface NitroStub {
     cloudflare?: unknown
     kv?: unknown
     preset?: string
+    vite?: {
+      plugins?: unknown
+    }
   }
 }
 
@@ -189,6 +198,19 @@ describe("Nitro module", () => {
     })
   })
 
+  it("rejects direct Vite plugin configuration with the Nitro module", async () => {
+    const nitro = createNitroStub({
+      vite: {
+        plugins: [{ name: "@vitehub/kv/vite" }],
+      },
+    })
+    const module = (await import("../src/nitro/module.ts")).default
+
+    await expect(module.setup(nitro as never)).rejects.toThrow(
+      "[vitehub] Do not configure @vitehub/kv/vite when using @vitehub/kv/nitro.",
+    )
+  })
+
   it("warns when Vercel is configured to use fs-lite", async () => {
     const nitro = createNitroStub({
       preset: "vercel",
@@ -291,6 +313,38 @@ describe("Nuxt module", () => {
     expect(nitroConfig.kv).toEqual({
       driver: "upstash",
     })
+  })
+
+  it("rejects direct Vite plugin configuration with the Nuxt module", async () => {
+    const module = (await import("../src/nuxt/module.ts")).default as (
+      inlineOptions: unknown,
+      nuxt: unknown,
+    ) => Promise<void>
+    const nuxt = createNuxtHarness({
+      vite: {
+        plugins: [{ name: "@vitehub/kv/vite" }],
+      },
+    })
+
+    await expect(module(undefined, nuxt as never)).rejects.toThrow(
+      "[vitehub] Do not configure @vitehub/kv/vite when using @vitehub/kv/nuxt.",
+    )
+  })
+
+  it("rejects direct Nitro module configuration with the Nuxt module", async () => {
+    const module = (await import("../src/nuxt/module.ts")).default as (
+      inlineOptions: unknown,
+      nuxt: unknown,
+    ) => Promise<void>
+    const nuxt = createNuxtHarness({
+      nitro: {
+        modules: ["@vitehub/kv/nitro"],
+      },
+    })
+
+    await expect(module(undefined, nuxt as never)).rejects.toThrow(
+      "[vitehub] Do not configure @vitehub/kv/nitro when using @vitehub/kv/nuxt.",
+    )
   })
 
   it("does not force fs-lite when no Nuxt config is provided", async () => {

--- a/packages/queue/src/nitro/module.ts
+++ b/packages/queue/src/nitro/module.ts
@@ -1,6 +1,6 @@
 import { createImportPath } from "@vitehub/internal/build/paths"
 import { createGeneratedDefinitionPath, createRuntimeRegistryContents, writeFileIfChanged } from "@vitehub/internal/definition-catalog"
-import { mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
+import { assertNoVitePluginInNitro, mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 import { resolve } from "node:path"
 import type { NitroModule, NitroRuntimeConfig } from "nitro/types"
 
@@ -29,6 +29,7 @@ function createCloudflareQueueBindings(definitions: DiscoveredQueueDefinition[])
 }
 
 const QUEUE_NITRO_IMPORTS_PRESET = { from: "@vitehub/queue", imports: ["defineQueue", "deferQueue", "getQueue", "runQueue"] }
+const QUEUE_VITE_PLUGIN_NAME = "@vitehub/queue/vite"
 
 function createNitroQueueRegistryPath(rootDir: string, buildDir: string) {
   return createGeneratedDefinitionPath(rootDir, { buildDir, fileName: "nitro-registry.mjs", segments: generatedDirSegments })
@@ -142,6 +143,8 @@ async function writeNitroQueueRuntimeFiles(nitro: { options: { buildDir: string,
 const queueNitroModule: NitroModule = {
   name: "@vitehub/queue",
   async setup(nitro: any) {
+    await assertNoVitePluginInNitro(nitro, QUEUE_VITE_PLUGIN_NAME, "@vitehub/queue/nitro")
+
     const resolved = normalizeQueueOptions(nitro.options.queue, {
       hosting: nitro.options.preset,
     })

--- a/packages/sandbox/src/internal/shared/feature-engine.ts
+++ b/packages/sandbox/src/internal/shared/feature-engine.ts
@@ -1,5 +1,6 @@
 import { readPackageJSON } from 'pkg-types'
 import { resolve as resolveFs } from 'pathe'
+import { assertNoVitePluginInNitro } from '@vitehub/internal/nitro'
 import type { Nitro, NitroModule } from 'nitro/types'
 import type { ConfigEnv, UserConfig } from 'vite'
 import { detectHosting } from './hosting'
@@ -195,6 +196,8 @@ export function createFeatureNitroBridge<TOptions, TInput, TConfig>(
   return {
     name: engine.name,
     async setup(nitro) {
+      await assertNoVitePluginInNitro(nitro, `${engine.name}/vite`, `${engine.name}/nitro`)
+
       const context = await buildFeatureNitroContext(engine, nitro)
       if (!context)
         return

--- a/packages/workflow/src/nitro/module.ts
+++ b/packages/workflow/src/nitro/module.ts
@@ -3,7 +3,7 @@ import { join, resolve } from "node:path"
 
 import { createImportPath } from "@vitehub/internal/build/paths"
 import { createGeneratedDefinitionPath, createRuntimeRegistryContents, writeFileIfChanged } from "@vitehub/internal/definition-catalog"
-import { mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
+import { assertNoVitePluginInNitro, mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 
 import type { Nitro, NitroModule, NitroRuntimeConfig } from "nitro/types"
 
@@ -13,6 +13,7 @@ import { createCloudflareWorkflowBindings, getCloudflareWorkflowClassName } from
 import type { DiscoveredWorkflowDefinition, ResolvedWorkflowOptions, WorkflowModuleOptions } from "../types.ts"
 
 const WORKFLOW_NITRO_IMPORTS_PRESET = { from: "@vitehub/workflow", imports: ["createWorkflow", "deferWorkflow", "defineWorkflow", "getWorkflowRun", "runWorkflow"] }
+const WORKFLOW_VITE_PLUGIN_NAME = "@vitehub/workflow/vite"
 
 function resolveRuntimeEntry(srcRelative: string, packageSubpath: string): string {
   return resolveEntry(srcRelative, packageSubpath, import.meta.url)
@@ -114,6 +115,8 @@ async function writeNitroWorkflowRuntimeFiles(nitro: Nitro): Promise<RuntimeFile
 const workflowNitroModule: NitroModule = {
   name: "@vitehub/workflow",
   async setup(nitro) {
+    await assertNoVitePluginInNitro(nitro, WORKFLOW_VITE_PLUGIN_NAME, "@vitehub/workflow/nitro")
+
     const resolved = normalizeWorkflowOptions(nitro.options.workflow, { hosting: nitro.options.preset })
     const runtimeConfig = (nitro.options.runtimeConfig ||= {} as NitroRuntimeConfig)
     if (nitro.options.preset) runtimeConfig.hosting ||= nitro.options.preset

--- a/packages/workspace/src/nitro/module.ts
+++ b/packages/workspace/src/nitro/module.ts
@@ -4,7 +4,7 @@ import { dirname, resolve } from "node:path"
 
 import { createImportPath } from "@vitehub/internal/build/paths"
 import { writeFileIfChanged } from "@vitehub/internal/definition-catalog"
-import { mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
+import { assertNoVitePluginInNitro, mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 
 import { initializeWorkspaceAssetRegistry, syncWorkspaceBuildAssets, writeWorkspaceRuntimeRegistry } from "../build-integration.ts"
 import { normalizeWorkspaceOptions } from "../config.ts"
@@ -19,6 +19,7 @@ const WORKSPACE_NITRO_IMPORTS_PRESET = {
   from: "@vitehub/workspace",
   imports: ["defineWorkspace", "useWorkspace"],
 }
+const WORKSPACE_VITE_PLUGIN_NAME = "@vitehub/workspace/vite"
 
 function resolveRuntimeEntry(srcRelative: string, packageSubpath: string) {
   return resolveEntry(srcRelative, packageSubpath, import.meta.url)
@@ -157,6 +158,8 @@ async function writePlugin(nitro: Nitro, registryFile: string, assetsRegistryFil
 const workspaceNitroModule: NitroModule = {
   name: "@vitehub/workspace",
   async setup(nitro) {
+    await assertNoVitePluginInNitro(nitro, WORKSPACE_VITE_PLUGIN_NAME, "@vitehub/workspace/nitro")
+
     const isDev = nitro.options.dev || process.env.VITEHUB_WORKSPACE_DEV === "true"
     const resolved = normalizeWorkspaceOptions((nitro.options as typeof nitro.options & { workspace?: false | WorkspaceModuleOptions }).workspace, {
       dev: isDev,


### PR DESCRIPTION
Adds shared integration-boundary checks so Nitro modules fail fast when the matching Vite plugin is configured through Nitro Vite options. Applies the guard across Blob, Chat, Env, KV, Queue, Sandbox, Workflow, and Workspace.

Extends the KV Nuxt module with the same boundary: Nuxt owns the Nitro install, so direct `@vitehub/kv/vite` and `@vitehub/kv/nitro` configuration now throws instead of being silently mixed. The tests cover the shared detection helpers and the KV Nuxt/Nitro behavior.

Checked with focused package tests, affected package typechecks, full KV and Blob tests, and repo lint. Lint still reports existing warnings outside this change.
