### PR TITLE
test(schedule): add live e2e proof

### DIFF
--- a/.github/workflows/manual-live-e2e.yml
+++ b/.github/workflows/manual-live-e2e.yml
@@ -456,7 +456,7 @@ jobs:
 
       - name: Schedule Live E2E (${{ matrix.provider }} × ${{ matrix.framework }})
         timeout-minutes: 5
-        run: pnpm --dir packages/schedule test:e2e --framework "${{ matrix.framework }}" --provider "${{ matrix.provider }}" --url "${{ steps.url.outputs.url }}"
+        run: pnpm --dir packages/schedule test:e2e --framework "${{ matrix.framework }}" --provider "${{ matrix.provider }}" --url "${{ steps.url.outputs.url }}" --timeout 270000
 
       - name: Sandbox Live E2E (${{ matrix.provider }} × ${{ matrix.framework }})
         run: pnpm --dir packages/sandbox test:e2e --mode live --provider ${{ matrix.provider }} --framework ${{ matrix.framework }} --url "${{ steps.url.outputs.url }}"

--- a/.github/workflows/manual-live-e2e.yml
+++ b/.github/workflows/manual-live-e2e.yml
@@ -228,6 +228,7 @@ jobs:
         if: matrix.framework == 'nitro' && matrix.provider == 'cloudflare'
         env:
           KV_NAMESPACE_ID: ${{ secrets.CLOUDFLARE_KV_NAMESPACE_ID }}
+          VITEHUB_HOSTING: cloudflare
         run: pnpm --dir playground/nitro exec nitro build --preset cloudflare-module
 
       - name: Assert Nitro Cloudflare bindings
@@ -282,6 +283,7 @@ jobs:
           VERCEL_ORG_ID: ${{ steps.prepare_vercel.outputs.org_id }}
           VERCEL_PROJECT_ID: ${{ steps.prepare_vercel.outputs.project_id }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VITEHUB_HOSTING: vercel
         run: |
           APP_DIR="${{ steps.prepare_vercel.outputs.app_dir }}"
           VITEHUB_WORKSPACE_BLOB_PREFIX="vitehub/workspace-e2e/${{ matrix.framework }}" \

--- a/.github/workflows/manual-live-e2e.yml
+++ b/.github/workflows/manual-live-e2e.yml
@@ -236,6 +236,9 @@ jobs:
           node <<'NODE'
           const { readFileSync } = require("node:fs")
           const wrangler = JSON.parse(readFileSync("playground/nitro/.output/server/wrangler.json", "utf8"))
+          if (!Array.isArray(wrangler.triggers?.crons) || !wrangler.triggers.crons.includes("* * * * *")) {
+            throw new Error("Expected Nitro Cloudflare wrangler.json to include the daily-marker schedule cron trigger.")
+          }
           if (!Array.isArray(wrangler.kv_namespaces) || wrangler.kv_namespaces.length === 0) {
             throw new Error("Expected Nitro Cloudflare wrangler.json to include kv_namespaces.")
           }
@@ -284,6 +287,25 @@ jobs:
           VITEHUB_WORKSPACE_BLOB_PREFIX="vitehub/workspace-e2e/${{ matrix.framework }}" \
             npx vercel env run --cwd "$APP_DIR" --token "$VERCEL_TOKEN" -e production -- pnpm exec nitro build --preset vercel
 
+      - name: Assert Nitro Vercel schedule artifacts
+        if: matrix.framework == 'nitro' && matrix.provider == 'vercel'
+        run: |
+          node <<'NODE'
+          const { existsSync, readFileSync } = require("node:fs")
+          const config = JSON.parse(readFileSync("playground/nitro/.vercel/output/config.json", "utf8"))
+          const expected = { path: "/api/vitehub/schedules/vercel/daily-marker", schedule: "* * * * *" }
+          if (!Array.isArray(config.crons) || !config.crons.some(cron => cron.path === expected.path && cron.schedule === expected.schedule)) {
+            throw new Error(`Expected Nitro Vercel config.json crons to include ${JSON.stringify(expected)}.`)
+          }
+          const functionFile = "playground/nitro/.vercel/output/functions/api/vitehub/schedules/vercel/daily-marker.func/index.mjs"
+          if (!existsSync(functionFile)) {
+            throw new Error(`Expected generated Nitro Vercel schedule function at ${functionFile}.`)
+          }
+          if (!readFileSync(functionFile, "utf8").includes("executeStaticSchedule")) {
+            throw new Error("Expected Nitro Vercel schedule function to execute the static schedule handler.")
+          }
+          NODE
+
       - name: Build Vite E2E (cloudflare)
         if: matrix.framework == 'vite' && matrix.provider == 'cloudflare'
         env:
@@ -312,6 +334,9 @@ jobs:
             throw new Error("Cloudflare Vite bundle must not include bare @cloudflare/sandbox imports.")
           }
           const wrangler = JSON.parse(readFileSync("playground/vite/dist/vite/wrangler.json", "utf8"))
