### PR TITLE
feat(schedule): emit provider cron output

### DIFF
--- a/packages/schedule/docs/index.md
+++ b/packages/schedule/docs/index.md
@@ -1,0 +1,52 @@
+---
+title: Schedule
+description: Define recurring cron work for Vite and Nitro apps.
+navigation.title: Overview
+navigation.order: 0
+icon: i-lucide-calendar-clock
+frameworks: [vite, nitro]
+---
+
+`@vitehub/schedule` defines recurring cron schedules that can run in Vite and Nitro apps. A Schedule Definition keeps the cron expression and handler together so provider output can discover it.
+
+Use Schedule when an app needs named recurring work such as daily reports, cleanup jobs, or provider-triggered maintenance tasks.
+
+```ts [server/schedules/daily-report.ts]
+import { defineSchedule } from '@vitehub/schedule'
+
+export default defineSchedule('0 9 * * *', async (context) => {
+  console.log(`Run daily report at ${context.scheduledAt.toISOString()}`)
+})
+```
+
+## What Schedule Owns
+
+::card-group
+  :::card
+  ---
+  icon: i-lucide-calendar-clock
+  title: Schedule definitions
+  ---
+  Keep recurring cron handlers in `defineSchedule()`.
+  :::
+
+  :::card
+  ---
+  icon: i-lucide-cloud
+  title: Provider output
+  ---
+  Emit Cloudflare and Vercel cron output from discovered definitions.
+  :::
+::
+
+## Start Here
+
+::u-page-grid{class="pb-2"}
+  :::u-page-card
+  ---
+  title: Quickstart
+  description: Register Schedule and define a first cron handler.
+  to: ./quickstart
+  ---
+  :::
+::

--- a/packages/schedule/docs/quickstart.md
+++ b/packages/schedule/docs/quickstart.md
@@ -1,0 +1,69 @@
+---
+title: Schedule quickstart
+description: Register Schedule and define a first cron handler.
+navigation.title: Quickstart
+navigation.order: 1
+icon: i-lucide-zap
+frameworks: [vite, nitro]
+---
+
+This guide creates one discovered Schedule Definition.
+
+::steps
+
+### Install Schedule
+
+```bash
+pnpm add @vitehub/schedule
+```
+
+### Register the integration
+
+::fw{id="vite:dev vite:build"}
+```ts [vite.config.ts]
+import { hubSchedule } from '@vitehub/schedule/vite'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    hubSchedule(),
+  ],
+})
+```
+::
+
+::fw{id="nitro:dev nitro:build"}
+```ts [nitro.config.ts]
+export default defineNitroConfig({
+  modules: ['@vitehub/schedule/nitro'],
+})
+```
+::
+
+### Define a schedule
+
+::fw{id="vite:dev vite:build"}
+```ts [src/daily-report.schedule.ts]
+import { defineSchedule } from '@vitehub/schedule'
+
+export default defineSchedule('0 9 * * *', async (context) => {
+  console.log(`Run daily report at ${context.scheduledAt.toISOString()}`)
+})
+```
+::
+
+::fw{id="nitro:dev nitro:build"}
+```ts [server/schedules/daily-report.ts]
+import { defineSchedule } from '@vitehub/schedule'
+
+export default defineSchedule('0 9 * * *', async (context) => {
+  console.log(`Run daily report at ${context.scheduledAt.toISOString()}`)
+})
+```
+::
+
+::
+
+## Verify
+
+The schedule is available through the generated registry. Provider builds can lower discovered static schedules into Cloudflare or Vercel cron output.

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -24,6 +24,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./nitro": "./dist/nitro.js",
+    "./runtime/execute": "./dist/runtime/execute.js",
     "./vite": "./dist/vite.js",
     "./package.json": "./package.json"
   },
@@ -58,5 +59,8 @@
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
+  },
+  "dependencies": {
+    "esbuild": "catalog:"
   }
 }

--- a/packages/schedule/src/index.ts
+++ b/packages/schedule/src/index.ts
@@ -1,6 +1,7 @@
 export { defineSchedule } from "./definition.ts"
 export { discoverScheduleDefinitions } from "./discovery.ts"
 export type {} from "./registry-module.d.ts"
