### PR TITLE
refactor: centralize docs rendering state

### DIFF
--- a/docs/app/composables/useDocsNavigation.ts
+++ b/docs/app/composables/useDocsNavigation.ts
@@ -1,137 +1,21 @@
 import { useRoute } from "#app/composables/router";
 import { computed } from "vue";
-import type { ContentNavigationItem } from "@nuxt/content";
 import { useFrameworkPreference } from "./useFrameworkPreference";
-import { docsManifest, getDocsPath, getDocsPathMeta, isDocsPageSupported, type DocsPage, type DocsSection } from "~~/modules/vitehub-docs/runtime/utils/docs";
-import type { Framework } from "~~/modules/vitehub-docs/runtime/utils/frameworks";
+import {
+  buildDocsSidebarNavigation,
+  getDocsActiveSection,
+  getSupportedDocsSections,
+} from "~~/modules/vitehub-docs/runtime/utils/docs-rendering";
 import { normalizeSitePath } from "~~/modules/vitehub-docs/runtime/utils/docs-routes";
-
-type DocsSectionLink = {
-  label: string;
-  description?: string;
-  icon?: string;
-  to: string;
-  active: boolean;
-};
-
-function createNavigationGroup(title: string, items: ContentNavigationItem[], options: { defaultOpen?: boolean } = {}) {
-  if (!items.length) return null;
-  return {
-    title,
-    path: items[0]?.path || "/docs",
-    children: items,
-    ...(options.defaultOpen !== undefined && { defaultOpen: options.defaultOpen }),
-  } satisfies ContentNavigationItem;
-}
-
-function isPathExact(itemPath: string, currentPath: string) {
-  const a = itemPath.replace(/\/+$/, "");
-  const b = currentPath.replace(/\/+$/, "");
-  return b === a;
-}
-
-function isPathActive(itemPath: string, currentPath: string) {
-  const a = itemPath.replace(/\/+$/, "");
-  const b = currentPath.replace(/\/+$/, "");
-  return b === a || b.startsWith(`${a}/`);
-}
-
-function toNavigationItem(item: { title: string; path: string; icon?: string | null }, currentPath?: string) {
-  return {
-    title: item.title,
-    path: item.path,
-    icon: item.icon || undefined,
-    ...(currentPath !== undefined && { active: isPathExact(item.path, currentPath) }),
-  } satisfies ContentNavigationItem;
-}
-
-function getSupportedPages(section: DocsSection, framework: Framework) {
-  return section.pages.filter(page => isDocsPageSupported(section.id, page.id, framework));
-}
-
-function getSectionPrimaryPage(section: DocsSection, framework: Framework) {
-  const pages = getSupportedPages(section, framework);
-  return pages.find(page => page.id === "index") || pages[0] || null;
-}
-
-function getSectionLink(section: DocsSection, framework: Framework, currentPath: string): DocsSectionLink | null {
-  const primaryPage = getSectionPrimaryPage(section, framework);
-  if (!primaryPage) return null;
-
-  const sectionPath = getDocsPath(section.id, framework);
-  return {
-    label: section.title,
-    description: section.description || undefined,
-    icon: section.icon || undefined,
-    to: getDocsPath(section.id, framework, primaryPage.id),
-    active: isPathActive(sectionPath, currentPath),
-  };
-}
-
-function buildDocsIndexSidebarNavigation(sections: DocsSection[], framework: Framework, currentPath: string) {
-  const gettingStartedSection = sections.find(section => section.id === "getting-started");
-  if (!gettingStartedSection) return [];
-
-  return [toNavigationItem({ title: gettingStartedSection.title, path: "/docs", icon: gettingStartedSection.icon }, currentPath)];
-}
-
-function buildSectionSidebarNavigation(section: DocsSection, framework: Framework, currentPath: string) {
-  const pages = getSupportedPages(section, framework);
-  const rootItems = [
-    toNavigationItem({ title: "Overview", path: getDocsPath(section.id, framework), icon: section.icon }, currentPath),
-    ...pages
-      .filter(page => page.id !== "index" && !page.group)
-      .map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath)),
-  ];
-  const groupedPages = new Map<string, DocsPage[]>();
-
-  for (const page of pages) {
-    if (!page.group) continue;
-    groupedPages.set(page.group, [...(groupedPages.get(page.group) || []), page]);
-  }
-
-  const groups = [
-    ...rootItems,
-    ...[...groupedPages.entries()]
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([group, items]) => createNavigationGroup(
-        group,
-        items.map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath)),
-        { defaultOpen: group === "Providers" },
-      )),
-  ];
-
-  return groups.filter(Boolean) as ContentNavigationItem[];
-}
 
 export function useDocsNavigation() {
   const route = useRoute();
   const { current } = useFrameworkPreference();
   const normalizedRoutePath = computed(() => normalizeSitePath(route.path));
 
-  const sections = computed(() => docsManifest.sections.filter(section => getSupportedPages(section, current.value).length > 0));
-  const activeSection = computed(() => {
-    const meta = getDocsPathMeta(normalizedRoutePath.value);
-    return meta ? sections.value.find(section => section.id === meta.section) || null : null;
-  });
-
-  const sidebarNavigation = computed(() => {
-    if (normalizedRoutePath.value === "/docs") {
-      return buildDocsIndexSidebarNavigation(sections.value, current.value, normalizedRoutePath.value);
-    }
-
-    if (!activeSection.value) {
-      const packageLinks = sections.value
-        .filter(section => section.id !== "getting-started")
-        .map(section => getSectionLink(section, current.value, normalizedRoutePath.value))
-        .filter((item): item is DocsSectionLink => Boolean(item))
-        .map(item => toNavigationItem({ title: item.label, path: item.to, icon: item.icon }, normalizedRoutePath.value));
-      const group = createNavigationGroup("Packages", packageLinks);
-      return group ? [group] : [];
-    }
-
-    return buildSectionSidebarNavigation(activeSection.value, current.value, normalizedRoutePath.value);
-  });
+  const sections = computed(() => getSupportedDocsSections(current.value));
+  const activeSection = computed(() => getDocsActiveSection(normalizedRoutePath.value, sections.value));
+  const sidebarNavigation = computed(() => buildDocsSidebarNavigation(normalizedRoutePath.value, current.value, sections.value));
 
   return {
     sections,

--- a/docs/app/composables/useDocsPage.ts
+++ b/docs/app/composables/useDocsPage.ts
@@ -4,36 +4,18 @@ import { useDocsRenderMode } from "./useDocsRenderMode";
 import { useFrameworkPreference } from "./useFrameworkPreference";
 import { useUsageModePreference } from "./useUsageModePreference";
 import type { DocsCollectionItem } from "@nuxt/content";
-import { normalizeFrameworkPage } from "~~/modules/vitehub-docs/runtime/utils/framework-content";
+import { renderDocsPage, type DocsPageFallback, type DocsPageState } from "~~/modules/vitehub-docs/runtime/utils/docs-rendering";
 
-export type ContentPage = DocsCollectionItem & {
-  data?: Record<string, unknown>;
-  seo?: { title?: string; description?: string };
-};
+export type ContentPage = DocsPageState<DocsCollectionItem>;
 
-export function useDocsPage(sourcePath: string | ComputedRef<string>, rawDoc: Ref<DocsCollectionItem | null | undefined>, fallback: { title: string; sourceTitle: string | null; description: string | null }) {
+export function useDocsPage(sourcePath: string | ComputedRef<string>, rawDoc: Ref<DocsCollectionItem | null | undefined>, fallback: DocsPageFallback) {
   const { current: framework } = useFrameworkPreference();
   const { current: mode } = useUsageModePreference();
   const { renderMode } = useDocsRenderMode();
 
   const path = typeof sourcePath === "string" ? computed(() => sourcePath) : sourcePath;
 
-  const sourcePage = computed(() => {
-    const doc = rawDoc.value;
-    if (!doc) return null;
-    const title = String(doc.title || fallback.sourceTitle || fallback.title);
-    const description = doc.description || fallback.description || "";
-    return {
-      ...doc,
-      path: path.value,
-      title,
-      description,
-      seo: { title: doc.seo?.title || title, description: doc.seo?.description || description },
-      data: doc.meta || {},
-    } satisfies ContentPage;
-  });
-
-  const page = computed<ContentPage | null>(() => normalizeFrameworkPage(sourcePage.value, {
+  const page = computed<ContentPage | null>(() => renderDocsPage(rawDoc.value, path.value, fallback, {
     framework: framework.value,
     mode: mode.value,
     renderMode: renderMode.value,

--- a/docs/app/pages/docs/[framework]/[...slug].vue
+++ b/docs/app/pages/docs/[framework]/[...slug].vue
@@ -4,35 +4,32 @@ import { createError } from "#app/composables/error";
 import { definePageMeta } from "#app/composables/pages";
 import { useRoute } from "#app/composables/router";
 import { useDocsPage } from "../../../composables/useDocsPage";
-import { getDocsPage, getDocsPath, getDocsPathMeta } from "~~/modules/vitehub-docs/runtime/utils/docs";
-import type { Framework } from "~~/modules/vitehub-docs/runtime/utils/frameworks";
+import { getDocsPageFallback, resolveDocsRoute } from "~~/modules/vitehub-docs/runtime/utils/docs-rendering";
 
 definePageMeta({
   layout: "docs",
 });
 
 const route = useRoute();
-const routeMeta = getDocsPathMeta(route.path);
+const routeState = resolveDocsRoute(route.path);
 
-if (!routeMeta) {
+if (!routeState) {
   throw createError({ statusCode: 404, statusMessage: "Page not found", fatal: true });
 }
 
-const docsPage = getDocsPage(routeMeta.section, routeMeta.page);
-const sourcePath = getDocsPath(routeMeta.section, routeMeta.framework as Framework, routeMeta.page);
 const { data: rawDoc } = await useAsyncData(
-  `docs:${sourcePath}`,
-  () => queryCollection("docs").path(sourcePath).first(),
+  `docs:${routeState.sourcePath}`,
+  () => queryCollection("docs").path(routeState.sourcePath).first(),
 );
 
-if (!docsPage || !docsPage.frameworks.includes(routeMeta.framework as Framework) || !rawDoc.value) {
+if (!routeState.page || !routeState.supported || !rawDoc.value) {
   throw createError({ statusCode: 404, statusMessage: "Page not found", fatal: true });
 }
 
 const { page } = useDocsPage(
-  sourcePath,
+  routeState.sourcePath,
   rawDoc,
-  { title: docsPage.title, sourceTitle: docsPage.sourceTitle, description: docsPage.description },
+  getDocsPageFallback(routeState.page),
 );
 </script>
 

--- a/docs/app/pages/docs/index.vue
+++ b/docs/app/pages/docs/index.vue
@@ -6,6 +6,7 @@ import { computed } from "vue";
 import { useDocsPage } from "../../composables/useDocsPage";
 import { useFrameworkPreference } from "../../composables/useFrameworkPreference";
 import { getDocsPage, getDocsPath } from "~~/modules/vitehub-docs/runtime/utils/docs";
+import { getDocsPageFallback } from "~~/modules/vitehub-docs/runtime/utils/docs-rendering";
 
 definePageMeta({
   layout: "docs",
@@ -28,7 +29,7 @@ if (!docsPage) {
 const { page } = useDocsPage(
   computed(() => "/docs"),
   rawDoc,
-  { title: docsPage.title, sourceTitle: docsPage.sourceTitle, description: docsPage.description },
+  getDocsPageFallback(docsPage),
 );
 </script>
 

--- a/docs/modules/vitehub-docs/runtime/utils/docs-rendering.ts
+++ b/docs/modules/vitehub-docs/runtime/utils/docs-rendering.ts
@@ -11,7 +11,7 @@ import {
 import { normalizeFrameworkPage, type DocsRenderOptions } from "./framework-content";
 import type { Framework } from "./frameworks";
 
-export type DocsRouteMeta = Omit<NonNullable<ReturnType<typeof getDocsPathMeta>>, "framework"> & { framework: Framework };
+type DocsRouteMeta = Omit<NonNullable<ReturnType<typeof getDocsPathMeta>>, "framework"> & { framework: Framework };
 
 type ContentPageInput = {
   title?: unknown;
@@ -35,7 +35,7 @@ export type DocsPageState<T extends ContentPageInput> = T & {
   data: Record<string, unknown>;
 };
 
-export type DocsResolvedRoute = {
+type DocsResolvedRoute = {
   meta: DocsRouteMeta;
   page: DocsPage | null;
   sourcePath: string;
@@ -140,7 +140,7 @@ function toNavigationItem(item: { title: string; path: string; icon?: string | n
   } satisfies ContentNavigationItem;
 }
 
-export function getSupportedDocsPages(section: DocsSection, framework: Framework) {
+function getSupportedDocsPages(section: DocsSection, framework: Framework) {
   return section.pages.filter(page => isDocsPageSupported(section.id, page.id, framework));
 }
 

--- a/docs/modules/vitehub-docs/runtime/utils/docs-rendering.ts
+++ b/docs/modules/vitehub-docs/runtime/utils/docs-rendering.ts
@@ -1,0 +1,229 @@
+import type { ContentNavigationItem } from "@nuxt/content";
+import {
+  docsManifest,
+  getDocsPage,
+  getDocsPath,
+  getDocsPathMeta,
+  isDocsPageSupported,
+  type DocsPage,
+  type DocsSection,
+} from "./docs";
+import { normalizeFrameworkPage, type DocsRenderOptions } from "./framework-content";
+import type { Framework } from "./frameworks";
+
+export type DocsRouteMeta = Omit<NonNullable<ReturnType<typeof getDocsPathMeta>>, "framework"> & { framework: Framework };
+
+type ContentPageInput = {
+  title?: unknown;
+  description?: string | null;
+  seo?: { title?: string; description?: string };
+  meta?: Record<string, unknown> | null;
+  body?: { value?: unknown[]; toc?: { links?: unknown[] } | null } | null;
+};
+
+export type DocsPageFallback = {
+  title: string;
+  sourceTitle: string | null;
+  description: string | null;
+};
+
+export type DocsPageState<T extends ContentPageInput> = T & {
+  path: string;
+  title: string;
+  description: string;
+  seo: { title: string; description: string };
+  data: Record<string, unknown>;
+};
+
+export type DocsResolvedRoute = {
+  meta: DocsRouteMeta;
+  page: DocsPage | null;
+  sourcePath: string;
+  supported: boolean;
+};
+
+type DocsSectionLink = {
+  label: string;
+  description?: string;
+  icon?: string;
+  to: string;
+  active: boolean;
+};
+
+export function resolveDocsRoute(path: string): DocsResolvedRoute | null {
+  const meta = getDocsPathMeta(path);
+
+  if (!meta) {
+    return null;
+  }
+
+  const framework = meta.framework as Framework;
+  const page = getDocsPage(meta.section, meta.page);
+  const sourcePath = getDocsPath(meta.section, framework, meta.page);
+
+  return {
+    meta: { ...meta, framework },
+    page,
+    sourcePath,
+    supported: Boolean(page && isDocsPageSupported(meta.section, meta.page, framework)),
+  };
+}
+
+export function getDocsPageFallback(page: DocsPage): DocsPageFallback {
+  return {
+    title: page.title,
+    sourceTitle: page.sourceTitle,
+    description: page.description,
+  };
+}
+
+export function createDocsPageState<T extends ContentPageInput>(
+  doc: T | null | undefined,
+  sourcePath: string,
+  fallback: DocsPageFallback,
+) {
+  if (!doc) return null;
+
+  const title = String(doc.title || fallback.sourceTitle || fallback.title);
+  const description = doc.description || fallback.description || "";
+
+  return {
+    ...doc,
+    path: sourcePath,
+    title,
+    description,
+    seo: {
+      title: doc.seo?.title || title,
+      description: doc.seo?.description || description,
+    },
+    data: doc.meta || {},
+  } satisfies DocsPageState<T>;
+}
+
+export function renderDocsPage<T extends ContentPageInput>(
+  doc: T | null | undefined,
+  sourcePath: string,
+  fallback: DocsPageFallback,
+  options: DocsRenderOptions,
+) {
+  return normalizeFrameworkPage(createDocsPageState(doc, sourcePath, fallback), options);
+}
+
+function createNavigationGroup(title: string, items: ContentNavigationItem[], options: { defaultOpen?: boolean } = {}) {
+  if (!items.length) return null;
+  return {
+    title,
+    path: items[0]?.path || "/docs",
+    children: items,
+    ...(options.defaultOpen !== undefined && { defaultOpen: options.defaultOpen }),
+  } satisfies ContentNavigationItem;
+}
+
+function isPathExact(itemPath: string, currentPath: string) {
+  const a = itemPath.replace(/\/+$/, "");
+  const b = currentPath.replace(/\/+$/, "");
+  return b === a;
+}
+
+function isPathActive(itemPath: string, currentPath: string) {
+  const a = itemPath.replace(/\/+$/, "");
+  const b = currentPath.replace(/\/+$/, "");
+  return b === a || b.startsWith(`${a}/`);
+}
+
+function toNavigationItem(item: { title: string; path: string; icon?: string | null }, currentPath?: string) {
+  return {
+    title: item.title,
+    path: item.path,
+    icon: item.icon || undefined,
+    ...(currentPath !== undefined && { active: isPathExact(item.path, currentPath) }),
+  } satisfies ContentNavigationItem;
+}
+
+export function getSupportedDocsPages(section: DocsSection, framework: Framework) {
+  return section.pages.filter(page => isDocsPageSupported(section.id, page.id, framework));
+}
+
+export function getSupportedDocsSections(framework: Framework) {
+  return docsManifest.sections.filter(section => getSupportedDocsPages(section, framework).length > 0);
+}
+
+function getSectionPrimaryPage(section: DocsSection, framework: Framework) {
+  const pages = getSupportedDocsPages(section, framework);
+  return pages.find(page => page.id === "index") || pages[0] || null;
+}
+
+function getSectionLink(section: DocsSection, framework: Framework, currentPath: string): DocsSectionLink | null {
+  const primaryPage = getSectionPrimaryPage(section, framework);
+  if (!primaryPage) return null;
+
+  const sectionPath = getDocsPath(section.id, framework);
+  return {
+    label: section.title,
+    description: section.description || undefined,
+    icon: section.icon || undefined,
+    to: getDocsPath(section.id, framework, primaryPage.id),
+    active: isPathActive(sectionPath, currentPath),
+  };
+}
+
+function buildDocsIndexSidebarNavigation(sections: DocsSection[], currentPath: string) {
+  const gettingStartedSection = sections.find(section => section.id === "getting-started");
+  if (!gettingStartedSection) return [];
+
+  return [toNavigationItem({ title: gettingStartedSection.title, path: "/docs", icon: gettingStartedSection.icon }, currentPath)];
+}
+
+function buildSectionSidebarNavigation(section: DocsSection, framework: Framework, currentPath: string) {
+  const pages = getSupportedDocsPages(section, framework);
+  const rootItems = [
+    toNavigationItem({ title: "Overview", path: getDocsPath(section.id, framework), icon: section.icon }, currentPath),
+    ...pages
+      .filter(page => page.id !== "index" && !page.group)
+      .map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath)),
+  ];
+  const groupedPages = new Map<string, DocsPage[]>();
+
+  for (const page of pages) {
+    if (!page.group) continue;
+    groupedPages.set(page.group, [...(groupedPages.get(page.group) || []), page]);
+  }
+
+  const groups = [
+    ...rootItems,
+    ...[...groupedPages.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([group, items]) => createNavigationGroup(
+        group,
+        items.map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath)),
+        { defaultOpen: group === "Providers" },
+      )),
+  ];
+
+  return groups.filter(Boolean) as ContentNavigationItem[];
+}
+
+export function getDocsActiveSection(path: string, sections: DocsSection[]) {
+  const meta = getDocsPathMeta(path);
+  return meta ? sections.find(section => section.id === meta.section) || null : null;
+}
+
+export function buildDocsSidebarNavigation(path: string, framework: Framework, sections = getSupportedDocsSections(framework)) {
+  if (path === "/docs") {
+    return buildDocsIndexSidebarNavigation(sections, path);
+  }
+
+  const activeSection = getDocsActiveSection(path, sections);
+
+  if (!activeSection) {
+    const packageLinks = sections
+      .filter(section => section.id !== "getting-started")
+      .map(section => getSectionLink(section, framework, path))
+      .filter((item): item is DocsSectionLink => Boolean(item))
+      .map(item => toNavigationItem({ title: item.label, path: item.to, icon: item.icon }, path));
+    const group = createNavigationGroup("Packages", packageLinks);
+    return group ? [group] : [];
+  }
+
+  return buildSectionSidebarNavigation(activeSection, framework, path);
+}

--- a/docs/test/docs-rendering.test.ts
+++ b/docs/test/docs-rendering.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDocsSidebarNavigation,
+  createDocsPageState,
+  getDocsPageFallback,
+  getSupportedDocsSections,
+  renderDocsPage,
+  resolveDocsRoute,
+} from "../modules/vitehub-docs/runtime/utils/docs-rendering";
+import { getDocsPage } from "../modules/vitehub-docs/runtime/utils/docs";
+
+describe("docs rendering state", () => {
+  it("resolves route meta, manifest page, support, and source path together", () => {
+    expect(resolveDocsRoute("/docs/vite/blob/quickstart")).toMatchObject({
+      meta: { framework: "vite", section: "blob", page: "quickstart" },
+      sourcePath: "/docs/vite/blob/quickstart",
+      supported: true,
+    });
+
+    expect(resolveDocsRoute("/docs/nuxt/blob")).toMatchObject({
+      sourcePath: "/docs/nuxt/blob",
+      supported: false,
+    });
+  });
+
+  it("normalizes content page state before rendering framework blocks", () => {
+    const page = getDocsPage("getting-started", "index");
+    expect(page).toBeTruthy();
+
+    const rendered = renderDocsPage(
+      {
+        title: "",
+        description: null,
+        meta: { package: "vitehub" },
+        body: {
+          toc: { links: [] },
+          value: [
+            ["h2", { id: "intro" }, "Intro"],
+            ["fw", { id: "vite:dev" }, ["h2", { id: "vite-dev" }, "Vite dev"]],
+            ["fw", { id: "nitro:dev" }, ["h2", { id: "nitro-dev" }, "Nitro dev"]],
+          ],
+        },
+      },
+      "/docs",
+      getDocsPageFallback(page!),
+      { framework: "vite", mode: "dev", renderMode: "single", tocMode: "current-selection" },
+    );
+
+    expect(rendered?.path).toBe("/docs");
+    expect(rendered?.title).toBe(page?.sourceTitle || page?.title);
+    expect(rendered?.data).toEqual({ package: "vitehub" });
+    expect(rendered?.body?.value).toEqual([
+      ["h2", { id: "intro" }, "Intro"],
+      ["fw", { id: "vite:dev" }, ["h2", { id: "vite-dev" }, "Vite dev"]],
+    ]);
+    expect(rendered?.body?.toc?.links?.map(link => link.id)).toEqual(["intro", "vite-dev"]);
+  });
+
+  it("builds navigation-facing docs state from supported pages", () => {
+    const sections = getSupportedDocsSections("vite");
+    const sidebar = buildDocsSidebarNavigation("/docs/vite/blob/quickstart", "vite", sections);
+
+    expect(sections.map(section => section.id)).toContain("blob");
+    expect(sidebar.some(item => item.path === "/docs/vite/blob/quickstart" && item.active)).toBe(true);
+  });
+
+  it("creates a content page state without mutating the source document", () => {
+    const doc = { title: "Source", description: "Desc", meta: { order: 1 } };
+    const state = createDocsPageState(doc, "/docs/vite/getting-started", {
+      title: "Fallback",
+      sourceTitle: null,
+      description: null,
+    });
+
+    expect(state).toMatchObject({
+      path: "/docs/vite/getting-started",
+      title: "Source",
+      description: "Desc",
+      seo: { title: "Source", description: "Desc" },
+      data: { order: 1 },
+    });
+    expect(doc).not.toHaveProperty("path");
+  });
+});


### PR DESCRIPTION
Adds a docs rendering/state module that owns docs route resolution, page fallback state, framework-aware body rendering, TOC normalization, and sidebar navigation state.

Updates docs composables and route pages to delegate to that module while preserving existing routes and rendered content behavior.

Checks run: `pnpm --dir docs test -- docs-rendering framework-content docs-routes`; `pnpm --dir docs typecheck`.