### PR TITLE
feat(workspace): rename build asset sync option

### DIFF
--- a/packages/workspace/docs/index.md
+++ b/packages/workspace/docs/index.md
@@ -71,7 +71,21 @@ await workspace.fs.writeFile('generated/notes.md', 'Hello')
 const files = await workspace.fs.glob('**/*.md')
 ```
 
-For build-time, read-only context, enable `syncOnBuild` and read bundled assets:
+Build-time, read-only context is bundled into an asset registry during production builds by default. Use `workspace.assets` in app config when you want to select or disable bundled workspaces:
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import { hubWorkspace } from '@vitehub/workspace/vite'
+
+export default defineConfig({
+  plugins: [hubWorkspace()],
+  workspace: {
+    assets: ['docs'],
+  },
+})
+```
+
+Read bundled assets through the same workspace facade:
 
 ```ts
 import { useWorkspace } from '@vitehub/workspace'
@@ -148,7 +162,7 @@ On open, ViteHub syncs the readable workspace contents into the configured sandb
 
 ## Lazy materialization
 
-Source mounts default to `materialize: 'build'`, which syncs files into the workspace store during build or explicit workspace sync.
+Source mounts default to `materialize: 'build'`, which syncs files into the workspace store during build or explicit workspace sync. This is separate from `workspace.assets`, which controls whether synced workspace files are also emitted into the read-only build asset registry.
 
 Use `materialize: 'lazy'` when the agent only needs source files on demand:
 

--- a/packages/workspace/src/build-assets.ts
+++ b/packages/workspace/src/build-assets.ts
@@ -28,8 +28,8 @@ export interface WorkspaceAssetBundle {
   name: string
 }
 
-export function shouldSyncWorkspace(syncOnBuild: boolean | string[] | undefined, name: string) {
-  return syncOnBuild === undefined || syncOnBuild === true || (Array.isArray(syncOnBuild) && syncOnBuild.includes(name))
+export function shouldBundleWorkspaceAssets(assets: boolean | string[] | undefined, name: string) {
+  return assets === undefined || assets === true || (Array.isArray(assets) && assets.includes(name))
 }
 
 function assetModuleName(workspace: string, path: string, content: WorkspaceContent) {
@@ -55,7 +55,7 @@ export async function syncDiscoveredWorkspaces(
 
   const workspaces: Workspace[] = []
   for (const definition of definitions) {
-    if (!shouldSyncWorkspace(options.syncOnBuild, definition.name)) continue
+    if (!shouldBundleWorkspaceAssets(options.assets, definition.name)) continue
 
     const mod = await import(pathToFileURL(definition.path).href) as { default?: WorkspaceDefinitionInput }
     if (!mod.default) throw new TypeError(`[vitehub] Workspace definition "${definition.name}" has no default export.`)
@@ -113,7 +113,7 @@ export async function syncDiscoveredWorkspaceAssetBundles(
 
   const bundles: WorkspaceAssetBundle[] = []
   for (const definition of definitions) {
-    if (!shouldSyncWorkspace(options.syncOnBuild, definition.name)) continue
+    if (!shouldBundleWorkspaceAssets(options.assets, definition.name)) continue
 
     const mod = await import(pathToFileURL(definition.path).href) as { default?: WorkspaceDefinitionInput }
     if (!mod.default) throw new TypeError(`[vitehub] Workspace definition "${definition.name}" has no default export.`)

--- a/packages/workspace/src/build-integration.ts
+++ b/packages/workspace/src/build-integration.ts
@@ -6,7 +6,7 @@ import { writeFileIfChanged } from "@vitehub/internal/definition-catalog"
 
 import {
   collectDirectoryWorkspaceAssetBundles,
-  shouldSyncWorkspace,
+  shouldBundleWorkspaceAssets,
   syncDiscoveredWorkspaceAssetBundles,
   writeWorkspaceAssetsRegistry,
 } from "./build-assets.ts"
@@ -70,7 +70,7 @@ export async function syncWorkspaceBuildAssets(
 ): Promise<void> {
   const syncedBundles = await syncDiscoveredWorkspaceAssetBundles(definitions, rootDir, options)
   const syncedNames = new Set(syncedBundles.map(bundle => bundle.name))
-  const selectedDefinitions = options ? definitions.filter(definition => shouldSyncWorkspace(options.syncOnBuild, definition.name)) : []
+  const selectedDefinitions = options ? definitions.filter(definition => shouldBundleWorkspaceAssets(options.assets, definition.name)) : []
   const directoryBundles = (await collectDirectoryWorkspaceAssetBundles(selectedDefinitions, rootDir))
     .filter(bundle => !syncedNames.has(bundle.name))
   await writeWorkspaceAssetsRegistry(assetsRegistryFile, [...directoryBundles, ...syncedBundles])

--- a/packages/workspace/src/config.ts
+++ b/packages/workspace/src/config.ts
@@ -33,8 +33,8 @@ export function normalizeWorkspaceOptions(
   const rootDir = input.rootDir || process.cwd()
   const root = resolvedOptions.root || ".vitehub/workspaces"
   return {
+    assets: resolvedOptions.assets,
     root: resolve(rootDir, root),
     store: normalizeWorkspaceStoreOptions(resolvedOptions.store, input) || { provider: "local" },
-    syncOnBuild: resolvedOptions.syncOnBuild,
   }
 }

--- a/packages/workspace/src/types.ts
+++ b/packages/workspace/src/types.ts
@@ -322,13 +322,13 @@ export type WorkspaceDefinitionInput = Omit<WorkspaceDefinition, "name"> & {
 
 export interface WorkspaceModuleOptions {
   root?: string
-  syncOnBuild?: boolean | string[]
+  assets?: boolean | string[]
   store?: WorkspaceStoreOptions
 }
 
 export interface ResolvedWorkspaceModuleOptions {
   root: string
-  syncOnBuild?: boolean | string[]
+  assets?: boolean | string[]
   store: Exclude<WorkspaceStoreOptions, WorkspaceStore>
 }
 

--- a/packages/workspace/test/config.test.ts
+++ b/packages/workspace/test/config.test.ts
@@ -3,6 +3,48 @@ import { describe, expect, it } from "vitest"
 import { normalizeWorkspaceOptions, resolveRuntimeVercelBlobWorkspaceStore } from "../src/config.ts"
 
 describe("workspace config", () => {
+  it("leaves build assets enabled by default", () => {
+    const config = normalizeWorkspaceOptions({}, {
+      env: {},
+      rootDir: "/repo",
+    })
+
+    expect(config && config.assets).toBeUndefined()
+  })
+
+  it("preserves explicit build asset selection", () => {
+    const config = normalizeWorkspaceOptions({
+      assets: ["docs"],
+    }, {
+      env: {},
+      rootDir: "/repo",
+    })
+
+    expect(config && config.assets).toEqual(["docs"])
+  })
+
+  it("preserves disabled build assets", () => {
+    const config = normalizeWorkspaceOptions({
+      assets: false,
+    }, {
+      env: {},
+      rootDir: "/repo",
+    })
+
+    expect(config && config.assets).toBe(false)
+  })
+
+  it("preserves explicit all-workspace build assets", () => {
+    const config = normalizeWorkspaceOptions({
+      assets: true,
+    }, {
+      env: {},
+      rootDir: "/repo",
+    })
+
+    expect(config && config.assets).toBe(true)
+  })
+
   it("defaults to memory without workspace options on Cloudflare hosting", () => {
     const config = normalizeWorkspaceOptions(undefined, {
       env: {},

--- a/packages/workspace/test/nitro-assets.test.ts
+++ b/packages/workspace/test/nitro-assets.test.ts
@@ -20,7 +20,7 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(path => rm(path, { recursive: true, force: true })))
 })
 
-describe("Nitro syncOnBuild", () => {
+describe("Nitro workspace assets", () => {
   it("aliases workspace subpaths before the main package alias", async () => {
     const root = await createRoot()
     const hooks: Record<string, Array<() => Promise<void>>> = {}
@@ -112,7 +112,7 @@ describe("Nitro syncOnBuild", () => {
     })
   })
 
-  it("syncs selected workspaces during build:before", async () => {
+  it("bundles selected workspaces during build:before", async () => {
     const root = await createRoot()
     await mkdir(join(root, "server/workspaces"), { recursive: true })
     await writeFile(join(root, "server/workspaces/selected.mjs"), `
