### PR TITLE
feat(schedule): add schedule run bookkeeping

### DIFF
--- a/packages/schedule/src/index.ts
+++ b/packages/schedule/src/index.ts
@@ -1,14 +1,17 @@
 export { defineSchedule } from "./definition.ts"
 export type {} from "./registry-module.d.ts"
 export { ScheduleError } from "./errors.ts"
+export { createScheduleRun, executeRuntimeSchedule, executeSchedule, executeStaticSchedule } from "./runtime/execute.ts"
 export { schedules, validateRuntimeScheduleCron } from "./runtime/client.ts"
-export { createMemoryRuntimeScheduleStore } from "./runtime/store.ts"
+export { createMemoryRuntimeScheduleStore, createMemoryScheduleRunStore } from "./runtime/store.ts"
 export {
   getRuntimeScheduleStore,
+  getScheduleRunStore,
   getScheduleRuntimeRegistry,
   loadScheduleDefinition,
   resetScheduleRuntime,
   setRuntimeScheduleStore,
+  setScheduleRunStore,
   setScheduleRuntimeRegistry,
 } from "./runtime/state.ts"
 
@@ -19,10 +22,16 @@ export type {
   RuntimeScheduleRecord,
   RuntimeScheduleStore,
   RuntimeScheduleUpdateInput,
+  ScheduleRunAttemptRecord,
+  ScheduleRunAttemptStatus,
   ScheduleDefinition,
   ScheduleDefinitionOptions,
   ScheduleDefinitionRegistry,
   ScheduleHandler,
   ScheduleRunContext,
+  ScheduleRunError,
+  ScheduleRunRecord,
+  ScheduleRunStatus,
+  ScheduleRunStore,
   ScheduleTargetName,
 } from "./types.ts"

--- a/packages/schedule/src/runtime/client.ts
+++ b/packages/schedule/src/runtime/client.ts
@@ -1,9 +1,10 @@
 import { randomId } from "@vitehub/internal/runtime/random"
 
 import { ScheduleError } from "../errors.ts"
-import { getRuntimeScheduleStore, loadScheduleDefinition } from "./state.ts"
+import { executeRuntimeSchedule } from "./execute.ts"
+import { getRuntimeScheduleStore, getScheduleRunStore, loadScheduleDefinition } from "./state.ts"
 
