### PR TITLE
refactor: share provider output writer

### DIFF
--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -2,13 +2,14 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { resolve } from "pathe"
 
 import { defaultCloudflareCompatibilityDate } from "@vitehub/internal/build/cloudflare"
-import { writeCloudflareDeploymentOutput, writeVercelDeploymentOutput } from "@vitehub/internal/build/deployment-output"
+import { writeProviderDeploymentOutputs } from "@vitehub/internal/build/deployment-output"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vitehub/internal/build/paths"
 import { resolveUserAppEntry } from "@vitehub/internal/build/user-entry"
 
 import { normalizeBlobOptions } from "../config.ts"
 
 import type { BlobModuleOptions, ResolvedBlobModuleOptions } from "../types.ts"
+import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vitehub/internal/build/deployment-output"
 
 export const blobPackageName = "@vitehub/blob"
 const productName = "blob"
@@ -189,7 +190,7 @@ async function writeProviderEntries(rootDir: string, blob: BlobModuleOptions | R
   } satisfies GeneratedBlobArtifacts
 }
 
-async function writeCloudflareOutput(rootDir: string, clientOutDir: string, blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined, artifacts: GeneratedBlobArtifacts) {
+function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined, artifacts: GeneratedBlobArtifacts): CloudflareProviderDeploymentOutput {
   const resolved = resolveBlobConfig(blob, "cloudflare")
 
   const wranglerConfig: CloudflareBlobConfig = {
@@ -200,7 +201,7 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, blob
     ...(createCloudflareR2Bindings(resolved) ? { r2_buckets: createCloudflareR2Bindings(resolved) } : {}),
   }
 
-  await writeCloudflareDeploymentOutput({
+  return {
     bundleEntry: artifacts.cloudflareWorkerFile,
     bundleOptions: {
       alias: {
@@ -211,14 +212,12 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, blob
       format: "esm",
       platform: "neutral",
     },
-    clientOutDir,
-    rootDir,
     wranglerConfig,
-  })
+  }
 }
 
-async function writeVercelOutput(rootDir: string, clientOutDir: string, artifacts: GeneratedBlobArtifacts) {
-  await writeVercelDeploymentOutput({
+function createVercelOutput(artifacts: GeneratedBlobArtifacts): VercelProviderDeploymentOutput {
+  return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
       alias: {
@@ -228,16 +227,16 @@ async function writeVercelOutput(rootDir: string, clientOutDir: string, artifact
       format: "esm",
       platform: "node",
     },
-    clientOutDir,
-    rootDir,
-  })
+  }
 }
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedBlobArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.blob)
-  await Promise.all([
-    writeCloudflareOutput(options.rootDir, options.clientOutDir, options.blob, artifacts),
-    writeVercelOutput(options.rootDir, options.clientOutDir, artifacts),
-  ])
+  await writeProviderDeploymentOutputs({
+    clientOutDir: options.clientOutDir,
+    cloudflare: createCloudflareOutput(options.blob, artifacts),
+    rootDir: options.rootDir,
+    vercel: createVercelOutput(artifacts),
+  })
   return artifacts
 }

--- a/packages/db/src/internal/vite-build.ts
+++ b/packages/db/src/internal/vite-build.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises"
 
-import { writeCloudflareDeploymentOutput, writeVercelDeploymentOutput } from "@vitehub/internal/build/deployment-output"
+import { writeProviderDeploymentOutputs } from "@vitehub/internal/build/deployment-output"
 import { defaultCloudflareCompatibilityDate } from "@vitehub/internal/build/cloudflare"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vitehub/internal/build/paths"
 import { resolveUserAppEntry } from "@vitehub/internal/build/user-entry"
@@ -9,6 +9,7 @@ import { resolve } from "pathe"
 import { serializeSchemaObject } from "./schema-serializer.ts"
 
 import type { ResolvedDBViteConfig, ResolvedDrizzleDatabaseConfig } from "../types.ts"
+import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vitehub/internal/build/deployment-output"
 
 export const dbPackageName = "@vitehub/db"
 const productName = "db"
@@ -187,7 +188,7 @@ interface ProviderWriteOptions {
   runtimeConfig: ResolvedDBViteConfig
 }
 
