### PR TITLE
refactor(workspace)!: derive source identity from keys

### DIFF
--- a/packages/workspace/docs/index.md
+++ b/packages/workspace/docs/index.md
@@ -54,7 +54,7 @@ export default defineWorkspace({
 ```
 
 In Nitro, place the same definition at `server/workspaces/docs.ts`.
-Source entries are keyed. The key becomes the default workspace mount path, so the example above exposes files at `docs/**` and `instructions/**`.
+Source entries are named origins. The source key becomes the default workspace mount path, so the example above exposes files at `docs/**` and `instructions/**`.
 For inline files, use `workspacePath` and `content`. For file-backed sources, use `path` for the source file and `workspacePath` for its path inside the mounted source.
 
 Workspace rules are path-scoped write policy, similar in shape to Nitro route rules:
@@ -190,7 +190,7 @@ On open, ViteHub syncs the readable workspace contents into the configured sandb
 
 ## Lazy materialization
 
-Source mounts default to `materialize: 'build'`, which syncs files into the workspace store during build or explicit workspace sync. This is separate from `workspace.assets`, which controls whether synced workspace files are also emitted into the read-only build asset registry.
+Sources default to `materialize: 'build'`, which syncs files into the workspace store during build or explicit workspace sync. This is separate from `workspace.assets`, which controls whether synced workspace files are also emitted into the read-only build asset registry.
 
 Use `materialize: 'lazy'` when the agent only needs source files on demand:
 

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -9,19 +9,19 @@ import { createSourceContext, normalizeWorkspaceSources, type ResolvedWorkspaceS
 import { createWorkspaceStoreFromProvider } from "./store-provider.ts"
 import { hasWorkspaceDirectoryConfig, isWorkspaceAssetFile } from "./workspace-config.ts"
 
-import type { LoaderContext, WorkspaceDefinition, WorkspaceSource, WorkspaceSourceItem, WorkspaceStore } from "./types.ts"
+import type { LoaderContext, WorkspaceDefinition, WorkspaceLoaderSource, WorkspaceSourceItem, WorkspaceStore } from "./types.ts"
 
 function workspaceDirectory(rootDir: string, name: string) {
   return resolve(rootDir, "server", "workspaces", ...name.split("/"))
 }
 
-function createImplicitWorkspaceDirectorySource(definition: WorkspaceDefinition): WorkspaceSource | undefined {
+function createImplicitWorkspaceDirectorySource(definition: WorkspaceDefinition): WorkspaceLoaderSource | undefined {
   const rootDir = definition.rootDir || process.cwd()
   const directory = workspaceDirectory(rootDir, definition.name)
   if (!hasWorkspaceDirectoryConfig(directory)) return
 
   return {
-    name: "directory-assets",
+    key: "directoryAssets",
     async getKeys() {
       return listMatchingFiles(directory, isWorkspaceAssetFile).map(file => normalizeWorkspacePath(relative(directory, file))).sort()
     },
@@ -72,9 +72,10 @@ export async function syncWorkspaceDefinition(definition: WorkspaceDefinition, s
   }
 }
 
-function createMountedBuildSource(source: ResolvedWorkspaceSource): WorkspaceSource {
+function createMountedBuildSource(source: ResolvedWorkspaceSource): WorkspaceLoaderSource {
   return {
     ...source.source,
+    key: source.key,
     async getKeys(ctx) {
       return await source.source.getKeys(ctx)
     },

--- a/packages/workspace/src/loaders/files.ts
+++ b/packages/workspace/src/loaders/files.ts
@@ -32,7 +32,7 @@ export function files(options: FilesLoaderOptions = {}): WorkspaceLoader {
           const path = normalizeWorkspacePath(item.path || rawPath)
           const content = item.content ?? (typeof item.data === "undefined" ? "" : JSON.stringify(item.data, null, 2))
           const digest = ctx.generateDigest({ content, metadata: item.metadata, mediaType: item.mediaType })
-          const metaKey = `loader:files:${source.name}:${path}:digest`
+          const metaKey = `loader:files:${source.key}:${path}:digest`
           const previousDigest = await ctx.store.getMeta?.(metaKey)
 
           if (previousDigest === digest) continue

--- a/packages/workspace/src/source-materialization.ts
+++ b/packages/workspace/src/source-materialization.ts
@@ -50,7 +50,6 @@ function sourceConfigFingerprint(source: ResolvedWorkspaceSource) {
     key: source.key,
     materialize: source.materialize,
     mountPath: source.mountPath,
-    name: source.source.name,
     source: source.source.fingerprint,
   }
 }

--- a/packages/workspace/src/types.ts
+++ b/packages/workspace/src/types.ts
@@ -275,7 +275,6 @@ export interface WorkspaceSourceItem {
 }
 
 export interface WorkspaceSource {
-  name: string
   mount?: WorkspaceSourceMount
   materialize?: WorkspaceMaterializeMode
   cache?: false | WorkspaceCacheOptions
@@ -290,10 +289,14 @@ export interface WorkspaceSource {
   watch?: unknown[]
 }
 
+export interface WorkspaceLoaderSource extends WorkspaceSource {
+  key: string
+}
+
 export interface LoaderContext {
   workspace: string
   rootDir: string
-  sources: WorkspaceSource[]
+  sources: WorkspaceLoaderSource[]
   store: WorkspaceStore
   parseData(input: { id: string, data: unknown, filePath?: string }): Promise<unknown>
   generateDigest(input: unknown): string

--- a/packages/workspace/test/lazy-sources.test.ts
+++ b/packages/workspace/test/lazy-sources.test.ts
@@ -34,7 +34,6 @@ describe("lazy sources", () => {
       name: "source-view",
       sources: {
         docs: source.custom({
-          name: "docs",
           materialize: "lazy" as const,
           async getKeys() {
             return ["foo.md"]
@@ -59,9 +58,8 @@ describe("lazy sources", () => {
   it("normalizes keyed source mounts and cache defaults", () => {
     const resolved = normalizeWorkspaceSources({
       docs: source.custom({
-          name: "docs",
-          materialize: "lazy",
-          cache: { maxAge: 3600 },
+        materialize: "lazy",
+        cache: { maxAge: 3600 },
         async getKeys() {
           return []
         },
@@ -70,7 +68,6 @@ describe("lazy sources", () => {
         },
       }),
       skills: source.custom({
-        name: "skills",
         async getKeys() {
           return []
         },
@@ -137,7 +134,6 @@ describe("lazy sources", () => {
       store: { provider: "memory" },
       sources: {
         docs: source.custom({
-          name: "docs",
           materialize: "lazy",
           async getKeys() {
             return ["foo.md", "nested/bar.md"]
@@ -216,7 +212,6 @@ describe("lazy sources", () => {
       store: { provider: "memory" },
       sources: {
         docs: source.custom({
-          name: "docs",
           materialize: "lazy",
           async getKeys() {
             return ["foo.md"]
@@ -249,7 +244,6 @@ describe("lazy sources", () => {
       store: { provider: "memory" },
       sources: {
         docs: source.custom({
-          name: "docs",
           materialize: "lazy",
           async getKeys() {
             return ["foo.md"]
@@ -284,7 +278,6 @@ describe("lazy sources", () => {
       store: { provider: "memory" },
       sources: {
         docs: source.custom({
-          name: "docs",
           materialize: "lazy",
           async getKeys() {
             return ["foo.md", "bar.md"]
@@ -319,7 +312,6 @@ describe("lazy sources", () => {
       store: { provider: "memory" },
       sources: {
         docs: source.custom({
-          name: "docs",
           cache: { maxAge: 3600 },
           materialize: "lazy",
           async getKeys() {

--- a/packages/workspace/test/nitro-assets.test.ts
+++ b/packages/workspace/test/nitro-assets.test.ts
@@ -120,7 +120,6 @@ export default {
   store: { provider: "memory" },
   sources: {
     files: {
-      name: "inline",
       async getKeys() {
         return ["selected.txt"]
       },
@@ -146,7 +145,6 @@ export default {
   store: { provider: "memory" },
   sources: {
     files: {
-      name: "inline",
       async getKeys() {
         return ["skipped.txt"]
       },
@@ -204,7 +202,6 @@ export default {
   store: { provider: "memory" },
   sources: {
     files: {
-      name: "inline",
       async getKeys() {
         return ["one.txt"]
       },
@@ -220,7 +217,6 @@ export default {
   store: { provider: "memory" },
   sources: {
     files: {
-      name: "inline",
       async getKeys() {
         return ["two.txt"]
       },
@@ -268,7 +264,6 @@ export default {
   store: { provider: "memory" },
   sources: {
     files: {
-      name: "inline",
       async getKeys() {
         return ["README.md"]
       },

--- a/packages/workspace/test/sandbox-runtime.test.ts
+++ b/packages/workspace/test/sandbox-runtime.test.ts
@@ -210,7 +210,6 @@ describe("sandbox workspace runtime", () => {
         store: { provider: "memory" },
         sources: {
           docs: {
-            name: "docs",
             materialize: "lazy",
             async getKeys() {
               return ["README.md"]
@@ -356,7 +355,6 @@ describe("sandbox workspace runtime", () => {
         store: { provider: "memory" },
         sources: {
           docs: {
-            name: "docs",
             materialize: "lazy",
             async getKeys() {
               return ["README.md"]

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -547,7 +547,6 @@ describe("sources, loaders, and publishers", () => {
       "  sources: {",
       "    docs: {",
       "      materialize: 'lazy',",
-      "      name: 'lazy-test',",
       "      async getKeys() { throw new Error('lazy source should not be fetched') },",
       "      async getItem() { throw new Error('lazy source should not be fetched') },",
       "    },",
@@ -603,7 +602,6 @@ describe("sources, loaders, and publishers", () => {
         docs: source.glob({ cwd: ".", include: ["**/*.md"] }),
         files: source.file({ path: "two.md", workspacePath: "two.md", content: "# Two\n" }),
         custom: source.custom({
-          name: "custom",
           async getKeys() {
             return ["custom.json"]
           },

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -35,7 +35,6 @@ async function createViteAssetRoot() {
       `  store: { provider: "memory" },`,
       `  sources: {`,
       `    files: {`,
-      `      name: "inline",`,
       `      async getKeys() { return ["README.md"] },`,
       `      async getItem(key) { return { key, path: key, content: "${name}\\n" } },`,
       `    },`,


### PR DESCRIPTION
Extracts the workspace source identity cleanup from #113.

Custom workspace sources no longer need a `name`; configured source keys are the source identity. Loader contexts expose `source.key`, and the files loader uses it for digest metadata. This removes duplicated naming from source definitions and keeps mount/default naming tied to config.

Breaking change: custom workspace loaders should read `WorkspaceLoaderSource.key` instead of `WorkspaceSource.name`.