+          if (!Array.isArray(wrangler.triggers?.crons) || !wrangler.triggers.crons.includes("* * * * *")) {
+            throw new Error("Expected Vite Cloudflare wrangler.json to include the daily-marker schedule cron trigger.")
+          }
           if (!Array.isArray(wrangler.kv_namespaces) || wrangler.kv_namespaces.length === 0) {
             throw new Error("Expected Vite Cloudflare wrangler.json to include kv_namespaces.")
           }
@@ -347,13 +372,25 @@ jobs:
         if: matrix.framework == 'vite' && matrix.provider == 'vercel'
         run: |
           node <<'NODE'
-          const { readFileSync } = require("node:fs")
+          const { existsSync, readFileSync } = require("node:fs")
           const bundle = readFileSync("playground/vite/.vercel/output/functions/__server.func/index.mjs", "utf8")
           if (/createCloudflareArtifactsWorkspaceStore|isomorphic-git/.test(bundle)) {
             throw new Error("Vercel Vite bundle must not include the Cloudflare Artifacts store implementation.")
           }
           if (/cloudflare:workers|@cloudflare\/sandbox/.test(bundle)) {
             throw new Error("Vercel Vite bundle must not include Cloudflare-only sandbox runtime code.")
+          }
+          const config = JSON.parse(readFileSync("playground/vite/.vercel/output/config.json", "utf8"))
+          const expected = { path: "/api/vitehub/schedules/vercel/daily-marker", schedule: "* * * * *" }
+          if (!Array.isArray(config.crons) || !config.crons.some(cron => cron.path === expected.path && cron.schedule === expected.schedule)) {
+            throw new Error(`Expected Vite Vercel config.json crons to include ${JSON.stringify(expected)}.`)
+          }
+          const functionFile = "playground/vite/.vercel/output/functions/api/vitehub/schedules/vercel/daily-marker.func/index.mjs"
+          if (!existsSync(functionFile)) {
+            throw new Error(`Expected generated Vite Vercel schedule function at ${functionFile}.`)
+          }
+          if (!readFileSync(functionFile, "utf8").includes("executeStaticSchedule")) {
+            throw new Error("Expected Vite Vercel schedule function to execute the static schedule handler.")
           }
           NODE
 
@@ -416,6 +453,10 @@ jobs:
       - name: Queue Live E2E (${{ matrix.provider }} × ${{ matrix.framework }})
         timeout-minutes: 5
         run: node packages/queue/test/e2e-live.mjs --framework "${{ matrix.framework }}" --provider "${{ matrix.provider }}" --url "${{ steps.url.outputs.url }}"
+
+      - name: Schedule Live E2E (${{ matrix.provider }} × ${{ matrix.framework }})
+        timeout-minutes: 5
+        run: pnpm --dir packages/schedule test:e2e --framework "${{ matrix.framework }}" --provider "${{ matrix.provider }}" --url "${{ steps.url.outputs.url }}"
 
       - name: Sandbox Live E2E (${{ matrix.provider }} × ${{ matrix.framework }})
         run: pnpm --dir packages/sandbox test:e2e --mode live --provider ${{ matrix.provider }} --framework ${{ matrix.framework }} --url "${{ steps.url.outputs.url }}"

