### PR TITLE
feat(agent): add capability runtime core

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -26,6 +26,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./ai-sdk": "./dist/ai-sdk.js",
+    "./capability-runtime": "./dist/capability-runtime.js",
     "./cloudflare": "./dist/cloudflare.js",
     "./nitro": "./dist/nitro.js",
     "./runtime/empty-registry": "./dist/runtime/empty-registry.js",

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1,5 +1,9 @@
 import { getMessageText } from "@vitehub/messages"
 import {
+  applyCapabilityInstructionSlots,
+  applyCapabilityToolTransforms,
+} from "./capability-runtime.ts"
+import {
   applyAgentToolPolicies,
   withAgentToolStepReporting,
 } from "./tool-runtime.ts"
@@ -348,12 +352,14 @@ async function createAgent(options: AiSdkAdapterOptions, context: AgentAdapterRu
   const instrumentedModel = options.instrumentModel
     ? await options.instrumentModel({ ...context.runtime, model, run: context.runtime.run })
     : model
-  const instructions = context.instructions ?? await resolveInstructions(options, metadataContext)
+  const instructions = context.instructions
+    ?? applyCapabilityInstructionSlots(await resolveInstructions(options, metadataContext), context.capabilityInstructions)
   const adapterTools = await resolveTools(options, metadataContext, context.devtools?.reportToolStep)
-  const tools = {
+  const tools = await applyCapabilityToolTransforms({
     ...(context.tools || {}),
     ...(adapterTools || {}),
-  }
+  }, [])
+  const toolSet = tools || {}
   const {
     fallback: _fallback,
     instructions: _instructions,
@@ -372,10 +378,10 @@ async function createAgent(options: AiSdkAdapterOptions, context: AgentAdapterRu
       instructions,
       model: instrumentedModel as never,
       stopWhen: ((settings as Record<string, unknown>).stopWhen ?? stepCountIs(stepLimit ?? 20)) as never,
-      ...(Object.keys(tools).length ? { tools: tools as never } : {}),
+      ...(Object.keys(toolSet).length ? { tools: toolSet as never } : {}),
     }),
     model: instrumentedModel,
-    tools: Object.keys(tools).length ? tools : undefined,
+    tools: Object.keys(toolSet).length ? toolSet : undefined,
   }
 }
 

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -158,6 +158,7 @@ export async function resolveAgentCapabilities<
   runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput,
   workspace?: ReadonlyWorkspaceFacade<Name>,
