### PR TITLE
docs(workspace): add live workspace sources ADR

### DIFF
--- a/.agents/adr/0015-live-workspace-sources.md
+++ b/.agents/adr/0015-live-workspace-sources.md
@@ -1,0 +1,18 @@
+# Live Workspace Sources
+
+Workspace Sources may be **Materialized Sources** or **Live Sources**. A Live Source exposes read-only addressable files or items through Workspace by resolving reads from its origin on demand, without writing item bodies into the Workspace Store by default. This refines ADR 0009: Sources are not limited to ingestion or materialization, but they remain explicit Workspace declarations, while model-facing actions, query-only operations, and side-effectful tools remain Capabilities.
+
+## Considered Options
+
+- Materializing all external data was rejected because API-backed and MCP-resource-backed origins can be too large, too fresh, or too expensive to copy into the Workspace Store by default.
+- Treating MCP/API access only as Capabilities was rejected because read-only addressable resources should also be inspectable through Workspace and DevTools without requiring an Agent-facing tool.
+- Calling non-store-backed Sources "Virtual Sources" or "Ephemeral Sources" was rejected because "virtual" collides with Vite's virtual-module vocabulary and "ephemeral" implies unstable identity.
+- Requiring every Source to enumerate all keys was rejected because some Live Sources can support direct reads for known Source-Backed Paths without cheap global listing.
+
+## Consequences
+
+Live Source cache policy must be explicit, opt-in, and separate from the Workspace Store. The first implementation may use process-local memory cache and should prefer the repo's existing cache utilities, but the cache does not define Workspace consistency.
+
+Workspace snapshots and diffs remain Store-based and exclude Live Source item bodies unless those items are explicitly materialized. A Live Source must support direct `stat` and `readFile` for known Source-Backed Paths; `list`, `glob`, and `search` are optional, and search hits must resolve to readable Source-Backed Paths.
+
+DevTools should show Live Sources in a separate Sources view first, including Source identity, Mount, cache policy, status, and supported Workspace operations. API-backed and MCP-backed Source implementations are deferred, but they must satisfy the addressable-item contract when introduced.

--- a/.agents/contexts/workspace/CONTEXT.md
+++ b/.agents/contexts/workspace/CONTEXT.md
@@ -20,8 +20,16 @@ The directory beside a Colocated Workspace Definition that contains local files 
 _Avoid_: Project root, worktree root, automatic sibling ingestion
 
 **Source**:
-A named origin that contributes read-only files or items into a Workspace.
-_Avoid_: Input, files, context, resource, mount
+A named origin that exposes read-only addressable files or items through a Workspace.
+_Avoid_: Input, files, context, resource, mount, connector
+
+**Materialized Source**:
+A Source whose items are written into the Workspace Store.
+_Avoid_: Stored connector, synced files
+
+**Live Source**:
+A Source whose items are fetched on demand without being written into the Workspace Store by default.
+_Avoid_: Virtual Source, Ephemeral Source, query tool
 
 **Source Map**:
 The keyed object that declares a Workspace's Sources.
@@ -66,6 +74,14 @@ _Avoid_: Workspace Capability, bash, raw tools
 - A **Workspace Source Root** is a `workspace/` directory beside the Colocated Workspace Definition when present, otherwise the definition directory.
 - A **Source Map** key is the canonical identity of its Source.
 - A **Source** has zero or one **Mount**.
+- A **Source** can expose local or external read-only information when that information has addressable files or items.
+- A **Source** must expose addressable files or items; query-only read tools belong outside the Source concept.
+- A **Materialized Source** persists its items in the **Workspace Store**.
+- A **Live Source** resolves Source-Backed Paths directly from its origin unless an explicit cache or materialization policy says otherwise.
+- A **Live Source** cache is separate from the **Workspace Store** and is opt-in.
+- A **Live Source** must support direct reads for known Source-Backed Paths, but it does not have to enumerate every item.
+- A **Live Source** can provide search, but search results must resolve to readable Source-Backed Paths.
+- A **Live Source** exposes which Workspace operations it supports for inspection surfaces such as DevTools.
 - A **Source-Backed Path** belongs to exactly one Source.
 - A **Single-File Source** path is relative to the Workspace Source Root.
 - A **Single-File Source** can default its Mount to the Workspace root and its Source-Backed Path to the source file basename.
@@ -83,7 +99,11 @@ _Avoid_: Workspace Capability, bash, raw tools
 
 ## Flagged Ambiguities
 
-- "source" can mean source code, provenance, or data connector - resolved: in Workspace, **Source** means a named origin that contributes files or items.
+- "source" can mean source code, provenance, or data connector - resolved: in Workspace, **Source** means a named origin that exposes read-only addressable files or items.
+- Query-only access to external information was considered a Source shape - resolved: a **Source** must expose addressable files or items, even when search or query helps discover them.
+- Non-store-backed external Sources were called "virtual" or "ephemeral" - resolved: use **Live Source** for on-demand read-through Sources and reserve "virtual" for Vite module surfaces.
+- Addressable Sources were assumed to be fully enumerable - resolved: a **Live Source** can support direct reads for known paths without global enumeration.
+- Live Source search was considered mandatory - resolved: search is optional, and any search hit must resolve to a readable Source-Backed Path.
 - "mount" was considered as the name for `workspace.sources` - resolved: **Mount** is only the placement of a Source inside the Workspace.
 - `workspace.sources` was considered as an array for simple one-off Sources - resolved: use a **Source Map** so every Source has stable identity.
 - Agent `workspace: { ... }` shorthand was considered as Agent-owned configuration - resolved: treat it as a **Colocated Workspace Definition**.


### PR DESCRIPTION
Adds a follow-on Workspace ADR for Live Sources, refining ADR 0009 without superseding it. The ADR records that Sources may be materialized or live while preserving the Source/Capability boundary.

Also updates the Workspace glossary with Source, Materialized Source, and Live Source language from the grilling session.
