### PR TITLE
docs(agents): add agent context map

### DIFF
--- a/.agents/CONTEXT-MAP.md
+++ b/.agents/CONTEXT-MAP.md
@@ -1,0 +1,31 @@
+# Context Map
+
+## Contexts
+
+- [Framework Integrations](./contexts/framework-integrations/CONTEXT.md) - names Vite, Nitro, discovery, runtime registry, and option lifecycle boundaries.
+- [Capabilities](./contexts/capabilities/CONTEXT.md) - names user-shareable abilities that agents can attach.
+- [Agents](./contexts/agents/CONTEXT.md) - names agent definitions, invocations, and agent-owned runtime behavior.
+- [KV](./contexts/kv/CONTEXT.md) - names key-value storage primitives and configured stores.
+- [Blob](./contexts/blob/CONTEXT.md) - names object/file storage primitives and configured stores.
+- [Workspace](./contexts/workspace/CONTEXT.md) - names persistent file-tree state and source ingestion.
+- [Agent Package](./contexts/packages/agent/CONTEXT.md) - names ownership boundaries for `@vitehub/agent`.
+- [Blob Package](./contexts/packages/blob/CONTEXT.md) - names ownership boundaries for `@vitehub/blob`.
+- [DB Package](./contexts/packages/db/CONTEXT.md) - names ownership boundaries for `@vitehub/db`.
+- [Env Package](./contexts/packages/env/CONTEXT.md) - names ownership boundaries for `@vitehub/env`.
+- [KV Package](./contexts/packages/kv/CONTEXT.md) - names ownership boundaries for `@vitehub/kv`.
+- [Queue Package](./contexts/packages/queue/CONTEXT.md) - names ownership boundaries for `@vitehub/queue`.
+- [Runtime Package](./contexts/packages/runtime/CONTEXT.md) - names ownership boundaries for `@vitehub/runtime`.
+- [Sandbox Package](./contexts/packages/sandbox/CONTEXT.md) - names ownership boundaries for `@vitehub/sandbox`.
+- [Shell Package](./contexts/packages/shell/CONTEXT.md) - names ownership boundaries for `@vitehub/shell`.
+- [Unsource Package](./contexts/packages/unsource/CONTEXT.md) - names ownership boundaries for `@vitehub/unsource`.
+- [Workflow Package](./contexts/packages/workflow/CONTEXT.md) - names ownership boundaries for `@vitehub/workflow`.
+- [Workspace Package](./contexts/packages/workspace/CONTEXT.md) - names ownership boundaries for `@vitehub/workspace`.
+
+## Relationships
+
+- **Framework Integrations -> Packages**: Packages use framework integrations to discover definitions, generate runtime registries, and bind provider output.
+- **Capabilities -> Agents**: Agents attach Capabilities to expose user-shareable abilities.
+- **Agents -> Workspace**: Agents can reference Workspaces for persistent file-tree state.
+- **Workspace -> Blob**: Hosted Workspace stores can use Blob Stores without making Blob the agent-facing boundary.
+- **Agents -> KV**: Agent-owned runtime behavior can use KV Stores internally when configured by ViteHub primitives.
+- **Packages -> Domain Contexts**: Package contexts define ownership boundaries; domain contexts define shared vocabulary.

--- a/.agents/CONTEXT-MAP.md
+++ b/.agents/CONTEXT-MAP.md
@@ -26,6 +26,6 @@
 - **Framework Integrations -> Packages**: Packages use framework integrations to discover definitions, generate runtime registries, and bind provider output.
 - **Capabilities -> Agents**: Agents attach Capabilities to expose user-shareable abilities.
 - **Agents -> Workspace**: Agents can reference Workspaces for persistent file-tree state.
-- **Workspace -> Blob**: Hosted Workspace stores can use Blob Stores without making Blob the agent-facing boundary.
+- **Workspace -> Blob**: Workspace Stores can use Blob Stores for persistence while Workspace owns file-tree behavior.
 - **Agents -> KV**: Agent-owned runtime behavior can use KV Stores internally when configured by ViteHub primitives.
 - **Packages -> Domain Contexts**: Package contexts define ownership boundaries; domain contexts define shared vocabulary.

--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -1,0 +1,48 @@
+# Agents
+
+Agents names definitions, invocations, and agent-owned runtime behavior.
+
+## Language
+
+**Agent**:
+A named server-side actor that receives inputs, runs model-backed behavior, and may attach Capabilities.
+_Avoid_: Bot, chat definition, workflow
+
+**Agent Definition**:
+The code declaration that names an Agent and configures its model, workspace, tools, instructions, and Capabilities.
+_Avoid_: Chat definition, server route
+
+**Agent Invocation**:
+One runtime request to an Agent.
+_Avoid_: Chat message, webhook call
+
+**Agent Runtime Behavior**:
+Internal behavior that an Agent or Capability needs to process invocations correctly.
+_Avoid_: User-facing Capability, public adapter
+
+**Invocation Coordination**:
+Agent Runtime Behavior that prevents conflicting concurrent invocations for the same coordination scope.
+_Avoid_: Chat lock, public lock API
+
+**Best-Effort Coordination**:
+Invocation Coordination that is acceptable only for local or single-process development.
+_Avoid_: Production lock, durable coordination
+
+## Relationships
+
+- An **Agent Definition** declares one **Agent**.
+- An **Agent** receives zero or more **Agent Invocations**.
+- An **Agent** can attach zero or more Capabilities.
+- **Agent Runtime Behavior** is internal unless exposed by a named Capability or primitive.
+- **Invocation Coordination** is **Agent Runtime Behavior**.
+- **Best-Effort Coordination** is not acceptable for hosted production runtimes.
+
+## Example Dialogue
+
+> **Dev:** "Should users configure a lock adapter on the agent?"
+> **Domain expert:** "No. That is **Agent Runtime Behavior**. If it becomes public, it needs a named ViteHub primitive or Capability boundary."
+
+## Flagged Ambiguities
+
+- Chat runtime state was considered a public Chat option - resolved: runtime coordination is **Agent Runtime Behavior** unless exposed through a named public boundary.
+- Local and hosted coordination were considered equivalent - resolved: hosted production runtimes require guaranteed **Invocation Coordination**; local single-process development can use **Best-Effort Coordination** with diagnostics.

--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -1,6 +1,6 @@
 # Agents
 
-Agents names definitions, invocations, and agent-owned runtime behavior.
+Agents names definitions, invocations, and runtime state for model-backed server actors.
 
 ## Language
 
@@ -9,40 +9,42 @@ A named server-side actor that receives inputs, runs model-backed behavior, and 
 _Avoid_: Bot, chat definition, workflow
 
 **Agent Definition**:
-The code declaration that names an Agent and configures its model, workspace, tools, instructions, and Capabilities.
+The code declaration that names an Agent and configures its model, workspace, instructions, and Capabilities.
 _Avoid_: Chat definition, server route
 
 **Agent Invocation**:
 One runtime request to an Agent.
 _Avoid_: Chat message, webhook call
 
-**Agent Runtime Behavior**:
-Internal behavior that an Agent or Capability needs to process invocations correctly.
-_Avoid_: User-facing Capability, public adapter
+**Agent Run State**:
+Runtime state created while an Agent Invocation is being processed.
+_Avoid_: Chat state, workflow state
 
-**Invocation Coordination**:
-Agent Runtime Behavior that prevents conflicting concurrent invocations for the same coordination scope.
-_Avoid_: Chat lock, public lock API
+**Concurrent Invocation Guard**:
+Internal Agent behavior that prevents overlapping invocations from mutating the same Agent Run State.
+_Avoid_: Public lock API, Capability
 
