### PR TITLE
fix(workflow): prefer inline definitions during discovery

### DIFF
--- a/packages/internal/src/definition-catalog.ts
+++ b/packages/internal/src/definition-catalog.ts
@@ -305,10 +305,12 @@ export function createRuntimeRegistryContents(registryFile: string, definitions:
 
     return [
       `  ${JSON.stringify(definition.name)}: async () => {`,
+      `    const cached = registryEntryCache.get(${JSON.stringify(definition.name)})`,
+      "    if (cached) return cached",
       indexImport ? `    ${indexImport}` : "",
       `    const steps = [${stepImports.join(", ")}]`,
       `    const definition = ${handler}`,
-      "    return {",
+      "    const entry = {",
       "      ...definition,",
       "      options: { ...definition.options, rootStep: false },",
       "      handler: async (context) => {",
@@ -316,6 +318,8 @@ export function createRuntimeRegistryContents(registryFile: string, definitions:
       "        return await definition.handler({ ...context, steps: workflowSteps })",
       "      },",
       "    }",
+      `    registryEntryCache.set(${JSON.stringify(definition.name)}, entry)`,
+      "    return entry",
       "  },",
     ].filter(Boolean).join("\n")
   })
@@ -323,6 +327,7 @@ export function createRuntimeRegistryContents(registryFile: string, definitions:
   return [
     ...runtimeImport,
     runtimeImport.length ? "" : "",
+    ...(needsWorkflowRuntime ? ["const registryEntryCache = new Map()", ""] : []),
     "const registry = {",
     ...imports,
     "}",

--- a/packages/internal/src/definition-catalog.ts
+++ b/packages/internal/src/definition-catalog.ts
@@ -283,7 +283,7 @@ export function createRuntimeRegistryContents(registryFile: string, definitions:
   const runtimeImport = needsWorkflowRuntime
     ? [
         `import { createWorkflowSteps } from "@vitehub/workflow/runtime/execute"`,
-        `import { getInlineWorkflowDefinitions } from "@vitehub/workflow/runtime/state"`,
+        `import { takeInlineWorkflowDefinition } from "@vitehub/workflow/runtime/state"`,
       ]
     : []
   const imports = definitions.map((definition) => {
@@ -300,7 +300,7 @@ export function createRuntimeRegistryContents(registryFile: string, definitions:
     const hasIndex = /\.(?:c|m)?[jt]s$/i.test(definition.handler)
     const indexImport = hasIndex ? `const index = await ${createImportExpression(registryFile, definition.handler)}` : ""
     const handler = hasIndex
-      ? `index.default?.handler ? index.default : getInlineWorkflowDefinitions().get(${JSON.stringify(definition.name)}) || { handler: index.default }`
+      ? `index.default?.handler ? index.default : takeInlineWorkflowDefinition(${JSON.stringify(definition.name)}) || { handler: index.default }`
       : "{ handler: async (context) => { let value = context.payload; for (const step of Object.values(context.steps || {})) value = await step(value); return value } }"
 
     return [

--- a/packages/internal/src/definition-catalog.ts
+++ b/packages/internal/src/definition-catalog.ts
@@ -281,7 +281,10 @@ function createImportExpression(registryFile: string, file: string): string {
 export function createRuntimeRegistryContents(registryFile: string, definitions: Array<Pick<DiscoveredDefinition, "handler" | "name"> & { steps?: string[] }>): string {
   const needsWorkflowRuntime = definitions.some(definition => definition.steps?.length)
   const runtimeImport = needsWorkflowRuntime
-    ? [`import { createWorkflowSteps } from "@vitehub/workflow/runtime/execute"`]
+    ? [
+        `import { createWorkflowSteps } from "@vitehub/workflow/runtime/execute"`,
+        `import { getInlineWorkflowDefinitions } from "@vitehub/workflow/runtime/state"`,
+      ]
     : []
   const imports = definitions.map((definition) => {
     if (!definition.steps?.length) {
@@ -297,7 +300,7 @@ export function createRuntimeRegistryContents(registryFile: string, definitions:
     const hasIndex = /\.(?:c|m)?[jt]s$/i.test(definition.handler)
     const indexImport = hasIndex ? `const index = await ${createImportExpression(registryFile, definition.handler)}` : ""
     const handler = hasIndex
-      ? "index.default?.handler ? index.default : { handler: index.default }"
+      ? `index.default?.handler ? index.default : getInlineWorkflowDefinitions().get(${JSON.stringify(definition.name)}) || { handler: index.default }`
       : "{ handler: async (context) => { let value = context.payload; for (const step of Object.values(context.steps || {})) value = await step(value); return value } }"
 
     return [

--- a/packages/internal/test/definition-discovery.test.ts
+++ b/packages/internal/test/definition-discovery.test.ts
@@ -104,6 +104,18 @@ describe("createRuntimeRegistryContents", () => {
     expect(contents).toContain('"release-notes": async () => import("../../server/sandboxes/release-notes.ts")')
     expect(contents).toContain("export default registry")
   })
+
+  it("creates workflow step registry entries that can wrap inline definitions", () => {
+    const registryFile = "/root/.vitehub/workflow/registry.mjs"
+    const contents = createRuntimeRegistryContents(registryFile, [{
+      handler: "/root/server/workflows/chat/index.ts",
+      name: "server/workflows/chat",
+      steps: ["/root/server/workflows/chat/01.reply.ts"],
+    }])
+
+    expect(contents).toContain('import { getInlineWorkflowDefinitions } from "@vitehub/workflow/runtime/state"')
+    expect(contents).toContain('getInlineWorkflowDefinitions().get("server/workflows/chat")')
+  })
 })
 
 describe("createNitroRuntimeFilePath", () => {

--- a/packages/internal/test/definition-discovery.test.ts
+++ b/packages/internal/test/definition-discovery.test.ts
@@ -114,7 +114,10 @@ describe("createRuntimeRegistryContents", () => {
     }])
 
     expect(contents).toContain('import { takeInlineWorkflowDefinition } from "@vitehub/workflow/runtime/state"')
+    expect(contents).toContain("const registryEntryCache = new Map()")
+    expect(contents).toContain('const cached = registryEntryCache.get("server/workflows/chat")')
     expect(contents).toContain('takeInlineWorkflowDefinition("server/workflows/chat")')
+    expect(contents).toContain('registryEntryCache.set("server/workflows/chat", entry)')
   })
 })
 

--- a/packages/internal/test/definition-discovery.test.ts
+++ b/packages/internal/test/definition-discovery.test.ts
@@ -113,8 +113,8 @@ describe("createRuntimeRegistryContents", () => {
       steps: ["/root/server/workflows/chat/01.reply.ts"],
     }])
 
-    expect(contents).toContain('import { getInlineWorkflowDefinitions } from "@vitehub/workflow/runtime/state"')
-    expect(contents).toContain('getInlineWorkflowDefinitions().get("server/workflows/chat")')
+    expect(contents).toContain('import { takeInlineWorkflowDefinition } from "@vitehub/workflow/runtime/state"')
+    expect(contents).toContain('takeInlineWorkflowDefinition("server/workflows/chat")')
   })
 })
 

--- a/packages/workflow/src/discovery.ts
+++ b/packages/workflow/src/discovery.ts
@@ -354,6 +354,6 @@ export function discoverWorkflowDefinitions(options:
       }),
     ]).filter(preferInlineHandler),
     discoverFlatServerWorkflowDefinitions(serverScanDirs, "nitro-server-workflows").filter(preferInlineHandler),
-    discoverWorkflowFolders(serverScanDirs, "nitro-server-workflows"),
+    discoverWorkflowFolders(serverScanDirs, "nitro-server-workflows").filter(preferInlineHandler),
   )
 }

