### PR TITLE
feat(chat): stream DevTools responses

### DIFF
--- a/packages/chat/examples/nitro/package.json
+++ b/packages/chat/examples/nitro/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@chat-adapter/telegram": "^4.27.0",
     "@vitehub/chat": "workspace:*",
-    "@vitejs/devtools": "^0.1.18",
+    "@vitejs/devtools": "catalog:",
     "chat": "catalog:",
     "chat-state-cloudflare-do": "catalog:",
     "nitro": "catalog:",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -54,7 +54,7 @@
     "test": "pnpm --filter @vitehub/chat build && vitest run"
   },
   "dependencies": {
-    "@vitejs/devtools-kit": "^0.1.18",
+    "@vitejs/devtools-kit": "catalog:",
     "@vercel/functions": "^3.4.3",
     "h3": "2.0.1-rc.20",
     "hookable": "^6.1.1"

--- a/packages/chat/src/cloudflare.ts
+++ b/packages/chat/src/cloudflare.ts
@@ -9,6 +9,7 @@ import type {
   ChatInput,
   ChatRuntimeContext,
   ChatWaitUntil,
+  ChatWebhookProcessingMode,
   CloudflareExportedHandlerFetchHandler,
   CloudflareDurableObjectStateOptions,
 } from "./types.ts"
@@ -151,7 +152,7 @@ export function cloudflareDurableObjectState(
 
 export function defineCloudflareChatHandler(
   chat: ChatInput<ChatRuntimeContext>,
-  options: { platform?: string } = {},
+  options: { processing?: ChatWebhookProcessingMode, platform?: string } = {},
 ): CloudflareExportedHandlerFetchHandler<Record<string, unknown>> {
   return async (request, env, executionContext) => {
     const platform = options.platform || inferPlatform(request)
@@ -159,7 +160,11 @@ export function defineCloudflareChatHandler(
       return new Response("Missing chat platform.", { status: 400 })
     }
 
-    const waitUntil: ChatWaitUntil = task => executionContext.waitUntil?.(task)
+    const pendingTasks: Promise<unknown>[] = []
+    const processing = options.processing || "defer"
+    const waitUntil: ChatWaitUntil = processing === "inline"
+      ? task => pendingTasks.push(task)
+      : task => executionContext.waitUntil?.(task)
     const runtimeContext = createChatRuntimeContext({
       cloudflare: {
         context: executionContext,
@@ -177,6 +182,13 @@ export function defineCloudflareChatHandler(
       return new Response(`Unknown chat platform: ${platform}`, { status: 404 })
     }
 
-    return await handler(request, { waitUntil }) as Response
+    try {
+      return await handler(request, { waitUntil }) as Response
+    }
+    finally {
+      if (processing === "inline") {
+        await Promise.all(pendingTasks)
+      }
+    }
   }
 }

--- a/packages/chat/src/config.ts
+++ b/packages/chat/src/config.ts
@@ -3,6 +3,7 @@ import type { ChatModuleOptions, ResolvedChatModuleOptions } from "./types.ts"
 const defaultChatWebhookRoute = "/api/webhooks/[platform]"
 const defaultChatWebhookChatParam = "chat"
 const defaultChatWebhookRouteParam = "platform"
+const defaultChatWebhookProcessing = "defer"
 const defaultChatCloudflareDurableObjectBinding = "CHAT_STATE"
 const defaultChatCloudflareDurableObjectClassName = "ChatStateDO"
 const defaultChatCloudflareDurableObjectMigrationTag = "v1"
@@ -22,6 +23,7 @@ function normalizeWebhookOptions(webhook: ChatModuleOptions["webhook"]): Resolve
   if (typeof webhook === "string") {
     return {
       chatParam: defaultChatWebhookChatParam,
+      processing: defaultChatWebhookProcessing,
       route: webhook,
       routeParam: defaultChatWebhookRouteParam,
     }
@@ -29,6 +31,7 @@ function normalizeWebhookOptions(webhook: ChatModuleOptions["webhook"]): Resolve
 
   return {
     chatParam: webhook?.chatParam || defaultChatWebhookChatParam,
+    processing: webhook?.processing || defaultChatWebhookProcessing,
     route: webhook?.route || defaultChatWebhookRoute,
     routeParam: webhook?.routeParam || defaultChatWebhookRouteParam,
   }

--- a/packages/chat/src/devtools-shared.ts
+++ b/packages/chat/src/devtools-shared.ts
@@ -49,8 +49,7 @@ export interface ChatDevtoolsClearInput {
   chat?: string
 }
 
-export interface ChatDevtoolsSendResult {
-  state: ChatDevtoolsStateResult
+export interface ChatDevtoolsSendResult extends ChatDevtoolsStateResult {
   streamId: string
 }
 

--- a/packages/chat/src/devtools-shared.ts
+++ b/packages/chat/src/devtools-shared.ts
@@ -5,6 +5,7 @@ export const chatDevtoolsBridgeRoute = "/__vitehub/chat/devtools"
 export const chatDevtoolsGetStateRpc = "@vitehub/chat:get-state"
 export const chatDevtoolsSendRpc = "@vitehub/chat:send"
 export const chatDevtoolsClearRpc = "@vitehub/chat:clear"
+export const chatDevtoolsStreamChannel = "@vitehub/chat:stream"
 export const chatDevtoolsUrlEnv = "VITEHUB_CHAT_DEVTOOLS_URL"
 export const chatDevtoolsAdapterName = "devtools"
 
@@ -47,3 +48,13 @@ export interface ChatDevtoolsSendInput {
 export interface ChatDevtoolsClearInput {
   chat?: string
 }
+
+export interface ChatDevtoolsSendResult {
+  state: ChatDevtoolsStateResult
+  streamId: string
+}
+
+export type ChatDevtoolsStreamEvent =
+  | { state: ChatDevtoolsStateResult, type: "state" }
+  | { type: "done" }
+  | { message: string, type: "error" }

--- a/packages/chat/src/devtools.ts
+++ b/packages/chat/src/devtools.ts
@@ -660,9 +660,10 @@ export function chatDevTools(options: ChatDevToolsOptions = {}): ChatDevToolsPlu
               }
               const stream = chatStream.start()
               void writeChatDevtoolsStream(ctx, route, { action: "send", ...input }, stream)
+              const state = await postChatDevtoolsBridge(ctx, route, { action: "get-state" })
               return {
+                ...state,
                 streamId: stream.id,
-                state: await postChatDevtoolsBridge(ctx, route, { action: "get-state" }),
               }
             },
           }),

--- a/packages/chat/src/devtools.ts
+++ b/packages/chat/src/devtools.ts
@@ -10,6 +10,7 @@ import {
   chatDevtoolsPanelId,
   chatDevtoolsRoute,
   chatDevtoolsSendRpc,
+  chatDevtoolsStreamChannel,
   chatDevtoolsTitle,
   chatDevtoolsUrlEnv,
 } from "./devtools-shared.js"
@@ -24,7 +25,9 @@ import type {
   ChatDevtoolsMessage,
   ChatDevtoolsMessageRole,
   ChatDevtoolsSendInput,
+  ChatDevtoolsSendResult,
   ChatDevtoolsStateResult,
+  ChatDevtoolsStreamEvent,
   ChatDevtoolsTool,
   ChatDevtoolsToolStatus,
 } from "./devtools-shared.js"
@@ -37,6 +40,7 @@ export {
   chatDevtoolsPanelId,
   chatDevtoolsRoute,
   chatDevtoolsSendRpc,
+  chatDevtoolsStreamChannel,
   chatDevtoolsTitle,
   chatDevtoolsUrlEnv,
 } from "./devtools-shared.js"
@@ -47,7 +51,9 @@ export type {
   ChatDevtoolsMessage,
   ChatDevtoolsMessageRole,
   ChatDevtoolsSendInput,
+  ChatDevtoolsSendResult,
   ChatDevtoolsStateResult,
+  ChatDevtoolsStreamEvent,
   ChatDevtoolsTool,
   ChatDevtoolsToolStatus,
 } from "./devtools-shared.js"
@@ -535,6 +541,64 @@ async function postChatDevtoolsBridge(ctx: ViteDevToolsNodeContext, route: strin
   return await response.json() as ChatDevtoolsStateResult
 }
 
+async function writeChatDevtoolsStream(
+  ctx: ViteDevToolsNodeContext,
+  route: string,
+  body: ChatDevtoolsBridgeRequest,
+  stream: { close: () => void, error: (error: unknown) => void, signal: AbortSignal, write: (event: ChatDevtoolsStreamEvent) => unknown },
+): Promise<void> {
+  try {
+    const response = await fetch(new URL(route, resolveViteServerUrl(ctx)), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...body, stream: true }),
+      signal: stream.signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`Chat DevTools bridge failed with ${response.status}: ${await response.text()}`)
+    }
+    if (!response.body) {
+      throw new Error("Chat DevTools bridge did not return a stream.")
+    }
+
+    const decoder = new TextDecoder()
+    const reader = response.body.getReader()
+    let pending = ""
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      pending += decoder.decode(value, { stream: true })
+      const lines = pending.split("\n")
+      pending = lines.pop() || ""
+      for (const line of lines) {
+        if (!line.trim()) continue
+        const event = JSON.parse(line) as ChatDevtoolsStreamEvent
+        if (event.type === "error") {
+          stream.write(event)
+          stream.close()
+          return
+        }
+        if (event.type === "done") {
+          stream.close()
+          return
+        }
+        stream.write(event)
+      }
+    }
+    const tail = pending.trim()
+    if (tail) {
+      stream.write(JSON.parse(tail) as ChatDevtoolsStreamEvent)
+    }
+    stream.close()
+  }
+  catch (cause) {
+    if (!stream.signal.aborted) {
+      stream.error(cause)
+    }
+  }
+}
+
 export function chatDevTools(options: ChatDevToolsOptions = {}): ChatDevToolsPlugin {
   const route = options.route || chatDevtoolsBridgeRoute
   const devtoolsUrl = options.devtools && typeof options.devtools === "object"
@@ -564,6 +628,12 @@ export function chatDevTools(options: ChatDevToolsOptions = {}): ChatDevToolsPlu
       setup(ctx) {
         if (options.devtools === false) return
 
+        const streaming = (ctx.rpc as { streaming?: { create: <T>(name: string, options?: { closedStreamRetention?: number, replayWindow?: number }) => { start: () => { close: () => void, error: (error: unknown) => void, id: string, signal: AbortSignal, write: (event: T) => unknown } } } }).streaming
+        const chatStream = streaming?.create<ChatDevtoolsStreamEvent>(chatDevtoolsStreamChannel, {
+          replayWindow: 1024,
+          closedStreamRetention: 30_000,
+        })
+
         registerViteHubDevtoolsPanel(ctx, {
           distDir: resolveChatDevtoolsClientDist(),
           icon: "i-lucide-message-square",
@@ -583,7 +653,19 @@ export function chatDevTools(options: ChatDevToolsOptions = {}): ChatDevToolsPlu
           name: chatDevtoolsSendRpc,
           type: "action",
           jsonSerializable: true,
-          setup: () => ({ handler: async input => await postChatDevtoolsBridge(ctx, route, { action: "send", ...input }) }),
+          setup: () => ({
+            handler: async (input): Promise<ChatDevtoolsSendResult> => {
+              if (!chatStream) {
+                throw new Error("Chat DevTools streaming requires a Vite DevTools version with ctx.rpc.streaming.")
+              }
+              const stream = chatStream.start()
+              void writeChatDevtoolsStream(ctx, route, { action: "send", ...input }, stream)
+              return {
+                streamId: stream.id,
+                state: await postChatDevtoolsBridge(ctx, route, { action: "get-state" }),
+              }
+            },
+          }),
         }) as never)
         ctx.rpc.register(defineRpcFunction({
           name: chatDevtoolsClearRpc,
@@ -599,7 +681,7 @@ export function chatDevTools(options: ChatDevToolsOptions = {}): ChatDevToolsPlu
 declare module "@vitejs/devtools-kit" {
   interface DevToolsRpcServerFunctions {
     [chatDevtoolsGetStateRpc]: () => Promise<ChatDevtoolsStateResult>
-    [chatDevtoolsSendRpc]: (input: ChatDevtoolsSendInput) => Promise<ChatDevtoolsStateResult>
+    [chatDevtoolsSendRpc]: (input: ChatDevtoolsSendInput) => Promise<ChatDevtoolsSendResult>
     [chatDevtoolsClearRpc]: (input: ChatDevtoolsClearInput) => Promise<ChatDevtoolsStateResult>
   }
 }

--- a/packages/chat/src/nitro/devtools.ts
+++ b/packages/chat/src/nitro/devtools.ts
@@ -8,7 +8,7 @@ import { getChatRuntimeConfig } from "../runtime/nitro-runtime-config.ts"
 
 import type { Adapter, AdapterPostableMessage, Chat as ChatInstance, FormattedContent, Message as ChatMessage, RawMessage } from "chat"
 import type { EventHandler, H3Event } from "h3"
-import type { ChatDevtoolsAdapter, ChatDevtoolsBridgeRequest, ChatDevtoolsConversation, ChatDevtoolsMessage, ChatDevtoolsStateResult } from "../devtools.ts"
+import type { ChatDevtoolsAdapter, ChatDevtoolsBridgeRequest, ChatDevtoolsConversation, ChatDevtoolsMessage, ChatDevtoolsStateResult, ChatDevtoolsStreamEvent } from "../devtools.ts"
 import type { ChatInput } from "../types.ts"
 import type { NitroChatRuntimeConfig, NitroChatRuntimeContext } from "./handler.ts"
 
@@ -27,6 +27,8 @@ interface ChatDevtoolsHandlerState {
   registry: ChatDevtoolsRegistry
   sessions: Map<string, ChatDevtoolsSession>
 }
+
+type ChatDevtoolsBridgeBody = ChatDevtoolsBridgeRequest & { stream?: boolean }
 
 function createChatDevtoolsMessage(role: ChatDevtoolsMessage["role"], text: string): ChatDevtoolsMessage {
   return {
@@ -78,16 +80,17 @@ function createSdkMessage(session: ChatDevtoolsSession, text: string): ChatMessa
   })
 }
 
-function createSessionDevtoolsAdapter(session: ChatDevtoolsSession): Adapter {
+function createSessionDevtoolsAdapter(session: ChatDevtoolsSession, onChange?: () => void | Promise<void>): Adapter {
   const adapter = createBaseDevtoolsAdapter()
 
-  function syncAdapterMessages() {
+  async function syncAdapterMessages() {
     const messages = adapter.getDevtoolsState(session.name).chats[0]?.messages || []
     for (const message of messages) {
       const existing = session.messages.find(item => item.id === message.id)
       if (existing) Object.assign(existing, message)
       else session.messages.push(message)
     }
+    await onChange?.()
   }
 
   return {
@@ -101,7 +104,7 @@ function createSessionDevtoolsAdapter(session: ChatDevtoolsSession): Adapter {
     deleteMessage: async () => {},
     editMessage: async (threadId, messageId, message) => {
       const result = await adapter.editMessage(threadId, messageId, message)
-      syncAdapterMessages()
+      await syncAdapterMessages()
       return result
     },
     fetchMessages: async () => ({ messages: [...session.messages] as never }),
@@ -117,14 +120,14 @@ function createSessionDevtoolsAdapter(session: ChatDevtoolsSession): Adapter {
     parseMessage: raw => raw as ChatMessage,
     postMessage: async (threadId, message): Promise<RawMessage> => {
       const result = await adapter.postMessage(threadId, message)
-      syncAdapterMessages()
+      await syncAdapterMessages()
       return result
     },
     removeReaction: async () => {},
     renderFormatted: content => toPlainText(content),
     startTyping: async (_threadId, status) => {
       await adapter.startTyping(_threadId, status)
-      syncAdapterMessages()
+      await syncAdapterMessages()
     },
   }
 }
@@ -195,7 +198,12 @@ function serializeState(state: ChatDevtoolsHandlerState, selected?: string): Cha
   }
 }
 
-async function sendDevtoolsMessage(event: H3Event, state: ChatDevtoolsHandlerState, input: { chat?: string, text?: string }): Promise<ChatDevtoolsStateResult> {
+async function sendDevtoolsMessage(
+  event: H3Event,
+  state: ChatDevtoolsHandlerState,
+  input: { chat?: string, text?: string },
+  onChange?: (next: ChatDevtoolsStateResult) => void | Promise<void>,
+): Promise<ChatDevtoolsStateResult> {
   const text = input.text?.trim()
   if (!text) {
     throw createError({
@@ -213,14 +221,43 @@ async function sendDevtoolsMessage(event: H3Event, state: ChatDevtoolsHandlerSta
   }
 
   const session = getSession(state, selected)
-  const adapter = createSessionDevtoolsAdapter(session)
+  const adapter = createSessionDevtoolsAdapter(session, async () => {
+    await onChange?.(serializeState(state, selected))
+  })
   const message = createSdkMessage(session, text)
   session.messages.push(createChatDevtoolsMessage("user", text))
+  await onChange?.(serializeState(state, selected))
 
   const bot = await resolveDevtoolsChat(event, state, session)
   await bot.handleIncomingMessage(adapter, message.threadId, message)
 
   return serializeState(state, selected)
+}
+
+function createChatDevtoolsStreamResponse(run: (emit: (event: ChatDevtoolsStreamEvent) => void) => Promise<void>): Response {
+  const encoder = new TextEncoder()
+  return new Response(new ReadableStream({
+    start(controller) {
+      const emit = (event: ChatDevtoolsStreamEvent) => {
+        controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`))
+      }
+
+      run(emit)
+        .then(() => {
+          emit({ type: "done" })
+          controller.close()
+        })
+        .catch((cause) => {
+          emit({
+            type: "error",
+            message: cause instanceof Error ? cause.message : "Chat DevTools stream failed.",
+          })
+          controller.close()
+        })
+    },
+  }), {
+    headers: { "content-type": "application/x-ndjson" },
+  })
 }
 
 function isChatDevtoolsAdapter(adapter: Adapter): adapter is ChatDevtoolsAdapter {
@@ -250,7 +287,7 @@ function getSingletonDevtoolsAdapter(): { adapter: ChatDevtoolsAdapter, chat: Ch
 
 export function defineChatDevtoolsSingletonHandler(): EventHandler {
   return defineEventHandler(async (event) => {
-    const body = await readBody<ChatDevtoolsBridgeRequest>(event)
+    const body = await readBody<ChatDevtoolsBridgeBody>(event)
     const { adapter, chat } = getSingletonDevtoolsAdapter()
     if (!body || typeof body.action !== "string" || body.action === "get-state") {
       return adapter.getDevtoolsState()
@@ -267,6 +304,15 @@ export function defineChatDevtoolsSingletonHandler(): EventHandler {
         throw createError({
           statusCode: 400,
           statusMessage: "Missing chat message text.",
+        })
+      }
+
+      if (body.stream) {
+        return createChatDevtoolsStreamResponse(async (emit) => {
+          const message = adapter.createDevtoolsMessage(text, body.chat)
+          emit({ type: "state", state: adapter.getDevtoolsState(body.chat) })
+          await chat.processMessage(adapter, message.threadId, message, { waitUntil: task => event.waitUntil(task) })
+          emit({ type: "state", state: adapter.getDevtoolsState(body.chat) })
         })
       }
 
@@ -296,7 +342,7 @@ export function defineChatDevtoolsRegistryHandler(registry: ChatDevtoolsRegistry
   }
 
   return defineEventHandler(async (event) => {
-    const body = await readBody<ChatDevtoolsBridgeRequest>(event)
+    const body = await readBody<ChatDevtoolsBridgeBody>(event)
     if (!body || typeof body.action !== "string") {
       throw createError({
         statusCode: 400,
@@ -308,6 +354,11 @@ export function defineChatDevtoolsRegistryHandler(registry: ChatDevtoolsRegistry
       return serializeState(state)
     }
     if (body.action === "send") {
+      if (body.stream) {
+        return createChatDevtoolsStreamResponse(async (emit) => {
+          await sendDevtoolsMessage(event, state, body, next => emit({ type: "state", state: next }))
+        })
+      }
       return await sendDevtoolsMessage(event, state, body)
     }
     if (body.action === "clear") {

--- a/packages/chat/src/nitro/handler.ts
+++ b/packages/chat/src/nitro/handler.ts
@@ -173,7 +173,11 @@ export function defineChatWebhookHandler(
     }
 
     const runtimeConfig = getRuntimeConfig(event)
-    const waitUntil: ChatWaitUntil = task => event.waitUntil(task)
+    const pendingTasks: Promise<unknown>[] = []
+    const processing = options.processing || "defer"
+    const waitUntil: ChatWaitUntil = processing === "inline"
+      ? task => pendingTasks.push(task)
+      : task => event.waitUntil(task)
     const context: NitroChatRuntimeContext = {
       cloudflare: getCloudflareRuntime(event, runtimeConfig),
       event,
@@ -199,7 +203,14 @@ export function defineChatWebhookHandler(
       }
 
       await hooks.callHook("webhook", { ...context, bot })
-      return await handler(context.request!, { waitUntil })
+      try {
+        return await handler(context.request!, { waitUntil })
+      }
+      finally {
+        if (processing === "inline") {
+          await Promise.all(pendingTasks)
+        }
+      }
     }
     catch (error) {
       await hooks.callHook("error", error, context)

--- a/packages/chat/src/nitro/module.ts
+++ b/packages/chat/src/nitro/module.ts
@@ -210,6 +210,7 @@ function createNitroSingleChatRouteContents(file: string, definition: Discovered
     `import { defineChatWebhookHandler } from "@vitehub/chat/nitro"`,
     "",
     `export default defineChatWebhookHandler(chat, ${renderOptions({
+      processing: options.webhook && options.webhook.processing !== "defer" ? options.webhook.processing : undefined,
       inferredName: definition.name,
       routeParam: options.webhook && options.webhook.routeParam !== "platform" ? options.webhook.routeParam : undefined,
     })})`,
@@ -224,6 +225,7 @@ function createNitroRegistryChatRouteContents(file: string, registryFile: string
     "",
     `export default defineChatWebhookRegistryHandler(chatRegistry, ${renderOptions({
       chatParam: options.webhook && options.webhook.chatParam !== "chat" ? options.webhook.chatParam : undefined,
+      processing: options.webhook && options.webhook.processing !== "defer" ? options.webhook.processing : undefined,
       routeParam: options.webhook && options.webhook.routeParam !== "platform" ? options.webhook.routeParam : undefined,
     })})`,
     "",

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -22,6 +22,7 @@ import type {
 export type MaybePromise<T> = T | Promise<T>
 export type ChatRuntimeName = "nitro" | "cloudflare" | "vercel" | "unknown"
 export type ChatWaitUntil = (task: Promise<unknown>) => void
+export type ChatWebhookProcessingMode = "defer" | "inline"
 
 export interface ChatRuntimeConfig {}
 
@@ -190,6 +191,7 @@ export interface ChatCloudflareDurableObjectModuleOptions {
 
 export interface ChatWebhookModuleOptions {
   chatParam?: string
+  processing?: ChatWebhookProcessingMode
   route?: string
   routeParam?: string
 }
@@ -226,6 +228,7 @@ export interface ResolvedChatModuleOptions {
 }
 
 export interface ChatWebhookHandlerOptions<TContext extends ChatRuntimeContext = ChatRuntimeContext> {
+  processing?: ChatWebhookProcessingMode
   inferredName?: string
   lifecycleHooks?: ChatWebhookRuntimeHooks<TContext>
   platform?: string

--- a/packages/chat/src/vite.ts
+++ b/packages/chat/src/vite.ts
@@ -163,9 +163,10 @@ function registerChatDevtoolsRpc(ctx: ViteDevToolsNodeContext): void {
         }
         const stream = chatStream.start()
         void writeChatDevtoolsStream(ctx, { action: "send", ...input }, stream)
+        const state = await postChatDevtoolsBridge(ctx, { action: "get-state" })
         return {
+          ...state,
           streamId: stream.id,
-          state: await postChatDevtoolsBridge(ctx, { action: "get-state" }),
         }
       },
     }),

--- a/packages/chat/src/vite.ts
+++ b/packages/chat/src/vite.ts
@@ -11,6 +11,7 @@ import {
   chatDevtoolsPanelId,
   chatDevtoolsRoute,
   chatDevtoolsSendRpc,
+  chatDevtoolsStreamChannel,
   chatDevtoolsTitle,
   chatDevtoolsUrlEnv,
 } from "./devtools.ts"
@@ -18,7 +19,7 @@ import {
 import type { NitroModule } from "nitro/types"
 import type { Plugin, UserConfig } from "vite"
 import type { ViteDevToolsNodeContext } from "@vitejs/devtools-kit"
-import type { ChatDevtoolsBridgeRequest, ChatDevtoolsStateResult } from "./devtools.ts"
+import type { ChatDevtoolsBridgeRequest, ChatDevtoolsSendResult, ChatDevtoolsStateResult, ChatDevtoolsStreamEvent } from "./devtools.ts"
 import type { ChatModuleOptions } from "./types.ts"
 
 export type ChatVitePlugin = Plugin & { nitro: NitroModule }
@@ -76,7 +77,72 @@ async function postChatDevtoolsBridge(ctx: ViteDevToolsNodeContext, body: ChatDe
   return await response.json() as ChatDevtoolsStateResult
 }
 
+async function writeChatDevtoolsStream(
+  ctx: ViteDevToolsNodeContext,
+  body: ChatDevtoolsBridgeRequest,
+  stream: { close: () => void, error: (error: unknown) => void, signal: AbortSignal, write: (event: ChatDevtoolsStreamEvent) => unknown },
+): Promise<void> {
+  try {
+    const response = await fetch(new URL(chatDevtoolsBridgeRoute, resolveViteServerUrl(ctx)), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ ...body, stream: true }),
+      signal: stream.signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`Chat DevTools bridge failed with ${response.status}: ${await response.text()}`)
+    }
+    if (!response.body) {
+      throw new Error("Chat DevTools bridge did not return a stream.")
+    }
+
+    const decoder = new TextDecoder()
+    const reader = response.body.getReader()
+    let pending = ""
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      pending += decoder.decode(value, { stream: true })
+      const lines = pending.split("\n")
+      pending = lines.pop() || ""
+      for (const line of lines) {
+        if (!line.trim()) continue
+        const event = JSON.parse(line) as ChatDevtoolsStreamEvent
+        if (event.type === "error") {
+          stream.write(event)
+          stream.close()
+          return
+        }
+        if (event.type === "done") {
+          stream.close()
+          return
+        }
+        stream.write(event)
+      }
+    }
+    const tail = pending.trim()
+    if (tail) {
+      stream.write(JSON.parse(tail) as ChatDevtoolsStreamEvent)
+    }
+    stream.close()
+  }
+  catch (cause) {
+    if (!stream.signal.aborted) {
+      stream.error(cause)
+    }
+  }
+}
+
 function registerChatDevtoolsRpc(ctx: ViteDevToolsNodeContext): void {
+  const streaming = (ctx.rpc as { streaming?: { create: <T>(name: string, options?: { closedStreamRetention?: number, replayWindow?: number }) => { start: () => { close: () => void, error: (error: unknown) => void, id: string, signal: AbortSignal, write: (event: T) => unknown } } } }).streaming
+  const chatStream = streaming?.create<ChatDevtoolsStreamEvent>(chatDevtoolsStreamChannel, {
+    replayWindow: 1024,
+    closedStreamRetention: 30_000,
+  })
+
   ctx.rpc.register(defineRpcFunction({
     name: chatDevtoolsGetStateRpc,
     type: "query",
@@ -91,7 +157,17 @@ function registerChatDevtoolsRpc(ctx: ViteDevToolsNodeContext): void {
     type: "action",
     jsonSerializable: true,
     setup: () => ({
-      handler: async input => await postChatDevtoolsBridge(ctx, { action: "send", ...input }),
+      handler: async (input): Promise<ChatDevtoolsSendResult> => {
+        if (!chatStream) {
+          throw new Error("Chat DevTools streaming requires a Vite DevTools version with ctx.rpc.streaming.")
+        }
+        const stream = chatStream.start()
+        void writeChatDevtoolsStream(ctx, { action: "send", ...input }, stream)
+        return {
+          streamId: stream.id,
+          state: await postChatDevtoolsBridge(ctx, { action: "get-state" }),
+        }
+      },
     }),
   }) as never)
 

--- a/packages/chat/test/devtools.test.ts
+++ b/packages/chat/test/devtools.test.ts
@@ -36,6 +36,13 @@ vi.mock("node:fs", async (importActual) => {
 })
 
 function createDevtoolsContext() {
+  const stream = {
+    close: vi.fn(),
+    error: vi.fn(),
+    id: "stream-1",
+    signal: new AbortController().signal,
+    write: vi.fn(),
+  }
   return {
     docks: {
       register: vi.fn(),
@@ -45,6 +52,11 @@ function createDevtoolsContext() {
     },
     rpc: {
       register: vi.fn(),
+      streaming: {
+        create: vi.fn(() => ({
+          start: vi.fn(() => stream),
+        })),
+      },
     },
     views: {
       hostStatic: vi.fn(),
@@ -59,6 +71,7 @@ function createDevtoolsContext() {
         local: ["http://127.0.0.1:3000/"],
       },
     },
+    stream,
   }
 }
 
@@ -88,6 +101,10 @@ describe("Chat DevTools Vite integration", () => {
       expect.stringContaining("dist/devtools-client"),
     )
     expect(ctx.rpc.register).toHaveBeenCalledTimes(3)
+    expect(ctx.rpc.streaming.create).toHaveBeenCalledWith("@vitehub/chat:stream", {
+      replayWindow: 1024,
+      closedStreamRetention: 30_000,
+    })
     expect(nitro.options.handlers).toEqual([
       expect.objectContaining({
         method: "POST",
@@ -166,10 +183,22 @@ describe("Chat DevTools Vite integration", () => {
   it("RPC handlers call the Nitro bridge route", async () => {
     const { hubChat } = await import("../src/vite.ts")
     const ctx = createDevtoolsContext()
-    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
-      chats: [{ name: "default", messages: [] }],
-      selected: "default",
-    })))
+    const fetchMock = vi.fn(async (_url: URL, init?: RequestInit) => {
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) as { stream?: boolean } : {}
+      if (body.stream) {
+        return new Response(`${JSON.stringify({
+          type: "state",
+          state: {
+            chats: [{ name: "default", messages: [] }],
+            selected: "default",
+          },
+        })}\n${JSON.stringify({ type: "done" })}\n`)
+      }
+      return new Response(JSON.stringify({
+        chats: [{ name: "default", messages: [] }],
+        selected: "default",
+      }))
+    })
     vi.stubGlobal("fetch", fetchMock)
 
     const plugin = hubChat()
@@ -177,16 +206,20 @@ describe("Chat DevTools Vite integration", () => {
 
     const functions = ctx.rpc.register.mock.calls.map(call => call[0])
     await functions.find(fn => fn.name === "@vitehub/chat:get-state")!.setup().handler()
-    await functions.find(fn => fn.name === "@vitehub/chat:send")!.setup().handler({ chat: "default", text: "hello" })
+    const sendResult = await functions.find(fn => fn.name === "@vitehub/chat:send")!.setup().handler({ chat: "default", text: "hello" })
     await functions.find(fn => fn.name === "@vitehub/chat:clear")!.setup().handler({ chat: "default" })
+    await new Promise(resolve => setTimeout(resolve, 0))
 
+    expect(sendResult).toMatchObject({ streamId: "stream-1" })
+    expect(ctx.stream.write).toHaveBeenCalledWith(expect.objectContaining({ type: "state" }))
+    expect(ctx.stream.close).toHaveBeenCalled()
     expect(fetchMock).toHaveBeenCalledWith(new URL("http://127.0.0.1:3000/__vitehub/chat/devtools"), expect.objectContaining({
       method: "POST",
     }))
     expect(fetchMock).toHaveBeenNthCalledWith(2, expect.any(URL), expect.objectContaining({
-      body: JSON.stringify({ action: "send", chat: "default", text: "hello" }),
+      body: JSON.stringify({ action: "send", chat: "default", text: "hello", stream: true }),
     }))
-    expect(fetchMock).toHaveBeenNthCalledWith(3, expect.any(URL), expect.objectContaining({
+    expect(fetchMock).toHaveBeenNthCalledWith(4, expect.any(URL), expect.objectContaining({
       body: JSON.stringify({ action: "clear", chat: "default" }),
     }))
   })

--- a/packages/chat/test/devtools.test.ts
+++ b/packages/chat/test/devtools.test.ts
@@ -210,7 +210,11 @@ describe("Chat DevTools Vite integration", () => {
     await functions.find(fn => fn.name === "@vitehub/chat:clear")!.setup().handler({ chat: "default" })
     await new Promise(resolve => setTimeout(resolve, 0))
 
-    expect(sendResult).toMatchObject({ streamId: "stream-1" })
+    expect(sendResult).toMatchObject({
+      chats: [{ name: "default", messages: [] }],
+      selected: "default",
+      streamId: "stream-1",
+    })
     expect(ctx.stream.write).toHaveBeenCalledWith(expect.objectContaining({ type: "state" }))
     expect(ctx.stream.close).toHaveBeenCalled()
     expect(fetchMock).toHaveBeenCalledWith(new URL("http://127.0.0.1:3000/__vitehub/chat/devtools"), expect.objectContaining({

--- a/packages/chat/test/nitro.test.ts
+++ b/packages/chat/test/nitro.test.ts
@@ -117,6 +117,51 @@ describe("defineChatWebhookHandler", () => {
     expect(waitUntil).toHaveBeenCalledWith(task)
   })
 
+  it("can await Nitro webhook waitUntil tasks inline", async () => {
+    const { defineChatWebhookHandler } = await import("../src/nitro.ts")
+    const waitUntil = vi.fn()
+    let completed = false
+    const task = (async () => {
+      await Promise.resolve()
+      completed = true
+    })()
+    const webhook = vi.fn((_request: Request, options: { waitUntil: (promise: Promise<unknown>) => void }) => {
+      options.waitUntil(task)
+      return new Response("ok")
+    })
+    const handler = defineChatWebhookHandler({
+      webhooks: { telegram: webhook },
+    } as never, { processing: "inline" })
+
+    const response = await handler(createEvent("telegram", waitUntil) as never)
+
+    expect(response).toBeInstanceOf(Response)
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(completed).toBe(true)
+  })
+
+  it("awaits Nitro inline tasks when the webhook throws", async () => {
+    const { defineChatWebhookHandler } = await import("../src/nitro.ts")
+    const waitUntil = vi.fn()
+    let completed = false
+    const task = (async () => {
+      await Promise.resolve()
+      completed = true
+    })()
+    const webhook = vi.fn((_request: Request, options: { waitUntil: (promise: Promise<unknown>) => void }) => {
+      options.waitUntil(task)
+      throw new Error("webhook failed")
+    })
+    const handler = defineChatWebhookHandler({
+      webhooks: { telegram: webhook },
+    } as never, { processing: "inline" })
+
+    await expect(handler(createEvent("telegram", waitUntil) as never)).rejects.toThrow("webhook failed")
+
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(completed).toBe(true)
+  })
+
   it("forwards Node-style Nitro request bodies to webhooks", async () => {
     const { defineChatWebhookHandler } = await import("../src/nitro.ts")
     const webhook = vi.fn(async (request: Request) => new Response(await request.text()))
@@ -410,6 +455,7 @@ describe("Nitro module", () => {
       imports: true,
       webhook: {
         chatParam: "chat",
+        processing: "defer",
         route: "/api/webhooks/[platform]",
         routeParam: "platform",
       },
@@ -462,6 +508,7 @@ describe("Nitro module", () => {
     const routeContents = await readFile(routeFile, "utf8")
     expect(routeContents).toContain("defineChatWebhookHandler(chat")
     expect(routeContents).toContain("inferredName: \"chat\"")
+    expect(routeContents).not.toContain("processing:")
     const devInitializerFile = nitro.options.alias["@vitehub/chat/runtime/nitro-dev-initialize"]
     expect(devInitializerFile).toContain("/.nitro/.vitehub/nitro-runtime/chat/dev-initialize.mjs")
     const devInitializerContents = await readFile(devInitializerFile, "utf8")
@@ -470,6 +517,22 @@ describe("Nitro module", () => {
     const devtoolsContents = await readFile(nitro.options.handlers[1]!.handler, "utf8")
     expect(devtoolsContents).toContain("defineChatDevtoolsHandler(chat")
     expect(devtoolsContents).toContain("inferredName: \"chat\"")
+  })
+
+  it("writes inline webhook processing to generated Nitro routes", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-chat-inline-"))
+    await writeSingleChat(rootDir, [
+      `export default defineChat({ state: {}, adapters: {} })`,
+    ].join("\n"))
+    const nitro = createNitroStub(rootDir, {
+      webhook: { processing: "inline" },
+    })
+    const module = (await import("../src/nitro/module.ts")).default
+
+    await module.setup(nitro as never)
+
+    const routeContents = await readFile(nitro.options.handlers[0]!.handler, "utf8")
+    expect(routeContents).toContain("processing: \"inline\"")
   })
 
   it("keeps the default Nitro runtime config reader when the env Nitro module is installed", async () => {

--- a/packages/chat/test/providers.test.ts
+++ b/packages/chat/test/providers.test.ts
@@ -135,6 +135,46 @@ describe("Cloudflare helpers", () => {
 
     expect(waitUntil).toHaveBeenCalledWith(task)
   })
+
+  it("can await raw Cloudflare webhook waitUntil tasks inline", async () => {
+    const { defineCloudflareChatHandler } = await import("../src/cloudflare.ts")
+    const waitUntil = vi.fn()
+    let completed = false
+    const task = (async () => {
+      await Promise.resolve()
+      completed = true
+    })()
+    const webhook = vi.fn((_request: Request, options: { waitUntil: (promise: Promise<unknown>) => void }) => {
+      options.waitUntil(task)
+      return new Response("ok")
+    })
+    const handler = defineCloudflareChatHandler({ webhooks: { telegram: webhook } } as never, { processing: "inline" })
+
+    await handler(new Request("https://example.com/api/webhooks/telegram"), {}, { waitUntil })
+
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(completed).toBe(true)
+  })
+
+  it("awaits raw Cloudflare inline tasks when the webhook throws", async () => {
+    const { defineCloudflareChatHandler } = await import("../src/cloudflare.ts")
+    const waitUntil = vi.fn()
+    let completed = false
+    const task = (async () => {
+      await Promise.resolve()
+      completed = true
+    })()
+    const webhook = vi.fn((_request: Request, options: { waitUntil: (promise: Promise<unknown>) => void }) => {
+      options.waitUntil(task)
+      throw new Error("webhook failed")
+    })
+    const handler = defineCloudflareChatHandler({ webhooks: { telegram: webhook } } as never, { processing: "inline" })
+
+    await expect(handler(new Request("https://example.com/api/webhooks/telegram"), {}, { waitUntil })).rejects.toThrow("webhook failed")
+
+    expect(waitUntil).not.toHaveBeenCalled()
+    expect(completed).toBe(true)
+  })
 })
 
 describe("Vercel helpers", () => {

--- a/packages/devtools/devtools/chat/app/app.vue
+++ b/packages/devtools/devtools/chat/app/app.vue
@@ -5,8 +5,11 @@ import {
   chatDevtoolsClearRpc,
   chatDevtoolsGetStateRpc,
   chatDevtoolsSendRpc,
+  chatDevtoolsStreamChannel,
   type ChatDevtoolsMessage,
+  type ChatDevtoolsSendResult,
   type ChatDevtoolsStateResult,
+  type ChatDevtoolsStreamEvent,
 } from "../../../../chat/src/devtools-shared"
 
 type ChatStatus = "ready" | "submitted" | "streaming" | "error"
@@ -21,6 +24,7 @@ const state = ref<ChatDevtoolsStateResult>({
   selected: "",
 })
 let rpcClient: Awaited<ReturnType<typeof getDevToolsRpcClient>> | undefined
+let currentReader: { cancel: () => unknown } | undefined
 
 const messages = computed(() => {
   const selected = state.value.chats.find(chat => chat.name === state.value.selected) || state.value.chats[0]
@@ -46,6 +50,16 @@ function isSendPending() {
   if (!assistant) return true
   const hasRunningTool = assistant.tools?.some(tool => tool.status === "running")
   return hasRunningTool || (!assistant.text.trim() && !assistant.tools?.length)
+}
+
+function applyStreamEvent(event: ChatDevtoolsStreamEvent) {
+  if (event.type === "state") {
+    state.value = event.state
+    return
+  }
+  if (event.type === "error") {
+    error.value = event.message
+  }
 }
 
 function renderToolOutput(output: unknown) {
@@ -114,16 +128,30 @@ async function send() {
 
   try {
     const chat = selectedChat()?.name
-    state.value = await callRpc<ChatDevtoolsStateResult>(chatDevtoolsSendRpc, {
+    currentReader?.cancel()
+    currentReader = undefined
+
+    const result = await callRpc<ChatDevtoolsSendResult>(chatDevtoolsSendRpc, {
       ...(chat ? { chat } : {}),
       text,
     })
+    state.value = result.state
     pendingUserMessageId.value = selectedChat()?.messages.findLast(message => message.role === "user")?.id
     status.value = "streaming"
-    for (let attempt = 0; attempt < 300 && isSendPending(); attempt++) {
-      await new Promise(resolve => setTimeout(resolve, 100))
-      await refresh()
+
+    const reader = rpcClient?.streaming.subscribe<ChatDevtoolsStreamEvent>(chatDevtoolsStreamChannel, result.streamId, {
+      highWaterMark: 1024,
+    })
+    if (!reader) {
+      throw new Error("Chat DevTools streaming client is unavailable.")
     }
+    currentReader = reader
+
+    for await (const event of reader) {
+      applyStreamEvent(event)
+      if (event.type === "error") break
+    }
+    status.value = isSendPending() ? "submitted" : "ready"
   }
   catch (cause) {
     const message = cause instanceof Error ? cause.message : "Chat DevTools send failed."
@@ -148,12 +176,15 @@ async function send() {
   }
   finally {
     pendingUserMessageId.value = undefined
+    currentReader = undefined
     status.value = "ready"
   }
 }
 
 async function clear() {
   try {
+    currentReader?.cancel()
+    currentReader = undefined
     state.value = await callRpc<ChatDevtoolsStateResult>(chatDevtoolsClearRpc, {
       chat: state.value.selected,
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,12 @@ catalogs:
     '@vercel/sandbox':
       specifier: ^1.10.0
       version: 1.10.0
+    '@vitejs/devtools':
+      specifier: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools@307
+      version: 0.1.19
     '@vitejs/devtools-kit':
-      specifier: ^0.1.18
-      version: 0.1.18
+      specifier: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307
+      version: 0.1.19
     async-retry:
       specifier: ^1.3.3
       version: 1.3.3
@@ -169,16 +172,16 @@ importers:
         version: link:../packages/chat
       '@vitejs/devtools-kit':
         specifier: 'catalog:'
-        version: 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
+        version: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
       docus:
         specifier: 'catalog:'
-        version: 5.9.0(a7a7c393954c263da31d189cc2d90fc5)
+        version: 5.9.0(41280f3cb6d62841219f75defe7cef35)
       h3:
         specifier: catalog:h3v1
         version: 1.15.11
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(0df96d8df5994186157c56ea98bf62fc)
+        version: 4.4.2(2ea8ffe6f022b1f4499757e3c66be132)
       shiki:
         specifier: 'catalog:'
         version: 4.0.2
@@ -228,7 +231,7 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -237,7 +240,7 @@ importers:
         version: 6.0.2
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8)
@@ -261,7 +264,7 @@ importers:
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/chat:
     dependencies:
@@ -269,8 +272,8 @@ importers:
         specifier: ^3.4.3
         version: 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13)
       '@vitejs/devtools-kit':
-        specifier: ^0.1.18
-        version: 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
+        specifier: 'catalog:'
+        version: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
       h3:
         specifier: 2.0.1-rc.20
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
@@ -301,13 +304,13 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
       vite:
         specifier: ^8.0.8
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8)
@@ -321,8 +324,8 @@ importers:
         specifier: workspace:*
         version: link:../..
       '@vitejs/devtools':
-        specifier: ^0.1.18
-        version: 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
+        specifier: 'catalog:'
+        version: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools@307(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
       chat:
         specifier: 'catalog:'
         version: 4.27.0
@@ -334,7 +337,7 @@ importers:
         version: 3.0.260311-beta(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(miniflare@4.20260415.0)(rollup@4.60.1)(vite@8.0.8)
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -366,7 +369,7 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -375,7 +378,7 @@ importers:
         version: 6.0.2
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8)
@@ -393,13 +396,13 @@ importers:
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/devtools:
     dependencies:
       '@vitejs/devtools-kit':
         specifier: 'catalog:'
-        version: 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
+        version: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
@@ -412,13 +415,13 @@ importers:
         version: 25.6.0
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(3e84c0322393640c0a6e72416b92d502)
+        version: 4.4.2(5ad1b1f5a672b20bdededb258034d6f9)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.2.2
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -449,7 +452,7 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -458,7 +461,7 @@ importers:
         version: 6.0.2
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8)
@@ -483,7 +486,7 @@ importers:
         version: link:../..
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -549,7 +552,7 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -558,7 +561,7 @@ importers:
         version: 6.0.2
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8)
@@ -579,7 +582,7 @@ importers:
         version: link:../..
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(4cbf57ccce37d9ca6d828ef7eab49e04)
+        version: 4.4.2(243bc5b918de3c48a1f63eb2bdcf78da)
 
   packages/kv/examples/vite:
     dependencies:
@@ -591,7 +594,7 @@ importers:
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/queue:
     dependencies:
@@ -631,13 +634,13 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8)
@@ -661,7 +664,7 @@ importers:
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/sandbox:
     dependencies:
@@ -725,13 +728,13 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8)
@@ -767,7 +770,7 @@ importers:
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/shell:
     dependencies:
@@ -786,7 +789,7 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -811,7 +814,7 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -845,7 +848,7 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -891,7 +894,7 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -900,7 +903,7 @@ importers:
         version: 6.0.2
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8)
@@ -924,7 +927,7 @@ importers:
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/workspace:
     dependencies:
@@ -976,7 +979,7 @@ importers:
         version: 0.3.18
       tsdown:
         specifier: ^0.21.8
-        version: 0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+        version: 0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -985,7 +988,7 @@ importers:
         version: 6.0.2
       vite:
         specifier: ^8.0.8
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8)
@@ -1012,7 +1015,7 @@ importers:
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   playground/nitro:
     dependencies:
@@ -1126,7 +1129,7 @@ importers:
         version: 1.3.1(typescript@6.0.2)
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -5471,16 +5474,39 @@ packages:
   '@vercel/sandbox@1.10.0':
     resolution: {integrity: sha512-rGA8KJB5ZwQeygzsndgrbHsys3HGWKHQaRQlmyIEHce2BFuTfQUgivHDj5DCZhWiyjjSEodLHpoJkZBd95K0/Q==}
 
-  '@vitejs/devtools-kit@0.1.18':
-    resolution: {integrity: sha512-vjwEd8wcBFP3cki2NUlNEktf3+AC4cG41GLVyBMnzdwDK+FbZnAesAPt1UWgm2F2FoSfYUUFAQz3/nxOT8Eoyg==}
+  '@vitejs/devtools-kit@0.1.19':
+    resolution: {integrity: sha512-ORzJxRH0s+D79wdUanWjFl9tkeazavCG1MNz1zCSV+UgOnoj2nAfbGS67YUIC6tXtvFdQG286yqlo43CkwKfyQ==}
     peerDependencies:
       vite: '*'
 
-  '@vitejs/devtools-rolldown@0.1.18':
-    resolution: {integrity: sha512-wA6jiKfAw1qOH0Jj4YCzH1xaY2x4VHTle3oiNcpdUK9EXHYyGdsS6PlQfkMz26FBOv+lR6w679Ce53k1DVYE4w==}
+  '@vitejs/devtools-kit@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@0348334':
+    resolution: {integrity: sha512-NdNVSygLaSxUTqV2S2dJLLlVPzATFYY6vzapbVSRzPjSIBkoWJc8dZfhn/Of1Kdym30f6hiUBFNvFFbuVoI+Vw==, tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@0348334}
+    version: 0.1.19
+    peerDependencies:
+      vite: '*'
 
-  '@vitejs/devtools@0.1.18':
-    resolution: {integrity: sha512-/XPGlE9EiWaHLe3AhMno9RipOTmltK5pIIoPLIk9Ekzs+74xFa2lwoeT9oKS1K2CMozd8jL61/qmFUlPtsIVHQ==}
+  '@vitejs/devtools-kit@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307':
+    resolution: {integrity: sha512-NdNVSygLaSxUTqV2S2dJLLlVPzATFYY6vzapbVSRzPjSIBkoWJc8dZfhn/Of1Kdym30f6hiUBFNvFFbuVoI+Vw==, tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307}
+    version: 0.1.19
+    peerDependencies:
+      vite: '*'
+
+  '@vitejs/devtools-rolldown@0.1.19':
+    resolution: {integrity: sha512-OtmgshVrDwtL7TqAoLgsP0DxjGF0mMlzL9+lXOtySP2Rr/qfrHiKnYlhnyi47ntQ9LWFPmIujUXabk40hPX9vA==}
+
+  '@vitejs/devtools-rolldown@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-rolldown@0348334':
+    resolution: {integrity: sha512-9Nm0QgKUsae0mmwDdZrIONTlPbH8cwSxXJorz+lKWd0ePgqSXLwZ4A08ZyG4zrYZXhNp7sNreZwSW0Qi0UXLsA==, tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-rolldown@0348334}
+    version: 0.1.19
+
+  '@vitejs/devtools@0.1.19':
+    resolution: {integrity: sha512-DWmOuOsv+VCxNFiJwPYM54c3ALQ3I8oVS23/cXOSZoevJ1YYStwIa8bHu4by5LmhmETdIauIGe6Ch+3JkCdxtw==}
+    hasBin: true
+    peerDependencies:
+      vite: '*'
+
+  '@vitejs/devtools@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools@307':
+    resolution: {integrity: sha512-sGZ42trCSQ6tw8AsAGObAoVsabxMdSFAKzhNSdijWEEhyxB0zsgJNfMVfWTPDt7Nm2xlKw63BBOjudDS2X7kBg==, tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools@307}
+    version: 0.1.19
     hasBin: true
     peerDependencies:
       vite: '*'
@@ -6644,8 +6670,8 @@ packages:
   devalue@5.7.1:
     resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
 
-  devframe@0.1.18:
-    resolution: {integrity: sha512-EHfBM4ew12HYvGtQ2GDubzRzEVvoZqFu9fKjyzV66RDFyroOBYO8Pjyksa9O78GhkXnoUDH1smwrQ2kYziH1Yg==}
+  devframe@0.1.19:
+    resolution: {integrity: sha512-wPxcZeWnO4aQV5mn513sEr2ELfgPR8oijl56oJiWCntQnZZWlZCVc2mqV0VZz6b6NqGwcogGr9JMRWEgRYHHeA==}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.0.0
       '@nuxt/kit': ^3.0.0 || ^4.0.0
@@ -12524,7 +12550,7 @@ snapshots:
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       execa: 8.0.1
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - magicast
 
@@ -12532,7 +12558,7 @@ snapshots:
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       tinyexec: 1.1.1
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - magicast
 
@@ -12547,7 +12573,7 @@ snapshots:
       pkg-types: 2.3.0
       semver: 7.7.4
 
-  '@nuxt/devtools@3.2.4(@vitejs/devtools@0.1.18)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))':
+  '@nuxt/devtools@3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))':
     dependencies:
       '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@8.0.8)
       '@nuxt/devtools-wizard': 3.2.4
@@ -12577,13 +12603,13 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.0
       tinyglobby: 0.2.16
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@8.0.8)
       vite-plugin-vue-tracer: 1.3.0(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))
       which: 6.0.1
       ws: 8.20.0
     optionalDependencies:
-      '@vitejs/devtools': 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
+      '@vitejs/devtools': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -12739,7 +12765,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(rolldown@1.0.0-rc.16)(srvx@0.11.15)(typescript@6.0.2)':
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(243bc5b918de3c48a1f63eb2bdcf78da))(rolldown@1.0.0-rc.16)(typescript@6.0.2)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -12758,7 +12784,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.3(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(rolldown@1.0.0-rc.16)(srvx@0.11.15)
-      nuxt: 4.4.2(0df96d8df5994186157c56ea98bf62fc)
+      nuxt: 4.4.2(243bc5b918de3c48a1f63eb2bdcf78da)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -12809,7 +12835,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(3e84c0322393640c0a6e72416b92d502))(rolldown@1.0.0-rc.16)(typescript@6.0.2)':
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(rolldown@1.0.0-rc.16)(srvx@0.11.15)(typescript@6.0.2)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -12828,7 +12854,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.3(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(rolldown@1.0.0-rc.16)(srvx@0.11.15)
-      nuxt: 4.4.2(3e84c0322393640c0a6e72416b92d502)
+      nuxt: 4.4.2(2ea8ffe6f022b1f4499757e3c66be132)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -12879,7 +12905,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(4cbf57ccce37d9ca6d828ef7eab49e04))(rolldown@1.0.0-rc.16)(typescript@6.0.2)':
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(5ad1b1f5a672b20bdededb258034d6f9))(rolldown@1.0.0-rc.16)(typescript@6.0.2)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -12898,7 +12924,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.3(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(rolldown@1.0.0-rc.16)(srvx@0.11.15)
-      nuxt: 4.4.2(4cbf57ccce37d9ca6d828ef7eab49e04)
+      nuxt: 4.4.2(5ad1b1f5a672b20bdededb258034d6f9)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -13200,7 +13226,7 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(243bc5b918de3c48a1f63eb2bdcf78da))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
@@ -13218,7 +13244,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(0df96d8df5994186157c56ea98bf62fc)
+      nuxt: 4.4.2(243bc5b918de3c48a1f63eb2bdcf78da)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -13261,7 +13287,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(3e84c0322393640c0a6e72416b92d502))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
@@ -13279,7 +13305,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(3e84c0322393640c0a6e72416b92d502)
+      nuxt: 4.4.2(2ea8ffe6f022b1f4499757e3c66be132)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -13322,7 +13348,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(4cbf57ccce37d9ca6d828ef7eab49e04))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(5ad1b1f5a672b20bdededb258034d6f9))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
@@ -13340,7 +13366,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(4cbf57ccce37d9ca6d828ef7eab49e04)
+      nuxt: 4.4.2(5ad1b1f5a672b20bdededb258034d6f9)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -13516,15 +13542,15 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxtjs/robots@6.0.7(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)':
+  '@nuxtjs/robots@6.0.7(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
       pathe: 2.0.3
       pkg-types: 2.3.0
       ufo: 1.6.3
@@ -15016,7 +15042,7 @@ snapshots:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@takumi-rs/core-darwin-arm64@0.73.1':
     optional: true
@@ -15513,13 +15539,45 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vitejs/devtools-kit@0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)':
+  '@vitejs/devtools-kit@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)':
     dependencies:
       birpc: 4.0.0
-      devframe: 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
       ohash: 2.0.11
       sirv: 3.0.2
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@nuxt/kit'
+      - bufferutil
+      - launch-editor
+      - typescript
+      - utf-8-validate
+    optional: true
+
+  '@vitejs/devtools-kit@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)':
+    dependencies:
+      birpc: 4.0.0
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
+      ohash: 2.0.11
+      sirv: 3.0.2
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@nuxt/kit'
+      - bufferutil
+      - launch-editor
+      - typescript
+      - utf-8-validate
+    optional: true
+
+  '@vitejs/devtools-kit@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@0348334(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)':
+    dependencies:
+      birpc: 4.0.0
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
+      ohash: 2.0.11
+      sirv: 3.0.2
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - '@nuxt/kit'
@@ -15528,13 +15586,13 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@vitejs/devtools-kit@0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)':
+  '@vitejs/devtools-kit@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)':
     dependencies:
       birpc: 4.0.0
-      devframe: 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
       ohash: 2.0.11
       sirv: 3.0.2
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - '@nuxt/kit'
@@ -15543,17 +15601,32 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@vitejs/devtools-rolldown@0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))':
+  '@vitejs/devtools-kit@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)':
+    dependencies:
+      birpc: 4.0.0
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
+      ohash: 2.0.11
+      sirv: 3.0.2
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@nuxt/kit'
+      - bufferutil
+      - launch-editor
+      - typescript
+      - utf-8-validate
+
+  '@vitejs/devtools-rolldown@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
       '@rolldown/debug': 1.0.0-rc.18
-      '@vitejs/devtools-kit': 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
+      '@vitejs/devtools-kit': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
       ansis: 4.2.0
       birpc: 4.0.0
       cac: 7.0.0
       d3-shape: 3.2.0
-      devframe: 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
       diff: 9.0.0
       get-port-please: 3.2.0
       h3: 1.15.11
@@ -15603,17 +15676,77 @@ snapshots:
       - vue
     optional: true
 
-  '@vitejs/devtools-rolldown@0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))':
+  '@vitejs/devtools-rolldown@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
       '@rolldown/debug': 1.0.0-rc.18
-      '@vitejs/devtools-kit': 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
+      '@vitejs/devtools-kit': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
       ansis: 4.2.0
       birpc: 4.0.0
       cac: 7.0.0
       d3-shape: 3.2.0
-      devframe: 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
+      diff: 9.0.0
+      get-port-please: 3.2.0
+      h3: 1.15.11
+      logs-sdk: 0.0.6
+      mlly: 1.8.2
+      mrmime: 2.0.1
+      ohash: 2.0.11
+      p-limit: 7.3.0
+      pathe: 2.0.3
+      publint: 0.3.18
+      sirv: 3.0.2
+      split2: 4.2.0
+      structured-clone-es: 2.0.0
+      tinyglobby: 0.2.16
+      unconfig: 7.5.0
+      unstorage: 1.17.5(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)
+      vue-virtual-scroller: 3.0.2(vue@3.5.34(typescript@6.0.2))
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@modelcontextprotocol/sdk'
+      - '@netlify/blobs'
+      - '@nuxt/kit'
+      - '@planetscale/database'
+      - '@pnpm/logger'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - idb-keyval
+      - ioredis
+      - launch-editor
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vue
+    optional: true
+
+  '@vitejs/devtools-rolldown@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-rolldown@0348334(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
+      '@rolldown/debug': 1.0.0-rc.18
+      '@vitejs/devtools-kit': https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@0348334(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
+      ansis: 4.2.0
+      birpc: 4.0.0
+      cac: 7.0.0
+      d3-shape: 3.2.0
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
       diff: 9.0.0
       get-port-please: 3.2.0
       h3: 1.15.11
@@ -15662,13 +15795,13 @@ snapshots:
       - vite
       - vue
 
-  '@vitejs/devtools@0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)':
+  '@vitejs/devtools@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)':
     dependencies:
-      '@vitejs/devtools-kit': 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
-      '@vitejs/devtools-rolldown': 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
+      '@vitejs/devtools-kit': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
+      '@vitejs/devtools-rolldown': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
       birpc: 4.0.0
       cac: 7.0.0
-      devframe: 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
       h3: 1.15.11
       immer: 11.1.6
       launch-editor: 2.13.2
@@ -15680,7 +15813,7 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       tinyexec: 1.1.2
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.34(typescript@6.0.2)
       ws: 8.20.0
     transitivePeerDependencies:
@@ -15711,13 +15844,13 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@vitejs/devtools@0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)':
+  '@vitejs/devtools@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)':
     dependencies:
-      '@vitejs/devtools-kit': 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
-      '@vitejs/devtools-rolldown': 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
+      '@vitejs/devtools-kit': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
+      '@vitejs/devtools-rolldown': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
       birpc: 4.0.0
       cac: 7.0.0
-      devframe: 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
       h3: 1.15.11
       immer: 11.1.6
       launch-editor: 2.13.2
@@ -15729,7 +15862,56 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       tinyexec: 1.1.2
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.34(typescript@6.0.2)
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@modelcontextprotocol/sdk'
+      - '@netlify/blobs'
+      - '@nuxt/kit'
+      - '@planetscale/database'
+      - '@pnpm/logger'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - idb-keyval
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+    optional: true
+
+  '@vitejs/devtools@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools@307(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)':
+    dependencies:
+      '@vitejs/devtools-kit': https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@0348334(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
+      '@vitejs/devtools-rolldown': https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-rolldown@0348334(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
+      birpc: 4.0.0
+      cac: 7.0.0
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
+      h3: 1.15.11
+      immer: 11.1.6
+      launch-editor: 2.13.2
+      logs-sdk: 0.0.6
+      mlly: 1.8.2
+      obug: 2.1.1
+      open: 11.0.0
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      tinyexec: 1.1.2
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.34(typescript@6.0.2)
       ws: 8.20.0
     transitivePeerDependencies:
@@ -15792,7 +15974,7 @@ snapshots:
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -17174,7 +17356,7 @@ snapshots:
 
   devalue@5.7.1: {}
 
-  devframe@0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2):
+  devframe@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2):
     dependencies:
       '@valibot/to-json-schema': 1.6.0(valibot@1.3.1(typescript@6.0.2))
       ansis: 4.2.0
@@ -17197,7 +17379,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  devframe@0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2):
+  devframe@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2):
     dependencies:
       '@valibot/to-json-schema': 1.6.0(valibot@1.3.1(typescript@6.0.2))
       ansis: 4.2.0
@@ -17230,7 +17412,7 @@ snapshots:
 
   diff@9.0.0: {}
 
-  docus@5.9.0(a7a7c393954c263da31d189cc2d90fc5):
+  docus@5.9.0(41280f3cb6d62841219f75defe7cef35):
     dependencies:
       '@ai-sdk/gateway': 3.0.96(zod@4.3.6)
       '@ai-sdk/mcp': 1.0.36(zod@4.3.6)
@@ -17245,7 +17427,7 @@ snapshots:
       '@nuxtjs/i18n': 10.2.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-dom@3.5.34)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(eslint@10.2.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(rollup@4.60.1)(typescript@6.0.2)(vue@3.5.34(typescript@6.0.2))
       '@nuxtjs/mcp-toolkit': 0.13.4(h3@1.15.11)(magicast@0.5.2)(zod@4.3.6)
       '@nuxtjs/mdc': 0.21.1(magicast@0.5.2)
-      '@nuxtjs/robots': 6.0.7(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      '@nuxtjs/robots': 6.0.7(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
       '@shikijs/core': 4.0.2
       '@shikijs/engine-javascript': 4.0.2
       '@shikijs/langs': 4.0.2
@@ -17258,9 +17440,9 @@ snapshots:
       exsolve: 1.0.8
       git-url-parse: 16.1.0
       motion-v: 2.2.1(@vueuse/core@14.2.1(vue@3.5.34(typescript@6.0.2)))(vue@3.5.34(typescript@6.0.2))
-      nuxt: 4.4.2(0df96d8df5994186157c56ea98bf62fc)
+      nuxt: 4.4.2(2ea8ffe6f022b1f4499757e3c66be132)
       nuxt-llms: 0.2.0(magicast@0.5.2)
-      nuxt-og-image: 6.4.1(37bb1e34f3eeb6aa0a60dc785f5ce4ad)
+      nuxt-og-image: 6.4.1(a829c5d3d60e838bf125094e8c31106f)
       pkg-types: 2.3.0
       scule: 1.3.0
       shiki-stream: 0.1.4(vue@3.5.34(typescript@6.0.2))
@@ -18030,7 +18212,7 @@ snapshots:
       unifont: 0.7.4
       unstorage: 1.17.5(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -19478,7 +19660,7 @@ snapshots:
       giget: 3.2.0
       jiti: 2.6.1
       rollup: 4.60.1
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -19705,7 +19887,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.4.1(37bb1e34f3eeb6aa0a60dc785f5ce4ad):
+  nuxt-og-image@6.4.1(a829c5d3d60e838bf125094e8c31106f):
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
@@ -19721,8 +19903,8 @@ snapshots:
       magic-string: 0.30.21
       magicast: 0.5.2
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
       nypm: 0.6.5
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -19763,12 +19945,12 @@ snapshots:
       - magicast
       - vue
 
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6):
+  nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6):
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magicast@0.5.2)(vue@3.5.34(typescript@6.0.2))
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
       pathe: 2.0.3
       pkg-types: 2.3.0
       site-config-stack: 4.0.8(vue@3.5.34(typescript@6.0.2))
@@ -19781,16 +19963,149 @@ snapshots:
       - vue
       - zod
 
-  nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc):
+  nuxt@4.4.2(243bc5b918de3c48a1f63eb2bdcf78da):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.18)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))
+      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(rolldown@1.0.0-rc.16)(srvx@0.11.15)(typescript@6.0.2)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(243bc5b918de3c48a1f63eb2bdcf78da))(rolldown@1.0.0-rc.16)(typescript@6.0.2)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)
+      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(243bc5b918de3c48a1f63eb2bdcf78da))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)
+      '@unhead/vue': 2.1.13(vue@3.5.32(typescript@6.0.2))
+      '@vue/shared': 3.5.32
+      c12: 3.3.4(magicast@0.5.2)
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      defu: 6.1.7
+      devalue: 5.7.1
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      hookable: 6.1.0
+      ignore: 7.0.5
+      impound: 1.1.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nypm: 0.6.5
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-minify: 0.117.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      oxc-parser: 0.117.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      oxc-transform: 0.117.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      oxc-walker: 0.7.0(oxc-parser@0.117.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.4
+      pkg-types: 2.3.0
+      rou3: 0.8.1
+      scule: 1.3.0
+      semver: 7.7.4
+      std-env: 4.0.0
+      tinyglobby: 0.2.16
+      ufo: 1.6.3
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unimport: 6.1.0
+      unplugin: 3.0.0
+      unrouting: 0.1.7
+      untyped: 2.0.0
+      vue: 3.5.32(typescript@6.0.2)
+      vue-router: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.32(typescript@6.0.2))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bufferutil
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxlint
+      - pinia
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - srvx
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - xml2js
+      - yaml
+
+  nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132):
+    dependencies:
+      '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
+      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(rolldown@1.0.0-rc.16)(srvx@0.11.15)(typescript@6.0.2)
+      '@nuxt/schema': 4.4.2
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
+      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)
       '@unhead/vue': 2.1.13(vue@3.5.32(typescript@6.0.2))
       '@vue/shared': 3.5.32
       c12: 3.3.4(magicast@0.5.2)
@@ -19914,16 +20229,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.2(3e84c0322393640c0a6e72416b92d502):
+  nuxt@4.4.2(5ad1b1f5a672b20bdededb258034d6f9):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.18)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))
+      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(3e84c0322393640c0a6e72416b92d502))(rolldown@1.0.0-rc.16)(typescript@6.0.2)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(5ad1b1f5a672b20bdededb258034d6f9))(rolldown@1.0.0-rc.16)(typescript@6.0.2)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(3e84c0322393640c0a6e72416b92d502))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)
+      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(5ad1b1f5a672b20bdededb258034d6f9))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)
       '@unhead/vue': 2.1.13(vue@3.5.32(typescript@6.0.2))
       '@vue/shared': 3.5.32
       c12: 3.3.4(magicast@0.5.2)
@@ -20047,140 +20362,7 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.2(4cbf57ccce37d9ca6d828ef7eab49e04):
-    dependencies:
-      '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.18)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(4cbf57ccce37d9ca6d828ef7eab49e04))(rolldown@1.0.0-rc.16)(typescript@6.0.2)
-      '@nuxt/schema': 4.4.2
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(4cbf57ccce37d9ca6d828ef7eab49e04))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)
-      '@unhead/vue': 2.1.13(vue@3.5.32(typescript@6.0.2))
-      '@vue/shared': 3.5.32
-      c12: 3.3.4(magicast@0.5.2)
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 2.0.1
-      defu: 6.1.7
-      devalue: 5.7.1
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      hookable: 6.1.0
-      ignore: 7.0.5
-      impound: 1.1.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      nanotar: 0.3.0
-      nypm: 0.6.5
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-minify: 0.117.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      oxc-parser: 0.117.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      oxc-transform: 0.117.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      oxc-walker: 0.7.0(oxc-parser@0.117.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.4
-      pkg-types: 2.3.0
-      rou3: 0.8.1
-      scule: 1.3.0
-      semver: 7.7.4
-      std-env: 4.0.0
-      tinyglobby: 0.2.16
-      ufo: 1.6.3
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unimport: 6.1.0
-      unplugin: 3.0.0
-      unrouting: 0.1.7
-      untyped: 2.0.0
-      vue: 3.5.32(typescript@6.0.2)
-      vue-router: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.32(typescript@6.0.2))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 25.6.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bufferutil
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - srvx
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - xml2js
-      - yaml
-
-  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6):
+  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6):
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@8.0.8)
@@ -20189,7 +20371,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.2(0df96d8df5994186157c56ea98bf62fc)
+      nuxt: 4.4.2(2ea8ffe6f022b1f4499757e3c66be132)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -20199,7 +20381,7 @@ snapshots:
       ufo: 1.6.3
       vue: 3.5.34(typescript@6.0.2)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(0df96d8df5994186157c56ea98bf62fc))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - magicast
@@ -21966,7 +22148,7 @@ snapshots:
     dependencies:
       typescript: 6.0.2
 
-  tsdown@0.21.9(@vitejs/devtools@0.1.18)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2)):
+  tsdown@0.21.9(@vitejs/devtools@0.1.19)(publint@0.3.18)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2)):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -21985,7 +22167,7 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.36
     optionalDependencies:
-      '@vitejs/devtools': 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
+      '@vitejs/devtools': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
       publint: 0.3.18
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -22365,12 +22547,12 @@ snapshots:
   vite-dev-rpc@1.1.0(vite@8.0.8):
     dependencies:
       birpc: 2.9.0
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-hot-client: 2.1.0(vite@8.0.8)
 
   vite-hot-client@2.1.0(vite@8.0.8):
     dependencies:
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite-node@5.3.0(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -22420,7 +22602,7 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-dev-rpc: 1.1.0(vite@8.0.8)
     optionalDependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
@@ -22434,7 +22616,7 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.32(typescript@6.0.2)
 
   vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
@@ -22454,7 +22636,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -22463,7 +22645,7 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.6.0
-      '@vitejs/devtools': 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
+      '@vitejs/devtools': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
       esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
@@ -22471,7 +22653,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -22480,7 +22662,7 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.6.0
-      '@vitejs/devtools': 0.1.18(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
+      '@vitejs/devtools': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
       esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.6.1
@@ -22508,7 +22690,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.18)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,12 +17,13 @@ catalog:
   '@vercel/blob': ^2.3.3
   '@vercel/functions': ^3.4.3
   '@vercel/sandbox': ^1.10.0
-  '@vitejs/devtools-kit': ^0.1.18
-  chat: ^4.27.0
-  chat-state-cloudflare-do: ^0.2.0
+  '@vitejs/devtools': https://pkg.pr.new/vitejs/devtools/@vitejs/devtools@307
+  '@vitejs/devtools-kit': https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307
   '@vueuse/nuxt': ^14.2.1
   async-retry: ^1.3.3
   better-sqlite3: ^12.9.0
+  chat: ^4.27.0
+  chat-state-cloudflare-do: ^0.2.0
   consola: ^3.4.2
   defu: ^6.1.4
   docus: ^5.9.0


### PR DESCRIPTION
Adds a Vite DevTools streaming channel for @vitehub/chat responses and pipes Nitro bridge transcript snapshots into the panel, replacing the client polling loop after sends. The existing get-state, send, and clear RPC names stay in place; send now returns stream metadata so the panel subscribes to the active response.

This currently pins the Vite DevTools preview packages from vitejs/devtools#307 because the latest npm release (0.1.19) does not include the streaming channel API yet. The branch also includes the existing inline chat webhook execution compatibility commit from the current Quiver preview pin, so Quiver can consume this package without losing its webhook processing option.

Note: the broader workspace test run currently stops in @vitehub/env's generated chat runtime config type test; the focused chat and devtools checks pass.