--- a/docs/content/docs/providers/cloudflare.md
+++ b/docs/content/docs/providers/cloudflare.md
@@ -38,6 +38,13 @@ Use this page to find package-specific Cloudflare guidance in ViteHub.
 
 - Setup overview: [Queue overview](/docs/vite/queue)
 - Provider details: [Queue on Cloudflare](/docs/vite/queue/providers/cloudflare)
+
+### Schedule
+
+`@vitehub/schedule` supports Cloudflare Provider Output on Vite and Nitro when the Vite Integration or Nitro Integration discovers Static Schedule Definitions.
+
+- Setup overview: [Schedule overview](/docs/vite/schedule)
+- Provider details: ViteHub writes worker cron triggers to `wrangler.json`; Cloudflare scheduled events wake the deployed worker and run matching Schedule Definitions.
 ::
 
 ::fw{id="nitro:dev nitro:build"}
@@ -54,8 +61,17 @@ Use this page to find package-specific Cloudflare guidance in ViteHub.
 
 - Setup overview: [Queue overview](/docs/nitro/queue)
 - Provider details: [Queue on Cloudflare](/docs/nitro/queue/providers/cloudflare)
+
+### Schedule
+
+`@vitehub/schedule` supports Cloudflare Provider Output on Vite and Nitro when the Vite Integration or Nitro Integration discovers Static Schedule Definitions.
+
+- Setup overview: [Schedule overview](/docs/nitro/schedule)
+- Provider details: ViteHub writes worker cron triggers to `wrangler.json`; Cloudflare scheduled events wake the deployed worker and run matching Schedule Definitions.
 ::
 
 ## What stays package-specific
 
 Bindings, namespace IDs, and exact config examples live with the package docs. Use this section as a routing page, not as the source of truth for package setup.
+
+Schedule Runtime Helpers are separate from Provider Output. Creating or changing a Runtime Schedule does not automatically provision Cloudflare cron triggers; worker cron configuration comes from Static Schedule Definitions discovered at build time.

--- a/docs/content/docs/providers/vercel.md
+++ b/docs/content/docs/providers/vercel.md
@@ -38,6 +38,13 @@ Use this page to find package-specific Vercel guidance in ViteHub.
 
 - Setup overview: [Queue overview](/docs/vite/queue)
 - Provider details: [Queue on Vercel](/docs/vite/queue/providers/vercel)
+
+### Schedule
+
+`@vitehub/schedule` supports Vercel Provider Output on Vite and Nitro when the Vite Integration or Nitro Integration discovers Static Schedule Definitions.
+
+- Setup overview: [Schedule overview](/docs/vite/schedule)
+- Provider details: ViteHub writes Vercel cron entries to `.vercel/output/config.json` and generated functions under `/api/vitehub/schedules/vercel/<name>` during the manual deploy build.
 ::
 
 ::fw{id="nitro:dev nitro:build"}
@@ -54,8 +61,17 @@ Use this page to find package-specific Vercel guidance in ViteHub.
 
 - Setup overview: [Queue overview](/docs/nitro/queue)
 - Provider details: [Queue on Vercel](/docs/nitro/queue/providers/vercel)
+
+### Schedule
+
+`@vitehub/schedule` supports Vercel Provider Output on Vite and Nitro when the Vite Integration or Nitro Integration discovers Static Schedule Definitions.
+
+- Setup overview: [Schedule overview](/docs/nitro/schedule)
+- Provider details: ViteHub writes Vercel cron entries to `.vercel/output/config.json` and generated functions under `/api/vitehub/schedules/vercel/<name>` during the manual deploy build.
 ::
 
 ## What stays package-specific
 
 Environment variables, fallback behavior, and exact config examples live with the package docs. Use this section as a routing page, not as the source of truth for package setup.
+
+Schedule Runtime Helpers are separate from Provider Output. Creating or changing a Runtime Schedule does not automatically provision Vercel cron configuration; provider cron paths come from Static Schedule Definitions discovered at build time.

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "build": "tsdown --tsconfig tsconfig.build.json",
     "dev": "tsdown --watch",
