### PR TITLE
feat(agent): expose definition version metadata

### DIFF
--- a/packages/agent/src/chat/devtools.ts
+++ b/packages/agent/src/chat/devtools.ts
@@ -142,7 +142,7 @@ export interface ChatDevtoolsTypingThread {
   startTyping(text?: string): Promise<unknown>
 }
 
-type ResolvedChatDevtoolsMetadata = Required<Omit<ChatDevtoolsMetadata, "title">> & Pick<ChatDevtoolsMetadata, "title">
+type ResolvedChatDevtoolsMetadata = Required<Omit<ChatDevtoolsMetadata, "title" | "version">> & Pick<ChatDevtoolsMetadata, "title" | "version">
 
 interface ChatDevtoolsFullStreamToolPart {
   error?: unknown
@@ -465,6 +465,7 @@ function normalizeDevtoolsMetadata(metadata: ChatDevtoolsMetadata | undefined): 
     instructions: metadata?.instructions ? [...metadata.instructions] : [],
     title: metadata?.title,
     tools: metadata?.tools ? [...metadata.tools] : [],
+    version: metadata?.version,
   }
 }
 
@@ -656,6 +657,7 @@ export function createDevtoolsAdapter(options: ChatDevtoolsAdapterOptions = {}):
         selected: chat && chats.some(item => item.name === chat) ? chat : chats[0]!.name,
         ...(metadata.title ? { title: metadata.title } : {}),
         tools: metadata.tools,
+        ...(metadata.version ? { version: metadata.version } : {}),
       }
     },
     handleWebhook: async () => new Response(null, { status: 204 }),

--- a/packages/agent/src/chat/nitro/devtools.ts
+++ b/packages/agent/src/chat/nitro/devtools.ts
@@ -21,7 +21,7 @@ type ChatDevtoolsMetadataInput =
   | ChatDevtoolsMetadata
   | ChatDevtoolsMetadataResolver
   | Record<string, ChatDevtoolsMetadata | ChatDevtoolsMetadataResolver | undefined>
-type ResolvedChatDevtoolsMetadata = Required<Omit<ChatDevtoolsMetadata, "title">> & Pick<ChatDevtoolsMetadata, "title">
+type ResolvedChatDevtoolsMetadata = Required<Omit<ChatDevtoolsMetadata, "title" | "version">> & Pick<ChatDevtoolsMetadata, "title" | "version">
 
 interface ChatDevtoolsSession {
   name: string
@@ -109,6 +109,7 @@ function normalizeDevtoolsMetadata(metadata: ChatDevtoolsMetadata | undefined): 
     instructions: metadata?.instructions ? [...metadata.instructions] : [],
     title: metadata?.title,
     tools: metadata?.tools ? [...metadata.tools] : [],
+    version: metadata?.version,
   }
 }
 