--- a/packages/workflow/src/discovery.ts
+++ b/packages/workflow/src/discovery.ts
@@ -341,13 +341,19 @@ export function discoverWorkflowDefinitions(options:
 
   const roots = resolveDefinitionScanRoots(options.rootDir, options.scanDirs)
   const serverScanDirs = roots.map(root => resolve(root, "server"))
+  const inlineDefinitions = discoverInlineWorkflowDefinitions(options)
+  const inlineHandlers = new Set(inlineDefinitions.map(definition => normalize(definition.handler)))
+  const preferInlineHandler = (definition: { handler: string }) => !inlineHandlers.has(normalize(definition.handler))
+
   return mergeDefinitions(
     "workflow",
-    discoverInlineWorkflowDefinitions(options),
+    inlineDefinitions,
     discoverDefinitions("workflow", [
-      createSuffixDefinitionSource("vite-suffix", roots, workflowSuffixPattern, normalizeSuffixWorkflowName),
-    ]),
-    discoverFlatServerWorkflowDefinitions(serverScanDirs, "nitro-server-workflows"),
+      createSuffixDefinitionSource<DiscoveredWorkflowDefinition>("vite-suffix", roots, workflowSuffixPattern, normalizeSuffixWorkflowName, {
+        createDefinition: ({ file, name }) => ({ handler: file, name, source: "vite-suffix" }),
+      }),
+    ]).filter(preferInlineHandler),
+    discoverFlatServerWorkflowDefinitions(serverScanDirs, "nitro-server-workflows").filter(preferInlineHandler),
     discoverWorkflowFolders(serverScanDirs, "nitro-server-workflows"),
   )
 }