@@ -184,7 +184,7 @@ export default {
         rootDir: root,
         runtimeConfig: {},
         workspace: {
-          syncOnBuild: ["selected"],
+          assets: ["selected"],
         },
       },
     }
@@ -196,7 +196,7 @@ export default {
     await expect(readFile(join(root, "server/assets/context/skipped.txt"), "utf8")).rejects.toThrow()
   })
 
-  it("syncs all discovered workspaces during build:before by default", async () => {
+  it("bundles all discovered workspaces during build:before by default", async () => {
     const root = await createRoot()
     await mkdir(join(root, "server/workspaces"), { recursive: true })
     await writeFile(join(root, "server/workspaces/one.mjs"), `
@@ -296,7 +296,7 @@ export default {
         rootDir: root,
         runtimeConfig: {},
         workspace: {
-          syncOnBuild: ["docs"],
+          assets: ["docs"],
         },
       },
     }
@@ -343,7 +343,7 @@ export default {
         rootDir: root,
         runtimeConfig: {},
         workspace: {
-          syncOnBuild: ["docs"],
+          assets: ["docs"],
         },
       },
     }

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -376,7 +376,7 @@ describe("sources, loaders, and publishers", () => {
     }], root, {
       root: join(root, ".vitehub", "workspaces"),
       store: { provider: "memory" },
-      syncOnBuild: true,
+      assets: true,
     }, registryFile)
 
     const contents = await readFile(registryFile, "utf8")
@@ -384,7 +384,7 @@ describe("sources, loaders, and publishers", () => {
     expect(contents.match(/"AGENTS.md"/g)).toHaveLength(1)
   })
 
-  it("filters directory workspace assets by syncOnBuild", async () => {
+  it("filters directory workspace assets by configured assets", async () => {
     const root = await createRoot()
     const selectedDirectory = join(root, "server", "workspaces", "selected")
     const skippedDirectory = join(root, "server", "workspaces", "skipped")
@@ -409,7 +409,7 @@ describe("sources, loaders, and publishers", () => {
     }], root, {
       root: join(root, ".vitehub", "workspaces"),
       store: { provider: "memory" },
-      syncOnBuild: ["selected"],
+      assets: ["selected"],
     }, registryFile)
 
     const registry = (await import(`${pathToFileURL(registryFile).href}?t=${Date.now()}`)).default
@@ -448,7 +448,7 @@ describe("sources, loaders, and publishers", () => {
     }], root, {
       root: join(root, ".vitehub", "workspaces"),
       store: { provider: "memory" },
-      syncOnBuild: true,
+      assets: true,
     }, registryFile)
 
     expect(fetch).not.toHaveBeenCalled()

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -13,6 +13,7 @@ import { createWorkspaceTools, type WorkspaceShellResult } from "../src/ai.ts"
 import { createWorkspaceAssets } from "../src/runtime/assets.ts"
 import * as source from "../src/source.ts"
 import { hubWorkspace } from "../src/vite.ts"
+import type { WorkspaceModuleOptions } from "../src/types.ts"
 
 declare global {
   interface ViteHubWorkspaceAssetMap {
@@ -60,6 +61,11 @@ describe("workspace types", () => {
     expectTypeOf(writable.tools).toMatchTypeOf<ToolSet>()
     expectTypeOf(writable.tools().writeFile).toMatchTypeOf<Tool<{ content: string, mediaType?: string, path: string }, { path: string }>>()
     expectTypeOf(writable.open).toBeFunction()
+    const workspaceOptions: WorkspaceModuleOptions = { assets: ["typed"], store: { provider: "memory" } }
+    // @ts-expect-error syncOnBuild was removed in favor of assets
+    const removedOptions: WorkspaceModuleOptions = { syncOnBuild: true }
+    expectTypeOf(workspaceOptions).toMatchTypeOf<WorkspaceModuleOptions>()
+    expectTypeOf(removedOptions).toMatchTypeOf<WorkspaceModuleOptions>()
     const session = null as unknown as Awaited<ReturnType<import("../src/types.ts").Workspace["open"]>>
     const workspace = null as unknown as import("../src/types.ts").Workspace
     // @ts-expect-error runtime selection belongs in workspace config, not open options

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -25,6 +25,28 @@ async function createViteRoot() {
   return rootDir
 }
 
+async function createViteAssetRoot() {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-vite-assets-"))
+  tempDirs.push(root)
+  await mkdir(join(root, "src"), { recursive: true })
+  for (const name of ["docs", "notes"]) {
+    await writeFile(join(root, "src", `${name}.workspace.mjs`), [
+      `export default {`,
+      `  store: { provider: "memory" },`,
+      `  sources: {`,
+      `    files: {`,
+      `      name: "inline",`,
+      `      async getKeys() { return ["README.md"] },`,
+      `      async getItem(key) { return { key, path: key, content: "${name}\\n" } },`,
+      `    },`,
+      `  },`,
+      `}`,
+      ``,
+    ].join("\n"))
+  }
+  return root
+}
+
 afterEach(async () => {
   delete process.env.VITEHUB_WORKSPACE_DEV
   await Promise.all(tempDirs.splice(0).map(path => rm(path, { recursive: true, force: true })))
@@ -72,22 +94,7 @@ describe("hubWorkspace", () => {
   })
 
   it("emits build-time workspace assets for Vite builds", async () => {
-    const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-vite-assets-"))
-    tempDirs.push(root)
-    await mkdir(join(root, "src"), { recursive: true })
-    await writeFile(join(root, "src/docs.workspace.mjs"), [
-      `export default {`,
-      `  store: { provider: "memory" },`,
-      `  sources: {`,
-      `    files: {`,
-      `      name: "inline",`,
-      `      async getKeys() { return ["README.md"] },`,
-      `      async getItem(key) { return { key, path: key, content: "docs\\n" } },`,
-      `    },`,
-      `  },`,
-      `}`,
-      ``,
-    ].join("\n"))
+    const root = await createViteAssetRoot()
 
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace()
@@ -102,9 +109,52 @@ describe("hubWorkspace", () => {
     const registry = (await import(`${pathToFileURL(registryId).href}?t=${Date.now()}`)).default
 
     await expect(readFile(registryId, "utf8")).resolves.toContain('"docs"')
+    await expect(readFile(registryId, "utf8")).resolves.toContain('"notes"')
     await expect(registry.docs.list()).resolves.toEqual([
       expect.objectContaining({ path: "files", type: "directory" }),
     ])
     await expect(registry.docs.readFile("files/README.md")).resolves.toBe("docs\n")
+    await expect(registry.notes.readFile("files/README.md")).resolves.toBe("notes\n")
+  })
+
+  it("emits selected build-time workspace assets for Vite builds", async () => {
+    const root = await createViteAssetRoot()
+
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace({ assets: ["docs"] })
+    const configResolved = plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>
+    const buildStart = plugin.buildStart as () => Promise<void>
+    const resolveId = plugin.resolveId as (id: string) => string | undefined
+
+    await configResolved({ command: "build", root })
+    await buildStart()
+
+    const registryId = resolveId("#vitehub-workspace-assets-registry")!
+    const registry = (await import(`${pathToFileURL(registryId).href}?t=${Date.now()}`)).default
+
+    await expect(readFile(registryId, "utf8")).resolves.toContain('"docs"')
+    await expect(readFile(registryId, "utf8")).resolves.not.toContain('"notes"')
+    await expect(registry.docs.readFile("files/README.md")).resolves.toBe("docs\n")
+    expect(registry.notes).toBeUndefined()
+  })
+
+  it("can disable build-time workspace assets for Vite builds", async () => {
+    const root = await createViteAssetRoot()
+
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace({ assets: false })
+    const configResolved = plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>
+    const buildStart = plugin.buildStart as () => Promise<void>
+    const resolveId = plugin.resolveId as (id: string) => string | undefined
+
+    await configResolved({ command: "build", root })
+    await buildStart()
+
+    const registryId = resolveId("#vitehub-workspace-assets-registry")!
+    const registry = (await import(`${pathToFileURL(registryId).href}?t=${Date.now()}`)).default
+
+    await expect(readFile(registryId, "utf8")).resolves.not.toContain('"docs"')
+    await expect(readFile(registryId, "utf8")).resolves.not.toContain('"notes"')
+    expect(registry).toEqual({})
   })
 })


### PR DESCRIPTION
Renames the workspace build asset selector from `syncOnBuild` to `assets` and removes the old public option without compatibility handling. `assets` keeps the current default of bundling all discovered workspaces, supports `true`, `false`, and selected workspace names, and is now carried through normalized Vite/Nitro workspace options.

This keeps the architecture split intact: `store` remains canonical persistence, source-level `materialize` remains source ingestion timing, and `runtime: 'sandbox'` remains executable session materialization. Docs and tests now describe build-time assets in those terms.

Checked with `pnpm --filter @vitehub/workspace exec vitest run test/config.test.ts test/vite.test.ts test/nitro-assets.test.ts`, `pnpm --filter @vitehub/workspace test`, `pnpm --filter @vitehub/workspace typecheck`, and `pnpm --filter @vitehub/workspace build`.