### PR TITLE
fix(workspace): support root file source mounts

### DIFF
--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -53,11 +53,11 @@ async function reconcileBuildSourceMounts(store: WorkspaceStore, currentSources:
     ...currentSources.map(source => source.mountPath),
   ])]
 
-  for (const mountPath of resetPaths.sort((a, b) => b.length - a.length)) {
+  for (const mountPath of resetPaths.filter(Boolean).sort((a, b) => b.length - a.length)) {
     await store.rm(mountPath, { recursive: true, force: true })
   }
 
-  for (const mountPath of [...new Set(currentSources.map(source => source.mountPath))].sort((a, b) => a.length - b.length)) {
+  for (const mountPath of [...new Set(currentSources.map(source => source.mountPath))].filter(Boolean).sort((a, b) => a.length - b.length)) {
     await store.mkdir(mountPath, { recursive: true })
   }
 

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -56,6 +56,9 @@ async function reconcileBuildSourceMounts(store: WorkspaceStore, currentSources:
   for (const mountPath of resetPaths.filter(Boolean).sort((a, b) => b.length - a.length)) {
     await store.rm(mountPath, { recursive: true, force: true })
   }
+  for (const source of [...previousSources, ...currentSources].filter(source => !source.mountPath)) {
+    await removeRootBuildSourceFiles(store, source)
+  }
 
   for (const mountPath of [...new Set(currentSources.map(source => source.mountPath))].filter(Boolean).sort((a, b) => a.length - b.length)) {
     await store.mkdir(mountPath, { recursive: true })
@@ -68,6 +71,15 @@ async function readSyncedBuildSources(store: WorkspaceStore): Promise<SyncedBuil
   const value = await store.getMeta?.(buildSourcesMetaKey)
   if (!Array.isArray(value)) return []
   return value.filter(isSyncedBuildSource)
+}
+
+async function removeRootBuildSourceFiles(store: WorkspaceStore, source: SyncedBuildSource) {
+  const entries = await store.list("", { recursive: true })
+  await Promise.all(entries.map(async (entry) => {
+    if (entry.type !== "file") return
+    const file = await store.readFile(entry.path)
+    if (file?.metadata?.source === source.key) await store.rm(entry.path, { force: true })
+  }))
 }
 
 function isSyncedBuildSource(value: unknown): value is SyncedBuildSource {
@@ -87,7 +99,7 @@ function createMountedBuildSource(source: ResolvedWorkspaceSource): WorkspaceLoa
     async getItem(key, ctx) {
       const item = await source.source.getItem(key, ctx)
       const path = normalizeWorkspacePath(`${source.mountPath}/${item.path || item.key}`)
-      return { ...item, path }
+      return { ...item, path, metadata: { ...item.metadata, source: source.key } }
     },
   }
 }

--- a/packages/workspace/src/source-config.ts
+++ b/packages/workspace/src/source-config.ts
@@ -51,6 +51,14 @@ export function normalizeWorkspaceSource(key: string, source: WorkspaceSource): 
   }
 }
 