-async function writeCloudflareOutput({ artifacts, clientOutDir, rootDir, runtimeConfig }: ProviderWriteOptions) {
+function createCloudflareOutput({ artifacts, runtimeConfig }: ProviderWriteOptions): CloudflareProviderDeploymentOutput {
   const databasesMissingNames = getCloudflareDatabasesMissingNames(runtimeConfig)
   if (databasesMissingNames.length) {
     throw new Error(`[vitehub] Cloudflare output requires \`db.cloudflare.databaseName\` when \`db.cloudflare.databaseId\` is set for databases: ${databasesMissingNames.join(", ")}.`)
@@ -208,7 +209,7 @@ async function writeCloudflareOutput({ artifacts, clientOutDir, rootDir, runtime
     observability: { enabled: true },
   }
 
-  await writeCloudflareDeploymentOutput({
+  return {
     bundleEntry: artifacts.cloudflareWorkerFile,
     bundleOptions: {
       alias: { "@vitehub/db/drizzle": artifacts.runtimeModuleFiles.cloudflare },
@@ -217,33 +218,34 @@ async function writeCloudflareOutput({ artifacts, clientOutDir, rootDir, runtime
       format: "esm",
       platform: "neutral",
     },
-    clientOutDir,
-    rootDir,
     wranglerConfig,
-  })
+  }
 }
 
-async function writeVercelOutput({ artifacts, clientOutDir, rootDir, runtimeConfig }: ProviderWriteOptions) {
+function createVercelOutput({ artifacts, runtimeConfig }: ProviderWriteOptions): VercelProviderDeploymentOutput {
   const unsupportedDatabases = getVercelUnsupportedDatabases(runtimeConfig)
   if (unsupportedDatabases.length) {
     throw new Error(`[vitehub] Vercel output requires a remote libSQL \`db.connection.url\` for databases: ${unsupportedDatabases.join(", ")}.`)
   }
 
-  await writeVercelDeploymentOutput({
+  return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
       alias: { "@vitehub/db/drizzle": artifacts.runtimeModuleFiles.vercel },
       format: "esm",
       platform: "node",
     },
-    clientOutDir,
-    rootDir,
-  })
+  }
 }
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedDBArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.runtimeConfig)
   const writeOptions: ProviderWriteOptions = { artifacts, ...options }
-  await Promise.all([writeCloudflareOutput(writeOptions), writeVercelOutput(writeOptions)])
+  await writeProviderDeploymentOutputs({
+    clientOutDir: options.clientOutDir,
+    cloudflare: createCloudflareOutput(writeOptions),
+    rootDir: options.rootDir,
+    vercel: createVercelOutput(writeOptions),
+  })
   return artifacts
 }

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -32,6 +32,14 @@ export interface VercelDeploymentOutputOptions extends SharedDeploymentOptions {
   staticOutputDir?: string
 }
 
+export type CloudflareProviderDeploymentOutput = Omit<CloudflareDeploymentOutputOptions, keyof SharedDeploymentOptions>
+export type VercelProviderDeploymentOutput = Omit<VercelDeploymentOutputOptions, keyof SharedDeploymentOptions>
+
+export interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
+  cloudflare: CloudflareProviderDeploymentOutput
+  vercel: VercelProviderDeploymentOutput
+}
+
 interface ResolvedClientOutput {
   clientDir: string
   staticIndex: boolean
@@ -95,5 +103,20 @@ export async function writeVercelDeploymentOutput(options: VercelDeploymentOutpu
     staticIndex
       ? copyClientOutput(clientDir, options.staticOutputDir ?? resolve(outputRoot, "static"))
       : Promise.resolve(),
+  ])
+}
+
+export async function writeProviderDeploymentOutputs(options: ProviderDeploymentOutputOptions): Promise<void> {
+  await Promise.all([
+    writeCloudflareDeploymentOutput({
+      ...options.cloudflare,
+      clientOutDir: options.clientOutDir,
+      rootDir: options.rootDir,
+    }),
+    writeVercelDeploymentOutput({
+      ...options.vercel,
+      clientOutDir: options.clientOutDir,
+      rootDir: options.rootDir,
+    }),
   ])
 }

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -2,7 +2,7 @@ import { mkdir, rm, writeFile } from "node:fs/promises"
 import { relative, resolve } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vitehub/internal/build/cloudflare"
