### PR TITLE
refactor: share definition discovery sources

### DIFF
--- a/packages/internal/src/definition-catalog.ts
+++ b/packages/internal/src/definition-catalog.ts
@@ -41,6 +41,42 @@ export type DefinitionCatalogSource<TDefinition extends DiscoveredDefinition> =
   | DirectoryDefinitionCatalogSource<TDefinition>
   | SuffixDefinitionCatalogSource<TDefinition>
 
+export function resolveDefinitionScanRoots(rootDir: string, scanDirs: string[] | undefined = []): string[] {
+  return [...new Set([rootDir, ...scanDirs].filter(Boolean))]
+}
+
+export function createDirectoryDefinitionSource<TDefinition extends DiscoveredDefinition>(
+  source: string,
+  scanDirs: string[],
+  subdir: string,
+  options: Pick<DirectoryDefinitionCatalogSource<TDefinition>, "createDefinition" | "includeHidden" | "normalizeName"> = {},
+): DirectoryDefinitionCatalogSource<TDefinition> {
+  return {
+    ...options,
+    kind: "directory",
+    scanDirs,
+    source,
+    subdir,
+  }
+}
+
+export function createSuffixDefinitionSource<TDefinition extends DiscoveredDefinition>(
+  source: string,
+  roots: string[],
+  pattern: RegExp,
+  normalizeName: SuffixDefinitionCatalogSource<TDefinition>["normalizeName"],
+  options: Pick<SuffixDefinitionCatalogSource<TDefinition>, "createDefinition" | "includeHidden"> = {},
+): SuffixDefinitionCatalogSource<TDefinition> {
+  return {
+    ...options,
+    kind: "suffix",
+    normalizeName,
+    pattern,
+    roots,
+    source,
+  }
+}
+
 function readDirEntries(root: string): Dirent[] {
   try {
     return readdirSync(root, { withFileTypes: true })

--- a/packages/queue/src/discovery.ts
+++ b/packages/queue/src/discovery.ts
@@ -1,7 +1,8 @@
-import { relative, resolve } from "node:path"
 import {
+  createDirectoryDefinitionSource,
+  createSuffixDefinitionSource,
   discoverDefinitions,
-  normalizePathDefinitionName,
+  resolveDefinitionScanRoots,
   normalizeSuffixDefinitionName,
 } from "@vitehub/internal/definition-catalog"
 
@@ -18,20 +19,12 @@ export function discoverQueueDefinitions(options:
   | { mode: "nitro-server-queues", scanDirs: string[] }
 ): DiscoveredQueueDefinition[] {
   if (options.mode === "nitro-server-queues") {
-    return discoverDefinitions("queue", [{
-      kind: "directory",
-      scanDirs: options.scanDirs,
-      source: "nitro-server-queues",
-      subdir: "queues",
-    }])
+    return discoverDefinitions("queue", [
+      createDirectoryDefinitionSource("nitro-server-queues", options.scanDirs, "queues"),
+    ])
   }
 
-  const roots = new Set([options.rootDir, ...(options.scanDirs || [])].filter(Boolean))
-  return discoverDefinitions("queue", [{
-    kind: "suffix",
-    normalizeName: normalizeSuffixQueueName,
-    pattern: queueSuffixPattern,
-    roots: [...roots],
-    source: "vite-suffix",
-  }])
+  return discoverDefinitions("queue", [
+    createSuffixDefinitionSource("vite-suffix", resolveDefinitionScanRoots(options.rootDir, options.scanDirs), queueSuffixPattern, normalizeSuffixQueueName),
+  ])
 }

--- a/packages/queue/test/discovery.test.ts
+++ b/packages/queue/test/discovery.test.ts
@@ -86,4 +86,20 @@ describe("discoverQueueDefinitions", () => {
       scanDirs: [firstNitroScanDir, secondNitroScanDir],
     })).toThrow(/Duplicate queue name/)
   })
+
+  it("deduplicates repeated scan roots without suppressing real duplicate names", async () => {
+    const viteRootDir = await createTempDir("vitehub-queue-vite-root-dedupe-")
+    await writeFile(join(viteRootDir, "welcome.queue.ts"), "export default null\n", "utf8")
+
+    expect(discoverQueueDefinitions({
+      mode: "vite-suffix",
+      rootDir: viteRootDir,
+      scanDirs: [viteRootDir],
+    })).toEqual([
+      expect.objectContaining({
+        name: "welcome",
+        source: "vite-suffix",
+      }),
+    ])
+  })
 })

