### PR TITLE
refactor: share nitro registry refresh

### DIFF
--- a/packages/internal/src/definition-catalog.ts
+++ b/packages/internal/src/definition-catalog.ts
@@ -305,6 +305,65 @@ export function createGeneratedDefinitionPath(
   return resolve(...pathSegments)
 }
 
+export function createNitroRuntimeFilePath(
+  rootDir: string,
+  options: {
+    buildDir?: string
+    fileName: string
+    productName?: string
+    segments?: readonly string[]
+  },
+): string {
+  return createGeneratedDefinitionPath(rootDir, options)
+}
+
+export interface RuntimeRegistryFiles<TDefinition extends Pick<DiscoveredDefinition, "handler" | "name">> {
+  definitions: TDefinition[]
+  pluginFile: string
+  registryFile: string
+}
+
+export async function writeRuntimeRegistryFiles<TDefinition extends Pick<DiscoveredDefinition, "handler" | "name">>(
+  options: {
+    createPluginContents: (pluginFile: string, registryFile: string) => string
+    definitions: TDefinition[]
+    pluginFile: string
+    registryFile: string
+  },
+): Promise<RuntimeRegistryFiles<TDefinition>> {
+  await Promise.all([
+    writeFileIfChanged(options.registryFile, createRuntimeRegistryContents(options.registryFile, options.definitions)),
+    writeFileIfChanged(options.pluginFile, options.createPluginContents(options.pluginFile, options.registryFile)),
+  ])
+
+  return {
+    definitions: options.definitions,
+    pluginFile: options.pluginFile,
+    registryFile: options.registryFile,
+  }
+}
+
+export function applyNitroRuntimeAliases(
+  nitro: { options: { alias?: Record<string, string> } },
+  aliases: Record<string, string>,
+): void {
+  nitro.options.alias ||= {}
+  Object.assign(nitro.options.alias, aliases)
+}
+
+export function hookNitroRuntimeRegistryRefresh<TRuntimeFiles>(
+  nitro: { hooks: { hook: (name: "build:before" | "dev:reload", handler: () => Promise<void>) => void } },
+  refresh: () => Promise<TRuntimeFiles>,
+  onRefresh: (runtimeFiles: TRuntimeFiles, hookName: "build:before" | "dev:reload") => Promise<void> | void = () => {},
+): void {
+  for (const hookName of ["build:before", "dev:reload"] as const) {
+    nitro.hooks.hook(hookName, async () => {
+      const runtimeFiles = await refresh()
+      await onRefresh(runtimeFiles, hookName)
+    })
+  }
+}
+
 export async function writeFileIfChanged(file: string, contents: string): Promise<void> {
   const existing = await readFile(file, "utf8").catch(() => undefined)
   if (existing === contents) {

--- a/packages/internal/src/definition-catalog.ts
+++ b/packages/internal/src/definition-catalog.ts
@@ -41,6 +41,42 @@ export type DefinitionCatalogSource<TDefinition extends DiscoveredDefinition> =
   | DirectoryDefinitionCatalogSource<TDefinition>
   | SuffixDefinitionCatalogSource<TDefinition>
 
+export function resolveDefinitionScanRoots(rootDir: string, scanDirs: string[] | undefined = []): string[] {
+  return [...new Set([rootDir, ...scanDirs].filter(Boolean))]
+}
+
+export function createDirectoryDefinitionSource<TDefinition extends DiscoveredDefinition>(
+  source: string,
+  scanDirs: string[],
+  subdir: string,
+  options: Pick<DirectoryDefinitionCatalogSource<TDefinition>, "createDefinition" | "includeHidden" | "normalizeName"> = {},
+): DirectoryDefinitionCatalogSource<TDefinition> {
+  return {
+    ...options,
+    kind: "directory",
+    scanDirs,
+    source,
+    subdir,
+  }
+}
+
+export function createSuffixDefinitionSource<TDefinition extends DiscoveredDefinition>(
+  source: string,
+  roots: string[],
+  pattern: RegExp,
+  normalizeName: SuffixDefinitionCatalogSource<TDefinition>["normalizeName"],
+  options: Pick<SuffixDefinitionCatalogSource<TDefinition>, "createDefinition" | "includeHidden"> = {},
+): SuffixDefinitionCatalogSource<TDefinition> {
+  return {
+    ...options,
+    kind: "suffix",
+    normalizeName,
+    pattern,
+    roots,
+    source,
+  }
+}
+
 function readDirEntries(root: string): Dirent[] {
   try {
     return readdirSync(root, { withFileTypes: true })

--- a/packages/internal/test/definition-discovery.test.ts
+++ b/packages/internal/test/definition-discovery.test.ts
@@ -6,12 +6,15 @@ import { afterEach, describe, expect, it } from "vitest"
 
 import {
   createRuntimeRegistryContents,
+  createNitroRuntimeFilePath,
+  hookNitroRuntimeRegistryRefresh,
   listSourceFiles,
   mergeDefinitions,
   normalizePathDefinitionName,
   registerDefinition,
   sanitizeDefinitionFilename,
   writeFileIfChanged,
+  writeRuntimeRegistryFiles,
 } from "../src/definition-discovery.ts"
 
 const dirs: string[] = []
@@ -100,6 +103,60 @@ describe("createRuntimeRegistryContents", () => {
     }])
     expect(contents).toContain('"release-notes": async () => import("../../server/sandboxes/release-notes.ts")')
     expect(contents).toContain("export default registry")
+  })
+})
+
+describe("createNitroRuntimeFilePath", () => {
+  it("keeps build-dir generated Nitro runtime paths stable", () => {
+    expect(createNitroRuntimeFilePath("/root", {
+      buildDir: "node_modules/.nitro",
+      fileName: "nitro-registry.mjs",
+      segments: [".vitehub", "queue"],
+    })).toBe("/root/node_modules/.nitro/.vitehub/queue/nitro-registry.mjs")
+  })
+
+  it("keeps root generated Nitro runtime paths stable", () => {
+    expect(createNitroRuntimeFilePath("/root", {
+      fileName: "assets/registry.mjs",
+      segments: [".vitehub", "nitro-runtime", "workspace"],
+    })).toBe("/root/.vitehub/nitro-runtime/workspace/assets/registry.mjs")
+  })
+})
+
+describe("writeRuntimeRegistryFiles", () => {
+  it("writes registry and plugin files with direct relative registry imports", async () => {
+    const root = await createTempDir("vitehub-internal-runtime-files-")
+    const registryFile = join(root, ".vitehub", "queue", "nitro-registry.mjs")
+    const pluginFile = join(root, ".vitehub", "queue", "nitro-plugin.ts")
+
+    await writeRuntimeRegistryFiles({
+      createPluginContents: (_plugin, registry) => `import registry from ${JSON.stringify(`./${registry.split("/").pop()}`)}\nexport default registry\n`,
+      definitions: [{ handler: join(root, "server", "queues", "welcome.ts"), name: "welcome" }],
+      pluginFile,
+      registryFile,
+    })
+
+    await expect(readFile(registryFile, "utf8")).resolves.toContain('"welcome": async () => import("../../server/queues/welcome.ts")')
+    await expect(readFile(pluginFile, "utf8")).resolves.toContain('import registry from "./nitro-registry.mjs"')
+  })
+})
+
+describe("hookNitroRuntimeRegistryRefresh", () => {
+  it("refreshes runtime files on build and dev reload hooks", async () => {
+    const handlers = new Map<string, () => Promise<void>>()
+    const refreshed: string[] = []
+    let count = 0
+
+    hookNitroRuntimeRegistryRefresh(
+      { hooks: { hook: (name, handler) => handlers.set(name, handler) } },
+      async () => ({ registryFile: `registry-${++count}.mjs` }),
+      async runtimeFiles => refreshed.push(runtimeFiles.registryFile),
+    )
+
+    await handlers.get("build:before")?.()
+    await handlers.get("dev:reload")?.()
+
+    expect(refreshed).toEqual(["registry-1.mjs", "registry-2.mjs"])
   })
 })
 

