### PR TITLE
docs(agent): add active development guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 ## Agent Context
 
+- This library is still in active development. Optimize changes for the final design, even when that means introducing breaking changes, removing legacy code, or dropping backwards compatibility.
 - Development-only agent guidance belongs under `.agents/`.
 - Before architecture or domain work, read [`.agents/domain.md`](.agents/domain.md), then use [`.agents/CONTEXT-MAP.md`](.agents/CONTEXT-MAP.md) to find relevant context glossaries.
 - Do not add new development-context files under `docs/agents/` or `docs/contexts/`; use `.agents/` instead.


### PR DESCRIPTION
Adds root AGENTS.md guidance that this library is still in active development and agents should optimize for the final design, even when that requires breaking changes, legacy removal, or dropping backwards compatibility.

This is documentation-only agent guidance.