--- a/packages/sandbox/src/discovery.ts
+++ b/packages/sandbox/src/discovery.ts
@@ -1,5 +1,5 @@
-import { resolve } from 'node:path'
 import {
+  createDirectoryDefinitionSource,
   discoverDefinitions,
 } from '@vitehub/internal/definition-catalog'
 import type { ScannedDefinition } from './internal/shared/feature-definitions'
@@ -9,21 +9,19 @@ export interface DiscoveredSandboxDefinition extends ScannedDefinition {
 }
 
 export function discoverNitroSandboxDefinitions(scanDirs: string[]): DiscoveredSandboxDefinition[] {
-  return discoverDefinitions("sandbox", [{
-    createDefinition({ file, name }) {
-      return {
-        handler: file,
-        name,
-        source: "nitro-server-sandboxes",
-        _meta: {
-          filename: name,
-          sourcePath: file,
-        },
-      }
-    },
-    kind: "directory",
-    scanDirs,
-    source: "nitro-server-sandboxes",
-    subdir: "sandboxes",
-  }])
+  return discoverDefinitions("sandbox", [
+    createDirectoryDefinitionSource<DiscoveredSandboxDefinition>("nitro-server-sandboxes", scanDirs, "sandboxes", {
+      createDefinition({ file, name }) {
+        return {
+          handler: file,
+          name,
+          source: "nitro-server-sandboxes",
+          _meta: {
+            filename: name,
+            sourcePath: file,
+          },
+        }
+      },
+    }),
+  ])
 }

--- a/packages/workflow/src/discovery.ts
+++ b/packages/workflow/src/discovery.ts
@@ -1,9 +1,12 @@
-import { normalize, relative, resolve } from "pathe"
+import { normalize, resolve } from "pathe"
 
 import {
+  createDirectoryDefinitionSource,
+  createSuffixDefinitionSource,
   discoverDefinitions,
   normalizePathDefinitionName,
   normalizeSuffixDefinitionName,
+  resolveDefinitionScanRoots,
 } from "@vitehub/internal/definition-catalog"
 
 import type { DiscoveredWorkflowDefinition } from "./types.ts"
@@ -19,25 +22,15 @@ export function discoverWorkflowDefinitions(options:
   | { mode: "nitro-server-workflows", scanDirs: string[] }
 ): DiscoveredWorkflowDefinition[] {
   if (options.mode === "nitro-server-workflows") {
-    return discoverDefinitions("workflow", [{
-      kind: "directory",
-      scanDirs: options.scanDirs,
-      source: "nitro-server-workflows",
-      subdir: "workflows",
-    }])
+    return discoverDefinitions("workflow", [
+      createDirectoryDefinitionSource("nitro-server-workflows", options.scanDirs, "workflows"),
+    ])
   }
 
-  const roots = new Set([options.rootDir, ...(options.scanDirs || [])].filter(Boolean))
+  const roots = resolveDefinitionScanRoots(options.rootDir, options.scanDirs)
   return discoverDefinitions("workflow", [
-    {
-      kind: "suffix",
-      normalizeName: normalizeSuffixWorkflowName,
-      pattern: workflowSuffixPattern,
-      roots: [...roots],
-      source: "vite-suffix",
-    },
-    {
-      kind: "directory",
+    createSuffixDefinitionSource("vite-suffix", roots, workflowSuffixPattern, normalizeSuffixWorkflowName),
+    createDirectoryDefinitionSource("nitro-server-workflows", roots.map(root => resolve(root, "server")), "workflows", {
       normalizeName(directory, file) {
         const serverWorkflowDir = normalize(directory)
         const normalizedFile = normalize(file)
@@ -45,9 +38,6 @@ export function discoverWorkflowDefinitions(options:
           return normalizePathDefinitionName(serverWorkflowDir, file)
         }
       },
-      scanDirs: [...roots].map(root => resolve(root, "server")),
-      source: "nitro-server-workflows",
-      subdir: "workflows",
-    },
+    }),
   ])
 }