--- a/packages/workflow/src/discovery.ts
+++ b/packages/workflow/src/discovery.ts
@@ -327,6 +327,22 @@ function discoverInlineWorkflowDefinitions(options: { rootDir: string, scanDirs?
   return sortDefinitions(definitions)
 }
 
+function mergeInlineWorkflowFolderSteps(
+  inlineDefinitions: DiscoveredWorkflowDefinition[],
+  folderDefinitions: DiscoveredWorkflowDefinition[],
+) {
+  const stepsByHandler = new Map(
+    folderDefinitions
+      .filter(definition => definition.steps?.length)
+      .map(definition => [normalize(definition.handler), definition.steps!]),
+  )
+
+  return inlineDefinitions.map((definition) => {
+    const steps = stepsByHandler.get(normalize(definition.handler))
+    return steps ? { ...definition, steps } : definition
+  })
+}
+
 export function discoverWorkflowDefinitions(options:
   | { mode?: "vite-suffix", rootDir: string, scanDirs?: string[] }
   | { mode: "nitro-server-workflows", scanDirs: string[] }
@@ -344,16 +360,17 @@ export function discoverWorkflowDefinitions(options:
   const inlineDefinitions = discoverInlineWorkflowDefinitions(options)
   const inlineHandlers = new Set(inlineDefinitions.map(definition => normalize(definition.handler)))
   const preferInlineHandler = (definition: { handler: string }) => !inlineHandlers.has(normalize(definition.handler))
+  const folderDefinitions = discoverWorkflowFolders(serverScanDirs, "nitro-server-workflows")
 
   return mergeDefinitions(
     "workflow",
-    inlineDefinitions,
+    mergeInlineWorkflowFolderSteps(inlineDefinitions, folderDefinitions),
     discoverDefinitions("workflow", [
       createSuffixDefinitionSource<DiscoveredWorkflowDefinition>("vite-suffix", roots, workflowSuffixPattern, normalizeSuffixWorkflowName, {
         createDefinition: ({ file, name }) => ({ handler: file, name, source: "vite-suffix" }),
       }),
     ]).filter(preferInlineHandler),
     discoverFlatServerWorkflowDefinitions(serverScanDirs, "nitro-server-workflows").filter(preferInlineHandler),
-    discoverWorkflowFolders(serverScanDirs, "nitro-server-workflows").filter(preferInlineHandler),
+    folderDefinitions.filter(preferInlineHandler),
   )
 }

--- a/packages/workflow/src/runtime/state.ts
+++ b/packages/workflow/src/runtime/state.ts
@@ -112,14 +112,11 @@ export async function loadWorkflowDefinition(name: string): Promise<WorkflowDefi
   const loadingEntry = Promise.resolve().then(() => loadingRegistryStorage.run(nextActiveLoads, async () => {
     const loaded = await entry()
     const registeredInlineDefinition = inlineRegistry.get(name)
-    if (registeredInlineDefinition) {
+    if (!loaded || typeof loaded !== "object") {
       return registeredInlineDefinition
     }
-    if (!loaded || typeof loaded !== "object") {
-      return undefined
-    }
     const definition = ("default" in loaded ? loaded.default : loaded) as WorkflowDefinition | undefined
-    return definition && typeof definition.handler === "function" ? definition : undefined
+    return definition && typeof definition.handler === "function" ? definition : registeredInlineDefinition
   }))
   loadingRegistryEntries.set(name, loadingEntry)
   try {

--- a/packages/workflow/src/runtime/state.ts
+++ b/packages/workflow/src/runtime/state.ts
@@ -56,6 +56,12 @@ export function getInlineWorkflowDefinitions(): ReadonlyMap<string, WorkflowDefi
   return inlineRegistry
 }
 
+export function takeInlineWorkflowDefinition(name: string): WorkflowDefinition | undefined {
+  const definition = inlineRegistry.get(name)
+  inlineRegistry.delete(name)
+  return definition
+}
+
 export function registerInlineWorkflowDefinition(name: string, definition: WorkflowDefinition): void {
   if (!name || typeof name !== "string") {
     throw new TypeError("`createWorkflow()` requires a workflow name.")

--- a/packages/workflow/src/runtime/state.ts
+++ b/packages/workflow/src/runtime/state.ts
@@ -9,6 +9,7 @@ let runtimeConfig: false | ResolvedWorkflowOptions | undefined
 let runtimeRegistry: WorkflowDefinitionRegistry | undefined
 const inlineRegistry = new Map<string, WorkflowDefinition>()
 const loadingRegistryEntries = new Map<string, Promise<WorkflowDefinition | undefined>>()
+const loadedRegistryEntries = new Map<string, WorkflowDefinition | undefined>()
 let fallbackEvent: unknown
 const eventStorage = new AsyncLocalStorage<unknown>()
 const loadingRegistryStorage = new AsyncLocalStorage<Set<string>>()
@@ -46,6 +47,7 @@ export function getWorkflowRuntimeConfig(): false | ResolvedWorkflowOptions | un
 
 export function setWorkflowRuntimeRegistry(registry: WorkflowDefinitionRegistry | undefined): void {
   runtimeRegistry = registry
+  loadedRegistryEntries.clear()
 }
 
 export function getWorkflowRuntimeRegistry(): WorkflowDefinitionRegistry | undefined {
@@ -95,11 +97,14 @@ export async function loadWorkflowDefinition(name: string): Promise<WorkflowDefi
   const inlineDefinition = inlineRegistry.get(name)
   const entry = runtimeRegistry?.[name]
 
-  if (inlineDefinition && entry) {
-    throw new Error(`Duplicate workflow name "${name}" from inline and discovered definitions.`)
+  if (entry && loadedRegistryEntries.has(name)) {
+    return loadedRegistryEntries.get(name)
   }
 
   if (inlineDefinition) {
+    if (entry) {
+      throw new Error(`Duplicate workflow name "${name}" from inline and discovered definitions.`)
+    }
     return inlineDefinition
   }
 
@@ -118,15 +123,20 @@ export async function loadWorkflowDefinition(name: string): Promise<WorkflowDefi
   const loadingEntry = Promise.resolve().then(() => loadingRegistryStorage.run(nextActiveLoads, async () => {
     const loaded = await entry()
     const registeredInlineDefinition = inlineRegistry.get(name)
-    if (!loaded || typeof loaded !== "object") {
+    if (registeredInlineDefinition) {
       return registeredInlineDefinition
     }
+    if (!loaded || typeof loaded !== "object") {
+      return undefined
+    }
     const definition = ("default" in loaded ? loaded.default : loaded) as WorkflowDefinition | undefined
-    return definition && typeof definition.handler === "function" ? definition : registeredInlineDefinition
+    return definition && typeof definition.handler === "function" ? definition : undefined
   }))
   loadingRegistryEntries.set(name, loadingEntry)
   try {
-    return await loadingEntry
+    const loaded = await loadingEntry
+    loadedRegistryEntries.set(name, loaded)
+    return loaded
   }
   finally {
     loadingRegistryEntries.delete(name)
@@ -167,6 +177,7 @@ export function resetWorkflowRuntime(): void {
   runtimeRegistry = undefined
   inlineRegistry.clear()
   loadingRegistryEntries.clear()
+  loadedRegistryEntries.clear()
   fallbackEvent = undefined
   runs.clear()
 }

--- a/packages/workflow/test/definition.test.ts
+++ b/packages/workflow/test/definition.test.ts
@@ -193,4 +193,23 @@ describe("workflow definitions", () => {
       }),
     ])
   })
+
+  it("prefers inline metadata over folder discovery for the same handler", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-workflow-inline-folder-"))
+    tempDirs.push(rootDir)
+    await mkdir(join(rootDir, "server", "workflows", "chat"), { recursive: true })
+    const file = join(rootDir, "server", "workflows", "chat", "index.ts")
+    await writeFile(file, [
+      `import { createWorkflow } from "@vitehub/workflow"`,
+      `export const chat = createWorkflow({ name: "server/workflows/chat", handler: async () => "ok" })`,
+    ].join("\n"), "utf8")
+
+    expect(discoverWorkflowDefinitions({ rootDir })).toEqual([
+      expect.objectContaining({
+        handler: file,
+        name: "server/workflows/chat",
+        source: "inline",
+      }),
+    ])
+  })
 })

--- a/packages/workflow/test/definition.test.ts
+++ b/packages/workflow/test/definition.test.ts
@@ -182,13 +182,13 @@ describe("workflow definitions", () => {
     const file = join(rootDir, "server", "chat.workflow.ts")
     await writeFile(file, [
       `import { createWorkflow } from "@vitehub/workflow"`,
-      `export const chat = createWorkflow({ name: "server/chat", handler: async () => "ok" })`,
+      `export const chat = createWorkflow({ name: "server/workflows/chat", handler: async () => "ok" })`,
     ].join("\n"), "utf8")
 
     expect(discoverWorkflowDefinitions({ rootDir })).toEqual([
       expect.objectContaining({
         handler: file,
-        name: "server/chat",
+        name: "server/workflows/chat",
         source: "inline",
       }),
     ])

--- a/packages/workflow/test/definition.test.ts
+++ b/packages/workflow/test/definition.test.ts
@@ -199,16 +199,19 @@ describe("workflow definitions", () => {
     tempDirs.push(rootDir)
     await mkdir(join(rootDir, "server", "workflows", "chat"), { recursive: true })
     const file = join(rootDir, "server", "workflows", "chat", "index.ts")
+    const step = join(rootDir, "server", "workflows", "chat", "01.reply.ts")
     await writeFile(file, [
       `import { createWorkflow } from "@vitehub/workflow"`,
       `export const chat = createWorkflow({ name: "server/workflows/chat", handler: async () => "ok" })`,
     ].join("\n"), "utf8")
+    await writeFile(step, "export default null\n", "utf8")
 
     expect(discoverWorkflowDefinitions({ rootDir })).toEqual([
       expect.objectContaining({
         handler: file,
         name: "server/workflows/chat",
         source: "inline",
+        steps: [step],
       }),
     ])
   })

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -6,7 +6,8 @@ import { resetOpenWorkflowRuntime, setOpenWorkflowImporter } from "../src/runtim
 import { createOpenWorkflowWorker } from "../src/runtime/openworkflow-worker.ts"
 import { runCloudflareWorkflow } from "../src/runtime/cloudflare-runner.ts"
 import { createWorkflow, deferWorkflow, getWorkflowRun, runWorkflow } from "../src/runtime/client.ts"
-import { enterWorkflowRuntimeEvent, resetWorkflowRuntime, setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry } from "../src/runtime/state.ts"
+import { createWorkflowSteps } from "../src/runtime/execute.ts"
+import { enterWorkflowRuntimeEvent, getInlineWorkflowDefinitions, resetWorkflowRuntime, setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry } from "../src/runtime/state.ts"
 
 const openWorkflowMock = vi.hoisted(() => {
   const runs = new Map<string, any>()
@@ -325,6 +326,41 @@ describe("workflow runtime", () => {
 
     expect(stepDo).toHaveBeenCalledTimes(2)
     expect(stepDo.mock.calls.map(call => call[0])).toEqual(["pipeline/01.first", "pipeline/02.second"])
+  })
+
+  it("runs inline folder workflows through generated step wrappers", async () => {
+    const stepDo = vi.fn(async (_name: string, _options: unknown, run: () => unknown) => await run())
+    const step = { do: stepDo } as WorkflowProviderStep
+
+    await expect(runCloudflareWorkflow({
+      config: { provider: "cloudflare" },
+      env: {},
+      event: { id: "run-1", payload: "start" },
+      name: "pipeline",
+      registry: {
+        pipeline: async () => {
+          createWorkflow("pipeline", async ({ payload, steps }) => await steps!.first(payload))
+          const definition = getInlineWorkflowDefinitions().get("pipeline")!
+          const steps = [{ name: "01.first.ts", run: async (input: unknown) => `${input}-step` }]
+          return {
+            ...definition,
+            options: { ...definition.options, rootStep: false },
+            handler: async context => await definition.handler({
+              ...context,
+              steps: createWorkflowSteps(context, steps),
+            }),
+          }
+        },
+      },
+      step,
+    })).resolves.toBe("start-step")
+
+    expect(stepDo).toHaveBeenCalledTimes(1)
+    expect(stepDo).toHaveBeenCalledWith(
+      "pipeline/01.first.ts",
+      { retries: { backoff: "exponential", delay: "10 seconds", limit: 3 } },
+      expect.any(Function),
+    )
   })
 
   it("runs registered definitions through the Vercel provider", async () => {

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -278,6 +278,29 @@ describe("workflow runtime", () => {
     await expect(runWorkflow("duplicate", {})).rejects.toThrow(/Duplicate workflow name "duplicate"/)
   })
 
+  it("prefers inline definitions registered while loading discovered entries", async () => {
+    const discovered = vi.fn(async () => "discovered")
+    const inline = vi.fn(async () => "inline")
+
+    setWorkflowRuntimeConfig({ provider: "vercel" })
+    setWorkflowRuntimeRegistry({
+      mixed: async () => {
+        createWorkflow("mixed", inline)
+        return { default: { handler: discovered } }
+      },
+    })
+
+    const firstRun = await runWorkflow("mixed", undefined, { id: "first" })
+    const secondRun = await runWorkflow("mixed", undefined, { id: "second" })
+
+    await vi.waitFor(async () => {
+      await expect(getWorkflowRun("mixed", firstRun.id)).resolves.toMatchObject({ result: "inline" })
+      await expect(getWorkflowRun("mixed", secondRun.id)).resolves.toMatchObject({ result: "inline" })
+    })
+    expect(inline).toHaveBeenCalledTimes(2)
+    expect(discovered).not.toHaveBeenCalled()
+  })
+
   it("wraps Cloudflare workflow handlers with provider steps", async () => {
     const stepDo = vi.fn(async (_name: string, _options: unknown, run: () => unknown) => await run())
     const step = { do: stepDo } as WorkflowProviderStep
@@ -340,7 +363,7 @@ describe("workflow runtime", () => {
       registry: {
         pipeline: async () => {
           createWorkflow("pipeline", async ({ payload, steps }) => await steps!.first(payload))
-          const definition = getInlineWorkflowDefinitions().get("pipeline")!
+          const definition = takeInlineWorkflowDefinition("pipeline")!
           const steps = [{ name: "01.first.ts", run: async (input: unknown) => `${input}-step` }]
           return {
             ...definition,

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -7,7 +7,7 @@ import { createOpenWorkflowWorker } from "../src/runtime/openworkflow-worker.ts"
 import { runCloudflareWorkflow } from "../src/runtime/cloudflare-runner.ts"
 import { createWorkflow, deferWorkflow, getWorkflowRun, runWorkflow } from "../src/runtime/client.ts"
 import { createWorkflowSteps } from "../src/runtime/execute.ts"
-import { enterWorkflowRuntimeEvent, getInlineWorkflowDefinitions, resetWorkflowRuntime, setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry } from "../src/runtime/state.ts"
+import { enterWorkflowRuntimeEvent, getInlineWorkflowDefinitions, resetWorkflowRuntime, setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry, takeInlineWorkflowDefinition } from "../src/runtime/state.ts"
 
 const openWorkflowMock = vi.hoisted(() => {
   const runs = new Map<string, any>()
@@ -475,6 +475,32 @@ describe("workflow runtime", () => {
     await createOpenWorkflowWorker()
 
     expect(openWorkflowMock.definitions.has("inline-worker")).toBe(true)
+  })
+
+  it("registers wrapped inline folder workflows in OpenWorkflow workers", async () => {
+    setWorkflowRuntimeConfig({
+      postgres: { url: "postgres://localhost/vitehub" },
+      provider: "openworkflow",
+    })
+    setWorkflowRuntimeRegistry({
+      pipeline: async () => {
+        createWorkflow("pipeline", async ({ payload, steps }) => await steps!.first(payload))
+        const definition = takeInlineWorkflowDefinition("pipeline")!
+        const steps = [{ name: "01.first.ts", run: async (input: unknown) => `${input}-step` }]
+        return {
+          ...definition,
+          options: { ...definition.options, rootStep: false },
+          handler: async context => await definition.handler({
+            ...context,
+            steps: createWorkflowSteps(context, steps),
+          }),
+        }
+      },
+    })
+
+    await createOpenWorkflowWorker()
+
+    expect(openWorkflowMock.definitions.has("pipeline")).toBe(true)
   })
 
   it("rejects duplicate inline and discovered OpenWorkflow worker definitions", async () => {


### PR DESCRIPTION
Extracts the workflow discovery precedence fix from #113.

When a workflow file declares inline metadata with `createWorkflow`, discovery now treats that inline definition as authoritative for that handler file. Suffix and flat Nitro discovery skip the same normalized handler path, preventing one file from appearing as two workflow definitions when the inline name differs from the inferred path name.