### PR TITLE
feat: add storage agent tools

### DIFF
--- a/packages/agent/docs/usage.md
+++ b/packages/agent/docs/usage.md
@@ -234,3 +234,31 @@ Workspace sources no longer imply model tools. Replace older workspace agents th
 ```
 
 Use `workspace.tools.none()` when a resolver needs to return an empty tool set, and reserve `workspace.tools.write()` for agents that intentionally receive mutable workspace access.
+
+## Compose Storage Tools
+
+Storage packages expose their own Agent-compatible Tools. Compose them in the same `tools` resolver used for custom and Workspace Tools:
+
+```ts [server/agents/storage.ts]
+import { defineAgent } from '@vitehub/agent'
+import { aiSdkAdapter } from '@vitehub/agent/ai-sdk'
+import { createBlobTools } from '@vitehub/blob/agent'
+import { createDbTools } from '@vitehub/db/agent'
+import { createKvTools } from '@vitehub/kv/agent'
+
+export default defineAgent({
+  adapter: aiSdkAdapter({
+    model,
+    tools: () => ({
+      ...createDbTools({ access: 'read' }),
+      ...createDbTools({ database: 'analytics', access: 'read' }),
+      ...createKvTools({ access: 'write' }),
+      ...createBlobTools({ access: 'read' }),
+    }),
+  }),
+})
+```
+
+Each package uses its configured runtime handle, so provider details stay in DB, KV, and Blob config.
+Install the storage package and `@vitehub/agent` when importing a storage `./agent` subpath.
+DB Tools infer the database when only one database is configured. Pass `database` when multiple databases are configured; the default database exposes `db_*` names, while named databases expose `<database>_db_*` names.

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -276,13 +276,41 @@ async function resolveInstructions(options: AiSdkAdapterOptions, context: AgentA
 
 async function resolveTools(options: AiSdkAdapterOptions, context: AgentAdapterMetadataContext, reportToolStep?: AgentAdapterRunContext["devtools"] extends infer T ? T extends { reportToolStep?: infer R } ? R : never : never) {
   if (!options.tools) return undefined
+  const { jsonSchema } = await import("ai")
   const resolved = await resolveValue(options.tools as never, context)
   const tools = applyAgentToolPolicies(resolved as AgentToolSet | undefined) || {}
   const { materialize_sources: materializeSources, ...reportableTools } = tools
   return {
-    ...withAgentToolStepReporting(reportableTools, reportToolStep as never),
+    ...normalizeAiSdkTools(withAgentToolStepReporting(reportableTools, reportToolStep as never), jsonSchema),
     ...(materializeSources ? { materialize_sources: materializeSources } : {}),
   }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+function isRawJsonSchema(value: unknown): value is Record<string, unknown> {
+  return isObject(value) && (
+    "$schema" in value
+    || "$defs" in value
+    || "anyOf" in value
+    || "oneOf" in value
+    || "properties" in value
+    || "type" in value
+  )
+}
+
+function normalizeAiSdkTools(
+  tools: AgentToolSet,
+  jsonSchema: (schema: Record<string, unknown>) => unknown,
+): AgentToolSet {
+  return Object.fromEntries(Object.entries(tools).map(([name, tool]) => [
+    name,
+    isRawJsonSchema(tool.inputSchema)
+      ? { ...tool, inputSchema: jsonSchema(tool.inputSchema) }
+      : tool,
+  ]))
 }
 
 function withRunCallbacks(settings: Record<string, unknown>, context: AgentAdapterRunContext) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,6 +12,7 @@ import {
   reportWorkspaceMaterialization,
   withAgentToolStepReporting,
 } from "./tool-runtime.ts"
+export { defineTool } from "./tool-definition.ts"
 
 import type {
   AgentAdapter,
@@ -101,6 +102,7 @@ export type {
   AgentStateProviderOptions,
   AgentToolResolver,
   AgentToolResolverWithWorkspace,
+  AgentToolSet,
   AgentToolStep,
   AgentWaitUntil,
   CloudflareExportedHandlerFetchHandler,
@@ -790,18 +792,6 @@ function getRunMessages(input: AgentRunInput): Message[] {
   if (input.messages) return input.messages
   if (Array.isArray(input.prompt)) return input.prompt
   return []
-}
-
-export function defineTool<TInput = unknown, TOutput = unknown>(
-  tool: AgentToolDefinition<TInput, TOutput>,
-): AgentToolDefinition<TInput, TOutput> {
-  if (!tool || typeof tool !== "object") {
-    throw new TypeError("[vitehub] defineTool() requires a tool definition.")
-  }
-  if (!tool.name || typeof tool.name !== "string") {
-    throw new TypeError("[vitehub] defineTool() requires a tool name.")
-  }
-  return tool
 }
 
 function toAgentRunResult(value: unknown): AgentRunResult {

--- a/packages/agent/src/tanstack-ai.ts
+++ b/packages/agent/src/tanstack-ai.ts
@@ -88,7 +88,6 @@ async function resolveTools(options: TanStackAiAdapterOptions, context: AgentAda
       inputSchema: tool.inputSchema as never,
       metadata: tool.metadata,
       name: tool.name,
-      needsApproval: tool.policy === "require-approval",
       outputSchema: tool.outputSchema as never,
     })
     return tool.execute ? definition.server(tool.execute as never) : definition

--- a/packages/agent/src/tool-definition.ts
+++ b/packages/agent/src/tool-definition.ts
@@ -1,0 +1,19 @@
+import type { AgentToolDefinition, AgentToolSet, MaybePromise } from "./types.ts"
+
+export type {
+  AgentToolDefinition,
+  AgentToolSet,
+  MaybePromise,
+}
+
+export function defineTool<TInput = unknown, TOutput = unknown>(
+  tool: AgentToolDefinition<TInput, TOutput>,
+): AgentToolDefinition<TInput, TOutput> {
+  if (!tool || typeof tool !== "object") {
+    throw new TypeError("[vitehub] defineTool() requires a tool definition.")
+  }
+  if (!tool.name || typeof tool.name !== "string") {
+    throw new TypeError("[vitehub] defineTool() requires a tool name.")
+  }
+  return tool
+}

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -35,7 +35,7 @@ function withToolPolicy(tool: AgentToolDefinition): AgentToolDefinition {
 
   return {
     ...tool,
-    async execute(input) {
+    async execute(input, ...args) {
       const decision = typeof policy === "function"
         ? await policy({
             name: tool.name,
@@ -59,7 +59,7 @@ function withToolPolicy(tool: AgentToolDefinition): AgentToolDefinition {
         throw new Error(`[vitehub:agent] Tool "${tool.name}" failed with a retryable policy decision.`)
       }
 
-      return await execute(input)
+      return await execute.call(tool, input, ...args)
     },
   }
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -342,7 +342,7 @@ export interface AgentToolPolicyContext {
 
 export interface AgentToolDefinition<TInput = unknown, TOutput = unknown> {
   description?: string
-  execute?: (input: TInput) => MaybePromise<TOutput>
+  execute?: (input: TInput, ...args: unknown[]) => MaybePromise<TOutput>
   inputSchema?: unknown
   metadata?: Record<string, unknown>
   name: string
@@ -350,7 +350,7 @@ export interface AgentToolDefinition<TInput = unknown, TOutput = unknown> {
   policy?: AgentToolPolicyDecision | ((context: AgentToolPolicyContext) => MaybePromise<AgentToolPolicyDecision>)
 }
 
-export type AgentToolSet = Record<string, AgentToolDefinition>
+export type AgentToolSet = Record<string, AgentToolDefinition<any, any>>
 
 export interface WorkspaceAgentWorkspaceOptions extends Omit<WorkspaceDefinitionInput, "name"> {}
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -277,6 +277,26 @@ describe("agent message protocol", () => {
     expect(execute).not.toHaveBeenCalled()
   })
 
+  it("preserves execution receiver and extra arguments when applying tool policies", async () => {
+    const { applyAgentToolPolicies } = await import("../src/index.ts")
+    const context = { toolCallId: "call_1" }
+    const tool = {
+      name: "inspect",
+      policy: "allow" as const,
+      marker: "receiver",
+      execute: vi.fn(function (this: { marker: string }, input: unknown, runContext: unknown) {
+        return { input, marker: this.marker, runContext }
+      }),
+    }
+    const tools = applyAgentToolPolicies({ inspect: tool })
+
+    await expect(tools?.inspect.execute?.({ ok: true }, context)).resolves.toEqual({
+      input: { ok: true },
+      marker: "receiver",
+      runContext: context,
+    })
+  })
+
   it("turns approval-required tool policy into an approval error", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const execute = vi.fn()

--- a/packages/agent/test/tanstack-ai.test.ts
+++ b/packages/agent/test/tanstack-ai.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const chat = vi.hoisted(() => vi.fn(async (options: unknown) => options))
+const toolDefinition = vi.hoisted(() => vi.fn((definition: Record<string, unknown>) => ({
+  definition,
+  server(execute: unknown) {
+    return { definition, execute }
+  },
+})))
+
+vi.mock("@tanstack/ai", () => ({
+  chat,
+  toolDefinition,
+}))
+
+function context() {
+  return {
+    input: { messages: [] },
+    memo: vi.fn(),
+    messages: [],
+    prompt: "run",
+    runtime: "unknown",
+    runtimeConfig: {},
+    waitUntil: vi.fn(),
+  } as never
+}
+
+describe("tanstackAiAdapter", () => {
+  beforeEach(() => {
+    chat.mockClear()
+    toolDefinition.mockClear()
+  })
+
+  it("keeps static approval-required tools on ViteHub policy handling", async () => {
+    const execute = vi.fn(async () => "done")
+    const { tanstackAiAdapter } = await import("../src/tanstack-ai.ts")
+    const adapter = tanstackAiAdapter({
+      adapter: {},
+      tools: {
+        migrate: {
+          execute,
+          name: "migrate",
+          policy: "require-approval",
+        },
+      },
+    })
+
+    const result = await adapter.generate(context()) as { raw: { tools: Array<{ definition: Record<string, unknown>, execute: (input: unknown) => Promise<unknown> }> } }
+    const tool = result.raw.tools[0]
+
+    expect(tool.definition).toMatchObject({
+      name: "migrate",
+    })
+    expect(tool.definition).not.toHaveProperty("needsApproval")
+    await expect(tool.execute({ statement: "create table notes (id text)" })).rejects.toMatchObject({
+      request: {
+        capability: "migrate",
+        input: { statement: "create table notes (id text)" },
+        state: "awaiting-approval",
+      },
+    })
+    expect(execute).not.toHaveBeenCalled()
+  })
+})

--- a/packages/agent/test/test-runner.test.ts
+++ b/packages/agent/test/test-runner.test.ts
@@ -7,6 +7,7 @@ const agentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
 const agentGenerate = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ finishReason: string, text: string, usage?: unknown }>>(async () => ({ finishReason: "stop", text: "ok" })))
 
 vi.mock("ai", () => ({
+  jsonSchema: vi.fn(schema => ({ jsonSchema: schema })),
   stepCountIs: vi.fn(count => ({ count })),
   ToolLoopAgent: class {
     constructor(public settings: Record<string, unknown>) {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -10,6 +10,7 @@ const agentGenerate = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ f
 
 vi.mock("ai", () => ({
   generateText,
+  jsonSchema: vi.fn(schema => ({ jsonSchema: schema })),
   stepCountIs: vi.fn(count => ({ count })),
   ToolLoopAgent: class {
     constructor(public settings: Record<string, unknown>) {

--- a/packages/blob/docs/runtime-api.md
+++ b/packages/blob/docs/runtime-api.md
@@ -145,6 +145,28 @@ return await blob.serve(event, 'avatars/user-1.png')
 
 Missing pathnames throw an H3 `404` error with `File not found`.
 
+## Agent Tools
+
+```ts
+import { createBlobTools } from '@vitehub/blob/agent'
+```
+
+`createBlobTools()` returns ViteHub Agent-compatible Tools backed by the same `blob` runtime handle:
+
+```ts
+createBlobTools({ access: 'read' })
+createBlobTools({ access: 'write' })
+```
+
+Install `@vitehub/agent` alongside `@vitehub/blob` when importing `@vitehub/blob/agent`.
+
+| Access | Tools |
+| --- | --- |
+| `read` | List objects, read metadata, and read one object as text. |
+| `write` | Includes `read`, plus write text, write JSON, and delete one object. |
+
+The write preset accepts text and JSON bodies only. Binary uploads and bulk deletes stay in application code.
+
 ## Validation API
 
 ### `ensureBlob(blob, options)`

--- a/packages/blob/docs/usage.md
+++ b/packages/blob/docs/usage.md
@@ -138,6 +138,27 @@ await blob.del([
 ])
 ```
 
