### PR TITLE
feat(chat): simplify direct message workflow dx

### DIFF
--- a/packages/chat/docs/index.md
+++ b/packages/chat/docs/index.md
@@ -17,15 +17,13 @@ import { defineChat } from '@vitehub/chat'
 import { cloudflareDurableObjectState } from '@vitehub/chat/cloudflare'
 
 export default defineChat({
-  adapters: {
-    telegram: ({ runtimeConfig }) => createTelegramAdapter({
+  adapters: ({ runtimeConfig }) => ({
+    telegram: createTelegramAdapter({
       botToken: runtimeConfig.telegram.botToken,
     }),
-  },
-  hooks: {
-    async onDirectMessage({ message, thread }) {
-      await thread.post(`Received: ${message.text}`)
-    },
+  }),
+  async onDirectMessage({ message, thread }) {
+    await thread.post(`Received: ${message.text}`)
   },
   state: cloudflareDurableObjectState(),
   userName: 'Support Bot',
@@ -58,7 +56,7 @@ Chat keeps bot behavior in one definition while deployment-specific wiring stays
   icon: i-lucide-bot
   title: One bot definition
   ---
-  Configure Chat SDK adapters, state, hooks, and setup code in `defineChat()`.
+  Configure Chat SDK adapters, state, and message handlers in `defineChat()`.
   :::
 
   :::card

--- a/packages/chat/docs/providers/cloudflare.md
+++ b/packages/chat/docs/providers/cloudflare.md
@@ -64,7 +64,9 @@ import { cloudflareDurableObjectState } from '@vitehub/chat/cloudflare'
 
 export default defineChat({
   adapters,
-  hooks,
+  async onDirectMessage({ message, thread }) {
+    await thread.post(`Received: ${message.text}`)
+  },
   state: cloudflareDurableObjectState(),
   userName: 'Support Bot',
 })

--- a/packages/chat/docs/quickstart.md
+++ b/packages/chat/docs/quickstart.md
@@ -99,10 +99,8 @@ import { cloudflareDurableObjectState } from '@vitehub/chat/cloudflare'
 
 export default defineChat({
   adapters: {},
-  hooks: {
-    async onDirectMessage({ message, thread }) {
-      await thread.post(`Received: ${message.text}`)
-    },
+  async onDirectMessage({ message, thread }) {
+    await thread.post(`Received: ${message.text}`)
   },
   state: cloudflareDurableObjectState(),
   userName: 'Demo Bot',
@@ -138,11 +136,11 @@ import { createTelegramAdapter } from '@chat-adapter/telegram'
 import { defineChat } from '@vitehub/chat'
 
 export default defineChat({
-  adapters: {
-    telegram: ({ runtimeConfig }) => createTelegramAdapter({
+  adapters: ({ runtimeConfig }) => ({
+    telegram: createTelegramAdapter({
       botToken: runtimeConfig.telegram.botToken,
     }),
-  },
+  }),
   state,
   userName: 'Support Bot',
 })

--- a/packages/chat/docs/runtime-api.md
+++ b/packages/chat/docs/runtime-api.md
@@ -66,6 +66,14 @@ function defineChat<TRuntimeConfig extends ChatRuntimeConfig>(
 interface DefineChatOptions<TRuntimeConfig> {
   adapters: AdapterInput<ResolvedChatRuntimeContext<TRuntimeConfig>>
   state: MaybeResolvable<StateAdapter, ChatRuntimeContext<TRuntimeConfig>>
+  onDirectMessage?: ChatDirectMessageHook<TRuntimeConfig>
+  onNewMention?: ChatMessageHook<TRuntimeConfig>
+  onNewMessage?: ChatNewMessageHook<TRuntimeConfig> | ChatNewMessageHook<TRuntimeConfig>[]
+  onReaction?: ChatReactionHookInput<TRuntimeConfig>
+  onAction?: ChatActionHookInput<TRuntimeConfig>
+  onModalSubmit?: ChatModalSubmitHookInput<TRuntimeConfig>
+  onSubscribedMessage?: ChatMessageHook<TRuntimeConfig>
+  workflow?: ChatWorkflowHandle
   hooks?: ChatEventHooks<TRuntimeConfig>
   lifecycleHooks?: ChatWebhookRuntimeHooks<ChatRuntimeContext<TRuntimeConfig>>
   setup?: (bot: Chat, context: ResolvedChatRuntimeContext<TRuntimeConfig>) => MaybePromise<void>
@@ -74,6 +82,8 @@ interface DefineChatOptions<TRuntimeConfig> {
 ```
 
 The type also accepts Chat SDK config fields except `adapters`, `state`, and `userName`, which ViteHub wraps so they can use runtime context.
+
+Top-level event handlers are the preferred API. `hooks` remains supported for older definitions, but a handler cannot be defined in both places.
 
 ## `resolveChat()`
 

--- a/packages/chat/docs/usage.md
+++ b/packages/chat/docs/usage.md
@@ -11,21 +11,19 @@ Use this page after the [Quickstart](./quickstart) when you need more than the d
 
 ## Define one chat
 
-`defineChat()` accepts Chat SDK config plus ViteHub-specific resolvers for adapters, state, hooks, and lifecycle behavior.
+`defineChat()` accepts Chat SDK config plus ViteHub-specific resolvers for adapters, state, top-level event handlers, and lifecycle behavior.
 
 ```ts [server/chat.ts]
 import { defineChat } from '@vitehub/chat'
 
 export default defineChat({
-  adapters: {
-    telegram: ({ runtimeConfig }) => createTelegramAdapter({
+  adapters: ({ runtimeConfig }) => ({
+    telegram: createTelegramAdapter({
       botToken: runtimeConfig.telegram.botToken,
     }),
-  },
-  hooks: {
-    async onDirectMessage({ message, thread }) {
-      await thread.post(`Received: ${message.text}`)
-    },
+  }),
+  async onDirectMessage({ message, thread }) {
+    await thread.post(`Received: ${message.text}`)
   },
   state: ({ runtimeConfig }) => createState(runtimeConfig),
   userName: 'Support Bot',
@@ -46,13 +44,11 @@ interface ChatRuntimeConfig {
 }
 
 export default defineChat<ChatRuntimeConfig>({
-  adapters({ runtimeConfig }) {
-    return {
-      telegram: createTelegramAdapter({
-        botToken: runtimeConfig.telegram.botToken,
-      }),
-    }
-  },
+  adapters: ({ runtimeConfig }) => ({
+    telegram: createTelegramAdapter({
+      botToken: runtimeConfig.telegram.botToken,
+    }),
+  }),
   state,
   userName: 'Support Bot',
 })
@@ -62,25 +58,23 @@ Pair Chat with `@vitehub/env` when you want typed server-only runtime config for
 
 ## Handle events
 
-The `hooks` object wraps common Chat SDK event registrations and passes object-style arguments.
+Top-level event handlers wrap common Chat SDK event registrations and pass object-style arguments.
 
 ```ts
 export default defineChat({
   adapters,
-  hooks: {
-    onDirectMessage: async ({ message, thread }) => {
-      await thread.post(`Received: ${message.text}`)
+  async onDirectMessage({ message, thread }) {
+    await thread.post(`Received: ${message.text}`)
+  },
+  onNewMessage: {
+    pattern: /^!help/,
+    handler: async ({ thread }) => {
+      await thread.post('Available commands: !help')
     },
-    onNewMessage: {
-      pattern: /^!help/,
-      handler: async ({ thread }) => {
-        await thread.post('Available commands: !help')
-      },
-    },
-    onReaction: {
-      thumbs_up: async ({ event }) => {
-        console.log('Reaction received', event)
-      },
+  },
+  onReaction: {
+    thumbs_up: async ({ event }) => {
+      console.log('Reaction received', event)
     },
   },
   state,
@@ -88,7 +82,7 @@ export default defineChat({
 })
 ```
 
-Supported hook keys are `onDirectMessage`, `onNewMention`, `onSubscribedMessage`, `onNewMessage`, `onReaction`, `onAction`, and `onModalSubmit`.
+Supported top-level handler keys are `onDirectMessage`, `onNewMention`, `onSubscribedMessage`, `onNewMessage`, `onReaction`, `onAction`, and `onModalSubmit`. The older `hooks` object still works, but do not define the same handler in both places.
 
 ## Run setup code
 

--- a/packages/chat/examples/nitro/package.json
+++ b/packages/chat/examples/nitro/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@chat-adapter/telegram": "^4.27.0",
     "@vitehub/chat": "workspace:*",
+    "@vitehub/workflow": "workspace:*",
     "@vitejs/devtools": "catalog:",
     "chat": "catalog:",
     "chat-state-cloudflare-do": "catalog:",

--- a/packages/chat/examples/nitro/server/chat.ts
+++ b/packages/chat/examples/nitro/server/chat.ts
@@ -1,8 +1,7 @@
 import { createTelegramAdapter } from "@chat-adapter/telegram"
 import { defineChat } from "@vitehub/chat"
 import { cloudflareDurableObjectState } from "@vitehub/chat/cloudflare"
-
-import { answerWithContext } from "./utils/agent"
+import { createWorkflow } from "@vitehub/workflow"
 
 interface ChatRuntimeConfig {
   telegram: {
@@ -17,40 +16,50 @@ interface ChatRuntimeConfig {
   }
 }
 
+interface ChatReplyPayload {
+  messageId: string
+  platform: string
+  text: string
+  threadId: string
+  vertex: ChatRuntimeConfig["vertex"]
+}
+
 export default defineChat<ChatRuntimeConfig>({
-  adapters({ runtimeConfig }) {
-    const telegram = runtimeConfig?.telegram
-    if (!telegram?.botToken || !telegram.webhookSecretToken) {
-      return {}
-    }
+  adapters: ({ runtimeConfig }) => ({
+    telegram: createTelegramAdapter(runtimeConfig.telegram),
+  }),
+  async onDirectMessage({ message, runtimeConfig, thread, workflow }) {
+    await thread.startTyping().catch(() => {})
 
-    const apiBaseUrl = telegram.apiBaseUrl?.trim()
-    const botUsername = telegram.botUsername?.trim()
-
-    return {
-      telegram: createTelegramAdapter({
-        botToken: telegram.botToken,
-        secretToken: telegram.webhookSecretToken,
-        ...(apiBaseUrl ? { apiBaseUrl } : {}),
-        ...(botUsername ? { userName: botUsername } : {}),
-      }),
+    const run = await workflow.run({
+      messageId: message.id,
+      platform: "telegram",
+      text: message.text,
+      threadId: thread.id,
+      vertex: runtimeConfig.vertex,
+    })
+    const result = await workflow.getRun(run.id)
+    if (result.status === "completed") {
+      await thread.post(result.result!.fullStream)
     }
-  },
-  fallbackStreamingPlaceholderText: "Reading Quiver data sources...",
-  hooks: {
-    async onDirectMessage({ message, runtimeConfig, thread }) {
-      await thread.startTyping().catch(() => {})
-      const vertex = runtimeConfig?.vertex
-      const result = await answerWithContext(
-        message.text,
-        vertex?.apiKey || "devtools",
-        vertex?.model || "dummy",
-      )
-      await thread.post(result.fullStream)
-    },
   },
   state: cloudflareDurableObjectState({
     name: "quiver-chat",
   }),
   streamingUpdateIntervalMs: 1_000,
+  workflow: createWorkflow<ChatReplyPayload, { fullStream: AsyncIterable<string> }>({
+    name: "chat-reply",
+    async handler({ payload }) {
+      async function answerWithContext(prompt: string, _apiKey: string, _model: string) {
+        return {
+          fullStream: (async function* () {
+            yield `Echo: ${prompt}`
+          })(),
+        }
+      }
+
+      return await answerWithContext(payload.text, payload.vertex.apiKey, payload.vertex.model)
+    },
+    id: ({ payload: { messageId, threadId } }) => `${threadId}:${messageId}`,
+  }),
 })

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -16,6 +16,7 @@ import type {
   ChatReactionHookInput,
   ChatRuntimeConfig,
   ChatRuntimeContext,
+  ChatWorkflowHandle,
   DefineChatOptions,
   MaybeResolvable,
   ResolvedChatRuntimeContext,
@@ -51,6 +52,7 @@ export type {
   ChatWebhookModuleOptions,
   ChatWebhookRegistryHandlerOptions,
   ChatWebhookRuntimeHooks,
+  ChatWorkflowHandle,
   CloudflareDurableObjectStateOptions,
   DefineChatOptions,
   DiscoveredChatDefinition,
@@ -66,6 +68,7 @@ export type {
   ResolvedChatModuleOptions,
   StateAdapter,
   Thread,
+  WorkflowRunLike,
 } from "./types.ts"
 export * from "./devtools.ts"
 
@@ -96,7 +99,7 @@ async function resolveValue<T, TContext extends ChatRuntimeContext>(
 }
 
 async function resolveAdapters<TRuntimeConfig extends ChatRuntimeConfig>(
-  adapters: DefineChatOptions<TRuntimeConfig>["adapters"],
+  adapters: DefineChatOptions<TRuntimeConfig, ChatWorkflowHandle<any, any> | undefined>["adapters"],
   context: ResolvedChatRuntimeContext<TRuntimeConfig>,
 ): Promise<Record<string, Adapter>> {
   if (typeof adapters === "function" || isResolvable(adapters as MaybeResolvable<Record<string, Adapter>, typeof context>)) {
@@ -110,10 +113,14 @@ async function resolveAdapters<TRuntimeConfig extends ChatRuntimeConfig>(
   return resolved
 }
 
-function createMessageHook<TRuntimeConfig extends ChatRuntimeConfig>(
+function createMessageHook<
+  TRuntimeConfig extends ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined,
+>(
   bot: Chat,
   runtimeConfig: TRuntimeConfig,
-  hook: ChatMessageHook<TRuntimeConfig>,
+  hook: ChatMessageHook<TRuntimeConfig, TWorkflow>,
+  workflow: TWorkflow,
 ) {
   return (thread: unknown, message: unknown, context?: unknown) => hook({
     bot,
@@ -121,13 +128,18 @@ function createMessageHook<TRuntimeConfig extends ChatRuntimeConfig>(
     message: message as Message,
     runtimeConfig,
     thread: wrapDevtoolsThread(thread) as never,
+    workflow,
   })
 }
 
-function createDirectMessageHook<TRuntimeConfig extends ChatRuntimeConfig>(
+function createDirectMessageHook<
+  TRuntimeConfig extends ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined,
+>(
   bot: Chat,
   runtimeConfig: TRuntimeConfig,
-  hook: ChatDirectMessageHook<TRuntimeConfig>,
+  hook: ChatDirectMessageHook<TRuntimeConfig, TWorkflow>,
+  workflow: TWorkflow,
 ) {
   return (thread: unknown, message: unknown, channel: unknown, context?: unknown) => hook({
     bot,
@@ -136,6 +148,7 @@ function createDirectMessageHook<TRuntimeConfig extends ChatRuntimeConfig>(
     message: message as Message,
     runtimeConfig,
     thread: wrapDevtoolsThread(thread) as never,
+    workflow,
   })
 }
 
@@ -174,125 +187,186 @@ function wrapDevtoolsThread(thread: unknown): unknown {
   })
 }
 
-function createEventHook<TEvent, TRuntimeConfig extends ChatRuntimeConfig>(
+function createEventHook<
+  TEvent,
+  TRuntimeConfig extends ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined,
+>(
   bot: Chat,
   runtimeConfig: TRuntimeConfig,
-  hook: ChatEventHook<TEvent, TRuntimeConfig>,
+  hook: ChatEventHook<TEvent, TRuntimeConfig, TWorkflow>,
+  workflow: TWorkflow,
 ) {
   return (event: TEvent) => hook({
     bot,
     event,
     runtimeConfig,
+    workflow,
   })
 }
 
-function registerNewMessageHooks<TRuntimeConfig extends ChatRuntimeConfig>(
+function registerNewMessageHooks<
+  TRuntimeConfig extends ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined,
+>(
   bot: Chat,
   runtimeConfig: TRuntimeConfig,
-  input: ChatNewMessageHook<TRuntimeConfig> | Array<ChatNewMessageHook<TRuntimeConfig>> | undefined,
+  input: ChatNewMessageHook<TRuntimeConfig, TWorkflow> | Array<ChatNewMessageHook<TRuntimeConfig, TWorkflow>> | undefined,
+  workflow: TWorkflow,
 ) {
   const hooks = input ? Array.isArray(input) ? input : [input] : []
   for (const hook of hooks) {
-    bot.onNewMessage(hook.pattern, createMessageHook(bot, runtimeConfig, hook.handler) as never)
+    bot.onNewMessage(hook.pattern, createMessageHook(bot, runtimeConfig, hook.handler, workflow) as never)
   }
 }
 
-function registerReactionHooks<TRuntimeConfig extends ChatRuntimeConfig>(
+function registerReactionHooks<
+  TRuntimeConfig extends ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined,
+>(
   bot: Chat,
   runtimeConfig: TRuntimeConfig,
-  input: ChatReactionHookInput<TRuntimeConfig> | undefined,
+  input: ChatReactionHookInput<TRuntimeConfig, TWorkflow> | undefined,
+  workflow: TWorkflow,
 ) {
   if (!input) return
 
   if (typeof input === "function") {
-    bot.onReaction(createEventHook(bot, runtimeConfig, input as ChatEventHook<ReactionEvent, TRuntimeConfig>) as never)
+    bot.onReaction(createEventHook(bot, runtimeConfig, input as ChatEventHook<ReactionEvent, TRuntimeConfig, TWorkflow>, workflow) as never)
     return
   }
 
   if ("emoji" in input && "handler" in input) {
-    bot.onReaction(input.emoji as never, createEventHook(bot, runtimeConfig, input.handler) as never)
+    bot.onReaction(input.emoji as never, createEventHook(bot, runtimeConfig, input.handler, workflow) as never)
     return
   }
 
   for (const [emoji, hook] of Object.entries(input)) {
     if (emoji === "$all") {
-      bot.onReaction(createEventHook(bot, runtimeConfig, hook as ChatEventHook<ReactionEvent, TRuntimeConfig>) as never)
+      bot.onReaction(createEventHook(bot, runtimeConfig, hook as ChatEventHook<ReactionEvent, TRuntimeConfig, TWorkflow>, workflow) as never)
     }
     else {
-      bot.onReaction([emoji] as never, createEventHook(bot, runtimeConfig, hook as ChatEventHook<ReactionEvent, TRuntimeConfig>) as never)
+      bot.onReaction([emoji] as never, createEventHook(bot, runtimeConfig, hook as ChatEventHook<ReactionEvent, TRuntimeConfig, TWorkflow>, workflow) as never)
     }
   }
 }
 
-function registerActionHooks<TRuntimeConfig extends ChatRuntimeConfig>(
+function registerActionHooks<
+  TRuntimeConfig extends ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined,
+>(
   bot: Chat,
   runtimeConfig: TRuntimeConfig,
-  input: ChatActionHookInput<TRuntimeConfig> | undefined,
+  input: ChatActionHookInput<TRuntimeConfig, TWorkflow> | undefined,
+  workflow: TWorkflow,
 ) {
   if (!input) return
 
   if (typeof input === "function") {
-    bot.onAction(createEventHook(bot, runtimeConfig, input as ChatEventHook<ActionEvent, TRuntimeConfig>) as never)
+    bot.onAction(createEventHook(bot, runtimeConfig, input as ChatEventHook<ActionEvent, TRuntimeConfig, TWorkflow>, workflow) as never)
     return
   }
 
   for (const [actionId, hook] of Object.entries(input)) {
     if (actionId === "$all") {
-      bot.onAction(createEventHook(bot, runtimeConfig, hook as ChatEventHook<ActionEvent, TRuntimeConfig>) as never)
+      bot.onAction(createEventHook(bot, runtimeConfig, hook as ChatEventHook<ActionEvent, TRuntimeConfig, TWorkflow>, workflow) as never)
     }
     else {
-      bot.onAction(actionId, createEventHook(bot, runtimeConfig, hook as ChatEventHook<ActionEvent, TRuntimeConfig>) as never)
+      bot.onAction(actionId, createEventHook(bot, runtimeConfig, hook as ChatEventHook<ActionEvent, TRuntimeConfig, TWorkflow>, workflow) as never)
     }
   }
 }
 
-function registerModalSubmitHooks<TRuntimeConfig extends ChatRuntimeConfig>(
+function registerModalSubmitHooks<
+  TRuntimeConfig extends ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined,
+>(
   bot: Chat,
   runtimeConfig: TRuntimeConfig,
-  input: ChatModalSubmitHookInput<TRuntimeConfig> | undefined,
+  input: ChatModalSubmitHookInput<TRuntimeConfig, TWorkflow> | undefined,
+  workflow: TWorkflow,
 ) {
   if (!input) return
 
   if (typeof input === "function") {
-    bot.onModalSubmit(createEventHook(bot, runtimeConfig, input as ChatEventHook<ModalSubmitEvent, TRuntimeConfig>) as never)
+    bot.onModalSubmit(createEventHook(bot, runtimeConfig, input as ChatEventHook<ModalSubmitEvent, TRuntimeConfig, TWorkflow>, workflow) as never)
     return
   }
 
   for (const [callbackId, hook] of Object.entries(input)) {
     if (callbackId === "$all") {
-      bot.onModalSubmit(createEventHook(bot, runtimeConfig, hook as ChatEventHook<ModalSubmitEvent, TRuntimeConfig>) as never)
+      bot.onModalSubmit(createEventHook(bot, runtimeConfig, hook as ChatEventHook<ModalSubmitEvent, TRuntimeConfig, TWorkflow>, workflow) as never)
     }
     else {
-      bot.onModalSubmit(callbackId, createEventHook(bot, runtimeConfig, hook as ChatEventHook<ModalSubmitEvent, TRuntimeConfig>) as never)
+      bot.onModalSubmit(callbackId, createEventHook(bot, runtimeConfig, hook as ChatEventHook<ModalSubmitEvent, TRuntimeConfig, TWorkflow>, workflow) as never)
     }
   }
 }
 
-function registerChatHooks<TRuntimeConfig extends ChatRuntimeConfig>(
+function registerChatHooks<
+  TRuntimeConfig extends ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined,
+>(
   bot: Chat,
   runtimeConfig: TRuntimeConfig,
-  hooks: ChatEventHooks<TRuntimeConfig> | undefined,
+  hooks: ChatEventHooks<TRuntimeConfig, TWorkflow> | undefined,
+  workflow: TWorkflow,
 ) {
   if (!hooks) return
 
   if (hooks.onNewMention) {
-    bot.onNewMention(createMessageHook(bot, runtimeConfig, hooks.onNewMention) as never)
+    bot.onNewMention(createMessageHook(bot, runtimeConfig, hooks.onNewMention, workflow) as never)
   }
   if (hooks.onSubscribedMessage) {
-    bot.onSubscribedMessage(createMessageHook(bot, runtimeConfig, hooks.onSubscribedMessage) as never)
+    bot.onSubscribedMessage(createMessageHook(bot, runtimeConfig, hooks.onSubscribedMessage, workflow) as never)
   }
   if (hooks.onDirectMessage) {
-    bot.onDirectMessage(createDirectMessageHook(bot, runtimeConfig, hooks.onDirectMessage) as never)
+    bot.onDirectMessage(createDirectMessageHook(bot, runtimeConfig, hooks.onDirectMessage, workflow) as never)
   }
 
-  registerNewMessageHooks(bot, runtimeConfig, hooks.onNewMessage)
-  registerReactionHooks(bot, runtimeConfig, hooks.onReaction)
-  registerActionHooks(bot, runtimeConfig, hooks.onAction)
-  registerModalSubmitHooks(bot, runtimeConfig, hooks.onModalSubmit)
+  registerNewMessageHooks(bot, runtimeConfig, hooks.onNewMessage, workflow)
+  registerReactionHooks(bot, runtimeConfig, hooks.onReaction, workflow)
+  registerActionHooks(bot, runtimeConfig, hooks.onAction, workflow)
+  registerModalSubmitHooks(bot, runtimeConfig, hooks.onModalSubmit, workflow)
 }
 
-async function createChat<TRuntimeConfig extends ChatRuntimeConfig>(
-  options: DefineChatOptions<TRuntimeConfig>,
+const chatHookNames = [
+  "onAction",
+  "onDirectMessage",
+  "onModalSubmit",
+  "onNewMention",
+  "onNewMessage",
+  "onReaction",
+  "onSubscribedMessage",
+] as const
+
+function resolveChatHooks<
+  TRuntimeConfig extends ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined,
+>(
+  options: DefineChatOptions<TRuntimeConfig, TWorkflow>,
+): ChatEventHooks<TRuntimeConfig, TWorkflow> {
+  const resolved = { ...(options.hooks || {}) } as Record<string, unknown>
+
+  for (const name of chatHookNames) {
+    const hook = options[name]
+    if (hook === undefined) {
+      continue
+    }
+    if (resolved[name] !== undefined) {
+      throw new Error(`Duplicate chat hook "${name}". Use either defineChat({ ${name} }) or defineChat({ hooks: { ${name} } }), not both.`)
+    }
+    resolved[name] = hook
+  }
+
+  return resolved as ChatEventHooks<TRuntimeConfig, TWorkflow>
+}
+
+async function createChat<
+  TRuntimeConfig extends ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined,
+>(
+  options: DefineChatOptions<TRuntimeConfig, TWorkflow>,
   context: ChatRuntimeContext<TRuntimeConfig>,
   resolveOptions: ResolveChatOptions = {},
 ) {
@@ -302,11 +376,19 @@ async function createChat<TRuntimeConfig extends ChatRuntimeConfig>(
   const state = await resolveValue(options.state, context)
   const {
     adapters: _adapters,
-    hooks,
+    hooks: _hooks,
     lifecycleHooks: _lifecycleHooks,
+    onAction: _onAction,
+    onDirectMessage: _onDirectMessage,
+    onModalSubmit: _onModalSubmit,
+    onNewMention: _onNewMention,
+    onNewMessage: _onNewMessage,
+    onReaction: _onReaction,
+    onSubscribedMessage: _onSubscribedMessage,
     setup,
     state: _state,
     userName: _userName,
+    workflow,
     ...chatOptions
   } = options
   const userName = options.userName || resolveOptions.inferredName
@@ -321,13 +403,16 @@ async function createChat<TRuntimeConfig extends ChatRuntimeConfig>(
     userName,
   })
 
-  registerChatHooks(bot, runtimeConfig, hooks)
+  registerChatHooks(bot, runtimeConfig, resolveChatHooks(options), workflow as TWorkflow)
   await setup?.(bot, resolvedContext)
   return bot
 }
 
-export function defineChat<TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig>(
-  options: DefineChatOptions<TRuntimeConfig>,
+export function defineChat<
+  TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined = ChatWorkflowHandle<any, any> | undefined,
+>(
+  options: DefineChatOptions<TRuntimeConfig, TWorkflow>,
 ): ChatDefinition<TRuntimeConfig> {
   const memoKey = `vitehub:chat:${++definitionId}`
   return {

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -61,7 +61,24 @@ export type AdapterInput<TContext extends ChatRuntimeContext<any> = ChatRuntimeC
   | MaybeResolvable<Record<string, Adapter>, TContext>
   | Record<string, MaybeResolvable<Adapter, TContext>>
 
-export interface ChatHookArgs<TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig> {
+export interface ChatWorkflowHandle<TPayload = any, TResult = any> {
+  defer: (payload: TPayload, options?: { id?: string }) => MaybePromise<WorkflowRunLike<TPayload>>
+  getRun: (id: string) => MaybePromise<WorkflowRunLike<TPayload, TResult>>
+  name: string
+  run: (payload: TPayload, options?: { id?: string }) => MaybePromise<WorkflowRunLike<TPayload, TResult>>
+}
+
+export interface WorkflowRunLike<TPayload = any, TResult = any> {
+  id: string
+  result?: TResult
+  status: string
+  payload?: TPayload
+}
+
+export interface ChatHookArgs<
+  TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined = ChatWorkflowHandle<any, any> | undefined,
+> {
   bot: Chat
   channel?: Channel
   context?: MessageContext
@@ -69,54 +86,80 @@ export interface ChatHookArgs<TRuntimeConfig extends ChatRuntimeConfig = ChatRun
   message?: Message
   runtimeConfig: TRuntimeConfig
   thread?: Thread
+  workflow: TWorkflow
 }
 
-export type ChatMessageHook<TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig> = (args: ChatHookArgs<TRuntimeConfig> & {
+export type ChatMessageHook<
+  TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined = ChatWorkflowHandle<any, any> | undefined,
+> = (args: ChatHookArgs<TRuntimeConfig, TWorkflow> & {
   context?: MessageContext
   message: Message
   thread: Thread
 }) => MaybePromise<void>
 
-export type ChatDirectMessageHook<TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig> = (args: ChatHookArgs<TRuntimeConfig> & {
+export type ChatDirectMessageHook<
+  TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined = ChatWorkflowHandle<any, any> | undefined,
+> = (args: ChatHookArgs<TRuntimeConfig, TWorkflow> & {
   channel: Channel
   context?: MessageContext
   message: Message
   thread: Thread
 }) => MaybePromise<void>
 
-export type ChatEventHook<TEvent, TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig> = (args: ChatHookArgs<TRuntimeConfig> & {
+export type ChatEventHook<
+  TEvent,
+  TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined = ChatWorkflowHandle<any, any> | undefined,
+> = (args: ChatHookArgs<TRuntimeConfig, TWorkflow> & {
   event: TEvent
 }) => MaybePromise<void>
 
-export interface ChatNewMessageHook<TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig> {
-  handler: ChatMessageHook<TRuntimeConfig>
+export interface ChatNewMessageHook<
+  TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined = ChatWorkflowHandle<any, any> | undefined,
+> {
+  handler: ChatMessageHook<TRuntimeConfig, TWorkflow>
   pattern: RegExp
 }
 
-export type ChatReactionHookInput<TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig> =
-  | ChatEventHook<ReactionEvent, TRuntimeConfig>
-  | Record<string, ChatEventHook<ReactionEvent, TRuntimeConfig>>
+export type ChatReactionHookInput<
+  TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined = ChatWorkflowHandle<any, any> | undefined,
+> =
+  | ChatEventHook<ReactionEvent, TRuntimeConfig, TWorkflow>
+  | Record<string, ChatEventHook<ReactionEvent, TRuntimeConfig, TWorkflow>>
   | {
     emoji: Array<EmojiValue | string>
-    handler: ChatEventHook<ReactionEvent, TRuntimeConfig>
+    handler: ChatEventHook<ReactionEvent, TRuntimeConfig, TWorkflow>
   }
 
-export type ChatActionHookInput<TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig> =
-  | ChatEventHook<ActionEvent, TRuntimeConfig>
-  | Record<string, ChatEventHook<ActionEvent, TRuntimeConfig>>
+export type ChatActionHookInput<
+  TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined = ChatWorkflowHandle<any, any> | undefined,
+> =
+  | ChatEventHook<ActionEvent, TRuntimeConfig, TWorkflow>
+  | Record<string, ChatEventHook<ActionEvent, TRuntimeConfig, TWorkflow>>
 
-export type ChatModalSubmitHookInput<TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig> =
-  | ChatEventHook<ModalSubmitEvent, TRuntimeConfig>
-  | Record<string, ChatEventHook<ModalSubmitEvent, TRuntimeConfig>>
+export type ChatModalSubmitHookInput<
+  TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined = ChatWorkflowHandle<any, any> | undefined,
+> =
+  | ChatEventHook<ModalSubmitEvent, TRuntimeConfig, TWorkflow>
+  | Record<string, ChatEventHook<ModalSubmitEvent, TRuntimeConfig, TWorkflow>>
 
-export interface ChatEventHooks<TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig> {
-  onAction?: ChatActionHookInput<TRuntimeConfig>
-  onDirectMessage?: ChatDirectMessageHook<TRuntimeConfig>
-  onModalSubmit?: ChatModalSubmitHookInput<TRuntimeConfig>
-  onNewMention?: ChatMessageHook<TRuntimeConfig>
-  onNewMessage?: ChatNewMessageHook<TRuntimeConfig> | Array<ChatNewMessageHook<TRuntimeConfig>>
-  onReaction?: ChatReactionHookInput<TRuntimeConfig>
-  onSubscribedMessage?: ChatMessageHook<TRuntimeConfig>
+export interface ChatEventHooks<
+  TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined = ChatWorkflowHandle<any, any> | undefined,
+> {
+  onAction?: ChatActionHookInput<TRuntimeConfig, TWorkflow>
+  onDirectMessage?: ChatDirectMessageHook<TRuntimeConfig, TWorkflow>
+  onModalSubmit?: ChatModalSubmitHookInput<TRuntimeConfig, TWorkflow>
+  onNewMention?: ChatMessageHook<TRuntimeConfig, TWorkflow>
+  onNewMessage?: ChatNewMessageHook<TRuntimeConfig, TWorkflow> | Array<ChatNewMessageHook<TRuntimeConfig, TWorkflow>>
+  onReaction?: ChatReactionHookInput<TRuntimeConfig, TWorkflow>
+  onSubscribedMessage?: ChatMessageHook<TRuntimeConfig, TWorkflow>
 }
 
 export interface ChatWebhookRuntimeHooks<TContext extends ChatRuntimeContext<any> = ChatRuntimeContext> {
@@ -128,11 +171,14 @@ export interface ChatWebhookRuntimeHooks<TContext extends ChatRuntimeContext<any
 
 type ChatConfigPassthrough = Omit<ChatConfig, "adapters" | "state" | "userName">
 
-export interface DefineChatOptions<TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig> extends ChatConfigPassthrough {
+export interface DefineChatOptions<
+  TRuntimeConfig extends ChatRuntimeConfig = ChatRuntimeConfig,
+  TWorkflow extends ChatWorkflowHandle<any, any> | undefined = ChatWorkflowHandle<any, any> | undefined,
+> extends ChatConfigPassthrough, ChatEventHooks<TRuntimeConfig, TWorkflow> {
   adapters: AdapterInput<ResolvedChatRuntimeContext<TRuntimeConfig>>
   concurrency?: ConcurrencyStrategy | ConcurrencyConfig
   fallbackStreamingPlaceholderText?: string | null
-  hooks?: ChatEventHooks<TRuntimeConfig>
+  hooks?: ChatEventHooks<TRuntimeConfig, TWorkflow>
   lifecycleHooks?: ChatWebhookRuntimeHooks<ChatRuntimeContext<TRuntimeConfig>>
   lockScope?: LockScope | ((context: LockScopeContext) => LockScope | Promise<LockScope>)
   logger?: Logger | LogLevel
@@ -140,6 +186,7 @@ export interface DefineChatOptions<TRuntimeConfig extends ChatRuntimeConfig = Ch
   setup?: (bot: Chat, context: ResolvedChatRuntimeContext<TRuntimeConfig>) => MaybePromise<void>
   state: MaybeResolvable<StateAdapter, ChatRuntimeContext<TRuntimeConfig>>
   userName?: ChatConfig["userName"]
+  workflow?: TWorkflow
 }
 
 export interface ResolveChatOptions {

--- a/packages/chat/test/runtime.test.ts
+++ b/packages/chat/test/runtime.test.ts
@@ -129,7 +129,51 @@ describe("defineChat", () => {
       message: { text: "hello" },
       runtimeConfig: context.runtimeConfig,
       thread: { id: "thread" },
+      workflow: undefined,
     })
+  })
+
+  it("registers top-level direct message hooks and passes workflow handles", async () => {
+    const { defineChat, resolveChat } = await import("../src/index.ts")
+    const directMessageSpy = vi.spyOn(Chat.prototype, "onDirectMessage")
+    const workflow = {
+      defer: vi.fn(),
+      getRun: vi.fn(),
+      name: "chat-reply",
+      run: vi.fn(),
+    }
+    const onDirectMessage = vi.fn()
+
+    const bot = await resolveChat(defineChat({
+      adapters: {},
+      onDirectMessage,
+      state: createState() as never,
+      userName: "Quiver Chat",
+      workflow,
+    }), createContext() as never)
+
+    const handler = directMessageSpy.mock.calls[0]?.[0]
+    await handler?.({ id: "thread" } as never, { text: "hello" } as never, { id: "channel" } as never)
+
+    expect(onDirectMessage).toHaveBeenCalledWith(expect.objectContaining({
+      bot,
+      message: { text: "hello" },
+      thread: { id: "thread" },
+      workflow,
+    }))
+  })
+
+  it("rejects duplicate flat and nested chat hooks", async () => {
+    const { defineChat, resolveChat } = await import("../src/index.ts")
+    const definition = defineChat({
+      adapters: {},
+      hooks: { onDirectMessage: vi.fn() },
+      onDirectMessage: vi.fn(),
+      state: createState() as never,
+      userName: "Quiver Chat",
+    })
+
+    await expect(resolveChat(definition, createContext() as never)).rejects.toThrow("Duplicate chat hook \"onDirectMessage\"")
   })
 
   it("wraps devtools thread streams so tool parts are reported automatically", async () => {

--- a/packages/internal/test/vite-e2e-output.test.ts
+++ b/packages/internal/test/vite-e2e-output.test.ts
@@ -11,6 +11,7 @@ const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
 const repoRoot = resolve(playgroundDir, "../..")
 const workspacePackages = ["blob", "chat", "db", "env", "kv", "queue", "sandbox", "unsource", "workflow", "workspace"] as const
 const tempDirs: string[] = []
+const execMaxBuffer = 16 * 1024 * 1024
 
 async function createWorkspaceTempDir(prefix: string) {
   const baseDir = join(playgroundDir, ".vitest-tmp")
@@ -64,6 +65,7 @@ beforeAll(async () => {
     await execFileAsync("pnpm", ["--filter", `@vitehub/${name}`, "build"], {
       cwd: repoRoot,
       env: process.env,
+      maxBuffer: execMaxBuffer,
     })
   }
 }, 120_000)
@@ -87,6 +89,7 @@ describe("unified vite e2e hosted outputs", () => {
         VITEHUB_HOSTING: "cloudflare",
         VITEHUB_VITE_MODE: "e2e",
       },
+      maxBuffer: execMaxBuffer,
     })
 
     const cloudflareWorker = join(rootDir, "dist", "vite", "index.js")
@@ -152,6 +155,7 @@ describe("unified vite e2e hosted outputs", () => {
         VITE_SANDBOX_TEAM_ID: "team-id",
         VITE_SANDBOX_TOKEN: "sandbox-token",
       },
+      maxBuffer: execMaxBuffer,
     })
 
     const vercelConfig = await readFile(join(rootDir, ".vercel", "output", "config.json"), "utf8")
@@ -186,6 +190,7 @@ describe("unified vite e2e hosted outputs", () => {
         ...process.env,
         VITEHUB_VITE_MODE: "env",
       },
+      maxBuffer: execMaxBuffer,
     })
 
     const envOutput = await readGeneratedJavaScript(join(envRoot, "dist"))
@@ -200,6 +205,7 @@ describe("unified vite e2e hosted outputs", () => {
         ...process.env,
         VITEHUB_VITE_MODE: "chat",
       },
+      maxBuffer: execMaxBuffer,
     })
 
     const chatOutput = await readGeneratedJavaScript(join(chatRoot, "dist"))

--- a/packages/workflow/docs/runtime-api.md
+++ b/packages/workflow/docs/runtime-api.md
@@ -36,48 +36,9 @@ export default defineNitroConfig({
 })
 ```
 
-## `createWorkflow(name, handler?, options?)`
-
-Creates a typed workflow handle. When `handler` is passed, the workflow is defined inline and does not need a file under `server/workflows`.
-
-```ts
-const welcome = createWorkflow<WelcomePayload, WelcomeResult>('welcome', async ({ payload }) => {
-  return { message: `Welcome ${payload.email}` }
-})
-
-await welcome.run({ email: 'ava@example.com' })
-await welcome.defer({ email: 'ava@example.com' })
-await welcome.getRun('welcome-signup-42')
-```
-
-When `handler` is omitted, the handle references an existing discovered workflow:
-
-```ts
-const welcome = createWorkflow<WelcomePayload, WelcomeResult>('welcome')
-await welcome.run({ email: 'ava@example.com' })
-```
-
-A workflow name can only be defined once. Do not define the same name inline and under `server/workflows`.
-
-Pass an `id` resolver when the workflow owns stable run identity. The resolved value is canonicalized and hashed with the workflow name. An explicit `run(payload, { id })` still wins.
-
-```ts
-const chatReply = createWorkflow<ChatReplyPayload, ChatReplyResult>('chat-reply', async ({ payload }) => {
-  return await replyToMessage(payload)
-}, {
-  id: ({ payload }) => ({
-    platform: payload?.platform,
-    threadId: payload?.threadId,
-    messageId: payload?.messageId,
-  }),
-})
-
-await chatReply.run(payload)
-```
-
 ## `defineWorkflow(handler, options?)`
 
-Defines a discovered workflow file. Prefer `createWorkflow(name, handler)` for inline one-step workflows.
+Defines a discovered workflow.
 
 ```ts
 export default defineWorkflow<Payload, Result>(async (context) => {
@@ -181,6 +142,25 @@ Reads and validates a Web `Request`.
 ```ts
 const payload = await readValidatedPayload(request, schema)
 ```
+
+## `createWorkflow(options)`
+
+Defines an inline workflow and returns a typed handle for starting and observing runs.
+
+```ts
+const chatReply = createWorkflow<ChatReplyPayload, ChatReplyResult>({
+  name: 'chat-reply',
+  handler: async ({ payload }) => {
+    return await answerWithContext(payload.text)
+  },
+  id: ({ payload: { threadId, messageId } }) => `${threadId}:${messageId}`,
+})
+
+const run = await chatReply.run(payload)
+const result = await chatReply.getRun(run.id)
+```
+
+`id` is optional. When provided, it must return a string. Passing `run(payload, { id })` or `defer(payload, { id })` overrides the resolver.
 
 ## Config options
 

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -17,6 +17,7 @@ export type {
   WorkflowDefinition,
   WorkflowDefinitionOptions,
   WorkflowDefinitionRegistry,
+  WorkflowCreateOptions,
   WorkflowDeferOptions,
   WorkflowExecutionContext,
   WorkflowHandle,

--- a/packages/workflow/src/runtime/client.ts
+++ b/packages/workflow/src/runtime/client.ts
@@ -103,19 +103,49 @@ async function resolveWorkflowStartOptions<TPayload>(
 }
 
 export function createWorkflow<TPayload = unknown, TResult = unknown>(
+  options: WorkflowCreateOptions<TPayload, TResult> & { handler: WorkflowHandler<TPayload, TResult>, name: string },
+): WorkflowHandle<TPayload, TResult>
+export function createWorkflow<TPayload = unknown, TResult = unknown>(
   name: string,
-  options?: WorkflowCreateOptions<TPayload>,
+  options?: WorkflowCreateOptions<TPayload, TResult>,
 ): WorkflowHandle<TPayload, TResult>
 export function createWorkflow<TPayload = unknown, TResult = unknown>(
   name: string,
   handler: WorkflowHandler<TPayload, TResult>,
-  options?: WorkflowCreateOptions<TPayload>,
+  options?: WorkflowCreateOptions<TPayload, TResult>,
 ): WorkflowHandle<TPayload, TResult>
 export function createWorkflow<TPayload = unknown, TResult = unknown>(
-  name: string,
-  handlerOrOptions?: WorkflowCreateOptions<TPayload> | WorkflowHandler<TPayload, TResult>,
-  options?: WorkflowCreateOptions<TPayload>,
+  nameOrOptions: string | WorkflowCreateOptions<TPayload, TResult>,
+  handlerOrOptions?: WorkflowCreateOptions<TPayload, TResult> | WorkflowHandler<TPayload, TResult>,
+  options?: WorkflowCreateOptions<TPayload, TResult>,
 ): WorkflowHandle<TPayload, TResult> {
+  if (typeof nameOrOptions === "object" && nameOrOptions !== null) {
+    const createOptions = nameOrOptions
+    const { handler, name } = createOptions
+    if (!name || typeof name !== "string") {
+      throw new TypeError("`createWorkflow()` requires a workflow name.")
+    }
+    if (typeof handler !== "function") {
+      throw new TypeError("`createWorkflow()` requires a workflow handler.")
+    }
+    registerInlineWorkflowDefinition(name, { handler: handler as WorkflowHandler })
+    return {
+      name,
+      defer: async (payload?: TPayload, options: WorkflowStartOptions = {}) => deferWorkflow<TPayload>(
+        name,
+        payload,
+        await resolveWorkflowStartOptions(name, payload, createOptions, options),
+      ),
+      getRun: (id: string) => getWorkflowRun<TPayload, TResult>(name, id),
+      run: async (payload?: TPayload, options: WorkflowStartOptions = {}) => runWorkflow<TPayload, TResult>(
+        name,
+        payload,
+        await resolveWorkflowStartOptions(name, payload, createOptions, options),
+      ),
+    }
+  }
+
+  const name = nameOrOptions
   if (!name || typeof name !== "string") {
     throw new TypeError("`createWorkflow()` requires a workflow name.")
   }

--- a/packages/workflow/src/runtime/state.ts
+++ b/packages/workflow/src/runtime/state.ts
@@ -8,6 +8,7 @@ const RUNS_TTL_MS = 5 * 60 * 1000
 let runtimeConfig: false | ResolvedWorkflowOptions | undefined
 let runtimeRegistry: WorkflowDefinitionRegistry | undefined
 const inlineRegistry = new Map<string, WorkflowDefinition>()
+const loadingRegistryEntries = new Set<string>()
 let fallbackEvent: unknown
 const eventStorage = new AsyncLocalStorage<unknown>()
 export interface WorkflowRunState<TResult = unknown> {
@@ -93,13 +94,25 @@ export async function loadWorkflowDefinition(name: string): Promise<WorkflowDefi
   if (!entry) {
     return undefined
   }
-
-  const loaded = await entry()
-  if (!loaded || typeof loaded !== "object") {
+  if (loadingRegistryEntries.has(name)) {
     return undefined
   }
-  const definition = ("default" in loaded ? loaded.default : loaded) as WorkflowDefinition | undefined
-  return definition && typeof definition.handler === "function" ? definition : undefined
+  loadingRegistryEntries.add(name)
+  try {
+    const loaded = await entry()
+    const registeredInlineDefinition = inlineRegistry.get(name)
+    if (registeredInlineDefinition) {
+      return registeredInlineDefinition
+    }
+    if (!loaded || typeof loaded !== "object") {
+      return undefined
+    }
+    const definition = ("default" in loaded ? loaded.default : loaded) as WorkflowDefinition | undefined
+    return definition && typeof definition.handler === "function" ? definition : undefined
+  }
+  finally {
+    loadingRegistryEntries.delete(name)
+  }
 }
 
 export function setWorkflowRun<TResult = unknown>(

--- a/packages/workflow/src/types.ts
+++ b/packages/workflow/src/types.ts
@@ -87,8 +87,10 @@ export type WorkflowRunIdValue =
   | { readonly [key: string]: WorkflowRunIdValue }
   | readonly WorkflowRunIdValue[]
 
-export interface WorkflowCreateOptions<TPayload = unknown> {
+export interface WorkflowCreateOptions<TPayload = unknown, TResult = unknown> {
+  handler?: WorkflowHandler<TPayload, TResult>
   id?: (context: { name: string, payload?: TPayload }) => Promise<WorkflowRunIdValue> | WorkflowRunIdValue
+  name?: string
 }
 
 export interface WorkflowDefinitionOptions {

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -217,6 +217,17 @@ describe("workflow runtime", () => {
     })
   })
 
+  it("does not recurse when an inline registry entry registers no definition", async () => {
+    setWorkflowRuntimeConfig({ provider: "vercel" })
+    setWorkflowRuntimeRegistry({
+      missing: async () => await runWorkflow("missing", {}),
+    } as never)
+
+    await expect(runWorkflow("missing", {})).rejects.toMatchObject({
+      code: "WORKFLOW_DEFINITION_NOT_FOUND",
+    })
+  })
+
   it("returns nonblocking status while local workflow runs are pending", async () => {
     let resolveRun: ((value: { ok: boolean }) => void) | undefined
     setWorkflowRuntimeConfig({ provider: "vercel" })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,16 +172,16 @@ importers:
         version: link:../packages/chat
       '@vitejs/devtools-kit':
         specifier: 'catalog:'
-        version: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
+        version: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
       docus:
         specifier: 'catalog:'
-        version: 5.9.0(41280f3cb6d62841219f75defe7cef35)
+        version: 5.9.0(fdb5fe3901af3981e6a838eeaed539f6)
       h3:
         specifier: catalog:h3v1
         version: 1.15.11
       nuxt:
         specifier: 'catalog:'
-        version: 4.4.2(2ea8ffe6f022b1f4499757e3c66be132)
+        version: 4.4.2(32aab04b720da05e4a0a650a7dca5f7c)
       shiki:
         specifier: 'catalog:'
         version: 4.0.2
@@ -323,6 +323,9 @@ importers:
       '@vitehub/chat':
         specifier: workspace:*
         version: link:../..
+      '@vitehub/workflow':
+        specifier: workspace:*
+        version: link:../../../workflow
       '@vitejs/devtools':
         specifier: 'catalog:'
         version: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools@307(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
@@ -1148,12 +1151,6 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.96':
-    resolution: {integrity: sha512-BDiVEMUVHGpngReeigzLyJobG0TvzYbNGzdHI8JYBZHrjOX4aL6qwIls7z3p7V4TuXVWUCbG8TSWEe7ksX4Vhw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   '@ai-sdk/mcp@1.0.36':
     resolution: {integrity: sha512-THQKwlknp7OU2ViLPfIU7W01XvDRM2eqH+4UULQgP64AopnwI9mGqqJeGIx2l/pxUu9yIDQtW9YtYM8kHm2CQg==}
     engines: {node: '>=18'}
@@ -1387,11 +1384,6 @@ packages:
   '@babel/helpers@7.29.2':
     resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.3':
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
@@ -5423,6 +5415,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/vue@2.1.13':
     resolution: {integrity: sha512-HYy0shaHRnLNW9r85gppO8IiGz0ONWVV3zGdlT8CQ0tbTwixznJCIiyqV4BSV1aIF1jJIye0pd1p/k6Eab8Z/A==}
@@ -5483,13 +5476,13 @@ packages:
       vite: '*'
 
   '@vitejs/devtools-kit@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@0348334':
-    resolution: {integrity: sha512-NdNVSygLaSxUTqV2S2dJLLlVPzATFYY6vzapbVSRzPjSIBkoWJc8dZfhn/Of1Kdym30f6hiUBFNvFFbuVoI+Vw==, tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@0348334}
+    resolution: {tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@0348334}
     version: 0.1.19
     peerDependencies:
       vite: '*'
 
   '@vitejs/devtools-kit@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307':
-    resolution: {integrity: sha512-NdNVSygLaSxUTqV2S2dJLLlVPzATFYY6vzapbVSRzPjSIBkoWJc8dZfhn/Of1Kdym30f6hiUBFNvFFbuVoI+Vw==, tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307}
+    resolution: {tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307}
     version: 0.1.19
     peerDependencies:
       vite: '*'
@@ -5498,7 +5491,7 @@ packages:
     resolution: {integrity: sha512-OtmgshVrDwtL7TqAoLgsP0DxjGF0mMlzL9+lXOtySP2Rr/qfrHiKnYlhnyi47ntQ9LWFPmIujUXabk40hPX9vA==}
 
   '@vitejs/devtools-rolldown@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-rolldown@0348334':
-    resolution: {integrity: sha512-9Nm0QgKUsae0mmwDdZrIONTlPbH8cwSxXJorz+lKWd0ePgqSXLwZ4A08ZyG4zrYZXhNp7sNreZwSW0Qi0UXLsA==, tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-rolldown@0348334}
+    resolution: {tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-rolldown@0348334}
     version: 0.1.19
 
   '@vitejs/devtools@0.1.19':
@@ -5508,7 +5501,7 @@ packages:
       vite: '*'
 
   '@vitejs/devtools@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools@307':
-    resolution: {integrity: sha512-sGZ42trCSQ6tw8AsAGObAoVsabxMdSFAKzhNSdijWEEhyxB0zsgJNfMVfWTPDt7Nm2xlKw63BBOjudDS2X7kBg==, tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools@307}
+    resolution: {tarball: https://pkg.pr.new/vitejs/devtools/@vitejs/devtools@307}
     version: 0.1.19
     hasBin: true
     peerDependencies:
@@ -5591,26 +5584,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@vue/compiler-core@3.5.32':
-    resolution: {integrity: sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==}
-
   '@vue/compiler-core@3.5.34':
     resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
-
-  '@vue/compiler-dom@3.5.32':
-    resolution: {integrity: sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==}
 
   '@vue/compiler-dom@3.5.34':
     resolution: {integrity: sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==}
 
-  '@vue/compiler-sfc@3.5.32':
-    resolution: {integrity: sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==}
-
   '@vue/compiler-sfc@3.5.34':
     resolution: {integrity: sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==}
-
-  '@vue/compiler-ssr@3.5.32':
-    resolution: {integrity: sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==}
 
   '@vue/compiler-ssr@3.5.34':
     resolution: {integrity: sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==}
@@ -5635,36 +5616,19 @@ packages:
   '@vue/language-core@3.2.6':
     resolution: {integrity: sha512-xYYYX3/aVup576tP/23sEUpgiEnujrENaoNRbaozC1/MA9I6EGFQRJb4xrt/MmUCAGlxTKL2RmT8JLTPqagCkg==}
 
-  '@vue/reactivity@3.5.32':
-    resolution: {integrity: sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==}
-
   '@vue/reactivity@3.5.34':
     resolution: {integrity: sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==}
-
-  '@vue/runtime-core@3.5.32':
-    resolution: {integrity: sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==}
 
   '@vue/runtime-core@3.5.34':
     resolution: {integrity: sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==}
 
-  '@vue/runtime-dom@3.5.32':
-    resolution: {integrity: sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==}
-
   '@vue/runtime-dom@3.5.34':
     resolution: {integrity: sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==}
-
-  '@vue/server-renderer@3.5.32':
-    resolution: {integrity: sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==}
-    peerDependencies:
-      vue: 3.5.32
 
   '@vue/server-renderer@3.5.34':
     resolution: {integrity: sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==}
     peerDependencies:
       vue: 3.5.34
-
-  '@vue/shared@3.5.32':
-    resolution: {integrity: sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==}
 
   '@vue/shared@3.5.34':
     resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
@@ -7097,10 +7061,6 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
-    engines: {node: '>=18.0.0'}
-
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
@@ -7570,9 +7530,6 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
-  hookable@6.1.0:
-    resolution: {integrity: sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==}
-
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
@@ -7840,11 +7797,6 @@ packages:
   isexe@4.0.0:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
-
-  isomorphic-git@1.37.5:
-    resolution: {integrity: sha512-wek54c5uFvd3WsxewLWt6h0GXKWQh0P8rRXns9bN1rHNjcgCb3+0lmyAsP594NeTtQFeCJQVS9b0kjbkD1l5qg==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   isomorphic-git@1.37.6:
     resolution: {integrity: sha512-qr1NFCPsVTZ6YGqTXw0CzamnsHyH9QQ1OTEfeXIweSljRUMzuHFCJdUn0wc6OcjtTDns6knxjPb7N6LmJeftOA==}
@@ -10710,14 +10662,6 @@ packages:
     peerDependencies:
       vue: ^3.3.0
 
-  vue@3.5.32:
-    resolution: {integrity: sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   vue@3.5.34:
     resolution: {integrity: sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==}
     peerDependencies:
@@ -10990,40 +10934,33 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.1
 
-  '@ai-sdk/gateway@3.0.83(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.83(zod@4.4.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.4.1)
       '@vercel/oidc': 3.1.0
-      zod: 4.3.6
+      zod: 4.4.1
 
-  '@ai-sdk/gateway@3.0.96(zod@4.3.6)':
+  '@ai-sdk/mcp@1.0.36(zod@4.4.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
-      '@vercel/oidc': 3.1.0
-      zod: 4.3.6
-
-  '@ai-sdk/mcp@1.0.36(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.4.1)
       pkce-challenge: 5.0.1
-      zod: 4.3.6
+      zod: 4.4.1
 
-  '@ai-sdk/provider-utils@4.0.21(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.21(zod@4.4.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 4.3.6
+      eventsource-parser: 3.0.8
+      zod: 4.4.1
 
-  '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.23(zod@4.4.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 4.3.6
+      eventsource-parser: 3.0.8
+      zod: 4.4.1
 
   '@ai-sdk/provider-utils@4.0.26(zod@4.4.1)':
     dependencies:
@@ -11040,10 +10977,10 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/vue@3.0.141(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)':
+  '@ai-sdk/vue@3.0.141(vue@3.5.34(typescript@6.0.2))(zod@4.4.1)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
-      ai: 6.0.141(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.4.1)
+      ai: 6.0.141(zod@4.4.1)
       swrv: 1.2.0(vue@3.5.34(typescript@6.0.2))
       vue: 3.5.34(typescript@6.0.2)
     transitivePeerDependencies:
@@ -11054,7 +10991,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
 
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
@@ -11286,7 +11223,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -11301,7 +11238,7 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -11403,10 +11340,6 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
-  '@babel/parser@7.29.2':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
@@ -11439,7 +11372,7 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.29.0':
@@ -11447,7 +11380,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -12112,7 +12045,7 @@ snapshots:
 
   '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.3.2)(@vue/compiler-dom@3.5.34)(vue-i18n@11.3.2(vue@3.5.34(typescript@6.0.2)))(vue@3.5.34(typescript@6.0.2))':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
     optionalDependencies:
       '@intlify/shared': 11.3.2
       '@vue/compiler-dom': 3.5.34
@@ -12277,28 +12210,6 @@ snapshots:
       json5: 2.2.3
       rollup: 4.60.1
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.12)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
-      jose: 6.2.2
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
-    transitivePeerDependencies:
-      - supports-color
-
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.1)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.12)
@@ -12308,7 +12219,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
       hono: 4.12.12
@@ -12320,7 +12231,6 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.1)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@mongodb-js/zstd@7.0.0':
     dependencies:
@@ -12474,7 +12384,7 @@ snapshots:
       srvx: 0.11.15
       std-env: 3.10.0
       tinyclip: 0.1.12
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
       ufo: 1.6.3
       youch: 4.1.1
     optionalDependencies:
@@ -12501,7 +12411,7 @@ snapshots:
       destr: 2.0.5
       git-url-parse: 16.1.0
       hookable: 5.5.3
-      isomorphic-git: 1.37.5
+      isomorphic-git: 1.37.6
       jiti: 2.6.1
       json-schema-to-typescript-lite: 15.0.0
       mdast-util-to-hast: 13.2.1
@@ -12560,7 +12470,7 @@ snapshots:
   '@nuxt/devtools-kit@4.0.0-alpha.3(magicast@0.5.2)(vite@8.0.8)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
       vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - magicast
@@ -12576,12 +12486,12 @@ snapshots:
       pkg-types: 2.3.0
       semver: 7.7.4
 
-  '@nuxt/devtools@3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))':
+  '@nuxt/devtools@3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))':
     dependencies:
       '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@8.0.8)
       '@nuxt/devtools-wizard': 3.2.4
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@6.0.2))
+      '@vue/devtools-core': 8.1.1(vue@3.5.34(typescript@6.0.2))
       '@vue/devtools-kit': 8.1.1
       birpc: 4.0.0
       consola: 3.4.2
@@ -12608,11 +12518,11 @@ snapshots:
       tinyglobby: 0.2.16
       vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@8.0.8)
-      vite-plugin-vue-tracer: 1.3.0(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))
+      vite-plugin-vue-tracer: 1.3.0(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
       which: 6.0.1
       ws: 8.20.0
     optionalDependencies:
-      '@vitejs/devtools': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
+      '@vitejs/devtools': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -12773,8 +12683,8 @@ snapshots:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@unhead/vue': 2.1.13(vue@3.5.32(typescript@6.0.2))
-      '@vue/shared': 3.5.32
+      '@unhead/vue': 2.1.13(vue@3.5.34(typescript@6.0.2))
+      '@vue/shared': 3.5.34
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
@@ -12797,7 +12707,7 @@ snapshots:
       ufo: 1.6.3
       unctx: 2.5.0
       unstorage: 1.17.5(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.34(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
     transitivePeerDependencies:
@@ -12838,13 +12748,13 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(rolldown@1.0.0-rc.16)(srvx@0.11.15)(typescript@6.0.2)':
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(rolldown@1.0.0-rc.16)(srvx@0.11.15)(typescript@6.0.2)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@unhead/vue': 2.1.13(vue@3.5.32(typescript@6.0.2))
-      '@vue/shared': 3.5.32
+      '@unhead/vue': 2.1.13(vue@3.5.34(typescript@6.0.2))
+      '@vue/shared': 3.5.34
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
@@ -12857,7 +12767,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.3(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(rolldown@1.0.0-rc.16)(srvx@0.11.15)
-      nuxt: 4.4.2(2ea8ffe6f022b1f4499757e3c66be132)
+      nuxt: 4.4.2(32aab04b720da05e4a0a650a7dca5f7c)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -12867,7 +12777,7 @@ snapshots:
       ufo: 1.6.3
       unctx: 2.5.0
       unstorage: 1.17.5(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.34(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
     transitivePeerDependencies:
@@ -12913,8 +12823,8 @@ snapshots:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@unhead/vue': 2.1.13(vue@3.5.32(typescript@6.0.2))
-      '@vue/shared': 3.5.32
+      '@unhead/vue': 2.1.13(vue@3.5.34(typescript@6.0.2))
+      '@vue/shared': 3.5.34
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
@@ -12937,7 +12847,7 @@ snapshots:
       ufo: 1.6.3
       unctx: 2.5.0
       unstorage: 1.17.5(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.34(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
     transitivePeerDependencies:
@@ -12984,7 +12894,7 @@ snapshots:
 
   '@nuxt/schema@4.4.2':
     dependencies:
-      '@vue/shared': 3.5.32
+      '@vue/shared': 3.5.34
       defu: 6.1.7
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -12998,121 +12908,6 @@ snapshots:
       ofetch: 2.0.0-alpha.3
       rc9: 3.0.1
       std-env: 4.0.0
-
-  '@nuxt/ui@4.6.1(@nuxt/content@3.13.0(@libsql/client@0.15.15)(@valibot/to-json-schema@1.6.0(valibot@1.3.1(typescript@6.0.2)))(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(magicast@0.5.2)(valibot@1.3.1(typescript@6.0.2)))(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@6.0.2)(valibot@1.3.1(typescript@6.0.2))(vite@8.0.8)(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(vue@3.5.34(typescript@6.0.2)))(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)':
-    dependencies:
-      '@floating-ui/dom': 1.7.6
-      '@iconify/vue': 5.0.0(vue@3.5.34(typescript@6.0.2))
-      '@internationalized/date': 3.12.0
-      '@internationalized/number': 3.6.5
-      '@nuxt/fonts': 0.14.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.8)
-      '@nuxt/icon': 2.2.1(magicast@0.5.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/schema': 4.4.2
-      '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
-      '@standard-schema/spec': 1.1.0
-      '@tailwindcss/postcss': 4.2.2
-      '@tailwindcss/vite': 4.2.2(vite@8.0.8)
-      '@tanstack/vue-table': 8.21.3(vue@3.5.34(typescript@6.0.2))
-      '@tanstack/vue-virtual': 3.13.23(vue@3.5.34(typescript@6.0.2))
-      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
-      '@tiptap/extension-bubble-menu': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
-      '@tiptap/extension-code': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
-      '@tiptap/extension-collaboration': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30)
-      '@tiptap/extension-drag-handle': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/extension-collaboration@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))
-      '@tiptap/extension-drag-handle-vue-3': 3.22.3(@tiptap/extension-drag-handle@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/extension-collaboration@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap/extension-node-range@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)))(@tiptap/pm@3.22.3)(@tiptap/vue-3@3.22.3(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)(vue@3.5.34(typescript@6.0.2)))(vue@3.5.34(typescript@6.0.2))
-      '@tiptap/extension-floating-menu': 3.22.3(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
-      '@tiptap/extension-horizontal-rule': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
-      '@tiptap/extension-image': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
-      '@tiptap/extension-mention': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)(@tiptap/suggestion@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
-      '@tiptap/extension-node-range': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
-      '@tiptap/extension-placeholder': 3.22.3(@tiptap/extensions@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
-      '@tiptap/markdown': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
-      '@tiptap/pm': 3.22.3
-      '@tiptap/starter-kit': 3.22.3
-      '@tiptap/suggestion': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
-      '@tiptap/vue-3': 3.22.3(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)(vue@3.5.34(typescript@6.0.2))
-      '@unhead/vue': 2.1.13(vue@3.5.34(typescript@6.0.2))
-      '@vueuse/core': 14.2.1(vue@3.5.34(typescript@6.0.2))
-      '@vueuse/integrations': 14.2.1(fuse.js@7.3.0)(vue@3.5.34(typescript@6.0.2))
-      '@vueuse/shared': 14.2.1(vue@3.5.34(typescript@6.0.2))
-      colortranslator: 5.0.0
-      consola: 3.4.2
-      defu: 6.1.7
-      embla-carousel-auto-height: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-auto-scroll: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-autoplay: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-class-names: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-fade: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-vue: 8.6.0(vue@3.5.34(typescript@6.0.2))
-      embla-carousel-wheel-gestures: 8.1.0(embla-carousel@8.6.0)
-      fuse.js: 7.3.0
-      hookable: 6.1.1
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      motion-v: 2.2.1(@vueuse/core@14.2.1(vue@3.5.34(typescript@6.0.2)))(vue@3.5.34(typescript@6.0.2))
-      ohash: 2.0.11
-      pathe: 2.0.3
-      reka-ui: 2.9.3(vue@3.5.34(typescript@6.0.2))
-      scule: 1.3.0
-      tailwind-merge: 3.5.0
-      tailwind-variants: 3.2.2(tailwind-merge@3.5.0)(tailwindcss@4.2.2)
-      tailwindcss: 4.2.2
-      tinyglobby: 0.2.16
-      typescript: 6.0.2
-      ufo: 1.6.3
-      unplugin: 3.0.0
-      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.2(magicast@0.5.2))(@vueuse/core@14.2.1(vue@3.5.34(typescript@6.0.2)))
-      unplugin-vue-components: 32.0.0(@nuxt/kit@4.4.2(magicast@0.5.2))(vue@3.5.34(typescript@6.0.2))
-      vaul-vue: 0.4.1(reka-ui@2.9.3(vue@3.5.34(typescript@6.0.2)))(vue@3.5.34(typescript@6.0.2))
-      vue-component-type-helpers: 3.2.6
-    optionalDependencies:
-      '@nuxt/content': 3.13.0(@libsql/client@0.15.15)(@valibot/to-json-schema@1.6.0(valibot@1.3.1(typescript@6.0.2)))(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(magicast@0.5.2)(valibot@1.3.1(typescript@6.0.2))
-      valibot: 1.3.1(typescript@6.0.2)
-      vue-router: 5.0.4(@vue/compiler-sfc@3.5.32)(vue@3.5.34(typescript@6.0.2))
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@emotion/is-prop-valid'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@tiptap/extensions'
-      - '@tiptap/y-tiptap'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vue/composition-api'
-      - async-validator
-      - aws4fetch
-      - axios
-      - change-case
-      - db0
-      - drauu
-      - embla-carousel
-      - focus-trap
-      - idb-keyval
-      - ioredis
-      - jwt-decode
-      - magicast
-      - nprogress
-      - qrcode
-      - react
-      - react-dom
-      - sortablejs
-      - universal-cookie
-      - uploadthing
-      - vite
-      - vue
-      - yjs
 
   '@nuxt/ui@4.6.1(f4c36ba86a67847d03e58c65ba63fadb)':
     dependencies:
@@ -13229,15 +13024,15 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(243bc5b918de3c48a1f63eb2bdcf78da))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(243bc5b918de3c48a1f63eb2bdcf78da))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.34(typescript@6.0.2))(yaml@2.8.3)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
-      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
-      autoprefixer: 10.5.0(postcss@8.5.9)
+      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.2))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.2))
+      autoprefixer: 10.5.0(postcss@8.5.14)
       consola: 3.4.2
-      cssnano: 7.1.5(postcss@8.5.9)
+      cssnano: 7.1.5(postcss@8.5.14)
       defu: 6.1.7
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -13251,7 +13046,7 @@ snapshots:
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
-      postcss: 8.5.9
+      postcss: 8.5.14
       seroval: 1.5.2
       std-env: 4.0.0
       ufo: 1.6.3
@@ -13259,7 +13054,7 @@ snapshots:
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-node: 5.3.0(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-checker: 0.12.0(eslint@10.2.0(jiti@2.6.1))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(typescript@6.0.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@6.0.2))
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.34(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -13290,15 +13085,15 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.34(typescript@6.0.2))(yaml@2.8.3)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
-      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
-      autoprefixer: 10.5.0(postcss@8.5.9)
+      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.2))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.2))
+      autoprefixer: 10.5.0(postcss@8.5.14)
       consola: 3.4.2
-      cssnano: 7.1.5(postcss@8.5.9)
+      cssnano: 7.1.5(postcss@8.5.14)
       defu: 6.1.7
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -13308,11 +13103,11 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(2ea8ffe6f022b1f4499757e3c66be132)
+      nuxt: 4.4.2(32aab04b720da05e4a0a650a7dca5f7c)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
-      postcss: 8.5.9
+      postcss: 8.5.14
       seroval: 1.5.2
       std-env: 4.0.0
       ufo: 1.6.3
@@ -13320,7 +13115,7 @@ snapshots:
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-node: 5.3.0(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-checker: 0.12.0(eslint@10.2.0(jiti@2.6.1))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(typescript@6.0.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@6.0.2))
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.34(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -13351,15 +13146,15 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(5ad1b1f5a672b20bdededb258034d6f9))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(5ad1b1f5a672b20bdededb258034d6f9))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.34(typescript@6.0.2))(yaml@2.8.3)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
-      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
-      autoprefixer: 10.5.0(postcss@8.5.9)
+      '@vitejs/plugin-vue': 6.0.6(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.2))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.2))
+      autoprefixer: 10.5.0(postcss@8.5.14)
       consola: 3.4.2
-      cssnano: 7.1.5(postcss@8.5.9)
+      cssnano: 7.1.5(postcss@8.5.14)
       defu: 6.1.7
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -13373,7 +13168,7 @@ snapshots:
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
-      postcss: 8.5.9
+      postcss: 8.5.14
       seroval: 1.5.2
       std-env: 4.0.0
       ufo: 1.6.3
@@ -13381,7 +13176,7 @@ snapshots:
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-node: 5.3.0(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-checker: 0.12.0(eslint@10.2.0(jiti@2.6.1))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(typescript@6.0.2)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@6.0.2))
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.34(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -13431,7 +13226,7 @@ snapshots:
       '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.60.1)
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-yaml': 4.1.2(rollup@4.60.1)
-      '@vue/compiler-sfc': 3.5.32
+      '@vue/compiler-sfc': 3.5.34
       defu: 6.1.7
       devalue: 5.7.1
       h3: 1.15.11
@@ -13449,7 +13244,7 @@ snapshots:
       unrouting: 0.1.7
       unstorage: 1.17.5(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)
       vue-i18n: 11.3.2(vue@3.5.34(typescript@6.0.2))
-      vue-router: 5.0.4(@vue/compiler-sfc@3.5.32)(vue@3.5.34(typescript@6.0.2))
+      vue-router: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@6.0.2))
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -13483,13 +13278,13 @@ snapshots:
       - uploadthing
       - vue
 
-  '@nuxtjs/mcp-toolkit@0.13.4(h3@1.15.11)(magicast@0.5.2)(zod@4.3.6)':
+  '@nuxtjs/mcp-toolkit@0.13.4(h3@1.15.11)(magicast@0.5.2)(zod@4.4.1)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.1)
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       h3: 1.15.11
       tinyglobby: 0.2.16
-      zod: 4.3.6
+      zod: 4.4.1
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - magicast
@@ -13505,7 +13300,7 @@ snapshots:
       '@shikijs/transformers': 4.0.2
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@vue/compiler-core': 3.5.32
+      '@vue/compiler-core': 3.5.34
       consola: 3.4.2
       debug: 4.4.3(supports-color@8.1.1)
       defu: 6.1.7
@@ -13545,20 +13340,20 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxtjs/robots@6.0.7(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)':
+  '@nuxtjs/robots@6.0.7(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1))(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1)
       pathe: 2.0.3
       pkg-types: 2.3.0
       ufo: 1.6.3
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.1
     transitivePeerDependencies:
       - '@nuxt/schema'
       - magicast
@@ -15450,12 +15245,6 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@unhead/vue@2.1.13(vue@3.5.32(typescript@6.0.2))':
-    dependencies:
-      hookable: 6.1.1
-      unhead: 2.1.13
-      vue: 3.5.32(typescript@6.0.2)
-
   '@unhead/vue@2.1.13(vue@3.5.34(typescript@6.0.2))':
     dependencies:
       hookable: 6.1.1
@@ -15542,22 +15331,6 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vitejs/devtools-kit@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)':
-    dependencies:
-      birpc: 4.0.0
-      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
-      ohash: 2.0.11
-      sirv: 3.0.2
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - '@nuxt/kit'
-      - bufferutil
-      - launch-editor
-      - typescript
-      - utf-8-validate
-    optional: true
-
   '@vitejs/devtools-kit@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)':
     dependencies:
       birpc: 4.0.0
@@ -15589,21 +15362,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@vitejs/devtools-kit@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)':
-    dependencies:
-      birpc: 4.0.0
-      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
-      ohash: 2.0.11
-      sirv: 3.0.2
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - '@nuxt/kit'
-      - bufferutil
-      - launch-editor
-      - typescript
-      - utf-8-validate
-
   '@vitejs/devtools-kit@https://pkg.pr.new/vitejs/devtools/@vitejs/devtools-kit@307(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)':
     dependencies:
       birpc: 4.0.0
@@ -15618,66 +15376,6 @@ snapshots:
       - launch-editor
       - typescript
       - utf-8-validate
-
-  '@vitejs/devtools-rolldown@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))':
-    dependencies:
-      '@floating-ui/dom': 1.7.6
-      '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
-      '@rolldown/debug': 1.0.0-rc.18
-      '@vitejs/devtools-kit': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
-      ansis: 4.2.0
-      birpc: 4.0.0
-      cac: 7.0.0
-      d3-shape: 3.2.0
-      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
-      diff: 9.0.0
-      get-port-please: 3.2.0
-      h3: 1.15.11
-      logs-sdk: 0.0.6
-      mlly: 1.8.2
-      mrmime: 2.0.1
-      ohash: 2.0.11
-      p-limit: 7.3.0
-      pathe: 2.0.3
-      publint: 0.3.18
-      sirv: 3.0.2
-      split2: 4.2.0
-      structured-clone-es: 2.0.0
-      tinyglobby: 0.2.16
-      unconfig: 7.5.0
-      unstorage: 1.17.5(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)
-      vue-virtual-scroller: 3.0.2(vue@3.5.34(typescript@6.0.2))
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@modelcontextprotocol/sdk'
-      - '@netlify/blobs'
-      - '@nuxt/kit'
-      - '@planetscale/database'
-      - '@pnpm/logger'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - idb-keyval
-      - ioredis
-      - launch-editor
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vue
-    optional: true
 
   '@vitejs/devtools-rolldown@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))':
     dependencies:
@@ -15798,55 +15496,6 @@ snapshots:
       - vite
       - vue
 
-  '@vitejs/devtools@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)':
-    dependencies:
-      '@vitejs/devtools-kit': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
-      '@vitejs/devtools-rolldown': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
-      birpc: 4.0.0
-      cac: 7.0.0
-      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)
-      h3: 1.15.11
-      immer: 11.1.6
-      launch-editor: 2.13.2
-      logs-sdk: 0.0.6
-      mlly: 1.8.2
-      obug: 2.1.1
-      open: 11.0.0
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      sirv: 3.0.2
-      tinyexec: 1.1.2
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vue: 3.5.34(typescript@6.0.2)
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@modelcontextprotocol/sdk'
-      - '@netlify/blobs'
-      - '@nuxt/kit'
-      - '@planetscale/database'
-      - '@pnpm/logger'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - idb-keyval
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-    optional: true
-
   '@vitejs/devtools@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(vite@8.0.8)':
     dependencies:
       '@vitejs/devtools-kit': 0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
@@ -15944,7 +15593,7 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))':
+  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
@@ -15952,15 +15601,15 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.16
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.34(typescript@6.0.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.6(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))':
+  '@vitejs/plugin-vue@6.0.6(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.34(typescript@6.0.2)
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -16015,19 +15664,9 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vue-macros/common@3.1.2(vue@3.5.32(typescript@6.0.2))':
-    dependencies:
-      '@vue/compiler-sfc': 3.5.32
-      ast-kit: 2.2.0
-      local-pkg: 1.1.2
-      magic-string-ast: 1.0.3
-      unplugin-utils: 0.3.1
-    optionalDependencies:
-      vue: 3.5.32(typescript@6.0.2)
-
   '@vue-macros/common@3.1.2(vue@3.5.34(typescript@6.0.2))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.32
+      '@vue/compiler-sfc': 3.5.34
       ast-kit: 2.2.0
       local-pkg: 1.1.2
       magic-string-ast: 1.0.3
@@ -16047,7 +15686,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@vue/babel-helper-vue-transform-on': 2.0.1
       '@vue/babel-plugin-resolve-type': 2.0.1(@babel/core@7.29.0)
-      '@vue/shared': 3.5.32
+      '@vue/shared': 3.5.34
     optionalDependencies:
       '@babel/core': 7.29.0
     transitivePeerDependencies:
@@ -16059,18 +15698,10 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/parser': 7.29.2
-      '@vue/compiler-sfc': 3.5.32
+      '@babel/parser': 7.29.3
+      '@vue/compiler-sfc': 3.5.34
     transitivePeerDependencies:
       - supports-color
-
-  '@vue/compiler-core@3.5.32':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@vue/shared': 3.5.32
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
 
   '@vue/compiler-core@3.5.34':
     dependencies:
@@ -16080,27 +15711,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.32':
-    dependencies:
-      '@vue/compiler-core': 3.5.32
-      '@vue/shared': 3.5.32
-
   '@vue/compiler-dom@3.5.34':
     dependencies:
       '@vue/compiler-core': 3.5.34
       '@vue/shared': 3.5.34
-
-  '@vue/compiler-sfc@3.5.32':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@vue/compiler-core': 3.5.32
-      '@vue/compiler-dom': 3.5.32
-      '@vue/compiler-ssr': 3.5.32
-      '@vue/shared': 3.5.32
-      estree-walker: 2.0.2
-      magic-string: 0.30.21
-      postcss: 8.5.9
-      source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.34':
     dependencies:
@@ -16114,11 +15728,6 @@ snapshots:
       postcss: 8.5.14
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.32':
-    dependencies:
-      '@vue/compiler-dom': 3.5.32
-      '@vue/shared': 3.5.32
-
   '@vue/compiler-ssr@3.5.34':
     dependencies:
       '@vue/compiler-dom': 3.5.34
@@ -16130,11 +15739,11 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 8.1.1
 
-  '@vue/devtools-core@8.1.1(vue@3.5.32(typescript@6.0.2))':
+  '@vue/devtools-core@8.1.1(vue@3.5.34(typescript@6.0.2))':
     dependencies:
       '@vue/devtools-kit': 8.1.1
       '@vue/devtools-shared': 8.1.1
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.34(typescript@6.0.2)
 
   '@vue/devtools-kit@8.1.1':
     dependencies:
@@ -16148,37 +15757,21 @@ snapshots:
   '@vue/language-core@3.2.6':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.32
-      '@vue/shared': 3.5.32
+      '@vue/compiler-dom': 3.5.34
+      '@vue/shared': 3.5.34
       alien-signals: 3.1.2
       muggle-string: 0.4.1
       path-browserify: 1.0.1
       picomatch: 4.0.4
 
-  '@vue/reactivity@3.5.32':
-    dependencies:
-      '@vue/shared': 3.5.32
-
   '@vue/reactivity@3.5.34':
     dependencies:
       '@vue/shared': 3.5.34
-
-  '@vue/runtime-core@3.5.32':
-    dependencies:
-      '@vue/reactivity': 3.5.32
-      '@vue/shared': 3.5.32
 
   '@vue/runtime-core@3.5.34':
     dependencies:
       '@vue/reactivity': 3.5.34
       '@vue/shared': 3.5.34
-
-  '@vue/runtime-dom@3.5.32':
-    dependencies:
-      '@vue/reactivity': 3.5.32
-      '@vue/runtime-core': 3.5.32
-      '@vue/shared': 3.5.32
-      csstype: 3.2.3
 
   '@vue/runtime-dom@3.5.34':
     dependencies:
@@ -16187,19 +15780,11 @@ snapshots:
       '@vue/shared': 3.5.34
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.32(vue@3.5.32(typescript@6.0.2))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.32
-      '@vue/shared': 3.5.32
-      vue: 3.5.32(typescript@6.0.2)
-
   '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@6.0.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.34
       '@vue/shared': 3.5.34
       vue: 3.5.34(typescript@6.0.2)
-
-  '@vue/shared@3.5.32': {}
 
   '@vue/shared@3.5.34': {}
 
@@ -16617,13 +16202,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.141(zod@4.3.6):
+  ai@6.0.141(zod@4.4.1):
     dependencies:
-      '@ai-sdk/gateway': 3.0.83(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.83(zod@4.4.1)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.21(zod@4.4.1)
       '@opentelemetry/api': 1.9.0
-      zod: 4.3.6
+      zod: 4.4.1
 
   ai@6.0.174(zod@4.4.1):
     dependencies:
@@ -16722,7 +16307,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       pathe: 2.0.3
 
   ast-kit@3.0.0-beta.1:
@@ -16733,7 +16318,7 @@ snapshots:
 
   ast-walker-scope@0.8.3:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       ast-kit: 2.2.0
 
   async-listen@3.0.0: {}
@@ -16748,13 +16333,13 @@ snapshots:
 
   async@3.2.6: {}
 
-  autoprefixer@10.5.0(postcss@8.5.9):
+  autoprefixer@10.5.0(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001788
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -17190,9 +16775,9 @@ snapshots:
     optionalDependencies:
       srvx: 0.11.15
 
-  css-declaration-sorter@7.4.0(postcss@8.5.9):
+  css-declaration-sorter@7.4.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
 
   css-select@5.2.2:
     dependencies:
@@ -17219,49 +16804,49 @@ snapshots:
   cssfilter@0.0.10:
     optional: true
 
-  cssnano-preset-default@7.0.13(postcss@8.5.9):
+  cssnano-preset-default@7.0.13(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      css-declaration-sorter: 7.4.0(postcss@8.5.9)
-      cssnano-utils: 5.0.1(postcss@8.5.9)
-      postcss: 8.5.9
-      postcss-calc: 10.1.1(postcss@8.5.9)
-      postcss-colormin: 7.0.8(postcss@8.5.9)
-      postcss-convert-values: 7.0.10(postcss@8.5.9)
-      postcss-discard-comments: 7.0.6(postcss@8.5.9)
-      postcss-discard-duplicates: 7.0.2(postcss@8.5.9)
-      postcss-discard-empty: 7.0.1(postcss@8.5.9)
-      postcss-discard-overridden: 7.0.1(postcss@8.5.9)
-      postcss-merge-longhand: 7.0.5(postcss@8.5.9)
-      postcss-merge-rules: 7.0.9(postcss@8.5.9)
-      postcss-minify-font-values: 7.0.1(postcss@8.5.9)
-      postcss-minify-gradients: 7.0.3(postcss@8.5.9)
-      postcss-minify-params: 7.0.7(postcss@8.5.9)
-      postcss-minify-selectors: 7.0.6(postcss@8.5.9)
-      postcss-normalize-charset: 7.0.1(postcss@8.5.9)
-      postcss-normalize-display-values: 7.0.1(postcss@8.5.9)
-      postcss-normalize-positions: 7.0.1(postcss@8.5.9)
-      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.9)
-      postcss-normalize-string: 7.0.1(postcss@8.5.9)
-      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.9)
-      postcss-normalize-unicode: 7.0.7(postcss@8.5.9)
-      postcss-normalize-url: 7.0.1(postcss@8.5.9)
-      postcss-normalize-whitespace: 7.0.1(postcss@8.5.9)
-      postcss-ordered-values: 7.0.2(postcss@8.5.9)
-      postcss-reduce-initial: 7.0.7(postcss@8.5.9)
-      postcss-reduce-transforms: 7.0.1(postcss@8.5.9)
-      postcss-svgo: 7.1.1(postcss@8.5.9)
-      postcss-unique-selectors: 7.0.5(postcss@8.5.9)
+      css-declaration-sorter: 7.4.0(postcss@8.5.14)
+      cssnano-utils: 5.0.1(postcss@8.5.14)
+      postcss: 8.5.14
+      postcss-calc: 10.1.1(postcss@8.5.14)
+      postcss-colormin: 7.0.8(postcss@8.5.14)
+      postcss-convert-values: 7.0.10(postcss@8.5.14)
+      postcss-discard-comments: 7.0.6(postcss@8.5.14)
+      postcss-discard-duplicates: 7.0.2(postcss@8.5.14)
+      postcss-discard-empty: 7.0.1(postcss@8.5.14)
+      postcss-discard-overridden: 7.0.1(postcss@8.5.14)
+      postcss-merge-longhand: 7.0.5(postcss@8.5.14)
+      postcss-merge-rules: 7.0.9(postcss@8.5.14)
+      postcss-minify-font-values: 7.0.1(postcss@8.5.14)
+      postcss-minify-gradients: 7.0.3(postcss@8.5.14)
+      postcss-minify-params: 7.0.7(postcss@8.5.14)
+      postcss-minify-selectors: 7.0.6(postcss@8.5.14)
+      postcss-normalize-charset: 7.0.1(postcss@8.5.14)
+      postcss-normalize-display-values: 7.0.1(postcss@8.5.14)
+      postcss-normalize-positions: 7.0.1(postcss@8.5.14)
+      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.14)
+      postcss-normalize-string: 7.0.1(postcss@8.5.14)
+      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.14)
+      postcss-normalize-unicode: 7.0.7(postcss@8.5.14)
+      postcss-normalize-url: 7.0.1(postcss@8.5.14)
+      postcss-normalize-whitespace: 7.0.1(postcss@8.5.14)
+      postcss-ordered-values: 7.0.2(postcss@8.5.14)
+      postcss-reduce-initial: 7.0.7(postcss@8.5.14)
+      postcss-reduce-transforms: 7.0.1(postcss@8.5.14)
+      postcss-svgo: 7.1.1(postcss@8.5.14)
+      postcss-unique-selectors: 7.0.5(postcss@8.5.14)
 
-  cssnano-utils@5.0.1(postcss@8.5.9):
+  cssnano-utils@5.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
 
-  cssnano@7.1.5(postcss@8.5.9):
+  cssnano@7.1.5(postcss@8.5.14):
     dependencies:
-      cssnano-preset-default: 7.0.13(postcss@8.5.9)
+      cssnano-preset-default: 7.0.13(postcss@8.5.14)
       lilconfig: 3.1.3
-      postcss: 8.5.9
+      postcss: 8.5.14
 
   csso@5.0.5:
     dependencies:
@@ -17359,29 +16944,6 @@ snapshots:
 
   devalue@5.7.1: {}
 
-  devframe@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2):
-    dependencies:
-      '@valibot/to-json-schema': 1.6.0(valibot@1.3.1(typescript@6.0.2))
-      ansis: 4.2.0
-      birpc: 4.0.0
-      cac: 7.0.0
-      h3: 1.15.11
-      logs-sdk: 0.0.6
-      ohash: 2.0.11
-      pathe: 2.0.3
-      sirv: 3.0.2
-      structured-clone-es: 2.0.0
-      valibot: 1.3.1(typescript@6.0.2)
-      ws: 8.20.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      launch-editor: 2.13.2
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-
   devframe@0.1.19(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@nuxt/kit@4.4.2(magicast@0.5.2))(launch-editor@2.13.2)(typescript@6.0.2):
     dependencies:
       '@valibot/to-json-schema': 1.6.0(valibot@1.3.1(typescript@6.0.2))
@@ -17415,45 +16977,45 @@ snapshots:
 
   diff@9.0.0: {}
 
-  docus@5.9.0(41280f3cb6d62841219f75defe7cef35):
+  docus@5.9.0(fdb5fe3901af3981e6a838eeaed539f6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.96(zod@4.3.6)
-      '@ai-sdk/mcp': 1.0.36(zod@4.3.6)
-      '@ai-sdk/vue': 3.0.141(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.109(zod@4.4.1)
+      '@ai-sdk/mcp': 1.0.36(zod@4.4.1)
+      '@ai-sdk/vue': 3.0.141(vue@3.5.34(typescript@6.0.2))(zod@4.4.1)
       '@iconify-json/lucide': 1.2.102
       '@iconify-json/simple-icons': 1.2.78
       '@iconify-json/vscode-icons': 1.2.45
       '@nuxt/content': 3.13.0(@libsql/client@0.15.15)(@valibot/to-json-schema@1.6.0(valibot@1.3.1(typescript@6.0.2)))(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(magicast@0.5.2)(valibot@1.3.1(typescript@6.0.2))
       '@nuxt/image': 2.0.0(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(magicast@0.5.2)(srvx@0.11.15)
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/ui': 4.6.1(@nuxt/content@3.13.0(@libsql/client@0.15.15)(@valibot/to-json-schema@1.6.0(valibot@1.3.1(typescript@6.0.2)))(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(magicast@0.5.2)(valibot@1.3.1(typescript@6.0.2)))(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@6.0.2)(valibot@1.3.1(typescript@6.0.2))(vite@8.0.8)(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(vue@3.5.34(typescript@6.0.2)))(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      '@nuxt/ui': 4.6.1(f4c36ba86a67847d03e58c65ba63fadb)
       '@nuxtjs/i18n': 10.2.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(@vue/compiler-dom@3.5.34)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(eslint@10.2.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(rollup@4.60.1)(typescript@6.0.2)(vue@3.5.34(typescript@6.0.2))
-      '@nuxtjs/mcp-toolkit': 0.13.4(h3@1.15.11)(magicast@0.5.2)(zod@4.3.6)
+      '@nuxtjs/mcp-toolkit': 0.13.4(h3@1.15.11)(magicast@0.5.2)(zod@4.4.1)
       '@nuxtjs/mdc': 0.21.1(magicast@0.5.2)
-      '@nuxtjs/robots': 6.0.7(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      '@nuxtjs/robots': 6.0.7(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1)
       '@shikijs/core': 4.0.2
       '@shikijs/engine-javascript': 4.0.2
       '@shikijs/langs': 4.0.2
       '@shikijs/themes': 4.0.2
       '@takumi-rs/core': 0.73.1
       '@vueuse/core': 14.2.1(vue@3.5.34(typescript@6.0.2))
-      ai: 6.0.141(zod@4.3.6)
+      ai: 6.0.141(zod@4.4.1)
       better-sqlite3: 12.9.0
       defu: 6.1.7
       exsolve: 1.0.8
       git-url-parse: 16.1.0
       motion-v: 2.2.1(@vueuse/core@14.2.1(vue@3.5.34(typescript@6.0.2)))(vue@3.5.34(typescript@6.0.2))
-      nuxt: 4.4.2(2ea8ffe6f022b1f4499757e3c66be132)
+      nuxt: 4.4.2(32aab04b720da05e4a0a650a7dca5f7c)
       nuxt-llms: 0.2.0(magicast@0.5.2)
-      nuxt-og-image: 6.4.1(a829c5d3d60e838bf125094e8c31106f)
+      nuxt-og-image: 6.4.1(aa569d0d029f022a0c9815539a30ebf6)
       pkg-types: 2.3.0
       scule: 1.3.0
       shiki-stream: 0.1.4(vue@3.5.34(typescript@6.0.2))
       tailwindcss: 4.2.2
       ufo: 1.6.3
       yaml: 2.8.3
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.1
+      zod-to-json-schema: 3.25.2(zod@4.4.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -17904,13 +17466,11 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.6: {}
-
   eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
 
   execa@8.0.1:
     dependencies:
@@ -18585,8 +18145,6 @@ snapshots:
 
   hookable@5.5.3: {}
 
-  hookable@6.1.0: {}
-
   hookable@6.1.1: {}
 
   html-void-elements@3.0.0: {}
@@ -18831,20 +18389,6 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@4.0.0: {}
-
-  isomorphic-git@1.37.5:
-    dependencies:
-      async-lock: 1.4.1
-      clean-git-ref: 2.0.1
-      crc-32: 1.2.2
-      diff3: 0.0.3
-      ignore: 5.3.2
-      minimisted: 2.0.1
-      pako: 1.0.11
-      pify: 4.0.1
-      readable-stream: 4.7.0
-      sha.js: 2.4.12
-      simple-get: 4.0.1
 
   isomorphic-git@1.37.6:
     dependencies:
@@ -19158,7 +18702,7 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
@@ -19890,12 +19434,12 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.4.1(a829c5d3d60e838bf125094e8c31106f):
+  nuxt-og-image@6.4.1(aa569d0d029f022a0c9815539a30ebf6):
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@unhead/vue': 2.1.13(vue@3.5.34(typescript@6.0.2))
-      '@vue/compiler-sfc': 3.5.32
+      '@vue/compiler-sfc': 3.5.34
       chrome-launcher: 1.2.1
       consola: 3.4.2
       culori: 4.0.2
@@ -19906,8 +19450,8 @@ snapshots:
       magic-string: 0.30.21
       magicast: 0.5.2
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1))(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1)
       nypm: 0.6.5
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -19918,7 +19462,7 @@ snapshots:
       radix3: 1.1.2
       std-env: 4.0.0
       strip-literal: 3.1.0
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
       tinyglobby: 0.2.16
       ufo: 1.6.3
       ultrahtml: 1.6.0
@@ -19948,12 +19492,12 @@ snapshots:
       - magicast
       - vue
 
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6):
+  nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1):
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magicast@0.5.2)(vue@3.5.34(typescript@6.0.2))
-      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
+      nuxtseo-shared: 5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1))(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1)
       pathe: 2.0.3
       pkg-types: 2.3.0
       site-config-stack: 4.0.8(vue@3.5.34(typescript@6.0.2))
@@ -19970,14 +19514,14 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))
+      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(243bc5b918de3c48a1f63eb2bdcf78da))(rolldown@1.0.0-rc.16)(typescript@6.0.2)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(243bc5b918de3c48a1f63eb2bdcf78da))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)
-      '@unhead/vue': 2.1.13(vue@3.5.32(typescript@6.0.2))
-      '@vue/shared': 3.5.32
+      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(243bc5b918de3c48a1f63eb2bdcf78da))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue@3.5.34(typescript@6.0.2))(yaml@2.8.3)
+      '@unhead/vue': 2.1.13(vue@3.5.34(typescript@6.0.2))
+      '@vue/shared': 3.5.34
       c12: 3.3.4(magicast@0.5.2)
       chokidar: 5.0.0
       compatx: 0.2.0
@@ -19988,7 +19532,7 @@ snapshots:
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
-      hookable: 6.1.0
+      hookable: 6.1.1
       ignore: 7.0.5
       impound: 1.1.5
       jiti: 2.6.1
@@ -20022,8 +19566,8 @@ snapshots:
       unplugin: 3.0.0
       unrouting: 0.1.7
       untyped: 2.0.0
-      vue: 3.5.32(typescript@6.0.2)
-      vue-router: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.32(typescript@6.0.2))
+      vue: 3.5.34(typescript@6.0.2)
+      vue-router: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@6.0.2))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 25.6.0
@@ -20099,18 +19643,18 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132):
+  nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))
+      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(rolldown@1.0.0-rc.16)(srvx@0.11.15)(typescript@6.0.2)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(rolldown@1.0.0-rc.16)(srvx@0.11.15)(typescript@6.0.2)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)
-      '@unhead/vue': 2.1.13(vue@3.5.32(typescript@6.0.2))
-      '@vue/shared': 3.5.32
+      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.34(typescript@6.0.2))(yaml@2.8.3)
+      '@unhead/vue': 2.1.13(vue@3.5.34(typescript@6.0.2))
+      '@vue/shared': 3.5.34
       c12: 3.3.4(magicast@0.5.2)
       chokidar: 5.0.0
       compatx: 0.2.0
@@ -20121,7 +19665,7 @@ snapshots:
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
-      hookable: 6.1.0
+      hookable: 6.1.1
       ignore: 7.0.5
       impound: 1.1.5
       jiti: 2.6.1
@@ -20155,8 +19699,8 @@ snapshots:
       unplugin: 3.0.0
       unrouting: 0.1.7
       untyped: 2.0.0
-      vue: 3.5.32(typescript@6.0.2)
-      vue-router: 5.0.4(@vue/compiler-sfc@3.5.32)(vue@3.5.32(typescript@6.0.2))
+      vue: 3.5.34(typescript@6.0.2)
+      vue-router: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@6.0.2))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 25.6.0
@@ -20236,14 +19780,14 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.32(typescript@6.0.2))
+      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.19)(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@libsql/client@0.15.15)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.13))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1)))(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(sql.js@1.14.1))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(5ad1b1f5a672b20bdededb258034d6f9))(rolldown@1.0.0-rc.16)(typescript@6.0.2)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(5ad1b1f5a672b20bdededb258034d6f9))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.32(typescript@6.0.2))(yaml@2.8.3)
-      '@unhead/vue': 2.1.13(vue@3.5.32(typescript@6.0.2))
-      '@vue/shared': 3.5.32
+      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.2(5ad1b1f5a672b20bdededb258034d6f9))(optionator@0.9.4)(oxlint@1.60.0(oxlint-tsgolint@0.20.0))(rolldown@1.0.0-rc.16)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.16)(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.34(typescript@6.0.2))(yaml@2.8.3)
+      '@unhead/vue': 2.1.13(vue@3.5.34(typescript@6.0.2))
+      '@vue/shared': 3.5.34
       c12: 3.3.4(magicast@0.5.2)
       chokidar: 5.0.0
       compatx: 0.2.0
@@ -20254,7 +19798,7 @@ snapshots:
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
-      hookable: 6.1.0
+      hookable: 6.1.1
       ignore: 7.0.5
       impound: 1.1.5
       jiti: 2.6.1
@@ -20288,8 +19832,8 @@ snapshots:
       unplugin: 3.0.0
       unrouting: 0.1.7
       untyped: 2.0.0
-      vue: 3.5.32(typescript@6.0.2)
-      vue-router: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.32(typescript@6.0.2))
+      vue: 3.5.34(typescript@6.0.2)
+      vue-router: 5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@6.0.2))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 25.6.0
@@ -20365,7 +19909,7 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6))(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6):
+  nuxtseo-shared@5.1.3(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1))(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1):
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@8.0.8)
@@ -20374,7 +19918,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.2(2ea8ffe6f022b1f4499757e3c66be132)
+      nuxt: 4.4.2(32aab04b720da05e4a0a650a7dca5f7c)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -20384,8 +19928,8 @@ snapshots:
       ufo: 1.6.3
       vue: 3.5.34(typescript@6.0.2)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(2ea8ffe6f022b1f4499757e3c66be132))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.3.6)