--- a/packages/workspace/src/discovery.ts
+++ b/packages/workspace/src/discovery.ts
@@ -2,7 +2,14 @@ import { readdirSync } from "node:fs"
 import { basename, dirname, relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
-import { createRuntimeRegistryContents, discoverDefinitions, normalizePathDefinitionName, normalizeSuffixDefinitionName } from "@vitehub/internal/definition-catalog"
+import {
+  createDirectoryDefinitionSource,
+  createRuntimeRegistryContents,
+  createSuffixDefinitionSource,
+  discoverDefinitions,
+  normalizePathDefinitionName,
+  normalizeSuffixDefinitionName,
+} from "@vitehub/internal/definition-catalog"
 
 import { workspaceConfigFileNames, workspaceConfigPattern, workspaceSuffixPattern } from "./workspace-config.ts"
 
@@ -71,36 +78,23 @@ function nitroWorkspaceSource(rootDir: string): WorkspaceDefinitionCatalogSource
   }
 
   return [
-    {
-      kind: "directory",
+    createDirectoryDefinitionSource("nitro-server-workspaces-directory-config", [resolve(rootDir, "server")], "workspaces", {
       includeHidden: true,
       normalizeName: normalizeDirectoryName,
-      scanDirs: [resolve(rootDir, "server")],
-      source: "nitro-server-workspaces-directory-config",
-      subdir: "workspaces",
       createDefinition: ({ file, name }) => ({ handler: file, name, path: file, source: "nitro-server-workspaces-directory-config" }),
-    },
-    {
-      kind: "directory",
+    }),
+    createDirectoryDefinitionSource("nitro-server-workspaces", [resolve(rootDir, "server")], "workspaces", {
       normalizeName: normalizeFlatName,
-      scanDirs: [resolve(rootDir, "server")],
-      source: "nitro-server-workspaces",
-      subdir: "workspaces",
       createDefinition: ({ file, name }) => ({ handler: file, name, path: file, source: "nitro-server-workspaces" }),
-    },
+    }),
   ]
 }
 
 function viteWorkspaceSource(rootDir: string): WorkspaceDefinitionCatalogSource[] {
   return [
-    {
-      kind: "suffix",
-      normalizeName: (root, file) => normalizeSuffixDefinitionName(root, file, workspaceSuffixPattern, { stripPrefix: "src/" }),
-      pattern: workspaceSuffixPattern,
-      roots: [rootDir],
-      source: "vite-workspace-suffix",
+    createSuffixDefinitionSource("vite-workspace-suffix", [rootDir], workspaceSuffixPattern, (root, file) => normalizeSuffixDefinitionName(root, file, workspaceSuffixPattern, { stripPrefix: "src/" }), {
       createDefinition: ({ file, name }) => ({ handler: file, name, path: file, source: "vite-workspace-suffix" }),
-    },
+    }),
   ]
 }
 

--- a/packages/workspace/test/discovery.test.ts
+++ b/packages/workspace/test/discovery.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
 
-import { discoverNitroWorkspaceDefinitions } from "../src/discovery.ts"
+import { createWorkspaceRegistryContents, discoverNitroWorkspaceDefinitions } from "../src/discovery.ts"
 
 const tempDirs: string[] = []
 
@@ -46,5 +46,15 @@ describe("discoverNitroWorkspaceDefinitions", () => {
     await writeFile(join(root, "server", "workspaces", "docs", ".config.ts"), "export default {}\n", "utf8")
 
     expect(() => discoverNitroWorkspaceDefinitions(root)).toThrow('Duplicate workspace name "docs"')
+  })
+
+  it("creates registry entries from discovered workspace definitions", async () => {
+    const root = await createRoot()
+    const registryFile = join(root, ".vitehub", "workspace", "registry.mjs")
+    await writeFile(join(root, "server", "workspaces", "docs.ts"), "export default {}\n", "utf8")
+
+    expect(createWorkspaceRegistryContents(registryFile, discoverNitroWorkspaceDefinitions(root))).toContain(
+      '"docs": async () => import(',
+    )
   })
 })


### PR DESCRIPTION
Adds shared helpers for feature definition scan roots and catalog source creation, then updates Queue, Workflow, Sandbox, and Workspace discovery modules to use them.

Preserves existing definition names, source labels, ordering, and duplicate error behavior.

Checks run: Queue discovery test; Workflow definition test; Sandbox discovery test; Workspace discovery test; `pnpm --filter @vitehub/internal typecheck`.