### PR TITLE
fix(workspace): handle raw GitHub content responses

### DIFF
--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -87,6 +87,29 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
     return await response.json() as T
   }
 
+  async function requestRawContent(repoPath: string, encodedPath: string, token: string) {
+    const response = await fetch(
+      `https://api.github.com/repos/${options.repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`,
+      {
+        headers: {
+          accept: "application/vnd.github.raw+json",
+          authorization: `Bearer ${token}`,
+          "user-agent": "vitehub-workspace",
+          "x-github-api-version": "2022-11-28",
+        },
+      },
+    )
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new WorkspaceError(`[vitehub] source.github(${JSON.stringify(options.repo)}) could not find ${JSON.stringify(repoPath)} at ref ${JSON.stringify(ref)}.`)
+      }
+      throw new WorkspaceError(`[vitehub] source.github(${JSON.stringify(options.repo)}) raw content request failed with ${response.status} for ${repoPath}.`)
+    }
+    const content = new Uint8Array(await response.arrayBuffer())
+    rejectUnsupportedRawContentPayload(repoPath, response.headers.get("content-type"), content)
+    return content
+  }
+
   function keyForRepoPath(path: string) {
     const normalized = normalizeWorkspacePath(path)
     if (!root) return normalized
@@ -190,7 +213,7 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
       token,
     ).then((file) => {
       if (file.encoding !== "base64" || typeof file.content !== "string") {
-        return fetchRawContent(repoPath, encodedPath, token)
+        return requestRawContent(repoPath, encodedPath, token)
       }
       return new Uint8Array(Buffer.from(file.content, "base64"))
     })
@@ -357,4 +380,28 @@ function stripArchiveRoot(path: string) {
   const slash = path.indexOf("/")
   if (slash === -1) return
   return normalizeWorkspacePath(path.slice(slash + 1))
+}
+
+function rejectUnsupportedRawContentPayload(repoPath: string, contentType: string | null, content: Uint8Array) {
+  if (!contentType?.includes("json")) return
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(Buffer.from(content).toString("utf8"))
+  }
+  catch {
+    return
+  }
+
+  if (isGitHubContentsPayload(payload) && payload.type !== "file") {
+    throw new WorkspaceError(`[vitehub] source.github raw content for ${JSON.stringify(repoPath)} resolved to unsupported GitHub content type ${JSON.stringify(payload.type)}.`)
+  }
+}
+
+function isGitHubContentsPayload(value: unknown): value is { type: string } {
+  return typeof value === "object"
+    && value !== null
+    && "type" in value
+    && typeof (value as { type?: unknown }).type === "string"
+    && ("download_url" in value || "git_url" in value || "html_url" in value || "url" in value)
 }

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -41,6 +41,7 @@ function jsonResponse(value: unknown, status = 200) {
 interface StubGitHubSourceOptions {
   apiStatus?: number
   archiveStatus?: number
+  rawPayloads?: Record<string, unknown>
 }
 
 function createTarGz(files: Record<string, string>) {
@@ -72,7 +73,7 @@ function stubGitHubSource(files: Record<string, string>, options: StubGitHubSour
   const apiStatus = typeof options === "number" ? options : options.apiStatus ?? 200
   const archiveStatus = typeof options === "number" ? options : options.archiveStatus ?? 200
 
-  vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
+  vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
     const requestUrl = String(url)
 
     if (requestUrl.startsWith("https://codeload.github.com/")) {
@@ -103,6 +104,16 @@ function stubGitHubSource(files: Record<string, string>, options: StubGitHubSour
     }
 
     const path = decodeURIComponent(requestUrl.match(/contents\/(?<path>.+)\?ref/)?.groups?.path ?? "")
+    const rawPayload = typeof options === "number" ? undefined : options.rawPayloads?.[path]
+    if (init?.headers && new Headers(init.headers).get("accept") === "application/vnd.github.raw+json") {
+      if (rawPayload) return jsonResponse(rawPayload)
+      return new Response(files[path] ?? "", {
+        headers: { "content-type": "application/vnd.github.raw+json" },
+      })
+    }
+    if (rawPayload) {
+      return jsonResponse({ content: "", encoding: "none" })
+    }
     return jsonResponse({
       content: Buffer.from(files[path] || "").toString("base64"),
       encoding: "base64",
@@ -231,11 +242,13 @@ describe("sources, loaders, and publishers", () => {
         })
       }
       if (requestUrl.includes("/contents/")) {
+        if (new Headers(init?.headers).get("accept") === "application/vnd.github.raw+json") {
+          expect((init?.headers as Record<string, string>).authorization).toBe("Bearer token")
+          return new Response("<metadata />\n", {
+            headers: { "content-type": "application/vnd.github.raw+json" },
+          })
+        }
         return jsonResponse({ content: "", encoding: "none" })
-      }
-      if (requestUrl.startsWith("https://raw.githubusercontent.com/")) {
-        expect((init?.headers as Record<string, string>).authorization).toBe("Bearer token")
-        return new Response("<metadata />\n")
       }
       throw new Error(`Unexpected GitHub request: ${requestUrl}`)
     })
@@ -248,6 +261,30 @@ describe("sources, loaders, and publishers", () => {
     const item = await githubSource.getItem("metadata.xml", { rootDir: "", workspace: "github-raw-fallback" })
 
     expect(Buffer.from(item.content as Uint8Array).toString("utf8")).toBe("<metadata />\n")
+  })
+
+  it("rejects non-file GitHub contents API payloads from authenticated raw content", async () => {
+    const symlinkPath = "docs/linked.md"
+    stubGitHubSource({
+      [symlinkPath]: "",
+    }, {
+      rawPayloads: {
+        [symlinkPath]: {
+          download_url: null,
+          html_url: "https://github.com/acme/app/blob/main/docs/linked.md",
+          type: "symlink",
+          url: "https://api.github.com/repos/acme/app/contents/docs/linked.md",
+        },
+      },
+    })
+
+    const githubSource = source.github({
+      auth: "github-token",
+      repo: "acme/app",
+    })
+
+    await expect(githubSource.getItem(symlinkPath, { rootDir: "", workspace: "github-raw" }))
+      .rejects.toThrow("unsupported GitHub content type")
   })
 
   it("reuses cached GitHub tree listings across lazy source navigation", async () => {


### PR DESCRIPTION
Fixes `source.github()` for authenticated files where the GitHub Contents API returns `encoding: "none"` instead of inline base64 content. In that case, the workspace source now retries the same contents endpoint with GitHub's raw media type and stores the returned bytes.

This unblocks build-time workspace materialization for repositories containing larger files, instead of failing with `received unsupported content`.

Adds a regression test covering authenticated raw content fallback in the GitHub source stub.