### PR TITLE
docs: capture chat title and summary capability decisions

### DIFF
--- a/.agents/adr/0024-chat-title-and-summary-capabilities.md
+++ b/.agents/adr/0024-chat-title-and-summary-capabilities.md
@@ -1,0 +1,19 @@
+# Chat Title and Summary Capabilities
+
+ViteHub will model chat title and chat summary as separate chat-scoped Agent Capabilities. `chatTitle()` produces first-user-message conversation metadata and exposes it through the existing Agent response and Agent Invocation Lifecycle path rather than through a separate endpoint. `chatSummary()` produces explicit summary artifacts and owns its natural Input Command surface by default because summary is the product ability and the command is only one trigger mechanism.
+
+## Considered Options
+
+- A generic `title()` or `summary()` helper was rejected because title and summary are chat-scoped product abilities in this design, not generic Agent utilities.
+- A single combined title/summary Capability was rejected because title generation has a stable one-message input contract while summary generation operates over conversation history and explicit user or host intent.
+- A separate title endpoint was rejected for V1 because title metadata is produced as part of handling the first chat request and should travel with that interaction for client support.
+- Naming the summary feature `compact` was rejected because compaction implies reducing or replacing model-facing Chat History, while this feature produces a summary artifact.
+- Requiring users to attach both `chatSummary()` and `inputCommands()` for the default summary command was rejected because official Capabilities should map to product abilities rather than implementation mechanisms.
+
+## Consequences
+
+`chatTitle()` is automatic chat metadata for the first user message only. It does not register an Input Command by default, does not support retitling from later messages in V1, does not mutate Chat History, and does not create a separate endpoint as the primary exposure path. Hosts remain responsible for persisting or rendering the generated title.
+
+`chatSummary()` is explicit summary behavior. It can register a natural Input Command by default, with opt-out or customization, but summary generation remains the Capability's product ability. Summary output is a host-visible artifact or metadata result, not hidden Chat History compaction.
+
+Both Capabilities may share an internal auxiliary model-call implementation, but routing, decision, and labelling behavior remain separate future work.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -112,6 +112,7 @@ _Avoid_: Input Command, Capability, model tool
 
 - An Agent attaches zero or more **Capabilities**.
 - Official helpers such as `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `sandbox()`, `kv()`, `blob()`, `db()`, and `webSearch()` create **Capability Definitions**.
+- Official helpers should map to product abilities rather than implementation mechanisms.
 - An **Input Command** is a **Capability** concern resolved before model-facing Agent behavior.
 - A **Host Command** is not an **Input Command** and is outside the Capability Lifecycle.
 - Primitive storage helpers such as `kv()`, `blob()`, and `db()` are first-class official **Capabilities**, not sample raw-tool wrappers.
@@ -192,6 +193,7 @@ _Avoid_: Input Command, Capability, model tool
 - Slash command was considered as the domain term - resolved: use **Input Command** for the Capability concept because it names the lifecycle position; slash syntax is only the initial invocation format.
 - Host/session commands were considered part of Input Commands - resolved: **Host Commands** are a separate future concern because they change chat, session, UI, or product state rather than Agent run input.
 - Input Command display metadata was considered capability-level - resolved: Capability id owns identity, while command descriptions are the user-facing metadata hosts may render.
+- Requiring users to attach one Capability per internal mechanism was considered - resolved: users attach one Capability per product ability, and official Capabilities can own their natural Input Command surface when that command is part of the expected user experience.
 - Storage Capability options were described as access levels in an older PR - resolved: official primitive Capabilities use `mode` for read/write exposure, while `access` is older proposal language.
 - Storage helpers were considered examples around raw tools - resolved: KV, Blob, and DB helpers are first-class official **Capabilities**.
 - Storage Capabilities were considered as direct primitive method proxies - resolved: official storage Capabilities should stay small with read/edit tools rather than method fanout.


### PR DESCRIPTION
## Summary

- Adds ADR 0024 for the `chatTitle()` and `chatSummary()` capability direction.
- Records that official Capabilities should map to product abilities rather than internal mechanisms.
- Keeps routing/decision/labelling out of this scope.

Refs #200, #201, and #149

## Validation

- `git diff --check -- .agents/contexts/capabilities/CONTEXT.md .agents/adr/0024-chat-title-and-summary-capabilities.md`