--- a/packages/queue/src/discovery.ts
+++ b/packages/queue/src/discovery.ts
@@ -1,7 +1,8 @@
-import { relative, resolve } from "node:path"
 import {
+  createDirectoryDefinitionSource,
+  createSuffixDefinitionSource,
   discoverDefinitions,
-  normalizePathDefinitionName,
+  resolveDefinitionScanRoots,
   normalizeSuffixDefinitionName,
 } from "@vitehub/internal/definition-catalog"
 
@@ -18,20 +19,12 @@ export function discoverQueueDefinitions(options:
   | { mode: "nitro-server-queues", scanDirs: string[] }
 ): DiscoveredQueueDefinition[] {
   if (options.mode === "nitro-server-queues") {
-    return discoverDefinitions("queue", [{
-      kind: "directory",
-      scanDirs: options.scanDirs,
-      source: "nitro-server-queues",
-      subdir: "queues",
-    }])
+    return discoverDefinitions("queue", [
+      createDirectoryDefinitionSource("nitro-server-queues", options.scanDirs, "queues"),
+    ])
   }
 
-  const roots = new Set([options.rootDir, ...(options.scanDirs || [])].filter(Boolean))
-  return discoverDefinitions("queue", [{
-    kind: "suffix",
-    normalizeName: normalizeSuffixQueueName,
-    pattern: queueSuffixPattern,
-    roots: [...roots],
-    source: "vite-suffix",
-  }])
+  return discoverDefinitions("queue", [
+    createSuffixDefinitionSource("vite-suffix", resolveDefinitionScanRoots(options.rootDir, options.scanDirs), queueSuffixPattern, normalizeSuffixQueueName),
+  ])
 }

