### PR TITLE
fix(sandbox): harden provider runtime loading

### DIFF
--- a/packages/sandbox/src/internal/shared/hosting.ts
+++ b/packages/sandbox/src/internal/shared/hosting.ts
@@ -16,7 +16,17 @@ export function normalizeHosting(hosting?: string | null): string {
 }
 
 export function detectHosting(target: HostingDetectionTarget) {
-  return normalizeHosting(process.env.NITRO_PRESET || target.options.nitro?.preset || target.options.preset || '')
+  return normalizeHosting(process.env.NITRO_PRESET || target.options.nitro?.preset || target.options.preset || detectPresetArg())
+}
+
+function detectPresetArg(): string {
+  const argv = process.argv || []
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index]
+    if (arg === '--preset') return argv[index + 1] || ''
+    if (arg?.startsWith('--preset=')) return arg.slice('--preset='.length)
+  }
+  return ''
 }
 
 export function getHostingProvider(hosting?: string | null): HostingProvider | undefined {

--- a/packages/sandbox/src/runtime/provider-loader-resolver.ts
+++ b/packages/sandbox/src/runtime/provider-loader-resolver.ts
@@ -5,10 +5,9 @@ type ProviderLoaderModule = {
   loadSandboxRuntimeProvider: (provider: SandboxProvider) => Promise<SandboxRuntimeProvider>
 }
 
-const dynamicImport = new Function('specifier', 'return import(specifier)') as <T>(specifier: string) => Promise<T>
-
 export async function loadSandboxProviderRuntime(provider: SandboxProvider): Promise<SandboxRuntimeProvider> {
-  const module = await dynamicImport<ProviderLoaderModule>('virtual:vitehub-sandbox-provider-loader').catch(() => {
+  const module = await import('#vitehub-sandbox-provider-loader').catch(() => {
+    const dynamicImport = new Function('specifier', 'return import(specifier)') as <T>(specifier: string) => Promise<T>
     return dynamicImport<ProviderLoaderModule>('@vitehub/sandbox/runtime/provider-loader')
   }) as ProviderLoaderModule
 

--- a/packages/sandbox/src/runtime/provider-loader.ts
+++ b/packages/sandbox/src/runtime/provider-loader.ts
@@ -12,19 +12,21 @@ export interface SandboxRuntimeProvider {
   createSandboxClient: (provider: SandboxProviderOptions | any) => Promise<SandboxClient>
 }
 
+const dynamicImport = new Function('specifier', 'return import(specifier)') as <T>(specifier: string) => Promise<T>
+
 export async function loadSandboxRuntimeProvider(provider: SandboxProvider): Promise<SandboxRuntimeProvider> {
   if (provider === 'cloudflare') {
     const [{ resolveSandboxProvider }, { createCloudflareSandboxClient }] = await Promise.all([
-      import('./providers/cloudflare'),
-      import('../sandbox/providers/cloudflare'),
+      dynamicImport<typeof import('./providers/cloudflare')>('./providers/cloudflare'),
+      dynamicImport<typeof import('../sandbox/providers/cloudflare')>('../sandbox/providers/cloudflare'),
     ])
     return { resolveSandboxProvider, createSandboxClient: createCloudflareSandboxClient }
   }
 
   if (provider === 'vercel') {
     const [{ resolveSandboxProvider }, { createVercelSandboxClient }] = await Promise.all([
-      import('./providers/vercel'),
-      import('../sandbox/providers/vercel'),
+      dynamicImport<typeof import('./providers/vercel')>('./providers/vercel'),
+      dynamicImport<typeof import('../sandbox/providers/vercel')>('../sandbox/providers/vercel'),
     ])
     return { resolveSandboxProvider, createSandboxClient: createVercelSandboxClient }
   }

--- a/packages/sandbox/src/runtime/provider-loader.ts
+++ b/packages/sandbox/src/runtime/provider-loader.ts
@@ -17,16 +17,16 @@ const dynamicImport = new Function('specifier', 'return import(specifier)') as <
 export async function loadSandboxRuntimeProvider(provider: SandboxProvider): Promise<SandboxRuntimeProvider> {
   if (provider === 'cloudflare') {
     const [{ resolveSandboxProvider }, { createCloudflareSandboxClient }] = await Promise.all([
-      dynamicImport<typeof import('./providers/cloudflare')>('./providers/cloudflare'),
-      dynamicImport<typeof import('../sandbox/providers/cloudflare')>('../sandbox/providers/cloudflare'),
+      dynamicImport<typeof import('./providers/cloudflare')>('./providers/cloudflare.js'),
+      dynamicImport<typeof import('../sandbox/providers/cloudflare')>('../sandbox/providers/cloudflare.js'),
     ])
     return { resolveSandboxProvider, createSandboxClient: createCloudflareSandboxClient }
   }
 
   if (provider === 'vercel') {
     const [{ resolveSandboxProvider }, { createVercelSandboxClient }] = await Promise.all([
-      dynamicImport<typeof import('./providers/vercel')>('./providers/vercel'),
-      dynamicImport<typeof import('../sandbox/providers/vercel')>('../sandbox/providers/vercel'),
+      dynamicImport<typeof import('./providers/vercel')>('./providers/vercel.js'),
+      dynamicImport<typeof import('../sandbox/providers/vercel')>('../sandbox/providers/vercel.js'),
     ])
     return { resolveSandboxProvider, createSandboxClient: createVercelSandboxClient }
   }

--- a/packages/sandbox/src/runtime/providers/cloudflare.ts
+++ b/packages/sandbox/src/runtime/providers/cloudflare.ts
@@ -1,7 +1,7 @@
 import { getSandbox as getCloudflareSandbox } from '@cloudflare/sandbox'
 import type { CloudflareSandboxDefinitionProviderOptions, SandboxDefinitionOptions } from '../../module-types'
 import { getCloudflareEnv } from '../../internal/shared/provider-detection'
-import type { DurableObjectNamespaceLike } from '../../sandbox/types'
+import type { CloudflareSandboxOptions, CloudflareSandboxStub, DurableObjectNamespaceLike } from '../../sandbox/types'
 
 type SandboxOptions = {
   local: SandboxDefinitionOptions
@@ -33,6 +33,7 @@ export async function resolveSandboxProvider(options: SandboxOptions, context: {
       keepAlive: options.provider.keepAlive,
       normalizeId: options.provider.normalizeId,
     },
-    getSandbox: getCloudflareSandbox,
+    getSandbox: (ns: DurableObjectNamespaceLike, sandboxId: string, opts?: CloudflareSandboxOptions) =>
+      getCloudflareSandbox(ns as never, sandboxId, opts) as unknown as CloudflareSandboxStub,
   }
 }

--- a/packages/sandbox/src/sandbox/providers/cloudflare.ts
+++ b/packages/sandbox/src/sandbox/providers/cloudflare.ts
@@ -8,7 +8,7 @@ export async function createCloudflareSandboxClient(provider: CloudflareSandboxP
     throw new SandboxError('Cloudflare sandbox requires a Durable Objects binding namespace.')
 
   const id = provider.sandboxId ?? `cloudflare-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-  const getSandbox = provider.getSandbox ?? ((ns, sandboxId, opts) => getCloudflareSandbox(ns, sandboxId, opts) as unknown as CloudflareSandboxStub)
+  const getSandbox = provider.getSandbox ?? ((ns, sandboxId, opts) => getCloudflareSandbox(ns as never, sandboxId, opts) as unknown as CloudflareSandboxStub)
   const stub = getSandbox(provider.namespace, id, provider.cloudflare)
   return new CloudflareSandboxAdapter(id, stub)
 }

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -1,5 +1,6 @@
 import type { NitroModule } from 'nitro/types'
 import type { Plugin } from 'vite'
+import { createNoExternalMerger, isServerEnvironment } from '@vitehub/internal/build/vite'
 import { createFeatureVitePlugin } from './internal/shared/vite'
 export { createViteHubDefinitionAutoImportsPlugin } from './internal/shared/vitehub-auto-imports'
 import { sandboxFeatureEngine, type SandboxPublicOptions } from './integration'
@@ -7,7 +8,27 @@ import { sandboxFeatureEngine, type SandboxPublicOptions } from './integration'
 export type SandboxVitePlugin = Plugin & { nitro?: NitroModule }
 
 export function hubSandbox(): SandboxVitePlugin {
-  return createFeatureVitePlugin(sandboxFeatureEngine) as SandboxVitePlugin
+  const plugin = createFeatureVitePlugin(sandboxFeatureEngine) as SandboxVitePlugin
+  const configEnvironment = plugin.configEnvironment
+  const mergeNoExternal = createNoExternalMerger('@vitehub/sandbox')
+  return {
+    ...plugin,
+    configEnvironment(name, config) {
+      const result = typeof configEnvironment === 'function'
+        ? configEnvironment.call(this, name, config, undefined as never)
+        : undefined
+      if (!isServerEnvironment(name, config)) {
+        return result
+      }
+      return {
+        ...(result || {}),
+        resolve: {
+          ...(typeof result === 'object' && result && 'resolve' in result ? result.resolve : {}),
+          noExternal: mergeNoExternal(config.resolve?.noExternal),
+        },
+      }
+    },
+  }
 }
 
 declare module 'vite' {

--- a/packages/sandbox/test/public-api.test.ts
+++ b/packages/sandbox/test/public-api.test.ts
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+
 import { describe, expect, it } from "vitest"
 
 import { defineSandbox, runSandbox } from "../src/index.ts"
@@ -27,5 +30,18 @@ describe("sandbox public api", () => {
     if (result.isErr()) {
       expect(result.error!.message).toContain("missing")
     }
+  })
+
+  it("emits extensioned provider loader imports for published ESM", async () => {
+    const loader = await readFile(join(import.meta.dirname, "../dist/runtime/provider-loader.js"), "utf8")
+
+    expect(loader).toContain('"./providers/cloudflare.js"')
+    expect(loader).toContain('"../sandbox/providers/cloudflare.js"')
+    expect(loader).toContain('"./providers/vercel.js"')
+    expect(loader).toContain('"../sandbox/providers/vercel.js"')
+    expect(loader).not.toContain('"./providers/cloudflare"')
+    expect(loader).not.toContain('"../sandbox/providers/cloudflare"')
+    expect(loader).not.toContain('"./providers/vercel"')
+    expect(loader).not.toContain('"../sandbox/providers/vercel"')
   })
 })

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -65,6 +65,9 @@ describe("hubSandbox", () => {
       define: {
         __VITEHUB_ENVIRONMENT_SANDBOX__: "\"rsc\"",
       },
+      resolve: {
+        noExternal: ["@vitehub/sandbox"],
+      },
     })
     expect(configEnvironment("client", { consumer: "client" })).toBeUndefined()
   })


### PR DESCRIPTION
Extracts an independent sandbox provider hardening slice from #113.

The sandbox runtime now imports the generated provider loader through the package import alias before falling back to the runtime provider loader, avoiding worker eval during normal provider resolution. The Vite integration also marks `@vitehub/sandbox` as noExternal for server environments and Nitro preset detection now handles CLI `--preset` arguments.