-import type { RuntimeScheduleCreateInput, RuntimeScheduleRecord, RuntimeScheduleUpdateInput, ScheduleTargetName } from "../types.ts"
+import type { RuntimeScheduleCreateInput, RuntimeScheduleRecord, RuntimeScheduleUpdateInput, ScheduleRunAttemptRecord, ScheduleRunRecord, ScheduleTargetName } from "../types.ts"
 
 const cronRange = {
   dayOfMonth: { max: 31, min: 1 },
@@ -194,8 +195,20 @@ export const schedules = {
   async get(id: string): Promise<RuntimeScheduleRecord | undefined> {
     return await getRuntimeScheduleStore().get(id)
   },
+  async getRun(id: string): Promise<ScheduleRunRecord | undefined> {
+    return await getScheduleRunStore().getRun(id)
+  },
   async list(): Promise<RuntimeScheduleRecord[]> {
     return await getRuntimeScheduleStore().list()
+  },
+  async listAttempts(runId: string): Promise<ScheduleRunAttemptRecord[]> {
+    return await getScheduleRunStore().listAttempts(runId)
+  },
+  async listRuns(): Promise<ScheduleRunRecord[]> {
+    return await getScheduleRunStore().listRuns()
+  },
+  async run(id: string, options: { scheduledAt?: Date } = {}): Promise<ScheduleRunRecord> {
+    return await executeRuntimeSchedule({ id, scheduledAt: options.scheduledAt })
   },
   async update<TTarget extends ScheduleTargetName>(id: string, input: RuntimeScheduleUpdateInput<TTarget>): Promise<RuntimeScheduleRecord> {
     return await updateRuntimeSchedule(id, input)

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -1,0 +1,207 @@
+import { randomId } from "@vitehub/internal/runtime/random"
+
+import { ScheduleError } from "../errors.ts"
+import { getRuntimeScheduleStore, getScheduleRunStore, loadScheduleDefinition } from "./state.ts"
+
+import type { RuntimeScheduleRecord, ScheduleDefinition, ScheduleRunAttemptRecord, ScheduleRunContext, ScheduleRunError, ScheduleRunRecord, ScheduleTargetName } from "../types.ts"
+
+interface ExecuteScheduleOptions {
+  definition: ScheduleDefinition
+  scheduleId: string
+  scheduledAt?: Date
+  target: ScheduleTargetName
+}
+
+interface ExecuteStaticScheduleOptions {
+  cron: string
+  definition: ScheduleDefinition
+  name: string
+  scheduledAt?: Date
+}
+
+interface ExecuteRuntimeScheduleOptions {
+  id: string
+  scheduledAt?: Date
+}
+
+function toRunId(scheduleId: string, scheduledAt: Date): string {
+  const normalizedScheduleId = scheduleId.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "schedule"
+  return `srun_${normalizedScheduleId}_${scheduledAt.toISOString()}`
+}
+
+function toRunError(error: unknown): ScheduleRunError {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    }
+  }
+  return { message: String(error) }
+}
+
+function requireUpdatedRun(run: ScheduleRunRecord | undefined): ScheduleRunRecord {
+  if (!run) {
+    throw new ScheduleError("Schedule Run bookkeeping update failed.", {
+      code: "SCHEDULE_RUN_NOT_FOUND",
+      httpStatus: 500,
+    })
+  }
+  return run
+}
+
+async function createOrGetRun(options: Omit<ExecuteScheduleOptions, "definition"> & { scheduledAt: Date }): Promise<{ created: boolean, run: ScheduleRunRecord }> {
+  const store = getScheduleRunStore()
+  const id = toRunId(options.scheduleId, options.scheduledAt)
+  const existing = await store.getRun(id)
+  if (existing) {
+    return { created: false, run: existing }
+  }
+
+  const now = new Date()
+  return {
+    created: true,
+    run: await store.createRun({
+      attemptCount: 0,
+      createdAt: now,
+      id,
+      scheduleId: options.scheduleId,
+      scheduledAt: options.scheduledAt,
+      status: "pending",
+      target: options.target,
+      updatedAt: now,
+    }),
+  }
+}
+
+async function startAttempt(run: ScheduleRunRecord): Promise<ScheduleRunAttemptRecord> {
+  const store = getScheduleRunStore()
+  const now = new Date()
+  const attempt = await store.createAttempt({
+    createdAt: now,
+    id: randomId("satt"),
+    runId: run.id,
+    startedAt: now,
+    status: "running",
+    updatedAt: now,
+  })
+  await store.updateRun(run.id, {
+    attemptCount: run.attemptCount + 1,
+    startedAt: run.startedAt ?? now,
+    status: "running",
+    updatedAt: now,
+  })
+  return attempt
+}
+
+function toHandlerContext(run: ScheduleRunRecord, attempt: ScheduleRunAttemptRecord): ScheduleRunContext {
+  return {
+    attemptId: attempt.id,
+    id: run.id,
+    runId: run.id,
+    scheduleId: run.scheduleId,
+    scheduledAt: run.scheduledAt,
+    target: run.target,
+  }
+}
+
+async function completeRun(run: ScheduleRunRecord, attempt: ScheduleRunAttemptRecord): Promise<ScheduleRunRecord> {
+  const store = getScheduleRunStore()
+  const now = new Date()
+  await store.updateAttempt(attempt.id, {
+    completedAt: now,
+    status: "succeeded",
+    updatedAt: now,
+  })
+  return requireUpdatedRun(await store.updateRun(run.id, {
+    completedAt: now,
+    status: "succeeded",
+    updatedAt: now,
+  }))
+}
+
+async function failRun(run: ScheduleRunRecord, attempt: ScheduleRunAttemptRecord, error: unknown): Promise<ScheduleRunRecord> {
+  const store = getScheduleRunStore()
+  const now = new Date()
+  const serializedError = toRunError(error)
+  await store.updateAttempt(attempt.id, {
+    completedAt: now,
+    error: serializedError,
+    status: "failed",
+    updatedAt: now,
+  })
+  return requireUpdatedRun(await store.updateRun(run.id, {
+    completedAt: now,
+    error: serializedError,
+    status: "failed",
+    updatedAt: now,
+  }))
+}
+
+export async function createScheduleRun(options: Omit<ExecuteScheduleOptions, "definition">): Promise<ScheduleRunRecord> {
+  const scheduledAt = options.scheduledAt ?? new Date()
+  return (await createOrGetRun({ ...options, scheduledAt })).run
+}
+
+export async function executeSchedule(options: ExecuteScheduleOptions): Promise<ScheduleRunRecord> {
+  const scheduledAt = options.scheduledAt ?? new Date()
+  const { created, run } = await createOrGetRun({ ...options, scheduledAt })
+
+  // v1 policy is intentionally fixed: the deterministic run id dedupes repeated
+  // delivery for one scheduled occurrence, and an existing run never overlaps or retries.
+  if (!created) {
+    return run
+  }
+
+  const attempt = await startAttempt(run)
+  try {
+    await options.definition.handler(toHandlerContext(run, attempt))
+    return await completeRun(run, attempt)
+  }
+  catch (error) {
+    await failRun(run, attempt, error)
+    throw error
+  }
+}
+
+export async function executeStaticSchedule(options: ExecuteStaticScheduleOptions): Promise<ScheduleRunRecord> {
+  return await executeSchedule({
+    definition: options.definition,
+    scheduleId: options.definition.options?.id ?? options.name,
+    scheduledAt: options.scheduledAt,
+    target: options.name,
+  })
+}
+
+async function loadRequiredRuntimeSchedule(id: string): Promise<RuntimeScheduleRecord> {
+  const schedule = await getRuntimeScheduleStore().get(id)
+  if (!schedule) {
+    throw new ScheduleError(`Runtime Schedule not found: ${id}`, {
+      code: "SCHEDULE_NOT_FOUND",
+      details: { id },
+      httpStatus: 404,
+    })
+  }
+  return schedule
+}
+
+export async function executeRuntimeSchedule(options: ExecuteRuntimeScheduleOptions | string): Promise<ScheduleRunRecord> {
+  const id = typeof options === "string" ? options : options.id
+  const scheduledAt = typeof options === "string" ? undefined : options.scheduledAt
+  const schedule = await loadRequiredRuntimeSchedule(id)
+  const definition = await loadScheduleDefinition(schedule.target)
+  if (!definition) {
+    throw new ScheduleError(`Unknown Runtime Schedule target: ${schedule.target}`, {
+      code: "SCHEDULE_TARGET_NOT_FOUND",
+      details: { target: schedule.target },
+      httpStatus: 404,
+    })
+  }
+
+  return await executeSchedule({
+    definition,
+    scheduleId: schedule.id,
+    scheduledAt,
+    target: schedule.target,
+  })
+}

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -59,18 +59,29 @@ async function createOrGetRun(options: Omit<ExecuteScheduleOptions, "definition"
   }
 
   const now = new Date()
-  return {
-    created: true,
-    run: await store.createRun({
-      attemptCount: 0,
-      createdAt: now,
-      id,
-      scheduleId: options.scheduleId,
-      scheduledAt: options.scheduledAt,
-      status: "pending",
-      target: options.target,
-      updatedAt: now,
-    }),
+  const runInput = {
+    attemptCount: 0,
+    createdAt: now,
+    id,
+    scheduleId: options.scheduleId,
+    scheduledAt: options.scheduledAt,
+    status: "pending" as const,
+    target: options.target,
+    updatedAt: now,
+  }
+
+  try {
+    return {
+      created: true,
+      run: await store.createRun(runInput),
+    }
+  }
+  catch (error) {
+    const run = await store.getRun(id)
+    if (run) {
+      return { created: false, run }
+    }
+    throw error
   }
 }
 

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -207,6 +207,13 @@ export async function executeRuntimeSchedule(options: ExecuteRuntimeScheduleOpti
       httpStatus: 404,
     })
   }
