### PR TITLE
feat(storage): add named stores

### DIFF
--- a/packages/blob/docs/runtime-api.md
+++ b/packages/blob/docs/runtime-api.md
@@ -145,6 +145,18 @@ return await blob.serve(event, 'avatars/user-1.png')
 
 Missing pathnames throw an H3 `404` error with `File not found`.
 
+### `blob.store(name)`
+
+Selects a named Blob Store from runtime config and returns the same Blob API for that store.
+
+```ts
+const assets = blob.store('assets')
+
+await assets.put('logo.png', file, {
+  contentType: 'image/png',
+})
+```
+
 ## Validation API
 
 ### `ensureBlob(blob, options)`
@@ -250,6 +262,7 @@ Blob accepts:
 | Shape | Description |
 | --- | --- |
 | `false` | Disable Blob runtime setup. |
+| `{ stores: { default: BlobStoreConfig, ... } }` | Configure multiple named Blob Stores. |
 | `{ driver: 'fs', base? }` | Local filesystem storage. Defaults to `.data/blob`. |
 | `{ driver: 'cloudflare-r2', binding?, bucketName? }` | Cloudflare R2 storage. `binding` defaults to `BLOB`. |
 | `{ driver: 'vercel-blob', access?, token? }` | Vercel Blob storage. `access` defaults to `public`. |
@@ -263,6 +276,17 @@ Blob accepts:
 | `{ driver: 'google-drive' | 'onedrive' | 'dropbox' | 'box', ... }` | Drive-backed providers. |
 
 On Cloudflare hosting, you can omit `driver` and pass `binding` or `bucketName`. Blob resolves those as Cloudflare R2 options.
+
+Use `stores.default` when configuring multiple stores:
+
+```ts
+blob: {
+  stores: {
+    default: { driver: 'fs', base: '.data/blob' },
+    assets: { driver: 'fs', base: '.data/assets' },
+  },
+}
+```
 
 ## Vite Virtual Config
 

--- a/packages/blob/src/config.ts
+++ b/packages/blob/src/config.ts
@@ -6,6 +6,7 @@ import { isPlainObject } from "@vitehub/internal/object"
 import type {
   BlobModuleOptions,
   BlobStoreConfig,
+  BlobStoresConfig,
   CloudflareR2BlobStoreConfig,
   FsBlobStoreConfig,
   ResolvedBlobModuleOptions,
@@ -83,6 +84,14 @@ function resolveExplicitStore(
   }
 }
 
+function createResolvedConfig(store: ResolvedBlobModuleOptions["store"], stores?: Record<string, ResolvedBlobModuleOptions["store"]>): ResolvedBlobModuleOptions {
+  return stores ? { store, stores: { default: store, ...stores } } : { store }
+}
+
+function hasStoresConfig(options: BlobModuleOptions | undefined): options is BlobStoresConfig {
+  return !!options && "stores" in options && isPlainObject((options as { stores?: unknown }).stores)
+}
+
 export function hasVercelBlobEnv(env: Record<string, string | undefined>): boolean {
   return Boolean(readEnv(env, "BLOB_READ_WRITE_TOKEN"))
 }
@@ -104,23 +113,32 @@ export function normalizeBlobOptions(
   const explicit = options as BlobStoreConfig | undefined
   const implicitCloudflare = options as Partial<CloudflareR2BlobStoreConfig> | undefined
 
+  if (hasStoresConfig(options)) {
+    const resolvedStores = Object.fromEntries(
+      Object.entries(options.stores).map(([name, store]) => [name, resolveExplicitStore(store, env)]),
+    )
+    const defaultStore = resolvedStores.default
+    if (!defaultStore) throw new TypeError("`blob.stores.default` is required when using named Blob stores.")
+    return createResolvedConfig(defaultStore, resolvedStores)
+  }
+
   if (explicit?.driver) {
-    return { store: resolveExplicitStore(explicit, env) }
+    return createResolvedConfig(resolveExplicitStore(explicit, env))
   }
 
   if (hosting.includes("cloudflare")) {
-    return { store: resolveCloudflareStore(implicitCloudflare, env) }
+    return createResolvedConfig(resolveCloudflareStore(implicitCloudflare, env))
   }
 
   if (hasVercelBlobEnv(env)) {
-    return { store: resolveVercelStore() }
+    return createResolvedConfig(resolveVercelStore())
   }
 
   if (hosting.includes("vercel")) {
-    return { store: resolveVercelStore() }
+    return createResolvedConfig(resolveVercelStore())
   }
 
-  return { store: resolveFsStore() }
+  return createResolvedConfig(resolveFsStore())
 }
 
 export function warnVercelBlobFallback(

--- a/packages/blob/src/config.ts
+++ b/packages/blob/src/config.ts
@@ -146,7 +146,9 @@ export function warnVercelBlobFallback(
   config: ResolvedBlobModuleOptions | undefined,
   hosting?: string,
 ): void {
-  if (!config || !hosting?.includes("vercel") || config.store.driver !== "fs") return
+  if (!config || !hosting?.includes("vercel")) return
+  const stores = Object.values(config.stores || { default: config.store })
+  if (!stores.some(store => store.driver === "fs")) return
   target.logger?.error?.("Vercel hosting requires Vercel Blob-backed storage. Set `BLOB_READ_WRITE_TOKEN`.")
 }
 

--- a/packages/blob/src/integrations/cloudflare.ts
+++ b/packages/blob/src/integrations/cloudflare.ts
@@ -14,7 +14,7 @@ export function configureCloudflareR2(
     target.cloudflare.wrangler ||= {}
     const buckets = (target.cloudflare.wrangler.r2_buckets ||= [])
 
-    if (buckets.some(b => b.binding === binding || b.bucket_name === bucketName)) continue
+    if (buckets.some(b => b.binding === binding)) continue
     buckets.push({ binding, bucket_name: bucketName })
   }
 }

