### PR TITLE
feat(agent): add memory capability

### DIFF
--- a/packages/agent/docs/usage.md
+++ b/packages/agent/docs/usage.md
@@ -235,3 +235,50 @@ Workspace sources do not imply model tools. Replace older workspace agents that 
 ```
 
 Use `bash({ mode: 'write' })` only with `workspace.mode: 'write'`. Raw tools should be wrapped in inline or factory capabilities instead of `defineAgent({ tools })`.
+
+## Use durable memory
+
+Memory stores expose scoped records through model tools. Configure at least one explicit scope value so records do not bleed across tenants, projects, users, or agents.
+
+```ts [server/agents/support.ts]
+import { defineAgent } from '@vitehub/agent'
+import { memory, workspaceJsonlMemoryStore } from '@vitehub/agent/capabilities'
+
+export default defineAgent({
+  capabilities: [
+    memory({
+      stores: {
+        agent: {
+          adapter: workspaceJsonlMemoryStore(),
+          read: {
+            preload: [{ kind: 'procedural', pinned: true }],
+          },
+          scope: { agent: 'support' },
+          write: { mode: 'tool', policy: 'require-approval' },
+        },
+      },
+    }),
+  ],
+  model,
+  provider: 'ai-sdk',
+})
+```
+
+The default JSONL file is `.vitehub/memory.jsonl`. Pass `workspaceJsonlMemoryStore({ path })` to choose another workspace path.
+
+When tools omit `store`, memory uses the `agent` store if it exists, or the only configured store. If multiple non-`agent` stores are configured, tool calls must pass `store` explicitly.
+
+Read permissions are enforced per selected store. A store with `read.tools.search: false` or `read.tools.read: false` cannot be reached through that tool even when another store exposes it.
+
+Thread IDs are recorded in memory provenance for writes, but they are not added to the record scope automatically. Add thread scoping explicitly when records should be isolated per chat thread:
+
+```ts
+memory({
+  stores: {
+    agent: {
+      adapter: workspaceJsonlMemoryStore(),
+      scope: context => ({ agent: 'support', thread: context.run?.threadId }),
+    },
+  },
+})
+```

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -26,8 +26,10 @@
   "exports": {
     ".": "./dist/index.js",
     "./ai-sdk": "./dist/ai-sdk.js",
+    "./capabilities": "./dist/capabilities.js",
     "./capability-runtime": "./dist/capability-runtime.js",
     "./cloudflare": "./dist/cloudflare.js",
+    "./memory": "./dist/memory.js",
     "./nitro": "./dist/nitro.js",
     "./runtime/empty-registry": "./dist/runtime/empty-registry.js",
     "./runtime/nitro-runtime-config": "./dist/runtime/nitro-runtime-config.js",

--- a/packages/agent/src/capabilities.ts
+++ b/packages/agent/src/capabilities.ts
@@ -1,0 +1,23 @@
+export {
+  memory,
+  workspaceJsonlMemoryStore,
+} from "./memory.ts"
+
+export type {
+  MemoryAppendRequest,
+  MemoryCapabilityInstructionsOption,
+  MemoryCapabilityOptions,
+  MemoryDeleteRequest,
+  MemoryExportRequest,
+  MemoryKind,
+  MemoryProvenance,
+  MemoryReadRequest,
+  MemoryRecord,
+  MemoryScope,
+  MemorySearchRequest,
+  MemorySearchResult,
+  MemoryStoreAdapter,
+  MemoryStoreFactory,
+  MemoryStoreOptions,
+  WorkspaceJsonlMemoryStoreOptions,
+} from "./memory.ts"

--- a/packages/agent/src/memory.ts
+++ b/packages/agent/src/memory.ts
@@ -1,0 +1,568 @@
+import { defineCapability } from "./capability-runtime.ts"
+
+import type {
+  AgentCapabilityContext,
+  AgentCapabilityDefinition,
+  AgentToolDefinition,
+  AgentToolPolicyDecision,
+  AgentToolSet,
+  MaybePromise,
+} from "./types.ts"
+import type { WritableWorkspaceFacade } from "@vitehub/workspace"
+
+export interface MemoryCapabilityInstructionsOption {
+  instructions?: string | false
+}
+
+export type MemoryKind = "episodic" | "procedural" | "profile" | "semantic" | (string & {})
+
+export interface MemoryScope {
+  agent?: string
+  environment?: string
+  project?: string
+  session?: string
+  tenant?: string
+  thread?: string
+  user?: string
+  workspace?: string
+}
+
+export interface MemoryProvenance {
+  messageIds?: string[]
+  runId?: string
+  source?: "assistant" | "background" | "import" | "system" | "tool" | "user" | (string & {})
+  threadId?: string
+  toolName?: string
+}
+
+export interface MemoryRecord {
+  confidence?: number
+  content: string
+  createdAt: string
+  digest: string
+  id: string
+  kind: MemoryKind
+  metadata?: Record<string, unknown>
+  pinned?: boolean
+  provenance?: MemoryProvenance
+  scope: MemoryScope
+  status: "active" | "deleted" | "superseded"
+  store: string
+  supersedes?: string[]
+  tags?: string[]
+  title?: string
+  updatedAt: string
+  version: number
+}
+
+export interface MemorySearchRequest {
+  after?: string
+  before?: string
+  kinds?: MemoryKind[]
+  limit?: number
+  query: string
+  scope: MemoryScope
+  store: string
+  tags?: string[]
+}
+
+export interface MemorySearchResult {
+  items: Array<{
+    createdAt: string
+    id: string
+    kind: MemoryKind
+    provenance?: MemoryProvenance
+    score?: number
+    snippet: string
+    tags?: string[]
+    title?: string
+    updatedAt: string
+  }>
+}
+
+export interface MemoryReadRequest {
+  id: string
+  scope: MemoryScope
+  store: string
+}
+
+export interface MemoryAppendRequest {
+  confidence?: number
+  content: string
+  kind: MemoryKind
+  metadata?: Record<string, unknown>
+  pinned?: boolean
+  provenance?: MemoryProvenance
+  scope: MemoryScope
+  store: string
+  supersedes?: string[]
+  tags?: string[]
+  title?: string
+}
+
+export interface MemoryDeleteRequest {
+  id: string
+  reason?: string
+  scope: MemoryScope
+  store: string
+}
+
+export interface MemoryExportRequest {
+  scope: MemoryScope
+  store: string
+}
+
+export interface MemoryStoreAdapter {
+  append: (request: MemoryAppendRequest) => MaybePromise<{ action: "created" | "superseded", item: MemoryRecord }>
+  delete: (request: MemoryDeleteRequest) => MaybePromise<{ deletedId: string, ok: true, tombstoneId: string }>
+  export: (request: MemoryExportRequest) => MaybePromise<{ items: MemoryRecord[] }>
+  read: (request: MemoryReadRequest) => MaybePromise<{ item: MemoryRecord | null }>
+  search: (request: MemorySearchRequest) => MaybePromise<MemorySearchResult>
+}
+
+export interface MemoryStoreFactory {
+  create: (context: AgentCapabilityContext) => MaybePromise<MemoryStoreAdapter>
+  kind: string
+}
+
+export interface MemoryStoreOptions {
+  adapter: MemoryStoreAdapter | MemoryStoreFactory
+  allowKinds?: MemoryKind[]
+  read?: {
+    preload?: Array<{
+      inject?: "instructions" | false
+      kind?: MemoryKind | MemoryKind[]
+      maxItems?: number
+      pinned?: boolean
+    }>
+    tools?: {
+      read?: boolean
+      search?: boolean
+    }
+  }
+  retention?: {
+    export?: boolean
+    hardDelete?: boolean
+  }
+  scope: MemoryScope | ((context: AgentCapabilityContext) => MemoryScope)
+  write?: {
+    mode?: "off" | "tool"
+    policy?: AgentToolPolicyDecision
+  }
+}
+
+export interface MemoryCapabilityOptions extends MemoryCapabilityInstructionsOption {
+  stores: Record<string, MemoryStoreOptions>
+}
+
+export interface WorkspaceJsonlMemoryStoreOptions {
+  path?: string
+}
+
+type MemoryEvent = MemoryUpsertEvent | MemorySupersedeEvent | MemoryDeleteEvent
+
+interface MemoryUpsertEvent extends Omit<MemoryRecord, "status"> {
+  op: "upsert"
+  status: "active" | "superseded"
+}
+
+interface MemorySupersedeEvent {
+  digest: string
+  id: string
+  op: "supersede"
+  scope: MemoryScope
+  store: string
+  supersededAt: string
+  supersededBy: string
+  version: number
+}
+
+interface MemoryDeleteEvent {
+  deletedAt: string
+  digest: string
+  id: string
+  op: "delete"
+  reason?: string
+  scope: MemoryScope
+  store: string
+  tombstoneId: string
+  version: number
+}
+
+function createTool<TInput = unknown, TOutput = unknown>(tool: AgentToolDefinition<TInput, TOutput>): AgentToolDefinition {
+  return tool as AgentToolDefinition
+}
+
+function createMemoryId(prefix = "mem") {
+  return `${prefix}_${globalThis.crypto?.randomUUID?.().replace(/-/g, "") || Math.random().toString(36).slice(2)}`
+}
+
+async function digestMemoryValue(value: unknown): Promise<string> {
+  const input = JSON.stringify(value)
+  if (globalThis.crypto?.subtle) {
+    const bytes = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(input))
+    return `sha256:${Array.from(new Uint8Array(bytes)).map(byte => byte.toString(16).padStart(2, "0")).join("")}`
+  }
+  let hash = 5381
+  for (let index = 0; index < input.length; index++) hash = ((hash << 5) + hash) ^ input.charCodeAt(index)
+  return `djb2:${(hash >>> 0).toString(16)}`
+}
+
+function normalizeMemoryScope(scope: MemoryScope | undefined): MemoryScope {
+  const normalized: MemoryScope = {}
+  for (const [key, value] of Object.entries(scope || {}) as Array<[keyof MemoryScope, string | undefined]>) {
+    if (value) normalized[key] = value
+  }
+  return normalized
+}
+
+function memoryScopeMatches(record: MemoryRecord | MemorySupersedeEvent | MemoryDeleteEvent, scope: MemoryScope) {
+  return Object.entries(scope).every(([key, value]) => (record.scope as Record<string, unknown>)[key] === value)
+}
+
+function normalizeMemoryKinds(kind: MemoryKind | MemoryKind[] | undefined): MemoryKind[] | undefined {
+  return kind ? Array.isArray(kind) ? kind : [kind] : undefined
+}
+
+function createMemorySnippet(record: MemoryRecord, query: string) {
+  const text = [record.title, record.content].filter(Boolean).join("\n")
+  const normalized = text.toLowerCase()
+  const needle = query.toLowerCase()
+  const index = needle ? normalized.indexOf(needle) : -1
+  if (index < 0) return text.slice(0, 300)
+  return text.slice(Math.max(0, index - 80), index + Math.max(needle.length, 1) + 220)
+}
+
+function scoreMemoryRecord(record: MemoryRecord, query: string) {
+  const needle = query.toLowerCase()
+  if (!needle) return 1
+  const haystack = [record.title, record.content, ...(record.tags || [])].filter(Boolean).join("\n").toLowerCase()
+  let score = 0
+  let index = haystack.indexOf(needle)
+  while (index >= 0) {
+    score++
+    index = haystack.indexOf(needle, index + needle.length)
+  }
+  return score
+}
+
+function getWritableWorkspace(context: AgentCapabilityContext): WritableWorkspaceFacade | undefined {
+  const workspace = context.workspace as WritableWorkspaceFacade | undefined
+  return workspace?.fs && "appendFile" in workspace.fs && "writeFile" in workspace.fs ? workspace : undefined
+}
+
+async function appendWorkspaceJsonl(path: string, context: AgentCapabilityContext, line: string) {
+  const workspace = getWritableWorkspace(context)
+  if (!workspace) throw new Error("[vitehub:agent] workspaceJsonlMemoryStore() requires an agent workspace with write access.")
+  await workspace.fs.mkdir(path.split("/").slice(0, -1).join("/") || ".", { recursive: true })
+  await workspace.fs.appendFile(path, `${line}\n`)
+}
+
+async function readWorkspaceJsonl(path: string, context: AgentCapabilityContext): Promise<MemoryEvent[]> {
+  const workspace = context.workspace
+  if (!workspace) throw new Error("[vitehub:agent] workspaceJsonlMemoryStore() requires an agent workspace.")
+  let contents = ""
+  try {
+    contents = await workspace.fs.readFile(path, { encoding: "utf8" })
+  }
+  catch {
+    return []
+  }
+  const events: MemoryEvent[] = []
+  for (const line of contents.split(/\r?\n/)) {
+    if (!line.trim()) continue
+    try {
+      const event = JSON.parse(line) as MemoryEvent
+      if (event && typeof event === "object" && "op" in event) events.push(event)
+    }
+    catch {
+      continue
+    }
+  }
+  return events
+}
+
+function reduceMemoryEvents(events: MemoryEvent[], scope: MemoryScope, store: string): MemoryRecord[] {
+  const records = new Map<string, MemoryRecord>()
+  for (const event of events) {
+    if (event.store !== store || !memoryScopeMatches(event, scope)) continue
+    if (event.op === "delete") {
+      const existing = records.get(event.id)
+      if (existing) records.set(event.id, { ...existing, status: "deleted", updatedAt: event.deletedAt, version: event.version })
+      continue
+    }
+    if (event.op === "supersede") {
+      const existing = records.get(event.id)
+      if (existing) {
+        records.set(event.id, {
+          ...existing,
+          status: "superseded",
+          supersedes: [...(existing.supersedes || []), event.supersededBy],
+          updatedAt: event.supersededAt,
+          version: event.version,
+        })
+      }
+      continue
+    }
+    const { op: _op, ...record } = event
+    records.set(event.id, {
+      ...record,
+      status: event.status || "active",
+    })
+  }
+  return [...records.values()].filter(record => record.status === "active")
+}
+
+function filterMemoryRecords(records: MemoryRecord[], request: Omit<MemorySearchRequest, "scope" | "store">) {
+  const kinds = request.kinds ? new Set(request.kinds) : undefined
+  const tags = request.tags ? new Set(request.tags) : undefined
+  const after = request.after ? Date.parse(request.after) : undefined
+  const before = request.before ? Date.parse(request.before) : undefined
+  return records
+    .filter(record => !kinds || kinds.has(record.kind))
+    .filter(record => !tags || record.tags?.some(tag => tags.has(tag)))
+    .filter(record => after === undefined || Date.parse(record.updatedAt) >= after)
+    .filter(record => before === undefined || Date.parse(record.updatedAt) <= before)
+}
+
+export function workspaceJsonlMemoryStore(options: WorkspaceJsonlMemoryStoreOptions = {}): MemoryStoreFactory {
+  const path = options.path || ".vitehub/memory/agent.jsonl"
+  return {
+    kind: "workspace-jsonl",
+    create(context) {
+      return {
+        async append(request) {
+          const now = new Date().toISOString()
+          const base = {
+            confidence: request.confidence,
+            content: request.content,
+            createdAt: now,
+            id: createMemoryId(),
+            kind: request.kind,
+            metadata: request.metadata,
+            pinned: request.pinned,
+            provenance: request.provenance,
+            scope: request.scope,
+            store: request.store,
+            supersedes: request.supersedes,
+            tags: request.tags,
+            title: request.title,
+            updatedAt: now,
+            version: 1,
+          }
+          const event: MemoryUpsertEvent = {
+            ...base,
+            digest: await digestMemoryValue(base),
+            op: "upsert",
+            status: "active",
+          }
+          const supersedeEvents = await Promise.all((request.supersedes || []).map(async id => ({
+            digest: await digestMemoryValue({ id, supersededAt: now, supersededBy: event.id }),
+            id,
+            op: "supersede" as const,
+            scope: request.scope,
+            store: request.store,
+            supersededAt: now,
+            supersededBy: event.id,
+            version: 1,
+          })))
+          for (const supersedeEvent of supersedeEvents) {
+            await appendWorkspaceJsonl(path, context, JSON.stringify(supersedeEvent))
+          }
+          await appendWorkspaceJsonl(path, context, JSON.stringify(event))
+          return { action: request.supersedes?.length ? "superseded" : "created", item: { ...event, status: "active" } }
+        },
+        async delete(request) {
+          const event: MemoryDeleteEvent = {
+            deletedAt: new Date().toISOString(),
+            digest: await digestMemoryValue(request),
+            id: request.id,
+            op: "delete",
+            reason: request.reason,
+            scope: request.scope,
+            store: request.store,
+            tombstoneId: createMemoryId("mem_del"),
+            version: 1,
+          }
+          await appendWorkspaceJsonl(path, context, JSON.stringify(event))
+          return { deletedId: request.id, ok: true, tombstoneId: event.tombstoneId }
+        },
+        async export(request) {
+          return { items: reduceMemoryEvents(await readWorkspaceJsonl(path, context), request.scope, request.store) }
+        },
+        async read(request) {
+          return { item: reduceMemoryEvents(await readWorkspaceJsonl(path, context), request.scope, request.store).find(record => record.id === request.id) || null }
+        },
+        async search(request) {
+          const matches = filterMemoryRecords(reduceMemoryEvents(await readWorkspaceJsonl(path, context), request.scope, request.store), request)
+            .map(record => ({ record, score: scoreMemoryRecord(record, request.query) }))
+            .filter(match => !request.query || match.score > 0)
+            .sort((left, right) => right.score - left.score || right.record.updatedAt.localeCompare(left.record.updatedAt))
+            .slice(0, request.limit || 10)
+          return {
+            items: matches.map(({ record, score }) => ({
+              createdAt: record.createdAt,
+              id: record.id,
+              kind: record.kind,
+              provenance: record.provenance,
+              score,
+              snippet: createMemorySnippet(record, request.query),
+              tags: record.tags,
+              title: record.title,
+              updatedAt: record.updatedAt,
+            })),
+          }
+        },
+      }
+    },
+  }
+}
+
+function resolveMemoryStore(adapter: MemoryStoreAdapter | MemoryStoreFactory, context: AgentCapabilityContext): MaybePromise<MemoryStoreAdapter> {
+  return "create" in adapter ? adapter.create(context) : adapter
+}
+
+function resolveMemoryScope(options: MemoryStoreOptions, context: AgentCapabilityContext): MemoryScope {
+  const scope = typeof options.scope === "function" ? options.scope(context) : options.scope
+  if (!scope || !Object.values(scope).some(Boolean)) {
+    throw new Error("[vitehub:agent] memory() stores require an explicit scope.")
+  }
+  return normalizeMemoryScope({
+    thread: context.run?.threadId,
+    ...scope,
+  })
+}
+
+function assertMemoryKind(options: MemoryStoreOptions, kind: MemoryKind) {
+  if (options.allowKinds?.length && !options.allowKinds.includes(kind)) {
+    throw new Error(`[vitehub:agent] Memory kind "${kind}" is not allowed for this store.`)
+  }
+}
+
+function renderMemoryPreload(items: MemoryRecord[]) {
+  if (!items.length) return false
+  return [
+    "Durable memory is available as scoped records. Treat memory as advisory context that can be stale or superseded by the current request.",
+    ...items.map(item => `- [${item.kind}] ${item.title ? `${item.title}: ` : ""}${item.content}`),
+  ].join("\n")
+}
+
+function sortMemoryPreloadRecords(left: MemoryRecord, right: MemoryRecord) {
+  const pinned = Number(Boolean(right.pinned)) - Number(Boolean(left.pinned))
+  return pinned || right.updatedAt.localeCompare(left.updatedAt)
+}
+
+export function memory(options: MemoryCapabilityOptions): AgentCapabilityDefinition {
+  return defineCapability({
+    id: "memory",
+    async input(context) {
+      for (const [storeName, storeOptions] of Object.entries(options.stores)) {
+        const adapter = await resolveMemoryStore(storeOptions.adapter, context)
+        const scope = resolveMemoryScope(storeOptions, context)
+        for (const preload of storeOptions.read?.preload || []) {
+          if (preload.inject === false) continue
+          const exported = await adapter.export({ scope, store: storeName })
+          const kinds = normalizeMemoryKinds(preload.kind)
+          const items = exported.items
+            .filter(item => !kinds || kinds.includes(item.kind))
+            .filter(item => preload.pinned === undefined || item.pinned === preload.pinned)
+            .sort(sortMemoryPreloadRecords)
+            .slice(0, preload.maxItems || 5)
+          context.instructions.add(renderMemoryPreload(items), { id: `memory.${storeName}` })
+        }
+      }
+    },
+    async resolve(context) {
+      const resolved = new Map<string, { adapter: MemoryStoreAdapter, options: MemoryStoreOptions, scope: MemoryScope }>()
+      for (const [storeName, storeOptions] of Object.entries(options.stores)) {
+        resolved.set(storeName, {
+          adapter: await resolveMemoryStore(storeOptions.adapter, context),
+          options: storeOptions,
+          scope: resolveMemoryScope(storeOptions, context),
+        })
+      }
+      const getStore = (name?: string) => {
+        const storeName = name || "agent"
+        const store = resolved.get(storeName)
+        if (!store) throw new Error(`[vitehub:agent] Unknown memory store "${storeName}".`)
+        return { storeName, ...store }
+      }
+      const assertWriteAllowed = (selected: ReturnType<typeof getStore>) => {
+        if (selected.options.write?.mode !== "tool") {
+          throw new Error(`[vitehub:agent] Memory store "${selected.storeName}" does not allow writes.`)
+        }
+      }
+      const writePolicy = ({ input }: { input?: unknown }) => {
+        const selected = getStore((input as { store?: string } | undefined)?.store)
+        assertWriteAllowed(selected)
+        return selected.options.write?.policy || "require-approval"
+      }
+      const tools: AgentToolSet = {}
+      if ([...resolved.values()].some(store => store.options.read?.tools?.search !== false)) {
+        tools.memory_search = createTool({
+          description: "Search durable scoped memory records.",
+          execute: ({ after, before, kinds, limit, query, store, tags }: MemorySearchRequest & { store?: string }) => {
+            const selected = getStore(store)
+            return selected.adapter.search({ after, before, kinds, limit, query, scope: selected.scope, store: selected.storeName, tags })
+          },
+          name: "memory_search",
+        })
+      }
+      if ([...resolved.values()].some(store => store.options.read?.tools?.read !== false)) {
+        tools.memory_read = createTool({
+          description: "Read one durable memory record by id.",
+          execute: ({ id, store }: { id: string, store?: string }) => {
+            const selected = getStore(store)
+            return selected.adapter.read({ id, scope: selected.scope, store: selected.storeName })
+          },
+          name: "memory_read",
+        })
+      }
+      if ([...resolved.values()].some(store => store.options.write?.mode === "tool")) {
+        tools.memory_remember = createTool({
+          description: "Create a durable scoped memory record. Use only for information that should persist across future agent invocations.",
+          execute: ({ confidence, content, kind, metadata, pinned, provenance, store, supersedes, tags, title }: MemoryAppendRequest & { store?: string }) => {
+            const selected = getStore(store)
+            assertWriteAllowed(selected)
+            assertMemoryKind(selected.options, kind)
+            return selected.adapter.append({
+              confidence,
+              content,
+              kind,
+              metadata,
+              pinned,
+              provenance: {
+                runId: context.run?.runId,
+                source: "tool",
+                threadId: context.run?.threadId,
+                toolName: "memory_remember",
+                ...provenance,
+              },
+              scope: selected.scope,
+              store: selected.storeName,
+              supersedes,
+              tags,
+              title,
+            })
+          },
+          name: "memory_remember",
+          policy: writePolicy,
+        })
+        tools.memory_delete = createTool({
+          description: "Soft-delete one durable memory record.",
+          execute: ({ id, reason, store }: { id: string, reason?: string, store?: string }) => {
+            const selected = getStore(store)
+            assertWriteAllowed(selected)
+            return selected.adapter.delete({ id, reason, scope: selected.scope, store: selected.storeName })
+          },
+          name: "memory_delete",
+          policy: writePolicy,
+        })
+      }
+      context.tools.add(tools)
+      if (options.instructions !== false) {
+        context.instructions.add(options.instructions || "Memory tools operate on durable scoped records. Treat recalled memory as advisory and prefer the current user request when they conflict.", { id: "memory" })
+      }
+    },
+  })
+}

--- a/packages/agent/src/memory.ts
+++ b/packages/agent/src/memory.ts
@@ -420,10 +420,10 @@ export function workspaceJsonlMemoryStore(options: WorkspaceJsonlMemoryStoreOpti
             supersededBy: event.id,
             version: 1,
           })))
+          await appendWorkspaceJsonl(path, context, JSON.stringify(event))
           for (const supersedeEvent of supersedeEvents) {
             await appendWorkspaceJsonl(path, context, JSON.stringify(supersedeEvent))
           }
-          await appendWorkspaceJsonl(path, context, JSON.stringify(event))
           return { action: request.supersedes?.length ? "superseded" : "created", item: { ...event, status: "active" } }
         },
         async delete(request) {

--- a/packages/agent/src/memory.ts
+++ b/packages/agent/src/memory.ts
@@ -159,6 +159,7 @@ export interface WorkspaceJsonlMemoryStoreOptions {
   path?: string
 }
 
+type JsonSchema = Record<string, unknown>
 type MemoryEvent = MemoryUpsertEvent | MemorySupersedeEvent | MemoryDeleteEvent
 
 interface MemoryUpsertEvent extends Omit<MemoryRecord, "status"> {
@@ -192,6 +193,59 @@ interface MemoryDeleteEvent {
 function createTool<TInput = unknown, TOutput = unknown>(tool: AgentToolDefinition<TInput, TOutput>): AgentToolDefinition {
   return tool as AgentToolDefinition
 }
+
+function jsonObjectSchema(properties: Record<string, JsonSchema>, required: string[] = []): JsonSchema {
+  return {
+    additionalProperties: false,
+    properties,
+    ...(required.length ? { required } : {}),
+    type: "object",
+  }
+}
+
+const storePropertySchema: JsonSchema = {
+  description: "Memory store name. Omit only when the capability has one store or an `agent` store.",
+  type: "string",
+}
+
+const stringArraySchema: JsonSchema = {
+  items: { type: "string" },
+  type: "array",
+}
+
+const memorySearchInputSchema = jsonObjectSchema({
+  after: { description: "Include records updated at or after this ISO timestamp.", type: "string" },
+  before: { description: "Include records updated at or before this ISO timestamp.", type: "string" },
+  kinds: stringArraySchema,
+  limit: { minimum: 1, type: "number" },
+  query: { type: "string" },
+  store: storePropertySchema,
+  tags: stringArraySchema,
+}, ["query"])
+
+const memoryReadInputSchema = jsonObjectSchema({
+  id: { type: "string" },
+  store: storePropertySchema,
+}, ["id"])
+
+const memoryRememberInputSchema = jsonObjectSchema({
+  confidence: { maximum: 1, minimum: 0, type: "number" },
+  content: { type: "string" },
+  kind: { type: "string" },
+  metadata: { additionalProperties: true, type: "object" },
+  pinned: { type: "boolean" },
+  provenance: { additionalProperties: true, type: "object" },
+  store: storePropertySchema,
+  supersedes: stringArraySchema,
+  tags: stringArraySchema,
+  title: { type: "string" },
+}, ["content", "kind"])
+
+const memoryDeleteInputSchema = jsonObjectSchema({
+  id: { type: "string" },
+  reason: { type: "string" },
+  store: storePropertySchema,
+}, ["id"])
 
 function createMemoryId(prefix = "mem") {
   return `${prefix}_${globalThis.crypto?.randomUUID?.().replace(/-/g, "") || Math.random().toString(36).slice(2)}`
@@ -326,7 +380,7 @@ function filterMemoryRecords(records: MemoryRecord[], request: Omit<MemorySearch
 }
 
 export function workspaceJsonlMemoryStore(options: WorkspaceJsonlMemoryStoreOptions = {}): MemoryStoreFactory {
-  const path = options.path || ".vitehub/memory/agent.jsonl"
+  const path = options.path || ".vitehub/memory.jsonl"
   return {
     kind: "workspace-jsonl",
     create(context) {
@@ -427,10 +481,7 @@ function resolveMemoryScope(options: MemoryStoreOptions, context: AgentCapabilit
   if (!scope || !Object.values(scope).some(Boolean)) {
     throw new Error("[vitehub:agent] memory() stores require an explicit scope.")
   }
-  return normalizeMemoryScope({
-    thread: context.run?.threadId,
-    ...scope,
-  })
+  return normalizeMemoryScope(scope)
 }
 
 function assertMemoryKind(options: MemoryStoreOptions, kind: MemoryKind) {
@@ -481,11 +532,23 @@ export function memory(options: MemoryCapabilityOptions): AgentCapabilityDefinit
           scope: resolveMemoryScope(storeOptions, context),
         })
       }
+      const defaultStoreName = resolved.has("agent")
+        ? "agent"
+        : resolved.size === 1
+          ? [...resolved.keys()][0]
+          : undefined
       const getStore = (name?: string) => {
-        const storeName = name || "agent"
+        const storeName = name || defaultStoreName
+        if (!storeName) throw new Error("[vitehub:agent] Multiple memory stores are configured; pass `store` explicitly.")
         const store = resolved.get(storeName)
         if (!store) throw new Error(`[vitehub:agent] Unknown memory store "${storeName}".`)
         return { storeName, ...store }
+      }
+      const readSearchAllowed = (options: MemoryStoreOptions) => options.read?.tools?.search !== false
+      const readOneAllowed = (options: MemoryStoreOptions) => options.read?.tools?.read !== false
+      const assertReadAllowed = (selected: ReturnType<typeof getStore>, tool: "read" | "search") => {
+        const allowed = tool === "search" ? readSearchAllowed(selected.options) : readOneAllowed(selected.options)
+        if (!allowed) throw new Error(`[vitehub:agent] Memory store "${selected.storeName}" does not allow ${tool}.`)
       }
       const assertWriteAllowed = (selected: ReturnType<typeof getStore>) => {
         if (selected.options.write?.mode !== "tool") {
@@ -498,23 +561,27 @@ export function memory(options: MemoryCapabilityOptions): AgentCapabilityDefinit
         return selected.options.write?.policy || "require-approval"
       }
       const tools: AgentToolSet = {}
-      if ([...resolved.values()].some(store => store.options.read?.tools?.search !== false)) {
+      if ([...resolved.values()].some(store => readSearchAllowed(store.options))) {
         tools.memory_search = createTool({
           description: "Search durable scoped memory records.",
           execute: ({ after, before, kinds, limit, query, store, tags }: MemorySearchRequest & { store?: string }) => {
             const selected = getStore(store)
+            assertReadAllowed(selected, "search")
             return selected.adapter.search({ after, before, kinds, limit, query, scope: selected.scope, store: selected.storeName, tags })
           },
+          inputSchema: memorySearchInputSchema,
           name: "memory_search",
         })
       }
-      if ([...resolved.values()].some(store => store.options.read?.tools?.read !== false)) {
+      if ([...resolved.values()].some(store => readOneAllowed(store.options))) {
         tools.memory_read = createTool({
           description: "Read one durable memory record by id.",
           execute: ({ id, store }: { id: string, store?: string }) => {
             const selected = getStore(store)
+            assertReadAllowed(selected, "read")
             return selected.adapter.read({ id, scope: selected.scope, store: selected.storeName })
           },
+          inputSchema: memoryReadInputSchema,
           name: "memory_read",
         })
       }
@@ -545,6 +612,7 @@ export function memory(options: MemoryCapabilityOptions): AgentCapabilityDefinit
               title,
             })
           },
+          inputSchema: memoryRememberInputSchema,
           name: "memory_remember",
           policy: writePolicy,
         })
@@ -555,6 +623,7 @@ export function memory(options: MemoryCapabilityOptions): AgentCapabilityDefinit
             assertWriteAllowed(selected)
             return selected.adapter.delete({ id, reason, scope: selected.scope, store: selected.storeName })
           },
+          inputSchema: memoryDeleteInputSchema,
           name: "memory_delete",
           policy: writePolicy,
         })

--- a/packages/agent/test/memory.test.ts
+++ b/packages/agent/test/memory.test.ts
@@ -163,6 +163,157 @@ describe("agent memory capability", () => {
     expect(readonly.delete).not.toHaveBeenCalled()
   })
 
+  it("enforces per-store read permissions for selected stores", async () => {
+    const readable: MemoryStoreAdapter = {
+      append: vi.fn(),
+      delete: vi.fn(),
+      export: vi.fn(async () => ({ items: [] })),
+      read: vi.fn(async () => ({ item: null })),
+      search: vi.fn(async () => ({ items: [] })),
+    }
+    const hidden: MemoryStoreAdapter = {
+      append: vi.fn(),
+      delete: vi.fn(),
+      export: vi.fn(async () => ({ items: [] })),
+      read: vi.fn(),
+      search: vi.fn(),
+    }
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { memory } = await import("../src/capabilities.ts")
+    let capturedTools: Record<string, { execute: (input: unknown) => Promise<unknown> | unknown }> = {}
+    const agent = defineAgent({
+      async run(context) {
+        capturedTools = context.tools as typeof capturedTools
+        return { text: Object.keys(context.tools || {}).sort().join(",") }
+      },
+      capabilities: [
+        memory({
+          stores: {
+            agent: {
+              adapter: readable,
+              scope: { agent: "support" },
+            },
+            hidden: {
+              adapter: hidden,
+              read: { tools: { read: false, search: false } },
+              scope: { agent: "support" },
+            },
+          },
+        }),
+      ],
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+      text: "memory_read,memory_search",
+    })
+    await expect(Promise.resolve().then(() => capturedTools.memory_search!.execute({ query: "anything", store: "hidden" }))).rejects.toThrow("does not allow search")
+    await expect(Promise.resolve().then(() => capturedTools.memory_read!.execute({ id: "mem_1", store: "hidden" }))).rejects.toThrow("does not allow read")
+    expect(hidden.search).not.toHaveBeenCalled()
+    expect(hidden.read).not.toHaveBeenCalled()
+  })
+
+  it("uses the sole configured memory store as the default when no agent store exists", async () => {
+    const adapter: MemoryStoreAdapter = {
+      append: vi.fn(async request => ({ action: "created" as const, item: memoryRecord({ ...request, id: "mem_1" }) })),
+      delete: vi.fn(async request => ({ deletedId: request.id, ok: true as const, tombstoneId: "mem_del_1" })),
+      export: vi.fn(async () => ({ items: [] })),
+      read: vi.fn(),
+      search: vi.fn(async () => ({ items: [] })),
+    }
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { memory } = await import("../src/capabilities.ts")
+    let capturedTools: Record<string, { execute: (input: unknown) => Promise<unknown> | unknown }> = {}
+    const agent = defineAgent({
+      async run(context) {
+        capturedTools = context.tools as typeof capturedTools
+        return { text: "ok" }
+      },
+      capabilities: [
+        memory({
+          stores: {
+            project: {
+              adapter,
+              scope: { project: "vitehub" },
+              write: { mode: "tool", policy: "allow" },
+            },
+          },
+        }),
+      ],
+    })
+
+    await runAgent(agent, runtime(), {})
+    await capturedTools.memory_search!.execute({ query: "anything" })
+    await capturedTools.memory_remember!.execute({ content: "Remember this.", kind: "semantic" })
+    expect(adapter.search).toHaveBeenCalledWith(expect.objectContaining({ store: "project" }))
+    expect(adapter.append).toHaveBeenCalledWith(expect.objectContaining({ store: "project" }))
+  })
+
+  it("requires an explicit store when multiple stores are configured without an agent default", async () => {
+    const adapter: MemoryStoreAdapter = {
+      append: vi.fn(),
+      delete: vi.fn(),
+      export: vi.fn(async () => ({ items: [] })),
+      read: vi.fn(),
+      search: vi.fn(),
+    }
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { memory } = await import("../src/capabilities.ts")
+    let capturedTools: Record<string, { execute: (input: unknown) => Promise<unknown> | unknown }> = {}
+    const agent = defineAgent({
+      async run(context) {
+        capturedTools = context.tools as typeof capturedTools
+        return { text: "ok" }
+      },
+      capabilities: [
+        memory({
+          stores: {
+            project: { adapter, scope: { project: "vitehub" } },
+            user: { adapter, scope: { user: "u_1" } },
+          },
+        }),
+      ],
+    })
+
+    await runAgent(agent, runtime(), {})
+    await expect(Promise.resolve().then(() => capturedTools.memory_search!.execute({ query: "anything" }))).rejects.toThrow("pass `store` explicitly")
+  })
+
+  it("adds input schemas to memory tools", async () => {
+    const adapter: MemoryStoreAdapter = {
+      append: vi.fn(),
+      delete: vi.fn(),
+      export: vi.fn(async () => ({ items: [] })),
+      read: vi.fn(),
+      search: vi.fn(),
+    }
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { memory } = await import("../src/capabilities.ts")
+    let capturedTools: Record<string, { inputSchema?: unknown }> = {}
+    const agent = defineAgent({
+      async run(context) {
+        capturedTools = context.tools as typeof capturedTools
+        return { text: "ok" }
+      },
+      capabilities: [
+        memory({
+          stores: {
+            agent: {
+              adapter,
+              scope: { agent: "support" },
+              write: { mode: "tool", policy: "allow" },
+            },
+          },
+        }),
+      ],
+    })
+
+    await runAgent(agent, runtime(), {})
+    expect(capturedTools.memory_search?.inputSchema).toMatchObject({ required: ["query"], type: "object" })
+    expect(capturedTools.memory_read?.inputSchema).toMatchObject({ required: ["id"], type: "object" })
+    expect(capturedTools.memory_remember?.inputSchema).toMatchObject({ required: ["content", "kind"], type: "object" })
+    expect(capturedTools.memory_delete?.inputSchema).toMatchObject({ required: ["id"], type: "object" })
+  })
+
   it("does not expose memory write tools unless at least one store opts in", async () => {
     const adapter: MemoryStoreAdapter = {
       append: vi.fn(),
@@ -221,6 +372,103 @@ describe("agent memory capability", () => {
     await adapter.delete({ id: created.item.id, scope: { agent: "support" }, store: "agent" })
     await expect(adapter.read({ id: created.item.id, scope: { agent: "support" }, store: "agent" })).resolves.toEqual({ item: null })
     expect(files.get(".vitehub/memory/test.jsonl")?.trim().split("\n")).toHaveLength(2)
+  })
+
+  it("uses a workspace-level JSONL path by default", async () => {
+    const files = new Map<string, string>()
+    const { workspaceJsonlMemoryStore } = await import("../src/capabilities.ts")
+    const adapter = await workspaceJsonlMemoryStore().create({
+      workspace: {
+        fs: {
+          appendFile: async (path: string, content: string) => files.set(path, `${files.get(path) || ""}${content}`),
+          mkdir: vi.fn(),
+          readFile: async (path: string) => files.get(path) || "",
+          writeFile: vi.fn(),
+        },
+      },
+    } as never)
+
+    await adapter.append({
+      content: "Default memory file.",
+      kind: "semantic",
+      scope: { agent: "support" },
+      store: "agent",
+    })
+
+    expect(files.has(".vitehub/memory.jsonl")).toBe(true)
+  })
+
+  it("does not add thread scope unless configured", async () => {
+    const adapter: MemoryStoreAdapter = {
+      append: vi.fn(async request => ({ action: "created" as const, item: memoryRecord({ ...request, id: "mem_1" }) })),
+      delete: vi.fn(),
+      export: vi.fn(async () => ({ items: [] })),
+      read: vi.fn(),
+      search: vi.fn(),
+    }
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { memory } = await import("../src/capabilities.ts")
+    let capturedTools: Record<string, { execute: (input: unknown) => Promise<unknown> | unknown }> = {}
+    const agent = defineAgent({
+      async run(context) {
+        capturedTools = context.tools as typeof capturedTools
+        return { text: "ok" }
+      },
+      capabilities: [
+        memory({
+          stores: {
+            agent: {
+              adapter,
+              scope: { agent: "support" },
+              write: { mode: "tool", policy: "allow" },
+            },
+          },
+        }),
+      ],
+    })
+
+    await runAgent(agent, { ...runtime(), run: { runId: "run_1", threadId: "thread_1" } }, {})
+    await capturedTools.memory_remember!.execute({ content: "Remember this.", kind: "semantic" })
+    expect(adapter.append).toHaveBeenCalledWith(expect.objectContaining({
+      provenance: expect.objectContaining({ threadId: "thread_1" }),
+      scope: { agent: "support" },
+    }))
+  })
+
+  it("supports explicit dynamic thread scoping", async () => {
+    const adapter: MemoryStoreAdapter = {
+      append: vi.fn(async request => ({ action: "created" as const, item: memoryRecord({ ...request, id: "mem_1" }) })),
+      delete: vi.fn(),
+      export: vi.fn(async () => ({ items: [] })),
+      read: vi.fn(),
+      search: vi.fn(),
+    }
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { memory } = await import("../src/capabilities.ts")
+    let capturedTools: Record<string, { execute: (input: unknown) => Promise<unknown> | unknown }> = {}
+    const agent = defineAgent({
+      async run(context) {
+        capturedTools = context.tools as typeof capturedTools
+        return { text: "ok" }
+      },
+      capabilities: [
+        memory({
+          stores: {
+            agent: {
+              adapter,
+              scope: context => ({ agent: "support", thread: context.run?.threadId }),
+              write: { mode: "tool", policy: "allow" },
+            },
+          },
+        }),
+      ],
+    })
+
+    await runAgent(agent, { ...runtime(), run: { runId: "run_1", threadId: "thread_1" } }, {})
+    await capturedTools.memory_remember!.execute({ content: "Remember this.", kind: "semantic" })
+    expect(adapter.append).toHaveBeenCalledWith(expect.objectContaining({
+      scope: { agent: "support", thread: "thread_1" },
+    }))
   })
 
   it("supersedes old workspace JSONL memory records", async () => {

--- a/packages/agent/test/memory.test.ts
+++ b/packages/agent/test/memory.test.ts
@@ -503,6 +503,8 @@ describe("agent memory capability", () => {
       items: [{ id: second.item.id }],
     })
     await expect(adapter.read({ id: first.item.id, scope: { agent: "support" }, store: "agent" })).resolves.toEqual({ item: null })
-    expect(files.get(".vitehub/memory/test.jsonl")?.trim().split("\n")).toHaveLength(3)
+    const lines = files.get(".vitehub/memory/test.jsonl")?.trim().split("\n").map(line => JSON.parse(line)) || []
+    expect(lines).toHaveLength(3)
+    expect(lines.map(line => line.op)).toEqual(["upsert", "upsert", "supersede"])
   })
 })

--- a/packages/agent/test/memory.test.ts
+++ b/packages/agent/test/memory.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { MemoryRecord, MemoryStoreAdapter } from "../src/memory.ts"
+
+const runtime = () => ({
+  memo: vi.fn(),
+  runtime: "unknown" as const,
+  waitUntil: vi.fn(),
+})
+
+function memoryRecord(record: Partial<MemoryRecord> & Pick<MemoryRecord, "content" | "id" | "kind">): MemoryRecord {
+  return {
+    content: record.content,
+    createdAt: record.createdAt || "2026-05-18T00:00:00.000Z",
+    digest: record.digest || `sha256:${record.id}`,
+    id: record.id,
+    kind: record.kind,
+    scope: record.scope || { agent: "support" },
+    status: record.status || "active",
+    store: record.store || "agent",
+    updatedAt: record.updatedAt || "2026-05-18T00:00:00.000Z",
+    version: record.version || 1,
+    ...(record.confidence === undefined ? {} : { confidence: record.confidence }),
+    ...(record.metadata === undefined ? {} : { metadata: record.metadata }),
+    ...(record.pinned === undefined ? {} : { pinned: record.pinned }),
+    ...(record.provenance === undefined ? {} : { provenance: record.provenance }),
+    ...(record.supersedes === undefined ? {} : { supersedes: record.supersedes }),
+    ...(record.tags === undefined ? {} : { tags: record.tags }),
+    ...(record.title === undefined ? {} : { title: record.title }),
+  }
+}
+
+describe("agent memory capability", () => {
+  it("adds record-oriented memory tools and preloads pinned procedural memory", async () => {
+    const records = [memoryRecord({
+      content: "Use gh CLI for GitHub operations.",
+      id: "mem_1",
+      kind: "procedural",
+      pinned: true,
+      title: "GitHub workflow",
+    })]
+    const adapter: MemoryStoreAdapter = {
+      append: vi.fn(async request => ({ action: "created" as const, item: memoryRecord({ ...request, id: "mem_2" }) })),
+      delete: vi.fn(async request => ({ deletedId: request.id, ok: true as const, tombstoneId: "mem_del_1" })),
+      export: vi.fn(async () => ({ items: records })),
+      read: vi.fn(async request => ({ item: records.find(record => record.id === request.id) || null })),
+      search: vi.fn(async () => ({ items: [{ createdAt: records[0]!.createdAt, id: "mem_1", kind: "procedural", snippet: records[0]!.content, title: records[0]!.title, updatedAt: records[0]!.updatedAt }] })),
+    }
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { memory } = await import("../src/capabilities.ts")
+    let capturedTools: Record<string, { execute: (input: unknown) => Promise<unknown> | unknown, policy?: unknown }> = {}
+    const agent = defineAgent({
+      async run(context) {
+        capturedTools = context.tools as typeof capturedTools
+        return { text: Object.keys(context.tools || {}).sort().join(",") }
+      },
+      capabilities: [
+        memory({
+          stores: {
+            agent: {
+              adapter,
+              allowKinds: ["procedural", "semantic"],
+              read: { preload: [{ kind: "procedural", pinned: true }] },
+              scope: { agent: "support" },
+              write: { mode: "tool", policy: "allow" },
+            },
+          },
+        }),
+      ],
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+      text: "memory_delete,memory_read,memory_remember,memory_search",
+    })
+    expect(adapter.export).toHaveBeenCalled()
+    await expect(capturedTools.memory_search!.execute({ query: "github" })).resolves.toMatchObject({ items: [{ id: "mem_1" }] })
+    await expect(capturedTools.memory_read!.execute({ id: "mem_1" })).resolves.toMatchObject({ item: { id: "mem_1" } })
+    await expect(capturedTools.memory_remember!.execute({ content: "Prefer workspace JSONL.", kind: "semantic" })).resolves.toMatchObject({ item: { id: "mem_2" } })
+    await expect(capturedTools.memory_delete!.execute({ id: "mem_1", reason: "obsolete" })).resolves.toMatchObject({ ok: true })
+    expect(await (capturedTools.memory_remember!.policy as (context: { input?: unknown }) => unknown)({ input: {} })).toBe("allow")
+  })
+
+  it("preloads newest matching memory records first", async () => {
+    const adapter: MemoryStoreAdapter = {
+      append: vi.fn(),
+      delete: vi.fn(),
+      export: vi.fn(async () => ({
+        items: [
+          memoryRecord({ content: "Old workflow.", id: "mem_old", kind: "procedural", pinned: true, updatedAt: "2026-05-17T00:00:00.000Z" }),
+          memoryRecord({ content: "New workflow.", id: "mem_new", kind: "procedural", pinned: true, updatedAt: "2026-05-18T00:00:00.000Z" }),
+        ],
+      })),
+      read: vi.fn(),
+      search: vi.fn(),
+    }
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { memory } = await import("../src/capabilities.ts")
+
+    const capabilities = await resolveAgentCapabilities({
+      capabilities: [
+        memory({
+          stores: {
+            agent: {
+              adapter,
+              read: { preload: [{ kind: "procedural", maxItems: 1, pinned: true }] },
+              scope: { agent: "support" },
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, {})
+
+    const preload = capabilities.capabilityInstructions.find(block => block.id === "memory.agent")
+    expect(preload?.instructions).toContain("New workflow.")
+    expect(preload?.instructions).not.toContain("Old workflow.")
+  })
+
+  it("enforces memory write mode and policy for the selected store", async () => {
+    const writable: MemoryStoreAdapter = {
+      append: vi.fn(async request => ({ action: "created" as const, item: memoryRecord({ ...request, id: "mem_1" }) })),
+      delete: vi.fn(async request => ({ deletedId: request.id, ok: true as const, tombstoneId: "mem_del_1" })),
+      export: vi.fn(async () => ({ items: [] })),
+      read: vi.fn(),
+      search: vi.fn(),
+    }
+    const readonly: MemoryStoreAdapter = {
+      append: vi.fn(),
+      delete: vi.fn(),
+      export: vi.fn(async () => ({ items: [] })),
+      read: vi.fn(),
+      search: vi.fn(),
+    }
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { memory } = await import("../src/capabilities.ts")
+    let capturedTools: Record<string, { execute: (input: unknown) => Promise<unknown> | unknown, policy?: (context: { input?: unknown }) => unknown }> = {}
+    const agent = defineAgent({
+      async run(context) {
+        capturedTools = context.tools as typeof capturedTools
+        return { text: "ok" }
+      },
+      capabilities: [
+        memory({
+          stores: {
+            agent: {
+              adapter: writable,
+              scope: { agent: "support" },
+              write: { mode: "tool", policy: "allow" },
+            },
+            readonly: {
+              adapter: readonly,
+              scope: { agent: "support" },
+            },
+          },
+        }),
+      ],
+    })
+
+    await runAgent(agent, runtime(), {})
+    expect(await capturedTools.memory_remember!.policy!({ input: { store: "agent" } })).toBe("allow")
+    await expect(Promise.resolve().then(() => capturedTools.memory_remember!.execute({ content: "Keep this.", kind: "semantic", store: "readonly" }))).rejects.toThrow("does not allow writes")
+    await expect(Promise.resolve().then(() => capturedTools.memory_delete!.execute({ id: "mem_1", store: "readonly" }))).rejects.toThrow("does not allow writes")
+    expect(readonly.append).not.toHaveBeenCalled()
+    expect(readonly.delete).not.toHaveBeenCalled()
+  })
+
+  it("does not expose memory write tools unless at least one store opts in", async () => {
+    const adapter: MemoryStoreAdapter = {
+      append: vi.fn(),
+      delete: vi.fn(),
+      export: vi.fn(async () => ({ items: [] })),
+      read: vi.fn(),
+      search: vi.fn(),
+    }
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { memory } = await import("../src/capabilities.ts")
+    const agent = defineAgent({
+      async run(context) {
+        return { text: Object.keys(context.tools || {}).sort().join(",") }
+      },
+      capabilities: [
+        memory({
+          stores: {
+            agent: {
+              adapter,
+              scope: { agent: "support" },
+            },
+          },
+        }),
+      ],
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+      text: "memory_read,memory_search",
+    })
+  })
+
+  it("persists workspace JSONL memory as append-only events", async () => {
+    const files = new Map<string, string>()
+    const { workspaceJsonlMemoryStore } = await import("../src/capabilities.ts")
+    const adapter = await workspaceJsonlMemoryStore({ path: ".vitehub/memory/test.jsonl" }).create({
+      workspace: {
+        fs: {
+          appendFile: async (path: string, content: string) => files.set(path, `${files.get(path) || ""}${content}`),
+          mkdir: vi.fn(),
+          readFile: async (path: string) => files.get(path) || "",
+          writeFile: vi.fn(),
+        },
+      },
+    } as never)
+
+    const created = await adapter.append({
+      content: "Memory is scoped durable context.",
+      kind: "semantic",
+      scope: { agent: "support" },
+      store: "agent",
+      title: "Memory definition",
+    })
+    await expect(adapter.search({ query: "scoped", scope: { agent: "support" }, store: "agent" })).resolves.toMatchObject({
+      items: [{ id: created.item.id }],
+    })
+    await adapter.delete({ id: created.item.id, scope: { agent: "support" }, store: "agent" })
+    await expect(adapter.read({ id: created.item.id, scope: { agent: "support" }, store: "agent" })).resolves.toEqual({ item: null })
+    expect(files.get(".vitehub/memory/test.jsonl")?.trim().split("\n")).toHaveLength(2)
+  })
+
+  it("supersedes old workspace JSONL memory records", async () => {
+    const files = new Map<string, string>()
+    const { workspaceJsonlMemoryStore } = await import("../src/capabilities.ts")
+    const adapter = await workspaceJsonlMemoryStore({ path: ".vitehub/memory/test.jsonl" }).create({
+      workspace: {
+        fs: {
+          appendFile: async (path: string, content: string) => files.set(path, `${files.get(path) || ""}${content}`),
+          mkdir: vi.fn(),
+          readFile: async (path: string) => files.get(path) || "",
+          writeFile: vi.fn(),
+        },
+      },
+    } as never)
+
+    const first = await adapter.append({
+      content: "Old workflow.",
+      kind: "procedural",
+      scope: { agent: "support" },
+      store: "agent",
+    })
+    const second = await adapter.append({
+      content: "New workflow.",
+      kind: "procedural",
+      scope: { agent: "support" },
+      store: "agent",
+      supersedes: [first.item.id],
+    })
+
+    await expect(adapter.search({ query: "workflow", scope: { agent: "support" }, store: "agent" })).resolves.toMatchObject({
+      items: [{ id: second.item.id }],
+    })
+    await expect(adapter.read({ id: first.item.id, scope: { agent: "support" }, store: "agent" })).resolves.toEqual({ item: null })
+    expect(files.get(".vitehub/memory/test.jsonl")?.trim().split("\n")).toHaveLength(3)
+  })
+})

--- a/packages/agent/tsdown.config.ts
+++ b/packages/agent/tsdown.config.ts
@@ -10,8 +10,10 @@ export default defineConfig({
   dts: true,
   entry: [
     "src/ai-sdk.ts",
+    "src/capabilities.ts",
     "src/capability-runtime.ts",
     "src/index.ts",
+    "src/memory.ts",
     "src/cloudflare.ts",
     "src/nitro.ts",
     "src/runtime/empty-registry.ts",


### PR DESCRIPTION
Adds the Agent Memory capability split from #113 on top of the runtime core.

This includes the dedicated memory module, public capabilities re-export, record-oriented memory types, preload injection, read/search/remember/delete tools, write policy handling, and append-only Workspace JSONL storage.

Kept the scope limited to memory: no chat, devtools, package removals, provider fixes, or e2e changes.