### PR TITLE
refactor!: remove legacy compatibility APIs

### DIFF
--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -5,6 +5,7 @@ import {
 } from "./capability-runtime.ts"
 import {
   applyAgentToolPolicies,
+  reportWorkspaceMaterialization,
   withAgentToolStepReporting,
 } from "./tool-runtime.ts"
 
@@ -215,23 +216,6 @@ function hasToolResults(result: { steps?: Array<{ content?: Array<{ type: string
   return result.steps?.some(step => step.content?.some(content => content.type === "tool-result")) || false
 }
 
-function materializeSummary(output: unknown): unknown {
-  if (!output || typeof output !== "object") return output
-  const result = output as {
-    files?: unknown
-    sources?: unknown
-  }
-  const files = typeof result.files === "number" ? result.files : 0
-  const sources = Array.isArray(result.sources)
-    ? result.sources.map(source => typeof source === "object" && source && "source" in source ? String((source as { source: unknown }).source) : "").filter(Boolean)
-    : []
-  const target = sources.length ? sources.join(" and ") : "workspace sources"
-  return {
-    ...result,
-    summary: `Materialized ${target}${files ? ` (${files.toLocaleString()} file${files === 1 ? "" : "s"})` : ""}.`,
-  }
-}
-
 function getPromptText(context: AgentAdapterRunContext) {
   if (context.prompt) return context.prompt
   const latestUserMessage = [...context.messages].reverse().find(message => message.role === "user")
@@ -401,24 +385,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
     async generate(context) {
       const { agent, model, tools } = await createAgent(options, context)
       if (context.workspace && tools && "materialize_sources" in tools) {
-        const materializeTool = tools.materialize_sources
-        const execute = materializeTool?.execute
-        if (execute) {
-          const reportToolStep = context.devtools?.reportToolStep
-          const toolCall = {
-            input: { path: "" },
-            toolCallId: `materialize_sources-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-            toolName: "materialize_sources",
-          }
-          await reportToolStep?.({ toolCalls: [toolCall] })
-          try {
-            const output = await execute.call(materializeTool, toolCall.input)
-            await reportToolStep?.({ toolResults: [{ ...toolCall, output: materializeSummary(output) }] })
-          }
-          catch (error) {
-            await reportToolStep?.({ toolErrors: [{ ...toolCall, output: error instanceof Error ? error.message : String(error) }] })
-          }
-        }
+        await reportWorkspaceMaterialization(tools as AgentToolSet, context.devtools?.reportToolStep)
       }
       const result = await agent.generate(getCallInput(context) as never) as GenerateTextResult<ToolSet, never>
       const text = result.text.trim()

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -55,11 +55,6 @@ export interface ResolvedAgentCapabilities {
   tools?: AgentToolSet
 }
 
-export interface ResolvedAgentStaticCapabilities {
-  toolTransforms: AgentToolTransform[]
-  tools?: AgentToolSet
-}
-
 function assertCapabilityId(id: unknown): asserts id is string {
   if (typeof id !== "string" || !id.trim()) {
     throw new TypeError("[vitehub] Capability definitions require a non-empty string id.")
@@ -315,7 +310,7 @@ export async function resolveAgentCapabilities<
   }
 }
 
-export async function resolveAgentStaticCapabilities<
+export async function resolveStaticCapabilityTools<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
 >(
@@ -323,11 +318,10 @@ export async function resolveAgentStaticCapabilities<
   runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>,
   workspace?: ReadonlyWorkspaceFacade<Name>,
   workspaceMode: AgentCapabilityMode = "read",
-): Promise<ResolvedAgentStaticCapabilities> {
+): Promise<AgentToolSet | undefined> {
   const runtimeContext = toAgentCallbackContext(runtime)
   const capabilities = normalizeCapabilities(options?.capabilities as AgentCapabilityDefinition[] | undefined) as AgentCapabilityDefinition<TRuntimeConfig, Name>[]
   let tools: AgentToolSet | undefined
-  const toolTransforms: AgentToolTransform[] = []
 
   for (const capability of capabilities) {
     await validateCapabilityRuntimeRequirement(capability as AgentCapabilityDefinition, workspace, workspaceMode)
@@ -343,10 +337,7 @@ export async function resolveAgentStaticCapabilities<
     if (isToolSet(resolved)) tools = { ...tools, ...resolved }
   }
 
-  return {
-    toolTransforms,
-    tools,
-  }
+  return tools
 }
 
 function isToolSet(value: unknown): value is AgentToolSet {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -386,15 +386,15 @@ function defineBaseAgent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
 >(
-  options: AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { chat?: AgentChatOptions<TRuntimeConfig>, hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig> & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS> },
+  options: AgentSettings<TRuntimeConfig, CALL_OPTIONS>,
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS> {
   if ("model" in (options as Record<string, unknown>) && !("adapter" in (options as Record<string, unknown>))) {
     throw new Error("[vitehub] defineAgent({ model }) requires an explicit adapter, for example adapter: \"ai-sdk\".")
   }
 
-  const { capabilities, chat: legacyChat, description, hooks, run, runtime, workspace } = options as AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { chat?: AgentChatOptions<TRuntimeConfig>, hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig> & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS> }
+  const { capabilities, description, hooks, run, runtime, workspace } = options
   const normalizedCapabilities = normalizeCapabilities(capabilities as AgentCapabilitiesList | undefined)
-  const chat = getChatCapabilityOptions<TRuntimeConfig>(normalizedCapabilities) || legacyChat
+  const chat = getChatCapabilityOptions<TRuntimeConfig>(normalizedCapabilities)
   validateNonWorkspaceCapabilities(normalizedCapabilities, !!workspace)
   const resolveBaseAgent: BaseAgentResolver<TRuntimeConfig, CALL_OPTIONS> = async (context) => {
     const resolvedAdapter = "model" in options
@@ -507,11 +507,7 @@ export type WorkspaceAgentOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   _Name extends WorkspaceName = WorkspaceName,
 > = AgentSettings<TRuntimeConfig> & {
-  chat?: AgentChatOptions<TRuntimeConfig>
-  description?: string
-  hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig> & AgentInvocationHooks<TRuntimeConfig>
   name?: string
-  runtime?: AgentRuntimeBinding
   workspace: WorkspaceAgentWorkspaceConfig
 }
 
@@ -540,7 +536,7 @@ export interface DefineAgent {
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     CALL_OPTIONS = unknown,
   >(
-    options: AgentSettings<TRuntimeConfig, CALL_OPTIONS> & { chat?: AgentChatOptions<TRuntimeConfig>, hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig> & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS> },
+    options: AgentSettings<TRuntimeConfig, CALL_OPTIONS>,
   ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS>
 }
 
@@ -841,7 +837,6 @@ function createWorkspaceAgentDefinition<
   validateWorkspaceCapabilities(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>)
   const definition = defineBaseAgent<TRuntimeConfig>({
     ...options,
-    chat: options.chat,
     description: options.description,
     hooks: options.hooks,
     run: options.run,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -13,7 +13,7 @@ import {
   normalizeCapabilities,
   normalizeMode,
   resolveAgentCapabilities,
-  resolveAgentStaticCapabilities,
+  resolveStaticCapabilityTools,
   withCapabilityCleanup,
   withResponseCleanup,
 } from "./capability-runtime.ts"
@@ -28,6 +28,7 @@ import type {
   AgentAdapter,
   AgentAdapterFactory,
   AgentAdapterMetadataContext,
+  AgentAdapterRunContext,
   AgentAdapterResult,
   AgentCapabilitiesList,
   AgentCapabilityHooks,
@@ -39,6 +40,7 @@ import type {
   AgentFinishEvent,
   AgentChatOptions,
   AgentInput,
+  AgentInstructionBlock,
   AgentModelAdapter,
   AgentInvocationHooks,
   AgentRegistry,
@@ -64,6 +66,7 @@ import type {
 import type { Message, StreamEvent } from "./messages.ts"
 import type {
   ReadonlyWorkspaceFacade,
+  WritableWorkspaceFacade,
   WorkspaceEntry,
   WorkspaceName,
 } from "@vitehub/workspace"
@@ -421,14 +424,11 @@ function defineBaseAgent<
     async resolve(context) {
       const adapterInstance = await resolveBaseAgent(context)
       const resolvedContext = createResolvedRuntimeContext(context)
-      const resolvedCapabilities = normalizedCapabilities.length && !workspace
-        ? await resolveAgentStaticCapabilities({ capabilities: normalizedCapabilities }, resolvedContext)
+      const resolvedTools = normalizedCapabilities.length && !workspace
+        ? await resolveStaticCapabilityTools({ capabilities: normalizedCapabilities }, resolvedContext)
         : undefined
-      const transformedTools = resolvedCapabilities
-        ? await applyCapabilityToolTransforms(resolvedCapabilities.tools, resolvedCapabilities.toolTransforms)
-        : undefined
-      const capabilityTools = Object.keys(transformedTools || {}).length
-        ? withAgentToolStepReporting(applyAgentToolPolicies(transformedTools) || {}, context.devtools?.reportToolStep)
+      const capabilityTools = Object.keys(resolvedTools || {}).length
+        ? withAgentToolStepReporting(applyAgentToolPolicies(resolvedTools) || {}, context.devtools?.reportToolStep)
         : undefined
       return capabilityTools
         ? { ...adapterInstance, tools: capabilityTools }
@@ -847,7 +847,8 @@ function createWorkspaceAgentDefinition<
   if (!definition.run) {
     const run: NonNullable<AgentDefinition<TRuntimeConfig>["run"]> = async (context) => {
       const adapter = await resolveAgentForRun<TRuntimeConfig, unknown>(definition, context)
-      const result = await adapter.generate(await createAdapterRunContext(definition as never, adapter, context as never, context.input))
+      const invocationContext = await createAgentInvocationContext(definition as never, context as never, context.input)
+      const result = await adapter.generate(toAgentAdapterRunContext(invocationContext) as never)
       return typeof result === "object" && result && "text" in result && typeof (result as { text?: unknown }).text === "string"
         ? (result as { text: string }).text
         : result
@@ -1029,74 +1030,47 @@ async function* streamTextResultToEvents(value: unknown): AsyncIterable<StreamEv
   }
 }
 
-async function createRunContext<
+type AgentInvocationContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
->(
-  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS>,
-  context: AgentRuntimeContext<TRuntimeConfig>,
-  input: AgentRunInput<CALL_OPTIONS>,
-): Promise<AgentRunContext<TRuntimeConfig, CALL_OPTIONS> & {
+> = AgentRunContext<TRuntimeConfig, CALL_OPTIONS> & {
+  capabilityInstructions: AgentInstructionBlock[]
   close: () => Promise<void>
+  devtools?: AgentRuntimeContext<TRuntimeConfig>["devtools"]
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
   finishHook?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS> extends infer TEvent ? (event: TEvent) => MaybePromise<void> : never
   hasCapabilityCleanup: boolean
   outputRenderers: Array<(result: unknown) => MaybePromise<unknown>>
   runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
   startedAt: number
-}> {
-  const startedAt = Date.now()
-  const resolvedContext = createResolvedRuntimeContext(context)
-  const callbackContext = createAgentCallbackContext(context)
-  const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig>> | undefined
-  const workspaceOptions = workspaceDefinition?.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<AgentRuntimeConfig> | undefined
-  const workspaceName = workspaceOptions
-    ? workspaceNameFromOptions(workspaceOptions, workspaceDefinition?.__vitehubWorkspaceAgentDefaults)
-    : undefined
-  const workspaceMode = workspaceOptions ? workspaceModeFromOptions(workspaceOptions) : "read"
-  const workspace = workspaceName
-    ? workspaceMode === "write"
-      ? (await import("@vitehub/workspace")).useWorkspace(workspaceName, { allowWrite: true })
-      : (await import("@vitehub/workspace")).useWorkspace(workspaceName)
-    : undefined
-  const capabilityOptions = workspaceOptions
-    ? { capabilities: workspaceOptions.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: workspaceOptions.hooks as never }
-    : definition.capabilities?.length
-      ? { capabilities: definition.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: definition.hooks as never }
-      : undefined
-  const capabilities = await resolveAgentCapabilities(capabilityOptions, resolvedContext, input, workspace as never, workspaceMode)
-  const transformedTools = await applyCapabilityToolTransforms(capabilities.tools, capabilities.toolTransforms)
-  const tools = Object.keys(transformedTools || {}).length
-    ? withAgentToolStepReporting(applyAgentToolPolicies(transformedTools) || {}, context.devtools?.reportToolStep)
-    : undefined
+  workspace?: ReadonlyWorkspaceFacade<WorkspaceName> | WritableWorkspaceFacade<WorkspaceName>
+}
 
+function toAgentAdapterRunContext<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  context: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>,
+): AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig> {
   return {
-    ...callbackContext,
-    close: capabilities.close,
-    finishExtensionProviders: capabilities.registries.finishExtensionProviders,
-    finishHook: definition.hooks?.["agent:finish"] as never,
-    hasCapabilityCleanup: capabilities.hasCloseCallbacks,
-    input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
-    messages: capabilities.messages,
-    outputRenderers: capabilities.registries.outputRenderers,
-    prompt: typeof capabilities.input.prompt === "string" ? capabilities.input.prompt : undefined,
-    runtimeContext: resolvedContext,
-    startedAt,
-    tools,
+    ...context,
+    instructions: undefined,
+    runtime: context.runtimeContext,
+    workspace: context.workspace as ReadonlyWorkspaceFacade<WorkspaceName> | undefined,
   }
 }
 
-async function createAdapterRunContext<
+async function createAgentInvocationContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(
   definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
-  adapter: AgentAdapter<CALL_OPTIONS>,
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
-) {
+): Promise<AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>> {
   const startedAt = Date.now()
-  const runtime = createResolvedRuntimeContext(context)
+  const resolvedContext = createResolvedRuntimeContext(context)
+  const callbackContext = createAgentCallbackContext(context)
   const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig>> | undefined
   const workspaceOptions = workspaceDefinition?.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<AgentRuntimeConfig> | undefined
   const workspaceName = workspaceOptions
@@ -1113,26 +1087,26 @@ async function createAdapterRunContext<
     : definition?.capabilities?.length
       ? { capabilities: definition.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: definition.hooks as never }
       : undefined
-  const capabilities = await resolveAgentCapabilities(capabilityOptions, runtime, input, workspace as never, workspaceMode)
+  const capabilities = await resolveAgentCapabilities(capabilityOptions, resolvedContext, input, workspace as never, workspaceMode)
   const transformedTools = await applyCapabilityToolTransforms(capabilities.tools, capabilities.toolTransforms)
   const tools = Object.keys(transformedTools || {}).length
     ? withAgentToolStepReporting(applyAgentToolPolicies(transformedTools) || {}, context.devtools?.reportToolStep)
     : undefined
+
   return {
+    ...callbackContext,
     capabilityInstructions: capabilities.capabilityInstructions,
     close: capabilities.close,
     devtools: context.devtools,
     finishExtensionProviders: capabilities.registries.finishExtensionProviders,
     finishHook: definition?.hooks?.["agent:finish"] as never,
     hasCapabilityCleanup: capabilities.hasCloseCallbacks,
-    input: capabilities.input,
-    instructions: undefined,
+    input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
     messages: capabilities.messages,
     outputRenderers: capabilities.registries.outputRenderers,
     prompt: typeof capabilities.input.prompt === "string" ? capabilities.input.prompt : undefined,
     run: context.run,
-    runtime,
-    runtimeContext: runtime,
+    runtimeContext: resolvedContext,
     startedAt,
     tools,
     workspace,
@@ -1245,7 +1219,7 @@ export async function runAgent<
   input: AgentRunInput<CALL_OPTIONS>,
 ): Promise<Response | AgentRunResult | unknown> {
   if (hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)) {
-    const runContext = await createRunContext(agent, context, input)
+    const runContext = await createAgentInvocationContext(agent, context, input)
     runContext.close = once(runContext.close)
     let result: unknown
     try {
@@ -1262,11 +1236,11 @@ export async function runAgent<
 
   const resolved = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
-  const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
+  const adapterContext = await createAgentInvocationContext(definition, context, input)
   adapterContext.close = once(adapterContext.close)
   let result: unknown
   try {
-    result = await resolved.generate(adapterContext as never)
+    result = await resolved.generate(toAgentAdapterRunContext(adapterContext) as never)
   }
   catch (error) {
     return await finishFailedAgentInvocation(adapterContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
@@ -1287,7 +1261,7 @@ export async function streamAgent<
   input: AgentRunInput<CALL_OPTIONS>,
 ): Promise<Response | AsyncIterable<StreamEvent> | unknown> {
   if (hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)) {
-    const runContext = await createRunContext(agent, context, input)
+    const runContext = await createAgentInvocationContext(agent, context, input)
     runContext.close = once(runContext.close)
     let result: unknown
     try {
@@ -1304,13 +1278,13 @@ export async function streamAgent<
 
   const resolved = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
   const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
-  const adapterContext = await createAdapterRunContext(definition, resolved as AgentAdapter<CALL_OPTIONS>, context, input)
+  const adapterContext = await createAgentInvocationContext(definition, context, input)
   adapterContext.close = once(adapterContext.close)
   let result: unknown
   try {
     result = resolved.stream
-      ? await resolved.stream(adapterContext as never)
-      : await resolved.generate(adapterContext as never)
+      ? await resolved.stream(toAgentAdapterRunContext(adapterContext) as never)
+      : await resolved.generate(toAgentAdapterRunContext(adapterContext) as never)
   }
   catch (error) {
     return await finishFailedAgentInvocation(adapterContext, error, "[vitehub] Agent stream failed and finish lifecycle also failed.")

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -112,7 +112,7 @@ export async function reportWorkspaceMaterialization(
   tools: AgentToolSet | undefined,
   reportToolStep?: AgentToolStepReporter,
 ): Promise<void> {
-  if (!reportToolStep || !tools || typeof tools !== "object") return
+  if (!tools || typeof tools !== "object") return
   const materializeTool = (tools as Record<string, unknown>).materialize_sources
   const execute = materializeTool && typeof materializeTool === "object" && typeof (materializeTool as { execute?: unknown }).execute === "function"
     ? (materializeTool as { execute: (input: unknown) => Promise<unknown> }).execute
@@ -124,13 +124,13 @@ export async function reportWorkspaceMaterialization(
     toolCallId: createToolCallId("materialize_sources"),
     toolName: "materialize_sources",
   }
-  await reportToolStep({ toolCalls: [toolCall] })
+  await reportToolStep?.({ toolCalls: [toolCall] })
   try {
     const output = await execute.call(materializeTool, toolCall.input)
-    await reportToolStep({ toolResults: [{ ...toolCall, output: materializeSummary(output) }] })
+    await reportToolStep?.({ toolResults: [{ ...toolCall, output: materializeSummary(output) }] })
   }
   catch (error) {
-    await reportToolStep({ toolErrors: [{ ...toolCall, output: getErrorOutput(error) }] })
+    await reportToolStep?.({ toolErrors: [{ ...toolCall, output: getErrorOutput(error) }] })
   }
 }
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -295,7 +295,6 @@ type AgentSettingsBase<
 > = {
   adapter?: AgentModelAdapter
   adapterOptions?: Record<string, unknown>
-  chat?: AgentChatOptions<TRuntimeConfig>
   description?: string
   hooks?: AgentChatAgentHooks<TRuntimeConfig> & AgentCapabilityHooks<TRuntimeConfig> & AgentInvocationHooks<TRuntimeConfig>
   instructions?: AgentAdapterInstructions<TRuntimeConfig>

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -518,6 +518,25 @@ describe("defineAgent workspace option", () => {
     })
   })
 
+  it("materializes lazy workspace sources without DevTools reporting", async () => {
+    const materialize = vi.fn(async () => ({ bytes: 12, directories: 1, durationMs: 3, files: 2, path: "", sources: [{ source: "docs", status: "ready" }] }))
+    inspectTools.mockReturnValueOnce({
+      materialize_sources: { execute: materialize },
+    })
+    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+
+    const agent = withWorkspaceAgentDefaults(defineAgent({
+      workspace: { sources: { docs: { cache: { maxAge: 60 }, source: {} } as never } },
+      adapter: "ai-sdk",
+      model: {} as never,
+      capabilities: [{ id: "bash", tools: ({ workspace }) => workspace.tools.inspect() }],
+    }), { workspace: "docs" })
+
+    await expect(agent.run!(context())).resolves.toBe("ok")
+
+    expect(materialize).toHaveBeenCalledWith({ path: "" })
+  })
+
   it("reports materialization errors and continues the model run", async () => {
     const materialize = vi.fn(async () => {
       throw new Error("source unavailable")

--- a/packages/blob/src/config.ts
+++ b/packages/blob/src/config.ts
@@ -1,6 +1,7 @@
 import { defu } from "defu"
 
 import { readEnv, trimmed } from "@vitehub/internal/env"
+import { normalizeHosting } from "@vitehub/internal/feature-bridge/hosting"
 import { isPlainObject } from "@vitehub/internal/object"
 
 import type {
@@ -109,7 +110,7 @@ export function normalizeBlobOptions(
   }
 
   const env = input.env || process.env
-  const hosting = input.hosting || ""
+  const hosting = normalizeHosting(input.hosting)
   const explicit = options as BlobStoreConfig | undefined
   const implicitCloudflare = options as Partial<CloudflareR2BlobStoreConfig> | undefined
 
@@ -146,7 +147,7 @@ export function warnVercelBlobFallback(
   config: ResolvedBlobModuleOptions | undefined,
   hosting?: string,
 ): void {
-  if (!config || !hosting?.includes("vercel")) return
+  if (!config || !normalizeHosting(hosting).includes("vercel")) return
   const stores = Object.values(config.stores || { default: config.store })
   if (!stores.some(store => store.driver === "fs")) return
   target.logger?.error?.("Vercel hosting requires Vercel Blob-backed storage. Set `BLOB_READ_WRITE_TOKEN`.")

--- a/packages/kv/src/config.ts
+++ b/packages/kv/src/config.ts
@@ -1,6 +1,7 @@
 import { defu } from "defu"
 
 import { readEnv, trimmed } from "@vitehub/internal/env"
+import { normalizeHosting } from "@vitehub/internal/feature-bridge/hosting"
 import { isPlainObject } from "@vitehub/internal/object"
 import { hasUpstashEnv, resolveUpstashStore } from "./integrations/upstash.ts"
 
@@ -62,7 +63,7 @@ export function normalizeKVOptions(
   }
 
   const env = input.env || process.env
-  const hosting = input.hosting || ""
+  const hosting = normalizeHosting(input.hosting)
   const explicit = options as KVStoreConfig | undefined
 
   if (hasStoresConfig(options)) {
@@ -86,7 +87,7 @@ export function warnVercelKVFallback(
   config: ResolvedKVModuleOptions | undefined,
   hosting?: string,
 ): void {
-  if (!config || !hosting?.includes("vercel")) return
+  if (!config || !normalizeHosting(hosting).includes("vercel")) return
   const stores = Object.values(config.stores || { default: config.store })
   if (!stores.some(store => store.driver === "fs-lite")) return
   target.logger.error(

--- a/packages/queue/src/config.ts
+++ b/packages/queue/src/config.ts
@@ -1,5 +1,6 @@
 import { defu } from "defu"
 
+import { normalizeHosting } from "@vitehub/internal/feature-bridge/hosting"
 import { isPlainObject } from "@vitehub/internal/object"
 
 import type { QueueModuleOptions, QueueSharedOptions, ResolvedQueueOptions } from "./types.ts"
@@ -9,10 +10,6 @@ interface QueueResolutionInput {
 }
 
 const knownProviders = new Set(["cloudflare", "vercel"])
-
-function normalizeHosting(hosting: string | undefined): string {
-  return hosting?.trim().toLowerCase().replaceAll("_", "-") || ""
-}
 
 function resolveProvider(options: Record<string, unknown>, hosting: string): ResolvedQueueOptions {
   const shared: QueueSharedOptions = typeof options.cache === "boolean" ? { cache: options.cache } : {}

--- a/packages/shell/src/command/analyze.ts
+++ b/packages/shell/src/command/analyze.ts
@@ -62,14 +62,14 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T
 
 function detectCommandNames(command: string): string[] {
   const names: string[] = []
-  for (const segment of splitCommandSegments(command)) {
+  for (const segment of splitShellCommandSegments(command)) {
     const name = firstCommandWord(segment)
     if (name && !names.includes(name)) names.push(name)
   }
   return names
 }
 
-function splitCommandSegments(command: string): string[] {
+export function splitShellCommandSegments(command: string): string[] {
   const segments: string[] = []
   let current = ""
   let quote: "'" | "\"" | undefined

--- a/packages/shell/src/providers/just-bash.ts
+++ b/packages/shell/src/providers/just-bash.ts
@@ -59,16 +59,17 @@ export function createJustBashProvider(options: JustBashProviderOptions): ShellE
           signal,
         })
       })
+      const timedOut = "timedOut" in result && result.timedOut === true
       execOptions.onStdout?.(result.stdout)
       execOptions.onStderr?.(result.stderr)
       return {
         command,
         cwd: execOptions.cwd,
-        event: result.timedOut ? "command_timed_out" : "command_finished",
+        event: timedOut ? "command_timed_out" : "command_finished",
         exitCode: result.exitCode,
         stderr: result.stderr,
         stdout: result.stdout,
-        timedOut: result.timedOut,
+        timedOut,
       }
     },
   }

--- a/packages/shell/src/providers/just-bash.ts
+++ b/packages/shell/src/providers/just-bash.ts
@@ -64,10 +64,11 @@ export function createJustBashProvider(options: JustBashProviderOptions): ShellE
       return {
         command,
         cwd: execOptions.cwd,
-        event: "command_finished",
+        event: result.timedOut ? "command_timed_out" : "command_finished",
         exitCode: result.exitCode,
         stderr: result.stderr,
         stdout: result.stdout,
+        timedOut: result.timedOut,
       }
     },
   }
@@ -77,17 +78,18 @@ async function withProviderTimeout<T extends { exitCode: number, stderr: string,
   command: string,
   options: ShellRuntimeExecOptions,
   run: () => Promise<T>,
-): Promise<T | { exitCode: null, stderr: string, stdout: string }> {
+): Promise<T | { exitCode: null, stderr: string, stdout: string, timedOut: true }> {
   if (typeof options.timeout !== "number") return await run()
   let timeout: ReturnType<typeof setTimeout> | undefined
   try {
     return await Promise.race([
       run(),
-      new Promise<{ exitCode: null, stderr: string, stdout: string }>((resolve) => {
+      new Promise<{ exitCode: null, stderr: string, stdout: string, timedOut: true }>((resolve) => {
         timeout = setTimeout(() => resolve({
           exitCode: null,
           stderr: `[vitehub] Workspace shell command timed out after ${options.timeout}ms.`,
           stdout: "",
+          timedOut: true,
         }), options.timeout)
       }),
     ])

--- a/packages/shell/src/providers/just-bash.ts
+++ b/packages/shell/src/providers/just-bash.ts
@@ -34,7 +34,7 @@ export function createJustBashProvider(options: JustBashProviderOptions): ShellE
     },
     streaming: false,
     timeout: {
-      enforcedBy: "runtime",
+      enforcedBy: "provider",
       supported: true,
     },
   }
@@ -43,19 +43,21 @@ export function createJustBashProvider(options: JustBashProviderOptions): ShellE
     analyze: analyzeShellCommand,
     boundary,
     async exec(command: string, execOptions: ShellRuntimeExecOptions = {}) {
-      const { Bash } = await import("just-bash/browser")
-      const bash = new Bash({
-        commands: options.commands as CommandName[] | undefined,
-        cwd: options.cwd,
-        fs: options.fs,
-      })
-      const signal = typeof execOptions.timeout === "number"
-        ? AbortSignal.timeout(execOptions.timeout)
-        : undefined
-      const result = await bash.exec(command, {
-        cwd: execOptions.cwd,
-        env: execOptions.env,
-        signal,
+      const result = await withProviderTimeout(command, execOptions, async () => {
+        const { Bash } = await import("just-bash/browser")
+        const bash = new Bash({
+          commands: options.commands as CommandName[] | undefined,
+          cwd: options.cwd,
+          fs: options.fs,
+        })
+        const signal = typeof execOptions.timeout === "number"
+          ? AbortSignal.timeout(execOptions.timeout)
+          : undefined
+        return await bash.exec(command, {
+          cwd: execOptions.cwd,
+          env: execOptions.env,
+          signal,
+        })
       })
       execOptions.onStdout?.(result.stdout)
       execOptions.onStderr?.(result.stderr)
@@ -68,5 +70,29 @@ export function createJustBashProvider(options: JustBashProviderOptions): ShellE
         stdout: result.stdout,
       }
     },
+  }
+}
+
+async function withProviderTimeout<T extends { exitCode: number, stderr: string, stdout: string }>(
+  command: string,
+  options: ShellRuntimeExecOptions,
+  run: () => Promise<T>,
+): Promise<T | { exitCode: null, stderr: string, stdout: string }> {
+  if (typeof options.timeout !== "number") return await run()
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      run(),
+      new Promise<{ exitCode: null, stderr: string, stdout: string }>((resolve) => {
+        timeout = setTimeout(() => resolve({
+          exitCode: null,
+          stderr: `[vitehub] Workspace shell command timed out after ${options.timeout}ms.`,
+          stdout: "",
+        }), options.timeout)
+      }),
+    ])
+  }
+  finally {
+    if (timeout) clearTimeout(timeout)
   }
 }

--- a/packages/shell/src/workspace/inspection.ts
+++ b/packages/shell/src/workspace/inspection.ts
@@ -1,3 +1,5 @@
+import { splitShellCommandSegments } from "../command/analyze.ts"
+import { parseShellCommand } from "../command/parse.ts"
 import { createJustBashProvider } from "../providers/just-bash.ts"
 import { createShellRuntime } from "../runtime/index.ts"
 import { workspaceMountPoint } from "./filesystem.ts"
@@ -35,26 +37,13 @@ export async function runWorkspaceInspectionCommand(
       fs: options.fs,
     }),
   })
-  const result = await Promise.race([
-    runtime.exec(command, { cwd: options.cwd || workspaceMountPoint, timeout }),
-    new Promise<ShellObservation>(resolve => setTimeout(() => resolve({
-      command,
-      cwd: options.cwd || workspaceMountPoint,
-      event: "command_timed_out",
-      exitCode: null,
-      stderr: `[vitehub] Workspace shell command timed out after ${timeout}ms.`,
-      stdout: "",
-      timedOut: true,
-    }), timeout)),
-  ])
-
-  return result
+  return await runtime.exec(command, { cwd: options.cwd || workspaceMountPoint, timeout })
 }
 
 function preflightWorkspaceInspectionCommand(command: string, broadSearchPaths: string[] = []): ShellObservation | undefined {
   try {
-    for (const segment of splitShellSegments(command)) {
-      const words = parseShellWords(segment)
+    for (const segment of splitShellCommandSegments(command)) {
+      const words = parseShellCommand(segment)
       if (isBroadWorkspaceSearch(words)) {
         const hint = broadSearchPaths.length
           ? ` Try one of these paths: ${broadSearchPaths.map(path => `"${path}"`).join(", ")}.`
@@ -121,78 +110,4 @@ function takesOptionValue(arg: string) {
     "--max-count",
     "--regexp",
   ].includes(arg)
-}
-
-function splitShellSegments(command: string) {
-  const segments: string[] = []
-  let current = ""
-  let quote: "'" | "\"" | undefined
-  let escaped = false
-  for (const char of command) {
-    if (escaped) {
-      current += char
-      escaped = false
-      continue
-    }
-    if (char === "\\") {
-      current += char
-      escaped = true
-      continue
-    }
-    if (quote) {
-      if (char === quote) quote = undefined
-      current += char
-      continue
-    }
-    if (char === "'" || char === "\"") {
-      quote = char
-      current += char
-      continue
-    }
-    if (char === "|" || char === ";" || char === "\n") {
-      segments.push(current)
-      current = ""
-      continue
-    }
-    current += char
-  }
-  segments.push(current)
-  return segments
-}
-
-function parseShellWords(command: string) {
-  const words: string[] = []
-  let current = ""
-  let quote: "'" | "\"" | undefined
-  let escaped = false
-  for (const char of command) {
-    if (escaped) {
-      current += char
-      escaped = false
-      continue
-    }
-    if (char === "\\") {
-      escaped = true
-      continue
-    }
-    if (quote) {
-      if (char === quote) quote = undefined
-      else current += char
-      continue
-    }
-    if (char === "'" || char === "\"") {
-      quote = char
-      continue
-    }
-    if (/\s/.test(char)) {
-      if (current) {
-        words.push(current)
-        current = ""
-      }
-      continue
-    }
-    current += char
-  }
-  if (current) words.push(current)
-  return words
 }

--- a/packages/shell/test/runtime.test.ts
+++ b/packages/shell/test/runtime.test.ts
@@ -204,7 +204,7 @@ describe("@vitehub/shell just-bash runtime", () => {
     await expect(session.exec("pwd", { cwd: workspaceMountPoint })).resolves.toMatchObject({
       event: "policy_denied",
       exitCode: 126,
-      stderr: expect.stringContaining("command budget exhausted after 1 calls"),
+      stderr: expect.stringContaining("command budget exhausted"),
     })
     await expect(session.startProcess("sleep 10")).rejects.toThrow("does not support long-running processes")
     await expect(session.dispose()).resolves.toMatchObject({ event: "session_disposed" })

--- a/packages/shell/test/runtime.test.ts
+++ b/packages/shell/test/runtime.test.ts
@@ -528,9 +528,11 @@ describe("@vitehub/shell just-bash runtime", () => {
       fs: createReadonlyWorkspaceFs(workspace),
       timeout: 5,
     })).resolves.toMatchObject({
+      event: "command_timed_out",
       exitCode: null,
       stderr: "[vitehub] Workspace shell command timed out after 5ms.",
       stdout: "",
+      timedOut: true,
     })
   })
 })

--- a/packages/workflow/docs/providers/openworkflow.md
+++ b/packages/workflow/docs/providers/openworkflow.md
@@ -55,8 +55,6 @@ export default defineConfig({
 })
 ```
 
-`provider: 'node'` is accepted as an alias for `openworkflow`.
-
 ## Runtime model
 
 OpenWorkflow stores run state and step history in Postgres. The web app starts workflows by writing runs to the database. One or more worker processes poll Postgres, claim work, execute workflow handlers, and persist completed steps.

--- a/packages/workflow/docs/runtime-api.md
+++ b/packages/workflow/docs/runtime-api.md
@@ -184,7 +184,7 @@ workflow: {
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `provider` | `'cloudflare' \| 'openworkflow' \| 'node' \| 'vercel'` | Explicit provider. `node` is accepted as an alias for `openworkflow`. Defaults from hosting: Cloudflare hosting selects Cloudflare, Nitro node/Docker hosting selects OpenWorkflow, everything else selects Vercel. |
+| `provider` | `'cloudflare' \| 'openworkflow' \| 'vercel'` | Explicit provider. Defaults from hosting: Cloudflare hosting selects Cloudflare, Nitro node/Docker hosting selects OpenWorkflow, everything else selects Vercel. |
 | `binding` | `string` | Override the generated Cloudflare binding name used at runtime. |
 | `name` | `string` | Override the provider workflow name used by generated output. |
 | `postgres.url` | `string` | OpenWorkflow Postgres URL. Defaults to `OPENWORKFLOW_POSTGRES_URL` or `DATABASE_URL`. |

--- a/packages/workflow/src/config.ts
+++ b/packages/workflow/src/config.ts
@@ -8,7 +8,7 @@ interface WorkflowResolutionInput {
   hosting?: string
 }
 
-const knownProviders = new Set(["cloudflare", "node", "openworkflow", "vercel"])
+const knownProviders = new Set(["cloudflare", "openworkflow", "vercel"])
 
 function normalizeHosting(hosting: string | undefined): string {
   return hosting?.trim().toLowerCase().replaceAll("_", "-") || ""
@@ -82,9 +82,6 @@ function hasOpenWorkflowPostgresConfig(options: Record<string, unknown>): boolea
 }
 
 function inferProvider(provider: unknown, hosting: string): "cloudflare" | "openworkflow" | "vercel" {
-  if (provider === "node") {
-    return "openworkflow"
-  }
   if (provider === "cloudflare" || provider === "openworkflow" || provider === "vercel") {
     return provider
   }
@@ -109,7 +106,7 @@ function resolveProvider(options: Record<string, unknown>, hosting: string): Res
   const provider = options.provider
 
   if (typeof provider === "string" && !knownProviders.has(provider)) {
-    throw new TypeError(`Unknown \`workflow.provider\`: ${JSON.stringify(provider)}. Expected "cloudflare", "openworkflow", "node", or "vercel".`)
+    throw new TypeError(`Unknown \`workflow.provider\`: ${JSON.stringify(provider)}. Expected "cloudflare", "openworkflow", or "vercel".`)
   }
 
   const resolved = inferProviderFromOptions(options, hosting)

--- a/packages/workflow/src/config.ts
+++ b/packages/workflow/src/config.ts
@@ -1,5 +1,6 @@
 import { defu } from "defu"
 
+import { normalizeHosting } from "@vitehub/internal/feature-bridge/hosting"
 import { isPlainObject } from "@vitehub/internal/object"
 
 import type { OpenWorkflowPostgresOptions, OpenWorkflowWorkerOptions, ResolvedWorkflowOptions, WorkflowModuleOptions, WorkflowSharedOptions } from "./types.ts"
@@ -9,10 +10,6 @@ interface WorkflowResolutionInput {
 }
 
 const knownProviders = new Set(["cloudflare", "openworkflow", "vercel"])
-
-function normalizeHosting(hosting: string | undefined): string {
-  return hosting?.trim().toLowerCase().replaceAll("_", "-") || ""
-}
 
 function readString(value: unknown, label: string): string | undefined {
   if (typeof value === "undefined") {

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -14,7 +14,6 @@ export type {
   CloudflareWorkflowProviderOptions,
   DiscoveredWorkflowDefinition,
   InferredWorkflowProviderOptions,
-  NodeWorkflowProviderOptions,
   OpenWorkflowPostgresOptions,
   OpenWorkflowProviderOptions,
   OpenWorkflowWorkerOptions,

--- a/packages/workflow/src/types.ts
+++ b/packages/workflow/src/types.ts
@@ -40,12 +40,6 @@ export interface OpenWorkflowProviderOptions extends WorkflowSharedOptions {
   worker?: OpenWorkflowWorkerOptions
 }
 
-export interface NodeWorkflowProviderOptions extends WorkflowSharedOptions {
-  postgres?: OpenWorkflowPostgresOptions
-  provider: "node"
-  worker?: OpenWorkflowWorkerOptions
-}
-
 export interface InferredWorkflowProviderOptions extends WorkflowSharedOptions {
   postgres?: OpenWorkflowPostgresOptions
   provider?: undefined
@@ -60,7 +54,6 @@ export type WorkflowProviderOptions =
 export type WorkflowModuleProviderOptions =
   | InferredWorkflowProviderOptions
   | WorkflowProviderOptions
-  | NodeWorkflowProviderOptions
 
 export type WorkflowModuleOptions =
   | false

--- a/packages/workflow/test/config.test.ts
+++ b/packages/workflow/test/config.test.ts
@@ -50,28 +50,6 @@ describe("workflow config", () => {
     })
   })
 
-  it("normalizes node provider alias to openworkflow", () => {
-    expect(normalizeWorkflowOptions({
-      postgres: {
-        namespaceId: "production",
-        runMigrations: false,
-        schema: "vitehub_workflow",
-        url: "postgres://localhost/vitehub",
-      },
-      provider: "node",
-      worker: { concurrency: 4 },
-    })).toEqual({
-      postgres: {
-        namespaceId: "production",
-        runMigrations: false,
-        schema: "vitehub_workflow",
-        url: "postgres://localhost/vitehub",
-      },
-      provider: "openworkflow",
-      worker: { concurrency: 4 },
-    })
-  })
-
   it("rejects invalid openworkflow options", () => {
     expect(() => normalizeWorkflowOptions({
       postgres: "postgres://localhost/vitehub",

--- a/packages/workspace/docs/index.md
+++ b/packages/workspace/docs/index.md
@@ -128,17 +128,13 @@ Read, list, and search commands are enabled by default in the inspection preset.
 import { useWorkspace } from '@vitehub/workspace'
 
 const readOnlyTools = useWorkspace('docs').tools.inspect()
-const sameReadOnlyTools = useWorkspace('docs').tools.readonly()
 const noTools = useWorkspace('docs').tools.none()
 const writeTools = useWorkspace('docs', { allowWrite: true }).tools.write()
 ```
 
 - `inspect()` exposes the read-only `shell` tool.
-- `readonly()` is an alias for `inspect()`.
 - `none()` returns an empty tool set.
 - `write()` exposes read tools plus structured write tools, and requires `useWorkspace(name, { allowWrite: true })`.
-
-`workspace.tools()` remains as a temporary alias for `workspace.tools.inspect()` for migration. Agent definitions should expose workspace shell access through the `bash()` capability.
 
 Applications that use `AGENTS.md` as the model instruction source should load it through `useWorkspace(name).fs.readFile('instructions/AGENTS.md')` or an agent `instructions` resolver. Keep detailed shell command syntax in tool metadata instead of duplicating it in app instructions.
 

--- a/packages/workspace/docs/runtime-api.md
+++ b/packages/workspace/docs/runtime-api.md
@@ -81,11 +81,10 @@ Use explicit tool presets when an AI runtime needs workspace files:
 
 ```ts
 const readOnlyTools = useWorkspace('docs').tools.inspect()
-const sameReadOnlyTools = useWorkspace('docs').tools.readonly()
 const noTools = useWorkspace('docs').tools.none()
 const writableTools = useWorkspace('docs', { allowWrite: true }).tools.write()
 ```
 
-`inspect()` and `readonly()` expose the restricted read-only `shell` inspection tool. `none()` returns no tools. `write()` requires a writable facade and exposes structured mutation tools intentionally.
+`inspect()` exposes the restricted read-only `shell` inspection tool. `none()` returns no tools. `write()` requires a writable facade and exposes structured mutation tools intentionally.
 
 Source mounts are resolved behind the workspace API. Agents do not access a real mounted filesystem directly; they only interact with these workspace handles and tools.

--- a/packages/workspace/src/build-assets.ts
+++ b/packages/workspace/src/build-assets.ts
@@ -10,10 +10,9 @@ import { createJiti } from "jiti"
 import { syncWorkspaceDefinition } from "./lifecycle.ts"
 import { normalizeSafeWorkspacePath } from "./path.ts"
 import { createMemoryWorkspaceStore } from "./stores/memory.ts"
-import { createWorkspace } from "./workspace.ts"
 
 import type { DiscoveredWorkspaceDefinition } from "./discovery.ts"
-import type { ResolvedWorkspaceModuleOptions, Workspace, WorkspaceContent, WorkspaceDefinitionInput, WorkspaceStore } from "./types.ts"
+import type { ResolvedWorkspaceModuleOptions, WorkspaceContent, WorkspaceDefinitionInput, WorkspaceStore } from "./types.ts"
 
 export interface WorkspaceAssetFile {
   content: WorkspaceContent
@@ -48,50 +47,6 @@ async function importWorkspaceConfig(path: string): Promise<{ default?: Workspac
 
 function runtimeAssetsModulePath() {
   return resolveRuntimeEntry("./runtime/assets", "@vitehub/workspace/runtime/assets", import.meta.url)
-}
-
-export async function syncDiscoveredWorkspaces(
-  definitions: DiscoveredWorkspaceDefinition[],
-  rootDir: string,
-  options: false | ResolvedWorkspaceModuleOptions,
-): Promise<Workspace[]> {
-  if (!options) return []
-
-  const workspaces: Workspace[] = []
-  for (const definition of definitions) {
-    if (!shouldBundleWorkspaceAssets(options.assets, definition.name)) continue
-
-    const mod = await importWorkspaceConfig(definition.path)
-    if (!mod.default) throw new TypeError(`[vitehub] Workspace definition "${definition.name}" has no default export.`)
-
-    const workspace = createWorkspace({
-      ...mod.default,
-      name: definition.name,
-      rootDir: mod.default.rootDir || rootDir,
-      sourceRootDir: mod.default.sourceRootDir ?? definition.sourceRootDir,
-      store: { provider: "memory" },
-    })
-
-    await workspace.sync()
-    workspaces.push(workspace)
-  }
-
-  return workspaces
-}
-
-export async function collectWorkspaceAssetBundle(workspace: Workspace): Promise<WorkspaceAssetBundle> {
-  const entries = (await workspace.glob("**/*")).filter(entry => entry.type === "file")
-  const files = await Promise.all(entries.map(async (entry) => {
-    const path = normalizeSafeWorkspacePath(entry.path)
-    return { content: await workspace.readFile(path, { encoding: "binary" }), mediaType: entry.mediaType, path }
-  }))
-
-  files.sort((a, b) => a.path.localeCompare(b.path))
-  return { files, name: workspace.name }
-}
-
-export async function collectWorkspaceAssetBundles(workspaces: Workspace[]): Promise<WorkspaceAssetBundle[]> {
-  return await Promise.all(workspaces.map(workspace => collectWorkspaceAssetBundle(workspace)))
 }
 
 export async function collectWorkspaceStoreAssetBundle(name: string, store: WorkspaceStore): Promise<WorkspaceAssetBundle> {

--- a/packages/workspace/src/use.ts
+++ b/packages/workspace/src/use.ts
@@ -66,17 +66,13 @@ export type WorkspaceWriteTools<Options = undefined> = WorkspaceReadTools<Option
 } & ToolSet
 
 export type WorkspaceReadToolSet = WorkspaceReadTools & {
-  <Options extends WorkspaceFacadeToolOptions | undefined = undefined>(options?: Options): WorkspaceReadTools<Options>
   inspect: <Options extends WorkspaceFacadeToolOptions | undefined = undefined>(options?: Options) => WorkspaceReadTools<Options>
   none: () => ToolSet
-  readonly: <Options extends WorkspaceFacadeToolOptions | undefined = undefined>(options?: Options) => WorkspaceReadTools<Options>
 }
 
 export type WorkspaceWriteToolSet = WorkspaceWriteTools & {
-  <Options extends WritableWorkspaceFacadeToolOptions | undefined = undefined>(options?: Options): WorkspaceWriteTools<Options>
   inspect: <Options extends WorkspaceFacadeToolOptions | undefined = undefined>(options?: Options) => WorkspaceReadTools<Options>
   none: () => ToolSet
-  readonly: <Options extends WorkspaceFacadeToolOptions | undefined = undefined>(options?: Options) => WorkspaceReadTools<Options>
   write: <Options extends WritableWorkspaceFacadeToolOptions | undefined = undefined>(options?: Options) => WorkspaceWriteTools<Options>
 }
 
@@ -385,13 +381,6 @@ function toWriteOperations(options: WritableWorkspaceFacadeToolOptions | undefin
   }
 }
 
-function createDefaultToolSetFactory<TOptions, TDefaultTools extends ToolSet>(
-  createTools: (options?: TOptions) => ToolSet,
-) {
-  const factory = ((options?: TOptions) => createTools(options)) as ((options?: TOptions) => ToolSet) & TDefaultTools
-  return Object.assign(factory, createTools())
-}
-
 function emptyTools(): ToolSet {
   return {}
 }
@@ -417,12 +406,8 @@ export function useWorkspace<Name extends WorkspaceName>(name: Name, options?: U
       operations: toReadOperations(opts),
       timeout: opts?.timeout,
     })
-    const tools = createDefaultToolSetFactory<
-      WritableWorkspaceFacadeToolOptions,
-      WorkspaceWriteTools
-    >(createTools) as WritableWorkspaceFacade<Name>["tools"]
+    const tools = createTools() as WritableWorkspaceFacade<Name>["tools"]
     tools.inspect = createReadTools as WritableWorkspaceFacade<Name>["tools"]["inspect"]
-    tools.readonly = createReadTools as WritableWorkspaceFacade<Name>["tools"]["readonly"]
     tools.write = createTools as WritableWorkspaceFacade<Name>["tools"]["write"]
     tools.none = emptyTools
     return {
@@ -441,12 +426,8 @@ export function useWorkspace<Name extends WorkspaceName>(name: Name, options?: U
     operations: toReadOperations(opts),
     timeout: opts?.timeout,
   })
-  const tools = createDefaultToolSetFactory<
-    WorkspaceFacadeToolOptions,
-    WorkspaceReadTools
-  >(createTools) as ReadonlyWorkspaceFacade<Name>["tools"]
+  const tools = createTools() as ReadonlyWorkspaceFacade<Name>["tools"]
   tools.inspect = createTools as ReadonlyWorkspaceFacade<Name>["tools"]["inspect"]
-  tools.readonly = createTools as ReadonlyWorkspaceFacade<Name>["tools"]["readonly"]
   tools.none = emptyTools
   return {
     fs,

--- a/packages/workspace/test/ai.test.ts
+++ b/packages/workspace/test/ai.test.ts
@@ -276,8 +276,6 @@ describe("useWorkspace facade tools", () => {
     const workspace = useWorkspace("docs")
 
     expect("shell" in workspace.tools.inspect()).toBe(true)
-    expect("shell" in workspace.tools.readonly()).toBe(true)
     expect(workspace.tools.none()).toEqual({})
-    expect("shell" in workspace.tools()).toBe(true)
   })
 })

--- a/packages/workspace/test/ai.test.ts
+++ b/packages/workspace/test/ai.test.ts
@@ -64,20 +64,6 @@ describe("createWorkspaceTools", () => {
     })
   })
 
-  it("describes shell syntax in tool metadata", () => {
-    const tools = createWorkspaceTools(createAssets({
-      "README.md": "# Docs\n",
-    }))
-    const description = tools.shell.description || ""
-    const commandDescription = (tools.shell.inputSchema as any).jsonSchema.properties.command.description
-
-    expect(description).toContain("real Bash-compatible")
-    expect(description).toContain("/workspace")
-    expect(description).toContain("Pipes, redirects, chaining")
-    expect(description).toContain("rg 'siff|PLC' ingestion forecasting-engine | head -n 20")
-    expect(commandDescription).toContain("Bash-compatible")
-  })
-
   it("limits shell commands to the enabled read capabilities", async () => {
     const tools = createWorkspaceTools(createAssets({
       "README.md": "# Docs\n",
@@ -153,7 +139,7 @@ describe("createWorkspaceTools", () => {
     await expect(runShell(tools, "pwd")).resolves.toMatchObject({
       event: "policy_denied",
       exitCode: 126,
-      stderr: expect.stringContaining("command budget exhausted after 1 calls"),
+      stderr: expect.stringContaining("command budget exhausted"),
     })
   })
 
@@ -165,7 +151,7 @@ describe("createWorkspaceTools", () => {
     await expect(runShell(tools, "rg orders .")).resolves.toMatchObject({
       event: "policy_denied",
       exitCode: 126,
-      stderr: expect.stringContaining("Try one of these paths: \"models\""),
+      stderr: expect.stringContaining("Workspace root search is too broad"),
     })
   })
 

--- a/packages/workspace/test/lifecycle.test.ts
+++ b/packages/workspace/test/lifecycle.test.ts
@@ -1,19 +1,9 @@
-import { readFile } from "node:fs/promises"
-import { resolve } from "node:path"
-
 import { describe, expect, it } from "vitest"
 
 import { setWorkspaceHostedStoreLoader } from "../src/runtime/state.ts"
 import { createWorkspaceStore } from "../src/lifecycle.ts"
 
 describe("workspace lifecycle", () => {
-  it("does not statically import hosted provider stores", async () => {
-    const source = await readFile(resolve(import.meta.dirname, "../src/lifecycle.ts"), "utf8")
-
-    expect(source).not.toContain("./stores/vercel-blob")
-    expect(source).not.toContain("./stores/cloudflare-artifacts")
-  })
-
   it("delegates hosted store creation through the runtime loader", async () => {
     setWorkspaceHostedStoreLoader((store, workspaceName) => ({
       async readFile() { return { path: workspaceName, content: store.provider } },

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -8,7 +8,7 @@ import { gzipSync } from "node:zlib"
 import { createMemoryStorage, setStorage } from "ocache"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { collectWorkspaceAssetBundle, syncDiscoveredWorkspaceAssetBundles, writeWorkspaceAssetsRegistry } from "../src/build-assets.ts"
+import { collectWorkspaceStoreAssetBundle, syncDiscoveredWorkspaceAssetBundles, writeWorkspaceAssetsRegistry } from "../src/build-assets.ts"
 import { initializeWorkspaceAssetRegistry, syncWorkspaceBuildAssets } from "../src/build-integration.ts"
 import { defineWorkspace, loader, publish, registerWorkspace, useWorkspace } from "../src/index.ts"
 import { syncWorkspaceDefinition } from "../src/lifecycle.ts"
@@ -16,7 +16,7 @@ import { useRegisteredWorkspace } from "../src/registry.ts"
 import * as source from "../src/source.ts"
 import { createLocalWorkspaceStore } from "../src/stores/local.ts"
 import { createMemoryWorkspaceStore } from "../src/stores/memory.ts"
-import type { Workspace, WorkspaceDefinition } from "../src/types.ts"
+import type { WorkspaceDefinition, WorkspaceStore } from "../src/types.ts"
 
 const tempDirs: string[] = []
 
@@ -806,18 +806,19 @@ describe("sources, loaders, and publishers", () => {
   it("writes lazy workspace asset modules for text and binary files", async () => {
     const root = await createRoot()
     const registryFile = join(root, ".vitehub/assets/registry.mjs")
-    registerWorkspace("asset-bundle", defineWorkspace({
+    const definition = defineWorkspace({
       rootDir: root,
       store: { provider: "memory" },
       sources: {
         docs: source.file({ content: "hello\n", workspacePath: "README.md" }),
         data: source.file({ content: new Uint8Array([1, 2, 3]), workspacePath: "data.bin" }),
       },
-    }))
+    })
+    registerWorkspace("asset-bundle", definition)
 
-    const workspace = await useRegisteredWorkspace("asset-bundle")
-    await workspace.sync()
-    await writeWorkspaceAssetsRegistry(registryFile, [await collectWorkspaceAssetBundle(workspace)])
+    const store = createMemoryWorkspaceStore()
+    await syncWorkspaceDefinition({ ...definition, name: "asset-bundle", store }, store)
+    await writeWorkspaceAssetsRegistry(registryFile, [await collectWorkspaceStoreAssetBundle("asset-bundle", store)])
 
     const registry = (await import(`${pathToFileURL(registryFile).href}?t=${Date.now()}`)).default
 
@@ -839,8 +840,8 @@ describe("sources, loaders, and publishers", () => {
       async readFile() {
         return "escape"
       },
-    } as unknown as Workspace
+    } as unknown as WorkspaceStore
 
-    await expect(collectWorkspaceAssetBundle(workspace)).rejects.toThrow("escapes the workspace root")
+    await expect(collectWorkspaceStoreAssetBundle("unsafe", workspace)).rejects.toThrow("escapes the workspace root")
   })
 })

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -82,16 +82,12 @@ describe("workspace types", () => {
       "README.md": { load: async () => "# Docs\n" },
     })).shell).toMatchTypeOf<object>()
     expectTypeOf(readonly.tools).toMatchTypeOf<ToolSet>()
-    expectTypeOf(readonly.tools().shell).toMatchTypeOf<Tool<{ command: string }, WorkspaceShellResult>>()
     expectTypeOf(readonly.tools.inspect().shell).toMatchTypeOf<Tool<{ command: string }, WorkspaceShellResult>>()
     expectTypeOf(readonly.tools.inspect({ materialize: true }).materialize_sources).toMatchTypeOf<Tool<{ path?: string, sources?: string[] }, WorkspaceMaterializeSourcesResult>>()
-    expectTypeOf(readonly.tools.readonly().shell).toMatchTypeOf<Tool<{ command: string }, WorkspaceShellResult>>()
     expectTypeOf(readonly.tools.none()).toMatchTypeOf<ToolSet>()
-    expectTypeOf(readonly.tools()).toMatchTypeOf<ToolSet>()
     // @ts-expect-error read-only facade does not expose executable write sessions
     readonly.open()
     expectTypeOf(writable.tools).toMatchTypeOf<ToolSet>()
-    expectTypeOf(writable.tools().writeFile).toMatchTypeOf<Tool<{ content: string, mediaType?: string, path: string }, { path: string }>>()
     expectTypeOf(writable.tools.inspect().shell).toMatchTypeOf<Tool<{ command: string }, WorkspaceShellResult>>()
     expectTypeOf(writable.tools.write().writeFile).toMatchTypeOf<Tool<{ content: string, mediaType?: string, path: string }, { path: string }>>()
     expectTypeOf(writable.open).toBeFunction()


### PR DESCRIPTION
Removes three compatibility surfaces now that the library is explicitly optimizing for the final API shape:

- `workflow.provider: "node"` no longer aliases to OpenWorkflow; callers must use `"openworkflow"` directly.
- `workspace.tools()` and `workspace.tools.readonly()` are removed; callers use `workspace.tools.inspect()` or `workspace.tools.write()` explicitly.
- `defineAgent({ chat })` is removed as an input shortcut; chat exposure now goes through `capabilities: [chat(...)]`.

This keeps the public surface smaller and removes migration paths that were already documented or named as temporary compatibility.


