### PR TITLE
fix(chat): show devtools fallback immediately

### DIFF
--- a/packages/chat/src/integrations/devtools.ts
+++ b/packages/chat/src/integrations/devtools.ts
@@ -20,6 +20,7 @@ export { chatDevtoolsAdapterName, chatDevtoolsRoute }
 export type { ChatDevtoolsResult, ChatDevtoolsTranscriptMessage } from "../devtools.ts"
 
 const transcript = new Map<string, ChatDevtoolsTranscriptMessage[]>()
+const typingMessages = new Map<string, string>()
 let messageId = 0
 
 function createId(prefix: string): string {
@@ -130,6 +131,25 @@ function replaceTranscriptMessage(threadId: string, messageId: string, text: str
   })
 }
 
+function createOrUpdateTypingMessage(threadId: string, text: string): RawMessage<ChatDevtoolsTranscriptMessage> {
+  const messageId = typingMessages.get(threadId) || createId("assistant")
+  typingMessages.set(threadId, messageId)
+  const entry = replaceTranscriptMessage(threadId, messageId, text)
+  return { id: messageId, raw: entry, threadId }
+}
+
+function postOrReplaceTypingMessage(threadId: string, message: AdapterPostableMessage): RawMessage<ChatDevtoolsTranscriptMessage> {
+  const text = normalizePostableMessage(message)
+  const typingMessageId = typingMessages.get(threadId)
+  if (typingMessageId) {
+    typingMessages.delete(threadId)
+    const entry = replaceTranscriptMessage(threadId, typingMessageId, text)
+    return { id: typingMessageId, raw: entry, threadId }
+  }
+
+  return createRawMessage(chatNameFromThreadId(threadId), createId("assistant"), threadId, text)
+}
+
 export function getChatDevtoolsTranscript(chatName?: string): ChatDevtoolsTranscriptMessage[] {
   if (chatName) {
     return [...getMessages(chatName)]
@@ -141,13 +161,19 @@ export function getChatDevtoolsTranscript(chatName?: string): ChatDevtoolsTransc
 export function clearChatDevtoolsTranscript(chatName?: string): void {
   if (chatName) {
     transcript.set(chatName, [])
+    for (const [threadId] of typingMessages) {
+      if (chatNameFromThreadId(threadId) === chatName) {
+        typingMessages.delete(threadId)
+      }
+    }
     return
   }
 
   transcript.clear()
+  typingMessages.clear()
 }
 
-export function createChatDevtoolsAdapter(userName: string): Adapter<string, ChatDevtoolsTranscriptMessage> {
+export function createChatDevtoolsAdapter(userName: string, fallbackStreamingPlaceholderText: string | null = "..."): Adapter<string, ChatDevtoolsTranscriptMessage> {
   return {
     addReaction: unsupported,
     channelIdFromThreadId: threadId => threadId,
@@ -175,12 +201,21 @@ export function createChatDevtoolsAdapter(userName: string): Adapter<string, Cha
     isDM: () => true,
     name: chatDevtoolsAdapterName,
     parseMessage: toChatMessage,
-    postMessage: async (threadId, message) => createRawMessage(chatNameFromThreadId(threadId), createId("assistant"), threadId, normalizePostableMessage(message)),
+    postMessage: async (threadId, message) => postOrReplaceTypingMessage(threadId, message),
     removeReaction: unsupported,
     renderFormatted: (content: FormattedContent) => stringifyMarkdown(content),
-    startTyping: async () => {},
+    startTyping: async (threadId, status) => {
+      const text = status ?? fallbackStreamingPlaceholderText
+      if (text !== null) {
+        createOrUpdateTypingMessage(threadId, text)
+      }
+    },
     userName,
   }
+}
+
+function getFallbackStreamingPlaceholderText(bot: Chat): string | null {
+  return (bot as unknown as { _fallbackStreamingPlaceholderText?: string | null })._fallbackStreamingPlaceholderText ?? "..."
 }
 
 export async function submitChatDevtoolsMessage(
@@ -191,7 +226,7 @@ export async function submitChatDevtoolsMessage(
 ): Promise<void> {
   const normalizedChatName = chatName || "chat"
   const threadId = threadIdForChat(normalizedChatName)
-  const adapter = createChatDevtoolsAdapter(bot.getUserName())
+  const adapter = createChatDevtoolsAdapter(bot.getUserName(), getFallbackStreamingPlaceholderText(bot))
   await adapter.initialize(bot)
   await bot.initialize()
 
@@ -201,6 +236,7 @@ export async function submitChatDevtoolsMessage(
     text,
     threadId,
   })
+  await adapter.startTyping(threadId)
   const task = (async () => {
     try {
       const directDispatch = bot as unknown as {

--- a/packages/chat/test/nitro.test.ts
+++ b/packages/chat/test/nitro.test.ts
@@ -381,6 +381,7 @@ describe("defineChatWebhookHandler", () => {
       userName: "ViteHub Chat",
     })
     bot.onDirectMessage(async (thread) => {
+      await thread.startTyping()
       async function* stream() {
         yield "Hel"
         await gate
@@ -401,6 +402,7 @@ describe("defineChatWebhookHandler", () => {
     })
 
     const first = await handler(createDevtoolsEvent({ stream: true, text: "Hi" }) as never) as unknown as { pending?: boolean, messages: Array<{ text: string }> }
+    const firstLastText = first.messages.at(-1)?.text
     await new Promise(resolve => setTimeout(resolve, 10))
     const pending = await handler(createDevtoolsEvent({}) as never) as unknown as { pending?: boolean, messages: Array<{ text: string }> }
     release()
@@ -412,6 +414,7 @@ describe("defineChatWebhookHandler", () => {
 
     expect(first.pending).toBe(true)
     expect(pending.pending).toBe(true)
+    expect(firstLastText).toBe("Thinking...")
     expect(pending.messages.at(-1)?.text).toContain("Hel")
   })
 })

--- a/packages/chat/test/runtime.test.ts
+++ b/packages/chat/test/runtime.test.ts
@@ -242,7 +242,9 @@ describe("defineChat", () => {
       userName: "ViteHub Chat",
     })
     bot.onDirectMessage(async (thread) => {
+      await thread.startTyping()
       async function* stream() {
+        await new Promise(resolve => setTimeout(resolve, 25))
         yield "Hello "
         yield "from DevTools"
       }
@@ -251,6 +253,12 @@ describe("defineChat", () => {
     })
 
     await submitChatDevtoolsMessage(bot, "runtime-test", "Ping", task => tasks.push(task))
+    await vi.waitFor(() => {
+      expect(getChatDevtoolsTranscript("runtime-test")).toMatchObject([
+        { author: "user", text: "Ping" },
+        { author: "assistant", text: "Thinking..." },
+      ])
+    })
     await Promise.allSettled(tasks)
 
     const messages = getChatDevtoolsTranscript("runtime-test")


### PR DESCRIPTION
Make the chat devtools bridge show a fallback assistant message as soon as a message is submitted, then reuse that same transcript entry for fallback stream edits. This keeps the devtools UI responsive during slow setup before the first streamed chunk arrives.

Also covers the behavior in runtime and Nitro devtools tests.