### PR TITLE
docs(schedule): document self-hosted runner

### DIFF
--- a/packages/schedule/docs/boundaries.md
+++ b/packages/schedule/docs/boundaries.md
@@ -1,0 +1,54 @@
+---
+title: Schedule boundaries
+description: Current limits for Runtime Schedules, the Basic Self-Hosted Schedule Runner, and production provider behavior.
+navigation.title: Boundaries
+navigation.order: 5
+icon: i-lucide-circle-slash
+frameworks: [vite, nitro]
+---
+
+Schedule currently provides definitions, Runtime Schedule records, run bookkeeping, and a Basic Self-Hosted Schedule Runner. It does not provide a production distributed scheduler.
+
+## Current runner boundary
+
+The Basic Self-Hosted Schedule Runner is intentionally small:
+
+- It scans one configured Runtime Schedule store.
+- It matches enabled records against the current UTC minute.
+- It dispatches due Runtime Schedules in the current process.
+- It records runs and attempts in the configured Schedule Run store.
+- It bounds local concurrency with the `concurrency` option.
+- It isolates scan and handler failures so future scans can continue.
+
+Use [Basic Self-Hosted Schedule Runner](./runner) for startup examples and exact behavior.
+
+## Single active runner per store
+
+Only one active runner should use a given Runtime Schedule store and Schedule Run store at a time.
+
+The runner checks for an existing run record before dispatching, but it does not claim the scheduled minute atomically across processes. Multiple active runners can race.
+
+## UTC minute matching, no backfill
+
+Runtime Schedule cron expressions are five-field UTC cron expressions.
+
+The runner floors `now()` to the current UTC minute during each scan. It does not calculate all missed occurrences between scans and it does not backfill after downtime.
+
+## Failure behavior
+
+A handler failure marks the run and attempt as `failed`. The runner reports the error through `onError` when provided and continues later scans.
+
+The current runner does not retry failed Runtime Schedule runs. Add retry behavior inside the target handler or use another execution primitive if retry semantics are required.
+
+## Out of scope
+
+These are intentionally not part of the current Schedule package behavior:
+
+- BullMQ or another queue-backed scheduler.
+- Distributed claiming, leases, leader election, or cross-process locking.
+- Docker Compose templates for a schedule runner service.
+- systemd unit generation.
+- cron file generation.
+- Production self-hosted provider behavior.
+
+Those features may become separate provider or deployment work later, but the current package docs and API describe only the basic self-hosted runner.

--- a/packages/schedule/docs/index.md
+++ b/packages/schedule/docs/index.md
@@ -1,0 +1,84 @@
+---
+title: Schedule
+description: Define cron schedules and manage Runtime Schedules with explicit self-hosted runner boundaries.
+navigation.title: Overview
+navigation.order: 0
+icon: i-lucide-calendar-clock
+frameworks: [vite, nitro]
+---
+
+`@vitehub/schedule` gives Vite and Nitro apps one way to define named cron work, create user-managed Runtime Schedules, and execute them from a process that you own.
+
+Use Schedule when recurring work should call a discovered handler. Static schedules live in code. Runtime Schedules live in a store and target definitions that explicitly opt in with `allowRuntimeSchedules: true`.
+
+::code-group
+```ts [server/schedules/reports.ts]
+import { defineSchedule } from '@vitehub/schedule'
+
+export default defineSchedule('0 9 * * *', async (context) => {
+  console.log('Running report for', context.scheduledAt.toISOString())
+}, {
+  allowRuntimeSchedules: true,
+})
+```
+
+```ts [server/api/schedules.post.ts]
+import { schedules } from '@vitehub/schedule'
+
+export default defineEventHandler(async () => {
+  return await schedules.create({
+    cron: '0 9 * * *',
+    id: 'daily-report',
+    target: 'reports',
+  })
+})
+```
+::
+
+## Discovery model
+
+::fw{id="vite:dev vite:build"}
+Vite discovers schedule definitions from `src/**/*.schedule.ts`.
+
+The schedule name comes from the path under `src`, without the `.schedule` suffix. `src/reports/daily.schedule.ts` becomes `reports/daily`.
+::
+
+::fw{id="nitro:dev nitro:build"}
+Nitro discovers schedule definitions from `server/schedules/**`.
+
+The schedule name comes from the path under `server/schedules`, without the file extension. `server/schedules/reports/daily.ts` becomes `reports/daily`.
+::
+
+## Runtime Schedules
+
+Runtime Schedules are persisted records with an id, cron expression, enabled flag, and target. They are useful when users or application state decide which recurring work should exist.
+
+Only targets that set `allowRuntimeSchedules: true` can be used by Runtime Schedules. This keeps runtime-created records from calling every static schedule handler by accident.
+
+Start with [Usage](./usage), then add the [Basic Self-Hosted Schedule Runner](./runner) when Runtime Schedules need automatic execution.
+
+## Next steps
+
+::u-page-grid{class="pb-2"}
+  :::u-page-card
+  ---
+  title: Usage
+  description: Define schedules, create Runtime Schedules, and inspect runs.
+  to: ./usage
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Basic Runner
+  description: Start the self-hosted runner from a Node, Nitro, or server entry point.
+  to: ./runner
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Boundaries
+  description: Review current runner limits and out-of-scope production provider behavior.
+  to: ./boundaries
+  ---
+  :::
+::