+export { createScheduleRun, executeStaticSchedule } from "./runtime/execute.ts"
 
 export type {
   DiscoveredScheduleDefinition,
@@ -10,3 +11,4 @@ export type {
   ScheduleHandler,
   ScheduleRunContext,
 } from "./types.ts"
+export type { ExecuteStaticScheduleOptions, ScheduleRun } from "./runtime/execute.ts"

--- a/packages/schedule/src/integrations/vercel.ts
+++ b/packages/schedule/src/integrations/vercel.ts
@@ -1,0 +1,3 @@
+export function getVercelSchedulePath(name: string): string {
+  return `/api/vitehub/schedules/vercel/${name.replace(/[^a-z0-9/_-]+/gi, "_")}`
+}

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -1,0 +1,292 @@
+import { readFileSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { defaultCloudflareCompatibilityDate } from "@vitehub/internal/build/cloudflare"
+import { createDefaultCloudflareOutputRoot, createDefaultVercelOutputRoot } from "@vitehub/internal/build/deployment-output"
+import { bundleEsmEntry } from "@vitehub/internal/build/esbuild"
+import { createImportPath, ensureGeneratedDir } from "@vitehub/internal/build/paths"
+import { createNodeFunctionConfig, createVercelConfigJson } from "@vitehub/internal/build/vercel-config"
+import { createRuntimeRegistryContents } from "@vitehub/internal/definition-catalog"
+
+import { discoverScheduleDefinitions } from "../discovery.ts"
+import { getVercelSchedulePath } from "../integrations/vercel.ts"
+
+import type { DiscoveredScheduleDefinition } from "../types.ts"
+
+export const schedulePackageName = "@vitehub/schedule"
+const productName = "schedule"
+const generatedRegistryFileName = "registry.mjs"
+
+export function resolveScheduleRuntimeEntry(metaUrl = import.meta.url) {
+  const file = fileURLToPath(metaUrl)
+  const normalizedFile = file.replace(/\\/g, "/")
+  return normalizedFile.endsWith("/src/internal/provider-output.ts")
+    ? resolve(dirname(file), "../runtime/execute.ts")
+    : resolve(dirname(file), "../runtime/execute.js")
+}
+
+const scheduleRuntimeEntry = resolveScheduleRuntimeEntry()
+
+interface GeneratedScheduleArtifacts {
+  cloudflareWorkerFile: string
+  definitions: DiscoveredScheduleDefinition[]
+  generatedDir: string
+  registryFile: string
+  vercelServerFile: string
+}
+
+interface GenerateProviderOutputsOptions {
+  bundleAlias?: Record<string, string>
+  clientOutDir: string
+  rootDir: string
+}
+
+const cronFieldPattern = /^[*,/\-0-9]+$/
+
+function readStringLiteral(source: string): string | undefined {
+  const quote = source.trim()[0]
+  if (quote !== "\"" && quote !== "'" && quote !== "`") return undefined
+  const trimmed = source.trim()
+  let value = ""
+  for (let index = 1; index < trimmed.length; index++) {
+    const char = trimmed[index]
+    if (char === "\\") {
+      value += trimmed[index + 1] ?? ""
+      index++
+      continue
+    }
+    if (char === quote) {
+      if (trimmed.slice(index + 1).trim()) return undefined
+      if (quote === "`" && value.includes("${")) return undefined
+      return value
+    }
+    value += char
+  }
+}
+
+export function validateProviderCron(cron: string, scheduleName: string): void {
+  const fields = cron.trim().split(/\s+/)
+  const hasVercelDayConflict = fields[2] !== "*" && fields[4] !== "*"
+  if (fields.length !== 5 || !fields.every(field => cronFieldPattern.test(field)) || hasVercelDayConflict) {
+    throw new Error(`Schedule "${scheduleName}" uses cron "${cron}", but provider wake output only supports five-field UTC cron syntax compatible with Cloudflare and Vercel.`)
+  }
+}
+
+function readStaticScheduleCron(file: string, scheduleName: string): string {
+  const source = readFileSync(file, "utf8")
+  const defineScheduleArgument = source.match(/\bexport\s+default\s+defineSchedule\s*\(\s*([^,]+?)\s*,/)?.[1]
+  const cron = (defineScheduleArgument ? readStringLiteral(defineScheduleArgument) : undefined)
+    ?? source.match(/\bexport\s+default\s*\{[\s\S]*?\bcron\s*:\s*(["'`])([^"'`]+)\1/)?.[2]
+  if (!cron) {
+    throw new Error(`Schedule "${scheduleName}" must declare a static cron string for provider wake output.`)
+  }
+  return cron
+}
+
+function renderProviderEntry(file: string, registryFile: string, provider: "cloudflare" | "vercel", scheduleName?: string) {
+  const runtimeImport = createImportPath(file, scheduleRuntimeEntry)
+  return [
+    `import scheduleRegistry from ${JSON.stringify(createImportPath(file, registryFile))}`,
+    `import { executeStaticSchedule } from ${JSON.stringify(runtimeImport)}`,
+    "",
+    "async function loadScheduleDefinition(name) {",
+    "  const loader = scheduleRegistry[name]",
+    "  if (!loader) return undefined",
+    "  const loaded = await loader()",
+    "  return loaded?.default ?? loaded",
+    "}",
+    "",
+    "async function runSchedule(name, cron, scheduledAt) {",
+    "  const definition = await loadScheduleDefinition(name)",
+    "  if (!definition) {",
+    "    throw new Error(`Missing schedule definition: ${name}`)",
+    "  }",
+    "  return await executeStaticSchedule({ cron, definition, name, scheduledAt })",
+    "}",
+    "",
+    provider === "cloudflare"
+      ? [
+          "export default {",
+          "  async fetch() {",
+          "    return new Response('ViteHub schedule provider wake endpoint')",
+          "  },",
+          "  async scheduled(event, env, ctx) {",
+          "    const tasks = Object.entries(scheduleRegistry).map(async ([name]) => {",
+          "      const definition = await loadScheduleDefinition(name)",
+          "      if (!definition || definition.cron !== event.cron) return",
+          "      await executeStaticSchedule({ cron: event.cron, definition, name, scheduledAt: new Date(event.scheduledTime) })",
+          "    })",
+          "    await Promise.all(tasks)",
+          "  },",
+          "}",
+        ].join("\n")
+      : [
+          "export default async function scheduleHandler(req, res) {",
+          "  const cronSecret = process.env.CRON_SECRET",
+          "  const authorization = req.headers?.authorization || req.headers?.Authorization",
+          "  if (cronSecret && authorization !== `Bearer ${cronSecret}`) {",
+          "    res.statusCode = 401",
+          "    res.end('Unauthorized.')",
+          "    return",
+          "  }",
+          "  const url = new URL(req.url || '/', 'https://vitehub.local')",
+          "  const prefix = '/api/vitehub/schedules/vercel/'",
+          scheduleName === undefined
+            ? "  const name = decodeURIComponent(url.pathname.startsWith(prefix) ? url.pathname.slice(prefix.length) : '')"
+            : `  const name = ${JSON.stringify(scheduleName)}`,
+          "  const definition = await loadScheduleDefinition(name)",
+          "  if (!definition) {",
+          "    res.statusCode = 404",
+          "    res.end('Missing schedule definition.')",
+          "    return",
+          "  }",
+          "  await runSchedule(name, definition.cron, new Date())",
+          "  res.statusCode = 204",
+          "  res.end()",
+          "}",
+        ].join("\n"),
+    "",
+  ].join("\n")
+}
+
+async function writeProviderEntries(rootDir: string): Promise<GeneratedScheduleArtifacts> {
+  const generatedDir = ensureGeneratedDir(rootDir, productName)
+  await mkdir(generatedDir, { recursive: true })
+
+  const registryFile = resolve(generatedDir, generatedRegistryFileName)
+  const definitions = discoverScheduleDefinitions({ rootDir })
+  await writeFile(registryFile, createRuntimeRegistryContents(registryFile, definitions), "utf8")
+
+  const cloudflareWorkerFile = resolve(generatedDir, "cloudflare-worker.mjs")
+  const vercelServerFile = resolve(generatedDir, "vercel-server.mjs")
+  await writeFile(cloudflareWorkerFile, renderProviderEntry(cloudflareWorkerFile, registryFile, "cloudflare"), "utf8")
+  await writeFile(vercelServerFile, renderProviderEntry(vercelServerFile, registryFile, "vercel"), "utf8")
+
+  return { cloudflareWorkerFile, definitions, generatedDir, registryFile, vercelServerFile }
+}
+
+export async function readDefinitionCrons(definitions: DiscoveredScheduleDefinition[]) {
+  const crons = new Map<string, string>()
+  for (const definition of definitions) {
+    const cron = readStaticScheduleCron(definition.handler, definition.name)
+    validateProviderCron(cron, definition.name)
+    crons.set(definition.name, cron)
+  }
+  return crons
+}
+
+export async function writeVercelScheduleFunctions(options: {
+  bundleAlias?: Record<string, string>
+  definitions: DiscoveredScheduleDefinition[]
+  outputRoot: string
+  registryFile: string
+  rootDir: string
+}, crons: Map<string, string>) {
+  const outputRoot = options.outputRoot
+  const functionRoot = resolve(outputRoot, "functions", "api", "vitehub", "schedules", "vercel")
+  await rm(functionRoot, { force: true, recursive: true })
+
+  const emittedFunctionNames = new Map<string, string>()
+  for (const definition of options.definitions) {
+    const safeName = definition.name.replace(/[^a-z0-9/_-]+/gi, "_").split("/").filter(Boolean).join("/")
+    const existingName = emittedFunctionNames.get(safeName)
+    if (existingName) {
+      throw new Error(`Schedule "${definition.name}" and "${existingName}" both emit the same Vercel function path: ${safeName}`)
+    }
+    emittedFunctionNames.set(safeName, definition.name)
+
+    const segments = safeName.split("/")
+    const functionDir = resolve(functionRoot, ...segments.slice(0, -1), `${segments.at(-1)}.func`)
+    const functionFile = resolve(functionDir, "index.mjs")
+    const wrapperFile = resolve(functionDir, "index.source.mjs")
+    await mkdir(functionDir, { recursive: true })
+    await writeFile(wrapperFile, renderProviderEntry(wrapperFile, options.registryFile, "vercel", definition.name), "utf8")
+    await bundleEsmEntry(wrapperFile, functionFile, { alias: options.bundleAlias, format: "esm", platform: "node" })
+    await rm(wrapperFile, { force: true })
+    await writeFile(resolve(functionDir, ".vc-config.json"), `${JSON.stringify(createNodeFunctionConfig(), null, 2)}\n`, "utf8")
+  }
+
+  const configFile = resolve(outputRoot, "config.json")
+  let vercelConfig = createVercelConfigJson() as ReturnType<typeof createVercelConfigJson> & { crons?: Array<{ path: string, schedule: string }> }
+  try {
+    vercelConfig = JSON.parse(await readFile(configFile, "utf8"))
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+  const schedulePathPrefix = "/api/vitehub/schedules/vercel/"
+  const existingCrons = vercelConfig.crons?.filter(cron => !cron.path.startsWith(schedulePathPrefix)) ?? []
+  vercelConfig.crons = [...existingCrons, ...options.definitions.map(definition => ({
+    path: getVercelSchedulePath(definition.name),
+    schedule: crons.get(definition.name)!,
+  }))]
+  await writeFile(configFile, `${JSON.stringify(vercelConfig, null, 2)}\n`, "utf8")
+}
+
+async function writeCloudflareScheduleOutput(options: {
+  bundleAlias?: Record<string, string>
+  bundleEntry: string
+  crons: string[]
+  rootDir: string
+}) {
+  const outputRoot = createDefaultCloudflareOutputRoot(options.rootDir)
+  await mkdir(outputRoot, { recursive: true })
+
+  const configFile = resolve(outputRoot, "wrangler.json")
+  let wranglerConfig: Record<string, unknown> = {}
+  try {
+    wranglerConfig = JSON.parse(await readFile(configFile, "utf8"))
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+
+  const existingTriggers = typeof wranglerConfig.triggers === "object" && wranglerConfig.triggers !== null
+    ? wranglerConfig.triggers as { crons?: string[] }
+    : {}
+  const main = typeof wranglerConfig.main === "string" && wranglerConfig.main
+    ? wranglerConfig.main
+    : "index.js"
+  wranglerConfig = {
+    ...wranglerConfig,
+    compatibility_date: wranglerConfig.compatibility_date ?? defaultCloudflareCompatibilityDate,
+    compatibility_flags: wranglerConfig.compatibility_flags ?? ["nodejs_compat"],
+    main,
+    observability: wranglerConfig.observability ?? { enabled: true },
+    triggers: {
+      ...existingTriggers,
+      crons: [...new Set([...(existingTriggers.crons ?? []), ...options.crons])],
+    },
+  }
+
+  await Promise.all([
+    bundleEsmEntry(options.bundleEntry, resolve(outputRoot, main), {
+      alias: options.bundleAlias,
+      conditions: ["workerd", "worker", "browser", "default"],
+      format: "esm",
+      platform: "neutral",
+    }),
+    writeFile(configFile, `${JSON.stringify(wranglerConfig, null, 2)}\n`, "utf8"),
+  ])
+}
+
+export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedScheduleArtifacts> {
+  const artifacts = await writeProviderEntries(options.rootDir)
+  const crons = await readDefinitionCrons(artifacts.definitions)
+  await writeCloudflareScheduleOutput({
+    bundleAlias: options.bundleAlias,
+    bundleEntry: artifacts.cloudflareWorkerFile,
+    crons: [...new Set(crons.values())],
+    rootDir: options.rootDir,
+  })
+  await writeVercelScheduleFunctions({
+    bundleAlias: options.bundleAlias,
+    definitions: artifacts.definitions,
+    outputRoot: createDefaultVercelOutputRoot(options.rootDir),
+    registryFile: artifacts.registryFile,
+    rootDir: options.rootDir,
+  }, crons)
+  return artifacts
+}

--- a/packages/schedule/src/nitro/module.ts
+++ b/packages/schedule/src/nitro/module.ts
@@ -1,9 +1,11 @@
 import { resolve } from "node:path"
 
-import { applyNitroRuntimeAliases, createNitroRuntimeFilePath, createRuntimeRegistryContents, hookNitroRuntimeRegistryRefresh, writeFileIfChanged } from "@vitehub/internal/definition-catalog"
+import { createImportPath } from "@vitehub/internal/build/paths"
+import { applyNitroRuntimeAliases, createNitroRuntimeFilePath, hookNitroRuntimeRegistryRefresh, writeRuntimeRegistryFiles } from "@vitehub/internal/definition-catalog"
 import { assertNoVitePluginInNitro, mergeNitroImportsPreset, resolveRuntimeEntry as resolveEntry } from "@vitehub/internal/nitro"
 
 import { discoverScheduleDefinitions } from "../discovery.ts"
+import { readDefinitionCrons, writeVercelScheduleFunctions } from "../internal/provider-output.ts"
 
 import type { Nitro, NitroModule } from "nitro/types"
 
@@ -22,20 +24,66 @@ function createNitroScheduleRegistryPath(rootDir: string, buildDir: string) {
   })
 }
 
+function createNitroSchedulePluginPath(rootDir: string, buildDir: string) {
+  return createNitroRuntimeFilePath(rootDir, {
+    buildDir,
+    fileName: "nitro-plugin.ts",
+    segments: ["vitehub", "schedule"],
+  })
+}
+
 function resolveNitroScheduleScanDirs(rootDir: string, scanDirs: string[] | undefined) {
   return scanDirs?.length ? scanDirs : [resolve(rootDir, "server")]
 }
 
-async function writeNitroScheduleRuntimeFiles(nitro: Nitro): Promise<string> {
+function registerNitroSchedulePlugin(nitro: Nitro, pluginFile: string) {
+  nitro.options.plugins ||= []
+  if (!nitro.options.plugins.includes(pluginFile)) {
+    nitro.options.plugins.push(pluginFile)
+  }
+}
+
+function createNitroSchedulePluginContents(file: string, registryFile: string) {
+  return [
+    "import { definePlugin as defineNitroPlugin } from \"nitro\"",
+    "import { executeStaticSchedule } from \"@vitehub/schedule\"",
+    "",
+    `import scheduleRegistry from ${JSON.stringify(createImportPath(file, registryFile))}`,
+    "",
+    "async function loadScheduleDefinition(name: string) {",
+    "  const loader = scheduleRegistry[name]",
+    "  if (!loader) return undefined",
+    "  const loaded = await loader()",
+    "  return loaded?.default ?? loaded",
+    "}",
+    "",
+    "export default defineNitroPlugin((nitroApp: any) => {",
+    "  nitroApp.hooks.hook(\"cloudflare:scheduled\", async ({ event }: { event: { cron: string, scheduledTime: number } }) => {",
+    "    await Promise.all(Object.keys(scheduleRegistry).map(async (name) => {",
+    "      const definition = await loadScheduleDefinition(name)",
+    "      if (!definition || definition.cron !== event.cron) return",
+    "      await executeStaticSchedule({ cron: event.cron, definition, name, scheduledAt: new Date(event.scheduledTime) })",
+    "    }))",
+    "  })",
+    "})",
+    "",
+  ].join("\n")
+}
+
+async function writeNitroScheduleRuntimeFiles(nitro: Nitro) {
   const registryFile = createNitroScheduleRegistryPath(nitro.options.rootDir, nitro.options.buildDir)
+  const pluginFile = createNitroSchedulePluginPath(nitro.options.rootDir, nitro.options.buildDir)
   const definitions = discoverScheduleDefinitions({
     mode: "nitro-server-schedules",
     scanDirs: resolveNitroScheduleScanDirs(nitro.options.rootDir, nitro.options.scanDirs),
   })
 
-  await writeFileIfChanged(registryFile, createRuntimeRegistryContents(registryFile, definitions))
-
-  return registryFile
+  return await writeRuntimeRegistryFiles({
+    createPluginContents: createNitroSchedulePluginContents,
+    definitions,
+    pluginFile,
+    registryFile,
+  })
 }
 
 const scheduleNitroModule: NitroModule = {
@@ -46,19 +94,67 @@ const scheduleNitroModule: NitroModule = {
     nitro.options.alias ||= {}
     nitro.options.alias["@vitehub/schedule"] = resolveRuntimeEntry("../index", "@vitehub/schedule")
 
-    let registryFile = await writeNitroScheduleRuntimeFiles(nitro)
-    applyNitroRuntimeAliases(nitro, { "#vitehub/schedule/registry": registryFile })
+    let runtimeFiles = await writeNitroScheduleRuntimeFiles(nitro)
+    applyNitroRuntimeAliases(nitro, { "#vitehub/schedule/registry": runtimeFiles.registryFile })
 
     const importsExplicitlyDisabled = nitro.options._config?.imports === false
     if (!importsExplicitlyDisabled) {
       nitro.options.imports = mergeNitroImportsPreset(nitro.options.imports === false ? {} : nitro.options.imports, SCHEDULE_NITRO_IMPORTS_PRESET) as typeof nitro.options.imports
     }
 
-    hookNitroRuntimeRegistryRefresh(nitro, () => writeNitroScheduleRuntimeFiles(nitro), (nextRegistryFile) => {
-      registryFile = nextRegistryFile
-      applyNitroRuntimeAliases(nitro, { "#vitehub/schedule/registry": registryFile })
+    if (runtimeFiles.definitions.length) {
+      registerNitroSchedulePlugin(nitro, runtimeFiles.pluginFile)
+    }
+
+    if (nitro.options.preset?.includes("cloudflare")) {
+      const crons = await readDefinitionCrons(runtimeFiles.definitions)
+      if (crons.size) {
+        nitro.options.cloudflare ||= {}
+        nitro.options.cloudflare.wrangler ||= {}
+        nitro.options.cloudflare.wrangler.triggers ||= { crons: [] }
+        const existing = nitro.options.cloudflare.wrangler.triggers.crons || []
+        nitro.options.cloudflare.wrangler.triggers.crons = [...new Set([...existing, ...crons.values()])]
+      }
+    }
+
+    hookNitroRuntimeRegistryRefresh(nitro, () => writeNitroScheduleRuntimeFiles(nitro), (nextRuntimeFiles) => {
+      runtimeFiles = nextRuntimeFiles
+      applyNitroRuntimeAliases(nitro, { "#vitehub/schedule/registry": runtimeFiles.registryFile })
+      if (runtimeFiles.definitions.length) {
+        registerNitroSchedulePlugin(nitro, runtimeFiles.pluginFile)
+      }
+    })
+
+    nitro.hooks.hook("compiled", async (currentNitro: Nitro) => {
+      if (!currentNitro.options.preset?.includes("vercel")) {
+        return
+      }
+      const definitions = discoverScheduleDefinitions({
+        mode: "nitro-server-schedules",
+        scanDirs: resolveNitroScheduleScanDirs(currentNitro.options.rootDir, currentNitro.options.scanDirs),
+      })
+      const crons = await readDefinitionCrons(definitions)
+      await writeVercelScheduleFunctions({
+        bundleAlias: currentNitro.options.alias,
+        definitions,
+        outputRoot: currentNitro.options.output.dir,
+        registryFile: runtimeFiles.registryFile,
+        rootDir: currentNitro.options.rootDir,
+      }, crons)
     })
   },
 }
 
 export default scheduleNitroModule
+
+declare module "nitro/types" {
+  interface NitroOptions {
+    cloudflare?: {
+      wrangler?: {
+        triggers?: {
+          crons?: string[]
+        }
+      }
+    }
+  }
+}

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -1,0 +1,28 @@
+import type { ScheduleDefinition, ScheduleRunContext } from "../types.ts"
+
+export interface ExecuteStaticScheduleOptions {
+  cron: string
+  definition: ScheduleDefinition
+  name: string
+  scheduledAt?: Date
+}
+
+export interface ScheduleRun extends ScheduleRunContext {
+  cron: string
+  scheduleId: string
+}
+
+export function createScheduleRun(options: Omit<ExecuteStaticScheduleOptions, "definition">): ScheduleRun {
+  const scheduledAt = options.scheduledAt ?? new Date()
+  return {
+    cron: options.cron,
+    id: `run_${options.name}_${scheduledAt.toISOString()}`,
+    scheduleId: options.name,
+    scheduledAt,
+  }
+}
+
+export async function executeStaticSchedule(options: ExecuteStaticScheduleOptions): Promise<unknown> {
+  const run = createScheduleRun(options)
+  return await options.definition.handler(run)
+}

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -1,14 +1,16 @@
 import { normalize, resolve } from "node:path"
 
-import { createRuntimeRegistryContents } from "@vitehub/internal/definition-catalog"
+import { shouldSkipViteProviderBuild } from "@vitehub/internal/build/deployment-output"
+import { getViteMode } from "@vitehub/internal/build/mode"
 import { createNoExternalMerger, isServerEnvironment } from "@vitehub/internal/build/vite"
+import { createRuntimeRegistryContents } from "@vitehub/internal/definition-catalog"
 
 import { discoverScheduleDefinitions } from "./discovery.ts"
+import { generateProviderOutputs, schedulePackageName } from "./internal/provider-output.ts"
 import scheduleNitroModule from "./nitro/module.ts"
 
 import type { Plugin, ResolvedConfig } from "vite"
 
-const schedulePackageName = "@vitehub/schedule"
 const SCHEDULE_VITE_PLUGIN_NAME = "@vitehub/schedule/vite"
 const SCHEDULE_REGISTRY_ID = "#vitehub/schedule/registry"
 const RESOLVED_SCHEDULE_REGISTRY_ID = "\0#vitehub/schedule/registry"
@@ -16,6 +18,16 @@ const registryImportAnchor = ".vitehub/schedule/registry.js"
 const mergeNoExternal = createNoExternalMerger(schedulePackageName)
 
 export type ScheduleVitePlugin = Plugin & { nitro: unknown }
+
+function resolveStringAliases(config: ResolvedConfig): Record<string, string> {
+  const aliases: Record<string, string> = {}
+  for (const alias of config.resolve.alias) {
+    if (typeof alias.find === "string" && typeof alias.replacement === "string") {
+      aliases[alias.find] = alias.replacement
+    }
+  }
+  return aliases
+}
 
 export function hubSchedule(): ScheduleVitePlugin {
   let resolved: ResolvedConfig | undefined
@@ -66,6 +78,16 @@ export function hubSchedule(): ScheduleVitePlugin {
       if (id === RESOLVED_SCHEDULE_REGISTRY_ID) {
         return createRegistryContents()
       }
+    },
+    async closeBundle() {
+      if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) {
+        return
+      }
+      await generateProviderOutputs({
+        bundleAlias: resolveStringAliases(resolved),
+        clientOutDir: resolved.build.outDir,
+        rootDir: resolved.root,
+      })
     },
   }
 }

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -1,0 +1,344 @@
+import { existsSync } from "node:fs"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterAll, describe, expect, it } from "vitest"
+import { createDefaultCloudflareOutputRoot } from "@vitehub/internal/build/deployment-output"
+
+import { generateProviderOutputs, resolveScheduleRuntimeEntry, validateProviderCron, writeVercelScheduleFunctions } from "../src/internal/provider-output.ts"
+
+const tempDirs: string[] = []
+
+async function createTempProject(prefix: string) {
+  const rootDir = await mkdtemp(join(tmpdir(), prefix))
+  tempDirs.push(rootDir)
+  await mkdir(join(rootDir, "src"), { recursive: true })
+  await mkdir(join(rootDir, "dist", "client"), { recursive: true })
+  await writeFile(join(rootDir, "src", "cleanup.schedule.ts"), [
+    "export default { cron: '0 0 * * *', handler: () => 'ok' }",
+    "",
+  ].join("\n"), "utf8")
+  return rootDir
+}
+
+afterAll(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
+})
+
+describe("schedule provider output", () => {
+  it("emits Cloudflare and Vercel schedule provider wake output", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-output-")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    const cloudflareRoot = createDefaultCloudflareOutputRoot(rootDir)
+    const cloudflareWorker = join(cloudflareRoot, "index.js")
+    const cloudflareConfig = join(cloudflareRoot, "wrangler.json")
+    const vercelConfig = join(rootDir, ".vercel", "output", "config.json")
+    const vercelFunction = join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "schedules", "vercel", "cleanup.func", "index.mjs")
+
+    expect(existsSync(cloudflareWorker)).toBe(true)
+    expect(JSON.parse(await readFile(cloudflareConfig, "utf8")).triggers.crons).toEqual(["0 0 * * *"])
+    expect(JSON.parse(await readFile(vercelConfig, "utf8")).crons).toEqual([{
+      path: "/api/vitehub/schedules/vercel/cleanup",
+      schedule: "0 0 * * *",
+    }])
+    expect(await readFile(vercelFunction, "utf8")).toContain("executeStaticSchedule")
+  })
+
+  it("preserves existing provider output files when adding schedule output", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-output-preserve-")
+    const cloudflareRoot = createDefaultCloudflareOutputRoot(rootDir)
+    const vercelRoot = join(rootDir, ".vercel", "output")
+    await mkdir(cloudflareRoot, { recursive: true })
+    await mkdir(vercelRoot, { recursive: true })
+    await writeFile(join(cloudflareRoot, "existing.txt"), "keep\n", "utf8")
+    await writeFile(join(vercelRoot, "existing.txt"), "keep\n", "utf8")
+    await writeFile(join(cloudflareRoot, "wrangler.json"), JSON.stringify({
+      main: "index.js",
+      triggers: { crons: ["0 1 * * *"] },
+    }), "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    await expect(readFile(join(cloudflareRoot, "existing.txt"), "utf8")).resolves.toBe("keep\n")
+    await expect(readFile(join(vercelRoot, "existing.txt"), "utf8")).resolves.toBe("keep\n")
+    expect(JSON.parse(await readFile(join(cloudflareRoot, "wrangler.json"), "utf8")).triggers.crons).toEqual(["0 1 * * *", "0 0 * * *"])
+  })
+
+  it("reports provider cron syntax limitations before output generation", () => {
+    expect(() => validateProviderCron("0 0 1 1 * 2026", "cleanup")).toThrow(/provider wake output only supports five-field UTC cron syntax/)
+    expect(() => validateProviderCron("0 0 * JAN *", "cleanup")).toThrow(/provider wake output only supports five-field UTC cron syntax/)
+    expect(() => validateProviderCron("0 0 1 * 1", "cleanup")).toThrow(/provider wake output only supports five-field UTC cron syntax/)
+  })
+
+  it("resolves the runtime execute entry from package source and dist layouts", () => {
+    expect(resolveScheduleRuntimeEntry("file:///repo/packages/schedule/src/internal/provider-output.ts")).toBe("/repo/packages/schedule/src/runtime/execute.ts")
+    expect(resolveScheduleRuntimeEntry("file:///C:/repo/packages/schedule/src/internal/provider-output.ts")).toBe("/C:/repo/packages/schedule/src/runtime/execute.ts")
+    expect(resolveScheduleRuntimeEntry("file:///repo/packages/schedule/dist/internal/provider-output.js")).toBe("/repo/packages/schedule/dist/runtime/execute.js")
+    expect(resolveScheduleRuntimeEntry("file:///home/user/src/app/node_modules/@vitehub/schedule/dist/internal/provider-output.js")).toBe("/home/user/src/app/node_modules/@vitehub/schedule/dist/runtime/execute.js")
+  })
+
+  it("writes Cloudflare schedule output to an existing Wrangler main", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-output-custom-main-")
+    const cloudflareRoot = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(cloudflareRoot, { recursive: true })
+    await writeFile(join(cloudflareRoot, "wrangler.json"), JSON.stringify({
+      main: "worker.js",
+    }), "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    expect(existsSync(join(cloudflareRoot, "worker.js"))).toBe(true)
+    expect(existsSync(join(cloudflareRoot, "index.js"))).toBe(false)
+    expect(JSON.parse(await readFile(join(cloudflareRoot, "wrangler.json"), "utf8")).main).toBe("worker.js")
+  })
+
+  it("rejects dynamic cron expressions before provider output generation", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-output-dynamic-cron-")
+    await writeFile(join(rootDir, "src", "cleanup.schedule.ts"), [
+      "const suffix = '0'",
+      "export default defineSchedule('0 0 * * *' + suffix, () => 'ok')",
+      "",
+    ].join("\n"), "utf8")
+
+    await expect(generateProviderOutputs({
+      clientOutDir: "dist/client",
+      rootDir,
+    })).rejects.toThrow(/must declare a static cron string/)
+  })
+
+  it("ignores commented defineSchedule examples when reading static provider cron", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-output-commented-cron-")
+    await writeFile(join(rootDir, "src", "cleanup.schedule.ts"), [
+      "// defineSchedule('0 1 * * *', () => 'docs')",
+      "export default defineSchedule('0 2 * * *', () => 'ok')",
+      "",
+    ].join("\n"), "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    const cloudflareConfig = join(createDefaultCloudflareOutputRoot(rootDir), "wrangler.json")
+    expect(JSON.parse(await readFile(cloudflareConfig, "utf8")).triggers.crons).toEqual(["0 2 * * *"])
+  })
+
+  it("preserves existing Vercel output config when adding schedule crons", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-vercel-config-")
+    const outputRoot = join(rootDir, ".vercel", "output")
+    await mkdir(outputRoot, { recursive: true })
+    await writeFile(join(outputRoot, "config.json"), JSON.stringify({
+      routes: [{ src: "/api/(.*)", dest: "/api/index.func" }],
+      version: 3,
+    }), "utf8")
+    const registryFile = join(rootDir, ".vitehub", "schedule", "registry.mjs")
+    await mkdir(join(rootDir, ".vitehub", "schedule"), { recursive: true })
+    await writeFile(registryFile, "export default {}\n", "utf8")
+
+    await writeVercelScheduleFunctions({
+      definitions: [{
+        handler: join(rootDir, "src", "cleanup.schedule.ts"),
+        name: "cleanup",
+      }],
+      outputRoot,
+      registryFile,
+      rootDir,
+    }, new Map([["cleanup", "0 0 * * *"]]))
+
+    expect(JSON.parse(await readFile(join(outputRoot, "config.json"), "utf8"))).toMatchObject({
+      crons: [{ path: "/api/vitehub/schedules/vercel/cleanup", schedule: "0 0 * * *" }],
+      routes: [{ src: "/api/(.*)", dest: "/api/index.func" }],
+      version: 3,
+    })
+  })
+
+  it("removes stale generated Vercel schedule crons when rewriting config", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-vercel-stale-crons-")
+    const outputRoot = join(rootDir, ".vercel", "output")
+    await mkdir(outputRoot, { recursive: true })
+    await writeFile(join(outputRoot, "config.json"), JSON.stringify({
+      crons: [
+        { path: "/api/user-cron", schedule: "0 1 * * *" },
+        { path: "/api/vitehub/schedules/vercel/old-cleanup", schedule: "0 2 * * *" },
+      ],
+      version: 3,
+    }), "utf8")
+    const registryFile = join(rootDir, ".vitehub", "schedule", "registry.mjs")
+    await mkdir(join(rootDir, ".vitehub", "schedule"), { recursive: true })
+    await writeFile(registryFile, "export default {}\n", "utf8")
+
+    await writeVercelScheduleFunctions({
+      definitions: [{
+        handler: join(rootDir, "src", "cleanup.schedule.ts"),
+        name: "cleanup",
+      }],
+      outputRoot,
+      registryFile,
+      rootDir,
+    }, new Map([["cleanup", "0 0 * * *"]]))
+
+    expect(JSON.parse(await readFile(join(outputRoot, "config.json"), "utf8")).crons).toEqual([
+      { path: "/api/user-cron", schedule: "0 1 * * *" },
+      { path: "/api/vitehub/schedules/vercel/cleanup", schedule: "0 0 * * *" },
+    ])
+  })
+
+  it("uses Nitro aliases when bundling Vercel schedule functions", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-vercel-alias-")
+    const aliasFile = join(rootDir, "nitro-imports.mjs")
+    const outputRoot = join(rootDir, ".vercel", "output")
+    const registryFile = join(rootDir, ".vitehub", "schedule", "registry.mjs")
+    await mkdir(join(rootDir, ".vitehub", "schedule"), { recursive: true })
+    await writeFile(aliasFile, "export const marker = 'nitro-alias-marker'\n", "utf8")
+    await writeFile(join(rootDir, "src", "cleanup.schedule.ts"), [
+      "import { marker } from '#imports'",
+      "export default { cron: '0 0 * * *', handler: () => marker }",
+      "",
+    ].join("\n"), "utf8")
+    await writeFile(registryFile, [
+      "const registry = {",
+      `  cleanup: async () => import(${JSON.stringify(join(rootDir, "src", "cleanup.schedule.ts"))}),`,
+      "}",
+      "export default registry",
+      "",
+    ].join("\n"), "utf8")
+
+    await writeVercelScheduleFunctions({
+      bundleAlias: { "#imports": aliasFile },
+      definitions: [{
+        handler: join(rootDir, "src", "cleanup.schedule.ts"),
+        name: "cleanup",
+      }],
+      outputRoot,
+      registryFile,
+      rootDir,
+    }, new Map([["cleanup", "0 0 * * *"]]))
+
+    await expect(readFile(join(outputRoot, "functions", "api", "vitehub", "schedules", "vercel", "cleanup.func", "index.mjs"), "utf8")).resolves.toContain("nitro-alias-marker")
+  })
+
+  it("uses Vite aliases when bundling provider output", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-output-vite-alias-")
+    const aliasFile = join(rootDir, "schedule-helper.mjs")
+    await writeFile(aliasFile, "export const marker = 'vite-alias-marker'\n", "utf8")
+    await writeFile(join(rootDir, "src", "cleanup.schedule.ts"), [
+      "import { marker } from '#schedule-helper'",
+      "export default { cron: '0 0 * * *', handler: () => marker }",
+      "",
+    ].join("\n"), "utf8")
+
+    await generateProviderOutputs({
+      bundleAlias: { "#schedule-helper": aliasFile },
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    await expect(readFile(join(createDefaultCloudflareOutputRoot(rootDir), "index.js"), "utf8")).resolves.toContain("vite-alias-marker")
+    await expect(readFile(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "schedules", "vercel", "cleanup.func", "index.mjs"), "utf8")).resolves.toContain("vite-alias-marker")
+  })
+
+  it("rejects sanitized Vercel function path collisions", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-vercel-collision-")
+    const registryFile = join(rootDir, ".vitehub", "schedule", "registry.mjs")
+    await mkdir(join(rootDir, ".vitehub", "schedule"), { recursive: true })
+    await writeFile(registryFile, "export default {}\n", "utf8")
+
+    await expect(writeVercelScheduleFunctions({
+      definitions: [
+        { handler: join(rootDir, "src", "cleanup.schedule.ts"), name: "daily?report" },
+        { handler: join(rootDir, "src", "cleanup.schedule.ts"), name: "daily:report" },
+      ],
+      outputRoot: join(rootDir, ".vercel", "output"),
+      registryFile,
+      rootDir,
+    }, new Map([
+      ["daily?report", "0 0 * * *"],
+      ["daily:report", "0 0 * * *"],
+    ]))).rejects.toThrow(/same Vercel function path/)
+  })
+
+  it("rejects normalized Vercel function path collisions", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-vercel-normalized-collision-")
+    const registryFile = join(rootDir, ".vitehub", "schedule", "registry.mjs")
+    await mkdir(join(rootDir, ".vitehub", "schedule"), { recursive: true })
+    await writeFile(registryFile, "export default {}\n", "utf8")
+
+    await expect(writeVercelScheduleFunctions({
+      definitions: [
+        { handler: join(rootDir, "src", "cleanup.schedule.ts"), name: "reports/daily" },
+        { handler: join(rootDir, "src", "cleanup.schedule.ts"), name: "reports//daily" },
+      ],
+      outputRoot: join(rootDir, ".vercel", "output"),
+      registryFile,
+      rootDir,
+    }, new Map([
+      ["reports/daily", "0 0 * * *"],
+      ["reports//daily", "0 0 * * *"],
+    ]))).rejects.toThrow(/same Vercel function path/)
+  })
+
+  it("emits Vercel handlers that load nested schedule names from the full path", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-vercel-nested-")
+    await mkdir(join(rootDir, ".vitehub", "schedule"), { recursive: true })
+    const registryFile = join(rootDir, ".vitehub", "schedule", "registry.mjs")
+    await writeFile(registryFile, "export default {}\n", "utf8")
+
+    await writeVercelScheduleFunctions({
+      definitions: [{ handler: join(rootDir, "src", "cleanup.schedule.ts"), name: "reports/daily" }],
+      outputRoot: join(rootDir, ".vercel", "output"),
+      registryFile,
+      rootDir,
+    }, new Map([["reports/daily", "0 0 * * *"]]))
+
+    const source = await readFile(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "schedules", "vercel", "reports", "daily.func", "index.mjs"), "utf8")
+    expect(source).toContain("const name = \"reports/daily\"")
+  })
+
+  it("emits Vercel handlers that require the cron secret when configured", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-vercel-auth-")
+    await mkdir(join(rootDir, ".vitehub", "schedule"), { recursive: true })
+    const registryFile = join(rootDir, ".vitehub", "schedule", "registry.mjs")
+    await writeFile(registryFile, "export default {}\n", "utf8")
+
+    await writeVercelScheduleFunctions({
+      definitions: [{ handler: join(rootDir, "src", "cleanup.schedule.ts"), name: "cleanup" }],
+      outputRoot: join(rootDir, ".vercel", "output"),
+      registryFile,
+      rootDir,
+    }, new Map([["cleanup", "0 0 * * *"]]))
+
+    const source = await readFile(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "schedules", "vercel", "cleanup.func", "index.mjs"), "utf8")
+    expect(source).toContain("process.env.CRON_SECRET")
+    expect(source).toContain("authorization !== `Bearer ${cronSecret}`")
+    expect(source).toContain("res.statusCode = 401")
+  })
+
+  it("emits Vercel handlers that load unsanitized schedule names", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-vercel-unsanitized-")
+    await mkdir(join(rootDir, ".vitehub", "schedule"), { recursive: true })
+    const registryFile = join(rootDir, ".vitehub", "schedule", "registry.mjs")
+    await writeFile(registryFile, "export default {}\n", "utf8")
+
+    await writeVercelScheduleFunctions({
+      definitions: [{ handler: join(rootDir, "src", "cleanup.schedule.ts"), name: "billing:daily" }],
+      outputRoot: join(rootDir, ".vercel", "output"),
+      registryFile,
+      rootDir,
+    }, new Map([["billing:daily", "0 0 * * *"]]))
+
+    const source = await readFile(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "schedules", "vercel", "billing_daily.func", "index.mjs"), "utf8")
+    expect(source).toContain("const name = \"billing:daily\"")
+  })
+})

