### PR TITLE
fix(workspace): improve github source loading

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -64,6 +64,7 @@
     "isomorphic-git": "^1.37.6",
     "minimatch": "^10.1.1",
     "mrmime": "^2.0.1",
+    "ocache": "^0.1.4",
     "tinyglobby": "^0.2.16"
   },
   "peerDependencies": {

--- a/packages/workspace/src/source-materialization.ts
+++ b/packages/workspace/src/source-materialization.ts
@@ -165,11 +165,6 @@ export async function searchResolvedSource(
   ctx: SourceContext,
 ): Promise<WorkspaceSearchHit[]> {
   const limit = query.limit ?? 100
-  const materializedPaths = new Set(
-    (await store.glob(`${source.mountPath}/**/*`))
-      .filter(entry => entry.type === "file")
-      .map(entry => entry.path),
-  )
   const materializedHits = await searchMaterializedStore(store, {
     ...query,
     paths: query.paths?.length ? query.paths : [source.mountPath],
@@ -189,22 +184,7 @@ export async function searchResolvedSource(
     }))]).slice(0, limit)
   }
 
-  const keys = await source.source.getKeys(ctx)
-  const result = [...materializedHits]
-
-  for (const key of keys) {
-    const fullPath = toMountedSourcePath(source, key)
-    if (!matchesSearchPath(fullPath, query.paths)) continue
-    if (materializedPaths.has(fullPath)) continue
-    if (result.length >= limit) break
-    const item = await source.source.getItem(key, ctx)
-    const content = item.content ?? (typeof item.data === "undefined" ? "" : JSON.stringify(item.data, null, 2))
-    const text = typeof content === "string" ? content : new TextDecoder().decode(content)
-    result.push(...searchText(fullPath, text, { ...query, limit: limit - result.length }))
-    if (result.length >= limit) break
-  }
-
-  return dedupeSearchHits(result).slice(0, limit)
+  return materializedHits.slice(0, limit)
 }
 
 export async function searchMaterializedStore(store: WorkspaceStore, query: WorkspaceSearchQuery): Promise<WorkspaceSearchHit[]> {
@@ -322,11 +302,6 @@ function toSourceSearchPaths(source: ResolvedWorkspaceSource, paths: string[] | 
 
 function toMountedSourcePath(source: ResolvedWorkspaceSource, key: string) {
   return normalizeWorkspacePath(posix.join(source.mountPath, key))
-}
-
-function matchesSearchPath(path: string, paths: string[] | undefined) {
-  if (!paths?.length) return true
-  return paths.some(prefix => path === prefix || path.startsWith(`${prefix}/`))
 }
 
 function addVirtualParents(entries: Map<string, WorkspaceStat>, basePath: string, path: string) {

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -2,10 +2,11 @@ import { Buffer } from "node:buffer"
 import { gunzipSync } from "node:zlib"
 
 import { getActiveCloudflareBinding } from "@vitehub/internal/runtime/cloudflare-env"
+import { defineCachedFunction } from "ocache"
 
 import { WorkspaceError } from "../errors.ts"
 import { matchesAny, normalizeWorkspacePath } from "../path.ts"
-import type { WorkspaceSource } from "../types.ts"
+import type { WorkspaceCacheOptions, WorkspaceSource } from "../types.ts"
 
 type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "materialize" | "mount" | "swr" | "validate">
 
@@ -51,8 +52,7 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
   const ref = options.ref || "main"
   const root = normalizeWorkspacePath(options.root || "")
   let auth: string | undefined
-  let filesPromise: Promise<GitHubFile[]> | undefined
-  const contentPromises = new Map<string, Promise<Uint8Array>>()
+  const providerCache = normalizeProviderCache(options)
 
   function resolveAuth(): string | undefined {
     const token = options.auth || getActiveCloudflareBinding<string>("GITHUB_TOKEN") || process.env.GITHUB_TOKEN
@@ -63,8 +63,6 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
     const nextAuth = resolveAuth()
     if (nextAuth !== auth) {
       auth = nextAuth
-      filesPromise = undefined
-      contentPromises.clear()
     }
     return auth
   }
@@ -153,7 +151,7 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
       .filter((file): file is GitHubFile => Boolean(file))
   }
 
-  async function loadFiles() {
+  async function loadFiles(token = auth) {
     try {
       return await loadTreeFiles()
     }
@@ -165,22 +163,25 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
     }
   }
 
+  const cachedLoadFiles = defineCachedFunction(loadFiles, {
+    ...providerCache,
+    getKey: token => cacheKey("tree", token || ""),
+    name: "github-source-tree",
+  })
+
   function getFiles() {
-    refreshAuth()
-    if (!filesPromise) filesPromise = loadFiles()
-    return filesPromise
+    return cachedLoadFiles(refreshAuth())
   }
 
   function repoPathForKey(key: string) {
     return root ? `${root}/${key}` : key
   }
 
-  function fetchContent(key: string, file: GitHubFile) {
+  function fetchContent(key: string, file: GitHubFile, token = auth) {
     if (file.content) return Promise.resolve(file.content)
 
     const repoPath = repoPathForKey(key)
     const encodedPath = encodeURIComponent(repoPath).replaceAll("%2F", "/")
-    const token = refreshAuth()
     if (!token) {
       return fetchRawContent(repoPath, encodedPath)
     }
@@ -189,15 +190,44 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
       token,
     ).then((file) => {
       if (file.encoding !== "base64" || typeof file.content !== "string") {
-        throw new WorkspaceError(`[vitehub] source.github(${JSON.stringify(options.repo)}) received unsupported content for ${JSON.stringify(repoPath)}.`)
+        return fetchRawContent(repoPath, encodedPath, token)
       }
       return new Uint8Array(Buffer.from(file.content, "base64"))
     })
   }
 
-  async function fetchRawContent(repoPath: string, encodedPath: string) {
+  const cachedFetchContent = defineCachedFunction(
+    async (key: string, token: string | undefined) => {
+      const file = (await getFiles()).find(file => file.key === key)
+      if (!file) {
+        throw new WorkspaceError(`[vitehub] source.github(${JSON.stringify(options.repo)}) could not find ${JSON.stringify(key)}.`)
+      }
+      return await fetchContent(key, file, token)
+    },
+    {
+      ...providerCache,
+      getKey: (key, token) => cacheKey("content", token || "", key),
+      name: "github-source-content",
+    },
+  )
+
+  function cacheKey(kind: string, token: string, key = "") {
+    return [
+      kind,
+      options.repo,
+      ref,
+      root,
+      normalizePatternCacheKey(options.include),
+      normalizePatternCacheKey(options.exclude),
+      token,
+      key,
+    ].join(":")
+  }
+
+  async function fetchRawContent(repoPath: string, encodedPath: string, token = auth) {
     const response = await fetch(`https://raw.githubusercontent.com/${options.repo}/${encodeURIComponent(ref)}/${encodedPath}`, {
       headers: {
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
         "user-agent": "vitehub-workspace",
       },
     })
@@ -229,19 +259,36 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
       }
     },
     async getItem(key) {
+      const token = refreshAuth()
       const file = (await getFiles()).find(file => file.key === key)
       if (!file) {
         throw new WorkspaceError(`[vitehub] source.github(${JSON.stringify(options.repo)}) could not find ${JSON.stringify(key)}.`)
       }
-      const contentPromise = contentPromises.get(key) || fetchContent(key, file)
-      contentPromises.set(key, contentPromise)
       return {
         key,
         path: file.path,
-        content: await contentPromise,
+        content: await cachedFetchContent(key, token),
       }
     },
   }
+}
+
+function normalizeProviderCache(options: Pick<WorkspaceSource, "cache" | "swr">): WorkspaceCacheOptions {
+  if (options.cache === false) return { maxAge: 0, swr: false }
+  if (options.cache && typeof options.cache === "object") {
+    return {
+      maxAge: options.cache.maxAge ?? 1,
+      staleMaxAge: options.cache.staleMaxAge,
+      swr: options.cache.swr ?? true,
+    }
+  }
+  if (typeof options.swr === "number") return { maxAge: options.swr, swr: true }
+  return { maxAge: 1, swr: options.swr === false ? false : true }
+}
+
+function normalizePatternCacheKey(value: string | string[] | undefined) {
+  if (!value) return ""
+  return Array.isArray(value) ? value.join(",") : value
 }
 
 function parseGitHubArchive(bytes: Uint8Array) {

--- a/packages/workspace/test/lazy-sources.test.ts
+++ b/packages/workspace/test/lazy-sources.test.ts
@@ -10,6 +10,7 @@ import { createMemoryWorkspaceStore } from "../src/stores/memory.ts"
 afterEach(() => {
   resetWorkspaceRegistry()
   vi.restoreAllMocks()
+  vi.useRealTimers()
 })
 
 describe("lazy sources", () => {
@@ -107,6 +108,8 @@ describe("lazy sources", () => {
       expect.objectContaining({ path: "docs/foo.md", type: "file" }),
       expect.objectContaining({ path: "docs/nested/bar.md", type: "file" }),
     ]))
+    await expect(workspace.stat("docs/foo.md")).resolves.toMatchObject({ path: "docs/foo.md", type: "file" })
+    await expect(workspace.exists("docs/nested/bar.md")).resolves.toBe(true)
     expect(getItem).not.toHaveBeenCalled()
     await expect(workspace.diff()).resolves.toMatchObject({ entries: [] })
 
@@ -178,7 +181,7 @@ describe("lazy sources", () => {
     await expect(workspace.diff()).resolves.toMatchObject({ entries: [] })
   })
 
-  it("falls back to source scanning for search without materializing files", async () => {
+  it("does not scan unmaterialized source files during search", async () => {
     const getItem = vi.fn(async (key: string) => ({
       key,
       path: key,
@@ -202,15 +205,52 @@ describe("lazy sources", () => {
     const workspace = await useRegisteredWorkspace("lazy-fallback-search")
     await workspace.sync()
 
-    await expect(workspace.search({ pattern: "hello", paths: ["docs"] })).resolves.toEqual([
-      { path: "docs/foo.md", line: 1, column: 1, text: "hello world" },
-    ])
-    expect(getItem).toHaveBeenCalledTimes(2)
+    await expect(workspace.search({ pattern: "hello", paths: ["docs"] })).resolves.toEqual([])
+    expect(getItem).not.toHaveBeenCalled()
     await expect(workspace.diff()).resolves.toMatchObject({ entries: [] })
 
     await expect(workspace.readFile("docs/foo.md")).resolves.toBe("hello world\n")
+    expect(getItem).toHaveBeenCalledTimes(1)
+    await expect(workspace.search({ pattern: "hello", paths: ["docs"] })).resolves.toEqual([
+      { path: "docs/foo.md", line: 1, column: 1, text: "hello world" },
+    ])
+    expect(getItem).toHaveBeenCalledTimes(1)
     await expect(workspace.diff()).resolves.toMatchObject({
       entries: expect.arrayContaining([expect.objectContaining({ path: "docs/foo.md", type: "added" })]),
     })
+  })
+
+  it("reuses cached materialized files within max age", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-05-05T12:00:00Z"))
+    const getItem = vi.fn(async (key: string) => ({
+      key,
+      path: key,
+      content: `version ${getItem.mock.calls.length}\n`,
+    }))
+
+    registerWorkspace("lazy-cache", defineWorkspace({
+      store: { provider: "memory" },
+      sources: {
+        docs: source.custom({
+          name: "docs",
+          cache: { maxAge: 3600, swr: true },
+          materialize: "lazy",
+          validate: "request",
+          async getKeys() {
+            return ["foo.md"]
+          },
+          getItem,
+        }),
+      },
+    }))
+
+    const workspace = await useRegisteredWorkspace("lazy-cache")
+    await workspace.sync()
+
+    await expect(workspace.readFile("docs/foo.md")).resolves.toBe("version 1\n")
+    vi.setSystemTime(new Date("2026-05-05T12:30:00Z"))
+    await expect(workspace.readFile("docs/foo.md")).resolves.toBe("version 1\n")
+    expect(getItem).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 import { gzipSync } from "node:zlib"
 
+import { createMemoryStorage, setStorage } from "ocache"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { collectWorkspaceAssetBundle, writeWorkspaceAssetsRegistry } from "../src/build-assets.ts"
@@ -25,6 +26,7 @@ async function createRoot() {
 afterEach(async () => {
   delete process.env.GITHUB_TOKEN
   delete (globalThis as { __env__?: Record<string, unknown> }).__env__
+  setStorage(createMemoryStorage())
   vi.unstubAllGlobals()
   await Promise.all(tempDirs.splice(0).map(path => rm(path, { recursive: true, force: true })))
 })
@@ -214,6 +216,104 @@ describe("sources, loaders, and publishers", () => {
       "docs/README.md",
     ])
     expect(vi.mocked(fetch).mock.calls.some(([url]) => String(url).startsWith("https://codeload.github.com/"))).toBe(true)
+  })
+
+  it("falls back to raw GitHub bytes when the contents API does not return base64", async () => {
+    stubGitHubSource({
+      "metadata.xml": "<metadata />\n",
+    })
+    vi.mocked(fetch).mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
+      const requestUrl = String(url)
+      if (requestUrl.includes("/git/trees/")) {
+        return jsonResponse({
+          sha: "tree-sha",
+          tree: [{ path: "metadata.xml", type: "blob" }],
+        })
+      }
+      if (requestUrl.includes("/contents/")) {
+        return jsonResponse({ content: "", encoding: "none" })
+      }
+      if (requestUrl.startsWith("https://raw.githubusercontent.com/")) {
+        expect((init?.headers as Record<string, string>).authorization).toBe("Bearer token")
+        return new Response("<metadata />\n")
+      }
+      throw new Error(`Unexpected GitHub request: ${requestUrl}`)
+    })
+
+    const githubSource = source.github({
+      auth: "token",
+      repo: "acme/app",
+    })
+
+    const item = await githubSource.getItem("metadata.xml", { rootDir: "", workspace: "github-raw-fallback" })
+
+    expect(Buffer.from(item.content as Uint8Array).toString("utf8")).toBe("<metadata />\n")
+  })
+
+  it("reuses cached GitHub tree listings across lazy source navigation", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+      "docs/guide/setup.md": "# Setup\n",
+    })
+
+    registerWorkspace("github-lazy-tree-cache", defineWorkspace({
+      store: { provider: "memory" },
+      sources: {
+        docs: source.github({
+          cache: { maxAge: 3600, swr: true },
+          materialize: "lazy",
+          repo: "acme/app",
+          root: "docs",
+        }),
+      },
+    }))
+
+    const workspace = await useRegisteredWorkspace("github-lazy-tree-cache")
+    await workspace.sync()
+
+    await expect(workspace.list("docs")).resolves.toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "docs/README.md", type: "file" }),
+      expect.objectContaining({ path: "docs/guide", type: "directory" }),
+    ]))
+    await expect(workspace.stat("docs/README.md")).resolves.toMatchObject({ path: "docs/README.md", type: "file" })
+    await expect(workspace.exists("docs/guide/setup.md")).resolves.toBe(true)
+
+    const treeCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).includes("/git/trees/"))
+    expect(treeCalls).toHaveLength(1)
+    await expect(workspace.diff()).resolves.toMatchObject({ entries: [] })
+  })
+
+  it("dedupes concurrent cached GitHub content reads while materializing once", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+
+    registerWorkspace("github-lazy-content-cache", defineWorkspace({
+      store: { provider: "memory" },
+      sources: {
+        docs: source.github({
+          cache: { maxAge: 3600, swr: true },
+          materialize: "lazy",
+          repo: "acme/app",
+          root: "docs",
+          validate: "request",
+        }),
+      },
+    }))
+
+    const workspace = await useRegisteredWorkspace("github-lazy-content-cache")
+    await workspace.sync()
+
+    await expect(Promise.all([
+      workspace.readFile("docs/README.md"),
+      workspace.readFile("docs/README.md"),
+    ])).resolves.toEqual(["# Docs\n", "# Docs\n"])
+
+    const contentCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://raw.githubusercontent.com/"))
+    expect(contentCalls).toHaveLength(1)
+    await expect(workspace.diff()).resolves.toMatchObject({
+      entries: expect.arrayContaining([expect.objectContaining({ path: "docs/README.md", type: "added" })]),
+    })
   })
 
   it("loads GitHub file bytes and writes them through the files loader", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,6 +854,9 @@ importers:
       mrmime:
         specifier: ^2.0.1
         version: 2.0.1
+      ocache:
+        specifier: ^0.1.4
+        version: 0.1.4
       tinyglobby:
         specifier: ^0.2.16
         version: 0.2.16


### PR DESCRIPTION
Extracts the workspace-only GitHub source fixes from #73.

This keeps the chat/devtools work out of scope and includes the source loader caching, raw/non-base64 content fallback, lazy source scan behavior, and focused workspace tests.