-**Best-Effort Coordination**:
-Invocation Coordination that is acceptable only for local or single-process development.
-_Avoid_: Production lock, durable coordination
+**Development State Provider**:
+An in-memory or local provider used only for single-process Agent development.
+_Avoid_: Production state provider, durable coordination
 
 ## Relationships
 
 - An **Agent Definition** declares one **Agent**.
 - An **Agent** receives zero or more **Agent Invocations**.
 - An **Agent** can attach zero or more Capabilities.
-- **Agent Runtime Behavior** is internal unless exposed by a named Capability or primitive.
-- **Invocation Coordination** is **Agent Runtime Behavior**.
-- **Best-Effort Coordination** is not acceptable for hosted production runtimes.
+- Tools are contributed by Capabilities, not by top-level Agent Definition fields.
+- An **Agent Invocation** can create or update **Agent Run State**.
+- A **Concurrent Invocation Guard** protects **Agent Run State**.
+- A **Development State Provider** is not acceptable for hosted production runtimes.
 
 ## Example Dialogue
 
-> **Dev:** "Should users configure a lock adapter on the agent?"
-> **Domain expert:** "No. That is **Agent Runtime Behavior**. If it becomes public, it needs a named ViteHub primitive or Capability boundary."
+> **Dev:** "Should users configure `tools` directly on the Agent Definition?"
+> **Domain expert:** "No. Tools belong inside Capability definitions so validation, policy, and DevTools metadata stay attached to the Capability."
 
 ## Flagged Ambiguities
 
-- Chat runtime state was considered a public Chat option - resolved: runtime coordination is **Agent Runtime Behavior** unless exposed through a named public boundary.
-- Local and hosted coordination were considered equivalent - resolved: hosted production runtimes require guaranteed **Invocation Coordination**; local single-process development can use **Best-Effort Coordination** with diagnostics.
+- Raw tools were considered as top-level Agent Definition fields - resolved: tools are contributed by Capabilities.
+- Chat runtime state was considered a public Chat option - resolved: use **Agent Run State** for Agent-owned runtime state.
+- Local and hosted state providers were considered equivalent - resolved: hosted production runtimes require a durable provider and a **Concurrent Invocation Guard**.

--- a/.agents/contexts/blob/CONTEXT.md
+++ b/.agents/contexts/blob/CONTEXT.md
@@ -1,0 +1,41 @@
+# Blob
+
+Blob names object/file storage primitives and configured stores.
+
+## Language
+
+**Blob**:
+The ViteHub object storage primitive for files, streams, binary bodies, and objects with metadata.
+_Avoid_: Workspace, artifact capability
+
+**Blob Store**:
+A named configured Blob backend that code and ViteHub storage layers can target.
+_Avoid_: Bucket, adapter, binding
+
+**Default Blob Store**:
+The Blob Store used when code does not select a named Blob Store.
+_Avoid_: Singleton, unnamed Blob, global Blob
+
+**Blob Store Selection**:
+The act of choosing a Blob Store by name from the Blob primitive.
+_Avoid_: Adapter selection, bucket binding
+
+## Relationships
+
+- **Blob** can expose one or more **Blob Stores**.
+- One **Blob Store** can be the **Default Blob Store**.
+- Single-store Blob configuration is normalized to the **Default Blob Store**.
+- Named Blob configuration declares a map of **Blob Stores**.
+- Runtime code selects non-default stores through **Blob Store Selection**.
+- A Workspace Store can be backed by a **Blob Store**.
+- Blob is not an Agent Capability when accessed through Workspace.
+
+## Example Dialogue
+
+> **Dev:** "Should agents get a Blob capability just because Workspace uses Blob underneath?"
+> **Domain expert:** "No. File access for agents goes through Workspace when Workspace is the boundary."
+
+## Flagged Ambiguities
+
+- Blob was considered as an Agent Capability - resolved: Blob-backed agent file access should go through Workspace unless a separate public use case is proven.
+- "bucket" was considered for multiple Blob backends - resolved: use **Blob Store** publicly because buckets and bindings are backend details.

--- a/.agents/contexts/blob/CONTEXT.md
+++ b/.agents/contexts/blob/CONTEXT.md
@@ -6,7 +6,7 @@ Blob names object/file storage primitives and configured stores.
 
 **Blob**:
 The ViteHub object storage primitive for files, streams, binary bodies, and objects with metadata.
-_Avoid_: Workspace, artifact capability
+_Avoid_: Workspace, Capability
 
 **Blob Store**:
 A named configured Blob backend that code and ViteHub storage layers can target.
@@ -27,15 +27,15 @@ _Avoid_: Adapter selection, bucket binding
 - Single-store Blob configuration is normalized to the **Default Blob Store**.
 - Named Blob configuration declares a map of **Blob Stores**.
 - Runtime code selects non-default stores through **Blob Store Selection**.
-- A Workspace Store can be backed by a **Blob Store**.
-- Blob is not an Agent Capability when accessed through Workspace.
+- Workspace Stores can use **Blob Stores** for persistence.
+- Workspace adds file-tree behavior and worktree-oriented DX on top of stored files.
 
 ## Example Dialogue
 
-> **Dev:** "Should agents get a Blob capability just because Workspace uses Blob underneath?"
-> **Domain expert:** "No. File access for agents goes through Workspace when Workspace is the boundary."
+> **Dev:** "Is a Workspace just a Blob Store?"
+> **Domain expert:** "No. Blob stores files and objects. Workspace decides how those files appear in a file tree."
 
 ## Flagged Ambiguities
 
-- Blob was considered as an Agent Capability - resolved: Blob-backed agent file access should go through Workspace unless a separate public use case is proven.
+- Blob was described through Agent access - resolved: Blob is the storage primitive; Workspace is one consumer that adds file-tree behavior.
 - "bucket" was considered for multiple Blob backends - resolved: use **Blob Store** publicly because buckets and bindings are backend details.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -1,0 +1,88 @@