+  if (definition.options?.allowRuntimeSchedules !== true) {
+    throw new ScheduleError(`Runtime Schedule target is not eligible: ${schedule.target}`, {
+      code: "SCHEDULE_TARGET_NOT_ELIGIBLE",
+      details: { target: schedule.target },
+      httpStatus: 400,
+    })
+  }
 
   return await executeSchedule({
     definition,

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -9,6 +9,7 @@ interface ExecuteScheduleOptions {
   definition: ScheduleDefinition
   scheduleId: string
   scheduledAt?: Date
+  source?: ScheduleRunSource
   target: ScheduleTargetName
 }
 
@@ -24,8 +25,10 @@ interface ExecuteRuntimeScheduleOptions {
   scheduledAt?: Date
 }
 
-function toRunId(scheduleId: string, scheduledAt: Date): string {
-  return `srun_${encodeURIComponent(scheduleId)}_${scheduledAt.toISOString()}`
+type ScheduleRunSource = "direct" | "runtime" | "static"
+
+function toRunId(source: ScheduleRunSource, scheduleId: string, scheduledAt: Date): string {
+  return `srun_${source}_${encodeURIComponent(scheduleId)}_${scheduledAt.toISOString()}`
 }
 
 function toRunError(error: unknown): ScheduleRunError {
@@ -49,9 +52,14 @@ function requireUpdatedRun(run: ScheduleRunRecord | undefined): ScheduleRunRecor
   return run
 }
 
-async function createOrGetRun(options: Omit<ExecuteScheduleOptions, "definition"> & { scheduledAt: Date }): Promise<{ created: boolean, run: ScheduleRunRecord }> {
+async function getExistingRun(options: { scheduleId: string, scheduledAt: Date, source: ScheduleRunSource }): Promise<ScheduleRunRecord | undefined> {
   const store = getScheduleRunStore()
-  const id = toRunId(options.scheduleId, options.scheduledAt)
+  return await store.getRun(toRunId(options.source, options.scheduleId, options.scheduledAt))
+}
+
+async function createOrGetRun(options: Omit<ExecuteScheduleOptions, "definition"> & { scheduledAt: Date, source: ScheduleRunSource }): Promise<{ created: boolean, run: ScheduleRunRecord }> {
+  const store = getScheduleRunStore()
+  const id = toRunId(options.source, options.scheduleId, options.scheduledAt)
   const existing = await store.getRun(id)
   if (existing) {
     return { created: false, run: existing }
@@ -150,12 +158,12 @@ async function failRun(run: ScheduleRunRecord, attempt: ScheduleRunAttemptRecord
 
 export async function createScheduleRun(options: Omit<ExecuteScheduleOptions, "definition">): Promise<ScheduleRunRecord> {
   const scheduledAt = options.scheduledAt ?? new Date()
-  return (await createOrGetRun({ ...options, scheduledAt })).run
+  return (await createOrGetRun({ ...options, scheduledAt, source: options.source ?? "direct" })).run
 }
 
 export async function executeSchedule(options: ExecuteScheduleOptions): Promise<ScheduleRunRecord> {
   const scheduledAt = options.scheduledAt ?? new Date()
-  const { created, run } = await createOrGetRun({ ...options, scheduledAt })
+  const { created, run } = await createOrGetRun({ ...options, scheduledAt, source: options.source ?? "direct" })
 
   // v1 policy is intentionally fixed: the deterministic run id dedupes repeated
   // delivery for one scheduled occurrence, and an existing run never overlaps or retries.
@@ -179,6 +187,7 @@ export async function executeStaticSchedule(options: ExecuteStaticScheduleOption
     definition: options.definition,
     scheduleId: options.definition.options?.id ?? options.name,
     scheduledAt: options.scheduledAt,
+    source: "static",
     target: options.name,
   })
 }
@@ -197,8 +206,12 @@ async function loadRequiredRuntimeSchedule(id: string): Promise<RuntimeScheduleR
 
 export async function executeRuntimeSchedule(options: ExecuteRuntimeScheduleOptions | string): Promise<ScheduleRunRecord> {
   const id = typeof options === "string" ? options : options.id
-  const scheduledAt = typeof options === "string" ? undefined : options.scheduledAt
+  const scheduledAt = typeof options === "string" ? new Date() : options.scheduledAt ?? new Date()
   const schedule = await loadRequiredRuntimeSchedule(id)
+  const existing = await getExistingRun({ scheduleId: schedule.id, scheduledAt, source: "runtime" })
+  if (existing) {
+    return existing
+  }
   if (!schedule.enabled) {
     throw new ScheduleError(`Runtime Schedule is disabled: ${id}`, {
       code: "SCHEDULE_DISABLED",
@@ -226,6 +239,7 @@ export async function executeRuntimeSchedule(options: ExecuteRuntimeScheduleOpti
     definition,
     scheduleId: schedule.id,
     scheduledAt,
+    source: "runtime",
     target: schedule.target,
   })
 }

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -25,8 +25,7 @@ interface ExecuteRuntimeScheduleOptions {
 }
 
 function toRunId(scheduleId: string, scheduledAt: Date): string {
-  const normalizedScheduleId = scheduleId.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "schedule"
-  return `srun_${normalizedScheduleId}_${scheduledAt.toISOString()}`
+  return `srun_${encodeURIComponent(scheduleId)}_${scheduledAt.toISOString()}`
 }
 
 function toRunError(error: unknown): ScheduleRunError {

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -199,6 +199,13 @@ export async function executeRuntimeSchedule(options: ExecuteRuntimeScheduleOpti
   const id = typeof options === "string" ? options : options.id
   const scheduledAt = typeof options === "string" ? undefined : options.scheduledAt
   const schedule = await loadRequiredRuntimeSchedule(id)
+  if (!schedule.enabled) {
+    throw new ScheduleError(`Runtime Schedule is disabled: ${id}`, {
+      code: "SCHEDULE_DISABLED",
+      details: { id },
+      httpStatus: 409,
+    })
+  }
   const definition = await loadScheduleDefinition(schedule.target)
   if (!definition) {
     throw new ScheduleError(`Unknown Runtime Schedule target: ${schedule.target}`, {

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -57,6 +57,10 @@ async function getExistingRun(options: { scheduleId: string, scheduledAt: Date, 
   return await store.getRun(toRunId(options.source, options.scheduleId, options.scheduledAt))
 }
 
+async function getExistingRuntimeRun(id: string, scheduledAt: Date): Promise<ScheduleRunRecord | undefined> {
+  return await getExistingRun({ scheduleId: id, scheduledAt, source: "runtime" })
+}
+
 async function createOrGetRun(options: Omit<ExecuteScheduleOptions, "definition"> & { scheduledAt: Date, source: ScheduleRunSource }): Promise<{ created: boolean, run: ScheduleRunRecord }> {
   const store = getScheduleRunStore()
   const id = toRunId(options.source, options.scheduleId, options.scheduledAt)
@@ -207,11 +211,11 @@ async function loadRequiredRuntimeSchedule(id: string): Promise<RuntimeScheduleR
 export async function executeRuntimeSchedule(options: ExecuteRuntimeScheduleOptions | string): Promise<ScheduleRunRecord> {
   const id = typeof options === "string" ? options : options.id
   const scheduledAt = typeof options === "string" ? new Date() : options.scheduledAt ?? new Date()
-  const schedule = await loadRequiredRuntimeSchedule(id)
-  const existing = await getExistingRun({ scheduleId: schedule.id, scheduledAt, source: "runtime" })
+  const existing = await getExistingRuntimeRun(id, scheduledAt)
   if (existing) {
     return existing
   }
+  const schedule = await loadRequiredRuntimeSchedule(id)
   if (!schedule.enabled) {
     throw new ScheduleError(`Runtime Schedule is disabled: ${id}`, {
       code: "SCHEDULE_DISABLED",

--- a/packages/schedule/src/runtime/state.ts
+++ b/packages/schedule/src/runtime/state.ts
@@ -1,10 +1,11 @@
-import { createMemoryRuntimeScheduleStore } from "./store.ts"
+import { createMemoryRuntimeScheduleStore, createMemoryScheduleRunStore } from "./store.ts"
 
-import type { RuntimeScheduleStore, ScheduleDefinition, ScheduleDefinitionRegistry } from "../types.ts"
+import type { RuntimeScheduleStore, ScheduleDefinition, ScheduleDefinitionRegistry, ScheduleRunStore } from "../types.ts"
 
 let runtimeRegistry: ScheduleDefinitionRegistry | undefined
 let runtimeStore: RuntimeScheduleStore | undefined
 let runtimeRegistryVersion = 0
+let runStore: ScheduleRunStore | undefined
 const loadedRegistryEntries = new Map<string, ScheduleDefinition | undefined>()
 const loadingRegistryEntries = new Map<string, Promise<ScheduleDefinition | undefined>>()
 
@@ -29,6 +30,14 @@ export function setRuntimeScheduleStore(store: RuntimeScheduleStore | undefined)
 
 export function getRuntimeScheduleStore(): RuntimeScheduleStore {
   return runtimeStore ??= createMemoryRuntimeScheduleStore()
+}
+
+export function setScheduleRunStore(store: ScheduleRunStore | undefined): void {
+  runStore = store
+}
+
+export function getScheduleRunStore(): ScheduleRunStore {
+  return runStore ??= createMemoryScheduleRunStore()
 }
 
 export async function loadScheduleDefinition(name: string): Promise<ScheduleDefinition | undefined> {
@@ -75,6 +84,7 @@ export async function loadScheduleDefinition(name: string): Promise<ScheduleDefi
 export function resetScheduleRuntime(): void {
   runtimeRegistry = undefined
   runtimeStore = undefined
+  runStore = undefined
   loadedRegistryEntries.clear()
   loadingRegistryEntries.clear()
 }

--- a/packages/schedule/src/runtime/store.ts
+++ b/packages/schedule/src/runtime/store.ts
@@ -58,6 +58,7 @@ function cloneScheduleRun(record: ScheduleRunRecord): ScheduleRunRecord {
     completedAt: record.completedAt ? new Date(record.completedAt) : undefined,
     createdAt: new Date(record.createdAt),
     scheduledAt: new Date(record.scheduledAt),
+    error: record.error ? { ...record.error } : undefined,
     startedAt: record.startedAt ? new Date(record.startedAt) : undefined,
     updatedAt: new Date(record.updatedAt),
   }
@@ -68,6 +69,7 @@ function cloneScheduleRunAttempt(record: ScheduleRunAttemptRecord): ScheduleRunA
     ...record,
     completedAt: record.completedAt ? new Date(record.completedAt) : undefined,
     createdAt: new Date(record.createdAt),
+    error: record.error ? { ...record.error } : undefined,
     startedAt: new Date(record.startedAt),
     updatedAt: new Date(record.updatedAt),
   }

--- a/packages/schedule/src/runtime/store.ts
+++ b/packages/schedule/src/runtime/store.ts
@@ -1,6 +1,6 @@
 import { ScheduleError } from "../errors.ts"
 
-import type { RuntimeScheduleRecord, RuntimeScheduleStore, RuntimeScheduleUpdateInput } from "../types.ts"
+import type { RuntimeScheduleRecord, RuntimeScheduleStore, RuntimeScheduleUpdateInput, ScheduleRunAttemptRecord, ScheduleRunRecord, ScheduleRunStore } from "../types.ts"
 
 function cloneRuntimeSchedule(record: RuntimeScheduleRecord): RuntimeScheduleRecord {
   return {
@@ -48,6 +48,91 @@ export function createMemoryRuntimeScheduleStore(): RuntimeScheduleStore {
       })
       records.set(id, next)
       return cloneRuntimeSchedule(next)
+    },
+  }
+}
+
+function cloneScheduleRun(record: ScheduleRunRecord): ScheduleRunRecord {
+  return {
+    ...record,
+    completedAt: record.completedAt ? new Date(record.completedAt) : undefined,
+    createdAt: new Date(record.createdAt),
+    scheduledAt: new Date(record.scheduledAt),
+    startedAt: record.startedAt ? new Date(record.startedAt) : undefined,
+    updatedAt: new Date(record.updatedAt),
+  }
+}
+
+function cloneScheduleRunAttempt(record: ScheduleRunAttemptRecord): ScheduleRunAttemptRecord {
+  return {
+    ...record,
+    completedAt: record.completedAt ? new Date(record.completedAt) : undefined,
+    createdAt: new Date(record.createdAt),
+    startedAt: new Date(record.startedAt),
+    updatedAt: new Date(record.updatedAt),
+  }
+}
+
+export function createMemoryScheduleRunStore(): ScheduleRunStore {
+  const runs = new Map<string, ScheduleRunRecord>()
+  const attempts = new Map<string, ScheduleRunAttemptRecord>()
+
+  return {
+    createAttempt(attempt) {
+      if (attempts.has(attempt.id)) {
+        throw new Error(`Schedule Run Attempt already exists: ${attempt.id}`)
+      }
+      attempts.set(attempt.id, cloneScheduleRunAttempt(attempt))
+      return cloneScheduleRunAttempt(attempt)
+    },
+    createRun(run) {
+      if (runs.has(run.id)) {
+        throw new Error(`Schedule Run already exists: ${run.id}`)
+      }
+      runs.set(run.id, cloneScheduleRun(run))
+      return cloneScheduleRun(run)
+    },
+    getAttempt(id) {
+      const attempt = attempts.get(id)
+      return attempt ? cloneScheduleRunAttempt(attempt) : undefined
+    },
+    getRun(id) {
+      const run = runs.get(id)
+      return run ? cloneScheduleRun(run) : undefined
+    },
+    listAttempts(runId) {
+      return [...attempts.values()]
+        .filter(attempt => attempt.runId === runId)
+        .map(cloneScheduleRunAttempt)
+    },
+    listRuns() {
+      return [...runs.values()].map(cloneScheduleRun)
+    },
+    updateAttempt(id, patch) {
+      const existing = attempts.get(id)
+      if (!existing) {
+        return undefined
+      }
+      const next = cloneScheduleRunAttempt({
+        ...existing,
+        ...patch,
+        updatedAt: patch.updatedAt,
+      })
+      attempts.set(id, next)
+      return cloneScheduleRunAttempt(next)
+    },
+    updateRun(id, patch) {
+      const existing = runs.get(id)
+      if (!existing) {
+        return undefined
+      }
+      const next = cloneScheduleRun({
+        ...existing,
+        ...patch,
+        updatedAt: patch.updatedAt,
+      })
+      runs.set(id, next)
+      return cloneScheduleRun(next)
     },
   }
 }

--- a/packages/schedule/src/types.ts
+++ b/packages/schedule/src/types.ts
@@ -1,6 +1,10 @@
 export interface ScheduleRunContext {
   id: string
+  attemptId?: string
+  runId?: string
+  scheduleId?: string
   scheduledAt: Date
+  target?: ScheduleTargetName
 }
 
 export type ScheduleHandler<TResult = unknown> = (context: ScheduleRunContext) => TResult | Promise<TResult>
@@ -53,6 +57,52 @@ export interface RuntimeScheduleStore {
   get: (id: string) => Promise<RuntimeScheduleRecord | undefined> | RuntimeScheduleRecord | undefined
   list: () => Promise<RuntimeScheduleRecord[]> | RuntimeScheduleRecord[]
   update: (id: string, patch: RuntimeScheduleUpdateInput & { updatedAt: Date }) => Promise<RuntimeScheduleRecord | undefined> | RuntimeScheduleRecord | undefined
+}
+
+export type ScheduleRunStatus = "pending" | "running" | "succeeded" | "failed"
+
+export type ScheduleRunAttemptStatus = "running" | "succeeded" | "failed"
+
+export interface ScheduleRunError {
+  message: string
+  name?: string
+  stack?: string
+}
+
+export interface ScheduleRunRecord {
+  attemptCount: number
+  completedAt?: Date
+  createdAt: Date
+  error?: ScheduleRunError
+  id: string
+  scheduleId: string
+  scheduledAt: Date
+  startedAt?: Date
+  status: ScheduleRunStatus
+  target: ScheduleTargetName
+  updatedAt: Date
+}
+
+export interface ScheduleRunAttemptRecord {
+  completedAt?: Date
+  createdAt: Date
+  error?: ScheduleRunError
+  id: string
+  runId: string
+  startedAt: Date
+  status: ScheduleRunAttemptStatus
+  updatedAt: Date
+}
+
+export interface ScheduleRunStore {
+  createAttempt: (attempt: ScheduleRunAttemptRecord) => Promise<ScheduleRunAttemptRecord> | ScheduleRunAttemptRecord
+  createRun: (run: ScheduleRunRecord) => Promise<ScheduleRunRecord> | ScheduleRunRecord
+  getAttempt: (id: string) => Promise<ScheduleRunAttemptRecord | undefined> | ScheduleRunAttemptRecord | undefined
+  getRun: (id: string) => Promise<ScheduleRunRecord | undefined> | ScheduleRunRecord | undefined
+  listAttempts: (runId: string) => Promise<ScheduleRunAttemptRecord[]> | ScheduleRunAttemptRecord[]
+  listRuns: () => Promise<ScheduleRunRecord[]> | ScheduleRunRecord[]
+  updateAttempt: (id: string, patch: Partial<Pick<ScheduleRunAttemptRecord, "completedAt" | "error" | "status">> & { updatedAt: Date }) => Promise<ScheduleRunAttemptRecord | undefined> | ScheduleRunAttemptRecord | undefined
+  updateRun: (id: string, patch: Partial<Pick<ScheduleRunRecord, "attemptCount" | "completedAt" | "error" | "startedAt" | "status">> & { updatedAt: Date }) => Promise<ScheduleRunRecord | undefined> | ScheduleRunRecord | undefined
 }
 
 export interface DiscoveredScheduleDefinition {

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -207,7 +207,7 @@ describe("Schedule Run bookkeeping", () => {
 
     expect(run).toMatchObject({
       attemptCount: 1,
-      id: "srun_schedule-1_2026-05-23T09:00:00.000Z",
+      id: "srun_runtime_schedule-1_2026-05-23T09:00:00.000Z",
       scheduleId: "schedule-1",
       scheduledAt,
       status: "succeeded",
@@ -249,6 +249,34 @@ describe("Schedule Run bookkeeping", () => {
     })
   })
 
+  it("returns an existing Runtime Schedule run after the target opts out", async () => {
+    let calls = 0
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {
+          calls += 1
+        },
+        options: { allowRuntimeSchedules: true },
+      }),
+    })
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+    const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
+    const first = await schedules.run("schedule-1", { scheduledAt })
+
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {
+          calls += 1
+        },
+      }),
+    })
+
+    await expect(schedules.run("schedule-1", { scheduledAt })).resolves.toEqual(first)
+    expect(calls).toBe(1)
+  })
+
   it("blocks execution when a persisted Runtime Schedule is disabled", async () => {
     setScheduleRuntimeRegistry({
       report: async () => ({
@@ -263,6 +291,26 @@ describe("Schedule Run bookkeeping", () => {
     await expect(schedules.run("schedule-1")).rejects.toMatchObject({
       code: "SCHEDULE_DISABLED",
     })
+  })
+
+  it("returns an existing Runtime Schedule run after the schedule is disabled", async () => {
+    let calls = 0
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {
+          calls += 1
+        },
+        options: { allowRuntimeSchedules: true },
+      }),
+    })
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+    const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
+    const first = await schedules.run("schedule-1", { scheduledAt })
+    await schedules.disable("schedule-1")
+
+    await expect(schedules.run("schedule-1", { scheduledAt })).resolves.toEqual(first)
+    expect(calls).toBe(1)
   })
 
   it("uses the same bookkeeping path for static provider-triggered schedules", async () => {
@@ -280,7 +328,7 @@ describe("Schedule Run bookkeeping", () => {
 
     expect(run).toMatchObject({
       attemptCount: 1,
-      id: "srun_static-report_2026-05-23T10:00:00.000Z",
+      id: "srun_static_static-report_2026-05-23T10:00:00.000Z",
       scheduleId: "static-report",
       scheduledAt,
       status: "succeeded",
@@ -327,8 +375,32 @@ describe("Schedule Run bookkeeping", () => {
       scheduledAt,
     })
 
-    expect(first.id).toBe("srun_daily%2Freport_2026-05-23T09:00:00.000Z")
-    expect(second.id).toBe("srun_daily-report_2026-05-23T09:00:00.000Z")
+    expect(first.id).toBe("srun_static_daily%2Freport_2026-05-23T09:00:00.000Z")
+    expect(second.id).toBe("srun_static_daily-report_2026-05-23T09:00:00.000Z")
+  })
+
+  it("keeps static and Runtime Schedule run ids distinct for matching schedule ids", async () => {
+    const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {},
+        options: { allowRuntimeSchedules: true },
+      }),
+    })
+    await schedules.create({ cron: "0 9 * * *", id: "shared-id", target: "report" })
+
+    const runtime = await schedules.run("shared-id", { scheduledAt })
+    const staticRun = await executeStaticSchedule({
+      cron: "0 9 * * *",
+      definition: { cron: "0 9 * * *", handler: async () => {}, options: { id: "shared-id" } },
+      name: "report",
+      scheduledAt,
+    })
+
+    expect(runtime.id).toBe("srun_runtime_shared-id_2026-05-23T09:00:00.000Z")
+    expect(staticRun.id).toBe("srun_static_shared-id_2026-05-23T09:00:00.000Z")
+    expect(await schedules.listRuns()).toHaveLength(2)
   })
 
   it("reloads an existing run when duplicate creation wins the race", async () => {
@@ -356,7 +428,7 @@ describe("Schedule Run bookkeeping", () => {
     const run = await schedules.run("schedule-1", { scheduledAt })
 
     expect(run).toMatchObject({
-      id: "srun_schedule-1_2026-05-23T09:00:00.000Z",
+      id: "srun_runtime_schedule-1_2026-05-23T09:00:00.000Z",
       status: "pending",
     })
     expect(calls).toBe(0)

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -360,6 +360,28 @@ describe("Schedule Run bookkeeping", () => {
     expect(await schedules.listAttempts(first.id)).toHaveLength(1)
   })
 
+  it("returns an existing Runtime Schedule run after the schedule record is deleted", async () => {
+    let calls = 0
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {
+          calls += 1
+        },
+        options: { allowRuntimeSchedules: true },
+      }),
+    })
+
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+    const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
+    const first = await schedules.run("schedule-1", { scheduledAt })
+    await schedules.delete("schedule-1")
+    const second = await schedules.run("schedule-1", { scheduledAt })
+
+    expect(second).toEqual(first)
+    expect(calls).toBe(1)
+  })
+
   it("keeps run ids distinct for schedule ids with the same sanitized form", async () => {
     const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
     const first = await executeStaticSchedule({

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -227,6 +227,28 @@ describe("Schedule Run bookkeeping", () => {
     ])
   })
 
+  it("blocks execution when a persisted Runtime Schedule target opts out", async () => {
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {},
+        options: { allowRuntimeSchedules: true },
+      }),
+    })
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {},
+      }),
+    })
+
+    await expect(schedules.run("schedule-1")).rejects.toMatchObject({
+      code: "SCHEDULE_TARGET_NOT_ELIGIBLE",
+    })
+  })
+
   it("uses the same bookkeeping path for static provider-triggered schedules", async () => {
     const scheduledAt = new Date("2026-05-23T10:00:00.000Z")
     const run = await executeStaticSchedule({

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest"
 
-import { ScheduleError, schedules } from "../src/index.ts"
+import { executeStaticSchedule, ScheduleError, schedules } from "../src/index.ts"
 import { loadScheduleDefinition, resetScheduleRuntime, setScheduleRuntimeRegistry } from "../src/runtime/state.ts"
 
 afterEach(() => {
@@ -185,6 +185,119 @@ describe("Runtime Schedule helper", () => {
     await expect(schedules.update("missing", { enabled: false })).rejects.toBeInstanceOf(ScheduleError)
     await expect(schedules.update("missing", { enabled: false })).rejects.toMatchObject({
       code: "SCHEDULE_NOT_FOUND",
+    })
+  })
+})
+
+describe("Schedule Run bookkeeping", () => {
+  it("records a run and one successful attempt for a Runtime Schedule", async () => {
+    const seen: unknown[] = []
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async context => seen.push(context),
+        options: { allowRuntimeSchedules: true },
+      }),
+    })
+
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+    const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
+    const run = await schedules.run("schedule-1", { scheduledAt })
+    const attempts = await schedules.listAttempts(run.id)
+
+    expect(run).toMatchObject({
+      attemptCount: 1,
+      id: "srun_schedule-1_2026-05-23T09:00:00.000Z",
+      scheduleId: "schedule-1",
+      scheduledAt,
+      status: "succeeded",
+      target: "report",
+    })
+    expect(attempts).toHaveLength(1)
+    expect(attempts[0]).toMatchObject({ runId: run.id, status: "succeeded" })
+    expect(seen).toEqual([
+      expect.objectContaining({
+        attemptId: attempts[0]!.id,
+        id: run.id,
+        runId: run.id,
+        scheduleId: "schedule-1",
+        scheduledAt,
+        target: "report",
+      }),
+    ])
+  })
+
+  it("uses the same bookkeeping path for static provider-triggered schedules", async () => {
+    const scheduledAt = new Date("2026-05-23T10:00:00.000Z")
+    const run = await executeStaticSchedule({
+      cron: "0 10 * * *",
+      definition: {
+        cron: "0 10 * * *",
+        handler: async () => {},
+        options: { id: "static-report" },
+      },
+      name: "report",
+      scheduledAt,
+    })
+
+    expect(run).toMatchObject({
+      attemptCount: 1,
+      id: "srun_static-report_2026-05-23T10:00:00.000Z",
+      scheduleId: "static-report",
+      scheduledAt,
+      status: "succeeded",
+      target: "report",
+    })
+    expect(await schedules.getRun(run.id)).toEqual(run)
+    expect(await schedules.listAttempts(run.id)).toHaveLength(1)
+  })
+
+  it("dedupes repeated due events and does not retry or overlap by default", async () => {
+    let calls = 0
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {
+          calls += 1
+        },
+        options: { allowRuntimeSchedules: true },
+      }),
+    })
+
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+    const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
+    const first = await schedules.run("schedule-1", { scheduledAt })
+    const second = await schedules.run("schedule-1", { scheduledAt })
+
+    expect(second).toEqual(first)
+    expect(calls).toBe(1)
+    expect(await schedules.listAttempts(first.id)).toHaveLength(1)
+  })
+
+  it("records failed handler diagnostics on the run and attempt", async () => {
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {
+          throw new TypeError("boom")
+        },
+        options: { allowRuntimeSchedules: true },
+      }),
+    })
+
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+    const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
+    await expect(schedules.run("schedule-1", { scheduledAt })).rejects.toThrow("boom")
+
+    const [run] = await schedules.listRuns()
+    expect(run).toMatchObject({
+      error: { message: "boom", name: "TypeError" },
+      status: "failed",
+    })
+    const [attempt] = await schedules.listAttempts(run!.id)
+    expect(attempt).toMatchObject({
+      error: { message: "boom", name: "TypeError" },
+      status: "failed",
     })
   })
 })

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest"
 