+export function sourceMountContainsPath(source: Pick<ResolvedWorkspaceSource, "mountPath">, workspacePath: string): boolean {
+  return workspacePath === source.mountPath || !!source.mountPath && workspacePath.startsWith(`${source.mountPath}/`)
+}
+
+export function sourceMountIntersectsPath(source: Pick<ResolvedWorkspaceSource, "mountPath">, workspacePath: string): boolean {
+  return !workspacePath || !source.mountPath || sourceMountContainsPath(source, workspacePath) || source.mountPath.startsWith(`${workspacePath}/`)
+}
+
 function normalizeSourceMount(source: WorkspaceSource) {
   if (typeof source.mount === "string") {
     return { path: source.mount }

--- a/packages/workspace/src/source-config.ts
+++ b/packages/workspace/src/source-config.ts
@@ -39,10 +39,11 @@ export function normalizeWorkspaceSources(sources: WorkspaceDefinition["sources"
 export function normalizeWorkspaceSource(key: string, source: WorkspaceSource): ResolvedWorkspaceSource {
   const mount = normalizeSourceMount(source)
   const cache = mount.cache ?? normalizeSourceCache(source) ?? false
+  const mountPath = typeof mount.path === "string" ? mount.path : key
   return {
     key,
     source,
-    mountPath: normalizeSafeWorkspacePath(mount.path || key),
+    mountPath: normalizeSafeWorkspacePath(mountPath, { allowEmpty: true }),
     materialize: mount.materialize || source.materialize || (cache ? "lazy" : "build"),
     cache,
     validate: mount.validate ?? source.validate ?? false,

--- a/packages/workspace/src/source-materialization.ts
+++ b/packages/workspace/src/source-materialization.ts
@@ -139,13 +139,15 @@ export async function materializeWorkspaceSources(
       const items = source.source.getItems
         ? await source.source.getItems(ctx)
         : await Promise.all((await source.source.getKeys(ctx)).map(async key => await source.source.getItem(key, ctx)))
-      await store.rm(source.mountPath, { recursive: true, force: true })
-      await store.mkdir(source.mountPath, { recursive: true })
+      if (source.mountPath) {
+        await store.rm(source.mountPath, { recursive: true, force: true })
+        await store.mkdir(source.mountPath, { recursive: true })
+      }
 
       let sourceFiles = 0
       let sourceBytes = 0
       let commit: string | undefined
-      const directorySet = new Set<string>([source.mountPath])
+      const directorySet = new Set<string>(source.mountPath ? [source.mountPath] : [])
       for (const item of items) {
         const content = item.content ?? (typeof item.data === "undefined" ? "" : JSON.stringify(item.data, null, 2))
         const path = normalizeWorkspacePath(`${source.mountPath}/${item.path || item.key}`)

--- a/packages/workspace/src/source-materialization.ts
+++ b/packages/workspace/src/source-materialization.ts
@@ -2,7 +2,7 @@ import { posix } from "node:path"
 
 import { WorkspaceError } from "./errors.ts"
 import { decodeFile, normalizeWorkspacePath, sha256 } from "./path.ts"
-import { createSourceContext, normalizeWorkspaceSources } from "./source-config.ts"
+import { createSourceContext, normalizeWorkspaceSources, sourceMountContainsPath, sourceMountIntersectsPath } from "./source-config.ts"
 import { searchText } from "./search.ts"
 import type { ResolvedWorkspaceSource } from "./source-config.ts"
 import type { ResolvedSourcePath } from "./source-resolver.ts"
@@ -92,7 +92,34 @@ function sourcePathMatches(path: string, source: ResolvedWorkspaceSource, option
   if (options?.sources?.length && !options.sources.includes(source.key)) return false
   const requested = normalizeWorkspacePath(options?.path || "")
   if (!requested) return true
-  return requested === source.mountPath || requested.startsWith(`${source.mountPath}/`) || source.mountPath.startsWith(`${requested}/`)
+  return sourceMountIntersectsPath(source, requested)
+}
+
+function parentDirectoryPaths(path: string) {
+  const parts = normalizeWorkspacePath(path).split("/").filter(Boolean)
+  const paths: string[] = []
+  for (let index = 1; index < parts.length; index++) paths.push(parts.slice(0, index).join("/"))
+  return paths
+}
+
+async function removeStaleMaterializedSourceFiles(store: WorkspaceStore, source: ResolvedWorkspaceSource, nextPaths: Set<string>) {
+  const entries = await store.list(source.mountPath, { recursive: true })
+  const nextDirectories = new Set([...nextPaths].flatMap(path => parentDirectoryPaths(path)))
+  const staleDirectories = new Set<string>()
+  await Promise.all(entries.map(async (entry) => {
+    if (nextPaths.has(entry.path) || entry.type !== "file") return
+    const file = await store.readFile(entry.path)
+    if (file?.metadata?.source === source.key) {
+      for (const directory of parentDirectoryPaths(entry.path)) staleDirectories.add(directory)
+      await store.rm(entry.path, { force: true })
+    }
+  }))
+  for (const entry of entries.filter(entry => entry.type === "directory" && staleDirectories.has(entry.path) && !nextDirectories.has(entry.path)).sort((a, b) => b.path.length - a.path.length)) {
+    try {
+      await store.rm(entry.path, { force: true })
+    }
+    catch {}
+  }
 }
 
 export async function materializeWorkspaceSources(
@@ -148,9 +175,11 @@ export async function materializeWorkspaceSources(
       let sourceBytes = 0
       let commit: string | undefined
       const directorySet = new Set<string>(source.mountPath ? [source.mountPath] : [])
+      const nextPaths = new Set<string>()
       for (const item of items) {
         const content = item.content ?? (typeof item.data === "undefined" ? "" : JSON.stringify(item.data, null, 2))
         const path = normalizeWorkspacePath(`${source.mountPath}/${item.path || item.key}`)
+        nextPaths.add(path)
         const parts = path.split("/")
         for (let index = 1; index < parts.length; index++) directorySet.add(parts.slice(0, index).join("/"))
         const metadata = item.metadata || {}
@@ -167,6 +196,7 @@ export async function materializeWorkspaceSources(
         sourceFiles++
         sourceBytes += contentSize(content)
       }
+      if (!source.mountPath) await removeStaleMaterializedSourceFiles(store, source, nextPaths)
 
       const ready: SourceSnapshotMetadata = {
         configHash,
@@ -457,7 +487,7 @@ function isCacheFresh(metadata: LazyMaterializedMetadata, cache: ResolvedSourceP
 
 function normalizeSourcePath(source: ResolvedWorkspaceSource, workspacePath: string) {
   if (workspacePath === source.mountPath) return ""
-  return workspacePath.startsWith(`${source.mountPath}/`)
+  return source.mountPath && workspacePath.startsWith(`${source.mountPath}/`)
     ? normalizeWorkspacePath(workspacePath.slice(source.mountPath.length + 1))
     : normalizeWorkspacePath(workspacePath)
 }
@@ -473,7 +503,7 @@ function readDigest(meta: Record<string, unknown> | undefined) {
 function toSourceSearchPaths(source: ResolvedWorkspaceSource, paths: string[] | undefined) {
   if (!paths?.length) return undefined
   return paths
-    .filter(path => path === source.mountPath || path.startsWith(`${source.mountPath}/`))
+    .filter(path => sourceMountContainsPath(source, path))
     .map(path => normalizeSourcePath(source, path))
 }
 

--- a/packages/workspace/src/source-resolver.ts
+++ b/packages/workspace/src/source-resolver.ts
@@ -1,5 +1,5 @@
 import { normalizeSafeWorkspacePath, normalizeWorkspacePath } from "./path.ts"
-import { normalizeWorkspaceSources, type ResolvedWorkspaceSource } from "./source-config.ts"
+import { normalizeWorkspaceSources, sourceMountContainsPath, type ResolvedWorkspaceSource } from "./source-config.ts"
 
 import type { WorkspaceDefinition, WorkspaceSearchQuery } from "./types.ts"
 
@@ -31,8 +31,8 @@ export function resolveWorkspacePath(definition: WorkspaceDefinition, path: stri
     if (workspacePath === source.mountPath) {
       return createSourceResolution(source, workspacePath, "")
     }
-    if (workspacePath.startsWith(`${source.mountPath}/`)) {
-      return createSourceResolution(source, workspacePath, workspacePath.slice(source.mountPath.length + 1))
+    if (sourceMountContainsPath(source, workspacePath)) {
+      return createSourceResolution(source, workspacePath, source.mountPath ? workspacePath.slice(source.mountPath.length + 1) : workspacePath)
     }
   }
 

--- a/packages/workspace/src/source-view.ts
+++ b/packages/workspace/src/source-view.ts
@@ -1,7 +1,7 @@
 import { WorkspaceError } from "./errors.ts"
 import { decodeFile, matchesAny, normalizeWorkspacePath } from "./path.ts"
 import { createWorkspaceWritePolicy } from "./rules.ts"
-import { createSourceContext, normalizeWorkspaceSources } from "./source-config.ts"
+import { createSourceContext, normalizeWorkspaceSources, sourceMountContainsPath, sourceMountIntersectsPath } from "./source-config.ts"
 import {
   hasCurrentSourceSnapshot,
   materializeWorkspaceSources,
@@ -49,16 +49,11 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
   const materializeBySource = new Map<string, Promise<void>>()
 
   function isLazySourcePath(path: string) {
-    return sources.some(source => path === source.mountPath || path.startsWith(`${source.mountPath}/`))
+    return sources.some(source => sourceMountContainsPath(source, path))
   }
 
   function getLazySourcesForPath(path: string) {
-    return sources.filter((source) => {
-      if (!path) return true
-      return path === source.mountPath
-        || path.startsWith(`${source.mountPath}/`)
-        || source.mountPath.startsWith(`${path}/`)
-    })
+    return sources.filter(source => sourceMountIntersectsPath(source, path))
   }
 
   async function ensurePrepared(sourceKey: string) {
@@ -96,21 +91,21 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
     for (const source of getLazySourcesForPath(path)) {
       await ensurePrepared(source.key)
       if (!path && options.recursive && !await hasCurrentSourceSnapshot(store, source)) {
-        if ([...result.keys()].some(key => key.startsWith(`${source.mountPath}/`))) {
+        if ([...result.keys()].some(key => sourceMountContainsPath(source, key))) {
           const allowed = await currentSourceTreePaths(source, sourceContext)
           for (const key of result.keys()) {
-            if ((key === source.mountPath || key.startsWith(`${source.mountPath}/`)) && !allowed.has(key)) result.delete(key)
+            if (sourceMountContainsPath(source, key) && !allowed.has(key)) result.delete(key)
           }
           result.set(source.mountPath, { path: source.mountPath, type: "directory" })
           continue
         }
         for (const key of result.keys()) {
-          if (key === source.mountPath || key.startsWith(`${source.mountPath}/`)) result.delete(key)
+          if (sourceMountContainsPath(source, key)) result.delete(key)
         }
         result.set(source.mountPath, { path: source.mountPath, type: "directory" })
         continue
       }
-      if (path === source.mountPath || path.startsWith(`${source.mountPath}/`)) {
+      if (sourceMountContainsPath(source, path) || !source.mountPath && path) {
         await ensureMaterialized(source.key)
         for (const entry of await store.list(path, options)) result.set(entry.path, entry)
       }
@@ -179,6 +174,37 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
     return await store.stat(path)
   }
 
+  async function materializeRootSourceForPath(path: string) {
+    for (const source of sources.filter(source => !source.mountPath)) {
+      await ensurePrepared(source.key)
+      await ensureMaterialized(source.key)
+      const file = await store.readFile(path)
+      if (file?.metadata?.source === source.key) return source
+    }
+  }
+
+  async function isSourceBackedStorePath(path: string) {
+    const file = await store.readFile(path)
+    if (typeof file?.metadata?.source === "string" && sources.some(source => source.key === file.metadata?.source)) return true
+    const stat = await store.stat(path)
+    if (stat?.type !== "directory") return false
+    const entries = await store.list(path, { recursive: true })
+    for (const entry of entries) {
+      if (entry.type !== "file") continue
+      const child = await store.readFile(entry.path)
+      if (typeof child?.metadata?.source === "string" && sources.some(source => source.key === child.metadata?.source)) return true
+    }
+    return false
+  }
+
+  async function assertWritableResolvedStorePath(path: string, workspacePath: string, type: "source" | "store") {
+    assertWritableStorePath(path, workspacePath, type)
+    await materializeRootSourceForPath(workspacePath)
+    if (await isSourceBackedStorePath(workspacePath)) {
+      throw new WorkspaceError(`[vitehub] Source-backed workspace paths are read-only: ${path}.`)
+    }
+  }
+
   return {
     async readFile(path, options) {
       const resolution = resolveWorkspacePath(definition, path)
@@ -187,13 +213,14 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
         await ensureMaterialized(resolution.sourceKey)
         return await readResolvedSourceFile(resolution, store, sourceContext, options)
       }
+      await materializeRootSourceForPath(resolution.workspacePath)
       const file = await store.readFile(resolution.workspacePath)
       if (!file) throw new WorkspaceError(`[vitehub] Workspace file does not exist: ${path}.`)
       return decodeFile(file.content, options)
     },
     async writeFile(path, content, options) {
       const resolution = resolveWorkspacePath(definition, path)
-      assertWritableStorePath(path, resolution.workspacePath, resolution.type)
+      await assertWritableResolvedStorePath(path, resolution.workspacePath, resolution.type)
       const input = await writePolicy.before({
         content,
         mediaType: options?.mediaType,
@@ -238,7 +265,11 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
         if (!result) throw new WorkspaceError(`[vitehub] Workspace path does not exist: ${path}.`)
         return result
       }
-      const result = await store.stat(resolution.workspacePath)
+      let result = await store.stat(resolution.workspacePath)
+      if (!result) {
+        await materializeRootSourceForPath(resolution.workspacePath)
+        result = await store.stat(resolution.workspacePath)
+      }
       if (!result) throw new WorkspaceError(`[vitehub] Workspace path does not exist: ${path}.`)
       return result
     },
@@ -252,11 +283,13 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
         await ensureMaterialized(resolution.sourceKey)
         return Boolean(await statVirtualSourcePath(resolution.source, resolution.workspacePath, store, sourceContext))
       }
+      if (await store.stat(resolution.workspacePath)) return true
+      await materializeRootSourceForPath(resolution.workspacePath)
       return Boolean(await store.stat(resolution.workspacePath))
     },
     async mkdir(path, options) {
       const resolution = resolveWorkspacePath(definition, path)
-      assertWritableStorePath(path, resolution.workspacePath, resolution.type)
+      await assertWritableResolvedStorePath(path, resolution.workspacePath, resolution.type)
       const input = await writePolicy.before({
         operation: "mkdir",
         path: resolution.workspacePath,
@@ -274,7 +307,7 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
     },
     async rm(path, options) {
       const resolution = resolveWorkspacePath(definition, path)
-      assertWritableStorePath(path, resolution.workspacePath, resolution.type)
+      await assertWritableResolvedStorePath(path, resolution.workspacePath, resolution.type)
       const input = await writePolicy.before({
         operation: "rm",
         path: resolution.workspacePath,

--- a/packages/workspace/src/stores/local.ts
+++ b/packages/workspace/src/stores/local.ts
@@ -29,7 +29,11 @@ async function walk(root: string, current = root): Promise<WorkspaceEntry[]> {
     const absolute = `${current}/${dirent.name}`
     const path = normalizeWorkspacePath(relative(root, absolute))
     const { stat, readFile } = await import("node:fs/promises")
-    const info = await stat(absolute)
+    const info = await stat(absolute).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined
+      throw error
+    })
+    if (!info) continue
     if (dirent.isDirectory()) {
       entries.push({ path, type: "directory", mtime: info.mtimeMs })
       entries.push(...await walk(root, absolute))

--- a/packages/workspace/test/lazy-sources.test.ts
+++ b/packages/workspace/test/lazy-sources.test.ts
@@ -231,6 +231,140 @@ describe("lazy sources", () => {
     await expect(workspace.readFile("artifacts/result.md")).resolves.toBe("ok")
   })
 
+  it("materializes root-mounted lazy source paths before reads and keeps them read-only", async () => {
+    registerWorkspace("lazy-root-files", defineWorkspace({
+      store: { provider: "memory" },
+      sources: {
+        rootFiles: source.custom({
+          materialize: "lazy",
+          mount: "",
+          async getKeys() {
+            return ["AGENTS.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "# Instructions\n" }
+          },
+        }),
+      },
+    }))
+
+    const workspace = await useRegisteredWorkspace("lazy-root-files")
+    await workspace.sync()
+
+    await expect(workspace.readFile("AGENTS.md")).resolves.toBe("# Instructions\n")
+    await expect(workspace.writeFile("AGENTS.md", "nope")).rejects.toThrow("read-only")
+    await expect(workspace.rm("AGENTS.md")).rejects.toThrow("read-only")
+    await expect(workspace.mkdir("AGENTS.md")).rejects.toThrow("read-only")
+    await expect(workspace.writeFile("generated/result.md", "ok")).resolves.toBeUndefined()
+    await expect(workspace.readFile("generated/result.md")).resolves.toBe("ok")
+  })
+
+  it("rejects root-mounted lazy source mutations before materialization", async () => {
+    registerWorkspace("lazy-root-prewrite", defineWorkspace({
+      store: { provider: "memory" },
+      sources: {
+        rootFiles: source.custom({
+          materialize: "lazy",
+          mount: "",
+          async getKeys() {
+            return ["AGENTS.md", "docs/guide.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: `# ${key}\n` }
+          },
+        }),
+      },
+    }))
+
+    const workspace = await useRegisteredWorkspace("lazy-root-prewrite")
+    await workspace.sync()
+
+    await expect(workspace.writeFile("AGENTS.md", "shadow")).rejects.toThrow("read-only")
+    await expect(workspace.rm("docs")).rejects.toThrow("read-only")
+    await expect(workspace.mkdir("docs")).rejects.toThrow("read-only")
+    await expect(workspace.writeFile("generated/result.md", "ok")).resolves.toBeUndefined()
+  })
+
+  it("materializes root-mounted lazy sources before returning existing store files", async () => {
+    const store = createMemoryWorkspaceStore()
+    await store.writeFile("AGENTS.md", { path: "AGENTS.md", content: "stale\n" })
+    const view = createWorkspaceSourceView({
+      name: "lazy-root-shadow",
+      sources: {
+        rootFiles: source.custom({
+          materialize: "lazy",
+          mount: "",
+          async getKeys() {
+            return ["AGENTS.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "# Source\n" }
+          },
+        }),
+      },
+    }, store)
+
+    await expect(view.readFile("AGENTS.md")).resolves.toBe("# Source\n")
+  })
+
+  it("removes stale root-mounted lazy source files on refresh", async () => {
+    let keys = ["AGENTS.md", "nested/stale.md"]
+    registerWorkspace("lazy-root-refresh", defineWorkspace({
+      store: { provider: "memory" },
+      sources: {
+        rootFiles: source.custom({
+          materialize: "lazy",
+          mount: "",
+          async getKeys() {
+            return keys
+          },
+          async getItem(key) {
+            return { key, path: key, content: `# ${key}\n` }
+          },
+        }),
+      },
+    }))
+
+    const workspace = await useRegisteredWorkspace("lazy-root-refresh")
+    await workspace.sync()
+    await workspace.mkdir("generated")
+    await workspace.materializeSources?.()
+    await expect(workspace.readFile("nested/stale.md")).resolves.toBe("# nested/stale.md\n")
+
+    keys = ["AGENTS.md"]
+    await workspace.materializeSources?.()
+
+    await expect(workspace.exists("nested/stale.md")).resolves.toBe(false)
+    await expect(workspace.exists("nested")).resolves.toBe(false)
+    await expect(workspace.exists("generated")).resolves.toBe(true)
+    await expect(workspace.readFile("AGENTS.md")).resolves.toBe("# AGENTS.md\n")
+  })
+
+  it("materializes root-mounted lazy sources for scoped paths", async () => {
+    const getItem = vi.fn(async (key: string) => ({ key, path: key, content: `# ${key}\n` }))
+    registerWorkspace("lazy-root-scoped", defineWorkspace({
+      store: { provider: "memory" },
+      sources: {
+        rootFiles: source.custom({
+          materialize: "lazy",
+          mount: "",
+          async getKeys() {
+            return ["docs/guide.md"]
+          },
+          getItem,
+        }),
+      },
+    }))
+
+    const workspace = await useRegisteredWorkspace("lazy-root-scoped")
+    await workspace.sync()
+
+    await expect(workspace.list("docs")).resolves.toEqual([
+      expect.objectContaining({ path: "docs/guide.md", type: "file" }),
+    ])
+    expect(getItem).toHaveBeenCalledTimes(1)
+  })
+
   it("searches materialized source snapshots", async () => {
     const getItem = vi.fn(async (key: string) => ({ key, path: key, content: "hello\n" }))
     const search = vi.fn(async () => [{

--- a/packages/workspace/test/public-api.test.ts
+++ b/packages/workspace/test/public-api.test.ts
@@ -56,6 +56,27 @@ describe("workspace public API", () => {
     expect(await workspace.fs.glob("**/*.md")).toHaveLength(3)
   })
 
+  it("mounts inline files at the workspace root", async () => {
+    registerWorkspace("root-file", defineWorkspace({
+      store: { provider: "memory" },
+      sources: {
+        instructions: source.file({
+          mount: "",
+          workspacePath: "AGENTS.md",
+          content: "# Instructions\n",
+        }),
+      },
+    }))
+
+    const workspace = useWorkspace("root-file", { allowWrite: true })
+
+    expect(await workspace.fs.readFile("AGENTS.md")).toBe("# Instructions\n")
+    expect(await workspace.fs.list()).toEqual([
+      expect.objectContaining({ path: "AGENTS.md", type: "file" }),
+    ])
+    await expect(workspace.fs.exists("instructions/AGENTS.md")).resolves.toBe(false)
+  })
+
   it("enforces workspace rules before writes reach the store", async () => {
     registerWorkspace("rules", defineWorkspace({
       store: { provider: "memory" },

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -549,6 +549,33 @@ describe("sources, loaders, and publishers", () => {
     await expect(store.list("", { recursive: true })).resolves.toEqual([])
   })
 
+  it("purges stale root-mounted build source files when source maps change", async () => {
+    const store = createMemoryWorkspaceStore()
+    let keys = ["AGENTS.md", "stale.md"]
+    const rootSource = source.custom({
+      async getKeys() {
+        return keys
+      },
+      async getItem(key) {
+        return { key, path: key, content: `# ${key}\n` }
+      },
+      mount: "",
+    })
+    const definition: WorkspaceDefinition = {
+      name: "stale-root-build-sources",
+      sources: { rootFiles: rootSource },
+    }
+
+    await syncWorkspaceDefinition(definition, store)
+    await expect(store.readFile("stale.md")).resolves.toMatchObject({ content: "# stale.md\n" })
+
+    keys = ["AGENTS.md"]
+    await syncWorkspaceDefinition(definition, store)
+
+    await expect(store.readFile("AGENTS.md")).resolves.toMatchObject({ content: "# AGENTS.md\n" })
+    await expect(store.readFile("stale.md")).resolves.toBeUndefined()
+  })
+
   it("purges stale local build source files after store restarts", async () => {
     const root = await createRoot()
     const storeRoot = join(root, ".vitehub", "workspaces", "docs")


### PR DESCRIPTION
Allows workspace sources to opt into an empty mount path so inline files such as AGENTS.md can be exposed at the workspace root instead of under an artificial source directory.\n\nThis keeps root-mounted sources from deleting or creating the workspace root during build-source reconciliation and materialization.