@@ -118,7 +119,8 @@ function isChatDevtoolsMetadata(metadata: unknown): metadata is ChatDevtoolsMeta
     && (Array.isArray((metadata as ChatDevtoolsMetadata).files)
       || Array.isArray((metadata as ChatDevtoolsMetadata).instructions)
       || typeof (metadata as ChatDevtoolsMetadata).title === "string"
-      || Array.isArray((metadata as ChatDevtoolsMetadata).tools))
+      || Array.isArray((metadata as ChatDevtoolsMetadata).tools)
+      || typeof (metadata as ChatDevtoolsMetadata).version === "string")
 }
 
 async function resolveDevtoolsMetadata(metadata: ChatDevtoolsMetadata | ChatDevtoolsMetadataResolver | undefined): Promise<ResolvedChatDevtoolsMetadata> {
@@ -213,6 +215,7 @@ async function serializeState(state: ChatDevtoolsHandlerState, selected?: string
     ...(title ? { title } : {}),
     tools: metadata.tools,
     uiMessages: selectedSession ? [...selectedSession.uiMessages] : [],
+    ...(metadata.version ? { version: metadata.version } : {}),
   }
 }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -410,7 +410,7 @@ function defineBaseAgent<
 >(
   options: AgentSettings<TRuntimeConfig, CALL_OPTIONS>,
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS> {
-  const { capabilities, description, hooks, run, runtime, title, workspace } = options
+  const { capabilities, description, hooks, run, runtime, title, version, workspace } = options
   const normalizedCapabilities = normalizeCapabilities(capabilities as AgentCapabilitiesList | undefined)
   const chat = getChatCapabilityOptions<TRuntimeConfig>(normalizedCapabilities)
   validateNonWorkspaceCapabilities(normalizedCapabilities, !!workspace)
@@ -436,6 +436,7 @@ function defineBaseAgent<
     runtime,
     run,
     title,
+    version,
     workspace,
     ...(normalizedCapabilities.length ? { capabilities: normalizedCapabilities } : {}),
     async resolve(context) {
@@ -489,10 +490,14 @@ export interface AgentDevtoolsMetadata {
   instructions?: string[]
   title?: string
   tools?: AgentDevtoolsToolDefinition[]
+  version?: string
 }
 
-function agentDevtoolsTitle(definition: Pick<AgentDefinition, "title">): Pick<AgentDevtoolsMetadata, "title"> {
-  return definition.title ? { title: definition.title } : {}
+function agentDevtoolsMetadata(definition: Pick<AgentDefinition, "title" | "version">): Pick<AgentDevtoolsMetadata, "title" | "version"> {
+  return {
+    ...(definition.title ? { title: definition.title } : {}),
+    ...(definition.version ? { version: definition.version } : {}),
+  }
 }
 
 function normalizeWorkspaceOptions(workspace: WorkspaceAgentWorkspaceConfig): NormalizedWorkspaceOptions {
@@ -807,14 +812,14 @@ export function createAgentDevtoolsMetadata<
 ): AgentDevtoolsMetadata {
   const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig, Name>>
   if (!workspaceDefinition.__vitehubWorkspaceAgent || !workspaceDefinition.__vitehubWorkspaceAgentOptions) {
-    return { files: [], ...agentDevtoolsTitle(definition), tools: [] }
+    return { files: [], ...agentDevtoolsMetadata(definition), tools: [] }
   }
 
   const options = workspaceDefinition.__vitehubWorkspaceAgentOptions as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>
   return {
     files: workspaceMetadataFiles(options, workspaceDefinition.__vitehubWorkspaceAgentDefaults || workspaceDefinition as WorkspaceAgentDefaults<Name>),
     instructions: workspaceMetadataInstructions(options),
-    ...agentDevtoolsTitle(workspaceDefinition as AgentDefinition),
+    ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition),
     tools: workspaceMetadataTools(options),
   }
 }
@@ -828,7 +833,7 @@ export async function resolveAgentDevtoolsMetadata<
 ): Promise<AgentDevtoolsMetadata> {
   const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig, Name>>
   if (!workspaceDefinition.__vitehubWorkspaceAgent || !workspaceDefinition.__vitehubWorkspaceAgentOptions) {
-    return { files: [], ...agentDevtoolsTitle(definition), tools: [] }
+    return { files: [], ...agentDevtoolsMetadata(definition), tools: [] }
   }
 
   const defaults = {
@@ -846,7 +851,7 @@ export async function resolveAgentDevtoolsMetadata<
   return {
     files: await resolveWorkspaceMetadataFiles(options, defaults, workspace),
     instructions: await resolveWorkspaceMetadataInstructions(options, workspace),
-    ...agentDevtoolsTitle(workspaceDefinition as AgentDefinition),
+    ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition),
     tools: workspaceMetadataTools(options),
   }
 }
@@ -866,6 +871,7 @@ function createWorkspaceAgentDefinition<
     hooks: options.hooks,
     run: options.run,
     runtime: options.runtime,
+    version: options.version,
     workspace: workspaceDefinition,
   } as never) as WorkspaceAgentDefinition<TRuntimeConfig, Name>
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -418,6 +418,7 @@ type AgentSettingsBase<
   model?: AgentModelResolver<TRuntimeConfig>
   runtime?: AgentRuntimeBinding
   title?: string
+  version?: string
   workspace?: WorkspaceAgentWorkspaceConfig
 }
 
@@ -446,6 +447,7 @@ export interface AgentDefinition<
   resolve(context: AgentRuntimeContext<TRuntimeConfig>): Promise<AgentAdapter<CALL_OPTIONS>>
   run?(context: AgentRunContext<TRuntimeConfig, CALL_OPTIONS>): MaybePromise<Response | AgentRunResult | AsyncIterable<StreamEvent> | unknown>
   title?: string
+  version?: string
   workspace?: WorkspaceAgentWorkspaceConfig
 }
 
@@ -695,7 +697,9 @@ export interface AgentDevtoolsToolDefinition {
 export interface AgentDevtoolsMetadata {
   files?: AgentDevtoolsFileTreeItem[]
   instructions?: string[]
+  title?: string
   tools?: AgentDevtoolsToolDefinition[]
+  version?: string
 }
 
 export interface AgentAdapterResult {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1379,6 +1379,7 @@ describe("agent message protocol", () => {
         files: async () => ({
           title: "Files agent",
           tools: [{ name: "reserved-chat-tool" }],
+          version: "1.2.3",
         }),
       },
     })
@@ -1389,11 +1390,12 @@ describe("agent message protocol", () => {
       headers: { "content-type": "application/json" },
       method: "POST",
     }))