-import { executeStaticSchedule, ScheduleError, schedules } from "../src/index.ts"
-import { loadScheduleDefinition, resetScheduleRuntime, setScheduleRuntimeRegistry } from "../src/runtime/state.ts"
+import { createMemoryScheduleRunStore, executeStaticSchedule, ScheduleError, schedules } from "../src/index.ts"
+import { loadScheduleDefinition, resetScheduleRuntime, setScheduleRunStore, setScheduleRuntimeRegistry } from "../src/runtime/state.ts"
 
 afterEach(() => {
   resetScheduleRuntime()
@@ -272,6 +272,37 @@ describe("Schedule Run bookkeeping", () => {
     expect(second).toEqual(first)
     expect(calls).toBe(1)
     expect(await schedules.listAttempts(first.id)).toHaveLength(1)
+  })
+
+  it("reloads an existing run when duplicate creation wins the race", async () => {
+    const store = createMemoryScheduleRunStore()
+    let calls = 0
+    setScheduleRunStore({
+      ...store,
+      async createRun(run) {
+        const created = await store.createRun(run)
+        throw new Error(`Schedule Run already exists: ${created.id}`)
+      },
+    })
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {
+          calls += 1
+        },
+        options: { allowRuntimeSchedules: true },
+      }),
+    })
+
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+    const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
+    const run = await schedules.run("schedule-1", { scheduledAt })
+
+    expect(run).toMatchObject({
+      id: "srun_schedule-1_2026-05-23T09:00:00.000Z",
+      status: "pending",
+    })
+    expect(calls).toBe(0)
   })
 
   it("records failed handler diagnostics on the run and attempt", async () => {

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -274,6 +274,25 @@ describe("Schedule Run bookkeeping", () => {
     expect(await schedules.listAttempts(first.id)).toHaveLength(1)
   })
 
+  it("keeps run ids distinct for schedule ids with the same sanitized form", async () => {
+    const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
+    const first = await executeStaticSchedule({
+      cron: "0 9 * * *",
+      definition: { cron: "0 9 * * *", handler: async () => {}, options: { id: "daily/report" } },
+      name: "daily/report",
+      scheduledAt,
+    })
+    const second = await executeStaticSchedule({
+      cron: "0 9 * * *",
+      definition: { cron: "0 9 * * *", handler: async () => {}, options: { id: "daily-report" } },
+      name: "daily-report",
+      scheduledAt,
+    })
+
+    expect(first.id).toBe("srun_daily%2Freport_2026-05-23T09:00:00.000Z")
+    expect(second.id).toBe("srun_daily-report_2026-05-23T09:00:00.000Z")
+  })
+
   it("reloads an existing run when duplicate creation wins the race", async () => {
     const store = createMemoryScheduleRunStore()
     let calls = 0
@@ -330,5 +349,24 @@ describe("Schedule Run bookkeeping", () => {
       error: { message: "boom", name: "TypeError" },
       status: "failed",
     })
+  })
+
+  it("isolates stored run errors from returned object mutation", async () => {
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {
+          throw new TypeError("boom")
+        },
+        options: { allowRuntimeSchedules: true },
+      }),
+    })
+
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+    await expect(schedules.run("schedule-1", { scheduledAt: new Date("2026-05-23T09:00:00.000Z") })).rejects.toThrow("boom")
+    const [run] = await schedules.listRuns()
+    run!.error!.message = "mutated"
+
+    expect((await schedules.getRun(run!.id))!.error).toMatchObject({ message: "boom" })
   })
 })

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -249,6 +249,22 @@ describe("Schedule Run bookkeeping", () => {
     })
   })
 
