### PR TITLE
refactor(agent): expose capabilities from subpath

### DIFF
--- a/docs/content/docs/tutorials/build-ai-chatbot.md
+++ b/docs/content/docs/tutorials/build-ai-chatbot.md
@@ -147,7 +147,7 @@ Time to swap the dummy reply for a real model. ViteHub agents live in `server/ag
 ::code-tree-intersection
 ```ts [server/agents/support/chat/config.ts]
 import { gateway } from '@ai-sdk/gateway'
-import { bash, defineAgent } from '@vitehub/agent'
+import { defineAgent } from '@vitehub/agent'
 
 export default defineAgent({
   description: 'Answer support chat messages.',
@@ -193,7 +193,8 @@ Models guess. Tools inspect. Add a Workspace to your agent so it can search, lis
 ::code-tree-intersection
 ```ts [server/agents/support/chat/config.ts]
 import { gateway } from '@ai-sdk/gateway'
-import { bash, defineAgent } from '@vitehub/agent'
+import { defineAgent } from '@vitehub/agent'
+import { bash } from '@vitehub/agent/capabilities'
 import * as source from '@vitehub/workspace/source'
 
 export default defineAgent({

--- a/packages/agent/docs/runtime-api.md
+++ b/packages/agent/docs/runtime-api.md
@@ -13,19 +13,21 @@ Use this page for exact names and shapes. For setup, start with [Quickstart](./q
 
 ```ts
 import {
-  bash,
-  blob,
-  db,
   defineAgent,
   defineCapability,
   getAgent,
-  kv,
-  mcp,
   runAgent,
-  sandbox,
-  skills,
   streamAgent,
 } from '@vitehub/agent'
+import {
+  bash,
+  blob,
+  db,
+  kv,
+  mcp,
+  sandbox,
+  skills,
+} from '@vitehub/agent/capabilities'
 ```
 
 ::fw{id="vite:dev vite:build"}

--- a/packages/agent/docs/usage.md
+++ b/packages/agent/docs/usage.md
@@ -165,7 +165,8 @@ Use `defineAgent()` with a `workspace` option from a colocated agent config when
 Add `bash()` when the model should inspect the mounted files:
 
 ```ts [server/agents/data-sources/config.ts]
-import { bash, defineAgent } from '@vitehub/agent'
+import { defineAgent } from '@vitehub/agent'
+import { bash } from '@vitehub/agent/capabilities'
 import * as source from '@vitehub/workspace/source'
 
 export default defineAgent({
@@ -222,7 +223,8 @@ export default defineAgent({
 Workspace sources do not imply model tools. Replace older workspace agents that relied on root or adapter-level tools with explicit capabilities:
 
 ```diff
- import { bash, defineAgent } from '@vitehub/agent'
+ import { defineAgent } from '@vitehub/agent'
++import { bash } from '@vitehub/agent/capabilities'
 
  export default defineAgent({
    workspace: { sources },
@@ -234,7 +236,7 @@ Workspace sources do not imply model tools. Replace older workspace agents that 
  })
 ```
 
-Use `bash({ mode: 'write' })` only with `workspace.mode: 'write'`. Raw tools should be wrapped in inline or factory capabilities instead of `defineAgent({ tools })`.
+Use `bash({ mode: 'write' })` only with `workspace.mode: 'write'`. Raw tools should be wrapped in inline or factory capabilities.
 
 ## Use durable memory
 

--- a/packages/agent/src/capabilities.ts
+++ b/packages/agent/src/capabilities.ts
@@ -1,3 +1,181 @@
+import {
+  defineCapability,
+  normalizeMode,
+} from "./capability-runtime.ts"
+
+import type {
+  AgentCapabilityContext,
+  AgentCapabilityDefinition,
+  AgentCapabilityMode,
+  AgentToolDefinition,
+  AgentToolSet,
+  MaybePromise,
+} from "./types.ts"
+
+function primitiveHandle(context: AgentCapabilityContext, name: string): unknown {
+  const handle = context.capabilities?.[name] as { value?: unknown } | unknown
+  return typeof handle === "object" && handle !== null && "value" in handle
+    ? (handle as { value?: unknown }).value
+    : handle
+}
+
+function requirePrimitive(context: AgentCapabilityContext, name: string): unknown {
+  const handle = primitiveHandle(context, name)
+  if (!handle) throw new Error(`[vitehub] Capability "${name}" requires the ${name} primitive to be configured.`)
+  return handle
+}
+
+function defineInternalTool<TInput = unknown, TOutput = unknown>(
+  tool: AgentToolDefinition<TInput, TOutput>,
+): AgentToolDefinition<TInput, TOutput> {
+  if (!tool || typeof tool !== "object") {
+    throw new TypeError("[vitehub] tool definitions must be objects.")
+  }
+  if (!tool.name || typeof tool.name !== "string") {
+    throw new TypeError("[vitehub] tool definitions require a tool name.")
+  }
+  return tool
+}
+
+function primitiveMethodTool(primitive: "blob" | "db" | "kv", method: string, handle: unknown): AgentToolDefinition {
+  return defineInternalTool({
+    description: `Call ${primitive}.${method}.`,
+    name: `${primitive}_${method}`,
+    async execute(input) {
+      const primitiveHandle = handle as Record<string, unknown>
+      const fn = primitiveHandle[method]
+      if (typeof fn !== "function") throw new Error(`[vitehub] ${primitive} primitive does not expose ${method}().`)
+      const args = Array.isArray(input) ? input : [input]
+      return await fn.apply(primitiveHandle, args)
+    },
+  })
+}
+
+function primitiveTools(primitive: "blob" | "db" | "kv", mode: AgentCapabilityMode): AgentCapabilityDefinition["tools"] {
+  return (context) => {
+    const handle = requirePrimitive(context as never, primitive)
+    if (primitive === "kv") {
+      return {
+        kv_get: primitiveMethodTool("kv", "get", handle),
+        kv_keys: primitiveMethodTool("kv", "keys", handle),
+        ...(mode === "write"
+          ? {
+              kv_del: primitiveMethodTool("kv", "del", handle),
+              kv_set: primitiveMethodTool("kv", "set", handle),
+            }
+          : {}),
+      }
+    }
+    if (primitive === "blob") {
+      return {
+        blob_get: primitiveMethodTool("blob", "get", handle),
+        blob_head: primitiveMethodTool("blob", "head", handle),
+        blob_list: primitiveMethodTool("blob", "list", handle),
+        ...(mode === "write"
+          ? {
+              blob_del: primitiveMethodTool("blob", "del", handle),
+              blob_put: primitiveMethodTool("blob", "put", handle),
+            }
+          : {}),
+      }
+    }
+    return {
+      db_query: primitiveMethodTool("db", "query", handle),
+      db_schema: primitiveMethodTool("db", "schema", handle),
+      ...(mode === "write" ? { db_execute: primitiveMethodTool("db", "execute", handle) } : {}),
+    }
+  }
+}
+
+function validateSandboxCommands(commands: unknown): string[] {
+  if (!Array.isArray(commands) || !commands.length) {
+    throw new TypeError("[vitehub] sandbox({ commands }) requires at least one executable name.")
+  }
+  for (const command of commands) {
+    if (typeof command !== "string" || !/^[A-Za-z0-9_.-]+$/.test(command)) {
+      throw new TypeError("[vitehub] sandbox({ commands }) accepts executable names only, not shell command strings.")
+    }
+  }
+  return commands
+}
+
+export function bash(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
+  const mode = normalizeMode(options.mode, "Bash")
+  return defineCapability({
+    id: "bash",
+    mode,
+    name: "Bash",
+    requires: [{ primitive: "workspace", workspace: { mode, required: true } }],
+    tools: ({ workspace }) => (mode === "write" && "write" in workspace.tools
+      ? (workspace.tools as unknown as { write: () => AgentToolSet }).write()
+      : workspace.tools.inspect()) as AgentToolSet,
+  })
+}
+
+export function sandbox(options: { commands: string[] }): AgentCapabilityDefinition {
+  const commands = validateSandboxCommands(options?.commands)
+  return defineCapability({
+    id: "sandbox",
+    metadata: { commands },
+    name: "Sandbox",
+    requires: [{ primitive: "workspace", workspace: { required: true } }, { primitive: "sandbox" }],
+    tools: (context) => {
+      const handle = requirePrimitive(context as never, "sandbox") as {
+        exec?: (command: string, args?: string[], options?: unknown) => MaybePromise<unknown>
+      }
+      return {
+        sandbox_exec: defineInternalTool({
+          description: `Run one allowed executable in an isolated sandbox. Allowed commands: ${commands.join(", ")}.`,
+          name: "sandbox_exec",
+          async execute(input) {
+            const value = input as { args?: string[], command?: string, cwd?: string, env?: Record<string, string>, timeout?: number }
+            if (!value || typeof value.command !== "string") throw new TypeError("[vitehub] sandbox_exec requires a command.")
+            if (!commands.includes(value.command)) throw new Error(`[vitehub] Sandbox command "${value.command}" is not allowed.`)
+            if (!handle.exec) throw new Error("[vitehub] Sandbox primitive does not expose exec().")
+            return await handle.exec(value.command, value.args || [], { cwd: value.cwd, env: value.env, timeout: value.timeout })
+          },
+        }),
+      }
+    },
+  })
+}
+
+export function kv(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
+  const mode = normalizeMode(options.mode, "KV")
+  return defineCapability({ id: "kv", mode, name: "KV", requires: [{ primitive: "kv" }], tools: primitiveTools("kv", mode) })
+}
+
+export function blob(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
+  const mode = normalizeMode(options.mode, "Blob")
+  return defineCapability({ id: "blob", mode, name: "Blob", requires: [{ primitive: "blob" }], tools: primitiveTools("blob", mode) })
+}
+
+export function db(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
+  const mode = normalizeMode(options.mode, "DB")
+  return defineCapability({ id: "db", mode, name: "DB", requires: [{ primitive: "db" }], tools: primitiveTools("db", mode) })
+}
+
+export function skills(options: { path?: string } = {}): AgentCapabilityDefinition {
+  const path = options.path || "skills"
+  const skillPath = path.replace(/\/+$/, "").endsWith("/SKILL.md")
+    ? path.replace(/\/+$/, "")
+    : `${path.replace(/\/+$/, "")}/SKILL.md`
+  return defineCapability({
+    id: "skills",
+    metadata: { path: path.replace(/\/+$/, ""), skillPath },
+    name: "Skills",
+    requires: [{ primitive: "workspace", workspace: { mode: "read", paths: [skillPath], required: true } }],
+  })
+}
+
+export function mcp(options: { servers?: Record<string, unknown> } = {}): AgentCapabilityDefinition {
+  return defineCapability({
+    id: "mcp",
+    metadata: { servers: options.servers || {} },
+    name: "MCP",
+  })
+}
+
 export {
   memory,
   workspaceJsonlMemoryStore,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -30,7 +30,6 @@ import type {
   AgentAdapterMetadataContext,
   AgentAdapterResult,
   AgentCapabilitiesList,
-  AgentCapabilityContext,
   AgentCapabilityDefinition,
   AgentCapabilityInput,
   AgentCapabilityMode,
@@ -249,82 +248,8 @@ function once<TArgs extends unknown[]>(callback: (...args: TArgs) => Promise<voi
 
 export { applyAgentToolPolicies, withAgentToolStepReporting } from "./tool-runtime.ts"
 export { defineCapability } from "./capability-runtime.ts"
+export { bash, blob, db, kv, mcp, sandbox, skills } from "./capabilities.ts"
 export * from "./messages.ts"
-
-function primitiveHandle(context: AgentCapabilityContext, name: string): unknown {
-  const handle = context.capabilities?.[name] as { value?: unknown } | unknown
-  return typeof handle === "object" && handle !== null && "value" in handle
-    ? (handle as { value?: unknown }).value
-    : handle
-}
-
-function requirePrimitive(context: AgentCapabilityContext, name: string): unknown {
-  const handle = primitiveHandle(context, name)
-  if (!handle) throw new Error(`[vitehub] Capability "${name}" requires the ${name} primitive to be configured.`)
-  return handle
-}
-
-function defineInternalTool<TInput = unknown, TOutput = unknown>(
-  tool: AgentToolDefinition<TInput, TOutput>,
-): AgentToolDefinition<TInput, TOutput> {
-  if (!tool || typeof tool !== "object") {
-    throw new TypeError("[vitehub] tool definitions must be objects.")
-  }
-  if (!tool.name || typeof tool.name !== "string") {
-    throw new TypeError("[vitehub] tool definitions require a tool name.")
-  }
-  return tool
-}
-
-function primitiveMethodTool(primitive: "blob" | "db" | "kv", method: string, handle: unknown): AgentToolDefinition {
-  return defineInternalTool({
-    description: `Call ${primitive}.${method}.`,
-    name: `${primitive}_${method}`,
-    async execute(input) {
-      const primitiveHandle = handle as Record<string, unknown>
-      const fn = primitiveHandle[method]
-      if (typeof fn !== "function") throw new Error(`[vitehub] ${primitive} primitive does not expose ${method}().`)
-      const args = Array.isArray(input) ? input : [input]
-      return await fn.apply(primitiveHandle, args)
-    },
-  })
-}
-
-function primitiveTools(primitive: "blob" | "db" | "kv", mode: AgentCapabilityMode): AgentCapabilityDefinition["tools"] {
-  return (context) => {
-    const handle = requirePrimitive(context as never, primitive)
-    if (primitive === "kv") {
-      return {
-        kv_get: primitiveMethodTool("kv", "get", handle),
-        kv_keys: primitiveMethodTool("kv", "keys", handle),
-        ...(mode === "write"
-          ? {
-              kv_del: primitiveMethodTool("kv", "del", handle),
-              kv_set: primitiveMethodTool("kv", "set", handle),
-            }
-          : {}),
-      }
-    }
-    if (primitive === "blob") {
-      return {
-        blob_get: primitiveMethodTool("blob", "get", handle),
-        blob_head: primitiveMethodTool("blob", "head", handle),
-        blob_list: primitiveMethodTool("blob", "list", handle),
-        ...(mode === "write"
-          ? {
-              blob_del: primitiveMethodTool("blob", "del", handle),
-              blob_put: primitiveMethodTool("blob", "put", handle),
-            }
-          : {}),
-      }
-    }
-    return {
-      db_query: primitiveMethodTool("db", "query", handle),
-      db_schema: primitiveMethodTool("db", "schema", handle),
-      ...(mode === "write" ? { db_execute: primitiveMethodTool("db", "execute", handle) } : {}),
-    }
-  }
-}
 
 function validateSandboxCommands(commands: unknown): string[] {
   if (!Array.isArray(commands) || !commands.length) {
@@ -395,83 +320,6 @@ function capabilityMetadataTool(capability: NormalizedCapability): AgentDevtools
     : undefined
 }
 
-export function bash(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
-  const mode = normalizeMode(options.mode, "Bash")
-  return defineCapability({
-    id: "bash",
-    mode,
-    name: "Bash",
-    requires: [{ primitive: "workspace", workspace: { mode, required: true } }],
-    tools: ({ workspace }) => (mode === "write" && "write" in workspace.tools
-      ? (workspace.tools as unknown as { write: () => AgentToolSet }).write()
-      : workspace.tools.inspect()) as AgentToolSet,
-  })
-}
-
-export function sandbox(options: { commands: string[] }): AgentCapabilityDefinition {
-  const commands = validateSandboxCommands(options?.commands)
-  return defineCapability({
-    id: "sandbox",
-    metadata: { commands },
-    name: "Sandbox",
-    requires: [{ primitive: "workspace", workspace: { required: true } }, { primitive: "sandbox" }],
-    tools: (context) => {
-      const handle = requirePrimitive(context as never, "sandbox") as {
-        exec?: (command: string, args?: string[], options?: unknown) => MaybePromise<unknown>
-      }
-      return {
-        sandbox_exec: defineInternalTool({
-          description: `Run one allowed executable in an isolated sandbox. Allowed commands: ${commands.join(", ")}.`,
-          name: "sandbox_exec",
-          async execute(input) {
-            const value = input as { args?: string[], command?: string, cwd?: string, env?: Record<string, string>, timeout?: number }
-            if (!value || typeof value.command !== "string") throw new TypeError("[vitehub] sandbox_exec requires a command.")
-            if (!commands.includes(value.command)) throw new Error(`[vitehub] Sandbox command "${value.command}" is not allowed.`)
-            if (!handle.exec) throw new Error("[vitehub] Sandbox primitive does not expose exec().")
-            return await handle.exec(value.command, value.args || [], { cwd: value.cwd, env: value.env, timeout: value.timeout })
-          },
-        }),
-      }
-    },
-  })
-}
-
-export function kv(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
-  const mode = normalizeMode(options.mode, "KV")
-  return defineCapability({ id: "kv", mode, name: "KV", requires: [{ primitive: "kv" }], tools: primitiveTools("kv", mode) })
-}
-
-export function blob(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
-  const mode = normalizeMode(options.mode, "Blob")
-  return defineCapability({ id: "blob", mode, name: "Blob", requires: [{ primitive: "blob" }], tools: primitiveTools("blob", mode) })
-}
-
-export function db(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
-  const mode = normalizeMode(options.mode, "DB")
-  return defineCapability({ id: "db", mode, name: "DB", requires: [{ primitive: "db" }], tools: primitiveTools("db", mode) })
-}
-
-export function skills(options: { path?: string } = {}): AgentCapabilityDefinition {
-  const path = options.path || "skills"
-  const skillPath = path.replace(/\/+$/, "").endsWith("/SKILL.md")
-    ? path.replace(/\/+$/, "")
-    : `${path.replace(/\/+$/, "")}/SKILL.md`
-  return defineCapability({
-    id: "skills",
-    metadata: { path: path.replace(/\/+$/, ""), skillPath },
-    name: "Skills",
-    requires: [{ primitive: "workspace", workspace: { mode: "read", paths: [skillPath], required: true } }],
-  })
-}
-
-export function mcp(options: { servers?: Record<string, unknown> } = {}): AgentCapabilityDefinition {
-  return defineCapability({
-    id: "mcp",
-    metadata: { servers: options.servers || {} },
-    name: "MCP",
-  })
-}
-
 function getChatCapabilityOptions<TRuntimeConfig extends AgentRuntimeConfig>(
   capabilities: NormalizedCapability[],
 ): AgentChatOptions<TRuntimeConfig> | undefined {
@@ -517,10 +365,6 @@ function defineBaseAgent<
 >(
   options: AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { chat?: AgentChatOptions<TRuntimeConfig>, hooks?: AgentChatAgentHooks<TRuntimeConfig> },
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS> {
-  if ("tools" in (options as Record<string, unknown>)) {
-    throw new Error("[vitehub] defineAgent({ tools }) is not public API. Expose raw tools through defineAgent({ capabilities: [...] }) instead.")
-  }
-
   if ("model" in (options as Record<string, unknown>) && !("provider" in (options as Record<string, unknown>))) {
     throw new Error("[vitehub] defineAgent({ model }) requires an explicit provider, for example provider: \"ai-sdk\".")
   }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -266,7 +266,6 @@ type AgentSettingsBase<
   model?: AgentModelResolver<TRuntimeConfig>
   provider?: AgentModelProvider
   runtime?: AgentRuntimeBinding
-  tools?: never
   workspace?: WorkspaceAgentWorkspaceConfig
   [key: string]: unknown
 }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -351,22 +351,17 @@ describe("agent message protocol", () => {
     expect(execute).not.toHaveBeenCalled()
   })
 
-  it("rejects public root-level tools", async () => {
+  it("requires an explicit provider for model agents", async () => {
     const { defineAgent } = await import("../src/index.ts")
 
     expect(() => defineAgent({
       model: {} as never,
     } as never)).toThrow("requires an explicit provider")
-
-    expect(() => defineAgent({
-      provider: "ai-sdk",
-      model: {} as never,
-      tools: {} as never,
-    })).toThrow("defineAgent({ tools }) is not public API")
   })
 
   it("validates capability ids and sandbox commands", async () => {
-    const { bash, defineAgent, sandbox } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { bash, sandbox } = await import("../src/capabilities.ts")
 
     expect(() => defineAgent({
       capabilities: [{ id: "custom" }, { id: "custom" }],
@@ -402,7 +397,8 @@ describe("agent message protocol", () => {
   })
 
   it("fails when a primitive capability has no backing primitive", async () => {
-    const { defineAgent, kv } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { kv } = await import("../src/capabilities.ts")
     const agent = defineAgent({
       capabilities: [kv()],
       provider: "ai-sdk",

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,12 +1,15 @@
 import { describe, it } from "vitest"
 
-import { bash, defineAgent, sandbox, skills } from "../src/index.ts"
+import { defineAgent } from "../src/index.ts"
+import { bash, db, kv, sandbox, skills } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
-  it("accepts capabilities and rejects root tools", () => {
+  it("accepts capabilities from the capabilities entry", () => {
     defineAgent({
       capabilities: [
         bash(),
+        db(),
+        kv(),
         skills(),
         sandbox({ commands: ["node"] }),
         {
@@ -25,13 +28,6 @@ describe("agent public types", () => {
     // @ts-expect-error model agents must select an explicit provider
     defineAgent({
       model: {} as never,
-    })
-
-    defineAgent({
-      provider: "ai-sdk",
-      model: {} as never,
-      // @ts-expect-error root-level tools are not public API
-      tools: {},
     })
 
     defineAgent({

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -64,7 +64,8 @@ describe("defineAgent workspace option", () => {
   })
 
   it("fails when a capability-required workspace path is missing", async () => {
-    const { defineAgent, skills } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
 
     const agent = defineAgent({
       capabilities: [skills({ path: "agent-skills/support" })],
@@ -95,7 +96,8 @@ describe("defineAgent workspace option", () => {
   })
 
   it("accepts skills() when SKILL.md exists", async () => {
-    const { defineAgent, skills } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
     exists.mockResolvedValue(true)
 
     const agent = defineAgent({


### PR DESCRIPTION
Moves the built-in capability factories into the `@vitehub/agent/capabilities` entrypoint while preserving root re-exports for existing consumers. This makes `kv()`, `db()`, and the other built-in capability helpers available from the capability-specific import path used by docs and tests.\n\nRemoves the explicit legacy `defineAgent({ tools })` handling and the public `tools?: never` type marker so root tools are no longer treated as a compatibility case in the agent definition surface.