### PR TITLE
Remove capability display metadata

### DIFF
--- a/.agents/adr/0001-agent-capabilities.md
+++ b/.agents/adr/0001-agent-capabilities.md
@@ -10,7 +10,8 @@ ViteHub agents will use agent-scoped Capabilities created with `defineCapability
 - Implicit adapter selection from `defineAgent({ model })` was rejected because package or model-shape detection makes provider choice surprising; model agents must select an explicit provider.
 - Global module-level capabilities were rejected because capabilities affect one agent's inputs, instructions, workspace behavior, and tool access.
 - Hooks-only design was rejected because phases provide a clearer primary lifecycle while hooks remain useful extension points around those phases.
+- Capability-level `name` and `description` were rejected because `id` is the stable capability identity and display label, while user-facing descriptions belong on concrete surfaces such as tools and commands.
 
 ## Consequences
 
-The first official capabilities are `skills()`, `mcp()`, `bash()`, `sandbox()`, `kv()`, `blob()`, and `db()`. Capabilities are single-instance by default, run in user-provided order, and may contribute named instruction blocks that users place with instruction slots such as `{{ skills }}`, `{{ mcp }}`, and `{{ capabilities }}`.
+The first official capabilities are `skills()`, `mcp()`, `bash()`, `sandbox()`, `kv()`, `blob()`, and `db()`. Capabilities are single-instance by default, run in user-provided order, and may contribute named instruction blocks that users place with instruction slots such as `{{ skills }}`, `{{ mcp }}`, and `{{ capabilities }}`. Capability definitions keep generic structured `metadata` for runtime configuration details, but do not carry capability-level display metadata.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -38,6 +38,7 @@ _Avoid_: Bash, raw workspace tools, built-in tool
 - Agent Memory is a separate Capability concern from the **Chat Capability**.
 - User-defined Capabilities use the same **Capability Definition** shape as official helpers.
 - A **Capability Definition** can contribute instructions, tools, policy, and metadata.
+- A **Capability Definition** uses `id` as its only capability-level identity and display label.
 - A **Capability** can declare **Capability Requirements**.
 - The **Capability Lifecycle** validates **Capability Requirements** as early as possible.
 - Tools are exposed through **Capability Definitions**, not through top-level Agent Definition fields.
@@ -55,3 +56,4 @@ _Avoid_: Bash, raw workspace tools, built-in tool
 - Chat History was considered as a standalone Capability - resolved: keep Chat History inside the **Chat Capability** for this stack and revisit during a future Agent Memory pass.
 - Agent Memory was considered dependent on the Chat Capability - resolved: stack Agent Memory directly on the capability runtime because memory and chat are separate Capability concerns.
 - Workspace inspection was considered a hand-written raw tool contribution or Bash concern - resolved: expose it through a **Workspace Capability**.
+- Capability-level name and description were considered separate display metadata - resolved: remove both as a breaking change and use **Capability** id as the only capability-level identity/display field.

--- a/packages/agent/src/capabilities.ts
+++ b/packages/agent/src/capabilities.ts
@@ -104,7 +104,6 @@ export function bash(options: { mode?: AgentCapabilityMode } = {}): AgentCapabil
   return defineCapability({
     id: "bash",
     mode,
-    name: "Bash",
     requires: [{ primitive: "workspace", workspace: { mode, required: true } }],
     tools: ({ workspace }) => (mode === "write" && "write" in workspace.tools
       ? (workspace.tools as unknown as { write: () => AgentToolSet }).write()
@@ -117,7 +116,6 @@ export function sandbox(options: { commands: string[] }): AgentCapabilityDefinit
   return defineCapability({
     id: "sandbox",
     metadata: { commands },
-    name: "Sandbox",
     requires: [{ primitive: "workspace", workspace: { required: true } }, { primitive: "sandbox" }],
     tools: (context) => {
       const handle = requirePrimitive(context as never, "sandbox") as {
@@ -142,17 +140,17 @@ export function sandbox(options: { commands: string[] }): AgentCapabilityDefinit
 
 export function kv(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
   const mode = normalizeMode(options.mode, "KV")
-  return defineCapability({ id: "kv", mode, name: "KV", requires: [{ primitive: "kv" }], tools: primitiveTools("kv", mode) })
+  return defineCapability({ id: "kv", mode, requires: [{ primitive: "kv" }], tools: primitiveTools("kv", mode) })
 }
 
 export function blob(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
   const mode = normalizeMode(options.mode, "Blob")
-  return defineCapability({ id: "blob", mode, name: "Blob", requires: [{ primitive: "blob" }], tools: primitiveTools("blob", mode) })
+  return defineCapability({ id: "blob", mode, requires: [{ primitive: "blob" }], tools: primitiveTools("blob", mode) })
 }
 
 export function db(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
   const mode = normalizeMode(options.mode, "DB")
-  return defineCapability({ id: "db", mode, name: "DB", requires: [{ primitive: "db" }], tools: primitiveTools("db", mode) })
+  return defineCapability({ id: "db", mode, requires: [{ primitive: "db" }], tools: primitiveTools("db", mode) })
 }
 
 export function skills(options: { path?: string } = {}): AgentCapabilityDefinition {
@@ -163,7 +161,6 @@ export function skills(options: { path?: string } = {}): AgentCapabilityDefiniti
   return defineCapability({
     id: "skills",
     metadata: { path: path.replace(/\/+$/, ""), skillPath },
-    name: "Skills",
     requires: [{ primitive: "workspace", workspace: { mode: "read", paths: [skillPath], required: true } }],
   })
 }
@@ -172,7 +169,6 @@ export function mcp(options: { servers?: Record<string, unknown> } = {}): AgentC
   return defineCapability({
     id: "mcp",
     metadata: { servers: options.servers || {} },
-    name: "MCP",
   })
 }
 

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -178,7 +178,6 @@ function removeRawUsage(usage: AgentUsage): AgentUsage {
 export function usageTelemetry(options: UsageTelemetryOptions = {}): AgentCapabilityDefinition {
   return defineCapability({
     id: "usage-telemetry",
-    name: "Usage Telemetry",
     output(context) {
       context.finish.provide((event: AgentFinishEvent) => isRecord(event.result)
         ? event.result.usageRecord

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -323,7 +323,6 @@ function capabilityMetadataTool(capability: NormalizedCapability): AgentDevtools
   return capability.tools
     ? {
         category: "capability",
-        description: capability.description,
         icon: "i-lucide-wrench",
         name: capability.id,
         status: "available",
@@ -347,7 +346,6 @@ export function chat<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCon
       chat: options,
       kind: "chat",
     } satisfies ChatCapabilityMetadata<TRuntimeConfig>,
-    name: "Chat",
     prepare(context) {
       context.state.require("chat-history", { optional: true })
     },

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -232,7 +232,6 @@ export interface AgentCapabilityDefinition<
   bind?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   close?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   configure?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
-  description?: string
   hooks?: AgentCapabilityHooks<TRuntimeConfig, Name>
   id: string
   input?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
@@ -242,7 +241,6 @@ export interface AgentCapabilityDefinition<
     | ((context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<AgentAdapterInstructionsValue | false | undefined>)
   metadata?: Record<string, unknown>
   mode?: AgentCapabilityMode
-  name?: string
   output?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   prepare?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   requires?: AgentCapabilityRequirement[]


### PR DESCRIPTION
Removes capability-level `name` and `description` from `AgentCapabilityDefinition` so `id` is the only capability-level identity/display field. Built-in capability helpers no longer set display labels, and generic DevTools metadata no longer reads capability descriptions.

Adds type coverage for both `defineAgent({ capabilities })` and direct `defineCapability()` calls rejecting capability-level display metadata. Updates the agent-owned glossary and ADR to record the breaking-change rationale.