### PR TITLE
feat(env): export generated runtime config types

### DIFF
--- a/packages/env/docs/usage.md
+++ b/packages/env/docs/usage.md
@@ -155,7 +155,17 @@ export default defineEventHandler((event) => {
 })
 ```
 
-The Nitro module also augments Nitro runtime config types with the generated shape.
+When application helpers need an explicit config type, import the generated type from the same module instead of declaring your own runtime config interface.
+
+```ts
+import type { RuntimeEnvConfig } from '#vitehub/env/server'
+
+export function createAgent(config: RuntimeEnvConfig) {
+  return createVertex({ apiKey: config.vertex.apiKey })(config.vertex.model)
+}
+```
+
+The Nitro module also augments Nitro runtime config and ViteHub Chat runtime config types with the generated shape.
 
 ## Enable diagnostics
 

--- a/packages/env/src/nitro/module.ts
+++ b/packages/env/src/nitro/module.ts
@@ -76,7 +76,6 @@ function createNitroServerTypes(registry: EnvRuntimeRegistry): string {
 function createNitroIntegrationTypes(registry: EnvRuntimeRegistry): string {
   const fields = createTypeFields(registry, 4)
   return [
-    "import \"@vitehub/chat\"",
     "import \"nitro/types\"",
     "",
     "declare module \"nitro/types\" {",

--- a/packages/env/src/nitro/module.ts
+++ b/packages/env/src/nitro/module.ts
@@ -39,32 +39,45 @@ function createPluginContents(file: string, registryFile: string): string {
   ].join("\n")
 }
 
-async function writeNitroTypes(nitro: Nitro, registry: EnvRuntimeRegistry): Promise<string> {
+async function writeNitroTypes(nitro: Nitro, registry: EnvRuntimeRegistry): Promise<string[]> {
   const dtsPath = resolve(nitro.options.buildDir, "types", "vitehub-env.d.ts")
-  await writeFileIfChanged(dtsPath, createNitroTypes(registry))
-  return dtsPath
+  const integrationsDtsPath = resolve(nitro.options.buildDir, "types", "vitehub-env-integrations.d.ts")
+  await writeFileIfChanged(dtsPath, createNitroServerTypes(registry))
+  await writeFileIfChanged(integrationsDtsPath, createNitroIntegrationTypes(registry))
+  return [dtsPath, integrationsDtsPath]
 }
 
 async function installNitroTypes(nitro: Nitro, registry: EnvRuntimeRegistry): Promise<void> {
   await writeNitroTypes(nitro, registry)
   nitro.hooks.hook("types:extend", async (types: { tsConfig?: { include?: string[] } }) => {
-    const dtsPath = await writeNitroTypes(nitro, registry)
+    const dtsPaths = await writeNitroTypes(nitro, registry)
     if (types.tsConfig) {
       types.tsConfig.include ||= []
-      types.tsConfig.include.push(dtsPath)
+      types.tsConfig.include.push(...dtsPaths)
     }
   })
 }
 
-function createNitroTypes(registry: EnvRuntimeRegistry): string {
+function createNitroServerTypes(registry: EnvRuntimeRegistry): string {
   const fields = createTypeFields(registry, 4)
   return [
     "declare module \"#vitehub/env/server\" {",
     "  export interface SafeRuntimeConfig {",
     ...fields,
     "  }",
+    "  export type RuntimeEnvConfig = SafeRuntimeConfig",
+    "  export type ViteHubEnvConfig = SafeRuntimeConfig",
     "  export function useSafeRuntimeConfig(event?: unknown): SafeRuntimeConfig",
     "}",
+    "",
+  ].join("\n")
+}
+
+function createNitroIntegrationTypes(registry: EnvRuntimeRegistry): string {
+  const fields = createTypeFields(registry, 4)
+  return [
+    "import \"@vitehub/chat\"",
+    "import \"nitro/types\"",
     "",
     "declare module \"nitro/types\" {",
     "  export interface NitroRuntimeConfig {",

--- a/packages/env/test/nitro.test.ts
+++ b/packages/env/test/nitro.test.ts
@@ -124,7 +124,7 @@ describe("Nitro module", () => {
     expect(types).toContain("useSafeRuntimeConfig(event?: unknown): SafeRuntimeConfig")
     expect(types).not.toContain("declare module \"nitro/types\"")
     expect(types).not.toContain("export {}")
-    expect(integrationTypes).toContain("import \"@vitehub/chat\"")
+    expect(integrationTypes).not.toContain("import \"@vitehub/chat\"")
     expect(integrationTypes).toContain("import \"nitro/types\"")
     expect(integrationTypes).toContain("declare module \"nitro/types\"")
     expect(integrationTypes).toContain("export interface NitroRuntimeConfig")

--- a/packages/env/test/nitro.test.ts
+++ b/packages/env/test/nitro.test.ts
@@ -106,6 +106,7 @@ describe("Nitro module", () => {
     const tsConfig = { include: [] as string[] }
     await typesHook?.({ tsConfig })
     const types = await readFile(join(root, ".nitro/types/vitehub-env.d.ts"), "utf8")
+    const integrationTypes = await readFile(join(root, ".nitro/types/vitehub-env-integrations.d.ts"), "utf8")
     expect(types).toContain("export interface SafeRuntimeConfig")
     expect(types).toContain("\"databaseUrl\": string")
     expect(types).toContain("\"optionalApiBase\": string | undefined")
@@ -118,14 +119,23 @@ describe("Nitro module", () => {
     expect(types).toContain("\"botToken\": string")
     expect(types).toContain("\"vertex\": {")
     expect(types).toContain("\"model\": string")
+    expect(types).toContain("export type RuntimeEnvConfig = SafeRuntimeConfig")
+    expect(types).toContain("export type ViteHubEnvConfig = SafeRuntimeConfig")
     expect(types).toContain("useSafeRuntimeConfig(event?: unknown): SafeRuntimeConfig")
-    expect(types).toContain("declare module \"nitro/types\"")
-    expect(types).toContain("export interface NitroRuntimeConfig")
-    expect(types).toContain("declare module \"@vitehub/chat\"")
-    expect(types).toContain("export interface ChatRuntimeConfig")
+    expect(types).not.toContain("declare module \"nitro/types\"")
+    expect(types).not.toContain("export {}")
+    expect(integrationTypes).toContain("import \"@vitehub/chat\"")
+    expect(integrationTypes).toContain("import \"nitro/types\"")
+    expect(integrationTypes).toContain("declare module \"nitro/types\"")
+    expect(integrationTypes).toContain("export interface NitroRuntimeConfig")
+    expect(integrationTypes).toContain("declare module \"@vitehub/chat\"")
+    expect(integrationTypes).toContain("export interface ChatRuntimeConfig")
     expect(types).toContain("\"botToken\": string")
-    expect(types).not.toContain("NitroChatRuntimeConfig")
+    expect(integrationTypes).toContain("\"botToken\": string")
+    expect(integrationTypes).not.toContain("NitroChatRuntimeConfig")
+    expect(integrationTypes).toContain("export {}")
     expect(tsConfig.include).toContain(join(root, ".nitro/types/vitehub-env.d.ts"))
+    expect(tsConfig.include).toContain(join(root, ".nitro/types/vitehub-env-integrations.d.ts"))
 
     const registry = await readFile(join(root, ".vitehub/nitro-runtime/env/registry.mjs"), "utf8")
     expect(registry).toContain("DATABASE_URL")
@@ -198,6 +208,81 @@ describe("Nitro module", () => {
       },
       files: [
         join(root, ".nitro/types/vitehub-env.d.ts"),
+        join(root, ".nitro/types/vitehub-env-integrations.d.ts"),
+        join(root, "typecheck.ts"),
+      ],
+    }, null, 2))
+
+    await execFileAsync("pnpm", ["exec", "tsc", "--noEmit", "-p", join(root, "tsconfig.json")], {
+      cwd: join(import.meta.dirname, ".."),
+      maxBuffer: 1024 * 1024 * 4,
+    })
+  })
+
+  it("exports generated runtime config types for application code", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-env-runtime-types-"))
+    const nitro: NitroStub = {
+      hooks: { hook: vi.fn() },
+      logger: { info: vi.fn() },
+      options: {
+        buildDir: join(root, ".nitro"),
+        env: {
+          telegram: {
+            apiBaseUrl: env({ optional: true }),
+            botToken: env({ secret: true }),
+          },
+          vertex: {
+            apiKey: env({ secret: true }),
+            model: env({ default: "gemini-3.1-pro-preview-customtools" }),
+          },
+        },
+        rootDir: root,
+      },
+    }
+
+    await envNitro().setup(nitro as never)
+    const typesHook = nitro.hooks.hook.mock.calls.find(([name]) => name === "types:extend")?.[1]
+    await typesHook?.({ tsConfig: { include: [] } })
+
+    await writeFile(join(root, "typecheck.ts"), [
+      "import { useSafeRuntimeConfig } from '#vitehub/env/server'",
+      "import type { RuntimeEnvConfig, SafeRuntimeConfig, ViteHubEnvConfig } from '#vitehub/env/server'",
+      "",
+      "function createAgent(config: RuntimeEnvConfig) {",
+      "  const apiKey: string = config.vertex.apiKey",
+      "  const model: string = config.vertex.model",
+      "  void apiKey",
+      "  void model",
+      "}",
+      "",
+      "function createTelegramAdapter(config: ViteHubEnvConfig) {",
+      "  const apiBaseUrl: string | undefined = config.telegram.apiBaseUrl",
+      "  const botToken: string = config.telegram.botToken",
+      "  void apiBaseUrl",
+      "  void botToken",
+      "}",
+      "",
+      "const config: SafeRuntimeConfig = useSafeRuntimeConfig()",
+      "createAgent(config)",
+      "createTelegramAdapter(config)",
+      "",
+    ].join("\n"), "utf8")
+    await writeFile(join(root, "tsconfig.json"), JSON.stringify({
+      compilerOptions: {
+        allowSyntheticDefaultImports: true,
+        allowImportingTsExtensions: true,
+        baseUrl: root,
+        ignoreDeprecations: "6.0",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        noEmit: true,
+        skipLibCheck: true,
+        strict: true,
+        target: "ES2023",
+      },
+      files: [
+        join(root, ".nitro/types/vitehub-env.d.ts"),
+        join(root, ".nitro/types/vitehub-env-integrations.d.ts"),
         join(root, "typecheck.ts"),
       ],
     }, null, 2))


### PR DESCRIPTION
Exports generated runtime config aliases from `#vitehub/env/server` so application code can use env-driven types without declaring local runtime config interfaces.

The Nitro env type generator now emits `RuntimeEnvConfig` and `ViteHubEnvConfig` aliases alongside `SafeRuntimeConfig`, keeps the existing Nitro and `@vitehub/chat` augmentation behavior, and documents the preferred helper typing pattern.

Checked with `pnpm --filter @vitehub/env test -- --runInBand`.