--- a/packages/schedule/docs/runner.md
+++ b/packages/schedule/docs/runner.md
@@ -1,0 +1,141 @@
+---
+title: Basic Self-Hosted Schedule Runner
+description: Start Runtime Schedule execution from a Node, Nitro, or server entry point and understand current runner behavior.
+navigation.title: Basic Runner
+navigation.order: 4
+icon: i-lucide-play-circle
+frameworks: [vite, nitro]
+---
+
+The Basic Self-Hosted Schedule Runner scans the configured Runtime Schedule store from a long-lived process and executes due Runtime Schedules in-process.
+
+Use it when the application owns a single server process or has a clearly elected single runner. It is not a distributed scheduler.
+
+## Minimal Runtime Schedule example
+
+First define a runtime-eligible target.
+
+::fw{id="vite:dev vite:build"}
+```ts [src/reports/daily.schedule.ts]
+import { defineSchedule } from '@vitehub/schedule'
+
+export default defineSchedule('0 9 * * *', async (context) => {
+  console.log('run daily report', context.scheduleId, context.scheduledAt.toISOString())
+}, {
+  allowRuntimeSchedules: true,
+})
+```
+::
+
+::fw{id="nitro:dev nitro:build"}
+```ts [server/schedules/reports/daily.ts]
+import { defineSchedule } from '@vitehub/schedule'
+
+export default defineSchedule('0 9 * * *', async (context) => {
+  console.log('run daily report', context.scheduleId, context.scheduledAt.toISOString())
+}, {
+  allowRuntimeSchedules: true,
+})
+```
+::
+
+Then create a Runtime Schedule that targets that definition.
+
+```ts
+import { schedules } from '@vitehub/schedule'
+
+await schedules.create({
+  cron: '0 9 * * *',
+  id: 'daily-report',
+  target: 'reports/daily',
+})
+```
+
+## Start from a Node entry point
+
+Start the runner once from the process that should own dispatch.
+
+```ts [server.ts]
+import { startScheduleRunner } from '@vitehub/schedule'
+
+const runner = startScheduleRunner({
+  concurrency: 1,
+  onError(error) {
+    console.error('Schedule runner error', error)
+  },
+})
+
+process.once('SIGINT', () => runner.stop())
+process.once('SIGTERM', () => runner.stop())
+```
+
+`startScheduleRunner()` returns a controller with `running` and `stop()`.
+
+## Start from a Nitro server plugin
+
+For Nitro, start the runner from one server plugin and stop it during shutdown.
+
+```ts [server/plugins/schedule-runner.ts]
+import { startScheduleRunner } from '@vitehub/schedule'
+
+export default defineNitroPlugin((nitroApp) => {
+  const runner = startScheduleRunner({
+    concurrency: 1,
+    onError(error) {
+      console.error('Schedule runner error', error)
+    },
+  })
+
+  nitroApp.hooks.hookOnce('close', () => {
+    runner.stop()
+  })
+})
+```
+
+Only install this plugin in the deployment process that should run schedules.
+
+## Start from another server entry point
+
+Any long-lived server entry can start the runner before listening for requests.
+
+```ts [app-server.ts]
+import { createServer } from 'node:http'
+import { startScheduleRunner } from '@vitehub/schedule'
+
+const runner = startScheduleRunner()
+
+const server = createServer((_request, response) => {
+  response.end('ok')
+})
+
+server.listen(3000)
+
+process.once('SIGTERM', () => {
+  runner.stop()
+  server.close()
+})
+```
+
+## Matching behavior
+
+The runner checks enabled Runtime Schedules on an interval. The default interval is one minute.
+
+For each scan, it floors the current time to the current UTC minute and matches Runtime Schedule cron expressions against that minute. It does not backfill missed minutes after process downtime, slow scans, deploys, or clock jumps.
+
+## Concurrency and failures
+
+`concurrency` bounds how many schedule executions this runner instance dispatches at once. The default is `1`.
+
+When a handler fails, the run and attempt are marked `failed`, the error is passed to `onError` when provided, and the runner keeps scanning future minutes. The current runner does not retry failed attempts.
+
+Before dispatching, the runner checks whether a run record already exists for the Runtime Schedule id and scheduled minute. That prevents duplicate dispatch from the same store when one active runner owns the store.
+
+## Single active runner per store
+
+Run only one active runner against a given Runtime Schedule store and Schedule Run store.
+
+The current runner does not provide distributed claiming or leases. If two server processes scan the same store at the same time, both can decide a schedule is due before either has written a run record.
+
+Use one elected process, one singleton service, or a deployment topology that guarantees only one active runner for each store. For anything else, treat this runner as a development or simple self-hosted primitive and keep distributed scheduling outside this package for now.
+
+For the explicit scope limits, read [Boundaries](./boundaries).