+# Capabilities
+
+Capabilities are user-shareable abilities that ViteHub agents can attach.
+
+## Language
+
+**Capability**:
+A shareable ViteHub bundle that adds a named agent ability.
+_Avoid_: Plugin, integration, extension
+
+**Official Capability**:
+A Capability shipped by ViteHub.
+_Avoid_: Built-in plugin, core feature
+
+**Capability Factory**:
+A function that returns a Capability.
+_Avoid_: Config mutator, setup callback
+
+**Capability Definition**:
+The public object shape used by official and user-defined Capabilities.
+_Avoid_: Internal plugin shape
+
+**Capability Phase**:
+A named lifecycle point where ViteHub collects and applies Capability contributions.
+_Avoid_: Random hook, raw setup
+
+**Capability Context**:
+The typed mutable object passed to a Capability Phase.
+_Avoid_: Return payload, raw config
+
+**Instruction Block**:
+A named system-instruction fragment contributed by a Capability.
+_Avoid_: Prompt snippet, system prompt
+
+**Instruction Slot**:
+A placeholder in an Agent's instructions that controls where Instruction Blocks are inserted.
+_Avoid_: Template variable, macro
+
+**Storage Capability**:
+A Capability that lets an Agent access a configured storage primitive.
+_Avoid_: Agent storage tool, package-owned runtime helper
+
+**Skills**:
+An Official Capability that lets an Agent consume Skill files from its workspace.
+_Avoid_: Skill plugin, skill system
+
+**MCP**:
+A Capability that lets an Agent use tools from configured Model Context Protocol servers.
+_Avoid_: MCP client plugin, MCP tools
+
+**Bash**:
+A Capability that exposes controlled shell-style workspace operations to an Agent.
+_Avoid_: Root shell, raw terminal
+
+**Capability Requirement**:
+A primitive, workspace mode, or workspace path that a Capability needs before it can be applied to an Agent.
+_Avoid_: Capability dependency, plugin dependency
+
+**Requirement Validation**:
+The earliest practical check that an Agent satisfies its Capability Requirements.
+_Avoid_: Runtime surprise, lazy capability check
+
+## Relationships
+
+- An **Official Capability** is a **Capability**.
+- A **Capability Factory** creates one **Capability**.
+- Official and user-defined Capabilities share the same **Capability Definition** shape.
+- A **Capability** can run one or more **Capability Phases**.
+- A **Capability Phase** receives a **Capability Context**.
+- A **Capability** can contribute one or more **Instruction Blocks**.
+- An Agent can place Instruction Blocks with **Instruction Slots**.
+- A **Storage Capability** is an **Official Capability**.
+- **Skills** is an **Official Capability**.
+- **MCP** is an **Official Capability**.
+- **Bash** is a Capability.
+- A **Capability** can declare **Capability Requirements**.
+- **Requirement Validation** should run as early as possible.
+
+## Example Dialogue
+
+> **Dev:** "Should DB access be a raw tool on the agent?"
+> **Domain expert:** "No. If model-facing database access is public, expose it as a **Storage Capability** with **Capability Requirements** and policy."
+
+## Flagged Ambiguities
+
+- "plugin" was used to mean both framework plugins and user-shareable ViteHub abilities - resolved: use **Capability** for the agent ability concept.
+- Tool-first surfaces were considered the primary model - resolved: use **Capability** for the product concept and tools only as one possible contribution.
+- Storage package runtime helpers were considered equivalent to model-facing abilities - resolved: use **Storage Capability** only when a primitive is exposed to an Agent.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -1,6 +1,6 @@
 # Capabilities
 
-Capabilities are user-shareable abilities that ViteHub agents can attach.
+Capabilities are user-shareable abilities that ViteHub agents can attach through `defineAgent({ capabilities })`.
 
 ## Language
 
@@ -8,81 +8,35 @@ Capabilities are user-shareable abilities that ViteHub agents can attach.
 A shareable ViteHub bundle that adds a named agent ability.
 _Avoid_: Plugin, integration, extension
 
-**Official Capability**:
-A Capability shipped by ViteHub.
-_Avoid_: Built-in plugin, core feature
-
-**Capability Factory**:
-A function that returns a Capability.
-_Avoid_: Config mutator, setup callback
-
 **Capability Definition**:
-The public object shape used by official and user-defined Capabilities.
-_Avoid_: Internal plugin shape
+The object shape, returned by a factory or written inline, that declares a Capability's id, instructions, tools, metadata, mode, and requirements.
+_Avoid_: Raw tool, config mutator
 
-**Capability Phase**:
-A named lifecycle point where ViteHub collects and applies Capability contributions.
+**Capability Lifecycle**:
+The ordered process that validates requirements, applies capability contributions, and exposes resulting instructions, tools, policy, and metadata to the Agent.
 _Avoid_: Random hook, raw setup
-
-**Capability Context**:
-The typed mutable object passed to a Capability Phase.
-_Avoid_: Return payload, raw config
-
-**Instruction Block**:
-A named system-instruction fragment contributed by a Capability.
-_Avoid_: Prompt snippet, system prompt
-
-**Instruction Slot**:
-A placeholder in an Agent's instructions that controls where Instruction Blocks are inserted.
-_Avoid_: Template variable, macro
-
-**Storage Capability**:
-A Capability that lets an Agent access a configured storage primitive.
-_Avoid_: Agent storage tool, package-owned runtime helper
-
-**Skills**:
-An Official Capability that lets an Agent consume Skill files from its workspace.
-_Avoid_: Skill plugin, skill system
-
-**MCP**:
-A Capability that lets an Agent use tools from configured Model Context Protocol servers.
-_Avoid_: MCP client plugin, MCP tools
-
-**Bash**:
-A Capability that exposes controlled shell-style workspace operations to an Agent.
-_Avoid_: Root shell, raw terminal
 
 **Capability Requirement**:
 A primitive, workspace mode, or workspace path that a Capability needs before it can be applied to an Agent.
 _Avoid_: Capability dependency, plugin dependency
 
-**Requirement Validation**:
-The earliest practical check that an Agent satisfies its Capability Requirements.
-_Avoid_: Runtime surprise, lazy capability check
-
 ## Relationships
 
-- An **Official Capability** is a **Capability**.
-- A **Capability Factory** creates one **Capability**.
-- Official and user-defined Capabilities share the same **Capability Definition** shape.
-- A **Capability** can run one or more **Capability Phases**.
-- A **Capability Phase** receives a **Capability Context**.
-- A **Capability** can contribute one or more **Instruction Blocks**.
-- An Agent can place Instruction Blocks with **Instruction Slots**.
-- A **Storage Capability** is an **Official Capability**.
-- **Skills** is an **Official Capability**.
-- **MCP** is an **Official Capability**.
-- **Bash** is a Capability.
+- An Agent attaches zero or more **Capabilities**.
+- Official helpers such as `skills()`, `mcp()`, `bash()`, `sandbox()`, `kv()`, `blob()`, and `db()` create **Capability Definitions**.
+- User-defined Capabilities use the same **Capability Definition** shape as official helpers.
+- A **Capability Definition** can contribute instructions, tools, policy, and metadata.
 - A **Capability** can declare **Capability Requirements**.
-- **Requirement Validation** should run as early as possible.
+- The **Capability Lifecycle** validates **Capability Requirements** as early as possible.
+- Tools are exposed through **Capability Definitions**, not through top-level Agent Definition fields.
 
 ## Example Dialogue
 
 > **Dev:** "Should DB access be a raw tool on the agent?"
-> **Domain expert:** "No. If model-facing database access is public, expose it as a **Storage Capability** with **Capability Requirements** and policy."
+> **Domain expert:** "No. Expose it through a **Capability Definition** with requirements and policy."
 
 ## Flagged Ambiguities
 
 - "plugin" was used to mean both framework plugins and user-shareable ViteHub abilities - resolved: use **Capability** for the agent ability concept.
-- Tool-first surfaces were considered the primary model - resolved: use **Capability** for the product concept and tools only as one possible contribution.
-- Storage package runtime helpers were considered equivalent to model-facing abilities - resolved: use **Storage Capability** only when a primitive is exposed to an Agent.
+- Tool-first surfaces were considered the primary model - resolved: tools are one contribution of a **Capability Definition**.
+- Capability phases, contexts, hooks, and instruction slots were considered glossary terms - resolved: group that detail under **Capability Lifecycle** unless a feature needs a sharper term.