+## Expose Blob Tools to an agent
+
+Use `@vitehub/blob/agent` when an agent should inspect stored objects or create text/JSON artifacts through the configured Blob runtime handle.
+
+```ts [server/agents/assets.ts]
+import { defineAgent } from '@vitehub/agent'
+import { aiSdkAdapter } from '@vitehub/agent/ai-sdk'
+import { createBlobTools } from '@vitehub/blob/agent'
+
+export default defineAgent({
+  adapter: aiSdkAdapter({
+    model,
+    tools: () => createBlobTools({ access: 'write' }),
+  }),
+})
+```
+
+Install `@vitehub/agent` alongside `@vitehub/blob` when importing `@vitehub/blob/agent`.
+
+`access: 'write'` can write text or JSON content and delete one object by pathname. Binary uploads and bulk deletes stay in application code.
+
 ## Keep Routes Provider-Neutral
 
 The route should not know whether local files, Cloudflare R2, or Vercel Blob is active.

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -24,6 +24,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./agent": "./dist/agent.js",
     "./config": "./dist/config.js",
     "./drivers/cloudflare": "./dist/drivers/cloudflare.js",
     "./drivers/files": "./dist/drivers/files.js",
@@ -60,12 +61,16 @@
     "pathe": "catalog:"
   },
   "peerDependencies": {
+    "@vitehub/agent": "workspace:*",
     "@vercel/blob": "catalog:",
     "files-sdk": "catalog:",
     "nitro": "^3.0.0-0",
     "vite": "^8.0.0"
   },
   "peerDependenciesMeta": {
+    "@vitehub/agent": {
+      "optional": true
+    },
     "@vercel/blob": {
       "optional": true
     },
@@ -82,6 +87,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@vercel/blob": "catalog:",
+    "@vitehub/agent": "workspace:*",
     "@vitehub/internal": "workspace:*",
     "files-sdk": "catalog:",
     "nitro": "catalog:",

--- a/packages/blob/src/agent.ts
+++ b/packages/blob/src/agent.ts
@@ -1,0 +1,189 @@
+import { defineTool } from "@vitehub/agent"
+
+import type { AgentToolDefinition, AgentToolSet } from "@vitehub/agent"
+
+export type BlobAgentToolAccess = "read" | "write"
+
+export type BlobAgentToolDefinition<TInput = unknown, TOutput = unknown> = AgentToolDefinition<TInput, TOutput>
+export type BlobAgentToolSet = AgentToolSet
+
+export interface BlobAgentStorage {
+  del(pathname: string): Promise<void>
+  get(pathname: string): Promise<Blob | null>
+  head(pathname: string): Promise<unknown>
+  list(options?: unknown): Promise<unknown>
+  put(pathname: string, body: string, options?: unknown): Promise<unknown>
+}
+
+export interface CreateBlobToolsOptions {
+  access?: BlobAgentToolAccess
+  blob?: BlobAgentStorage
+}
+
+interface PathInput {
+  pathname: string
+}
+
+interface ListInput {
+  cursor?: string
+  folded?: boolean
+  limit?: number
+  prefix?: string
+}
+
+interface PutTextInput extends PathInput {
+  content: string
+  contentType?: string
+  customMetadata?: Record<string, string>
+  prefix?: string
+}
+
+interface PutJsonInput extends PathInput {
+  content: unknown
+  customMetadata?: Record<string, string>
+  prefix?: string
+}
+
+const metadata = {
+  category: "blob",
+  preset: "vitehub-blob",
+}
+
+async function getBlob(options: CreateBlobToolsOptions) {
+  if (options.blob) return options.blob
+  const module = await import("./index.ts")
+  return module.blob
+}
+
+function pathnameProperty() {
+  return {
+    pathname: { description: "Blob object pathname.", type: "string" },
+  }
+}
+
+function putOptionsProperties() {
+  return {
+    customMetadata: {
+      additionalProperties: { type: "string" },
+      description: "Optional string metadata to store with the object.",
+      type: "object",
+    },
+    prefix: { description: "Optional driver-specific path prefix.", type: "string" },
+  }
+}
+
+function readTools(options: CreateBlobToolsOptions): BlobAgentToolSet {
+  return {
+    blob_list: defineTool<ListInput, unknown>({
+      description: "List blob objects.",
+      execute: async input => await (await getBlob(options)).list(input),
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          cursor: { description: "Pagination cursor from a previous list result.", type: "string" },
+          folded: { description: "Group results by folder-like prefixes when supported.", type: "boolean" },
+          limit: { description: "Maximum number of objects to return.", maximum: 100, minimum: 1, type: "number" },
+          prefix: { description: "Only list objects whose pathname starts with this prefix.", type: "string" },
+        },
+        type: "object",
+      },
+      metadata,
+      name: "blob_list",
+    }),
+    blob_head: defineTool<PathInput, unknown>({
+      description: "Read metadata for one blob object.",
+      execute: async ({ pathname }) => await (await getBlob(options)).head(pathname),
+      inputSchema: {
+        additionalProperties: false,
+        properties: pathnameProperty(),
+        required: ["pathname"],
+        type: "object",
+      },
+      metadata,
+      name: "blob_head",
+    }),
+    blob_get_text: defineTool<PathInput, { content: string | null, pathname: string }>({
+      description: "Read one blob object as text.",
+      execute: async ({ pathname }) => {
+        const value = await (await getBlob(options)).get(pathname)
+        return { content: value ? await value.text() : null, pathname }
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: pathnameProperty(),
+        required: ["pathname"],
+        type: "object",
+      },
+      metadata,
+      name: "blob_get_text",
+    }),
+  }
+}
+
+function writeTools(options: CreateBlobToolsOptions): BlobAgentToolSet {
+  return {
+    blob_put_text: defineTool<PutTextInput, unknown>({
+      description: "Write text content to one blob object.",
+      execute: async ({ content, contentType = "text/plain; charset=utf-8", customMetadata, pathname, prefix }) => {
+        return await (await getBlob(options)).put(pathname, content, { contentType, customMetadata, prefix })
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          ...pathnameProperty(),
+          ...putOptionsProperties(),
+          content: { description: "Text content to store.", type: "string" },
+          contentType: { description: "MIME content type for the stored text.", type: "string" },
+        },
+        required: ["pathname", "content"],
+        type: "object",
+      },
+      metadata,
+      name: "blob_put_text",
+    }),
+    blob_put_json: defineTool<PutJsonInput, unknown>({
+      description: "Write JSON content to one blob object.",
+      execute: async ({ content, customMetadata, pathname, prefix }) => {
+        return await (await getBlob(options)).put(pathname, JSON.stringify(content), {
+          contentType: "application/json; charset=utf-8",
+          customMetadata,
+          prefix,
+        })
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          ...pathnameProperty(),
+          ...putOptionsProperties(),
+          content: { description: "JSON-serializable content to store." },
+        },
+        required: ["pathname", "content"],
+        type: "object",
+      },
+      metadata,
+      name: "blob_put_json",
+    }),
+    blob_delete: defineTool<PathInput, { pathname: string }>({
+      description: "Delete one blob object.",
+      execute: async ({ pathname }) => {
+        await (await getBlob(options)).del(pathname)
+        return { pathname }
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: pathnameProperty(),
+        required: ["pathname"],
+        type: "object",
+      },
+      metadata,
+      name: "blob_delete",
+    }),
+  }
+}
+
+export function createBlobTools(options: CreateBlobToolsOptions = {}): BlobAgentToolSet {
+  const access = options.access || "read"
+  if (access === "read") return readTools(options)
+  if (access === "write") return { ...readTools(options), ...writeTools(options) }
+  throw new TypeError(`[vitehub] Unknown Blob agent tool access: ${String(access)}`)
+}