--- a/packages/queue/src/nitro/module.ts
+++ b/packages/queue/src/nitro/module.ts
@@ -1,5 +1,5 @@
 import { createImportPath } from "@vitehub/internal/build/paths"
-import { createGeneratedDefinitionPath, createRuntimeRegistryContents, writeFileIfChanged } from "@vitehub/internal/definition-catalog"
+import { applyNitroRuntimeAliases, createNitroRuntimeFilePath, hookNitroRuntimeRegistryRefresh, writeRuntimeRegistryFiles } from "@vitehub/internal/definition-catalog"
 import { mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 import { resolve } from "node:path"
 import type { NitroModule, NitroRuntimeConfig } from "nitro/types"
@@ -31,11 +31,11 @@ function createCloudflareQueueBindings(definitions: DiscoveredQueueDefinition[])
 const QUEUE_NITRO_IMPORTS_PRESET = { from: "@vitehub/queue", imports: ["defineQueue", "deferQueue", "getQueue", "runQueue"] }
 
 function createNitroQueueRegistryPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, { buildDir, fileName: "nitro-registry.mjs", segments: generatedDirSegments })
+  return createNitroRuntimeFilePath(rootDir, { buildDir, fileName: "nitro-registry.mjs", segments: generatedDirSegments })
 }
 
 function createNitroQueuePluginPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, { buildDir, fileName: "nitro-plugin.ts", segments: generatedDirSegments })