--- a/.agents/contexts/framework-integrations/CONTEXT.md
+++ b/.agents/contexts/framework-integrations/CONTEXT.md
@@ -1,0 +1,76 @@
+# Framework Integrations
+
+Framework Integrations names how ViteHub packages connect portable declarations to Vite builds, Nitro servers, generated registries, and provider output.
+
+## Language
+
+**Definition**:
+A portable user declaration that names work or state without depending on one framework runtime.
+_Avoid_: Route, module config, runtime helper
+
+**Discovered Definition**:
+A Definition found by package-specific scanning rules.
+_Avoid_: Import, route file, generated handler
+
+**Vite Integration**:
+The build and dev integration installed through a Vite plugin.
+_Avoid_: Nitro module, runtime client
+
+**Nitro Integration**:
+The server integration installed through a Nitro module.
+_Avoid_: Vite plugin, route helper
+
+**Runtime Registry**:
+A generated module that maps discovered names to lazy-loaded Definitions.
+_Avoid_: Definition list, route table
+
+**Provider Output**:
+Generated deployment or runtime artifacts required by a provider.
+_Avoid_: Runtime option, user handler
+
+**Integration Options**:
+Configuration passed to framework integrations such as Vite plugins, Vite config, Nitro modules, or Nitro config.
+_Avoid_: Invocation options, definition options
+
+**Definition Options**:
+Portable options stored with a Definition.
+_Avoid_: Integration options, provider config
+
+**Invocation Options**:
+Runtime per-call options passed when starting or using a Definition.
+_Avoid_: Module config, build config
+
+**Runtime Config**:
+Resolved configuration made available to server runtime code after an integration has run.
+_Avoid_: User options, provider output
+
+**Provider Selection**:
+An Integration Option that chooses the provider used for generated output, bindings, imports, or deployment behavior.
+_Avoid_: Invocation option, runtime helper option
+
+**Runtime Helper**:
+A runtime API used by application code to call, inspect, or use a configured ViteHub primitive.
+_Avoid_: Composable, Vite plugin, Nitro module
+
+## Relationships
+
+- A **Definition** can become a **Discovered Definition**.
+- A **Vite Integration** can discover Definitions and generate Provider Output.
+- A **Nitro Integration** can discover Definitions and write a Runtime Registry.
+- A **Runtime Registry** contains Discovered Definitions.
+- **Integration Options** are resolved into Runtime Config when runtime code needs them.
+- **Definition Options** travel with one Definition.
+- **Invocation Options** are supplied to Runtime Helpers.
+- **Provider Selection** belongs in Integration Options when it changes generated output, bindings, imports, or deployment behavior.
+- Options should live as late as possible unless static analysis, type generation, provider binding, generated files, or deployment output require earlier placement.
+
+## Example Dialogue
+
+> **Dev:** "Should the sandbox provider be passed to every sandbox run?"
+> **Domain expert:** "No. **Provider Selection** changes generated provider wiring, so it belongs in **Integration Options**. A stable sandbox id can be an **Invocation Option**."
+
+## Flagged Ambiguities
+
+- "composable" was used for runtime calls - resolved: use **Runtime Helper** unless referring to a Nuxt or Vue composable.
+- Vite and Nitro behavior were considered part of Definitions - resolved: Definitions stay portable; framework-specific behavior belongs to **Vite Integration** or **Nitro Integration**.
+- Provider fields were considered runtime-call options - resolved: use **Provider Selection** for provider choices that affect generated output or deployment binding.

--- a/.agents/contexts/kv/CONTEXT.md
+++ b/.agents/contexts/kv/CONTEXT.md
@@ -1,0 +1,54 @@
+# KV
+
+KV names key-value storage primitives and configured stores.
+
+## Language
+
+**KV**:
+The ViteHub key-value storage primitive for small addressable values.
+_Avoid_: Cache, database, namespace
+
+**KV Store**:
+A named configured KV backend that code and ViteHub runtime behavior can target.
+_Avoid_: KV namespace, adapter, binding
+
+**Default KV Store**:
+The KV Store used when code does not select a named KV Store.
+_Avoid_: Singleton, unnamed KV, global KV
+
+**Dedicated KV Store**:
+A KV Store reserved for one infrastructure concern or application data boundary.
+_Avoid_: Required store, hidden store
+
+**KV Store Selection**:
+The act of choosing a KV Store by name from the KV primitive.
+_Avoid_: Adapter selection, namespace binding
+
+**KV Store Name**:
+The generated typed name of a configured KV Store.
+_Avoid_: Untyped string, binding name, namespace id
+
+**KV Coordination**:
+Internal concurrency guarantees provided by a KV Store for ViteHub runtime behavior.
+_Avoid_: Public lock API, adapter lock
+
+## Relationships
+
+- **KV** can expose one or more **KV Stores**.
+- One **KV Store** can be the **Default KV Store**.
+- A **Dedicated KV Store** is a **KV Store**.
+- Single-store KV configuration is normalized to the **Default KV Store**.
+- Named KV configuration declares a map of **KV Stores**.
+- Runtime code selects non-default stores through **KV Store Selection** using a **KV Store Name**.
+- Invalid **KV Store Names** fail during build-time validation and runtime selection.
+- A **KV Store** may provide **KV Coordination**.
+
+## Example Dialogue
+
+> **Dev:** "Should runtime behavior accept a raw KV adapter?"
+> **Domain expert:** "No. Runtime behavior should target a **KV Store**; ViteHub owns adapter selection and validation."
+
+## Flagged Ambiguities
+
+- "namespace" was considered for multiple KV backends - resolved: use **KV Store** publicly because provider namespaces and bindings are backend details.
+- Named KV APIs were considered as separate top-level exports - resolved: keep the default KV API and add **KV Store Selection**.

--- a/.agents/contexts/packages/agent/CONTEXT.md
+++ b/.agents/contexts/packages/agent/CONTEXT.md
@@ -1,0 +1,36 @@
+# Agent Package
+
+Agent Package names ownership boundaries for `@vitehub/agent`.
+
+## Language
+
+**Agent Package**:
+The package that owns Agent definitions, Agent invocations, and Agent capability composition.
+_Avoid_: Chat package, runtime package
+
+**Agent Route Owner**:
+The Agent Package role that exposes discovered Agents over HTTP when routes are enabled.
+_Avoid_: Nitro route package, adapter owner
+
+**Agent Adapter Boundary**:
+The package boundary where provider-specific model adapters meet ViteHub Agent runtime behavior.
+_Avoid_: Provider package, model package
+
+## Relationships
+
+- The **Agent Package** owns Agent Definition shape.
+- The **Agent Package** owns Agent invocation handling.
+- The **Agent Package** owns Agent capability composition.
+- The **Agent Route Owner** is the Agent Package when generated Agent routes are enabled.
+- The **Agent Adapter Boundary** keeps provider-specific model options behind Agent behavior.
+- Shared runtime capabilities, approvals, and tracing belong to the Runtime Package.
+
+## Example Dialogue
+
+> **Dev:** "Should a model provider decide how ViteHub resolves workspace tools?"
+> **Domain expert:** "No. That crosses the **Agent Adapter Boundary**. The provider handles model calls; the **Agent Package** owns Agent runtime behavior."
+
+## Flagged Ambiguities
+
+- Agent routes were considered generic Nitro routes - resolved: generated Agent routes belong to the **Agent Package**.
+- Provider adapters were considered owners of runtime behavior - resolved: adapters sit behind the **Agent Adapter Boundary**.

--- a/.agents/contexts/packages/blob/CONTEXT.md
+++ b/.agents/contexts/packages/blob/CONTEXT.md
@@ -6,7 +6,7 @@ Blob Package names ownership boundaries for `@vitehub/blob`.
 
 **Blob Package**:
 The package that owns Blob Stores, Default Blob Store behavior, and Blob Store Selection.
-_Avoid_: Workspace package, Agent capability package
+_Avoid_: Workspace package, Capability package
 
 **Blob Driver Boundary**:
 The package boundary where provider-specific object storage drivers meet ViteHub Blob behavior.
@@ -18,13 +18,13 @@ _Avoid_: Store API, workspace store
 - The **Blob Package** preserves Default Blob Store ergonomics.
 - The **Blob Driver Boundary** hides provider-specific bucket, token, and binding details.
 - Workspace can use Blob Stores as hosted Workspace backing stores.
-- Blob-backed agent file access belongs behind Workspace, not a direct Blob Agent Capability.
+- Worktree-oriented file behavior belongs to Workspace, not the Blob Package.
 
 ## Example Dialogue
 