--- a/packages/schedule/tsdown.config.ts
+++ b/packages/schedule/tsdown.config.ts
@@ -7,12 +7,14 @@ export default defineConfig({
   ],
   deps: {
     alwaysBundle: [/^@vitehub\/internal/],
+    neverBundle: ["esbuild"],
     onlyBundle: false,
   },
   dts: true,
   entry: [
     "src/index.ts",
     "src/nitro.ts",
+    "src/runtime/execute.ts",
     "src/vite.ts",
   ],
   exports: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -869,6 +869,10 @@ importers:
         version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/schedule:
+    dependencies:
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.28.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -878,7 +882,7 @@ importers:
         version: link:../internal
       nitro:
         specifier: 'catalog:'
-        version: 3.0.260311-beta(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@libsql/client@0.15.15)(@netlify/blobs@10.7.5)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(miniflare@4.20260415.0)(rollup@4.60.1)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.2.2))(vite@8.0.8)
+        version: 3.0.260311-beta(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@libsql/client@0.15.15)(@netlify/blobs@10.7.5)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(miniflare@4.20260415.0)(rollup@4.60.1)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.2.2))(vite@8.0.8)
       publint:
         specifier: ^0.3.15
         version: 0.3.21
@@ -890,10 +894,31 @@ importers:
         version: 6.0.2
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.8)
+
+  packages/schedule/examples/nitro:
+    dependencies:
+      '@vitehub/schedule':
+        specifier: workspace:*
+        version: link:../..
+      nitro:
+        specifier: 'catalog:'
+        version: 3.0.260311-beta(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@libsql/client@0.15.15)(@netlify/blobs@10.7.5)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.3.5)(miniflare@4.20260415.0)(rollup@4.60.1)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.2.2))(vite@8.0.8)
+
+  packages/schedule/examples/vite:
+    dependencies:
+      '@vitehub/schedule':
+        specifier: workspace:*
+        version: link:../..
+      h3:
+        specifier: 'catalog:'
+        version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/shell:
     dependencies:
@@ -17914,7 +17939,7 @@ snapshots:
       devframe: 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(crossws@0.4.5(srvx@0.11.15))(typescript@6.0.2)
       diff: 9.0.0
       get-port-please: 3.2.0
-      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15))
+      h3: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       mlly: 1.8.2
       mrmime: 2.0.1
       nostics: 0.2.0
@@ -18060,7 +18085,7 @@ snapshots:
       birpc: 4.0.0
       cac: 7.0.0
       devframe: 0.4.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.1))(crossws@0.4.5(srvx@0.11.15))(typescript@6.0.2)
-      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15))
+      h3: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       mlly: 1.8.2
       nostics: 0.2.0
       obug: 2.1.1
@@ -19613,7 +19638,7 @@ snapshots:
       '@valibot/to-json-schema': 1.7.0(valibot@1.4.0(typescript@6.0.2))
       birpc: 4.0.0
       cac: 7.0.0
-      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15))
+      h3: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
       mrmime: 2.0.1
       nostics: 0.2.0
       pathe: 2.0.3
@@ -22355,7 +22380,7 @@ snapshots:
       crossws: 0.4.5(srvx@0.11.15)
       db0: 0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1))
       env-runner: 0.1.7(miniflare@4.20260415.0)
-      h3: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
+      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15))
       hookable: 6.1.1
       nf3: 0.3.16
       ocache: 0.1.4
@@ -22408,7 +22433,7 @@ snapshots:
       crossws: 0.4.5(srvx@0.11.15)
       db0: 0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1))
       env-runner: 0.1.7(miniflare@4.20260415.0)
-      h3: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
+      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15))
       hookable: 6.1.1
       nf3: 0.3.16
       ocache: 0.1.4
@@ -22461,7 +22486,7 @@ snapshots:
       crossws: 0.4.5(srvx@0.11.15)
       db0: 0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1))
       env-runner: 0.1.7(miniflare@4.20260415.0)
-      h3: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
+      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15))
       hookable: 6.1.1
       nf3: 0.3.16
       ocache: 0.1.4


### PR DESCRIPTION
Adds provider wake output for static Schedule Definitions. Vite builds emit Cloudflare and Vercel output from discovered schedules, and the Nitro integration wires Cloudflare cron triggers plus Vercel Build Output API functions that load definitions through the generated schedule registry before invoking handlers.

This PR intentionally avoids schedule Discovery Identity changes. #212 owns location-derived Schedule identity and the object-shaped `defineSchedule({ cron, handler, ...options })` cleanup.

Closes #170