+  return createNitroRuntimeFilePath(rootDir, { buildDir, fileName: "nitro-plugin.ts", segments: generatedDirSegments })
 }
 
 function resolveNitroQueueScanDirs(rootDir: string, scanDirs: string[] | undefined) {
@@ -129,14 +129,12 @@ async function writeNitroQueueRuntimeFiles(nitro: { options: { buildDir: string,
     scanDirs: resolveNitroQueueScanDirs(nitro.options.rootDir, nitro.options.scanDirs),
   })
 
-  await writeFileIfChanged(registryFile, createRuntimeRegistryContents(registryFile, definitions))
-  await writeFileIfChanged(pluginFile, createNitroQueuePluginContents(pluginFile, registryFile))
-
-  return {
+  return await writeRuntimeRegistryFiles({
+    createPluginContents: createNitroQueuePluginContents,
     definitions,
     pluginFile,
     registryFile,
-  }
+  })
 }
 
 const queueNitroModule: NitroModule = {
@@ -154,7 +152,7 @@ const queueNitroModule: NitroModule = {
     nitro.options.alias["@vitehub/queue/runtime/state"] = resolveRuntimeEntry("../runtime/state", "@vitehub/queue/runtime/state")
 
     let runtimeFiles = await writeNitroQueueRuntimeFiles(nitro)
-    nitro.options.alias["#vitehub/queue/registry"] = runtimeFiles.registryFile
+    applyNitroRuntimeAliases(nitro, { "#vitehub/queue/registry": runtimeFiles.registryFile })
     const { definitions } = runtimeFiles
 
     const importsExplicitlyDisabled = nitro.options._config?.imports === false
@@ -195,11 +193,9 @@ const queueNitroModule: NitroModule = {
       }
     }
 
-    nitro.hooks.hook("build:before", async () => {
-      runtimeFiles = await writeNitroQueueRuntimeFiles(nitro)
-    })
-    nitro.hooks.hook("dev:reload", async () => {
-      runtimeFiles = await writeNitroQueueRuntimeFiles(nitro)
+    hookNitroRuntimeRegistryRefresh(nitro, () => writeNitroQueueRuntimeFiles(nitro), (nextRuntimeFiles) => {
+      runtimeFiles = nextRuntimeFiles
+      applyNitroRuntimeAliases(nitro, { "#vitehub/queue/registry": runtimeFiles.registryFile })
     })
     nitro.hooks.hook("compiled", async (currentNitro: any) => {
       if (currentNitro.options.preset?.includes("vercel")) {

--- a/packages/queue/test/discovery.test.ts
+++ b/packages/queue/test/discovery.test.ts
@@ -86,4 +86,20 @@ describe("discoverQueueDefinitions", () => {
       scanDirs: [firstNitroScanDir, secondNitroScanDir],
     })).toThrow(/Duplicate queue name/)
   })
+
+  it("deduplicates repeated scan roots without suppressing real duplicate names", async () => {
+    const viteRootDir = await createTempDir("vitehub-queue-vite-root-dedupe-")
+    await writeFile(join(viteRootDir, "welcome.queue.ts"), "export default null\n", "utf8")
+
+    expect(discoverQueueDefinitions({
+      mode: "vite-suffix",
+      rootDir: viteRootDir,
+      scanDirs: [viteRootDir],
+    })).toEqual([
+      expect.objectContaining({
+        name: "welcome",
+        source: "vite-suffix",
+      }),
+    ])
+  })
 })

--- a/packages/sandbox/src/discovery.ts
+++ b/packages/sandbox/src/discovery.ts
@@ -1,5 +1,5 @@
-import { resolve } from 'node:path'
 import {
+  createDirectoryDefinitionSource,
   discoverDefinitions,
 } from '@vitehub/internal/definition-catalog'
 import type { ScannedDefinition } from './internal/shared/feature-definitions'
@@ -9,21 +9,19 @@ export interface DiscoveredSandboxDefinition extends ScannedDefinition {
 }
 
 export function discoverNitroSandboxDefinitions(scanDirs: string[]): DiscoveredSandboxDefinition[] {
-  return discoverDefinitions("sandbox", [{
-    createDefinition({ file, name }) {
-      return {
-        handler: file,
-        name,
-        source: "nitro-server-sandboxes",
-        _meta: {
-          filename: name,
-          sourcePath: file,
-        },
-      }
-    },
-    kind: "directory",
-    scanDirs,
-    source: "nitro-server-sandboxes",
-    subdir: "sandboxes",
-  }])
+  return discoverDefinitions("sandbox", [
+    createDirectoryDefinitionSource<DiscoveredSandboxDefinition>("nitro-server-sandboxes", scanDirs, "sandboxes", {
+      createDefinition({ file, name }) {
+        return {
+          handler: file,
+          name,
+          source: "nitro-server-sandboxes",
+          _meta: {
+            filename: name,
+            sourcePath: file,
+          },
+        }
+      },
+    }),
+  ])
 }

--- a/packages/sandbox/src/nitro/module.ts
+++ b/packages/sandbox/src/nitro/module.ts
@@ -1,6 +1,6 @@
 import { readPackageJSON } from 'pkg-types'
 
-import { writeFileIfChanged } from '@vitehub/internal/definition-discovery'
+import { hookNitroRuntimeRegistryRefresh, writeFileIfChanged } from '@vitehub/internal/definition-discovery'
 
 import { createSandboxProviderLoaderContents } from '../feature'
 import { hasInstalledDependency } from '../internal/shared/dependency'
@@ -55,11 +55,8 @@ const sandboxNitroModule: NitroModule = {
 
     extendSandboxNitro(nitro, config, deps, providerLoader.providerLoaderTarget)
 
-    nitro.hooks.hook('build:before', async () => {
-      runtimeFiles = await writeNitroSandboxRuntimeFiles(nitro)
-    })
-    nitro.hooks.hook('dev:reload', async () => {
-      runtimeFiles = await writeNitroSandboxRuntimeFiles(nitro)
+    hookNitroRuntimeRegistryRefresh(nitro, () => writeNitroSandboxRuntimeFiles(nitro), (nextRuntimeFiles) => {
+      runtimeFiles = nextRuntimeFiles
     })
 
     if (provider?.provider === 'vercel' && !hasInstalledDependency(deps, '@vercel/sandbox', { paths: [nitro.options.rootDir] }))

--- a/packages/sandbox/src/nitro/runtime-files.ts
+++ b/packages/sandbox/src/nitro/runtime-files.ts
@@ -2,7 +2,7 @@ import { mkdir } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 import { createImportPath, generatedDirSegments } from '@vitehub/internal/build/paths'
-import { createGeneratedDefinitionPath, createRuntimeRegistryContents, sanitizeDefinitionFilename, writeFileIfChanged } from '@vitehub/internal/definition-catalog'
+import { createNitroRuntimeFilePath, sanitizeDefinitionFilename, writeFileIfChanged, writeRuntimeRegistryFiles } from '@vitehub/internal/definition-catalog'
 
 import { bundleSandboxDefinition } from '../bundle'
 import { extractSandboxDefinitionOptions } from '../definition-options'
@@ -16,15 +16,15 @@ import type { Nitro } from 'nitro/types'
 export const sandboxGeneratedDir = generatedDirSegments('sandbox')
 
 export function createNitroSandboxRegistryPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, { buildDir, fileName: 'nitro-registry.mjs', segments: sandboxGeneratedDir })
+  return createNitroRuntimeFilePath(rootDir, { buildDir, fileName: 'nitro-registry.mjs', segments: sandboxGeneratedDir })
 }
 
 export function createNitroSandboxPluginPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, { buildDir, fileName: 'nitro-plugin.ts', segments: sandboxGeneratedDir })
+  return createNitroRuntimeFilePath(rootDir, { buildDir, fileName: 'nitro-plugin.ts', segments: sandboxGeneratedDir })
 }
 
 export function createNitroSandboxDefinitionPath(rootDir: string, buildDir: string, name: string) {
-  return createGeneratedDefinitionPath(rootDir, {
+  return createNitroRuntimeFilePath(rootDir, {
     buildDir,
     fileName: `definitions/${sanitizeDefinitionFilename(name)}.mjs`,
     segments: sandboxGeneratedDir,
@@ -91,8 +91,12 @@ export async function writeNitroSandboxRuntimeFiles(nitro: Nitro) {
   }))
 
   registryDefinitions.sort((left, right) => left.name.localeCompare(right.name))
-  await writeFileIfChanged(registryFile, createRuntimeRegistryContents(registryFile, registryDefinitions))
-  await writeFileIfChanged(pluginFile, createNitroSandboxPluginContents(pluginFile, registryFile))
+  await writeRuntimeRegistryFiles({
+    createPluginContents: createNitroSandboxPluginContents,
+    definitions: registryDefinitions,
+    pluginFile,
+    registryFile,
+  })
 
   return {
     definitions,

--- a/packages/workflow/src/discovery.ts
+++ b/packages/workflow/src/discovery.ts
@@ -1,9 +1,12 @@
-import { normalize, relative, resolve } from "pathe"
+import { normalize, resolve } from "pathe"
 
 import {
+  createDirectoryDefinitionSource,
+  createSuffixDefinitionSource,
   discoverDefinitions,
   normalizePathDefinitionName,
   normalizeSuffixDefinitionName,
+  resolveDefinitionScanRoots,
 } from "@vitehub/internal/definition-catalog"
 
 import type { DiscoveredWorkflowDefinition } from "./types.ts"
@@ -19,25 +22,15 @@ export function discoverWorkflowDefinitions(options:
   | { mode: "nitro-server-workflows", scanDirs: string[] }
 ): DiscoveredWorkflowDefinition[] {
   if (options.mode === "nitro-server-workflows") {
-    return discoverDefinitions("workflow", [{
-      kind: "directory",
-      scanDirs: options.scanDirs,
-      source: "nitro-server-workflows",
-      subdir: "workflows",
-    }])
+    return discoverDefinitions("workflow", [
+      createDirectoryDefinitionSource("nitro-server-workflows", options.scanDirs, "workflows"),
+    ])
   }
 
-  const roots = new Set([options.rootDir, ...(options.scanDirs || [])].filter(Boolean))
+  const roots = resolveDefinitionScanRoots(options.rootDir, options.scanDirs)
   return discoverDefinitions("workflow", [
-    {
-      kind: "suffix",
-      normalizeName: normalizeSuffixWorkflowName,
-      pattern: workflowSuffixPattern,
-      roots: [...roots],
-      source: "vite-suffix",
-    },
-    {
-      kind: "directory",
+    createSuffixDefinitionSource("vite-suffix", roots, workflowSuffixPattern, normalizeSuffixWorkflowName),
+    createDirectoryDefinitionSource("nitro-server-workflows", roots.map(root => resolve(root, "server")), "workflows", {
       normalizeName(directory, file) {
         const serverWorkflowDir = normalize(directory)
         const normalizedFile = normalize(file)
@@ -45,9 +38,6 @@ export function discoverWorkflowDefinitions(options:
           return normalizePathDefinitionName(serverWorkflowDir, file)
         }
       },
-      scanDirs: [...roots].map(root => resolve(root, "server")),
-      source: "nitro-server-workflows",
-      subdir: "workflows",
-    },
+    }),
   ])
 }

--- a/packages/workflow/src/nitro/module.ts
+++ b/packages/workflow/src/nitro/module.ts
@@ -2,7 +2,7 @@ import { appendFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
 
 import { createImportPath } from "@vitehub/internal/build/paths"
-import { createGeneratedDefinitionPath, createRuntimeRegistryContents, writeFileIfChanged } from "@vitehub/internal/definition-catalog"
+import { applyNitroRuntimeAliases, createNitroRuntimeFilePath, hookNitroRuntimeRegistryRefresh, writeRuntimeRegistryFiles } from "@vitehub/internal/definition-catalog"
 import { mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 
 import type { Nitro, NitroModule, NitroRuntimeConfig } from "nitro/types"
@@ -19,7 +19,7 @@ function resolveRuntimeEntry(srcRelative: string, packageSubpath: string): strin
 }
 
 function createNitroWorkflowRegistryPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, {
+  return createNitroRuntimeFilePath(rootDir, {
     buildDir,
     fileName: "nitro-registry.mjs",
     segments: ["vitehub", "workflow"],
@@ -27,7 +27,7 @@ function createNitroWorkflowRegistryPath(rootDir: string, buildDir: string) {
 }
 
 function createNitroWorkflowPluginPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, {
+  return createNitroRuntimeFilePath(rootDir, {
     buildDir,
     fileName: "nitro-plugin.ts",
     segments: ["vitehub", "workflow"],
@@ -103,12 +103,12 @@ async function writeNitroWorkflowRuntimeFiles(nitro: Nitro): Promise<RuntimeFile
     scanDirs: resolveNitroWorkflowScanDirs(nitro.options.rootDir, nitro.options.scanDirs),
   })
 
-  await Promise.all([
-    writeFileIfChanged(registryFile, createRuntimeRegistryContents(registryFile, definitions)),
-    writeFileIfChanged(pluginFile, createNitroWorkflowPluginContents(pluginFile, registryFile)),
-  ])
-
-  return { definitions, pluginFile, registryFile }
+  return await writeRuntimeRegistryFiles({
+    createPluginContents: createNitroWorkflowPluginContents,
+    definitions,
+    pluginFile,
+    registryFile,
+  })
 }
 
 const workflowNitroModule: NitroModule = {
@@ -125,7 +125,7 @@ const workflowNitroModule: NitroModule = {
     nitro.options.alias["@vitehub/workflow/runtime/cloudflare-runner"] = resolveRuntimeEntry("../runtime/cloudflare-runner", "@vitehub/workflow/runtime/cloudflare-runner")
 
     let runtimeFiles = await writeNitroWorkflowRuntimeFiles(nitro)
-    nitro.options.alias["#vitehub/workflow/registry"] = runtimeFiles.registryFile
+    applyNitroRuntimeAliases(nitro, { "#vitehub/workflow/registry": runtimeFiles.registryFile })
 
     const importsExplicitlyDisabled = nitro.options._config?.imports === false
     if (!importsExplicitlyDisabled) {
@@ -156,11 +156,9 @@ const workflowNitroModule: NitroModule = {
       }
     }
 
-    nitro.hooks.hook("build:before", async () => {
-      runtimeFiles = await writeNitroWorkflowRuntimeFiles(nitro)
-    })
-    nitro.hooks.hook("dev:reload", async () => {
-      runtimeFiles = await writeNitroWorkflowRuntimeFiles(nitro)
+    hookNitroRuntimeRegistryRefresh(nitro, () => writeNitroWorkflowRuntimeFiles(nitro), (nextRuntimeFiles) => {
+      runtimeFiles = nextRuntimeFiles
+      applyNitroRuntimeAliases(nitro, { "#vitehub/workflow/registry": runtimeFiles.registryFile })
     })
     nitro.hooks.hook("compiled", async (currentNitro) => {
       if (resolved.provider !== "cloudflare" || !currentNitro.options.preset?.includes("cloudflare")) {

--- a/packages/workspace/src/discovery.ts
+++ b/packages/workspace/src/discovery.ts
@@ -2,7 +2,14 @@ import { readdirSync } from "node:fs"
 import { basename, dirname, relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
-import { createRuntimeRegistryContents, discoverDefinitions, normalizePathDefinitionName, normalizeSuffixDefinitionName } from "@vitehub/internal/definition-catalog"
+import {
+  createDirectoryDefinitionSource,
+  createRuntimeRegistryContents,
+  createSuffixDefinitionSource,
+  discoverDefinitions,
+  normalizePathDefinitionName,
+  normalizeSuffixDefinitionName,
+} from "@vitehub/internal/definition-catalog"
 
 import { workspaceConfigFileNames, workspaceConfigPattern, workspaceSuffixPattern } from "./workspace-config.ts"
 
@@ -71,36 +78,23 @@ function nitroWorkspaceSource(rootDir: string): WorkspaceDefinitionCatalogSource
   }
 
   return [
-    {
-      kind: "directory",
+    createDirectoryDefinitionSource("nitro-server-workspaces-directory-config", [resolve(rootDir, "server")], "workspaces", {
       includeHidden: true,
       normalizeName: normalizeDirectoryName,
-      scanDirs: [resolve(rootDir, "server")],
-      source: "nitro-server-workspaces-directory-config",
-      subdir: "workspaces",
       createDefinition: ({ file, name }) => ({ handler: file, name, path: file, source: "nitro-server-workspaces-directory-config" }),
-    },
-    {
-      kind: "directory",
+    }),
+    createDirectoryDefinitionSource("nitro-server-workspaces", [resolve(rootDir, "server")], "workspaces", {
       normalizeName: normalizeFlatName,
-      scanDirs: [resolve(rootDir, "server")],
-      source: "nitro-server-workspaces",
-      subdir: "workspaces",
       createDefinition: ({ file, name }) => ({ handler: file, name, path: file, source: "nitro-server-workspaces" }),
-    },
+    }),
   ]
 }
 
 function viteWorkspaceSource(rootDir: string): WorkspaceDefinitionCatalogSource[] {
   return [
-    {
-      kind: "suffix",
-      normalizeName: (root, file) => normalizeSuffixDefinitionName(root, file, workspaceSuffixPattern, { stripPrefix: "src/" }),
-      pattern: workspaceSuffixPattern,
-      roots: [rootDir],
-      source: "vite-workspace-suffix",
+    createSuffixDefinitionSource("vite-workspace-suffix", [rootDir], workspaceSuffixPattern, (root, file) => normalizeSuffixDefinitionName(root, file, workspaceSuffixPattern, { stripPrefix: "src/" }), {
       createDefinition: ({ file, name }) => ({ handler: file, name, path: file, source: "vite-workspace-suffix" }),
-    },
+    }),
   ]
 }
 

--- a/packages/workspace/src/nitro/module.ts
+++ b/packages/workspace/src/nitro/module.ts
@@ -1,9 +1,8 @@
-import { mkdir, writeFile } from "node:fs/promises"
 import { createRequire } from "node:module"
 import { dirname, resolve } from "node:path"
 
 import { createImportPath } from "@vitehub/internal/build/paths"
-import { writeFileIfChanged } from "@vitehub/internal/definition-catalog"
+import { applyNitroRuntimeAliases, createNitroRuntimeFilePath, hookNitroRuntimeRegistryRefresh, writeFileIfChanged } from "@vitehub/internal/definition-catalog"
 import { mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 
 import { initializeWorkspaceAssetRegistry, syncWorkspaceBuildAssets, writeWorkspaceRuntimeRegistry } from "../build-integration.ts"
@@ -37,15 +36,24 @@ function resolveIsomorphicGitHttpWebEsmEntry() {
 }
 
 function registryPath(nitro: Nitro) {
-  return resolve(nitro.options.rootDir, ".vitehub/nitro-runtime/workspace/registry.mjs")
+  return createNitroRuntimeFilePath(nitro.options.rootDir, {
+    fileName: "registry.mjs",
+    segments: [".vitehub", "nitro-runtime", "workspace"],
+  })
 }
 
 function pluginPath(nitro: Nitro) {
-  return resolve(nitro.options.rootDir, ".vitehub/nitro-runtime/workspace/plugin.mjs")
+  return createNitroRuntimeFilePath(nitro.options.rootDir, {
+    fileName: "plugin.mjs",
+    segments: [".vitehub", "nitro-runtime", "workspace"],
+  })
 }
 
 function assetsRegistryPath(nitro: Nitro) {
-  return resolve(nitro.options.rootDir, ".vitehub/nitro-runtime/workspace/assets/registry.mjs")
+  return createNitroRuntimeFilePath(nitro.options.rootDir, {
+    fileName: "assets/registry.mjs",
+    segments: [".vitehub", "nitro-runtime", "workspace"],
+  })
 }
 
 function workspaceNitroConfigTypes(definitions: DiscoveredWorkspaceDefinition[]) {
@@ -149,9 +157,15 @@ function createNitroPluginContents(file: string, registryFile: string, assetsReg
 
 async function writePlugin(nitro: Nitro, registryFile: string, assetsRegistryFile: string, options: false | ResolvedWorkspaceModuleOptions) {
   const path = pluginPath(nitro)
-  await mkdir(dirname(path), { recursive: true })
-  await writeFile(path, createNitroPluginContents(path, registryFile, assetsRegistryFile, options), "utf8")
+  await writeFileIfChanged(path, createNitroPluginContents(path, registryFile, assetsRegistryFile, options))
   return path
+}
+
+function applyWorkspaceRuntimeAliases(nitro: Nitro, registryFile: string, assetsRegistryFile: string) {
+  applyNitroRuntimeAliases(nitro, {
+    "#vitehub-workspace-assets-registry": assetsRegistryFile,
+    "#vitehub-workspace-registry": registryFile,
+  })
 }
 
 const workspaceNitroModule: NitroModule = {
@@ -183,8 +197,7 @@ const workspaceNitroModule: NitroModule = {
     const assetsRegistryFile = assetsRegistryPath(nitro)
     await initializeWorkspaceAssetRegistry(assetsRegistryFile)
     const plugin = await writePlugin(nitro, registryFile, assetsRegistryFile, resolved)
-    nitro.options.alias["#vitehub-workspace-registry"] = registryFile
-    nitro.options.alias["#vitehub-workspace-assets-registry"] = assetsRegistryFile
+    applyWorkspaceRuntimeAliases(nitro, registryFile, assetsRegistryFile)
     installNitroConfigTypes(nitro, () => definitions)
 
     const importsExplicitlyDisabled = nitro.options._config?.imports === false
@@ -199,20 +212,16 @@ const workspaceNitroModule: NitroModule = {
       configureCloudflareArtifacts(nitro.options, resolved)
     }
 
-    nitro.hooks.hook("build:before", async () => {
+    hookNitroRuntimeRegistryRefresh(nitro, async () => {
       definitions = discoverNitroWorkspaceDefinitions(nitro.options.rootDir)
       const nextPath = await writeWorkspaceRuntimeRegistry(registryPath(nitro), definitions)
-      nitro.options.alias ||= {}
-      nitro.options.alias["#vitehub-workspace-registry"] = nextPath
-      nitro.options.alias["#vitehub-workspace-assets-registry"] = assetsRegistryFile
-      await syncWorkspaceBuildAssets(definitions, nitro.options.rootDir, resolved, assetsRegistryFile)
-      await writePlugin(nitro, nextPath, assetsRegistryFile, resolved)
-    })
-    nitro.hooks.hook("dev:reload", async () => {
-      definitions = discoverNitroWorkspaceDefinitions(nitro.options.rootDir)
-      const nextPath = await writeWorkspaceRuntimeRegistry(registryPath(nitro), definitions)
-      nitro.options.alias ||= {}
-      nitro.options.alias["#vitehub-workspace-registry"] = nextPath
+      return { definitions, registryFile: nextPath }
+    }, async (runtimeFiles, hookName) => {
+      applyWorkspaceRuntimeAliases(nitro, runtimeFiles.registryFile, assetsRegistryFile)
+      if (hookName === "build:before") {
+        await syncWorkspaceBuildAssets(definitions, nitro.options.rootDir, resolved, assetsRegistryFile)
+        await writePlugin(nitro, runtimeFiles.registryFile, assetsRegistryFile, resolved)
+      }
     })
 
     nitro.logger.info(`@vitehub/workspace enabled with ${definitions.length} workspace definition${definitions.length === 1 ? "" : "s"}`)

--- a/packages/workspace/test/discovery.test.ts
+++ b/packages/workspace/test/discovery.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
 
-import { discoverNitroWorkspaceDefinitions } from "../src/discovery.ts"
+import { createWorkspaceRegistryContents, discoverNitroWorkspaceDefinitions } from "../src/discovery.ts"
 
 const tempDirs: string[] = []
 
@@ -46,5 +46,15 @@ describe("discoverNitroWorkspaceDefinitions", () => {
     await writeFile(join(root, "server", "workspaces", "docs", ".config.ts"), "export default {}\n", "utf8")
 
     expect(() => discoverNitroWorkspaceDefinitions(root)).toThrow('Duplicate workspace name "docs"')
+  })
+
+  it("creates registry entries from discovered workspace definitions", async () => {
+    const root = await createRoot()
+    const registryFile = join(root, ".vitehub", "workspace", "registry.mjs")
+    await writeFile(join(root, "server", "workspaces", "docs.ts"), "export default {}\n", "utf8")
+
+    expect(createWorkspaceRegistryContents(registryFile, discoverNitroWorkspaceDefinitions(root))).toContain(
+      '"docs": async () => import(',
+    )
   })
 })


### PR DESCRIPTION
Stacks on #94.

Adds shared internal helpers for Nitro runtime registry file paths, registry/plugin writes, alias application, and build/dev reload refresh hooks. Migrates Queue, Workflow, Sandbox, and Workspace Nitro registry refresh paths while preserving generated filenames and aliases.

Checks run: `pnpm --filter @vitehub/internal exec vitest run test/definition-discovery.test.ts`; package typechecks for Internal, Queue, Workflow, Sandbox, and Workspace.