-> **Dev:** "Should `@vitehub/agent` add a direct Blob tool when Workspace is Blob-backed?"
-> **Domain expert:** "No. The **Blob Package** backs storage, and Workspace is the agent-facing boundary."
+> **Dev:** "Should the Blob Package decide how files appear in a worktree?"
+> **Domain expert:** "No. The **Blob Package** owns storage. Workspace owns file-tree behavior."
 
 ## Flagged Ambiguities
 
-- Blob Store access was considered direct Agent access - resolved: Blob-backed agent file access goes through Workspace.
+- Blob Store access was described through Agent file access - resolved: the **Blob Package** owns storage; Workspace owns file-tree behavior.

--- a/.agents/contexts/packages/blob/CONTEXT.md
+++ b/.agents/contexts/packages/blob/CONTEXT.md
@@ -1,0 +1,30 @@
+# Blob Package
+
+Blob Package names ownership boundaries for `@vitehub/blob`.
+
+## Language
+
+**Blob Package**:
+The package that owns Blob Stores, Default Blob Store behavior, and Blob Store Selection.
+_Avoid_: Workspace package, Agent capability package
+
+**Blob Driver Boundary**:
+The package boundary where provider-specific object storage drivers meet ViteHub Blob behavior.
+_Avoid_: Store API, workspace store
+
+## Relationships
+
+- The **Blob Package** owns named Blob Store configuration and runtime selection.
+- The **Blob Package** preserves Default Blob Store ergonomics.
+- The **Blob Driver Boundary** hides provider-specific bucket, token, and binding details.
+- Workspace can use Blob Stores as hosted Workspace backing stores.
+- Blob-backed agent file access belongs behind Workspace, not a direct Blob Agent Capability.
+
+## Example Dialogue
+
+> **Dev:** "Should `@vitehub/agent` add a direct Blob tool when Workspace is Blob-backed?"
+> **Domain expert:** "No. The **Blob Package** backs storage, and Workspace is the agent-facing boundary."
+
+## Flagged Ambiguities
+
+- Blob Store access was considered direct Agent access - resolved: Blob-backed agent file access goes through Workspace.

--- a/.agents/contexts/packages/db/CONTEXT.md
+++ b/.agents/contexts/packages/db/CONTEXT.md
@@ -1,0 +1,43 @@
+# DB Package
+
+DB Package names ownership boundaries for `@vitehub/db`.
+
+## Language
+
+**DB Package**:
+The package that owns database Integration Options, database discovery, and the generated database runtime surface.
+_Avoid_: ORM package, migration package
+
+**Default Database**:
+The database used when runtime code does not select a named database.
+_Avoid_: Singleton database, global database
+
+**Named Database**:
+A configured database addressed by name through the generated database runtime surface.
+_Avoid_: Connection string, binding
+
+**Database Schema Source**:
+The source files that describe a database schema for generated runtime access.
+_Avoid_: Migration, table list
+
+**Drizzle Runtime Surface**:
+The generated runtime access point for Drizzle databases and schema.
+_Avoid_: Raw client, ORM config
+
+## Relationships
+
+- The **DB Package** owns **Default Database** and **Named Database** configuration.
+- A **Named Database** is selected through the **Drizzle Runtime Surface**.
+- A **Database Schema Source** belongs to one configured database.
+- The **DB Package** owns Vite-centered database integration until a Nitro boundary is explicitly designed.
+- Provider-specific database details stay behind DB Integration Options and generated runtime output.
+
+## Example Dialogue
+
+> **Dev:** "Is a Cloudflare D1 binding the database name?"
+> **Domain expert:** "No. The binding is provider wiring. The **Named Database** is the ViteHub name used by the **Drizzle Runtime Surface**."
+
+## Flagged Ambiguities
+
+- Provider bindings were considered database identities - resolved: ViteHub database names are the public identity; provider bindings are integration details.
+- Migrations were considered schema discovery - resolved: **Database Schema Sources** describe runtime schema access; migrations remain provider or ORM workflow.

--- a/.agents/contexts/packages/env/CONTEXT.md
+++ b/.agents/contexts/packages/env/CONTEXT.md
@@ -1,0 +1,48 @@
+# Env Package
+
+Env Package names ownership boundaries for `@vitehub/env`.
+
+## Language
+
+**Env Package**:
+The package that owns typed environment declarations, diagnostics, generated env access, and secret masking.
+_Avoid_: Dotenv wrapper, provider secret manager
+
+**Env Declaration**:
+The typed declaration of one environment value.
+_Avoid_: Process env read, config property
+
+**Build Env**:
+Environment values resolved for Vite build and transform usage.
+_Avoid_: Runtime secret, server config
+
+**Runtime Env**:
+Environment values resolved for server runtime usage.
+_Avoid_: Public build value, compile-time define
+
+**Env Source**:
+An origin that can provide an Env Declaration value.
+_Avoid_: Provider, adapter, dotenv file
+
+**Secret Env**:
+A Runtime Env value that diagnostics must mask.
+_Avoid_: Private build value, hidden config
+
+## Relationships
+
+- The **Env Package** owns **Env Declarations**.
+- **Build Env** belongs to Vite integration.
+- **Runtime Env** belongs to Nitro integration.
+- A **Secret Env** is a Runtime Env value.
+- An **Env Source** can provide an Env Declaration value.
+- Generated env access should preserve the difference between Build Env and Runtime Env.
+
+## Example Dialogue
+
+> **Dev:** "Can a server token be exposed through the Vite build virtual module?"
+> **Domain expert:** "No. That is **Runtime Env**, and if it is sensitive it is **Secret Env**."
+
+## Flagged Ambiguities
+
+- Build-time and server runtime values were considered one config surface - resolved: use **Build Env** and **Runtime Env**.
+- Secret handling was considered provider-specific - resolved: **Secret Env** is ViteHub language for values diagnostics must mask.

--- a/.agents/contexts/packages/kv/CONTEXT.md
+++ b/.agents/contexts/packages/kv/CONTEXT.md
@@ -1,0 +1,35 @@
+# KV Package
+
+KV Package names ownership boundaries for `@vitehub/kv`.
+
+## Language
+
+**KV Package**:
+The package that owns KV Stores, Default KV Store behavior, and KV Store Selection.
+_Avoid_: Cache package, namespace package
+
+**KV Driver Boundary**:
+The package boundary where provider-specific key-value drivers meet ViteHub KV behavior.
+_Avoid_: Public lock API, runtime state package
+
+**Internal KV Coordination API**:
+The non-public KV Package surface used by ViteHub runtime behavior that needs coordination guarantees.
+_Avoid_: Public lock API, Chat lock API
+
+## Relationships
+
+- The **KV Package** owns named KV Store configuration and runtime selection.
+- The **KV Package** owns generated KV Store Name types.
+- The **KV Package** preserves Default KV Store ergonomics.
+- The **KV Driver Boundary** hides provider-specific namespace and credential details.
+- The **KV Package** can expose an **Internal KV Coordination API** to ViteHub packages.
+
+## Example Dialogue
+
+> **Dev:** "Should a runtime feature implement its own distributed lock on top of `kv.get()` and `kv.set()`?"
+> **Domain expert:** "No. The **KV Package** owns the coordination guarantee through an **Internal KV Coordination API**."
+
+## Flagged Ambiguities
+
+- KV locking was considered a public KV feature - resolved: coordination starts as an **Internal KV Coordination API** for ViteHub runtime users.
+- KV Store names were considered untyped runtime strings - resolved: the **KV Package** owns generated store-name types.

