### PR TITLE
fix(env): allow static nitro env values

### DIFF
--- a/packages/env/src/core/resolve.ts
+++ b/packages/env/src/core/resolve.ts
@@ -314,11 +314,20 @@ function isNitroStaticValue(value: unknown): value is EnvNitroStaticValue {
   }
   switch (typeof value) {
     case "boolean":
-    case "number":
     case "string":
       return true
+    case "number":
+      return Number.isFinite(value)
     case "object":
-      return Array.isArray(value) && value.every(isNitroStaticValue)
+      if (!Array.isArray(value)) {
+        return false
+      }
+      for (let index = 0; index < value.length; index += 1) {
+        if (!(index in value) || !isNitroStaticValue(value[index])) {
+          return false
+        }
+      }
+      return true
     default:
       return false
   }

--- a/packages/env/src/core/resolve.ts
+++ b/packages/env/src/core/resolve.ts
@@ -11,6 +11,7 @@ import type {
   EnvDiagnosticEntry,
   EnvMode,
   EnvNitroConfigOptions,
+  EnvNitroStaticValue,
   EnvRuntimeRegistry,
   EnvSource,
   EnvSourceContext,
@@ -160,6 +161,9 @@ function buildRegistry(declarations: EnvNitroConfigOptions | undefined, path: st
   return Object.fromEntries(Object.entries(declarations).map(([key, value]) => {
     const valuePath = `${path}.${key}`
     if (!isEnvVariableDeclaration(value)) {
+      if (isNitroStaticValue(value)) {
+        return [key, { kind: "literal", value }]
+      }
       return [key, buildRegistry(value as EnvNitroConfigOptions, valuePath, prefix)]
     }
     const source = resolveEnvSource(value, valuePath, prefix)
@@ -246,8 +250,11 @@ function validateNitroDeclarations(declarations: EnvNitroConfigOptions, path: st
       }
       continue
     }
+    if (isNitroStaticValue(value)) {
+      continue
+    }
     if (!isPlainRecord(value)) {
-      throw new EnvError(`Invalid declaration at ${valuePath}. Use envVariable() or a nested object of envVariable() declarations.`)
+      throw new EnvError(`Invalid declaration at ${valuePath}. Use envVariable(), a serializable literal, or a nested object.`)
     }
     validateNitroDeclarations(value as EnvNitroConfigOptions, valuePath)
   }
@@ -294,7 +301,27 @@ export function isEnvVariableDeclaration(value: unknown): value is EnvVariableDe
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false
+  }
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === null || prototype === Object.prototype
+}
+
+function isNitroStaticValue(value: unknown): value is EnvNitroStaticValue {
+  if (value === null) {
+    return true
+  }
+  switch (typeof value) {
+    case "boolean":
+    case "number":
+    case "string":
+      return true
+    case "object":
+      return Array.isArray(value) && value.every(isNitroStaticValue)
+    default:
+      return false
+  }
 }
 
 async function readPackageJson(rootDir: string): Promise<Record<string, unknown>> {

--- a/packages/env/src/nitro/module.ts
+++ b/packages/env/src/nitro/module.ts
@@ -8,7 +8,7 @@ import { formatDiagnostics } from "../core/diagnostics.ts"
 import { envSource, envVariable } from "../core/declarations.ts"
 import { createRuntimeRegistry, isEnvVariableDeclaration, resolveEnvSource, validateEnvConfigShape } from "../core/resolve.ts"
 
-import type { EnvDiagnosticEntry, EnvIntegrationOptions, EnvNitroConfigOptions, EnvNitroUserConfig, EnvRegistryEntry, EnvRuntimeRegistry, EnvRuntimeRegistryValue } from "../types.ts"
+import type { EnvDiagnosticEntry, EnvIntegrationOptions, EnvNitroConfigOptions, EnvNitroUserConfig, EnvRegistryEntry, EnvRuntimeLiteralEntry, EnvRuntimeRegistry, EnvRuntimeRegistryValue } from "../types.ts"
 import type { Nitro, NitroModule } from "nitro/types"
 
 export { envSource, envVariable }
@@ -89,6 +89,9 @@ function createTypeFields(registry: EnvRuntimeRegistry, indent: number): string[
     if (isRegistryEntry(entry)) {
       return [`${prefix}${JSON.stringify(key)}: ${resolveTypeName(entry)}`]
     }
+    if (isLiteralEntry(entry)) {
+      return [`${prefix}${JSON.stringify(key)}: ${resolveLiteralTypeName(entry.value)}`]
+    }
     return [
       `${prefix}${JSON.stringify(key)}: {`,
       ...createTypeFields(entry, indent + 2),
@@ -102,6 +105,21 @@ function resolveTypeName(entry: EnvRegistryEntry): string {
     return entry.type
   }
   return entry.required || typeof entry.default !== "undefined" ? "string" : "string | undefined"
+}
+
+function resolveLiteralTypeName(value: unknown): string {
+  switch (typeof value) {
+    case "boolean":
+      return value ? "true" : "false"
+    case "number":
+      return Number.isFinite(value) ? JSON.stringify(value) : "number"
+    case "string":
+      return JSON.stringify(value)
+    case "object":
+      return value === null ? "null" : "unknown[]"
+    default:
+      return "unknown"
+  }
 }
 
 export function envNitro(options: EnvIntegrationOptions = {}): NitroModule {
@@ -175,6 +193,9 @@ function collectRequiredSecretNames(declarations: EnvNitroConfigOptions | undefi
       const source = resolveEnvSource(value, valuePath, prefix)
       return value.secret && value.required && source.kind === "env" ? [source.name] : []
     }
+    if (!isPlainRecord(value)) {
+      return []
+    }
     return collectRequiredSecretNames(value as EnvNitroConfigOptions, prefix, valuePath)
   })
 }
@@ -193,6 +214,9 @@ function describeRuntimeEntries(
   return Object.entries(declarations || {}).flatMap(([key, value]) => {
     const valuePath = `${path}.${key}`
     if (!isEnvVariableDeclaration(value)) {
+      if (!isPlainRecord(value)) {
+        return []
+      }
       return describeRuntimeEntries(value as EnvNitroConfigOptions, prefix, valuePath)
     }
     const source = resolveEnvSource(value, valuePath, prefix)
@@ -220,6 +244,21 @@ function isRegistryEntry(value: EnvRuntimeRegistryValue): value is EnvRegistryEn
     && source !== null
     && (source as { kind?: unknown }).kind === "env"
     && typeof (source as { name?: unknown }).name === "string"
+}
+
+function isLiteralEntry(value: EnvRuntimeRegistryValue): value is EnvRuntimeLiteralEntry {
+  return typeof value === "object"
+    && value !== null
+    && !Array.isArray(value)
+    && (value as { kind?: unknown }).kind === "literal"
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false
+  }
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === null || prototype === Object.prototype
 }
 
 const nitroModule: NitroModule = envNitro()

--- a/packages/env/src/runtime/server.ts
+++ b/packages/env/src/runtime/server.ts
@@ -1,6 +1,6 @@
 import { getCloudflareEnv } from "@vitehub/internal/runtime/cloudflare-env"
 
-import type { EnvRegistryEntry, EnvRuntimeRegistry, EnvRuntimeRegistryValue, EnvRuntimeSchema, SafeRuntimeConfig } from "../types.ts"
+import type { EnvRegistryEntry, EnvRuntimeLiteralEntry, EnvRuntimeRegistry, EnvRuntimeRegistryValue, EnvRuntimeSchema, SafeRuntimeConfig } from "../types.ts"
 
 let registry: EnvRuntimeRegistry = {}
 
@@ -33,6 +33,10 @@ function resolveRuntimeEnv(event?: unknown): Record<string, string | undefined> 
 function resolveRuntimeValues(declarations: EnvRuntimeRegistry, env: Record<string, string | undefined>, path = "env"): Record<string, unknown> {
   const values: Record<string, unknown> = {}
   for (const [key, entry] of Object.entries(declarations)) {
+    if (isLiteralEntry(entry)) {
+      values[key] = entry.value
+      continue
+    }
     if (!isRegistryEntry(entry)) {
       values[key] = resolveRuntimeValues(entry, env, `${path}.${key}`)
       continue
@@ -80,6 +84,13 @@ function isRegistryEntry(value: EnvRuntimeRegistryValue): value is EnvRegistryEn
     && source !== null
     && (source as { kind?: unknown }).kind === "env"
     && typeof (source as { name?: unknown }).name === "string"
+}
+
+function isLiteralEntry(value: EnvRuntimeRegistryValue): value is EnvRuntimeLiteralEntry {
+  return typeof value === "object"
+    && value !== null
+    && !Array.isArray(value)
+    && (value as { kind?: unknown }).kind === "literal"
 }
 
 function isPlainRuntimeObject(value: unknown): value is Record<string, unknown> {

--- a/packages/env/src/types.ts
+++ b/packages/env/src/types.ts
@@ -77,7 +77,9 @@ export interface EnvViteConfigOptions {
   public?: Record<string, EnvVariableDeclaration>
 }
 
-type EnvNitroConfigValue = EnvNitroConfigOptions | EnvVariableDeclaration
+export type EnvNitroStaticValue = null | string | number | boolean | EnvNitroStaticValue[]
+
+type EnvNitroConfigValue = EnvNitroConfigOptions | EnvNitroStaticValue | EnvVariableDeclaration
 
 export interface EnvNitroConfigOptions {
   [key: string]: EnvNitroConfigValue
@@ -125,7 +127,12 @@ export interface EnvRuntimeSchema {
   kind: "string"
 }
 
-export type EnvRuntimeRegistryValue = EnvRegistryEntry | EnvRuntimeRegistry
+export interface EnvRuntimeLiteralEntry {
+  kind: "literal"
+  value: EnvNitroStaticValue
+}
+
+export type EnvRuntimeRegistryValue = EnvRegistryEntry | EnvRuntimeLiteralEntry | EnvRuntimeRegistry
 
 export interface EnvRuntimeRegistry {
   [key: string]: EnvRuntimeRegistryValue

--- a/packages/env/test/declarations.test.ts
+++ b/packages/env/test/declarations.test.ts
@@ -102,6 +102,10 @@ describe("env declarations", () => {
       public: {
         apiBase: envVariable(),
       },
+      teams: {
+        appId: envVariable({ secret: true }),
+        appType: "SingleTenant",
+      },
       telegram: {
         botToken: envVariable({ secret: true }),
       },
@@ -109,6 +113,19 @@ describe("env declarations", () => {
         model: envVariable({ default: "gemini-3.1-pro-preview-customtools" }),
       },
     }, "nitro")).not.toThrow()
+  })
+
+  it("rejects unsupported Nitro runtime values", () => {
+    expect(() => validateEnvConfigShape({
+      teams: {
+        appType: () => "SingleTenant",
+      },
+    } as never, "nitro")).toThrow("serializable literal")
+    expect(() => validateEnvConfigShape({
+      teams: {
+        createdAt: new Date(),
+      },
+    } as never, "nitro")).toThrow("serializable literal")
   })
 
   it("rejects secret Nitro public runtime declarations", () => {
@@ -121,10 +138,19 @@ describe("env declarations", () => {
 
   it("creates a runtime registry with inferred nested env sources", () => {
     expect(createRuntimeRegistry({
+      teams: {
+        appType: "SingleTenant",
+      },
       telegram: {
         botToken: envVariable({ secret: true }),
       },
     }, { prefix: "VITEHUB_" })).toMatchObject({
+      teams: {
+        appType: {
+          kind: "literal",
+          value: "SingleTenant",
+        },
+      },
       telegram: {
         botToken: {
           source: {

--- a/packages/env/test/declarations.test.ts
+++ b/packages/env/test/declarations.test.ts
@@ -128,6 +128,24 @@ describe("env declarations", () => {
     } as never, "nitro")).toThrow("serializable literal")
   })
 
+  it("rejects Nitro runtime literals that JSON cannot preserve", () => {
+    expect(() => validateEnvConfigShape({
+      teams: {
+        retryDelay: Number.NaN,
+      },
+    }, "nitro")).toThrow("serializable literal")
+    expect(() => validateEnvConfigShape({
+      teams: {
+        retryDelay: Number.POSITIVE_INFINITY,
+      },
+    }, "nitro")).toThrow("serializable literal")
+    expect(() => validateEnvConfigShape({
+      teams: {
+        labels: [, "primary"],
+      },
+    } as never, "nitro")).toThrow("serializable literal")
+  })
+
   it("rejects secret Nitro public runtime declarations", () => {
     expect(() => validateEnvConfigShape({
       public: {

--- a/packages/env/test/nitro.test.ts
+++ b/packages/env/test/nitro.test.ts
@@ -70,6 +70,13 @@ describe("Nitro module", () => {
           public: {
             apiBase: envVariable({ source: envSource.env("PUBLIC_API_BASE") }),
           },
+          teams: {
+            apiUrl: envVariable({ optional: true }),
+            appId: envVariable({ secret: true }),
+            appPassword: envVariable({ secret: true }),
+            appTenantId: envVariable({ secret: true }),
+            appType: "SingleTenant",
+          },
           telegram: {
             apiBaseUrl: envVariable({ optional: true }),
             botToken: envVariable({ secret: true }),
@@ -88,10 +95,11 @@ describe("Nitro module", () => {
     expect(nitro.options.alias?.["#vitehub/env/server"]).toContain("/packages/env/src/runtime/server.ts")
     expect(nitro.options.plugins).toHaveLength(1)
     expect(nitro.options.handlers).toBeUndefined()
-    expect(nitro.options.cloudflare?.wrangler?.secrets?.required).toEqual(["EXISTING_SECRET", "AUTH_SECRET", "TELEGRAM_BOT_TOKEN"])
+    expect(nitro.options.cloudflare?.wrangler?.secrets?.required).toEqual(["EXISTING_SECRET", "AUTH_SECRET", "TEAMS_APP_ID", "TEAMS_APP_PASSWORD", "TEAMS_APP_TENANT_ID", "TELEGRAM_BOT_TOKEN"])
     expect(nitro.logger.info).toHaveBeenCalledWith(expect.stringContaining("env.databaseUrl"))
     expect(nitro.logger.info).toHaveBeenCalledWith(expect.stringContaining("env.public.apiBase"))
     expect(nitro.logger.info).toHaveBeenCalledWith(expect.stringContaining("public runtime transport"))
+    expect(nitro.logger.info).not.toHaveBeenCalledWith(expect.stringContaining("env.teams.appType"))
     expect(nitro.logger.info).toHaveBeenCalledWith(expect.stringContaining("env.telegram.botToken"))
 
     const typesHook = nitro.hooks.hook.mock.calls.find(([name]) => name === "types:extend")?.[1]
@@ -103,6 +111,8 @@ describe("Nitro module", () => {
     expect(types).toContain("\"optionalApiBase\": string | undefined")
     expect(types).toContain("\"public\": {")
     expect(types).toContain("\"apiBase\": string")
+    expect(types).toContain("\"teams\": {")
+    expect(types).toContain("\"appType\": \"SingleTenant\"")
     expect(types).toContain("\"telegram\": {")
     expect(types).toContain("\"apiBaseUrl\": string | undefined")
     expect(types).toContain("\"botToken\": string")
@@ -120,6 +130,9 @@ describe("Nitro module", () => {
     const registry = await readFile(join(root, ".vitehub/nitro-runtime/env/registry.mjs"), "utf8")
     expect(registry).toContain("DATABASE_URL")
     expect(registry).toContain("PUBLIC_API_BASE")
+    expect(registry).toContain("SingleTenant")
+    expect(registry).toContain("\"kind\": \"literal\"")
+    expect(registry).not.toContain("TEAMS_APP_TYPE")
     expect(registry).toContain("TELEGRAM_BOT_TOKEN")
     expect(registry).toContain("\"required\": false")
     expect(registry).not.toContain("aaaaaaaa")
@@ -254,6 +267,12 @@ describe("Nitro module", () => {
           source: { kind: "env", label: "env:PUBLIC_API_BASE", name: "PUBLIC_API_BASE", serializable: true },
         },
       },
+      teams: {
+        appType: {
+          kind: "literal",
+          value: "SingleTenant",
+        },
+      },
       telegram: {
         apiBaseUrl: {
           required: false,
@@ -278,10 +297,12 @@ describe("Nitro module", () => {
 
     const config = useSafeRuntimeConfig(undefined) as {
       public: { apiBase: string }
+      teams: { appType: "SingleTenant" }
       telegram: { apiBaseUrl?: string, botToken: string }
       vertex: { model: string }
     }
 
+    expect(config.teams.appType).toBe("SingleTenant")
     expect(config.telegram.botToken).toBe("telegram-secret")
     expect(config.telegram.apiBaseUrl).toBeUndefined()
     expect(config.public.apiBase).toBe("https://api.example.com")
@@ -292,6 +313,7 @@ describe("Nitro module", () => {
     expect(runtimeConfig).toMatchObject({
       chat: { enabled: true },
       public: { apiBase: "https://api.example.com", existing: "keep" },
+      teams: { appType: "SingleTenant" },
       telegram: { botToken: "telegram-secret" },
       vertex: { model: "gemini-3.1-pro-preview-customtools" },
     })


### PR DESCRIPTION
Allows Nitro env config to mix envVariable() declarations with static serializable runtime values, so configs like teams.appType: 'SingleTenant' are preserved in runtime config instead of being treated as env declarations. Static values are skipped for diagnostics and Cloudflare required-secret collection, while generated runtime types include literal values where possible.

Checks run:
- pnpm --filter @vitehub/env typecheck
- pnpm --filter @vitehub/env test