### PR TITLE
feat(workspace)!: require explicit sources

### DIFF
--- a/.agents/adr/0007-workspace-source-boundaries.md
+++ b/.agents/adr/0007-workspace-source-boundaries.md
@@ -1,0 +1,14 @@
+# Workspace Source Boundaries
+
+Workspace remains a separate primitive for the filesystem boundary, while Capabilities only declare and consume the Workspace access they need. A colocated Agent `workspace: { ... }` is a Colocated Workspace Definition, not Agent-owned capability configuration, and sibling files are not ingested automatically; users must declare explicit Sources.
+
+## Considered Options
+
+- Treating Workspace as a Capability was rejected because Workspace is useful outside agent execution and is the boundary that Capabilities consume.
+- Allowing Capabilities to mutate Workspace configuration was rejected because Sources, rules, and write policy must remain visible at the Workspace boundary.
+- Automatically ingesting files next to a Colocated Workspace Definition was rejected because it hides the file-tree boundary and makes config/source-code exclusions surprising.
+- Root-mounting Sources was deferred because it needs explicit conflict and write-policy semantics before Source-backed paths can safely share the Workspace root with normal store paths.
+
+## Consequences
+
+Sources ingest content into a Workspace; Capabilities expose model-facing abilities. Source keys stay relative to the Source scan base, while Mount owns Workspace placement. Local glob Sources should use familiar glob vocabulary and safe defaults, including explicit hidden-file inclusion and source-root-bound `cwd` handling.

--- a/.agents/contexts/workspace/CONTEXT.md
+++ b/.agents/contexts/workspace/CONTEXT.md
@@ -11,6 +11,10 @@ A named persistent file tree that agents and server code can inspect, mutate whe
 The configured backing store used to persist a Workspace file tree.
 _Avoid_: Blob Store, Source, Chat State
 
+**Colocated Workspace Definition**:
+A Workspace Definition declared inline with the consumer that primarily uses it.
+_Avoid_: Agent Workspace, Capability Workspace
+
 **Source**:
 A named origin that contributes read-only files or items into a Workspace.
 _Avoid_: Input, files, context, resource, mount
@@ -42,6 +46,7 @@ _Avoid_: Capability, source, loader
 ## Relationships
 
 - A **Workspace** has one **Workspace Store**.
+- A **Colocated Workspace Definition** still defines a **Workspace**.
 - A **Workspace Store** can be backed by a Blob Store.
 - A **Workspace** has zero or more **Sources**.
 - A **Workspace** declares Sources through one **Source Map**.
@@ -63,3 +68,5 @@ _Avoid_: Capability, source, loader
 - "source" can mean source code, provenance, or data connector - resolved: in Workspace, **Source** means a named origin that contributes files or items.
 - "mount" was considered as the name for `workspace.sources` - resolved: **Mount** is only the placement of a Source inside the Workspace.
 - `workspace.sources` was considered as an array for simple one-off Sources - resolved: use a **Source Map** so every Source has stable identity.
+- Agent `workspace: { ... }` shorthand was considered as Agent-owned configuration - resolved: treat it as a **Colocated Workspace Definition**.
+- Sibling files next to a **Colocated Workspace Definition** were considered for automatic ingestion - resolved: require explicit **Sources** instead.