--- a/.agents/contexts/packages/queue/CONTEXT.md
+++ b/.agents/contexts/packages/queue/CONTEXT.md
@@ -1,0 +1,48 @@
+# Queue Package
+
+Queue Package names ownership boundaries for `@vitehub/queue`.
+
+## Language
+
+**Queue Package**:
+The package that owns queue Definitions, queue delivery, and provider-neutral enqueue behavior.
+_Avoid_: Job runner package, workflow package
+
+**Queue Definition**:
+A portable handler declaration for background jobs delivered through a Queue Provider.
+_Avoid_: Callback route, provider consumer
+
+**Queue Job**:
+The normalized job payload and metadata delivered to a Queue Definition.
+_Avoid_: Provider message, event
+
+**Queue Provider**:
+The backend that accepts and delivers queued jobs.
+_Avoid_: Queue definition, runtime helper
+
+**Queue Delivery**:
+The provider-triggered runtime flow that invokes a Queue Definition with a Queue Job.
+_Avoid_: Enqueue, workflow step
+
+**Queue Enqueue**:
+The runtime action of sending a job to a Queue Provider.
+_Avoid_: Queue delivery, direct handler call
+
+## Relationships
+
+- The **Queue Package** owns **Queue Definitions**.
+- A **Queue Provider** delivers **Queue Jobs**.
+- **Queue Delivery** invokes a Queue Definition.
+- **Queue Enqueue** sends work to a Queue Provider.
+- Queue Provider selection belongs to Integration Options.
+- Queue delay, region, retention, and idempotency belong to Invocation Options when supplied per enqueue.
+
+## Example Dialogue
+
+> **Dev:** "Should `runQueue()` return the queue handler result?"
+> **Domain expert:** "No. **Queue Enqueue** means the provider accepted the job. The handler result belongs to **Queue Delivery**."
+
+## Flagged Ambiguities
+
+- Queue enqueue and provider delivery were considered one lifecycle - resolved: use **Queue Enqueue** for sending and **Queue Delivery** for handler invocation.
+- Provider messages were considered the public job shape - resolved: the public handler receives a **Queue Job**.

--- a/.agents/contexts/packages/runtime/CONTEXT.md
+++ b/.agents/contexts/packages/runtime/CONTEXT.md
@@ -1,0 +1,51 @@
+# Runtime Package
+
+Runtime Package names ownership boundaries for `@vitehub/runtime`.
+
+## Language
+
+**Runtime Package**:
+The package that owns shared runtime context, runtime capability handles, policy decisions, approvals, tracing, and leases.
+_Avoid_: Agent package, provider adapter package
+
+**Runtime Host Context**:
+The host-provided runtime information shared across ViteHub packages.
+_Avoid_: Agent context, request object
+
+**Runtime Capability**:
+A host resource exposed through the Runtime Package for package-to-package use.
+_Avoid_: Agent Capability, model tool
+
+**Policy Decision**:
+The allow, deny, approval, or retry outcome for a runtime operation.
+_Avoid_: Permission boolean, validation error
+
+**Approval Request**:
+A runtime request for human or external approval before an operation continues.
+_Avoid_: Policy error, confirmation prompt
+
+**Trace Event**:
+A structured runtime event used for observability across package boundaries.
+_Avoid_: Log line, console message
+
+**Lease**:
+A temporary claim on a runtime key used for coordination.
+_Avoid_: Lock, cache entry
+
+## Relationships
+
+- The **Runtime Package** owns **Runtime Host Context**.
+- A **Runtime Capability** is not an Agent Capability.
+- A **Policy Decision** can require an **Approval Request**.
+- A **Trace Event** can describe policy, approval, capability, error, lifecycle, or run activity.
+- A **Lease** coordinates runtime work without becoming a public storage primitive.
+
+## Example Dialogue
+
+> **Dev:** "Should Agent own tracing for Workflow and Sandbox too?"
+> **Domain expert:** "No. Cross-package tracing belongs to the **Runtime Package** through **Trace Events**."
+
+## Flagged Ambiguities
+
+- Runtime capabilities were considered Agent Capabilities - resolved: **Runtime Capability** is a package-to-package handle, not a model-facing ability.
+- Leases were considered public locks - resolved: **Lease** is runtime coordination language, not a user-facing KV API.

--- a/.agents/contexts/packages/sandbox/CONTEXT.md
+++ b/.agents/contexts/packages/sandbox/CONTEXT.md
@@ -1,0 +1,48 @@
+# Sandbox Package
+
+Sandbox Package names ownership boundaries for `@vitehub/sandbox`.
+
+## Language
+
+**Sandbox Package**:
+The package that owns isolated execution Definitions, sandbox runs, and sandbox provider integration.
+_Avoid_: Shell package, workflow package
+
+**Sandbox Definition**:
+A portable declaration of isolated work that can run through a Sandbox Provider.
+_Avoid_: Runtime command, provider sandbox
+
+**Sandbox Run**:
+One runtime execution of a Sandbox Definition.
+_Avoid_: Workflow run, shell command
+
+**Sandbox Provider**:
+The backend that creates or reuses isolated execution environments.
+_Avoid_: Sandbox Definition, runtime helper
+
+**Sandbox Payload**:
+The input value passed to a Sandbox Run.
+_Avoid_: Request body, environment config
+
+**Sandbox Identity**:
+An optional stable identity used when a provider can reuse an underlying sandbox environment.
+_Avoid_: Sandbox name, Definition name
+
+## Relationships
+
+- The **Sandbox Package** owns **Sandbox Definitions**.
+- A **Sandbox Definition** can receive a **Sandbox Payload**.
+- A **Sandbox Run** executes one Sandbox Definition.
+- A **Sandbox Provider** backs Sandbox Runs.
+- Sandbox Provider selection belongs to Integration Options.
+- **Sandbox Identity** belongs to Invocation Options when supplied per run.
+
+## Example Dialogue
+
+> **Dev:** "Should the provider be passed every time we call a sandbox?"
+> **Domain expert:** "No. The **Sandbox Provider** changes generated wiring, so provider selection belongs to Integration Options. A **Sandbox Identity** can be per-run."
+
+## Flagged Ambiguities
+
+- Sandbox provider selection was considered a runtime call option - resolved: provider selection is Integration Options when it affects generated output or bindings.
+- Sandbox identity was considered the Definition name - resolved: **Sandbox Identity** is an optional provider reuse hint, not the portable Definition identity.

--- a/.agents/contexts/packages/shell/CONTEXT.md
+++ b/.agents/contexts/packages/shell/CONTEXT.md
@@ -1,0 +1,43 @@
+# Shell Package
+
+Shell Package names ownership boundaries for `@vitehub/shell`.
+
+## Language
+
+**Shell Package**:
+The package that owns controlled shell runtimes over workspace-like file systems.
+_Avoid_: Sandbox package, terminal package
+
+**Shell Runtime**:
+A controlled command execution environment with a configured file-system boundary.
+_Avoid_: Raw terminal, provider sandbox
+
+**Shell Workspace**:
+The file-system boundary exposed to a Shell Runtime.
+_Avoid_: Workspace package, host filesystem
+
+**Workspace File System**:
+The adapter that lets a Shell Runtime read or mutate workspace-backed files.
+_Avoid_: Workspace Store, Blob Store
+
+**Command Analysis**:
+The inspection of a command before execution.
+_Avoid_: Policy decision, shell parsing
+
+## Relationships
+
+- The **Shell Package** owns **Shell Runtime** behavior.
+- A **Shell Runtime** runs against one **Shell Workspace**.
+- A **Workspace File System** adapts workspace-backed files to shell execution.
+- **Command Analysis** can inform whether a command is acceptable before execution.
+- Sandbox can provide a host for Shell Runtime execution, but Shell and Sandbox are separate package boundaries.
+
+## Example Dialogue
+
+> **Dev:** "Is Shell the same as Sandbox?"
+> **Domain expert:** "No. **Shell Runtime** is the command surface; Sandbox is one possible isolated execution provider."
+
+## Flagged Ambiguities
+
+- Shell was considered equivalent to Sandbox - resolved: Shell owns command execution language; Sandbox owns isolated provider execution.
+- Shell Workspace was considered the same as Workspace Store - resolved: **Shell Workspace** is the file-system boundary exposed to the shell, not persistence.

