### PR TITLE
ci: pack preview packages with pnpm

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -23,4 +23,4 @@ jobs:
       - run: pnpm -r --filter './packages/*' --if-present run build
 
       - name: Publish preview packages
-        run: pnpm dlx pkg-pr-new publish './packages/*' --packageManager=pnpm
+        run: pnpm dlx pkg-pr-new publish './packages/*' --pnpm --packageManager=pnpm


### PR DESCRIPTION
Updates the pkg.pr.new workflow to pack workspace packages with pnpm so pnpm catalog dependencies are rewritten in preview packages.