### PR TITLE
fix(chat): add inline webhook execution

### DIFF
--- a/packages/chat/src/cloudflare.ts
+++ b/packages/chat/src/cloudflare.ts
@@ -2,6 +2,7 @@ import { resolveChat } from "./index.ts"
 import { createChatRuntimeContext } from "./runtime/context.ts"
 import { defaultChatCloudflareDurableObjectName } from "./config.ts"
 import { createMemoryChatStateAdapter } from "./runtime/memory-state.ts"
+import { flushWaitUntilTasks } from "./runtime/wait-until.ts"
 
 import type { Chat, StateAdapter, WebhookOptions } from "chat"
 import type {
@@ -176,18 +177,32 @@ export function defineCloudflareChatHandler(
       waitUntil,
     })
 
-    const bot = await resolveChat(chat, runtimeContext)
-    const handler = getWebhook(bot, platform)
-    if (!handler) {
-      return new Response(`Unknown chat platform: ${platform}`, { status: 404 })
-    }
-
+    let caughtError: unknown
     try {
-      return await handler(request, { waitUntil }) as Response
+      try {
+        const bot = await resolveChat(chat, runtimeContext)
+        const handler = getWebhook(bot, platform)
+        if (!handler) {
+          return new Response(`Unknown chat platform: ${platform}`, { status: 404 })
+        }
+
+        return await handler(request, { waitUntil }) as Response
+      }
+      catch (error) {
+        caughtError = error
+        throw error
+      }
     }
     finally {
       if (processing === "inline") {
-        await Promise.all(pendingTasks)
+        try {
+          await flushWaitUntilTasks(pendingTasks)
+        }
+        catch (error) {
+          if (!caughtError) {
+            throw error
+          }
+        }
       }
     }
   }