--- a/.agents/contexts/packages/unsource/CONTEXT.md
+++ b/.agents/contexts/packages/unsource/CONTEXT.md
@@ -1,0 +1,42 @@
+# Unsource Package
+
+Unsource Package names ownership boundaries for `@vitehub/unsource`.
+
+## Language
+
+**Unsource Package**:
+The package that owns typed source retrieval primitives.
+_Avoid_: Workspace package, loader package
+
+**Source Definition**:
+A portable declaration of a retrievable source.
+_Avoid_: Workspace Source, file mount
+
+**Source Registry**:
+The runtime registry of named Source Definitions.
+_Avoid_: Workspace source map, loader list
+
+**Source Path**:
+A validated path used to retrieve an item from a Source Definition.
+_Avoid_: Filesystem path, mount path
+
+**Source Loader**:
+The source-specific retrieval behavior for files, globs, markdown, GitHub, or custom data.
+_Avoid_: Workspace loader, build plugin
+
+## Relationships
+
+- The **Unsource Package** owns **Source Definitions**.
+- A **Source Registry** contains named Source Definitions.
+- A **Source Path** is validated before source retrieval.
+- A **Source Loader** retrieves items for a Source Definition.
+- Workspace can consume source retrieval concepts, but Workspace owns file-tree placement and persistence.
+
+## Example Dialogue
+
+> **Dev:** "Is an Unsource source the same as a Workspace Source?"
+> **Domain expert:** "No. **Unsource Package** owns retrieval. Workspace owns where retrieved content appears in a file tree."
+
+## Flagged Ambiguities
+
+- Source retrieval and Workspace file placement were considered one concept - resolved: Unsource owns retrieval, Workspace owns file-tree placement.

--- a/.agents/contexts/packages/workflow/CONTEXT.md
+++ b/.agents/contexts/packages/workflow/CONTEXT.md
@@ -1,0 +1,49 @@
+# Workflow Package
+
+Workflow Package names ownership boundaries for `@vitehub/workflow`.
+
+## Language
+
+**Workflow Package**:
+The package that owns long-running work Definitions, workflow runs, workflow steps, and workflow provider integration.
+_Avoid_: Queue package, job package
+
+**Workflow Definition**:
+A portable declaration of long-running work.
+_Avoid_: Queue handler, provider workflow
+
+**Workflow Run**:
+One provider-tracked execution of a Workflow Definition.
+_Avoid_: Queue job, request handler
+
+**Workflow Step**:
+A named unit of work inside a Workflow Run that a provider may checkpoint or retry.
+_Avoid_: Function call, queue message
+
+**Workflow Provider**:
+The backend that starts, tracks, and resumes Workflow Runs.
+_Avoid_: Workflow Definition, runtime helper
+
+**Workflow Start**:
+The runtime action of asking a Workflow Provider to begin a Workflow Run.
+_Avoid_: Direct handler call, queue enqueue
+
+## Relationships
+
+- The **Workflow Package** owns **Workflow Definitions**.
+- A **Workflow Start** creates or resumes a **Workflow Run**.
+- A **Workflow Run** executes one Workflow Definition.
+- A **Workflow Run** can contain zero or more **Workflow Steps**.
+- A **Workflow Provider** backs Workflow Runs.
+- Workflow Provider selection belongs to Integration Options.
+- Workflow run ids belong to Invocation Options when supplied at start time.
+
+## Example Dialogue
+
+> **Dev:** "Should a Workflow be modeled as a Queue?"
+> **Domain expert:** "No. A Queue delivers jobs. A **Workflow Run** is provider-tracked long-running work with optional **Workflow Steps**."
+
+## Flagged Ambiguities
+
+- Workflow starts and direct handler calls were considered equivalent - resolved: **Workflow Start** means asking the provider to start or resume a run.
+- Queue jobs and Workflow Runs were considered interchangeable - resolved: Queue is delivery; Workflow is durable long-running execution.

--- a/.agents/contexts/packages/workspace/CONTEXT.md
+++ b/.agents/contexts/packages/workspace/CONTEXT.md
@@ -1,0 +1,40 @@
+# Workspace Package
+
+Workspace Package names ownership boundaries for `@vitehub/workspace`.
+
+## Language
+
+**Workspace Package**:
+The package that owns Workspace definitions, Workspace Stores, Sources, and agent-facing file-tree access.
+_Avoid_: Blob package, source package
+
+**Workspace Definition**:
+A portable declaration of a named Workspace.
+_Avoid_: Workspace Store, source map
+
+**Workspace Runtime Surface**:
+The runtime access point for reading, writing, snapshotting, diffing, and opening a Workspace.
+_Avoid_: Store adapter, file system
+
+**Workspace Asset Surface**:
+The generated read-only runtime access point for build-time Workspace assets.
+_Avoid_: Workspace Store, Source
+
+## Relationships
+
+- The **Workspace Package** owns **Workspace Definitions**.
+- The **Workspace Package** owns Workspace Stores.
+- A Workspace Store can be backed by a Blob Store.
+- The **Workspace Runtime Surface** enforces Workspace Rules before writes reach the store.
+- The **Workspace Asset Surface** exposes build-time readable assets.
+- Agents access files through Workspace when Workspace is the boundary.
+
+## Example Dialogue
+
+> **Dev:** "If an agent writes a file that lands in Blob, is that a Blob Capability?"
+> **Domain expert:** "No. The agent uses Workspace; the Workspace Store may be Blob-backed."
+
+## Flagged Ambiguities
+
+- Blob-backed Workspace persistence was considered equivalent to direct Blob access - resolved: Workspace owns the agent-facing file-tree boundary.
+- Workspace assets were considered the same as mutable Workspace files - resolved: **Workspace Asset Surface** is read-only generated access.

--- a/.agents/contexts/workspace/CONTEXT.md
+++ b/.agents/contexts/workspace/CONTEXT.md
@@ -1,0 +1,65 @@
+# Workspace
+
+Workspace names persistent file-tree state and source ingestion for agent-oriented Vite and Nitro apps.
+
+## Language
+
+**Workspace**:
+A named persistent file tree that agents and server code can inspect, mutate when allowed, snapshot, and sync into execution runtimes.
+
+**Workspace Store**:
+The configured backing store used to persist a Workspace file tree.
+_Avoid_: Blob Store, Source, Chat State
+
+**Source**:
+A named origin that contributes read-only files or items into a Workspace.
+_Avoid_: Input, files, context, resource, mount
+
+**Source Map**:
+The keyed object that declares a Workspace's Sources.
+_Avoid_: Source list, source array
+
+**Mount**:
+The placement of a Source inside a Workspace file tree.
+_Avoid_: Source
+
+**Source-Backed Path**:
+A workspace path whose contents come from a Source.
+_Avoid_: Editable source file, synced file
+
+**Source Sync**:
+An explicit future mechanism that reconciles Source-Backed Paths with their Sources.
+_Avoid_: Implicit write-back, normal workspace write
+
+**Workspace Rule**:
+A path-scoped policy that controls reads, writes, write size, media type, and write validation.
+_Avoid_: Capability rule, tool permission
+
+**Workspace Plugin**:
+A reusable Workspace extension that contributes Workspace Rules and Workspace hooks.
+_Avoid_: Capability, source, loader
+
+## Relationships
+
+- A **Workspace** has one **Workspace Store**.
+- A **Workspace Store** can be backed by a Blob Store.
+- A **Workspace** has zero or more **Sources**.
+- A **Workspace** declares Sources through one **Source Map**.
+- A **Source Map** key is the canonical identity of its Source.
+- A **Source** has zero or one **Mount**.
+- A **Source-Backed Path** belongs to exactly one Source.
+- Current workspace writes target normal Workspace paths, not Source-Backed Paths.
+- **Source Sync** is distinct from normal workspace writes.
+- A **Workspace Rule** is path-scoped.
+- A **Workspace Plugin** can contribute Workspace Rules.
+
+## Example Dialogue
+
+> **Dev:** "Should we rename `workspace.sources` to `workspace.mounts`?"
+> **Domain expert:** "No. A **Source** is the origin. The **Mount** only says where that source appears inside the **Workspace**."
+
+## Flagged Ambiguities
+
+- "source" can mean source code, provenance, or data connector - resolved: in Workspace, **Source** means a named origin that contributes files or items.
+- "mount" was considered as the name for `workspace.sources` - resolved: **Mount** is only the placement of a Source inside the Workspace.
+- `workspace.sources` was considered as an array for simple one-off Sources - resolved: use a **Source Map** so every Source has stable identity.

