### PR TITLE
feat(agent): type access source grants

### DIFF
--- a/.agents/adr/0038-capability-type-contracts.md
+++ b/.agents/adr/0038-capability-type-contracts.md
@@ -1,13 +1,14 @@
-# Capability Type Contracts for Agent Definition Inputs
+# Narrow Capability Type Contracts for Agent Definition Inputs
 
-ViteHub will let official Capabilities declare a type-only **Capability Type Contract** against Agent Definition inputs they consume, starting with `access()` checking Workspace Source keys and schema-validated chat invocation context. This avoids downstream helper constants and `as any` workarounds while preserving the runtime rule that authority comes from explicit Capability resolvers and Standard Schema validation, not from inferred TypeScript types.
+ViteHub will let official Capabilities declare narrow type-only **Capability Type Contracts** for Agent Definition inputs they directly consume. `defineAgent()` can use those contracts to check inline configuration, starting with `access()` checking Workspace Source keys and schema-validated chat invocation context. Runtime authority still comes from explicit Capability resolvers and Standard Schema validation inside the Capability Lifecycle, not from inferred TypeScript types.
 
 ## Considered Options
 
 - Requiring apps to extract shared constants and pass helper types was rejected because the obvious Agent Definition API should keep Workspace Sources and Capabilities inline.
-- A broad builder or new prepare callback was deferred because the first proven need is smaller: official Capabilities need to carry type contracts that `defineAgent()` can check.
+- A broad builder, new prepare callback, or generic invocation-context schema API was deferred because the first proven need is smaller: official Capabilities need to carry type-only contracts that `defineAgent()` can check.
 - Ambient app context keys were rejected as authority; typed invocation metadata must be validated at the Capability boundary before a resolver trusts it.
+- Treating Capability Type Contracts as a public custom-Capability extension framework was deferred until user-defined Capabilities prove a stable contract story.
 
 ## Consequences
 
-Capability Type Contracts are compile-time contracts over Agent Definition shape. They can reject mismatched Source keys and expose schema output types to Capability callbacks, but they do not attach Capabilities dynamically, mutate Workspace Definitions, or replace runtime validation.
+Capability Type Contracts are compile-time contracts over Agent Definition shape. They can reject mismatched Source keys and expose schema output types to Capability callbacks when the Capability directly consumes that input. They do not attach Capabilities dynamically, mutate Workspace Definitions, replace Agent Invocation Context Values for Capability-produced runtime values, or replace runtime validation.

--- a/.agents/adr/0038-capability-type-contracts.md
+++ b/.agents/adr/0038-capability-type-contracts.md
@@ -1,0 +1,13 @@
+# Capability Type Contracts for Agent Definition Inputs
+
+ViteHub will let official Capabilities declare a type-only **Capability Type Contract** against Agent Definition inputs they consume, starting with `access()` checking Workspace Source keys and schema-validated chat invocation context. This avoids downstream helper constants and `as any` workarounds while preserving the runtime rule that authority comes from explicit Capability resolvers and Standard Schema validation, not from inferred TypeScript types.
+
+## Considered Options
+
+- Requiring apps to extract shared constants and pass helper types was rejected because the obvious Agent Definition API should keep Workspace Sources and Capabilities inline.
+- A broad builder or new prepare callback was deferred because the first proven need is smaller: official Capabilities need to carry type contracts that `defineAgent()` can check.
+- Ambient app context keys were rejected as authority; typed invocation metadata must be validated at the Capability boundary before a resolver trusts it.
+
+## Consequences
+
+Capability Type Contracts are compile-time contracts over Agent Definition shape. They can reject mismatched Source keys and expose schema output types to Capability callbacks, but they do not attach Capabilities dynamically, mutate Workspace Definitions, or replace runtime validation.

--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -128,6 +128,7 @@ _Avoid_: Fake agent, dummy model, test bot
 - A **Chat History Window** is configured by the Agent Definition when the application wants bounded Chat History.
 - The Chat Capability can require state for **Chat History** through the Agent State Provider.
 - The Chat Capability can produce **Chat Identity** before later Capabilities resolve.
+- The default **Chat Identity** for Chat Platform Adapter messages is platform-scoped as `adapter:userId`; applications can override it when they own a stronger cross-platform identity.
 - **Chat Identity** is available through Agent Invocation Context Values and is not model-facing by default.
 - Chat History is explicit application behavior and is not enabled by default.
 - **Agent Invocation Context Values** can be produced by Pre-Invocation Decisions and read by later Agent or Capability callbacks.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -12,6 +12,10 @@ _Avoid_: Plugin, integration, extension
 The object shape, returned by a factory or written inline, that declares a Capability's id, instructions, tools, metadata, mode, and requirements.
 _Avoid_: Raw tool, config mutator
 
+**Capability Type Contract**:
+A type-only contract a Capability declares against Agent Definition inputs it consumes.
+_Avoid_: Generic helper, runtime preparation, ambient app type
+
 **Capability Lifecycle**:
 The ordered process that validates requirements, applies capability contributions, and exposes resulting instructions, tools, policy, and metadata to the Agent.
 _Avoid_: Random hook, raw setup
@@ -178,11 +182,14 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Official helpers such as `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `access()`, `sandbox()`, `kv()`, `blob()`, `db()`, `webSearch()`, `llmRoute()`, and `llmGate()` create **Capability Definitions**.
 - Official Capability factories and Capability-owned helper functions are imported from `@vite-hub/agent/capabilities`, not from the root `@vite-hub/agent` Agent Package entry.
 - Official helpers should map to product abilities rather than implementation mechanisms.
+- A **Capability Definition** may carry a **Capability Type Contract** when it consumes typed Agent Definition inputs such as Source keys or schema-validated invocation context.
+- A **Capability Type Contract** checks developer configuration at Agent Definition time; it does not grant runtime authority.
 - A **Capability Definition** may provide a **Capability Trigger Contribution** when the ability needs to start Agent Invocations from a product event.
 - A **Capability Trigger Contribution** is composed from `defineAgent({ capabilities })`, not registered through a separate helper.
 - A **Capability Trigger Contribution** belongs directly to the Capability shape unless a broader grouping earns its name later.
 - A **Capability Trigger Contribution** maps product event input into Agent Invocation input and run metadata; Agent execution remains owned by the Agent Package.
 - A **Prompt Template** belongs to the Capability that renders it and should expose only the **Prompt Template Variables** that are stable for that Capability.
+- Standard Schema validation is the preferred runtime boundary for app-owned invocation metadata that an official **Capability** consumes.
 - An **Input Command** is a **Capability** concern resolved before model-facing Agent behavior.
 - A **Host Command** is not an **Input Command** and is outside the Capability Lifecycle.
 - A **Pre-Invocation Decision** is an internal primitive used by Capabilities before the main Agent Invocation.
@@ -275,6 +282,9 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 >
 > **Dev:** "Can an LLM route decision attach `workspaceShell()` for this one request?"
 > **Domain expert:** "No. **Capabilities** are static and validated early. A route can influence instructions or other conditional contributions, but it cannot grant a new Capability."
+>
+> **Dev:** "Can `access()` read Source keys and chat metadata from the Agent Definition without app helper types?"
+> **Domain expert:** "Yes, when the Capability declares a **Capability Type Contract**. The type contract checks the Agent Definition shape, while runtime trust still comes from explicit resolvers and validation."
 
 ## Flagged Ambiguities
 
@@ -319,6 +329,7 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Multiple route or gate decisions writing the same context key were considered for priority or merging - resolved: **Pre-Invocation Decision** ids are unique per Agent, with duplicate ids failing early.
 - Dynamic Capability activation through route decisions was considered - resolved: Pre-Invocation Decisions can influence conditional contributions but must not attach, remove, or grant **Capabilities** at runtime.
 - A generic `decisionPolicy()` helper and request-refinement Capability were considered - resolved: defer them until **LLM Route Capability**, **LLM Gate Capability**, and Chat Sessions prove the internal primitive.
+- Typed capability preparation was considered as a runtime lifecycle phase - resolved: use **Capability Type Contract** for type-only Agent Definition checks and keep runtime validation inside the **Capability Lifecycle**.
 - Input Command display metadata was considered capability-level - resolved: Capability id owns identity, while command descriptions are the user-facing metadata hosts may render.
 - Requiring users to attach one Capability per internal mechanism was considered - resolved: users attach one Capability per product ability, and official Capabilities can own their natural Input Command surface when that command is part of the expected user experience.
 - Storage Capability options were described as access levels in an older PR - resolved: official primitive Capabilities use `mode` for read/write exposure, while `access` is older proposal language.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -13,8 +13,8 @@ The object shape, returned by a factory or written inline, that declares a Capab
 _Avoid_: Raw tool, config mutator
 
 **Capability Type Contract**:
-A type-only contract a Capability declares against Agent Definition inputs it consumes.
-_Avoid_: Generic helper, runtime preparation, ambient app type
+A narrow type-only contract an official Capability declares for Agent Definition inputs it directly consumes.
+_Avoid_: Generic helper, runtime preparation, ambient app type, custom Capability framework
 
 **Capability Lifecycle**:
 The ordered process that validates requirements, applies capability contributions, and exposes resulting instructions, tools, policy, and metadata to the Agent.
@@ -182,14 +182,14 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Official helpers such as `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `access()`, `sandbox()`, `kv()`, `blob()`, `db()`, `webSearch()`, `llmRoute()`, and `llmGate()` create **Capability Definitions**.
 - Official Capability factories and Capability-owned helper functions are imported from `@vite-hub/agent/capabilities`, not from the root `@vite-hub/agent` Agent Package entry.
 - Official helpers should map to product abilities rather than implementation mechanisms.
-- A **Capability Definition** may carry a **Capability Type Contract** when it consumes typed Agent Definition inputs such as Source keys or schema-validated invocation context.
-- A **Capability Type Contract** checks developer configuration at Agent Definition time; it does not grant runtime authority.
+- An official **Capability Definition** may carry a narrow **Capability Type Contract** when it directly consumes typed Agent Definition inputs such as Source keys or schema-validated invocation context.
+- A **Capability Type Contract** checks developer configuration at Agent Definition time; it does not grant runtime authority or act as a generic invocation-context schema system.
 - A **Capability Definition** may provide a **Capability Trigger Contribution** when the ability needs to start Agent Invocations from a product event.
 - A **Capability Trigger Contribution** is composed from `defineAgent({ capabilities })`, not registered through a separate helper.
 - A **Capability Trigger Contribution** belongs directly to the Capability shape unless a broader grouping earns its name later.
 - A **Capability Trigger Contribution** maps product event input into Agent Invocation input and run metadata; Agent execution remains owned by the Agent Package.
 - A **Prompt Template** belongs to the Capability that renders it and should expose only the **Prompt Template Variables** that are stable for that Capability.
-- Standard Schema validation is the preferred runtime boundary for app-owned invocation metadata that an official **Capability** consumes.
+- Standard Schema validation is the preferred runtime boundary for app-owned invocation metadata that an official **Capability** directly consumes.
 - An **Input Command** is a **Capability** concern resolved before model-facing Agent behavior.
 - A **Host Command** is not an **Input Command** and is outside the Capability Lifecycle.
 - A **Pre-Invocation Decision** is an internal primitive used by Capabilities before the main Agent Invocation.
@@ -329,7 +329,8 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Multiple route or gate decisions writing the same context key were considered for priority or merging - resolved: **Pre-Invocation Decision** ids are unique per Agent, with duplicate ids failing early.
 - Dynamic Capability activation through route decisions was considered - resolved: Pre-Invocation Decisions can influence conditional contributions but must not attach, remove, or grant **Capabilities** at runtime.
 - A generic `decisionPolicy()` helper and request-refinement Capability were considered - resolved: defer them until **LLM Route Capability**, **LLM Gate Capability**, and Chat Sessions prove the internal primitive.