+  workspaceMode: AgentCapabilityMode = "read",
 ): Promise<ResolvedAgentCapabilities> {
   const capabilities = normalizeCapabilities(options?.capabilities as AgentCapabilityDefinition[] | undefined) as AgentCapabilityDefinition<TRuntimeConfig, Name>[]
   let currentInput = input
@@ -187,7 +188,7 @@ export async function resolveAgentCapabilities<
 
   try {
     for (const capability of capabilities) {
-      await validateCapabilityRuntimeRequirement(capability as AgentCapabilityDefinition, workspace)
+      await validateCapabilityRuntimeRequirement(capability as AgentCapabilityDefinition, workspace, workspaceMode)
       const capabilityContext: AgentCapabilityRuntimeContext<TRuntimeConfig, Name> = {
         ...runtime,
         capability,
@@ -287,6 +288,7 @@ function isToolSet(value: unknown): value is AgentToolSet {
 export async function validateCapabilityRuntimeRequirement<Name extends WorkspaceName>(
   capability: AgentCapabilityDefinition,
   workspace?: ReadonlyWorkspaceFacade<Name>,
+  workspaceMode: AgentCapabilityMode = "read",
 ): Promise<void> {
   for (const requirement of capability.requires || []) {
     if (!requirement.workspace) continue
@@ -294,6 +296,9 @@ export async function validateCapabilityRuntimeRequirement<Name extends Workspac
       throw new Error(`[vitehub] ${capability.id}() requires an explicit workspace.`)
     }
     if (!workspace) continue
+    if (requirement.workspace.mode === "write" && workspaceMode !== "write") {
+      throw new Error(`[vitehub] ${capability.id}() requires workspace.mode: "write".`)
+    }
     for (const path of requirement.workspace.paths || []) {
       if (!await workspace.fs.exists(path as never)) {
         throw new Error(`[vitehub] ${capability.id}() requires workspace path ${path}.`)
@@ -398,9 +403,36 @@ export function withResponseCleanup(response: Response, close: () => Promise<voi
   if (!response.body) {
     return close().then(() => response)
   }
-  return new Response(response.body.pipeThrough(new TransformStream({
-    async flush() {
-      await close()
+  const reader = response.body.getReader()
+  let closed = false
+  async function closeOnce() {
+    if (closed) return
+    closed = true
+    await close()
+  }
+  return new Response(new ReadableStream({
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason)
+      }
+      finally {
+        await closeOnce()
+      }
     },
-  })), response)
+    async pull(controller) {
+      try {
+        const result = await reader.read()
+        if (result.done) {
+          controller.close()
+          await closeOnce()
+          return
+        }
+        controller.enqueue(result.value)
+      }
+      catch (error) {
+        await closeOnce()
+        throw error
+      }
+    },
+  }), response)
 }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -369,7 +369,10 @@ export async function applyCapabilityToolTransforms(
   return current
 }
 
-export async function applyOutputRenderers(result: unknown, renderers: ResolvedAgentOutputRenderer[] = []) {
+export async function applyOutputRenderers(
+  result: unknown,
+  renderers: ResolvedAgentOutputRenderer[] = [],
+): Promise<unknown> {
   let current = result
   for (const renderer of renderers) {
     current = await renderer(current)

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1,0 +1,403 @@
+import { resolveRuntimeValue } from "@vitehub/runtime"
+
+import type {
+  AgentAdapterInstructionsValue,
+  AgentCapabilityDefinition,
+  AgentCapabilityHookName,
+  AgentCapabilityHooks,
+  AgentCapabilityMode,
+  AgentCapabilityRuntimeContext,
+  AgentInstructionBlock,
+  AgentOutputRenderer,
+  AgentRunInput,
+  AgentRuntimeConfig,
+  AgentToolSet,
+  AgentToolTransform,
+  MaybePromise,
+  ResolvedAgentRuntimeContext,
+} from "./types.ts"
+import type { Message } from "@vitehub/messages"
+import type { ReadonlyWorkspaceFacade, WorkspaceName } from "@vitehub/workspace"
+
+type ResolvedAgentOutputRenderer = (result: unknown) => MaybePromise<unknown>
+
+export interface AgentCapabilityRegistries {
+  outputRenderers: ResolvedAgentOutputRenderer[]
+  stateRequirements: Array<{ name: string, optional?: boolean }>
+}
+
+export interface AgentCapabilityOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> {
+  capabilities?: AgentCapabilityDefinition<TRuntimeConfig, Name>[]
+  hooks?: AgentCapabilityHooks<TRuntimeConfig, Name>
+}
+
+export interface ResolvedAgentCapabilities {
+  capabilityInstructions: AgentInstructionBlock[]
+  close: () => Promise<void>
+  hasCloseCallbacks: boolean
+  input: AgentRunInput
+  messages: Message[]
+  registries: AgentCapabilityRegistries
+  toolTransforms: AgentToolTransform[]
+  tools?: AgentToolSet
+}
+
+function assertCapabilityId(id: unknown): asserts id is string {
+  if (typeof id !== "string" || !id.trim()) {
+    throw new TypeError("[vitehub] Capability definitions require a non-empty string id.")
+  }
+  if (!/^[a-z][a-z0-9-_.]*$/i.test(id)) {
+    throw new TypeError(`[vitehub] Capability id "${id}" must be a stable identifier.`)
+  }
+}
+
+export function defineCapability<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+>(
+  capability: AgentCapabilityDefinition<TRuntimeConfig, Name>,
+): AgentCapabilityDefinition<TRuntimeConfig, Name> {
+  if (!capability || typeof capability !== "object") {
+    throw new TypeError("[vitehub] defineCapability() requires a capability definition.")
+  }
+  assertCapabilityId((capability as { id?: unknown }).id)
+  return capability
+}
+
+export function normalizeMode(value: unknown, label: string): AgentCapabilityMode {
+  if (value === undefined) return "read"
+  if (value === "read" || value === "write") return value
+  throw new TypeError(`[vitehub] ${label} mode must be "read" or "write".`)
+}
+
+export function normalizeCapabilities(
+  capabilities: AgentCapabilityDefinition[] | undefined,
+): AgentCapabilityDefinition[] {
+  if (capabilities === undefined) return []
+  if (!Array.isArray(capabilities)) {
+    throw new TypeError("[vitehub] defineAgent({ capabilities }) must be an ordered array.")
+  }
+  const seen = new Set<string>()
+  return capabilities.map((capability) => {
+    const normalized = defineCapability(capability)
+    if (seen.has(normalized.id)) {
+      throw new Error(`[vitehub] Duplicate capability id "${normalized.id}" in one agent.`)
+    }
+    seen.add(normalized.id)
+    return normalized
+  })
+}
+
+function getRunMessages(input: AgentRunInput): Message[] {
+  if (input.messages) return input.messages
+  if (Array.isArray(input.prompt)) return input.prompt
+  return []
+}
+
+function withMessages(input: AgentRunInput, messages: Message[]): AgentRunInput {
+  if (input.messages) return { ...input, messages }
+  if (Array.isArray(input.prompt)) return { ...input, prompt: messages }
+  return { ...input, messages }
+}
+
+async function callHooks<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  name: AgentCapabilityHookName,
+  context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
+  agentHooks?: AgentCapabilityHooks<TRuntimeConfig, Name>,
+) {
+  await context.capability.hooks?.[name]?.(context)
+  await agentHooks?.[name]?.(context)
+}
+
+function addInstructionBlock(
+  capabilityInstructions: AgentInstructionBlock[],
+  capabilityId: string,
+  value: AgentAdapterInstructionsValue | false | undefined,
+  options?: { id?: string },
+) {
+  if (value === false || value === undefined) return
+  const instructions = (Array.isArray(value) ? value : [value])
+    .map(part => part.trim())
+    .filter(Boolean)
+    .join("\n\n")
+  if (instructions) {
+    capabilityInstructions.push({
+      id: options?.id || capabilityId,
+      instructions,
+    })
+  }
+}
+
+async function resolveInstructionValue<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  capability: AgentCapabilityDefinition<TRuntimeConfig, Name>,
+  context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
+) {
+  const parts = Array.isArray(capability.instructions)
+    ? capability.instructions
+    : [capability.instructions]
+  const values = await Promise.all(parts.map(part => typeof part === "function"
+    ? (part as (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<AgentAdapterInstructionsValue | false | undefined>)(context)
+    : part))
+  return values.flatMap(value => Array.isArray(value) ? value : [value])
+}
+
+export async function resolveAgentCapabilities<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: AgentCapabilityOptions<TRuntimeConfig, Name> | undefined,
+  runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>,
+  input: AgentRunInput,
+  workspace?: ReadonlyWorkspaceFacade<Name>,
+): Promise<ResolvedAgentCapabilities> {
+  const capabilities = normalizeCapabilities(options?.capabilities as AgentCapabilityDefinition[] | undefined) as AgentCapabilityDefinition<TRuntimeConfig, Name>[]
+  let currentInput = input
+  let messages = getRunMessages(currentInput)
+  let tools: AgentToolSet | undefined
+  const capabilityInstructions: AgentInstructionBlock[] = []
+  const closeCallbacks: Array<() => MaybePromise<void>> = []
+  const toolTransforms: AgentToolTransform[] = []
+  const registries: AgentCapabilityRegistries = {
+    outputRenderers: [],
+    stateRequirements: [],
+  }
+
+  async function closeRegisteredCallbacks() {
+    const errors: unknown[] = []
+    for (const callback of [...closeCallbacks].reverse()) {
+      try {
+        await callback()
+      }
+      catch (error) {
+        errors.push(error)
+      }
+    }
+    if (errors.length === 1) throw errors[0]
+    if (errors.length > 1) throw new AggregateError(errors, "[vitehub] Multiple capability close callbacks failed.")
+  }
+
+  try {
+    for (const capability of capabilities) {
+      await validateCapabilityRuntimeRequirement(capability as AgentCapabilityDefinition, workspace)
+      const capabilityContext: AgentCapabilityRuntimeContext<TRuntimeConfig, Name> = {
+        ...runtime,
+        capability,
+        fs: workspace?.fs,
+        mode: capability.mode,
+        instructions: {
+          add(value, options) {
+            addInstructionBlock(capabilityInstructions, capability.id, value, options)
+          },
+        },
+        input: {
+          get: () => currentInput,
+          messages: () => messages,
+          set(value) {
+            currentInput = value
+            messages = getRunMessages(currentInput)
+          },
+          setMessages(value) {
+            messages = value
+            currentInput = withMessages(currentInput, messages)
+          },
+        },
+        output: {
+          render(renderer: AgentOutputRenderer) {
+            registries.outputRenderers.push(result => renderer(result, capabilityContext))
+          },
+        },
+        state: {
+          require(name, options) {
+            if (!registries.stateRequirements.some(requirement => requirement.name === name)) {
+              registries.stateRequirements.push({ name, optional: options?.optional })
+            }
+          },
+        },
+        tools: {
+          add(value) {
+            if (!value) return
+            tools = { ...(tools || {}), ...value }
+          },
+          transform(transform) {
+            toolTransforms.push(transform)
+          },
+        },
+        workspace,
+      } as AgentCapabilityRuntimeContext<TRuntimeConfig, Name>
+
+      closeCallbacks.push(async () => {
+        await callHooks("capability:close", capabilityContext, options?.hooks)
+        await capability.close?.(capabilityContext)
+        await callHooks("capability:close:after", capabilityContext, options?.hooks)
+      })
+
+      for (const phase of ["configure", "prepare", "bind", "input", "resolve", "output"] as const) {
+        await callHooks(`capability:${phase}`, capabilityContext, options?.hooks)
+        await capability[phase]?.(capabilityContext)
+        await callHooks(`capability:${phase}:after`, capabilityContext, options?.hooks)
+      }
+
+      if (capability.instructions !== undefined) {
+        const values = await resolveInstructionValue(capability, capabilityContext)
+        for (const value of values) {
+          addInstructionBlock(capabilityInstructions, capability.id, value)
+        }
+      }
+      if (capability.tools) {
+        const resolved = await resolveRuntimeValue(capability.tools as never, capabilityContext) as unknown
+        if (isToolSet(resolved)) tools = { ...(tools || {}), ...resolved }
+      }
+    }
+  }
+  catch (error) {
+    try {
+      await closeRegisteredCallbacks()
+    }
+    catch (closeError) {
+      throw new AggregateError([error, closeError], "[vitehub] Capability setup failed and cleanup also failed.")
+    }
+    throw error
+  }
+
+  return {
+    capabilityInstructions,
+    close: closeRegisteredCallbacks,
+    hasCloseCallbacks: closeCallbacks.length > 0,
+    input: currentInput,
+    messages,
+    registries,
+    toolTransforms,
+    tools,
+  }
+}
+
+function isToolSet(value: unknown): value is AgentToolSet {
+  return typeof value === "object" && value !== null
+}
+
+export async function validateCapabilityRuntimeRequirement<Name extends WorkspaceName>(
+  capability: AgentCapabilityDefinition,
+  workspace?: ReadonlyWorkspaceFacade<Name>,
+): Promise<void> {
+  for (const requirement of capability.requires || []) {
+    if (!requirement.workspace) continue
+    if (requirement.workspace.required && !workspace) {
+      throw new Error(`[vitehub] ${capability.id}() requires an explicit workspace.`)
+    }
+    if (!workspace) continue
+    for (const path of requirement.workspace.paths || []) {
+      if (!await workspace.fs.exists(path as never)) {
+        throw new Error(`[vitehub] ${capability.id}() requires workspace path ${path}.`)
+      }
+    }
+  }
+}
+
+function levenshtein(left: string, right: string) {
+  const costs = Array.from({ length: right.length + 1 }, (_, index) => index)
+  for (let i = 1; i <= left.length; i++) {
+    let prev = i
+    for (let j = 1; j <= right.length; j++) {
+      const next = left[i - 1] === right[j - 1]
+        ? costs[j - 1]
+        : Math.min(costs[j - 1], prev, costs[j]) + 1
+      costs[j - 1] = prev
+      prev = next
+    }
+    costs[right.length] = prev
+  }
+  return costs[right.length]
+}
+
+function suggestSlot(slot: string, ids: string[]) {
+  const matches = ids
+    .map(id => ({ distance: levenshtein(slot, id), id }))
+    .filter(match => match.distance <= Math.max(2, Math.floor(slot.length / 2)))
+    .sort((left, right) => left.distance - right.distance)
+    .slice(0, 3)
+    .map(match => match.id)
+  return matches.length ? ` Did you mean ${matches.map(id => `{{ ${id} }}`).join(", ")}?` : ""
+}
+
+export function applyCapabilityInstructionSlots(instructions: string, blocks: AgentInstructionBlock[] = []): string {
+  if (!blocks.length) return instructions
+
+  const remaining = [...blocks]
+  const known = new Set(blocks.map(block => block.id))
+  const used = new Set<string>()
+  const slotPattern = /\{\{\s*([a-zA-Z][\w.-]*)\s*\}\}/g
+  const rendered = instructions.replace(slotPattern, (match, slot: string) => {
+    if (slot === "capabilities") {
+      return remaining.splice(0).map(block => block.instructions).join("\n\n")
+    }
+    if (!known.has(slot)) {
+      throw new Error(`[vitehub] Unknown capability instruction slot "${slot}".${suggestSlot(slot, ["capabilities", ...known])}`)
+    }
+    if (used.has(slot)) {
+      throw new Error(`[vitehub] Duplicate capability instruction slot "${slot}". Use {{ capabilities }} for repeated catch-all insertion.`)
+    }
+    used.add(slot)
+    const selected = remaining.filter(block => block.id === slot)
+    for (const block of selected) {
+      const index = remaining.indexOf(block)
+      if (index >= 0) remaining.splice(index, 1)
+    }
+    return selected.map(block => block.instructions).join("\n\n")
+  })
+
+  const appendix = remaining.map(block => block.instructions).join("\n\n")
+  return [rendered.trim(), appendix.trim()].filter(Boolean).join("\n\n")
+}
+
+export async function applyCapabilityToolTransforms(
+  tools: AgentToolSet | undefined,
+  transforms: AgentToolTransform[] = [],
+): Promise<AgentToolSet | undefined> {
+  let current = tools
+  for (const transform of transforms) {
+    current = await transform(current)
+  }
+  return current
+}
+
+export async function applyOutputRenderers(result: unknown, renderers: ResolvedAgentOutputRenderer[] = []) {
+  let current = result
+  for (const renderer of renderers) {
+    current = await renderer(current)
+  }
+  return current
+}
+
+export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(
+  stream: T,
+  close: () => Promise<void>,
+): AsyncIterable<unknown> {
+  return (async function* () {
+    try {
+      yield* stream
+    }
+    finally {
+      await close()
+    }
+  })()
+}
+
+export function withResponseCleanup(response: Response, close: () => Promise<void>): Response | Promise<Response> {
+  if (!response.body) {
+    return close().then(() => response)
+  }
+  return new Response(response.body.pipeThrough(new TransformStream({
+    async flush() {
+      await close()
+    },
+  })), response)
+}

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -2,6 +2,7 @@ import { resolveRuntimeValue } from "@vitehub/runtime"
 
 import type {
   AgentAdapterInstructionsValue,
+  AgentCapabilityContext,
   AgentCapabilityDefinition,
   AgentCapabilityHookName,
   AgentCapabilityHooks,
@@ -41,6 +42,11 @@ export interface ResolvedAgentCapabilities {
   input: AgentRunInput
   messages: Message[]
   registries: AgentCapabilityRegistries
+  toolTransforms: AgentToolTransform[]
+  tools?: AgentToolSet
+}
+
+export interface ResolvedAgentStaticCapabilities {
   toolTransforms: AgentToolTransform[]
   tools?: AgentToolSet
 }
@@ -226,7 +232,7 @@ export async function resolveAgentCapabilities<
         tools: {
           add(value) {
             if (!value) return
-            tools = { ...(tools || {}), ...value }
+            tools = { ...tools, ...value }
           },
           transform(transform) {
             toolTransforms.push(transform)
@@ -255,7 +261,7 @@ export async function resolveAgentCapabilities<
       }
       if (capability.tools) {
         const resolved = await resolveRuntimeValue(capability.tools as never, capabilityContext) as unknown
-        if (isToolSet(resolved)) tools = { ...(tools || {}), ...resolved }
+        if (isToolSet(resolved)) tools = { ...tools, ...resolved }
       }
     }
   }
@@ -276,6 +282,39 @@ export async function resolveAgentCapabilities<
     input: currentInput,
     messages,
     registries,
+    toolTransforms,
+    tools,
+  }
+}
+
+export async function resolveAgentStaticCapabilities<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: AgentCapabilityOptions<TRuntimeConfig, Name> | undefined,
+  runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>,
+  workspace?: ReadonlyWorkspaceFacade<Name>,
+  workspaceMode: AgentCapabilityMode = "read",
+): Promise<ResolvedAgentStaticCapabilities> {
+  const capabilities = normalizeCapabilities(options?.capabilities as AgentCapabilityDefinition[] | undefined) as AgentCapabilityDefinition<TRuntimeConfig, Name>[]
+  let tools: AgentToolSet | undefined
+  const toolTransforms: AgentToolTransform[] = []
+
+  for (const capability of capabilities) {
+    await validateCapabilityRuntimeRequirement(capability as AgentCapabilityDefinition, workspace, workspaceMode)
+    if (!capability.tools) continue
+
+    const capabilityContext = {
+      ...runtime,
+      fs: workspace?.fs,
+      mode: capability.mode,
+      workspace,
+    } as unknown as AgentCapabilityContext<TRuntimeConfig, Name>
+    const resolved = await resolveRuntimeValue(capability.tools as never, capabilityContext as never) as unknown
+    if (isToolSet(resolved)) tools = { ...tools, ...resolved }
+  }
+
+  return {
     toolTransforms,
     tools,
   }
@@ -307,32 +346,6 @@ export async function validateCapabilityRuntimeRequirement<Name extends Workspac
   }
 }
 
-function levenshtein(left: string, right: string) {
-  const costs = Array.from({ length: right.length + 1 }, (_, index) => index)
-  for (let i = 1; i <= left.length; i++) {
-    let prev = i
-    for (let j = 1; j <= right.length; j++) {
-      const next = left[i - 1] === right[j - 1]
-        ? costs[j - 1]
-        : Math.min(costs[j - 1], prev, costs[j]) + 1
-      costs[j - 1] = prev
-      prev = next
-    }
-    costs[right.length] = prev
-  }
-  return costs[right.length]
-}
-
-function suggestSlot(slot: string, ids: string[]) {
-  const matches = ids
-    .map(id => ({ distance: levenshtein(slot, id), id }))
-    .filter(match => match.distance <= Math.max(2, Math.floor(slot.length / 2)))
-    .sort((left, right) => left.distance - right.distance)
-    .slice(0, 3)
-    .map(match => match.id)
-  return matches.length ? ` Did you mean ${matches.map(id => `{{ ${id} }}`).join(", ")}?` : ""
-}
-
 export function applyCapabilityInstructionSlots(instructions: string, blocks: AgentInstructionBlock[] = []): string {
   if (!blocks.length) return instructions
 
@@ -345,7 +358,7 @@ export function applyCapabilityInstructionSlots(instructions: string, blocks: Ag
       return remaining.splice(0).map(block => block.instructions).join("\n\n")
     }
     if (!known.has(slot)) {
-      throw new Error(`[vitehub] Unknown capability instruction slot "${slot}".${suggestSlot(slot, ["capabilities", ...known])}`)
+      return match
     }
     if (used.has(slot)) {
       throw new Error(`[vitehub] Duplicate capability instruction slot "${slot}". Use {{ capabilities }} for repeated catch-all insertion.`)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1346,6 +1346,7 @@ export async function runAgent<
 ): Promise<Response | AgentRunResult | unknown> {
   if (hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)) {
     const runContext = await createRunContext(agent, context, input)
+    runContext.close = once(runContext.close)
     try {
       const result = await agent.run(runContext)
       if (result instanceof Response) return runContext.hasCapabilityCleanup ? await withResponseCleanup(result, runContext.close) : result
@@ -1398,6 +1399,7 @@ export async function streamAgent<
 ): Promise<Response | AsyncIterable<StreamEvent> | unknown> {
   if (hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)) {
     const runContext = await createRunContext(agent, context, input)
+    runContext.close = once(runContext.close)
     try {
       const result = await agent.run(runContext)
       if (result instanceof Response) return runContext.hasCapabilityCleanup ? await withResponseCleanup(result, runContext.close) : result

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,6 +6,16 @@ import {
   resolveRuntimeValue,
 } from "@vitehub/runtime"
 
+import {
+  applyCapabilityToolTransforms,
+  applyOutputRenderers,
+  defineCapability,
+  normalizeCapabilities,
+  normalizeMode,
+  resolveAgentCapabilities,
+  withCapabilityCleanup,
+  withResponseCleanup,
+} from "./capability-runtime.ts"
 import { formatUnknownAgentMessage } from "./registry-error.ts"
 import {
   applyAgentToolPolicies,
@@ -54,8 +64,6 @@ import type {
   WorkspaceName,
 } from "@vitehub/workspace"
 
-type AgentToolStepReporter = NonNullable<AgentRuntimeContext["devtools"]>["reportToolStep"]
-
 export type {
   AgentAdapter,
   AgentAdapterFactory,
@@ -70,8 +78,12 @@ export type {
   AgentCapabilityHandle,
   AgentCapabilityContext,
   AgentCapabilityDefinition,
+  AgentCapabilityHookName,
+  AgentCapabilityHooks,
   AgentCapabilityInput,
   AgentCapabilityMode,
+  AgentCapabilityPhase,
+  AgentCapabilityRuntimeContext,
   AgentChatAgentHookArgs,
   AgentChatAgentHooks,
   AgentChatEventHookArgs,
@@ -82,6 +94,7 @@ export type {
   AgentExecution,
   AgentHandlerOptions,
   AgentInput,
+  AgentInstructionBlock,
   AgentIntegrationOption,
   AgentIntegrationsOptions,
   AgentModelInput,
@@ -111,6 +124,7 @@ export type {
   AgentSchedulerProviderOptions,
   AgentSettings,
   AgentToolDefinition,
+  AgentToolTransform,
   AgentToolPolicyContext,
   AgentToolPolicyDecision,
   AgentStateProviderOptions,
@@ -211,51 +225,7 @@ function createResolvedRuntimeContext<TRuntimeConfig extends AgentRuntimeConfig>
 }
 
 export { applyAgentToolPolicies, withAgentToolStepReporting } from "./tool-runtime.ts"
-
-function assertCapabilityId(id: unknown): asserts id is string {
-  if (typeof id !== "string" || !id.trim()) {
-    throw new TypeError("[vitehub] Capability definitions require a non-empty string id.")
-  }
-}
-
-export function defineCapability<
-  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  Name extends WorkspaceName = WorkspaceName,
->(
-  capability: AgentCapabilityInput<TRuntimeConfig, Name>,
-): AgentCapabilityDefinition<TRuntimeConfig, Name> {
-  if (!capability || typeof capability !== "object") {
-    throw new TypeError("[vitehub] defineCapability() requires a capability definition.")
-  }
-  assertCapabilityId((capability as { id?: unknown }).id)
-  return capability as AgentCapabilityDefinition<TRuntimeConfig, Name>
-}
-
-function normalizeMode(value: unknown, label: string): AgentCapabilityMode {
-  if (value === undefined) return "read"
-  if (value === "read" || value === "write") return value
-  throw new TypeError(`[vitehub] ${label} mode must be "read" or "write".`)
-}
-
-function normalizeCapabilities(capabilities: AgentCapabilitiesList | undefined): NormalizedCapability[] {
-  if (capabilities === undefined) return []
-  if (!Array.isArray(capabilities)) {
-    throw new TypeError("[vitehub] defineAgent({ capabilities }) must be an ordered array.")
-  }
-  const seen = new Set<string>()
-  return capabilities.map((capability) => {
-    const normalized = defineCapability(capability) as NormalizedCapability
-    if (seen.has(normalized.id)) {
-      throw new Error(`[vitehub] Duplicate capability id "${normalized.id}" in one agent.`)
-    }
-    seen.add(normalized.id)
-    return normalized
-  })
-}
-
-function isToolSet(value: unknown): value is AgentToolSet {
-  return typeof value === "object" && value !== null
-}
+export { defineCapability } from "./capability-runtime.ts"
 
 function primitiveHandle(context: AgentCapabilityContext, name: string): unknown {
   const handle = context.capabilities?.[name] as { value?: unknown } | unknown
@@ -531,8 +501,14 @@ function defineBaseAgent<
       const adapterInstance = typeof resolvedAdapter === "function"
         ? await (resolvedAdapter as AgentAdapterFactory<TRuntimeConfig, CALL_OPTIONS>)(resolvedContext)
         : resolvedAdapter
-      const capabilityTools = normalizedCapabilities.length && !workspace
-        ? await resolveCapabilityToolsFromList(normalizedCapabilities, resolvedContext, undefined, context.devtools?.reportToolStep)
+      const resolvedCapabilities = normalizedCapabilities.length && !workspace
+        ? await resolveAgentCapabilities({ capabilities: normalizedCapabilities }, resolvedContext, {})
+        : undefined
+      const transformedTools = resolvedCapabilities
+        ? await applyCapabilityToolTransforms(resolvedCapabilities.tools, resolvedCapabilities.toolTransforms)
+        : undefined
+      const capabilityTools = Object.keys(transformedTools || {}).length
+        ? withAgentToolStepReporting(applyAgentToolPolicies(transformedTools) || {}, context.devtools?.reportToolStep)
         : undefined
       return capabilityTools
         ? { ...adapterInstance, tools: capabilityTools }
@@ -979,69 +955,6 @@ async function resolveWorkspaceMetadataInstructions<
     .filter((part): part is string => Boolean(part))
 }
 
-async function resolveCapabilityTools<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  Name extends WorkspaceName,
->(
-  options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
-  runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>,
-  workspace: ReadonlyWorkspaceFacade<Name>,
-  reportToolStep?: AgentToolStepReporter,
-): Promise<AgentToolSet | undefined> {
-  const capabilities = normalizeCapabilities(options.capabilities as AgentCapabilitiesList | undefined)
-  return await resolveCapabilityToolsFromList(capabilities, runtime, workspace, reportToolStep)
-}
-
-async function resolveCapabilityToolsFromList<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  Name extends WorkspaceName = WorkspaceName,
->(
-  capabilities: NormalizedCapability[],
-  runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>,
-  workspace?: ReadonlyWorkspaceFacade<Name>,
-  reportToolStep?: AgentToolStepReporter,
-): Promise<AgentToolSet | undefined> {
-  if (!capabilities.length) return undefined
-
-  const tools: AgentToolSet = {}
-  for (const capability of capabilities) {
-    await validateCapabilityRuntimeRequirement(capability, workspace)
-    if (!capability.tools) continue
-    const context = {
-      ...runtime,
-      fs: workspace?.fs,
-      mode: capability.mode,
-      workspace,
-    } as unknown as AgentCapabilityContext<TRuntimeConfig, Name>
-    const resolved = typeof capability.tools === "function"
-      ? await capability.tools(context)
-      : capability.tools
-    if (isToolSet(resolved)) Object.assign(tools, resolved as AgentToolSet)
-  }
-
-  return Object.keys(tools).length
-    ? withAgentToolStepReporting(applyAgentToolPolicies(tools) || {}, reportToolStep)
-    : undefined
-}
-
-async function validateCapabilityRuntimeRequirement<Name extends WorkspaceName>(
-  capability: NormalizedCapability,
-  workspace?: ReadonlyWorkspaceFacade<Name>,
-): Promise<void> {
-  for (const requirement of capability.requires || []) {
-    if (!requirement.workspace) continue
-    if (requirement.workspace.required && !workspace) {
-      throw new Error(`[vitehub] ${capability.id}() requires an explicit workspace.`)
-    }
-    if (!workspace) continue
-    for (const path of requirement.workspace.paths || []) {
-      if (!await workspace.fs.exists(path as never)) {
-        throw new Error(`[vitehub] ${capability.id}() requires workspace path ${path}.`)
-      }
-    }
-  }
-}
-
 export function createAgentDevtoolsMetadata<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
@@ -1291,19 +1204,50 @@ async function* streamTextResultToEvents(value: unknown): AsyncIterable<StreamEv
   }
 }
 
-function createRunContext<
+async function createRunContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(
   definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS>,
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
-): AgentRunContext<TRuntimeConfig, CALL_OPTIONS> {
+): Promise<AgentRunContext<TRuntimeConfig, CALL_OPTIONS> & {
+  close: () => Promise<void>
+  hasCapabilityCleanup: boolean
+  outputRenderers: Array<(result: unknown) => MaybePromise<unknown>>
+}> {
   const resolvedContext = createResolvedRuntimeContext(context)
+  const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig>> | undefined
+  const workspaceOptions = workspaceDefinition?.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<AgentRuntimeConfig> | undefined
+  const workspaceName = workspaceOptions
+    ? workspaceNameFromOptions(workspaceOptions, workspaceDefinition?.__vitehubWorkspaceAgentDefaults)
+    : undefined
+  const workspaceMode = workspaceOptions ? workspaceModeFromOptions(workspaceOptions) : "read"
+  const workspace = workspaceName
+    ? workspaceMode === "write"
+      ? (await import("@vitehub/workspace")).useWorkspace(workspaceName, { allowWrite: true })
+      : (await import("@vitehub/workspace")).useWorkspace(workspaceName)
+    : undefined
+  const capabilityOptions = workspaceOptions
+    ? { capabilities: workspaceOptions.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: workspaceOptions.hooks as never }
+    : definition.capabilities?.length
+      ? { capabilities: definition.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: definition.hooks as never }
+      : undefined
+  const capabilities = await resolveAgentCapabilities(capabilityOptions, resolvedContext, input, workspace as never)
+  const transformedTools = await applyCapabilityToolTransforms(capabilities.tools, capabilities.toolTransforms)
+  const tools = Object.keys(transformedTools || {}).length
+    ? withAgentToolStepReporting(applyAgentToolPolicies(transformedTools) || {}, context.devtools?.reportToolStep)
+    : undefined
 
   return {
     ...resolvedContext,
-    input,
+    close: capabilities.close,
+    hasCapabilityCleanup: capabilities.hasCloseCallbacks,
+    input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
+    messages: capabilities.messages,
+    outputRenderers: capabilities.registries.outputRenderers,
+    prompt: typeof capabilities.input.prompt === "string" ? capabilities.input.prompt : undefined,
+    tools,
   }
 }
 
@@ -1328,17 +1272,26 @@ async function createAdapterRunContext<
       ? (await import("@vitehub/workspace")).useWorkspace(workspaceName, { allowWrite: true })
       : (await import("@vitehub/workspace")).useWorkspace(workspaceName)
     : undefined
-  const tools = workspaceOptions && workspace
-    ? await resolveCapabilityTools(workspaceOptions, runtime, workspace as never, context.devtools?.reportToolStep)
+  const capabilityOptions = workspaceOptions && workspace
+    ? { capabilities: workspaceOptions.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: workspaceOptions.hooks as never }
     : definition?.capabilities?.length
-      ? await resolveCapabilityToolsFromList(definition.capabilities as NormalizedCapability[], runtime, undefined, context.devtools?.reportToolStep)
+      ? { capabilities: definition.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: definition.hooks as never }
+      : undefined
+  const capabilities = await resolveAgentCapabilities(capabilityOptions, runtime, input, workspace as never)
+  const transformedTools = await applyCapabilityToolTransforms(capabilities.tools, capabilities.toolTransforms)
+  const tools = Object.keys(transformedTools || {}).length
+    ? withAgentToolStepReporting(applyAgentToolPolicies(transformedTools) || {}, context.devtools?.reportToolStep)
     : undefined
   return {
+    capabilityInstructions: capabilities.capabilityInstructions,
+    close: capabilities.close,
     devtools: context.devtools,
-    input,
+    hasCapabilityCleanup: capabilities.hasCloseCallbacks,
+    input: capabilities.input,
     instructions: undefined,
-    messages: getRunMessages(input),
-    prompt: typeof input.prompt === "string" ? input.prompt : undefined,
+    messages: capabilities.messages,
+    outputRenderers: capabilities.registries.outputRenderers,
+    prompt: typeof capabilities.input.prompt === "string" ? capabilities.input.prompt : undefined,
     runtime,
     tools,
     workspace,
@@ -1354,13 +1307,46 @@ export async function runAgent<
   input: AgentRunInput<CALL_OPTIONS>,
 ): Promise<Response | AgentRunResult | unknown> {
   if (hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)) {
-    return await agent.run(createRunContext(agent, context, input))
+    const runContext = await createRunContext(agent, context, input)
+    try {
+      const result = await agent.run(runContext)
+      if (result instanceof Response) return runContext.hasCapabilityCleanup ? await withResponseCleanup(result, runContext.close) : result
+      if (isAsyncIterable(result)) return runContext.hasCapabilityCleanup ? withCapabilityCleanup(result, runContext.close) : result
+      const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
+      await runContext.close()
+      return rendered
+    }
+    catch (error) {
+      try {
+        await runContext.close()
+      }
+      catch (closeError) {
+        throw new AggregateError([error, closeError], "[vitehub] Agent run failed and capability cleanup also failed.")
+      }
+      throw error
+    }
   }
 
   const resolved = await resolveAgent(agent, context)
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
-  const result = await resolved.generate(await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input))
-  return isTransportReadyResult(result) ? result : toAgentRunResult(result)
+  const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
+  try {
+    const result = await resolved.generate(adapterContext)
+    if (result instanceof Response) return adapterContext.hasCapabilityCleanup ? await withResponseCleanup(result, adapterContext.close) : result
+    if (isAsyncIterable(result)) return adapterContext.hasCapabilityCleanup ? withCapabilityCleanup(result, adapterContext.close) : result
+    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
+    await adapterContext.close()
+    return toAgentRunResult(rendered)
+  }
+  catch (error) {
+    try {
+      await adapterContext.close()
+    }
+    catch (closeError) {
+      throw new AggregateError([error, closeError], "[vitehub] Agent run failed and capability cleanup also failed.")
+    }
+    throw error
+  }
 }
 
 export async function streamAgent<
@@ -1372,16 +1358,47 @@ export async function streamAgent<
   input: AgentRunInput<CALL_OPTIONS>,
 ): Promise<Response | AsyncIterable<StreamEvent> | unknown> {
   if (hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)) {
-    return await agent.run(createRunContext(agent, context, input))
+    const runContext = await createRunContext(agent, context, input)
+    try {
+      const result = await agent.run(runContext)
+      if (result instanceof Response) return runContext.hasCapabilityCleanup ? await withResponseCleanup(result, runContext.close) : result
+      if (isAsyncIterable(result)) return runContext.hasCapabilityCleanup ? withCapabilityCleanup(result, runContext.close) : result
+      const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
+      await runContext.close()
+      return streamTextResultToEvents(rendered)
+    }
+    catch (error) {
+      try {
+        await runContext.close()
+      }
+      catch (closeError) {
+        throw new AggregateError([error, closeError], "[vitehub] Agent run failed and capability cleanup also failed.")
+      }
+      throw error
+    }
   }
 
   const resolved = await resolveAgent(agent, context)
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
   const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
-  const result = resolved.stream
-    ? await resolved.stream(adapterContext)
-    : await resolved.generate(adapterContext)
-  return isTransportReadyResult(result) ? result : streamTextResultToEvents(result)
+  try {
+    const result = resolved.stream
+      ? await resolved.stream(adapterContext)
+      : await resolved.generate(adapterContext)
+    if (result instanceof Response) return adapterContext.hasCapabilityCleanup ? await withResponseCleanup(result, adapterContext.close) : result
+    if (isAsyncIterable(result)) return adapterContext.hasCapabilityCleanup ? withCapabilityCleanup(result, adapterContext.close) : result
+    const events = streamTextResultToEvents(await applyOutputRenderers(result, adapterContext.outputRenderers))
+    return adapterContext.hasCapabilityCleanup ? withCapabilityCleanup(events, adapterContext.close) : events
+  }
+  catch (error) {
+    try {
+      await adapterContext.close()
+    }
+    catch (closeError) {
+      throw new AggregateError([error, closeError], "[vitehub] Agent stream failed and capability cleanup also failed.")
+    }
+    throw error
+  }
 }
 
 export async function getAgent<TContext extends AgentRuntimeContext>(

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -154,10 +154,19 @@ export type {
 } from "@vitehub/messages"
 
 const syntheticWorkspaceRun = Symbol("vitehub.syntheticWorkspaceRun")
+const baseAgentResolve = Symbol("vitehub.baseAgentResolve")
 const defaultWorkspaceName = "workspace"
 
 type NormalizedWorkspaceOptions = WorkspaceAgentWorkspaceOptions & { mode: AgentCapabilityMode }
 type NormalizedCapability = AgentCapabilityDefinition & { mode?: AgentCapabilityMode }
+type BaseAgentResolver<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig, CALL_OPTIONS = unknown> =
+  (context: AgentRuntimeContext<TRuntimeConfig>) => Promise<AgentAdapter<CALL_OPTIONS>>
+type AgentDefinitionWithBaseResolve<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> = AgentDefinition<TRuntimeConfig, CALL_OPTIONS> & {
+  [baseAgentResolve]?: BaseAgentResolver<TRuntimeConfig, CALL_OPTIONS>
+}
 
 const readCommands = ["pwd", "ls", "find", "rg", "grep", "cat", "head", "tail", "wc"]
 const writeCommands = [...readCommands, "mkdir", "touch", "cp", "mv", "rm"]
@@ -481,8 +490,21 @@ function defineBaseAgent<
   const { capabilities, chat, description, hooks, run, runtime, workspace } = options as AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { chat?: AgentChatOptions<TRuntimeConfig>, hooks?: AgentChatAgentHooks<TRuntimeConfig> }
   const normalizedCapabilities = normalizeCapabilities(capabilities as AgentCapabilitiesList | undefined)
   validateNonWorkspaceCapabilities(normalizedCapabilities, !!workspace)
+  const resolveBaseAgent: BaseAgentResolver<TRuntimeConfig, CALL_OPTIONS> = async (context) => {
+    const resolvedAdapter = "model" in options
+      ? await resolveProviderAdapter((options as AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { provider: AgentModelProvider }).provider, options as AgentSettings<TRuntimeConfig, CALL_OPTIONS>)
+      : undefined
+    if (!resolvedAdapter) {
+      throw new Error("[vitehub] Agent model and provider are required unless the agent defines a custom run() handler.")
+    }
+    const resolvedContext = createResolvedRuntimeContext(context)
+    return typeof resolvedAdapter === "function"
+      ? await (resolvedAdapter as AgentAdapterFactory<TRuntimeConfig, CALL_OPTIONS>)(resolvedContext)
+      : resolvedAdapter
+  }
 
   return {
+    [baseAgentResolve]: resolveBaseAgent,
     chat,
     description,
     hooks,
@@ -491,16 +513,8 @@ function defineBaseAgent<
     workspace,
     ...(normalizedCapabilities.length ? { capabilities: normalizedCapabilities } : {}),
     async resolve(context) {
-      const resolvedAdapter = "model" in options
-        ? await resolveProviderAdapter((options as AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { provider: AgentModelProvider }).provider, options as AgentSettings<TRuntimeConfig, CALL_OPTIONS>)
-        : undefined
-      if (!resolvedAdapter) {
-        throw new Error("[vitehub] Agent model and provider are required unless the agent defines a custom run() handler.")
-      }
+      const adapterInstance = await resolveBaseAgent(context)
       const resolvedContext = createResolvedRuntimeContext(context)
-      const adapterInstance = typeof resolvedAdapter === "function"
-        ? await (resolvedAdapter as AgentAdapterFactory<TRuntimeConfig, CALL_OPTIONS>)(resolvedContext)
-        : resolvedAdapter
       const resolvedCapabilities = normalizedCapabilities.length && !workspace
         ? await resolveAgentCapabilities({ capabilities: normalizedCapabilities }, resolvedContext, {})
         : undefined
@@ -514,7 +528,7 @@ function defineBaseAgent<
         ? { ...adapterInstance, tools: capabilityTools }
         : adapterInstance
     },
-  }
+  } as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS>
 }
 
 export function workflow(name?: string): AgentWorkflowRuntimeBinding {
@@ -1026,7 +1040,7 @@ function createWorkspaceAgentDefinition<
 
   if (!definition.run) {
     const run: NonNullable<AgentDefinition<TRuntimeConfig>["run"]> = async (context) => {
-      const adapter = await definition.resolve(context)
+      const adapter = await resolveAgentForRun<TRuntimeConfig, unknown>(definition, context)
       const result = await adapter.generate(await createAdapterRunContext(definition as never, adapter, context as never, context.input))
       return typeof result === "object" && result && "text" in result && typeof (result as { text?: unknown }).text === "string"
         ? (result as { text: string }).text
@@ -1073,6 +1087,20 @@ export async function resolveAgent<TContext extends AgentRuntimeContext>(
   }
 
   throw new TypeError("[vitehub] Invalid agent definition.")
+}
+
+async function resolveAgentForRun<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  context: AgentRuntimeContext<TRuntimeConfig>,
+): Promise<AgentAdapter<CALL_OPTIONS>> {
+  if (hasAgentDefinition(agent)) {
+    const resolver = (agent as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS>)[baseAgentResolve]
+    if (resolver) return await resolver(context)
+  }
+  return await resolveAgent(agent, context) as AgentAdapter<CALL_OPTIONS>
 }
 
 export async function getAgentFromRegistry<TContext extends AgentRuntimeContext>(
@@ -1327,11 +1355,11 @@ export async function runAgent<
     }
   }
 
-  const resolved = await resolveAgent(agent, context)
+  const resolved = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
   const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
   try {
-    const result = await resolved.generate(adapterContext)
+    const result = await resolved.generate(adapterContext as never)
     if (result instanceof Response) return adapterContext.hasCapabilityCleanup ? await withResponseCleanup(result, adapterContext.close) : result
     if (isAsyncIterable(result)) return adapterContext.hasCapabilityCleanup ? withCapabilityCleanup(result, adapterContext.close) : result
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
@@ -1378,13 +1406,13 @@ export async function streamAgent<
     }
   }
 
-  const resolved = await resolveAgent(agent, context)
+  const resolved = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
   const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
   try {
     const result = resolved.stream
-      ? await resolved.stream(adapterContext)
-      : await resolved.generate(adapterContext)
+      ? await resolved.stream(adapterContext as never)
+      : await resolved.generate(adapterContext as never)
     if (result instanceof Response) return adapterContext.hasCapabilityCleanup ? await withResponseCleanup(result, adapterContext.close) : result
     if (isAsyncIterable(result)) return adapterContext.hasCapabilityCleanup ? withCapabilityCleanup(result, adapterContext.close) : result
     const events = streamTextResultToEvents(await applyOutputRenderers(result, adapterContext.outputRenderers))

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1365,7 +1365,7 @@ export async function streamAgent<
       if (isAsyncIterable(result)) return runContext.hasCapabilityCleanup ? withCapabilityCleanup(result, runContext.close) : result
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
       await runContext.close()
-      return streamTextResultToEvents(rendered)
+      return rendered
     }
     catch (error) {
       try {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -13,6 +13,7 @@ import {
   normalizeCapabilities,
   normalizeMode,
   resolveAgentCapabilities,
+  resolveAgentStaticCapabilities,
   withCapabilityCleanup,
   withResponseCleanup,
 } from "./capability-runtime.ts"
@@ -514,7 +515,19 @@ function defineBaseAgent<
     ...(normalizedCapabilities.length ? { capabilities: normalizedCapabilities } : {}),
     async resolve(context) {
       const adapterInstance = await resolveBaseAgent(context)
-      return adapterInstance
+      const resolvedContext = createResolvedRuntimeContext(context)
+      const resolvedCapabilities = normalizedCapabilities.length && !workspace
+        ? await resolveAgentStaticCapabilities({ capabilities: normalizedCapabilities }, resolvedContext)
+        : undefined
+      const transformedTools = resolvedCapabilities
+        ? await applyCapabilityToolTransforms(resolvedCapabilities.tools, resolvedCapabilities.toolTransforms)
+        : undefined
+      const capabilityTools = Object.keys(transformedTools || {}).length
+        ? withAgentToolStepReporting(applyAgentToolPolicies(transformedTools) || {}, context.devtools?.reportToolStep)
+        : undefined
+      return capabilityTools
+        ? { ...adapterInstance, tools: capabilityTools }
+        : adapterInstance
     },
   } as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS>
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -234,6 +234,15 @@ function createResolvedRuntimeContext<TRuntimeConfig extends AgentRuntimeConfig>
   return resolveRuntimeContext(context) as ResolvedAgentRuntimeContext<TRuntimeConfig>
 }
 
+function once<TArgs extends unknown[]>(callback: (...args: TArgs) => Promise<void>): (...args: TArgs) => Promise<void> {
+  let called = false
+  return async (...args) => {
+    if (called) return
+    called = true
+    await callback(...args)
+  }
+}
+
 export { applyAgentToolPolicies, withAgentToolStepReporting } from "./tool-runtime.ts"
 export { defineCapability } from "./capability-runtime.ts"
 
@@ -1359,6 +1368,7 @@ export async function runAgent<
   const resolved = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
   const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
+  adapterContext.close = once(adapterContext.close)
   try {
     const result = await resolved.generate(adapterContext as never)
     if (result instanceof Response) return adapterContext.hasCapabilityCleanup ? await withResponseCleanup(result, adapterContext.close) : result
@@ -1410,6 +1420,7 @@ export async function streamAgent<
   const resolved = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
   const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
+  adapterContext.close = once(adapterContext.close)
   try {
     const result = resolved.stream
       ? await resolved.stream(adapterContext as never)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -514,19 +514,7 @@ function defineBaseAgent<
     ...(normalizedCapabilities.length ? { capabilities: normalizedCapabilities } : {}),
     async resolve(context) {
       const adapterInstance = await resolveBaseAgent(context)
-      const resolvedContext = createResolvedRuntimeContext(context)
-      const resolvedCapabilities = normalizedCapabilities.length && !workspace
-        ? await resolveAgentCapabilities({ capabilities: normalizedCapabilities }, resolvedContext, {})
-        : undefined
-      const transformedTools = resolvedCapabilities
-        ? await applyCapabilityToolTransforms(resolvedCapabilities.tools, resolvedCapabilities.toolTransforms)
-        : undefined
-      const capabilityTools = Object.keys(transformedTools || {}).length
-        ? withAgentToolStepReporting(applyAgentToolPolicies(transformedTools) || {}, context.devtools?.reportToolStep)
-        : undefined
-      return capabilityTools
-        ? { ...adapterInstance, tools: capabilityTools }
-        : adapterInstance
+      return adapterInstance
     },
   } as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS>
 }
@@ -1261,7 +1249,7 @@ async function createRunContext<
     : definition.capabilities?.length
       ? { capabilities: definition.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: definition.hooks as never }
       : undefined
-  const capabilities = await resolveAgentCapabilities(capabilityOptions, resolvedContext, input, workspace as never)
+  const capabilities = await resolveAgentCapabilities(capabilityOptions, resolvedContext, input, workspace as never, workspaceMode)
   const transformedTools = await applyCapabilityToolTransforms(capabilities.tools, capabilities.toolTransforms)
   const tools = Object.keys(transformedTools || {}).length
     ? withAgentToolStepReporting(applyAgentToolPolicies(transformedTools) || {}, context.devtools?.reportToolStep)
@@ -1305,7 +1293,7 @@ async function createAdapterRunContext<
     : definition?.capabilities?.length
       ? { capabilities: definition.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: definition.hooks as never }
       : undefined
-  const capabilities = await resolveAgentCapabilities(capabilityOptions, runtime, input, workspace as never)
+  const capabilities = await resolveAgentCapabilities(capabilityOptions, runtime, input, workspace as never, workspaceMode)
   const transformedTools = await applyCapabilityToolTransforms(capabilities.tools, capabilities.toolTransforms)
   const tools = Object.keys(transformedTools || {}).length
     ? withAgentToolStepReporting(applyAgentToolPolicies(transformedTools) || {}, context.devtools?.reportToolStep)

--- a/packages/agent/src/tanstack-ai.ts
+++ b/packages/agent/src/tanstack-ai.ts
@@ -1,4 +1,5 @@
 import { getMessageText } from "@vitehub/messages"
+import { applyCapabilityInstructionSlots } from "./capability-runtime.ts"
 import {
   applyAgentToolPolicies,
   withAgentToolStepReporting,
@@ -101,7 +102,8 @@ async function createChatOptions(options: TanStackAiAdapterOptions, context: Age
     fs: context.workspace?.fs,
     workspace: context.workspace,
   } as AgentAdapterMetadataContext
-  const instructions = context.instructions ?? await resolveInstructions(options, metadataContext)
+  const instructions = context.instructions
+    ?? applyCapabilityInstructionSlots(await resolveInstructions(options, metadataContext), context.capabilityInstructions)
   const {
     adapter,
     instructions: _instructions,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -89,6 +89,9 @@ export interface AgentRunContext<
 > extends ResolvedAgentRuntimeContext<TRuntimeConfig> {
   adapter?: AgentAdapter<CALL_OPTIONS>
   input: AgentRunInput<CALL_OPTIONS>
+  messages: Message[]
+  prompt?: string
+  tools?: AgentToolSet
 }
 
 export type AgentRunHandler<
@@ -133,17 +136,78 @@ export type AgentCapabilityToolResolver<
   | Record<string, unknown>
   | ((context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<Record<string, unknown> | undefined>)
 
+export type AgentCapabilityPhase = "configure" | "prepare" | "bind" | "input" | "resolve" | "output" | "close"
+export type AgentCapabilityHookName = `capability:${AgentCapabilityPhase}` | `capability:${AgentCapabilityPhase}:after`
+
+export interface AgentInstructionBlock {
+  id: string
+  instructions: string
+}
+
+export type AgentToolTransform = (tools: AgentToolSet | undefined) => MaybePromise<AgentToolSet | undefined>
+export type AgentOutputRenderer = (
+  result: unknown,
+  context: AgentCapabilityRuntimeContext,
+) => MaybePromise<unknown>
+
+export interface AgentCapabilityStateRequirement {
+  name: string
+  optional?: boolean
+}
+
+export type AgentCapabilityHooks<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> = Partial<Record<AgentCapabilityHookName, (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>>>
+
+export interface AgentCapabilityRuntimeContext<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> extends AgentCapabilityContext<TRuntimeConfig, Name> {
+  capability: AgentCapabilityDefinition<TRuntimeConfig, Name>
+  instructions: {
+    add: (instructions: AgentAdapterInstructionsValue | false | undefined, options?: { id?: string }) => void
+  }
+  input: {
+    get: () => AgentRunInput
+    messages: () => Message[]
+    set: (input: AgentRunInput) => void
+    setMessages: (messages: Message[]) => void
+  }
+  output: {
+    render: (renderer: AgentOutputRenderer) => void
+  }
+  state: {
+    require: (name: string, options?: { optional?: boolean }) => void
+  }
+  tools: {
+    add: (tools: AgentToolSet | undefined) => void
+    transform: (transform: AgentToolTransform) => void
+  }
+}
+
 export interface AgentCapabilityDefinition<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > {
+  bind?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
+  close?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
+  configure?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   description?: string
+  hooks?: AgentCapabilityHooks<TRuntimeConfig, Name>
   id: string
-  instructions?: AgentAdapterInstructions<TRuntimeConfig, Name>
+  input?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
+  instructions?:
+    | AgentAdapterInstructions<TRuntimeConfig, Name>
+    | false
+    | ((context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<AgentAdapterInstructionsValue | false | undefined>)
   metadata?: Record<string, unknown>
   mode?: AgentCapabilityMode
   name?: string
+  output?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
+  prepare?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   requires?: AgentCapabilityRequirement[]
+  resolve?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   tools?: AgentCapabilityToolResolver<TRuntimeConfig, Name>
 }
 
@@ -195,7 +259,7 @@ type AgentSettingsBase<
 > = {
   chat?: AgentChatOptions<TRuntimeConfig>
   description?: string
-  hooks?: AgentChatAgentHooks<TRuntimeConfig>
+  hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig>
   instructions?: AgentAdapterInstructions<TRuntimeConfig>
   instrumentModel?: AgentModelInstrumentation<TRuntimeConfig>
   capabilities?: AgentCapabilitiesList<TRuntimeConfig>
@@ -228,7 +292,7 @@ export interface AgentDefinition<
   capabilities?: AgentCapabilityDefinition<TRuntimeConfig>[]
   chat?: AgentChatOptions<TRuntimeConfig>
   description?: string
-  hooks?: AgentChatAgentHooks<TRuntimeConfig>
+  hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig>
   runtime?: AgentRuntimeBinding
   resolve(context: AgentRuntimeContext<TRuntimeConfig>): Promise<AgentAdapter<CALL_OPTIONS>>
   run?(context: AgentRunContext<TRuntimeConfig, CALL_OPTIONS>): MaybePromise<Response | AgentRunResult | AsyncIterable<StreamEvent> | unknown>
@@ -455,10 +519,14 @@ export interface AgentAdapterRunContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > {
+  capabilityInstructions?: AgentInstructionBlock[]
+  close?: () => Promise<void>
   devtools?: AgentRuntimeContext<TRuntimeConfig>["devtools"]
+  hasCapabilityCleanup?: boolean
   input: AgentRunInput<TOptions>
   instructions?: string
   messages: Message[]
+  outputRenderers?: Array<(result: unknown) => MaybePromise<unknown>>
   prompt?: string
   runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>
   tools?: AgentToolSet

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -100,6 +100,7 @@ describe("agent capability runtime", () => {
       expect.objectContaining({ text: "rewritten" }),
     ])
     expect(applyCapabilityInstructionSlots("Base\n{{ skills }}", resolved.capabilityInstructions)).toBe("Base\nSkill instructions.")
+    expect(applyCapabilityInstructionSlots("Base {{ user_name }}\n{{ skills }}", resolved.capabilityInstructions)).toBe("Base {{ user_name }}\nSkill instructions.")
     await expect(applyCapabilityToolTransforms(resolved.tools, resolved.toolTransforms)).resolves.toEqual({
       added: { name: "added" },
       original: { name: "original" },

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -135,6 +135,38 @@ describe("agent capability runtime", () => {
     expect(order).toEqual(["close"])
   })
 
+  it("closes Response outputs when the body is canceled", async () => {
+    const { withResponseCleanup } = await import("../src/capability-runtime.ts")
+    const order: string[] = []
+
+    const response = await withResponseCleanup(new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial"))
+      },
+    })), async () => { order.push("close") }) as Response
+
+    await response.body?.cancel()
+    expect(order).toEqual(["close"])
+  })
+
+  it("rejects write workspace requirements when the run workspace is read-only", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const workspace = {
+      fs: {
+        exists: vi.fn(async () => true),
+      },
+    }
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "writer",
+          requires: [{ workspace: { mode: "write", required: true } }],
+        }),
+      ],
+    }, runtime(), {}, workspace as never, "read")).rejects.toThrow("requires workspace.mode: \"write\"")
+  })
+
   it("runs model-backed capability lifecycle once per agent run", async () => {
     vi.doMock("ai", () => ({
       ToolLoopAgent: class {
@@ -160,6 +192,40 @@ describe("agent capability runtime", () => {
 
       await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({ text: "ok" })
       expect(order).toEqual(["configure", "close"])
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
+  it("does not run invocation-scoped capability phases during agent resolution", async () => {
+    vi.doMock("ai", () => ({
+      ToolLoopAgent: class {
+        async generate() {
+          return { text: "ok" }
+        }
+      },
+      stepCountIs: () => () => false,
+    }))
+
+    try {
+      const { defineAgent, resolveAgent, runAgent } = await import("../src/index.ts")
+      const order: string[] = []
+      const agent = defineAgent({
+        capabilities: [{
+          id: "tracked",
+          input: () => { order.push("input") },
+          resolve: () => { order.push("resolve") },
+        }],
+        model: {} as never,
+        provider: "ai-sdk",
+      })
+
+      await resolveAgent(agent, runtime())
+      expect(order).toEqual([])
+
+      await runAgent(agent, runtime(), { messages: [createMessage({ role: "user", text: "hello" })] })
+      expect(order).toEqual(["input", "resolve"])
     }
     finally {
       vi.doUnmock("ai")

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -134,4 +134,35 @@ describe("agent capability runtime", () => {
     await expect((response as Response).text()).resolves.toBe("ok")
     expect(order).toEqual(["close"])
   })
+
+  it("runs model-backed capability lifecycle once per agent run", async () => {
+    vi.doMock("ai", () => ({
+      ToolLoopAgent: class {
+        async generate() {
+          return { text: "ok" }
+        }
+      },
+      stepCountIs: () => () => false,
+    }))
+
+    try {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const order: string[] = []
+      const agent = defineAgent({
+        capabilities: [{
+          close: () => { order.push("close") },
+          configure: () => { order.push("configure") },
+          id: "tracked",
+        }],
+        model: {} as never,
+        provider: "ai-sdk",
+      })
+
+      await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({ text: "ok" })
+      expect(order).toEqual(["configure", "close"])
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
 })

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createMessage } from "@vitehub/messages"
+
+const runtime = () => ({
+  memo: vi.fn(),
+  runtime: "unknown" as const,
+  runtimeConfig: {},
+  waitUntil: vi.fn(),
+})
+
+describe("agent capability runtime", () => {
+  it("runs lifecycle phases in capability order and closes in reverse order", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const order: string[] = []
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "first",
+          close: () => { order.push("close:first") },
+          configure: () => { order.push("configure:first") },
+          resolve: () => { order.push("resolve:first") },
+        }),
+        defineCapability({
+          id: "second",
+          close: () => { order.push("close:second") },
+          configure: () => { order.push("configure:second") },
+          resolve: () => { order.push("resolve:second") },
+        }),
+      ],
+    }, runtime(), {})
+
+    await resolved.close()
+
+    expect(order).toEqual([
+      "configure:first",
+      "resolve:first",
+      "configure:second",
+      "resolve:second",
+      "close:second",
+      "close:first",
+    ])
+  })
+
+  it("cleans up initialized capabilities after setup failures", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const order: string[] = []
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "first",
+          close: () => { order.push("close:first") },
+          resolve: () => { order.push("resolve:first") },
+        }),
+        defineCapability({
+          id: "second",
+          close: () => { order.push("close:second") },
+          resolve() {
+            order.push("resolve:second")
+            throw new Error("setup failed")
+          },
+        }),
+      ],
+    }, runtime(), {})).rejects.toThrow("setup failed")
+
+    expect(order).toEqual(["resolve:first", "resolve:second", "close:second", "close:first"])
+  })
+
+  it("applies instruction slots, tool transforms, renderers, and input mutation", async () => {
+    const {
+      applyCapabilityInstructionSlots,
+      applyCapabilityToolTransforms,
+      applyOutputRenderers,
+      defineCapability,
+      resolveAgentCapabilities,
+    } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "skills",
+          input(context) {
+            context.input.setMessages([createMessage({ role: "user", text: "rewritten" })])
+          },
+          instructions: "Skill instructions.",
+          output(context) {
+            context.output.render(result => ({ text: `${(result as { text: string }).text}:rendered` }))
+          },
+          resolve(context) {
+            context.tools.add({ original: { name: "original" } })
+            context.tools.transform(tools => ({ ...(tools || {}), added: { name: "added" } }))
+          },
+        }),
+      ],
+    }, runtime(), { messages: [createMessage({ role: "user", text: "initial" })] })
+
+    expect(resolved.messages.map(message => message.parts[0])).toEqual([
+      expect.objectContaining({ text: "rewritten" }),
+    ])
+    expect(applyCapabilityInstructionSlots("Base\n{{ skills }}", resolved.capabilityInstructions)).toBe("Base\nSkill instructions.")
+    await expect(applyCapabilityToolTransforms(resolved.tools, resolved.toolTransforms)).resolves.toEqual({
+      added: { name: "added" },
+      original: { name: "original" },
+    })
+    await expect(applyOutputRenderers({ text: "base" }, resolved.registries.outputRenderers)).resolves.toEqual({ text: "base:rendered" })
+  })
+
+  it("closes streamed and Response outputs after consumption", async () => {
+    const { defineAgent, runAgent, streamAgent } = await import("../src/index.ts")
+    const order: string[] = []
+    const capability = {
+      close: () => { order.push("close") },
+      id: "cleanup",
+    }
+
+    const stream = await streamAgent(defineAgent({
+      capabilities: [capability],
+      run: () => (async function* () {
+        yield "hello"
+        order.push("stream:done")
+      })(),
+    }), runtime(), {})
+
+    for await (const _event of stream as AsyncIterable<unknown>) {}
+    expect(order).toEqual(["stream:done", "close"])
+
+    order.length = 0
+    const response = await runAgent(defineAgent({
+      capabilities: [capability],
+      run: () => new Response("ok"),
+    }), runtime(), {})
+    await expect((response as Response).text()).resolves.toBe("ok")
+    expect(order).toEqual(["close"])
+  })
+})

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -199,6 +199,38 @@ describe("agent capability runtime", () => {
     }
   })
 
