### PR TITLE
docs(agents): preserve context decisions

### DIFF
--- a/.agents/adr/0017-agent-invocation-lifecycle-hooks.md
+++ b/.agents/adr/0017-agent-invocation-lifecycle-hooks.md
@@ -1,0 +1,13 @@
+# Agent Invocation Lifecycle Hooks
+
+ViteHub agents will expose Agent Invocation Lifecycle hooks on the Agent Definition, with `agent:finish` as the canonical final hook for observing a completed invocation. Capabilities may augment lifecycle events through Agent Invocation Extensions keyed by Capability ID, but V1 capabilities should not expose generic finish/export callbacks such as `usageTelemetry({ sync })`; exporting, logging, and syncing completed invocation data belongs in `agent:finish`.
+
+## Considered Options
+
+- Capability-local export callbacks were rejected for V1 because they create a second lifecycle observation surface, make ordering harder to explain, and risk every Capability growing its own mini hook API.
+- Top-level event fields such as `event.usage` were rejected because they make optional Capability-owned data look like part of the core Agent Finish Hook contract.
+- Dynamic extension properties such as `event.extensions.usageTelemetry` were rejected because they turn Capability IDs into property names and make user-defined Capabilities awkward.
+
+## Consequences
+
+The Agent Finish Hook event should keep a small stable envelope and expose optional Capability data through `event.extensions.get("<capability-id>")`, such as `event.extensions.get("usage-telemetry")`. Capability order can still determine how Capabilities augment invocation data, while Agent Definition hooks remain the single public place to observe Agent Invocation Lifecycle moments.

--- a/.agents/adr/0018-http-request-core-for-sources-and-capabilities.md
+++ b/.agents/adr/0018-http-request-core-for-sources-and-capabilities.md
@@ -1,0 +1,38 @@
+# HTTP Request Core for Sources and Capabilities
+
+API-backed Workspace Sources and API Capabilities share a neutral HTTP Request Definition core, but remain separate public projections. The core owns request execution concerns such as method, URL, query, headers, body, timeout, abort, retry, response decoding, redaction, and hooks; Sources add read-only addressable Workspace item semantics, while Capabilities add model-facing tool semantics and query/effect policy.
+
+## Considered Options
+
+- Treating `fetch` as the Source abstraction was rejected because a Workspace Source must expose a stable read-only address space, not arbitrary HTTP calls.
+- Treating API calls only as Capabilities was rejected because read-only API data can be useful Workspace evidence outside Agents when it maps to Source-Backed Paths.
+- Sharing one undifferentiated API abstraction across Sources and Capabilities was rejected because Source reads and model-facing tools have different identity, cache, materialization, schema export, and side-effect rules.
+- Requiring JSON Schema at definition time was rejected because ViteHub should accept Standard Schema-compatible validators as the TypeScript authoring surface and only require JSON Schema conversion when an adapter or export target needs it.
+
+## Consequences
+
+An API-backed Source is valid only when it exposes stable read targets that can map to Source item keys and Source-Backed Paths. Query-only, aggregate-only, arbitrary-parameter, and side-effectful API calls remain Capability tools even when they share the same HTTP Request Definition core.
+
+This ADR does not name the future API/HTTP Capability helper. Capability naming and tool option shape are deferred because query/effect classification, approval policy, retry/idempotency behavior, and model-facing descriptions need their own design pass.
+
+The first API-backed Source helper should be `source.fetch(...)` for one declared HTTP read target and one Source-Backed Path, with the path derived from the URL when safe and overridable when needed. Multiple static HTTP items should be represented as multiple Source Map entries rather than a nested item map. Shared origin/client configuration and enumerable API collections are deferred until a real many-item Source design is needed.
+
+Default Source-Backed Path derivation should parse URLs with the platform `URL` class, use the URL pathname, ignore protocol, host, credentials, hash, and query parameters, and require an explicit path when query parameters materially distinguish the resource. Query parameters should not be encoded into default paths because they create unstable names and may leak sensitive data.
+
+`source.fetch(...)` should support HTTP GET, HEAD, and POST because many read-style APIs use POST bodies for structured queries. ViteHub cannot prove whether a POST mutates remote state, so it should not expose a fake `readOnly` flag. Documentation and DevTools should make POST-backed Sources visible as a trust boundary: developers are responsible for using POST only for stable read targets, while mutation, side-effectful commands, and arbitrary model-parameterized requests remain Capability tools.
+
+Request factories execute in server/runtime context but do not receive app-owned Runtime Env or raw runtime config as callback parameters. Code that needs app-owned Runtime Env should import `useServerEnv()` from `#vitehub/env/server`; Secret Env values are unsealed only at the request boundary. Runtime config may remain an internal integration transport, not the public request-factory API.
+
+The Source definition remains static so Source identity and Source-Backed Paths can be discovered without executing user code. Only `request` may be a static object or zero-argument factory for runtime-sensitive request details such as headers; the entire `source.fetch(...)` options object should not be a factory in v1.
+
+DevTools and diagnostics should show a redacted request summary for `source.fetch(...)`, not full resolved request details. Method, origin/path, Source key, Source-Backed Path, cache policy, response status, freshness, decoded type, errors, and whether a runtime request factory exists are useful; headers, query values, request bodies, and known Secret Env underlying values should be hidden or redacted by default.
+
+Live Source item bodies are fetched lazily and are not written into the Workspace Store by default. Cache is disabled by default; when configured, it is separate from the Workspace Store and keyed by source identity, item identity, request variables, projection-affecting options, and workspace or security scope. In-flight dedupe is allowed as an internal optimization but is not a user-facing cache guarantee. Explicit materialization creates a point-in-time Workspace artifact; v1 does not promise real-time synchronization.
+
+Schema-bearing Source and Capability fields use Standard Schema-compatible validators by default, including request inputs, response bodies, Source item metadata, and Capability tool inputs and outputs. JSON Schema is an interoperability artifact for model-provider tool descriptors, OpenAPI export, generated clients, forms, and non-TypeScript integrations. Conversion happens at the adapter or export boundary; if the selected adapter/export requires JSON Schema and no converter exists for a schema, ViteHub fails there with a clear error.
+
+`source.fetch(...)` v1 should use `schema` for Standard Schema-compatible validation of the decoded response body and `transform` for post-validation shaping of the final Workspace-facing item body. The transformed body type is inferred from the `transform` return type; explicit TypeScript generics are only an escape hatch for inference gaps. Post-transform `outputSchema` and `input`/`output` field names are deferred because they better fit Capability tools or future HTTP contract surfaces than the first Source helper.
+
+For `responseType: "json"`, the Workspace-facing body should be stable pretty JSON after schema validation and optional transform. `source.fetch(...)` exposes canonical readable Source content, not raw wire bytes; exact wire preservation should require an explicit binary/raw mode.
+
+ViteHub may use hookable and ofetch-aligned lifecycle phases internally, but `source.fetch(...)` v1 should not expose public lifecycle hooks such as `beforeRequest`, `afterResponse`, or `onError`. Public source fetch hooks should wait for a plugin-level extension boundary and concrete requirements for hook timing, context types, mutability, redaction, retry/cache behavior, validation, transform, and error propagation.