-- Typed capability preparation was considered as a runtime lifecycle phase - resolved: use **Capability Type Contract** for type-only Agent Definition checks and keep runtime validation inside the **Capability Lifecycle**.
+- Typed capability preparation was considered as a runtime lifecycle phase - resolved: use narrow **Capability Type Contracts** for type-only Agent Definition checks on official Capabilities, and keep runtime validation inside the **Capability Lifecycle**.
+- A generic custom-Capability contract framework was considered - resolved: defer it until user-defined Capabilities prove a stable story; the current contract exists for official Capabilities that directly consume Agent Definition inputs.
 - Input Command display metadata was considered capability-level - resolved: Capability id owns identity, while command descriptions are the user-facing metadata hosts may render.
 - Requiring users to attach one Capability per internal mechanism was considered - resolved: users attach one Capability per product ability, and official Capabilities can own their natural Input Command surface when that command is part of the expected user experience.
 - Storage Capability options were described as access levels in an older PR - resolved: official primitive Capabilities use `mode` for read/write exposure, while `access` is older proposal language.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -182,7 +182,7 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Official helpers such as `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `access()`, `sandbox()`, `kv()`, `blob()`, `db()`, `webSearch()`, `llmRoute()`, and `llmGate()` create **Capability Definitions**.
 - Official Capability factories and Capability-owned helper functions are imported from `@vite-hub/agent/capabilities`, not from the root `@vite-hub/agent` Agent Package entry.
 - Official helpers should map to product abilities rather than implementation mechanisms.
-- An official **Capability Definition** may carry a narrow **Capability Type Contract** when it directly consumes typed Agent Definition inputs such as Source keys or schema-validated invocation context.
+- An official **Capability Definition** may carry a narrow **Capability Type Contract** when it directly consumes typed Agent Definition inputs such as Source keys, trusted Chat Capability origins, or schema-validated invocation context.
 - A **Capability Type Contract** checks developer configuration at Agent Definition time; it does not grant runtime authority or act as a generic invocation-context schema system.
 - A **Capability Definition** may provide a **Capability Trigger Contribution** when the ability needs to start Agent Invocations from a product event.
 - A **Capability Trigger Contribution** is composed from `defineAgent({ capabilities })`, not registered through a separate helper.
@@ -202,6 +202,8 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Primitive storage helpers such as `kv()`, `blob()`, and `db()` are first-class official **Capabilities**, not sample raw-tool wrappers.
 - A **Chat Capability** owns Chat History behavior for the current stack.
 - A **Chat Capability** may declare **Chat Platform Adapters** through a **Chat Adapter Callback**.
+- A **Chat Capability** carries trusted Chat Capability origins from its Chat App Route origin and Chat Platform Adapter names.
+- A **Chat Capability** provides a platform-scoped **Chat Identity** default for Chat Platform Adapter messages when transcript persistence needs one.
 - A **Chat Platform Adapter** may come from a **Chat Adapter Package** that remains an explicit optional application dependency.
 - The Agent Package should not generate exports for every **Chat Adapter Package**.
 - A **Chat Adapter Facade** is reserved for first-party-supported adapters where ViteHub owns the public compatibility surface.
@@ -221,6 +223,8 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - In the first version, an **Access Capability** applies **Workspace Scope** only.
 - An **Access Capability** can record the active Workspace Scope as an Agent Invocation Context Value for later callbacks and instructions.
 - An **Access Capability** owns both Workspace Scope selection and application, but keeps resolver logic separate from grants.
+- An **Access Capability** may reference a **Chat Capability** for typed origin context instead of asking users to repeat Chat Capability origins in Access configuration.
+- An **Access Capability** can use static named Workspace Scopes or an inline Workspace Scope definition returned by its resolver.
 - An **Access Capability** must be ordered before other Workspace-reading Capabilities so Workspace Scope is applied before they resolve tools or requirements.
 - An **Access Capability** provides tiny default **Access Roles** for the first version.
 - The default `viewer` **Access Role** can read granted Source keys and path prefixes through Workspace Scope Grants.
@@ -308,6 +312,7 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Trigger handlers were considered for direct Agent execution - resolved: trigger contributions map input and run metadata, while the Agent Package executes the Agent Invocation through the standard lifecycle.
 - Public chat webhook registration helpers were considered for platform adapters - resolved: use **Chat Webhook Autowiring** from the **Chat Capability** so adapter configuration remains the only source of truth.
 - Build-time Chat Platform Adapter detection was considered - resolved: resolve the **Chat Adapter Callback** at request time because platform credentials and adapter construction can depend on Server Env.
+- Repeating Chat Capability origins in `access()` was considered - resolved: Access input configuration can reference the Chat Capability so resolver types derive from the Chat App Route origin and Chat Platform Adapter names.
 - Capability phases, contexts, hooks, and instruction slots were considered glossary terms - resolved: group that detail under **Capability Lifecycle** unless a feature needs a sharper term.
 - Chat History was considered as a standalone Capability - resolved: keep Chat History inside the **Chat Capability** for this stack and revisit during a future Agent Memory pass.
 - Agent Memory was considered dependent on the Chat Capability - resolved: stack Agent Memory directly on the capability runtime because memory and chat are separate Capability concerns.
@@ -315,6 +320,7 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Workspace Scope was considered as Workspace Definition mutation by a Capability - resolved: use an **Access Capability** to narrow an already-declared Workspace at invocation time instead of changing Sources or Workspace Rules.
 - `workspaceScope()` was considered as the public helper name - resolved: use `access()` for the Capability while preserving **Workspace Scope** for the Workspace-specific boundary.
 - `organization()` was considered as the public helper name - resolved: reject it because access decisions may come from organizations, customer domains, local config, or other trusted invocation context.
+- Pre-registering every customer Workspace Scope was considered necessary - resolved: an Access Capability resolver may return an inline Workspace Scope definition for invocation-specific grants.
 - "audio input", "voice input", and "voice transcription" were considered as names for spoken user messages - resolved: use **Transcription** for the capability.
 - `transcribe({ workspace })` was considered for persisted transcript and audio artifacts - resolved: use **Transcription Artifacts** so the option does not masquerade as a Workspace Definition.
 - Separate Transcription Artifacts `directory`, `stem`, and `extension` fields were considered - resolved: use a **Transcript Workspace Path** as the canonical destination and derive path parts internally.

--- a/.agents/contexts/workspace/CONTEXT.md
+++ b/.agents/contexts/workspace/CONTEXT.md
@@ -148,6 +148,7 @@ _Avoid_: Open workspace, sandbox, mount
 - A Source-key **Workspace Scope Grant** fails closed for unknown Sources and root-mounted Sources; root-mounted Sources require explicit path grants.
 - A **Workspace Scope Resolver** selects the Workspace Scope before Workspace Tools or Workspace-backed instructions are exposed.
 - A **Workspace Scope Resolver** can read trusted host, auth, and invocation context, but it does not use model output as authority.
+- A **Workspace Scope Resolver** can select a static named Workspace Scope or return an inline Workspace Scope definition for invocation-specific grants.
 - Workspace Scope is read-only in the first version.
 - Scoped Workspace Scope does not expose source materialization in the first version.
 - An out-of-scope Workspace path is a **Scope-Masked Miss** to the model.
@@ -187,6 +188,7 @@ _Avoid_: Open workspace, sandbox, mount
 - Workspace Scope write grants were considered for the first version - resolved: keep Workspace Scope read-only until read isolation is proven.
 - `workspaceScope()` was considered as the Capability helper name - resolved: keep **Workspace Scope** as Workspace language and use `access()` for the broader Capability.
 - Ambient `workspaceScope` invocation context was considered as authority - resolved: require an explicit **Workspace Scope Resolver** or **Default Workspace Scope**.
+- Static pre-registration for every customer scope was considered necessary - resolved: use inline Workspace Scope definitions from the **Workspace Scope Resolver** when grants are derived from trusted invocation context.
 - Source materialization under scoped access was considered for the first version - resolved: disable materialization for scoped V1 to avoid source metadata leakage.
 - Build-time Workspace assets were considered a second user-facing read surface - resolved: users read one **Workspace File Tree** while asset provenance remains internal by default.
 - `open()` was considered as the Workspace execution-session method - resolved: use `startSession()` because it names the **Workspace Session** lifecycle.

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -124,6 +124,6 @@ export default defineAgent({
 
 The scope resolver sees the parsed schema output. In this example, portal chat requests must include a customer in message metadata, while non-portal chat surfaces can use the explicit all-scopes Workspace Scope. The resolver returns inline Workspace Scope definitions, so the app does not need to pre-register one scope per customer.
 
-The Chat App Route origin is configured in `chat({ app })` so the access decision does not trust a browser-controlled payload. Passing the Chat Capability to `access({ input.chat.capability })` lets the resolver infer `chat.run.origin` from the Chat App Route origin and Chat Platform Adapter names.
+The Chat App Route origin is configured in `chat({ app })` so the access decision does not trust a browser-controlled payload. A request body may repeat the same `run.origin`, but it cannot override the configured app origin; mismatches are rejected as bad requests so app-level proxies fail closed when their contract drifts. Passing the Chat Capability to `access({ input.chat.capability })` lets the resolver infer `chat.run.origin` from the Chat App Route origin and Chat Platform Adapter names.
 
 Order matters. Access should run before Workspace-reading Capabilities so the scope is applied before tools are exposed.

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -43,17 +43,87 @@ Use write mode only when the Agent is explicitly supposed to mutate Workspace fi
 
 Use the Access Capability when invocation identity should narrow the visible Workspace Scope.
 
-```ts
-import { access, workspaceShell } from '@vite-hub/agent/capabilities'
+```ts [server/agents/support/config.ts]
+import { gateway } from '@ai-sdk/gateway'
+import { createTeamsAdapter } from '@chat-adapter/teams'
+import { defineAgent } from '@vite-hub/agent'
+import { access, chat, workspaceShell } from '@vite-hub/agent/capabilities'
+import { source } from '@vite-hub/workspace'
+import { z } from 'zod'
+
+const portalMetadataSchema = z.object({
+  quiver: z.object({
+    customer: z.string().min(1),
+  }),
+})
+
+const portalUserSchema = z.object({
+  email: z.string().email().optional(),
+})
+
+const supportChat = chat({
+  adapters: () => ({
+    teams: createTeamsAdapter({
+      apiUrl: process.env.TEAMS_API_URL,
+      appId: process.env.TEAMS_APP_ID!,
+      appPassword: process.env.TEAMS_APP_PASSWORD!,
+      appTenantId: process.env.TEAMS_APP_TENANT_ID!,
+      appType: 'SingleTenant',
+    }),
+  }),
+  app: 'portal',
+})
 
 export default defineAgent({
+  workspace: {
+    sources: {
+      instructions: source.file('AGENTS.md'),
+      ingestion: source.github({
+        repo: 'quiverdk/ingestion',
+        root: 'dbt',
+      }),
+      forecastingEngine: source.github({
+        repo: 'quiverdk/forecasting-engine',
+      }),
+    },
+  },
   capabilities: [
-    access({ roles }),
+    access({
+      input: {
+        chat: {
+          capability: supportChat,
+          message: { metadata: portalMetadataSchema },
+          user: portalUserSchema,
+        },
+      },
+      workspace: {
+        resolve({ input }) {
+          const chat = input.get().context?.chat
+          if (chat?.run?.origin !== 'portal')
+            return { all: true, role: 'admin', scope: 'support' }
+
+          const customer = chat.message?.metadata.quiver.customer
+          return {
+            grants: [
+              { path: 'AGENTS.md' },
+              { source: 'forecastingEngine' },
+              { path: `ingestion/${customer}` },
+            ],
+            scope: customer,
+          }
+        },
+      },
+    }),
     workspaceShell({ mode: 'read' }),
+    supportChat,
   ],
-  instructions,
-  model,
+  instructions: 'Answer from the scoped customer workspace.',
+  model: gateway('openai/gpt-5.1-mini'),
 })
 ```
+
+The scope resolver sees the parsed schema output. In this example, portal chat requests must include a customer in message metadata, while non-portal chat surfaces can use the explicit all-scopes Workspace Scope. The resolver returns inline Workspace Scope definitions, so the app does not need to pre-register one scope per customer.
+
+The Chat App Route origin is configured in `chat({ app })` so the access decision does not trust a browser-controlled payload. Passing the Chat Capability to `access({ input.chat.capability })` lets the resolver infer `chat.run.origin` from the Chat App Route origin and Chat Platform Adapter names.
 
 Order matters. Access should run before Workspace-reading Capabilities so the scope is applied before tools are exposed.

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -1,14 +1,17 @@
 import { workspaceOverrideSymbol } from "../access-runtime.ts"
 import { defineCapability } from "../capability-runtime.ts"
+import { parseStandardSchema } from "@vite-hub/internal/http-request"
 import { createWorkspaceTools } from "@vite-hub/workspace"
 
 import type {
   AgentCapabilityDefinition,
   AgentCapabilityRuntimeContext,
+  AgentCapabilityTypeContract,
   AgentRunInput,
   AgentRuntimeConfig,
   MaybePromise,
 } from "../types.ts"
