### PR TITLE
ci: publish all preview packages

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -20,10 +20,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
-      - run: pnpm --filter @vitehub/workspace build
-      - run: pnpm --filter @vitehub/chat build
-      - run: pnpm --filter @vitehub/shell build
-      - run: pnpm --filter @vitehub/env build
+      - run: pnpm -r --filter './packages/*' --if-present run build
 
       - name: Publish preview packages
-        run: pnpm dlx pkg-pr-new publish './packages/workspace' './packages/chat' './packages/shell' './packages/env' --packageManager=pnpm
+        run: pnpm dlx pkg-pr-new publish './packages/*' --packageManager=pnpm


### PR DESCRIPTION
Updates the pkg.pr.new workflow to build package workspaces recursively and publish preview packages with the supported packages glob. This keeps the preview package set current as packages are added to the monorepo.