### PR TITLE
feat(agent): add sqlite state provider

### DIFF
--- a/.agents/adr/0039-invocation-profiles-drive-capability-effects.md
+++ b/.agents/adr/0039-invocation-profiles-drive-capability-effects.md
@@ -1,0 +1,9 @@
+# Invocation Profiles Drive Capability Effects
+
+ViteHub will use reusable Invocation Profiles to resolve trusted invocation context once and let concrete Capabilities consume the selected profile for their own effects. This keeps `access()` focused on enforcing Workspace Scope, lets `audience()` contribute model-facing instructions, and avoids both `defineAgent({ profiles })` ceremony and a standalone no-effect profile Capability.
+
+**Considered Options**
+
+- Put profiles under `defineAgent({ profiles })`: rejected because the concept has not earned top-level Agent Definition status.
+- Make `profile()` a Capability: rejected because a classifier without tools, instructions, triggers, or policy weakens the Capability concept.
+- Call the concept `invoker`: rejected because it sounds like the caller or trigger that starts an Agent Invocation.

--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -72,6 +72,10 @@ _Avoid_: Chat History identity, Agent Memory, model-facing user profile
 A typed value recorded for one Agent Invocation and exposed to later Agent and Capability callbacks through invocation context access.
 _Avoid_: Runtime Config, Agent Memory, dynamic Capability, arbitrary metadata
 
+**Invocation Profile**:
+A reusable Agent Package definition that resolves trusted invocation context into one typed profile value for Capabilities to consume during an Agent Invocation.
+_Avoid_: Access Role, Workspace Scope, Invoker, top-level Agent Definition profile
+
 **Agent Memory**:
 Durable knowledge or preferences an Agent can carry across Agent Invocations when explicitly configured.
 _Avoid_: Chat History, better chat state
@@ -134,6 +138,9 @@ _Avoid_: Fake agent, dummy model, test bot
 - **Agent Invocation Context Values** can be produced by Pre-Invocation Decisions and read by later Agent or Capability callbacks.
 - **Agent Invocation Context Values** do not grant Capabilities dynamically.
 - **Agent Invocation Context Value** ids must be unique per Agent so every invocation has one writer per context value.
+- An **Invocation Profile** is resolved once per Agent Invocation and exposed as an **Agent Invocation Context Value**.
+- An **Invocation Profile** can drive multiple Capability effects, but each effect remains explicit.
+- An **Invocation Profile** is not a top-level Agent Definition option and does not grant Capabilities dynamically.
 - **Agent Memory** can outlive one conversation.
 - A **Concurrent Invocation Guard** protects **Agent Run State**.
 - A **Development State Provider** is not acceptable for hosted production runtimes.
@@ -157,6 +164,9 @@ _Avoid_: Fake agent, dummy model, test bot
 > **Dev:** "Should an instruction callback read a routing decision from arbitrary metadata?"
 > **Domain expert:** "No. Read it as an **Agent Invocation Context Value** produced by a Pre-Invocation Decision."
 >
+> **Dev:** "Should we put customer, staff, and technical-user branching into both `access()` and prompt instructions?"
+> **Domain expert:** "No. Resolve one **Invocation Profile**, then let `access()` map it to Workspace Scope and an audience Capability map it to instructions."
+>
 > **Dev:** "Is a new Chat Session the same as Agent Memory reset?"
 > **Domain expert:** "No. A **Chat Session** changes which Chat History messages enter the Chat History Window; **Agent Memory** is durable knowledge across invocations."
 
@@ -170,6 +180,8 @@ _Avoid_: Fake agent, dummy model, test bot
 - Chat Sessions were considered as Agent Memory or separate Chat Session Capabilities - resolved: **Chat Session** is Chat History behavior owned by the Chat Capability.
 - Hidden model-selected history slicing was considered - resolved: **Chat Session** selection is a host-visible boundary over preserved Chat History, not destructive message truncation.
 - Route and gate results were considered for ad hoc input context or metadata - resolved: expose them as typed **Agent Invocation Context Values**.
+- Shared access-and-audience branching was considered for `defineAgent({ profiles })` - resolved: use reusable **Invocation Profiles** consumed by Capabilities rather than a top-level Agent Definition option.
+- `invoker` was considered as the name for trusted invocation classification - resolved: reject it because it sounds like the caller or trigger that starts an **Agent Invocation**, not the selected profile value.
 - Chat state was considered separate from Agent State Provider - resolved: Chat History state is satisfied through the Agent State Provider when available.
 - Chat actor identity was considered a chat-history-only detail - resolved: expose **Chat Identity** as a trusted Agent Invocation Context Value so other Capabilities can consume it.
 - Chat History was considered an implicit Chat Capability default - resolved: keep Chat History opt-in, aligned with Chat SDK-style application control.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -40,6 +40,10 @@ _Avoid_: Dynamic prompt, hardcoded prompt, prompt callback
 A named value available when rendering a Prompt Template.
 _Avoid_: Placeholder, interpolation value, prompt arg
 
+**Audience Capability**:
+A Capability created by `audience()` that contributes model-facing instruction blocks for the selected invocation audience.
+_Avoid_: Access Role, model role, user profile, prompt middleware
+
 **Storage Capability Tool Surface**:
 The two-tool read/edit shape used by official storage Capabilities to expose scoped storage operations to a model.
 _Avoid_: Primitive method proxy, storage method fanout
@@ -183,7 +187,7 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 ## Relationships
 
 - An Agent attaches zero or more **Capabilities**.
-- Official helpers such as `entry()`, `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `access()`, `sandbox()`, `kv()`, `blob()`, `db()`, `webSearch()`, `llmRoute()`, and `llmGate()` create **Capability Definitions**.
+- Official helpers such as `entry()`, `audience()`, `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `access()`, `sandbox()`, `kv()`, `blob()`, `db()`, `webSearch()`, `llmRoute()`, and `llmGate()` create **Capability Definitions**.
 - Official Capability factories and Capability-owned helper functions are imported from `@vite-hub/agent/capabilities`, not from the root `@vite-hub/agent` Agent Package entry.
 - Official helpers should map to product abilities rather than implementation mechanisms.
 - An official **Capability Definition** may carry a narrow **Capability Type Contract** when it directly consumes typed Agent Definition inputs such as Source keys, trusted Chat Capability origins, or schema-validated invocation context.
@@ -195,6 +199,7 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - An **Entry Capability** is the official small helper for app-owned product events when a full product-specific Capability has not earned a name yet.
 - An **Entry Capability** may expose a trusted Chat App Route origin without adding app-route fields to Chat Capability options.
 - A **Prompt Template** belongs to the Capability that renders it and should expose only the **Prompt Template Variables** that are stable for that Capability.
+- An **Audience Capability** contributes prompt instructions; it does not apply access boundaries.
 - Standard Schema validation is the preferred runtime boundary for app-owned invocation metadata that an official **Capability** directly consumes.
 - An **Input Command** is a **Capability** concern resolved before model-facing Agent behavior.
 - A **Host Command** is not an **Input Command** and is outside the Capability Lifecycle.
@@ -230,6 +235,7 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - In the first version, an **Access Capability** applies **Workspace Scope** only.
 - An **Access Capability** can record the active Workspace Scope as an Agent Invocation Context Value for later callbacks and instructions.
 - An **Access Capability** owns both Workspace Scope selection and application, but keeps resolver logic separate from grants.
+- An **Access Capability** may consume an **Invocation Profile** to select Workspace Scope without owning the profile resolution.
 - An **Access Capability** may reference a **Chat Capability** for typed origin context instead of asking users to repeat Chat Capability origins in Access configuration.
 - An **Access Capability** can use static named Workspace Scopes or an inline Workspace Scope definition returned by its resolver.
 - An **Access Capability** must be ordered before other Workspace-reading Capabilities so Workspace Scope is applied before they resolve tools or requirements.
@@ -285,6 +291,9 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 > **Dev:** "Can I add any request field to a Prompt Template?"
 > **Domain expert:** "No. Use only the Prompt Template Variables exposed by that Capability, or provide a callback when the prompt needs custom runtime data."
 >
+> **Dev:** "Should technical-user answer style be an Access Role?"
+> **Domain expert:** "No. Use an **Audience Capability** for model-facing style and keep **Access Role** for scope-selection authority."
+>
 > **Dev:** "Should Chat DevTools wire its own chat send helper?"
 > **Domain expert:** "No. The **Chat Capability** should provide a **Capability Trigger Contribution**, and DevTools should consume the resolved Agent Trigger."
 >
@@ -328,6 +337,8 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - `workspaceScope()` was considered as the public helper name - resolved: use `access()` for the Capability while preserving **Workspace Scope** for the Workspace-specific boundary.
 - `organization()` was considered as the public helper name - resolved: reject it because access decisions may come from organizations, customer domains, local config, or other trusted invocation context.
 - Pre-registering every customer Workspace Scope was considered necessary - resolved: an Access Capability resolver may return an inline Workspace Scope definition for invocation-specific grants.
+- Prompt audience was considered part of the **Access Capability** because it may use the same trusted identity facts - resolved: keep **Audience Capability** separate and let both capabilities consume an **Invocation Profile** when they need shared selection.
+- Prompt audience variants were considered as roles - resolved: reserve **Access Role** for access authority and use audience language for model-facing instructions.
 - "audio input", "voice input", and "voice transcription" were considered as names for spoken user messages - resolved: use **Transcription** for the capability.
 - `transcribe({ workspace })` was considered for persisted transcript and audio artifacts - resolved: use **Transcription Artifacts** so the option does not masquerade as a Workspace Definition.
 - Separate Transcription Artifacts `directory`, `stem`, and `extension` fields were considered - resolved: use a **Transcript Workspace Path** as the canonical destination and derive path parts internally.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -24,6 +24,10 @@ _Avoid_: Random hook, raw setup
 A Capability-owned server-side contribution that registers Agent Trigger behavior for a product event.
 _Avoid_: Chat helper, DevTools bridge, raw server route, server-only bucket
 
+**Entry Capability**:
+A small official Capability created by `entry()` that lets an Agent receive app-owned product events through Capability Trigger Contributions and trusted Chat App Route exposure.
+_Avoid_: Chat App Capability, route helper, trigger helper
+
 **Capability Requirement**:
 A primitive, workspace mode, or workspace path that a Capability needs before it can be applied to an Agent.
 _Avoid_: Capability dependency, plugin dependency
@@ -179,7 +183,7 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 ## Relationships
 
 - An Agent attaches zero or more **Capabilities**.
-- Official helpers such as `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `access()`, `sandbox()`, `kv()`, `blob()`, `db()`, `webSearch()`, `llmRoute()`, and `llmGate()` create **Capability Definitions**.
+- Official helpers such as `entry()`, `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `access()`, `sandbox()`, `kv()`, `blob()`, `db()`, `webSearch()`, `llmRoute()`, and `llmGate()` create **Capability Definitions**.
 - Official Capability factories and Capability-owned helper functions are imported from `@vite-hub/agent/capabilities`, not from the root `@vite-hub/agent` Agent Package entry.
 - Official helpers should map to product abilities rather than implementation mechanisms.
 - An official **Capability Definition** may carry a narrow **Capability Type Contract** when it directly consumes typed Agent Definition inputs such as Source keys, trusted Chat Capability origins, or schema-validated invocation context.
@@ -188,6 +192,8 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - A **Capability Trigger Contribution** is composed from `defineAgent({ capabilities })`, not registered through a separate helper.
 - A **Capability Trigger Contribution** belongs directly to the Capability shape unless a broader grouping earns its name later.
 - A **Capability Trigger Contribution** maps product event input into Agent Invocation input and run metadata; Agent execution remains owned by the Agent Package.
+- An **Entry Capability** is the official small helper for app-owned product events when a full product-specific Capability has not earned a name yet.
+- An **Entry Capability** may expose a trusted Chat App Route origin without adding app-route fields to Chat Capability options.
 - A **Prompt Template** belongs to the Capability that renders it and should expose only the **Prompt Template Variables** that are stable for that Capability.
 - Standard Schema validation is the preferred runtime boundary for app-owned invocation metadata that an official **Capability** directly consumes.
 - An **Input Command** is a **Capability** concern resolved before model-facing Agent behavior.
@@ -202,7 +208,8 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Primitive storage helpers such as `kv()`, `blob()`, and `db()` are first-class official **Capabilities**, not sample raw-tool wrappers.
 - A **Chat Capability** owns Chat History behavior for the current stack.
 - A **Chat Capability** may declare **Chat Platform Adapters** through a **Chat Adapter Callback**.
-- A **Chat Capability** carries trusted Chat Capability origins from its Chat App Route origin and Chat Platform Adapter names.
+- A **Chat Capability** carries trusted Chat Capability origins from its Chat Platform Adapter names.
+- An **Entry Capability** carries trusted Chat Capability origins from its Chat App Route origin and a linked Chat Capability's Chat Platform Adapter names.
 - A **Chat Capability** provides a platform-scoped **Chat Identity** default for Chat Platform Adapter messages when transcript persistence needs one.
 - A **Chat Platform Adapter** may come from a **Chat Adapter Package** that remains an explicit optional application dependency.
 - The Agent Package should not generate exports for every **Chat Adapter Package**.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -328,7 +328,7 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Trigger handlers were considered for direct Agent execution - resolved: trigger contributions map input and run metadata, while the Agent Package executes the Agent Invocation through the standard lifecycle.
 - Public chat webhook registration helpers were considered for platform adapters - resolved: use **Chat Webhook Autowiring** from the **Chat Capability** so adapter configuration remains the only source of truth.
 - Build-time Chat Platform Adapter detection was considered - resolved: resolve the **Chat Adapter Callback** at request time because platform credentials and adapter construction can depend on Server Env.
-- Repeating Chat Capability origins in `access()` was considered - resolved: Access input configuration can reference the Chat Capability so resolver types derive from the Chat App Route origin and Chat Platform Adapter names.
+- Repeating Chat Capability origins in `access()` was considered - resolved: Invocation Profiles declare trusted chat origins explicitly, and Access consumes the resolved profile rather than owning chat input configuration.
 - Capability phases, contexts, hooks, and instruction slots were considered glossary terms - resolved: group that detail under **Capability Lifecycle** unless a feature needs a sharper term.
 - Chat History was considered as a standalone Capability - resolved: keep Chat History inside the **Chat Capability** for this stack and revisit during a future Agent Memory pass.
 - Agent Memory was considered dependent on the Chat Capability - resolved: stack Agent Memory directly on the capability runtime because memory and chat are separate Capability concerns.

--- a/.agents/contexts/packages/agent/CONTEXT.md
+++ b/.agents/contexts/packages/agent/CONTEXT.md
@@ -72,6 +72,7 @@ _Avoid_: Root Agent Package export, generated adapter barrel, upstream package m
 - A public endpoint consumes an **Agent Trigger**; it does not own, declare, or attach the trigger.
 - The **Agent Package** owns Agent capability composition.
 - The root `@vite-hub/agent` entry exports Agent Definition, invocation, message, and generic composition primitives; official Capability factories live on `@vite-hub/agent/capabilities`.
+- The root `@vite-hub/agent` entry exports Invocation Profile helpers as generic Agent Invocation composition primitives.
 - The root `@vite-hub/agent` entry does not export optional Chat Platform Adapter factories.
 - The **Agent Package** may expose a **Chat Adapter Facade** only for a first-party-supported adapter with a stable shim and clear missing-package diagnostics.
 - The **Agent Package** should not mirror every upstream `@chat-adapter/*` package as public ViteHub API.
@@ -107,6 +108,7 @@ _Avoid_: Root Agent Package export, generated adapter barrel, upstream package m
 - Full multi-agent chat selection in DevTools was deferred during **Chat Definition Removal** - resolved: the first cleanup can support the first discovered Agent with a `chat.message` trigger to keep the new pattern small.
 - App-owned Teams webhook files and public webhook registration helpers were considered for ChatSDK adapters - resolved: the Agent Package owns automatic **Chat Webhook Routes** that consume Chat Capability adapter configuration.
 - Root-exporting Chat and other official Capability factories was considered for quickstart convenience - resolved: import them from `@vite-hub/agent/capabilities` so Chat remains visibly a Capability and the Agent Package root does not become an ability grab bag.
+- Root-exporting Invocation Profile helpers was considered alongside Capability factories - resolved: export them from the root Agent Package entry because they are reusable Agent Invocation composition primitives, not Capability factories.
 - A separate client chat route Capability was considered for app UIs - resolved: app-owned Chat App Route exposure belongs to the Entry Capability, while the Chat Capability keeps the shared `chat.message` trigger and chat behavior.
 - "Endpoint has an Agent Trigger" was used for route exposure - resolved: Capabilities contribute **Agent Triggers**, while public endpoints are **Agent Trigger Consumers**.
 - "Nuxt UI adapter" was considered for application chat UIs - resolved: application chat UIs use **Chat App Routes**, while Chat Platform Adapters remain for external chat platforms.

--- a/.agents/contexts/packages/agent/CONTEXT.md
+++ b/.agents/contexts/packages/agent/CONTEXT.md
@@ -49,7 +49,7 @@ The Agent Package generated Nitro POST route that lets application chat UIs send
 _Avoid_: DevTools bridge, webhook route, client SDK route
 
 **Chat App Exposure**:
-The Chat Capability choice that makes a discovered Agent reachable through a Chat App Route.
+The Entry Capability choice that makes a discovered Agent reachable through a Chat App Route.
 _Avoid_: Nuxt UI adapter, public chat trigger, route capability
 
 **Chat Adapter Facade**:
@@ -66,7 +66,7 @@ _Avoid_: Root Agent Package export, generated adapter barrel, upstream package m
 - A **Chat Webhook Handler** consumes resolved Chat Capability options and platform adapters; it does not declare Chat Capability behavior itself.
 - A **Chat Webhook Route** is automatic for discovered chat-capable Agents and does not require a public registration helper or app-owned route file.
 - Generated **Chat Webhook Route** and **Chat App Route** paths live under `/api/_vitehub/agents/:agent/...` so Agent identity stays explicit and package-owned API space is clear.
-- **Chat App Exposure** belongs to the Chat Capability and is not a separate Capability.
+- **Chat App Exposure** belongs to the Entry Capability so app-route exposure stays out of Chat Capability options.
 - A **Chat App Route** is automatic for discovered Agents with **Chat App Exposure**.
 - A **Chat App Route** is an **Agent Trigger Consumer**; it consumes `chat.message` and does not declare Chat Capability behavior itself.
 - A public endpoint consumes an **Agent Trigger**; it does not own, declare, or attach the trigger.
@@ -77,7 +77,7 @@ _Avoid_: Root Agent Package export, generated adapter barrel, upstream package m
 - The **Agent Package** should not mirror every upstream `@chat-adapter/*` package as public ViteHub API.
 - The **Agent Package** owns chat behavior after the **Chat Package Migration**.
 - **Chat Definition Removal** means chat behavior is discovered through Agent Definitions that attach the Chat Capability, not through chat definitions, chat modules, or standalone chat discovery.
-- A discovered Agent Definition that attaches the Chat Capability is implicitly chat-capable; no separate chat route option, chat module, or chat registry declares that capability.
+- A discovered Agent Definition that attaches the Chat Capability is implicitly chat-capable; an Entry Capability can additionally expose the generated Chat App Route for app-owned chat UIs.
 - An **Agent File Name** provides Discovery Identity for discovered Agent Definitions.
 - The **Agent Route Owner** is the Agent Package when generated Agent routes are enabled.
 - The legacy **Agent Adapter Boundary** is removed from the public Agent Definition shape while AI SDK is the only model execution path.
@@ -107,6 +107,6 @@ _Avoid_: Root Agent Package export, generated adapter barrel, upstream package m
 - Full multi-agent chat selection in DevTools was deferred during **Chat Definition Removal** - resolved: the first cleanup can support the first discovered Agent with a `chat.message` trigger to keep the new pattern small.
 - App-owned Teams webhook files and public webhook registration helpers were considered for ChatSDK adapters - resolved: the Agent Package owns automatic **Chat Webhook Routes** that consume Chat Capability adapter configuration.
 - Root-exporting Chat and other official Capability factories was considered for quickstart convenience - resolved: import them from `@vite-hub/agent/capabilities` so Chat remains visibly a Capability and the Agent Package root does not become an ability grab bag.