--- a/packages/blob/test/agent.test.ts
+++ b/packages/blob/test/agent.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createBlobTools } from "../src/agent.ts"
+
+describe("createBlobTools", () => {
+  it("gates tools by access level without exposing bulk delete", () => {
+    expect(Object.keys(createBlobTools({ access: "read", blob: {} as never })).sort()).toEqual([
+      "blob_get_text",
+      "blob_head",
+      "blob_list",
+    ])
+    expect(Object.keys(createBlobTools({ access: "write", blob: {} as never })).sort()).toEqual([
+      "blob_delete",
+      "blob_get_text",
+      "blob_head",
+      "blob_list",
+      "blob_put_json",
+      "blob_put_text",
+    ])
+    expect(createBlobTools({ access: "write", blob: {} as never })).not.toHaveProperty("blob_delete_many")
+  })
+
+  it("calls the Blob runtime handle for read and text/json writes", async () => {
+    const blob = {
+      del: vi.fn(async () => {}),
+      get: vi.fn(async () => new Blob(["hello"], { type: "text/plain" })),
+      head: vi.fn(async () => ({ pathname: "notes/hello.txt" })),
+      list: vi.fn(async () => ({ blobs: [], hasMore: false })),
+      put: vi.fn(async (pathname: string) => ({ pathname })),
+    }
+    const tools = createBlobTools({ access: "write", blob })
+
+    await expect(tools.blob_list.execute?.({ prefix: "notes/" })).resolves.toEqual({ blobs: [], hasMore: false })
+    await expect(tools.blob_head.execute?.({ pathname: "notes/hello.txt" })).resolves.toEqual({ pathname: "notes/hello.txt" })
+    await expect(tools.blob_get_text.execute?.({ pathname: "notes/hello.txt" })).resolves.toEqual({ content: "hello", pathname: "notes/hello.txt" })
+    await expect(tools.blob_put_text.execute?.({ content: "hello", pathname: "notes/hello.txt" })).resolves.toEqual({ pathname: "notes/hello.txt" })
+    await expect(tools.blob_put_json.execute?.({ content: { ok: true }, pathname: "notes/data.json" })).resolves.toEqual({ pathname: "notes/data.json" })
+    await expect(tools.blob_delete.execute?.({ pathname: "notes/hello.txt" })).resolves.toEqual({ pathname: "notes/hello.txt" })
+
+    expect(blob.put).toHaveBeenCalledWith("notes/hello.txt", "hello", {
+      contentType: "text/plain; charset=utf-8",
+      customMetadata: undefined,
+      prefix: undefined,
+    })
+    expect(blob.put).toHaveBeenCalledWith("notes/data.json", "{\"ok\":true}", {
+      contentType: "application/json; charset=utf-8",
+      customMetadata: undefined,
+      prefix: undefined,
+    })
+    expect(blob.del).toHaveBeenCalledWith("notes/hello.txt")
+  })
+})

--- a/packages/blob/test/types.test-d.ts
+++ b/packages/blob/test/types.test-d.ts
@@ -5,6 +5,7 @@ import virtualConfig, { blob as virtualBlob, hosting as virtualHosting } from "v
 import { describe, expectTypeOf, it } from "vitest"
 
 import { blob, type BlobModuleOptions, type BlobStoreConfig, type ResolvedBlobModuleOptions } from "../src/index.ts"