--- a/packages/blob/src/integrations/cloudflare.ts
+++ b/packages/blob/src/integrations/cloudflare.ts
@@ -5,14 +5,16 @@ export function configureCloudflareR2(
   target: Pick<NitroOptions, "cloudflare">,
   config: ResolvedBlobModuleOptions,
 ): void {
-  if (config.store.driver !== "cloudflare-r2" || !config.store.bucketName) return
+  for (const store of Object.values(config.stores || { default: config.store })) {
+    if (store.driver !== "cloudflare-r2" || !store.bucketName) continue
 
-  const { binding, bucketName } = config.store
+    const { binding, bucketName } = store
 
-  target.cloudflare ||= {}
-  target.cloudflare.wrangler ||= {}
-  const buckets = (target.cloudflare.wrangler.r2_buckets ||= [])
+    target.cloudflare ||= {}
+    target.cloudflare.wrangler ||= {}
+    const buckets = (target.cloudflare.wrangler.r2_buckets ||= [])
 
-  if (buckets.some(b => b.binding === binding || b.bucket_name === bucketName)) return
-  buckets.push({ binding, bucket_name: bucketName })
+    if (buckets.some(b => b.binding === binding || b.bucket_name === bucketName)) continue
+    buckets.push({ binding, bucket_name: bucketName })
+  }
 }

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -126,33 +126,68 @@ function renderProviderEntry(
 }
 
 function renderBlobRuntimeModule(file: string, blobConfig: false | ResolvedBlobModuleOptions) {
+  const stores = blobConfig ? Object.values(blobConfig.stores || { default: blobConfig.store }) : []
+  const driverModules = [...new Set(stores.map(store => store.driver === "cloudflare-r2" ? "cloudflare" : store.driver === "fs" ? "fs" : store.driver === "vercel-blob" ? "vercel" : "files"))]
+  const driverImports = {
+    cloudflare: "createCloudflareDriver",
+    files: "createFilesDriver",
+    fs: "createFsDriver",
+    vercel: "createVercelDriver",
+  } as const
   const imports = [
     `import { ensureBlob } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("ensure")))}`,
     `import { setBlobRuntimeConfig, setBlobRuntimeStorage } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("runtime/state")))}`,
   ]
-  const driverModule = blobConfig ? `drivers/${blobConfig.store.driver === "cloudflare-r2" ? "cloudflare" : blobConfig.store.driver === "fs" ? "fs" : blobConfig.store.driver === "vercel-blob" ? "vercel" : "files"}` : undefined
-  if (driverModule) {
+  if (driverModules.length > 0) {
     imports.push(`import { createBlobStorage } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("storage")))}`)
-    imports.push(`import { createDriver } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule(driverModule)))}`)
   }
-  if (blobConfig && blobConfig.store.driver === "vercel-blob") {
+  for (const driverModule of driverModules) {
+    const driverImport = driverImports[driverModule as keyof typeof driverImports]
+    imports.push(`import { createDriver as ${driverImport} } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule(`drivers/${driverModule}`)))}`)
+  }
+  if (stores.some(store => store.driver === "vercel-blob")) {
     imports.push(`import { resolveRuntimeVercelBlobStore } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("config")))}`)
   }
 
-  const storageExpression = !blobConfig
-    ? undefined
-    : blobConfig.store.driver === "vercel-blob"
-      ? "createBlobStorage(createDriver(resolveRuntimeVercelBlobStore(blobConfig.store, process.env)))"
-      : "createBlobStorage(createDriver(blobConfig.store))"
+  const createDriverCases = [
+    driverModules.includes("cloudflare") ? `    case "cloudflare-r2": return createCloudflareDriver(store)` : undefined,
+    driverModules.includes("fs") ? `    case "fs": return createFsDriver(store)` : undefined,
+    driverModules.includes("vercel") ? `    case "vercel-blob": return createVercelDriver(resolveRuntimeVercelBlobStore(store, process.env))` : undefined,
+    driverModules.includes("files") ? `    default: return createFilesDriver(store)` : undefined,
+  ].filter(Boolean)
 
   return [
     ...imports,
     "",
     `const blobConfig = ${JSON.stringify(blobConfig, null, 2)}`,
     "setBlobRuntimeConfig(blobConfig)",
-    ...(storageExpression
+    ...(blobConfig
       ? [
-          `export const blob = ${storageExpression}`,
+          "const blobStorages = new Map()",
+          "",
+          "function createBlobDriver(store) {",
+          "  switch (store.driver) {",
+          ...createDriverCases,
+          "  }",
+          "}",
+          "",
+          "function resolveBlobStoreConfig(name) {",
+          "  const stores = blobConfig.stores || { default: blobConfig.store }",
+          "  const store = stores[name]",
+          "  if (!store) throw new Error(`Unknown Blob store \"${name}\".`)",
+          "  return store",
+          "}",
+          "",
+          "function createGeneratedBlobStorage(name = \"default\") {",
+          "  const existing = blobStorages.get(name)",
+          "  if (existing) return existing",
+          "  const storage = createBlobStorage(createBlobDriver(resolveBlobStoreConfig(name)))",
+          "  const runtimeStorage = { ...storage, store: storeName => createGeneratedBlobStorage(storeName) }",
+          "  blobStorages.set(name, runtimeStorage)",
+          "  return runtimeStorage",
+          "}",
+          "",
+          "export const blob = createGeneratedBlobStorage()",
           "setBlobRuntimeStorage(blob)",
         ]
       : [

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -71,12 +71,17 @@ function createCloudflareR2Bindings(config: false | ResolvedBlobModuleOptions | 
     return undefined
   }
 
-  const bindings = Object.values(config.stores || { default: config.store })
-    .filter(isCloudflareR2StoreWithBucket)
-    .map(store => ({
+  const bindingsByBinding = new Map<string, { binding: string, bucket_name: string }>()
+  for (const store of Object.values(config.stores || { default: config.store })) {
+    if (!isCloudflareR2StoreWithBucket(store) || bindingsByBinding.has(store.binding)) {
+      continue
+    }
+    bindingsByBinding.set(store.binding, {
       binding: store.binding,
       bucket_name: store.bucketName,
-    }))
+    })
+  }
+  const bindings = [...bindingsByBinding.values()]
 
   return bindings.length > 0 ? bindings : undefined
 }

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -8,7 +8,7 @@ import { resolveUserAppEntry } from "@vitehub/internal/build/user-entry"
 
 import { normalizeBlobOptions } from "../config.ts"
 
-import type { BlobModuleOptions, ResolvedBlobModuleOptions } from "../types.ts"
+import type { BlobModuleOptions, ResolvedBlobModuleOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
 import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vitehub/internal/build/deployment-output"
 
 export const blobPackageName = "@vitehub/blob"
@@ -62,15 +62,23 @@ interface CloudflareBlobConfig {
   r2_buckets?: Array<{ binding: string, bucket_name: string }>
 }
 
-function createCloudflareR2Bindings(config: false | ResolvedBlobModuleOptions | undefined) {
-  if (!config || config.store.driver !== "cloudflare-r2" || !config.store.bucketName) {
+function isCloudflareR2StoreWithBucket(store: ResolvedBlobModuleOptions["store"]): store is ResolvedCloudflareR2BlobStoreConfig & { bucketName: string } {
+  return store.driver === "cloudflare-r2" && Boolean(store.bucketName)
+}
+
+function createCloudflareR2Bindings(config: false | ResolvedBlobModuleOptions | undefined): Array<{ binding: string, bucket_name: string }> | undefined {
+  if (!config) {
     return undefined
   }
 
-  return [{
-    binding: config.store.binding,
-    bucket_name: config.store.bucketName,
-  }]
+  const bindings = Object.values(config.stores || { default: config.store })
+    .filter(isCloudflareR2StoreWithBucket)
+    .map(store => ({
+      binding: store.binding,
+      bucket_name: store.bucketName,
+    }))
+
+  return bindings.length > 0 ? bindings : undefined
 }
 
 function resolveBlobConfig(

--- a/packages/blob/src/runtime/state.ts
+++ b/packages/blob/src/runtime/state.ts
@@ -13,7 +13,7 @@ import type { BlobStorage, ResolvedBlobModuleOptions } from "../types.ts"
 
 let runtimeConfig: false | ResolvedBlobModuleOptions | undefined
 let runtimeConfigPromise: Promise<false | ResolvedBlobModuleOptions> | undefined
-let runtimeStorage: BlobStorage | undefined
+const runtimeStorages = new Map<string, BlobStorage>()
 
 export {
   clearActiveCloudflareEnv,
@@ -50,7 +50,11 @@ export async function getBlobRuntimeConfig(): Promise<false | ResolvedBlobModule
 }
 
 export function getBlobRuntimeStorage(): BlobStorage | undefined {
-  return runtimeStorage
+  return getNamedBlobRuntimeStorage("default")
+}
+
+export function getNamedBlobRuntimeStorage(name: string): BlobStorage | undefined {
+  return runtimeStorages.get(name)
 }
 
 export function setBlobRuntimeConfig(config: false | ResolvedBlobModuleOptions | undefined): void {
@@ -59,5 +63,10 @@ export function setBlobRuntimeConfig(config: false | ResolvedBlobModuleOptions |
 }
 
 export function setBlobRuntimeStorage(storage: BlobStorage | undefined): void {
-  runtimeStorage = storage
+  setNamedBlobRuntimeStorage("default", storage)
+}
+
+export function setNamedBlobRuntimeStorage(name: string, storage: BlobStorage | undefined): void {
+  if (storage) runtimeStorages.set(name, storage)
+  else runtimeStorages.delete(name)
 }

--- a/packages/blob/src/runtime/storage.ts
+++ b/packages/blob/src/runtime/storage.ts
@@ -1,9 +1,9 @@
 import { createBlobStorage } from "../storage.ts"
 import { resolveRuntimeVercelBlobStore } from "../config.ts"
 
-import { getBlobRuntimeConfig, getBlobRuntimeStorage, setBlobRuntimeStorage } from "./state.ts"
+import { getBlobRuntimeConfig, getNamedBlobRuntimeStorage, setNamedBlobRuntimeStorage } from "./state.ts"
 
-import type { BlobStorage, ResolvedBlobModuleOptions, ResolvedBlobStoreConfig } from "../types.ts"
+import type { BlobStorage, BlobStoreName, ResolvedBlobModuleOptions, ResolvedBlobStoreConfig } from "../types.ts"
 
 async function importRuntimeDriver(config: ResolvedBlobStoreConfig) {
   const isSourceRuntime = typeof import.meta !== "undefined"
@@ -48,8 +48,8 @@ async function createConfiguredBlobStorage(config: ResolvedBlobModuleOptions): P
   return createBlobStorage(driver)
 }
 
-async function resolveStorage() {
-  const existing = getBlobRuntimeStorage()
+async function resolveStorage(name = "default") {
+  const existing = getNamedBlobRuntimeStorage(name)
   if (existing) {
     return existing
   }
@@ -59,16 +59,24 @@ async function resolveStorage() {
     throw new Error("Blob runtime is disabled.")
   }
 
-  const storage = await createConfiguredBlobStorage(config)
-  setBlobRuntimeStorage(storage)
+  const stores = config.stores || { default: config.store }
+  const store = stores[name]
+  if (!store) throw new Error(`Unknown Blob store "${name}".`)
+  const storage = await createConfiguredBlobStorage({ store, stores: { default: store, [name]: store } })
+  setNamedBlobRuntimeStorage(name, storage)
   return storage
 }
 
-export const blob: BlobStorage = {
-  async del(pathnames) { await (await resolveStorage()).del(pathnames) },
-  async get(pathname) { return (await resolveStorage()).get(pathname) },
-  async head(pathname) { return (await resolveStorage()).head(pathname) },
-  async list(options) { return (await resolveStorage()).list(options) },
-  async put(pathname, body, options) { return (await resolveStorage()).put(pathname, body, options) },
-  async serve(event, pathname) { return (await resolveStorage()).serve(event, pathname) },
+function createRuntimeBlobStorage(name = "default"): BlobStorage {
+  return {
+    async del(pathnames) { await (await resolveStorage(name)).del(pathnames) },
+    async get(pathname) { return (await resolveStorage(name)).get(pathname) },
+    async head(pathname) { return (await resolveStorage(name)).head(pathname) },
+    async list(options) { return (await resolveStorage(name)).list(options) },
+    async put(pathname, body, options) { return (await resolveStorage(name)).put(pathname, body, options) },
+    async serve(event, pathname) { return (await resolveStorage(name)).serve(event, pathname) },
+    store(storeName: BlobStoreName) { return createRuntimeBlobStorage(storeName) },
+  }
 }
+
+export const blob: BlobStorage = createRuntimeBlobStorage()

--- a/packages/blob/src/storage.ts
+++ b/packages/blob/src/storage.ts
@@ -118,5 +118,8 @@ export function createBlobStorage(driver: BlobDriverAdapter<any>): BlobStorage {
         },
       })
     },
+    store() {
+      throw new Error("Named Blob stores are only available from the @vitehub/blob runtime export.")
+    },
   }
 }

--- a/packages/blob/src/types.ts
+++ b/packages/blob/src/types.ts
@@ -83,6 +83,7 @@ export interface BlobStorage {
   list(options?: BlobListOptions): Promise<BlobListResult>
   put(pathname: string, body: BlobPutBody, options?: BlobPutOptions): Promise<BlobObject>
   serve(event: H3Event, pathname: string): Promise<ReadableStream>
+  store(name: BlobStoreName): BlobStorage
 }
 
 export interface CloudflareR2BlobStoreConfig {
@@ -278,11 +279,19 @@ export type ResolvedBlobStoreConfig =
   | ResolvedFsBlobStoreConfig
   | ResolvedVercelBlobStoreConfig
 
+export type BlobStoreName = "default" | (string & {})
+
+export interface BlobStoresConfig {
+  stores: Record<string, BlobStoreConfig>
+}
+
 export type BlobModuleOptions =
   | false
+  | BlobStoresConfig
   | ({ driver?: undefined } & Partial<Pick<ResolvedCloudflareR2BlobStoreConfig, "binding" | "bucketName">>)
   | BlobStoreConfig
 
 export interface ResolvedBlobModuleOptions {
   store: ResolvedBlobStoreConfig
+  stores?: Record<string, ResolvedBlobStoreConfig>
 }

--- a/packages/blob/test/config.test.ts
+++ b/packages/blob/test/config.test.ts
@@ -145,6 +145,28 @@ describe("blob config", () => {
     )
   })
 
+  it("warns when a named Vercel store uses fs", () => {
+    const logger = {
+      error: vi.fn(),
+    }
+
+    warnVercelBlobFallback({ logger }, normalizeBlobOptions({
+      stores: {
+        assets: {
+          base: ".data/assets",
+          driver: "fs",
+        },
+        default: {
+          driver: "vercel-blob",
+        },
+      },
+    }), "vercel")
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "Vercel hosting requires Vercel Blob-backed storage. Set `BLOB_READ_WRITE_TOKEN`.",
+    )
+  })
+
   it("does not require a logger for the Vercel fs fallback warning", () => {
     expect(() => warnVercelBlobFallback({}, {
       store: {

--- a/packages/blob/test/config.test.ts
+++ b/packages/blob/test/config.test.ts
@@ -73,6 +73,47 @@ describe("blob config", () => {
     expect(() => normalizeBlobOptions("blob" as never)).toThrow("`blob` must be a plain object.")
   })
 
+  it("normalizes named stores with a required default store", () => {
+    expect(normalizeBlobOptions({
+      stores: {
+        assets: {
+          base: ".data/assets",
+          driver: "fs",
+        },
+        default: {
+          base: ".data/blob",
+          driver: "fs",
+        },
+      },
+    })).toEqual({
+      store: {
+        base: ".data/blob",
+        driver: "fs",
+      },
+      stores: {
+        assets: {
+          base: ".data/assets",
+          driver: "fs",
+        },
+        default: {
+          base: ".data/blob",
+          driver: "fs",
+        },
+      },
+    })
+  })
+
+  it("rejects named stores without a default store", () => {
+    expect(() => normalizeBlobOptions({
+      stores: {
+        assets: {
+          base: ".data/assets",
+          driver: "fs",
+        },
+      },
+    })).toThrow("`blob.stores.default` is required when using named Blob stores.")
+  })
+
   it("rehydrates the Vercel token at runtime", () => {
     expect(resolveRuntimeVercelBlobStore({
       access: "public",

--- a/packages/blob/test/frameworks.test.ts
+++ b/packages/blob/test/frameworks.test.ts
@@ -84,6 +84,44 @@ describe("Nitro module", () => {
     })
   })
 
+  it("preserves distinct Cloudflare R2 bindings that share a bucket", async () => {
+    const nitro = createNitroStub({
+      blob: {
+        stores: {
+          assets: {
+            binding: "ASSETS",
+            bucketName: "shared",
+            driver: "cloudflare-r2",
+          },
+          default: {
+            binding: "BLOB",
+            bucketName: "shared",
+            driver: "cloudflare-r2",
+          },
+        },
+      },
+      preset: "cloudflare-module",
+    })
+    const module = (await import("../src/nitro/module.ts")).default
+
+    await module.setup(nitro as never)
+
+    expect(nitro.options.cloudflare).toMatchObject({
+      wrangler: {
+        r2_buckets: [
+          {
+            binding: "BLOB",
+            bucket_name: "shared",
+          },
+          {
+            binding: "ASSETS",
+            bucket_name: "shared",
+          },
+        ],
+      },
+    })
+  })
+
   it("warns when Vercel explicitly uses fs", async () => {
     const nitro = createNitroStub({
       blob: {

--- a/packages/blob/test/runtime.test.ts
+++ b/packages/blob/test/runtime.test.ts
@@ -250,6 +250,54 @@ describe("blob runtime", () => {
     }))
   })
 
+  it("selects named stores from runtime config", async () => {
+    setBlobRuntimeConfig({
+      store: {
+        access: "public",
+        driver: "vercel-blob",
+        token: "default-token",
+      },
+      stores: {
+        assets: {
+          access: "public",
+          driver: "vercel-blob",
+          token: "assets-token",
+        },
+        default: {
+          access: "public",
+          driver: "vercel-blob",
+          token: "default-token",
+        },
+      },
+    })
+
+    await blob.store("assets").put("notes/assets.txt", "value")
+
+    expect(vercelBlobMock.put).toHaveBeenCalledWith("notes/assets.txt", "value", expect.objectContaining({
+      access: "public",
+      token: "assets-token",
+    }))
+  })
+
+  it("rejects missing named stores at runtime", async () => {
+    setBlobRuntimeConfig({
+      store: {
+        access: "public",
+        driver: "vercel-blob",
+        token: "default-token",
+      },
+      stores: {
+        default: {
+          access: "public",
+          driver: "vercel-blob",
+          token: "default-token",
+        },
+      },
+    })
+
+    await expect(blob.store("missing").get("notes/missing.txt")).rejects.toThrow("Unknown Blob store \"missing\".")
+  })
+
   it("uses the active Cloudflare binding", async () => {
     setBlobRuntimeConfig({
       store: {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -168,6 +168,41 @@ describe("Vite provider outputs", () => {
     expect(await readFile(join(rootDir, "dist", toSafeAppName(rootDir), "wrangler.json"), "utf8")).not.toContain("\"r2_buckets\"")
   })
 
+  it("emits Cloudflare bucket bindings for named R2 stores", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-named-r2-")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist", "client"), { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+
+    await generateProviderOutputs({
+      blob: {
+        stores: {
+          assets: {
+            binding: "ASSETS",
+            bucketName: "assets",
+            driver: "cloudflare-r2",
+          },
+          default: {
+            binding: "DEFAULT",
+            driver: "cloudflare-r2",
+          },
+        },
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    const wranglerConfig = JSON.parse(await readFile(join(rootDir, "dist", toSafeAppName(rootDir), "wrangler.json"), "utf8")) as {
+      r2_buckets?: Array<{ binding: string, bucket_name: string }>
+    }
+    expect(wranglerConfig.r2_buckets).toEqual([
+      {
+        binding: "ASSETS",
+        bucket_name: "assets",
+      },
+    ])
+  })
+
   it("rehydrates masked Vercel tokens from generated runtime output", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-vercel-runtime-")
     await mkdir(join(rootDir, "src"), { recursive: true })

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -182,6 +182,11 @@ describe("Vite provider outputs", () => {
             bucketName: "assets",
             driver: "cloudflare-r2",
           },
+          assetsAlias: {
+            binding: "ASSETS",
+            bucketName: "assets",
+            driver: "cloudflare-r2",
+          },
           default: {
             binding: "DEFAULT",
             driver: "cloudflare-r2",

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -185,6 +185,9 @@ describe("Vite provider outputs", () => {
     const runtimeModule = await import(runtimeModulePath) as {
       blob: {
         put: (pathname: string, body: string) => Promise<unknown>
+        store: (name: string) => {
+          put: (pathname: string, body: string) => Promise<unknown>
+        }
       }
     }
 
@@ -200,6 +203,55 @@ describe("Vite provider outputs", () => {
 
     const runtimeContents = await readFile(join(rootDir, ".vitehub", "blob", "vercel-runtime.mjs"), "utf8")
     expect(runtimeContents).toContain("resolveRuntimeVercelBlobStore")
-    expect(runtimeContents).toContain("createDriver(resolveRuntimeVercelBlobStore(blobConfig.store, process.env))")
+    expect(runtimeContents).toContain("createVercelDriver(resolveRuntimeVercelBlobStore(store, process.env))")
+  })
+
+  it("selects named stores from generated runtime output", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-named-runtime-")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist"), { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+
+    await generateProviderOutputs({
+      blob: {
+        stores: {
+          assets: {
+            access: "public",
+            driver: "vercel-blob",
+            token: "assets-token",
+          },
+          default: {
+            access: "public",
+            driver: "vercel-blob",
+            token: "default-token",
+          },
+        },
+      },
+      clientOutDir: "dist",
+      rootDir,
+    })
+
+    const runtimeModulePath = `${pathToFileURL(join(rootDir, ".vitehub", "blob", "vercel-runtime.mjs")).href}?t=${Date.now()}`
+    const runtimeModule = await import(runtimeModulePath) as {
+      blob: {
+        store: (name: string) => {
+          put: (pathname: string, body: string) => Promise<unknown>
+        }
+      }
+    }
+
+    await runtimeModule.blob.store("assets").put("notes/assets.txt", "hello")
+
+    expect(vercelBlobMock.put).toHaveBeenCalledWith(
+      "notes/assets.txt",
+      "hello",
+      expect.objectContaining({
+        token: "assets-token",
+      }),
+    )
+
+    const runtimeContents = await readFile(join(rootDir, ".vitehub", "blob", "vercel-runtime.mjs"), "utf8")
+    expect(runtimeContents).toContain("store: storeName => createGeneratedBlobStorage(storeName)")
+    expect(runtimeContents).toContain("export const blob = createGeneratedBlobStorage()")
   })
 })

--- a/packages/kv/docs/runtime-api.md
+++ b/packages/kv/docs/runtime-api.md
@@ -65,6 +65,7 @@ interface KVStorage {
   has(key: string, options?: unknown): Promise<boolean>
   keys(base?: string, options?: unknown): Promise<string[]>
   set<T = unknown>(key: string, value: T, options?: unknown): Promise<void>
+  store(name: KVStoreName): KVStorage
 }
 ```
 
@@ -76,18 +77,37 @@ interface KVStorage {
 | `kv.del(key, options?)` | Remove one key. |
 | `kv.keys(base?, options?)` | List keys, optionally under a prefix. |
 | `kv.clear(base?, options?)` | Clear the whole store or one prefix. |
+| `kv.store(name)` | Select a named KV store. |
 
 Method options are passed to the underlying unstorage driver. Treat them as provider-specific.
+
+Use `kv.store(name)` when an app has multiple configured stores:
+
+```ts
+await kv.store('chat').set('thread:1', { status: 'open' })
+const state = await kv.store('chat').get('thread:1')
+```
 
 ## Module Options
 
 ### `KVModuleOptions`
 
 ```ts
-type KVModuleOptions = KVStoreConfig | false
+type KVModuleOptions = KVStoreConfig | KVStoresConfig | false
 ```
 
 Set `kv: false` to disable runtime mounting.
+
+Use `stores.default` when configuring multiple stores:
+
+```ts
+kv: {
+  stores: {
+    default: { driver: 'fs-lite', base: '.data/kv' },
+    chat: { driver: 'fs-lite', base: '.data/chat-kv' },
+  },
+}
+```
 
 ### `KVDriver`
 

--- a/packages/kv/src/config.ts
+++ b/packages/kv/src/config.ts
@@ -9,6 +9,7 @@ import type {
   FsLiteKVStoreConfig,
   KVModuleOptions,
   KVStoreConfig,
+  KVStoresConfig,
   ResolvedCloudflareKVStoreConfig,
   ResolvedFsLiteKVStoreConfig,
   ResolvedKVModuleOptions,
@@ -42,6 +43,14 @@ function resolveExplicitStore(store: KVStoreConfig, env: Record<string, string |
   }
 }
 
+function createResolvedConfig(store: ResolvedKVModuleOptions["store"], stores?: Record<string, ResolvedKVModuleOptions["store"]>): ResolvedKVModuleOptions {
+  return stores ? { store, stores: { default: store, ...stores } } : { store }
+}
+
+function hasStoresConfig(options: KVModuleOptions | undefined): options is KVStoresConfig {
+  return !!options && "stores" in options && isPlainObject((options as { stores?: unknown }).stores)
+}
+
 export function normalizeKVOptions(
   options: KVModuleOptions | undefined,
   input: KVResolutionInput = {},
@@ -56,11 +65,20 @@ export function normalizeKVOptions(
   const hosting = input.hosting || ""
   const explicit = options as KVStoreConfig | undefined
 
-  if (explicit?.driver) return { store: resolveExplicitStore(explicit, env) }
-  if (hasUpstashEnv(env)) return { store: resolveUpstashStore() }
-  if (hosting.includes("vercel")) return { store: resolveUpstashStore() }
-  if (hosting.includes("cloudflare")) return { store: resolveCloudflareStore({}, env) }
-  return { store: resolveFsLiteStore() }
+  if (hasStoresConfig(options)) {
+    const resolvedStores = Object.fromEntries(
+      Object.entries(options.stores).map(([name, store]) => [name, resolveExplicitStore(store, env)]),
+    )
+    const defaultStore = resolvedStores.default
+    if (!defaultStore) throw new TypeError("`kv.stores.default` is required when using named KV stores.")
+    return createResolvedConfig(defaultStore, resolvedStores)
+  }
+
+  if (explicit?.driver) return createResolvedConfig(resolveExplicitStore(explicit, env))
+  if (hasUpstashEnv(env)) return createResolvedConfig(resolveUpstashStore())
+  if (hosting.includes("vercel")) return createResolvedConfig(resolveUpstashStore())
+  if (hosting.includes("cloudflare")) return createResolvedConfig(resolveCloudflareStore({}, env))
+  return createResolvedConfig(resolveFsLiteStore())
 }
 
 export function warnVercelKVFallback(

--- a/packages/kv/src/config.ts
+++ b/packages/kv/src/config.ts
@@ -86,7 +86,9 @@ export function warnVercelKVFallback(
   config: ResolvedKVModuleOptions | undefined,
   hosting?: string,
 ): void {
-  if (!config || !hosting?.includes("vercel") || config.store.driver !== "fs-lite") return
+  if (!config || !hosting?.includes("vercel")) return
+  const stores = Object.values(config.stores || { default: config.store })
+  if (!stores.some(store => store.driver === "fs-lite")) return
   target.logger.error(
     "Vercel hosting requires Upstash-backed KV. Set `KV_REST_API_URL` and `KV_REST_API_TOKEN`.",
   )

--- a/packages/kv/src/integrations/cloudflare.ts
+++ b/packages/kv/src/integrations/cloudflare.ts
@@ -7,17 +7,19 @@ export function configureCloudflareKV(
   target: Pick<NitroOptions, "cloudflare">,
   config: ResolvedKVModuleOptions,
 ): void {
-  if (config.store.driver !== "cloudflare-kv-binding" || !config.store.namespaceId) return
+  for (const store of Object.values(config.stores || { default: config.store })) {
+    if (store.driver !== "cloudflare-kv-binding" || !store.namespaceId) continue
 
-  const { binding, namespaceId } = config.store
+    const { binding, namespaceId } = store
 
-  target.cloudflare ||= {}
-  target.cloudflare.wrangler ||= {}
-  target.cloudflare.wrangler.kv_namespaces ||= []
+    target.cloudflare ||= {}
+    target.cloudflare.wrangler ||= {}
+    target.cloudflare.wrangler.kv_namespaces ||= []
 
-  pushUnique(
-    target.cloudflare.wrangler.kv_namespaces,
-    { binding, id: namespaceId },
-    entry => entry.binding,
-  )
+    pushUnique(
+      target.cloudflare.wrangler.kv_namespaces,
+      { binding, id: namespaceId },
+      entry => entry.binding,
+    )
+  }
 }

--- a/packages/kv/src/runtime/hosted-storage.ts
+++ b/packages/kv/src/runtime/hosted-storage.ts
@@ -21,7 +21,17 @@ function assertHostedConfig(config: false | ResolvedKVModuleOptions | undefined)
 }
 
 export function createHostedKVStorage(config: false | ResolvedKVModuleOptions | undefined): RuntimeStorage {
+  return createNamedHostedKVStorage(config, "default")
+}
+
+export function createNamedHostedKVStorage(config: false | ResolvedKVModuleOptions | undefined, name: string): RuntimeStorage {
+  const resolved = assertHostedConfig(config)
+  const stores = resolved.stores || { default: resolved.store }
+  const store = stores[name]
+  if (!store) {
+    throw new Error(`[vitehub] Unknown KV store "${name}".`)
+  }
   return createStorage({
-    driver: createLazyKVRuntimeDriver(assertHostedConfig(config)),
+    driver: createLazyKVRuntimeDriver({ store, stores: { default: store, [name]: store } }),
   }) as RuntimeStorage
 }

--- a/packages/kv/src/runtime/nitro-plugin.ts
+++ b/packages/kv/src/runtime/nitro-plugin.ts
@@ -16,6 +16,13 @@ const kvNitroPlugin: ReturnType<typeof defineNitroPlugin> = defineNitroPlugin(as
   const storage = useStorage()
   await storage.unmount("kv")
   storage.mount("kv", createLazyKVRuntimeDriver(runtimeConfig.kv))
+
+  const stores = runtimeConfig.kv.stores || { default: runtimeConfig.kv.store }
+  for (const [name, store] of Object.entries(stores)) {
+    if (name === "default") continue
+    await storage.unmount(`kv:${name}`)
+    storage.mount(`kv:${name}`, createLazyKVRuntimeDriver({ store, stores: { default: store, [name]: store } }))
+  }
 })
 
 export default kvNitroPlugin

--- a/packages/kv/src/runtime/storage.ts
+++ b/packages/kv/src/runtime/storage.ts
@@ -2,10 +2,10 @@ import { readEnv } from "@vitehub/internal/env"
 import { getActiveCloudflareEnv } from "@vitehub/internal/runtime/cloudflare-env"
 
 import { normalizeKVOptions } from "../config.ts"
-import type { KVStorage, ResolvedKVModuleOptions } from "../types.ts"
-import { createHostedKVStorage, type RuntimeStorage } from "./hosted-storage.ts"
+import type { KVStorage, KVStoreName, ResolvedKVModuleOptions } from "../types.ts"
+import { createHostedKVStorage, createNamedHostedKVStorage, type RuntimeStorage } from "./hosted-storage.ts"
 
-let storagePromise: Promise<RuntimeStorage> | undefined
+const storagePromises = new Map<string, Promise<RuntimeStorage>>()
 
 function inferHosting(env: Record<string, string | undefined>) {
   if (getActiveCloudflareEnv()) {
@@ -46,21 +46,51 @@ async function resolveHostedConfig(): Promise<false | ResolvedKVModuleOptions | 
   }
 }
 
-async function resolveStorage() {
-  storagePromise ||= import("nitro/storage")
-    .then(module => module.useStorage("kv") as RuntimeStorage)
-    .catch(async () => {
-      const config = await resolveHostedConfig()
-      return createHostedKVStorage(config)
-    })
-  return storagePromise
+async function assertRuntimeStore(name: string): Promise<void> {
+  if (name === "default") return
+  try {
+    const module = await import("nitro/runtime-config")
+    const runtimeConfig = module.useRuntimeConfig() as { kv?: false | ResolvedKVModuleOptions }
+    const config = runtimeConfig.kv
+    if (config) {
+      const stores = config.stores || { default: config.store }
+      if (!stores[name]) throw new Error(`[vitehub] Unknown KV store "${name}".`)
+    }
+  }
+  catch (error) {
+    if ((error as Error).message.startsWith("[vitehub] Unknown KV store")) throw error
+  }
 }
 
-export const kv: KVStorage = {
-  async clear(base, options) { await (await resolveStorage()).clear(base, options) },
-  async del(key, options) { await (await resolveStorage()).removeItem(key, options) },
-  async get(key, options) { return (await resolveStorage()).getItem(key, options) },
-  async has(key, options) { return (await resolveStorage()).hasItem(key, options) },
-  async keys(base, options) { return (await resolveStorage()).getKeys(base, options) },
-  async set(key, value, options) { await (await resolveStorage()).setItem(key, value, options) },
+async function resolveStorage(name = "default") {
+  const existing = storagePromises.get(name)
+  if (existing) return existing
+  const storageName = name === "default" ? "kv" : `kv:${name}`
+  const promise = assertRuntimeStore(name).then(() => import("nitro/storage"))
+    .then(module => module.useStorage(storageName) as RuntimeStorage)
+    .catch(async () => {
+      if (name === "default") {
+        const config = await resolveHostedConfig()
+        return createHostedKVStorage(config)
+      }
+
+      const config = await resolveHostedConfig()
+      return createNamedHostedKVStorage(config, name)
+    })
+  storagePromises.set(name, promise)
+  return promise
 }
+
+function createKVStorage(name = "default"): KVStorage {
+  return {
+    async clear(base, options) { await (await resolveStorage(name)).clear(base, options) },
+    async del(key, options) { await (await resolveStorage(name)).removeItem(key, options) },
+    async get(key, options) { return (await resolveStorage(name)).getItem(key, options) },
+    async has(key, options) { return (await resolveStorage(name)).hasItem(key, options) },
+    async keys(base, options) { return (await resolveStorage(name)).getKeys(base, options) },
+    async set(key, value, options) { await (await resolveStorage(name)).setItem(key, value, options) },
+    store(storeName: KVStoreName) { return createKVStorage(storeName) },
+  }
+}
+
+export const kv: KVStorage = createKVStorage()

--- a/packages/kv/src/types.ts
+++ b/packages/kv/src/types.ts
@@ -37,10 +37,17 @@ export type ResolvedKVStoreConfig =
   | ResolvedUpstashKVStoreConfig
   | ResolvedFsLiteKVStoreConfig
 
-export type KVModuleOptions = KVStoreConfig | false
+export type KVStoreName = "default" | (string & {})
+
+export interface KVStoresConfig {
+  stores: Record<string, KVStoreConfig>
+}
+
+export type KVModuleOptions = KVStoreConfig | KVStoresConfig | false
 
 export interface ResolvedKVModuleOptions {
   store: ResolvedKVStoreConfig
+  stores?: Record<string, ResolvedKVStoreConfig>
 }
 
 export interface KVStorage {
@@ -50,4 +57,5 @@ export interface KVStorage {
   has(key: string, options?: unknown): Promise<boolean>
   keys(base?: string, options?: unknown): Promise<string[]>
   set<T = unknown>(key: string, value: T, options?: unknown): Promise<void>
+  store(name: KVStoreName): KVStorage
 }

--- a/packages/kv/test/config.test.ts
+++ b/packages/kv/test/config.test.ts
@@ -115,6 +115,53 @@ describe("normalizeKVOptions", () => {
     })
   })
 
+  it("normalizes named stores with a required default store", () => {
+    expect(normalizeKVOptions({
+      stores: {
+        chat: {
+          base: ".data/chat-kv",
+          driver: "fs-lite",
+        },
+        default: {
+          base: ".data/kv",
+          driver: "fs-lite",
+        },
+      },
+    }, {
+      env: {},
+      hosting: "",
+    })).toEqual({
+      store: {
+        base: ".data/kv",
+        driver: "fs-lite",
+      },
+      stores: {
+        chat: {
+          base: ".data/chat-kv",
+          driver: "fs-lite",
+        },
+        default: {
+          base: ".data/kv",
+          driver: "fs-lite",
+        },
+      },
+    })
+  })
+
+  it("rejects named stores without a default store", () => {
+    expect(() => normalizeKVOptions({
+      stores: {
+        chat: {
+          base: ".data/chat-kv",
+          driver: "fs-lite",
+        },
+      },
+    }, {
+      env: {},
+      hosting: "",
+    })).toThrow("`kv.stores.default` is required when using named KV stores.")
+  })
+
   it("rejects non-object config", () => {
     expect(() => normalizeKVOptions(true as never, {
       env: {},

--- a/packages/kv/test/config.test.ts
+++ b/packages/kv/test/config.test.ts
@@ -214,4 +214,26 @@ describe("warnVercelKVFallback", () => {
       "Vercel hosting requires Upstash-backed KV. Set `KV_REST_API_URL` and `KV_REST_API_TOKEN`.",
     )
   })
+
+  it("reports named fs-lite stores on Vercel hosting", () => {
+    const error = vi.fn()
+
+    warnVercelKVFallback({
+      logger: { error },
+    }, normalizeKVOptions({
+      stores: {
+        chat: {
+          base: ".data/chat",
+          driver: "fs-lite",
+        },
+        default: {
+          driver: "upstash",
+        },
+      },
+    }), "vercel")
+
+    expect(error).toHaveBeenCalledWith(
+      "Vercel hosting requires Upstash-backed KV. Set `KV_REST_API_URL` and `KV_REST_API_TOKEN`.",
+    )
+  })
 })

--- a/packages/kv/test/runtime.test.ts
+++ b/packages/kv/test/runtime.test.ts
@@ -142,6 +142,63 @@ describe("kv runtime", () => {
     })
   })
 
+  it("selects named stores from runtime config", async () => {
+    runtimeState.config = {
+      kv: {
+        store: {
+          base: ".data/kv",
+          driver: "fs-lite",
+        },
+        stores: {
+          chat: {
+            base: ".data/chat-kv",
+            driver: "fs-lite",
+          },
+          default: {
+            base: ".data/kv",
+            driver: "fs-lite",
+          },
+        },
+      },
+    }
+
+    const plugin = (await import("../src/runtime/nitro-plugin.ts")).default as () => void | Promise<void>
+    await plugin()
+
+    const { kv } = await import("../src/runtime/storage.ts")
+    await kv.store("chat").set("state", "ok")
+
+    expect(await kv.store("chat").get("state")).toBe("ok")
+    expect(mountedDrivers.fsLite).toMatchObject({
+      base: ".data/chat-kv",
+      driver: "fs-lite",
+    })
+  })
+
+  it("rejects missing named stores at runtime", async () => {
+    runtimeState.config = {
+      kv: {
+        store: {
+          base: ".data/kv",
+          driver: "fs-lite",
+        },
+        stores: {
+          default: {
+            base: ".data/kv",
+            driver: "fs-lite",
+          },
+        },
+      },
+    }
+
+    const plugin = (await import("../src/runtime/nitro-plugin.ts")).default as () => void | Promise<void>
+    await plugin()
+
+    const { kv } = await import("../src/runtime/storage.ts")
+
+    await expect(kv.store("missing").get("state")).rejects.toThrow("[vitehub] Unknown KV store \"missing\".")
+  })
+
   it("prefers runtime env vars over masked Upstash config values", async () => {
     process.env.KV_REST_API_URL = "https://upstash.example.com"
     process.env.KV_REST_API_TOKEN = "upstash-token"


### PR DESCRIPTION
Adds named store configuration and runtime selection to `@vitehub/kv` and `@vitehub/blob`.

The default runtime handles continue to target the default store, while `kv.store(name)` and `blob.store(name)` select configured named stores. Cloudflare integration now emits bindings for all configured stores, and the runtime API docs describe the `stores.default` shape.