### PR TITLE
fix(workspace): load asset configs with jiti

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -63,6 +63,7 @@
     "defu": "^6.1.4",
     "exsolve": "^1.0.8",
     "isomorphic-git": "^1.37.6",
+    "jiti": "^2.6.1",
     "minimatch": "^10.1.1"
   },
   "peerDependencies": {

--- a/packages/workspace/src/build-assets.ts
+++ b/packages/workspace/src/build-assets.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url"
 import { createImportPath } from "@vitehub/internal/build/paths"
 import { listMatchingFiles } from "@vitehub/internal/definition-catalog"
 import { resolveRuntimeEntry } from "@vitehub/internal/nitro"
+import { createJiti } from "jiti"
 
 import { syncWorkspaceDefinition } from "./lifecycle.ts"
 import { normalizeSafeWorkspacePath } from "./path.ts"
@@ -42,6 +43,12 @@ function serializeContent(content: WorkspaceContent) {
   return `new Uint8Array(${JSON.stringify([...content])})`
 }
 
+const workspaceConfigLoader = createJiti(import.meta.url, { moduleCache: false })
+
+async function importWorkspaceConfig(path: string): Promise<{ default?: WorkspaceDefinitionInput }> {
+  return await workspaceConfigLoader.import(path)
+}
+
 function runtimeAssetsModulePath() {
   return resolveRuntimeEntry("./runtime/assets", "@vitehub/workspace/runtime/assets", import.meta.url)
 }
@@ -57,7 +64,7 @@ export async function syncDiscoveredWorkspaces(
   for (const definition of definitions) {
     if (!shouldBundleWorkspaceAssets(options.assets, definition.name)) continue
 
-    const mod = await import(pathToFileURL(definition.path).href) as { default?: WorkspaceDefinitionInput }
+    const mod = await importWorkspaceConfig(definition.path)
     if (!mod.default) throw new TypeError(`[vitehub] Workspace definition "${definition.name}" has no default export.`)
 
     const workspace = createWorkspace({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -943,6 +943,9 @@ importers:
       isomorphic-git:
         specifier: ^1.37.6
         version: 1.37.6
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
       minimatch:
         specifier: ^10.1.1
         version: 10.2.5


### PR DESCRIPTION
Moves the Quiver Chat pnpm patch upstream into `@vitehub/workspace`.

Workspace asset bundling now loads discovered workspace config files through `jiti` with module caching disabled, so TypeScript/config files can be evaluated during Nitro/Vite build output instead of relying on native dynamic import of the source path.