+  it("does not close model-backed capability contexts twice when cleanup fails", async () => {
+    vi.doMock("ai", () => ({
+      ToolLoopAgent: class {
+        async generate() {
+          return { text: "ok" }
+        }
+      },
+      stepCountIs: () => () => false,
+    }))
+
+    try {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const close = vi.fn(() => {
+        throw new Error("cleanup failed")
+      })
+      const agent = defineAgent({
+        capabilities: [{
+          close,
+          id: "tracked",
+        }],
+        model: {} as never,
+        provider: "ai-sdk",
+      })
+
+      await expect(runAgent(agent, runtime(), {})).rejects.toThrow("cleanup failed")
+      expect(close).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
   it("does not run invocation-scoped capability phases during agent resolution", async () => {
     vi.doMock("ai", () => ({
       ToolLoopAgent: class {

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -23,6 +23,12 @@
       "@vitehub/internal/*": [
         "packages/internal/src/*"
       ],
+      "@vitehub/agent": [
+        "packages/agent/src/index.ts"
+      ],
+      "@vitehub/agent/*": [
+        "packages/agent/src/*"
+      ],
       "@vitehub/messages": [
         "packages/messages/src/index.ts"
       ],

--- a/packages/agent/tsdown.config.ts
+++ b/packages/agent/tsdown.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   dts: true,
   entry: [
     "src/ai-sdk.ts",
+    "src/capability-runtime.ts",
     "src/index.ts",
     "src/cloudflare.ts",
     "src/nitro.ts",


### PR DESCRIPTION
Extracts the minimal Agent Capability Runtime Core from #113.

Adds the shared Capability Lifecycle used by `defineAgent({ capabilities })`: ordered lifecycle phases, instruction blocks and slots, tool contributions and transforms, output renderers, state requirements, and cleanup handling for plain results, Responses, and streams.

This intentionally keeps tools inside Capability Definitions, leaves top-level `defineAgent({ tools })` rejected, and excludes chat, memory, devtools assets, and provider/e2e hardening.