-import { writeCloudflareDeploymentOutput, writeVercelDeploymentOutput } from "@vitehub/internal/build/deployment-output"
+import { createDefaultVercelOutputRoot, writeProviderDeploymentOutputs } from "@vitehub/internal/build/deployment-output"
 import { bundleEsmEntry } from "@vitehub/internal/build/esbuild"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg, toGeneratedPath } from "@vitehub/internal/build/paths"
 import { resolveUserAppEntry } from "@vitehub/internal/build/user-entry"
@@ -15,6 +15,7 @@ import { getCloudflareQueueBindingName, getCloudflareQueueName } from "../integr
 import { getVercelQueueTopicName } from "../integrations/vercel.ts"
 
 import type { DiscoveredQueueDefinition, QueueModuleOptions, QueueProvider } from "../types.ts"
+import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vitehub/internal/build/deployment-output"
 
 export const queuePackageName = "@vitehub/queue"
 const productName = "queue"
@@ -147,7 +148,7 @@ export async function createCloudflareQueueConfig(options: CloudflareQueueConfig
   }
 }
 
-async function writeCloudflareOutput(rootDir: string, clientOutDir: string, artifacts: GeneratedQueueArtifacts) {
+function createCloudflareOutput(artifacts: GeneratedQueueArtifacts): CloudflareProviderDeploymentOutput {
   const queues = createCloudflareQueueBindings(artifacts.definitions)
 
   const wranglerConfig: CloudflareQueueConfig = {
@@ -158,7 +159,7 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, arti
     ...(queues ? { queues } : {}),
   }
 
-  await writeCloudflareDeploymentOutput({
+  return {
     bundleEntry: artifacts.cloudflareWorkerFile,
     bundleOptions: {
       conditions: ["workerd", "worker", "browser", "default"],
@@ -166,10 +167,8 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, arti
       format: "esm",
       platform: "neutral",
     },
-    clientOutDir,
-    rootDir,
     wranglerConfig,
-  })
+  }
 }
 
 function sanitizeVercelConsumerName(functionPath: string) {
@@ -218,21 +217,20 @@ function createVercelQueueWrapperContents(file: string, registryFile: string, na
   ].join("\n")
 }
 
-async function writeVercelOutput(rootDir: string, clientOutDir: string, queue: QueueModuleOptions | undefined, artifacts: GeneratedQueueArtifacts) {
-  const outputRoot = resolve(rootDir, ".vercel", "output")
-  const queueRoot = resolve(outputRoot, "functions", "api", "vitehub", "queues", "vercel")
-  const queueConfig = normalizeQueueOptions(queue, { hosting: "vercel" }) || false
-
-  await writeVercelDeploymentOutput({
+function createVercelOutput(artifacts: GeneratedQueueArtifacts): VercelProviderDeploymentOutput {
+  return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
       format: "esm",
       platform: "node",
     },
-    clientOutDir,
-    outputRoot,
-    rootDir,
-  })
+  }
+}
+
+async function writeVercelQueueFunctions(rootDir: string, queue: QueueModuleOptions | undefined, artifacts: GeneratedQueueArtifacts) {
+  const outputRoot = createDefaultVercelOutputRoot(rootDir)
+  const queueRoot = resolve(outputRoot, "functions", "api", "vitehub", "queues", "vercel")
+  const queueConfig = normalizeQueueOptions(queue, { hosting: "vercel" }) || false
 
   if (queueConfig === false) {
     return
@@ -272,9 +270,12 @@ async function writeVercelOutput(rootDir: string, clientOutDir: string, queue: Q
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedQueueArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.queue)
-  await Promise.all([
-    writeCloudflareOutput(options.rootDir, options.clientOutDir, artifacts),
-    writeVercelOutput(options.rootDir, options.clientOutDir, options.queue, artifacts),
-  ])
+  await writeProviderDeploymentOutputs({
+    clientOutDir: options.clientOutDir,
+    cloudflare: createCloudflareOutput(artifacts),
+    rootDir: options.rootDir,
+    vercel: createVercelOutput(artifacts),
+  })
+  await writeVercelQueueFunctions(options.rootDir, options.queue, artifacts)
   return artifacts
 }

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { resolve } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vitehub/internal/build/cloudflare"
-import { createDefaultCloudflareOutputRoot, writeCloudflareDeploymentOutput, writeVercelDeploymentOutput } from "@vitehub/internal/build/deployment-output"
+import { createDefaultCloudflareOutputRoot, writeProviderDeploymentOutputs } from "@vitehub/internal/build/deployment-output"
 import { VITEHUB_MODES, getViteMode } from "@vitehub/internal/build/mode"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vitehub/internal/build/paths"
 import { resolveUserAppEntry } from "@vitehub/internal/build/user-entry"
@@ -13,6 +13,7 @@ import { discoverWorkflowDefinitions } from "../discovery.ts"
 import { createCloudflareWorkflowBindings, getCloudflareWorkflowClassName } from "../integrations/cloudflare.ts"
 
 import type { DiscoveredWorkflowDefinition, ResolvedWorkflowOptions, WorkflowModuleOptions, WorkflowProvider } from "../types.ts"
+import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vitehub/internal/build/deployment-output"
 
 export const workflowPackageName = "@vitehub/workflow"
 const productName = "workflow"
@@ -173,8 +174,7 @@ async function writeProviderEntries(rootDir: string, workflow: WorkflowModuleOpt
   }
 }
 
