### PR TITLE
fix: load GitHub source token from env files

### DIFF
--- a/packages/workspace/src/env.ts
+++ b/packages/workspace/src/env.ts
@@ -1,0 +1,27 @@
+const envByRoot = new Map<string, Record<string, string>>()
+let viteLoadEnv: ((mode: string, root: string, prefix: string) => Record<string, string>) | undefined | null
+
+export async function resolveWorkspaceEnv(rootDir: string, name: string): Promise<string | undefined> {
+  return (await loadWorkspaceEnv(rootDir))?.[name]
+}
+
+export async function loadWorkspaceEnv(rootDir: string): Promise<Record<string, string> | undefined> {
+  if (envByRoot.has(rootDir)) return envByRoot.get(rootDir)
+  const env = await loadViteEnv(rootDir)
+  if (env) envByRoot.set(rootDir, env)
+  return env
+}
+
+async function loadViteEnv(rootDir: string): Promise<Record<string, string> | undefined> {
+  if (viteLoadEnv === null) return
+  if (!viteLoadEnv) {
+    try {
+      viteLoadEnv = (await import("vite")).loadEnv
+    }
+    catch {
+      viteLoadEnv = null
+      return
+    }
+  }
+  return viteLoadEnv("", rootDir, "")
+}

--- a/packages/workspace/src/env.ts
+++ b/packages/workspace/src/env.ts
@@ -1,4 +1,3 @@
-const envByRoot = new Map<string, Record<string, string>>()
 let viteLoadEnv: ((mode: string, root: string, prefix: string) => Record<string, string>) | undefined | null
 
 export async function resolveWorkspaceEnv(rootDir: string, name: string): Promise<string | undefined> {
@@ -6,10 +5,7 @@ export async function resolveWorkspaceEnv(rootDir: string, name: string): Promis
 }
 
 export async function loadWorkspaceEnv(rootDir: string): Promise<Record<string, string> | undefined> {
-  if (envByRoot.has(rootDir)) return envByRoot.get(rootDir)
-  const env = await loadViteEnv(rootDir)
-  if (env) envByRoot.set(rootDir, env)
-  return env
+  return await loadViteEnv(rootDir)
 }
 
 async function loadViteEnv(rootDir: string): Promise<Record<string, string> | undefined> {

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -1,6 +1,7 @@
 import { getActiveCloudflareBinding } from "@vitehub/internal/runtime/cloudflare-env"
 import { github as createGitHubSource, type GitHubSourceOptions as UnsourceGitHubSourceOptions } from "@vitehub/unsource"
 
+import { resolveWorkspaceEnv } from "../env.ts"
 import type { SourceContext, WorkspaceSource } from "../types.ts"
 
 type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "materialize" | "mount" | "swr" | "validate">
@@ -11,79 +12,63 @@ export interface GitHubSourceOptions extends Omit<UnsourceGitHubSourceOptions, "
 }
 
 export function github(options: GitHubSourceOptions): WorkspaceSource {
-  let envFileToken: string | undefined
-  async function prepareEnvFileToken(ctx: SourceContext) {
-    envFileToken = await prepareGitHubEnvFileToken(ctx.rootDir)
+  const baseSource = createGitHubSource({
+    ...options,
+    auth: createGitHubAuthResolver(options.auth),
+  })
+  const sourceByRoot = new Map<string, typeof baseSource>()
+
+  async function getSourceForRoot(rootDir: string) {
+    const cachedSource = sourceByRoot.get(rootDir)
+    if (cachedSource) return cachedSource
+    const envFileToken = await resolveWorkspaceEnv(rootDir, "GITHUB_TOKEN")
+    const source = createGitHubSource({
+      ...options,
+      auth: createGitHubAuthResolver(options.auth, envFileToken),
+    })
+    sourceByRoot.set(rootDir, source)
+    return source
   }
 
-  const source = createGitHubSource({
-    ...options,
-    auth: createGitHubAuthResolver(options.auth, () => envFileToken),
-  })
-
   return {
-    ...source,
+    ...baseSource,
     cache: options.cache,
     materialize: options.materialize,
     mount: options.mount,
     swr: options.swr,
     validate: options.validate,
     async prepare(ctx) {
-      await prepareEnvFileToken(ctx)
+      const source = await getSourceForRoot(ctx.rootDir)
       await source.prepare?.(ctx)
     },
     async getKeys(ctx) {
-      await prepareEnvFileToken(ctx)
+      const source = await getSourceForRoot(ctx.rootDir)
       return await source.getKeys(ctx)
     },
     async getItem(key, ctx) {
-      await prepareEnvFileToken(ctx)
+      const source = await getSourceForRoot(ctx.rootDir)
       return await source.getItem(key, ctx)
     },
     async getMeta(key, ctx) {
-      await prepareEnvFileToken(ctx)
+      const source = await getSourceForRoot(ctx.rootDir)
       return await source.getMeta?.(key, ctx)
     },
     async search(query, ctx) {
-      await prepareEnvFileToken(ctx)
+      const source = await getSourceForRoot(ctx.rootDir)
       return await source.search?.(query, ctx) ?? []
     },
   }
 }
 
-const envFileTokenByRoot = new Map<string, string | undefined>()
-let viteLoadEnv: ((mode: string, root: string, prefix: string) => Record<string, string>) | undefined | null
-
-function createGitHubAuthResolver(auth: GitHubAuth | undefined, getEnvFileToken: () => string | undefined) {
+function createGitHubAuthResolver(auth: GitHubAuth | undefined, envFileToken?: string) {
   return () => {
     return resolveGitHubAuth(auth)
       || getActiveCloudflareBinding<string>("GITHUB_TOKEN")
       || process.env.GITHUB_TOKEN
-      || getEnvFileToken()
+      || envFileToken
   }
 }
 
 function resolveGitHubAuth(auth: GitHubAuth | undefined): string | undefined {
   return typeof auth === "function" ? auth() : auth
-}
-
-async function prepareGitHubEnvFileToken(rootDir: string): Promise<string | undefined> {
-  if (envFileTokenByRoot.has(rootDir)) return envFileTokenByRoot.get(rootDir)
-  const token = (await loadViteEnv(rootDir))?.GITHUB_TOKEN
-  envFileTokenByRoot.set(rootDir, token)
-  return token
-}
-
-async function loadViteEnv(rootDir: string): Promise<Record<string, string> | undefined> {
-  if (viteLoadEnv === null) return
-  if (!viteLoadEnv) {
-    try {
-      viteLoadEnv = (await import("vite")).loadEnv
-    }
-    catch {
-      viteLoadEnv = null
-      return
-    }
-  }
-  return viteLoadEnv("", rootDir, "")
 }

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -1,18 +1,24 @@
 import { getActiveCloudflareBinding } from "@vitehub/internal/runtime/cloudflare-env"
 import { github as createGitHubSource, type GitHubSourceOptions as UnsourceGitHubSourceOptions } from "@vitehub/unsource"
 
-import type { WorkspaceSource } from "../types.ts"
+import type { SourceContext, WorkspaceSource } from "../types.ts"
 
 type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "materialize" | "mount" | "swr" | "validate">
+type GitHubAuth = NonNullable<UnsourceGitHubSourceOptions["auth"]>
 
 export interface GitHubSourceOptions extends Omit<UnsourceGitHubSourceOptions, "auth">, SourceRuntimeOptions {
-  auth?: string
+  auth?: GitHubAuth
 }
 
 export function github(options: GitHubSourceOptions): WorkspaceSource {
+  let envFileToken: string | undefined
+  async function prepareEnvFileToken(ctx: SourceContext) {
+    envFileToken = await prepareGitHubEnvFileToken(ctx.rootDir)
+  }
+
   const source = createGitHubSource({
     ...options,
-    auth: () => options.auth || getActiveCloudflareBinding<string>("GITHUB_TOKEN") || process.env.GITHUB_TOKEN,
+    auth: createGitHubAuthResolver(options.auth, () => envFileToken),
   })
 
   return {
@@ -22,5 +28,62 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
     mount: options.mount,
     swr: options.swr,
     validate: options.validate,
+    async prepare(ctx) {
+      await prepareEnvFileToken(ctx)
+      await source.prepare?.(ctx)
+    },
+    async getKeys(ctx) {
+      await prepareEnvFileToken(ctx)
+      return await source.getKeys(ctx)
+    },
+    async getItem(key, ctx) {
+      await prepareEnvFileToken(ctx)
+      return await source.getItem(key, ctx)
+    },
+    async getMeta(key, ctx) {
+      await prepareEnvFileToken(ctx)
+      return await source.getMeta?.(key, ctx)
+    },
+    async search(query, ctx) {
+      await prepareEnvFileToken(ctx)
+      return await source.search?.(query, ctx) ?? []
+    },
   }
+}
+
+const envFileTokenByRoot = new Map<string, string | undefined>()
+let viteLoadEnv: ((mode: string, root: string, prefix: string) => Record<string, string>) | undefined | null
+
+function createGitHubAuthResolver(auth: GitHubAuth | undefined, getEnvFileToken: () => string | undefined) {
+  return () => {
+    return resolveGitHubAuth(auth)
+      || getActiveCloudflareBinding<string>("GITHUB_TOKEN")
+      || process.env.GITHUB_TOKEN
+      || getEnvFileToken()
+  }
+}
+
+function resolveGitHubAuth(auth: GitHubAuth | undefined): string | undefined {
+  return typeof auth === "function" ? auth() : auth
+}
+
+async function prepareGitHubEnvFileToken(rootDir: string): Promise<string | undefined> {
+  if (envFileTokenByRoot.has(rootDir)) return envFileTokenByRoot.get(rootDir)
+  const token = (await loadViteEnv(rootDir))?.GITHUB_TOKEN
+  envFileTokenByRoot.set(rootDir, token)
+  return token
+}
+
+async function loadViteEnv(rootDir: string): Promise<Record<string, string> | undefined> {
+  if (viteLoadEnv === null) return
+  if (!viteLoadEnv) {
+    try {
+      viteLoadEnv = (await import("vite")).loadEnv
+    }
+    catch {
+      viteLoadEnv = null
+      return
+    }
+  }
+  return viteLoadEnv("", rootDir, "")
 }

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -16,17 +16,18 @@ export function github(options: GitHubSourceOptions): WorkspaceSource {
     ...options,
     auth: createGitHubAuthResolver(options.auth),
   })
-  const sourceByRoot = new Map<string, typeof baseSource>()
+  const sourceByRootAndToken = new Map<string, typeof baseSource>()
 
   async function getSourceForRoot(rootDir: string) {
-    const cachedSource = sourceByRoot.get(rootDir)
-    if (cachedSource) return cachedSource
     const envFileToken = await resolveWorkspaceEnv(rootDir, "GITHUB_TOKEN")
+    const cacheKey = `${rootDir}\0${envFileToken ?? ""}`
+    const cachedSource = sourceByRootAndToken.get(cacheKey)
+    if (cachedSource) return cachedSource
     const source = createGitHubSource({
       ...options,
       auth: createGitHubAuthResolver(options.auth, envFileToken),
     })
-    sourceByRoot.set(rootDir, source)
+    sourceByRootAndToken.set(cacheKey, source)
     return source
   }
 

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -194,6 +194,25 @@ describe("sources, loaders, and publishers", () => {
     expect(process.env.GITHUB_TOKEN).toBeUndefined()
   })
 
+  it("re-reads GitHub auth from local env files", async () => {
+    const root = await createRoot()
+    await writeFile(join(root, ".env"), "GITHUB_TOKEN=first-env-file-token\n")
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+
+    const githubSource = source.github({ repo: "acme/private" })
+
+    await expect(githubSource.getKeys({ rootDir: root, workspace: "github-env-file-auth" })).resolves.toEqual(["docs/README.md"])
+    await writeFile(join(root, ".env"), "GITHUB_TOKEN=second-env-file-token\n")
+    await expect(githubSource.getKeys({ rootDir: root, workspace: "github-env-file-auth" })).resolves.toEqual(["docs/README.md"])
+
+    expect(treeRequestAuthorizations()).toEqual([
+      "Bearer first-env-file-token",
+      "Bearer second-env-file-token",
+    ])
+  })
+
   it("prefers runtime GitHub auth over local env files", async () => {
     const root = await createRoot()
     await writeFile(join(root, ".env"), "GITHUB_TOKEN=env-file-token\n")

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -110,6 +110,17 @@ function stubGitHubSource(files: Record<string, string>, options: StubGitHubSour
   }))
 }
 