--- a/docs/content/docs/tutorials/build-ai-chatbot.md
+++ b/docs/content/docs/tutorials/build-ai-chatbot.md
@@ -202,7 +202,7 @@ export default defineAgent({
   workspace: {
     sources: {
       docs: source.glob({
-        cwd: process.cwd(),
+        cwd: '.',
         include: ['README.md', 'docs/**/*.md'],
       }),
       knowledgeBase: source.github({

--- a/packages/unsource/src/sources/glob.ts
+++ b/packages/unsource/src/sources/glob.ts
@@ -1,16 +1,18 @@
 import { glob as tinyglobby } from "tinyglobby"
 
 import { UnsourceError } from "../core/errors.ts"
-import { matchesAny, normalizeSourcePath } from "../core/path.ts"
+import { matchesAny, normalizeSafeSourcePath, normalizeSourcePath } from "../core/path.ts"
 
 import type { Source, SourceContext, SourceItem } from "../core/types.ts"
 
 export interface GlobSourceOptions {
   cwd?: string
+  dot?: boolean
+  followSymlinks?: boolean
   include: string | string[]
-  exclude?: string | string[]
+  ignore?: string | string[]
   keyCache?: boolean
-  root?: string
+  prefix?: string
 }
 
 export function glob<const TKey extends string = string>(options: GlobSourceOptions): Source<TKey> {
@@ -18,22 +20,22 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
   let latest: { key: string, keys: TKey[] } | undefined
 
   async function getContextKey(ctx: SourceContext) {
-    const { resolve } = await import("node:path")
-    return resolve(ctx.rootDir, options.cwd || ".")
+    return resolveCwd(ctx.rootDir, options.cwd)
   }
 
   async function loadKeys(ctx: SourceContext) {
-    const { resolve } = await import("node:path")
-    const cwd = resolve(ctx.rootDir, options.cwd || ".")
+    const cwd = await resolveCwd(ctx.rootDir, options.cwd)
+    const ignore = normalizePatterns(options.ignore)
     const files = await tinyglobby(options.include, {
       cwd,
-      dot: true,
-      ignore: ["**/.git/**", "**/node_modules/**", ...(Array.isArray(options.exclude) ? options.exclude : options.exclude ? [options.exclude] : [])],
+      dot: options.dot ?? false,
+      followSymbolicLinks: options.followSymlinks ?? false,
+      ignore: ["**/.git/**", "**/node_modules/**", ...ignore],
       onlyFiles: true,
     })
     return files
       .map(file => normalizeSourcePath(file))
-      .filter(file => matchesAny(file, options.include) && !(options.exclude && matchesAny(file, options.exclude)))
+      .filter(file => matchesAny(file, options.include) && !matchesAny(file, ignore))
       .sort((left, right) => left.localeCompare(right)) as TKey[]
   }
 
@@ -82,7 +84,7 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
       await assertKey(key, ctx)
       const { stat } = await import("node:fs/promises")
       const { resolve } = await import("node:path")
-      const cwd = resolve(ctx.rootDir, options.cwd || ".")
+      const cwd = await resolveCwd(ctx.rootDir, options.cwd)
       const info = await stat(resolve(cwd, key))
       return {
         digest: `${info.size}:${info.mtimeMs}`,
@@ -92,17 +94,32 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
       await assertKey(key, ctx)
       const { readFile, stat } = await import("node:fs/promises")
       const { resolve } = await import("node:path")
-      const cwd = resolve(ctx.rootDir, options.cwd || ".")
-      const root = normalizeSourcePath(options.root || "")
+      const cwd = await resolveCwd(ctx.rootDir, options.cwd)
+      const prefix = normalizeSafeSourcePath(options.prefix || "", { allowEmpty: true })
       const bytes = await readFile(resolve(cwd, key))
       const info = await stat(resolve(cwd, key))
       return {
         key,
-        path: normalizeSourcePath(root ? `${root}/${key}` : key),
+        path: normalizeSourcePath(prefix ? `${prefix}/${key}` : key),
         content: new Uint8Array(bytes),
         metadata: { mtime: info.mtimeMs },
       }
     },
   }
   return source
+}
+
+function normalizePatterns(patterns: string | string[] | undefined): string[] {
+  return Array.isArray(patterns) ? patterns : patterns ? [patterns] : []
+}
+
+async function resolveCwd(rootDir: string, cwd = "."): Promise<string> {
+  const { isAbsolute, relative, resolve, sep } = await import("node:path")
+  const resolvedRoot = resolve(rootDir)
+  const resolvedCwd = isAbsolute(cwd) ? resolve(cwd) : resolve(resolvedRoot, cwd)
+  const rel = relative(resolvedRoot, resolvedCwd)
+  if (rel.startsWith("..") || rel === ".." || rel.includes(`..${sep}`)) {
+    throw new UnsourceError(`[vitehub] source.glob cwd escapes the source root: ${JSON.stringify(cwd)}.`)
+  }
+  return resolvedCwd
 }

--- a/packages/unsource/src/sources/glob.ts
+++ b/packages/unsource/src/sources/glob.ts
@@ -114,11 +114,13 @@ function normalizePatterns(patterns: string | string[] | undefined): string[] {
 }
 
 async function resolveCwd(rootDir: string, cwd = "."): Promise<string> {
-  const { isAbsolute, relative, resolve, sep } = await import("node:path")
-  const resolvedRoot = resolve(rootDir)
-  const resolvedCwd = isAbsolute(cwd) ? resolve(cwd) : resolve(resolvedRoot, cwd)
+  const { realpath } = await import("node:fs/promises")
+  const { isAbsolute, relative, resolve } = await import("node:path")
+  const resolvedRoot = await realpath(resolve(rootDir))
+  const resolvedCwdPath = isAbsolute(cwd) ? resolve(cwd) : resolve(resolvedRoot, cwd)
+  const resolvedCwd = await realpath(resolvedCwdPath)
   const rel = relative(resolvedRoot, resolvedCwd)
-  if (rel.startsWith("..") || rel === ".." || rel.includes(`..${sep}`)) {
+  if (rel && (rel.startsWith("..") || isAbsolute(rel))) {
     throw new UnsourceError(`[vitehub] source.glob cwd escapes the source root: ${JSON.stringify(cwd)}.`)
   }
   return resolvedCwd

--- a/packages/unsource/test/sources/file-glob-markdown.test.ts
+++ b/packages/unsource/test/sources/file-glob-markdown.test.ts
@@ -1,6 +1,6 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
 
@@ -51,5 +51,42 @@ describe("@vitehub/unsource local file sources", () => {
       .rejects.toThrow("source.file could not find")
     await expect(useSource("docs", { rootDir: root }).read("../package.json" as any))
       .rejects.toThrow("source.glob could not find")
+  })
+
+  it("uses ignore, dot, prefix, and cwd boundary options for glob providers", async () => {
+    const root = await createRoot()
+    const outside = await createRoot()
+    await mkdir(join(root, "workspace", "drafts"), { recursive: true })
+    await writeFile(join(root, "workspace", "README.md"), "# Docs\n")
+    await writeFile(join(root, "workspace", ".secret.md"), "# Secret\n")
+    await writeFile(join(root, "workspace", "drafts", "skip.md"), "# Skip\n")
+    await writeFile(join(outside, "outside.md"), "# Outside\n")
+    await symlink(join(outside, "outside.md"), join(root, "workspace", "linked.md"))
+
+    const docs = glob({
+      cwd: "workspace",
+      dot: true,
+      ignore: "drafts/**",
+      include: "**/*.md",
+      prefix: "content",
+    })
+
+    await expect(docs.getKeys({ rootDir: root })).resolves.toEqual([
+      ".secret.md",
+      "README.md",
+    ])
+    await expect(docs.getItem("README.md", { rootDir: root })).resolves.toMatchObject({
+      path: "content/README.md",
+    })
+    await expect(glob({ cwd: "workspace", include: "**/*.md" }).getKeys({ rootDir: root })).resolves.toEqual([
+      "drafts/skip.md",
+      "README.md",
+    ])
+    await expect(glob({ cwd: resolve(root, "workspace"), include: "**/*.md" }).getKeys({ rootDir: root })).resolves.toEqual([
+      "drafts/skip.md",
+      "README.md",
+    ])
+    await expect(glob({ cwd: outside, include: "**/*.md" }).getKeys({ rootDir: root }))
+      .rejects.toThrow("source.glob cwd escapes the source root")
   })
 })

--- a/packages/unsource/test/sources/file-glob-markdown.test.ts
+++ b/packages/unsource/test/sources/file-glob-markdown.test.ts
@@ -62,6 +62,7 @@ describe("@vitehub/unsource local file sources", () => {
     await writeFile(join(root, "workspace", "drafts", "skip.md"), "# Skip\n")
     await writeFile(join(outside, "outside.md"), "# Outside\n")
     await symlink(join(outside, "outside.md"), join(root, "workspace", "linked.md"))
+    await symlink(outside, join(root, "workspace", "outside"))
 
     const docs = glob({
       cwd: "workspace",
@@ -87,6 +88,8 @@ describe("@vitehub/unsource local file sources", () => {
       "README.md",
     ])
     await expect(glob({ cwd: outside, include: "**/*.md" }).getKeys({ rootDir: root }))
+      .rejects.toThrow("source.glob cwd escapes the source root")
+    await expect(glob({ cwd: "workspace/outside", include: "**/*.md" }).getKeys({ rootDir: root }))
       .rejects.toThrow("source.glob cwd escapes the source root")
   })
 })

--- a/packages/workspace/docs/index.md
+++ b/packages/workspace/docs/index.md
@@ -42,7 +42,7 @@ import * as workspaceSource from '@vitehub/workspace/source'
 export default defineWorkspace({
   sources: {
     docs: workspaceSource.glob({
-      cwd: process.cwd(),
+      cwd: '.',
       include: ['README.md', 'docs/**/*.md'],
     }),
     instructions: source.file({
@@ -56,6 +56,7 @@ export default defineWorkspace({
 In Nitro, place the same definition at `server/workspaces/docs.ts`.
 Source entries are named origins. The source key becomes the default workspace mount path, so the example above exposes files at `docs/**` and `instructions/**`.
 For inline files, use `workspacePath` and `content`. For file-backed sources, use `path` for the source file and `workspacePath` for its path inside the mounted source.
+Directory workspaces and colocated agent workspaces do not ingest sibling files automatically; declare every file origin through `sources`.
 
 Workspace rules are path-scoped write policy, similar in shape to Nitro route rules:
 
@@ -213,7 +214,7 @@ The agent never receives a real filesystem mount. It only sees workspace tools s
 
 Source-backed paths are read-only in this release. Write generated or editable files to normal workspace paths such as `artifacts/**` or `generated/**`.
 
-Nitro supports both flat workspace files like `server/workspaces/docs.ts` and directory workspaces like `server/workspaces/docs/config.ts`. Duplicate workspace names across those shapes are invalid.
+Nitro supports both flat workspace files like `server/workspaces/docs.ts` and directory workspaces like `server/workspaces/docs/config.ts`. Agents can also declare colocated workspaces through `server/agents/docs/config.ts`, but sibling files still require explicit Sources. Duplicate workspace names across those shapes are invalid.
 
 ## Hosted Providers
 

--- a/packages/workspace/src/build-assets.ts
+++ b/packages/workspace/src/build-assets.ts
@@ -1,11 +1,9 @@
 import { createHash } from "node:crypto"
-import { existsSync } from "node:fs"
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
-import { dirname, join, relative, resolve } from "node:path"
+import { dirname, join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { createImportPath } from "@vitehub/internal/build/paths"
-import { listMatchingFiles } from "@vitehub/internal/definition-catalog"
 import { resolveRuntimeEntry } from "@vitehub/internal/nitro"
 import { createJiti } from "jiti"
 
@@ -13,7 +11,6 @@ import { syncWorkspaceDefinition } from "./lifecycle.ts"
 import { normalizeSafeWorkspacePath } from "./path.ts"
 import { createMemoryWorkspaceStore } from "./stores/memory.ts"
 import { createWorkspace } from "./workspace.ts"
-import { isWorkspaceAssetFile, workspaceConfigFileNames } from "./workspace-config.ts"
 
 import type { DiscoveredWorkspaceDefinition } from "./discovery.ts"
 import type { ResolvedWorkspaceModuleOptions, Workspace, WorkspaceContent, WorkspaceDefinitionInput, WorkspaceStore } from "./types.ts"
@@ -135,28 +132,6 @@ export async function syncDiscoveredWorkspaceAssetBundles(
     bundles.push(await collectWorkspaceStoreAssetBundle(definition.name, store))
   }
 
-  return bundles
-}
-
-export async function collectDirectoryWorkspaceAssetBundles(
-  definitions: DiscoveredWorkspaceDefinition[],
-  rootDir: string,
-): Promise<WorkspaceAssetBundle[]> {
-  const bundles: WorkspaceAssetBundle[] = []
-  for (const definition of definitions) {
-    const directory = definition.path ? dirname(definition.path) : resolve(rootDir, "server", "workspaces", ...definition.name.split("/"))
-    if (!workspaceConfigFileNames.some(file => existsSync(resolve(directory, file)))) continue
-
-    const files = await Promise.all(listMatchingFiles(directory, isWorkspaceAssetFile).map(async (file) => {
-      const path = normalizeSafeWorkspacePath(relative(directory, file))
-      return {
-        content: await readFile(file),
-        path,
-      }
-    }))
-    files.sort((a, b) => a.path.localeCompare(b.path))
-    bundles.push({ files, name: definition.name })
-  }
   return bundles
 }
 

--- a/packages/workspace/src/build-integration.ts
+++ b/packages/workspace/src/build-integration.ts
@@ -5,8 +5,6 @@ import { dirname, resolve } from "node:path"
 import { writeFileIfChanged } from "@vitehub/internal/definition-catalog"
 
 import {
-  collectDirectoryWorkspaceAssetBundles,
-  shouldBundleWorkspaceAssets,
   syncDiscoveredWorkspaceAssetBundles,
   type WorkspaceAssetBundle,
   writeWorkspaceAssetsRegistry,
@@ -57,10 +55,10 @@ export async function writeWorkspaceRuntimeRegistry(registryFile: string, defini
 
 export async function initializeWorkspaceAssetRegistry(
   assetsRegistryFile: string,
-  definitions: DiscoveredWorkspaceDefinition[] = [],
-  rootDir = process.cwd(),
+  _definitions: DiscoveredWorkspaceDefinition[] = [],
+  _rootDir = process.cwd(),
 ): Promise<void> {
-  await writeWorkspaceAssetsRegistry(assetsRegistryFile, await collectDirectoryWorkspaceAssetBundles(definitions, rootDir))
+  await writeWorkspaceAssetsRegistry(assetsRegistryFile, [])
 }
 
 export async function syncWorkspaceBuildAssets(
@@ -70,9 +68,7 @@ export async function syncWorkspaceBuildAssets(
   assetsRegistryFile: string,
 ): Promise<void> {
   const syncedBundles = await syncDiscoveredWorkspaceAssetBundles(definitions, rootDir, options)
-  const selectedDefinitions = options ? definitions.filter(definition => shouldBundleWorkspaceAssets(options.assets, definition.name)) : []
-  const directoryBundles = await collectDirectoryWorkspaceAssetBundles(selectedDefinitions, rootDir)
-  await writeWorkspaceAssetsRegistry(assetsRegistryFile, mergeWorkspaceAssetBundles([...directoryBundles, ...syncedBundles]))
+  await writeWorkspaceAssetsRegistry(assetsRegistryFile, mergeWorkspaceAssetBundles(syncedBundles))
 }
 
 function mergeWorkspaceAssetBundles(bundles: WorkspaceAssetBundle[]): WorkspaceAssetBundle[] {

--- a/packages/workspace/src/generated-types.ts
+++ b/packages/workspace/src/generated-types.ts
@@ -1,39 +1,6 @@
-import { basename, dirname, relative } from "node:path"
-
-import { listMatchingFiles } from "@vitehub/internal/definition-catalog"
-
-import { isWorkspaceAssetFile, workspaceConfigPattern } from "./workspace-config.ts"
-
-function listDirectoryWorkspaceAssetPaths(root: string) {
-  return listMatchingFiles(root, isWorkspaceAssetFile).map(file => relative(root, file).replace(/\\/g, "/")).sort()
-}
-
-function createWorkspaceAssetMap(definitions: Array<{ name: string, path: string }>) {
-  const map: Record<string, string[]> = {}
-  for (const definition of definitions) {
-    if (!workspaceConfigPattern.test(basename(definition.path))) continue
-    const assets = listDirectoryWorkspaceAssetPaths(dirname(definition.path))
-    if (assets.length) map[definition.name] = assets
-  }
-  return map
-}
-
-function toTypeUnion(values: string[]) {
-  return values.length ? values.map(value => JSON.stringify(value)).join(" | ") : "never"
-}
-
-function createAssetPathType(values: string[]) {
-  const known = toTypeUnion(values)
-  return values.length ? `${known} | (string & {})` : "string & {}"
-}
-
 export function createWorkspaceTypeAugmentation(definitions: Array<{ name: string, path: string }>): string {
   const names = [...new Set(definitions.map(definition => definition.name))].sort()
   const nameProperties = names.map(name => `    ${JSON.stringify(name)}: true`)
-  const assetMap = createWorkspaceAssetMap(definitions)
-  const assetProperties = Object.entries(assetMap)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([name, assets]) => `    ${JSON.stringify(name)}: ${createAssetPathType(assets)}`)
 
   return [
     "declare global {",
@@ -42,7 +9,7 @@ export function createWorkspaceTypeAugmentation(definitions: Array<{ name: strin
     "  }",
     "",
     "  interface ViteHubWorkspaceAssetMap {",
-    ...(assetProperties.length ? assetProperties : ["    __vitehub_no_workspace_assets__?: never"]),
+    "    __vitehub_no_workspace_assets__?: never",
     "  }",
     "}",
     "",

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -5,6 +5,13 @@ import { createWorkspaceStoreFromProvider } from "./store-provider.ts"
 
 import type { LoaderContext, WorkspaceDefinition, WorkspaceLoaderSource, WorkspaceStore } from "./types.ts"
 
+const buildSourcesMetaKey = "workspace:build-sources"
+
+interface SyncedBuildSource {
+  key: string
+  mountPath: string
+}
+
 export function createWorkspaceStore(definition: WorkspaceDefinition): WorkspaceStore {
   return createWorkspaceStoreFromProvider(definition)
 }
@@ -12,9 +19,10 @@ export function createWorkspaceStore(definition: WorkspaceDefinition): Workspace
 export async function syncWorkspaceDefinition(definition: WorkspaceDefinition, store: WorkspaceStore): Promise<void> {
   const loaders = definition.loaders?.length ? definition.loaders : [filesLoader()]
   const ctxSource = createSourceContext(definition)
-  const normalizedSources = normalizeWorkspaceSources(definition.sources)
+  const buildSources = normalizeWorkspaceSources(definition.sources)
     .filter(source => source.materialize === "build")
-    .map(source => createMountedBuildSource(source))
+  await reconcileBuildSourceMounts(store, buildSources)
+  const normalizedSources = buildSources.map(source => createMountedBuildSource(source))
   const ctx: LoaderContext = {
     workspace: definition.name,
     rootDir: ctxSource.rootDir,
@@ -36,6 +44,37 @@ export async function syncWorkspaceDefinition(definition: WorkspaceDefinition, s
       rootDir: definition.rootDir || process.cwd(),
     })
   }
+}
+
+async function reconcileBuildSourceMounts(store: WorkspaceStore, currentSources: ResolvedWorkspaceSource[]) {
+  const previousSources = await readSyncedBuildSources(store)
+  const resetPaths = [...new Set([
+    ...previousSources.map(source => source.mountPath),
+    ...currentSources.map(source => source.mountPath),
+  ])]
+
+  for (const mountPath of resetPaths.sort((a, b) => b.length - a.length)) {
+    await store.rm(mountPath, { recursive: true, force: true })
+  }
+
+  for (const mountPath of [...new Set(currentSources.map(source => source.mountPath))].sort((a, b) => a.length - b.length)) {
+    await store.mkdir(mountPath, { recursive: true })
+  }
+
+  await store.setMeta?.(buildSourcesMetaKey, currentSources.map(({ key, mountPath }) => ({ key, mountPath })))
+}
+
+async function readSyncedBuildSources(store: WorkspaceStore): Promise<SyncedBuildSource[]> {
+  const value = await store.getMeta?.(buildSourcesMetaKey)
+  if (!Array.isArray(value)) return []
+  return value.filter(isSyncedBuildSource)
+}
+
+function isSyncedBuildSource(value: unknown): value is SyncedBuildSource {
+  return !!value
+    && typeof value === "object"
+    && typeof (value as SyncedBuildSource).key === "string"
+    && typeof (value as SyncedBuildSource).mountPath === "string"
 }
 
 function createMountedBuildSource(source: ResolvedWorkspaceSource): WorkspaceLoaderSource {

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -1,42 +1,9 @@
-import { readFile, stat } from "node:fs/promises"
-import { relative, resolve } from "node:path"
-
-import { listMatchingFiles } from "@vitehub/internal/definition-catalog"
-
 import { files as filesLoader } from "./loaders/files.ts"
 import { normalizeWorkspacePath } from "./path.ts"
 import { createSourceContext, normalizeWorkspaceSources, type ResolvedWorkspaceSource } from "./source-config.ts"
 import { createWorkspaceStoreFromProvider } from "./store-provider.ts"
-import { hasWorkspaceDirectoryConfig, isWorkspaceAssetFile } from "./workspace-config.ts"
 
-import type { LoaderContext, WorkspaceDefinition, WorkspaceLoaderSource, WorkspaceSourceItem, WorkspaceStore } from "./types.ts"
-
-function workspaceDirectory(rootDir: string, name: string) {
-  return resolve(rootDir, "server", "workspaces", ...name.split("/"))
-}
-
-function createImplicitWorkspaceDirectorySource(definition: WorkspaceDefinition): WorkspaceLoaderSource | undefined {
-  const rootDir = definition.rootDir || process.cwd()
-  const directory = workspaceDirectory(rootDir, definition.name)
-  if (!hasWorkspaceDirectoryConfig(directory)) return
-
-  return {
-    key: "directoryAssets",
-    async getKeys() {
-      return listMatchingFiles(directory, isWorkspaceAssetFile).map(file => normalizeWorkspacePath(relative(directory, file))).sort()
-    },
-    async getItem(key: string): Promise<WorkspaceSourceItem> {
-      const target = resolve(directory, key)
-      const [bytes, info] = await Promise.all([readFile(target), stat(target)])
-      return {
-        key,
-        path: key,
-        content: new Uint8Array(bytes),
-        metadata: { mtime: info.mtimeMs },
-      }
-    },
-  }
-}
+import type { LoaderContext, WorkspaceDefinition, WorkspaceLoaderSource, WorkspaceStore } from "./types.ts"
 
 export function createWorkspaceStore(definition: WorkspaceDefinition): WorkspaceStore {
   return createWorkspaceStoreFromProvider(definition)
@@ -44,7 +11,6 @@ export function createWorkspaceStore(definition: WorkspaceDefinition): Workspace
 
 export async function syncWorkspaceDefinition(definition: WorkspaceDefinition, store: WorkspaceStore): Promise<void> {
   const loaders = definition.loaders?.length ? definition.loaders : [filesLoader()]
-  const implicitDirectorySource = createImplicitWorkspaceDirectorySource(definition)
   const ctxSource = createSourceContext(definition)
   const normalizedSources = normalizeWorkspaceSources(definition.sources)
     .filter(source => source.materialize === "build")
@@ -52,7 +18,7 @@ export async function syncWorkspaceDefinition(definition: WorkspaceDefinition, s
   const ctx: LoaderContext = {
     workspace: definition.name,
     rootDir: ctxSource.rootDir,
-    sources: implicitDirectorySource ? [implicitDirectorySource, ...normalizedSources] : normalizedSources,
+    sources: normalizedSources,
     store,
     parseData: async input => input.data,
     generateDigest: input => JSON.stringify(input),

--- a/packages/workspace/src/loaders/files.ts
+++ b/packages/workspace/src/loaders/files.ts
@@ -35,7 +35,7 @@ export function files(options: FilesLoaderOptions = {}): WorkspaceLoader {
           const metaKey = `loader:files:${source.key}:${path}:digest`
           const previousDigest = await ctx.store.getMeta?.(metaKey)
 
-          if (previousDigest === digest) continue
+          if (previousDigest === digest && await ctx.store.stat(path)) continue
 
           await ctx.store.writeFile(path, {
             path,

--- a/packages/workspace/src/stores/local.ts
+++ b/packages/workspace/src/stores/local.ts
@@ -53,8 +53,12 @@ class LocalWorkspaceStore implements WorkspaceStore {
   #baseline: WorkspaceSnapshot | undefined
   #files = new Map<string, Pick<WorkspaceFile, "mediaType" | "metadata">>()
   #meta = new Map<string, unknown>()
+  #metaLoaded = false
+  #metaPath: string
 
-  constructor(public root: string) {}
+  constructor(public root: string) {
+    this.#metaPath = `${root}.meta.json`
+  }
 
   async readFile(path: string): Promise<WorkspaceFile | undefined> {
     const { readFile } = await import("node:fs/promises")
@@ -175,11 +179,14 @@ class LocalWorkspaceStore implements WorkspaceStore {
   }
 
   async getMeta(key: string): Promise<unknown> {
+    await this.#loadMeta()
     return this.#meta.get(key)
   }
 
   async setMeta(key: string, value: unknown): Promise<void> {
+    await this.#loadMeta()
     this.#meta.set(key, value)
+    await this.#writeMeta()
   }
 
   async #createSnapshot(name?: string): Promise<WorkspaceSnapshot> {
@@ -197,6 +204,27 @@ class LocalWorkspaceStore implements WorkspaceStore {
       createdAt: new Date().toISOString(),
       entries,
     }
+  }
+
+  async #loadMeta() {
+    if (this.#metaLoaded) return
+    this.#metaLoaded = true
+    const { readFile } = await import("node:fs/promises")
+    const content = await readFile(this.#metaPath, "utf8").catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined
+      throw error
+    })
+    if (!content) return
+    const value = JSON.parse(content) as unknown
+    if (!value || typeof value !== "object" || Array.isArray(value)) return
+    this.#meta = new Map(Object.entries(value))
+  }
+
+  async #writeMeta() {
+    const { dirname } = await import("node:path")
+    const { mkdir, writeFile } = await import("node:fs/promises")
+    await mkdir(dirname(this.#metaPath), { recursive: true })
+    await writeFile(this.#metaPath, JSON.stringify(Object.fromEntries(this.#meta), null, 2))
   }
 }
 

--- a/packages/workspace/test/nitro-assets.test.ts
+++ b/packages/workspace/test/nitro-assets.test.ts
@@ -308,7 +308,7 @@ export default {
     ])
   })
 
-  it("auto-mounts visible sibling files for directory workspaces", async () => {
+  it("does not auto-ingest sibling files for directory workspaces", async () => {
     const root = await createRoot()
     await mkdir(join(root, "server", "workspaces", "docs", "nested"), { recursive: true })
     await writeFile(join(root, "server", "workspaces", "docs", "config.mjs"), [
@@ -349,21 +349,16 @@ export default {
 
     const registryFile = join(root, ".vitehub/nitro-runtime/workspace/assets/registry.mjs")
     const registry = (await import(`${pathToFileURL(registryFile).href}?t=${Date.now()}`)).default
-    await expect(registry.docs.list("", { recursive: true })).resolves.toEqual([
-      expect.objectContaining({ path: "AGENTS.md", type: "file" }),
-      expect.objectContaining({ path: "nested", type: "directory" }),
-      expect.objectContaining({ path: "nested/glossary.md", type: "file" }),
-      expect.objectContaining({ path: "notes.txt", type: "file" }),
-    ])
-    await expect(registry.docs.readFile("AGENTS.md")).resolves.toBe("# Instructions\n")
-    await expect(registry.docs.readFile("notes.txt")).resolves.toBe("notes\n")
-    await expect(registry.docs.readFile("nested/glossary.md")).resolves.toBe("glossary\n")
+    await expect(registry.docs.list("", { recursive: true })).resolves.toEqual([])
     await expect(registry.docs.exists("config.mjs" as never)).resolves.toBe(false)
     await expect(registry.docs.exists("agent.ts" as never)).resolves.toBe(false)
+    await expect(registry.docs.exists("AGENTS.md" as never)).resolves.toBe(false)
+    await expect(registry.docs.exists("notes.txt" as never)).resolves.toBe(false)
+    await expect(registry.docs.exists("nested/glossary.md" as never)).resolves.toBe(false)
     await expect(registry.docs.exists(".hidden.md" as never)).resolves.toBe(false)
   })
 
-  it("auto-mounts AGENTS.md for colocated agent workspaces", async () => {
+  it("does not auto-ingest AGENTS.md for colocated agent workspaces", async () => {
     const root = await createRoot()
     await mkdir(join(root, "server", "agents", "docs"), { recursive: true })
     await writeFile(join(root, "server", "agents", "docs", "config.ts"), "const defineAgent = <T>(value: T): T => value\nexport default defineAgent({ workspace: {}, model: {} })\n", "utf8")
@@ -395,7 +390,7 @@ export default {
 
     const registryFile = join(root, ".vitehub/nitro-runtime/workspace/assets/registry.mjs")
     const registry = (await import(`${pathToFileURL(registryFile).href}?t=${Date.now()}`)).default
-    await expect(registry.docs.readFile("AGENTS.md")).resolves.toBe("# Agent Instructions\n")
+    await expect(registry.docs.exists("AGENTS.md" as never)).resolves.toBe(false)
     await expect(registry.docs.exists("config.ts" as never)).resolves.toBe(false)
   })
 

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -11,9 +11,11 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { collectWorkspaceAssetBundle, writeWorkspaceAssetsRegistry } from "../src/build-assets.ts"
 import { initializeWorkspaceAssetRegistry, syncWorkspaceBuildAssets } from "../src/build-integration.ts"
 import { defineWorkspace, loader, publish, registerWorkspace, useWorkspace } from "../src/index.ts"
+import { syncWorkspaceDefinition } from "../src/lifecycle.ts"
 import { useRegisteredWorkspace } from "../src/registry.ts"
 import * as source from "../src/source.ts"
-import type { Workspace } from "../src/types.ts"
+import { createMemoryWorkspaceStore } from "../src/stores/memory.ts"
+import type { Workspace, WorkspaceDefinition } from "../src/types.ts"
 
 const tempDirs: string[] = []
 
@@ -512,6 +514,38 @@ describe("sources, loaders, and publishers", () => {
     const contents = await readFile(registryFile, "utf8")
     expect(contents.match(/"docs": createWorkspaceAssets/g)).toHaveLength(1)
     expect(contents.match(/"instructions\/AGENTS.md"/g)).toHaveLength(1)
+  })
+
+  it("purges stale build source files when source maps change", async () => {
+    const store = createMemoryWorkspaceStore()
+    let keys = ["README.md", "stale.md"]
+    const docsSource = source.custom({
+      async getKeys() {
+        return keys
+      },
+      async getItem(key) {
+        return { key, path: key, content: `# ${key}\n` }
+      },
+      mount: "docs",
+    })
+    const definition: WorkspaceDefinition = {
+      name: "stale-build-sources",
+      sources: { docs: docsSource },
+    }
+
+    await syncWorkspaceDefinition(definition, store)
+    await expect(store.readFile("docs/stale.md")).resolves.toMatchObject({ content: "# stale.md\n" })
+
+    keys = ["README.md"]
+    await syncWorkspaceDefinition(definition, store)
+    await expect(store.readFile("docs/README.md")).resolves.toMatchObject({ content: "# README.md\n" })
+    await expect(store.readFile("docs/stale.md")).resolves.toBeUndefined()
+
+    await syncWorkspaceDefinition({
+      name: "stale-build-sources",
+      sources: {},
+    }, store)
+    await expect(store.list("", { recursive: true })).resolves.toEqual([])
   })
 
   it("filters synced explicit workspace assets by configured assets", async () => {

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -14,6 +14,7 @@ import { defineWorkspace, loader, publish, registerWorkspace, useWorkspace } fro
 import { syncWorkspaceDefinition } from "../src/lifecycle.ts"
 import { useRegisteredWorkspace } from "../src/registry.ts"
 import * as source from "../src/source.ts"
+import { createLocalWorkspaceStore } from "../src/stores/local.ts"
 import { createMemoryWorkspaceStore } from "../src/stores/memory.ts"
 import type { Workspace, WorkspaceDefinition } from "../src/types.ts"
 
@@ -546,6 +547,26 @@ describe("sources, loaders, and publishers", () => {
       sources: {},
     }, store)
     await expect(store.list("", { recursive: true })).resolves.toEqual([])
+  })
+
+  it("purges stale local build source files after store restarts", async () => {
+    const root = await createRoot()
+    const storeRoot = join(root, ".vitehub", "workspaces", "docs")
+    const docsSource = source.file({ content: "# Docs\n", path: "README.md", workspacePath: "README.md", mount: "docs" })
+    const definition: WorkspaceDefinition = {
+      name: "stale-local-build-sources",
+      sources: { docs: docsSource },
+    }
+
+    await syncWorkspaceDefinition(definition, createLocalWorkspaceStore(storeRoot))
+    await expect(createLocalWorkspaceStore(storeRoot).readFile("docs/README.md")).resolves.toMatchObject({ path: "docs/README.md" })
+
+    await syncWorkspaceDefinition({
+      name: "stale-local-build-sources",
+      sources: {},
+    }, createLocalWorkspaceStore(storeRoot))
+
+    await expect(createLocalWorkspaceStore(storeRoot).readFile("docs/README.md")).resolves.toBeUndefined()
   })
 
   it("filters synced explicit workspace assets by configured assets", async () => {

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -460,7 +460,7 @@ describe("sources, loaders, and publishers", () => {
     await expect(workspace.fs.readFile("docs/models/marts/orders.sql")).resolves.toBe("select 1\n")
   })
 
-  it("initializes directory workspace assets for Nitro dev", async () => {
+  it("initializes empty workspace assets before explicit source sync", async () => {
     const root = await createRoot()
     const directory = join(root, "server", "workspaces", "docs")
     await mkdir(directory, { recursive: true })
@@ -477,15 +477,24 @@ describe("sources, loaders, and publishers", () => {
     }], root)
 
     const registry = (await import(`${pathToFileURL(registryFile).href}?t=${Date.now()}`)).default
-    await expect(registry.docs.readFile("AGENTS.md")).resolves.toBe("# Instructions\n")
-    await expect(registry.docs.glob("**/*.md")).resolves.toHaveLength(2)
+    expect(registry.docs).toBeUndefined()
   })
 
-  it("keeps one asset bundle when directory workspaces are synced on build", async () => {
+  it("syncs explicit directory workspace sources on build", async () => {
     const root = await createRoot()
     const directory = join(root, "server", "workspaces", "docs")
     await mkdir(directory, { recursive: true })
-    await writeFile(join(directory, "config.mjs"), "export default {}\n")
+    await writeFile(join(directory, "config.mjs"), [
+      "export default {",
+      "  sources: {",
+      "    instructions: {",
+      "      async getKeys() { return ['AGENTS.md'] },",
+      "      async getItem(key) { return { key, path: key, content: '# Instructions\\n' } },",
+      "    },",
+      "  },",
+      "}",
+      "",
+    ].join("\n"))
     await writeFile(join(directory, "AGENTS.md"), "# Instructions\n")
     const registryFile = join(root, ".vitehub", "nitro-runtime", "workspace", "assets", "registry.mjs")
 
@@ -502,19 +511,37 @@ describe("sources, loaders, and publishers", () => {
 
     const contents = await readFile(registryFile, "utf8")
     expect(contents.match(/"docs": createWorkspaceAssets/g)).toHaveLength(1)
-    expect(contents.match(/"AGENTS.md"/g)).toHaveLength(1)
+    expect(contents.match(/"instructions\/AGENTS.md"/g)).toHaveLength(1)
   })
 
-  it("filters directory workspace assets by configured assets", async () => {
+  it("filters synced explicit workspace assets by configured assets", async () => {
     const root = await createRoot()
     const selectedDirectory = join(root, "server", "workspaces", "selected")
     const skippedDirectory = join(root, "server", "workspaces", "skipped")
     await mkdir(selectedDirectory, { recursive: true })
     await mkdir(skippedDirectory, { recursive: true })
-    await writeFile(join(selectedDirectory, "config.mjs"), "export default {}\n")
-    await writeFile(join(selectedDirectory, "AGENTS.md"), "# Selected\n")
-    await writeFile(join(skippedDirectory, "config.mjs"), "export default {}\n")
-    await writeFile(join(skippedDirectory, "AGENTS.md"), "# Skipped\n")
+    await writeFile(join(selectedDirectory, "config.mjs"), [
+      "export default {",
+      "  sources: {",
+      "    instructions: {",
+      "      async getKeys() { return ['AGENTS.md'] },",
+      "      async getItem(key) { return { key, path: key, content: '# Selected\\n' } },",
+      "    },",
+      "  },",
+      "}",
+      "",
+    ].join("\n"))
+    await writeFile(join(skippedDirectory, "config.mjs"), [
+      "export default {",
+      "  sources: {",
+      "    instructions: {",
+      "      async getKeys() { return ['AGENTS.md'] },",
+      "      async getItem(key) { return { key, path: key, content: '# Skipped\\n' } },",
+      "    },",
+      "  },",
+      "}",
+      "",
+    ].join("\n"))
     const registryFile = join(root, ".vitehub", "nitro-runtime", "workspace", "assets", "registry.mjs")
 
     await syncWorkspaceBuildAssets([{
@@ -534,7 +561,7 @@ describe("sources, loaders, and publishers", () => {
     }, registryFile)
 
     const registry = (await import(`${pathToFileURL(registryFile).href}?t=${Date.now()}`)).default
-    await expect(registry.selected.readFile("AGENTS.md")).resolves.toBe("# Selected\n")
+    await expect(registry.selected.readFile("instructions/AGENTS.md")).resolves.toBe("# Selected\n")
     expect(registry.skipped).toBeUndefined()
   })
 
@@ -573,7 +600,7 @@ describe("sources, loaders, and publishers", () => {
 
     expect(fetch).not.toHaveBeenCalled()
     const registry = (await import(`${pathToFileURL(registryFile).href}?t=${Date.now()}`)).default
-    await expect(registry.docs.readFile("AGENTS.md")).resolves.toBe("# Instructions\n")
+    await expect(registry.docs.readFile("AGENTS.md")).rejects.toThrow("Workspace file does not exist")
   })
 
   it("reports inaccessible GitHub repositories with a source-specific error", async () => {
@@ -635,17 +662,28 @@ describe("sources, loaders, and publishers", () => {
     expect(await readFile(join(root, "workspace.d.ts"), "utf8")).toContain('virtual:vitehub/workspaces/sources')
   })
 
-  it("ignores .git and node_modules when discovering glob sources", async () => {
+  it("ignores hidden files, .git, and node_modules when discovering glob sources by default", async () => {
     const root = await createRoot()
     await mkdir(join(root, "node_modules/pkg"), { recursive: true })
     await mkdir(join(root, ".git/hooks"), { recursive: true })
     await writeFile(join(root, "visible.md"), "# Visible\n")
+    await writeFile(join(root, ".hidden.md"), "# Hidden\n")
     await writeFile(join(root, "node_modules/pkg/hidden.md"), "# Hidden\n")
     await writeFile(join(root, ".git/hooks/pre-commit"), "hook\n")
 
     const keys = await source.glob({ cwd: ".", include: "**/*" }).getKeys({ rootDir: root, workspace: "glob-source" })
 
     expect(keys).toEqual(["visible.md"])
+  })
+
+  it("can include hidden glob source files explicitly", async () => {
+    const root = await createRoot()
+    await writeFile(join(root, "visible.md"), "# Visible\n")
+    await writeFile(join(root, ".hidden.md"), "# Hidden\n")
+
+    const keys = await source.glob({ cwd: ".", dot: true, include: "**/*" }).getKeys({ rootDir: root, workspace: "glob-source" })
+
+    expect(keys).toEqual([".hidden.md", "visible.md"])
   })
 
   it("writes lazy workspace asset modules for text and binary files", async () => {

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -58,6 +58,14 @@ describe("workspace types", () => {
       include: "**/*.md",
       exclude: "docs/drafts/**",
     })
+    source.glob({
+      cwd: "docs",
+      dot: true,
+      followSymlinks: false,
+      ignore: "drafts/**",
+      include: "**/*.md",
+      prefix: "content",
+    })
     defineWorkspace({
       // @ts-expect-error workspace names are inferred from definition filenames
       name: "typed",


### PR DESCRIPTION
This PR records and implements the Workspace source boundary decision from ADR-0007.

Workspace remains the explicit filesystem primitive. Colocated agent workspaces are treated as colocated Workspace definitions, but sibling files are no longer ingested implicitly; files must enter through declared Sources. Build asset bundling and generated asset path types now reflect explicit synced Sources rather than directory siblings.

It also tightens local `source.glob` options around familiar glob vocabulary and safer defaults: `ignore`, `prefix`, `dot`, `followSymlinks`, and `cwd` constrained to the Source root. This is a breaking API cleanup for local glob Sources.