--- a/packages/schedule/docs/usage.md
+++ b/packages/schedule/docs/usage.md
@@ -1,0 +1,106 @@
+---
+title: Schedule usage
+description: Practical patterns for schedule definitions, Runtime Schedules, runtime-eligible targets, and run inspection.
+navigation.title: Usage
+navigation.order: 3
+icon: i-lucide-calendar-plus
+frameworks: [vite, nitro]
+---
+
+After Schedule discovery is configured, most application code falls into three patterns: define a schedule target, create or update Runtime Schedules, and inspect run records.
+
+## Define a runtime-eligible target
+
+Runtime Schedules can only target definitions that opt in with `allowRuntimeSchedules: true`.
+
+::fw{id="vite:dev vite:build"}
+```ts [src/reports/daily.schedule.ts]
+import { defineSchedule } from '@vitehub/schedule'
+
+export default defineSchedule('0 9 * * *', async (context) => {
+  console.log('daily report', context.scheduleId, context.scheduledAt)
+}, {
+  allowRuntimeSchedules: true,
+})
+```
+::
+
+::fw{id="nitro:dev nitro:build"}
+```ts [server/schedules/reports/daily.ts]
+import { defineSchedule } from '@vitehub/schedule'
+
+export default defineSchedule('0 9 * * *', async (context) => {
+  console.log('daily report', context.scheduleId, context.scheduledAt)
+}, {
+  allowRuntimeSchedules: true,
+})
+```
+::
+
+The cron string on the definition still describes the static schedule. Runtime Schedules store their own cron expression and use the definition as the target handler.
+
+## Create a Runtime Schedule
+
+Use `schedules.create()` from server code after validating the caller is allowed to create recurring work.
+
+```ts
+import { schedules } from '@vitehub/schedule'
+
+const runtimeSchedule = await schedules.create({
+  cron: '0 9 * * *',
+  id: 'daily-report',
+  target: 'reports/daily',
+})
+```
+
+Runtime Schedule cron expressions are five-field UTC cron expressions. The helper rejects unknown targets and targets that did not set `allowRuntimeSchedules: true`.
+
+## Update and disable schedules
+
+```ts
+await schedules.update('daily-report', {
+  cron: '30 9 * * 1-5',
+})
+
+await schedules.disable('daily-report')
+await schedules.enable('daily-report')
+await schedules.delete('daily-report')
+```
+
+Disabling a Runtime Schedule prevents automatic runner dispatch and direct `schedules.run(id)` execution.
+
+## Run one schedule manually
+
+Use `schedules.run()` when an explicit action should execute a Runtime Schedule now or for a known scheduled minute.
+
+```ts
+const run = await schedules.run('daily-report', {
+  scheduledAt: new Date('2026-05-24T09:00:00.000Z'),
+})
+```
+
+Each run is keyed by Runtime Schedule id and scheduled minute. Re-running the same id for the same `scheduledAt` returns the existing run instead of creating another attempt.
+
+## Start automatic execution
+
+Runtime Schedules do not execute automatically until a process starts the [Basic Self-Hosted Schedule Runner](./runner).
+
+```ts
+import { startScheduleRunner } from '@vitehub/schedule'
+
+const runner = startScheduleRunner()
+
+process.once('SIGTERM', () => runner.stop())
+```
+
+Read [Boundaries](./boundaries) before running more than one process against the same schedule store.
+
+## Inspect runs
+
+```ts
+const runs = await schedules.listRuns()
+const run = await schedules.getRun('srun_daily-report_2026-05-24T09:00:00.000Z')
+const attempts = await schedules.listAttempts(run!.id)
+```
+
+Run status values are `pending`, `running`, `succeeded`, and `failed`. Attempt status values are `running`, `succeeded`, and `failed`.


### PR DESCRIPTION
## Summary
- document basic self-hosted Schedule Runner startup patterns
- describe runtime-eligible targets, persisted stores, concurrency, and failure behavior
- call out current non-goals and operational boundaries

## Tests
- corepack pnpm --filter @vitehub/schedule typecheck
- corepack pnpm --dir docs test
- corepack pnpm --dir docs build

Depends on #198
Closes #193