+    "test:e2e": "node ./test/e2e-live.mjs",
     "typecheck": "tsc --noEmit -p ./tsconfig.json",
     "test": "pnpm --dir . build && vitest run"
   },

--- a/packages/schedule/test/e2e-live.mjs
+++ b/packages/schedule/test/e2e-live.mjs
@@ -20,7 +20,14 @@ async function waitForSchedule(run) {
       const payload = await requestJson(new URL("/api/tests/schedule", run.url))
       lastPayload = payload
       const ranAt = typeof payload?.marker?.ranAt === "string" ? Date.parse(payload.marker.ranAt) : Number.NaN
-      if (payload?.ok && payload?.seen === true && payload?.marker?.schedule === "daily-marker" && ranAt >= startedAt) {
+      if (
+        payload?.ok
+        && payload?.seen === true
+        && payload?.marker?.framework === run.framework
+        && payload?.marker?.provider === run.provider
+        && payload?.marker?.schedule === "daily-marker"
+        && ranAt >= startedAt
+      ) {
         return
       }
     }

--- a/packages/schedule/test/e2e-live.mjs
+++ b/packages/schedule/test/e2e-live.mjs
@@ -9,6 +9,7 @@ async function dispatch() {
 
 async function waitForSchedule(run) {
   const startedAt = Date.now()
+  const startedAtIso = new Date(startedAt).toISOString()
   let attempts = 0
   let lastPayload
   let lastError
@@ -18,7 +19,8 @@ async function waitForSchedule(run) {
     try {
       const payload = await requestJson(new URL("/api/tests/schedule", run.url))
       lastPayload = payload
-      if (payload?.ok && payload?.seen === true && payload?.marker?.schedule === "daily-marker") {
+      const ranAt = typeof payload?.marker?.ranAt === "string" ? Date.parse(payload.marker.ranAt) : Number.NaN
+      if (payload?.ok && payload?.seen === true && payload?.marker?.schedule === "daily-marker" && ranAt >= startedAt) {
         return
       }
     }
@@ -35,6 +37,7 @@ async function waitForSchedule(run) {
     lastError: lastError instanceof Error ? lastError.message : lastError ? String(lastError) : undefined,
     lastPayload,
     provider: run.provider,
+    startedAt: startedAtIso,
     timeoutMs: run.timeoutMs,
     url: new URL("/api/tests/schedule", run.url).toString(),
   })}`)

--- a/packages/schedule/test/e2e-live.mjs
+++ b/packages/schedule/test/e2e-live.mjs
@@ -1,0 +1,46 @@
+import process from "node:process"
+import { setTimeout as sleep } from "node:timers/promises"
+
+import { requestJson, runE2E } from "@vitehub/internal/test/e2e-live"
+
+async function dispatch() {
+  return undefined
+}
+
+async function waitForSchedule(run) {
+  const startedAt = Date.now()
+  let attempts = 0
+  let lastPayload
+  let lastError
+
+  while (Date.now() - startedAt < run.timeoutMs) {
+    attempts += 1
+    try {
+      const payload = await requestJson(new URL("/api/tests/schedule", run.url))
+      lastPayload = payload
+      if (payload?.ok && payload?.seen === true && payload?.marker?.schedule === "daily-marker") {
+        return
+      }
+    }
+    catch (error) {
+      lastError = error
+    }
+
+    await sleep(5_000)
+  }
+
+  throw new Error(`Schedule marker was not observed before timeout: ${JSON.stringify({
+    attempts,
+    framework: run.framework,
+    lastError: lastError instanceof Error ? lastError.message : lastError ? String(lastError) : undefined,
+    lastPayload,
+    provider: run.provider,
+    timeoutMs: run.timeoutMs,
+    url: new URL("/api/tests/schedule", run.url).toString(),
+  })}`)
+}
+
+runE2E({ namespace: "schedule", dispatch, wait: waitForSchedule }).catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
Adds a package-local schedule live e2e command and wires it into the manual live workflow across Vite and Nitro on Cloudflare and Vercel. The workflow now checks generated Provider Output before deploy and waits for the deployed schedule probe to observe provider wake execution.

Stacked on #190.

Closes #187