### PR TITLE
fix(agent): unblock nitro chat devtools

### DIFF
--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -367,7 +367,6 @@ function normalizeChatWebhookRegistrations(
 function inferredChatWebhookRegistrations(options: AgentChatOptions): AgentWebhookRegistrationDefinition[] {
   if (!isStaticAdapterMap(options.adapters)) return []
   return Object.keys(options.adapters)
-    .filter(isKnownChatWebhookPlatform)
     .filter(platform => !hasExplicitChatWebhook(options, platform))
     .flatMap(platform => normalizeChatWebhookRegistrations(platform, {}))
 }

--- a/packages/agent/src/chat/nitro/devtools.ts
+++ b/packages/agent/src/chat/nitro/devtools.ts
@@ -84,6 +84,15 @@ function createRuntimeContext(event: H3Event): NitroAgentDevtoolsRuntimeContext 
   }) as NitroAgentDevtoolsRuntimeContext
 }
 
+function createDevtoolsDiscoveryContext(event: H3Event): NitroAgentDevtoolsRuntimeContext {
+  return createAgentRuntimeContext({
+    event,
+    runtime: "nitro",
+    runtimeConfig: {},
+    waitUntil: task => event.waitUntil(task),
+  }) as NitroAgentDevtoolsRuntimeContext
+}
+
 function resolveRegistryModule(module: AgentRegistryModule): AgentInput<NitroAgentDevtoolsRuntimeContext> {
   return typeof module === "object" && module !== null && "default" in module
     ? module.default as AgentInput<NitroAgentDevtoolsRuntimeContext>
@@ -232,6 +241,7 @@ function createRunMetadata(session: ChatDevtoolsSession, userMessageId: string):
 function createUserUIMessage(text: string): UIMessage {
   return {
     id: `devtools-user-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    metadata: {},
     role: "user",
     parts: [{ type: "text", text }],
   }
@@ -415,7 +425,6 @@ export function defineAgentDevtoolsRegistryHandler(registry: AgentDevtoolsRegist
 
   return defineEventHandler(async (event) => {
     setHeader(event, "access-control-allow-origin", "*")
-    state.registry = await chatCapableAgentRegistry(registry, createRuntimeContext(event))
     const body = parseChatDevtoolsBridgeBody(await readBody<ChatDevtoolsBridgeBody | string>(event))
     if (!body || typeof body.action !== "string") {
       throw createError({
@@ -425,6 +434,7 @@ export function defineAgentDevtoolsRegistryHandler(registry: AgentDevtoolsRegist
     }
 
     const action = normalizeChatDevtoolsAction(body.action)
+    state.registry = await chatCapableAgentRegistry(registry, createDevtoolsDiscoveryContext(event))
     if (body.chat && getChatNames(state).includes(body.chat)) {
       state.selected = body.chat
     }

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -12,6 +12,11 @@ import type { DiscoveredAgentDefinition } from "./types.ts"
 
 const agentSuffixPattern = /\.agent\.(?:c|m)?[jt]s$/i
 const configPattern = /^config\.(?:c|m)?[jt]s$/i
+const evalDefinitionPattern = /^(?:.+\.)?eval\.(?:c|m)?[jt]s$/i
+
+function isEvalDefinitionFile(file: string): boolean {
+  return evalDefinitionPattern.test(basename(file))
+}
 
 function normalizeSuffixAgentName(rootDir: string, file: string) {
   const name = normalizeSuffixDefinitionName(rootDir, file, agentSuffixPattern, { stripPrefix: "src/" })
@@ -77,7 +82,7 @@ export function discoverAgentDefinitions(options:
     const directoryDefinitions = discoverDefinitions("agent", [
       createDirectoryDefinitionSource<DiscoveredAgentDefinition>("nitro-server-agents", options.scanDirs, "agents", {
         normalizeName(directory, file) {
-          if (configPattern.test(basename(file))) return
+          if (configPattern.test(basename(file)) || isEvalDefinitionFile(file)) return
           return relative(directory, file).replace(/\.(?:c|m)?[jt]s$/i, "").replace(/\/index$/i, "")
         },
         createDefinition({ file, name }) {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -43,6 +43,22 @@ describe("agent discovery", () => {
     ])
   })
 
+  it("ignores eval definitions during Nitro server agent discovery", async () => {
+    const root = await createTempRoot("vitehub-agent-nitro-eval-")
+    await mkdir(join(root, "server", "agents", "support"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "config.eval.ts"), "export default defineEval({})", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "eval.ts"), "export default defineEval({})", "utf8")
+    await writeFile(join(root, "server", "agents", "support.eval.ts"), "export default defineEval({})", "utf8")
+
+    expect(discoverAgentDefinitions({
+      mode: "nitro-server-agents",
+      scanDirs: [join(root, "server")],
+    })).toEqual([
+      expect.objectContaining({ name: "support", source: "nitro-server-agent-workspace", workspace: "support" }),
+    ])
+  })
+
   it("uses folder identity for colocated workspace agents", async () => {
     const root = await createTempRoot("vitehub-agent-workspace-name-")
     await mkdir(join(root, "server", "agents", "docs"), { recursive: true })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -295,13 +295,14 @@ describe("agent message protocol", () => {
     })
   })
 
-  it("infers telegram webhook registration metadata from static chat adapters", async () => {
+  it("infers webhook registration metadata from static chat adapters", async () => {
     const { chat } = await import("../src/chat-trigger.ts")
     const { resolveAgentTriggers } = await import("../src/trigger-runtime.ts")
     const agent = {
       capabilities: [
         chat({
           adapters: {
+            teams: () => ({}) as never,
             telegram: () => ({}) as never,
           },
         }),
@@ -312,6 +313,10 @@ describe("agent message protocol", () => {
     await expect(resolveAgentTriggers(agent, { memo: vi.fn(), runtime: "unknown" as const, runtimeConfig: {}, waitUntil: vi.fn() })).resolves.toMatchObject({
       "chat.message": {
         webhooks: [{
+          id: "teams",
+          method: "POST",
+          provider: "teams",
+        }, {
           id: "telegram",
           method: "POST",
           provider: "telegram",

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1403,6 +1403,42 @@ describe("agent message protocol", () => {
     expect(state.version).toBe("1.2.3")
   })
 
+  it("does not resolve Nitro runtime env for chat-capable DevTools state discovery", async () => {
+    const { createApp, toWebHandler } = await import("h3")
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineAgentDevtoolsRegistryHandler } = await import("../src/chat/nitro/devtools.ts")
+    const app = createApp()
+    const applyRuntimeEnv = vi.fn(() => {
+      throw new Error("runtime env should not be resolved for DevTools state discovery")
+    })
+    globalThis.__vitehubApplyRuntimeEnvToRuntimeConfig = applyRuntimeEnv
+    app.use(defineAgentDevtoolsRegistryHandler({
+      ignored: async () => defineAgent({
+        run: () => "not a chat",
+      }),
+      support: async () => defineAgent({
+        capabilities: [chat({ concurrency: "queue" })],
+        run: () => "ok",
+      }),
+    }))
+
+    try {
+      const response = await toWebHandler(app)(new Request("http://example.test", {
+        body: JSON.stringify({ action: "get-state", chat: "support" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }))
+      const state = await response.json() as { chats?: Array<{ name: string }> }
+
+      expect(response.status).toBe(200)
+      expect(state.chats?.map(chat => chat.name)).toEqual(["support"])
+      expect(applyRuntimeEnv).not.toHaveBeenCalled()
+    }
+    finally {
+      delete globalThis.__vitehubApplyRuntimeEnvToRuntimeConfig
+    }
+  })
+
   it("resolves direct title-only DevTools metadata", async () => {
     const { createApp, toWebHandler } = await import("h3")
     const { defineAgent } = await import("../src/index.ts")
@@ -1469,10 +1505,10 @@ describe("agent message protocol", () => {
         state?: {
           chats: Array<{
             messages: Array<{ loading?: boolean, role: string, text: string }>
-            uiMessages?: Array<{ parts: Array<{ text?: string, toolCallId?: string, type: string }>, role: string }>
+            uiMessages?: Array<{ metadata?: Record<string, unknown>, parts: Array<{ text?: string, toolCallId?: string, type: string }>, role: string }>
           }>
           thinkingFallback?: string | null
-          uiMessages?: Array<{ parts: Array<{ text?: string, toolCallId?: string, type: string }>, role: string }>
+          uiMessages?: Array<{ metadata?: Record<string, unknown>, parts: Array<{ text?: string, toolCallId?: string, type: string }>, role: string }>
         }
         type: string
       })
@@ -1497,6 +1533,7 @@ describe("agent message protocol", () => {
         { parts: ["text", "tool-search"], role: "assistant" },
       ])
       expect(finalState?.uiMessages?.[1]?.parts.filter(part => part.type === "tool-search")).toHaveLength(1)
+      expect(finalState?.uiMessages?.[0]?.metadata).toEqual({})
       expect(state.thinkingFallback).toBe("Thinking from config...")
       expect(state.uiMessages?.[1]?.parts.map(part => part.type)).toEqual(["text", "tool-search"])
     }

--- a/packages/devtools/devtools/chat/app/app.vue
+++ b/packages/devtools/devtools/chat/app/app.vue
@@ -928,7 +928,7 @@ onBeforeUnmount(() => {
         />
       </header>
 
-      <div class="grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[minmax(0,1fr)_1px_minmax(280px,var(--chat-devtools-sidebar-width))]" :style="splitterStyle">
+      <div class="grid min-h-0 flex-1 grid-cols-1 grid-rows-[minmax(0,1fr)_minmax(220px,40vh)] overflow-hidden lg:grid-cols-[minmax(0,1fr)_1px_minmax(280px,var(--chat-devtools-sidebar-width))] lg:grid-rows-1" :style="splitterStyle">
         <section class="flex min-h-0 flex-col overflow-hidden">
           <div class="min-h-0 flex-1 overflow-y-auto overflow-x-hidden pb-2">
             <UChatMessages
@@ -1042,6 +1042,20 @@ onBeforeUnmount(() => {
                 title: 'text-xs font-normal leading-5',
               }"
             />
+            <UAlert
+              v-if="error"
+              color="error"
+              variant="soft"
+              icon="i-lucide-triangle-alert"
+              :title="error"
+              class="mb-1"
+              :ui="{
+                root: 'rounded-md bg-transparent !py-1 !pl-8 !pr-2 gap-0',
+                icon: 'absolute left-3 top-1/2 size-3.5 -translate-y-1/2 opacity-80',
+                wrapper: 'min-w-0',
+                title: 'text-xs font-normal leading-5',
+              }"
+            />
             <form
               class="flex min-h-9 items-center gap-1 rounded-md border border-default bg-default px-2 py-1 shadow-xs"
               @submit.prevent="submitComposer"
@@ -1078,7 +1092,7 @@ onBeforeUnmount(() => {
           <span class="block h-full w-px bg-transparent group-hover:bg-primary" />
         </button>
 
-        <aside class="hidden min-h-0 border-l border-default p-2 lg:block">
+        <aside class="min-h-0 border-t border-default p-2 lg:border-l lg:border-t-0">
           <UCard
             variant="subtle"
             class="flex h-full min-h-0 flex-col"

--- a/packages/env/src/runtime/server.ts
+++ b/packages/env/src/runtime/server.ts
@@ -20,8 +20,7 @@ export function useServerEnv(event?: unknown): ServerEnv {
 }
 
 export function applyRuntimeEnvToRuntimeConfig(runtimeConfig: Record<string, unknown>, event?: unknown): ServerEnv {
-  const values = resolveRuntimeValues(registry, resolveRuntimeEnv(event))
-  assignRuntimeValues(runtimeConfig, values)
+  assignRuntimeEntries(runtimeConfig, registry, resolveRuntimeEnv(event))
   return runtimeConfig as ServerEnv
 }
 
@@ -46,30 +45,19 @@ function resolveRuntimeEnv(event?: unknown): Record<string, string | undefined> 
   ]))
 }
 
-function resolveRuntimeValues(declarations: EnvRuntimeRegistry, env: Record<string, string | undefined>, path = "env"): Record<string, unknown> {
-  const values: Record<string, unknown> = {}
-  for (const [key, entry] of Object.entries(declarations)) {
-    if (isLiteralEntry(entry)) {
-      values[key] = entry.value
-      continue
-    }
-    if (!isRegistryEntry(entry)) {
-      values[key] = resolveRuntimeValues(entry, env, `${path}.${key}`)
-      continue
-    }
-    const declaration = entry
-    const rawValue = resolveEnvValue(declaration.source, env) ?? declaration.default
-    if (typeof rawValue === "undefined") {
-      if (declaration.required) {
-        throw new Error(`[vitehub] Missing runtime env value ${path}.${key} from ${declaration.source.label}.`)
-      }
-      values[key] = undefined
-      continue
-    }
-    const value = parseRuntimeValue(declaration.schema, rawValue, `${path}.${key}`)
-    values[key] = declaration.secret ? new SecretEnv(value) : value
+function resolveRuntimeEntry(entry: EnvRegistryEntry | EnvRuntimeLiteralEntry, env: Record<string, string | undefined>, path: string): unknown {
+  if (isLiteralEntry(entry)) {
+    return entry.value
   }
-  return values
+  const rawValue = resolveEnvValue(entry.source, env) ?? entry.default
+  if (typeof rawValue === "undefined") {
+    if (entry.required) {
+      throw new Error(`[vitehub] Missing runtime env value ${path} from ${entry.source.label}.`)
+    }
+    return undefined
+  }
+  const value = parseRuntimeValue(entry.schema, rawValue, path)
+  return entry.secret ? new SecretEnv(value) : value
 }
 
 function parseRuntimeValue(schema: EnvRuntimeSchema | undefined, value: unknown, label: string): unknown {
@@ -92,16 +80,22 @@ function resolveEnvValue(source: EnvRegistryEntry["source"], env: Record<string,
   return undefined
 }
 
-function assignRuntimeValues(target: Record<string, unknown>, values: Record<string, unknown>): void {
-  for (const [key, value] of Object.entries(values)) {
-    if (isPlainRuntimeObject(value)) {
-      const existing = target[key]
+function assignRuntimeEntries(target: Record<string, unknown>, entries: EnvRuntimeRegistry, env: Record<string, string | undefined>, path = "env"): void {
+  for (const [key, entry] of Object.entries(entries)) {
+    const nextPath = `${path}.${key}`
+    if (!isRegistryEntry(entry) && !isLiteralEntry(entry)) {
+      const descriptor = Object.getOwnPropertyDescriptor(target, key)
+      const existing = descriptor && "value" in descriptor ? descriptor.value : undefined
       const next = isPlainRuntimeObject(existing) ? existing : {}
-      assignRuntimeValues(next, value)
+      assignRuntimeEntries(next, entry, env, nextPath)
       target[key] = next
       continue
     }
-    target[key] = value
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: true,
+      get: () => resolveRuntimeEntry(entry, env, nextPath),
+    })
   }
 }
 

--- a/packages/env/test/nitro.test.ts
+++ b/packages/env/test/nitro.test.ts
@@ -51,6 +51,7 @@ afterEach(() => {
   delete process.env.OPENWORKFLOW_WORKER_CONCURRENCY
   delete process.env.PUBLIC_API_BASE
   delete process.env.TELEGRAM_BOT_TOKEN
+  delete process.env.VERTEX_MODEL
 })
 
 describe("Nitro module", () => {
@@ -634,7 +635,38 @@ describe("Nitro module", () => {
       },
     })
 
-    expect(() => applyRuntimeEnvToRuntimeConfig({})).toThrow("Missing runtime env value env.telegram.botToken")
+    const config = applyRuntimeEnvToRuntimeConfig({}) as {
+      telegram: { botToken: unknown }
+    }
+    expect(() => config.telegram.botToken).toThrow("Missing runtime env value env.telegram.botToken")
+  })
+
+  it("does not resolve missing sibling Server Env values until they are read", async () => {
+    const { applyRuntimeEnvToRuntimeConfig, setEnvRegistry } = await import("../src/runtime/server.ts")
+
+    setEnvRegistry({
+      githubToken: {
+        required: true,
+        secret: true,
+        source: { kind: "env", label: "env:GITHUB_TOKEN", name: "GITHUB_TOKEN", serializable: true },
+      },
+      vertex: {
+        model: {
+          default: "gemini-3.1-pro-preview-customtools",
+          required: true,
+          secret: false,
+          source: { kind: "env", label: "env:VERTEX_MODEL", name: "VERTEX_MODEL", serializable: true },
+        },
+      },
+    })
+
+    const config = applyRuntimeEnvToRuntimeConfig({}) as {
+      githubToken: unknown
+      vertex: { model: string }
+    }
+
+    expect(config.vertex.model).toBe("gemini-3.1-pro-preview-customtools")
+    expect(() => config.githubToken).toThrow("Missing runtime env value env.githubToken")
   })
 
   it("validates serialized runtime registry defaults", async () => {
@@ -652,7 +684,10 @@ describe("Nitro module", () => {
       },
     })
 
-    expect(() => applyRuntimeEnvToRuntimeConfig({})).toThrow("Invalid env.vertex.model: Expected string")
+    const config = applyRuntimeEnvToRuntimeConfig({}) as {
+      vertex: { model: string }
+    }
+    expect(() => config.vertex.model).toThrow("Invalid env.vertex.model: Expected string")
   })
 
   it("rejects custom Nitro runtime schemas because generated registries cannot preserve them", async () => {


### PR DESCRIPTION

- Infers chat webhook registration metadata for every static Chat Platform Adapter key, not just known Telegram defaults.
- Keeps provider-specific defaults where ViteHub knows them; Telegram still gets its secret header default, while Teams gets provider/id/method metadata from the adapter key.