+function treeRequestAuthorizations() {
+  return vi.mocked(fetch).mock.calls
+    .filter(([url]) => String(url).includes("/git/trees/"))
+    .map(([, init]) => (init?.headers as Record<string, string> | undefined)?.authorization)
+}
+
+function treeRequestAuthorization() {
+  const [authorization] = treeRequestAuthorizations()
+  return authorization
+}
+
 describe("sources, loaders, and publishers", () => {
   it("lists GitHub files under the configured root with relative keys", async () => {
     stubGitHubSource({
@@ -162,11 +173,55 @@ describe("sources, loaders, and publishers", () => {
     process.env.GITHUB_TOKEN = "second-token"
     await expect(githubSource.getKeys({ rootDir: "", workspace: "github-auth" })).resolves.toEqual(["docs/README.md"])
 
-    const treeCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).includes("/git/trees/"))
-    expect(treeCalls.map(([, init]) => (init?.headers as Record<string, string>).authorization)).toEqual([
+    expect(treeRequestAuthorizations()).toEqual([
       "Bearer first-token",
       "Bearer second-token",
     ])
+  })
+
+  it("resolves GitHub auth from local env files without mutating process env", async () => {
+    const root = await createRoot()
+    await writeFile(join(root, ".env"), "GITHUB_TOKEN=env-file-token\n")
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+
+    const githubSource = source.github({ repo: "acme/private" })
+
+    await expect(githubSource.getKeys({ rootDir: root, workspace: "github-env-file-auth" })).resolves.toEqual(["docs/README.md"])
+
+    expect(treeRequestAuthorization()).toBe("Bearer env-file-token")
+    expect(process.env.GITHUB_TOKEN).toBeUndefined()
+  })
+
+  it("prefers runtime GitHub auth over local env files", async () => {
+    const root = await createRoot()
+    await writeFile(join(root, ".env"), "GITHUB_TOKEN=env-file-token\n")
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+    process.env.GITHUB_TOKEN = "runtime-token"
+
+    const githubSource = source.github({ repo: "acme/private" })
+
+    await githubSource.getKeys({ rootDir: root, workspace: "github-runtime-auth" })
+
+    expect(treeRequestAuthorization()).toBe("Bearer runtime-token")
+  })
+
+  it("prefers Cloudflare GitHub auth over local env files", async () => {
+    const root = await createRoot()
+    await writeFile(join(root, ".env"), "GITHUB_TOKEN=env-file-token\n")
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+    ;(globalThis as { __env__?: Record<string, unknown> }).__env__ = { GITHUB_TOKEN: "cloudflare-token" }
+
+    const githubSource = source.github({ repo: "acme/private" })
+
+    await githubSource.getKeys({ rootDir: root, workspace: "github-cloudflare-auth" })
+
+    expect(treeRequestAuthorization()).toBe("Bearer cloudflare-token")
   })
 
   it("prefers explicit GitHub auth over Cloudflare runtime env", async () => {
@@ -179,8 +234,33 @@ describe("sources, loaders, and publishers", () => {
 
     await githubSource.getKeys({ rootDir: "", workspace: "github-auth" })
 
-    const treeCall = vi.mocked(fetch).mock.calls.find(([url]) => String(url).includes("/git/trees/"))
-    expect((treeCall?.[1]?.headers as Record<string, string>).authorization).toBe("Bearer explicit-token")
+    expect(treeRequestAuthorization()).toBe("Bearer explicit-token")
+  })
+
+  it("prefers explicit GitHub auth over local env files", async () => {
+    const root = await createRoot()
+    await writeFile(join(root, ".env"), "GITHUB_TOKEN=env-file-token\n")
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+
+    const githubSource = source.github({ auth: "explicit-token", repo: "acme/private" })
+
+    await githubSource.getKeys({ rootDir: root, workspace: "github-explicit-auth" })
+
+    expect(treeRequestAuthorization()).toBe("Bearer explicit-token")
+  })
+
+  it("keeps public GitHub source requests unauthenticated when no token exists", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+
+    const githubSource = source.github({ repo: "acme/public" })
+
+    await githubSource.getKeys({ rootDir: "", workspace: "github-public" })
+
+    expect(treeRequestAuthorization()).toBeUndefined()
   })
 
   it("falls back to GitHub archives when the public tree API is rate limited", async () => {
@@ -234,7 +314,7 @@ describe("sources, loaders, and publishers", () => {
         return jsonResponse({ content: "", encoding: "none" })
       }
       if (requestUrl.startsWith("https://raw.githubusercontent.com/")) {
-        expect((init?.headers as Record<string, string>).authorization).toBe("Bearer token")
+        expect((init?.headers as Record<string, string> | undefined)?.authorization).toBe("Bearer token")
         return new Response("<metadata />\n")
       }
       throw new Error(`Unexpected GitHub request: ${requestUrl}`)


### PR DESCRIPTION
Updates workspace GitHub sources to discover GITHUB_TOKEN from local env files when no explicit auth, Cloudflare binding, or process env token is available. This lets apps with private GitHub sources rely on their existing .env without manually copying GITHUB_TOKEN into process.env.\n\nThe token remains optional, public repos still work unauthenticated, and explicit auth keeps highest precedence.