### PR TITLE
fix: require schedule boundary exports for provider cron extraction

### DIFF
--- a/packages/schedule/docs/runner.md
+++ b/packages/schedule/docs/runner.md
@@ -19,7 +19,6 @@ First define a runtime-eligible target.
 ```ts [src/reports/daily.schedule.ts]
 import { defineSchedule } from '@vitehub/schedule'
 
-export default defineSchedule('0 9 * * *', async (context) => {
 export default defineSchedule({
   allowRuntimeSchedules: true,
   cron: '0 9 * * *',
@@ -34,7 +33,6 @@ export default defineSchedule({
 ```ts [server/schedules/reports/daily.ts]
 import { defineSchedule } from '@vitehub/schedule'
 
-export default defineSchedule('0 9 * * *', async (context) => {
 export default defineSchedule({
   allowRuntimeSchedules: true,
   cron: '0 9 * * *',

--- a/packages/schedule/examples/nitro/server/schedules/daily-report.ts
+++ b/packages/schedule/examples/nitro/server/schedules/daily-report.ts
@@ -1,5 +1,8 @@
 import { defineSchedule } from "@vitehub/schedule"
 
-export default defineSchedule("0 8 * * *", async ({ scheduledAt }) => {
-  console.log(`Generating daily report for ${scheduledAt.toISOString()}`)
+export default defineSchedule({
+  cron: "0 8 * * *",
+  handler: async ({ scheduledAt }) => {
+    console.log(`Generating daily report for ${scheduledAt.toISOString()}`)
+  },
 })

--- a/packages/schedule/examples/nitro/server/schedules/database-cleanup.ts
+++ b/packages/schedule/examples/nitro/server/schedules/database-cleanup.ts
@@ -1,12 +1,9 @@
 import { defineSchedule } from "@vitehub/schedule"
 
-export default defineSchedule(
-  "0 2 * * 0",
-  async ({ id, scheduledAt }) => {
+export default defineSchedule({
+  allowRuntimeSchedules: true,
+  cron: "0 2 * * 0",
+  handler: async ({ id, scheduledAt }) => {
     console.log(`Running cleanup ${id} at ${scheduledAt.toISOString()}`)
   },
-  {
-    allowRuntimeSchedules: true,
-    id: "database-cleanup",
-  },
-)
+})

--- a/packages/schedule/examples/vite/src/daily-report.schedule.ts
+++ b/packages/schedule/examples/vite/src/daily-report.schedule.ts
@@ -1,5 +1,8 @@
 import { defineSchedule } from "@vitehub/schedule"
 
-export default defineSchedule("0 8 * * *", async ({ scheduledAt }) => {
-  console.log(`Generating daily report for ${scheduledAt.toISOString()}`)
+export default defineSchedule({
+  cron: "0 8 * * *",
+  handler: async ({ scheduledAt }) => {
+    console.log(`Generating daily report for ${scheduledAt.toISOString()}`)
+  },
 })

--- a/packages/schedule/examples/vite/src/database-cleanup.schedule.ts
+++ b/packages/schedule/examples/vite/src/database-cleanup.schedule.ts
@@ -1,12 +1,9 @@
 import { defineSchedule } from "@vitehub/schedule"
 
-export default defineSchedule(
-  "0 2 * * 0",
-  async ({ id, scheduledAt }) => {
+export default defineSchedule({
+  allowRuntimeSchedules: true,
+  cron: "0 2 * * 0",
+  handler: async ({ id, scheduledAt }) => {
     console.log(`Running cleanup ${id} at ${scheduledAt.toISOString()}`)
   },
-  {
-    allowRuntimeSchedules: true,
-    id: "database-cleanup",
-  },
-)
+})

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -61,7 +61,7 @@ export function validateProviderCron(cron: string, scheduleName: string): void {
 
 function readStaticScheduleCron(file: string, scheduleName: string): string {
   const source = readFileSync(file, "utf8")
-  const cron = readDefaultDefineScheduleCron(source) ?? readDefaultObjectCron(source)
+  const cron = readDefaultDefineScheduleCron(source)
   if (!cron) {
     throw new Error(`Schedule "${scheduleName}" must declare a static cron string for provider wake output.`)
   }
@@ -400,18 +400,6 @@ function readDefaultDefineScheduleCron(source: string): string | undefined {
     const objectSource = readDefineScheduleObjectAfterDefault(source, match.index + match[0].length)
     if (!objectSource) continue
     return readTopLevelCronProperty(objectSource)
-  }
-}
-
-function readDefaultObjectCron(source: string): string | undefined {
-  let match: RegExpExecArray | null
-  const pattern = /\bexport\s+default\b/g
-  while ((match = pattern.exec(source))) {
-    if (isInsideNonCode(source, match.index)) continue
-
-    const objectStart = skipIgnorable(source, match.index + match[0].length)
-    const objectSource = readBalancedObject(source, objectStart)
-    if (objectSource) return readTopLevelCronProperty(objectSource)
   }
 }
 

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -16,7 +16,7 @@ async function createTempProject(prefix: string) {
   await mkdir(join(rootDir, "src"), { recursive: true })
   await mkdir(join(rootDir, "dist", "client"), { recursive: true })
   await writeFile(join(rootDir, "src", "cleanup.schedule.ts"), [
-    "export default { cron: '0 0 * * *', handler: () => 'ok' }",
+    "export default defineSchedule({ cron: '0 0 * * *', handler: () => 'ok' })",
     "",
   ].join("\n"), "utf8")
   return rootDir
@@ -325,21 +325,18 @@ describe("schedule provider output", () => {
     expect(JSON.parse(await readFile(cloudflareConfig, "utf8")).triggers.crons).toEqual(["0 2 * * *"])
   })
 
-  it("continues to later object default exports when earlier defaults are not objects", async () => {
-    const rootDir = await createTempProject("vitehub-schedule-output-later-object-cron-")
+  it("rejects raw default objects for provider cron extraction", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-output-raw-object-cron-")
     await writeFile(join(rootDir, "src", "cleanup.schedule.ts"), [
       "const docs = 'export default helper'",
       "export default { cron: '0 2 * * *', handler: () => 'ok' }",
       "",
     ].join("\n"), "utf8")
 
-    await generateProviderOutputs({
+    await expect(generateProviderOutputs({
       clientOutDir: "dist/client",
       rootDir,
-    })
-
-    const cloudflareConfig = join(createDefaultCloudflareOutputRoot(rootDir), "wrangler.json")
-    expect(JSON.parse(await readFile(cloudflareConfig, "utf8")).triggers.crons).toEqual(["0 2 * * *"])
+    })).rejects.toThrow(/must declare a static cron string/)
   })
 
   it("preserves existing Vercel output config when adding schedule crons", async () => {
@@ -411,7 +408,7 @@ describe("schedule provider output", () => {
     await writeFile(aliasFile, "export const marker = 'nitro-alias-marker'\n", "utf8")
     await writeFile(join(rootDir, "src", "cleanup.schedule.ts"), [
       "import { marker } from '#imports'",
-      "export default { cron: '0 0 * * *', handler: () => marker }",
+      "export default defineSchedule({ cron: '0 0 * * *', handler: () => marker })",
       "",
     ].join("\n"), "utf8")
     await writeFile(registryFile, [
@@ -442,7 +439,7 @@ describe("schedule provider output", () => {
     await writeFile(aliasFile, "export const marker = 'vite-alias-marker'\n", "utf8")
     await writeFile(join(rootDir, "src", "cleanup.schedule.ts"), [
       "import { marker } from '#schedule-helper'",
-      "export default { cron: '0 0 * * *', handler: () => marker }",
+      "export default defineSchedule({ cron: '0 0 * * *', handler: () => marker })",
       "",
     ].join("\n"), "utf8")
 


### PR DESCRIPTION
## Summary

- remove the Schedule provider-output fallback that accepted raw default-exported schedule objects for static cron extraction
- require provider cron extraction to come from direct default-exported `defineSchedule(...)` calls
- update Schedule examples and runner docs to use object-shaped `defineSchedule({ cron, handler })` definitions without definition `id` overrides

Closes #207.

## Validation

- `TMPDIR="$(realpath "${TMPDIR:-/tmp}")" pnpm --filter @vitehub/schedule test`
- `pnpm --filter @vitehub/schedule typecheck`
- `pnpm typecheck`
- proof search: `rg -n "parseAgentName|discoverNamedExports|inline createWorkflow|export default defineSchedule\\(\\s*[']|defineSchedule\\(\\s*[']|readDefaultObjectCron" packages .agents docs`

Note: the plain Schedule test command hits a macOS `/var` vs `/private/var` temp-path alias in provider-output bundling tests; normalizing `TMPDIR` avoids that local path alias and all Schedule tests pass.
