### PR TITLE
fix(blob): bundle vercel blob driver imports

### DIFF
--- a/packages/blob/src/drivers/vercel.ts
+++ b/packages/blob/src/drivers/vercel.ts
@@ -1,12 +1,6 @@
-import { importOptionalPeer } from "../internal/optional-peer.ts"
+import { del, get, head, list, put } from "@vercel/blob"
 
 import type { BlobDriverAdapter, BlobListOptions, BlobListResult, BlobObject, BlobPutBody, BlobPutOptions, ResolvedVercelBlobStoreConfig } from "../types.ts"
-
-type VercelBlobModule = typeof import("@vercel/blob")
-
-async function loadVercelBlob() {
-  return await importOptionalPeer<VercelBlobModule>("@vercel/blob", "vercel-blob")
-}
 
 function isNotFound(error: unknown): boolean {
   return error instanceof Error && /not found/i.test(error.message)
@@ -42,7 +36,6 @@ export function createDriver(options: ResolvedVercelBlobStoreConfig): BlobDriver
     name: "vercel-blob",
     options,
     async delete(pathnames) {
-      const { del } = await loadVercelBlob()
       await Promise.all((Array.isArray(pathnames) ? pathnames : [pathnames]).map(pathname => del(pathname, commandOptions(options))))
     },
     async get(pathname) {
@@ -50,7 +43,6 @@ export function createDriver(options: ResolvedVercelBlobStoreConfig): BlobDriver
       return bytes ? new Blob([bytes]) : null
     },
     async getArrayBuffer(pathname) {
-      const { get } = await loadVercelBlob()
       const result = await get(pathname, {
         access: options.access || "public",
         ...commandOptions(options),
@@ -58,7 +50,6 @@ export function createDriver(options: ResolvedVercelBlobStoreConfig): BlobDriver
       return result?.stream ? await new Response(result.stream).arrayBuffer() : null
     },
     async head(pathname) {
-      const { head } = await loadVercelBlob()
       try {
         return mapBlob(await head(pathname, commandOptions(options)))
       }
@@ -68,7 +59,6 @@ export function createDriver(options: ResolvedVercelBlobStoreConfig): BlobDriver
       }
     },
     async list(listOptions: BlobListOptions = {}): Promise<BlobListResult> {
-      const { list } = await loadVercelBlob()
       const result = await list({
         cursor: listOptions.cursor,
         limit: listOptions.limit ?? 1000,
@@ -84,7 +74,6 @@ export function createDriver(options: ResolvedVercelBlobStoreConfig): BlobDriver
       }
     },
     async put(pathname: string, body: BlobPutBody, putOptions: BlobPutOptions = {}) {
-      const { put } = await loadVercelBlob()
       return mapBlob(await put(pathname, body as Parameters<typeof put>[1], {
         access: putOptions.access || options.access || "public",
         addRandomSuffix: false,

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -295,7 +295,6 @@ function createVercelOutput(artifacts: GeneratedBlobArtifacts): VercelProviderDe
         "@vitehub/blob": artifacts.runtimeModuleFiles.vercel,
       },
       external: [
-        "@vercel/blob",
         "files-sdk",
         "files-sdk/akamai",
         "files-sdk/azure",

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -242,8 +242,11 @@ describe("Vite provider outputs", () => {
     )
 
     const runtimeContents = await readFile(join(rootDir, ".vitehub", "blob", "vercel-runtime.mjs"), "utf8")
+    const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
     expect(runtimeContents).toContain("resolveRuntimeVercelBlobStore")
     expect(runtimeContents).toContain("createVercelDriver(resolveRuntimeVercelBlobStore(store, process.env))")
+    expect(vercelServerContents).not.toContain("from \"@vercel/blob\"")
+    expect(vercelServerContents).not.toContain("from '@vercel/blob'")
   })
 
   it("selects named stores from generated runtime output", async () => {


### PR DESCRIPTION
Statically imports the Vercel Blob SDK from the Vercel Blob driver so generated provider builds can include the driver dependency instead of relying on runtime optional-peer loading.

This is split from #113 provider/e2e hardening work and stays scoped to `@vitehub/blob`.