-- A separate client chat route Capability was considered for app UIs - resolved: automatic **Chat App Routes** are exposed through **Chat App Exposure** on the existing Chat Capability, not from a second route-specific Capability.
+- A separate client chat route Capability was considered for app UIs - resolved: app-owned Chat App Route exposure belongs to the Entry Capability, while the Chat Capability keeps the shared `chat.message` trigger and chat behavior.
 - "Endpoint has an Agent Trigger" was used for route exposure - resolved: Capabilities contribute **Agent Triggers**, while public endpoints are **Agent Trigger Consumers**.
 - "Nuxt UI adapter" was considered for application chat UIs - resolved: application chat UIs use **Chat App Routes**, while Chat Platform Adapters remain for external chat platforms.

--- a/docs/content/docs/agents/capabilities/official-capabilities.md
+++ b/docs/content/docs/agents/capabilities/official-capabilities.md
@@ -15,6 +15,7 @@ import {
   blob,
   chat,
   db,
+  entry,
   kv,
   llmGate,
   llmRoute,
@@ -31,6 +32,7 @@ import {
 | Ability | Capability | Use it when |
 | --- | --- | --- |
 | Chat behavior | `chat()` | A chat surface should start Agent Invocations and manage Chat History. |
+| App entry | `entry()` | An app-owned surface should expose a trusted Chat App Route or custom Agent Trigger. |
 | Workspace files | `workspaceShell()` | The model should inspect or edit Workspace files. |
 | Storage | `kv()`, `blob()`, `db()` | The model needs scoped access to configured storage primitives. |
 | Isolated execution | `sandbox()` | The model should run explicit commands in an isolated runtime. |

--- a/docs/content/docs/agents/capabilities/official-capabilities.md
+++ b/docs/content/docs/agents/capabilities/official-capabilities.md
@@ -46,6 +46,25 @@ Storage Capabilities are intentionally small. KV and Blob expose read/edit surfa
 
 Writes require approval by default unless the developer opts into autonomous behavior.
 
+## Chat state
+
+The Chat Capability can use an Agent State Provider for Chat History and the Concurrent Invocation Guard. Cloudflare deployments can use the Cloudflare Agent State Provider. Nitro node deployments can opt into the SQLite/libSQL provider explicitly:
+
+```ts [vite.config.ts]
+export default defineConfig({
+  agent: {
+    providers: {
+      state: {
+        provider: 'sqlite',
+        url: process.env.VITEHUB_AGENT_STATE_URL,
+      },
+    },
+  },
+})
+```
+
+`file:` URLs use local SQLite. Hosted libSQL URLs use the same provider with an auth token when needed. This state is internal Agent runtime state, not model-facing Database Capability access.
+
 ## Execution capabilities
 
 Sandbox and Workspace Shell are different.

--- a/docs/content/docs/agents/triggers.md
+++ b/docs/content/docs/agents/triggers.md
@@ -27,12 +27,18 @@ export default defineEventHandler(async (event) => {
 Some Capabilities own product event behavior. Chat is the clearest example: a chat platform event is adapted into an Agent Invocation through the Chat Capability.
 
 ```ts
-import { chat } from '@vite-hub/agent/capabilities'
+import { chat, entry } from '@vite-hub/agent/capabilities'
+
+const supportChat = chat({
+  history: { maxMessages: 20 },
+})
 
 export default defineAgent({
   capabilities: [
-    chat({
-      history: { maxMessages: 20 },
+    supportChat,
+    entry({
+      id: 'portal',
+      chat: { capability: supportChat, origin: 'portal' },
     }),
   ],
   instructions,

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -12,7 +12,7 @@ The Workspace is the file boundary. Capabilities decide which model-facing tools
 ## Colocate workspace context
 
 ```ts [server/agents/docs/config.ts]
-import { defineAgent } from '@vite-hub/agent'
+import { defineAgent, defineInvocationProfile } from '@vite-hub/agent'
 import { workspaceShell } from '@vite-hub/agent/capabilities'
 import { source } from '@vite-hub/workspace'
 
@@ -78,6 +78,27 @@ const portalEntry = entry({
   chat: { capability: supportChat, origin: 'portal' },
 })
 
+const supportProfile = defineInvocationProfile({
+  id: 'support',
+  input: {
+    chat: {
+      message: { metadata: portalMetadataSchema, runOrigin: ['portal'] },
+      run: { origin: ['portal', 'teams'] },
+      user: portalUserSchema,
+    },
+  },
+  resolve({ input }) {
+    const chat = input.get().context?.chat
+    if (chat?.run?.origin !== 'portal')
+      return { kind: 'support' as const }
+
+    return {
+      customer: chat.message?.metadata.quiver.customer,
+      kind: 'portal' as const,
+    }
+  },
+})
+
 export default defineAgent({
   workspace: {
     sources: {
@@ -93,27 +114,19 @@ export default defineAgent({
   },
   capabilities: [
     access({
-      input: {
-        chat: {
-          capability: portalEntry,
-          message: { metadata: portalMetadataSchema },
-          user: portalUserSchema,
-        },
-      },
+      profile: supportProfile,
       workspace: {
-        resolve({ input }) {
-          const chat = input.get().context?.chat
-          if (chat?.run?.origin !== 'portal')
+        resolve({ profile }) {
+          if (profile.kind !== 'portal')
             return { all: true, role: 'admin', scope: 'support' }
 
-          const customer = chat.message?.metadata.quiver.customer
           return {
             grants: [
               { path: 'AGENTS.md' },
               { source: 'forecastingEngine' },
-              { path: `ingestion/${customer}` },
+              { path: `ingestion/${profile.customer}` },
             ],
-            scope: customer,
+            scope: profile.customer,
           }
         },
       },
@@ -127,8 +140,8 @@ export default defineAgent({
 })
 ```
 
-The scope resolver sees the parsed schema output. In this example, portal chat requests must include a customer in message metadata, while non-portal chat surfaces can use the explicit all-scopes Workspace Scope. The resolver returns inline Workspace Scope definitions, so the app does not need to pre-register one scope per customer.
+The Invocation Profile sees the parsed schema output. In this example, portal chat requests must include a customer in message metadata, while non-portal chat surfaces can use the explicit all-scopes Workspace Scope. The resolver returns inline Workspace Scope definitions, so the app does not need to pre-register one scope per customer.
 
-The Chat App Route origin is configured in `entry({ chat })` so the access decision does not trust a browser-controlled payload. A request body may repeat the same `run.origin`, but it cannot override the configured entry origin; mismatches are rejected as bad requests so app-level proxies fail closed when their contract drifts. Passing the Entry Capability to `access({ input.chat.capability })` lets the resolver infer `chat.run.origin` from the Chat App Route origin and linked Chat Platform Adapter names.
+The Chat App Route origin is configured in `entry({ chat })` so the access decision does not trust a browser-controlled payload. A request body may repeat the same `run.origin`, but it cannot override the configured entry origin; mismatches are rejected as bad requests so app-level proxies fail closed when their contract drifts. The Invocation Profile declares accepted `chat.run.origin` values explicitly and uses `message.runOrigin` when a message metadata schema applies to only some origins.
 
 Order matters. Access should run before Workspace-reading Capabilities so the scope is applied before tools are exposed.

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -47,7 +47,7 @@ Use the Access Capability when invocation identity should narrow the visible Wor
 import { gateway } from '@ai-sdk/gateway'
 import { createTeamsAdapter } from '@chat-adapter/teams'
 import { defineAgent } from '@vite-hub/agent'
-import { access, chat, workspaceShell } from '@vite-hub/agent/capabilities'
+import { access, chat, entry, workspaceShell } from '@vite-hub/agent/capabilities'
 import { source } from '@vite-hub/workspace'
 import { z } from 'zod'
 
@@ -71,7 +71,11 @@ const supportChat = chat({
       appType: 'SingleTenant',
     }),
   }),
-  app: 'portal',
+})
+
+const portalEntry = entry({
+  id: 'portal',
+  chat: { capability: supportChat, origin: 'portal' },
 })
 
 export default defineAgent({
@@ -91,7 +95,7 @@ export default defineAgent({
     access({
       input: {
         chat: {
-          capability: supportChat,
+          capability: portalEntry,
           message: { metadata: portalMetadataSchema },
           user: portalUserSchema,
         },
@@ -116,6 +120,7 @@ export default defineAgent({
     }),
     workspaceShell({ mode: 'read' }),
     supportChat,
+    portalEntry,
   ],
   instructions: 'Answer from the scoped customer workspace.',
   model: gateway('openai/gpt-5.1-mini'),
@@ -124,6 +129,6 @@ export default defineAgent({
 
 The scope resolver sees the parsed schema output. In this example, portal chat requests must include a customer in message metadata, while non-portal chat surfaces can use the explicit all-scopes Workspace Scope. The resolver returns inline Workspace Scope definitions, so the app does not need to pre-register one scope per customer.
 
-The Chat App Route origin is configured in `chat({ app })` so the access decision does not trust a browser-controlled payload. A request body may repeat the same `run.origin`, but it cannot override the configured app origin; mismatches are rejected as bad requests so app-level proxies fail closed when their contract drifts. Passing the Chat Capability to `access({ input.chat.capability })` lets the resolver infer `chat.run.origin` from the Chat App Route origin and Chat Platform Adapter names.
+The Chat App Route origin is configured in `entry({ chat })` so the access decision does not trust a browser-controlled payload. A request body may repeat the same `run.origin`, but it cannot override the configured entry origin; mismatches are rejected as bad requests so app-level proxies fail closed when their contract drifts. Passing the Entry Capability to `access({ input.chat.capability })` lets the resolver infer `chat.run.origin` from the Chat App Route origin and linked Chat Platform Adapter names.
 
 Order matters. Access should run before Workspace-reading Capabilities so the scope is applied before tools are exposed.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -76,6 +76,40 @@ export default defineNitroConfig({
 - `sandbox()` and `schedule()` expose [`@vite-hub/sandbox`](../sandbox/README.md) and [`@vite-hub/schedule`](../schedule/README.md).
 - `skills()`, `access()`, `memory()`, `fetch()`, `llmRoute()`, `llmGate()`, and `usageTelemetry()` cover prompt skills, workspace scope, durable notes, HTTP reads, pre-run decisions, and usage reporting.
 
+## Chat state
+
+Chat History and the Concurrent Invocation Guard need an Agent State Provider when they should survive a process restart. Nitro uses memory state by default outside Cloudflare, so hosted node deployments should configure a durable provider explicitly.
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  agent: {
+    providers: {
+      state: {
+        provider: "sqlite",
+        url: process.env.VITEHUB_AGENT_STATE_URL,
+      },
+    },
+  },
+})
+```
+
+`provider: "sqlite"` uses the built-in libSQL-compatible state backend, so `file:` URLs work for local SQLite and hosted libSQL URLs work for remote deployments.
+
+You can also wire the adapter manually when `chat({ state })` should own the state provider:
+
+```ts
+import { createLibsqlAgentState } from "@vite-hub/agent/state/sqlite"
+
+chat({
+  state: () => createLibsqlAgentState({
+    url: process.env.VITEHUB_AGENT_STATE_URL!,
+  }),
+})
+```
+
+This is not the Database Capability. It is Agent-owned runtime state for chat behavior.
+
 ## Built on
 
 Vite discovers agent files for local development. Nitro mounts the generated agent routes. Model execution uses [AI SDK](https://ai-sdk.dev/docs); provider tools stay capability-scoped instead of becoming one global agent config.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -40,6 +40,7 @@
     "./runtime/chat-devtools-handler": "./dist/runtime/chat-devtools-handler.js",
     "./runtime/empty-registry": "./dist/runtime/empty-registry.js",
     "./runtime/nitro-runtime-config": "./dist/runtime/nitro-runtime-config.js",
+    "./state/sqlite": "./dist/state/sqlite.js",
     "./test": "./dist/test.js",
     "./vercel": "./dist/vercel.js",
     "./vite": "./dist/vite.js",
@@ -62,6 +63,7 @@
     "test": "pnpm --filter @vite-hub/agent... build && vitest run"
   },
   "dependencies": {
+    "@libsql/client": "catalog:database",
     "@vite-hub/runtime": "workspace:*",
     "@vite-hub/workspace": "workspace:*",
     "@vite-hub/devtools": "workspace:*",

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -1,6 +1,6 @@
 import { workspaceOverrideSymbol } from "../access-runtime.ts"
 import { defineCapability } from "../capability-runtime.ts"
-import { applyInvocationProfileInputSchemas, resolveInvocationProfile } from "../invocation-profile.ts"
+import { resolveInvocationProfile } from "../invocation-profile.ts"
 import { createWorkspaceTools } from "@vite-hub/workspace"
 
 import type {
@@ -12,15 +12,7 @@ import type {
   MaybePromise,
 } from "../types.ts"
 import type {
-  AgentInvocationProfileChatInputSchemaOptions,
-  AgentInvocationProfileChatMessageInputSchemaOptions,
-  AgentInvocationProfileChatRunInputOptions,
   AgentInvocationProfileDefinition,
-  AgentInvocationProfileInputContextFromSchemas,
-  AgentInvocationProfileInputSchemaOptions,
-  AgentInvocationProfileStandardSchemaResultFailure,
-  AgentInvocationProfileStandardSchemaResultSuccess,
-  AgentInvocationProfileStandardSchemaV1,
 } from "../invocation-profile.ts"
 import type {
   ListOptions,
@@ -36,35 +28,6 @@ import type {
 import type { WorkspaceOverrideRuntime } from "../access-runtime.ts"
 
 export type AccessRoleName = "viewer" | "admin" | (string & {})
-
-export type AccessCapabilityStandardSchemaResultSuccess<T = unknown> = AgentInvocationProfileStandardSchemaResultSuccess<T>
-export type AccessCapabilityStandardSchemaResultFailure = AgentInvocationProfileStandardSchemaResultFailure
-export type AccessCapabilityStandardSchemaV1<T = unknown> = AgentInvocationProfileStandardSchemaV1<T>
-
-type AccessObjectSchema = AccessCapabilityStandardSchemaV1<object>
-
-export type AccessChatMessageInputSchemaOptions<TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined> =
-  AgentInvocationProfileChatMessageInputSchemaOptions<TMessageMetadataSchema>
-
-export type AccessChatRunInputOptions<TOrigin extends string = string> =
-  AgentInvocationProfileChatRunInputOptions<TOrigin>
-
-export type AccessChatInputSchemaOptions<
-  TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
-  TUserSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
-  TOrigin extends string = string,
-  TChatCapability = unknown,
-> = AgentInvocationProfileChatInputSchemaOptions<TMessageMetadataSchema, TUserSchema, TOrigin, TChatCapability>
-
-export type AccessInputSchemaOptions<
-  TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
-  TUserSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
-  TOrigin extends string = string,
-  TChatCapability = unknown,
-> = AgentInvocationProfileInputSchemaOptions<TMessageMetadataSchema, TUserSchema, TOrigin, TChatCapability>
-
-export type AccessInputContextFromSchemas<TInputSchemas> =
-  AgentInvocationProfileInputContextFromSchemas<TInputSchemas>
 
 export type AccessCapabilityTypeContract<
   TSourceName extends string = string,
@@ -167,10 +130,8 @@ export interface AccessCapabilityOptions<
   Name extends WorkspaceName = WorkspaceName,
   TSourceName extends string = string,
   TInputContext extends object = Record<string, unknown>,
-  TInputSchemas extends AccessInputSchemaOptions | undefined = undefined,
   TProfile = undefined,
 > {
-  input?: TInputSchemas
   profile?: AgentInvocationProfileDefinition<TProfile, TRuntimeConfig, Name, TInputContext>
   workspace: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext, TProfile>
 }
@@ -226,12 +187,6 @@ export function access<
   TInputContext extends object = Record<string, unknown>,
   const TWorkspace extends AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext> = AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext>,
 >(options: { input?: undefined, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext>>
-export function access<
-  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  Name extends WorkspaceName = WorkspaceName,
-  const TInputSchemas extends AccessInputSchemaOptions = AccessInputSchemaOptions,
-  const TWorkspace extends AccessWorkspaceOptions<TRuntimeConfig, Name, string, AccessInputContextFromSchemas<TInputSchemas>> = AccessWorkspaceOptions<TRuntimeConfig, Name, string, AccessInputContextFromSchemas<TInputSchemas>>,
->(options: { input: TInputSchemas, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, AccessInputContextFromSchemas<TInputSchemas>>>
 export function access(options: AccessCapabilityOptions): AgentCapabilityDefinition {
   if (!options || typeof options !== "object" || !options.workspace) {
     throw new TypeError("[vitehub] access() requires workspace options.")
@@ -247,8 +202,6 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
       if ("diff" in context.workspace) {
         throw new Error("[vitehub] access({ workspace }) is read-only in the first version and requires workspace.mode: \"read\".")
       }
-      const input = await applyInvocationProfileInputSchemas(options.input, context.input.get())
-      if (input !== context.input.get()) context.input.set(input)
       const profile = options.profile
         ? await resolveInvocationProfile(options.profile, context)
         : undefined

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -7,13 +7,12 @@ import type {
   AgentCapabilityDefinition,
   AgentCapabilityRuntimeContext,
   AgentCapabilityTypeContract,
-  AgentChatAppExposure,
-  AgentChatOptions,
   AgentRunInput,
   AgentRuntimeConfig,
   MaybePromise,
 } from "../types.ts"
 import type { AgentChatCapabilityOrigin, AgentChatRunContext } from "../chat-trigger.ts"
+import type { AgentEntryChatOptions } from "./entry.ts"
 import type {
   ListOptions,
   ReadonlyWorkspaceFacade,
@@ -340,25 +339,24 @@ async function applyAccessInputSchemas(
   }
 }
 
-function chatCapabilityOptions(value: unknown): AgentChatOptions | undefined {
+function capabilityMetadata(value: unknown): Record<string, unknown> | undefined {
   const metadata = isRecord(value) ? value.metadata : undefined
-  return isRecord(metadata) && metadata.kind === "chat" && isRecord(metadata.chat)
-    ? metadata.chat as AgentChatOptions
-    : undefined
+  return isRecord(metadata) ? metadata : undefined
 }
 
-function chatAppOrigin(app: AgentChatAppExposure | undefined): string | undefined {
-  if (!app) return
-  if (typeof app === "string") return app
-  if (app === true) return "http"
-  return typeof app.origin === "string" && app.origin ? app.origin : "http"
+function entryChatOptions(value: unknown): AgentEntryChatOptions | undefined {
+  const metadata = capabilityMetadata(value)
+  const entry = isRecord(metadata?.entry) ? metadata.entry : undefined
+  return metadata?.kind === "entry" && isRecord(entry?.chat)
+    ? entry.chat as AgentEntryChatOptions
+    : undefined
 }
 
 function shouldValidateChatMessageMetadata(
   schemas: AccessChatInputSchemaOptions,
   chat: Record<string, unknown>,
 ): boolean {
-  const appOrigin = chatAppOrigin(chatCapabilityOptions(schemas.capability)?.app)
+  const appOrigin = entryChatOptions(schemas.capability)?.origin
   if (!appOrigin) return true
   const run = isRecord(chat.run) ? chat.run : undefined
   const origin = run?.origin

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -1,6 +1,6 @@
 import { workspaceOverrideSymbol } from "../access-runtime.ts"
 import { defineCapability } from "../capability-runtime.ts"
-import { parseStandardSchema } from "@vite-hub/internal/http-request"
+import { applyInvocationProfileInputSchemas, resolveInvocationProfile } from "../invocation-profile.ts"
 import { createWorkspaceTools } from "@vite-hub/workspace"
 
 import type {
@@ -11,8 +11,17 @@ import type {
   AgentRuntimeConfig,
   MaybePromise,
 } from "../types.ts"
-import type { AgentChatCapabilityOrigin, AgentChatRunContext } from "../chat-trigger.ts"
-import type { AgentEntryChatOptions } from "./entry.ts"
+import type {
+  AgentInvocationProfileChatInputSchemaOptions,
+  AgentInvocationProfileChatMessageInputSchemaOptions,
+  AgentInvocationProfileChatRunInputOptions,
+  AgentInvocationProfileDefinition,
+  AgentInvocationProfileInputContextFromSchemas,
+  AgentInvocationProfileInputSchemaOptions,
+  AgentInvocationProfileStandardSchemaResultFailure,
+  AgentInvocationProfileStandardSchemaResultSuccess,
+  AgentInvocationProfileStandardSchemaV1,
+} from "../invocation-profile.ts"
 import type {
   ListOptions,
   ReadonlyWorkspaceFacade,
@@ -28,76 +37,34 @@ import type { WorkspaceOverrideRuntime } from "../access-runtime.ts"
 
 export type AccessRoleName = "viewer" | "admin" | (string & {})
 
-export interface AccessCapabilityStandardSchemaResultSuccess<T = unknown> {
-  issues?: undefined
-  value: T
-}
-
-export interface AccessCapabilityStandardSchemaResultFailure {
-  issues: readonly unknown[]
-}
-
-export interface AccessCapabilityStandardSchemaV1<T = unknown> {
-  "~standard": {
-    validate: (input: unknown) => AccessCapabilityStandardSchemaResultSuccess<T> | AccessCapabilityStandardSchemaResultFailure | Promise<AccessCapabilityStandardSchemaResultSuccess<T> | AccessCapabilityStandardSchemaResultFailure>
-  }
-}
+export type AccessCapabilityStandardSchemaResultSuccess<T = unknown> = AgentInvocationProfileStandardSchemaResultSuccess<T>
+export type AccessCapabilityStandardSchemaResultFailure = AgentInvocationProfileStandardSchemaResultFailure
+export type AccessCapabilityStandardSchemaV1<T = unknown> = AgentInvocationProfileStandardSchemaV1<T>
 
 type AccessObjectSchema = AccessCapabilityStandardSchemaV1<object>
 
-export interface AccessChatMessageInputSchemaOptions<TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined> {
-  metadata?: TMessageMetadataSchema
-}
+export type AccessChatMessageInputSchemaOptions<TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined> =
+  AgentInvocationProfileChatMessageInputSchemaOptions<TMessageMetadataSchema>
 
-export interface AccessChatRunInputOptions<TOrigin extends string = string> {
-  origin?: readonly TOrigin[]
-}
+export type AccessChatRunInputOptions<TOrigin extends string = string> =
+  AgentInvocationProfileChatRunInputOptions<TOrigin>
 
-export interface AccessChatInputSchemaOptions<
+export type AccessChatInputSchemaOptions<
   TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
   TUserSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
   TOrigin extends string = string,
   TChatCapability = unknown,
-> {
-  capability?: TChatCapability
-  message?: AccessChatMessageInputSchemaOptions<TMessageMetadataSchema>
-  run?: AccessChatRunInputOptions<TOrigin>
-  user?: TUserSchema
-}
+> = AgentInvocationProfileChatInputSchemaOptions<TMessageMetadataSchema, TUserSchema, TOrigin, TChatCapability>
 
-export interface AccessInputSchemaOptions<
+export type AccessInputSchemaOptions<
   TMessageMetadataSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
   TUserSchema extends AccessObjectSchema | undefined = AccessObjectSchema | undefined,
   TOrigin extends string = string,
   TChatCapability = unknown,
-> {
-  chat?: AccessChatInputSchemaOptions<TMessageMetadataSchema, TUserSchema, TOrigin, TChatCapability>
-}
-
-type AccessSchemaObjectOutput<TSchema> =
-  TSchema extends AccessCapabilityStandardSchemaV1<infer TOutput>
-    ? TOutput extends object ? TOutput : Record<string, unknown>
-    : Record<string, unknown>
-
-type AccessChatRunOrigin<TChat> =
-  TChat extends { run?: { origin?: readonly (infer TOrigin)[] } }
-    ? Extract<TOrigin, string>
-    : TChat extends { capability?: infer TChatCapability }
-      ? AgentChatCapabilityOrigin<TChatCapability>
-    : string
+> = AgentInvocationProfileInputSchemaOptions<TMessageMetadataSchema, TUserSchema, TOrigin, TChatCapability>
 
 export type AccessInputContextFromSchemas<TInputSchemas> =
-  TInputSchemas extends { chat?: infer TChat }
-    ? AgentChatRunContext<
-        TChat extends { message?: { metadata?: infer TMessageMetadataSchema } }
-          ? AccessSchemaObjectOutput<TMessageMetadataSchema>
-          : Record<string, unknown>,
-        TChat extends { user?: infer TUserSchema }
-          ? AccessSchemaObjectOutput<TUserSchema>
-          : Record<string, unknown>,
-        AccessChatRunOrigin<TChat>
-      >
-    : Record<string, unknown>
+  AgentInvocationProfileInputContextFromSchemas<TInputSchemas>
 
 export type AccessCapabilityTypeContract<
   TSourceName extends string = string,
@@ -166,19 +133,21 @@ export type AccessWorkspaceResolverContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
   TInputContext extends object = Record<string, unknown>,
+  TProfile = undefined,
 > = Omit<AgentCapabilityRuntimeContext<TRuntimeConfig, Name>, "input"> & {
   input: Omit<AgentCapabilityRuntimeContext<TRuntimeConfig, Name>["input"], "get"> & {
     get: () => AgentRunInput<unknown, TInputContext>
   }
-}
+} & ([TProfile] extends [undefined] ? {} : { profile: TProfile })
 
 export type AccessWorkspaceScopeResolver<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
   TInputContext extends object = Record<string, unknown>,
   TSourceName extends string = string,
+  TProfile = undefined,
 > = (
-  context: AccessWorkspaceResolverContext<TRuntimeConfig, Name, TInputContext>,
+  context: AccessWorkspaceResolverContext<TRuntimeConfig, Name, TInputContext, TProfile>,
 ) => MaybePromise<AccessWorkspaceScopeSelectionInput<TSourceName> | undefined>
 
 export interface AccessWorkspaceOptions<
@@ -186,9 +155,10 @@ export interface AccessWorkspaceOptions<
   Name extends WorkspaceName = WorkspaceName,
   TSourceName extends string = string,
   TInputContext extends object = Record<string, unknown>,
+  TProfile = undefined,
 > {
   defaultScope?: string
-  resolve?: AccessWorkspaceScopeSelectionInput<TSourceName> | AccessWorkspaceScopeResolver<TRuntimeConfig, Name, TInputContext, TSourceName>
+  resolve?: AccessWorkspaceScopeSelectionInput<TSourceName> | AccessWorkspaceScopeResolver<TRuntimeConfig, Name, TInputContext, TSourceName, TProfile>
   scopes?: Record<string, AccessWorkspaceScopeDefinition<TSourceName>>
 }
 
@@ -198,9 +168,11 @@ export interface AccessCapabilityOptions<
   TSourceName extends string = string,
   TInputContext extends object = Record<string, unknown>,
   TInputSchemas extends AccessInputSchemaOptions | undefined = undefined,
+  TProfile = undefined,
 > {
   input?: TInputSchemas
-  workspace: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext>
+  profile?: AgentInvocationProfileDefinition<TProfile, TRuntimeConfig, Name, TInputContext>
+  workspace: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext, TProfile>
 }
 
 export type AccessWorkspaceSourceName<TWorkspace extends { sources?: Record<string, WorkspaceSource> }> =
@@ -211,7 +183,8 @@ export type AccessWorkspaceOptionsFor<
   TInputContext extends object = Record<string, unknown>,
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
-> = AccessWorkspaceOptions<TRuntimeConfig, Name, AccessWorkspaceSourceName<TWorkspace>, TInputContext>
+  TProfile = undefined,
+> = AccessWorkspaceOptions<TRuntimeConfig, Name, AccessWorkspaceSourceName<TWorkspace>, TInputContext, TProfile>
 
 interface ResolvedWorkspaceScope {
   all: boolean
@@ -243,6 +216,13 @@ function setWorkspaceOverride<
 export function access<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
+  TProfile = unknown,
+  TInputContext extends object = Record<string, unknown>,
+  const TWorkspace extends AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext, TProfile> = AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext, TProfile>,
+>(options: { input?: undefined, profile: AgentInvocationProfileDefinition<TProfile, TRuntimeConfig, Name, TInputContext>, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext>>
+export function access<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
   TInputContext extends object = Record<string, unknown>,
   const TWorkspace extends AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext> = AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext>,
 >(options: { input?: undefined, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext>>
@@ -267,9 +247,12 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
       if ("diff" in context.workspace) {
         throw new Error("[vitehub] access({ workspace }) is read-only in the first version and requires workspace.mode: \"read\".")
       }
-      const input = await applyAccessInputSchemas(options.input, context.input.get())
+      const input = await applyInvocationProfileInputSchemas(options.input, context.input.get())
       if (input !== context.input.get()) context.input.set(input)
-      const scope = await resolveWorkspaceScope(options.workspace, context)
+      const profile = options.profile
+        ? await resolveInvocationProfile(options.profile, context)
+        : undefined
+      const scope = await resolveWorkspaceScope(options.workspace, context, profile)
       const scopedWorkspace = scope.all
         ? context.workspace
         : createScopedWorkspaceFacade(context.workspace, scope)
@@ -287,92 +270,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-async function applyAccessInputSchemas(
-  schemas: AccessInputSchemaOptions | undefined,
-  input: AgentRunInput,
-): Promise<AgentRunInput> {
-  const chatSchemas = schemas?.chat
-  if (!chatSchemas) return input
-
-  const inputContext = isRecord(input.context) ? input.context : undefined
-  const chat = isRecord(inputContext?.chat) ? inputContext.chat : {}
-
-  let nextChat = chat
-  const message = isRecord(chat.message) ? chat.message : undefined
-  const metadataSchema = chatSchemas.message?.metadata
-  if (metadataSchema && shouldValidateChatMessageMetadata(chatSchemas, chat)) {
-    const metadata = await parseStandardSchema(metadataSchema, message?.metadata, "chat.message.metadata")
-    nextChat = {
-      ...nextChat,
-      message: {
-        ...(message || {}),
-        metadata,
-      },
-    }
-  }
-
-  const userSchema = chatSchemas.user
-  if (userSchema) {
-    const user = await parseStandardSchema(userSchema, chat.user, "chat.user")
-    nextChat = {
-      ...nextChat,
-      user,
-    }
-  }
-
-  const origins = chatSchemas.run?.origin
-  if (origins) {
-    const run = isRecord(chat.run) ? chat.run : undefined
-    const origin = run?.origin
-    if (typeof origin !== "string" || !origins.includes(origin)) {
-      throw new Error(`[vitehub] Invalid chat.run.origin: expected one of ${origins.map(value => JSON.stringify(value)).join(", ")}.`)
-    }
-  }
-
-  if (nextChat === chat) return input
-  return {
-    ...input,
-    context: {
-      ...(inputContext || {}),
-      chat: nextChat,
-    },
-  }
-}
-
-function capabilityMetadata(value: unknown): Record<string, unknown> | undefined {
-  const metadata = isRecord(value) ? value.metadata : undefined
-  return isRecord(metadata) ? metadata : undefined
-}
-
-function entryChatOptions(value: unknown): AgentEntryChatOptions | undefined {
-  const metadata = capabilityMetadata(value)
-  const entry = isRecord(metadata?.entry) ? metadata.entry : undefined
-  return metadata?.kind === "entry" && isRecord(entry?.chat)
-    ? entry.chat as AgentEntryChatOptions
-    : undefined
-}
-
-function shouldValidateChatMessageMetadata(
-  schemas: AccessChatInputSchemaOptions,
-  chat: Record<string, unknown>,
-): boolean {
-  const appOrigin = entryChatOptions(schemas.capability)?.origin
-  if (!appOrigin) return true
-  const run = isRecord(chat.run) ? chat.run : undefined
-  const origin = run?.origin
-  return typeof origin !== "string" || origin === appOrigin
-}
-
 async function resolveWorkspaceScope<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
   TSourceName extends string,
   TInputContext extends object,
+  TProfile,
 >(
-  options: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext>,
+  options: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext, TProfile>,
   context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
+  profile: TProfile | undefined,
 ): Promise<ResolvedWorkspaceScope> {
-  const selection = normalizeSelection(await resolveSelection(options, context))
+  const selection = normalizeSelection(await resolveSelection(options, context, profile))
   if (!selection) {
     throw new Error("[vitehub] access({ workspace }) could not resolve a Workspace Scope. Configure defaultScope or resolve().")
   }
@@ -401,13 +310,18 @@ async function resolveSelection<
   Name extends WorkspaceName,
   TSourceName extends string,
   TInputContext extends object,
+  TProfile,
 >(
-  options: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext>,
+  options: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext, TProfile>,
   context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
+  profile: TProfile | undefined,
 ): Promise<AccessWorkspaceScopeSelectionInput<TSourceName> | undefined> {
   if (options.resolve !== undefined) {
+    const resolverContext = profile === undefined
+      ? context
+      : { ...context, profile }
     const resolved = typeof options.resolve === "function"
-      ? await options.resolve(context as AccessWorkspaceResolverContext<TRuntimeConfig, Name, TInputContext>)
+      ? await options.resolve(resolverContext as AccessWorkspaceResolverContext<TRuntimeConfig, Name, TInputContext, TProfile>)
       : options.resolve
     return normalizeSelection(resolved) ? resolved : options.defaultScope
   }

--- a/packages/agent/src/capabilities/audience.ts
+++ b/packages/agent/src/capabilities/audience.ts
@@ -1,0 +1,62 @@
+import { defineCapability } from "../capability-runtime.ts"
+import { resolveInvocationProfile } from "../invocation-profile.ts"
+
+import type {
+  AgentAdapterInstructionsValue,
+  AgentCapabilityDefinition,
+  AgentCapabilityRuntimeContext,
+  AgentRuntimeConfig,
+  MaybePromise,
+} from "../types.ts"
+import type { AgentInvocationProfileDefinition } from "../invocation-profile.ts"
+import type { WorkspaceName } from "@vite-hub/workspace"
+
+export type AudienceInstructionsResolver<
+  TProfile = unknown,
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> = (
+  context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name> & { profile: TProfile },
+) => MaybePromise<AgentAdapterInstructionsValue | false | undefined>
+
+export interface AudienceCapabilityOptions<
+  TProfile = unknown,
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> {
+  id?: string
+  instructions:
+    | AgentAdapterInstructionsValue
+    | false
+    | AudienceInstructionsResolver<TProfile, TRuntimeConfig, Name>
+  profile?: AgentInvocationProfileDefinition<TProfile, TRuntimeConfig, Name, any>
+}
+
+export function audience<
+  TProfile = unknown,
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+>(
+  options: AudienceCapabilityOptions<TProfile, TRuntimeConfig, Name>,
+): AgentCapabilityDefinition<TRuntimeConfig, Name> {
+  if (!options || typeof options !== "object") {
+    throw new TypeError("[vitehub] audience() requires options.")
+  }
+  const id = options.id || "audience"
+  return defineCapability({
+    id,
+    metadata: {
+      kind: "audience",
+      ...(options.profile ? { profile: options.profile.id } : {}),
+    },
+    async prepare(context) {
+      const profile = options.profile
+        ? await resolveInvocationProfile(options.profile, context as AgentCapabilityRuntimeContext<TRuntimeConfig, Name>)
+        : undefined
+      const instructions = typeof options.instructions === "function"
+        ? await options.instructions({ ...context, profile } as AgentCapabilityRuntimeContext<TRuntimeConfig, Name> & { profile: TProfile })
+        : options.instructions
+      context.instructions.add(instructions, { id })
+    },
+  })
+}

--- a/packages/agent/src/capabilities/entry.ts
+++ b/packages/agent/src/capabilities/entry.ts
@@ -12,7 +12,6 @@ import type { WorkspaceName } from "@vite-hub/workspace"
 export interface AgentEntryChatOptions<TOrigin extends string = string, TChatCapability = unknown> {
   capability?: TChatCapability
   origin?: TOrigin
-  route?: never
 }
 
 export type AgentEntryChatExposure<TOrigin extends string = string, TChatCapability = unknown> =
@@ -67,10 +66,9 @@ export function normalizeEntryChatOptions(chat: AgentEntryChatExposure | undefin
   if (!chat) return undefined
   if (typeof chat === "string") return { origin: chat }
   if (chat === true) return { origin: "http" }
-  const { route: _route, ...options } = chat as AgentEntryChatOptions & { route?: unknown }
   return {
-    ...options,
-    origin: options.origin || "http",
+    ...chat,
+    origin: chat.origin || "http",
   }
 }
 

--- a/packages/agent/src/capabilities/entry.ts
+++ b/packages/agent/src/capabilities/entry.ts
@@ -1,0 +1,111 @@
+import { defineCapability } from "../capability-runtime.ts"
+
+import type { AgentChatCapabilityOrigin } from "../chat-trigger.ts"
+import type {
+  AgentCapabilityDefinition,
+  AgentCapabilityTypeContract,
+  AgentRuntimeConfig,
+  AgentTriggerDefinition,
+} from "../types.ts"
+import type { WorkspaceName } from "@vite-hub/workspace"
+
+export interface AgentEntryChatOptions<TOrigin extends string = string, TChatCapability = unknown> {
+  capability?: TChatCapability
+  origin?: TOrigin
+  route?: never
+}
+
+export type AgentEntryChatExposure<TOrigin extends string = string, TChatCapability = unknown> =
+  | boolean
+  | TOrigin
+  | AgentEntryChatOptions<TOrigin, TChatCapability>
+
+export interface AgentEntryOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  TChat extends AgentEntryChatExposure | undefined = AgentEntryChatExposure | undefined,
+> {
+  chat?: TChat
+  id: string
+  triggers?: Record<string, AgentTriggerDefinition<TRuntimeConfig, Name, any, any>>
+}
+
+export interface AgentEntryCapabilityMetadata {
+  entry: {
+    chat?: AgentEntryChatOptions
+    id: string
+  }
+  kind: "entry"
+}
+
+type AgentEntryChatOwnOrigin<TChat> =
+  TChat extends string
+    ? TChat
+    : TChat extends true
+      ? "http"
+      : TChat extends { origin?: infer TOrigin }
+        ? [Extract<TOrigin, string>] extends [never] ? "http" : Extract<TOrigin, string>
+        : never
+
+type AgentEntryChatLinkedOrigin<TChat> =
+  TChat extends { capability?: infer TCapability }
+    ? AgentChatCapabilityOrigin<TCapability>
+    : never
+
+type AgentEntryChatOrigin<TChat> = AgentEntryChatOwnOrigin<TChat> | AgentEntryChatLinkedOrigin<TChat>
+
+export type AgentEntryOptionsOrigin<TOptions> =
+  TOptions extends { chat?: infer TChat }
+    ? [AgentEntryChatOrigin<TChat>] extends [never] ? string : AgentEntryChatOrigin<TChat>
+    : string
+
+type EntryCapabilityTypeContract<TOrigin extends string = string> = AgentCapabilityTypeContract & {
+  chatOrigins: TOrigin
+}
+
+export function normalizeEntryChatOptions(chat: AgentEntryChatExposure | undefined): AgentEntryChatOptions | undefined {
+  if (!chat) return undefined
+  if (typeof chat === "string") return { origin: chat }
+  if (chat === true) return { origin: "http" }
+  const { route: _route, ...options } = chat as AgentEntryChatOptions & { route?: unknown }
+  return {
+    ...options,
+    origin: options.origin || "http",
+  }
+}
+
+function entryMetadata(capability: AgentCapabilityDefinition): AgentEntryCapabilityMetadata | undefined {
+  const metadata = capability.metadata as AgentEntryCapabilityMetadata | undefined
+  return metadata?.kind === "entry" ? metadata : undefined
+}
+
+export function getEntryChatOptions(capabilities: AgentCapabilityDefinition[]): AgentEntryChatOptions | undefined {
+  const entries = capabilities
+    .map(entryMetadata)
+    .filter((metadata): metadata is AgentEntryCapabilityMetadata => Boolean(metadata?.entry.chat))
+  if (entries.length > 1) {
+    throw new Error("[vitehub] Only one entry({ chat }) capability can expose the generated Chat App Route for an Agent.")
+  }
+  return entries[0]?.entry.chat
+}
+
+export function entry<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  const TOptions extends AgentEntryOptions<TRuntimeConfig, Name> = AgentEntryOptions<TRuntimeConfig, Name>,
+>(
+  options: TOptions,
+): AgentCapabilityDefinition<TRuntimeConfig, Name, EntryCapabilityTypeContract<AgentEntryOptionsOrigin<TOptions>>> {
+  const chat = normalizeEntryChatOptions(options.chat)
+  return defineCapability({
+    id: options.id,
+    metadata: {
+      entry: {
+        ...(chat ? { chat } : {}),
+        id: options.id,
+      },
+      kind: "entry",
+    } satisfies AgentEntryCapabilityMetadata,
+    triggers: options.triggers,
+  })
+}

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -5,6 +5,9 @@ export {
   chat,
 } from "../chat-trigger.ts"
 export {
+  entry,
+} from "./entry.ts"
+export {
   chatSummary,
 } from "./chat-summary.ts"
 export {
@@ -94,6 +97,13 @@ export type {
   AgentChatOptionsOrigin,
   AgentChatRunContext,
 } from "../chat-trigger.ts"
+export type {
+  AgentEntryCapabilityMetadata,
+  AgentEntryChatExposure,
+  AgentEntryChatOptions,
+  AgentEntryOptions,
+  AgentEntryOptionsOrigin,
+} from "./entry.ts"
 export type {
   AgentChatAdapterResolver,
   AgentChatAdaptersResolver,

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -79,14 +79,6 @@ export type {
 } from "./audience.ts"
 export type {
   AccessCapabilityOptions,
-  AccessCapabilityStandardSchemaResultFailure,
-  AccessCapabilityStandardSchemaResultSuccess,
-  AccessCapabilityStandardSchemaV1,
-  AccessChatInputSchemaOptions,
-  AccessChatMessageInputSchemaOptions,
-  AccessChatRunInputOptions,
-  AccessInputContextFromSchemas,
-  AccessInputSchemaOptions,
   AccessRoleName,
   AccessWorkspaceOptions,
   AccessWorkspaceOptionsFor,

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -2,6 +2,9 @@ export {
   access,
 } from "./access.ts"
 export {
+  audience,
+} from "./audience.ts"
+export {
   chat,
 } from "../chat-trigger.ts"
 export {
@@ -70,6 +73,10 @@ export {
   webSearch,
 } from "./web-search/index.ts"
 
+export type {
+  AudienceCapabilityOptions,
+  AudienceInstructionsResolver,
+} from "./audience.ts"
 export type {
   AccessCapabilityOptions,
   AccessCapabilityStandardSchemaResultFailure,

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -30,21 +30,11 @@ type ResolvedMaybeResolvable<T> =
       ? Awaited<TResult>
       : T
 
-type AgentChatAppOrigin<TApp> =
-  TApp extends string
-    ? TApp
-    : TApp extends true
-      ? "http"
-      : TApp extends { origin?: infer TOrigin }
-        ? Extract<TOrigin, string>
-        : never
-
 type AgentChatAdapterOrigin<TAdapters> =
   Extract<keyof NonNullable<ResolvedMaybeResolvable<TAdapters>>, string>
 
 type AgentChatKnownOrigin<TOptions> =
-  (TOptions extends { app?: infer TApp } ? AgentChatAppOrigin<TApp> : never)
-  | (TOptions extends { adapters?: infer TAdapters } ? AgentChatAdapterOrigin<TAdapters> : never)
+  TOptions extends { adapters?: infer TAdapters } ? AgentChatAdapterOrigin<TAdapters> : never
 
 export type AgentChatOptionsOrigin<TOptions> =
   [AgentChatKnownOrigin<TOptions>] extends [never]

--- a/packages/agent/src/config.ts
+++ b/packages/agent/src/config.ts
@@ -22,6 +22,7 @@ export function normalizeAgentOptions(options: AgentModuleOptions | false | unde
         provider: options?.providers?.scheduler?.provider || "auto",
       },
       state: {
+        ...options?.providers?.state,
         provider: options?.providers?.state?.provider || "auto",
       },
     },

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -105,8 +105,6 @@ export type {
   AgentCapabilityPhase,
   AgentCapabilityRuntimeContext,
   AgentChatAgentHookArgs,
-  AgentChatAppExposure,
-  AgentChatAppOptions,
   AgentChatEventHookArgs,
   AgentChatEventHooks,
   AgentChatIdentityResolver,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -173,6 +173,7 @@ export type {
   MaybeResolvable,
   Resolvable,
   ResolvedAgentModuleOptions,
+  ResolvedAgentStateProviderOptions,
   ResolvedAgentTriggerDefinition,
   ResolvedAgentRuntimeContext,
   WorkspaceAgentWorkspaceOptions,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5,6 +5,7 @@ import {
   resolveRuntimeContext,
 } from "@vite-hub/runtime"
 import { getChatCapabilityOptions } from "./chat-trigger.ts"
+import { defineInvocationProfile } from "./invocation-profile.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
 
 import {
@@ -177,6 +178,26 @@ export type {
   WorkspaceAgentWorkspaceOptions,
   WorkspaceAgentWorkspaceConfig,
 } from "./types.ts"
+
+export {
+  defineInvocationProfile,
+}
+
+export type {
+  AgentInvocationProfileChatInputSchemaOptions,
+  AgentInvocationProfileChatMessageInputSchemaOptions,
+  AgentInvocationProfileChatRunInputOptions,
+  AgentInvocationProfileContextValueId,
+  AgentInvocationProfileDefinition,
+  AgentInvocationProfileInputContextFromSchemas,
+  AgentInvocationProfileInputSchemaOptions,
+  AgentInvocationProfileOptions,
+  AgentInvocationProfileResolver,
+  AgentInvocationProfileResolverContext,
+  AgentInvocationProfileStandardSchemaResultFailure,
+  AgentInvocationProfileStandardSchemaResultSuccess,
+  AgentInvocationProfileStandardSchemaV1,
+} from "./invocation-profile.ts"
 
 export type {
   Message,

--- a/packages/agent/src/invocation-profile.ts
+++ b/packages/agent/src/invocation-profile.ts
@@ -1,7 +1,6 @@
 import { parseStandardSchema } from "@vite-hub/internal/http-request"
 
-import type { AgentChatCapabilityOrigin, AgentChatRunContext } from "./chat-trigger.ts"
-import type { AgentEntryChatOptions } from "./capabilities/entry.ts"
+import type { AgentChatRunContext } from "./chat-trigger.ts"
 import type {
   AgentCapabilityRuntimeContext,
   AgentInvocationContextStore,
@@ -28,8 +27,12 @@ export interface AgentInvocationProfileStandardSchemaV1<T = unknown> {
 
 type ProfileObjectSchema = AgentInvocationProfileStandardSchemaV1<object>
 
-export interface AgentInvocationProfileChatMessageInputSchemaOptions<TMessageMetadataSchema extends ProfileObjectSchema | undefined = ProfileObjectSchema | undefined> {
+export interface AgentInvocationProfileChatMessageInputSchemaOptions<
+  TMessageMetadataSchema extends ProfileObjectSchema | undefined = ProfileObjectSchema | undefined,
+  TOrigin extends string = string,
+> {
   metadata?: TMessageMetadataSchema
+  runOrigin?: readonly TOrigin[]
 }
 
 export interface AgentInvocationProfileChatRunInputOptions<TOrigin extends string = string> {
@@ -40,10 +43,8 @@ export interface AgentInvocationProfileChatInputSchemaOptions<
   TMessageMetadataSchema extends ProfileObjectSchema | undefined = ProfileObjectSchema | undefined,
   TUserSchema extends ProfileObjectSchema | undefined = ProfileObjectSchema | undefined,
   TOrigin extends string = string,
-  TChatCapability = unknown,
 > {
-  capability?: TChatCapability
-  message?: AgentInvocationProfileChatMessageInputSchemaOptions<TMessageMetadataSchema>
+  message?: AgentInvocationProfileChatMessageInputSchemaOptions<TMessageMetadataSchema, TOrigin>
   run?: AgentInvocationProfileChatRunInputOptions<TOrigin>
   user?: TUserSchema
 }
@@ -52,9 +53,8 @@ export interface AgentInvocationProfileInputSchemaOptions<
   TMessageMetadataSchema extends ProfileObjectSchema | undefined = ProfileObjectSchema | undefined,
   TUserSchema extends ProfileObjectSchema | undefined = ProfileObjectSchema | undefined,
   TOrigin extends string = string,
-  TChatCapability = unknown,
 > {
-  chat?: AgentInvocationProfileChatInputSchemaOptions<TMessageMetadataSchema, TUserSchema, TOrigin, TChatCapability>
+  chat?: AgentInvocationProfileChatInputSchemaOptions<TMessageMetadataSchema, TUserSchema, TOrigin>
 }
 
 type ProfileSchemaObjectOutput<TSchema> =
@@ -65,8 +65,6 @@ type ProfileSchemaObjectOutput<TSchema> =
 type ProfileChatRunOrigin<TChat> =
   TChat extends { run?: { origin?: readonly (infer TOrigin)[] } }
     ? Extract<TOrigin, string>
-    : TChat extends { capability?: infer TChatCapability }
-      ? AgentChatCapabilityOrigin<TChatCapability>
     : string
 
 export type AgentInvocationProfileInputContextFromSchemas<TInputSchemas> =
@@ -141,28 +139,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function capabilityMetadata(value: unknown): Record<string, unknown> | undefined {
-  const metadata = isRecord(value) ? value.metadata : undefined
-  return isRecord(metadata) ? metadata : undefined
-}
-
-function entryChatOptions(value: unknown): AgentEntryChatOptions | undefined {
-  const metadata = capabilityMetadata(value)
-  const entry = isRecord(metadata?.entry) ? metadata.entry : undefined
-  return metadata?.kind === "entry" && isRecord(entry?.chat)
-    ? entry.chat as AgentEntryChatOptions
-    : undefined
-}
-
 function shouldValidateChatMessageMetadata(
-  schemas: AgentInvocationProfileChatInputSchemaOptions,
+  schemas: AgentInvocationProfileChatMessageInputSchemaOptions,
   chat: Record<string, unknown>,
 ): boolean {
-  const appOrigin = entryChatOptions(schemas.capability)?.origin
-  if (!appOrigin) return true
+  const runOrigins = schemas.runOrigin
+  if (!runOrigins?.length) return true
   const run = isRecord(chat.run) ? chat.run : undefined
   const origin = run?.origin
-  return typeof origin !== "string" || origin === appOrigin
+  return typeof origin === "string" && runOrigins.includes(origin)
 }
 
 export async function applyInvocationProfileInputSchemas(
@@ -177,8 +162,9 @@ export async function applyInvocationProfileInputSchemas(
 
   let nextChat = chat
   const message = isRecord(chat.message) ? chat.message : undefined
-  const metadataSchema = chatSchemas.message?.metadata
-  if (metadataSchema && shouldValidateChatMessageMetadata(chatSchemas, chat)) {
+  const messageSchemas = chatSchemas.message
+  const metadataSchema = messageSchemas?.metadata
+  if (messageSchemas && metadataSchema && shouldValidateChatMessageMetadata(messageSchemas, chat)) {
     const metadata = await parseStandardSchema(metadataSchema, message?.metadata, "chat.message.metadata")
     nextChat = {
       ...nextChat,

--- a/packages/agent/src/invocation-profile.ts
+++ b/packages/agent/src/invocation-profile.ts
@@ -1,0 +1,267 @@
+import { parseStandardSchema } from "@vite-hub/internal/http-request"
+
+import type { AgentChatCapabilityOrigin, AgentChatRunContext } from "./chat-trigger.ts"
+import type { AgentEntryChatOptions } from "./capabilities/entry.ts"
+import type {
+  AgentCapabilityRuntimeContext,
+  AgentInvocationContextStore,
+  AgentRunInput,
+  AgentRuntimeConfig,
+  MaybePromise,
+} from "./types.ts"
+import type { WorkspaceName } from "@vite-hub/workspace"
+
+export interface AgentInvocationProfileStandardSchemaResultSuccess<T = unknown> {
+  issues?: undefined
+  value: T
+}
+
+export interface AgentInvocationProfileStandardSchemaResultFailure {
+  issues: readonly unknown[]
+}
+
+export interface AgentInvocationProfileStandardSchemaV1<T = unknown> {
+  "~standard": {
+    validate: (input: unknown) => AgentInvocationProfileStandardSchemaResultSuccess<T> | AgentInvocationProfileStandardSchemaResultFailure | Promise<AgentInvocationProfileStandardSchemaResultSuccess<T> | AgentInvocationProfileStandardSchemaResultFailure>
+  }
+}
+
+type ProfileObjectSchema = AgentInvocationProfileStandardSchemaV1<object>
+
+export interface AgentInvocationProfileChatMessageInputSchemaOptions<TMessageMetadataSchema extends ProfileObjectSchema | undefined = ProfileObjectSchema | undefined> {
+  metadata?: TMessageMetadataSchema
+}
+
+export interface AgentInvocationProfileChatRunInputOptions<TOrigin extends string = string> {
+  origin?: readonly TOrigin[]
+}
+
+export interface AgentInvocationProfileChatInputSchemaOptions<
+  TMessageMetadataSchema extends ProfileObjectSchema | undefined = ProfileObjectSchema | undefined,
+  TUserSchema extends ProfileObjectSchema | undefined = ProfileObjectSchema | undefined,
+  TOrigin extends string = string,
+  TChatCapability = unknown,
+> {
+  capability?: TChatCapability
+  message?: AgentInvocationProfileChatMessageInputSchemaOptions<TMessageMetadataSchema>
+  run?: AgentInvocationProfileChatRunInputOptions<TOrigin>
+  user?: TUserSchema
+}
+
+export interface AgentInvocationProfileInputSchemaOptions<
+  TMessageMetadataSchema extends ProfileObjectSchema | undefined = ProfileObjectSchema | undefined,
+  TUserSchema extends ProfileObjectSchema | undefined = ProfileObjectSchema | undefined,
+  TOrigin extends string = string,
+  TChatCapability = unknown,
+> {
+  chat?: AgentInvocationProfileChatInputSchemaOptions<TMessageMetadataSchema, TUserSchema, TOrigin, TChatCapability>
+}
+
+type ProfileSchemaObjectOutput<TSchema> =
+  TSchema extends AgentInvocationProfileStandardSchemaV1<infer TOutput>
+    ? TOutput extends object ? TOutput : Record<string, unknown>
+    : Record<string, unknown>
+
+type ProfileChatRunOrigin<TChat> =
+  TChat extends { run?: { origin?: readonly (infer TOrigin)[] } }
+    ? Extract<TOrigin, string>
+    : TChat extends { capability?: infer TChatCapability }
+      ? AgentChatCapabilityOrigin<TChatCapability>
+    : string
+
+export type AgentInvocationProfileInputContextFromSchemas<TInputSchemas> =
+  TInputSchemas extends { chat?: infer TChat }
+    ? AgentChatRunContext<
+        TChat extends { message?: { metadata?: infer TMessageMetadataSchema } }
+          ? ProfileSchemaObjectOutput<TMessageMetadataSchema>
+          : Record<string, unknown>,
+        TChat extends { user?: infer TUserSchema }
+          ? ProfileSchemaObjectOutput<TUserSchema>
+          : Record<string, unknown>,
+        ProfileChatRunOrigin<TChat>
+      >
+    : Record<string, unknown>
+
+export type AgentInvocationProfileContextValueId<TId extends string = string> = `invocationProfile.${TId}`
+
+export type AgentInvocationProfileResolverContext<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  TInputContext extends object = Record<string, unknown>,
+> = Omit<AgentCapabilityRuntimeContext<TRuntimeConfig, Name>, "input"> & {
+  input: Omit<AgentCapabilityRuntimeContext<TRuntimeConfig, Name>["input"], "get"> & {
+    get: () => AgentRunInput<unknown, TInputContext>
+  }
+}
+
+export type AgentInvocationProfileResolver<
+  TProfile,
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  TInputContext extends object = Record<string, unknown>,
+> = (
+  context: AgentInvocationProfileResolverContext<TRuntimeConfig, Name, TInputContext>,
+) => MaybePromise<TProfile>
+
+export interface AgentInvocationProfileDefinition<
+  TProfile = unknown,
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  TInputContext extends object = Record<string, unknown>,
+> {
+  id: string
+  input?: AgentInvocationProfileInputSchemaOptions
+  resolve: AgentInvocationProfileResolver<TProfile, TRuntimeConfig, Name, TInputContext>
+}
+
+export interface AgentInvocationProfileOptions<
+  TProfile,
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  TInputSchemas extends AgentInvocationProfileInputSchemaOptions | undefined = undefined,
+  TInputContext extends object = TInputSchemas extends AgentInvocationProfileInputSchemaOptions ? AgentInvocationProfileInputContextFromSchemas<TInputSchemas> : Record<string, unknown>,
+> {
+  id: string
+  input?: TInputSchemas
+  resolve: AgentInvocationProfileResolver<TProfile, TRuntimeConfig, Name, TInputContext>
+}
+
+const resolvedProfiles = new WeakMap<AgentInvocationContextStore, WeakMap<object, unknown>>()
+
+function assertInvocationProfileId(id: unknown): asserts id is string {
+  if (typeof id !== "string" || !id.trim()) {
+    throw new TypeError("[vitehub] defineInvocationProfile() requires a non-empty string id.")
+  }
+  if (!/^[a-z][a-z0-9-_.]*$/i.test(id)) {
+    throw new TypeError(`[vitehub] Invocation Profile id "${id}" must be a stable identifier.`)
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function capabilityMetadata(value: unknown): Record<string, unknown> | undefined {
+  const metadata = isRecord(value) ? value.metadata : undefined
+  return isRecord(metadata) ? metadata : undefined
+}
+
+function entryChatOptions(value: unknown): AgentEntryChatOptions | undefined {
+  const metadata = capabilityMetadata(value)
+  const entry = isRecord(metadata?.entry) ? metadata.entry : undefined
+  return metadata?.kind === "entry" && isRecord(entry?.chat)
+    ? entry.chat as AgentEntryChatOptions
+    : undefined
+}
+
+function shouldValidateChatMessageMetadata(
+  schemas: AgentInvocationProfileChatInputSchemaOptions,
+  chat: Record<string, unknown>,
+): boolean {
+  const appOrigin = entryChatOptions(schemas.capability)?.origin
+  if (!appOrigin) return true
+  const run = isRecord(chat.run) ? chat.run : undefined
+  const origin = run?.origin
+  return typeof origin !== "string" || origin === appOrigin
+}
+
+export async function applyInvocationProfileInputSchemas(
+  schemas: AgentInvocationProfileInputSchemaOptions | undefined,
+  input: AgentRunInput,
+): Promise<AgentRunInput> {
+  const chatSchemas = schemas?.chat
+  if (!chatSchemas) return input
+
+  const inputContext = isRecord(input.context) ? input.context : undefined
+  const chat = isRecord(inputContext?.chat) ? inputContext.chat : {}
+
+  let nextChat = chat
+  const message = isRecord(chat.message) ? chat.message : undefined
+  const metadataSchema = chatSchemas.message?.metadata
+  if (metadataSchema && shouldValidateChatMessageMetadata(chatSchemas, chat)) {
+    const metadata = await parseStandardSchema(metadataSchema, message?.metadata, "chat.message.metadata")
+    nextChat = {
+      ...nextChat,
+      message: {
+        ...(message || {}),
+        metadata,
+      },
+    }
+  }
+
+  const userSchema = chatSchemas.user
+  if (userSchema) {
+    const user = await parseStandardSchema(userSchema, chat.user, "chat.user")
+    nextChat = {
+      ...nextChat,
+      user,
+    }
+  }
+
+  const origins = chatSchemas.run?.origin
+  if (origins) {
+    const run = isRecord(chat.run) ? chat.run : undefined
+    const origin = run?.origin
+    if (typeof origin !== "string" || !origins.includes(origin)) {
+      throw new Error(`[vitehub] Invalid chat.run.origin: expected one of ${origins.map(value => JSON.stringify(value)).join(", ")}.`)
+    }
+  }
+
+  if (nextChat === chat) return input
+  return {
+    ...input,
+    context: {
+      ...(inputContext || {}),
+      chat: nextChat,
+    },
+  }
+}
+
+export function defineInvocationProfile<
+  TProfile,
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  const TInputSchemas extends AgentInvocationProfileInputSchemaOptions | undefined = undefined,
+>(
+  options: AgentInvocationProfileOptions<TProfile, TRuntimeConfig, Name, TInputSchemas>,
+): AgentInvocationProfileDefinition<
+  TProfile,
+  TRuntimeConfig,
+  Name,
+  TInputSchemas extends AgentInvocationProfileInputSchemaOptions ? AgentInvocationProfileInputContextFromSchemas<TInputSchemas> : Record<string, unknown>
+> {
+  if (!options || typeof options !== "object") {
+    throw new TypeError("[vitehub] defineInvocationProfile() requires options.")
+  }
+  assertInvocationProfileId(options.id)
+  if (typeof options.resolve !== "function") {
+    throw new TypeError("[vitehub] defineInvocationProfile() requires a resolve callback.")
+  }
+  return options as never
+}
+
+export async function resolveInvocationProfile<
+  TProfile,
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+  TInputContext extends object,
+>(
+  definition: AgentInvocationProfileDefinition<TProfile, TRuntimeConfig, Name, TInputContext>,
+  context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
+): Promise<TProfile> {
+  let cache = resolvedProfiles.get(context.context)
+  if (!cache) {
+    cache = new WeakMap()
+    resolvedProfiles.set(context.context, cache)
+  }
+  if (cache.has(definition)) return cache.get(definition) as TProfile
+
+  const input = await applyInvocationProfileInputSchemas(definition.input, context.input.get())
+  if (input !== context.input.get()) context.input.set(input)
+
+  const profile = await definition.resolve(context as AgentInvocationProfileResolverContext<TRuntimeConfig, Name, TInputContext>)
+  const contextId: AgentInvocationProfileContextValueId = `invocationProfile.${definition.id}`
+  context.context.set(contextId, profile)
+  cache.set(definition, profile)
+  return profile
+}

--- a/packages/agent/src/nitro/chat-state.ts
+++ b/packages/agent/src/nitro/chat-state.ts
@@ -12,6 +12,7 @@ type MemoryList = { expiresAt?: number, values: unknown[] }
 const defaultChatStates = new WeakMap<AgentChatOptions, StateAdapter>()
 const configuredChatStates = new WeakMap<AgentChatOptions, StateAdapter>()
 const cloudflareChatStates = new WeakMap<AgentChatOptions, WeakMap<object, StateAdapter>>()
+const sqliteChatStates = new Map<string, Promise<StateAdapter>>()
 
 function memoryExpiresAt(ttlMs: number | undefined): number | undefined {
   return typeof ttlMs === "number" && ttlMs > 0 ? Date.now() + ttlMs : undefined
@@ -128,8 +129,17 @@ function getConfiguredStateProvider(context: NitroChatRuntimeContext): string {
   return agentConfig && agentConfig.providers.state.provider || "auto"
 }
 
+function getConfiguredStateProviderOptions(context: NitroChatRuntimeContext): ResolvedAgentModuleOptions["providers"]["state"] | undefined {
+  const agentConfig = (context.runtimeConfig as { agent?: false | ResolvedAgentModuleOptions }).agent
+  return agentConfig ? agentConfig.providers.state : undefined
+}
+
 function isCloudflareAgentStateProvider(provider: string): boolean {
   return provider === "auto" || provider === "cloudflare" || provider === "cloudflare-agents"
+}
+
+function isSqliteAgentStateProvider(provider: string): boolean {
+  return provider === "sqlite" || provider === "libsql"
 }
 
 function isCloudflareAgentStateNamespace(value: unknown): value is ViteHubAgentStateDurableObjectNamespace & object {
@@ -150,6 +160,34 @@ function getCloudflareChatState(options: AgentChatOptions, namespace: ViteHubAge
   const state = createCloudflareAgentState({ namespace })
   states.set(namespace, state)
   return state
+}
+
+function readEnv(name: string): string | undefined {
+  const value = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.[name]
+  return typeof value === "string" && value.trim() ? value.trim() : undefined
+}
+
+function sqliteStateUrl(providerOptions: ResolvedAgentModuleOptions["providers"]["state"] | undefined): string | undefined {
+  return providerOptions?.url || readEnv("VITEHUB_AGENT_STATE_URL")
+}
+
+async function getSqliteChatState(providerOptions: ResolvedAgentModuleOptions["providers"]["state"] | undefined): Promise<StateAdapter> {
+  const url = sqliteStateUrl(providerOptions)
+  if (!url) {
+    throw new Error("[vitehub] Agent State Provider \"sqlite\" requires providers.state.url or VITEHUB_AGENT_STATE_URL.")
+  }
+  const authToken = providerOptions?.authToken || readEnv("VITEHUB_AGENT_STATE_AUTH_TOKEN")
+  const key = JSON.stringify({ authToken, tablePrefix: providerOptions?.tablePrefix, url })
+  let state = sqliteChatStates.get(key)
+  if (!state) {
+    state = import("../state/sqlite.ts").then(({ createLibsqlAgentState }) => createLibsqlAgentState({
+      ...(authToken ? { authToken } : {}),
+      ...(providerOptions?.tablePrefix ? { tablePrefix: providerOptions.tablePrefix } : {}),
+      url,
+    }))
+    sqliteChatStates.set(key, state)
+  }
+  return await state
 }
 
 function createChatStateKeyPrefix(agentName: string): string {
@@ -254,8 +292,11 @@ export async function resolveChatState(
   if (provider === "memory") {
     return getDefaultChatState(options)
   }
+  if (isSqliteAgentStateProvider(provider)) {
+    return namespaceChatState(await getSqliteChatState(getConfiguredStateProviderOptions(context)), stateKeyPrefix)
+  }
   if (!isCloudflareAgentStateProvider(provider)) {
-    throw new Error(`[vitehub] Unsupported Agent State Provider "${provider}". Configure chat({ state }) or use providers.state.provider: "auto", "cloudflare", or "memory".`)
+    throw new Error(`[vitehub] Unsupported Agent State Provider "${provider}". Configure chat({ state }) or use providers.state.provider: "auto", "cloudflare", "memory", or "sqlite".`)
   }
 
   if (context.cloudflare?.env) {

--- a/packages/agent/src/nitro/handler.ts
+++ b/packages/agent/src/nitro/handler.ts
@@ -3,6 +3,7 @@ import { createError, defineEventHandler, getRouterParam } from "h3"
 import { createRuntimeWaitUntilController } from "@vite-hub/runtime"
 
 import { chatWebhookRegistrations, getChatCapabilityOptions } from "../chat-trigger.ts"
+import { getEntryChatOptions } from "../capabilities/entry.ts"
 import { normalizeCapabilities } from "../capability-runtime.ts"
 import { resolveAgent, resolveAgentTriggers, runAgent, streamAgent, streamAgentTrigger } from "../index.ts"
 import { getHttpErrorMessage, getHttpErrorStatusCode } from "../http-error.ts"
@@ -18,7 +19,6 @@ import type { NitroRuntimeConfig } from "nitro/types"
 import type { AgentChatMessageTriggerInput } from "../chat-trigger.ts"
 import type {
   AgentCapabilityDefinition,
-  AgentChatAppOptions,
   AgentChatOptions,
   AgentHandlerOptions,
   AgentInput,
@@ -30,6 +30,7 @@ import type {
   AgentRuntimeContext,
   AgentRuntimeHooks,
 } from "../types.ts"
+import type { AgentEntryChatOptions } from "../capabilities/entry.ts"
 
 export interface NitroAgentRuntimeConfig extends NitroRuntimeConfig, AgentRuntimeConfig {}
 
@@ -337,12 +338,15 @@ function createChatSdkOptions(options: AgentChatOptions, adapters: Record<string
   const {
     adapters: _adapters,
     agent: _agent,
+    app: _app,
     event: _event,
     execution: _execution,
     fallbackStreamingPlaceholderText: _fallbackStreamingPlaceholderText,
+    history: _history,
     hooks: _hooks,
     identity,
     lifecycleHooks: _lifecycleHooks,
+    sessions: _sessions,
     state: _state,
     transcripts,
     userName,
@@ -746,16 +750,10 @@ function normalizeChatRouteSession(body: AgentChatRouteBody): AgentChatMessageTr
   return body.id ? { id: body.id } : undefined
 }
 
-function normalizeChatAppOptions(app: AgentChatOptions["app"]): AgentChatAppOptions | undefined {
-  if (!app) return
-  if (typeof app === "string") return { origin: app }
-  return app === true ? {} : app
-}
-
 function createChatRouteRunMetadata(
   body: AgentChatRouteBody,
   agentName: string | undefined,
-  app: AgentChatAppOptions,
+  app: AgentEntryChatOptions,
 ): AgentRunMetadata {
   const session = normalizeChatRouteSession(body)
   const message = body.messages?.at(-1)
@@ -765,7 +763,7 @@ function createChatRouteRunMetadata(
   if (requestedOrigin && requestedOrigin !== origin) {
     throw createError({
       statusCode: 400,
-      statusMessage: `Chat App Route run.origin ${JSON.stringify(requestedOrigin)} does not match configured origin ${JSON.stringify(origin)}. Configure chat({ app }) with that origin or remove run.origin from the request.`,
+      statusMessage: `Chat App Route run.origin ${JSON.stringify(requestedOrigin)} does not match configured origin ${JSON.stringify(origin)}. Configure entry({ chat }) with that origin or remove run.origin from the request.`,
     })
   }
 
@@ -781,7 +779,7 @@ function createChatRouteRunMetadata(
 function createChatRouteTriggerInput(
   body: AgentChatRouteBody,
   agentName: string | undefined,
-  app: AgentChatAppOptions,
+  app: AgentEntryChatOptions,
 ): AgentChatMessageTriggerInput {
   if (!Array.isArray(body.messages) || !body.messages.length) {
     throw createError({
@@ -803,21 +801,23 @@ function createChatRouteTriggerInput(
   }
 }
 
-function requireChatAppExposure(agent: AgentInput<NitroAgentRuntimeContext>, agentName?: string): AgentChatAppOptions {
-  const options = getChatCapabilityOptions(agentCapabilityOptions(agent))
-  if (!options) {
+function requireChatAppExposure(agent: AgentInput<NitroAgentRuntimeContext>, agentName?: string): AgentEntryChatOptions {
+  const capabilities = agentCapabilityOptions(agent)
+  const chatOptions = getChatCapabilityOptions(capabilities)
+  if (!chatOptions) {
     throw createError({
       statusCode: 404,
       statusMessage: `Agent "${agentName || "default"}" does not define chat().`,
     })
   }
-  if (!options.app) {
+  const appOptions = getEntryChatOptions(capabilities)
+  if (!appOptions) {
     throw createError({
       statusCode: 404,
-      statusMessage: `Agent "${agentName || "default"}" does not expose a Chat App Route.`,
+      statusMessage: `Agent "${agentName || "default"}" does not expose a Chat App Route. Attach entry({ id, chat }) to expose it.`,
     })
   }
-  return normalizeChatAppOptions(options.app) || {}
+  return appOptions
 }
 
 export function defineAgentHandler(

--- a/packages/agent/src/nitro/module.ts
+++ b/packages/agent/src/nitro/module.ts
@@ -181,6 +181,7 @@ function installAliases(nitro: Nitro, registryFile: string | undefined): void {
   nitro.options.alias["@vite-hub/agent/eval"] = resolveRuntimeEntry("../eval", "@vite-hub/agent/eval")
   nitro.options.alias["@vite-hub/agent/nitro"] = resolveRuntimeEntry("../nitro", "@vite-hub/agent/nitro")
   nitro.options.alias["@vite-hub/agent/runtime/nitro-runtime-config"] = resolveRuntimeEntry("../runtime/nitro-runtime-config", "@vite-hub/agent/runtime/nitro-runtime-config")
+  nitro.options.alias["@vite-hub/agent/state/sqlite"] = resolveRuntimeEntry("../state/sqlite", "@vite-hub/agent/state/sqlite")
   nitro.options.alias["@vite-hub/agent/vercel"] = resolveRuntimeEntry("../vercel", "@vite-hub/agent/vercel")
   nitro.options.alias["#vitehub/agent/registry"] = registryFile || resolveRuntimeEntry("../runtime/empty-registry", "@vite-hub/agent/runtime/empty-registry")
 }

--- a/packages/agent/src/state/sqlite.ts
+++ b/packages/agent/src/state/sqlite.ts
@@ -1,0 +1,393 @@
+import type { Lock, QueueEntry, StateAdapter } from "chat"
+
+type MaybePromise<T> = T | Promise<T>
+
+export type SqliteAgentStateRow = Record<string, unknown>
+
+export interface SqliteAgentStateResult {
+  rows?: SqliteAgentStateRow[]
+}
+
+export interface SqliteAgentStateExecutor {
+  execute: (statement: string, args?: unknown[]) => MaybePromise<SqliteAgentStateResult | SqliteAgentStateRow[] | void>
+}
+
+export interface SqliteAgentStateDriver extends SqliteAgentStateExecutor {
+  connect?: () => MaybePromise<void>
+  disconnect?: () => MaybePromise<void>
+  transaction?: <T>(run: (executor: SqliteAgentStateExecutor) => MaybePromise<T>) => MaybePromise<T>
+}
+
+export interface SqliteAgentStateOptions {
+  driver: SqliteAgentStateDriver
+  tablePrefix?: string
+}
+
+export interface LibsqlAgentStateClient {
+  close?: () => MaybePromise<void>
+  execute: (statement: string | { args?: unknown[], sql: string }) => MaybePromise<SqliteAgentStateResult>
+  transaction?: (mode?: "deferred" | "read" | "write") => MaybePromise<{
+    close?: () => MaybePromise<void>
+    commit: () => MaybePromise<void>
+    execute: (statement: string | { args?: unknown[], sql: string }) => MaybePromise<SqliteAgentStateResult>
+    rollback: () => MaybePromise<void>
+  }>
+}
+
+export interface LibsqlAgentStateOptions extends Omit<SqliteAgentStateOptions, "driver"> {
+  authToken?: string
+  client?: LibsqlAgentStateClient
+  url?: string
+}
+
+interface StateTables {
+  cache: string
+  lists: string
+  locks: string
+  queue: string
+  schemaVersion: string
+  subscriptions: string
+}
+
+function randomToken(): string {
+  return globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function tableName(prefix: string, name: string): string {
+  const candidate = `${prefix}${name}`
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(candidate)) {
+    throw new Error(`[vitehub] Invalid SQLite Agent State table name "${candidate}". Use an alphanumeric tablePrefix.`)
+  }
+  return candidate
+}
+
+function createTables(prefix = "vitehub_agent_state_"): StateTables {
+  return {
+    cache: tableName(prefix, "cache"),
+    lists: tableName(prefix, "lists"),
+    locks: tableName(prefix, "locks"),
+    queue: tableName(prefix, "queue"),
+    schemaVersion: tableName(prefix, "schema_version"),
+    subscriptions: tableName(prefix, "subscriptions"),
+  }
+}
+
+function rows(result: SqliteAgentStateResult | SqliteAgentStateRow[] | void): SqliteAgentStateRow[] {
+  if (Array.isArray(result)) return result
+  if (Array.isArray(result?.rows)) return result.rows
+  return []
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "bigint" ? Number(value) : Number(value || 0)
+}
+
+async function execute(executor: SqliteAgentStateExecutor, statement: string, args: unknown[] = []): Promise<SqliteAgentStateRow[]> {
+  return rows(await executor.execute(statement, args))
+}
+
+export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
+  private connected = false
+  private readonly driver: SqliteAgentStateDriver
+  private readonly tables: StateTables
+
+  constructor(options: SqliteAgentStateOptions) {
+    if (!options.driver) {
+      throw new Error("[vitehub] SQLite Agent State requires a driver.")
+    }
+    this.driver = options.driver
+    this.tables = createTables(options.tablePrefix)
+  }
+
+  async acquireLock(threadId: string, ttlMs: number): Promise<Lock | null> {
+    return await this.transaction(async (tx) => {
+      const now = Date.now()
+      await execute(tx, `DELETE FROM ${this.tables.locks} WHERE thread_id = ? AND expires_at <= ?`, [threadId, now])
+      const existing = await execute(tx, `SELECT 1 FROM ${this.tables.locks} WHERE thread_id = ? LIMIT 1`, [threadId])
+      if (existing.length > 0) return null
+
+      const token = randomToken()
+      const expiresAt = now + ttlMs
+      await execute(tx, `INSERT INTO ${this.tables.locks} (thread_id, token, expires_at) VALUES (?, ?, ?)`, [threadId, token, expiresAt])
+      return { expiresAt, threadId, token }
+    })
+  }
+
+  async appendToList(key: string, value: unknown, options?: { maxLength?: number, ttlMs?: number }): Promise<void> {
+    this.ensureConnected()
+    const expiresAt = options?.ttlMs ? Date.now() + options.ttlMs : null
+    await this.transaction(async (tx) => {
+      await execute(tx, `INSERT INTO ${this.tables.lists} (key, value, expires_at) VALUES (?, ?, ?)`, [key, JSON.stringify(value), expiresAt])
+      await execute(tx, `UPDATE ${this.tables.lists} SET expires_at = ? WHERE key = ?`, [expiresAt, key])
+      if (options?.maxLength != null && options.maxLength > 0) {
+        await execute(
+          tx,
+          `DELETE FROM ${this.tables.lists} WHERE key = ? AND id NOT IN (
+            SELECT id FROM ${this.tables.lists} WHERE key = ? ORDER BY id DESC LIMIT ?
+          )`,
+          [key, key, options.maxLength],
+        )
+      }
+    })
+  }
+
+  async cleanupExpiredState(): Promise<void> {
+    this.ensureConnected()
+    const now = Date.now()
+    await execute(this.driver, `DELETE FROM ${this.tables.locks} WHERE expires_at <= ?`, [now])
+    await execute(this.driver, `DELETE FROM ${this.tables.cache} WHERE expires_at IS NOT NULL AND expires_at <= ?`, [now])
+    await execute(this.driver, `DELETE FROM ${this.tables.queue} WHERE expires_at <= ?`, [now])
+    await execute(this.driver, `DELETE FROM ${this.tables.lists} WHERE expires_at IS NOT NULL AND expires_at <= ?`, [now])
+  }
+
+  async connect(): Promise<void> {
+    await this.driver.connect?.()
+    this.connected = true
+    try {
+      await this.migrate()
+    }
+    catch (error) {
+      this.connected = false
+      throw error
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    this.ensureConnected()
+    await execute(this.driver, `DELETE FROM ${this.tables.cache} WHERE key = ?`, [key])
+    await execute(this.driver, `DELETE FROM ${this.tables.lists} WHERE key = ?`, [key])
+  }
+
+  async dequeue(threadId: string): Promise<QueueEntry | null> {
+    return await this.transaction(async (tx) => {
+      const now = Date.now()
+      await execute(tx, `DELETE FROM ${this.tables.queue} WHERE thread_id = ? AND expires_at <= ?`, [threadId, now])
+      const queueRows = await execute(tx, `SELECT id, value FROM ${this.tables.queue} WHERE thread_id = ? ORDER BY id ASC LIMIT 1`, [threadId])
+      const row = queueRows[0]
+      if (!row) return null
+      await execute(tx, `DELETE FROM ${this.tables.queue} WHERE id = ?`, [row.id])
+      return typeof row.value === "string" ? JSON.parse(row.value) as QueueEntry : null
+    })
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false
+    await this.driver.disconnect?.()
+  }
+
+  async enqueue(threadId: string, entry: QueueEntry, maxSize: number): Promise<number> {
+    return await this.transaction(async (tx) => {
+      await execute(
+        tx,
+        `INSERT INTO ${this.tables.queue} (thread_id, value, enqueued_at, expires_at) VALUES (?, ?, ?, ?)`,
+        [threadId, JSON.stringify(entry), entry.enqueuedAt, entry.expiresAt],
+      )
+      await execute(
+        tx,
+        `DELETE FROM ${this.tables.queue} WHERE thread_id = ? AND id NOT IN (
+          SELECT id FROM ${this.tables.queue} WHERE thread_id = ? ORDER BY id DESC LIMIT ?
+        )`,
+        [threadId, threadId, maxSize],
+      )
+      const countRows = await execute(tx, `SELECT COUNT(*) as count FROM ${this.tables.queue} WHERE thread_id = ?`, [threadId])
+      return numberValue(countRows[0]?.count)
+    })
+  }
+
+  async extendLock(lock: Lock, ttlMs: number): Promise<boolean> {
+    return await this.transaction(async (tx) => {
+      const now = Date.now()
+      const updated = await execute(
+        tx,
+        `UPDATE ${this.tables.locks} SET expires_at = ?
+          WHERE thread_id = ? AND token = ? AND expires_at > ?
+          RETURNING thread_id`,
+        [now + ttlMs, lock.threadId, lock.token, now],
+      )
+      return updated.length > 0
+    })
+  }
+
+  async forceReleaseLock(threadId: string): Promise<void> {
+    this.ensureConnected()
+    await execute(this.driver, `DELETE FROM ${this.tables.locks} WHERE thread_id = ?`, [threadId])
+  }
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    this.ensureConnected()
+    const valueRows = await execute(
+      this.driver,
+      `SELECT value FROM ${this.tables.cache} WHERE key = ? AND (expires_at IS NULL OR expires_at > ?)`,
+      [key, Date.now()],
+    )
+    const value = valueRows[0]?.value
+    return typeof value === "string" ? JSON.parse(value) as T : null
+  }
+
+  async getList<T = unknown>(key: string): Promise<T[]> {
+    this.ensureConnected()
+    const now = Date.now()
+    await execute(this.driver, `DELETE FROM ${this.tables.lists} WHERE key = ? AND expires_at IS NOT NULL AND expires_at <= ?`, [key, now])
+    const valueRows = await execute(this.driver, `SELECT value FROM ${this.tables.lists} WHERE key = ? ORDER BY id ASC`, [key])
+    return valueRows.map(row => JSON.parse(String(row.value)) as T)
+  }
+
+  async isSubscribed(threadId: string): Promise<boolean> {
+    this.ensureConnected()
+    const subscriptions = await execute(this.driver, `SELECT 1 FROM ${this.tables.subscriptions} WHERE thread_id = ? LIMIT 1`, [threadId])
+    return subscriptions.length > 0
+  }
+
+  async queueDepth(threadId: string): Promise<number> {
+    this.ensureConnected()
+    const countRows = await execute(
+      this.driver,
+      `SELECT COUNT(*) as count FROM ${this.tables.queue} WHERE thread_id = ? AND expires_at > ?`,
+      [threadId, Date.now()],
+    )
+    return numberValue(countRows[0]?.count)
+  }
+
+  async releaseLock(lock: Lock): Promise<void> {
+    this.ensureConnected()
+    await execute(this.driver, `DELETE FROM ${this.tables.locks} WHERE thread_id = ? AND token = ?`, [lock.threadId, lock.token])
+  }
+
+  async set<T = unknown>(key: string, value: T, ttlMs?: number): Promise<void> {
+    this.ensureConnected()
+    const expiresAt = ttlMs ? Date.now() + ttlMs : null
+    await execute(this.driver, `INSERT OR REPLACE INTO ${this.tables.cache} (key, value, expires_at) VALUES (?, ?, ?)`, [key, JSON.stringify(value), expiresAt])
+  }
+
+  async setIfNotExists(key: string, value: unknown, ttlMs?: number): Promise<boolean> {
+    return await this.transaction(async (tx) => {
+      const now = Date.now()
+      const existing = await execute(
+        tx,
+        `SELECT 1 FROM ${this.tables.cache} WHERE key = ? AND (expires_at IS NULL OR expires_at > ?)`,
+        [key, now],
+      )
+      if (existing.length > 0) return false
+
+      await execute(tx, `DELETE FROM ${this.tables.cache} WHERE key = ? AND expires_at IS NOT NULL AND expires_at <= ?`, [key, now])
+      const expiresAt = ttlMs ? Date.now() + ttlMs : null
+      await execute(tx, `INSERT INTO ${this.tables.cache} (key, value, expires_at) VALUES (?, ?, ?)`, [key, JSON.stringify(value), expiresAt])
+      return true
+    })
+  }
+
+  async subscribe(threadId: string): Promise<void> {
+    this.ensureConnected()
+    await execute(this.driver, `INSERT OR IGNORE INTO ${this.tables.subscriptions} (thread_id) VALUES (?)`, [threadId])
+  }
+
+  async unsubscribe(threadId: string): Promise<void> {
+    this.ensureConnected()
+    await execute(this.driver, `DELETE FROM ${this.tables.subscriptions} WHERE thread_id = ?`, [threadId])
+  }
+
+  private ensureConnected(): void {
+    if (!this.connected) {
+      throw new Error("[vitehub] SQLite Agent State is not connected. Call connect() before using state.")
+    }
+  }
+
+  private async migrate(): Promise<void> {
+    await this.transaction(async (tx) => {
+      await execute(tx, `CREATE TABLE IF NOT EXISTS ${this.tables.schemaVersion} (version INTEGER PRIMARY KEY)`)
+      const versionRows = await execute(tx, `SELECT COALESCE(MAX(version), 0) as version FROM ${this.tables.schemaVersion}`)
+      const version = numberValue(versionRows[0]?.version)
+      if (version < 1) {
+        await execute(tx, `CREATE TABLE IF NOT EXISTS ${this.tables.subscriptions} (thread_id TEXT PRIMARY KEY)`)
+        await execute(tx, `CREATE TABLE IF NOT EXISTS ${this.tables.locks} (thread_id TEXT PRIMARY KEY, token TEXT NOT NULL, expires_at INTEGER NOT NULL)`)
+        await execute(tx, `CREATE TABLE IF NOT EXISTS ${this.tables.cache} (key TEXT PRIMARY KEY, value TEXT NOT NULL, expires_at INTEGER)`)
+        await execute(tx, `CREATE INDEX IF NOT EXISTS idx_${this.tables.locks}_expires ON ${this.tables.locks}(expires_at)`)
+        await execute(tx, `CREATE INDEX IF NOT EXISTS idx_${this.tables.cache}_expires ON ${this.tables.cache}(expires_at) WHERE expires_at IS NOT NULL`)
+        await execute(tx, `INSERT INTO ${this.tables.schemaVersion} (version) VALUES (1)`)
+      }
+      if (version < 2) {
+        await execute(tx, `CREATE TABLE IF NOT EXISTS ${this.tables.queue} (id INTEGER PRIMARY KEY AUTOINCREMENT, thread_id TEXT NOT NULL, value TEXT NOT NULL, enqueued_at INTEGER NOT NULL, expires_at INTEGER NOT NULL)`)
+        await execute(tx, `CREATE INDEX IF NOT EXISTS idx_${this.tables.queue}_thread ON ${this.tables.queue}(thread_id, id)`)
+        await execute(tx, `CREATE INDEX IF NOT EXISTS idx_${this.tables.queue}_expires ON ${this.tables.queue}(expires_at)`)
+        await execute(tx, `CREATE TABLE IF NOT EXISTS ${this.tables.lists} (id INTEGER PRIMARY KEY AUTOINCREMENT, key TEXT NOT NULL, value TEXT NOT NULL, expires_at INTEGER)`)
+        await execute(tx, `CREATE INDEX IF NOT EXISTS idx_${this.tables.lists}_key ON ${this.tables.lists}(key, id)`)
+        await execute(tx, `CREATE INDEX IF NOT EXISTS idx_${this.tables.lists}_expires ON ${this.tables.lists}(expires_at) WHERE expires_at IS NOT NULL`)
+        await execute(tx, `INSERT INTO ${this.tables.schemaVersion} (version) VALUES (2)`)
+      }
+    })
+  }
+
+  private async transaction<T>(run: (executor: SqliteAgentStateExecutor) => MaybePromise<T>): Promise<T> {
+    this.ensureConnected()
+    if (this.driver.transaction) {
+      return await this.driver.transaction(run)
+    }
+    await execute(this.driver, "BEGIN IMMEDIATE")
+    try {
+      const result = await run(this.driver)
+      await execute(this.driver, "COMMIT")
+      return result
+    }
+    catch (error) {
+      await execute(this.driver, "ROLLBACK").catch(() => undefined)
+      throw error
+    }
+  }
+}
+
+export function createSqliteAgentState(options: SqliteAgentStateOptions): StateAdapter {
+  return new ViteHubSqliteAgentStateAdapter(options)
+}
+
+function libsqlExecute(client: LibsqlAgentStateClient): SqliteAgentStateExecutor["execute"] {
+  return async (statement, args = []) => await client.execute({ args, sql: statement })
+}
+
+export function createLibsqlAgentState(options: LibsqlAgentStateOptions): StateAdapter {
+  if (!options.client && !options.url) {
+    throw new Error("[vitehub] libSQL Agent State requires `url` or `client`.")
+  }
+  const ownsClient = !options.client
+  let client: LibsqlAgentStateClient | undefined
+  const openClient = async () => {
+    if (options.client) return options.client
+    const { createClient } = await import("@libsql/client")
+    return createClient({ authToken: options.authToken, url: options.url! }) as LibsqlAgentStateClient
+  }
+
+  return createSqliteAgentState({
+    ...options,
+    driver: {
+      async connect() {
+        client ||= await openClient()
+      },
+      async disconnect() {
+        if (ownsClient) await client?.close?.()
+        client = undefined
+      },
+      async execute(statement, args) {
+        if (!client) throw new Error("[vitehub] libSQL Agent State is not connected.")
+        return await libsqlExecute(client)(statement, args)
+      },
+      async transaction(run) {
+        if (!client) throw new Error("[vitehub] libSQL Agent State is not connected.")
+        if (!client.transaction) {
+          return await run({ execute: libsqlExecute(client) })
+        }
+        const transaction = await client.transaction("write")
+        try {
+          const result = await run({ execute: libsqlExecute(transaction) })
+          await transaction.commit()
+          return result
+        }
+        catch (error) {
+          await Promise.resolve(transaction.rollback()).catch(() => undefined)
+          throw error
+        }
+        finally {
+          await transaction.close?.()
+        }
+      },
+    },
+  })
+}

--- a/packages/agent/src/state/sqlite.ts
+++ b/packages/agent/src/state/sqlite.ts
@@ -2,6 +2,8 @@ import type { Lock, QueueEntry, StateAdapter } from "chat"
 
 type MaybePromise<T> = T | Promise<T>
 
+const SQLITE_STATE_CLEANUP_INTERVAL_MS = 5 * 60 * 1000
+
 export type SqliteAgentStateRow = Record<string, unknown>
 
 export interface SqliteAgentStateResult {
@@ -89,6 +91,7 @@ async function execute(executor: SqliteAgentStateExecutor, statement: string, ar
 export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   private connected = false
   private readonly driver: SqliteAgentStateDriver
+  private nextCleanupAt = 0
   private readonly tables: StateTables
 
   constructor(options: SqliteAgentStateOptions) {
@@ -100,6 +103,7 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   }
 
   async acquireLock(threadId: string, ttlMs: number): Promise<Lock | null> {
+    await this.cleanupExpiredStateIfDue()
     return await this.transaction(async (tx) => {
       const now = Date.now()
       await execute(tx, `DELETE FROM ${this.tables.locks} WHERE thread_id = ? AND expires_at <= ?`, [threadId, now])
@@ -114,9 +118,11 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   }
 
   async appendToList(key: string, value: unknown, options?: { maxLength?: number, ttlMs?: number }): Promise<void> {
-    this.ensureConnected()
-    const expiresAt = options?.ttlMs ? Date.now() + options.ttlMs : null
+    await this.cleanupExpiredStateIfDue()
+    const now = Date.now()
+    const expiresAt = options?.ttlMs ? now + options.ttlMs : null
     await this.transaction(async (tx) => {
+      await execute(tx, `DELETE FROM ${this.tables.lists} WHERE key = ? AND expires_at IS NOT NULL AND expires_at <= ?`, [key, now])
       await execute(tx, `INSERT INTO ${this.tables.lists} (key, value, expires_at) VALUES (?, ?, ?)`, [key, JSON.stringify(value), expiresAt])
       await execute(tx, `UPDATE ${this.tables.lists} SET expires_at = ? WHERE key = ?`, [expiresAt, key])
       if (options?.maxLength != null && options.maxLength > 0) {
@@ -134,10 +140,8 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   async cleanupExpiredState(): Promise<void> {
     this.ensureConnected()
     const now = Date.now()
-    await execute(this.driver, `DELETE FROM ${this.tables.locks} WHERE expires_at <= ?`, [now])
-    await execute(this.driver, `DELETE FROM ${this.tables.cache} WHERE expires_at IS NOT NULL AND expires_at <= ?`, [now])
-    await execute(this.driver, `DELETE FROM ${this.tables.queue} WHERE expires_at <= ?`, [now])
-    await execute(this.driver, `DELETE FROM ${this.tables.lists} WHERE expires_at IS NOT NULL AND expires_at <= ?`, [now])
+    await this.deleteExpiredRows(now)
+    this.nextCleanupAt = now + SQLITE_STATE_CLEANUP_INTERVAL_MS
   }
 
   async connect(): Promise<void> {
@@ -150,15 +154,17 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
       this.connected = false
       throw error
     }
+    await this.cleanupExpiredState()
   }
 
   async delete(key: string): Promise<void> {
-    this.ensureConnected()
+    await this.cleanupExpiredStateIfDue()
     await execute(this.driver, `DELETE FROM ${this.tables.cache} WHERE key = ?`, [key])
     await execute(this.driver, `DELETE FROM ${this.tables.lists} WHERE key = ?`, [key])
   }
 
   async dequeue(threadId: string): Promise<QueueEntry | null> {
+    await this.cleanupExpiredStateIfDue()
     return await this.transaction(async (tx) => {
       const now = Date.now()
       await execute(tx, `DELETE FROM ${this.tables.queue} WHERE thread_id = ? AND expires_at <= ?`, [threadId, now])
@@ -176,6 +182,7 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   }
 
   async enqueue(threadId: string, entry: QueueEntry, maxSize: number): Promise<number> {
+    await this.cleanupExpiredStateIfDue()
     return await this.transaction(async (tx) => {
       await execute(
         tx,
@@ -195,6 +202,7 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   }
 
   async extendLock(lock: Lock, ttlMs: number): Promise<boolean> {
+    await this.cleanupExpiredStateIfDue()
     return await this.transaction(async (tx) => {
       const now = Date.now()
       const updated = await execute(
@@ -209,12 +217,12 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   }
 
   async forceReleaseLock(threadId: string): Promise<void> {
-    this.ensureConnected()
+    await this.cleanupExpiredStateIfDue()
     await execute(this.driver, `DELETE FROM ${this.tables.locks} WHERE thread_id = ?`, [threadId])
   }
 
   async get<T = unknown>(key: string): Promise<T | null> {
-    this.ensureConnected()
+    await this.cleanupExpiredStateIfDue()
     const valueRows = await execute(
       this.driver,
       `SELECT value FROM ${this.tables.cache} WHERE key = ? AND (expires_at IS NULL OR expires_at > ?)`,
@@ -225,7 +233,7 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   }
 
   async getList<T = unknown>(key: string): Promise<T[]> {
-    this.ensureConnected()
+    await this.cleanupExpiredStateIfDue()
     const now = Date.now()
     await execute(this.driver, `DELETE FROM ${this.tables.lists} WHERE key = ? AND expires_at IS NOT NULL AND expires_at <= ?`, [key, now])
     const valueRows = await execute(this.driver, `SELECT value FROM ${this.tables.lists} WHERE key = ? ORDER BY id ASC`, [key])
@@ -233,13 +241,13 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   }
 
   async isSubscribed(threadId: string): Promise<boolean> {
-    this.ensureConnected()
+    await this.cleanupExpiredStateIfDue()
     const subscriptions = await execute(this.driver, `SELECT 1 FROM ${this.tables.subscriptions} WHERE thread_id = ? LIMIT 1`, [threadId])
     return subscriptions.length > 0
   }
 
   async queueDepth(threadId: string): Promise<number> {
-    this.ensureConnected()
+    await this.cleanupExpiredStateIfDue()
     const countRows = await execute(
       this.driver,
       `SELECT COUNT(*) as count FROM ${this.tables.queue} WHERE thread_id = ? AND expires_at > ?`,
@@ -249,17 +257,18 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   }
 
   async releaseLock(lock: Lock): Promise<void> {
-    this.ensureConnected()
+    await this.cleanupExpiredStateIfDue()
     await execute(this.driver, `DELETE FROM ${this.tables.locks} WHERE thread_id = ? AND token = ?`, [lock.threadId, lock.token])
   }
 
   async set<T = unknown>(key: string, value: T, ttlMs?: number): Promise<void> {
-    this.ensureConnected()
+    await this.cleanupExpiredStateIfDue()
     const expiresAt = ttlMs ? Date.now() + ttlMs : null
     await execute(this.driver, `INSERT OR REPLACE INTO ${this.tables.cache} (key, value, expires_at) VALUES (?, ?, ?)`, [key, JSON.stringify(value), expiresAt])
   }
 
   async setIfNotExists(key: string, value: unknown, ttlMs?: number): Promise<boolean> {
+    await this.cleanupExpiredStateIfDue()
     return await this.transaction(async (tx) => {
       const now = Date.now()
       const existing = await execute(
@@ -277,12 +286,12 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   }
 
   async subscribe(threadId: string): Promise<void> {
-    this.ensureConnected()
+    await this.cleanupExpiredStateIfDue()
     await execute(this.driver, `INSERT OR IGNORE INTO ${this.tables.subscriptions} (thread_id) VALUES (?)`, [threadId])
   }
 
   async unsubscribe(threadId: string): Promise<void> {
-    this.ensureConnected()
+    await this.cleanupExpiredStateIfDue()
     await execute(this.driver, `DELETE FROM ${this.tables.subscriptions} WHERE thread_id = ?`, [threadId])
   }
 
@@ -290,6 +299,23 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
     if (!this.connected) {
       throw new Error("[vitehub] SQLite Agent State is not connected. Call connect() before using state.")
     }
+  }
+
+  private async cleanupExpiredStateIfDue(): Promise<void> {
+    this.ensureConnected()
+    const now = Date.now()
+    if (this.nextCleanupAt > now) {
+      return
+    }
+    await this.deleteExpiredRows(now)
+    this.nextCleanupAt = now + SQLITE_STATE_CLEANUP_INTERVAL_MS
+  }
+
+  private async deleteExpiredRows(now: number): Promise<void> {
+    await execute(this.driver, `DELETE FROM ${this.tables.locks} WHERE expires_at <= ?`, [now])
+    await execute(this.driver, `DELETE FROM ${this.tables.cache} WHERE expires_at IS NOT NULL AND expires_at <= ?`, [now])
+    await execute(this.driver, `DELETE FROM ${this.tables.queue} WHERE expires_at <= ?`, [now])
+    await execute(this.driver, `DELETE FROM ${this.tables.lists} WHERE expires_at IS NOT NULL AND expires_at <= ?`, [now])
   }
 
   private async migrate(): Promise<void> {

--- a/packages/agent/src/state/sqlite.ts
+++ b/packages/agent/src/state/sqlite.ts
@@ -149,12 +149,12 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
     this.connected = true
     try {
       await this.migrate()
+      await this.cleanupExpiredState()
     }
     catch (error) {
       this.connected = false
       throw error
     }
-    await this.cleanupExpiredState()
   }
 
   async delete(key: string): Promise<void> {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -112,13 +112,6 @@ export interface AgentWebhookRegistrationDefinition {
 export type AgentChatWebhookRegistrationDefinition =
   Omit<AgentWebhookRegistrationDefinition, "provider"> & { provider?: string }
 
-export interface AgentChatAppOptions<TOrigin extends string = string> {
-  origin?: TOrigin
-  route?: never
-}
-
-export type AgentChatAppExposure<TOrigin extends string = string> = boolean | TOrigin | AgentChatAppOptions<TOrigin>
-
 export interface AgentTriggerContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
@@ -628,7 +621,6 @@ export type AgentChatStateResolver<TRuntimeConfig extends AgentRuntimeConfig = A
 export interface AgentChatOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   adapters?: AgentChatAdaptersResolver<TRuntimeConfig>
   agent?: never
-  app?: AgentChatAppExposure
   event?: AgentChatAgentBindingOptions["event"]
   execution?: never
   fallbackStreamingPlaceholderText?: string | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -462,8 +462,14 @@ export type AgentRegistry<TContext extends AgentRuntimeContext<any> = AgentRunti
   Record<string, () => MaybePromise<AgentRegistryModule<TContext>>>
 
 export interface AgentStateProviderOptions {
-  provider?: "auto" | "cloudflare" | "cloudflare-agents" | "memory" | (string & {})
+  authToken?: string
+  provider?: "auto" | "cloudflare" | "cloudflare-agents" | "libsql" | "memory" | "sqlite" | (string & {})
+  tablePrefix?: string
+  url?: string
 }
+
+export type ResolvedAgentStateProviderOptions =
+  Omit<AgentStateProviderOptions, "provider"> & { provider: NonNullable<AgentStateProviderOptions["provider"]> }
 
 export interface AgentSchedulerProviderOptions {
   provider?: "auto" | "cloudflare-agents" | "memory" | (string & {})
@@ -519,7 +525,7 @@ export interface ResolvedAgentModuleOptions {
   providers: {
     sandbox: Required<AgentSandboxProviderOptions>
     scheduler: Required<AgentSchedulerProviderOptions>
-    state: Required<AgentStateProviderOptions>
+    state: ResolvedAgentStateProviderOptions
   }
   route: false | string
   runtime: AgentRuntime

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import type { AgentRuntimeContext, AgentToolSet } from "../src/types.ts"
 import type { ReadonlyWorkspaceFacade, WorkspaceEntry, WorkspaceSearchHit, WorkspaceStat } from "@vite-hub/workspace"
@@ -137,6 +137,88 @@ describe("access capability", () => {
 
     await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(false)
     await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(true)
+  })
+
+  it("shares an Invocation Profile across access and audience capabilities", async () => {
+    const { defineInvocationProfile } = await import("../src/index.ts")
+    const { applyCapabilityInstructionSlots, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access, audience } = await import("../src/capabilities.ts")
+
+    const profileResolver = vi.fn(({ input }) => {
+      const chat = input.get().context?.chat
+      const email = chat?.user?.email?.toLowerCase()
+      if (email === "maximo@quiver.dk") return { kind: "quiverTechnical" as const }
+      const customer = chat?.message?.metadata?.quiver?.customer
+      if (customer) return { customer, kind: "customerPortal" as const }
+      throw new Error("missing profile")
+    })
+    const supportProfile = defineInvocationProfile({
+      id: "quiver-support",
+      input: {
+        chat: {
+          message: {
+            metadata: {
+              "~standard": {
+                validate(input: unknown) {
+                  const metadata = typeof input === "object" && input !== null ? input as { quiver?: { customer?: string } } : {}
+                  return { value: metadata }
+                },
+              },
+            },
+          },
+          user: {
+            "~standard": {
+              validate(input: unknown) {
+                const user = typeof input === "object" && input !== null ? input as { email?: string } : {}
+                return { value: user }
+              },
+            },
+          },
+        },
+      },
+      resolve: profileResolver,
+    })
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          profile: supportProfile,
+          workspace: {
+            resolve({ profile }) {
+              if (profile.kind === "quiverTechnical") return { role: "admin", scope: "quiver" }
+              return { role: "viewer", scope: profile.customer }
+            },
+            scopes: {
+              acme: { paths: ["customers/acme"] },
+              quiver: { all: true },
+            },
+          },
+        }),
+        audience({
+          profile: supportProfile,
+          instructions({ profile }) {
+            return profile.kind === "quiverTechnical"
+              ? "Prefer implementation details."
+              : "Prefer product-level support answers."
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, {
+      context: {
+        chat: {
+          message: {
+            metadata: { quiver: { customer: "acme" } },
+          },
+          user: { email: "customer@example.com" },
+        },
+      },
+      prompt: "check",
+    }, createWorkspace())
+
+    expect(profileResolver).toHaveBeenCalledOnce()
+    await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(true)
+    await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(false)
+    expect(applyCapabilityInstructionSlots("{{ audience }}", resolved.capabilityInstructions)).toBe("Prefer product-level support answers.")
   })
 
   it("can resolve an inline Workspace Scope definition", async () => {

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -412,12 +412,12 @@ describe("access capability", () => {
 
   it("gates Chat App Route metadata schemas by chat run origin", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
-    const { access, chat } = await import("../src/capabilities.ts")
+    const { access, chat, entry } = await import("../src/capabilities.ts")
 
     const supportChat = chat({
       adapters: { teams: {} as never },
-      app: "portal",
     })
+    const portalEntry = entry({ id: "portal", chat: { capability: supportChat, origin: "portal" } })
     const metadataSchema = {
       "~standard": {
         validate(input: unknown) {
@@ -434,7 +434,7 @@ describe("access capability", () => {
         access({
           input: {
             chat: {
-              capability: supportChat,
+              capability: portalEntry,
               message: { metadata: metadataSchema },
             },
           },
@@ -453,6 +453,7 @@ describe("access capability", () => {
           },
         }),
         supportChat,
+        portalEntry,
       ],
     }, { ...runtime(), runtimeConfig: {} }, {
       context: {
@@ -473,7 +474,7 @@ describe("access capability", () => {
         access({
           input: {
             chat: {
-              capability: supportChat,
+              capability: portalEntry,
               message: { metadata: metadataSchema },
             },
           },
@@ -485,6 +486,7 @@ describe("access capability", () => {
           },
         }),
         supportChat,
+        portalEntry,
       ],
     }, { ...runtime(), runtimeConfig: {} }, {
       context: {

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -297,6 +297,7 @@ describe("access capability", () => {
   })
 
   it("validates chat input schemas before resolving Workspace Scope", async () => {
+    const { defineInvocationProfile } = await import("../src/index.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
 
@@ -309,17 +310,22 @@ describe("access capability", () => {
         },
       },
     }
+    const supportProfile = defineInvocationProfile({
+      id: "metadata-customer",
+      input: {
+        chat: {
+          message: { metadata: metadataSchema },
+        },
+      },
+      resolve: ({ input }) => input.get().context?.chat?.message?.metadata?.quiver?.customer,
+    })
 
     const resolved = await resolveAgentCapabilities({
       capabilities: [
         access({
-          input: {
-            chat: {
-              message: { metadata: metadataSchema },
-            },
-          },
+          profile: supportProfile,
           workspace: {
-            resolve: ({ input }) => input.get().context?.chat?.message?.metadata?.quiver?.customer,
+            resolve: ({ profile }) => profile,
             scopes: {
               acme: { paths: ["customers/acme"] },
             },
@@ -350,23 +356,29 @@ describe("access capability", () => {
   })
 
   it("fails closed when chat input schema validation fails", async () => {
+    const { defineInvocationProfile } = await import("../src/index.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
+    const supportProfile = defineInvocationProfile({
+      id: "metadata-fails",
+      input: {
+        chat: {
+          message: {
+            metadata: {
+              "~standard": {
+                validate: () => ({ issues: ["missing customer"] }),
+              },
+            },
+          },
+        },
+      },
+      resolve: () => "acme",
+    })
 
     await expect(resolveAgentCapabilities({
       capabilities: [
         access({
-          input: {
-            chat: {
-              message: {
-                metadata: {
-                  "~standard": {
-                    validate: () => ({ issues: ["missing customer"] }),
-                  },
-                },
-              },
-            },
-          },
+          profile: supportProfile,
           workspace: {
             defaultScope: "acme",
             scopes: {
@@ -388,6 +400,7 @@ describe("access capability", () => {
   })
 
   it("fails closed when configured chat input schema fields are missing", async () => {
+    const { defineInvocationProfile } = await import("../src/index.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
 
@@ -400,16 +413,21 @@ describe("access capability", () => {
         },
       },
     })
+    const supportProfile = defineInvocationProfile({
+      id: "metadata-and-user-required",
+      input: {
+        chat: {
+          message: { metadata: requiredObjectSchema("metadata") },
+          user: requiredObjectSchema("user"),
+        },
+      },
+      resolve: () => "acme",
+    })
 
     await expect(resolveAgentCapabilities({
       capabilities: [
         access({
-          input: {
-            chat: {
-              message: { metadata: requiredObjectSchema("metadata") },
-              user: requiredObjectSchema("user"),
-            },
-          },
+          profile: supportProfile,
           workspace: {
             defaultScope: "acme",
             scopes: {
@@ -432,12 +450,7 @@ describe("access capability", () => {
     await expect(resolveAgentCapabilities({
       capabilities: [
         access({
-          input: {
-            chat: {
-              message: { metadata: requiredObjectSchema("metadata") },
-              user: requiredObjectSchema("user"),
-            },
-          },
+          profile: supportProfile,
           workspace: {
             defaultScope: "acme",
             scopes: {
@@ -460,27 +473,33 @@ describe("access capability", () => {
   })
 
   it("fails closed when configured chat input schemas receive no chat context", async () => {
+    const { defineInvocationProfile } = await import("../src/index.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
-
-    await expect(resolveAgentCapabilities({
-      capabilities: [
-        access({
-          input: {
-            chat: {
-              message: {
-                metadata: {
-                  "~standard": {
-                    validate(input: unknown) {
-                      return typeof input === "object" && input !== null
-                        ? { value: input as Record<string, unknown> }
-                        : { issues: ["missing metadata"] }
-                    },
-                  },
+    const supportProfile = defineInvocationProfile({
+      id: "metadata-required",
+      input: {
+        chat: {
+          message: {
+            metadata: {
+              "~standard": {
+                validate(input: unknown) {
+                  return typeof input === "object" && input !== null
+                    ? { value: input as Record<string, unknown> }
+                    : { issues: ["missing metadata"] }
                 },
               },
             },
           },
+        },
+      },
+      resolve: () => "acme",
+    })
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          profile: supportProfile,
           workspace: {
             defaultScope: "acme",
             scopes: {
@@ -492,14 +511,10 @@ describe("access capability", () => {
     }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace())).rejects.toThrow("Invalid chat.message.metadata")
   })
 
-  it("gates Chat App Route metadata schemas by chat run origin", async () => {
+  it("gates profile metadata schemas by explicit chat run origin", async () => {
+    const { defineInvocationProfile } = await import("../src/index.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
-    const { access, chat, entry } = await import("../src/capabilities.ts")
-
-    const supportChat = chat({
-      adapters: { teams: {} as never },
-    })
-    const portalEntry = entry({ id: "portal", chat: { capability: supportChat, origin: "portal" } })
+    const { access } = await import("../src/capabilities.ts")
     const metadataSchema = {
       "~standard": {
         validate(input: unknown) {
@@ -510,32 +525,43 @@ describe("access capability", () => {
         },
       },
     }
+    const supportProfile = defineInvocationProfile({
+      id: "support-origin",
+      input: {
+        chat: {
+          message: { metadata: metadataSchema, runOrigin: ["portal"] },
+          run: { origin: ["portal", "teams"] },
+        },
+      },
+      resolve({ input }) {
+        const chat = input.get().context?.chat
+        if (chat?.run?.origin !== "portal") {
+          return { kind: "internal" as const }
+        }
+        const metadata = chat.message?.metadata as { quiver: { customer: string } }
+        return {
+          customer: metadata.quiver.customer,
+          kind: "portal" as const,
+        }
+      },
+    })
 
     const resolved = await resolveAgentCapabilities({
       capabilities: [
         access({
-          input: {
-            chat: {
-              capability: portalEntry,
-              message: { metadata: metadataSchema },
-            },
-          },
+          profile: supportProfile,
           workspace: {
-            resolve({ input }) {
-              const chat = input.get().context?.chat
-              if (chat?.run?.origin !== "portal") {
+            resolve({ profile }) {
+              if (profile.kind !== "portal") {
                 return { all: true, role: "admin", scope: "support" }
               }
-              const metadata = chat.message?.metadata as { quiver?: { customer?: string } } | undefined
-              return metadata?.quiver?.customer
+              return profile.customer
             },
             scopes: {
               acme: { paths: ["customers/acme"] },
             },
           },
         }),
-        supportChat,
-        portalEntry,
       ],
     }, { ...runtime(), runtimeConfig: {} }, {
       context: {
@@ -554,12 +580,7 @@ describe("access capability", () => {
     await expect(resolveAgentCapabilities({
       capabilities: [
         access({
-          input: {
-            chat: {
-              capability: portalEntry,
-              message: { metadata: metadataSchema },
-            },
-          },
+          profile: supportProfile,
           workspace: {
             defaultScope: "acme",
             scopes: {
@@ -567,8 +588,6 @@ describe("access capability", () => {
             },
           },
         }),
-        supportChat,
-        portalEntry,
       ],
     }, { ...runtime(), runtimeConfig: {} }, {
       context: {
@@ -584,17 +603,23 @@ describe("access capability", () => {
   })
 
   it("fails closed when configured chat run origins do not match", async () => {
+    const { defineInvocationProfile } = await import("../src/index.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
+    const supportProfile = defineInvocationProfile({
+      id: "origin-required",
+      input: {
+        chat: {
+          run: { origin: ["portal", "teams"] },
+        },
+      },
+      resolve: () => "acme",
+    })
 
     await expect(resolveAgentCapabilities({
       capabilities: [
         access({
-          input: {
-            chat: {
-              run: { origin: ["portal", "teams"] },
-            },
-          },
+          profile: supportProfile,
           workspace: {
             defaultScope: "acme",
             scopes: {

--- a/packages/agent/test/config.test.ts
+++ b/packages/agent/test/config.test.ts
@@ -24,12 +24,12 @@ describe("agent config", () => {
   it("preserves route opt out and provider options", () => {
     expect(normalizeAgentOptions({
       integrations: { sandbox: false },
-      providers: { state: { provider: "cloudflare-agents" } },
+      providers: { state: { provider: "sqlite", tablePrefix: "agent_state_", url: "file:agent-state.sqlite" } },
       route: false,
       runtime: "cloudflare-agents",
     })).toMatchObject({
       integrations: { sandbox: false, workflow: "auto" },
-      providers: { state: { provider: "cloudflare-agents" } },
+      providers: { state: { provider: "sqlite", tablePrefix: "agent_state_", url: "file:agent-state.sqlite" } },
       route: false,
       runtime: "cloudflare-agents",
     })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -120,6 +120,7 @@ describe("agent Nitro runtime files", () => {
     await expect(readFile(routeFile, "utf8")).resolves.toContain("./nitro-registry.ts")
     expect((nitro.options.alias as Record<string, string>)["@vite-hub/agent/capabilities"]).toContain("/packages/agent/src/capabilities.ts")
     expect((nitro.options.alias as Record<string, string>)["@vite-hub/agent/eval"]).toContain("/packages/agent/src/eval.ts")
+    expect((nitro.options.alias as Record<string, string>)["@vite-hub/agent/state/sqlite"]).toContain("/packages/agent/src/state/sqlite.ts")
     expect(hooks.map(hook => hook.name)).toEqual(["build:before", "dev:reload", "compiled"])
   })
 })

--- a/packages/agent/test/nitro-chat-handler.test.ts
+++ b/packages/agent/test/nitro-chat-handler.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { createApp, toWebHandler } from "h3"
 import { describe, expect, it, vi } from "vitest"
 
-import { chat } from "../src/capabilities.ts"
+import { chat, entry } from "../src/capabilities.ts"
 
 import type { UIMessage } from "ai"
 
@@ -33,7 +33,7 @@ describe("agent Nitro chat routes", () => {
     const { defineAgentChatHandler } = await import("../src/nitro.ts")
     const seen: Array<{ chat: unknown, messages: string[], run: unknown }> = []
     const agent = defineAgent({
-      capabilities: [chat({ app: true, sessions: true })],
+      capabilities: [chat({ sessions: true }), entry({ id: "app", chat: true })],
       run(context) {
         seen.push({
           chat: context.input.context?.chat,
@@ -91,7 +91,7 @@ describe("agent Nitro chat routes", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineAgentChatRegistryHandler } = await import("../src/nitro.ts")
     const agent = defineAgent({
-      capabilities: [chat({ app: true })],
+      capabilities: [chat(), entry({ id: "app", chat: true })],
       run: () => "registry answer",
     })
     const app = createApp()
@@ -117,7 +117,7 @@ describe("agent Nitro chat routes", () => {
     const { defineAgentChatHandler } = await import("../src/nitro.ts")
     const app = createApp()
     app.use(defineAgentChatHandler(defineAgent({
-      capabilities: [chat({ app: true })],
+      capabilities: [chat(), entry({ id: "app", chat: true })],
       run: () => "agent answer",
     })))
     const response = await toWebHandler(app)(new Request("https://example.test/api/_vitehub/agents/support/chat", {
@@ -157,9 +157,9 @@ describe("agent Nitro chat routes", () => {
     await mkdir(join(root, "server", "agents"), { recursive: true })
     await writeFile(join(root, "server", "agents", "support.ts"), [
       "import { defineAgent } from '@vite-hub/agent'",
-      "import { chat } from '@vite-hub/agent/capabilities'",
+      "import { chat, entry } from '@vite-hub/agent/capabilities'",
       "export default defineAgent({",
-      "  capabilities: [chat({ app: true })],",
+      "  capabilities: [chat(), entry({ id: 'app', chat: true })],",
       "  run: () => 'ok',",
       "})",
     ].join("\n"), "utf8")
@@ -207,9 +207,9 @@ describe("agent Nitro chat routes", () => {
     await mkdir(join(root, "server", "agents"), { recursive: true })
     await writeFile(join(root, "server", "agents", "support.ts"), [
       "import { defineAgent } from '@vite-hub/agent'",
-      "import { chat } from '@vite-hub/agent/capabilities'",
+      "import { chat, entry } from '@vite-hub/agent/capabilities'",
       "export default defineAgent({",
-      "  capabilities: [chat({ app: { route: '/api/support-chat' } })],",
+      "  capabilities: [chat(), entry({ id: 'app', chat: { route: '/api/support-chat' } })],",
       "  run: () => 'ok',",
       "})",
     ].join("\n"), "utf8")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { createMessage } from "@vite-hub/agent"
+import { createMessage, getMessageText } from "@vite-hub/agent"
 import { chat, chatTitle, schedule } from "../src/capabilities.ts"
 
 describe("agent message protocol", () => {
@@ -251,6 +251,28 @@ describe("agent message protocol", () => {
         run: { runId: "trigger-run" },
       }),
     }))
+  })
+
+  it("creates custom trigger capabilities with entry()", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { entry } = await import("../src/capabilities.ts")
+    const agent = defineAgent({
+      capabilities: [entry({
+        id: "portal",
+        triggers: {
+          message: {
+            invoke: (_context, input: { text: string }) => ({
+              input: { messages: [createMessage({ role: "user", text: input.text })] },
+              run: { origin: "portal", runId: "portal-run" },
+            }),
+          },
+        },
+      })],
+      run: context => `received ${getMessageText(context.messages[0]!)}`,
+    })
+    const runtime = { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }
+
+    await expect(runAgentTrigger(agent, runtime, "portal.message", { text: "hello" })).resolves.toBe("received hello")
   })
 
   it("exposes chat webhook registration metadata through agent triggers", async () => {

--- a/packages/agent/test/sqlite-state-provider.test.ts
+++ b/packages/agent/test/sqlite-state-provider.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
+import { createClient } from "@libsql/client"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createLibsqlAgentState, createSqliteAgentState, ViteHubSqliteAgentStateAdapter } from "../src/state/sqlite.ts"
@@ -100,6 +101,42 @@ describe("SQLite Agent State Provider", () => {
     vi.setSystemTime(new Date("2026-06-02T10:00:00.200Z"))
 
     await expect(state.getList("history")).resolves.toEqual(["one", "two"])
+    await state.disconnect()
+  })
+
+  it("does not restore expired list entries when appending", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-02T10:00:00.000Z"))
+    const { state } = await createState()
+    await state.connect()
+
+    await state.appendToList("history", "expired", { ttlMs: 100 })
+    vi.setSystemTime(new Date("2026-06-02T10:00:00.200Z"))
+    await state.appendToList("history", "fresh")
+
+    await expect(state.getList("history")).resolves.toEqual(["fresh"])
+    await state.disconnect()
+  })
+
+  it("periodically removes expired durable rows", async () => {
+    const tablePrefix = "cleanup_agent_state_"
+    const { state, url } = await createState(tablePrefix)
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-02T10:00:00.000Z"))
+    await state.connect()
+
+    await state.set("expired-cache", "old", 100)
+    await state.appendToList("expired-list", "old", { ttlMs: 100 })
+    vi.setSystemTime(new Date("2026-06-02T10:06:00.000Z"))
+    await state.set("fresh-cache", "new")
+
+    const client = createClient({ url })
+    const cacheRows = await client.execute(`SELECT key FROM ${tablePrefix}cache ORDER BY key`)
+    const listRows = await client.execute(`SELECT key FROM ${tablePrefix}lists ORDER BY key`)
+    client.close()
+
+    expect(cacheRows.rows.map(row => row.key)).toEqual(["fresh-cache"])
+    expect(listRows.rows).toEqual([])
     await state.disconnect()
   })
 

--- a/packages/agent/test/sqlite-state-provider.test.ts
+++ b/packages/agent/test/sqlite-state-provider.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { createLibsqlAgentState, createSqliteAgentState, ViteHubSqliteAgentStateAdapter } from "../src/state/sqlite.ts"
+
+import type { QueueEntry, StateAdapter } from "chat"
+
+const tempDirs: string[] = []
+
+async function createState(tablePrefix = "test_agent_state_"): Promise<{ state: StateAdapter, url: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "vitehub-agent-state-"))
+  tempDirs.push(dir)
+  const url = `file:${join(dir, "state.db")}`
+  return {
+    state: createLibsqlAgentState({ tablePrefix, url }),
+    url,
+  }
+}
+
+function queueEntry(text = "hello"): QueueEntry {
+  return {
+    enqueuedAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+    message: { author: { fullName: "User", isBot: false, isMe: false, userId: "u", userName: "user" }, formatted: { children: [], type: "root" }, id: "m", raw: {}, text, threadId: "thread" } as never,
+  }
+}
+
+describe("SQLite Agent State Provider", () => {
+  afterEach(async () => {
+    vi.useRealTimers()
+    await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
+  })
+
+  it("persists Chat SDK state in a libSQL-compatible SQLite database", async () => {
+    const { state, url } = await createState()
+    await state.connect()
+
+    expect(await state.setIfNotExists("seen", { id: 1 })).toBe(true)
+    expect(await state.setIfNotExists("seen", { id: 2 })).toBe(false)
+    await expect(state.get("seen")).resolves.toEqual({ id: 1 })
+
+    await state.appendToList("history", "one")
+    await state.appendToList("history", "two", { maxLength: 1 })
+    await expect(state.getList("history")).resolves.toEqual(["two"])
+    await state.delete("history")
+    await expect(state.getList("history")).resolves.toEqual([])
+
+    await expect(state.enqueue("thread", queueEntry("one"), 10)).resolves.toBe(1)
+    await expect(state.enqueue("thread", queueEntry("two"), 1)).resolves.toBe(1)
+    await expect(state.queueDepth("thread")).resolves.toBe(1)
+    await expect(state.dequeue("thread")).resolves.toMatchObject({ message: { text: "two" } })
+
+    await state.subscribe("thread")
+    await expect(state.isSubscribed("thread")).resolves.toBe(true)
+    await state.unsubscribe("thread")
+    await expect(state.isSubscribed("thread")).resolves.toBe(false)
+
+    const lock = await state.acquireLock("thread", 30_000)
+    expect(lock).toMatchObject({ threadId: "thread" })
+    await expect(state.acquireLock("thread", 30_000)).resolves.toBeNull()
+    await expect(state.extendLock(lock!, 30_000)).resolves.toBe(true)
+    await state.releaseLock(lock!)
+    await expect(state.acquireLock("thread", 30_000)).resolves.toMatchObject({ threadId: "thread" })
+    await state.disconnect()
+
+    const restored = createLibsqlAgentState({ tablePrefix: "test_agent_state_", url })
+    await restored.connect()
+    await expect(restored.get("seen")).resolves.toEqual({ id: 1 })
+    await restored.disconnect()
+  })
+
+  it("requires connect before using the state adapter", async () => {
+    const { state } = await createState()
+    await expect(state.get("seen")).rejects.toThrow("not connected")
+  })
+
+  it("can reconnect an owned libSQL client after disconnect", async () => {
+    const { state } = await createState()
+    await state.connect()
+    await state.set("seen", "yes")
+    await state.disconnect()
+
+    await state.connect()
+    await expect(state.get("seen")).resolves.toBe("yes")
+    await state.disconnect()
+  })
+
+  it("clears list expiry when appending without ttlMs", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-06-02T10:00:00.000Z"))
+    const { state } = await createState()
+    await state.connect()
+
+    await state.appendToList("history", "one", { ttlMs: 100 })
+    vi.setSystemTime(new Date("2026-06-02T10:00:00.050Z"))
+    await state.appendToList("history", "two")
+    vi.setSystemTime(new Date("2026-06-02T10:00:00.200Z"))
+
+    await expect(state.getList("history")).resolves.toEqual(["one", "two"])
+    await state.disconnect()
+  })
+
+  it("validates generated table names before opening the database", () => {
+    expect(() => createSqliteAgentState({
+      driver: { execute: async () => ({ rows: [] }) },
+      tablePrefix: "bad-prefix-",
+    })).toThrow("Invalid SQLite Agent State table name")
+  })
+
+  it("supports injected SQLite-compatible drivers", async () => {
+    const executed: string[] = []
+    const adapter = new ViteHubSqliteAgentStateAdapter({
+      driver: {
+        async execute(statement) {
+          executed.push(statement)
+          if (statement.includes("COALESCE(MAX(version)")) return { rows: [{ version: 2 }] }
+          return { rows: [] }
+        },
+        async transaction(run) {
+          return await run(this)
+        },
+      },
+    })
+
+    await adapter.connect()
+    expect(executed.some(statement => statement.includes("CREATE TABLE IF NOT EXISTS"))).toBe(true)
+  })
+})

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, type AgentRuntimeContext } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, entry, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, transcribe, webSearch, workspaceShell } from "../src/capabilities.ts"
+import { defineAgent, defineInvocationProfile, type AgentRuntimeContext } from "../src/index.ts"
+import { access, audience, blob, chat, chatTitle, db, entry, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, transcribe, webSearch, workspaceShell } from "../src/capabilities.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
@@ -413,6 +413,78 @@ describe("agent public types", () => {
             scopes: {
               customer: { source: "missing" },
             },
+          },
+        }),
+      ],
+      model: {} as never,
+      workspace: {
+        sources: {
+          docs: source.file("AGENTS.md"),
+        },
+      },
+    })
+  })
+
+  it("types Invocation Profile consumers in access and audience capabilities", () => {
+    interface SupportMessageMetadata {
+      quiver?: {
+        customer?: "acme"
+      }
+    }
+    interface SupportChatUser {
+      email?: string
+    }
+    type SupportProfile =
+      | { kind: "quiverTechnical" }
+      | { customer: "acme", kind: "customerPortal" }
+
+    const metadataSchema = {
+      "~standard": {
+        validate: (input: unknown) => ({ value: input as SupportMessageMetadata }),
+      },
+    } satisfies AccessCapabilityStandardSchemaV1<SupportMessageMetadata>
+    const userSchema = {
+      "~standard": {
+        validate: (input: unknown) => ({ value: input as SupportChatUser }),
+      },
+    } satisfies AccessCapabilityStandardSchemaV1<SupportChatUser>
+    const supportProfile = defineInvocationProfile({
+      id: "quiver-support",
+      input: {
+        chat: {
+          message: { metadata: metadataSchema },
+          user: userSchema,
+        },
+      },
+      resolve({ input }) {
+        expectTypeOf(input.get().context?.chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<"acme" | undefined>()
+        expectTypeOf(input.get().context?.chat?.user?.email).toEqualTypeOf<string | undefined>()
+        return { kind: "quiverTechnical" } as SupportProfile
+      },
+    })
+
+    defineAgent({
+      capabilities: [
+        access({
+          profile: supportProfile,
+          workspace: {
+            resolve({ profile }) {
+              if (profile.kind === "quiverTechnical") return { role: "admin", scope: "quiver" }
+              expectTypeOf(profile.customer).toEqualTypeOf<"acme">()
+              return { role: "viewer", scope: profile.customer }
+            },
+            scopes: {
+              acme: { source: "docs" },
+              quiver: { all: true },
+            },
+          },
+        }),
+        audience({
+          profile: supportProfile,
+          instructions({ profile }) {
+            if (profile.kind === "quiverTechnical") return "technical"
+            expectTypeOf(profile.customer).toEqualTypeOf<"acme">()
+            return "customer"
           },
         }),
       ],

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineInvocationProfile, type AgentRuntimeContext } from "../src/index.ts"
+import { defineAgent, defineInvocationProfile, type AgentInvocationProfileStandardSchemaV1, type AgentRuntimeContext } from "../src/index.ts"
 import { access, audience, blob, chat, chatTitle, db, entry, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, transcribe, webSearch, workspaceShell } from "../src/capabilities.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -8,7 +8,7 @@ import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import type { AgentInvocationContextStore, AgentUsageRecord } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
 import { source } from "@vite-hub/workspace"
-import type { AccessCapabilityStandardSchemaV1, AccessWorkspaceOptionsFor, AgentChatAdapterResolver, AgentChatRunContext, FetchCapabilityToolOptions, TranscriptionResult } from "../src/capabilities.ts"
+import type { AccessWorkspaceOptionsFor, AgentChatAdapterResolver, AgentChatRunContext, FetchCapabilityToolOptions, TranscriptionResult } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
   it("accepts capabilities from the capabilities entry", () => {
@@ -331,7 +331,7 @@ describe("agent public types", () => {
     expectTypeOf(invalidInlineAccess).toMatchTypeOf<AccessWorkspaceOptionsFor<typeof workspace>>()
   })
 
-  it("types inline access source grants and chat input schemas from defineAgent", () => {
+  it("types profile source grants and chat input schemas from defineAgent", () => {
     interface SupportMessageMetadata {
       quiver?: {
         customer?: string
@@ -344,12 +344,12 @@ describe("agent public types", () => {
       "~standard": {
         validate: (input: unknown) => ({ value: input as SupportMessageMetadata }),
       },
-    } satisfies AccessCapabilityStandardSchemaV1<SupportMessageMetadata>
+    } satisfies AgentInvocationProfileStandardSchemaV1<SupportMessageMetadata>
     const userSchema = {
       "~standard": {
         validate: (input: unknown) => ({ value: input as SupportChatUser }),
       },
-    } satisfies AccessCapabilityStandardSchemaV1<SupportChatUser>
+    } satisfies AgentInvocationProfileStandardSchemaV1<SupportChatUser>
     const teamsAdapter = {} as AgentChatAdapterResolver
     const supportChat = chat({
       adapters: () => ({ teams: teamsAdapter }),
@@ -364,24 +364,32 @@ describe("agent public types", () => {
       },
     })
     const portalEntry = entry({ id: "portal", chat: { capability: supportChat, origin: "portal" } })
+    const supportProfile = defineInvocationProfile({
+      id: "support",
+      input: {
+        chat: {
+          message: { metadata: metadataSchema, runOrigin: ["portal"] },
+          run: { origin: ["portal", "teams"] },
+          user: userSchema,
+        },
+      },
+      resolve({ input }) {
+        const chat = input.get().context?.chat
+        expectTypeOf(chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<string | undefined>()
+        expectTypeOf(chat?.run?.origin).toEqualTypeOf<"portal" | "teams" | undefined>()
+        expectTypeOf(chat?.user?.email).toEqualTypeOf<string | undefined>()
+        return { customer: chat?.message?.metadata?.quiver?.customer || "customer" }
+      },
+    })
 
     defineAgent({
       capabilities: [
         access({
-          input: {
-            chat: {
-              capability: portalEntry,
-              message: { metadata: metadataSchema },
-              user: userSchema,
-            },
-          },
+          profile: supportProfile,
           workspace: {
-            resolve({ input }) {
-              const chat = input.get().context?.chat
-              expectTypeOf(chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<string | undefined>()
-              expectTypeOf(chat?.run?.origin).toEqualTypeOf<"portal" | "teams" | undefined>()
-              expectTypeOf(chat?.user?.email).toEqualTypeOf<string | undefined>()
-              return "customer"
+            resolve({ profile }) {
+              expectTypeOf(profile.customer).toEqualTypeOf<string>()
+              return profile.customer
             },
             scopes: {
               customer: {
@@ -442,12 +450,12 @@ describe("agent public types", () => {
       "~standard": {
         validate: (input: unknown) => ({ value: input as SupportMessageMetadata }),
       },
-    } satisfies AccessCapabilityStandardSchemaV1<SupportMessageMetadata>
+    } satisfies AgentInvocationProfileStandardSchemaV1<SupportMessageMetadata>
     const userSchema = {
       "~standard": {
         validate: (input: unknown) => ({ value: input as SupportChatUser }),
       },
-    } satisfies AccessCapabilityStandardSchemaV1<SupportChatUser>
+    } satisfies AgentInvocationProfileStandardSchemaV1<SupportChatUser>
     const supportProfile = defineInvocationProfile({
       id: "quiver-support",
       input: {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, type AgentRuntimeContext } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, transcribe, webSearch, workspaceShell } from "../src/capabilities.ts"
+import { access, blob, chat, chatTitle, db, entry, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, transcribe, webSearch, workspaceShell } from "../src/capabilities.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
@@ -353,7 +353,6 @@ describe("agent public types", () => {
     const teamsAdapter = {} as AgentChatAdapterResolver
     const supportChat = chat({
       adapters: () => ({ teams: teamsAdapter }),
-      app: "portal",
       identity({ adapter, author }) {
         expectTypeOf(adapter).toEqualTypeOf<string>()
         expectTypeOf(author.userId).toEqualTypeOf<string>()
@@ -364,13 +363,14 @@ describe("agent public types", () => {
         retention: "30d",
       },
     })
+    const portalEntry = entry({ id: "portal", chat: { capability: supportChat, origin: "portal" } })
 
     defineAgent({
       capabilities: [
         access({
           input: {
             chat: {
-              capability: supportChat,
+              capability: portalEntry,
               message: { metadata: metadataSchema },
               user: userSchema,
             },
@@ -394,6 +394,7 @@ describe("agent public types", () => {
           },
         }),
         supportChat,
+        portalEntry,
       ],
       model: {} as never,
       workspace: {

--- a/packages/agent/tsdown.config.ts
+++ b/packages/agent/tsdown.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     "src/cli.ts",
     "src/eval.ts",
     "src/nitro.ts",
+    "src/state/sqlite.ts",
     "src/cloudflare/state.ts",
     "src/runtime/empty-registry.ts",
     "src/runtime/chat-devtools-handler.ts",

--- a/packages/workflow/src/nitro/module.ts
+++ b/packages/workflow/src/nitro/module.ts
@@ -158,14 +158,18 @@ async function writeNitroWorkflowRuntimeFiles(nitro: Nitro, resolved: false | Re
   return { ...runtimeFiles, providerDefinitions }
 }
 
+function hasOpenWorkflowSqliteStorage(options: ResolvedWorkflowOptions): boolean {
+  return options.provider === "openworkflow" && Boolean(options.sqlite?.path || process.env.OPENWORKFLOW_SQLITE_PATH)
+}
+
 function getOpenWorkflowNitroTraceDeps(options: ResolvedWorkflowOptions) {
-  return options.provider === "openworkflow" && options.sqlite?.path
+  return hasOpenWorkflowSqliteStorage(options)
     ? OPENWORKFLOW_SQLITE_NITRO_TRACE_DEPS
     : OPENWORKFLOW_POSTGRES_NITRO_TRACE_DEPS
 }
 
 function getOpenWorkflowNitroTraceImports(options: ResolvedWorkflowOptions) {
-  return options.provider === "openworkflow" && options.sqlite?.path
+  return hasOpenWorkflowSqliteStorage(options)
     ? OPENWORKFLOW_SQLITE_NITRO_TRACE_IMPORTS
     : OPENWORKFLOW_POSTGRES_NITRO_TRACE_IMPORTS
 }

--- a/packages/workflow/src/runtime/openworkflow.ts
+++ b/packages/workflow/src/runtime/openworkflow.ts
@@ -4,6 +4,8 @@ import type { RetryPolicy } from "openworkflow"
 import type { ResolvedWorkflowOptions, WorkflowDefinition, WorkflowDeferOptions, WorkflowProviderStep, WorkflowRun, WorkflowRunStatus, WorkflowRuntimeConfigValue, WorkflowRuntimeEnvDeclarationLike, WorkflowStepOptions } from "../types.ts"
 
 type OpenWorkflowModule = typeof import("openworkflow")
+type NodeFsModule = typeof import("node:fs")
+type NodePathModule = typeof import("node:path")
 type OpenWorkflowPostgresModule = typeof import("openworkflow/postgres")
 type OpenWorkflowSqliteModule = typeof import("openworkflow/sqlite")
 type OpenWorkflowClient = InstanceType<OpenWorkflowModule["OpenWorkflow"]>
@@ -54,6 +56,17 @@ function normalizeSqlitePath(path: string): string {
   return path.startsWith("file:") ? path.slice("file:".length) : path
 }
 
+async function prepareSqlitePath(path: string): Promise<string> {
+  if (path !== ":memory:") {
+    const [{ mkdirSync }, { dirname }] = await Promise.all([
+      openWorkflowImporter<NodeFsModule>("node:fs"),
+      openWorkflowImporter<NodePathModule>("node:path"),
+    ])
+    mkdirSync(dirname(path), { recursive: true })
+  }
+  return path
+}
+
 type OpenWorkflowStorageConfig =
   | { backend: "postgres", namespaceId: string, runMigrations?: boolean, schema: string, url: string }
   | { backend: "sqlite", namespaceId: string, path: string, runMigrations?: boolean }
@@ -102,7 +115,7 @@ async function createOpenWorkflowRuntime(config: ResolvedWorkflowOptions): Promi
       : openWorkflowImporter<OpenWorkflowPostgresModule>("openworkflow/postgres"),
   ])
   const backend = options.backend === "sqlite"
-    ? (backendModule as OpenWorkflowSqliteModule).BackendSqlite.connect(options.path, {
+    ? (backendModule as OpenWorkflowSqliteModule).BackendSqlite.connect(await prepareSqlitePath(options.path), {
         namespaceId: options.namespaceId,
         ...(typeof options.runMigrations === "boolean" ? { runMigrations: options.runMigrations } : {}),
       })

--- a/packages/workflow/test/nitro.test.ts
+++ b/packages/workflow/test/nitro.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -77,6 +77,40 @@ describe("Nitro module", () => {
 
     expect(nitro.options.traceDeps).toContain("openworkflow")
     expect(nitro.options.traceDeps).not.toContain("postgres")
+  })
+
+  it("uses SQLite tracing when OpenWorkflow storage comes from OPENWORKFLOW_SQLITE_PATH", async () => {
+    const previous = process.env.OPENWORKFLOW_SQLITE_PATH
+    process.env.OPENWORKFLOW_SQLITE_PATH = ".data/env-workflow.sqlite"
+    try {
+      const root = await mkdtemp(join(tmpdir(), "vitehub-workflow-nitro-openworkflow-env-sqlite-"))
+      const nitro = {
+        hooks: { hook: vi.fn() },
+        options: {
+          alias: {},
+          buildDir: join(root, ".nitro"),
+          imports: undefined as { presets?: Array<{ from: string, imports: string[] }> } | undefined,
+          output: { serverDir: join(root, ".output/server") },
+          plugins: [],
+          rootDir: root,
+          scanDirs: [],
+          traceDeps: undefined as string[] | undefined,
+          workflow: { provider: "openworkflow" },
+        },
+      }
+
+      await workflowNitroModule.setup(nitro as never)
+
+      expect(nitro.options.traceDeps).toContain("openworkflow")
+      expect(nitro.options.traceDeps).not.toContain("postgres")
+      const plugin = await readFile(nitro.options.plugins[0]!, "utf8")
+      expect(plugin).toContain(`import "openworkflow/sqlite"`)
+      expect(plugin).not.toContain(`import "openworkflow/postgres"`)
+    }
+    finally {
+      if (typeof previous === "string") process.env.OPENWORKFLOW_SQLITE_PATH = previous
+      else delete process.env.OPENWORKFLOW_SQLITE_PATH
+    }
   })
 
   it("resolves OpenWorkflow storage from a Database Definition", async () => {

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -1,3 +1,8 @@
+import { existsSync } from "node:fs"
+import { mkdtemp } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { WorkflowProviderStep } from "../src/types.ts"
@@ -644,6 +649,30 @@ describe("workflow runtime", () => {
       runMigrations: false,
     })
     expect(openWorkflowMock.connect).not.toHaveBeenCalled()
+  })
+
+  it("creates parent directories for OpenWorkflow SQLite files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workflow-sqlite-parent-"))
+    const path = join(root, ".data/workflow/openworkflow.sqlite")
+    expect(existsSync(dirname(path))).toBe(false)
+    setWorkflowRuntimeConfig({
+      provider: "openworkflow",
+      sqlite: {
+        path,
+        runMigrations: false,
+      },
+    })
+    setWorkflowRuntimeRegistry({
+      welcome: async () => ({ default: { handler: async () => ({ ok: true }) } }),
+    })
+
+    await runWorkflow("welcome", {})
+
+    expect(existsSync(dirname(path))).toBe(true)
+    expect(openWorkflowMock.sqliteConnect).toHaveBeenCalledWith(path, {
+      namespaceId: "production",
+      runMigrations: false,
+    })
   })
 
   it("reads OpenWorkflow SQLite connection options from runtime environment", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,9 @@ importers:
 
   packages/agent:
     dependencies:
+      '@libsql/client':
+        specifier: catalog:database
+        version: 0.15.15
       '@vercel/functions':
         specifier: catalog:vercel
         version: 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38)


### PR DESCRIPTION
Adds a first-party SQLite Agent State Provider behind `@vite-hub/agent` so Node/Nitro chat runtimes can persist Chat History and Concurrent Invocation Guard state without a project-local Chat SDK state shim. The new `@vite-hub/agent/state/sqlite` subpath exposes a generic SQLite-compatible adapter plus `createLibsqlAgentState()` for `file:` SQLite and hosted libSQL URLs, while Nitro can resolve explicit `providers.state.provider: "sqlite" | "libsql"` configuration.

This also preserves provider state options during Agent config normalization, aliases the new state subpath for Nitro runtime builds, documents durable chat state for hosted Node deployments, and expands Agent coverage for persistence, queue/list/lock/subscription behavior, reconnects, table-prefix validation, injected drivers, and Nitro alias registration.