-async function writeCloudflareOutput(rootDir: string, clientOutDir: string, artifacts: GeneratedWorkflowArtifacts) {
-  const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+function createCloudflareOutput(rootDir: string, artifacts: GeneratedWorkflowArtifacts): CloudflareProviderDeploymentOutput {
   const workflowConfig = artifacts.cloudflareWorkflowConfig && artifacts.cloudflareWorkflowConfig.provider === "cloudflare"
     ? artifacts.cloudflareWorkflowConfig
     : false
@@ -189,7 +189,7 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, arti
     ...(workflows ? { workflows } : {}),
   }
 
-  await writeCloudflareDeploymentOutput({
+  return {
     bundleEntry: artifacts.cloudflareWorkerFile,
     bundleOptions: {
       conditions: ["workerd", "worker", "browser", "default"],
@@ -209,33 +209,39 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, arti
       platform: "neutral",
     },
     bundleOutfileName: "worker.mjs",
-    clientOutDir,
-    outputRoot,
-    rootDir,
+    outputRoot: createDefaultCloudflareOutputRoot(rootDir),
     wranglerConfig,
-  })
+  }
+}
 
+async function writeCloudflareWorkflowWrapper(rootDir: string, artifacts: GeneratedWorkflowArtifacts) {
+  const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+  const workflowConfig = artifacts.cloudflareWorkflowConfig && artifacts.cloudflareWorkflowConfig.provider === "cloudflare"
+    ? artifacts.cloudflareWorkflowConfig
+    : false
+  const workflowDefinitions = workflowConfig ? artifacts.definitions : []
   await writeFile(resolve(outputRoot, "index.js"), renderCloudflareWorkerWrapper(workflowDefinitions), "utf8")
 }
 
-async function writeVercelOutput(rootDir: string, clientOutDir: string, artifacts: GeneratedWorkflowArtifacts) {
-  await writeVercelDeploymentOutput({
+function createVercelOutput(artifacts: GeneratedWorkflowArtifacts): VercelProviderDeploymentOutput {
+  return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
       external: ["@cloudflare/sandbox", "cloudflare:workers", "workflow", "workflow/api", "workflow/runtime"],
       format: "esm",
       platform: "node",
     },
-    clientOutDir,
-    rootDir,
-  })
+  }
 }
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedWorkflowArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.workflow)
-  await Promise.all([
-    writeCloudflareOutput(options.rootDir, options.clientOutDir, artifacts),
-    writeVercelOutput(options.rootDir, options.clientOutDir, artifacts),
-  ])
+  await writeProviderDeploymentOutputs({
+    clientOutDir: options.clientOutDir,
+    cloudflare: createCloudflareOutput(options.rootDir, artifacts),
+    rootDir: options.rootDir,
+    vercel: createVercelOutput(artifacts),
+  })
+  await writeCloudflareWorkflowWrapper(options.rootDir, artifacts)
   return artifacts
 }


### PR DESCRIPTION
Refactors Blob, DB, Queue, and Workflow provider output generation to build Cloudflare/Vercel output specs and delegate writing to a shared internal provider output helper.

Keeps provider-specific config and post-output artifacts local, including Queue Vercel queue functions and Workflow Cloudflare wrapper generation.

Checks run in the integration workspace before splitting: package typechecks for Blob/DB/Queue/Workflow, targeted provider-output tests for Blob and DB, touched-file oxlint, and diff whitespace checks.