### PR TITLE
feat(agent): add invocation finish hooks

### DIFF
--- a/packages/agent/docs/runtime-api.md
+++ b/packages/agent/docs/runtime-api.md
@@ -54,6 +54,7 @@ export default defineNitroConfig({
 defineAgent({
   description?: string
   capabilities?: AgentCapabilityDefinition[]
+  hooks?: AgentInvocationHooks
   instructions?: AgentAdapterInstructions
   model?: unknown
   adapter?: 'ai-sdk' | 'tanstack-ai' | string
@@ -121,6 +122,44 @@ defineAgent({
 })
 ```
 
+## Agent invocation hooks
+
+Use `agent:finish` to observe a completed Agent Invocation. The hook runs after object results are rendered and after streamed or `Response` results are consumed or canceled.
+
+```ts
+defineAgent({
+  hooks: {
+    'agent:finish'(event) {
+      const usage = event.extensions.get<AgentUsageRecord>('usage-telemetry')
+    },
+  },
+  capabilities: [
+    usageTelemetry(),
+  ],
+  model,
+  provider: 'ai-sdk',
+})
+```
+
+```ts
+interface AgentFinishEvent {
+  input: AgentRunInput
+  result?: unknown
+  error?: unknown
+  runtime: ResolvedAgentRuntimeContext
+  invocation: {
+    durationMs: number
+    run?: AgentRunMetadata
+  }
+  extensions: {
+    get<T = unknown>(capabilityId: string): T | undefined
+    has(capabilityId: string): boolean
+  }
+}
+```
+
+Capabilities can expose optional data on finish events through extension keys that match their Capability ID. ViteHub-owned usage telemetry uses `usage-telemetry`.
+
 ## Run input
 
 ```ts
@@ -162,7 +201,7 @@ interface AgentUsageRecord {
 }
 ```
 
-`usageTelemetry()` uses the Capability output phase. It normalizes finished object results only; streamed `Response` and async iterable results are returned unchanged.
+`usageTelemetry()` uses the Capability output phase. It normalizes finished object results only; streamed `Response` and async iterable results are returned unchanged. When an Agent Finish Hook is configured, the same record is available through `event.extensions.get('usage-telemetry')`.
 
 ```ts
 usageTelemetry({

--- a/packages/agent/docs/runtime-api.md
+++ b/packages/agent/docs/runtime-api.md
@@ -153,12 +153,22 @@ interface AgentFinishEvent {
   }
   extensions: {
     get<T = unknown>(capabilityId: string): T | undefined
-    has(capabilityId: string): boolean
   }
 }
 ```
 
-Capabilities can expose optional data on finish events through extension keys that match their Capability ID. ViteHub-owned usage telemetry uses `usage-telemetry`.
+Capabilities can expose optional data on finish events through extension keys that match their Capability ID. Return `undefined` to omit the extension value for that invocation.
+
+```ts
+defineCapability({
+  id: 'audit-log',
+  output(context) {
+    context.finish.provide(event => event.result)
+  },
+})
+```
+
+ViteHub-owned usage telemetry uses `usage-telemetry`.
 
 ## Run input
 

--- a/packages/agent/docs/usage.md
+++ b/packages/agent/docs/usage.md
@@ -108,7 +108,26 @@ result.usage
 result.usageRecord?.cost
 ```
 
-The v1 capability does not define export callbacks or persistence hooks. Future lifecycle hooks can consume the same usage record.
+The capability does not define export callbacks or persistence hooks. Use the Agent Finish Hook to export, log, or sync completed usage records.
+
+```ts
+export default defineAgent({
+  capabilities: [
+    usageTelemetry({
+      pricing: vercelAiGatewayPricing(),
+    }),
+  ],
+  hooks: {
+    'agent:finish'(event) {
+      const usage = event.extensions.get('usage-telemetry')
+      if (usage) event.runtime.waitUntil(syncUsage(usage))
+    },
+  },
+  instructions: 'Triage support requests.',
+  model,
+  provider: 'ai-sdk',
+})
+```
 
 ## Customize a run
 

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -180,7 +180,7 @@ export function usageTelemetry(options: UsageTelemetryOptions = {}): AgentCapabi
     id: "usage-telemetry",
     name: "Usage Telemetry",
     output(context) {
-      context.extensions.provide("agent:finish", (event: AgentFinishEvent) => isRecord(event.result)
+      context.finish.provide((event: AgentFinishEvent) => isRecord(event.result)
         ? event.result.usageRecord
         : undefined)
       context.output.render(async (result) => {

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -2,6 +2,7 @@ import { defineCapability } from "../capability-runtime.ts"
 
 import type {
   AgentCapabilityDefinition,
+  AgentFinishEvent,
   AgentRunMetadata,
   AgentUsage,
   AgentUsageCost,
@@ -179,6 +180,9 @@ export function usageTelemetry(options: UsageTelemetryOptions = {}): AgentCapabi
     id: "usage-telemetry",
     name: "Usage Telemetry",
     output(context) {
+      context.extensions.provide("agent:finish", (event: AgentFinishEvent) => isRecord(event.result)
+        ? event.result.usageRecord
+        : undefined)
       context.output.render(async (result) => {
         if (!isRecord(result)) return result
         const usageRecord = await createAgentUsageRecord(result, options, context.run)

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -455,16 +455,16 @@ export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(
   })()
 }
 
-export function withResponseCleanup(response: Response, close: () => Promise<void>): Response | Promise<Response> {
+export function withResponseCleanup(response: Response, close: (error?: unknown) => Promise<void>): Response | Promise<Response> {
   if (!response.body) {
     return close().then(() => response)
   }
   const reader = response.body.getReader()
   let closed = false
-  async function closeOnce() {
+  async function closeOnce(error?: unknown) {
     if (closed) return
     closed = true
-    await close()
+    await close(error)
   }
   return new Response(new ReadableStream({
     async cancel(reason) {
@@ -486,7 +486,7 @@ export function withResponseCleanup(response: Response, close: () => Promise<voi
         controller.enqueue(result.value)
       }
       catch (error) {
-        await closeOnce()
+        await closeOnce(error)
         throw error
       }
     },

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -468,11 +468,16 @@ export function withResponseCleanup(response: Response, close: (error?: unknown)
   }
   return new Response(new ReadableStream({
     async cancel(reason) {
+      let cancelError: unknown
       try {
         await reader.cancel(reason)
       }
+      catch (error) {
+        cancelError = error
+        throw error
+      }
       finally {
-        await closeOnce()
+        await closeOnce(cancelError)
       }
     },
     async pull(controller) {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -443,14 +443,21 @@ export async function createAgentInvocationExtensions(
 
 export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(
   stream: T,
-  close: () => Promise<void>,
+  close: (error?: unknown) => Promise<void>,
 ): AsyncIterable<unknown> {
   return (async function* () {
+    let error: unknown
+    let failed = false
     try {
       yield* stream
     }
+    catch (caught) {
+      failed = true
+      error = caught
+      throw caught
+    }
     finally {
-      await close()
+      await close(failed ? error : undefined)
     }
   })()
 }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -231,9 +231,8 @@ export async function resolveAgentCapabilities<
             registries.outputRenderers.push(result => renderer(result, capabilityContext))
           },
         },
-        extensions: {
-          provide(hook, value) {
-            if (hook !== "agent:finish") return
+        finish: {
+          provide(value) {
             registries.finishExtensionProviders.push({
               id: capability.id,
               resolve: typeof value === "function"
@@ -426,9 +425,6 @@ export async function createAgentInvocationExtensions(
   const extensions: AgentFinishEvent["extensions"] = {
     get<T = unknown>(capabilityId: string): T | undefined {
       return values.get(capabilityId) as T | undefined
-    },
-    has(capabilityId: string): boolean {
-      return values.has(capabilityId)
     },
   }
   const finishEvent = { ...event, extensions } as AgentFinishEvent

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -8,6 +8,8 @@ import type {
   AgentCapabilityHooks,
   AgentCapabilityMode,
   AgentCapabilityRuntimeContext,
+  AgentFinishEvent,
+  AgentFinishExtensionProvider,
   AgentInstructionBlock,
   AgentOutputRenderer,
   AgentRunInput,
@@ -22,7 +24,13 @@ import type { ReadonlyWorkspaceFacade, WorkspaceName } from "@vitehub/workspace"
 
 type ResolvedAgentOutputRenderer = (result: unknown) => MaybePromise<unknown>
 
+export interface ResolvedAgentFinishExtensionProvider {
+  id: string
+  resolve: AgentFinishExtensionProvider
+}
+
 export interface AgentCapabilityRegistries {
+  finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
   outputRenderers: ResolvedAgentOutputRenderer[]
   stateRequirements: Array<{ name: string, optional?: boolean }>
 }
@@ -174,6 +182,7 @@ export async function resolveAgentCapabilities<
   const closeCallbacks: Array<() => MaybePromise<void>> = []
   const toolTransforms: AgentToolTransform[] = []
   const registries: AgentCapabilityRegistries = {
+    finishExtensionProviders: [],
     outputRenderers: [],
     stateRequirements: [],
   }
@@ -220,6 +229,17 @@ export async function resolveAgentCapabilities<
         output: {
           render(renderer: AgentOutputRenderer) {
             registries.outputRenderers.push(result => renderer(result, capabilityContext))
+          },
+        },
+        extensions: {
+          provide(hook, value) {
+            if (hook !== "agent:finish") return
+            registries.finishExtensionProviders.push({
+              id: capability.id,
+              resolve: typeof value === "function"
+                ? value as AgentFinishExtensionProvider
+                : () => value,
+            })
           },
         },
         state: {
@@ -396,6 +416,29 @@ export async function applyOutputRenderers(
     current = await renderer(current)
   }
   return current
+}
+
+export async function createAgentInvocationExtensions(
+  event: Omit<AgentFinishEvent, "extensions">,
+  providers: ResolvedAgentFinishExtensionProvider[] = [],
+): Promise<AgentFinishEvent["extensions"]> {
+  const values = new Map<string, unknown>()
+  const extensions: AgentFinishEvent["extensions"] = {
+    get<T = unknown>(capabilityId: string): T | undefined {
+      return values.get(capabilityId) as T | undefined
+    },
+    has(capabilityId: string): boolean {
+      return values.has(capabilityId)
+    },
+  }
+  const finishEvent = { ...event, extensions } as AgentFinishEvent
+  for (const provider of providers) {
+    const value = await provider.resolve(finishEvent)
+    if (value !== undefined) {
+      values.set(provider.id, value)
+    }
+  }
+  return extensions
 }
 
 export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -14,6 +14,7 @@ import {
   normalizeMode,
   resolveAgentCapabilities,
   resolveAgentStaticCapabilities,
+  withCapabilityCleanup,
   withResponseCleanup,
 } from "./capability-runtime.ts"
 import type { ResolvedAgentFinishExtensionProvider } from "./capability-runtime.ts"
@@ -1181,27 +1182,6 @@ async function finishAgentInvocation<
   await context.finishHook?.({ ...eventBase, extensions })
 }
 
-function withFinishCleanup<T extends AsyncIterable<unknown>>(
-  stream: T,
-  finish: (error?: unknown) => Promise<void>,
-): AsyncIterable<unknown> {
-  return (async function* () {
-    let error: unknown
-    let failed = false
-    try {
-      yield* stream
-    }
-    catch (caught) {
-      failed = true
-      error = caught
-      throw caught
-    }
-    finally {
-      await finish(failed ? error : undefined)
-    }
-  })()
-}
-
 export async function runAgent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -1217,7 +1197,7 @@ export async function runAgent<
     try {
       const result = await agent.run(runContext)
       if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
-      if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
+      if (isAsyncIterable(result)) return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
       await finishAgentInvocation(runContext, rendered)
       return rendered
@@ -1241,7 +1221,7 @@ export async function runAgent<
   try {
     const result = await resolved.generate(adapterContext as never)
     if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
-    if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
+    if (isAsyncIterable(result)) return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
     const runResult = toAgentRunResult(rendered)
     await finishAgentInvocation(adapterContext, rendered)
@@ -1273,7 +1253,7 @@ export async function streamAgent<
     try {
       const result = await agent.run(runContext)
       if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
-      if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
+      if (isAsyncIterable(result)) return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
       await finishAgentInvocation(runContext, rendered)
       return rendered
@@ -1299,10 +1279,10 @@ export async function streamAgent<
       ? await resolved.stream(adapterContext as never)
       : await resolved.generate(adapterContext as never)
     if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
-    if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
+    if (isAsyncIterable(result)) return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
     const events = streamTextResultToEvents(rendered)
-    return shouldWrapOutput ? withFinishCleanup(events, error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error)) : events
+    return shouldWrapOutput ? withCapabilityCleanup(events, error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error)) : events
   }
   catch (error) {
     try {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1300,8 +1300,9 @@ export async function streamAgent<
       : await resolved.generate(adapterContext as never)
     if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, () => finishAgentInvocation(adapterContext, result)) : result
     if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
-    const events = streamTextResultToEvents(await applyOutputRenderers(result, adapterContext.outputRenderers))
-    return shouldWrapOutput ? withFinishCleanup(events, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : events
+    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
+    const events = streamTextResultToEvents(rendered)
+    return shouldWrapOutput ? withFinishCleanup(events, error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error)) : events
   }
   catch (error) {
     try {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -8,14 +8,15 @@ import {
 import {
   applyCapabilityToolTransforms,
   applyOutputRenderers,
+  createAgentInvocationExtensions,
   defineCapability,
   normalizeCapabilities,
   normalizeMode,
   resolveAgentCapabilities,
   resolveAgentStaticCapabilities,
-  withCapabilityCleanup,
   withResponseCleanup,
 } from "./capability-runtime.ts"
+import type { ResolvedAgentFinishExtensionProvider } from "./capability-runtime.ts"
 import { formatUnknownAgentMessage } from "./registry-error.ts"
 import {
   applyAgentToolPolicies,
@@ -28,13 +29,17 @@ import type {
   AgentAdapterMetadataContext,
   AgentAdapterResult,
   AgentCapabilitiesList,
+  AgentCapabilityHooks,
+  AgentCapabilityContext,
   AgentCapabilityDefinition,
   AgentCapabilityInput,
   AgentCapabilityMode,
   AgentDefinition,
+  AgentFinishEvent,
   AgentChatOptions,
   AgentInput,
   AgentModelAdapter,
+  AgentInvocationHooks,
   AgentRegistry,
   AgentRegistryModule,
   AgentRequestBody,
@@ -90,10 +95,14 @@ export type {
   AgentRequestBody,
   AgentDefinition,
   AgentExecution,
+  AgentFinishEvent,
+  AgentFinishHook,
   AgentHandlerOptions,
   AgentInput,
   AgentInstructionBlock,
   AgentIntegrationOption,
+  AgentInvocationExtensions,
+  AgentInvocationHooks,
   AgentIntegrationsOptions,
   AgentModelInput,
   AgentModelInstrumentation,
@@ -371,13 +380,13 @@ function defineBaseAgent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
 >(
-  options: AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { chat?: AgentChatOptions<TRuntimeConfig>, hooks?: AgentChatAgentHooks<TRuntimeConfig> },
+  options: AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { chat?: AgentChatOptions<TRuntimeConfig>, hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig> & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS> },
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS> {
   if ("model" in (options as Record<string, unknown>) && !("adapter" in (options as Record<string, unknown>))) {
     throw new Error("[vitehub] defineAgent({ model }) requires an explicit adapter, for example adapter: \"ai-sdk\".")
   }
 
-  const { capabilities, chat: legacyChat, description, hooks, run, runtime, workspace } = options as AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { chat?: AgentChatOptions<TRuntimeConfig>, hooks?: AgentChatAgentHooks<TRuntimeConfig> }
+  const { capabilities, chat: legacyChat, description, hooks, run, runtime, workspace } = options as AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { chat?: AgentChatOptions<TRuntimeConfig>, hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig> & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS> }
   const normalizedCapabilities = normalizeCapabilities(capabilities as AgentCapabilitiesList | undefined)
   const chat = getChatCapabilityOptions<TRuntimeConfig>(normalizedCapabilities) || legacyChat
   validateNonWorkspaceCapabilities(normalizedCapabilities, !!workspace)
@@ -494,7 +503,7 @@ export type WorkspaceAgentOptions<
 > = AgentSettings<TRuntimeConfig> & {
   chat?: AgentChatOptions<TRuntimeConfig>
   description?: string
-  hooks?: AgentChatAgentHooks<TRuntimeConfig>
+  hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig> & AgentInvocationHooks<TRuntimeConfig>
   name?: string
   runtime?: AgentRuntimeBinding
   workspace: WorkspaceAgentWorkspaceConfig
@@ -525,7 +534,7 @@ export interface DefineAgent {
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     CALL_OPTIONS = unknown,
   >(
-    options: AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { chat?: AgentChatOptions<TRuntimeConfig>, hooks?: AgentChatAgentHooks<TRuntimeConfig> },
+    options: AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { chat?: AgentChatOptions<TRuntimeConfig>, hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig> & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS> },
   ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS>
 }
 
@@ -939,7 +948,7 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
 
 function hasCustomRun<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
   agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
-): agent is AgentDefinition<TRuntimeConfig, CALL_OPTIONS> & { run: NonNullable<AgentDefinition<TRuntimeConfig, CALL_OPTIONS>["run"]> } {
+): agent is AgentDefinition<TRuntimeConfig, any> & { run: NonNullable<AgentDefinition<TRuntimeConfig, CALL_OPTIONS>["run"]> } {
   return hasAgentDefinition(agent)
     && typeof agent.run === "function"
     && !(syntheticWorkspaceRun in agent.run)
@@ -1028,9 +1037,14 @@ async function createRunContext<
   input: AgentRunInput<CALL_OPTIONS>,
 ): Promise<AgentRunContext<TRuntimeConfig, CALL_OPTIONS> & {
   close: () => Promise<void>
+  finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
+  finishHook?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS> extends infer TEvent ? (event: TEvent) => MaybePromise<void> : never
   hasCapabilityCleanup: boolean
   outputRenderers: Array<(result: unknown) => MaybePromise<unknown>>
+  runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
+  startedAt: number
 }> {
+  const startedAt = Date.now()
   const resolvedContext = createResolvedRuntimeContext(context)
   const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig>> | undefined
   const workspaceOptions = workspaceDefinition?.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<AgentRuntimeConfig> | undefined
@@ -1057,11 +1071,15 @@ async function createRunContext<
   return {
     ...resolvedContext,
     close: capabilities.close,
+    finishExtensionProviders: capabilities.registries.finishExtensionProviders,
+    finishHook: definition.hooks?.["agent:finish"] as never,
     hasCapabilityCleanup: capabilities.hasCloseCallbacks,
     input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
     messages: capabilities.messages,
     outputRenderers: capabilities.registries.outputRenderers,
     prompt: typeof capabilities.input.prompt === "string" ? capabilities.input.prompt : undefined,
+    runtimeContext: resolvedContext,
+    startedAt,
     tools,
   }
 }
@@ -1075,6 +1093,7 @@ async function createAdapterRunContext<
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
 ) {
+  const startedAt = Date.now()
   const runtime = createResolvedRuntimeContext(context)
   const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig>> | undefined
   const workspaceOptions = workspaceDefinition?.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<AgentRuntimeConfig> | undefined
@@ -1101,6 +1120,8 @@ async function createAdapterRunContext<
     capabilityInstructions: capabilities.capabilityInstructions,
     close: capabilities.close,
     devtools: context.devtools,
+    finishExtensionProviders: capabilities.registries.finishExtensionProviders,
+    finishHook: definition?.hooks?.["agent:finish"] as never,
     hasCapabilityCleanup: capabilities.hasCloseCallbacks,
     input: capabilities.input,
     instructions: undefined,
@@ -1108,9 +1129,77 @@ async function createAdapterRunContext<
     outputRenderers: capabilities.registries.outputRenderers,
     prompt: typeof capabilities.input.prompt === "string" ? capabilities.input.prompt : undefined,
     runtime,
+    runtimeContext: runtime,
+    startedAt,
     tools,
     workspace,
   }
+}
+
+type InvocationRunContext<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+> = {
+  close: () => Promise<void>
+  finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
+  finishHook?: (event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void>
+  input: AgentRunInput<CALL_OPTIONS>
+  runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
+  run?: AgentRunContext<TRuntimeConfig, CALL_OPTIONS>["run"]
+  startedAt: number
+}
+
+function hasFinishWork<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>): boolean {
+  return Boolean(context.finishHook || context.finishExtensionProviders.length)
+}
+
+async function finishAgentInvocation<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+  result?: unknown,
+  error?: unknown,
+): Promise<void> {
+  await context.close()
+  if (!hasFinishWork(context)) return
+
+  const eventBase = {
+    ...(error !== undefined ? { error } : {}),
+    input: context.input,
+    invocation: {
+      durationMs: Date.now() - context.startedAt,
+      ...(context.run ? { run: context.run } : {}),
+    },
+    ...(result !== undefined ? { result } : {}),
+    runtime: context.runtimeContext,
+  } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
+  const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
+  await context.finishHook?.({ ...eventBase, extensions })
+}
+
+function withFinishCleanup<T extends AsyncIterable<unknown>>(
+  stream: T,
+  finish: (error?: unknown) => Promise<void>,
+): AsyncIterable<unknown> {
+  return (async function* () {
+    let error: unknown
+    let failed = false
+    try {
+      yield* stream
+    }
+    catch (caught) {
+      failed = true
+      error = caught
+      throw caught
+    }
+    finally {
+      await finish(failed ? error : undefined)
+    }
+  })()
 }
 
 export async function runAgent<
@@ -1124,20 +1213,21 @@ export async function runAgent<
   if (hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)) {
     const runContext = await createRunContext(agent, context, input)
     runContext.close = once(runContext.close)
+    const shouldWrapOutput = runContext.hasCapabilityCleanup || hasFinishWork(runContext)
     try {
       const result = await agent.run(runContext)
-      if (result instanceof Response) return runContext.hasCapabilityCleanup ? await withResponseCleanup(result, runContext.close) : result
-      if (isAsyncIterable(result)) return runContext.hasCapabilityCleanup ? withCapabilityCleanup(result, runContext.close) : result
+      if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, () => finishAgentInvocation(runContext, result)) : result
+      if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
-      await runContext.close()
+      await finishAgentInvocation(runContext, rendered)
       return rendered
     }
     catch (error) {
       try {
-        await runContext.close()
+        await finishAgentInvocation(runContext, undefined, error)
       }
-      catch (closeError) {
-        throw new AggregateError([error, closeError], "[vitehub] Agent run failed and capability cleanup also failed.")
+      catch (finishError) {
+        throw new AggregateError([error, finishError], "[vitehub] Agent run failed and finish lifecycle also failed.")
       }
       throw error
     }
@@ -1147,20 +1237,22 @@ export async function runAgent<
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
   const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
   adapterContext.close = once(adapterContext.close)
+  const shouldWrapOutput = adapterContext.hasCapabilityCleanup || hasFinishWork(adapterContext)
   try {
     const result = await resolved.generate(adapterContext as never)
-    if (result instanceof Response) return adapterContext.hasCapabilityCleanup ? await withResponseCleanup(result, adapterContext.close) : result
-    if (isAsyncIterable(result)) return adapterContext.hasCapabilityCleanup ? withCapabilityCleanup(result, adapterContext.close) : result
+    if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, () => finishAgentInvocation(adapterContext, result)) : result
+    if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
-    await adapterContext.close()
-    return toAgentRunResult(rendered)
+    const runResult = toAgentRunResult(rendered)
+    await finishAgentInvocation(adapterContext, runResult)
+    return runResult
   }
   catch (error) {
     try {
-      await adapterContext.close()
+      await finishAgentInvocation(adapterContext, undefined, error)
     }
-    catch (closeError) {
-      throw new AggregateError([error, closeError], "[vitehub] Agent run failed and capability cleanup also failed.")
+    catch (finishError) {
+      throw new AggregateError([error, finishError], "[vitehub] Agent run failed and finish lifecycle also failed.")
     }
     throw error
   }
@@ -1177,20 +1269,21 @@ export async function streamAgent<
   if (hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)) {
     const runContext = await createRunContext(agent, context, input)
     runContext.close = once(runContext.close)
+    const shouldWrapOutput = runContext.hasCapabilityCleanup || hasFinishWork(runContext)
     try {
       const result = await agent.run(runContext)
-      if (result instanceof Response) return runContext.hasCapabilityCleanup ? await withResponseCleanup(result, runContext.close) : result
-      if (isAsyncIterable(result)) return runContext.hasCapabilityCleanup ? withCapabilityCleanup(result, runContext.close) : result
+      if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, () => finishAgentInvocation(runContext, result)) : result
+      if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
-      await runContext.close()
+      await finishAgentInvocation(runContext, rendered)
       return rendered
     }
     catch (error) {
       try {
-        await runContext.close()
+        await finishAgentInvocation(runContext, undefined, error)
       }
-      catch (closeError) {
-        throw new AggregateError([error, closeError], "[vitehub] Agent run failed and capability cleanup also failed.")
+      catch (finishError) {
+        throw new AggregateError([error, finishError], "[vitehub] Agent run failed and finish lifecycle also failed.")
       }
       throw error
     }
@@ -1200,21 +1293,22 @@ export async function streamAgent<
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
   const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
   adapterContext.close = once(adapterContext.close)
+  const shouldWrapOutput = adapterContext.hasCapabilityCleanup || hasFinishWork(adapterContext)
   try {
     const result = resolved.stream
       ? await resolved.stream(adapterContext as never)
       : await resolved.generate(adapterContext as never)
-    if (result instanceof Response) return adapterContext.hasCapabilityCleanup ? await withResponseCleanup(result, adapterContext.close) : result
-    if (isAsyncIterable(result)) return adapterContext.hasCapabilityCleanup ? withCapabilityCleanup(result, adapterContext.close) : result
+    if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, () => finishAgentInvocation(adapterContext, result)) : result
+    if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
     const events = streamTextResultToEvents(await applyOutputRenderers(result, adapterContext.outputRenderers))
-    return adapterContext.hasCapabilityCleanup ? withCapabilityCleanup(events, adapterContext.close) : events
+    return shouldWrapOutput ? withFinishCleanup(events, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : events
   }
   catch (error) {
     try {
-      await adapterContext.close()
+      await finishAgentInvocation(adapterContext, undefined, error)
     }
-    catch (closeError) {
-      throw new AggregateError([error, closeError], "[vitehub] Agent stream failed and capability cleanup also failed.")
+    catch (finishError) {
+      throw new AggregateError([error, finishError], "[vitehub] Agent stream failed and finish lifecycle also failed.")
     }
     throw error
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1183,6 +1183,58 @@ async function finishAgentInvocation<
   await context.finishHook?.({ ...eventBase, extensions })
 }
 
+async function finishFailedAgentInvocation<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+  error: unknown,
+  message: string,
+): Promise<never> {
+  try {
+    await finishAgentInvocation(context, undefined, error)
+  }
+  catch (finishError) {
+    throw new AggregateError([error, finishError], message)
+  }
+  throw error
+}
+
+async function finalizeAgentInvocationResult<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+  TResult,
+>(
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS> & { hasCapabilityCleanup: boolean },
+  result: unknown,
+  finalizeObject: (result: unknown) => MaybePromise<{ deferFinish?: boolean, finishResult: unknown, value: TResult }>,
+  failureMessage: string,
+): Promise<Response | AsyncIterable<unknown> | TResult> {
+  const shouldWrapOutput = context.hasCapabilityCleanup || hasFinishWork(context)
+  let finishLifecycleStarted = false
+  try {
+    if (result instanceof Response) {
+      const response = shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(context, error === undefined ? result : undefined, error)) : result
+      finishLifecycleStarted = shouldWrapOutput
+      return response
+    }
+    if (isAsyncIterable(result)) {
+      finishLifecycleStarted = shouldWrapOutput
+      return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(context, error === undefined ? result : undefined, error)) : result
+    }
+    const finalized = await finalizeObject(result)
+    finishLifecycleStarted = true
+    if (!finalized.deferFinish) {
+      await finishAgentInvocation(context, finalized.finishResult)
+    }
+    return finalized.value
+  }
+  catch (error) {
+    if (finishLifecycleStarted) throw error
+    return await finishFailedAgentInvocation(context, error, failureMessage)
+  }
+}
+
 export async function runAgent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -1194,69 +1246,35 @@ export async function runAgent<
   if (hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)) {
     const runContext = await createRunContext(agent, context, input)
     runContext.close = once(runContext.close)
-    const shouldWrapOutput = runContext.hasCapabilityCleanup || hasFinishWork(runContext)
-    let finishLifecycleStarted = false
+    let result: unknown
     try {
-      const result = await agent.run(runContext)
-      if (result instanceof Response) {
-        const response = shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
-        finishLifecycleStarted = shouldWrapOutput
-        return response
-      }
-      if (isAsyncIterable(result)) {
-        finishLifecycleStarted = shouldWrapOutput
-        return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
-      }
-      const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
-      finishLifecycleStarted = true
-      await finishAgentInvocation(runContext, rendered)
-      return rendered
+      result = await agent.run(runContext)
     }
     catch (error) {
-      if (finishLifecycleStarted) throw error
-      try {
-        await finishAgentInvocation(runContext, undefined, error)
-      }
-      catch (finishError) {
-        throw new AggregateError([error, finishError], "[vitehub] Agent run failed and finish lifecycle also failed.")
-      }
-      throw error
+      return await finishFailedAgentInvocation(runContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
     }
+    return await finalizeAgentInvocationResult(runContext, result, async (result) => {
+      const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
+      return { finishResult: rendered, value: rendered }
+    }, "[vitehub] Agent run failed and finish lifecycle also failed.")
   }
 
   const resolved = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
   const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
   adapterContext.close = once(adapterContext.close)
-  const shouldWrapOutput = adapterContext.hasCapabilityCleanup || hasFinishWork(adapterContext)
-  let finishLifecycleStarted = false
+  let result: unknown
   try {
-    const result = await resolved.generate(adapterContext as never)
-    if (result instanceof Response) {
-      const response = shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
-      finishLifecycleStarted = shouldWrapOutput
-      return response
-    }
-    if (isAsyncIterable(result)) {
-      finishLifecycleStarted = shouldWrapOutput
-      return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
-    }
-    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
-    const runResult = toAgentRunResult(rendered)
-    finishLifecycleStarted = true
-    await finishAgentInvocation(adapterContext, rendered)
-    return runResult
+    result = await resolved.generate(adapterContext as never)
   }
   catch (error) {
-    if (finishLifecycleStarted) throw error
-    try {
-      await finishAgentInvocation(adapterContext, undefined, error)
-    }
-    catch (finishError) {
-      throw new AggregateError([error, finishError], "[vitehub] Agent run failed and finish lifecycle also failed.")
-    }
-    throw error
+    return await finishFailedAgentInvocation(adapterContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
   }
+  return await finalizeAgentInvocationResult(adapterContext, result, async (result) => {
+    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
+    const runResult = toAgentRunResult(rendered)
+    return { finishResult: rendered, value: runResult }
+  }, "[vitehub] Agent run failed and finish lifecycle also failed.")
 }
 
 export async function streamAgent<
@@ -1270,70 +1288,42 @@ export async function streamAgent<
   if (hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)) {
     const runContext = await createRunContext(agent, context, input)
     runContext.close = once(runContext.close)
-    const shouldWrapOutput = runContext.hasCapabilityCleanup || hasFinishWork(runContext)
-    let finishLifecycleStarted = false
+    let result: unknown
     try {
-      const result = await agent.run(runContext)
-      if (result instanceof Response) {
-        const response = shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
-        finishLifecycleStarted = shouldWrapOutput
-        return response
-      }
-      if (isAsyncIterable(result)) {
-        finishLifecycleStarted = shouldWrapOutput
-        return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
-      }
-      const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
-      finishLifecycleStarted = true
-      await finishAgentInvocation(runContext, rendered)
-      return rendered
+      result = await agent.run(runContext)
     }
     catch (error) {
-      if (finishLifecycleStarted) throw error
-      try {
-        await finishAgentInvocation(runContext, undefined, error)
-      }
-      catch (finishError) {
-        throw new AggregateError([error, finishError], "[vitehub] Agent run failed and finish lifecycle also failed.")
-      }
-      throw error
+      return await finishFailedAgentInvocation(runContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
     }
+    return await finalizeAgentInvocationResult(runContext, result, async (result) => {
+      const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
+      return { finishResult: rendered, value: rendered }
+    }, "[vitehub] Agent run failed and finish lifecycle also failed.")
   }
 
   const resolved = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
   const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
   adapterContext.close = once(adapterContext.close)
-  const shouldWrapOutput = adapterContext.hasCapabilityCleanup || hasFinishWork(adapterContext)
-  let finishLifecycleStarted = false
+  let result: unknown
   try {
-    const result = resolved.stream
+    result = resolved.stream
       ? await resolved.stream(adapterContext as never)
       : await resolved.generate(adapterContext as never)
-    if (result instanceof Response) {
-      const response = shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
-      finishLifecycleStarted = shouldWrapOutput
-      return response
-    }
-    if (isAsyncIterable(result)) {
-      finishLifecycleStarted = shouldWrapOutput
-      return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
-    }
-    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
-    const events = streamTextResultToEvents(rendered)
-    finishLifecycleStarted = shouldWrapOutput
-    return shouldWrapOutput ? withCapabilityCleanup(events, error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error)) : events
   }
   catch (error) {
-    if (finishLifecycleStarted) throw error
-    try {
-      await finishAgentInvocation(adapterContext, undefined, error)
-    }
-    catch (finishError) {
-      throw new AggregateError([error, finishError], "[vitehub] Agent stream failed and finish lifecycle also failed.")
-    }
-    throw error
+    return await finishFailedAgentInvocation(adapterContext, error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
   }
+  return await finalizeAgentInvocationResult(adapterContext, result, async (result) => {
+    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
+    const events = streamTextResultToEvents(rendered)
+    const shouldWrapOutput = adapterContext.hasCapabilityCleanup || hasFinishWork(adapterContext)
+    return {
+      deferFinish: shouldWrapOutput,
+      finishResult: rendered,
+      value: shouldWrapOutput ? withCapabilityCleanup(events, error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error)) : events,
+    }
+  }, "[vitehub] Agent stream failed and finish lifecycle also failed.")
 }
 
 export async function getAgent<TContext extends AgentRuntimeContext>(

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1216,7 +1216,7 @@ export async function runAgent<
     const shouldWrapOutput = runContext.hasCapabilityCleanup || hasFinishWork(runContext)
     try {
       const result = await agent.run(runContext)
-      if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, () => finishAgentInvocation(runContext, result)) : result
+      if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
       if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
       await finishAgentInvocation(runContext, rendered)
@@ -1240,7 +1240,7 @@ export async function runAgent<
   const shouldWrapOutput = adapterContext.hasCapabilityCleanup || hasFinishWork(adapterContext)
   try {
     const result = await resolved.generate(adapterContext as never)
-    if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, () => finishAgentInvocation(adapterContext, result)) : result
+    if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
     if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
     const runResult = toAgentRunResult(rendered)
@@ -1272,7 +1272,7 @@ export async function streamAgent<
     const shouldWrapOutput = runContext.hasCapabilityCleanup || hasFinishWork(runContext)
     try {
       const result = await agent.run(runContext)
-      if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, () => finishAgentInvocation(runContext, result)) : result
+      if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
       if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
       await finishAgentInvocation(runContext, rendered)
@@ -1298,7 +1298,7 @@ export async function streamAgent<
     const result = resolved.stream
       ? await resolved.stream(adapterContext as never)
       : await resolved.generate(adapterContext as never)
-    if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, () => finishAgentInvocation(adapterContext, result)) : result
+    if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
     if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
     const events = streamTextResultToEvents(rendered)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1154,7 +1154,7 @@ function hasFinishWork<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>): boolean {
-  return Boolean(context.finishHook || context.finishExtensionProviders.length)
+  return Boolean(context.finishHook)
 }
 
 async function finishAgentInvocation<
@@ -1194,15 +1194,24 @@ export async function runAgent<
     const runContext = await createRunContext(agent, context, input)
     runContext.close = once(runContext.close)
     const shouldWrapOutput = runContext.hasCapabilityCleanup || hasFinishWork(runContext)
+    let finishLifecycleStarted = false
     try {
       const result = await agent.run(runContext)
-      if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
-      if (isAsyncIterable(result)) return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
+      if (result instanceof Response) {
+        finishLifecycleStarted = shouldWrapOutput
+        return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
+      }
+      if (isAsyncIterable(result)) {
+        finishLifecycleStarted = shouldWrapOutput
+        return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
+      }
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
+      finishLifecycleStarted = true
       await finishAgentInvocation(runContext, rendered)
       return rendered
     }
     catch (error) {
+      if (finishLifecycleStarted) throw error
       try {
         await finishAgentInvocation(runContext, undefined, error)
       }
@@ -1218,16 +1227,25 @@ export async function runAgent<
   const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
   adapterContext.close = once(adapterContext.close)
   const shouldWrapOutput = adapterContext.hasCapabilityCleanup || hasFinishWork(adapterContext)
+  let finishLifecycleStarted = false
   try {
     const result = await resolved.generate(adapterContext as never)
-    if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
-    if (isAsyncIterable(result)) return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
+    if (result instanceof Response) {
+      finishLifecycleStarted = shouldWrapOutput
+      return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
+    }
+    if (isAsyncIterable(result)) {
+      finishLifecycleStarted = shouldWrapOutput
+      return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
+    }
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
     const runResult = toAgentRunResult(rendered)
+    finishLifecycleStarted = true
     await finishAgentInvocation(adapterContext, rendered)
     return runResult
   }
   catch (error) {
+    if (finishLifecycleStarted) throw error
     try {
       await finishAgentInvocation(adapterContext, undefined, error)
     }
@@ -1250,15 +1268,24 @@ export async function streamAgent<
     const runContext = await createRunContext(agent, context, input)
     runContext.close = once(runContext.close)
     const shouldWrapOutput = runContext.hasCapabilityCleanup || hasFinishWork(runContext)
+    let finishLifecycleStarted = false
     try {
       const result = await agent.run(runContext)
-      if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
-      if (isAsyncIterable(result)) return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
+      if (result instanceof Response) {
+        finishLifecycleStarted = shouldWrapOutput
+        return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
+      }
+      if (isAsyncIterable(result)) {
+        finishLifecycleStarted = shouldWrapOutput
+        return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
+      }
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
+      finishLifecycleStarted = true
       await finishAgentInvocation(runContext, rendered)
       return rendered
     }
     catch (error) {
+      if (finishLifecycleStarted) throw error
       try {
         await finishAgentInvocation(runContext, undefined, error)
       }
@@ -1274,17 +1301,26 @@ export async function streamAgent<
   const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
   adapterContext.close = once(adapterContext.close)
   const shouldWrapOutput = adapterContext.hasCapabilityCleanup || hasFinishWork(adapterContext)
+  let finishLifecycleStarted = false
   try {
     const result = resolved.stream
       ? await resolved.stream(adapterContext as never)
       : await resolved.generate(adapterContext as never)
-    if (result instanceof Response) return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
-    if (isAsyncIterable(result)) return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
+    if (result instanceof Response) {
+      finishLifecycleStarted = shouldWrapOutput
+      return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
+    }
+    if (isAsyncIterable(result)) {
+      finishLifecycleStarted = shouldWrapOutput
+      return shouldWrapOutput ? withCapabilityCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
+    }
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
     const events = streamTextResultToEvents(rendered)
+    finishLifecycleStarted = shouldWrapOutput
     return shouldWrapOutput ? withCapabilityCleanup(events, error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error)) : events
   }
   catch (error) {
+    if (finishLifecycleStarted) throw error
     try {
       await finishAgentInvocation(adapterContext, undefined, error)
     }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1129,6 +1129,7 @@ async function createAdapterRunContext<
     messages: capabilities.messages,
     outputRenderers: capabilities.registries.outputRenderers,
     prompt: typeof capabilities.input.prompt === "string" ? capabilities.input.prompt : undefined,
+    run: context.run,
     runtime,
     runtimeContext: runtime,
     startedAt,
@@ -1198,8 +1199,9 @@ export async function runAgent<
     try {
       const result = await agent.run(runContext)
       if (result instanceof Response) {
+        const response = shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
         finishLifecycleStarted = shouldWrapOutput
-        return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
+        return response
       }
       if (isAsyncIterable(result)) {
         finishLifecycleStarted = shouldWrapOutput
@@ -1231,8 +1233,9 @@ export async function runAgent<
   try {
     const result = await resolved.generate(adapterContext as never)
     if (result instanceof Response) {
+      const response = shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
       finishLifecycleStarted = shouldWrapOutput
-      return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
+      return response
     }
     if (isAsyncIterable(result)) {
       finishLifecycleStarted = shouldWrapOutput
@@ -1272,8 +1275,9 @@ export async function streamAgent<
     try {
       const result = await agent.run(runContext)
       if (result instanceof Response) {
+        const response = shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
         finishLifecycleStarted = shouldWrapOutput
-        return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(runContext, error === undefined ? result : undefined, error)) : result
+        return response
       }
       if (isAsyncIterable(result)) {
         finishLifecycleStarted = shouldWrapOutput
@@ -1307,8 +1311,9 @@ export async function streamAgent<
       ? await resolved.stream(adapterContext as never)
       : await resolved.generate(adapterContext as never)
     if (result instanceof Response) {
+      const response = shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
       finishLifecycleStarted = shouldWrapOutput
-      return shouldWrapOutput ? await withResponseCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
+      return response
     }
     if (isAsyncIterable(result)) {
       finishLifecycleStarted = shouldWrapOutput

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1244,7 +1244,7 @@ export async function runAgent<
     if (isAsyncIterable(result)) return shouldWrapOutput ? withFinishCleanup(result, error => finishAgentInvocation(adapterContext, error === undefined ? result : undefined, error)) : result
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
     const runResult = toAgentRunResult(rendered)
-    await finishAgentInvocation(adapterContext, runResult)
+    await finishAgentInvocation(adapterContext, rendered)
     return runResult
   }
   catch (error) {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -86,7 +86,6 @@ export interface AgentRunResult {
 
 export interface AgentInvocationExtensions {
   get<T = unknown>(capabilityId: string): T | undefined
-  has(capabilityId: string): boolean
 }
 
 export interface AgentFinishEvent<
@@ -211,8 +210,8 @@ export interface AgentCapabilityRuntimeContext<
   output: {
     render: (renderer: AgentOutputRenderer) => void
   }
-  extensions: {
-    provide: (hook: "agent:finish", value: unknown | AgentFinishExtensionProvider) => void
+  finish: {
+    provide: (value: unknown | AgentFinishExtensionProvider) => void
   }
   state: {
     require: (name: string, options?: { optional?: boolean }) => void

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -84,6 +84,38 @@ export interface AgentRunResult {
   warnings?: unknown
 }
 
+export interface AgentInvocationExtensions {
+  get<T = unknown>(capabilityId: string): T | undefined
+  has(capabilityId: string): boolean
+}
+
+export interface AgentFinishEvent<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> {
+  error?: unknown
+  extensions: AgentInvocationExtensions
+  input: AgentRunInput<CALL_OPTIONS>
+  invocation: {
+    durationMs: number
+    run?: AgentRunMetadata
+  }
+  result?: unknown
+  runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>
+}
+
+export type AgentFinishHook<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> = (event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void>
+
+export interface AgentInvocationHooks<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> {
+  "agent:finish"?: AgentFinishHook<TRuntimeConfig, CALL_OPTIONS>
+}
+
 export interface AgentRunContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -150,6 +182,7 @@ export type AgentOutputRenderer = (
   result: unknown,
   context: AgentCapabilityRuntimeContext,
 ) => MaybePromise<unknown>
+export type AgentFinishExtensionProvider = (event: AgentFinishEvent) => MaybePromise<unknown>
 
 export interface AgentCapabilityStateRequirement {
   name: string
@@ -177,6 +210,9 @@ export interface AgentCapabilityRuntimeContext<
   }
   output: {
     render: (renderer: AgentOutputRenderer) => void
+  }
+  extensions: {
+    provide: (hook: "agent:finish", value: unknown | AgentFinishExtensionProvider) => void
   }
   state: {
     require: (name: string, options?: { optional?: boolean }) => void
@@ -261,7 +297,7 @@ type AgentSettingsBase<
   adapterOptions?: Record<string, unknown>
   chat?: AgentChatOptions<TRuntimeConfig>
   description?: string
-  hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig>
+  hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig> & AgentInvocationHooks<TRuntimeConfig>
   instructions?: AgentAdapterInstructions<TRuntimeConfig>
   instrumentModel?: AgentModelInstrumentation<TRuntimeConfig>
   capabilities?: AgentCapabilitiesList<TRuntimeConfig>
@@ -291,7 +327,7 @@ export interface AgentDefinition<
   capabilities?: AgentCapabilityDefinition<TRuntimeConfig>[]
   chat?: AgentChatOptions<TRuntimeConfig>
   description?: string
-  hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig>
+  hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig, WorkspaceName> & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS>
   runtime?: AgentRuntimeBinding
   resolve(context: AgentRuntimeContext<TRuntimeConfig>): Promise<AgentAdapter<CALL_OPTIONS>>
   run?(context: AgentRunContext<TRuntimeConfig, CALL_OPTIONS>): MaybePromise<Response | AgentRunResult | AsyncIterable<StreamEvent> | unknown>

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -150,6 +150,24 @@ describe("agent capability runtime", () => {
     expect(order).toEqual(["close"])
   })
 
+  it("passes Response cancel errors into cleanup", async () => {
+    const { withResponseCleanup } = await import("../src/capability-runtime.ts")
+    const cancelError = new Error("cancel failed")
+    const cleanupErrors: unknown[] = []
+    const responseBody = new ReadableStream()
+    vi.spyOn(responseBody, "getReader").mockReturnValue({
+      cancel: vi.fn(async () => { throw cancelError }),
+      read: vi.fn(() => new Promise(() => {})),
+      releaseLock: vi.fn(),
+      closed: Promise.resolve(undefined),
+    } as never)
+
+    const response = await withResponseCleanup(new Response(responseBody), async error => { cleanupErrors.push(error) }) as Response
+
+    await expect(response.body?.cancel()).rejects.toThrow("cancel failed")
+    expect(cleanupErrors).toEqual([cancelError])
+  })
+
   it("rejects write workspace requirements when the run workspace is read-only", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const workspace = {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -104,6 +104,58 @@ describe("agent message protocol", () => {
     expect(event.extensions.has("missing")).toBe(false)
   })
 
+  it("skips finish extension providers when no finish hook is registered", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const extension = vi.fn(() => {
+      throw new Error("extension should not run")
+    })
+    const agent = defineAgent({
+      capabilities: [{
+        id: "unused",
+        output(context) {
+          context.extensions.provide("agent:finish", extension)
+        },
+      }],
+      run: () => ({ text: "ok" }),
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).resolves.toMatchObject({ text: "ok" })
+    expect(extension).not.toHaveBeenCalled()
+  })
+
+  it("does not rerun finish lifecycle when a finish hook fails", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finishError = new Error("finish failed")
+    const extension = vi.fn(() => "extension-value")
+    const finish = vi.fn(() => {
+      throw finishError
+    })
+    const agent = defineAgent({
+      capabilities: [{
+        id: "finish-extension",
+        output(context) {
+          context.extensions.provide("agent:finish", extension)
+        },
+      }],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({ text: "ok" }),
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).rejects.toThrow("finish failed")
+    expect(extension).toHaveBeenCalledTimes(1)
+    expect(finish).toHaveBeenCalledTimes(1)
+  })
+
   it("runs agent finish hooks for model-backed object results", async () => {
     vi.doMock("ai", () => ({
       ToolLoopAgent: class {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -121,6 +121,13 @@ describe("agent message protocol", () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const finish = vi.fn()
       const agent = defineAgent({
+        capabilities: [{
+          id: "finish-metadata",
+          output(context) {
+            context.output.render(result => ({ ...result as Record<string, unknown>, finishMetadata: { id: "rendered-1" } }))
+            context.extensions.provide("agent:finish", event => (event.result as { finishMetadata?: unknown }).finishMetadata)
+          },
+        }],
         hooks: {
           "agent:finish": finish,
         },
@@ -135,8 +142,12 @@ describe("agent message protocol", () => {
       }, {})).resolves.toMatchObject({ finishReason: "stop", text: "ok" })
 
       expect(finish).toHaveBeenCalledWith(expect.objectContaining({
-        result: expect.objectContaining({ finishReason: "stop", text: "ok" }),
+        extensions: expect.objectContaining({
+          get: expect.any(Function),
+        }),
+        result: expect.objectContaining({ finishMetadata: { id: "rendered-1" }, finishReason: "stop", text: "ok" }),
       }))
+      expect(finish.mock.calls[0]![0].extensions.get("finish-metadata")).toEqual({ id: "rendered-1" })
     }
     finally {
       vi.doUnmock("ai")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -64,13 +64,13 @@ describe("agent message protocol", () => {
         {
           id: "first",
           output(context) {
-            context.extensions.provide("agent:finish", (event: { result?: unknown }) => `${(event.result as { text: string }).text}:first`)
+            context.finish.provide((event: { result?: unknown }) => `${(event.result as { text: string }).text}:first`)
           },
         },
         {
           id: "second",
           output(context) {
-            context.extensions.provide("agent:finish", "second-value")
+            context.finish.provide("second-value")
           },
         },
       ],
@@ -98,10 +98,9 @@ describe("agent message protocol", () => {
       runtime: expect.objectContaining({ runtime: "unknown" }),
     }))
     const event = finish.mock.calls[0]![0]
-    expect(event.extensions.has("first")).toBe(true)
     expect(event.extensions.get("first")).toBe("ok:first")
     expect(event.extensions.get("second")).toBe("second-value")
-    expect(event.extensions.has("missing")).toBe(false)
+    expect(event.extensions.get("missing")).toBeUndefined()
   })
 
   it("skips finish extension providers when no finish hook is registered", async () => {
@@ -113,7 +112,7 @@ describe("agent message protocol", () => {
       capabilities: [{
         id: "unused",
         output(context) {
-          context.extensions.provide("agent:finish", extension)
+          context.finish.provide(extension)
         },
       }],
       run: () => ({ text: "ok" }),
@@ -138,7 +137,7 @@ describe("agent message protocol", () => {
       capabilities: [{
         id: "finish-extension",
         output(context) {
-          context.extensions.provide("agent:finish", extension)
+          context.finish.provide(extension)
         },
       }],
       hooks: {
@@ -174,12 +173,12 @@ describe("agent message protocol", () => {
       const finish = vi.fn()
       const agent = defineAgent({
         capabilities: [{
-          id: "finish-metadata",
-          output(context) {
-            context.output.render(result => ({ ...result as Record<string, unknown>, finishMetadata: { id: "rendered-1" } }))
-            context.extensions.provide("agent:finish", (event: { result?: unknown }) => (event.result as { finishMetadata?: unknown }).finishMetadata)
-          },
-        }],
+        id: "finish-metadata",
+        output(context) {
+          context.output.render(result => ({ ...result as Record<string, unknown>, finishMetadata: { id: "rendered-1" } }))
+          context.finish.provide((event: { result?: unknown }) => (event.result as { finishMetadata?: unknown }).finishMetadata)
+        },
+      }],
         hooks: {
           "agent:finish": finish,
         },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -110,6 +110,9 @@ describe("agent message protocol", () => {
         async generate() {
           return { finishReason: "stop", text: "ok" }
         }
+        async stream() {
+          return await this.generate()
+        }
       },
       stepCountIs: () => () => false,
     }))
@@ -133,6 +136,53 @@ describe("agent message protocol", () => {
 
       expect(finish).toHaveBeenCalledWith(expect.objectContaining({
         result: expect.objectContaining({ finishReason: "stop", text: "ok" }),
+      }))
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
+  it("runs stream finish hooks with rendered model-backed object results", async () => {
+    vi.doMock("ai", () => ({
+      ToolLoopAgent: class {
+        async generate() {
+          return { finishReason: "stop", text: "ok" }
+        }
+        async stream() {
+          return await this.generate()
+        }
+      },
+      stepCountIs: () => () => false,
+    }))
+
+    try {
+      const { defineAgent, streamAgent } = await import("../src/index.ts")
+      const finish = vi.fn()
+      const agent = defineAgent({
+        capabilities: [{
+          id: "usage",
+          output(context) {
+            context.output.render(result => ({ ...result as Record<string, unknown>, usageRecord: { id: "usage-1" } }))
+          },
+        }],
+        hooks: {
+          "agent:finish": finish,
+        },
+        model: {} as never,
+        provider: "ai-sdk",
+      })
+
+      const stream = await streamAgent(agent, {
+        memo: vi.fn(),
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, {})
+
+      for await (const _event of stream as AsyncIterable<unknown>) {}
+
+      expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+        result: expect.objectContaining({ usageRecord: { id: "usage-1" } }),
       }))
     }
     finally {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -189,6 +189,7 @@ describe("agent message protocol", () => {
 
       await expect(runAgent(agent, {
         memo: vi.fn(),
+        run: { runId: "run-model-1" },
         runtime: "unknown",
         waitUntil: vi.fn(),
       }, {})).resolves.toMatchObject({ finishReason: "stop", text: "ok" })
@@ -196,6 +197,9 @@ describe("agent message protocol", () => {
       expect(finish).toHaveBeenCalledWith(expect.objectContaining({
         extensions: expect.objectContaining({
           get: expect.any(Function),
+        }),
+        invocation: expect.objectContaining({
+          run: { runId: "run-model-1" },
         }),
         result: expect.objectContaining({ finishMetadata: { id: "rendered-1" }, finishReason: "stop", text: "ok" }),
       }))
@@ -329,6 +333,25 @@ describe("agent message protocol", () => {
     const response = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}) as Response
     await response.body?.cancel()
     expect(finish).toHaveBeenCalledTimes(1)
+  })
+
+  it("runs agent finish hooks when Response wrapping fails", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const body = new ReadableStream()
+    body.getReader()
+    const agent = defineAgent({
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => new Response(body),
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).rejects.toThrow()
+    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+      error: expect.any(TypeError),
+    }))
+    expect(finish.mock.calls[0]![0]).not.toHaveProperty("result")
   })
 
   it("returns generated Response results unchanged", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -125,14 +125,14 @@ describe("agent message protocol", () => {
           id: "finish-metadata",
           output(context) {
             context.output.render(result => ({ ...result as Record<string, unknown>, finishMetadata: { id: "rendered-1" } }))
-            context.extensions.provide("agent:finish", event => (event.result as { finishMetadata?: unknown }).finishMetadata)
+            context.extensions.provide("agent:finish", (event: { result?: unknown }) => (event.result as { finishMetadata?: unknown }).finishMetadata)
           },
         }],
         hooks: {
           "agent:finish": finish,
         },
+        adapter: "ai-sdk",
         model: {} as never,
-        provider: "ai-sdk",
       })
 
       await expect(runAgent(agent, {
@@ -180,8 +180,8 @@ describe("agent message protocol", () => {
         hooks: {
           "agent:finish": finish,
         },
+        adapter: "ai-sdk",
         model: {} as never,
-        provider: "ai-sdk",
       })
 
       const stream = await streamAgent(agent, {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -56,6 +56,145 @@ describe("agent message protocol", () => {
     }))
   })
 
+  it("runs agent finish hooks for custom object results after extensions are resolved", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [
+        {
+          id: "first",
+          output(context) {
+            context.extensions.provide("agent:finish", (event: { result?: unknown }) => `${(event.result as { text: string }).text}:first`)
+          },
+        },
+        {
+          id: "second",
+          output(context) {
+            context.extensions.provide("agent:finish", "second-value")
+          },
+        },
+      ],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({ text: "ok" }),
+    })
+    const input = { prompt: "hello" }
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-1" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, input)).resolves.toMatchObject({ text: "ok" })
+
+    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+      input,
+      invocation: expect.objectContaining({
+        durationMs: expect.any(Number),
+        run: { runId: "run-1" },
+      }),
+      result: { text: "ok" },
+      runtime: expect.objectContaining({ runtime: "unknown" }),
+    }))
+    const event = finish.mock.calls[0]![0]
+    expect(event.extensions.has("first")).toBe(true)
+    expect(event.extensions.get("first")).toBe("ok:first")
+    expect(event.extensions.get("second")).toBe("second-value")
+    expect(event.extensions.has("missing")).toBe(false)
+  })
+
+  it("runs agent finish hooks for model-backed object results", async () => {
+    vi.doMock("ai", () => ({
+      ToolLoopAgent: class {
+        async generate() {
+          return { finishReason: "stop", text: "ok" }
+        }
+      },
+      stepCountIs: () => () => false,
+    }))
+
+    try {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const finish = vi.fn()
+      const agent = defineAgent({
+        hooks: {
+          "agent:finish": finish,
+        },
+        model: {} as never,
+        provider: "ai-sdk",
+      })
+
+      await expect(runAgent(agent, {
+        memo: vi.fn(),
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, {})).resolves.toMatchObject({ finishReason: "stop", text: "ok" })
+
+      expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+        result: expect.objectContaining({ finishReason: "stop", text: "ok" }),
+      }))
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
+  it("runs agent finish hooks after generated streams are consumed", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const order: string[] = []
+    const agent = defineAgent({
+      hooks: {
+        "agent:finish": () => { order.push("finish") },
+      },
+      run: () => (async function* () {
+        yield "hello"
+        order.push("stream:done")
+      })(),
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})
+    expect(order).toEqual([])
+    for await (const _event of stream as AsyncIterable<unknown>) {}
+
+    expect(order).toEqual(["stream:done", "finish"])
+  })
+
+  it("runs agent finish hooks after Response bodies are read", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => new Response("ok"),
+    })
+
+    const response = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}) as Response
+    expect(finish).not.toHaveBeenCalled()
+    await expect(response.text()).resolves.toBe("ok")
+    expect(finish).toHaveBeenCalledTimes(1)
+  })
+
+  it("runs agent finish hooks when Response bodies are canceled", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => new Response(new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("partial"))
+        },
+      })),
+    })
+
+    const response = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}) as Response
+    await response.body?.cancel()
+    expect(finish).toHaveBeenCalledTimes(1)
+  })
+
   it("returns generated Response results unchanged", async () => {
     const { runAgent } = await import("../src/index.ts")
     const response = Response.json({ ok: true })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -226,6 +226,29 @@ describe("agent message protocol", () => {
     expect(finish).toHaveBeenCalledTimes(1)
   })
 
+  it("runs agent finish hooks with Response body read errors", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const error = new Error("upstream failed")
+    const agent = defineAgent({
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => new Response(new ReadableStream({
+        pull() {
+          throw error
+        },
+      })),
+    })
+
+    const response = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}) as Response
+    await expect(response.text()).rejects.toThrow("upstream failed")
+    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+      error,
+    }))
+    expect(finish.mock.calls[0]![0]).not.toHaveProperty("result")
+  })
+
   it("runs agent finish hooks when Response bodies are canceled", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finish = vi.fn()

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,8 @@
-import { describe, it } from "vitest"
+import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent } from "../src/index.ts"
 import { bash, db, kv, sandbox, skills } from "../src/capabilities.ts"
+import type { AgentUsageRecord } from "../src/index.ts"
 
 describe("agent public types", () => {
   it("accepts capabilities from the capabilities entry", () => {
@@ -28,6 +29,23 @@ describe("agent public types", () => {
     // @ts-expect-error model agents must select an explicit adapter
     defineAgent({
       model: {} as never,
+    })
+
+    defineAgent({
+      adapter: "ai-sdk",
+      model: {} as never,
+      hooks: {
+        "agent:finish"(event) {
+          expectTypeOf(event.extensions.get<AgentUsageRecord>("usage-telemetry")).toEqualTypeOf<AgentUsageRecord | undefined>()
+        },
+      },
+    })
+
+    defineAgent({
+      adapter: "ai-sdk",
+      model: {} as never,
+      // @ts-expect-error root-level tools are not public API
+      tools: {},
     })
 
     defineAgent({

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -42,6 +42,19 @@ describe("agent public types", () => {
     })
 
     defineAgent({
+      capabilities: [{
+        id: "finish-extension",
+        output(context) {
+          context.finish.provide("ok")
+          // @ts-expect-error finish extensions are registered through context.finish
+          context.extensions.provide("agent:finish", "ok")
+        },
+      }],
+      adapter: "ai-sdk",
+      model: {} as never,
+    })
+
+    defineAgent({
       adapter: "ai-sdk",
       model: {} as never,
       // @ts-expect-error root-level tools are not public API

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -16,6 +16,7 @@ describe("usage telemetry", () => {
   it("normalizes usage and attaches a priced usage record", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
+    const finish = vi.fn()
 
     const agent = defineAgent({
       capabilities: [
@@ -28,6 +29,9 @@ describe("usage telemetry", () => {
           }),
         }),
       ],
+      hooks: {
+        "agent:finish": finish,
+      },
       run: () => ({
         finishReason: "stop",
         response: {
@@ -43,7 +47,9 @@ describe("usage telemetry", () => {
       }),
     })
 
-    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+    const result = await runAgent(agent, runtime(), {})
+
+    expect(result).toMatchObject({
       finishReason: "stop",
       text: "ok",
       usage: {
@@ -78,11 +84,15 @@ describe("usage telemetry", () => {
         },
       },
     })
+    expect(finish).toHaveBeenCalledTimes(1)
+    const usageRecord = (result as { usageRecord?: unknown }).usageRecord
+    expect(finish.mock.calls[0]![0].extensions.get("usage-telemetry")).toEqual(usageRecord)
   })
 
   it("does not fail the invocation when pricing fails", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")
+    const finish = vi.fn()
 
     const agent = defineAgent({
       capabilities: [
@@ -92,6 +102,9 @@ describe("usage telemetry", () => {
           },
         }),
       ],
+      hooks: {
+        "agent:finish": finish,
+      },
       run: () => ({
         text: "ok",
         usage: {
@@ -116,6 +129,32 @@ describe("usage telemetry", () => {
         },
       },
     })
+    expect(finish.mock.calls[0]![0].extensions.has("usage-telemetry")).toBe(true)
+  })
+
+  it("does not add a usage telemetry extension when no usage record is produced", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const finish = vi.fn()
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry(),
+      ],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({
+        text: "ok",
+      }),
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+      text: "ok",
+    })
+    expect(finish).toHaveBeenCalledTimes(1)
+    expect(finish.mock.calls[0]![0].extensions.has("usage-telemetry")).toBe(false)
+    expect(finish.mock.calls[0]![0].extensions.get("usage-telemetry")).toBeUndefined()
   })
 
   it("loads Vercel AI Gateway pricing from the models endpoint", async () => {

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -129,7 +129,13 @@ describe("usage telemetry", () => {
         },
       },
     })
-    expect(finish.mock.calls[0]![0].extensions.has("usage-telemetry")).toBe(true)
+    expect(finish.mock.calls[0]![0].extensions.get("usage-telemetry")).toEqual(expect.objectContaining({
+      usage: {
+        inputTokens: 1,
+        outputTokens: 2,
+        totalTokens: 3,
+      },
+    }))
   })
 
   it("does not add a usage telemetry extension when no usage record is produced", async () => {
@@ -153,7 +159,6 @@ describe("usage telemetry", () => {
       text: "ok",
     })
     expect(finish).toHaveBeenCalledTimes(1)
-    expect(finish.mock.calls[0]![0].extensions.has("usage-telemetry")).toBe(false)
     expect(finish.mock.calls[0]![0].extensions.get("usage-telemetry")).toBeUndefined()
   })
 


### PR DESCRIPTION
Adds `agent:finish` as the first Agent Invocation Lifecycle hook, with a small finish event envelope and capability-owned extensions keyed by Capability ID.

`usageTelemetry()` still normalizes finished object results into `result.usage` and `result.usageRecord`, and now also exposes the same usage record through `event.extensions.get("usage-telemetry")` for finish hooks. Stream and Response results run the finish lifecycle after consumption or cancellation, preserving existing cleanup behavior.

Stacked on #139 because this builds on the new `packages/agent/src/capabilities/usage-telemetry.ts` location.