+import { createBlobTools } from "../src/agent.ts"
 import { hubBlob } from "../src/vite.ts"
 
 describe("types", () => {
@@ -42,6 +43,13 @@ describe("types", () => {
     expectTypeOf(blob.get).returns.toEqualTypeOf<Promise<Blob | null>>()
     expectTypeOf(blob.list).toBeFunction()
     expectTypeOf(blob.put).toBeFunction()
+  })
+
+  it("exposes Blob agent tools", () => {
+    const tools = createBlobTools({ access: "write" })
+
+    expectTypeOf(tools.blob_get_text.name).toEqualTypeOf<string>()
+    expectTypeOf(tools.blob_put_text.execute).toMatchTypeOf<unknown>()
   })
 
   it("returns a vite plugin with runtime config access", () => {

--- a/packages/blob/tsconfig.json
+++ b/packages/blob/tsconfig.json
@@ -5,6 +5,18 @@
     "rootDir": "..",
     "baseUrl": "../..",
     "paths": {
+      "@vitehub/agent": [
+        "packages/agent/src/tool-definition.ts"
+      ],
+      "@vitehub/messages": [
+        "packages/messages/src/index.ts"
+      ],
+      "@vitehub/runtime": [
+        "packages/runtime/src/index.ts"
+      ],
+      "@vitehub/workspace": [
+        "packages/workspace/src/index.ts"
+      ],
       "@vitehub/internal/*": [
         "packages/internal/src/*"
       ]

--- a/packages/blob/tsdown.config.ts
+++ b/packages/blob/tsdown.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   },
   dts: true,
   entry: [
+    "src/agent.ts",
     "src/config.ts",
     "src/ensure.ts",
     "src/storage.ts",

--- a/packages/db/docs/runtime-api.md
+++ b/packages/db/docs/runtime-api.md
@@ -56,6 +56,30 @@ import { databases, db, schema } from '@vitehub/db/drizzle'
 - `schema` is `databases.default.schema`.
 - `databases.default` and every `databases.<name>` entry expose `{ db, schema }`.
 
+## Agent Tools
+
+```ts
+import { createDbTools } from '@vitehub/db/agent'
+```
+
+`createDbTools()` returns ViteHub Agent-compatible Tools backed by the same `@vitehub/db/drizzle` runtime handles:
+
+```ts
+createDbTools({ access: 'read' })
+createDbTools({ database: 'analytics', access: 'write' })
+createDbTools({ database: 'analytics', access: 'schema' })
+```
+
+| Access | Tools |
+| --- | --- |
+| `read` | List schema tables, select rows, and run `SELECT` SQL for the configured database. |
+| `write` | Includes `read`, plus seed-style insert, update, and delete operations through Drizzle tables. |
+| `schema` | Includes `write`, plus approval-gated runtime DDL SQL execution through Drizzle SQL primitives. |
+
+Each factory call is scoped to one database. `database` can be omitted when only one database is configured; pass it when multiple databases are configured. The default database exposes `db_*` Tool names. Named databases expose `<database>_db_*` Tool names, or use `prefix` to choose a different Tool prefix.
+
+Schema Tools execute explicit runtime DDL. They do not replace Drizzle Kit, provider migration commands, or the deployment migration workflow.
+
 ## Runtime Resolution
 
 For each database entry, ViteHub resolves the runtime in this order:

--- a/packages/db/docs/usage.md
+++ b/packages/db/docs/usage.md
@@ -109,6 +109,36 @@ export default defineConfig({
 
 Run migrations with your Drizzle or provider workflow, then keep route code on the same `@vitehub/db/drizzle` runtime import.
 
+## Expose DB Tools to an agent
+
+Use `@vitehub/db/agent` when an agent should inspect or change configured databases through the same runtime handles used by route code.
+
+```ts [server/agents/data.ts]
+import { defineAgent } from '@vitehub/agent'
+import { aiSdkAdapter } from '@vitehub/agent/ai-sdk'
+import { createDbTools } from '@vitehub/db/agent'
+
+export default defineAgent({
+  adapter: aiSdkAdapter({
+    model,
+    tools: () => createDbTools({ access: 'read' }),
+  }),
+})
+```
+
+Install `@vitehub/agent` alongside `@vitehub/db` when importing `@vitehub/db/agent`.
+
+`database` can be omitted when the project has a single configured database. Pass `database` when multiple databases are configured so the agent receives Tools scoped to one database. The default database uses `db_*` Tool names; named databases use `<database>_db_*` names:
+
+```ts
+tools: () => ({
+  ...createDbTools({ access: 'write' }),
+  ...createDbTools({ database: 'analytics', access: 'read' }),
+})
+```
+
+Use `access: 'write'` for seed-style row changes. Use `access: 'schema'` only for explicit runtime DDL; deployment migrations still belong to Drizzle or provider workflows.
+
 ## Keep hosted code provider-neutral
 
 Application code should not branch on Cloudflare or Vercel:

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -24,6 +24,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./agent": "./dist/agent.js",
     "./drizzle": "./dist/drizzle.js",
     "./runtime/cloudflare-vite": "./dist/runtime/cloudflare-vite.js",
     "./runtime/hosted": "./dist/runtime/hosted.js",
@@ -50,15 +51,20 @@
     "pathe": "catalog:"
   },
   "peerDependencies": {
+    "@vitehub/agent": "workspace:*",
     "drizzle-orm": "catalog:",
     "vite": ">=6.0.0"
   },
   "peerDependenciesMeta": {
+    "@vitehub/agent": {
+      "optional": true
+    },
     "vite": {
       "optional": true
     }
   },
   "devDependencies": {
+    "@vitehub/agent": "workspace:*",
     "@vitehub/internal": "workspace:*",
     "drizzle-orm": "catalog:",
     "publint": "^0.3.15",

--- a/packages/db/src/agent.ts
+++ b/packages/db/src/agent.ts
@@ -1,0 +1,395 @@
+import { eq, isTable, sql } from "drizzle-orm"
+import { defineTool } from "@vitehub/agent"
+
+import type { AgentToolDefinition, AgentToolSet } from "@vitehub/agent"
+
+export type DbAgentToolAccess = "read" | "schema" | "write"
+
+export type DbAgentToolDefinition<TInput = unknown, TOutput = unknown> = AgentToolDefinition<TInput, TOutput>
+export type DbAgentToolSet = AgentToolSet
+
+export interface DbAgentDatabaseEntry {
+  db: Record<string, unknown>
+  schema: Record<string, unknown>
+}
+
+export interface CreateDbToolsOptions {
+  access?: DbAgentToolAccess
+  database?: string
+  databases?: Record<string, DbAgentDatabaseEntry>
+  prefix?: string
+}
+
+type ResolvedCreateDbToolsOptions = CreateDbToolsOptions & {
+  database: string
+}
+
+interface SelectInput {
+  limit?: number
+  offset?: number
+  orderBy?: string
+  table: string
+}
+
+interface InsertInput {
+  table: string
+  values: Record<string, unknown> | Array<Record<string, unknown>>
+}
+
+interface MatchInput {
+  column: string
+  table: string
+  value: unknown
+}
+
+interface UpdateInput extends MatchInput {
+  values: Record<string, unknown>
+}
+
+interface SchemaSqlInput {
+  statement: string
+}
+
+const metadata = {
+  category: "database",
+  preset: "vitehub-db",
+}
+
+async function getDatabases(options: CreateDbToolsOptions) {
+  if (options.databases) return options.databases
+  const module = await import("./drizzle.ts")
+  return module.databases as unknown as Record<string, DbAgentDatabaseEntry>
+}
+
+async function getDatabase(options: ResolvedCreateDbToolsOptions) {
+  const databases = await getDatabases(options)
+  const entry = databases[options.database]
+  if (!entry) {
+    throw new Error(`[vitehub] Database "${options.database}" is not configured.`)
+  }
+  return entry
+}
+
+function getTable(entry: DbAgentDatabaseEntry, tableName: string) {
+  const table = entry.schema[tableName]
+  if (!isTable(table)) {
+    throw new Error(`[vitehub] Database table "${tableName}" was not found in the configured schema.`)
+  }
+  return table as unknown as Record<string, unknown>
+}
+
+function listTables(entry: DbAgentDatabaseEntry) {
+  return Object.entries(entry.schema)
+    .filter(([, value]) => isTable(value))
+    .map(([name]) => name)
+    .sort()
+}
+
+function getColumn(table: Record<string, unknown>, columnName: string) {
+  const column = table[columnName]
+  if (!column || typeof column !== "object") {
+    throw new Error(`[vitehub] Database column "${columnName}" was not found on the selected table.`)
+  }
+  return column
+}
+
+function isReadStatement(statement: string) {
+  if (!/^\s*select\b/i.test(statement)) return false
+
+  let quote: "\"" | "'" | "`" | undefined
+  let bracketIdentifier = false
+  for (let index = 0; index < statement.length; index++) {
+    const char = statement[index]
+    const next = statement[index + 1]
+
+    if (quote) {
+      if (char === quote && next === quote) {
+        index++
+        continue
+      }
+      if (char === quote) quote = undefined
+      continue
+    }
+
+    if (bracketIdentifier) {
+      if (char === "]") bracketIdentifier = false
+      continue
+    }
+
+    if (char === "-" && next === "-") {
+      index += 2
+      while (index < statement.length && statement[index] !== "\n" && statement[index] !== "\r") index++
+      continue
+    }
+
+    if (char === "/" && next === "*") {
+      index += 2
+      while (index < statement.length && !(statement[index] === "*" && statement[index + 1] === "/")) index++
+      if (index >= statement.length) return false
+      index++
+      continue
+    }
+
+    if (char === "\"" || char === "'" || char === "`") {
+      quote = char
+      continue
+    }
+
+    if (char === "[") {
+      bracketIdentifier = true
+      continue
+    }
+
+    if (char === ";") {
+      return hasOnlyTrailingComments(statement.slice(index + 1))
+    }
+  }
+
+  return !quote && !bracketIdentifier
+}
+
+function hasOnlyTrailingComments(value: string) {
+  let index = 0
+  while (index < value.length) {
+    const char = value[index]
+    const next = value[index + 1]
+
+    if (/\s/.test(char || "")) {
+      index++
+      continue
+    }
+    if (char === "-" && next === "-") {
+      index += 2
+      while (index < value.length && value[index] !== "\n" && value[index] !== "\r") index++
+      continue
+    }
+    if (char === "/" && next === "*") {
+      index += 2
+      while (index < value.length && !(value[index] === "*" && value[index + 1] === "/")) index++
+      if (index >= value.length) return false
+      index += 2
+      continue
+    }
+    return false
+  }
+
+  return true
+}
+
+function tableProperty() {
+  return {
+    table: {
+      description: "Schema export name for the target Drizzle table.",
+      type: "string",
+    },
+  }
+}
+
+function toolKey(prefix: string, operation: string) {
+  return `${prefix}_${operation}`
+}
+
+function sanitizeToolPrefix(value: string) {
+  const sanitized = value
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase()
+  return sanitized || "db"
+}
+
+function resolveToolPrefix(options: ResolvedCreateDbToolsOptions) {
+  if (options.prefix) return sanitizeToolPrefix(options.prefix)
+  if (options.database === "default") return "db"
+  return `${sanitizeToolPrefix(options.database)}_db`
+}
+
+function resolveDatabaseName(options: CreateDbToolsOptions): string {
+  if (options.database) return options.database
+  if (!options.databases) return "default"
+
+  const names = Object.keys(options.databases)
+  if (names.length === 0) return "default"
+  if (names.length === 1 && names[0]) return names[0]
+
+  throw new TypeError("[vitehub] createDbTools() requires a database name when multiple databases are configured.")
+}
+
+function readTools(options: ResolvedCreateDbToolsOptions, prefix: string): DbAgentToolSet {
+  return {
+    [toolKey(prefix, "list_tables")]: defineTool<Record<string, never>, { database: string, tables: string[] }>({
+      description: `List schema table exports for the ${options.database} database.`,
+      execute: async () => {
+        const entry = await getDatabase(options)
+        return { database: options.database, tables: listTables(entry) }
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {},
+        type: "object",
+      },
+      metadata,
+      name: toolKey(prefix, "list_tables"),
+    }),
+    [toolKey(prefix, "select")]: defineTool<SelectInput, unknown>({
+      description: `Read rows from a Drizzle table in the ${options.database} database.`,
+      execute: async ({ limit = 25, offset = 0, orderBy, table }) => {
+        const entry = await getDatabase(options)
+        const schemaTable = getTable(entry, table)
+        let query = (entry.db.select as () => { from: (table: unknown) => unknown })().from(schemaTable)
+        if (orderBy) {
+          query = (query as { orderBy: (column: unknown) => unknown }).orderBy(getColumn(schemaTable, orderBy))
+        }
+        query = (query as { limit: (limit: number) => unknown }).limit(Math.min(Math.max(limit, 1), 100))
+        query = (query as { offset: (offset: number) => unknown }).offset(Math.max(offset, 0))
+        return await query
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          ...tableProperty(),
+          limit: { maximum: 100, minimum: 1, type: "number" },
+          offset: { minimum: 0, type: "number" },
+          orderBy: { description: "Optional schema column export name to order ascending.", type: "string" },
+        },
+        required: ["table"],
+        type: "object",
+      },
+      metadata,
+      name: toolKey(prefix, "select"),
+    }),
+    [toolKey(prefix, "read_sql")]: defineTool<SchemaSqlInput, unknown>({
+      description: `Run a read-only SQL statement through the ${options.database} database.`,
+      execute: async ({ statement }) => {
+        if (!isReadStatement(statement)) {
+          throw new Error(`[vitehub] ${toolKey(prefix, "read_sql")} only accepts SELECT statements.`)
+        }
+        const entry = await getDatabase(options)
+        return await (entry.db.all as (query: unknown) => Promise<unknown>)(sql.raw(statement))
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          statement: { description: "SELECT statement to execute.", type: "string" },
+        },
+        required: ["statement"],
+        type: "object",
+      },
+      metadata,
+      name: toolKey(prefix, "read_sql"),
+    }),
+  }
+}
+
+function writeTools(options: ResolvedCreateDbToolsOptions, prefix: string): DbAgentToolSet {
+  return {
+    [toolKey(prefix, "insert")]: defineTool<InsertInput, unknown>({
+      description: `Insert seed-style rows through a Drizzle table in the ${options.database} database.`,
+      execute: async ({ table, values }) => {
+        const entry = await getDatabase(options)
+        const schemaTable = getTable(entry, table)
+        return await (entry.db.insert as (table: unknown) => { values: (values: unknown) => { returning: () => Promise<unknown> } })(schemaTable).values(values).returning()
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          ...tableProperty(),
+          values: {
+            oneOf: [
+              { additionalProperties: true, type: "object" },
+              { items: { additionalProperties: true, type: "object" }, type: "array" },
+            ],
+          },
+        },
+        required: ["table", "values"],
+        type: "object",
+      },
+      metadata,
+      name: toolKey(prefix, "insert"),
+    }),
+    [toolKey(prefix, "update")]: defineTool<UpdateInput, unknown>({
+      description: `Update rows matching one equality condition through a Drizzle table in the ${options.database} database.`,
+      execute: async ({ column, table, value, values }) => {
+        const entry = await getDatabase(options)
+        const schemaTable = getTable(entry, table)
+        return await (entry.db.update as (table: unknown) => { set: (values: unknown) => { where: (condition: unknown) => { returning: () => Promise<unknown> } } })(schemaTable)
+          .set(values)
+          .where(eq(getColumn(schemaTable, column) as never, value))
+          .returning()
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          ...tableProperty(),
+          column: { description: "Schema column export name for the equality match.", type: "string" },
+          value: { description: "Value to match in the equality condition." },
+          values: { additionalProperties: true, type: "object" },
+        },
+        required: ["table", "column", "value", "values"],
+        type: "object",
+      },
+      metadata,
+      name: toolKey(prefix, "update"),
+    }),
+    [toolKey(prefix, "delete")]: defineTool<MatchInput, unknown>({
+      description: `Delete rows matching one equality condition through a Drizzle table in the ${options.database} database.`,
+      execute: async ({ column, table, value }) => {
+        const entry = await getDatabase(options)
+        const schemaTable = getTable(entry, table)
+        return await (entry.db.delete as (table: unknown) => { where: (condition: unknown) => { returning: () => Promise<unknown> } })(schemaTable)
+          .where(eq(getColumn(schemaTable, column) as never, value))
+          .returning()
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          ...tableProperty(),
+          column: { description: "Schema column export name for the equality match.", type: "string" },
+          value: { description: "Value to match in the equality condition." },
+        },
+        required: ["table", "column", "value"],
+        type: "object",
+      },
+      metadata,
+      name: toolKey(prefix, "delete"),
+    }),
+  }
+}
+
+function schemaTools(options: ResolvedCreateDbToolsOptions, prefix: string): DbAgentToolSet {
+  return {
+    [toolKey(prefix, "run_schema_sql")]: defineTool<SchemaSqlInput, unknown>({
+      description: `Run explicit runtime DDL SQL through the ${options.database} database.`,
+      execute: async ({ statement }) => {
+        const entry = await getDatabase(options)
+        return await (entry.db.run as (query: unknown) => Promise<unknown>)(sql.raw(statement))
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          statement: { description: "DDL SQL statement to execute.", type: "string" },
+        },
+        required: ["statement"],
+        type: "object",
+      },
+      metadata,
+      name: toolKey(prefix, "run_schema_sql"),
+      policy: "require-approval",
+    }),
+  }
+}
+
+export function createDbTools(options: CreateDbToolsOptions): DbAgentToolSet {
+  if (!options || typeof options !== "object") {
+    throw new TypeError("[vitehub] createDbTools() requires options.")
+  }
+  if (options.database !== undefined && typeof options.database !== "string") {
+    throw new TypeError("[vitehub] createDbTools() database must be a string.")
+  }
+  const resolvedOptions = { ...options, database: resolveDatabaseName(options) }
+  const prefix = resolveToolPrefix(resolvedOptions)
+  const access = resolvedOptions.access || "read"
+  if (access === "read") return readTools(resolvedOptions, prefix)
+  if (access === "write") return { ...readTools(resolvedOptions, prefix), ...writeTools(resolvedOptions, prefix) }
+  if (access === "schema") return { ...readTools(resolvedOptions, prefix), ...writeTools(resolvedOptions, prefix), ...schemaTools(resolvedOptions, prefix) }
+  throw new TypeError(`[vitehub] Unknown DB agent tool access: ${String(access)}`)
+}

--- a/packages/db/test/agent.test.ts
+++ b/packages/db/test/agent.test.ts
@@ -1,0 +1,131 @@
+import { sqliteTable, text } from "drizzle-orm/sqlite-core"
+import { describe, expect, it, vi } from "vitest"
+
+import { createDbTools } from "../src/agent.ts"
+
+const notesTable = sqliteTable("notes", {
+  title: text("title"),
+})
+
+const eventsTable = sqliteTable("events", {
+  name: text("name"),
+})
+
+describe("createDbTools", () => {
+  it("gates tools by access level", () => {
+    expect(Object.keys(createDbTools({ access: "read" })).sort()).toEqual([
+      "db_list_tables",
+      "db_read_sql",
+      "db_select",
+    ])
+    expect(createDbTools({ access: "write", database: "default", databases: {} })).toHaveProperty("db_insert")
+    expect(createDbTools({ access: "write", database: "default", databases: {} })).not.toHaveProperty("db_run_schema_sql")
+    expect(createDbTools({ access: "schema", database: "default", databases: {} })).toHaveProperty("db_run_schema_sql")
+    expect(createDbTools({ access: "schema", database: "default", databases: {} }).db_run_schema_sql.policy).toBe("require-approval")
+  })
+
+  it("uses the default database when no database map is provided", () => {
+    const tools = createDbTools({ access: "read" })
+
+    expect(Object.keys(tools).sort()).toEqual([
+      "db_list_tables",
+      "db_read_sql",
+      "db_select",
+    ])
+  })
+
+  it("infers the only configured database when database is omitted", async () => {
+    const tools = createDbTools({
+      databases: {
+        analytics: { db: {}, schema: { events: eventsTable } },
+      },
+    })
+
+    expect(Object.keys(tools).sort()).toEqual([
+      "analytics_db_list_tables",
+      "analytics_db_read_sql",
+      "analytics_db_select",
+    ])
+    await expect(tools.analytics_db_list_tables.execute?.({})).resolves.toEqual({ database: "analytics", tables: ["events"] })
+  })
+
+  it("requires a database name when multiple databases are configured", () => {
+    expect(() => createDbTools({
+      databases: {
+        analytics: { db: {}, schema: { events: eventsTable } },
+        default: { db: {}, schema: { notes: notesTable } },
+      },
+    })).toThrow("requires a database name when multiple databases are configured")
+  })
+
+  it("scopes tools to the configured database", async () => {
+    const tools = createDbTools({
+      database: "analytics",
+      databases: {
+        analytics: { db: {}, schema: { events: eventsTable, helper: () => "not a table" } },
+        default: { db: {}, schema: { notes: notesTable } },
+      },
+    })
+
+    expect(Object.keys(tools).sort()).toEqual([
+      "analytics_db_list_tables",
+      "analytics_db_read_sql",
+      "analytics_db_select",
+    ])
+    await expect(tools.analytics_db_list_tables.execute?.({})).resolves.toEqual({ database: "analytics", tables: ["events"] })
+  })
+
+  it("supports a custom tool prefix", () => {
+    expect(createDbTools({ database: "analytics", databases: {}, prefix: "warehouse" })).toHaveProperty("warehouse_list_tables")
+  })
+
+  it("executes structured inserts through the selected Drizzle table", async () => {
+    const returning = vi.fn(async () => [{ id: 1, title: "hello" }])
+    const values = vi.fn(() => ({ returning }))
+    const insert = vi.fn(() => ({ values }))
+    const tools = createDbTools({
+      access: "write",
+      database: "default",
+      databases: {
+        default: {
+          db: { insert },
+          schema: { notes: notesTable },
+        },
+      },
+    })
+
+    await expect(tools.db_insert.execute?.({ table: "notes", values: { title: "hello" } })).resolves.toEqual([{ id: 1, title: "hello" }])
+    expect(insert).toHaveBeenCalledWith(notesTable)
+    expect(values).toHaveBeenCalledWith({ title: "hello" })
+  })
+
+  it("rejects missing databases and tables clearly", async () => {
+    const tools = createDbTools({
+      database: "default",
+      databases: {
+        default: { db: {}, schema: {} },
+      },
+    })
+
+    await expect(tools.db_select.execute?.({ table: "missing" })).rejects.toThrow('Database table "missing" was not found')
+    const missingTools = createDbTools({ database: "missing", databases: {} })
+    await expect(missingTools.missing_db_list_tables.execute?.({})).rejects.toThrow('Database "missing" is not configured')
+  })
+
+  it("rejects write SQL through the read SQL tool", async () => {
+    const all = vi.fn(async () => [])
+    const tools = createDbTools({
+      database: "default",
+      databases: {
+        default: { db: { all }, schema: {} },
+      },
+    })
+
+    await expect(tools.db_read_sql.execute?.({ statement: "delete from notes" })).rejects.toThrow("only accepts SELECT")
+    await expect(tools.db_read_sql.execute?.({ statement: "with deleted as (delete from notes returning *) select * from deleted" })).rejects.toThrow("only accepts SELECT")
+    await expect(tools.db_read_sql.execute?.({ statement: "pragma writable_schema = 1" })).rejects.toThrow("only accepts SELECT")
+    await expect(tools.db_read_sql.execute?.({ statement: "select 1; delete from notes" })).rejects.toThrow("only accepts SELECT")
+    await expect(tools.db_read_sql.execute?.({ statement: "select ';' as value; -- trailing comment" })).resolves.toEqual([])
+    expect(all).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/db/test/types.test.ts
+++ b/packages/db/test/types.test.ts
@@ -5,6 +5,7 @@ import "../src/virtual.ts"
 import { describe, expectTypeOf, it } from "vitest"
 
 import type { DBModuleOptions } from "../src/index.ts"
+import { createDbTools } from "../src/agent.ts"
 
 type DrizzleModule = typeof import("../src/drizzle.ts")
 
@@ -25,5 +26,12 @@ describe("types", () => {
     expectTypeOf<DrizzleModule["schema"]>().toMatchTypeOf<Record<string, unknown>>()
     expectTypeOf<DrizzleModule["databases"]["default"]["schema"]>().toMatchTypeOf<DrizzleModule["schema"]>()
     expectTypeOf<DrizzleModule["db"]>().toMatchTypeOf<DrizzleModule["databases"]["default"]["db"]>()
+  })
+
+  it("exposes DB agent tools", () => {
+    const tools = createDbTools({ access: "schema", database: "default" })
+
+    expectTypeOf(tools.db_list_tables.name).toEqualTypeOf<string>()
+    expectTypeOf(tools.db_run_schema_sql.execute).toMatchTypeOf<unknown>()
   })
 })

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -8,6 +8,18 @@
     ],
     "baseUrl": "../..",
     "paths": {
+      "@vitehub/agent": [
+        "packages/agent/src/tool-definition.ts"
+      ],
+      "@vitehub/messages": [
+        "packages/messages/src/index.ts"
+      ],
+      "@vitehub/runtime": [
+        "packages/runtime/src/index.ts"
+      ],
+      "@vitehub/workspace": [
+        "packages/workspace/src/index.ts"
+      ],
       "@vitehub/internal/*": [
         "packages/internal/src/*"
       ]

--- a/packages/db/tsdown.config.ts
+++ b/packages/db/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   },
   dts: true,
   entry: [
+    "src/agent.ts",
     "src/index.ts",
     "src/drizzle.ts",
     "src/virtual.ts",

--- a/packages/kv/docs/runtime-api.md
+++ b/packages/kv/docs/runtime-api.md
@@ -79,6 +79,28 @@ interface KVStorage {
 
 Method options are passed to the underlying unstorage driver. Treat them as provider-specific.
 
+## Agent Tools
+
+```ts
+import { createKvTools } from '@vitehub/kv/agent'
+```
+
+`createKvTools()` returns ViteHub Agent-compatible Tools backed by the same `kv` runtime handle:
+
+```ts
+createKvTools({ access: 'read' })
+createKvTools({ access: 'write' })
+```
+
+Install `@vitehub/agent` alongside `@vitehub/kv` when importing `@vitehub/kv/agent`.
+
+| Access | Tools |
+| --- | --- |
+| `read` | Get one key, check one key, and list keys by optional prefix. |
+| `write` | Includes `read`, plus set one key and delete one key. |
+
+The write preset intentionally does not expose `kv.clear()`.
+
 ## Module Options
 
 ### `KVModuleOptions`

--- a/packages/kv/docs/usage.md
+++ b/packages/kv/docs/usage.md
@@ -98,6 +98,27 @@ await kv.del('settings')
 
 Use this for explicit user actions such as resetting preferences or removing a cache entry.
 
+## Expose KV Tools to an agent
+
+Use `@vitehub/kv/agent` when an agent should read or write provider-neutral KV state through the configured runtime handle.
+
+```ts [server/agents/settings.ts]
+import { defineAgent } from '@vitehub/agent'
+import { aiSdkAdapter } from '@vitehub/agent/ai-sdk'
+import { createKvTools } from '@vitehub/kv/agent'
+
+export default defineAgent({
+  adapter: aiSdkAdapter({
+    model,
+    tools: () => createKvTools({ access: 'write' }),
+  }),
+})
+```
+
+Install `@vitehub/agent` alongside `@vitehub/kv` when importing `@vitehub/kv/agent`.
+
+`access: 'write'` can set and delete individual keys. It does not expose `kv.clear()`.
+
 ## Clear a Prefix
 
 `kv.clear()` clears the whole active store. Pass a prefix when only one feature namespace should be removed:

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -25,6 +25,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./agent": "./dist/agent.js",
     "./nitro": "./dist/nitro.js",
     "./nuxt": "./dist/nuxt.js",
     "./runtime/nitro-plugin": "./dist/runtime/nitro-plugin.js",
@@ -50,11 +51,15 @@
     "unstorage": "catalog:"
   },
   "peerDependencies": {
+    "@vitehub/agent": "workspace:*",
     "@upstash/redis": "^1.37.0",
     "nitro": "^3.0.0-0",
     "vite": ">=6.0.0"
   },
   "peerDependenciesMeta": {
+    "@vitehub/agent": {
+      "optional": true
+    },
     "@upstash/redis": {
       "optional": true
     },
@@ -67,6 +72,7 @@
   },
   "devDependencies": {
     "@nuxt/schema": "catalog:",
+    "@vitehub/agent": "workspace:*",
     "@vitehub/internal": "workspace:*",
     "nitro": "catalog:",
     "ofetch": "catalog:",

--- a/packages/kv/src/agent.ts
+++ b/packages/kv/src/agent.ts
@@ -1,0 +1,141 @@
+import { defineTool } from "@vitehub/agent"
+
+import type { AgentToolDefinition, AgentToolSet } from "@vitehub/agent"
+
+export type KvAgentToolAccess = "read" | "write"
+
+export type KvAgentToolDefinition<TInput = unknown, TOutput = unknown> = AgentToolDefinition<TInput, TOutput>
+export type KvAgentToolSet = AgentToolSet
+
+export interface KvAgentStorage {
+  del(key: string, options?: unknown): Promise<void>
+  get(key: string, options?: unknown): Promise<unknown | null>
+  has(key: string, options?: unknown): Promise<boolean>
+  keys(base?: string, options?: unknown): Promise<string[]>
+  set(key: string, value: unknown, options?: unknown): Promise<void>
+}
+
+export interface CreateKvToolsOptions {
+  access?: KvAgentToolAccess
+  kv?: KvAgentStorage
+}
+
+interface KeyInput {
+  key: string
+  options?: unknown
+}
+
+interface KeysInput {
+  base?: string
+  options?: unknown
+}
+
+interface SetInput extends KeyInput {
+  value: unknown
+}
+
+const metadata = {
+  category: "kv",
+  preset: "vitehub-kv",
+}
+
+async function getKv(options: CreateKvToolsOptions) {
+  if (options.kv) return options.kv
+  const module = await import("./index.ts")
+  return module.kv
+}
+
+function keyProperties() {
+  return {
+    key: { description: "Storage key to read or write.", type: "string" },
+    options: { description: "Optional driver-specific options." },
+  }
+}
+
+function readTools(options: CreateKvToolsOptions): KvAgentToolSet {
+  return {
+    kv_get: defineTool<KeyInput, { key: string, value: unknown }>({
+      description: "Read one KV value by key.",
+      execute: async ({ key, options: driverOptions }) => ({ key, value: await (await getKv(options)).get(key, driverOptions) }),
+      inputSchema: {
+        additionalProperties: false,
+        properties: keyProperties(),
+        required: ["key"],
+        type: "object",
+      },
+      metadata,
+      name: "kv_get",
+    }),
+    kv_has: defineTool<KeyInput, { exists: boolean, key: string }>({
+      description: "Check whether one KV key exists.",
+      execute: async ({ key, options: driverOptions }) => ({ exists: await (await getKv(options)).has(key, driverOptions), key }),
+      inputSchema: {
+        additionalProperties: false,
+        properties: keyProperties(),
+        required: ["key"],
+        type: "object",
+      },
+      metadata,
+      name: "kv_has",
+    }),
+    kv_keys: defineTool<KeysInput, { keys: string[] }>({
+      description: "List KV keys, optionally under a prefix.",
+      execute: async ({ base, options: driverOptions }) => ({ keys: await (await getKv(options)).keys(base, driverOptions) }),
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          base: { description: "Optional key prefix to list under.", type: "string" },
+          options: { description: "Optional driver-specific options." },
+        },
+        type: "object",
+      },
+      metadata,
+      name: "kv_keys",
+    }),
+  }
+}
+
+function writeTools(options: CreateKvToolsOptions): KvAgentToolSet {
+  return {
+    kv_set: defineTool<SetInput, { key: string }>({
+      description: "Write one JSON-serializable KV value by key.",
+      execute: async ({ key, options: driverOptions, value }) => {
+        await (await getKv(options)).set(key, value, driverOptions)
+        return { key }
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          ...keyProperties(),
+          value: { description: "JSON-serializable value to store." },
+        },
+        required: ["key", "value"],
+        type: "object",
+      },
+      metadata,
+      name: "kv_set",
+    }),
+    kv_delete: defineTool<KeyInput, { key: string }>({
+      description: "Delete one KV key.",
+      execute: async ({ key, options: driverOptions }) => {
+        await (await getKv(options)).del(key, driverOptions)
+        return { key }
+      },
+      inputSchema: {
+        additionalProperties: false,
+        properties: keyProperties(),
+        required: ["key"],
+        type: "object",
+      },
+      metadata,
+      name: "kv_delete",
+    }),
+  }
+}
+
+export function createKvTools(options: CreateKvToolsOptions = {}): KvAgentToolSet {
+  const access = options.access || "read"
+  if (access === "read") return readTools(options)
+  if (access === "write") return { ...readTools(options), ...writeTools(options) }
+  throw new TypeError(`[vitehub] Unknown KV agent tool access: ${String(access)}`)
+}

--- a/packages/kv/test/agent.test.ts
+++ b/packages/kv/test/agent.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createKvTools } from "../src/agent.ts"
+
+describe("createKvTools", () => {
+  it("gates tools by access level without exposing clear", () => {
+    expect(Object.keys(createKvTools({ access: "read", kv: {} as never })).sort()).toEqual([
+      "kv_get",
+      "kv_has",
+      "kv_keys",
+    ])
+    expect(Object.keys(createKvTools({ access: "write", kv: {} as never })).sort()).toEqual([
+      "kv_delete",
+      "kv_get",
+      "kv_has",
+      "kv_keys",
+      "kv_set",
+    ])
+    expect(createKvTools({ access: "write", kv: {} as never })).not.toHaveProperty("kv_clear")
+  })
+
+  it("calls the KV runtime handle", async () => {
+    const kv = {
+      del: vi.fn(async () => {}),
+      get: vi.fn(async () => ({ enabled: true })),
+      has: vi.fn(async () => true),
+      keys: vi.fn(async () => ["settings"]),
+      set: vi.fn(async () => {}),
+    }
+    const tools = createKvTools({ access: "write", kv })
+
+    await expect(tools.kv_get.execute?.({ key: "settings" })).resolves.toEqual({ key: "settings", value: { enabled: true } })
+    await expect(tools.kv_has.execute?.({ key: "settings" })).resolves.toEqual({ exists: true, key: "settings" })
+    await expect(tools.kv_keys.execute?.({ base: "settings" })).resolves.toEqual({ keys: ["settings"] })
+    await expect(tools.kv_set.execute?.({ key: "settings", value: { enabled: true } })).resolves.toEqual({ key: "settings" })
+    await expect(tools.kv_delete.execute?.({ key: "settings" })).resolves.toEqual({ key: "settings" })
+    expect(kv.get).toHaveBeenCalledWith("settings", undefined)
+    expect(kv.set).toHaveBeenCalledWith("settings", { enabled: true }, undefined)
+    expect(kv.del).toHaveBeenCalledWith("settings", undefined)
+  })
+})