+  it("blocks execution when a persisted Runtime Schedule is disabled", async () => {
+    setScheduleRuntimeRegistry({
+      report: async () => ({
+        cron: "0 9 * * *",
+        handler: async () => {},
+        options: { allowRuntimeSchedules: true },
+      }),
+    })
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+    await schedules.disable("schedule-1")
+
+    await expect(schedules.run("schedule-1")).rejects.toMatchObject({
+      code: "SCHEDULE_DISABLED",
+    })
+  })
+
   it("uses the same bookkeeping path for static provider-triggered schedules", async () => {
     const scheduledAt = new Date("2026-05-23T10:00:00.000Z")
     const run = await executeStaticSchedule({

--- a/packages/schedule/test/types.test-d.ts
+++ b/packages/schedule/test/types.test-d.ts
@@ -2,13 +2,12 @@ import { expectTypeOf, it } from "vitest"
 
 import { defineSchedule, schedules } from "../src/index.ts"
 
+import type { ScheduleRunContext } from "../src/index.ts"
+
 it("infers schedule handler result types", () => {
   const schedule = defineSchedule("0 9 * * *", async context => context.id)
 
-  expectTypeOf(schedule.handler).parameters.toEqualTypeOf<[{
-    id: string
-    scheduledAt: Date
-  }]>()
+  expectTypeOf(schedule.handler).parameters.toEqualTypeOf<[ScheduleRunContext]>()
   expectTypeOf(schedule.handler).returns.toEqualTypeOf<string | Promise<string>>()
 })
 


### PR DESCRIPTION
## Summary

- add Schedule Run and Schedule Run Attempt records with in-memory runtime storage
- route Runtime Schedule execution and static provider-triggered execution through shared bookkeeping
- pass schedule-owned run metadata to handlers and record success/failure diagnostics
- document fixed v1 dedupe/no-overlap/no-retry behavior in execution code and tests

## Stack

- Base: #180 / `feat/schedule-runtime-helper-171`
- Coordinates with provider output work in #179 without merging unrelated provider-output code

Closes #172

## Checks

- `corepack pnpm --filter @vitehub/schedule typecheck`
- `PATH="/tmp/codex-pnpm-bin:$PATH" corepack pnpm --filter @vitehub/schedule test`

## Validation

- Pre-merge validation decision: skipped for this isolated draft because the change is internal runtime bookkeeping with no packaged consumer artifact or external provider integration yet; repo-local schedule build/test/typecheck exercise the runtime behavior. Revisit once the provider-output stack exposes installable consumer behavior.