--- a/.agents/domain.md
+++ b/.agents/domain.md
@@ -4,22 +4,28 @@ How the engineering skills should consume this repo's domain documentation when 
 
 ## Before exploring, read these
 
-- **`CONTEXT-MAP.md`** at the repo root. It points at one `CONTEXT.md` per context. Read each one relevant to the topic.
-- **`docs/adr/`** for repo-wide architectural decisions, if present.
-- Context-local `docs/adr/` directories for decisions scoped to a specific context, if present.
+- **`.agents/CONTEXT-MAP.md`**. It points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`.agents/adr/`** for agent-facing architectural decisions, if present.
+- Context-local `adr/` directories for decisions scoped to a specific context, if present.
 
 If any of these files don't exist, proceed silently. Don't flag their absence or suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
 
 ## File Structure
 
-No public domain contexts are currently mapped:
+This is a multi-context repo:
 
 ```text
 /
-+-- CONTEXT-MAP.md
++-- .agents/
+    +-- CONTEXT-MAP.md
+    +-- domain.md
+    +-- adr/
+    +-- contexts/
+        +-- framework-integrations/
+        +-- capabilities/
+        +-- agents/
+        +-- packages/
 ```
-
-Internal agent design artifacts live under `.agents/` and are not domain context docs.
 
 ## Use The Glossary's Vocabulary
 

--- a/.agents/issue-tracker.md
+++ b/.agents/issue-tracker.md
@@ -1,0 +1,17 @@
+# Issue Tracker
+
+Issues for this repo live in GitHub Issues for `vite-hub/vitehub`.
+
+## Workflow
+
+- Use the `gh` CLI for GitHub issue and pull request actions.
+- Do not use the GitHub web UI for agent-driven issue or pull request work.
+- Never comment on issues or pull requests without explicit user consent.
+- Prefer reading issue and pull request context before creating new tracker items.
+
+## Commands
+
+- Read an issue: `gh issue view <number>`
+- List issues: `gh issue list`
+- Create an issue only when explicitly asked or when a skill workflow has confirmed the issue content with the user: `gh issue create`
+- Read a pull request: `gh pr view <number>`

--- a/.agents/triage-labels.md
+++ b/.agents/triage-labels.md
@@ -22,4 +22,4 @@ Will not be actioned.
 ## Notes
 
 - Do not create duplicate labels with alternate names unless the user asks.
-- If the repo later adopts a different label vocabulary, update this file and the `AGENTS.md` Agent skills block together.
+- If the repo later adopts a different label vocabulary, update this file and any agent-facing tracker guidance together.

--- a/.agents/triage-labels.md
+++ b/.agents/triage-labels.md
@@ -1,0 +1,25 @@
+# Triage Labels
+
+The engineering skills use five canonical triage roles. Use these label strings unless the repository configures different labels later.
+
+## Label Mapping
+
+**needs-triage**:
+Maintainer needs to evaluate the issue.
+
+**needs-info**:
+Waiting on the reporter or requester for missing information.
+
+**ready-for-agent**:
+Fully specified and ready for an AFK agent to pick up with no extra human context.
+
+**ready-for-human**:
+Needs human implementation or judgment.
+
+**wontfix**:
+Will not be actioned.
+
+## Notes
+
+- Do not create duplicate labels with alternate names unless the user asks.
+- If the repo later adopts a different label vocabulary, update this file and the `AGENTS.md` Agent skills block together.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,7 @@
 # AGENTS.md instructions for vitehub
 
-Code comments: only when necessary; explain *why*, not *what*. If code is self-explanatory, skip comments.
-
-## Git / GitHub
-
-- For GitHub actions (PRs, issues, releases, etc.) use `gh` CLI (not the web UI).
-- Never comment on Issues or Pull Request without explicit consent.
-
-## CLI
-
-- `gh`, `vercel`, `wrangler`
-- NuxtHub CLI is deprecated: never use `npx nuxthub`. Deployments happen via git push -> Cloudflare CI.
-
 ## Agent Context
 
 - Development-only agent guidance belongs under `.agents/`.
 - Before architecture or domain work, read `.agents/domain.md`, then use `.agents/CONTEXT-MAP.md` to find relevant context glossaries.
 - Do not add new development-context files under `docs/agents/` or `docs/contexts/`; use `.agents/` instead.
-
-## Agent skills
-
-### Issue tracker
-
-Issues live in GitHub Issues for `vite-hub/vitehub`; use the `gh` CLI and do not comment without explicit consent. See `.agents/issue-tracker.md`.
-
-### Triage labels
-
-Use the default five-role triage vocabulary unless the repo configures different labels. See `.agents/triage-labels.md`.
-
-### Domain docs
-
-This is a multi-context repo with agent-facing domain docs under `.agents/`. See `.agents/domain.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md instructions for vitehub
+
+Code comments: only when necessary; explain *why*, not *what*. If code is self-explanatory, skip comments.
+
+## Git / GitHub
+
+- For GitHub actions (PRs, issues, releases, etc.) use `gh` CLI (not the web UI).
+- Never comment on Issues or Pull Request without explicit consent.
+
+## CLI
+
+- `gh`, `vercel`, `wrangler`
+- NuxtHub CLI is deprecated: never use `npx nuxthub`. Deployments happen via git push -> Cloudflare CI.
+
+## Agent Context
+
+- Development-only agent guidance belongs under `.agents/`.
+- Before architecture or domain work, read `.agents/domain.md`, then use `.agents/CONTEXT-MAP.md` to find relevant context glossaries.
+- Do not add new development-context files under `docs/agents/` or `docs/contexts/`; use `.agents/` instead.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues for `vite-hub/vitehub`; use the `gh` CLI and do not comment without explicit consent. See `.agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the default five-role triage vocabulary unless the repo configures different labels. See `.agents/triage-labels.md`.
+
+### Domain docs
+
+This is a multi-context repo with agent-facing domain docs under `.agents/`. See `.agents/domain.md`.


### PR DESCRIPTION
Moves agent-facing domain guidance under `.agents/` and adds the repo-level context map used by engineering skills.

Adds shared glossaries for framework integrations, agents, capabilities, KV, Blob, and Workspace, plus package ownership contexts for the public packages that need stable language. Also records the GitHub issue tracker and default triage label vocabulary under `.agents/`.