--- a/packages/kv/test/types.test-d.ts
+++ b/packages/kv/test/types.test-d.ts
@@ -4,6 +4,7 @@ import virtualConfig, { hosting as virtualHosting, kv as virtualKV } from "virtu
 import { describe, expectTypeOf, it } from "vitest"
 
 import { kv, type KVModuleOptions, type KVStoreConfig, type ResolvedKVModuleOptions } from "../src/index.ts"
+import { createKvTools } from "../src/agent.ts"
 import { hubKv } from "../src/vite.ts"
 
 describe("types", () => {
@@ -42,6 +43,13 @@ describe("types", () => {
     expectTypeOf(kv.has).returns.toEqualTypeOf<Promise<boolean>>()
     expectTypeOf(kv.keys).returns.toEqualTypeOf<Promise<string[]>>()
     expectTypeOf(kv.set<string>).returns.toEqualTypeOf<Promise<void>>()
+  })
+
+  it("exposes KV agent tools", () => {
+    const tools = createKvTools({ access: "write" })
+
+    expectTypeOf(tools.kv_get.name).toEqualTypeOf<string>()
+    expectTypeOf(tools.kv_set.execute).toMatchTypeOf<unknown>()
   })
 
   it("returns a vite plugin with runtime config access", () => {

--- a/packages/kv/tsconfig.json
+++ b/packages/kv/tsconfig.json
@@ -5,6 +5,18 @@
     "rootDir": "..",
     "baseUrl": "../..",
     "paths": {
+      "@vitehub/agent": [
+        "packages/agent/src/tool-definition.ts"
+      ],
+      "@vitehub/messages": [
+        "packages/messages/src/index.ts"
+      ],
+      "@vitehub/runtime": [
+        "packages/runtime/src/index.ts"
+      ],
+      "@vitehub/workspace": [
+        "packages/workspace/src/index.ts"
+      ],
       "@vitehub/internal/*": [
         "packages/internal/src/*"
       ]

--- a/packages/kv/tsdown.config.ts
+++ b/packages/kv/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   ],
   dts: true,
   entry: [
+    "src/agent.ts",
     "src/index.ts",
     "src/vite.ts",
     "src/nitro.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       '@vercel/blob':
         specifier: 'catalog:'
         version: 2.3.3
+      '@vitehub/agent':
+        specifier: workspace:*
+        version: link:../agent
       '@vitehub/internal':
         specifier: workspace:*
         version: link:../internal
@@ -498,6 +501,9 @@ importers:
         specifier: 'catalog:'
         version: 2.0.3
     devDependencies:
+      '@vitehub/agent':
+        specifier: workspace:*
+        version: link:../agent
       '@vitehub/internal':
         specifier: workspace:*
         version: link:../internal
@@ -687,6 +693,9 @@ importers:
       '@nuxt/schema':
         specifier: 'catalog:'
         version: 4.4.2
+      '@vitehub/agent':
+        specifier: workspace:*
+        version: link:../agent
       '@vitehub/internal':
         specifier: workspace:*
         version: link:../internal


### PR DESCRIPTION
Adds package-owned Agent tool factories for DB, KV, and Blob so storage primitives can be composed in normal agent `tools` resolvers without coupling storage packages to `@vitehub/agent`.

The new subpaths are `@vitehub/db/agent`, `@vitehub/kv/agent`, and `@vitehub/blob/agent`. DB supports read/write/schema access, while KV and Blob support read/write access with broad destructive operations and binary Blob writes intentionally left out of v1.

Docs now show package-level usage and a composed Agent example.