--- a/packages/chat/src/nitro/handler.ts
+++ b/packages/chat/src/nitro/handler.ts
@@ -229,7 +229,10 @@ export function defineChatWebhookHandler(
     }
     catch (error) {
       caughtError = error
-      await hooks.callHook("error", error, context)
+      try {
+        await hooks.callHook("error", error, context)
+      }
+      catch {}
       if (processing === "inline") {
         try {
           await flushWaitUntilTasks(pendingTasks)

--- a/packages/chat/src/nitro/handler.ts
+++ b/packages/chat/src/nitro/handler.ts
@@ -230,6 +230,12 @@ export function defineChatWebhookHandler(
     catch (error) {
       caughtError = error
       await hooks.callHook("error", error, context)
+      if (processing === "inline") {
+        try {
+          await flushWaitUntilTasks(pendingTasks)
+        }
+        catch {}
+      }
       throw error
     }
   })

--- a/packages/chat/src/nitro/handler.ts
+++ b/packages/chat/src/nitro/handler.ts
@@ -5,6 +5,7 @@ import { resolveChat } from "../index.ts"
 import { createMemo } from "../runtime/context.ts"
 import { getChatDefinitionLifecycleHooks } from "../runtime/definition.ts"
 import { getChatRuntimeConfig } from "../runtime/nitro-runtime-config.ts"
+import { flushWaitUntilTasks } from "../runtime/wait-until.ts"
 
 import type { Chat, WebhookOptions } from "chat"
 import type { EventHandler, H3Event } from "h3"
@@ -189,30 +190,45 @@ export function defineChatWebhookHandler(
       waitUntil,
     }
 
+    let caughtError: unknown
     try {
-      await hooks.callHook("request", context)
-      const bot = await resolveChat(chat, context, { inferredName: options.inferredName })
-      await hooks.callHook("resolved", { ...context, bot })
-
-      const handler = getChatWebhook(bot, platform)
-      if (!handler) {
-        throw createError({
-          statusCode: 404,
-          statusMessage: `Unknown chat platform: ${platform}`,
-        })
-      }
-
-      await hooks.callHook("webhook", { ...context, bot })
       try {
-        return await handler(context.request!, { waitUntil })
+        try {
+          await hooks.callHook("request", context)
+          const bot = await resolveChat(chat, context, { inferredName: options.inferredName })
+          await hooks.callHook("resolved", { ...context, bot })
+
+          const handler = getChatWebhook(bot, platform)
+          if (!handler) {
+            throw createError({
+              statusCode: 404,
+              statusMessage: `Unknown chat platform: ${platform}`,
+            })
+          }
+
+          await hooks.callHook("webhook", { ...context, bot })
+          return await handler(context.request!, { waitUntil })
+        }
+        catch (error) {
+          caughtError = error
+          throw error
+        }
       }
       finally {
         if (processing === "inline") {
-          await Promise.all(pendingTasks)
+          try {
+            await flushWaitUntilTasks(pendingTasks)
+          }
+          catch (error) {
+            if (!caughtError) {
+              throw error
+            }
+          }
         }
       }
     }
     catch (error) {
+      caughtError = error
       await hooks.callHook("error", error, context)
       throw error
     }

--- a/packages/chat/src/runtime/wait-until.ts
+++ b/packages/chat/src/runtime/wait-until.ts
@@ -1,0 +1,7 @@
+export async function flushWaitUntilTasks(tasks: Promise<unknown>[]) {
+  const results = await Promise.allSettled(tasks)
+  const rejection = results.find(result => result.status === "rejected")
+  if (rejection) {
+    throw rejection.reason
+  }
+}

--- a/packages/chat/test/nitro.test.ts
+++ b/packages/chat/test/nitro.test.ts
@@ -268,6 +268,35 @@ describe("defineChatWebhookHandler", () => {
     expect(completed).toBe(true)
   })
 
+  it("flushes Nitro inline tasks when error hooks throw", async () => {
+    const { defineChatWebhookHandler } = await import("../src/nitro.ts")
+    const waitUntil = vi.fn()
+    let completed = false
+    const task = (async () => {
+      await Promise.resolve()
+      completed = true
+    })()
+    const webhook = vi.fn(() => {
+      throw new Error("webhook failed")
+    })
+    const handler = defineChatWebhookHandler({
+      webhooks: { telegram: webhook },
+    } as never, {
+      lifecycleHooks: {
+        error: (_error, context) => {
+          context.waitUntil(task)
+          throw new Error("error hook failed")
+        },
+      },
+      processing: "inline",
+    })
+
+    await expect(handler(createEvent("telegram", waitUntil) as never)).rejects.toThrow("webhook failed")
+
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(completed).toBe(true)
+  })
+
   it("forwards Node-style Nitro request bodies to webhooks", async () => {
     const { defineChatWebhookHandler } = await import("../src/nitro.ts")
     const webhook = vi.fn(async (request: Request) => new Response(await request.text()))

--- a/packages/chat/test/nitro.test.ts
+++ b/packages/chat/test/nitro.test.ts
@@ -140,6 +140,34 @@ describe("defineChatWebhookHandler", () => {
     expect(completed).toBe(true)
   })
 
+  it("awaits all Nitro inline tasks when one rejects", async () => {
+    const { defineChatWebhookHandler } = await import("../src/nitro.ts")
+    const waitUntil = vi.fn()
+    let completed = false
+    const rejected = (async () => {
+      await Promise.resolve()
+      throw new Error("task failed")
+    })()
+    const completedTask = (async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      completed = true
+    })()
+    const webhook = vi.fn((_request: Request, options: { waitUntil: (promise: Promise<unknown>) => void }) => {
+      options.waitUntil(rejected)
+      options.waitUntil(completedTask)
+      return new Response("ok")
+    })
+    const handler = defineChatWebhookHandler({
+      webhooks: { telegram: webhook },
+    } as never, { processing: "inline" })
+
+    await expect(handler(createEvent("telegram", waitUntil) as never)).rejects.toThrow("task failed")
+
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(completed).toBe(true)
+  })
+
   it("awaits Nitro inline tasks when the webhook throws", async () => {
     const { defineChatWebhookHandler } = await import("../src/nitro.ts")
     const waitUntil = vi.fn()
@@ -158,6 +186,58 @@ describe("defineChatWebhookHandler", () => {
 
     await expect(handler(createEvent("telegram", waitUntil) as never)).rejects.toThrow("webhook failed")
 
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(completed).toBe(true)
+  })
+
+  it("keeps Nitro webhook errors when inline tasks also reject", async () => {
+    const { defineChatWebhookHandler } = await import("../src/nitro.ts")
+    const waitUntil = vi.fn()
+    let completed = false
+    const rejected = Promise.reject(new Error("task failed"))
+    const completedTask = (async () => {
+      await Promise.resolve()
+      completed = true
+    })()
+    const webhook = vi.fn((_request: Request, options: { waitUntil: (promise: Promise<unknown>) => void }) => {
+      options.waitUntil(rejected)
+      options.waitUntil(completedTask)
+      throw new Error("webhook failed")
+    })
+    const handler = defineChatWebhookHandler({
+      webhooks: { telegram: webhook },
+    } as never, { processing: "inline" })
+
+    await expect(handler(createEvent("telegram", waitUntil) as never)).rejects.toThrow("webhook failed")
+
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(completed).toBe(true)
+  })
+
+  it("flushes Nitro inline tasks when lifecycle hooks fail before the webhook", async () => {
+    const { defineChatWebhookHandler } = await import("../src/nitro.ts")
+    const waitUntil = vi.fn()
+    let completed = false
+    const task = (async () => {
+      await Promise.resolve()
+      completed = true
+    })()
+    const webhook = vi.fn(() => new Response("ok"))
+    const handler = defineChatWebhookHandler({
+      webhooks: { telegram: webhook },
+    } as never, {
+      lifecycleHooks: {
+        request: context => context.waitUntil(task),
+        resolved: () => {
+          throw new Error("resolved failed")
+        },
+      },
+      processing: "inline",
+    })
+
+    await expect(handler(createEvent("telegram", waitUntil) as never)).rejects.toThrow("resolved failed")
+
+    expect(webhook).not.toHaveBeenCalled()
     expect(waitUntil).not.toHaveBeenCalled()
     expect(completed).toBe(true)
   })

--- a/packages/chat/test/nitro.test.ts
+++ b/packages/chat/test/nitro.test.ts
@@ -242,6 +242,32 @@ describe("defineChatWebhookHandler", () => {
     expect(completed).toBe(true)
   })
 
+  it("flushes Nitro inline tasks queued by error hooks", async () => {
+    const { defineChatWebhookHandler } = await import("../src/nitro.ts")
+    const waitUntil = vi.fn()
+    let completed = false
+    const task = (async () => {
+      await Promise.resolve()
+      completed = true
+    })()
+    const webhook = vi.fn(() => {
+      throw new Error("webhook failed")
+    })
+    const handler = defineChatWebhookHandler({
+      webhooks: { telegram: webhook },
+    } as never, {
+      lifecycleHooks: {
+        error: (_error, context) => context.waitUntil(task),
+      },
+      processing: "inline",
+    })
+
+    await expect(handler(createEvent("telegram", waitUntil) as never)).rejects.toThrow("webhook failed")
+
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(completed).toBe(true)
+  })
+
   it("forwards Node-style Nitro request bodies to webhooks", async () => {
     const { defineChatWebhookHandler } = await import("../src/nitro.ts")
     const webhook = vi.fn(async (request: Request) => new Response(await request.text()))

--- a/packages/chat/test/providers.test.ts
+++ b/packages/chat/test/providers.test.ts
@@ -156,6 +156,32 @@ describe("Cloudflare helpers", () => {
     expect(completed).toBe(true)
   })
 
+  it("awaits all raw Cloudflare inline tasks when one rejects", async () => {
+    const { defineCloudflareChatHandler } = await import("../src/cloudflare.ts")
+    const waitUntil = vi.fn()
+    let completed = false
+    const rejected = (async () => {
+      await Promise.resolve()
+      throw new Error("task failed")
+    })()
+    const completedTask = (async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      completed = true
+    })()
+    const webhook = vi.fn((_request: Request, options: { waitUntil: (promise: Promise<unknown>) => void }) => {
+      options.waitUntil(rejected)
+      options.waitUntil(completedTask)
+      return new Response("ok")
+    })
+    const handler = defineCloudflareChatHandler({ webhooks: { telegram: webhook } } as never, { processing: "inline" })
+
+    await expect(handler(new Request("https://example.com/api/webhooks/telegram"), {}, { waitUntil })).rejects.toThrow("task failed")
+
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(completed).toBe(true)
+  })
+
   it("awaits raw Cloudflare inline tasks when the webhook throws", async () => {
     const { defineCloudflareChatHandler } = await import("../src/cloudflare.ts")
     const waitUntil = vi.fn()
@@ -166,6 +192,28 @@ describe("Cloudflare helpers", () => {
     })()
     const webhook = vi.fn((_request: Request, options: { waitUntil: (promise: Promise<unknown>) => void }) => {
       options.waitUntil(task)
+      throw new Error("webhook failed")
+    })
+    const handler = defineCloudflareChatHandler({ webhooks: { telegram: webhook } } as never, { processing: "inline" })
+
+    await expect(handler(new Request("https://example.com/api/webhooks/telegram"), {}, { waitUntil })).rejects.toThrow("webhook failed")
+
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(completed).toBe(true)
+  })
+
+  it("keeps raw Cloudflare webhook errors when inline tasks also reject", async () => {
+    const { defineCloudflareChatHandler } = await import("../src/cloudflare.ts")
+    const waitUntil = vi.fn()
+    let completed = false
+    const rejected = Promise.reject(new Error("task failed"))
+    const completedTask = (async () => {
+      await Promise.resolve()
+      completed = true
+    })()
+    const webhook = vi.fn((_request: Request, options: { waitUntil: (promise: Promise<unknown>) => void }) => {
+      options.waitUntil(rejected)
+      options.waitUntil(completedTask)
       throw new Error("webhook failed")
     })
     const handler = defineCloudflareChatHandler({ webhooks: { telegram: webhook } } as never, { processing: "inline" })

--- a/packages/env/src/nitro/module.ts
+++ b/packages/env/src/nitro/module.ts
@@ -31,6 +31,7 @@ function createPluginContents(file: string, registryFile: string): string {
     "",
     "export default function vitehubEnvPlugin(nitroApp) {",
     "  setEnvRegistry(registry)",
+    "  globalThis.__vitehubApplyEnvRuntimeConfig = (runtimeConfig, event) => applyEnvRegistryToRuntimeConfig(runtimeConfig, event)",
     "  nitroApp?.hooks?.hook?.(\"request\", (event) => {",
     "    applyEnvRegistryToRuntimeConfig(useRuntimeConfig(), event)",
     "  })",

--- a/packages/env/src/nitro/module.ts
+++ b/packages/env/src/nitro/module.ts
@@ -160,6 +160,7 @@ export function envNitro(options: EnvIntegrationOptions = {}): NitroModule {
       nitro.options.alias ||= {}
       nitro.options.alias["@vitehub/env"] = resolveEntry("../index", "@vitehub/env")
       nitro.options.alias["#vitehub/env/server"] = resolveEntry("../runtime/server", "@vitehub/env/runtime/server")
+      nitro.options.alias["#vitehub/env/registry"] = registryFile
 
       nitro.options.plugins ||= []
       if (!nitro.options.plugins.includes(pluginFile)) {

--- a/packages/env/test/nitro.test.ts
+++ b/packages/env/test/nitro.test.ts
@@ -93,6 +93,7 @@ describe("Nitro module", () => {
     await envNitro({ diagnostics: "trace" }).setup(nitro as never)
 
     expect(nitro.options.alias?.["#vitehub/env/server"]).toContain("/packages/env/src/runtime/server.ts")
+    expect(nitro.options.alias?.["#vitehub/env/registry"]).toBe(join(root, ".vitehub/nitro-runtime/env/registry.mjs"))
     expect(nitro.options.plugins).toHaveLength(1)
     expect(nitro.options.handlers).toBeUndefined()
     expect(nitro.options.cloudflare?.wrangler?.secrets?.required).toEqual(["EXISTING_SECRET", "AUTH_SECRET", "TEAMS_APP_ID", "TEAMS_APP_PASSWORD", "TEAMS_APP_TENANT_ID", "TELEGRAM_BOT_TOKEN"])

--- a/packages/workflow/docs/providers/cloudflare.md
+++ b/packages/workflow/docs/providers/cloudflare.md
@@ -8,7 +8,7 @@ icon: i-simple-icons-cloudflare
 frameworks: [vite, nitro]
 ---
 
-Cloudflare hosting selects the Cloudflare provider automatically. You can also set it explicitly when local builds should emit Cloudflare output.
+Cloudflare hosting selects the Cloudflare provider automatically. Register the integration and ViteHub emits Workflow bindings for Cloudflare builds. You can also set `workflow.provider` explicitly when local builds should emit Cloudflare output.
 
 ::tabs{sync="framework"}
   :::tabs-item{label="Vite" icon="i-simple-icons-vite" class="p-4"}
@@ -18,9 +18,6 @@ Cloudflare hosting selects the Cloudflare provider automatically. You can also s
 
     export default defineConfig({
       plugins: [hubWorkflow()],
-      workflow: {
-        provider: 'cloudflare',
-      },
     })
     ```
   :::
@@ -31,9 +28,6 @@ Cloudflare hosting selects the Cloudflare provider automatically. You can also s
 
     export default defineNitroConfig({
       modules: ['@vitehub/workflow/nitro'],
-      workflow: {
-        provider: 'cloudflare',
-      },
     })
     ```
   :::

--- a/packages/workflow/docs/quickstart.md
+++ b/packages/workflow/docs/quickstart.md
@@ -18,7 +18,7 @@ Set up @vitehub/workflow in this app.
 
 - Install @vitehub/workflow
 - Register hubWorkflow() for Vite or @vitehub/workflow/nitro for Nitro
-- Configure workflow.provider as cloudflare or vercel
+- Configure workflow.provider only when the hosting provider cannot be inferred
 - Define welcome as a discovered workflow
 - Call runWorkflow('welcome', payload) from a route
 - Return the workflow run to the caller
@@ -41,7 +41,7 @@ Cloudflare uses runtime Workflow bindings. Vercel uses generated ViteHub runtime
 ### Register the integration
 
 ::fw{id="vite:dev vite:build"}
-Register the Vite plugin and choose the provider:
+Register the Vite plugin. Cloudflare and Vercel hosting are detected automatically; set `workflow.provider` only when you need to override the detected provider.
 
 ::tabs{sync="provider"}
   :::tabs-item{label="Cloudflare" icon="i-simple-icons-cloudflare" class="p-4"}
@@ -51,9 +51,6 @@ Register the Vite plugin and choose the provider:
 
     export default defineConfig({
       plugins: [hubWorkflow()],
-      workflow: {
-        provider: 'cloudflare',
-      },
     })
     ```
   :::
@@ -75,7 +72,7 @@ Register the Vite plugin and choose the provider:
 ::
 
 ::fw{id="nitro:dev nitro:build"}
-Register the Nitro module and choose the provider:
+Register the Nitro module. Cloudflare and Vercel hosting are detected automatically; set `workflow.provider` only when you need to override the detected provider.
 
 ::tabs{sync="provider"}
   :::tabs-item{label="Cloudflare" icon="i-simple-icons-cloudflare" class="p-4"}
@@ -84,9 +81,6 @@ Register the Nitro module and choose the provider:
 
     export default defineNitroConfig({
       modules: ['@vitehub/workflow/nitro'],
-      workflow: {
-        provider: 'cloudflare',
-      },
     })
     ```
   :::

--- a/packages/workflow/examples/nitro/nitro.config.ts
+++ b/packages/workflow/examples/nitro/nitro.config.ts
@@ -2,7 +2,4 @@ import { defineNitroConfig } from "nitro/config"
 
 export default defineNitroConfig({
   modules: ["@vitehub/workflow/nitro"],
-  workflow: {
-    provider: "cloudflare",
-  },
 })

--- a/packages/workflow/src/nitro/module.ts
+++ b/packages/workflow/src/nitro/module.ts
@@ -39,36 +39,19 @@ function resolveNitroWorkflowScanDirs(rootDir: string, scanDirs: string[] | unde
   return scanDirs?.length ? scanDirs : [resolve(rootDir, "server")]
 }
 
-function createNitroWorkflowPluginContents(file: string, registryFile: string, envRegistryAlias?: string) {
-  const envRuntimeImports = envRegistryAlias
-    ? [
-        "import envRegistry from \"#vitehub/env/registry\"",
-        "import { applyEnvRegistryToRuntimeConfig, setEnvRegistry as setViteHubEnvRegistry } from \"#vitehub/env/server\"",
-      ]
-    : []
-  const envRuntimeHelpers = envRegistryAlias
-    ? [
-        "",
-        "function applyWorkflowEnvRuntimeConfig(runtimeConfig, env) {",
-        "  setViteHubEnvRegistry(envRegistry)",
-        "  applyEnvRegistryToRuntimeConfig(runtimeConfig, { env: env || {} })",
-        "}",
-      ]
-    : [
-        "",
-        "function applyWorkflowEnvRuntimeConfig() {}",
-      ]
-
+function createNitroWorkflowPluginContents(file: string, registryFile: string) {
   return [
     "import { definePlugin as defineNitroPlugin } from \"nitro\"",
     "import { useRuntimeConfig } from \"nitro/runtime-config\"",
     "",
     "import { runCloudflareWorkflow } from \"@vitehub/workflow/runtime/cloudflare-runner\"",
     "import { enterWorkflowRuntimeEvent, setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry } from \"@vitehub/workflow/runtime/state\"",
-    ...envRuntimeImports,
     "",
     `import workflowRegistry from ${JSON.stringify(createImportPath(file, registryFile))}`,
-    ...envRuntimeHelpers,
+    "",
+    "function applyWorkflowEnvRuntimeConfig(runtimeConfig, env) {",
+    "  globalThis.__vitehubApplyEnvRuntimeConfig?.(runtimeConfig, { env: env || {} })",
+    "}",
     "",
     "export async function runNitroWorkflowDefinition(name, env, event, step) {",
     "  const runtimeConfig = useRuntimeConfig()",
@@ -121,14 +104,13 @@ interface RuntimeFiles { definitions: DiscoveredWorkflowDefinition[], pluginFile
 async function writeNitroWorkflowRuntimeFiles(nitro: Nitro): Promise<RuntimeFiles> {
   const registryFile = createNitroWorkflowRegistryPath(nitro.options.rootDir, nitro.options.buildDir)
   const pluginFile = createNitroWorkflowPluginPath(nitro.options.rootDir, nitro.options.buildDir)
-  const envRegistryAlias = nitro.options.alias?.["#vitehub/env/registry"]
   const definitions = discoverWorkflowDefinitions({
     mode: "nitro-server-workflows",
     scanDirs: resolveNitroWorkflowScanDirs(nitro.options.rootDir, nitro.options.scanDirs),
   })
 
   return await writeRuntimeRegistryFiles({
-    createPluginContents: (file, nextRegistryFile) => createNitroWorkflowPluginContents(file, nextRegistryFile, envRegistryAlias),
+    createPluginContents: createNitroWorkflowPluginContents,
     definitions,
     pluginFile,
     registryFile,

--- a/packages/workflow/src/nitro/module.ts
+++ b/packages/workflow/src/nitro/module.ts
@@ -39,18 +39,40 @@ function resolveNitroWorkflowScanDirs(rootDir: string, scanDirs: string[] | unde
   return scanDirs?.length ? scanDirs : [resolve(rootDir, "server")]
 }
 
-function createNitroWorkflowPluginContents(file: string, registryFile: string) {
+function createNitroWorkflowPluginContents(file: string, registryFile: string, envRegistryAlias?: string) {
+  const envRuntimeImports = envRegistryAlias
+    ? [
+        "import envRegistry from \"#vitehub/env/registry\"",
+        "import { applyEnvRegistryToRuntimeConfig, setEnvRegistry as setViteHubEnvRegistry } from \"#vitehub/env/server\"",
+      ]
+    : []
+  const envRuntimeHelpers = envRegistryAlias
+    ? [
+        "",
+        "function applyWorkflowEnvRuntimeConfig(runtimeConfig, env) {",
+        "  setViteHubEnvRegistry(envRegistry)",
+        "  applyEnvRegistryToRuntimeConfig(runtimeConfig, { env: env || {} })",
+        "}",
+      ]
+    : [
+        "",
+        "function applyWorkflowEnvRuntimeConfig() {}",
+      ]
+
   return [
     "import { definePlugin as defineNitroPlugin } from \"nitro\"",
     "import { useRuntimeConfig } from \"nitro/runtime-config\"",
     "",
     "import { runCloudflareWorkflow } from \"@vitehub/workflow/runtime/cloudflare-runner\"",
     "import { enterWorkflowRuntimeEvent, setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry } from \"@vitehub/workflow/runtime/state\"",
+    ...envRuntimeImports,
     "",
     `import workflowRegistry from ${JSON.stringify(createImportPath(file, registryFile))}`,
+    ...envRuntimeHelpers,
     "",
     "export async function runNitroWorkflowDefinition(name, env, event, step) {",
     "  const runtimeConfig = useRuntimeConfig()",
+    "  applyWorkflowEnvRuntimeConfig(runtimeConfig, env)",
     "  return await runCloudflareWorkflow({ config: runtimeConfig.workflow, env: env || {}, event, name, registry: workflowRegistry, step })",
     "}",
     "",
@@ -58,6 +80,7 @@ function createNitroWorkflowPluginContents(file: string, registryFile: string) {
     "",
     "const workflowNitroPlugin = defineNitroPlugin((nitroApp) => {",
     "  const runtimeConfig = useRuntimeConfig()",
+    "  applyWorkflowEnvRuntimeConfig(runtimeConfig)",
     "  setWorkflowRuntimeConfig(runtimeConfig.workflow)",
     "  setWorkflowRuntimeRegistry(workflowRegistry)",
     "",
@@ -99,13 +122,14 @@ interface RuntimeFiles { definitions: DiscoveredWorkflowDefinition[], pluginFile
 async function writeNitroWorkflowRuntimeFiles(nitro: Nitro): Promise<RuntimeFiles> {
   const registryFile = createNitroWorkflowRegistryPath(nitro.options.rootDir, nitro.options.buildDir)
   const pluginFile = createNitroWorkflowPluginPath(nitro.options.rootDir, nitro.options.buildDir)
+  const envRegistryAlias = nitro.options.alias?.["#vitehub/env/registry"]
   const definitions = discoverWorkflowDefinitions({
     mode: "nitro-server-workflows",
     scanDirs: resolveNitroWorkflowScanDirs(nitro.options.rootDir, nitro.options.scanDirs),
   })
 
   return await writeRuntimeRegistryFiles({
-    createPluginContents: createNitroWorkflowPluginContents,
+    createPluginContents: (file, nextRegistryFile) => createNitroWorkflowPluginContents(file, nextRegistryFile, envRegistryAlias),
     definitions,
     pluginFile,
     registryFile,

--- a/packages/workflow/src/nitro/module.ts
+++ b/packages/workflow/src/nitro/module.ts
@@ -80,7 +80,6 @@ function createNitroWorkflowPluginContents(file: string, registryFile: string, e
     "",
     "const workflowNitroPlugin = defineNitroPlugin((nitroApp) => {",
     "  const runtimeConfig = useRuntimeConfig()",
-    "  applyWorkflowEnvRuntimeConfig(runtimeConfig)",
     "  setWorkflowRuntimeConfig(runtimeConfig.workflow)",
     "  setWorkflowRuntimeRegistry(workflowRegistry)",
     "",

--- a/packages/workflow/test/config.test.ts
+++ b/packages/workflow/test/config.test.ts
@@ -11,6 +11,12 @@ describe("workflow config", () => {
     })
   })
 
+  it("infers cloudflare from hosting without workflow options", () => {
+    expect(normalizeWorkflowOptions(undefined, { hosting: "cloudflare-module" })).toEqual({
+      provider: "cloudflare",
+    })
+  })
+
   it("defaults to vercel", () => {
     expect(normalizeWorkflowOptions(undefined)).toEqual({
       provider: "vercel",

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -123,6 +123,28 @@ describe("Vite workflow provider outputs", () => {
     })
   }, 30_000)
 
+  it("applies @vitehub/env runtime config in Nitro Cloudflare workflows", async () => {
+    const rootDir = await createPlaygroundCopy("vitehub-workflow-nitro-env-")
+    const nitroConfig = join(rootDir, "nitro.config.ts")
+    const contents = await readFile(nitroConfig, "utf8")
+    await writeFile(nitroConfig, [
+      `import { env } from "@vitehub/env/nitro"`,
+      contents
+        .replace(`"@vitehub/workflow/nitro"`, `"@vitehub/env/nitro", "@vitehub/workflow/nitro"`)
+        .replace("  queue: {},", "  env: { vertex: { apiKey: env({ secret: true }) } },\n  queue: {},"),
+    ].join("\n"))
+
+    await execFileAsync("pnpm", ["exec", "nitro", "build", "--preset", "cloudflare-module"], {
+      cwd: rootDir,
+      env: { ...process.env, VITEHUB_NITRO_MODE: "workflow" },
+    })
+
+    const serverEntryContents = await readFile(join(rootDir, ".output", "server", "index.mjs"), "utf8")
+
+    expect(serverEntryContents).toContain("applyEnvRegistryToRuntimeConfig")
+    expect(serverEntryContents).toContain("VERTEX_API_KEY")
+  }, 30_000)
+
   it("does not emit Cloudflare workflow artifacts for Vercel provider overrides", async () => {
     const rootDir = await createPlaygroundCopy("vitehub-workflow-vercel-override-")
     const viteConfig = join(rootDir, "vite.config.ts")

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -143,6 +143,8 @@ describe("Vite workflow provider outputs", () => {
 
     expect(serverEntryContents).toContain("applyEnvRegistryToRuntimeConfig")
     expect(serverEntryContents).toContain("VERTEX_API_KEY")
+    expect(serverEntryContents).toContain("applyWorkflowEnvRuntimeConfig(runtimeConfig, env)")
+    expect(serverEntryContents).not.toContain("applyWorkflowEnvRuntimeConfig(runtimeConfig)\n  setWorkflowRuntimeConfig")
   }, 30_000)
 
   it("does not emit Cloudflare workflow artifacts for Vercel provider overrides", async () => {

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -103,6 +103,26 @@ describe("Vite workflow provider outputs", () => {
     expect(serverEntryContents).toContain('__vitehubRunNitroWorkflowDefinition("welcome"')
   }, 30_000)
 
+  it("infers Nitro Cloudflare workflow output when workflow options are omitted", async () => {
+    const rootDir = await createPlaygroundCopy("vitehub-workflow-nitro-cloudflare-inferred-")
+    const nitroConfig = join(rootDir, "nitro.config.ts")
+    await writeFile(nitroConfig, (await readFile(nitroConfig, "utf8")).replace("  workflow: workflowEnabled ? {} : false,\n", ""))
+
+    await execFileAsync("pnpm", ["exec", "nitro", "build", "--preset", "cloudflare-module"], {
+      cwd: rootDir,
+      env: { ...process.env, VITEHUB_NITRO_MODE: "workflow" },
+    })
+
+    const wrangler = JSON.parse(await readFile(join(rootDir, ".output", "server", "wrangler.json"), "utf8"))
+    const className = getCloudflareWorkflowClassName("welcome")
+
+    expect(wrangler.workflows).toContainEqual({
+      binding: "WORKFLOW_77656C636F6D65",
+      class_name: className,
+      name: "workflow--77656c636f6d65",
+    })
+  }, 30_000)
+
   it("does not emit Cloudflare workflow artifacts for Vercel provider overrides", async () => {
     const rootDir = await createPlaygroundCopy("vitehub-workflow-vercel-override-")
     const viteConfig = join(rootDir, "vite.config.ts")


### PR DESCRIPTION
Adds an explicit inline webhook execution mode for @vitehub/chat so Cloudflare and Nitro handlers can await webhook background tasks before returning the webhook response.

This keeps the existing deferred waitUntil behavior as the default, while allowing applications with long-running chat responses to avoid Cloudflare cancelling post-response waitUntil work and leaving fallback streaming messages stuck.

Checks run: pnpm --filter @vitehub/chat test; pnpm --filter @vitehub/chat typecheck.
