### PR TITLE
feat(env): simplify declaration api

### DIFF
--- a/packages/chat/src/devtools.ts
+++ b/packages/chat/src/devtools.ts
@@ -142,7 +142,10 @@ interface ChatDevtoolsFullStreamToolPart {
 
 const chatDevtoolsToolStatusType = "vitehub.chat.devtools.tool"
 const defaultOutputPreviewLength = 4_000
-const chatDevtoolsClientDist = new URL("../dist/devtools-client", import.meta.url).pathname
+
+function resolveChatDevtoolsClientDist(): string {
+  return new URL("../dist/devtools-client", import.meta.url).pathname
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object"
@@ -562,7 +565,7 @@ export function chatDevTools(options: ChatDevToolsOptions = {}): ChatDevToolsPlu
         if (options.devtools === false) return
 
         registerViteHubDevtoolsPanel(ctx, {
-          distDir: chatDevtoolsClientDist,
+          distDir: resolveChatDevtoolsClientDist(),
           icon: "i-lucide-message-square",
           id: chatDevtoolsPanelId,
           route: chatDevtoolsRoute,

--- a/packages/chat/src/vite.ts
+++ b/packages/chat/src/vite.ts
@@ -26,7 +26,10 @@ export type ChatVitePlugin = Plugin & { nitro: NitroModule }
 const chatPackageName = "@vitehub/chat"
 const mergeNoExternal = createNoExternalMerger(chatPackageName)
 const cloudflareWorkersDevAlias = new URL("./runtime/cloudflare-workers-dev.js", import.meta.url).pathname
-const chatDevtoolsClientDist = fileURLToPath(new URL("../dist/devtools-client", import.meta.url))
+
+function resolveChatDevtoolsClientDist(): string {
+  return fileURLToPath(new URL("../dist/devtools-client", import.meta.url))
+}
 
 function isChatDevtoolsEnabled(chat: ChatModuleOptions | false | undefined): boolean {
   return chat !== false && chat?.dev !== false && chat?.dev?.devtools !== false
@@ -136,7 +139,7 @@ export function hubChat(options?: ChatModuleOptions): ChatVitePlugin {
         }
 
         registerViteHubDevtoolsPanel(ctx, {
-          distDir: chatDevtoolsClientDist,
+          distDir: resolveChatDevtoolsClientDist(),
           icon: "i-lucide-message-square",
           id: chatDevtoolsPanelId,
           route: chatDevtoolsRoute,

--- a/packages/env/docs/index.md
+++ b/packages/env/docs/index.md
@@ -13,20 +13,20 @@ Use Env when configuration needs to be explicit and typed instead of scattered a
 
 ::code-group
 ```ts [vite.config.ts]
-import { envSource, envVariable, envVite } from '@vitehub/env/vite'
+import { env, envVite } from '@vitehub/env/vite'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [envVite({ prefix: 'VITEHUB_' })],
   env: {
     define: {
-      __APP_VERSION__: envVariable({
+      __APP_VERSION__: env({
         mode: 'build',
-        source: envSource.packageJson('version'),
+        source: env.packageJson('version'),
       }),
     },
     public: {
-      appName: envVariable({
+      appName: env({
         default: 'ViteHub Env',
         mode: 'build',
       }),
@@ -36,14 +36,14 @@ export default defineConfig({
 ```
 
 ```ts [nitro.config.ts]
-import { envNitro, envVariable } from '@vitehub/env/nitro'
+import { env, envNitro } from '@vitehub/env/nitro'
 import { defineNitroConfig } from 'nitro/config'
 
 export default defineNitroConfig({
   modules: [envNitro()],
   env: {
     auth: {
-      token: envVariable({ secret: true }),
+      token: env({ secret: true }),
     },
   },
 })
@@ -100,11 +100,11 @@ Nitro handles server runtime values. Use nested `env` declarations, then read th
 
 ## Source model
 
-Each `envVariable()` declaration can read from:
+Each `env()` declaration can read from:
 
 - an inferred environment variable name
-- an explicit environment variable through `envSource.env(name)`
-- `package.json` through `envSource.packageJson(path)`
+- an explicit environment variable through `env.source(name)`
+- `package.json` through `env.packageJson(path)`
 - git branch or commit metadata
 - a custom build-only resolver
 

--- a/packages/env/docs/quickstart.md
+++ b/packages/env/docs/quickstart.md
@@ -42,14 +42,14 @@ pnpm add @vitehub/env
 Register `envVite()` and declare a public build value:
 
 ```ts [vite.config.ts]
-import { envVariable, envVite } from '@vitehub/env/vite'
+import { env, envVite } from '@vitehub/env/vite'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [envVite({ prefix: 'VITEHUB_' })],
   env: {
     public: {
-      appName: envVariable({
+      appName: env({
         default: 'ViteHub Env',
         mode: 'build',
       }),
@@ -63,14 +63,14 @@ export default defineConfig({
 Register the Nitro module and declare a server-only secret:
 
 ```ts [nitro.config.ts]
-import { envNitro, envVariable } from '@vitehub/env/nitro'
+import { env, envNitro } from '@vitehub/env/nitro'
 import { defineNitroConfig } from 'nitro/config'
 
 export default defineNitroConfig({
   modules: [envNitro()],
   env: {
     auth: {
-      token: envVariable({
+      token: env({
         secret: true,
       }),
     },

--- a/packages/env/docs/runtime-api.md
+++ b/packages/env/docs/runtime-api.md
@@ -14,14 +14,14 @@ Use this page when you need exact names and option fields. For a guided setup, s
 Shared helpers import from `@vitehub/env`:
 
 ```ts
-import { envSource, envVariable, parseSchema } from '@vitehub/env'
+import { env, parseSchema } from '@vitehub/env'
 ```
 
 ::fw{id="vite:dev vite:build"}
 Vite config imports from `@vitehub/env/vite`:
 
 ```ts
-import { envSource, envVariable, envVite } from '@vitehub/env/vite'
+import { env, envVite } from '@vitehub/env/vite'
 ```
 ::
 
@@ -29,7 +29,7 @@ import { envSource, envVariable, envVite } from '@vitehub/env/vite'
 Nitro config registers the module function:
 
 ```ts
-import { envNitro, envSource, envVariable } from '@vitehub/env/nitro'
+import { env, envNitro } from '@vitehub/env/nitro'
 
 export default defineNitroConfig({
   modules: [envNitro()],
@@ -43,10 +43,13 @@ import { useSafeRuntimeConfig } from '#vitehub/env/server'
 ```
 ::
 
-## `envVariable()`
+## `env()`
 
 ```ts
-function envVariable(options?: EnvVariableOptions): EnvVariableDeclaration
+const env: {
+  (options?: EnvVariableOptions): EnvVariableDeclaration
+  variable(options?: EnvVariableOptions): EnvVariableDeclaration
+}
 ```
 
 ```ts
@@ -76,14 +79,14 @@ interface EnvVariableOptions {
 ## Sources
 
 ```ts
-envSource.env(name)
-envSource.packageJson(path)
-envSource.gitBranch()
-envSource.gitCommit({ short: true })
-envSource.custom(label, resolver)
+env.source(name)
+env.packageJson(path)
+env.gitBranch()
+env.gitCommit({ short: true })
+env.custom(label, resolver)
 ```
 
-Runtime Nitro registries can serialize `envSource.env()` values. Build-time Vite declarations can also use package, git, and custom sources.
+Runtime Nitro registries can serialize `env.source()` values. Build-time Vite declarations can also use package, git, and custom sources.
 
 ## Vite plugin
 

--- a/packages/env/docs/troubleshooting.md
+++ b/packages/env/docs/troubleshooting.md
@@ -19,7 +19,7 @@ Fix: set the environment variable, add a safe `default`, or mark the declaration
 
 ```ts
 env: {
-  optionalApiBase: envVariable({
+  optionalApiBase: env({
     optional: true,
   }),
 }
@@ -34,9 +34,9 @@ Fix: use an explicit source when the provider uses a different name.
 ```ts
 env: {
   auth: {
-    token: envVariable({
+    token: env({
       secret: true,
-      source: envSource.env('TELEGRAM_BOT_TOKEN'),
+      source: env.source('TELEGRAM_BOT_TOKEN'),
     }),
   },
 }

--- a/packages/env/docs/usage.md
+++ b/packages/env/docs/usage.md
@@ -16,7 +16,7 @@ When a declaration has no explicit source, Env infers an environment variable na
 ```ts
 env: {
   auth: {
-    token: envVariable({ secret: true }),
+    token: env({ secret: true }),
   },
 }
 ```
@@ -39,7 +39,7 @@ Use `default` when local development can use a safe fallback.
 ```ts
 env: {
   app: {
-    name: envVariable({
+    name: env({
       default: 'Docs App',
     }),
   },
@@ -54,25 +54,25 @@ Use `optional: true` when missing values should resolve to `undefined`.
 
 ```ts
 env: {
-  optionalApiBase: envVariable({
+  optionalApiBase: env({
     optional: true,
   }),
 }
 ```
 
-Do not combine `optional` and `required`. `envVariable()` rejects declarations that set both.
+Do not combine `optional` and `required`. `env()` rejects declarations that set both.
 
 ## Use explicit sources
 
-Use `envSource.env()` when the env var name should not be inferred from the config path.
+Use `env.source()` when the env var name should not be inferred from the config path.
 
 ```ts
-import { envSource, envVariable } from '@vitehub/env/nitro'
+import { env } from '@vitehub/env/nitro'
 
 env: {
-  optionalApiBase: envVariable({
+  optionalApiBase: env({
     optional: true,
-    source: envSource.env('PUBLIC_API_BASE'),
+    source: env.source('PUBLIC_API_BASE'),
   }),
 }
 ```
@@ -80,17 +80,17 @@ env: {
 Use build-only sources for values that can be resolved during Vite config:
 
 ```ts
-import { envSource, envVariable } from '@vitehub/env/vite'
+import { env } from '@vitehub/env/vite'
 
 env: {
   define: {
-    __APP_VERSION__: envVariable({
+    __APP_VERSION__: env({
       mode: 'build',
-      source: envSource.packageJson('version'),
+      source: env.packageJson('version'),
     }),
-    __GIT_COMMIT__: envVariable({
+    __GIT_COMMIT__: env({
       mode: 'build',
-      source: envSource.gitCommit({ short: true }),
+      source: env.gitCommit({ short: true }),
     }),
   },
 }
@@ -113,7 +113,7 @@ const booleanSchema = {
 
 env: {
   define: {
-    __SENTRY_DEBUG__: envVariable({
+    __SENTRY_DEBUG__: env({
       mode: 'build',
       schema: booleanSchema,
       type: 'boolean',

--- a/packages/env/examples/nitro/nitro.config.ts
+++ b/packages/env/examples/nitro/nitro.config.ts
@@ -1,22 +1,22 @@
-import { envNitro, envSource, envVariable } from '@vitehub/env/nitro'
+import { env, envNitro } from '@vitehub/env/nitro'
 import { defineNitroConfig } from 'nitro/config'
 
 export default defineNitroConfig({
   modules: [envNitro()],
   env: {
     app: {
-      name: envVariable({
+      name: env({
         default: 'ViteHub Env',
       }),
     },
     auth: {
-      token: envVariable({
+      token: env({
         secret: true,
       }),
     },
-    optionalApiBase: envVariable({
+    optionalApiBase: env({
       optional: true,
-      source: envSource.env('PUBLIC_API_BASE'),
+      source: env.source('PUBLIC_API_BASE'),
     }),
   },
 })

--- a/packages/env/examples/showcase.json
+++ b/packages/env/examples/showcase.json
@@ -9,7 +9,7 @@
       "id": "cloudflare",
       "label": "Cloudflare",
       "icon": "i-simple-icons-cloudflare",
-      "configOverride": "  env: {\n    auth: {\n      token: envVariable({ secret: true }),\n    },\n  },",
+      "configOverride": "  env: {\n    auth: {\n      token: env({ secret: true }),\n    },\n  },",
       "envOverride": "AUTH_TOKEN=<auth-token>"
     },
     {
@@ -17,7 +17,7 @@
       "label": "Vercel",
       "icon": "i-simple-icons-vercel",
       "darkInvert": true,
-      "configOverride": "  env: {\n    auth: {\n      token: envVariable({ secret: true }),\n    },\n  },",
+      "configOverride": "  env: {\n    auth: {\n      token: env({ secret: true }),\n    },\n  },",
       "envOverride": "AUTH_TOKEN=<auth-token>"
     }
   ],

--- a/packages/env/examples/vite/vite.config.ts
+++ b/packages/env/examples/vite/vite.config.ts
@@ -1,17 +1,17 @@
-import { envSource, envVariable, envVite } from '@vitehub/env/vite'
+import { env, envVite } from '@vitehub/env/vite'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [envVite({ prefix: 'VITEHUB_' })],
   env: {
     define: {
-      __APP_VERSION__: envVariable({
+      __APP_VERSION__: env({
         mode: 'build',
-        source: envSource.packageJson('version'),
+        source: env.packageJson('version'),
       }),
     },
     public: {
-      appName: envVariable({
+      appName: env({
         default: 'ViteHub Env',
         mode: 'build',
       }),

--- a/packages/env/src/core/declarations.ts
+++ b/packages/env/src/core/declarations.ts
@@ -20,60 +20,72 @@ const defaultStringSchemas = new WeakMap<EnvVariableDeclaration, DefaultStringSc
 const defaultStringSchemaParsers = new WeakSet<DefaultStringSchema["safeParse"]>()
 defaultStringSchemaParsers.add(defaultStringSchema.safeParse)
 
-export const envSource = {
-  custom(label: string, resolver: EnvSourceResolver): EnvSource {
-    return {
-      kind: "custom",
-      label,
-      resolver,
-      serializable: false,
-    }
-  },
-  env(name: string): EnvSource {
-    return {
-      kind: "env",
-      label: `env:${name}`,
-      name,
-      serializable: true,
-    }
-  },
-  gitBranch(): EnvSource {
-    return {
-      kind: "git-branch",
-      label: "git:branch",
-      serializable: true,
-    }
-  },
-  gitCommit(options: { short?: boolean } = {}): EnvSource {
-    return {
-      kind: "git-commit",
-      label: "git:commit",
-      serializable: true,
-      short: options.short,
-    }
-  },
-  packageJson(path: string): EnvSource {
-    return {
-      kind: "package-json",
-      label: `package.json:${path}`,
-      path,
-      serializable: true,
-    }
-  },
+interface EnvNamespace {
+  (options?: EnvVariableOptions): EnvVariableDeclaration
+  custom: (label: string, resolver: EnvSourceResolver) => EnvSource
+  gitBranch: () => EnvSource
+  gitCommit: (options?: { short?: boolean }) => EnvSource
+  packageJson: (path: string) => EnvSource
+  source: (name: string) => EnvSource
+  variable: (options?: EnvVariableOptions) => EnvVariableDeclaration
 }
 
-export function envVariable(options: EnvVariableOptions = {}): EnvVariableDeclaration {
+function source(name: string): EnvSource {
+  return {
+    kind: "env",
+    label: `env:${name}`,
+    name,
+    serializable: true,
+  }
+}
+
+function custom(label: string, resolver: EnvSourceResolver): EnvSource {
+  return {
+    kind: "custom",
+    label,
+    resolver,
+    serializable: false,
+  }
+}
+
+function gitBranch(): EnvSource {
+  return {
+    kind: "git-branch",
+    label: "git:branch",
+    serializable: true,
+  }
+}
+
+function gitCommit(options: { short?: boolean } = {}): EnvSource {
+  return {
+    kind: "git-commit",
+    label: "git:commit",
+    serializable: true,
+    short: options.short,
+  }
+}
+
+function packageJson(path: string): EnvSource {
+  return {
+    kind: "package-json",
+    label: `package.json:${path}`,
+    path,
+    serializable: true,
+  }
+}
+
+function variable(options: EnvVariableOptions = {}): EnvVariableDeclaration {
   if (typeof options !== "object" || options === null || Array.isArray(options)) {
-    throw new TypeError("envVariable() only accepts a single options object.")
+    throw new TypeError("env() only accepts a single options object.")
   }
   if (options.optional && typeof options.required !== "undefined") {
-    throw new TypeError("envVariable() cannot use both optional and required.")
+    throw new TypeError("env() cannot use both optional and required.")
   }
 
   const required = options.optional ? false : options.required ?? true
 
   const source = typeof options.source === "function"
-    ? envSource.custom("custom", options.source)
+    ? custom("custom", options.source)
     : options.source
 
   const schema = options.schema ?? defaultStringSchema
@@ -98,6 +110,15 @@ export function envVariable(options: EnvVariableOptions = {}): EnvVariableDeclar
 
   return declaration
 }
+
+export const env: EnvNamespace = Object.assign(variable, {
+  custom: custom,
+  gitBranch: gitBranch,
+  gitCommit: gitCommit,
+  packageJson: packageJson,
+  source: source,
+  variable: variable,
+})
 
 export function isDefaultStringEnvVariable(declaration: EnvVariableDeclaration): boolean {
   return defaultStringSchemas.get(declaration) === declaration.schema

--- a/packages/env/src/core/resolve.ts
+++ b/packages/env/src/core/resolve.ts
@@ -168,7 +168,7 @@ function buildRegistry(declarations: EnvNitroConfigOptions | undefined, path: st
     }
     const source = resolveEnvSource(value, valuePath, prefix)
     if (source.kind !== "env") {
-      throw new EnvError(`Runtime declaration ${valuePath} must use envSource.env() in v1.`)
+      throw new EnvError(`Runtime declaration ${valuePath} must use env.source() in v1.`)
     }
     if (!isDefaultStringEnvVariable(value)) {
       throw new EnvError(`Runtime declaration ${valuePath} uses a custom schema, but Nitro runtime schemas cannot be serialized in v1.`)
@@ -231,7 +231,7 @@ function validateNitroDeclarations(declarations: EnvNitroConfigOptions, path: st
     const valuePath = `${path}.${key}`
     if (path === "env" && key === "public") {
       if (!isPlainRecord(value) || isEnvVariableDeclaration(value)) {
-        throw new EnvError("Invalid declaration at env.public. Use a nested object of public envVariable() declarations.")
+        throw new EnvError("Invalid declaration at env.public. Use a nested object of public env() declarations.")
       }
       validateNitroDeclarations(value as EnvNitroConfigOptions, valuePath)
       continue
@@ -254,7 +254,7 @@ function validateNitroDeclarations(declarations: EnvNitroConfigOptions, path: st
       continue
     }
     if (!isPlainRecord(value)) {
-      throw new EnvError(`Invalid declaration at ${valuePath}. Use envVariable(), a serializable literal, or a nested object.`)
+      throw new EnvError(`Invalid declaration at ${valuePath}. Use env(), a serializable literal, or a nested object.`)
     }
     validateNitroDeclarations(value as EnvNitroConfigOptions, valuePath)
   }
@@ -262,7 +262,7 @@ function validateNitroDeclarations(declarations: EnvNitroConfigOptions, path: st
 
 function assertEnvVariableDeclaration(path: string, declaration: unknown): asserts declaration is EnvVariableDeclaration {
   if (!isEnvVariableDeclaration(declaration)) {
-    throw new EnvError(`Invalid declaration at ${path}. Use envVariable().`)
+    throw new EnvError(`Invalid declaration at ${path}. Use env().`)
   }
 }
 

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,4 +1,4 @@
-export { envSource, envVariable } from "./core/declarations.ts"
+export { env } from "./core/declarations.ts"
 export { parseSchema } from "./schema.ts"
 export type { StandardSchemaV1 } from "./schema.ts"
 export type {

--- a/packages/env/src/nitro/module.ts
+++ b/packages/env/src/nitro/module.ts
@@ -5,13 +5,13 @@ import { writeFileIfChanged } from "@vitehub/internal/definition-catalog"
 import { assertNoVitePluginInNitro, resolveRuntimeEntry } from "@vitehub/internal/nitro"
 
 import { formatDiagnostics } from "../core/diagnostics.ts"
-import { envSource, envVariable } from "../core/declarations.ts"
+import { env } from "../core/declarations.ts"
 import { createRuntimeRegistry, isEnvVariableDeclaration, resolveEnvSource, validateEnvConfigShape } from "../core/resolve.ts"
 
 import type { EnvDiagnosticEntry, EnvIntegrationOptions, EnvNitroConfigOptions, EnvNitroUserConfig, EnvRegistryEntry, EnvRuntimeLiteralEntry, EnvRuntimeRegistry, EnvRuntimeRegistryValue } from "../types.ts"
 import type { Nitro, NitroModule } from "nitro/types"
 
-export { envSource, envVariable }
+export { env }
 
 const ENV_VITE_PLUGIN_NAME = "@vitehub/env/vite"
 

--- a/packages/env/src/vite.ts
+++ b/packages/env/src/vite.ts
@@ -4,7 +4,7 @@ import { writeFileIfChanged } from "@vitehub/internal/definition-catalog"
 import { loadEnv } from "vite"
 
 import { formatDiagnostics } from "./core/diagnostics.ts"
-import { envSource, envVariable } from "./core/declarations.ts"
+import { env } from "./core/declarations.ts"
 import { createSourceContext, resolveEnvEntries, validateEnvConfigShape } from "./core/resolve.ts"
 
 import type { EnvIntegrationOptions, EnvViteConfigOptions, EnvViteUserConfig } from "./types.ts"
@@ -15,7 +15,7 @@ export const ENV_BUILD_VIRTUAL_ID = "virtual:@vitehub/env/build"
 
 const RESOLVED_BUILD_VIRTUAL_ID = `\0${ENV_BUILD_VIRTUAL_ID}`
 
-export { envSource, envVariable }
+export { env }
 
 export interface EnvVitePluginAPI {
   getBuildConfig: () => Record<string, unknown>

--- a/packages/env/test/declarations.test.ts
+++ b/packages/env/test/declarations.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest"
 
-import { envSource, envVariable } from "../src/index.ts"
+import { env } from "../src/index.ts"
 import { defaultStringSchema } from "../src/core/declarations.ts"
 import { createRuntimeRegistry, resolveEnvSource, validateEnvConfigShape } from "../src/core/resolve.ts"
 import { parseSchema } from "../src/schema.ts"
 
 describe("env declarations", () => {
   it("defaults env variable declarations to required runtime strings", () => {
-    expect(envVariable()).toMatchObject({
+    expect(env()).toMatchObject({
       kind: "env-variable",
       mode: "runtime",
       required: true,
@@ -16,7 +16,7 @@ describe("env declarations", () => {
   })
 
   it("supports optional and secret env variable options", () => {
-    expect(envVariable({
+    expect(env({
       optional: true,
       secret: true,
     })).toMatchObject({
@@ -26,23 +26,23 @@ describe("env declarations", () => {
   })
 
   it("rejects conflicting optional and required options", () => {
-    expect(() => envVariable({
+    expect(() => env({
       optional: true,
       required: true,
     })).toThrow("cannot use both optional and required")
   })
 
   it("rejects legacy string arguments", () => {
-    expect(() => envVariable("DATABASE_URL" as never)).toThrow("single options object")
+    expect(() => env("DATABASE_URL" as never)).toThrow("single options object")
   })
 
   it("infers env sources from config paths and prefixes", () => {
-    expect(resolveEnvSource(envVariable(), "env.telegram.botToken")).toMatchObject({
+    expect(resolveEnvSource(env(), "env.telegram.botToken")).toMatchObject({
       kind: "env",
       label: "env:TELEGRAM_BOT_TOKEN",
       name: "TELEGRAM_BOT_TOKEN",
     })
-    expect(resolveEnvSource(envVariable(), "env.define.__APP_VERSION__", "VITEHUB_")).toMatchObject({
+    expect(resolveEnvSource(env(), "env.define.__APP_VERSION__", "VITEHUB_")).toMatchObject({
       kind: "env",
       label: "env:VITEHUB_DEFINE_APP_VERSION",
       name: "VITEHUB_DEFINE_APP_VERSION",
@@ -50,7 +50,7 @@ describe("env declarations", () => {
   })
 
   it("keeps explicit env source overrides", () => {
-    expect(resolveEnvSource(envVariable({ source: envSource.env("CUSTOM_NAME") }), "env.telegram.botToken")).toMatchObject({
+    expect(resolveEnvSource(env({ source: env.source("CUSTOM_NAME") }), "env.telegram.botToken")).toMatchObject({
       kind: "env",
       label: "env:CUSTOM_NAME",
       name: "CUSTOM_NAME",
@@ -58,21 +58,21 @@ describe("env declarations", () => {
   })
 
   it("creates built-in and custom sources", () => {
-    expect(envSource.packageJson("version")).toMatchObject({
+    expect(env.packageJson("version")).toMatchObject({
       kind: "package-json",
       label: "package.json:version",
       path: "version",
     })
-    expect(envSource.gitBranch()).toMatchObject({
+    expect(env.gitBranch()).toMatchObject({
       kind: "git-branch",
       label: "git:branch",
     })
-    expect(envSource.gitCommit({ short: true })).toMatchObject({
+    expect(env.gitCommit({ short: true })).toMatchObject({
       kind: "git-commit",
       label: "git:commit",
       short: true,
     })
-    expect(envSource.custom("custom:preview", () => true)).toMatchObject({
+    expect(env.custom("custom:preview", () => true)).toMatchObject({
       kind: "custom",
       label: "custom:preview",
       serializable: false,
@@ -81,36 +81,36 @@ describe("env declarations", () => {
 
   it("rejects flat runtime declarations in Vite config", () => {
     expect(() => validateEnvConfigShape({
-      databaseUrl: envVariable(),
+      databaseUrl: env(),
     }, "vite")).toThrow("Invalid declaration")
   })
 
   it("rejects nested Nitro server buckets", () => {
     expect(() => validateEnvConfigShape({
-      server: envVariable(),
+      server: env(),
     }, "nitro")).toThrow("`env.server` is not available")
   })
 
   it("rejects scalar Nitro public runtime declarations", () => {
     expect(() => validateEnvConfigShape({
-      public: envVariable(),
+      public: env(),
     }, "nitro")).toThrow("Invalid declaration at env.public")
   })
 
   it("accepts nested Nitro runtime declaration groups and public runtime transport", () => {
     expect(() => validateEnvConfigShape({
       public: {
-        apiBase: envVariable(),
+        apiBase: env(),
       },
       teams: {
-        appId: envVariable({ secret: true }),
+        appId: env({ secret: true }),
         appType: "SingleTenant",
       },
       telegram: {
-        botToken: envVariable({ secret: true }),
+        botToken: env({ secret: true }),
       },
       vertex: {
-        model: envVariable({ default: "gemini-3.1-pro-preview-customtools" }),
+        model: env({ default: "gemini-3.1-pro-preview-customtools" }),
       },
     }, "nitro")).not.toThrow()
   })
@@ -149,7 +149,7 @@ describe("env declarations", () => {
   it("rejects secret Nitro public runtime declarations", () => {
     expect(() => validateEnvConfigShape({
       public: {
-        apiBase: envVariable({ secret: true }),
+        apiBase: env({ secret: true }),
       },
     }, "nitro")).toThrow("env.public.apiBase cannot be marked secret")
   })
@@ -160,7 +160,7 @@ describe("env declarations", () => {
         appType: "SingleTenant",
       },
       telegram: {
-        botToken: envVariable({ secret: true }),
+        botToken: env({ secret: true }),
       },
     }, { prefix: "VITEHUB_" })).toMatchObject({
       teams: {
@@ -181,7 +181,7 @@ describe("env declarations", () => {
   })
 
   it("accepts default string schemas after config cloning", () => {
-    const declaration = envVariable({ default: "Docs App" })
+    const declaration = env({ default: "Docs App" })
     const schema = { ...(declaration.schema as Record<string, unknown>) }
 
     expect(createRuntimeRegistry({
@@ -202,7 +202,7 @@ describe("env declarations", () => {
 
     expect(() => createRuntimeRegistry({
       appName: {
-        ...envVariable({ default: "Docs App" }),
+        ...env({ default: "Docs App" }),
         schema: {
           __vitehubDefaultRuntimeSchema: marker,
         },
@@ -211,7 +211,7 @@ describe("env declarations", () => {
 
     expect(() => createRuntimeRegistry({
       appName: {
-        ...envVariable({ default: "Docs App" }),
+        ...env({ default: "Docs App" }),
         schema: {
           __vitehubDefaultRuntimeSchema: marker,
           safeParse: () => ({ data: 123, success: true }),
@@ -221,7 +221,7 @@ describe("env declarations", () => {
 
     expect(() => createRuntimeRegistry({
       appName: {
-        ...envVariable({ default: "Docs App" }),
+        ...env({ default: "Docs App" }),
         schema: {
           __vitehubDefaultRuntimeSchema: marker,
           "~standard": {
@@ -234,7 +234,7 @@ describe("env declarations", () => {
 
     expect(() => createRuntimeRegistry({
       appName: {
-        ...envVariable({ default: "Docs App" }),
+        ...env({ default: "Docs App" }),
         schema: Object.assign(Object.create({
           "~standard": {
             validate: () => ({ value: 123 }),
@@ -254,7 +254,7 @@ describe("env declarations", () => {
     }
     expect(() => createRuntimeRegistry({
       appName: {
-        ...envVariable({ default: "Docs App" }),
+        ...env({ default: "Docs App" }),
         schema: accessorSchema,
       },
     })).toThrow("custom schema")
@@ -288,7 +288,7 @@ describe("env declarations", () => {
     })
     expect(() => createRuntimeRegistry({
       appName: {
-        ...envVariable({ default: 123 as never }),
+        ...env({ default: 123 as never }),
         schema: proxySchema,
       },
     })).toThrow("Expected string")
@@ -296,15 +296,15 @@ describe("env declarations", () => {
 
   it("rejects non-string Nitro runtime types", () => {
     expect(() => createRuntimeRegistry({
-      sentryDebug: envVariable({ type: "boolean" }),
+      sentryDebug: env({ type: "boolean" }),
     })).toThrow("Nitro runtime values are strings")
   })
 
   it("rejects custom runtime sources in Nitro config", () => {
     expect(() => validateEnvConfigShape({
-      commit: envVariable({
+      commit: env({
         mode: "runtime",
-        source: envSource.gitCommit(),
+        source: env.gitCommit(),
       }),
     }, "nitro")).toThrow("build-only")
   })

--- a/packages/env/test/nitro.test.ts
+++ b/packages/env/test/nitro.test.ts
@@ -6,7 +6,7 @@ import { promisify } from "node:util"
 
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { envNitro, envSource, envVariable } from "../src/nitro.ts"
+import { env, envNitro } from "../src/nitro.ts"
 
 import { booleanSchema, stringSchema } from "./helpers.ts"
 
@@ -64,25 +64,25 @@ describe("Nitro module", () => {
           },
         },
         env: {
-          authSecret: envVariable({ secret: true }),
-          databaseUrl: envVariable(),
-          optionalApiBase: envVariable({ optional: true, source: envSource.env("PUBLIC_API_BASE") }),
+          authSecret: env({ secret: true }),
+          databaseUrl: env(),
+          optionalApiBase: env({ optional: true, source: env.source("PUBLIC_API_BASE") }),
           public: {
-            apiBase: envVariable({ source: envSource.env("PUBLIC_API_BASE") }),
+            apiBase: env({ source: env.source("PUBLIC_API_BASE") }),
           },
           teams: {
-            apiUrl: envVariable({ optional: true }),
-            appId: envVariable({ secret: true }),
-            appPassword: envVariable({ secret: true }),
-            appTenantId: envVariable({ secret: true }),
+            apiUrl: env({ optional: true }),
+            appId: env({ secret: true }),
+            appPassword: env({ secret: true }),
+            appTenantId: env({ secret: true }),
             appType: "SingleTenant",
           },
           telegram: {
-            apiBaseUrl: envVariable({ optional: true }),
-            botToken: envVariable({ secret: true }),
+            apiBaseUrl: env({ optional: true }),
+            botToken: env({ secret: true }),
           },
           vertex: {
-            model: envVariable({ default: "gemini-3.1-pro-preview-customtools" }),
+            model: env({ default: "gemini-3.1-pro-preview-customtools" }),
           },
         },
         preset: "cloudflare-module",
@@ -148,11 +148,11 @@ describe("Nitro module", () => {
         buildDir: join(root, ".nitro"),
         env: {
           teams: {
-            apiUrl: envVariable({ optional: true }),
-            appId: envVariable({ secret: true }),
+            apiUrl: env({ optional: true }),
+            appId: env({ secret: true }),
           },
           vertex: {
-            model: envVariable({ default: "gemini-3.1-pro-preview-customtools" }),
+            model: env({ default: "gemini-3.1-pro-preview-customtools" }),
           },
         },
         rootDir: root,
@@ -218,7 +218,7 @@ describe("Nitro module", () => {
         cloudflare: {},
         env: {
           telegram: {
-            botToken: envVariable({ secret: true }),
+            botToken: env({ secret: true }),
           },
         },
         rootDir: root,
@@ -240,7 +240,7 @@ describe("Nitro module", () => {
       options: {
         buildDir: join(root, ".nitro"),
         env: {
-          authSecret: envVariable({ secret: true }),
+          authSecret: env({ secret: true }),
         },
         rootDir: root,
         vite: {
@@ -362,7 +362,7 @@ describe("Nitro module", () => {
       options: {
         buildDir: join(root, ".nitro"),
         env: {
-          sentryDebug: envVariable({
+          sentryDebug: env({
             schema: booleanSchema(),
             type: "boolean",
           }),
@@ -378,7 +378,7 @@ describe("Nitro module", () => {
     process.env.AUTH_SECRET = "a".repeat(32)
 
     const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
-    const declaration = envVariable({ secret: true })
+    const declaration = env({ secret: true })
     const nitro: NitroStub = {
       hooks: { hook: vi.fn() },
       logger: { info: vi.fn() },
@@ -405,7 +405,7 @@ describe("Nitro module", () => {
       options: {
         buildDir: join(root, ".nitro"),
         env: {
-          apiKey: envVariable({
+          apiKey: env({
             schema: {
               __vitehubDefaultRuntimeSchema: "string",
               safeParse(input: unknown) {
@@ -423,7 +423,7 @@ describe("Nitro module", () => {
 
   it("rejects default runtime declarations that are mutated to custom schemas", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
-    const apiKey = envVariable()
+    const apiKey = env()
     apiKey.schema = stringSchema()
 
     const nitro: NitroStub = {
@@ -441,11 +441,11 @@ describe("Nitro module", () => {
 
   it("rejects custom runtime schemas that copy default runtime markers", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
-    const defaultDeclaration = envVariable()
+    const defaultDeclaration = env()
     const marker = (defaultDeclaration as unknown as Record<string, unknown>).__vitehubDefaultRuntimeSchema
     const schema = stringSchema() as ReturnType<typeof stringSchema> & { __vitehubDefaultRuntimeSchema?: unknown }
     schema.__vitehubDefaultRuntimeSchema = marker
-    const apiKey = envVariable({ schema })
+    const apiKey = env({ schema })
     const apiKeyRecord = apiKey as unknown as Record<string, unknown>
     apiKeyRecord.__vitehubDefaultRuntimeSchema = marker
 
@@ -464,13 +464,13 @@ describe("Nitro module", () => {
 
   it("rejects custom runtime schemas that spoof the default parser source", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
-    const defaultDeclaration = envVariable()
+    const defaultDeclaration = env()
     const marker = (defaultDeclaration as unknown as Record<string, unknown>).__vitehubDefaultRuntimeSchema
     const defaultSchema = defaultDeclaration.schema as { safeParse: (input: unknown) => unknown }
     const schema = stringSchema() as ReturnType<typeof stringSchema> & { __vitehubDefaultRuntimeSchema?: unknown }
     schema.__vitehubDefaultRuntimeSchema = marker
     schema.safeParse.toString = () => defaultSchema.safeParse.toString()
-    const apiKey = envVariable({ schema })
+    const apiKey = env({ schema })
     const apiKeyRecord = apiKey as unknown as Record<string, unknown>
     apiKeyRecord.__vitehubDefaultRuntimeSchema = marker
 
@@ -489,14 +489,14 @@ describe("Nitro module", () => {
 
   it("rejects custom runtime schemas registered through a forged global parser allowlist", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-env-nitro-"))
-    const defaultDeclaration = envVariable()
+    const defaultDeclaration = env()
     const marker = (defaultDeclaration as unknown as Record<string, unknown>).__vitehubDefaultRuntimeSchema
     const schema = stringSchema() as ReturnType<typeof stringSchema> & { __vitehubDefaultRuntimeSchema?: unknown }
     schema.__vitehubDefaultRuntimeSchema = marker
     const parsersKey = Symbol.for("vitehub.env.defaultRuntimeSchemaParsers")
     const forgedGlobal = globalThis as typeof globalThis & Record<symbol, WeakSet<typeof schema.safeParse> | undefined>
     forgedGlobal[parsersKey] = new WeakSet([schema.safeParse])
-    const apiKey = envVariable({ schema })
+    const apiKey = env({ schema })
     const apiKeyRecord = apiKey as unknown as Record<string, unknown>
     apiKeyRecord.__vitehubDefaultRuntimeSchema = marker
 
@@ -526,9 +526,9 @@ describe("Nitro module", () => {
       options: {
         buildDir: join(root, ".nitro"),
         env: {
-          commit: envVariable({
+          commit: env({
             schema: stringSchema(),
-            source: envSource.custom("custom", () => "abc123"),
+            source: env.custom("custom", () => "abc123"),
           }),
         },
         rootDir: root,

--- a/packages/env/test/nuxt.test.ts
+++ b/packages/env/test/nuxt.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { envVariable } from "../src/index.ts"
+import { env as vitehubEnv } from "../src/index.ts"
 
 interface NitroHarnessOptions {
   env?: unknown
@@ -83,8 +83,8 @@ describe("Nuxt module", () => {
       nuxt: unknown,
     ) => Promise<void>
     const env = {
-      authSecret: envVariable({ secret: true }),
-      databaseUrl: envVariable(),
+      authSecret: vitehubEnv.variable({ secret: true }),
+      databaseUrl: vitehubEnv.variable(),
     }
     const inlineOptions = { diagnostics: "trace" as const, prefix: "VITEHUB_" }
     const nuxt = createNuxtHarness({
@@ -140,9 +140,9 @@ describe("Nuxt module", () => {
       nuxt: unknown,
     ) => Promise<void>
     const env = {
-      authSecret: envVariable({ secret: true }),
+      authSecret: vitehubEnv.variable({ secret: true }),
       public: {
-        apiBase: envVariable(),
+        apiBase: vitehubEnv.variable(),
       },
     }
     const nuxt = createNuxtHarness({
@@ -174,11 +174,11 @@ describe("Nuxt module", () => {
       nuxt: unknown,
     ) => Promise<void>
     const initialEnv = {
-      authSecret: envVariable({ secret: true }),
+      authSecret: vitehubEnv.variable({ secret: true }),
     }
     const updatedEnv = {
-      authSecret: envVariable({ secret: true }),
-      databaseUrl: envVariable(),
+      authSecret: vitehubEnv.variable({ secret: true }),
+      databaseUrl: vitehubEnv.variable(),
     }
     const nuxt = createNuxtHarness({
       env: initialEnv,
@@ -223,7 +223,7 @@ describe("Nuxt module", () => {
       nuxt: unknown,
     ) => Promise<void>
     const env = {
-      authSecret: envVariable({ secret: true }),
+      authSecret: vitehubEnv.variable({ secret: true }),
     }
     const nuxt = createNuxtHarness({
       env,
@@ -243,7 +243,7 @@ describe("Nuxt module", () => {
       nuxt: unknown,
     ) => Promise<void>
     const env = {
-      authSecret: envVariable({ secret: true }),
+      authSecret: vitehubEnv.variable({ secret: true }),
     }
     const existingModule = { name: "@vitehub/env", setup: vi.fn() }
     const nuxt = createNuxtHarness({
@@ -265,7 +265,7 @@ describe("Nuxt module", () => {
     ) => Promise<void>
     const nuxt = createNuxtHarness({
       env: {
-        authSecret: envVariable({ secret: true }),
+        authSecret: vitehubEnv.variable({ secret: true }),
       },
       vite: {
         plugins: [{ name: "@vitehub/env/vite" }],

--- a/packages/env/test/types.test-d.ts
+++ b/packages/env/test/types.test-d.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, it } from "vitest"
 import type { Plugin } from "vite"
 import type { NitroModule } from "nitro/types"
 
-import { envSource, envVariable, type EnvVariableDeclaration } from "../src/index.ts"
+import { env, type EnvVariableDeclaration } from "../src/index.ts"
 import { envNitro } from "../src/nitro.ts"
 import { envVite } from "../src/vite.ts"
 
@@ -10,9 +10,10 @@ describe("types", () => {
   it("types framework integrations and declarations", () => {
     expectTypeOf(envVite()).toMatchTypeOf<Plugin>()
     expectTypeOf(envNitro()).toMatchTypeOf<NitroModule>()
-    expectTypeOf(envSource.gitCommit({ short: true }).label).toMatchTypeOf<string>()
-    expectTypeOf(envVariable({ secret: true })).toMatchTypeOf<EnvVariableDeclaration>()
+    expectTypeOf(env.gitCommit({ short: true }).label).toMatchTypeOf<string>()
+    expectTypeOf(env({ secret: true })).toMatchTypeOf<EnvVariableDeclaration>()
+    expectTypeOf(env.variable({ secret: true })).toMatchTypeOf<EnvVariableDeclaration>()
     // @ts-expect-error string shorthands were intentionally removed
-    envVariable("SECRET")
+    env("SECRET")
   })
 })

--- a/packages/env/test/vite.test.ts
+++ b/packages/env/test/vite.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 
 import { describe, expect, it, vi } from "vitest"
 
-import { envSource, envVariable, envVite } from "../src/vite.ts"
+import { env, envVite } from "../src/vite.ts"
 
 import { booleanSchema, stringSchema } from "./helpers.ts"
 
@@ -19,23 +19,23 @@ describe("Vite plugin", () => {
     const result = await configHook({
       env: {
         define: {
-          __APP_VERSION__: envVariable({
+          __APP_VERSION__: env({
             mode: "build",
             schema: stringSchema(),
-            source: envSource.packageJson("version"),
+            source: env.packageJson("version"),
           }),
-          __GIT_COMMIT__: envVariable({
+          __GIT_COMMIT__: env({
             mode: "build",
             schema: stringSchema(),
-            source: envSource.custom("git:commit", () => "abc123"),
+            source: env.custom("git:commit", () => "abc123"),
           }),
-          __SENTRY_DEBUG__: envVariable({
+          __SENTRY_DEBUG__: env({
             mode: "build",
             schema: booleanSchema(),
           }),
         },
         public: {
-          appName: envVariable({
+          appName: env({
             mode: "build",
             schema: stringSchema(),
           }),
@@ -78,7 +78,7 @@ describe("Vite plugin", () => {
     await configHook({
       env: {
         public: {
-          appName: envVariable({
+          appName: env({
             mode: "build",
             schema: stringSchema(),
           }),

--- a/playground/vite/vite.config.ts
+++ b/playground/vite/vite.config.ts
@@ -136,15 +136,15 @@ export default defineConfig(async () => {
   }
 
   if (buildMode === VITEHUB_MODES.env) {
-    const { envVariable, envVite } = await import("@vitehub/env/vite")
+    const { env, envVite } = await import("@vitehub/env/vite")
     return {
       ...baseConfig,
       env: {
         define: {
-          __VITEHUB_PLAYGROUND_ENV__: envVariable({ default: "enabled", mode: "build" }),
+          __VITEHUB_PLAYGROUND_ENV__: env({ default: "enabled", mode: "build" }),
         },
         public: {
-          appName: envVariable({ default: "Vite playground", mode: "build" }),
+          appName: env({ default: "Vite playground", mode: "build" }),
         },
       },
       plugins: [envVite()],


### PR DESCRIPTION
Replaces the old top-level env declaration helpers with a single `env` namespace. Declarations now use `env.variable()`, explicit environment variable sources use `env.source('NAME')`, and build-only sources remain grouped as `env.source.packageJson()`, `env.source.gitCommit()`, and related helpers.

This also updates Env docs, examples, playground usage, and tests to the new breaking API.