### PR TITLE
refactor: drop legacy compatibility aliases

### DIFF
--- a/packages/blob/docs/runtime-api.md
+++ b/packages/blob/docs/runtime-api.md
@@ -127,10 +127,6 @@ await blob.del('avatars/user-1.png')
 await blob.del(['avatars/user-2.png', 'avatars/user-3.png'])
 ```
 
-### `blob.delete(pathname | pathnames[])`
-
-Alias for `blob.del(...)`.
-
 ### `blob.serve(event, pathname)`
 
 Loads one blob body and returns a `ReadableStream`.

--- a/packages/blob/docs/usage.md
+++ b/packages/blob/docs/usage.md
@@ -129,12 +129,10 @@ export default defineEventHandler(async (event) => {
 
 ## Delete One or Many Objects
 
-`del()` and `delete()` are aliases.
-
 ```ts
 await blob.del('avatars/user-1.png')
 
-await blob.delete([
+await blob.del([
   'avatars/user-2.png',
   'avatars/user-3.png',
 ])

--- a/packages/blob/src/runtime/storage.ts
+++ b/packages/blob/src/runtime/storage.ts
@@ -60,7 +60,6 @@ async function resolveStorage() {
 }
 
 export const blob: BlobStorage = {
-  async delete(pathnames) { await (await resolveStorage()).delete(pathnames) },
   async del(pathnames) { await (await resolveStorage()).del(pathnames) },
   async get(pathname) { return (await resolveStorage()).get(pathname) },
   async head(pathname) { return (await resolveStorage()).head(pathname) },

--- a/packages/blob/src/storage.ts
+++ b/packages/blob/src/storage.ts
@@ -68,9 +68,6 @@ function normalizeBlobPath(pathname: string, options: BlobPutOptions) {
 
 export function createBlobStorage(driver: BlobDriverAdapter<any>): BlobStorage {
   return {
-    async delete(pathnames: string | string[]) {
-      await this.del(pathnames)
-    },
     async del(pathnames: string | string[]) {
       await driver.delete(toArray(pathnames).map(value => normalizePathname(value)))
     },

--- a/packages/blob/src/types.ts
+++ b/packages/blob/src/types.ts
@@ -59,7 +59,6 @@ export interface BlobEnsureOptions {
 }
 
 export interface BlobStorage {
-  delete(pathnames: string | string[]): Promise<void>
   del(pathnames: string | string[]): Promise<void>
   get(pathname: string): Promise<Blob | null>
   head(pathname: string): Promise<BlobObject>

--- a/packages/kv/docs/index.md
+++ b/packages/kv/docs/index.md
@@ -107,10 +107,9 @@ ViteHub resolves KV config in this order:
 | --- | --- | --- |
 | 1 | Explicit `kv.driver` | The configured driver |
 | 2 | `KV_REST_API_URL` and `KV_REST_API_TOKEN` | `upstash` |
-| 3 | `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` | `upstash` |
-| 4 | Vercel hosting | `upstash` |
-| 5 | Cloudflare hosting | `cloudflare-kv-binding` |
-| 6 | Everything else | `fs-lite` |
+| 3 | Vercel hosting | `upstash` |
+| 4 | Cloudflare hosting | `cloudflare-kv-binding` |
+| 5 | Everything else | `fs-lite` |
 
 Explicit config always wins. That means you can force `fs-lite` locally, force Cloudflare for a Worker, or force Upstash for any runtime.
 

--- a/packages/kv/docs/providers/vercel.md
+++ b/packages/kv/docs/providers/vercel.md
@@ -62,18 +62,11 @@ export default defineNuxtConfig({
 
 ## Add Runtime Environment Variables
 
-Set the preferred Upstash REST variables:
+Set the Upstash REST variables:
 
 ```bash
 KV_REST_API_URL=https://example.upstash.io
 KV_REST_API_TOKEN=<upstash-rest-token>
-```
-
-ViteHub also accepts the Upstash Redis REST aliases:
-
-```bash
-UPSTASH_REDIS_REST_URL=https://example.upstash.io
-UPSTASH_REDIS_REST_TOKEN=<upstash-rest-token>
 ```
 
 ## Let Hosting Select Upstash
@@ -146,8 +139,8 @@ Expected response:
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| `Missing runtime environment variable \`KV_REST_API_URL\`` | Upstash URL is missing at runtime. | Set `KV_REST_API_URL` or `UPSTASH_REDIS_REST_URL`. |
-| `Missing runtime environment variable \`KV_REST_API_TOKEN\`` | Upstash token is missing at runtime. | Set `KV_REST_API_TOKEN` or `UPSTASH_REDIS_REST_TOKEN`. |
+| `Missing runtime environment variable \`KV_REST_API_URL\`` | Upstash URL is missing at runtime. | Set `KV_REST_API_URL`. |
+| `Missing runtime environment variable \`KV_REST_API_TOKEN\`` | Upstash token is missing at runtime. | Set `KV_REST_API_TOKEN`. |
 | Vercel logs warn about `fs-lite` | Explicit local driver was deployed. | Set `kv.driver` to `upstash` or rely on Vercel hosting inference. |
 
 ## Related Pages

--- a/packages/kv/docs/runtime-api.md
+++ b/packages/kv/docs/runtime-api.md
@@ -136,10 +136,10 @@ When credentials come from env vars, ViteHub stores masked placeholders at build
 
 Supported env vars:
 
-| Value | Preferred env var | Alias |
-| --- | --- | --- |
-| REST URL | `KV_REST_API_URL` | `UPSTASH_REDIS_REST_URL` |
-| REST token | `KV_REST_API_TOKEN` | `UPSTASH_REDIS_REST_TOKEN` |
+| Value | Env var |
+| --- | --- |
+| REST URL | `KV_REST_API_URL` |
+| REST token | `KV_REST_API_TOKEN` |
 
 ### `FsLiteKVStoreConfig`
 

--- a/packages/kv/docs/troubleshooting.md
+++ b/packages/kv/docs/troubleshooting.md
@@ -37,16 +37,10 @@ export default defineNuxtConfig({
 
 **Cause:** The active driver is `upstash`, but the runtime environment does not contain a REST URL.
 
-**Fix:** Set one of the supported URL variables:
+**Fix:** Set the supported URL variable:
 
 ```bash
 KV_REST_API_URL=https://example.upstash.io
-```
-
-or:
-
-```bash
-UPSTASH_REDIS_REST_URL=https://example.upstash.io
 ```
 
 **Verify:** Restart the runtime and call the KV route again.
@@ -55,16 +49,10 @@ UPSTASH_REDIS_REST_URL=https://example.upstash.io
 
 **Cause:** The active driver is `upstash`, but the runtime environment does not contain a REST token.
 
-**Fix:** Set one of the supported token variables:
+**Fix:** Set the supported token variable:
 
 ```bash
 KV_REST_API_TOKEN=<upstash-rest-token>
-```
-
-or:
-
-```bash
-UPSTASH_REDIS_REST_TOKEN=<upstash-rest-token>
 ```
 
 **Verify:** Restart the runtime and call the KV route again.

--- a/packages/kv/src/integrations/upstash.ts
+++ b/packages/kv/src/integrations/upstash.ts
@@ -5,8 +5,8 @@ import type { ResolvedUpstashKVStoreConfig, UpstashKVStoreConfig } from "../type
 const maskedUpstashRuntimeValue = "********"
 
 export function hasUpstashEnv(env: Record<string, string | undefined>): boolean {
-  const url = readEnv(env, "KV_REST_API_URL", "UPSTASH_REDIS_REST_URL")
-  const token = readEnv(env, "KV_REST_API_TOKEN", "UPSTASH_REDIS_REST_TOKEN")
+  const url = readEnv(env, "KV_REST_API_URL")
+  const token = readEnv(env, "KV_REST_API_TOKEN")
   return Boolean(url && token)
 }
 

--- a/packages/kv/src/runtime/storage.ts
+++ b/packages/kv/src/runtime/storage.ts
@@ -17,7 +17,7 @@ function inferHosting(env: Record<string, string | undefined>) {
     return explicit
   }
 
-  return readEnv(env, "KV_REST_API_URL", "UPSTASH_REDIS_REST_URL") ? "vercel" : undefined
+  return readEnv(env, "KV_REST_API_URL") ? "vercel" : undefined
 }
 
 function shouldFallbackHostedConfigImport(error: unknown) {

--- a/packages/kv/src/runtime/upstash.ts
+++ b/packages/kv/src/runtime/upstash.ts
@@ -19,8 +19,8 @@ function resolveRuntimeUpstashStore(
   config: ResolvedUpstashKVStoreConfig,
   env: Record<string, string | undefined>,
 ): ResolvedUpstashKVStoreConfig {
-  const envUrl = readEnv(env, "KV_REST_API_URL", "UPSTASH_REDIS_REST_URL")
-  const envToken = readEnv(env, "KV_REST_API_TOKEN", "UPSTASH_REDIS_REST_TOKEN")
+  const envUrl = readEnv(env, "KV_REST_API_URL")
+  const envToken = readEnv(env, "KV_REST_API_TOKEN")
 
   const resolved = {
     ...config,

--- a/packages/kv/test/config.test.ts
+++ b/packages/kv/test/config.test.ts
@@ -64,22 +64,6 @@ describe("normalizeKVOptions", () => {
     })
   })
 
-  it("accepts legacy Upstash env var aliases", () => {
-    expect(normalizeKVOptions(undefined, {
-      env: {
-        UPSTASH_REDIS_REST_TOKEN: "token",
-        UPSTASH_REDIS_REST_URL: "https://upstash.example.com",
-      },
-      hosting: "vercel",
-    })).toEqual({
-      store: {
-        driver: "upstash",
-        token: "********",
-        url: "********",
-      },
-    })
-  })
-
   it("defaults Vercel hosting to masked Upstash runtime config", () => {
     expect(normalizeKVOptions(undefined, {
       env: {},

--- a/packages/kv/test/runtime.test.ts
+++ b/packages/kv/test/runtime.test.ts
@@ -117,8 +117,6 @@ describe("kv runtime", () => {
   afterEach(() => {
     delete process.env.KV_REST_API_URL
     delete process.env.KV_REST_API_TOKEN
-    delete process.env.UPSTASH_REDIS_REST_URL
-    delete process.env.UPSTASH_REDIS_REST_TOKEN
   })
 
   it("mounts fs-lite storage when the local fallback is active", async () => {
@@ -170,34 +168,6 @@ describe("kv runtime", () => {
       driver: "upstash",
       token: "upstash-token",
       url: "https://upstash.example.com",
-    })
-  })
-
-  it("accepts legacy Upstash runtime env var aliases", async () => {
-    process.env.UPSTASH_REDIS_REST_URL = "https://legacy-upstash.example.com"
-    process.env.UPSTASH_REDIS_REST_TOKEN = "legacy-upstash-token"
-    runtimeState.config = {
-      kv: {
-        store: {
-          driver: "upstash",
-          token: "************",
-          url: "************",
-        },
-      },
-    }
-
-    const plugin = (await import("../src/runtime/nitro-plugin.ts")).default as () => void | Promise<void>
-    await plugin()
-
-    expect(mountedDrivers.upstash).toBeUndefined()
-
-    const { kv } = await import("../src/runtime/storage.ts")
-    await kv.has("notes/hello")
-
-    expect(mountedDrivers.upstash).toMatchObject({
-      driver: "upstash",
-      token: "legacy-upstash-token",
-      url: "https://legacy-upstash.example.com",
     })
   })
 

--- a/packages/sandbox/docs/guides/validate-payloads.md
+++ b/packages/sandbox/docs/guides/validate-payloads.md
@@ -66,16 +66,6 @@ const payload = await readValidatedPayload(body, validateReleaseNotes, {
 })
 ```
 
-## Use `validatePayload`
-
-`validatePayload` is an alias for `readValidatedPayload`.
-
-```ts
-import { validatePayload } from '@vitehub/sandbox'
-
-const payload = await validatePayload(body, validateReleaseNotes)
-```
-
 ## Full route
 
 ::fw{id="vite:dev vite:build"}

--- a/packages/sandbox/docs/runtime-api.md
+++ b/packages/sandbox/docs/runtime-api.md
@@ -19,7 +19,6 @@ import {
   readRequestPayload,
   readValidatedPayload,
   runSandbox,
-  validatePayload,
 } from '@vitehub/sandbox'
 ```
 
@@ -189,16 +188,6 @@ const payload = await readValidatedPayload(body, (value) => {
     notes: String((value as { notes?: unknown }).notes || ''),
   }
 })
-```
-
-### `validatePayload`
-
-`validatePayload` is an alias for `readValidatedPayload`.
-
-```ts
-import { validatePayload } from '@vitehub/sandbox'
-
-const payload = await validatePayload(body, validator)
 ```
 
 ## Provider config

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,6 +1,6 @@
 export { defineSandbox } from './runtime/registry'
 export { readRequestPayload } from './internal/shared/request-payload'
-export { readValidatedPayload, validatePayload } from './runtime/validation'
+export { readValidatedPayload } from './runtime/validation'
 export { createSandboxWithConfig } from './runtime/runtime'
 export { runSandbox } from './runtime/public'
 export type * from './module-types'

--- a/packages/sandbox/src/runtime/validation.ts
+++ b/packages/sandbox/src/runtime/validation.ts
@@ -1,4 +1,1 @@
-export {
-  readValidatedPayload,
-  readValidatedPayload as validatePayload,
-} from '../internal/shared/validation'
+export { readValidatedPayload } from '../internal/shared/validation'

--- a/packages/sandbox/src/sandbox/adapters/cloudflare.ts
+++ b/packages/sandbox/src/sandbox/adapters/cloudflare.ts
@@ -3,7 +3,7 @@ import { Buffer } from 'node:buffer'
 import { NotSupportedError, SandboxError } from '../errors'
 import { shellQuote } from '../utils'
 import { BaseSandboxAdapter } from './base'
-import { CloudflareProcessHandle, type CloudflareProcessHandleCompat } from './cloudflare/process'
+import { CloudflareProcessHandle, type CloudflareNativeProcessHandle } from './cloudflare/process'
 import {
   CLOUDFLARE_CONTROL_PLANE_TIMEOUT_MS,
   CLOUDFLARE_READ_FILE_TIMEOUT_MS,
@@ -255,7 +255,7 @@ export class CloudflareSandboxAdapter extends BaseSandboxAdapter<'cloudflare'> {
     if (!this.native.startProcess)
       throw new NotSupportedError('startProcess', 'cloudflare')
 
-    const processInfo = await this.native.startProcess(args.length ? `${shellQuote(cmd)} ${args.map(shellQuote).join(' ')}` : shellQuote(cmd), opts) as CloudflareProcessHandleCompat
+    const processInfo = await this.native.startProcess(args.length ? `${shellQuote(cmd)} ${args.map(shellQuote).join(' ')}` : shellQuote(cmd), opts) as CloudflareNativeProcessHandle
     if (
       typeof processInfo.getLogs !== 'function'
       || typeof processInfo.waitForExit !== 'function'

--- a/packages/sandbox/src/sandbox/adapters/cloudflare/process.ts
+++ b/packages/sandbox/src/sandbox/adapters/cloudflare/process.ts
@@ -3,7 +3,7 @@ import { normalizeLogPattern, sleep } from '../_shared'
 
 import type { SandboxProcess, SandboxWaitForPortOptions } from '../../types/common'
 
-export type CloudflareProcessHandleCompat = {
+export type CloudflareNativeProcessHandle = {
   id: string
   command: string
   kill: (signal?: string) => Promise<void>

--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -271,7 +271,7 @@ function renderSandboxRuntimeModule(file: string) {
   return [
     `export { defineSandbox } from ${JSON.stringify(createImportPath(file, resolvePackageRuntime(sandboxPackageDir, "runtime/registry")))}`,
     `export { runSandbox } from ${JSON.stringify(createImportPath(file, resolvePackageRuntime(sandboxPackageDir, "runtime/public")))}`,
-    `export { readValidatedPayload, validatePayload } from ${JSON.stringify(createImportPath(file, resolvePackageRuntime(sandboxPackageDir, "runtime/validation")))}`,
+    `export { readValidatedPayload } from ${JSON.stringify(createImportPath(file, resolvePackageRuntime(sandboxPackageDir, "runtime/validation")))}`,
     `export { readRequestPayload } from ${JSON.stringify(createImportPath(file, resolvePackageRuntime(sandboxPackageDir, "internal/shared/request-payload")))}`,
     "",
   ].join("\n")


### PR DESCRIPTION
Drops several legacy compatibility surfaces from main now that we do not need to preserve those aliases. KV now only reads `KV_REST_API_URL` and `KV_REST_API_TOKEN`, Blob exposes only `blob.del(...)`, and Sandbox exposes only `readValidatedPayload` for payload validation.

Also updates the matching docs, removes legacy alias tests, and renames the internal Cloudflare native process handle type so it no longer reads like a compatibility shim.