--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -24,6 +24,18 @@ _Avoid_: Top-level Agent Definition fields, passthrough, provider options
 One runtime request to an Agent.
 _Avoid_: Chat message, webhook call
 
+**Agent Invocation Lifecycle**:
+The ordered runtime moments that occur while one Agent Invocation is processed.
+_Avoid_: Capability Lifecycle, chat event hooks, request middleware
+
+**Agent Finish Hook**:
+The final Agent Invocation Lifecycle hook for observing the completed invocation outcome.
+_Avoid_: onUsage, onRecord, afterRun
+
+**Agent Invocation Extension**:
+Capability-owned data attached to an Agent Invocation Lifecycle event without becoming a top-level lifecycle field.
+_Avoid_: Event metadata, arbitrary event fields, built-in usage field
+
 **Agent Eval**:
 A repeatable development check that runs an Agent Definition against one or more cases and scores the resulting Agent Invocations.
 _Avoid_: Benchmark, unit test, arena
@@ -52,6 +64,18 @@ _Avoid_: Public lock API, Capability
 An in-memory or local provider used only for single-process Agent development.
 _Avoid_: Production state provider, durable coordination
 
+**Agent Usage**:
+Normalized model usage information produced by an Agent Invocation, including token counts and provider-reported usage details.
+_Avoid_: Metadata, metrics
+
+**Agent Usage Telemetry**:
+Runtime measurement of an Agent Invocation's model usage, latency, throughput, and cost.
+_Avoid_: Metadata, chat analytics, generic observability
+
+**Agent Usage Record**:
+The final completed accounting record captured after one Agent Invocation finishes, combining Agent Usage with model, response, latency, and optional cost information.
+_Avoid_: Live stream event, token log
+
 **Mock Agent Adapter**:
 A deterministic Agent Adapter that exercises Agent Invocation behavior without calling a paid model provider.
 _Avoid_: Fake agent, dummy model, test bot
@@ -62,6 +86,9 @@ _Avoid_: Fake agent, dummy model, test bot
 - An **Agent Definition** selects one **Agent Model Adapter** when it uses a model.
 - **Agent Adapter Options** belong to the selected **Agent Model Adapter**.
 - An **Agent** receives zero or more **Agent Invocations**.
+- An **Agent Invocation** follows one **Agent Invocation Lifecycle**.
+- An **Agent Finish Hook** belongs to the **Agent Invocation Lifecycle**.
+- Capabilities can expose **Agent Invocation Extensions** on Agent Invocation Lifecycle events.
 - An **Agent Eval** runs an **Agent Definition** to create scored **Agent Invocations**.
 - An **Agent** can attach zero or more Capabilities.
 - Tools are contributed by Capabilities, not by top-level Agent Definition fields.
@@ -74,6 +101,9 @@ _Avoid_: Fake agent, dummy model, test bot
 - **Agent Memory** can outlive one conversation.
 - A **Concurrent Invocation Guard** protects **Agent Run State**.
 - A **Development State Provider** is not acceptable for hosted production runtimes.
+- **Agent Usage** belongs to one **Agent Invocation**.
+- **Agent Usage Telemetry** observes **Agent Usage Records**.
+- **Agent Usage Telemetry** can expose an **Agent Usage Record** as an **Agent Invocation Extension**.
 - A **Mock Agent Adapter** can support playgrounds and end-to-end tests without creating provider cost.
 - Agent callbacks receive Agent-owned runtime metadata, not app-owned Runtime Env; server code reads app-owned Runtime Env through Server Env.
 


### PR DESCRIPTION
Preserves two development-context decisions that were sitting only in local worktrees: Agent Invocation Lifecycle hooks and the shared HTTP Request Definition core for API-backed Sources and API Capabilities.

Also updates the Agent context glossary with lifecycle, finish hook, invocation extension, and usage telemetry language so future implementation work has stable terms.