### PR TITLE
feat: align integration option helpers

### DIFF
--- a/packages/queue/docs/runtime-api.md
+++ b/packages/queue/docs/runtime-api.md
@@ -28,6 +28,8 @@ Vite config imports the plugin from `@vitehub/queue/vite`:
 ```ts
 import { hubQueue } from '@vitehub/queue/vite'
 ```
+
+`hubQueue(options?)` accepts the same integration options as `vite.config.queue`. When both are present, `vite.config.queue` takes precedence.
 ::
 
 ::fw{id="nitro:dev nitro:build"}

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -15,15 +15,15 @@ export { createCloudflareQueueConfig, type CloudflareQueueConfig, type Cloudflar
 
 const mergeNoExternal = createNoExternalMerger(queuePackageName)
 
-export function hubQueue(): QueueVitePlugin {
+export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
   let resolved: ResolvedConfig | undefined
-  let queue: QueueModuleOptions | undefined
+  let queue: QueueModuleOptions | undefined = options
 
   return {
     name: "@vitehub/queue/vite",
     nitro: queueNitroModule,
     config(config) {
-      queue = config.queue
+      queue = config.queue ?? queue
     },
     configResolved(config) {
       resolved = config

--- a/packages/queue/test/types.test-d.ts
+++ b/packages/queue/test/types.test-d.ts
@@ -8,6 +8,7 @@ import { hubQueue } from "../src/vite.ts"
 
 it("returns a vite plugin", () => {
   expectTypeOf(hubQueue()).toMatchTypeOf<Plugin>()
+  expectTypeOf(hubQueue({ provider: "cloudflare" })).toMatchTypeOf<Plugin>()
 })
 
 it("exposes a Nitro module surface", () => {

--- a/packages/sandbox/docs/runtime-api.md
+++ b/packages/sandbox/docs/runtime-api.md
@@ -28,6 +28,8 @@ Vite config imports the plugin from `@vitehub/sandbox/vite`:
 ```ts
 import { hubSandbox } from '@vitehub/sandbox/vite'
 ```
+
+`hubSandbox(options?)` accepts the same integration options as `vite.config.sandbox`. When both are present, `vite.config.sandbox` takes precedence.
 ::
 
 ::fw{id="nitro:dev nitro:build"}

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -1,13 +1,23 @@
-import type { NitroModule } from 'nitro/types'
 import type { Plugin } from 'vite'
+import type { NitroModule } from 'nitro/types'
+
 import { createFeatureVitePlugin } from './internal/shared/vite'
-export { createViteHubDefinitionAutoImportsPlugin } from './internal/shared/vitehub-auto-imports'
 import { sandboxFeatureEngine, type SandboxPublicOptions } from './integration'
 
-export type SandboxVitePlugin = Plugin & { nitro?: NitroModule }
+export { createViteHubDefinitionAutoImportsPlugin } from './internal/shared/vitehub-auto-imports'
 
-export function hubSandbox(): SandboxVitePlugin {
-  return createFeatureVitePlugin(sandboxFeatureEngine) as SandboxVitePlugin
+export type SandboxVitePlugin = Plugin & { nitro: NitroModule }
+
+export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
+  return createFeatureVitePlugin({
+    ...sandboxFeatureEngine,
+    readPublicOptions(source) {
+      const configOptions = sandboxFeatureEngine.readPublicOptions(source)
+      return source.kind === 'vite' && typeof configOptions === 'undefined'
+        ? options
+        : configOptions
+    },
+  }) as SandboxVitePlugin
 }
 
 declare module 'vite' {

--- a/packages/sandbox/test/types.test-d.ts
+++ b/packages/sandbox/test/types.test-d.ts
@@ -33,6 +33,7 @@ describe("types", () => {
   it("returns a Vite plugin with an attached Nitro module", () => {
     const plugin = hubSandbox()
 
-    expectTypeOf(plugin).toMatchTypeOf<{ nitro?: { name?: string } }>()
+    expectTypeOf(hubSandbox({ provider: "cloudflare" })).toMatchTypeOf<typeof plugin>()
+    expectTypeOf(plugin).toMatchTypeOf<{ nitro: { name?: string } }>()
   })
 })

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -56,6 +56,52 @@ describe("hubSandbox", () => {
     expect(configResult).toEqual({})
   })
 
+  it("accepts direct integration options", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "vercel" })
+    const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const resolveId = plugin.resolveId as (id: string) => string | undefined | Promise<string | undefined>
+    const load = plugin.load as (id: string) => string | undefined | Promise<string | undefined>
+
+    await configHook({
+      root: rootDir,
+    }, {
+      command: "serve",
+      mode: "development",
+    })
+
+    const resolvedId = await resolveId("virtual:vitehub/sandbox")
+    const code = await load(resolvedId as string)
+
+    expect(code).toContain('"provider": "vercel"')
+  })
+
+  it("lets Vite config override direct integration options", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const resolveId = plugin.resolveId as (id: string) => string | undefined | Promise<string | undefined>
+    const load = plugin.load as (id: string) => string | undefined | Promise<string | undefined>
+
+    await configHook({
+      root: rootDir,
+      sandbox: {
+        provider: "vercel",
+      },
+    }, {
+      command: "serve",
+      mode: "development",
+    })
+
+    const resolvedId = await resolveId("virtual:vitehub/sandbox")
+    const code = await load(resolvedId as string)
+
+    expect(code).toContain('"provider": "vercel"')
+    expect(code).not.toContain('"provider": "cloudflare"')
+  })
+
   it("adds server-environment markers through the Environment API", async () => {
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox()

--- a/packages/workspace/docs/runtime-api.md
+++ b/packages/workspace/docs/runtime-api.md
@@ -12,6 +12,16 @@ Most application code imports from `@vitehub/workspace`:
 import { defineWorkspace, useWorkspace } from '@vitehub/workspace'
 ```
 
+## Integration API
+
+Vite config imports the plugin from `@vitehub/workspace/vite`:
+
+```ts
+import { hubWorkspace } from '@vitehub/workspace/vite'
+```
+
+`hubWorkspace(options?)` accepts the same integration options as `vite.config.workspace`. When both are present, `vite.config.workspace` takes precedence.
+
 The workspace handle is file-tree oriented:
 
 ```ts

--- a/packages/workspace/src/vite.ts
+++ b/packages/workspace/src/vite.ts
@@ -45,7 +45,7 @@ export interface WorkspaceVitePluginAPI {
 
 export type WorkspaceVitePlugin = Plugin & { api: WorkspaceVitePluginAPI, nitro: NitroModule }
 
-export function hubWorkspace(_options?: WorkspaceModuleOptions): WorkspaceVitePlugin {
+export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlugin {
   let resolved: ResolvedConfig | undefined
   let resolvedOptions: ReturnType<typeof normalizeWorkspaceOptions> = false
   let assetsRegistryFile: string | undefined
@@ -97,7 +97,7 @@ export function hubWorkspace(_options?: WorkspaceModuleOptions): WorkspaceVitePl
         process.env.VITEHUB_WORKSPACE_DEV = "true"
       else
         delete process.env.VITEHUB_WORKSPACE_DEV
-      resolvedOptions = normalizeWorkspaceOptions(_options ?? (config as ResolvedConfig & { workspace?: false | WorkspaceModuleOptions }).workspace, {
+      resolvedOptions = normalizeWorkspaceOptions((config as ResolvedConfig & { workspace?: false | WorkspaceModuleOptions }).workspace ?? options, {
         dev: config.command !== "build",
         env: process.env,
         hosting: process.env.VITEHUB_HOSTING,

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -157,4 +157,24 @@ describe("hubWorkspace", () => {
     await expect(readFile(registryId, "utf8")).resolves.not.toContain('"notes"')
     expect(registry).toEqual({})
   })
+
+  it("lets Vite config override direct integration options", async () => {
+    const root = await createViteAssetRoot()
+
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace({ assets: ["docs"] })
+    const configResolved = plugin.configResolved as (config: { command: "build", root: string, workspace?: { assets?: boolean | string[] } }) => Promise<void>
+    const buildStart = plugin.buildStart as () => Promise<void>
+    const resolveId = plugin.resolveId as (id: string) => string | undefined
+
+    await configResolved({ command: "build", root, workspace: { assets: false } })
+    await buildStart()
+
+    const registryId = resolveId("#vitehub-workspace-assets-registry")!
+    const registry = (await import(`${pathToFileURL(registryId).href}?t=${Date.now()}`)).default
+
+    await expect(readFile(registryId, "utf8")).resolves.not.toContain('"docs"')
+    await expect(readFile(registryId, "utf8")).resolves.not.toContain('"notes"')
+    expect(registry).toEqual({})
+  })
 })


### PR DESCRIPTION
Aligns Vite integration helpers so direct plugin options and config-level options follow the same DX rule.

`hubQueue(options?)` and `hubSandbox(options?)` now accept integration options directly. `vite.config.*` remains the project-level override when both are present, matching the existing workflow-style behavior. Workspace now follows the same precedence, and the runtime API docs call out the rule for queue, sandbox, and workspace.