-    const state = await response.json() as { chats?: Array<{ name: string, title?: string }>, title?: string, tools?: Array<{ name: string }> }
+    const state = await response.json() as { chats?: Array<{ name: string, title?: string }>, title?: string, tools?: Array<{ name: string }>, version?: string }
 
     expect(state.chats?.map(chat => chat.name)).toEqual(["files", "support"])
     expect(state.title).toBe("Files agent")
     expect(state.tools).toEqual([{ name: "reserved-chat-tool" }])
+    expect(state.version).toBe("1.2.3")
   })
 
   it("resolves direct title-only DevTools metadata", async () => {
@@ -1407,7 +1409,7 @@ describe("agent message protocol", () => {
         run: () => "ok",
       }),
     }, {
-      metadata: { title: "Support agent" },
+      metadata: { title: "Support agent", version: "2.0.0" },
     }))
 
     const response = await toWebHandler(app)(new Request("http://example.test", {
@@ -1415,9 +1417,10 @@ describe("agent message protocol", () => {
       headers: { "content-type": "application/json" },
       method: "POST",
     }))
-    const state = await response.json() as { title?: string }
+    const state = await response.json() as { title?: string, version?: string }
 
     expect(state.title).toBe("Support agent")
+    expect(state.version).toBe("2.0.0")
   })
 
   it("streams DevTools sends without timer state polling and returns final assistant state", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -846,6 +846,7 @@ describe("defineAgent workspace option", () => {
       instructions: "Answer from the workspace.",
       model: {} as never,
       title: "Support agent",
+      version: "1.2.3",
       capabilities: [{ id: "workspace-shell", tools: ({ workspace }) => workspace.tools.inspect() }],
     }), { workspace: "support" })
 
@@ -861,6 +862,7 @@ describe("defineAgent workspace option", () => {
       }],
       instructions: ["Answer from the workspace."],
       title: "Support agent",
+      version: "1.2.3",
       tools: expect.arrayContaining([
         expect.objectContaining({
           commands: ["pwd", "ls", "find", "rg", "grep", "cat", "head", "tail", "wc"],

--- a/packages/devtools/devtools/chat/app/app.vue
+++ b/packages/devtools/devtools/chat/app/app.vue
@@ -78,6 +78,7 @@ const splitterStyle = computed(() => ({
 }))
 const thinkingFallback = computed(() => state.value.thinkingFallback || undefined)
 const chatTitleTarget = computed(() => normalizeChatTitle(selectedChat()?.title || state.value.title))
+const agentVersion = computed(() => state.value.version?.trim())
 const recentTools = computed(() => {
   const tools = new Map<string, ChatDevtoolsTool>()
   for (const message of messages.value) {
@@ -906,6 +907,15 @@ onBeforeUnmount(() => {
           <span class="min-w-0 truncate">
             {{ chatTitleTarget }}
           </span>
+          <UBadge
+            v-if="agentVersion"
+            color="neutral"
+            variant="subtle"
+            size="sm"
+            class="ml-2 shrink-0"
+          >
+            v{{ agentVersion }}
+          </UBadge>
         </h1>
         <UButton
           icon="i-lucide-trash-2"

--- a/packages/devtools/src/chat-shared.ts
+++ b/packages/devtools/src/chat-shared.ts
@@ -51,6 +51,7 @@ export interface ChatDevtoolsMetadata {
   instructions?: string[]
   title?: string
   tools?: ChatDevtoolsToolDefinition[]
+  version?: string
 }
 
 export interface ChatDevtoolsMessage {
@@ -78,6 +79,7 @@ export interface ChatDevtoolsStateResult {
   title?: string
   tools?: ChatDevtoolsToolDefinition[]
   uiMessages?: UIMessage[]
+  version?: string
 }
 
 export interface ChatDevtoolsSendInput {


### PR DESCRIPTION
Adds an optional Agent Definition `version` field to `defineAgent` and carries it into resolved Agent DevTools metadata. Agent Chat DevTools now includes that value in chat state and registry metadata, then renders it in the chat header when an agent exposes a version.

This gives downstream canary apps a stable place to align released app/package versions with the agent definition they deploy, without overloading variants or runtime state. Workspace and runtime coverage now checks the metadata and DevTools propagation paths.
