### PR TITLE
refactor: land preview package follow-up stack

### DIFF
--- a/docs/app/composables/useDocsNavigation.ts
+++ b/docs/app/composables/useDocsNavigation.ts
@@ -1,137 +1,21 @@
 import { useRoute } from "#app/composables/router";
 import { computed } from "vue";
-import type { ContentNavigationItem } from "@nuxt/content";
 import { useFrameworkPreference } from "./useFrameworkPreference";
-import { docsManifest, getDocsPath, getDocsPathMeta, isDocsPageSupported, type DocsPage, type DocsSection } from "~~/modules/vitehub-docs/runtime/utils/docs";
-import type { Framework } from "~~/modules/vitehub-docs/runtime/utils/frameworks";
+import {
+  buildDocsSidebarNavigation,
+  getDocsActiveSection,
+  getSupportedDocsSections,
+} from "~~/modules/vitehub-docs/runtime/utils/docs-rendering";
 import { normalizeSitePath } from "~~/modules/vitehub-docs/runtime/utils/docs-routes";
-
-type DocsSectionLink = {
-  label: string;
-  description?: string;
-  icon?: string;
-  to: string;
-  active: boolean;
-};
-
-function createNavigationGroup(title: string, items: ContentNavigationItem[], options: { defaultOpen?: boolean } = {}) {
-  if (!items.length) return null;
-  return {
-    title,
-    path: items[0]?.path || "/docs",
-    children: items,
-    ...(options.defaultOpen !== undefined && { defaultOpen: options.defaultOpen }),
-  } satisfies ContentNavigationItem;
-}
-
-function isPathExact(itemPath: string, currentPath: string) {
-  const a = itemPath.replace(/\/+$/, "");
-  const b = currentPath.replace(/\/+$/, "");
-  return b === a;
-}
-
-function isPathActive(itemPath: string, currentPath: string) {
-  const a = itemPath.replace(/\/+$/, "");
-  const b = currentPath.replace(/\/+$/, "");
-  return b === a || b.startsWith(`${a}/`);
-}
-
-function toNavigationItem(item: { title: string; path: string; icon?: string | null }, currentPath?: string) {
-  return {
-    title: item.title,
-    path: item.path,
-    icon: item.icon || undefined,
-    ...(currentPath !== undefined && { active: isPathExact(item.path, currentPath) }),
-  } satisfies ContentNavigationItem;
-}
-
-function getSupportedPages(section: DocsSection, framework: Framework) {
-  return section.pages.filter(page => isDocsPageSupported(section.id, page.id, framework));
-}
-
-function getSectionPrimaryPage(section: DocsSection, framework: Framework) {
-  const pages = getSupportedPages(section, framework);
-  return pages.find(page => page.id === "index") || pages[0] || null;
-}
-
-function getSectionLink(section: DocsSection, framework: Framework, currentPath: string): DocsSectionLink | null {
-  const primaryPage = getSectionPrimaryPage(section, framework);
-  if (!primaryPage) return null;
-
-  const sectionPath = getDocsPath(section.id, framework);
-  return {
-    label: section.title,
-    description: section.description || undefined,
-    icon: section.icon || undefined,
-    to: getDocsPath(section.id, framework, primaryPage.id),
-    active: isPathActive(sectionPath, currentPath),
-  };
-}
-
-function buildDocsIndexSidebarNavigation(sections: DocsSection[], framework: Framework, currentPath: string) {
-  const gettingStartedSection = sections.find(section => section.id === "getting-started");
-  if (!gettingStartedSection) return [];
-
-  return [toNavigationItem({ title: gettingStartedSection.title, path: "/docs", icon: gettingStartedSection.icon }, currentPath)];
-}
-
-function buildSectionSidebarNavigation(section: DocsSection, framework: Framework, currentPath: string) {
-  const pages = getSupportedPages(section, framework);
-  const rootItems = [
-    toNavigationItem({ title: "Overview", path: getDocsPath(section.id, framework), icon: section.icon }, currentPath),
-    ...pages
-      .filter(page => page.id !== "index" && !page.group)
-      .map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath)),
-  ];
-  const groupedPages = new Map<string, DocsPage[]>();
-
-  for (const page of pages) {
-    if (!page.group) continue;
-    groupedPages.set(page.group, [...(groupedPages.get(page.group) || []), page]);
-  }
-
-  const groups = [
-    ...rootItems,
-    ...[...groupedPages.entries()]
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([group, items]) => createNavigationGroup(
-        group,
-        items.map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath)),
-        { defaultOpen: group === "Providers" },
-      )),
-  ];
-
-  return groups.filter(Boolean) as ContentNavigationItem[];
-}
 
 export function useDocsNavigation() {
   const route = useRoute();
   const { current } = useFrameworkPreference();
   const normalizedRoutePath = computed(() => normalizeSitePath(route.path));
 
-  const sections = computed(() => docsManifest.sections.filter(section => getSupportedPages(section, current.value).length > 0));
-  const activeSection = computed(() => {
-    const meta = getDocsPathMeta(normalizedRoutePath.value);
-    return meta ? sections.value.find(section => section.id === meta.section) || null : null;
-  });
-
-  const sidebarNavigation = computed(() => {
-    if (normalizedRoutePath.value === "/docs") {
-      return buildDocsIndexSidebarNavigation(sections.value, current.value, normalizedRoutePath.value);
-    }
-
-    if (!activeSection.value) {
-      const packageLinks = sections.value
-        .filter(section => section.id !== "getting-started")
-        .map(section => getSectionLink(section, current.value, normalizedRoutePath.value))
-        .filter((item): item is DocsSectionLink => Boolean(item))
-        .map(item => toNavigationItem({ title: item.label, path: item.to, icon: item.icon }, normalizedRoutePath.value));
-      const group = createNavigationGroup("Packages", packageLinks);
-      return group ? [group] : [];
-    }
-
-    return buildSectionSidebarNavigation(activeSection.value, current.value, normalizedRoutePath.value);
-  });
+  const sections = computed(() => getSupportedDocsSections(current.value));
+  const activeSection = computed(() => getDocsActiveSection(normalizedRoutePath.value, sections.value));
+  const sidebarNavigation = computed(() => buildDocsSidebarNavigation(normalizedRoutePath.value, current.value, sections.value));
 
   return {
     sections,

--- a/docs/app/composables/useDocsPage.ts
+++ b/docs/app/composables/useDocsPage.ts
@@ -4,36 +4,18 @@ import { useDocsRenderMode } from "./useDocsRenderMode";
 import { useFrameworkPreference } from "./useFrameworkPreference";
 import { useUsageModePreference } from "./useUsageModePreference";
 import type { DocsCollectionItem } from "@nuxt/content";
-import { normalizeFrameworkPage } from "~~/modules/vitehub-docs/runtime/utils/framework-content";
+import { renderDocsPage, type DocsPageFallback, type DocsPageState } from "~~/modules/vitehub-docs/runtime/utils/docs-rendering";
 
-export type ContentPage = DocsCollectionItem & {
-  data?: Record<string, unknown>;
-  seo?: { title?: string; description?: string };
-};
+export type ContentPage = DocsPageState<DocsCollectionItem>;
 
-export function useDocsPage(sourcePath: string | ComputedRef<string>, rawDoc: Ref<DocsCollectionItem | null | undefined>, fallback: { title: string; sourceTitle: string | null; description: string | null }) {
+export function useDocsPage(sourcePath: string | ComputedRef<string>, rawDoc: Ref<DocsCollectionItem | null | undefined>, fallback: DocsPageFallback) {
   const { current: framework } = useFrameworkPreference();
   const { current: mode } = useUsageModePreference();
   const { renderMode } = useDocsRenderMode();
 
   const path = typeof sourcePath === "string" ? computed(() => sourcePath) : sourcePath;
 
-  const sourcePage = computed(() => {
-    const doc = rawDoc.value;
-    if (!doc) return null;
-    const title = String(doc.title || fallback.sourceTitle || fallback.title);
-    const description = doc.description || fallback.description || "";
-    return {
-      ...doc,
-      path: path.value,
-      title,
-      description,
-      seo: { title: doc.seo?.title || title, description: doc.seo?.description || description },
-      data: doc.meta || {},
-    } satisfies ContentPage;
-  });
-
-  const page = computed<ContentPage | null>(() => normalizeFrameworkPage(sourcePage.value, {
+  const page = computed<ContentPage | null>(() => renderDocsPage(rawDoc.value, path.value, fallback, {
     framework: framework.value,
     mode: mode.value,
     renderMode: renderMode.value,

--- a/docs/app/pages/docs/[framework]/[...slug].vue
+++ b/docs/app/pages/docs/[framework]/[...slug].vue
@@ -4,35 +4,32 @@ import { createError } from "#app/composables/error";
 import { definePageMeta } from "#app/composables/pages";
 import { useRoute } from "#app/composables/router";
 import { useDocsPage } from "../../../composables/useDocsPage";
-import { getDocsPage, getDocsPath, getDocsPathMeta } from "~~/modules/vitehub-docs/runtime/utils/docs";
-import type { Framework } from "~~/modules/vitehub-docs/runtime/utils/frameworks";
+import { getDocsPageFallback, resolveDocsRoute } from "~~/modules/vitehub-docs/runtime/utils/docs-rendering";
 
 definePageMeta({
   layout: "docs",
 });
 
 const route = useRoute();
-const routeMeta = getDocsPathMeta(route.path);
+const routeState = resolveDocsRoute(route.path);
 
-if (!routeMeta) {
+if (!routeState) {
   throw createError({ statusCode: 404, statusMessage: "Page not found", fatal: true });
 }
 
-const docsPage = getDocsPage(routeMeta.section, routeMeta.page);
-const sourcePath = getDocsPath(routeMeta.section, routeMeta.framework as Framework, routeMeta.page);
 const { data: rawDoc } = await useAsyncData(
-  `docs:${sourcePath}`,
-  () => queryCollection("docs").path(sourcePath).first(),
+  `docs:${routeState.sourcePath}`,
+  () => queryCollection("docs").path(routeState.sourcePath).first(),
 );
 
-if (!docsPage || !docsPage.frameworks.includes(routeMeta.framework as Framework) || !rawDoc.value) {
+if (!routeState.page || !routeState.supported || !rawDoc.value) {
   throw createError({ statusCode: 404, statusMessage: "Page not found", fatal: true });
 }
 
 const { page } = useDocsPage(
-  sourcePath,
+  routeState.sourcePath,
   rawDoc,
-  { title: docsPage.title, sourceTitle: docsPage.sourceTitle, description: docsPage.description },
+  getDocsPageFallback(routeState.page),
 );
 </script>
 

--- a/docs/app/pages/docs/index.vue
+++ b/docs/app/pages/docs/index.vue
@@ -6,6 +6,7 @@ import { computed } from "vue";
 import { useDocsPage } from "../../composables/useDocsPage";
 import { useFrameworkPreference } from "../../composables/useFrameworkPreference";
 import { getDocsPage, getDocsPath } from "~~/modules/vitehub-docs/runtime/utils/docs";
+import { getDocsPageFallback } from "~~/modules/vitehub-docs/runtime/utils/docs-rendering";
 
 definePageMeta({
   layout: "docs",
@@ -28,7 +29,7 @@ if (!docsPage) {
 const { page } = useDocsPage(
   computed(() => "/docs"),
   rawDoc,
-  { title: docsPage.title, sourceTitle: docsPage.sourceTitle, description: docsPage.description },
+  getDocsPageFallback(docsPage),
 );
 </script>
 

--- a/docs/modules/vitehub-docs/runtime/utils/docs-rendering.ts
+++ b/docs/modules/vitehub-docs/runtime/utils/docs-rendering.ts
@@ -1,0 +1,229 @@
+import type { ContentNavigationItem } from "@nuxt/content";
+import {
+  docsManifest,
+  getDocsPage,
+  getDocsPath,
+  getDocsPathMeta,
+  isDocsPageSupported,
+  type DocsPage,
+  type DocsSection,
+} from "./docs";
+import { normalizeFrameworkPage, type DocsRenderOptions } from "./framework-content";
+import type { Framework } from "./frameworks";
+
+type DocsRouteMeta = Omit<NonNullable<ReturnType<typeof getDocsPathMeta>>, "framework"> & { framework: Framework };
+
+type ContentPageInput = {
+  title?: unknown;
+  description?: string | null;
+  seo?: { title?: string; description?: string };
+  meta?: Record<string, unknown> | null;
+  body?: { value?: unknown[]; toc?: { links?: unknown[] } | null } | null;
+};
+
+export type DocsPageFallback = {
+  title: string;
+  sourceTitle: string | null;
+  description: string | null;
+};
+
+export type DocsPageState<T extends ContentPageInput> = T & {
+  path: string;
+  title: string;
+  description: string;
+  seo: { title: string; description: string };
+  data: Record<string, unknown>;
+};
+
+type DocsResolvedRoute = {
+  meta: DocsRouteMeta;
+  page: DocsPage | null;
+  sourcePath: string;
+  supported: boolean;
+};
+
+type DocsSectionLink = {
+  label: string;
+  description?: string;
+  icon?: string;
+  to: string;
+  active: boolean;
+};
+
+export function resolveDocsRoute(path: string): DocsResolvedRoute | null {
+  const meta = getDocsPathMeta(path);
+
+  if (!meta) {
+    return null;
+  }
+
+  const framework = meta.framework as Framework;
+  const page = getDocsPage(meta.section, meta.page);
+  const sourcePath = getDocsPath(meta.section, framework, meta.page);
+
+  return {
+    meta: { ...meta, framework },
+    page,
+    sourcePath,
+    supported: Boolean(page && isDocsPageSupported(meta.section, meta.page, framework)),
+  };
+}
+
+export function getDocsPageFallback(page: DocsPage): DocsPageFallback {
+  return {
+    title: page.title,
+    sourceTitle: page.sourceTitle,
+    description: page.description,
+  };
+}
+
+export function createDocsPageState<T extends ContentPageInput>(
+  doc: T | null | undefined,
+  sourcePath: string,
+  fallback: DocsPageFallback,
+) {
+  if (!doc) return null;
+
+  const title = String(doc.title || fallback.sourceTitle || fallback.title);
+  const description = doc.description || fallback.description || "";
+
+  return {
+    ...doc,
+    path: sourcePath,
+    title,
+    description,
+    seo: {
+      title: doc.seo?.title || title,
+      description: doc.seo?.description || description,
+    },
+    data: doc.meta || {},
+  } satisfies DocsPageState<T>;
+}
+
+export function renderDocsPage<T extends ContentPageInput>(
+  doc: T | null | undefined,
+  sourcePath: string,
+  fallback: DocsPageFallback,
+  options: DocsRenderOptions,
+) {
+  return normalizeFrameworkPage(createDocsPageState(doc, sourcePath, fallback), options);
+}
+
+function createNavigationGroup(title: string, items: ContentNavigationItem[], options: { defaultOpen?: boolean } = {}) {
+  if (!items.length) return null;
+  return {
+    title,
+    path: items[0]?.path || "/docs",
+    children: items,
+    ...(options.defaultOpen !== undefined && { defaultOpen: options.defaultOpen }),
+  } satisfies ContentNavigationItem;
+}
+
+function isPathExact(itemPath: string, currentPath: string) {
+  const a = itemPath.replace(/\/+$/, "");
+  const b = currentPath.replace(/\/+$/, "");
+  return b === a;
+}
+
+function isPathActive(itemPath: string, currentPath: string) {
+  const a = itemPath.replace(/\/+$/, "");
+  const b = currentPath.replace(/\/+$/, "");
+  return b === a || b.startsWith(`${a}/`);
+}
+
+function toNavigationItem(item: { title: string; path: string; icon?: string | null }, currentPath?: string) {
+  return {
+    title: item.title,
+    path: item.path,
+    icon: item.icon || undefined,
+    ...(currentPath !== undefined && { active: isPathExact(item.path, currentPath) }),
+  } satisfies ContentNavigationItem;
+}
+
+function getSupportedDocsPages(section: DocsSection, framework: Framework) {
+  return section.pages.filter(page => isDocsPageSupported(section.id, page.id, framework));
+}
+
+export function getSupportedDocsSections(framework: Framework) {
+  return docsManifest.sections.filter(section => getSupportedDocsPages(section, framework).length > 0);
+}
+
+function getSectionPrimaryPage(section: DocsSection, framework: Framework) {
+  const pages = getSupportedDocsPages(section, framework);
+  return pages.find(page => page.id === "index") || pages[0] || null;
+}
+
+function getSectionLink(section: DocsSection, framework: Framework, currentPath: string): DocsSectionLink | null {
+  const primaryPage = getSectionPrimaryPage(section, framework);
+  if (!primaryPage) return null;
+
+  const sectionPath = getDocsPath(section.id, framework);
+  return {
+    label: section.title,
+    description: section.description || undefined,
+    icon: section.icon || undefined,
+    to: getDocsPath(section.id, framework, primaryPage.id),
+    active: isPathActive(sectionPath, currentPath),
+  };
+}
+
+function buildDocsIndexSidebarNavigation(sections: DocsSection[], currentPath: string) {
+  const gettingStartedSection = sections.find(section => section.id === "getting-started");
+  if (!gettingStartedSection) return [];
+
+  return [toNavigationItem({ title: gettingStartedSection.title, path: "/docs", icon: gettingStartedSection.icon }, currentPath)];
+}
+
+function buildSectionSidebarNavigation(section: DocsSection, framework: Framework, currentPath: string) {
+  const pages = getSupportedDocsPages(section, framework);
+  const rootItems = [
+    toNavigationItem({ title: "Overview", path: getDocsPath(section.id, framework), icon: section.icon }, currentPath),
+    ...pages
+      .filter(page => page.id !== "index" && !page.group)
+      .map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath)),
+  ];
+  const groupedPages = new Map<string, DocsPage[]>();
+
+  for (const page of pages) {
+    if (!page.group) continue;
+    groupedPages.set(page.group, [...(groupedPages.get(page.group) || []), page]);
+  }
+
+  const groups = [
+    ...rootItems,
+    ...[...groupedPages.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([group, items]) => createNavigationGroup(
+        group,
+        items.map(page => toNavigationItem({ title: page.title, path: getDocsPath(section.id, framework, page.id), icon: page.icon }, currentPath)),
+        { defaultOpen: group === "Providers" },
+      )),
+  ];
+
+  return groups.filter(Boolean) as ContentNavigationItem[];
+}
+
+export function getDocsActiveSection(path: string, sections: DocsSection[]) {
+  const meta = getDocsPathMeta(path);
+  return meta ? sections.find(section => section.id === meta.section) || null : null;
+}
+
+export function buildDocsSidebarNavigation(path: string, framework: Framework, sections = getSupportedDocsSections(framework)) {
+  if (path === "/docs") {
+    return buildDocsIndexSidebarNavigation(sections, path);
+  }
+
+  const activeSection = getDocsActiveSection(path, sections);
+
+  if (!activeSection) {
+    const packageLinks = sections
+      .filter(section => section.id !== "getting-started")
+      .map(section => getSectionLink(section, framework, path))
+      .filter((item): item is DocsSectionLink => Boolean(item))
+      .map(item => toNavigationItem({ title: item.label, path: item.to, icon: item.icon }, path));
+    const group = createNavigationGroup("Packages", packageLinks);
+    return group ? [group] : [];
+  }
+
+  return buildSectionSidebarNavigation(activeSection, framework, path);
+}

--- a/docs/test/docs-rendering.test.ts
+++ b/docs/test/docs-rendering.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDocsSidebarNavigation,
+  createDocsPageState,
+  getDocsPageFallback,
+  getSupportedDocsSections,
+  renderDocsPage,
+  resolveDocsRoute,
+} from "../modules/vitehub-docs/runtime/utils/docs-rendering";
+import { getDocsPage } from "../modules/vitehub-docs/runtime/utils/docs";
+
+describe("docs rendering state", () => {
+  it("resolves route meta, manifest page, support, and source path together", () => {
+    expect(resolveDocsRoute("/docs/vite/blob/quickstart")).toMatchObject({
+      meta: { framework: "vite", section: "blob", page: "quickstart" },
+      sourcePath: "/docs/vite/blob/quickstart",
+      supported: true,
+    });
+
+    expect(resolveDocsRoute("/docs/nuxt/blob")).toMatchObject({
+      sourcePath: "/docs/nuxt/blob",
+      supported: false,
+    });
+  });
+
+  it("normalizes content page state before rendering framework blocks", () => {
+    const page = getDocsPage("getting-started", "index");
+    expect(page).toBeTruthy();
+
+    const rendered = renderDocsPage(
+      {
+        title: "",
+        description: null,
+        meta: { package: "vitehub" },
+        body: {
+          toc: { links: [] },
+          value: [
+            ["h2", { id: "intro" }, "Intro"],
+            ["fw", { id: "vite:dev" }, ["h2", { id: "vite-dev" }, "Vite dev"]],
+            ["fw", { id: "nitro:dev" }, ["h2", { id: "nitro-dev" }, "Nitro dev"]],
+          ],
+        },
+      },
+      "/docs",
+      getDocsPageFallback(page!),
+      { framework: "vite", mode: "dev", renderMode: "single", tocMode: "current-selection" },
+    );
+
+    expect(rendered?.path).toBe("/docs");
+    expect(rendered?.title).toBe(page?.sourceTitle || page?.title);
+    expect(rendered?.data).toEqual({ package: "vitehub" });
+    expect(rendered?.body?.value).toEqual([
+      ["h2", { id: "intro" }, "Intro"],
+      ["fw", { id: "vite:dev" }, ["h2", { id: "vite-dev" }, "Vite dev"]],
+    ]);
+    expect(rendered?.body?.toc?.links?.map(link => link.id)).toEqual(["intro", "vite-dev"]);
+  });
+
+  it("builds navigation-facing docs state from supported pages", () => {
+    const sections = getSupportedDocsSections("vite");
+    const sidebar = buildDocsSidebarNavigation("/docs/vite/blob/quickstart", "vite", sections);
+
+    expect(sections.map(section => section.id)).toContain("blob");
+    expect(sidebar.some(item => item.path === "/docs/vite/blob/quickstart" && item.active)).toBe(true);
+  });
+
+  it("creates a content page state without mutating the source document", () => {
+    const doc = { title: "Source", description: "Desc", meta: { order: 1 } };
+    const state = createDocsPageState(doc, "/docs/vite/getting-started", {
+      title: "Fallback",
+      sourceTitle: null,
+      description: null,
+    });
+
+    expect(state).toMatchObject({
+      path: "/docs/vite/getting-started",
+      title: "Source",
+      description: "Desc",
+      seo: { title: "Source", description: "Desc" },
+      data: { order: 1 },
+    });
+    expect(doc).not.toHaveProperty("path");
+  });
+});

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -2,13 +2,14 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { resolve } from "pathe"
 
 import { defaultCloudflareCompatibilityDate } from "@vitehub/internal/build/cloudflare"
-import { writeCloudflareDeploymentOutput, writeVercelDeploymentOutput } from "@vitehub/internal/build/deployment-output"
+import { writeProviderDeploymentOutputs } from "@vitehub/internal/build/deployment-output"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vitehub/internal/build/paths"
 import { resolveUserAppEntry } from "@vitehub/internal/build/user-entry"
 
 import { normalizeBlobOptions } from "../config.ts"
 
 import type { BlobModuleOptions, ResolvedBlobModuleOptions } from "../types.ts"
+import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vitehub/internal/build/deployment-output"
 
 export const blobPackageName = "@vitehub/blob"
 const productName = "blob"
@@ -189,7 +190,7 @@ async function writeProviderEntries(rootDir: string, blob: BlobModuleOptions | R
   } satisfies GeneratedBlobArtifacts
 }
 
-async function writeCloudflareOutput(rootDir: string, clientOutDir: string, blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined, artifacts: GeneratedBlobArtifacts) {
+function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined, artifacts: GeneratedBlobArtifacts): CloudflareProviderDeploymentOutput {
   const resolved = resolveBlobConfig(blob, "cloudflare")
 
   const wranglerConfig: CloudflareBlobConfig = {
@@ -200,7 +201,7 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, blob
     ...(createCloudflareR2Bindings(resolved) ? { r2_buckets: createCloudflareR2Bindings(resolved) } : {}),
   }
 
-  await writeCloudflareDeploymentOutput({
+  return {
     bundleEntry: artifacts.cloudflareWorkerFile,
     bundleOptions: {
       alias: {
@@ -211,14 +212,12 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, blob
       format: "esm",
       platform: "neutral",
     },
-    clientOutDir,
-    rootDir,
     wranglerConfig,
-  })
+  }
 }
 
-async function writeVercelOutput(rootDir: string, clientOutDir: string, artifacts: GeneratedBlobArtifacts) {
-  await writeVercelDeploymentOutput({
+function createVercelOutput(artifacts: GeneratedBlobArtifacts): VercelProviderDeploymentOutput {
+  return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
       alias: {
@@ -228,16 +227,16 @@ async function writeVercelOutput(rootDir: string, clientOutDir: string, artifact
       format: "esm",
       platform: "node",
     },
-    clientOutDir,
-    rootDir,
-  })
+  }
 }
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedBlobArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.blob)
-  await Promise.all([
-    writeCloudflareOutput(options.rootDir, options.clientOutDir, options.blob, artifacts),
-    writeVercelOutput(options.rootDir, options.clientOutDir, artifacts),
-  ])
+  await writeProviderDeploymentOutputs({
+    clientOutDir: options.clientOutDir,
+    cloudflare: createCloudflareOutput(options.blob, artifacts),
+    rootDir: options.rootDir,
+    vercel: createVercelOutput(artifacts),
+  })
   return artifacts
 }

--- a/packages/db/src/internal/vite-build.ts
+++ b/packages/db/src/internal/vite-build.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises"
 
-import { writeCloudflareDeploymentOutput, writeVercelDeploymentOutput } from "@vitehub/internal/build/deployment-output"
+import { writeProviderDeploymentOutputs } from "@vitehub/internal/build/deployment-output"
 import { defaultCloudflareCompatibilityDate } from "@vitehub/internal/build/cloudflare"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vitehub/internal/build/paths"
 import { resolveUserAppEntry } from "@vitehub/internal/build/user-entry"
@@ -9,6 +9,7 @@ import { resolve } from "pathe"
 import { serializeSchemaObject } from "./schema-serializer.ts"
 
 import type { ResolvedDBViteConfig, ResolvedDrizzleDatabaseConfig } from "../types.ts"
+import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vitehub/internal/build/deployment-output"
 
 export const dbPackageName = "@vitehub/db"
 const productName = "db"
@@ -187,7 +188,7 @@ interface ProviderWriteOptions {
   runtimeConfig: ResolvedDBViteConfig
 }
 
-async function writeCloudflareOutput({ artifacts, clientOutDir, rootDir, runtimeConfig }: ProviderWriteOptions) {
+function createCloudflareOutput({ artifacts, runtimeConfig }: ProviderWriteOptions): CloudflareProviderDeploymentOutput {
   const databasesMissingNames = getCloudflareDatabasesMissingNames(runtimeConfig)
   if (databasesMissingNames.length) {
     throw new Error(`[vitehub] Cloudflare output requires \`db.cloudflare.databaseName\` when \`db.cloudflare.databaseId\` is set for databases: ${databasesMissingNames.join(", ")}.`)
@@ -208,7 +209,7 @@ async function writeCloudflareOutput({ artifacts, clientOutDir, rootDir, runtime
     observability: { enabled: true },
   }
 
-  await writeCloudflareDeploymentOutput({
+  return {
     bundleEntry: artifacts.cloudflareWorkerFile,
     bundleOptions: {
       alias: { "@vitehub/db/drizzle": artifacts.runtimeModuleFiles.cloudflare },
@@ -217,33 +218,34 @@ async function writeCloudflareOutput({ artifacts, clientOutDir, rootDir, runtime
       format: "esm",
       platform: "neutral",
     },
-    clientOutDir,
-    rootDir,
     wranglerConfig,
-  })
+  }
 }
 
-async function writeVercelOutput({ artifacts, clientOutDir, rootDir, runtimeConfig }: ProviderWriteOptions) {
+function createVercelOutput({ artifacts, runtimeConfig }: ProviderWriteOptions): VercelProviderDeploymentOutput {
   const unsupportedDatabases = getVercelUnsupportedDatabases(runtimeConfig)
   if (unsupportedDatabases.length) {
     throw new Error(`[vitehub] Vercel output requires a remote libSQL \`db.connection.url\` for databases: ${unsupportedDatabases.join(", ")}.`)
   }
 
-  await writeVercelDeploymentOutput({
+  return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
       alias: { "@vitehub/db/drizzle": artifacts.runtimeModuleFiles.vercel },
       format: "esm",
       platform: "node",
     },
-    clientOutDir,
-    rootDir,
-  })
+  }
 }
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedDBArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.runtimeConfig)
   const writeOptions: ProviderWriteOptions = { artifacts, ...options }
-  await Promise.all([writeCloudflareOutput(writeOptions), writeVercelOutput(writeOptions)])
+  await writeProviderDeploymentOutputs({
+    clientOutDir: options.clientOutDir,
+    cloudflare: createCloudflareOutput(writeOptions),
+    rootDir: options.rootDir,
+    vercel: createVercelOutput(writeOptions),
+  })
   return artifacts
 }

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -12,6 +12,8 @@
     "./arrays": "./src/arrays.ts",
     "./definition-catalog": "./src/definition-catalog.ts",
     "./definition-discovery": "./src/definition-discovery.ts",
+    "./feature-bridge": "./src/feature-bridge/feature-engine.ts",
+    "./feature-bridge/hosting": "./src/feature-bridge/hosting.ts",
     "./integrations/hex": "./src/integrations/hex.ts",
     "./nitro": "./src/nitro.ts",
     "./object": "./src/object.ts",

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -32,6 +32,14 @@ export interface VercelDeploymentOutputOptions extends SharedDeploymentOptions {
   staticOutputDir?: string
 }
 
+export type CloudflareProviderDeploymentOutput = Omit<CloudflareDeploymentOutputOptions, keyof SharedDeploymentOptions>
+export type VercelProviderDeploymentOutput = Omit<VercelDeploymentOutputOptions, keyof SharedDeploymentOptions>
+
+export interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
+  cloudflare: CloudflareProviderDeploymentOutput
+  vercel: VercelProviderDeploymentOutput
+}
+
 interface ResolvedClientOutput {
   clientDir: string
   staticIndex: boolean
@@ -95,5 +103,20 @@ export async function writeVercelDeploymentOutput(options: VercelDeploymentOutpu
     staticIndex
       ? copyClientOutput(clientDir, options.staticOutputDir ?? resolve(outputRoot, "static"))
       : Promise.resolve(),
+  ])
+}
+
+export async function writeProviderDeploymentOutputs(options: ProviderDeploymentOutputOptions): Promise<void> {
+  await Promise.all([
+    writeCloudflareDeploymentOutput({
+      ...options.cloudflare,
+      clientOutDir: options.clientOutDir,
+      rootDir: options.rootDir,
+    }),
+    writeVercelDeploymentOutput({
+      ...options.vercel,
+      clientOutDir: options.clientOutDir,
+      rootDir: options.rootDir,
+    }),
   ])
 }

--- a/packages/internal/src/definition-catalog.ts
+++ b/packages/internal/src/definition-catalog.ts
@@ -305,6 +305,65 @@ export function createGeneratedDefinitionPath(
   return resolve(...pathSegments)
 }
 
+export function createNitroRuntimeFilePath(
+  rootDir: string,
+  options: {
+    buildDir?: string
+    fileName: string
+    productName?: string
+    segments?: readonly string[]
+  },
+): string {
+  return createGeneratedDefinitionPath(rootDir, options)
+}
+
+export interface RuntimeRegistryFiles<TDefinition extends Pick<DiscoveredDefinition, "handler" | "name">> {
+  definitions: TDefinition[]
+  pluginFile: string
+  registryFile: string
+}
+
+export async function writeRuntimeRegistryFiles<TDefinition extends Pick<DiscoveredDefinition, "handler" | "name">>(
+  options: {
+    createPluginContents: (pluginFile: string, registryFile: string) => string
+    definitions: TDefinition[]
+    pluginFile: string
+    registryFile: string
+  },
+): Promise<RuntimeRegistryFiles<TDefinition>> {
+  await Promise.all([
+    writeFileIfChanged(options.registryFile, createRuntimeRegistryContents(options.registryFile, options.definitions)),
+    writeFileIfChanged(options.pluginFile, options.createPluginContents(options.pluginFile, options.registryFile)),
+  ])
+
+  return {
+    definitions: options.definitions,
+    pluginFile: options.pluginFile,
+    registryFile: options.registryFile,
+  }
+}
+
+export function applyNitroRuntimeAliases(
+  nitro: { options: { alias?: Record<string, string> } },
+  aliases: Record<string, string>,
+): void {
+  nitro.options.alias ||= {}
+  Object.assign(nitro.options.alias, aliases)
+}
+
+export function hookNitroRuntimeRegistryRefresh<TRuntimeFiles>(
+  nitro: { hooks: { hook: (name: "build:before" | "dev:reload", handler: () => Promise<void>) => void } },
+  refresh: () => Promise<TRuntimeFiles>,
+  onRefresh: (runtimeFiles: TRuntimeFiles, hookName: "build:before" | "dev:reload") => Promise<void> | void = () => {},
+): void {
+  for (const hookName of ["build:before", "dev:reload"] as const) {
+    nitro.hooks.hook(hookName, async () => {
+      const runtimeFiles = await refresh()
+      await onRefresh(runtimeFiles, hookName)
+    })
+  }
+}
+
 export async function writeFileIfChanged(file: string, contents: string): Promise<void> {
   const existing = await readFile(file, "utf8").catch(() => undefined)
   if (existing === contents) {

--- a/packages/internal/src/definition-catalog.ts
+++ b/packages/internal/src/definition-catalog.ts
@@ -41,6 +41,42 @@ export type DefinitionCatalogSource<TDefinition extends DiscoveredDefinition> =
   | DirectoryDefinitionCatalogSource<TDefinition>
   | SuffixDefinitionCatalogSource<TDefinition>
 
+export function resolveDefinitionScanRoots(rootDir: string, scanDirs: string[] | undefined = []): string[] {
+  return [...new Set([rootDir, ...scanDirs].filter(Boolean))]
+}
+
+export function createDirectoryDefinitionSource<TDefinition extends DiscoveredDefinition>(
+  source: string,
+  scanDirs: string[],
+  subdir: string,
+  options: Pick<DirectoryDefinitionCatalogSource<TDefinition>, "createDefinition" | "includeHidden" | "normalizeName"> = {},
+): DirectoryDefinitionCatalogSource<TDefinition> {
+  return {
+    ...options,
+    kind: "directory",
+    scanDirs,
+    source,
+    subdir,
+  }
+}
+
+export function createSuffixDefinitionSource<TDefinition extends DiscoveredDefinition>(
+  source: string,
+  roots: string[],
+  pattern: RegExp,
+  normalizeName: SuffixDefinitionCatalogSource<TDefinition>["normalizeName"],
+  options: Pick<SuffixDefinitionCatalogSource<TDefinition>, "createDefinition" | "includeHidden"> = {},
+): SuffixDefinitionCatalogSource<TDefinition> {
+  return {
+    ...options,
+    kind: "suffix",
+    normalizeName,
+    pattern,
+    roots,
+    source,
+  }
+}
+
 function readDirEntries(root: string): Dirent[] {
   try {
     return readdirSync(root, { withFileTypes: true })

--- a/packages/internal/src/feature-bridge/feature-engine.ts
+++ b/packages/internal/src/feature-bridge/feature-engine.ts
@@ -1,0 +1,250 @@
+import { readFile } from 'node:fs/promises'
+import { resolve as resolveFs } from 'pathe'
+import { detectHosting } from './hosting.ts'
+import { normalizeFeatureOptions } from './feature-options.ts'
+import { assertNoVitePluginInNitro } from '../nitro.ts'
+
+export interface FeatureNitroLike {
+  options: {
+    rootDir: string
+    nitro?: {
+      preset?: string | null
+    }
+    preset?: string | null
+    runtimeConfig?: Record<string, unknown>
+  }
+}
+
+export interface FeatureNitroModuleLike {
+  name: string
+  setup: (nitro: FeatureNitroLike) => void | Promise<void>
+}
+
+export interface FeatureConfigEnvLike {
+  command: 'build' | 'serve'
+  mode: string
+}
+
+export interface FeatureUserConfigLike {
+  build?: {
+    outDir?: string
+  }
+  define?: Record<string, unknown>
+  resolve?: {
+    alias?: Record<string, string>
+  }
+  [key: string]: unknown
+}
+
+export interface FeatureResolvedState<TConfig> {
+  rootDir: string
+  config: TConfig
+  deps: Record<string, string>
+  runtimeConfig: Record<string, unknown>
+  hosting?: string
+}
+
+export interface FeatureViteContext<TConfig> extends FeatureResolvedState<TConfig> {
+  command: FeatureConfigEnvLike['command']
+  mode: string
+}
+
+export type FeatureModuleContext<TConfig> = FeatureResolvedState<TConfig>
+
+export interface FeatureViteSetupResult {
+  config?: FeatureUserConfigLike
+}
+
+export type FeatureStateSource<_TOptions> =
+  | {
+    kind: 'vite'
+    userConfig: Record<string, unknown>
+    env: FeatureConfigEnvLike
+  }
+  | {
+    kind: 'nitro'
+    nitro: FeatureNitroLike
+  }
+
+export interface FeatureEngine<TOptions, TInput, TConfig = TInput> {
+  name: string
+  feature: string
+  configKey: string
+  defaultOptions?: TOptions | (() => TOptions)
+  loadDeps?: boolean
+  normalizeOptions: (options: TOptions | false | undefined) => TInput | undefined
+  resolveConfig?: (config: TInput, hosting?: string) => TConfig
+  assignRuntimeConfig?: (runtimeConfig: Record<string, unknown>, config: TConfig) => void
+  readPublicOptions: (source: FeatureStateSource<TOptions>) => TOptions | false | undefined
+  setupVite?: (context: FeatureViteContext<TConfig>) => Promise<FeatureViteSetupResult | void> | FeatureViteSetupResult | void
+  setupNitro?: (nitro: FeatureNitroLike, context: FeatureModuleContext<TConfig>) => void | Promise<void>
+}
+
+export function createFeatureEngine<TOptions, TInput, TConfig = TInput>(
+  options: FeatureEngine<TOptions, TInput, TConfig>,
+) {
+  return options
+}
+
+export function normalizeFeaturePublicOptions<TOptions extends object>(
+  feature: string,
+  options: TOptions | false | undefined,
+): TOptions | undefined {
+  return normalizeFeatureOptions(feature, options)
+}
+
+export function readFeaturePublicOptions<TOptions>(
+  source: FeatureStateSource<TOptions>,
+  key: string,
+): TOptions | undefined {
+  if (source.kind === 'vite')
+    return source.userConfig[key] as TOptions | undefined
+
+  return (source.nitro.options as typeof source.nitro.options & Record<string, TOptions | undefined>)[key]
+}
+
+export function resolveDefaultOptions<TOptions>(defaultOptions: TOptions | (() => TOptions)) {
+  return typeof defaultOptions === 'function'
+    ? (defaultOptions as () => TOptions)()
+    : defaultOptions
+}
+
+export function applyRuntimeConfig<TConfig>(runtimeConfig: Record<string, unknown>, key: string, config: TConfig) {
+  runtimeConfig[key] = config
+}
+
+export async function readWorkspaceDeps(rootDir: string) {
+  const packageJson = JSON.parse(await readFile(resolveFs(rootDir, 'package.json'), 'utf8')) as {
+    dependencies?: Record<string, string>
+    devDependencies?: Record<string, string>
+  }
+  return {
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
+  }
+}
+
+export function resolveViteRoot(config: Record<string, unknown>) {
+  return resolveFs(process.cwd(), typeof config.root === 'string' ? config.root : '.')
+}
+
+function resolveRawOptions<TOptions, TInput, TConfig>(
+  engine: FeatureEngine<TOptions, TInput, TConfig>,
+  source: FeatureStateSource<TOptions>,
+) {
+  const rawOptions = engine.readPublicOptions(source)
+  return typeof rawOptions === 'undefined' && typeof engine.defaultOptions !== 'undefined'
+    ? resolveDefaultOptions(engine.defaultOptions)
+    : rawOptions
+}
+
+function resolveNormalizedConfig<TOptions, TInput, TConfig>(
+  engine: FeatureEngine<TOptions, TInput, TConfig>,
+  source: FeatureStateSource<TOptions>,
+) {
+  const rawOptions = resolveRawOptions(engine, source)
+  const hosting = source.kind === 'vite'
+    ? detectHosting({ options: source.userConfig as { nitro?: { preset?: string | null }, preset?: string | null } })
+    : detectHosting(source.nitro)
+
+  if (rawOptions === false) {
+    return {
+      config: false as TConfig,
+      hosting: hosting || undefined,
+    }
+  }
+
+  const normalizedOptions = engine.normalizeOptions(rawOptions)
+  if (!normalizedOptions)
+    return undefined
+
+  const config = engine.resolveConfig
+    ? engine.resolveConfig(normalizedOptions, hosting)
+    : normalizedOptions as unknown as TConfig
+
+  return {
+    config,
+    hosting: hosting || undefined,
+  }
+}
+
+export async function buildFeatureResolvedState<TOptions, TInput, TConfig>(
+  engine: FeatureEngine<TOptions, TInput, TConfig>,
+  source: FeatureStateSource<TOptions>,
+): Promise<FeatureResolvedState<TConfig> | undefined> {
+  const resolved = resolveNormalizedConfig(engine, source)
+  if (!resolved)
+    return undefined
+
+  const rootDir = source.kind === 'vite'
+    ? resolveViteRoot(source.userConfig)
+    : source.nitro.options.rootDir
+  const runtimeConfig: Record<string, unknown> = source.kind === 'nitro'
+    ? ((source.nitro.options as typeof source.nitro.options & { runtimeConfig?: Record<string, unknown> }).runtimeConfig ||= {})
+    : {}
+
+  if (resolved.hosting)
+    runtimeConfig.hosting ||= resolved.hosting
+
+  if (engine.assignRuntimeConfig)
+    engine.assignRuntimeConfig(runtimeConfig, resolved.config)
+  else
+    applyRuntimeConfig(runtimeConfig, engine.configKey, resolved.config)
+
+  const deps = engine.loadDeps ? await readWorkspaceDeps(rootDir) : {}
+
+  return {
+    rootDir,
+    config: resolved.config,
+    deps,
+    runtimeConfig,
+    hosting: resolved.hosting,
+  }
+}
+
+export async function buildFeatureViteContext<TOptions, TInput, TConfig>(
+  engine: FeatureEngine<TOptions, TInput, TConfig>,
+  userConfig: Record<string, unknown>,
+  env: FeatureConfigEnvLike,
+): Promise<FeatureViteContext<TConfig> | undefined> {
+  const state = await buildFeatureResolvedState(engine, {
+    kind: 'vite',
+    userConfig,
+    env,
+  })
+  if (!state)
+    return undefined
+
+  return {
+    ...state,
+    command: env.command,
+    mode: env.mode,
+  }
+}
+
+export async function buildFeatureNitroContext<TOptions, TInput, TConfig>(
+  engine: FeatureEngine<TOptions, TInput, TConfig>,
+  nitro: FeatureNitroLike,
+): Promise<FeatureModuleContext<TConfig> | undefined> {
+  return await buildFeatureResolvedState(engine, {
+    kind: 'nitro',
+    nitro,
+  })
+}
+
+export function createFeatureNitroBridge<TOptions, TInput, TConfig>(
+  engine: FeatureEngine<TOptions, TInput, TConfig>,
+): FeatureNitroModuleLike {
+  return {
+    name: engine.name,
+    async setup(nitro) {
+      await assertNoVitePluginInNitro(nitro, `${engine.name}/vite`, `${engine.name}/nitro`)
+
+      const context = await buildFeatureNitroContext(engine, nitro)
+      if (!context)
+        return
+
+      await engine.setupNitro?.(nitro, context)
+    },
+  }
+}

--- a/packages/internal/src/feature-bridge/feature-options.ts
+++ b/packages/internal/src/feature-bridge/feature-options.ts
@@ -1,0 +1,18 @@
+import { isPlainObject } from '@vitehub/internal/object'
+
+function cloneFeatureOptions<T extends object>(feature: string, options: T): T {
+  if (!isPlainObject(options))
+    throw new TypeError(`[vitehub] \`${feature}\` must be a plain object.`)
+
+  return { ...options } as T
+}
+
+export function normalizeFeatureOptions<T extends object>(
+  feature: string,
+  options: T | false | undefined,
+): T | undefined {
+  if (options === false || typeof options === 'undefined')
+    return undefined
+
+  return cloneFeatureOptions(feature, options)
+}

--- a/packages/internal/src/feature-bridge/hosting.ts
+++ b/packages/internal/src/feature-bridge/hosting.ts
@@ -1,0 +1,46 @@
+export type HostingProvider = 'cloudflare' | 'netlify' | 'vercel'
+
+export interface HostingDetectionTarget {
+  options: {
+    nitro?: {
+      preset?: string | null
+    }
+    preset?: string | null
+  }
+}
+
+export function normalizeHosting(hosting?: string | null): string {
+  const normalized = hosting?.trim().toLowerCase().replaceAll('_', '-') || ''
+  if (normalized === 'cloudflare') return 'cloudflare-module'
+  return normalized
+}
+
+export function detectHosting(target: HostingDetectionTarget) {
+  return normalizeHosting(target.options.nitro?.preset || target.options.preset || process.env.NITRO_PRESET || '')
+}
+
+export function getHostingProvider(hosting?: string | null): HostingProvider | undefined {
+  const normalized = normalizeHosting(hosting)
+
+  if (!normalized)
+    return undefined
+
+  if (normalized.startsWith('cloudflare'))
+    return 'cloudflare'
+  if (normalized.startsWith('vercel'))
+    return 'vercel'
+  if (normalized.startsWith('netlify'))
+    return 'netlify'
+  return undefined
+}
+
+export function getSupportedHostingProvider<TProvider extends HostingProvider>(
+  hosting: string | undefined,
+  supportedProviders: readonly TProvider[],
+) {
+  const provider = getHostingProvider(hosting)
+  if (!provider || !supportedProviders.includes(provider as TProvider))
+    return undefined
+
+  return provider as TProvider
+}

--- a/packages/internal/test/definition-discovery.test.ts
+++ b/packages/internal/test/definition-discovery.test.ts
@@ -6,12 +6,15 @@ import { afterEach, describe, expect, it } from "vitest"
 
 import {
   createRuntimeRegistryContents,
+  createNitroRuntimeFilePath,
+  hookNitroRuntimeRegistryRefresh,
   listSourceFiles,
   mergeDefinitions,
   normalizePathDefinitionName,
   registerDefinition,
   sanitizeDefinitionFilename,
   writeFileIfChanged,
+  writeRuntimeRegistryFiles,
 } from "../src/definition-discovery.ts"
 
 const dirs: string[] = []
@@ -100,6 +103,60 @@ describe("createRuntimeRegistryContents", () => {
     }])
     expect(contents).toContain('"release-notes": async () => import("../../server/sandboxes/release-notes.ts")')
     expect(contents).toContain("export default registry")
+  })
+})
+
+describe("createNitroRuntimeFilePath", () => {
+  it("keeps build-dir generated Nitro runtime paths stable", () => {
+    expect(createNitroRuntimeFilePath("/root", {
+      buildDir: "node_modules/.nitro",
+      fileName: "nitro-registry.mjs",
+      segments: [".vitehub", "queue"],
+    })).toBe("/root/node_modules/.nitro/.vitehub/queue/nitro-registry.mjs")
+  })
+
+  it("keeps root generated Nitro runtime paths stable", () => {
+    expect(createNitroRuntimeFilePath("/root", {
+      fileName: "assets/registry.mjs",
+      segments: [".vitehub", "nitro-runtime", "workspace"],
+    })).toBe("/root/.vitehub/nitro-runtime/workspace/assets/registry.mjs")
+  })
+})
+
+describe("writeRuntimeRegistryFiles", () => {
+  it("writes registry and plugin files with direct relative registry imports", async () => {
+    const root = await createTempDir("vitehub-internal-runtime-files-")
+    const registryFile = join(root, ".vitehub", "queue", "nitro-registry.mjs")
+    const pluginFile = join(root, ".vitehub", "queue", "nitro-plugin.ts")
+
+    await writeRuntimeRegistryFiles({
+      createPluginContents: (_plugin, registry) => `import registry from ${JSON.stringify(`./${registry.split("/").pop()}`)}\nexport default registry\n`,
+      definitions: [{ handler: join(root, "server", "queues", "welcome.ts"), name: "welcome" }],
+      pluginFile,
+      registryFile,
+    })
+
+    await expect(readFile(registryFile, "utf8")).resolves.toContain('"welcome": async () => import("../../server/queues/welcome.ts")')
+    await expect(readFile(pluginFile, "utf8")).resolves.toContain('import registry from "./nitro-registry.mjs"')
+  })
+})
+
+describe("hookNitroRuntimeRegistryRefresh", () => {
+  it("refreshes runtime files on build and dev reload hooks", async () => {
+    const handlers = new Map<string, () => Promise<void>>()
+    const refreshed: string[] = []
+    let count = 0
+
+    hookNitroRuntimeRegistryRefresh(
+      { hooks: { hook: (name, handler) => handlers.set(name, handler) } },
+      async () => ({ registryFile: `registry-${++count}.mjs` }),
+      async runtimeFiles => refreshed.push(runtimeFiles.registryFile),
+    )
+
+    await handlers.get("build:before")?.()
+    await handlers.get("dev:reload")?.()
+
+    expect(refreshed).toEqual(["registry-1.mjs", "registry-2.mjs"])
   })
 })
 

--- a/packages/internal/test/feature-bridge.test.ts
+++ b/packages/internal/test/feature-bridge.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  buildFeatureNitroContext,
+  createFeatureEngine,
+} from '../src/feature-bridge/feature-engine.ts'
+import { detectHosting } from '../src/feature-bridge/hosting.ts'
+
+afterEach(() => {
+  delete process.env.NITRO_PRESET
+})
+
+describe('feature bridge hosting', () => {
+  it('prefers configured Nitro preset over NITRO_PRESET env', () => {
+    process.env.NITRO_PRESET = 'cloudflare'
+
+    expect(detectHosting({
+      options: {
+        preset: 'vercel',
+      },
+    })).toBe('vercel')
+  })
+})
+
+describe('feature bridge state', () => {
+  it('preserves explicit false config in Nitro runtime config', async () => {
+    const setupNitro = vi.fn()
+    const engine = createFeatureEngine<false | { enabled: boolean }, { enabled: boolean }, false | { enabled: boolean }>({
+      name: '@vitehub/test-feature',
+      feature: 'testFeature',
+      configKey: 'testFeature',
+      normalizeOptions(options) {
+        if (options === false) return
+        return options
+      },
+      readPublicOptions(source) {
+        return source.kind === 'nitro'
+          ? (source.nitro.options as { testFeature?: false | { enabled: boolean } }).testFeature
+          : undefined
+      },
+      setupNitro,
+    })
+    const nitro = {
+      options: {
+        rootDir: process.cwd(),
+        runtimeConfig: {},
+        testFeature: false,
+      },
+    }
+
+    const context = await buildFeatureNitroContext(engine, nitro)
+
+    expect(nitro.options.runtimeConfig).toEqual({
+      testFeature: false,
+    })
+    expect(context?.config).toBe(false)
+  })
+})

--- a/packages/kv/src/feature.ts
+++ b/packages/kv/src/feature.ts
@@ -1,0 +1,72 @@
+import { createFeatureEngine, normalizeFeaturePublicOptions, readFeaturePublicOptions } from "@vitehub/internal/feature-bridge"
+import { resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
+
+import { warnVercelKVFallback } from "./config.ts"
+import { configureCloudflareKV } from "./integrations/cloudflare.ts"
+import { resolveKVViteConfig } from "./vite-config.ts"
+
+import type { FeatureStateSource } from "@vitehub/internal/feature-bridge"
+import type { FeatureNitroLike } from "@vitehub/internal/feature-bridge"
+import type { KVModuleOptions, ResolvedKVModuleOptions } from "./types.ts"
+
+type KVNitroOptions = FeatureNitroLike["options"] & {
+  alias?: Record<string, string>
+  cloudflare?: { wrangler?: { kv_namespaces?: { binding: string, id: string }[] } }
+  plugins?: string[]
+  storage?: Record<string, unknown>
+}
+
+type KVNitroTarget = FeatureNitroLike & {
+  logger: {
+    error: (message: string) => void
+  }
+  options: KVNitroOptions
+}
+
+function resolveRuntimeEntry(srcRelative: string, packageSubpath: string): string {
+  return resolveEntry(srcRelative, packageSubpath, import.meta.url)
+}
+
+function normalizeKVPublicOptions(options: KVModuleOptions | false | undefined): KVModuleOptions | undefined {
+  return normalizeFeaturePublicOptions("kv", options)
+}
+
+function readKVPublicOptions(source: FeatureStateSource<KVModuleOptions>): KVModuleOptions | undefined {
+  const options = readFeaturePublicOptions<KVModuleOptions>(source, "kv")
+  return typeof options === "undefined" ? ({} as KVModuleOptions) : options
+}
+
+export const kvFeatureEngine = createFeatureEngine<KVModuleOptions, KVModuleOptions, false | ResolvedKVModuleOptions>({
+  name: "@vitehub/kv",
+  feature: "kv",
+  configKey: "kv",
+  normalizeOptions: normalizeKVPublicOptions,
+  resolveConfig(options, hosting) {
+    return resolveKVViteConfig(options, {
+      env: process.env,
+      hosting,
+    }).kv
+  },
+  readPublicOptions: readKVPublicOptions,
+  setupNitro(nitro: FeatureNitroLike, context) {
+    if (!context.config)
+      return
+
+    const target = nitro as KVNitroTarget
+    const resolved = context.config
+
+    target.options.alias ||= {}
+    target.options.alias["@vitehub/kv"] = resolveRuntimeEntry("./index", "@vitehub/kv")
+
+    target.options.plugins ||= []
+    const plugin = resolveRuntimeEntry("./runtime/nitro-plugin", "@vitehub/kv/runtime/nitro-plugin")
+    if (!target.options.plugins.includes(plugin))
+      target.options.plugins.push(plugin)
+
+    target.options.storage ||= {}
+    target.options.storage.kv = resolved.store
+
+    configureCloudflareKV(target.options, resolved)
+    warnVercelKVFallback(target, resolved, context.hosting)
+  },
+})

--- a/packages/kv/src/nitro/module.ts
+++ b/packages/kv/src/nitro/module.ts
@@ -1,49 +1,10 @@
-import { assertNoVitePluginInNitro, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
-import type { NitroModule, NitroRuntimeConfig } from "nitro/types"
+import { createFeatureNitroBridge } from "@vitehub/internal/feature-bridge"
 
-import { warnVercelKVFallback } from "../config.ts"
-import { configureCloudflareKV } from "../integrations/cloudflare.ts"
-import { KV_VITE_PLUGIN_NAME, resolveKVViteConfig } from "../vite-config.ts"
+import { kvFeatureEngine } from "../feature.ts"
+import type { NitroModule } from "nitro/types"
 import type { KVModuleOptions, ResolvedKVModuleOptions } from "../types.ts"
 
-function resolveRuntimeEntry(srcRelative: string, packageSubpath: string): string {
-  return resolveEntry(srcRelative, packageSubpath, import.meta.url)
-}
-
-const kvNitroModule: NitroModule = {
-  name: "@vitehub/kv",
-  async setup(nitro) {
-    await assertNoVitePluginInNitro(nitro, KV_VITE_PLUGIN_NAME, "@vitehub/kv/nitro")
-
-    const viteConfig = resolveKVViteConfig(nitro.options.kv, {
-      env: process.env,
-      hosting: nitro.options.preset,
-    })
-    const { hosting } = viteConfig
-
-    const runtimeConfig = (nitro.options.runtimeConfig ||= {} as NitroRuntimeConfig)
-    if (hosting) runtimeConfig.hosting ||= hosting
-    runtimeConfig.kv = viteConfig.kv
-
-    if (!viteConfig.kv) return
-    const resolved = viteConfig.kv
-
-    nitro.options.alias ||= {}
-    nitro.options.alias["@vitehub/kv"] = resolveRuntimeEntry("../index", "@vitehub/kv")
-
-    nitro.options.plugins ||= []
-    const plugin = resolveRuntimeEntry("../runtime/nitro-plugin", "@vitehub/kv/runtime/nitro-plugin")
-    if (!nitro.options.plugins.includes(plugin)) {
-      nitro.options.plugins.push(plugin)
-    }
-
-    nitro.options.storage ||= {}
-    nitro.options.storage.kv = resolved.store
-
-    configureCloudflareKV(nitro.options, resolved)
-    warnVercelKVFallback(nitro, resolved, hosting)
-  },
-}
+const kvNitroModule: NitroModule = createFeatureNitroBridge(kvFeatureEngine)
 
 export default kvNitroModule
 

--- a/packages/queue/src/discovery.ts
+++ b/packages/queue/src/discovery.ts
@@ -1,7 +1,8 @@
-import { relative, resolve } from "node:path"
 import {
+  createDirectoryDefinitionSource,
+  createSuffixDefinitionSource,
   discoverDefinitions,
-  normalizePathDefinitionName,
+  resolveDefinitionScanRoots,
   normalizeSuffixDefinitionName,
 } from "@vitehub/internal/definition-catalog"
 
@@ -18,20 +19,12 @@ export function discoverQueueDefinitions(options:
   | { mode: "nitro-server-queues", scanDirs: string[] }
 ): DiscoveredQueueDefinition[] {
   if (options.mode === "nitro-server-queues") {
-    return discoverDefinitions("queue", [{
-      kind: "directory",
-      scanDirs: options.scanDirs,
-      source: "nitro-server-queues",
-      subdir: "queues",
-    }])
+    return discoverDefinitions("queue", [
+      createDirectoryDefinitionSource("nitro-server-queues", options.scanDirs, "queues"),
+    ])
   }
 
-  const roots = new Set([options.rootDir, ...(options.scanDirs || [])].filter(Boolean))
-  return discoverDefinitions("queue", [{
-    kind: "suffix",
-    normalizeName: normalizeSuffixQueueName,
-    pattern: queueSuffixPattern,
-    roots: [...roots],
-    source: "vite-suffix",
-  }])
+  return discoverDefinitions("queue", [
+    createSuffixDefinitionSource("vite-suffix", resolveDefinitionScanRoots(options.rootDir, options.scanDirs), queueSuffixPattern, normalizeSuffixQueueName),
+  ])
 }

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -2,7 +2,7 @@ import { mkdir, rm, writeFile } from "node:fs/promises"
 import { relative, resolve } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vitehub/internal/build/cloudflare"
-import { writeCloudflareDeploymentOutput, writeVercelDeploymentOutput } from "@vitehub/internal/build/deployment-output"
+import { createDefaultVercelOutputRoot, writeProviderDeploymentOutputs } from "@vitehub/internal/build/deployment-output"
 import { bundleEsmEntry } from "@vitehub/internal/build/esbuild"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg, toGeneratedPath } from "@vitehub/internal/build/paths"
 import { resolveUserAppEntry } from "@vitehub/internal/build/user-entry"
@@ -15,6 +15,7 @@ import { getCloudflareQueueBindingName, getCloudflareQueueName } from "../integr
 import { getVercelQueueTopicName } from "../integrations/vercel.ts"
 
 import type { DiscoveredQueueDefinition, QueueModuleOptions, QueueProvider } from "../types.ts"
+import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vitehub/internal/build/deployment-output"
 
 export const queuePackageName = "@vitehub/queue"
 const productName = "queue"
@@ -147,7 +148,7 @@ export async function createCloudflareQueueConfig(options: CloudflareQueueConfig
   }
 }
 
-async function writeCloudflareOutput(rootDir: string, clientOutDir: string, artifacts: GeneratedQueueArtifacts) {
+function createCloudflareOutput(artifacts: GeneratedQueueArtifacts): CloudflareProviderDeploymentOutput {
   const queues = createCloudflareQueueBindings(artifacts.definitions)
 
   const wranglerConfig: CloudflareQueueConfig = {
@@ -158,7 +159,7 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, arti
     ...(queues ? { queues } : {}),
   }
 
-  await writeCloudflareDeploymentOutput({
+  return {
     bundleEntry: artifacts.cloudflareWorkerFile,
     bundleOptions: {
       conditions: ["workerd", "worker", "browser", "default"],
@@ -166,10 +167,8 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, arti
       format: "esm",
       platform: "neutral",
     },
-    clientOutDir,
-    rootDir,
     wranglerConfig,
-  })
+  }
 }
 
 function sanitizeVercelConsumerName(functionPath: string) {
@@ -218,21 +217,20 @@ function createVercelQueueWrapperContents(file: string, registryFile: string, na
   ].join("\n")
 }
 
-async function writeVercelOutput(rootDir: string, clientOutDir: string, queue: QueueModuleOptions | undefined, artifacts: GeneratedQueueArtifacts) {
-  const outputRoot = resolve(rootDir, ".vercel", "output")
-  const queueRoot = resolve(outputRoot, "functions", "api", "vitehub", "queues", "vercel")
-  const queueConfig = normalizeQueueOptions(queue, { hosting: "vercel" }) || false
-
-  await writeVercelDeploymentOutput({
+function createVercelOutput(artifacts: GeneratedQueueArtifacts): VercelProviderDeploymentOutput {
+  return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
       format: "esm",
       platform: "node",
     },
-    clientOutDir,
-    outputRoot,
-    rootDir,
-  })
+  }
+}
+
+async function writeVercelQueueFunctions(rootDir: string, queue: QueueModuleOptions | undefined, artifacts: GeneratedQueueArtifacts) {
+  const outputRoot = createDefaultVercelOutputRoot(rootDir)
+  const queueRoot = resolve(outputRoot, "functions", "api", "vitehub", "queues", "vercel")
+  const queueConfig = normalizeQueueOptions(queue, { hosting: "vercel" }) || false
 
   if (queueConfig === false) {
     return
@@ -272,9 +270,12 @@ async function writeVercelOutput(rootDir: string, clientOutDir: string, queue: Q
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedQueueArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.queue)
-  await Promise.all([
-    writeCloudflareOutput(options.rootDir, options.clientOutDir, artifacts),
-    writeVercelOutput(options.rootDir, options.clientOutDir, options.queue, artifacts),
-  ])
+  await writeProviderDeploymentOutputs({
+    clientOutDir: options.clientOutDir,
+    cloudflare: createCloudflareOutput(artifacts),
+    rootDir: options.rootDir,
+    vercel: createVercelOutput(artifacts),
+  })
+  await writeVercelQueueFunctions(options.rootDir, options.queue, artifacts)
   return artifacts
 }

--- a/packages/queue/src/nitro/module.ts
+++ b/packages/queue/src/nitro/module.ts
@@ -1,5 +1,5 @@
 import { createImportPath } from "@vitehub/internal/build/paths"
-import { createGeneratedDefinitionPath, createRuntimeRegistryContents, writeFileIfChanged } from "@vitehub/internal/definition-catalog"
+import { applyNitroRuntimeAliases, createNitroRuntimeFilePath, hookNitroRuntimeRegistryRefresh, writeRuntimeRegistryFiles } from "@vitehub/internal/definition-catalog"
 import { assertNoVitePluginInNitro, mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 import { resolve } from "node:path"
 import type { NitroModule, NitroRuntimeConfig } from "nitro/types"
@@ -32,11 +32,11 @@ const QUEUE_NITRO_IMPORTS_PRESET = { from: "@vitehub/queue", imports: ["defineQu
 const QUEUE_VITE_PLUGIN_NAME = "@vitehub/queue/vite"
 
 function createNitroQueueRegistryPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, { buildDir, fileName: "nitro-registry.mjs", segments: generatedDirSegments })
+  return createNitroRuntimeFilePath(rootDir, { buildDir, fileName: "nitro-registry.mjs", segments: generatedDirSegments })
 }
 
 function createNitroQueuePluginPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, { buildDir, fileName: "nitro-plugin.ts", segments: generatedDirSegments })
+  return createNitroRuntimeFilePath(rootDir, { buildDir, fileName: "nitro-plugin.ts", segments: generatedDirSegments })
 }
 
 function resolveNitroQueueScanDirs(rootDir: string, scanDirs: string[] | undefined) {
@@ -130,14 +130,12 @@ async function writeNitroQueueRuntimeFiles(nitro: { options: { buildDir: string,
     scanDirs: resolveNitroQueueScanDirs(nitro.options.rootDir, nitro.options.scanDirs),
   })
 
-  await writeFileIfChanged(registryFile, createRuntimeRegistryContents(registryFile, definitions))
-  await writeFileIfChanged(pluginFile, createNitroQueuePluginContents(pluginFile, registryFile))
-
-  return {
+  return await writeRuntimeRegistryFiles({
+    createPluginContents: createNitroQueuePluginContents,
     definitions,
     pluginFile,
     registryFile,
-  }
+  })
 }
 
 const queueNitroModule: NitroModule = {
@@ -157,7 +155,7 @@ const queueNitroModule: NitroModule = {
     nitro.options.alias["@vitehub/queue/runtime/state"] = resolveRuntimeEntry("../runtime/state", "@vitehub/queue/runtime/state")
 
     let runtimeFiles = await writeNitroQueueRuntimeFiles(nitro)
-    nitro.options.alias["#vitehub/queue/registry"] = runtimeFiles.registryFile
+    applyNitroRuntimeAliases(nitro, { "#vitehub/queue/registry": runtimeFiles.registryFile })
     const { definitions } = runtimeFiles
 
     const importsExplicitlyDisabled = nitro.options._config?.imports === false
@@ -198,11 +196,9 @@ const queueNitroModule: NitroModule = {
       }
     }
 
-    nitro.hooks.hook("build:before", async () => {
-      runtimeFiles = await writeNitroQueueRuntimeFiles(nitro)
-    })
-    nitro.hooks.hook("dev:reload", async () => {
-      runtimeFiles = await writeNitroQueueRuntimeFiles(nitro)
+    hookNitroRuntimeRegistryRefresh(nitro, () => writeNitroQueueRuntimeFiles(nitro), (nextRuntimeFiles) => {
+      runtimeFiles = nextRuntimeFiles
+      applyNitroRuntimeAliases(nitro, { "#vitehub/queue/registry": runtimeFiles.registryFile })
     })
     nitro.hooks.hook("compiled", async (currentNitro: any) => {
       if (currentNitro.options.preset?.includes("vercel")) {

--- a/packages/queue/test/discovery.test.ts
+++ b/packages/queue/test/discovery.test.ts
@@ -86,4 +86,20 @@ describe("discoverQueueDefinitions", () => {
       scanDirs: [firstNitroScanDir, secondNitroScanDir],
     })).toThrow(/Duplicate queue name/)
   })
+
+  it("deduplicates repeated scan roots without suppressing real duplicate names", async () => {
+    const viteRootDir = await createTempDir("vitehub-queue-vite-root-dedupe-")
+    await writeFile(join(viteRootDir, "welcome.queue.ts"), "export default null\n", "utf8")
+
+    expect(discoverQueueDefinitions({
+      mode: "vite-suffix",
+      rootDir: viteRootDir,
+      scanDirs: [viteRootDir],
+    })).toEqual([
+      expect.objectContaining({
+        name: "welcome",
+        source: "vite-suffix",
+      }),
+    ])
+  })
 })

--- a/packages/sandbox/src/discovery.ts
+++ b/packages/sandbox/src/discovery.ts
@@ -1,5 +1,5 @@
-import { resolve } from 'node:path'
 import {
+  createDirectoryDefinitionSource,
   discoverDefinitions,
 } from '@vitehub/internal/definition-catalog'
 import type { ScannedDefinition } from './internal/shared/feature-definitions'
@@ -9,21 +9,19 @@ export interface DiscoveredSandboxDefinition extends ScannedDefinition {
 }
 
 export function discoverNitroSandboxDefinitions(scanDirs: string[]): DiscoveredSandboxDefinition[] {
-  return discoverDefinitions("sandbox", [{
-    createDefinition({ file, name }) {
-      return {
-        handler: file,
-        name,
-        source: "nitro-server-sandboxes",
-        _meta: {
-          filename: name,
-          sourcePath: file,
-        },
-      }
-    },
-    kind: "directory",
-    scanDirs,
-    source: "nitro-server-sandboxes",
-    subdir: "sandboxes",
-  }])
+  return discoverDefinitions("sandbox", [
+    createDirectoryDefinitionSource<DiscoveredSandboxDefinition>("nitro-server-sandboxes", scanDirs, "sandboxes", {
+      createDefinition({ file, name }) {
+        return {
+          handler: file,
+          name,
+          source: "nitro-server-sandboxes",
+          _meta: {
+            filename: name,
+            sourcePath: file,
+          },
+        }
+      },
+    }),
+  ])
 }

--- a/packages/sandbox/src/nitro/module.ts
+++ b/packages/sandbox/src/nitro/module.ts
@@ -1,6 +1,6 @@
 import { readPackageJSON } from 'pkg-types'
 
-import { writeFileIfChanged } from '@vitehub/internal/definition-discovery'
+import { hookNitroRuntimeRegistryRefresh, writeFileIfChanged } from '@vitehub/internal/definition-discovery'
 
 import { createSandboxProviderLoaderContents } from '../feature'
 import { hasInstalledDependency } from '../internal/shared/dependency'
@@ -55,11 +55,8 @@ const sandboxNitroModule: NitroModule = {
 
     extendSandboxNitro(nitro, config, deps, providerLoader.providerLoaderTarget)
 
-    nitro.hooks.hook('build:before', async () => {
-      runtimeFiles = await writeNitroSandboxRuntimeFiles(nitro)
-    })
-    nitro.hooks.hook('dev:reload', async () => {
-      runtimeFiles = await writeNitroSandboxRuntimeFiles(nitro)
+    hookNitroRuntimeRegistryRefresh(nitro, () => writeNitroSandboxRuntimeFiles(nitro), (nextRuntimeFiles) => {
+      runtimeFiles = nextRuntimeFiles
     })
 
     if (provider?.provider === 'vercel' && !hasInstalledDependency(deps, '@vercel/sandbox', { paths: [nitro.options.rootDir] }))

--- a/packages/sandbox/src/nitro/runtime-files.ts
+++ b/packages/sandbox/src/nitro/runtime-files.ts
@@ -2,7 +2,7 @@ import { mkdir } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 import { createImportPath, generatedDirSegments } from '@vitehub/internal/build/paths'
-import { createGeneratedDefinitionPath, createRuntimeRegistryContents, sanitizeDefinitionFilename, writeFileIfChanged } from '@vitehub/internal/definition-catalog'
+import { createNitroRuntimeFilePath, sanitizeDefinitionFilename, writeFileIfChanged, writeRuntimeRegistryFiles } from '@vitehub/internal/definition-catalog'
 
 import { bundleSandboxDefinition } from '../bundle'
 import { extractSandboxDefinitionOptions } from '../definition-options'
@@ -16,15 +16,15 @@ import type { Nitro } from 'nitro/types'
 export const sandboxGeneratedDir = generatedDirSegments('sandbox')
 
 export function createNitroSandboxRegistryPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, { buildDir, fileName: 'nitro-registry.mjs', segments: sandboxGeneratedDir })
+  return createNitroRuntimeFilePath(rootDir, { buildDir, fileName: 'nitro-registry.mjs', segments: sandboxGeneratedDir })
 }
 
 export function createNitroSandboxPluginPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, { buildDir, fileName: 'nitro-plugin.ts', segments: sandboxGeneratedDir })
+  return createNitroRuntimeFilePath(rootDir, { buildDir, fileName: 'nitro-plugin.ts', segments: sandboxGeneratedDir })
 }
 
 export function createNitroSandboxDefinitionPath(rootDir: string, buildDir: string, name: string) {
-  return createGeneratedDefinitionPath(rootDir, {
+  return createNitroRuntimeFilePath(rootDir, {
     buildDir,
     fileName: `definitions/${sanitizeDefinitionFilename(name)}.mjs`,
     segments: sandboxGeneratedDir,
@@ -91,8 +91,12 @@ export async function writeNitroSandboxRuntimeFiles(nitro: Nitro) {
   }))
 
   registryDefinitions.sort((left, right) => left.name.localeCompare(right.name))
-  await writeFileIfChanged(registryFile, createRuntimeRegistryContents(registryFile, registryDefinitions))
-  await writeFileIfChanged(pluginFile, createNitroSandboxPluginContents(pluginFile, registryFile))
+  await writeRuntimeRegistryFiles({
+    createPluginContents: createNitroSandboxPluginContents,
+    definitions: registryDefinitions,
+    pluginFile,
+    registryFile,
+  })
 
   return {
     definitions,

--- a/packages/workflow/src/discovery.ts
+++ b/packages/workflow/src/discovery.ts
@@ -1,9 +1,12 @@
-import { normalize, relative, resolve } from "pathe"
+import { normalize, resolve } from "pathe"
 
 import {
+  createDirectoryDefinitionSource,
+  createSuffixDefinitionSource,
   discoverDefinitions,
   normalizePathDefinitionName,
   normalizeSuffixDefinitionName,
+  resolveDefinitionScanRoots,
 } from "@vitehub/internal/definition-catalog"
 
 import type { DiscoveredWorkflowDefinition } from "./types.ts"
@@ -19,25 +22,15 @@ export function discoverWorkflowDefinitions(options:
   | { mode: "nitro-server-workflows", scanDirs: string[] }
 ): DiscoveredWorkflowDefinition[] {
   if (options.mode === "nitro-server-workflows") {
-    return discoverDefinitions("workflow", [{
-      kind: "directory",
-      scanDirs: options.scanDirs,
-      source: "nitro-server-workflows",
-      subdir: "workflows",
-    }])
+    return discoverDefinitions("workflow", [
+      createDirectoryDefinitionSource("nitro-server-workflows", options.scanDirs, "workflows"),
+    ])
   }
 
-  const roots = new Set([options.rootDir, ...(options.scanDirs || [])].filter(Boolean))
+  const roots = resolveDefinitionScanRoots(options.rootDir, options.scanDirs)
   return discoverDefinitions("workflow", [
-    {
-      kind: "suffix",
-      normalizeName: normalizeSuffixWorkflowName,
-      pattern: workflowSuffixPattern,
-      roots: [...roots],
-      source: "vite-suffix",
-    },
-    {
-      kind: "directory",
+    createSuffixDefinitionSource("vite-suffix", roots, workflowSuffixPattern, normalizeSuffixWorkflowName),
+    createDirectoryDefinitionSource("nitro-server-workflows", roots.map(root => resolve(root, "server")), "workflows", {
       normalizeName(directory, file) {
         const serverWorkflowDir = normalize(directory)
         const normalizedFile = normalize(file)
@@ -45,9 +38,6 @@ export function discoverWorkflowDefinitions(options:
           return normalizePathDefinitionName(serverWorkflowDir, file)
         }
       },
-      scanDirs: [...roots].map(root => resolve(root, "server")),
-      source: "nitro-server-workflows",
-      subdir: "workflows",
-    },
+    }),
   ])
 }

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { resolve } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vitehub/internal/build/cloudflare"
-import { createDefaultCloudflareOutputRoot, writeCloudflareDeploymentOutput, writeVercelDeploymentOutput } from "@vitehub/internal/build/deployment-output"
+import { createDefaultCloudflareOutputRoot, writeProviderDeploymentOutputs } from "@vitehub/internal/build/deployment-output"
 import { VITEHUB_MODES, getViteMode } from "@vitehub/internal/build/mode"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vitehub/internal/build/paths"
 import { resolveUserAppEntry } from "@vitehub/internal/build/user-entry"
@@ -13,6 +13,7 @@ import { discoverWorkflowDefinitions } from "../discovery.ts"
 import { createCloudflareWorkflowBindings, getCloudflareWorkflowClassName } from "../integrations/cloudflare.ts"
 
 import type { DiscoveredWorkflowDefinition, ResolvedWorkflowOptions, WorkflowModuleOptions, WorkflowProvider } from "../types.ts"
+import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vitehub/internal/build/deployment-output"
 
 export const workflowPackageName = "@vitehub/workflow"
 const productName = "workflow"
@@ -173,8 +174,7 @@ async function writeProviderEntries(rootDir: string, workflow: WorkflowModuleOpt
   }
 }
 
-async function writeCloudflareOutput(rootDir: string, clientOutDir: string, artifacts: GeneratedWorkflowArtifacts) {
-  const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+function createCloudflareOutput(rootDir: string, artifacts: GeneratedWorkflowArtifacts): CloudflareProviderDeploymentOutput {
   const workflowConfig = artifacts.cloudflareWorkflowConfig && artifacts.cloudflareWorkflowConfig.provider === "cloudflare"
     ? artifacts.cloudflareWorkflowConfig
     : false
@@ -189,7 +189,7 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, arti
     ...(workflows ? { workflows } : {}),
   }
 
-  await writeCloudflareDeploymentOutput({
+  return {
     bundleEntry: artifacts.cloudflareWorkerFile,
     bundleOptions: {
       conditions: ["workerd", "worker", "browser", "default"],
@@ -209,33 +209,39 @@ async function writeCloudflareOutput(rootDir: string, clientOutDir: string, arti
       platform: "neutral",
     },
     bundleOutfileName: "worker.mjs",
-    clientOutDir,
-    outputRoot,
-    rootDir,
+    outputRoot: createDefaultCloudflareOutputRoot(rootDir),
     wranglerConfig,
-  })
+  }
+}
 
+async function writeCloudflareWorkflowWrapper(rootDir: string, artifacts: GeneratedWorkflowArtifacts) {
+  const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+  const workflowConfig = artifacts.cloudflareWorkflowConfig && artifacts.cloudflareWorkflowConfig.provider === "cloudflare"
+    ? artifacts.cloudflareWorkflowConfig
+    : false
+  const workflowDefinitions = workflowConfig ? artifacts.definitions : []
   await writeFile(resolve(outputRoot, "index.js"), renderCloudflareWorkerWrapper(workflowDefinitions), "utf8")
 }
 
-async function writeVercelOutput(rootDir: string, clientOutDir: string, artifacts: GeneratedWorkflowArtifacts) {
-  await writeVercelDeploymentOutput({
+function createVercelOutput(artifacts: GeneratedWorkflowArtifacts): VercelProviderDeploymentOutput {
+  return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
       external: ["@cloudflare/sandbox", "cloudflare:workers", "workflow", "workflow/api", "workflow/runtime"],
       format: "esm",
       platform: "node",
     },
-    clientOutDir,
-    rootDir,
-  })
+  }
 }
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedWorkflowArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.workflow)
-  await Promise.all([
-    writeCloudflareOutput(options.rootDir, options.clientOutDir, artifacts),
-    writeVercelOutput(options.rootDir, options.clientOutDir, artifacts),
-  ])
+  await writeProviderDeploymentOutputs({
+    clientOutDir: options.clientOutDir,
+    cloudflare: createCloudflareOutput(options.rootDir, artifacts),
+    rootDir: options.rootDir,
+    vercel: createVercelOutput(artifacts),
+  })
+  await writeCloudflareWorkflowWrapper(options.rootDir, artifacts)
   return artifacts
 }

--- a/packages/workflow/src/nitro/module.ts
+++ b/packages/workflow/src/nitro/module.ts
@@ -2,7 +2,7 @@ import { appendFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
 
 import { createImportPath } from "@vitehub/internal/build/paths"
-import { createGeneratedDefinitionPath, createRuntimeRegistryContents, writeFileIfChanged } from "@vitehub/internal/definition-catalog"
+import { applyNitroRuntimeAliases, createNitroRuntimeFilePath, hookNitroRuntimeRegistryRefresh, writeRuntimeRegistryFiles } from "@vitehub/internal/definition-catalog"
 import { assertNoVitePluginInNitro, mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 
 import type { Nitro, NitroModule, NitroRuntimeConfig } from "nitro/types"
@@ -20,7 +20,7 @@ function resolveRuntimeEntry(srcRelative: string, packageSubpath: string): strin
 }
 
 function createNitroWorkflowRegistryPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, {
+  return createNitroRuntimeFilePath(rootDir, {
     buildDir,
     fileName: "nitro-registry.mjs",
     segments: ["vitehub", "workflow"],
@@ -28,7 +28,7 @@ function createNitroWorkflowRegistryPath(rootDir: string, buildDir: string) {
 }
 
 function createNitroWorkflowPluginPath(rootDir: string, buildDir: string) {
-  return createGeneratedDefinitionPath(rootDir, {
+  return createNitroRuntimeFilePath(rootDir, {
     buildDir,
     fileName: "nitro-plugin.ts",
     segments: ["vitehub", "workflow"],
@@ -104,12 +104,12 @@ async function writeNitroWorkflowRuntimeFiles(nitro: Nitro): Promise<RuntimeFile
     scanDirs: resolveNitroWorkflowScanDirs(nitro.options.rootDir, nitro.options.scanDirs),
   })
 
-  await Promise.all([
-    writeFileIfChanged(registryFile, createRuntimeRegistryContents(registryFile, definitions)),
-    writeFileIfChanged(pluginFile, createNitroWorkflowPluginContents(pluginFile, registryFile)),
-  ])
-
-  return { definitions, pluginFile, registryFile }
+  return await writeRuntimeRegistryFiles({
+    createPluginContents: createNitroWorkflowPluginContents,
+    definitions,
+    pluginFile,
+    registryFile,
+  })
 }
 
 const workflowNitroModule: NitroModule = {
@@ -128,7 +128,7 @@ const workflowNitroModule: NitroModule = {
     nitro.options.alias["@vitehub/workflow/runtime/cloudflare-runner"] = resolveRuntimeEntry("../runtime/cloudflare-runner", "@vitehub/workflow/runtime/cloudflare-runner")
 
     let runtimeFiles = await writeNitroWorkflowRuntimeFiles(nitro)
-    nitro.options.alias["#vitehub/workflow/registry"] = runtimeFiles.registryFile
+    applyNitroRuntimeAliases(nitro, { "#vitehub/workflow/registry": runtimeFiles.registryFile })
 
     const importsExplicitlyDisabled = nitro.options._config?.imports === false
     if (!importsExplicitlyDisabled) {
@@ -159,11 +159,9 @@ const workflowNitroModule: NitroModule = {
       }
     }
 
-    nitro.hooks.hook("build:before", async () => {
-      runtimeFiles = await writeNitroWorkflowRuntimeFiles(nitro)
-    })
-    nitro.hooks.hook("dev:reload", async () => {
-      runtimeFiles = await writeNitroWorkflowRuntimeFiles(nitro)
+    hookNitroRuntimeRegistryRefresh(nitro, () => writeNitroWorkflowRuntimeFiles(nitro), (nextRuntimeFiles) => {
+      runtimeFiles = nextRuntimeFiles
+      applyNitroRuntimeAliases(nitro, { "#vitehub/workflow/registry": runtimeFiles.registryFile })
     })
     nitro.hooks.hook("compiled", async (currentNitro) => {
       if (resolved.provider !== "cloudflare" || !currentNitro.options.preset?.includes("cloudflare")) {

--- a/packages/workspace/src/discovery.ts
+++ b/packages/workspace/src/discovery.ts
@@ -2,7 +2,14 @@ import { readdirSync } from "node:fs"
 import { basename, dirname, relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
-import { createRuntimeRegistryContents, discoverDefinitions, normalizePathDefinitionName, normalizeSuffixDefinitionName } from "@vitehub/internal/definition-catalog"
+import {
+  createDirectoryDefinitionSource,
+  createRuntimeRegistryContents,
+  createSuffixDefinitionSource,
+  discoverDefinitions,
+  normalizePathDefinitionName,
+  normalizeSuffixDefinitionName,
+} from "@vitehub/internal/definition-catalog"
 
 import { workspaceConfigFileNames, workspaceConfigPattern, workspaceSuffixPattern } from "./workspace-config.ts"
 
@@ -71,36 +78,23 @@ function nitroWorkspaceSource(rootDir: string): WorkspaceDefinitionCatalogSource
   }
 
   return [
-    {
-      kind: "directory",
+    createDirectoryDefinitionSource("nitro-server-workspaces-directory-config", [resolve(rootDir, "server")], "workspaces", {
       includeHidden: true,
       normalizeName: normalizeDirectoryName,
-      scanDirs: [resolve(rootDir, "server")],
-      source: "nitro-server-workspaces-directory-config",
-      subdir: "workspaces",
       createDefinition: ({ file, name }) => ({ handler: file, name, path: file, source: "nitro-server-workspaces-directory-config" }),
-    },
-    {
-      kind: "directory",
+    }),
+    createDirectoryDefinitionSource("nitro-server-workspaces", [resolve(rootDir, "server")], "workspaces", {
       normalizeName: normalizeFlatName,
-      scanDirs: [resolve(rootDir, "server")],
-      source: "nitro-server-workspaces",
-      subdir: "workspaces",
       createDefinition: ({ file, name }) => ({ handler: file, name, path: file, source: "nitro-server-workspaces" }),
-    },
+    }),
   ]
 }
 
 function viteWorkspaceSource(rootDir: string): WorkspaceDefinitionCatalogSource[] {
   return [
-    {
-      kind: "suffix",
-      normalizeName: (root, file) => normalizeSuffixDefinitionName(root, file, workspaceSuffixPattern, { stripPrefix: "src/" }),
-      pattern: workspaceSuffixPattern,
-      roots: [rootDir],
-      source: "vite-workspace-suffix",
+    createSuffixDefinitionSource("vite-workspace-suffix", [rootDir], workspaceSuffixPattern, (root, file) => normalizeSuffixDefinitionName(root, file, workspaceSuffixPattern, { stripPrefix: "src/" }), {
       createDefinition: ({ file, name }) => ({ handler: file, name, path: file, source: "vite-workspace-suffix" }),
-    },
+    }),
   ]
 }
 

--- a/packages/workspace/src/nitro/module.ts
+++ b/packages/workspace/src/nitro/module.ts
@@ -1,9 +1,8 @@
-import { mkdir, writeFile } from "node:fs/promises"
 import { createRequire } from "node:module"
 import { dirname, resolve } from "node:path"
 
 import { createImportPath } from "@vitehub/internal/build/paths"
-import { writeFileIfChanged } from "@vitehub/internal/definition-catalog"
+import { applyNitroRuntimeAliases, createNitroRuntimeFilePath, hookNitroRuntimeRegistryRefresh, writeFileIfChanged } from "@vitehub/internal/definition-catalog"
 import { assertNoVitePluginInNitro, mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 
 import { initializeWorkspaceAssetRegistry, syncWorkspaceBuildAssets, writeWorkspaceRuntimeRegistry } from "../build-integration.ts"
@@ -38,15 +37,24 @@ function resolveIsomorphicGitHttpWebEsmEntry() {
 }
 
 function registryPath(nitro: Nitro) {
-  return resolve(nitro.options.rootDir, ".vitehub/nitro-runtime/workspace/registry.mjs")
+  return createNitroRuntimeFilePath(nitro.options.rootDir, {
+    fileName: "registry.mjs",
+    segments: [".vitehub", "nitro-runtime", "workspace"],
+  })
 }
 
 function pluginPath(nitro: Nitro) {
-  return resolve(nitro.options.rootDir, ".vitehub/nitro-runtime/workspace/plugin.mjs")
+  return createNitroRuntimeFilePath(nitro.options.rootDir, {
+    fileName: "plugin.mjs",
+    segments: [".vitehub", "nitro-runtime", "workspace"],
+  })
 }
 
 function assetsRegistryPath(nitro: Nitro) {
-  return resolve(nitro.options.rootDir, ".vitehub/nitro-runtime/workspace/assets/registry.mjs")
+  return createNitroRuntimeFilePath(nitro.options.rootDir, {
+    fileName: "assets/registry.mjs",
+    segments: [".vitehub", "nitro-runtime", "workspace"],
+  })
 }
 
 function workspaceNitroConfigTypes(definitions: DiscoveredWorkspaceDefinition[]) {
@@ -150,9 +158,15 @@ function createNitroPluginContents(file: string, registryFile: string, assetsReg
 
 async function writePlugin(nitro: Nitro, registryFile: string, assetsRegistryFile: string, options: false | ResolvedWorkspaceModuleOptions) {
   const path = pluginPath(nitro)
-  await mkdir(dirname(path), { recursive: true })
-  await writeFile(path, createNitroPluginContents(path, registryFile, assetsRegistryFile, options), "utf8")
+  await writeFileIfChanged(path, createNitroPluginContents(path, registryFile, assetsRegistryFile, options))
   return path
+}
+
+function applyWorkspaceRuntimeAliases(nitro: Nitro, registryFile: string, assetsRegistryFile: string) {
+  applyNitroRuntimeAliases(nitro, {
+    "#vitehub-workspace-assets-registry": assetsRegistryFile,
+    "#vitehub-workspace-registry": registryFile,
+  })
 }
 
 const workspaceNitroModule: NitroModule = {
@@ -186,8 +200,7 @@ const workspaceNitroModule: NitroModule = {
     const assetsRegistryFile = assetsRegistryPath(nitro)
     await initializeWorkspaceAssetRegistry(assetsRegistryFile, definitions, nitro.options.rootDir)
     const plugin = await writePlugin(nitro, registryFile, assetsRegistryFile, resolved)
-    nitro.options.alias["#vitehub-workspace-registry"] = registryFile
-    nitro.options.alias["#vitehub-workspace-assets-registry"] = assetsRegistryFile
+    applyWorkspaceRuntimeAliases(nitro, registryFile, assetsRegistryFile)
     installNitroConfigTypes(nitro, () => definitions)
 
     const importsExplicitlyDisabled = nitro.options._config?.imports === false
@@ -202,22 +215,16 @@ const workspaceNitroModule: NitroModule = {
       configureCloudflareArtifacts(nitro.options, resolved)
     }
 
-    nitro.hooks.hook("build:before", async () => {
+    hookNitroRuntimeRegistryRefresh(nitro, async () => {
       definitions = discoverNitroWorkspaceDefinitions(nitro.options.rootDir)
       const nextPath = await writeWorkspaceRuntimeRegistry(registryPath(nitro), definitions)
-      nitro.options.alias ||= {}
-      nitro.options.alias["#vitehub-workspace-registry"] = nextPath
-      nitro.options.alias["#vitehub-workspace-assets-registry"] = assetsRegistryFile
-      await syncWorkspaceBuildAssets(definitions, nitro.options.rootDir, resolved, assetsRegistryFile)
-      await writePlugin(nitro, nextPath, assetsRegistryFile, resolved)
-    })
-    nitro.hooks.hook("dev:reload", async () => {
-      definitions = discoverNitroWorkspaceDefinitions(nitro.options.rootDir)
-      const nextPath = await writeWorkspaceRuntimeRegistry(registryPath(nitro), definitions)
-      await initializeWorkspaceAssetRegistry(assetsRegistryFile, definitions, nitro.options.rootDir)
-      nitro.options.alias ||= {}
-      nitro.options.alias["#vitehub-workspace-registry"] = nextPath
-      nitro.options.alias["#vitehub-workspace-assets-registry"] = assetsRegistryFile
+      return { definitions, registryFile: nextPath }
+    }, async (runtimeFiles, hookName) => {
+      applyWorkspaceRuntimeAliases(nitro, runtimeFiles.registryFile, assetsRegistryFile)
+      if (hookName === "build:before") {
+        await syncWorkspaceBuildAssets(definitions, nitro.options.rootDir, resolved, assetsRegistryFile)
+        await writePlugin(nitro, runtimeFiles.registryFile, assetsRegistryFile, resolved)
+      }
     })
 
     nitro.logger.info(`@vitehub/workspace enabled with ${definitions.length} workspace definition${definitions.length === 1 ? "" : "s"}`)

--- a/packages/workspace/test/discovery.test.ts
+++ b/packages/workspace/test/discovery.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
 
-import { discoverNitroWorkspaceDefinitions } from "../src/discovery.ts"
+import { createWorkspaceRegistryContents, discoverNitroWorkspaceDefinitions } from "../src/discovery.ts"
 
 const tempDirs: string[] = []
 
@@ -46,5 +46,15 @@ describe("discoverNitroWorkspaceDefinitions", () => {
     await writeFile(join(root, "server", "workspaces", "docs", ".config.ts"), "export default {}\n", "utf8")
 
     expect(() => discoverNitroWorkspaceDefinitions(root)).toThrow('Duplicate workspace name "docs"')
+  })
+
+  it("creates registry entries from discovered workspace definitions", async () => {
+    const root = await createRoot()
+    const registryFile = join(root, ".vitehub", "workspace", "registry.mjs")
+    await writeFile(join(root, "server", "workspaces", "docs.ts"), "export default {}\n", "utf8")
+
+    expect(createWorkspaceRegistryContents(registryFile, discoverNitroWorkspaceDefinitions(root))).toContain(
+      '"docs": async () => import(',
+    )
   })
 })


### PR DESCRIPTION
Brings the follow-up commits from the preview package branch back to main after several stacked PRs were merged into chore/pkg-pr-new-all-packages instead of main.

Includes the merged stack from #91, #92, #93, #94, and #95, plus the remaining branch commits that are not reachable from main.