-      zod: 4.3.6
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.2)(magicast@0.5.2)(nuxt@4.4.2(32aab04b720da05e4a0a650a7dca5f7c))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))(zod@4.4.1)
+      zod: 4.4.1
     transitivePeerDependencies:
       - magicast
       - vite
@@ -20394,7 +19938,7 @@ snapshots:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
 
   object-assign@4.1.1: {}
 
@@ -20859,142 +20403,142 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-calc@10.1.1(postcss@8.5.9):
+  postcss-calc@10.1.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@7.0.8(postcss@8.5.9):
+  postcss-colormin@7.0.8(postcss@8.5.14):
     dependencies:
       '@colordx/core': 5.0.3
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@7.0.10(postcss@8.5.9):
+  postcss-convert-values@7.0.10(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-discard-comments@7.0.6(postcss@8.5.9):
+  postcss-discard-comments@7.0.6(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-discard-duplicates@7.0.2(postcss@8.5.9):
+  postcss-discard-duplicates@7.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
 
-  postcss-discard-empty@7.0.1(postcss@8.5.9):
+  postcss-discard-empty@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
 
-  postcss-discard-overridden@7.0.1(postcss@8.5.9):
+  postcss-discard-overridden@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
 
-  postcss-merge-longhand@7.0.5(postcss@8.5.9):
+  postcss-merge-longhand@7.0.5(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
-      stylehacks: 7.0.9(postcss@8.5.9)
+      stylehacks: 7.0.9(postcss@8.5.14)
 
-  postcss-merge-rules@7.0.9(postcss@8.5.9):
+  postcss-merge-rules@7.0.9(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      cssnano-utils: 5.0.1(postcss@8.5.9)
-      postcss: 8.5.9
+      cssnano-utils: 5.0.1(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-minify-font-values@7.0.1(postcss@8.5.9):
+  postcss-minify-font-values@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@7.0.3(postcss@8.5.9):
+  postcss-minify-gradients@7.0.3(postcss@8.5.14):
     dependencies:
       '@colordx/core': 5.0.3
-      cssnano-utils: 5.0.1(postcss@8.5.9)
-      postcss: 8.5.9
+      cssnano-utils: 5.0.1(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@7.0.7(postcss@8.5.9):
+  postcss-minify-params@7.0.7(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      cssnano-utils: 5.0.1(postcss@8.5.9)
-      postcss: 8.5.9
+      cssnano-utils: 5.0.1(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@7.0.6(postcss@8.5.9):
+  postcss-minify-selectors@7.0.6(postcss@8.5.14):
     dependencies:
       cssesc: 3.0.0
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-normalize-charset@7.0.1(postcss@8.5.9):
+  postcss-normalize-charset@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
 
-  postcss-normalize-display-values@7.0.1(postcss@8.5.9):
+  postcss-normalize-display-values@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@7.0.1(postcss@8.5.9):
+  postcss-normalize-positions@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@7.0.1(postcss@8.5.9):
+  postcss-normalize-repeat-style@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@7.0.1(postcss@8.5.9):
+  postcss-normalize-string@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@7.0.1(postcss@8.5.9):
+  postcss-normalize-timing-functions@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@7.0.7(postcss@8.5.9):
+  postcss-normalize-unicode@7.0.7(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@7.0.1(postcss@8.5.9):
+  postcss-normalize-url@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@7.0.1(postcss@8.5.9):
+  postcss-normalize-whitespace@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-ordered-values@7.0.2(postcss@8.5.9):
+  postcss-ordered-values@7.0.2(postcss@8.5.14):
     dependencies:
-      cssnano-utils: 5.0.1(postcss@8.5.9)
-      postcss: 8.5.9
+      cssnano-utils: 5.0.1(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@7.0.7(postcss@8.5.9):
+  postcss-reduce-initial@7.0.7(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      postcss: 8.5.9
+      postcss: 8.5.14
 
-  postcss-reduce-transforms@7.0.1(postcss@8.5.9):
+  postcss-reduce-transforms@7.0.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   postcss-selector-parser@7.1.1:
@@ -21002,15 +20546,15 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-svgo@7.1.1(postcss@8.5.9):
+  postcss-svgo@7.1.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
       svgo: 4.0.1
 
-  postcss-unique-selectors@7.0.5(postcss@8.5.9):
+  postcss-unique-selectors@7.0.5(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   postcss-value-parser@4.2.0: {}
@@ -21962,10 +21506,10 @@ snapshots:
 
   structured-clone-es@2.0.0: {}
 
-  stylehacks@7.0.9(postcss@8.5.9):
+  stylehacks@7.0.9(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.9
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   super-regex@1.1.0:
@@ -22612,7 +22156,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.3.0(vite@8.0.8)(vue@3.5.32(typescript@6.0.2)):
+  vite-plugin-vue-tracer@1.3.0(vite@8.0.8)(vue@3.5.34(typescript@6.0.2)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
@@ -22620,14 +22164,14 @@ snapshots:
       pathe: 2.0.3
       source-map-js: 1.2.1
       vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.34(typescript@6.0.2)
 
   vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.14
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -22731,75 +22275,6 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.34(typescript@6.0.2)
 
-  vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(vue@3.5.32(typescript@6.0.2)):
-    dependencies:
-      '@babel/generator': 7.29.1
-      '@vue-macros/common': 3.1.2(vue@3.5.32(typescript@6.0.2))
-      '@vue/devtools-api': 8.1.1
-      ast-walker-scope: 0.8.3
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      scule: 1.3.0
-      tinyglobby: 0.2.16
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.5.32(typescript@6.0.2)
-      yaml: 2.8.3
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.32
-
-  vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(vue@3.5.34(typescript@6.0.2)):
-    dependencies:
-      '@babel/generator': 7.29.1
-      '@vue-macros/common': 3.1.2(vue@3.5.34(typescript@6.0.2))
-      '@vue/devtools-api': 8.1.1
-      ast-walker-scope: 0.8.3
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      scule: 1.3.0
-      tinyglobby: 0.2.16
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.5.34(typescript@6.0.2)
-      yaml: 2.8.3
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.32
-
-  vue-router@5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.32(typescript@6.0.2)):
-    dependencies:
-      '@babel/generator': 7.29.1
-      '@vue-macros/common': 3.1.2(vue@3.5.32(typescript@6.0.2))
-      '@vue/devtools-api': 8.1.1
-      ast-walker-scope: 0.8.3
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      scule: 1.3.0
-      tinyglobby: 0.2.16
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.5.32(typescript@6.0.2)
-      yaml: 2.8.3
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.34
-
   vue-router@5.0.4(@vue/compiler-sfc@3.5.34)(vue@3.5.34(typescript@6.0.2)):
     dependencies:
       '@babel/generator': 7.29.1
@@ -22822,7 +22297,6 @@ snapshots:
       yaml: 2.8.3
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.34
-    optional: true
 
   vue-tsc@3.2.6(typescript@6.0.2):
     dependencies:
@@ -22833,16 +22307,6 @@ snapshots:
   vue-virtual-scroller@3.0.2(vue@3.5.34(typescript@6.0.2)):
     dependencies:
       vue: 3.5.34(typescript@6.0.2)
-
-  vue@3.5.32(typescript@6.0.2):
-    dependencies:
-      '@vue/compiler-dom': 3.5.32
-      '@vue/compiler-sfc': 3.5.32
-      '@vue/runtime-dom': 3.5.32
-      '@vue/server-renderer': 3.5.32(vue@3.5.32(typescript@6.0.2))
-      '@vue/shared': 3.5.32
-    optionalDependencies:
-      typescript: 6.0.2
 
   vue@3.5.34(typescript@6.0.2):
     dependencies:
@@ -23094,14 +22558,9 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
-
   zod-to-json-schema@3.25.2(zod@4.4.1):
     dependencies:
       zod: 4.4.1
-    optional: true
 
   zod@3.24.4: {}
 


### PR DESCRIPTION
Simplifies chat definitions around flat direct-message handlers and workflow handles.

Adds top-level chat event handlers, injects configured workflow handles into hook args, introduces object-style createWorkflow handles with string id resolvers, and discovers inline workflow definitions for generated registries.

Updates the Nitro chat example and docs to show the new primary DX.