+import type { AgentChatRunContext } from "../chat-trigger.ts"
 import type {
   ListOptions,
   ReadonlyWorkspaceFacade,
@@ -23,6 +26,86 @@ import type {
 import type { WorkspaceOverrideRuntime } from "../access-runtime.ts"
 
 export type AccessRoleName = "viewer" | "admin" | (string & {})
+
+export interface AccessCapabilityStandardSchemaResultSuccess<T = unknown> {
+  issues?: undefined
+  value: T
+}
+
+export interface AccessCapabilityStandardSchemaResultFailure {
+  issues: readonly unknown[]
+}
+
+export interface AccessCapabilityStandardSchemaV1<T = unknown> {
+  "~standard": {
+    validate: (input: unknown) => AccessCapabilityStandardSchemaResultSuccess<T> | AccessCapabilityStandardSchemaResultFailure | Promise<AccessCapabilityStandardSchemaResultSuccess<T> | AccessCapabilityStandardSchemaResultFailure>
+  }
+}
+
+type AccessObjectSchema = AccessCapabilityStandardSchemaV1<Record<string, unknown>>
+
+export interface AccessChatMessageInputSchemaOptions<TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined> {
+  metadata?: TMessageMetadataSchema
+}
+
+export interface AccessChatInputSchemaOptions<
+  TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
+  TUserSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
+> {
+  message?: AccessChatMessageInputSchemaOptions<TMessageMetadataSchema>
+  user?: TUserSchema
+}
+
+export interface AccessInputSchemaOptions<
+  TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
+  TUserSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
+> {
+  chat?: AccessChatInputSchemaOptions<TMessageMetadataSchema, TUserSchema>
+}
+
+type AccessSchemaObjectOutput<TSchema> =
+  TSchema extends AccessCapabilityStandardSchemaV1<infer TOutput>
+    ? TOutput extends Record<string, unknown> ? TOutput : Record<string, unknown>
+    : Record<string, unknown>
+
+export type AccessInputContextFromSchemas<TInputSchemas> =
+  TInputSchemas extends { chat?: infer TChat }
+    ? AgentChatRunContext<
+        TChat extends { message?: { metadata?: infer TMessageMetadataSchema } }
+          ? AccessSchemaObjectOutput<TMessageMetadataSchema>
+          : Record<string, unknown>,
+        TChat extends { user?: infer TUserSchema }
+          ? AccessSchemaObjectOutput<TUserSchema>
+          : Record<string, unknown>
+      >
+    : Record<string, unknown>
+
+export type AccessCapabilityTypeContract<
+  TSourceName extends string = string,
+  TInputContext extends object = Record<string, unknown>,
+> = AgentCapabilityTypeContract & {
+  inputContext: TInputContext
+  workspaceSources: TSourceName
+}
+
+type AccessGrantSourceName<TGrant> =
+  (TGrant extends { source?: infer TSource }
+    ? TSource
+    : never)
+  | (TGrant extends { sources?: readonly (infer TSource)[] }
+    ? TSource
+    : never)
+
+type AccessScopeDefinitionSourceName<TDefinition> =
+  AccessGrantSourceName<TDefinition>
+  | (TDefinition extends { grants?: readonly (infer TGrant)[] }
+    ? AccessGrantSourceName<TGrant>
+    : never)
+
+export type AccessWorkspaceScopeSourceName<TWorkspace> =
+  TWorkspace extends { scopes: infer TScopes }
+    ? Extract<{ [Scope in keyof TScopes]: AccessScopeDefinitionSourceName<TScopes[Scope]> }[keyof TScopes], string>
+    : string
 
 export interface AccessWorkspaceScopeGrant<TSourceName extends string = string> {
   path?: string
@@ -83,7 +166,9 @@ export interface AccessCapabilityOptions<
   Name extends WorkspaceName = WorkspaceName,
   TSourceName extends string = string,
   TInputContext extends object = Record<string, unknown>,
+  TInputSchemas extends AccessInputSchemaOptions | undefined = undefined,
 > {
+  input?: TInputSchemas
   workspace: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext>
 }
 
@@ -121,9 +206,16 @@ function setWorkspaceOverride<
 export function access<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
-  TSourceName extends string = string,
   TInputContext extends object = Record<string, unknown>,
->(options: AccessCapabilityOptions<TRuntimeConfig, Name, TSourceName, TInputContext>): AgentCapabilityDefinition<TRuntimeConfig, Name> {
+  const TWorkspace extends AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext> = AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext>,
+>(options: { input?: undefined, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext>>
+export function access<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  const TInputSchemas extends AccessInputSchemaOptions = AccessInputSchemaOptions,
+  const TWorkspace extends AccessWorkspaceOptions<TRuntimeConfig, Name, string, AccessInputContextFromSchemas<TInputSchemas>> = AccessWorkspaceOptions<TRuntimeConfig, Name, string, AccessInputContextFromSchemas<TInputSchemas>>,
+>(options: { input: TInputSchemas, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, AccessInputContextFromSchemas<TInputSchemas>>>
+export function access(options: AccessCapabilityOptions): AgentCapabilityDefinition {
   if (!options || typeof options !== "object" || !options.workspace) {
     throw new TypeError("[vitehub] access() requires workspace options.")
   }
@@ -138,6 +230,8 @@ export function access<
       if ("diff" in context.workspace) {
         throw new Error("[vitehub] access({ workspace }) is read-only in the first version and requires workspace.mode: \"read\".")
       }
+      const input = await applyAccessInputSchemas(options.input, context.input.get())
+      if (input !== context.input.get()) context.input.set(input)
       const scope = await resolveWorkspaceScope(options.workspace, context)
       const scopedWorkspace = scope.all
         ? context.workspace
@@ -150,6 +244,54 @@ export function access<
       setWorkspaceOverride(context, scopedWorkspace)
     },
   })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+async function applyAccessInputSchemas(
+  schemas: AccessInputSchemaOptions | undefined,
+  input: AgentRunInput,
+): Promise<AgentRunInput> {
+  const chatSchemas = schemas?.chat
+  if (!chatSchemas) return input
+
+  const inputContext = isRecord(input.context) ? input.context : undefined
+  const chat = isRecord(inputContext?.chat) ? inputContext.chat : undefined
+  if (!chat) return input
+
+  let nextChat = chat
+  const message = isRecord(chat.message) ? chat.message : undefined
+  const metadataSchema = chatSchemas.message?.metadata
+  if (metadataSchema && message && message.metadata !== undefined) {
+    const metadata = await parseStandardSchema(metadataSchema, message.metadata, "chat.message.metadata")
+    nextChat = {
+      ...nextChat,
+      message: {
+        ...message,
+        metadata,
+      },
+    }
+  }
+
+  const userSchema = chatSchemas.user
+  if (userSchema && chat.user !== undefined) {
+    const user = await parseStandardSchema(userSchema, chat.user, "chat.user")
+    nextChat = {
+      ...nextChat,
+      user,
+    }
+  }
+
+  if (nextChat === chat) return input
+  return {
+    ...input,
+    context: {
+      ...(inputContext || {}),
+      chat: nextChat,
+    },
+  }
 }
 
 async function resolveWorkspaceScope<

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -42,7 +42,7 @@ export interface AccessCapabilityStandardSchemaV1<T = unknown> {
   }
 }
 
-type AccessObjectSchema = AccessCapabilityStandardSchemaV1<Record<string, unknown>>
+type AccessObjectSchema = AccessCapabilityStandardSchemaV1<object>
 
 export interface AccessChatMessageInputSchemaOptions<TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined> {
   metadata?: TMessageMetadataSchema
@@ -65,7 +65,7 @@ export interface AccessInputSchemaOptions<
 
 type AccessSchemaObjectOutput<TSchema> =
   TSchema extends AccessCapabilityStandardSchemaV1<infer TOutput>
-    ? TOutput extends Record<string, unknown> ? TOutput : Record<string, unknown>
+    ? TOutput extends object ? TOutput : Record<string, unknown>
     : Record<string, unknown>
 
 export type AccessInputContextFromSchemas<TInputSchemas> =

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -109,18 +109,18 @@ export type AccessWorkspaceScopeSourceName<TWorkspace> =
 
 export interface AccessWorkspaceScopeGrant<TSourceName extends string = string> {
   path?: string
-  paths?: string[]
+  paths?: readonly string[]
   source?: TSourceName
-  sources?: TSourceName[]
+  sources?: readonly TSourceName[]
 }
 
 export interface AccessWorkspaceScopeDefinition<TSourceName extends string = string> {
   all?: boolean
-  grants?: AccessWorkspaceScopeGrant<TSourceName>[]
+  grants?: readonly AccessWorkspaceScopeGrant<TSourceName>[]
   path?: string
-  paths?: string[]
+  paths?: readonly string[]
   source?: TSourceName
-  sources?: TSourceName[]
+  sources?: readonly TSourceName[]
 }
 
 export interface AccessWorkspaceScopeSelection {
@@ -372,7 +372,7 @@ function scopePaths(definition: AccessWorkspaceScopeDefinition, workspaceDefinit
   return normalized.sort((left, right) => left.length - right.length || left.localeCompare(right))
 }
 
-function normalizeStringList(single: string | undefined, multiple: string[] | undefined): string[] {
+function normalizeStringList(single: string | undefined, multiple: readonly string[] | undefined): string[] {
   return [
     ...(single ? [single] : []),
     ...(multiple || []),

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -7,6 +7,8 @@ import type {
   AgentCapabilityDefinition,
   AgentCapabilityRuntimeContext,
   AgentCapabilityTypeContract,
+  AgentChatAppExposure,
+  AgentChatOptions,
   AgentRunInput,
   AgentRuntimeConfig,
   MaybePromise,
@@ -294,13 +296,12 @@ async function applyAccessInputSchemas(
   if (!chatSchemas) return input
 
   const inputContext = isRecord(input.context) ? input.context : undefined
-  const chat = isRecord(inputContext?.chat) ? inputContext.chat : undefined
-  if (!chat) return input
+  const chat = isRecord(inputContext?.chat) ? inputContext.chat : {}
 
   let nextChat = chat
   const message = isRecord(chat.message) ? chat.message : undefined
   const metadataSchema = chatSchemas.message?.metadata
-  if (metadataSchema) {
+  if (metadataSchema && shouldValidateChatMessageMetadata(chatSchemas, chat)) {
     const metadata = await parseStandardSchema(metadataSchema, message?.metadata, "chat.message.metadata")
     nextChat = {
       ...nextChat,
@@ -337,6 +338,31 @@ async function applyAccessInputSchemas(
       chat: nextChat,
     },
   }
+}
+
+function chatCapabilityOptions(value: unknown): AgentChatOptions | undefined {
+  const metadata = isRecord(value) ? value.metadata : undefined
+  return isRecord(metadata) && metadata.kind === "chat" && isRecord(metadata.chat)
+    ? metadata.chat as AgentChatOptions
+    : undefined
+}
+
+function chatAppOrigin(app: AgentChatAppExposure | undefined): string | undefined {
+  if (!app) return
+  if (typeof app === "string") return app
+  if (app === true) return "http"
+  return typeof app.origin === "string" && app.origin ? app.origin : "http"
+}
+
+function shouldValidateChatMessageMetadata(
+  schemas: AccessChatInputSchemaOptions,
+  chat: Record<string, unknown>,
+): boolean {
+  const appOrigin = chatAppOrigin(chatCapabilityOptions(schemas.capability)?.app)
+  if (!appOrigin) return true
+  const run = isRecord(chat.run) ? chat.run : undefined
+  const origin = run?.origin
+  return typeof origin !== "string" || origin === appOrigin
 }
 
 async function resolveWorkspaceScope<
@@ -390,13 +416,26 @@ async function resolveSelection<
   return options.defaultScope
 }
 
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0
+}
+
+function hasNonEmptyStringList(value: unknown): boolean {
+  return Array.isArray(value) && value.some(hasNonEmptyString)
+}
+
+function hasNonEmptyScopeGrant(value: unknown): boolean {
+  return isRecord(value)
+    && (hasNonEmptyString(value.path)
+      || hasNonEmptyStringList(value.paths)
+      || hasNonEmptyString(value.source)
+      || hasNonEmptyStringList(value.sources))
+}
+
 function hasInlineScopeDefinition(value: Record<string, unknown>): boolean {
-  return "all" in value
-    || "grants" in value
-    || "path" in value
-    || "paths" in value
-    || "source" in value
-    || "sources" in value
+  return value.all === true
+    || (Array.isArray(value.grants) && value.grants.some(hasNonEmptyScopeGrant))
+    || hasNonEmptyScopeGrant(value)
 }
 
 function normalizeSelection<TSourceName extends string>(value: unknown): NormalizedWorkspaceScopeSelection<TSourceName> | undefined {

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -11,7 +11,7 @@ import type {
   AgentRuntimeConfig,
   MaybePromise,
 } from "../types.ts"
-import type { AgentChatRunContext } from "../chat-trigger.ts"
+import type { AgentChatCapabilityOrigin, AgentChatRunContext } from "../chat-trigger.ts"
 import type {
   ListOptions,
   ReadonlyWorkspaceFacade,
@@ -48,25 +48,42 @@ export interface AccessChatMessageInputSchemaOptions<TMessageMetadataSchema exte
   metadata?: TMessageMetadataSchema
 }
 
+export interface AccessChatRunInputOptions<TOrigin extends string = string> {
+  origin?: readonly TOrigin[]
+}
+
 export interface AccessChatInputSchemaOptions<
   TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
   TUserSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
+  TOrigin extends string = string,
+  TChatCapability = unknown,
 > {
+  capability?: TChatCapability
   message?: AccessChatMessageInputSchemaOptions<TMessageMetadataSchema>
+  run?: AccessChatRunInputOptions<TOrigin>
   user?: TUserSchema
 }
 
 export interface AccessInputSchemaOptions<
   TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
   TUserSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
+  TOrigin extends string = string,
+  TChatCapability = unknown,
 > {
-  chat?: AccessChatInputSchemaOptions<TMessageMetadataSchema, TUserSchema>
+  chat?: AccessChatInputSchemaOptions<TMessageMetadataSchema, TUserSchema, TOrigin, TChatCapability>
 }
 
 type AccessSchemaObjectOutput<TSchema> =
   TSchema extends AccessCapabilityStandardSchemaV1<infer TOutput>
     ? TOutput extends object ? TOutput : Record<string, unknown>
     : Record<string, unknown>
+
+type AccessChatRunOrigin<TChat> =
+  TChat extends { run?: { origin?: readonly (infer TOrigin)[] } }
+    ? Extract<TOrigin, string>
+    : TChat extends { capability?: infer TChatCapability }
+      ? AgentChatCapabilityOrigin<TChatCapability>
+    : string
 
 export type AccessInputContextFromSchemas<TInputSchemas> =
   TInputSchemas extends { chat?: infer TChat }
@@ -76,7 +93,8 @@ export type AccessInputContextFromSchemas<TInputSchemas> =
           : Record<string, unknown>,
         TChat extends { user?: infer TUserSchema }
           ? AccessSchemaObjectOutput<TUserSchema>
-          : Record<string, unknown>
+          : Record<string, unknown>,
+        AccessChatRunOrigin<TChat>
       >
     : Record<string, unknown>
 
@@ -102,10 +120,21 @@ type AccessScopeDefinitionSourceName<TDefinition> =
     ? AccessGrantSourceName<TGrant>
     : never)
 
+type AccessResolvedScopeSelection<TResolve> =
+  TResolve extends (...args: any[]) => infer TResult
+    ? Awaited<TResult>
+    : TResolve
+
 export type AccessWorkspaceScopeSourceName<TWorkspace> =
-  TWorkspace extends { scopes: infer TScopes }
-    ? Extract<{ [Scope in keyof TScopes]: AccessScopeDefinitionSourceName<TScopes[Scope]> }[keyof TScopes], string>
-    : string
+  Extract<
+    (TWorkspace extends { scopes?: infer TScopes }
+      ? { [Scope in keyof NonNullable<TScopes>]: AccessScopeDefinitionSourceName<NonNullable<TScopes>[Scope]> }[keyof NonNullable<TScopes>]
+      : never)
+    | (TWorkspace extends { resolve?: infer TResolve }
+      ? AccessScopeDefinitionSourceName<AccessResolvedScopeSelection<NonNullable<TResolve>>>
+      : never),
+    string
+  >
 
 export interface AccessWorkspaceScopeGrant<TSourceName extends string = string> {
   path?: string
@@ -123,14 +152,14 @@ export interface AccessWorkspaceScopeDefinition<TSourceName extends string = str
   sources?: readonly TSourceName[]
 }
 
-export interface AccessWorkspaceScopeSelection {
+export interface AccessWorkspaceScopeSelection<TSourceName extends string = string> extends AccessWorkspaceScopeDefinition<TSourceName> {
   role?: AccessRoleName
   scope: string
 }
 
-export type AccessWorkspaceScopeSelectionInput =
+export type AccessWorkspaceScopeSelectionInput<TSourceName extends string = string> =
   | string
-  | AccessWorkspaceScopeSelection
+  | AccessWorkspaceScopeSelection<TSourceName>
 
 export type AccessWorkspaceResolverContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -146,9 +175,10 @@ export type AccessWorkspaceScopeResolver<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
   TInputContext extends object = Record<string, unknown>,
+  TSourceName extends string = string,
 > = (
   context: AccessWorkspaceResolverContext<TRuntimeConfig, Name, TInputContext>,
-) => MaybePromise<AccessWorkspaceScopeSelectionInput | undefined>
+) => MaybePromise<AccessWorkspaceScopeSelectionInput<TSourceName> | undefined>
 
 export interface AccessWorkspaceOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -157,8 +187,8 @@ export interface AccessWorkspaceOptions<
   TInputContext extends object = Record<string, unknown>,
 > {
   defaultScope?: string
-  resolve?: AccessWorkspaceScopeSelectionInput | AccessWorkspaceScopeResolver<TRuntimeConfig, Name, TInputContext>
-  scopes: Record<string, AccessWorkspaceScopeDefinition<TSourceName>>
+  resolve?: AccessWorkspaceScopeSelectionInput<TSourceName> | AccessWorkspaceScopeResolver<TRuntimeConfig, Name, TInputContext, TSourceName>
+  scopes?: Record<string, AccessWorkspaceScopeDefinition<TSourceName>>
 }
 
 export interface AccessCapabilityOptions<
@@ -186,6 +216,12 @@ interface ResolvedWorkspaceScope {
   all: boolean
   paths: string[]
   role: AccessRoleName
+  scope: string
+}
+
+interface NormalizedWorkspaceScopeSelection<TSourceName extends string = string> {
+  definition?: AccessWorkspaceScopeDefinition<TSourceName>
+  role?: AccessRoleName
   scope: string
 }
 
@@ -264,23 +300,32 @@ async function applyAccessInputSchemas(
   let nextChat = chat
   const message = isRecord(chat.message) ? chat.message : undefined
   const metadataSchema = chatSchemas.message?.metadata
-  if (metadataSchema && message && message.metadata !== undefined) {
-    const metadata = await parseStandardSchema(metadataSchema, message.metadata, "chat.message.metadata")
+  if (metadataSchema) {
+    const metadata = await parseStandardSchema(metadataSchema, message?.metadata, "chat.message.metadata")
     nextChat = {
       ...nextChat,
       message: {
-        ...message,
+        ...(message || {}),
         metadata,
       },
     }
   }
 
   const userSchema = chatSchemas.user
-  if (userSchema && chat.user !== undefined) {
+  if (userSchema) {
     const user = await parseStandardSchema(userSchema, chat.user, "chat.user")
     nextChat = {
       ...nextChat,
       user,
+    }
+  }
+
+  const origins = chatSchemas.run?.origin
+  if (origins) {
+    const run = isRecord(chat.run) ? chat.run : undefined
+    const origin = run?.origin
+    if (typeof origin !== "string" || !origins.includes(origin)) {
+      throw new Error(`[vitehub] Invalid chat.run.origin: expected one of ${origins.map(value => JSON.stringify(value)).join(", ")}.`)
     }
   }
 
@@ -308,9 +353,9 @@ async function resolveWorkspaceScope<
     throw new Error("[vitehub] access({ workspace }) could not resolve a Workspace Scope. Configure defaultScope or resolve().")
   }
 
-  const definition = options.scopes[selection.scope]
+  const definition = selection.definition || options.scopes?.[selection.scope]
   if (!definition) {
-    throw new Error(`[vitehub] access({ workspace }) resolved unknown Workspace Scope "${selection.scope}".`)
+    throw new Error(`[vitehub] access({ workspace }) resolved unknown Workspace Scope "${selection.scope}". Configure scopes.${selection.scope} or return an inline scope definition.`)
   }
 
   const role = selection.role || "viewer"
@@ -335,22 +380,34 @@ async function resolveSelection<
 >(
   options: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext>,
   context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
-): Promise<AccessWorkspaceScopeSelectionInput | undefined> {
+): Promise<AccessWorkspaceScopeSelectionInput<TSourceName> | undefined> {
   if (options.resolve !== undefined) {
     const resolved = typeof options.resolve === "function"
       ? await options.resolve(context as AccessWorkspaceResolverContext<TRuntimeConfig, Name, TInputContext>)
       : options.resolve
-    return normalizeSelection(resolved) || options.defaultScope
+    return normalizeSelection(resolved) ? resolved : options.defaultScope
   }
   return options.defaultScope
 }
 
-function normalizeSelection(value: unknown): AccessWorkspaceScopeSelection | undefined {
+function hasInlineScopeDefinition(value: Record<string, unknown>): boolean {
+  return "all" in value
+    || "grants" in value
+    || "path" in value
+    || "paths" in value
+    || "source" in value
+    || "sources" in value
+}
+
+function normalizeSelection<TSourceName extends string>(value: unknown): NormalizedWorkspaceScopeSelection<TSourceName> | undefined {
   if (typeof value === "string" && value.trim()) return { scope: value }
   if (!value || typeof value !== "object") return undefined
   const candidate = value as { role?: unknown, scope?: unknown }
   if (typeof candidate.scope !== "string" || !candidate.scope.trim()) return undefined
   return {
+    ...(hasInlineScopeDefinition(value as Record<string, unknown>)
+      ? { definition: value as AccessWorkspaceScopeDefinition<TSourceName> }
+      : {}),
     ...(typeof candidate.role === "string" && candidate.role.trim() ? { role: candidate.role } : {}),
     scope: candidate.scope,
   }

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -5,6 +5,7 @@ import { createWorkspaceTools } from "@vite-hub/workspace"
 import type {
   AgentCapabilityDefinition,
   AgentCapabilityRuntimeContext,
+  AgentRunInput,
   AgentRuntimeConfig,
   MaybePromise,
 } from "../types.ts"
@@ -17,25 +18,26 @@ import type {
   WorkspaceName,
   WorkspaceSearchHit,
   WorkspaceSearchQuery,
+  WorkspaceSource,
 } from "@vite-hub/workspace"
 import type { WorkspaceOverrideRuntime } from "../access-runtime.ts"
 
 export type AccessRoleName = "viewer" | "admin" | (string & {})
 
-export interface AccessWorkspaceScopeGrant {
+export interface AccessWorkspaceScopeGrant<TSourceName extends string = string> {
   path?: string
   paths?: string[]
-  source?: string
-  sources?: string[]
+  source?: TSourceName
+  sources?: TSourceName[]
 }
 
-export interface AccessWorkspaceScopeDefinition {
+export interface AccessWorkspaceScopeDefinition<TSourceName extends string = string> {
   all?: boolean
-  grants?: AccessWorkspaceScopeGrant[]
+  grants?: AccessWorkspaceScopeGrant<TSourceName>[]
   path?: string
   paths?: string[]
-  source?: string
-  sources?: string[]
+  source?: TSourceName
+  sources?: TSourceName[]
 }
 
 export interface AccessWorkspaceScopeSelection {
@@ -47,28 +49,53 @@ export type AccessWorkspaceScopeSelectionInput =
   | string
   | AccessWorkspaceScopeSelection
 
+export type AccessWorkspaceResolverContext<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  TInputContext extends object = Record<string, unknown>,
+> = Omit<AgentCapabilityRuntimeContext<TRuntimeConfig, Name>, "input"> & {
+  input: Omit<AgentCapabilityRuntimeContext<TRuntimeConfig, Name>["input"], "get"> & {
+    get: () => AgentRunInput<unknown, TInputContext>
+  }
+}
+
 export type AccessWorkspaceScopeResolver<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
+  TInputContext extends object = Record<string, unknown>,
 > = (
-  context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
+  context: AccessWorkspaceResolverContext<TRuntimeConfig, Name, TInputContext>,
 ) => MaybePromise<AccessWorkspaceScopeSelectionInput | undefined>
 
 export interface AccessWorkspaceOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
+  TSourceName extends string = string,
+  TInputContext extends object = Record<string, unknown>,
 > {
   defaultScope?: string
-  resolve?: AccessWorkspaceScopeSelectionInput | AccessWorkspaceScopeResolver<TRuntimeConfig, Name>
-  scopes: Record<string, AccessWorkspaceScopeDefinition>
+  resolve?: AccessWorkspaceScopeSelectionInput | AccessWorkspaceScopeResolver<TRuntimeConfig, Name, TInputContext>
+  scopes: Record<string, AccessWorkspaceScopeDefinition<TSourceName>>
 }
 
 export interface AccessCapabilityOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
+  TSourceName extends string = string,
+  TInputContext extends object = Record<string, unknown>,
 > {
-  workspace: AccessWorkspaceOptions<TRuntimeConfig, Name>
+  workspace: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext>
 }
+
+export type AccessWorkspaceSourceName<TWorkspace extends { sources?: Record<string, WorkspaceSource> }> =
+  Extract<keyof NonNullable<TWorkspace["sources"]>, string>
+
+export type AccessWorkspaceOptionsFor<
+  TWorkspace extends { sources?: Record<string, WorkspaceSource> },
+  TInputContext extends object = Record<string, unknown>,
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> = AccessWorkspaceOptions<TRuntimeConfig, Name, AccessWorkspaceSourceName<TWorkspace>, TInputContext>
 
 interface ResolvedWorkspaceScope {
   all: boolean
@@ -94,7 +121,9 @@ function setWorkspaceOverride<
 export function access<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
->(options: AccessCapabilityOptions<TRuntimeConfig, Name>): AgentCapabilityDefinition<TRuntimeConfig, Name> {
+  TSourceName extends string = string,
+  TInputContext extends object = Record<string, unknown>,
+>(options: AccessCapabilityOptions<TRuntimeConfig, Name, TSourceName, TInputContext>): AgentCapabilityDefinition<TRuntimeConfig, Name> {
   if (!options || typeof options !== "object" || !options.workspace) {
     throw new TypeError("[vitehub] access() requires workspace options.")
   }
@@ -126,8 +155,10 @@ export function access<
 async function resolveWorkspaceScope<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
+  TSourceName extends string,
+  TInputContext extends object,
 >(
-  options: AccessWorkspaceOptions<TRuntimeConfig, Name>,
+  options: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext>,
   context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
 ): Promise<ResolvedWorkspaceScope> {
   const selection = normalizeSelection(await resolveSelection(options, context))
@@ -157,13 +188,15 @@ async function resolveWorkspaceScope<
 async function resolveSelection<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
+  TSourceName extends string,
+  TInputContext extends object,
 >(
-  options: AccessWorkspaceOptions<TRuntimeConfig, Name>,
+  options: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext>,
   context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
 ): Promise<AccessWorkspaceScopeSelectionInput | undefined> {
   if (options.resolve !== undefined) {
     const resolved = typeof options.resolve === "function"
-      ? await options.resolve(context)
+      ? await options.resolve(context as AccessWorkspaceResolverContext<TRuntimeConfig, Name, TInputContext>)
       : options.resolve
     return normalizeSelection(resolved) || options.defaultScope
   }

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -72,7 +72,6 @@ export type {
   AccessCapabilityStandardSchemaResultFailure,
   AccessCapabilityStandardSchemaResultSuccess,
   AccessCapabilityStandardSchemaV1,
-  AccessCapabilityTypeContract,
   AccessChatInputSchemaOptions,
   AccessChatMessageInputSchemaOptions,
   AccessInputContextFromSchemas,

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -74,6 +74,7 @@ export type {
   AccessCapabilityStandardSchemaV1,
   AccessChatInputSchemaOptions,
   AccessChatMessageInputSchemaOptions,
+  AccessChatRunInputOptions,
   AccessInputContextFromSchemas,
   AccessInputSchemaOptions,
   AccessRoleName,
@@ -88,7 +89,9 @@ export type {
   AccessWorkspaceSourceName,
 } from "./access.ts"
 export type {
+  AgentChatCapabilityOrigin,
   AgentChatMessageTriggerInput,
+  AgentChatOptionsOrigin,
   AgentChatRunContext,
 } from "../chat-trigger.ts"
 export type {
@@ -98,6 +101,7 @@ export type {
   AgentChatAgentHookArgs,
   AgentChatEventHookArgs,
   AgentChatEventHooks,
+  AgentChatIdentityResolver,
   AgentChatMessageHookArgs,
   AgentChatOptions,
   AgentChatSessionOptions,

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -69,6 +69,14 @@ export {
 
 export type {
   AccessCapabilityOptions,
+  AccessCapabilityStandardSchemaResultFailure,
+  AccessCapabilityStandardSchemaResultSuccess,
+  AccessCapabilityStandardSchemaV1,
+  AccessCapabilityTypeContract,
+  AccessChatInputSchemaOptions,
+  AccessChatMessageInputSchemaOptions,
+  AccessInputContextFromSchemas,
+  AccessInputSchemaOptions,
   AccessRoleName,
   AccessWorkspaceOptions,
   AccessWorkspaceOptionsFor,

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -71,14 +71,18 @@ export type {
   AccessCapabilityOptions,
   AccessRoleName,
   AccessWorkspaceOptions,
+  AccessWorkspaceOptionsFor,
+  AccessWorkspaceResolverContext,
   AccessWorkspaceScopeDefinition,
   AccessWorkspaceScopeGrant,
   AccessWorkspaceScopeResolver,
   AccessWorkspaceScopeSelection,
   AccessWorkspaceScopeSelectionInput,
+  AccessWorkspaceSourceName,
 } from "./access.ts"
 export type {
   AgentChatMessageTriggerInput,
+  AgentChatRunContext,
 } from "../chat-trigger.ts"
 export type {
   AgentChatAdapterResolver,

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -7,6 +7,7 @@ import type {
   AgentCallbackContext,
   AgentCapabilityContext,
   AgentCapabilityDefinition,
+  AgentCapabilityTypeContract,
   AgentCapabilityHookName,
   AgentCapabilityHooks,
   AgentCapabilityMode,
@@ -95,9 +96,10 @@ function assertTriggerName(name: unknown, capabilityId: string): asserts name is
 export function defineCapability<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
+  TTypeContract extends AgentCapabilityTypeContract = AgentCapabilityTypeContract,
 >(
-  capability: AgentCapabilityDefinition<TRuntimeConfig, Name>,
-): AgentCapabilityDefinition<TRuntimeConfig, Name> {
+  capability: AgentCapabilityDefinition<TRuntimeConfig, Name, TTypeContract>,
+): AgentCapabilityDefinition<TRuntimeConfig, Name, TTypeContract> {
   if (!capability || typeof capability !== "object") {
     throw new TypeError("[vitehub] defineCapability() requires a capability definition.")
   }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -7,7 +7,6 @@ import type {
   AgentCallbackContext,
   AgentCapabilityContext,
   AgentCapabilityDefinition,
-  AgentCapabilityTypeContract,
   AgentCapabilityHookName,
   AgentCapabilityHooks,
   AgentCapabilityMode,
@@ -96,10 +95,9 @@ function assertTriggerName(name: unknown, capabilityId: string): asserts name is
 export function defineCapability<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
-  TTypeContract extends AgentCapabilityTypeContract = AgentCapabilityTypeContract,
 >(
-  capability: AgentCapabilityDefinition<TRuntimeConfig, Name, TTypeContract>,
-): AgentCapabilityDefinition<TRuntimeConfig, Name, TTypeContract> {
+  capability: AgentCapabilityDefinition<TRuntimeConfig, Name>,
+): AgentCapabilityDefinition<TRuntimeConfig, Name> {
   if (!capability || typeof capability !== "object") {
     throw new TypeError("[vitehub] defineCapability() requires a capability definition.")
   }

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -52,6 +52,18 @@ export interface AgentChatMessageTriggerInput {
   user?: Record<string, unknown>
 }
 
+export interface AgentChatRunContext<
+  TMessageMetadata extends Record<string, unknown> = Record<string, unknown>,
+  TUser extends Record<string, unknown> = Record<string, unknown>,
+> {
+  chat?: {
+    message?: Omit<AgentChatAgentHookArgs["message"], "metadata"> & { metadata?: TMessageMetadata }
+    run?: AgentRunMetadata
+    session?: AgentChatMessageTriggerInput["session"]
+    user?: TUser
+  }
+}
+
 function uiMessageText(message: UIMessageLike): string {
   const parts = Array.isArray(message.parts) ? message.parts : []
   return parts

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -3,6 +3,7 @@ import { createMessage } from "./messages.ts"
 
 import type {
   AgentCapabilityDefinition,
+  AgentCapabilityTypeContract,
   AgentChatAgentHookArgs,
   AgentChatAdapterResolver,
   AgentChatOptions,
@@ -21,6 +22,45 @@ type ChatCapabilityMetadata<TRuntimeConfig extends AgentRuntimeConfig = AgentRun
   chat: AgentChatOptions<TRuntimeConfig>
   kind: "chat"
 }
+
+type ResolvedMaybeResolvable<T> =
+  T extends (...args: any[]) => infer TResult
+    ? Awaited<TResult>
+    : T extends { resolve: (...args: any[]) => infer TResult }
+      ? Awaited<TResult>
+      : T
+
+type AgentChatAppOrigin<TApp> =
+  TApp extends string
+    ? TApp
+    : TApp extends true
+      ? "http"
+      : TApp extends { origin?: infer TOrigin }
+        ? Extract<TOrigin, string>
+        : never
+
+type AgentChatAdapterOrigin<TAdapters> =
+  Extract<keyof NonNullable<ResolvedMaybeResolvable<TAdapters>>, string>
+
+type AgentChatKnownOrigin<TOptions> =
+  (TOptions extends { app?: infer TApp } ? AgentChatAppOrigin<TApp> : never)
+  | (TOptions extends { adapters?: infer TAdapters } ? AgentChatAdapterOrigin<TAdapters> : never)
+
+export type AgentChatOptionsOrigin<TOptions> =
+  [AgentChatKnownOrigin<TOptions>] extends [never]
+    ? string
+    : AgentChatKnownOrigin<TOptions>
+
+type ChatCapabilityTypeContract<TOrigin extends string = string> = AgentCapabilityTypeContract & {
+  chatOrigins: TOrigin
+}
+
+export type AgentChatCapabilityOrigin<TCapability> =
+  TCapability extends AgentCapabilityDefinition<any, any, infer TTypeContract>
+    ? TTypeContract extends { chatOrigins: infer TOrigin }
+      ? Extract<TOrigin, string>
+      : string
+    : string
 
 const CHAT_WEBHOOK_DEFAULTS = {
   telegram: {
@@ -55,10 +95,11 @@ export interface AgentChatMessageTriggerInput {
 export interface AgentChatRunContext<
   TMessageMetadata extends object = Record<string, unknown>,
   TUser extends object = Record<string, unknown>,
+  TOrigin extends string = string,
 > {
   chat?: {
     message?: Omit<AgentChatAgentHookArgs["message"], "metadata"> & { metadata?: TMessageMetadata }
-    run?: AgentRunMetadata
+    run?: AgentRunMetadata<TOrigin>
     session?: AgentChatMessageTriggerInput["session"]
     user?: TUser
   }
@@ -386,9 +427,12 @@ export function getChatCapabilityOptions<TRuntimeConfig extends AgentRuntimeConf
     ?.metadata?.chat as AgentChatOptions<TRuntimeConfig> | undefined
 }
 
-export function chat<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
-  options: AgentChatOptions<TRuntimeConfig> = {},
-): AgentCapabilityDefinition<TRuntimeConfig> {
+export function chat<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  const TOptions extends AgentChatOptions<TRuntimeConfig> = AgentChatOptions<TRuntimeConfig>,
+>(
+  options: TOptions = {} as TOptions,
+): AgentCapabilityDefinition<TRuntimeConfig, WorkspaceName, ChatCapabilityTypeContract<AgentChatOptionsOrigin<TOptions>>> {
   return defineCapability({
     id: "chat",
     metadata: {

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -53,8 +53,8 @@ export interface AgentChatMessageTriggerInput {
 }
 
 export interface AgentChatRunContext<
-  TMessageMetadata extends Record<string, unknown> = Record<string, unknown>,
-  TUser extends Record<string, unknown> = Record<string, unknown>,
+  TMessageMetadata extends object = Record<string, unknown>,
+  TUser extends object = Record<string, unknown>,
 > {
   chat?: {
     message?: Omit<AgentChatAgentHookArgs["message"], "metadata"> & { metadata?: TMessageMetadata }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -104,7 +104,6 @@ export type {
   AgentCapabilityMode,
   AgentCapabilityPhase,
   AgentCapabilityRuntimeContext,
-  AgentCapabilityTypeContract,
   AgentChatAgentHookArgs,
   AgentChatAppExposure,
   AgentChatAppOptions,
@@ -205,6 +204,9 @@ type WorkspaceSourceNames<TWorkspace> =
   TWorkspace extends { sources: infer TSources }
     ? Extract<keyof NonNullable<TSources>, string>
     : string
+type InvalidWorkspaceSourceGrant<TSourceName> = {
+  readonly __vitehubInvalidWorkspaceSourceGrant: TSourceName
+}
 type ValidateCapabilityWorkspaceSources<
   TSourceName,
   TWorkspace,
@@ -217,7 +219,7 @@ type ValidateCapabilityWorkspaceSources<
       ? TCapability
       : Exclude<TSourceName, WorkspaceSourceNames<TWorkspace>> extends never
         ? TCapability
-        : never
+        : TCapability & InvalidWorkspaceSourceGrant<Exclude<TSourceName, WorkspaceSourceNames<TWorkspace>>>
     : TCapability
 type ValidateAgentCapability<TCapability, TWorkspace> =
   TCapability extends AgentCapabilityDefinition<any, any, infer TTypeContract>

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -109,6 +109,7 @@ export type {
   AgentChatAppOptions,
   AgentChatEventHookArgs,
   AgentChatEventHooks,
+  AgentChatIdentityResolver,
   AgentChatMessageHookArgs,
   AgentChatOptions,
   AgentChatSessionOptions,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -188,6 +188,10 @@ export type {
   ToolInvocationState,
 } from "./messages.ts"
 
+export type {
+  AgentChatRunContext,
+} from "./chat-trigger.ts"
+
 const syntheticWorkspaceRun = Symbol("vitehub.syntheticWorkspaceRun")
 const baseAgentResolve = Symbol("vitehub.baseAgentResolve")
 const baseAgentModel = Symbol("vitehub.baseAgentModel")

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -45,6 +45,7 @@ import type {
   AgentCapabilityDefinition,
   AgentCapabilityInput,
   AgentCapabilityMode,
+  AgentCapabilityTypeContract,
   AgentDefinition,
   AgentFinishEvent,
   AgentChatOptions,
@@ -103,6 +104,7 @@ export type {
   AgentCapabilityMode,
   AgentCapabilityPhase,
   AgentCapabilityRuntimeContext,
+  AgentCapabilityTypeContract,
   AgentChatAgentHookArgs,
   AgentChatAppExposure,
   AgentChatAppOptions,
@@ -199,6 +201,40 @@ const defaultWorkspaceName = "workspace"
 
 type NormalizedWorkspaceOptions = WorkspaceAgentWorkspaceOptions & { mode: AgentCapabilityMode }
 type NormalizedCapability = AgentCapabilityDefinition & { mode?: AgentCapabilityMode }
+type WorkspaceSourceNames<TWorkspace> =
+  TWorkspace extends { sources: infer TSources }
+    ? Extract<keyof NonNullable<TSources>, string>
+    : string
+type ValidateCapabilityWorkspaceSources<
+  TSourceName,
+  TWorkspace,
+  TCapability,
+> =
+  [TSourceName] extends [never]
+    ? TCapability
+    : TSourceName extends string
+    ? string extends TSourceName
+      ? TCapability
+      : Exclude<TSourceName, WorkspaceSourceNames<TWorkspace>> extends never
+        ? TCapability
+        : never
+    : TCapability
+type ValidateAgentCapability<TCapability, TWorkspace> =
+  TCapability extends AgentCapabilityDefinition<any, any, infer TTypeContract>
+    ? TTypeContract extends AgentCapabilityTypeContract
+      ? ValidateCapabilityWorkspaceSources<TTypeContract["workspaceSources"], TWorkspace, TCapability>
+      : TCapability
+    : TCapability
+type ValidateAgentCapabilities<TCapabilities, TWorkspace> =
+  TCapabilities extends readonly [unknown, ...unknown[]] | readonly []
+    ? { [Index in keyof TCapabilities]: ValidateAgentCapability<TCapabilities[Index], TWorkspace> }
+    : TCapabilities extends readonly (infer TCapability)[]
+      ? ValidateAgentCapability<TCapability, TWorkspace>[]
+      : TCapabilities
+type ValidateWorkspaceAgentOptions<TOptions> =
+  TOptions extends { capabilities?: infer TCapabilities, workspace: infer TWorkspace }
+    ? { capabilities?: ValidateAgentCapabilities<TCapabilities, TWorkspace> }
+    : unknown
 type BaseAgentResolver<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig, CALL_OPTIONS = unknown> =
   (context: AgentRuntimeContext<TRuntimeConfig>) => Promise<AgentAdapter<CALL_OPTIONS>>
 type AgentDefinitionWithBaseResolve<
@@ -512,8 +548,9 @@ export interface DefineAgent {
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     Name extends WorkspaceName = WorkspaceName,
+    const TOptions extends WorkspaceAgentOptions<TRuntimeConfig, Name> = WorkspaceAgentOptions<TRuntimeConfig, Name>,
   >(
-    options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
+    options: TOptions & ValidateWorkspaceAgentOptions<TOptions>,
   ): WorkspaceAgentDefinition<TRuntimeConfig, Name>
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,

--- a/packages/agent/src/invocation-context.ts
+++ b/packages/agent/src/invocation-context.ts
@@ -9,7 +9,7 @@ function assertContextId(id: unknown): asserts id is string {
   }
 }
 
-export function createAgentInvocationContextStore(initial?: Record<string, unknown>): AgentInvocationContextStore {
+export function createAgentInvocationContextStore(initial?: object): AgentInvocationContextStore {
   const values = new Map<string, unknown>()
 
   for (const [id, value] of Object.entries(initial || {})) {

--- a/packages/agent/src/nitro/handler.ts
+++ b/packages/agent/src/nitro/handler.ts
@@ -12,12 +12,13 @@ import { resolveChatState } from "./chat-state.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
 import { getAgentRuntimeConfig } from "../runtime/nitro-runtime-config.ts"
 
-import type { Adapter, Attachment, ChatConfig, Channel, Message as ChatMessage, SentMessage, StateAdapter, Thread } from "chat"
+import type { Adapter, Attachment, ChatConfig, Channel, IdentityContext, IdentityResolver, Message as ChatMessage, SentMessage, StateAdapter, Thread } from "chat"
 import type { EventHandler, H3Event } from "h3"
 import type { NitroRuntimeConfig } from "nitro/types"
 import type { AgentChatMessageTriggerInput } from "../chat-trigger.ts"
 import type {
   AgentCapabilityDefinition,
+  AgentChatAppOptions,
   AgentChatOptions,
   AgentHandlerOptions,
   AgentInput,
@@ -43,7 +44,7 @@ type AgentRegistryModule = { default?: AgentInput<NitroAgentRuntimeContext> } | 
 type AgentRegistry = Record<string, () => Promise<AgentRegistryModule>>
 type WorkspaceAgentOptions = { capabilities?: AgentCapabilityDefinition[] }
 type WorkspaceAgentDefinition = { __vitehubWorkspaceAgentOptions?: WorkspaceAgentOptions }
-type ChatConfigRecord = Omit<ChatConfig<Record<string, Adapter>>, "adapters" | "fallbackStreamingPlaceholderText" | "state" | "userName">
+type ChatConfigRecord = Omit<ChatConfig<Record<string, Adapter>>, "adapters" | "fallbackStreamingPlaceholderText" | "identity" | "state" | "transcripts" | "userName">
 
 type RequestInitWithDuplex = RequestInit & { duplex?: "half" }
 type RequestHeaders = NonNullable<RequestInit["headers"]>
@@ -67,7 +68,7 @@ export interface AgentChatRouteBody {
   id?: string
   messageId?: string
   messages?: AgentChatMessageTriggerInput["messages"]
-  run?: Partial<AgentRunMetadata>
+  run?: Omit<Partial<AgentRunMetadata>, "origin">
   session?: AgentChatMessageTriggerInput["session"] | string
   timeout?: number
   user?: Record<string, unknown>
@@ -325,6 +326,13 @@ async function resolveChatAdapters(options: AgentChatOptions, context: NitroAgen
   return adapters
 }
 
+function defaultChatIdentity({ adapter, author }: IdentityContext): string | null {
+  if (author.isMe || author.isBot === true) return null
+  const adapterName = adapter.trim()
+  const userId = author.userId.trim()
+  return adapterName && userId && userId !== "unknown" ? `${adapterName}:${userId}` : null
+}
+
 function createChatSdkOptions(options: AgentChatOptions, adapters: Record<string, Adapter>, state: StateAdapter, agentName: string): ChatConfig<Record<string, Adapter>> {
   const {
     adapters: _adapters,
@@ -333,19 +341,24 @@ function createChatSdkOptions(options: AgentChatOptions, adapters: Record<string
     execution: _execution,
     fallbackStreamingPlaceholderText: _fallbackStreamingPlaceholderText,
     hooks: _hooks,
+    identity,
     lifecycleHooks: _lifecycleHooks,
     state: _state,
+    transcripts,
     userName,
     webhooks: _webhooks,
     workflow: _workflow,
     ...chatOptions
-  } = options as AgentChatOptions & { userName?: string }
+  } = options
+  const resolvedIdentity: IdentityResolver | undefined = identity || (transcripts ? defaultChatIdentity : undefined)
 
   return {
     ...(chatOptions as ChatConfigRecord),
     adapters,
     fallbackStreamingPlaceholderText: null,
+    ...(resolvedIdentity ? { identity: resolvedIdentity } : {}),
     state,
+    ...(transcripts ? { transcripts } : {}),
     userName: typeof userName === "string" && userName ? userName : agentName,
   }
 }
@@ -586,6 +599,7 @@ async function handleChatMessage(
     timeout: 90_000,
     user: {
       id: message.author?.userId,
+      ...(typeof message.userKey === "string" && message.userKey ? { key: message.userKey } : {}),
       name: message.author?.userName,
     },
   }
@@ -732,20 +746,34 @@ function normalizeChatRouteSession(body: AgentChatRouteBody): AgentChatMessageTr
   return body.id ? { id: body.id } : undefined
 }
 
-function createChatRouteRunMetadata(body: AgentChatRouteBody, agentName: string | undefined): AgentRunMetadata {
+function normalizeChatAppOptions(app: AgentChatOptions["app"]): AgentChatAppOptions | undefined {
+  if (!app) return
+  if (typeof app === "string") return { origin: app }
+  return app === true ? {} : app
+}
+
+function createChatRouteRunMetadata(
+  body: AgentChatRouteBody,
+  agentName: string | undefined,
+  app: AgentChatAppOptions,
+): AgentRunMetadata {
   const session = normalizeChatRouteSession(body)
   const message = body.messages?.at(-1)
   const run = typeof body.run === "object" && body.run !== null ? body.run : {}
   return {
     channelId: firstString(run.channelId, session?.id ? `http:${session.id}` : undefined, agentName ? `http:${agentName}` : undefined),
     messageId: firstString(run.messageId, body.messageId, message?.id),
-    origin: firstString(run.origin, "http"),
+    origin: firstString(app.origin, "http"),
     runId: firstString(run.runId) || randomRunId(),
     threadId: firstString(run.threadId, session?.id, body.id, agentName),
   }
 }
 
-function createChatRouteTriggerInput(body: AgentChatRouteBody, agentName: string | undefined): AgentChatMessageTriggerInput {
+function createChatRouteTriggerInput(
+  body: AgentChatRouteBody,
+  agentName: string | undefined,
+  app: AgentChatAppOptions,
+): AgentChatMessageTriggerInput {
   if (!Array.isArray(body.messages) || !body.messages.length) {
     throw createError({
       statusCode: 400,
@@ -755,7 +783,7 @@ function createChatRouteTriggerInput(body: AgentChatRouteBody, agentName: string
 
   const user = typeof body.user === "object" && body.user !== null ? body.user : undefined
   const timeout = typeof body.timeout === "number" ? body.timeout : 90_000
-  const run = createChatRouteRunMetadata(body, agentName)
+  const run = createChatRouteRunMetadata(body, agentName, app)
   return {
     history: body.history,
     messages: body.messages,
@@ -766,7 +794,7 @@ function createChatRouteTriggerInput(body: AgentChatRouteBody, agentName: string
   }
 }
 
-function requireChatAppExposure(agent: AgentInput<NitroAgentRuntimeContext>, agentName?: string): void {
+function requireChatAppExposure(agent: AgentInput<NitroAgentRuntimeContext>, agentName?: string): AgentChatAppOptions {
   const options = getChatCapabilityOptions(agentCapabilityOptions(agent))
   if (!options) {
     throw createError({
@@ -780,6 +808,7 @@ function requireChatAppExposure(agent: AgentInput<NitroAgentRuntimeContext>, age
       statusMessage: `Agent "${agentName || "default"}" does not expose a Chat App Route.`,
     })
   }
+  return normalizeChatAppOptions(options.app) || {}
 }
 
 export function defineAgentHandler(
@@ -836,8 +865,8 @@ export function defineAgentChatHandler(
         await hooks.resolved({ ...context, agent: resolved })
       }
 
-      requireChatAppExposure(agent, options.inferredName)
-      const triggerInput = createChatRouteTriggerInput(body, options.inferredName)
+      const appOptions = requireChatAppExposure(agent, options.inferredName)
+      const triggerInput = createChatRouteTriggerInput(body, options.inferredName, appOptions)
       const result = await streamAgentTrigger(agent, { ...context, run: triggerInput.run } as never, "chat.message", triggerInput, {
         output: "ui-message-stream",
       })

--- a/packages/agent/src/nitro/handler.ts
+++ b/packages/agent/src/nitro/handler.ts
@@ -68,7 +68,7 @@ export interface AgentChatRouteBody {
   id?: string
   messageId?: string
   messages?: AgentChatMessageTriggerInput["messages"]
-  run?: Omit<Partial<AgentRunMetadata>, "origin">
+  run?: Partial<AgentRunMetadata>
   session?: AgentChatMessageTriggerInput["session"] | string
   timeout?: number
   user?: Record<string, unknown>
@@ -760,10 +760,19 @@ function createChatRouteRunMetadata(
   const session = normalizeChatRouteSession(body)
   const message = body.messages?.at(-1)
   const run = typeof body.run === "object" && body.run !== null ? body.run : {}
+  const origin = firstString(app.origin, "http")!
+  const requestedOrigin = firstString(run.origin)
+  if (requestedOrigin && requestedOrigin !== origin) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `Chat App Route run.origin ${JSON.stringify(requestedOrigin)} does not match configured origin ${JSON.stringify(origin)}. Configure chat({ app }) with that origin or remove run.origin from the request.`,
+    })
+  }
+
   return {
     channelId: firstString(run.channelId, session?.id ? `http:${session.id}` : undefined, agentName ? `http:${agentName}` : undefined),
     messageId: firstString(run.messageId, body.messageId, message?.id),
-    origin: firstString(app.origin, "http"),
+    origin,
     runId: firstString(run.runId) || randomRunId(),
     threadId: firstString(run.threadId, session?.id, body.id, agentName),
   }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -64,9 +64,12 @@ export interface AgentInvocationContextStore {
   toJSON: () => Record<string, unknown>
 }
 
-export interface AgentRunInput<CALL_OPTIONS = unknown> {
+export interface AgentRunInput<
+  CALL_OPTIONS = unknown,
+  TContext extends object = Record<string, unknown>,
+> {
   abortSignal?: AbortSignal
-  context?: Record<string, unknown>
+  context?: TContext
   messages?: Message[]
   options?: CALL_OPTIONS
   prompt?: string | Message[]

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -331,10 +331,17 @@ export interface AgentCapabilityRuntimeContext<
   }
 }
 
+export interface AgentCapabilityTypeContract {
+  inputContext?: object
+  workspaceSources?: string
+}
+
 export interface AgentCapabilityDefinition<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
+  TTypeContract extends AgentCapabilityTypeContract = AgentCapabilityTypeContract,
 > {
+  readonly __vitehubTypeContract?: TTypeContract
   bind?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   close?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   configure?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1,5 +1,5 @@
 import type { Message, StreamEvent } from "./messages.ts"
-import type { Adapter, StateAdapter } from "chat"
+import type { Adapter, IdentityResolver, StateAdapter, TranscriptsConfig } from "chat"
 import type {
   MaybePromise,
   MaybeResolvable,
@@ -85,10 +85,10 @@ export interface AgentScheduleInvocationInput {
   target?: string
 }
 
-export interface AgentRunMetadata {
+export interface AgentRunMetadata<TOrigin extends string = string> {
   channelId?: string
   messageId?: string
-  origin?: string
+  origin?: TOrigin
   runId: string
   threadId?: string
 }
@@ -112,11 +112,12 @@ export interface AgentWebhookRegistrationDefinition {
 export type AgentChatWebhookRegistrationDefinition =
   Omit<AgentWebhookRegistrationDefinition, "provider"> & { provider?: string }
 
-export interface AgentChatAppOptions {
+export interface AgentChatAppOptions<TOrigin extends string = string> {
+  origin?: TOrigin
   route?: never
 }
 
-export type AgentChatAppExposure = boolean | AgentChatAppOptions
+export type AgentChatAppExposure<TOrigin extends string = string> = boolean | TOrigin | AgentChatAppOptions<TOrigin>
 
 export interface AgentTriggerContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -603,6 +604,8 @@ export type AgentChatAdapterResolver<TRuntimeConfig extends AgentRuntimeConfig =
 export type AgentChatAdaptersResolver<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> =
   MaybeResolvable<Record<string, AgentChatAdapterResolver<TRuntimeConfig>>, AgentCallbackContext<TRuntimeConfig>>
 
+export type AgentChatIdentityResolver = IdentityResolver
+
 export interface AgentChatStateContext<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
   extends AgentCallbackContext<TRuntimeConfig> {
   chat: {
@@ -623,9 +626,12 @@ export interface AgentChatOptions<TRuntimeConfig extends AgentRuntimeConfig = Ag
   fallbackStreamingPlaceholderText?: string | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   history?: AgentChatAgentBindingOptions["history"]
   hooks?: AgentChatEventHooks<TRuntimeConfig>
+  identity?: AgentChatIdentityResolver
   lifecycleHooks?: Record<string, unknown>
   sessions?: boolean | AgentChatSessionOptions
   state?: AgentChatStateResolver<TRuntimeConfig>
+  transcripts?: TranscriptsConfig
+  userName?: string
   webhooks?: Record<string, AgentChatWebhookRegistrationDefinition | AgentChatWebhookRegistrationDefinition[]>
   workflow?: never
   [key: string]: unknown

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -169,6 +169,33 @@ describe("access capability", () => {
     await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(false)
   })
 
+  it("uses registered Workspace Scopes when inline scope markers are empty", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            resolve: () => ({
+              all: false,
+              grants: [],
+              scope: "acme",
+              source: undefined,
+              sources: [],
+            }),
+            scopes: {
+              acme: { paths: ["customers/acme"] },
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace())
+
+    await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(true)
+    await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(false)
+  })
+
   it("can resolve an inline all-scopes Workspace Scope definition for admin roles", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
@@ -348,6 +375,128 @@ describe("access capability", () => {
       },
       prompt: "check",
     }, createWorkspace())).rejects.toThrow("Invalid chat.user")
+  })
+
+  it("fails closed when configured chat input schemas receive no chat context", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          input: {
+            chat: {
+              message: {
+                metadata: {
+                  "~standard": {
+                    validate(input: unknown) {
+                      return typeof input === "object" && input !== null
+                        ? { value: input as Record<string, unknown> }
+                        : { issues: ["missing metadata"] }
+                    },
+                  },
+                },
+              },
+            },
+          },
+          workspace: {
+            defaultScope: "acme",
+            scopes: {
+              acme: { paths: ["customers/acme"] },
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace())).rejects.toThrow("Invalid chat.message.metadata")
+  })
+
+  it("gates Chat App Route metadata schemas by chat run origin", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access, chat } = await import("../src/capabilities.ts")
+
+    const supportChat = chat({
+      adapters: { teams: {} as never },
+      app: "portal",
+    })
+    const metadataSchema = {
+      "~standard": {
+        validate(input: unknown) {
+          const metadata = typeof input === "object" && input !== null ? input as Record<string, unknown> : {}
+          return typeof metadata.customer === "string"
+            ? { value: { quiver: { customer: metadata.customer } } }
+            : { issues: ["missing customer"] }
+        },
+      },
+    }
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          input: {
+            chat: {
+              capability: supportChat,
+              message: { metadata: metadataSchema },
+            },
+          },
+          workspace: {
+            resolve({ input }) {
+              const chat = input.get().context?.chat
+              if (chat?.run?.origin !== "portal") {
+                return { all: true, role: "admin", scope: "support" }
+              }
+              const metadata = chat.message?.metadata as { quiver?: { customer?: string } } | undefined
+              return metadata?.quiver?.customer
+            },
+            scopes: {
+              acme: { paths: ["customers/acme"] },
+            },
+          },
+        }),
+        supportChat,
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, {
+      context: {
+        chat: {
+          message: {
+            metadata: { source: "chat" },
+          },
+          run: { origin: "teams", runId: "run-1" },
+        },
+      },
+      prompt: "check",
+    }, createWorkspace())
+
+    await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(true)
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          input: {
+            chat: {
+              capability: supportChat,
+              message: { metadata: metadataSchema },
+            },
+          },
+          workspace: {
+            defaultScope: "acme",
+            scopes: {
+              acme: { paths: ["customers/acme"] },
+            },
+          },
+        }),
+        supportChat,
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, {
+      context: {
+        chat: {
+          message: {
+            metadata: { source: "portal" },
+          },
+          run: { origin: "portal", runId: "run-2" },
+        },
+      },
+      prompt: "check",
+    }, createWorkspace())).rejects.toThrow("Invalid chat.message.metadata")
   })
 
   it("fails closed when configured chat run origins do not match", async () => {

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -139,6 +139,97 @@ describe("access capability", () => {
     await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(true)
   })
 
+  it("validates chat input schemas before resolving Workspace Scope", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    const metadataSchema = {
+      "~standard": {
+        validate(input: unknown) {
+          const metadata = typeof input === "object" && input !== null ? input as Record<string, unknown> : {}
+          const customer = typeof metadata.customer === "string" ? metadata.customer : undefined
+          return { value: { quiver: { customer } } }
+        },
+      },
+    }
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          input: {
+            chat: {
+              message: { metadata: metadataSchema },
+            },
+          },
+          workspace: {
+            resolve: ({ input }) => input.get().context?.chat?.message?.metadata?.quiver?.customer,
+            scopes: {
+              acme: { paths: ["customers/acme"] },
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, {
+      context: {
+        chat: {
+          message: {
+            metadata: { customer: "acme" },
+          },
+        },
+      },
+      prompt: "check",
+    }, createWorkspace())
+
+    await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(true)
+    expect(resolved.input.context).toMatchObject({
+      chat: {
+        message: {
+          metadata: {
+            quiver: { customer: "acme" },
+          },
+        },
+      },
+    })
+  })
+
+  it("fails closed when chat input schema validation fails", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          input: {
+            chat: {
+              message: {
+                metadata: {
+                  "~standard": {
+                    validate: () => ({ issues: ["missing customer"] }),
+                  },
+                },
+              },
+            },
+          },
+          workspace: {
+            defaultScope: "acme",
+            scopes: {
+              acme: { paths: ["customers/acme"] },
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, {
+      context: {
+        chat: {
+          message: {
+            metadata: {},
+          },
+        },
+      },
+      prompt: "check",
+    }, createWorkspace())).rejects.toThrow("Invalid chat.message.metadata")
+  })
+
   it("falls back to default scope when an explicit resolver returns no scope", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -139,6 +139,54 @@ describe("access capability", () => {
     await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(true)
   })
 
+  it("can resolve an inline Workspace Scope definition", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            resolve: ({ input }) => {
+              const context = input.get().context as { customer?: unknown } | undefined
+              const customer = typeof context?.customer === "string"
+                ? context.customer
+                : "public"
+              return {
+                grants: [
+                  { path: "AGENTS.md" },
+                  { path: `customers/${customer}` },
+                ],
+                scope: customer,
+              }
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { context: { customer: "acme" }, prompt: "check" }, createWorkspace())
+
+    await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(true)
+    await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(false)
+  })
+
+  it("can resolve an inline all-scopes Workspace Scope definition for admin roles", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            resolve: { all: true, role: "admin", scope: "support" },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace())
+
+    await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(true)
+    await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(true)
+  })
+
   it("validates chat input schemas before resolving Workspace Scope", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
@@ -228,6 +276,108 @@ describe("access capability", () => {
       },
       prompt: "check",
     }, createWorkspace())).rejects.toThrow("Invalid chat.message.metadata")
+  })
+
+  it("fails closed when configured chat input schema fields are missing", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    const requiredObjectSchema = (label: string) => ({
+      "~standard": {
+        validate(input: unknown) {
+          return typeof input === "object" && input !== null
+            ? { value: input as Record<string, unknown> }
+            : { issues: [`missing ${label}`] }
+        },
+      },
+    })
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          input: {
+            chat: {
+              message: { metadata: requiredObjectSchema("metadata") },
+              user: requiredObjectSchema("user"),
+            },
+          },
+          workspace: {
+            defaultScope: "acme",
+            scopes: {
+              acme: { paths: ["customers/acme"] },
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, {
+      context: {
+        chat: {
+          message: {
+            text: "check",
+          },
+        },
+      },
+      prompt: "check",
+    }, createWorkspace())).rejects.toThrow("Invalid chat.message.metadata")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          input: {
+            chat: {
+              message: { metadata: requiredObjectSchema("metadata") },
+              user: requiredObjectSchema("user"),
+            },
+          },
+          workspace: {
+            defaultScope: "acme",
+            scopes: {
+              acme: { paths: ["customers/acme"] },
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, {
+      context: {
+        chat: {
+          message: {
+            metadata: {},
+            text: "check",
+          },
+        },
+      },
+      prompt: "check",
+    }, createWorkspace())).rejects.toThrow("Invalid chat.user")
+  })
+
+  it("fails closed when configured chat run origins do not match", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          input: {
+            chat: {
+              run: { origin: ["portal", "teams"] },
+            },
+          },
+          workspace: {
+            defaultScope: "acme",
+            scopes: {
+              acme: { paths: ["customers/acme"] },
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, {
+      context: {
+        chat: {
+          run: { origin: "http", runId: "run-1" },
+        },
+      },
+      prompt: "check",
+    }, createWorkspace())).rejects.toThrow("Invalid chat.run.origin")
   })
 
   it("falls back to default scope when an explicit resolver returns no scope", async () => {

--- a/packages/agent/test/nitro-chat-handler.test.ts
+++ b/packages/agent/test/nitro-chat-handler.test.ts
@@ -130,6 +130,36 @@ describe("agent Nitro chat routes", () => {
     expect(await response.text()).toContain("Agent chat route requires messages.")
   })
 
+  it("uses the configured Chat App Route origin instead of request body origin", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineAgentChatHandler } = await import("../src/nitro.ts")
+    let seenRun: unknown
+    const app = createApp()
+    app.use(defineAgentChatHandler(defineAgent({
+      capabilities: [chat({ app: "portal" })],
+      run(context) {
+        seenRun = context.run
+        return "agent answer"
+      },
+    })))
+    const response = await toWebHandler(app)(new Request("https://example.test/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        id: "support-session",
+        messages: [{ id: "user-1", parts: [{ text: "hello", type: "text" }], role: "user" }],
+        run: { origin: "teams" },
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }))
+
+    expect(response.status).toBe(200)
+    expect(seenRun).toEqual(expect.objectContaining({
+      messageId: "user-1",
+      origin: "portal",
+      threadId: "support-session",
+    }))
+  })
+
   it("does not expose agents without Chat App Exposure through chat route handlers", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineAgentChatHandler } = await import("../src/nitro.ts")

--- a/packages/agent/test/nitro-chat-handler.test.ts
+++ b/packages/agent/test/nitro-chat-handler.test.ts
@@ -130,7 +130,37 @@ describe("agent Nitro chat routes", () => {
     expect(await response.text()).toContain("Agent chat route requires messages.")
   })
 
-  it("uses the configured Chat App Route origin instead of request body origin", async () => {
+  it("accepts a request body origin that matches the configured Chat App Route origin", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineAgentChatHandler } = await import("../src/nitro.ts")
+    let seenRun: unknown
+    const app = createApp()
+    app.use(defineAgentChatHandler(defineAgent({
+      capabilities: [chat({ app: "portal" })],
+      run(context) {
+        seenRun = context.run
+        return "agent answer"
+      },
+    })))
+    const response = await toWebHandler(app)(new Request("https://example.test/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        id: "support-session",
+        messages: [{ id: "user-1", parts: [{ text: "hello", type: "text" }], role: "user" }],
+        run: { origin: "portal" },
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }))
+
+    expect(response.status).toBe(200)
+    expect(seenRun).toEqual(expect.objectContaining({
+      messageId: "user-1",
+      origin: "portal",
+      threadId: "support-session",
+    }))
+  })
+
+  it("rejects a request body origin that differs from the configured Chat App Route origin", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineAgentChatHandler } = await import("../src/nitro.ts")
     let seenRun: unknown
@@ -152,12 +182,9 @@ describe("agent Nitro chat routes", () => {
       method: "POST",
     }))
 
-    expect(response.status).toBe(200)
-    expect(seenRun).toEqual(expect.objectContaining({
-      messageId: "user-1",
-      origin: "portal",
-      threadId: "support-session",
-    }))
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("does not match configured origin")
+    expect(seenRun).toBeUndefined()
   })
 
   it("does not expose agents without Chat App Exposure through chat route handlers", async () => {

--- a/packages/agent/test/nitro-chat-handler.test.ts
+++ b/packages/agent/test/nitro-chat-handler.test.ts
@@ -130,63 +130,6 @@ describe("agent Nitro chat routes", () => {
     expect(await response.text()).toContain("Agent chat route requires messages.")
   })
 
-  it("accepts a request body origin that matches the configured Chat App Route origin", async () => {
-    const { defineAgent } = await import("../src/index.ts")
-    const { defineAgentChatHandler } = await import("../src/nitro.ts")
-    let seenRun: unknown
-    const app = createApp()
-    app.use(defineAgentChatHandler(defineAgent({
-      capabilities: [chat({ app: "portal" })],
-      run(context) {
-        seenRun = context.run
-        return "agent answer"
-      },
-    })))
-    const response = await toWebHandler(app)(new Request("https://example.test/api/_vitehub/agents/support/chat", {
-      body: JSON.stringify({
-        id: "support-session",
-        messages: [{ id: "user-1", parts: [{ text: "hello", type: "text" }], role: "user" }],
-        run: { origin: "portal" },
-      }),
-      headers: { "content-type": "application/json" },
-      method: "POST",
-    }))
-
-    expect(response.status).toBe(200)
-    expect(seenRun).toEqual(expect.objectContaining({
-      messageId: "user-1",
-      origin: "portal",
-      threadId: "support-session",
-    }))
-  })
-
-  it("rejects a request body origin that differs from the configured Chat App Route origin", async () => {
-    const { defineAgent } = await import("../src/index.ts")
-    const { defineAgentChatHandler } = await import("../src/nitro.ts")
-    let seenRun: unknown
-    const app = createApp()
-    app.use(defineAgentChatHandler(defineAgent({
-      capabilities: [chat({ app: "portal" })],
-      run(context) {
-        seenRun = context.run
-        return "agent answer"
-      },
-    })))
-    const response = await toWebHandler(app)(new Request("https://example.test/api/_vitehub/agents/support/chat", {
-      body: JSON.stringify({
-        id: "support-session",
-        messages: [{ id: "user-1", parts: [{ text: "hello", type: "text" }], role: "user" }],
-        run: { origin: "teams" },
-      }),
-      headers: { "content-type": "application/json" },
-      method: "POST",
-    }))
-
-    expect(response.status).toBe(400)
-    expect(await response.text()).toContain("does not match configured origin")
-    expect(seenRun).toBeUndefined()
-  })
-
   it("does not expose agents without Chat App Exposure through chat route handlers", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineAgentChatHandler } = await import("../src/nitro.ts")

--- a/packages/agent/test/nitro-chat-webhook.test.ts
+++ b/packages/agent/test/nitro-chat-webhook.test.ts
@@ -820,6 +820,52 @@ describe("agent Nitro chat webhooks", () => {
     expect(output.edits).toEqual(["agent answer"])
   })
 
+  it("provides a default chat identity when transcripts are configured", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineAgentChatWebhookRegistryHandler } = await import("../src/nitro.ts")
+    const output: { edits: unknown[], posts: unknown[] } = { edits: [], posts: [] }
+    const seenUsers: unknown[] = []
+    const adapter = createWebhookAdapter(output)
+    const handler = defineAgentChatWebhookRegistryHandler({
+      support: async () => defineAgent({
+        capabilities: [chat({
+          adapters: {
+            teams: () => adapter,
+          },
+          state: () => createMemoryState(),
+          transcripts: {
+            maxPerUser: 50,
+            retention: "30d",
+          },
+        })],
+        run(context) {
+          seenUsers.push((context.input.context as { chat?: { user?: unknown } } | undefined)?.chat?.user)
+          return "agent answer"
+        },
+      }),
+    })
+
+    const response = await handler({
+      context: {
+        params: {
+          agent: "support",
+          platform: "teams",
+        },
+      },
+      req: new Request("https://example.test/api/_vitehub/agents/support/chat/teams", {
+        body: JSON.stringify({ text: "hello from Teams" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+      waitUntil: vi.fn(),
+    } as never) as Response
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("ok")
+    expect(seenUsers).toEqual([{ id: "maxi", key: "teams:maxi", name: "Maxi" }])
+    expect(output.edits).toEqual(["agent answer"])
+  })
+
   it("memoizes configured chat state factories per agent definition", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineAgentChatWebhookRegistryHandler } = await import("../src/nitro.ts")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -243,9 +243,13 @@ describe("agent public types", () => {
     type RootAgentExports = typeof import("../src/index.ts")
     // @ts-expect-error official capability factories are not root Agent Package exports
     type _RootInputCommands = RootAgentExports["inputCommands"]
+    // @ts-expect-error Capability Type Contracts are not a public custom-Capability extension point
+    type _RootAgentCapabilityTypeContract = RootAgentExports["AgentCapabilityTypeContract"]
 
     type CapabilityExports = typeof import("../src/capabilities.ts")
     type _PublicAudioBytes = CapabilityExports["audioBytes"]
+    // @ts-expect-error Access Capability Type Contract is internal to access() inference
+    type _PublicAccessCapabilityTypeContract = CapabilityExports["AccessCapabilityTypeContract"]
     // @ts-expect-error transcription extension inference is internal, not public capabilities API
     type _PublicAudioExtensionFor = CapabilityExports["audioExtensionFor"]
     // @ts-expect-error transcription context storage key is internal, not public capabilities API

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,13 +1,14 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, type AgentRuntimeContext } from "../src/index.ts"
-import { blob, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, transcribe, webSearch, workspaceShell } from "../src/capabilities.ts"
+import { access, blob, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, transcribe, webSearch, workspaceShell } from "../src/capabilities.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import type { AgentInvocationContextStore, AgentUsageRecord } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
-import type { FetchCapabilityToolOptions, TranscriptionResult } from "../src/capabilities.ts"
+import { source } from "@vite-hub/workspace"
+import type { AccessWorkspaceOptionsFor, AgentChatRunContext, FetchCapabilityToolOptions, TranscriptionResult } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
   it("accepts capabilities from the capabilities entry", () => {
@@ -249,6 +250,55 @@ describe("agent public types", () => {
     type _PublicAudioExtensionFor = CapabilityExports["audioExtensionFor"]
     // @ts-expect-error transcription context storage key is internal, not public capabilities API
     type _PublicTranscriptionContextKey = CapabilityExports["TRANSCRIPTION_RESULTS_CONTEXT_KEY"]
+  })
+
+  it("types access workspace source grants and chat run context", () => {
+    const workspace = {
+      sources: {
+        docs: source.file("AGENTS.md"),
+        forecastingEngine: source.github({ repo: "acme/forecasting-engine" }),
+      },
+    }
+    type ChatContext = AgentChatRunContext<
+      { quiver?: { customer?: string } },
+      { email?: string }
+    >
+    const workspaceAccess: AccessWorkspaceOptionsFor<typeof workspace, ChatContext> = {
+      defaultScope: "customer",
+      resolve({ input }) {
+        const chat = input.get().context?.chat
+        expectTypeOf(chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<string | undefined>()
+        expectTypeOf(chat?.user?.email).toEqualTypeOf<string | undefined>()
+        return chat?.user?.email?.endsWith("@quiver.dk")
+          ? { role: "admin", scope: "quiver" }
+          : "customer"
+      },
+      scopes: {
+        customer: {
+          grants: [
+            { path: "AGENTS.md" },
+            { source: "forecastingEngine" },
+            { sources: ["docs"] },
+          ],
+        },
+        quiver: { all: true },
+      },
+    }
+    access({ workspace: workspaceAccess })
+
+    const invalidAccess: AccessWorkspaceOptionsFor<typeof workspace> = {
+      scopes: {
+        customer: {
+          grants: [
+            // @ts-expect-error source grants are limited to the workspace source map
+            { source: "missing" },
+          ],
+          // @ts-expect-error source grants are limited to the workspace source map
+          sources: ["missing"],
+        },
+      },
+    }
+    expectTypeOf(invalidAccess).toMatchTypeOf<AccessWorkspaceOptionsFor<typeof workspace>>()
   })
 
   it("accepts agent eval definitions", () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -8,7 +8,7 @@ import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import type { AgentInvocationContextStore, AgentUsageRecord } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
 import { source } from "@vite-hub/workspace"
-import type { AccessWorkspaceOptionsFor, AgentChatRunContext, FetchCapabilityToolOptions, TranscriptionResult } from "../src/capabilities.ts"
+import type { AccessCapabilityStandardSchemaV1, AccessWorkspaceOptionsFor, AgentChatRunContext, FetchCapabilityToolOptions, TranscriptionResult } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
   it("accepts capabilities from the capabilities entry", () => {
@@ -299,6 +299,74 @@ describe("agent public types", () => {
       },
     }
     expectTypeOf(invalidAccess).toMatchTypeOf<AccessWorkspaceOptionsFor<typeof workspace>>()
+  })
+
+  it("types inline access source grants and chat input schemas from defineAgent", () => {
+    const metadataSchema = {
+      "~standard": {
+        validate: (input: unknown) => ({ value: input as { quiver?: { customer?: string } } }),
+      },
+    } satisfies AccessCapabilityStandardSchemaV1<{ quiver?: { customer?: string } }>
+    const userSchema = {
+      "~standard": {
+        validate: (input: unknown) => ({ value: input as { email?: string } }),
+      },
+    } satisfies AccessCapabilityStandardSchemaV1<{ email?: string }>
+
+    defineAgent({
+      capabilities: [
+        access({
+          input: {
+            chat: {
+              message: { metadata: metadataSchema },
+              user: userSchema,
+            },
+          },
+          workspace: {
+            resolve({ input }) {
+              const chat = input.get().context?.chat
+              expectTypeOf(chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<string | undefined>()
+              expectTypeOf(chat?.user?.email).toEqualTypeOf<string | undefined>()
+              return "customer"
+            },
+            scopes: {
+              customer: {
+                grants: [
+                  { source: "forecastingEngine" },
+                  { sources: ["docs"] },
+                ],
+              },
+            },
+          },
+        }),
+      ],
+      model: {} as never,
+      workspace: {
+        sources: {
+          docs: source.file("AGENTS.md"),
+          forecastingEngine: source.github({ repo: "acme/forecasting-engine" }),
+        },
+      },
+    })
+
+    // @ts-expect-error inline access source grants are checked against defineAgent({ workspace.sources })
+    defineAgent({
+      capabilities: [
+        access({
+          workspace: {
+            scopes: {
+              customer: { source: "missing" },
+            },
+          },
+        }),
+      ],
+      model: {} as never,
+      workspace: {
+        sources: {
+          docs: source.file("AGENTS.md"),
+        },
+      },
+    })
   })
 
   it("accepts agent eval definitions", () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -302,16 +302,24 @@ describe("agent public types", () => {
   })
 
   it("types inline access source grants and chat input schemas from defineAgent", () => {
+    interface SupportMessageMetadata {
+      quiver?: {
+        customer?: string
+      }
+    }
+    interface SupportChatUser {
+      email?: string
+    }
     const metadataSchema = {
       "~standard": {
-        validate: (input: unknown) => ({ value: input as { quiver?: { customer?: string } } }),
+        validate: (input: unknown) => ({ value: input as SupportMessageMetadata }),
       },
-    } satisfies AccessCapabilityStandardSchemaV1<{ quiver?: { customer?: string } }>
+    } satisfies AccessCapabilityStandardSchemaV1<SupportMessageMetadata>
     const userSchema = {
       "~standard": {
-        validate: (input: unknown) => ({ value: input as { email?: string } }),
+        validate: (input: unknown) => ({ value: input as SupportChatUser }),
       },
-    } satisfies AccessCapabilityStandardSchemaV1<{ email?: string }>
+    } satisfies AccessCapabilityStandardSchemaV1<SupportChatUser>
 
     defineAgent({
       capabilities: [

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,14 +1,14 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, type AgentRuntimeContext } from "../src/index.ts"
-import { access, blob, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, transcribe, webSearch, workspaceShell } from "../src/capabilities.ts"
+import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, transcribe, webSearch, workspaceShell } from "../src/capabilities.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import type { AgentInvocationContextStore, AgentUsageRecord } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
 import { source } from "@vite-hub/workspace"
-import type { AccessCapabilityStandardSchemaV1, AccessWorkspaceOptionsFor, AgentChatRunContext, FetchCapabilityToolOptions, TranscriptionResult } from "../src/capabilities.ts"
+import type { AccessCapabilityStandardSchemaV1, AccessWorkspaceOptionsFor, AgentChatAdapterResolver, AgentChatRunContext, FetchCapabilityToolOptions, TranscriptionResult } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
   it("accepts capabilities from the capabilities entry", () => {
@@ -265,13 +265,15 @@ describe("agent public types", () => {
     }
     type ChatContext = AgentChatRunContext<
       { quiver?: { customer?: string } },
-      { email?: string }
+      { email?: string },
+      "portal" | "teams"
     >
     const workspaceAccess: AccessWorkspaceOptionsFor<typeof workspace, ChatContext> = {
       defaultScope: "customer",
       resolve({ input }) {
         const chat = input.get().context?.chat
         expectTypeOf(chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<string | undefined>()
+        expectTypeOf(chat?.run?.origin).toEqualTypeOf<"portal" | "teams" | undefined>()
         expectTypeOf(chat?.user?.email).toEqualTypeOf<string | undefined>()
         return chat?.user?.email?.endsWith("@quiver.dk")
           ? { role: "admin", scope: "quiver" }
@@ -290,6 +292,21 @@ describe("agent public types", () => {
     }
     access({ workspace: workspaceAccess })
 
+    const inlineWorkspaceAccess: AccessWorkspaceOptionsFor<typeof workspace, ChatContext> = {
+      resolve({ input }) {
+        const customer = input.get().context?.chat?.message?.metadata?.quiver?.customer || "public"
+        return {
+          grants: [
+            { path: "AGENTS.md" },
+            { source: "forecastingEngine" },
+            { path: `ingestion/${customer}` },
+          ],
+          scope: customer,
+        }
+      },
+    }
+    access({ workspace: inlineWorkspaceAccess })
+
     const invalidAccess: AccessWorkspaceOptionsFor<typeof workspace> = {
       scopes: {
         customer: {
@@ -303,6 +320,15 @@ describe("agent public types", () => {
       },
     }
     expectTypeOf(invalidAccess).toMatchTypeOf<AccessWorkspaceOptionsFor<typeof workspace>>()
+
+    const invalidInlineAccess: AccessWorkspaceOptionsFor<typeof workspace> = {
+      // @ts-expect-error inline source grants are limited to the workspace source map
+      resolve: () => ({
+        scope: "customer",
+        source: "missing",
+      }),
+    }
+    expectTypeOf(invalidInlineAccess).toMatchTypeOf<AccessWorkspaceOptionsFor<typeof workspace>>()
   })
 
   it("types inline access source grants and chat input schemas from defineAgent", () => {
@@ -324,12 +350,27 @@ describe("agent public types", () => {
         validate: (input: unknown) => ({ value: input as SupportChatUser }),
       },
     } satisfies AccessCapabilityStandardSchemaV1<SupportChatUser>
+    const teamsAdapter = {} as AgentChatAdapterResolver
+    const supportChat = chat({
+      adapters: () => ({ teams: teamsAdapter }),
+      app: "portal",
+      identity({ adapter, author }) {
+        expectTypeOf(adapter).toEqualTypeOf<string>()
+        expectTypeOf(author.userId).toEqualTypeOf<string>()
+        return `${adapter}:${author.userId}`
+      },
+      transcripts: {
+        maxPerUser: 50,
+        retention: "30d",
+      },
+    })
 
     defineAgent({
       capabilities: [
         access({
           input: {
             chat: {
+              capability: supportChat,
               message: { metadata: metadataSchema },
               user: userSchema,
             },
@@ -338,6 +379,7 @@ describe("agent public types", () => {
             resolve({ input }) {
               const chat = input.get().context?.chat
               expectTypeOf(chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<string | undefined>()
+              expectTypeOf(chat?.run?.origin).toEqualTypeOf<"portal" | "teams" | undefined>()
               expectTypeOf(chat?.user?.email).toEqualTypeOf<string | undefined>()
               return "customer"
             },
@@ -351,6 +393,7 @@ describe("agent public types", () => {
             },
           },
         }),
+        supportChat,
       ],
       model: {} as never,
       workspace: {
@@ -361,7 +404,7 @@ describe("agent public types", () => {
       },
     })
 
-    // @ts-expect-error inline access source grants are checked against defineAgent({ workspace.sources })
+    // @ts-expect-error access source grants are checked against defineAgent({ workspace.sources })
     defineAgent({
       capabilities: [
         access({

--- a/packages/workflow/src/nitro/module.ts
+++ b/packages/workflow/src/nitro/module.ts
@@ -13,6 +13,8 @@ import { createCloudflareWorkflowBindings, getCloudflareWorkflowClassName } from
 import type { DiscoveredWorkflowDefinition, ResolvedWorkflowOptions, WorkflowModuleOptions } from "../types.ts"
 
 const WORKFLOW_NITRO_IMPORTS_PRESET = { from: "@vite-hub/workflow", imports: ["defineWorkflow", "getWorkflowRun"] }
+const OPENWORKFLOW_NITRO_TRACE_DEPS = ["openworkflow", "postgres"] as const
+const OPENWORKFLOW_NITRO_TRACE_IMPORTS = ["openworkflow", "openworkflow/postgres"] as const
 const WORKFLOW_VITE_PLUGIN_NAME = "@vite-hub/workflow/vite"
 
 function resolveRuntimeEntry(srcRelative: string, packageSubpath: string): string {
@@ -39,7 +41,11 @@ function resolveNitroWorkflowScanDirs(rootDir: string, scanDirs: string[] | unde
   return scanDirs?.length ? scanDirs : [resolve(rootDir, "server")]
 }
 
-function createNitroWorkflowPluginContents(file: string, registryFile: string) {
+function createNitroWorkflowPluginContents(file: string, registryFile: string, options: false | ResolvedWorkflowOptions) {
+  const openWorkflowTraceImports = options && options.provider === "openworkflow"
+    ? OPENWORKFLOW_NITRO_TRACE_IMPORTS.map(specifier => `import ${JSON.stringify(specifier)}`)
+    : []
+
   return [
     "import { definePlugin as defineNitroPlugin } from \"nitro\"",
     "import { useRuntimeConfig } from \"nitro/runtime-config\"",
@@ -47,6 +53,7 @@ function createNitroWorkflowPluginContents(file: string, registryFile: string) {
     "import { runCloudflareWorkflow } from \"@vite-hub/workflow/runtime/cloudflare-runner\"",
     "import { startOpenWorkflowWorker } from \"@vite-hub/workflow/runtime/openworkflow-worker\"",
     "import { enterWorkflowRuntimeEvent, setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry } from \"@vite-hub/workflow/runtime/state\"",
+    ...openWorkflowTraceImports,
     "",
     `import workflowRegistry from ${JSON.stringify(createImportPath(file, registryFile))}`,
     "",
@@ -130,7 +137,7 @@ function createCloudflareWorkflowClassExports(definitions: DiscoveredWorkflowDef
 
 interface RuntimeFiles { definitions: DiscoveredWorkflowDefinition[], pluginFile: string, providerDefinitions: DiscoveredWorkflowDefinition[], registryFile: string }
 
-async function writeNitroWorkflowRuntimeFiles(nitro: Nitro): Promise<RuntimeFiles> {
+async function writeNitroWorkflowRuntimeFiles(nitro: Nitro, resolved: false | ResolvedWorkflowOptions): Promise<RuntimeFiles> {
   const registryFile = createNitroWorkflowRegistryPath(nitro.options.rootDir, nitro.options.buildDir)
   const pluginFile = createNitroWorkflowPluginPath(nitro.options.rootDir, nitro.options.buildDir)
   const definitions = discoverWorkflowDefinitions({
@@ -140,13 +147,23 @@ async function writeNitroWorkflowRuntimeFiles(nitro: Nitro): Promise<RuntimeFile
   const providerDefinitions = definitions
 
   const runtimeFiles = await writeRuntimeRegistryFiles({
-    createPluginContents: createNitroWorkflowPluginContents,
+    createPluginContents: (file, registryFile) => createNitroWorkflowPluginContents(file, registryFile, resolved),
     definitions,
     pluginFile,
     registryFile,
   })
 
   return { ...runtimeFiles, providerDefinitions }
+}
+
+function addOpenWorkflowNitroTraceDeps(nitro: Nitro): void {
+  const options = nitro.options as typeof nitro.options & { traceDeps?: string[] }
+  options.traceDeps ||= []
+  for (const dependency of OPENWORKFLOW_NITRO_TRACE_DEPS) {
+    if (!options.traceDeps.includes(dependency)) {
+      options.traceDeps.push(dependency)
+    }
+  }
 }
 
 const workflowNitroModule: NitroModule = {
@@ -167,7 +184,11 @@ const workflowNitroModule: NitroModule = {
     nitro.options.alias["@vite-hub/workflow/runtime/openworkflow"] = resolveRuntimeEntry("../runtime/openworkflow", "@vite-hub/workflow/runtime/openworkflow")
     nitro.options.alias["@vite-hub/workflow/runtime/openworkflow-worker"] = resolveRuntimeEntry("../runtime/openworkflow-worker", "@vite-hub/workflow/runtime/openworkflow-worker")
 
-    let runtimeFiles = await writeNitroWorkflowRuntimeFiles(nitro)
+    if (resolved?.provider === "openworkflow") {
+      addOpenWorkflowNitroTraceDeps(nitro)
+    }
+
+    let runtimeFiles = await writeNitroWorkflowRuntimeFiles(nitro, resolved || false)
     applyNitroRuntimeAliases(nitro, { "#vitehub/workflow/registry": runtimeFiles.registryFile })
 
     const importsExplicitlyDisabled = nitro.options._config?.imports === false
@@ -199,7 +220,7 @@ const workflowNitroModule: NitroModule = {
       }
     }
 
-    hookNitroRuntimeRegistryRefresh(nitro, () => writeNitroWorkflowRuntimeFiles(nitro), (nextRuntimeFiles) => {
+    hookNitroRuntimeRegistryRefresh(nitro, () => writeNitroWorkflowRuntimeFiles(nitro, resolved || false), (nextRuntimeFiles) => {
       runtimeFiles = nextRuntimeFiles
       applyNitroRuntimeAliases(nitro, { "#vitehub/workflow/registry": runtimeFiles.registryFile })
     })

--- a/packages/workflow/test/nitro.test.ts
+++ b/packages/workflow/test/nitro.test.ts
@@ -33,4 +33,26 @@ describe("Nitro module", () => {
       ],
     })
   })
+
+  it("marks OpenWorkflow provider dependencies for Nitro tracing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workflow-nitro-openworkflow-"))
+    const nitro = {
+      hooks: { hook: vi.fn() },
+      options: {
+        alias: {},
+        buildDir: join(root, ".nitro"),
+        imports: undefined as { presets?: Array<{ from: string, imports: string[] }> } | undefined,
+        output: { serverDir: join(root, ".output/server") },
+        plugins: [],
+        rootDir: root,
+        scanDirs: [],
+        traceDeps: undefined as string[] | undefined,
+        workflow: { provider: "openworkflow", postgres: { url: "postgres://example" } },
+      },
+    }
+
+    await workflowNitroModule.setup(nitro as never)
+
+    expect(nitro.options.traceDeps).toEqual(expect.arrayContaining(["openworkflow", "postgres"]))
+  })
 })

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs"
-import { cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
-import { join, resolve } from "node:path"
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import { createRequire } from "node:module"
+import { dirname, join, resolve } from "node:path"
 import { execFile } from "node:child_process"
 import { promisify } from "node:util"
 
@@ -8,11 +9,13 @@ import { afterAll, describe, expect, it } from "vitest"
 
 import { getCloudflareWorkflowClassName } from "../src/integrations/cloudflare.ts"
 
+const require = createRequire(import.meta.url)
 const execFileAsync = promisify(execFile)
 const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
 const nitroBin = join(playgroundDir, "node_modules", ".bin", "nitro")
 const viteBin = join(playgroundDir, "node_modules", ".bin", "vite")
 const buildOutputTestTimeout = 60_000
+const tempNodeModuleBuildDirs = new Set([".nitro", ".nitro-output-test", ".vite-temp"])
 const tempDirs: string[] = []
 
 async function createWorkspaceTempDir(prefix: string) {
@@ -25,6 +28,43 @@ async function createWorkspaceTempDir(prefix: string) {
   const rootDir = await mkdtemp(join(baseDir, prefix))
   tempDirs.push(rootDir)
   return rootDir
+}
+
+function resolvePackageRoot(specifier: string) {
+  const packageParts = specifier.startsWith("@")
+    ? specifier.split("/").slice(0, 2)
+    : specifier.split("/").slice(0, 1)
+  let directory = dirname(require.resolve(specifier))
+  while (!packageParts.every((part, index) => directory.split(/[\\/]/).slice(-packageParts.length)[index] === part)) {
+    const parent = dirname(directory)
+    if (parent === directory) {
+      throw new Error(`Could not find package root for ${specifier}.`)
+    }
+    directory = parent
+  }
+  if (!existsSync(join(directory, "package.json"))) {
+    throw new Error(`Could not find package root for ${specifier}.`)
+  }
+  return directory
+}
+
+async function linkNodeModules(sourceDir: string, targetDir: string) {
+  await mkdir(targetDir, { recursive: true })
+  for (const entry of await readdir(sourceDir, { withFileTypes: true })) {
+    if (tempNodeModuleBuildDirs.has(entry.name)) {
+      continue
+    }
+    await symlink(join(sourceDir, entry.name), join(targetDir, entry.name), entry.isDirectory() ? "dir" : "file")
+  }
+}
+
+async function linkPackage(rootDir: string, packageName: string) {
+  const parts = packageName.split("/")
+  const packageDir = resolvePackageRoot(packageName)
+  const target = join(rootDir, "node_modules", ...parts)
+  await mkdir(dirname(target), { recursive: true })
+  await rm(target, { force: true, recursive: true })
+  await symlink(packageDir, target, "dir")
 }
 
 async function createPlaygroundCopy(prefix: string) {
@@ -40,7 +80,7 @@ async function createPlaygroundCopy(prefix: string) {
   await cp(join(playgroundDir, "nitro.config.ts"), join(rootDir, "nitro.config.ts"))
   await cp(join(playgroundDir, "src"), join(rootDir, "src"), { recursive: true })
   await cp(join(playgroundDir, "server"), join(rootDir, "server"), { recursive: true })
-  await symlink(nodeModules, join(rootDir, "node_modules"), "dir")
+  await linkNodeModules(nodeModules, join(rootDir, "node_modules"))
 
   return rootDir
 }
@@ -48,7 +88,7 @@ async function createPlaygroundCopy(prefix: string) {
 async function writeWorkflowNitroConfig(rootDir: string, options: {
   env?: boolean
   omitWorkflowOptions?: boolean
-  provider?: "vercel"
+  provider?: "openworkflow" | "vercel"
 } = {}) {
   const imports = options.env
     ? [
@@ -59,9 +99,14 @@ async function writeWorkflowNitroConfig(rootDir: string, options: {
   const modules = options.env
     ? `["@vite-hub/env/nitro", "@vite-hub/workflow/nitro"]`
     : `["@vite-hub/workflow/nitro"]`
+  const workflowOptions = options.provider === "openworkflow"
+    ? `{ provider: "openworkflow", postgres: { url: "postgres://example" } }`
+    : options.provider
+      ? `{ provider: "${options.provider}" }`
+      : "{}"
   const workflow = options.omitWorkflowOptions
     ? []
-    : [`  workflow: ${options.provider ? `{ provider: "${options.provider}" }` : "{}"},`]
+    : [`  workflow: ${workflowOptions},`]
   const envConfig = options.env
     ? [`  env: { vertex: { apiKey: env({ secret: true }) } },`]
     : []
@@ -225,5 +270,20 @@ describe("Vite workflow provider outputs", () => {
 
     expect(wrangler.workflows).toBeUndefined()
     expect(serverEntryContents).not.toContain("extends ViteHubWorkflowEntrypoint")
+  }, buildOutputTestTimeout)
+
+  it("traces OpenWorkflow runtime dependencies in Nitro node output", async () => {
+    const rootDir = await createPlaygroundCopy("vitehub-workflow-nitro-openworkflow-")
+    await linkPackage(rootDir, "openworkflow")
+    await linkPackage(rootDir, "postgres")
+    await writeWorkflowNitroConfig(rootDir, { provider: "openworkflow" })
+
+    await execFileAsync(nitroBin, ["build"], {
+      cwd: rootDir,
+      env: { ...process.env, VITEHUB_NITRO_MODE: "workflow" },
+    })
+
+    expect(existsSync(join(rootDir, ".output", "server", "node_modules", "openworkflow"))).toBe(true)
+    expect(existsSync(join(rootDir, ".output", "server", "node_modules", "postgres"))).toBe(true)
   }, buildOutputTestTimeout)
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ catalogs:
       version: 1.0.0-beta.16
   chat:
     chat:
-      specifier: ^4.27.0
-      version: 4.27.0
+      specifier: ^4.29.0
+      version: 4.29.0
     chat-state-cloudflare-do:
       specifier: ^0.2.0
       version: 0.2.0
@@ -344,7 +344,7 @@ importers:
         version: 0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(ai@6.0.174(zod@4.4.3))(react@19.2.6)(rolldown@1.0.0-rc.16)(vite@8.0.8)(zod@4.4.3)
       chat:
         specifier: catalog:chat
-        version: 4.27.0
+        version: 4.29.0(ai@6.0.174(zod@4.4.3))(zod@4.4.3)
       h3:
         specifier: catalog:unjs
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
@@ -1337,10 +1337,10 @@ importers:
         version: 1.3.3
       chat:
         specifier: catalog:chat
-        version: 4.27.0
+        version: 4.29.0(ai@6.0.174(zod@4.4.3))(zod@4.4.3)
       chat-state-cloudflare-do:
         specifier: catalog:chat
-        version: 0.2.0(chat@4.27.0)
+        version: 0.2.0(chat@4.29.0(zod@4.4.3))
       h3:
         specifier: catalog:unjs
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
@@ -1406,10 +1406,10 @@ importers:
         version: 0.2.0(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(crossws@0.4.5(srvx@0.11.15))(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(vite@8.0.8)
       chat:
         specifier: catalog:chat
-        version: 4.27.0
+        version: 4.29.0(ai@6.0.174(zod@4.4.3))(zod@4.4.3)
       chat-state-cloudflare-do:
         specifier: catalog:chat
-        version: 0.2.0(chat@4.27.0)
+        version: 0.2.0(chat@4.29.0(zod@4.4.3))
       drizzle-orm:
         specifier: catalog:database
         version: 0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1)
@@ -7305,8 +7305,17 @@ packages:
     peerDependencies:
       chat: ^4.26.0
 
-  chat@4.27.0:
-    resolution: {integrity: sha512-PrL4k263DSIlckhX8eHLT84RdTSznOBxCCfaDc5JVJtWaS0lJkCNctm/g3gIrI41AcDHcpc/3WDoUHVrbh0W4w==}
+  chat@4.29.0:
+    resolution: {integrity: sha512-KdPfzaie5ivYytyRICTERg5xT+LeCbYefokvNAqTHe92eqkFaoTMXXkSitikxJVWhZIb2YoXF1b9UZHyzSzKzw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      ai: ^6.0.182
+      zod: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      ai:
+        optional: true
+      zod:
+        optional: true
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -18174,6 +18183,55 @@ snapshots:
       - utf-8-validate
     optional: true
 
+  '@vitejs/devtools@0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(vite@8.0.8)':
+    dependencies:
+      '@vitejs/devtools-kit': 0.1.19(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@nuxt/kit@4.4.6(magicast@0.5.3))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
+      '@vitejs/devtools-rolldown': 0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
+      birpc: 4.0.0
+      cac: 7.0.0
+      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@nuxt/kit@4.4.6(magicast@0.5.3))(launch-editor@2.13.2)(typescript@6.0.2)
+      h3: 1.15.11
+      immer: 11.1.6
+      launch-editor: 2.13.2
+      logs-sdk: 0.0.6
+      mlly: 1.8.2
+      obug: 2.1.1
+      open: 11.0.0
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      tinyexec: 1.1.2
+      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+      vue: 3.5.34(typescript@6.0.2)
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@modelcontextprotocol/sdk'
+      - '@netlify/blobs'
+      - '@nuxt/kit'
+      - '@planetscale/database'
+      - '@pnpm/logger'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - idb-keyval
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+    optional: true
+
   '@vitejs/devtools@0.2.0(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(crossws@0.4.5(srvx@0.11.15))(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(vite@8.0.8)':
     dependencies:
       '@vitejs/devtools-kit': 0.2.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(crossws@0.4.5(srvx@0.11.15))(typescript@6.0.2)(vite@8.0.8)
@@ -19340,11 +19398,11 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  chat-state-cloudflare-do@0.2.0(chat@4.27.0):
+  chat-state-cloudflare-do@0.2.0(chat@4.29.0(zod@4.4.3)):
     dependencies:
-      chat: 4.27.0
+      chat: 4.29.0(ai@6.0.174(zod@4.4.3))(zod@4.4.3)
 
-  chat@4.27.0:
+  chat@4.29.0(ai@6.0.174(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -19353,6 +19411,9 @@ snapshots:
       remark-stringify: 11.0.0
       remend: 1.3.0
       unified: 11.0.5
+    optionalDependencies:
+      ai: 6.0.174(zod@4.4.3)
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -25775,7 +25836,7 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.6.0
-      '@vitejs/devtools': 0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(vite@8.0.8)
+      '@vitejs/devtools': 0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(vite@8.0.8)
       esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ catalogs:
   ai-compat:
     ai: ^6.0.0
   chat:
-    chat: ^4.27.0
+    chat: ^4.29.0
     chat-state-cloudflare-do: ^0.2.0
   database:
     '@libsql/client': ^0.15.15


### PR DESCRIPTION
Adds narrow Capability Type Contracts to the Agent Package so `access()` can type-check Workspace Scope Grants against declared Workspace Sources while keeping runtime authority in the Access Capability resolver. The Access Capability now supports typed Source grants, readonly grant inputs, inline scope definitions, and schema-validated chat invocation context for resolver callbacks.

This also exports the supporting Access Capability types and `AgentChatRunContext`, documents Workspace Scope source-grant behavior, records the Capability Type Contract ADR, and expands runtime/type coverage for unknown Source grants, chat metadata/user context, trusted chat origins, and mismatched Chat App Route origins.