### PR TITLE
feat(workflow): support database-backed OpenWorkflow storage

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -25,6 +25,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./cli": "./dist/cli.js",
+    "./config": "./dist/config.js",
     "./drizzle": "./dist/drizzle.js",
     "./runtime/cloudflare-vite": "./dist/runtime/cloudflare-vite.js",
     "./runtime/hosted": "./dist/runtime/hosted.js",

--- a/packages/database/src/config.ts
+++ b/packages/database/src/config.ts
@@ -23,6 +23,8 @@ import type {
   ResolvedDrizzleDatabaseConfig,
 } from "./types.ts"
 
+export { resolveConfigValue } from "./config-value.ts"
+
 const configFilePattern = /^config\.(?:c|m)?[jt]s$/i
 const viteDatabaseSuffixPattern = /\.database\.(?:c|m)?[jt]s$/i
 

--- a/packages/database/tsdown.config.ts
+++ b/packages/database/tsdown.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   entry: [
     "src/index.ts",
     "src/cli.ts",
+    "src/config.ts",
     "src/drizzle.ts",
     "src/virtual.ts",
     "src/vite.ts",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -47,7 +47,7 @@
     "build": "tsdown --tsconfig tsconfig.build.json",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit -p ./tsconfig.json",
-    "test": "pnpm --filter @vite-hub/workflow build && vitest run",
+    "test": "pnpm --filter @vite-hub/database build && pnpm --filter @vite-hub/env build && pnpm --filter @vite-hub/workflow build && vitest run",
     "test:e2e": "node ./test/e2e-live.mjs"
   },
   "dependencies": {
@@ -58,20 +58,20 @@
     "pathe": "catalog:unjs"
   },
   "peerDependencies": {
+    "@vite-hub/database": "workspace:*",
     "nitro": "catalog:nitro-compat",
     "openworkflow": "catalog:workflow",
-    "postgres": "catalog:database",
     "vite": "catalog:vite8-compat",
     "workflow": "catalog:workflow"
   },
   "peerDependenciesMeta": {
+    "@vite-hub/database": {
+      "optional": true
+    },
     "nitro": {
       "optional": true
     },
     "openworkflow": {
-      "optional": true
-    },
-    "postgres": {
       "optional": true
     },
     "vite": {
@@ -83,10 +83,12 @@
   },
   "devDependencies": {
     "@types/node": "catalog:tooling",
+    "@vite-hub/database": "workspace:*",
     "@vite-hub/internal": "workspace:*",
     "nitro": "catalog:unjs",
     "ofetch": "catalog:unjs",
     "openworkflow": "catalog:workflow",
+    "postgres": "catalog:database",
     "publint": "catalog:tooling",
     "tsdown": "catalog:tooling",
     "tsx": "catalog:tooling",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -88,7 +88,6 @@
     "nitro": "catalog:unjs",
     "ofetch": "catalog:unjs",
     "openworkflow": "catalog:workflow",
-    "postgres": "catalog:database",
     "publint": "catalog:tooling",
     "tsdown": "catalog:tooling",
     "tsx": "catalog:tooling",

--- a/packages/workflow/src/config.ts
+++ b/packages/workflow/src/config.ts
@@ -3,7 +3,7 @@ import { defu } from "defu"
 import { normalizeHosting } from "@vite-hub/internal/feature-bridge/hosting"
 import { isPlainObject } from "@vite-hub/internal/object"
 
-import type { OpenWorkflowPostgresOptions, OpenWorkflowWorkerOptions, ResolvedWorkflowOptions, WorkflowModuleOptions, WorkflowSharedOptions } from "./types.ts"
+import type { OpenWorkflowPostgresOptions, OpenWorkflowSqliteOptions, OpenWorkflowWorkerOptions, ResolvedWorkflowOptions, RuntimeEnvDeclarationLike, WorkflowModuleOptions, WorkflowRuntimeConfigValue, WorkflowSharedOptions } from "./types.ts"
 
 interface WorkflowResolutionInput {
   hosting?: string
@@ -21,6 +21,19 @@ function readString(value: unknown, label: string): string | undefined {
   return value.trim()
 }
 
+function readRuntimeConfigValue(value: unknown, label: string): WorkflowRuntimeConfigValue | undefined {
+  if (typeof value === "undefined") {
+    return undefined
+  }
+  if (typeof value === "string") {
+    return readString(value, label)
+  }
+  if (!isRuntimeEnvDeclaration(value)) {
+    throw new TypeError(`\`${label}\` must be a string or runtime env declaration.`)
+  }
+  return value
+}
+
 function readBoolean(value: unknown, label: string): boolean | undefined {
   if (typeof value === "undefined") {
     return undefined
@@ -29,6 +42,23 @@ function readBoolean(value: unknown, label: string): boolean | undefined {
     throw new TypeError(`\`${label}\` must be a boolean when provided.`)
   }
   return value
+}
+
+function isRuntimeEnvDeclaration(value: unknown): value is RuntimeEnvDeclarationLike {
+  return isPlainObject(value)
+    && value.kind === "env-variable"
+    && (!("source" in value) || isRuntimeEnvSource(value.source))
+}
+
+function isRuntimeEnvSource(value: unknown): value is RuntimeEnvDeclarationLike["source"] {
+  return isPlainObject(value)
+    && value.kind === "env"
+    && typeof value.name === "string"
+    && (!("names" in value) || Array.isArray(value.names) && value.names.every(name => typeof name === "string"))
+}
+
+function readDatabaseName(value: unknown): string | undefined {
+  return readString(value, "workflow.database")
 }
 
 function readPositiveInteger(value: unknown, label: string): number | undefined {
@@ -52,13 +82,32 @@ function normalizeOpenWorkflowPostgresOptions(value: unknown): OpenWorkflowPostg
   const namespaceId = readString(value.namespaceId, "workflow.postgres.namespaceId")
   const runMigrations = readBoolean(value.runMigrations, "workflow.postgres.runMigrations")
   const schema = readString(value.schema, "workflow.postgres.schema")
-  const url = readString(value.url, "workflow.postgres.url")
+  const url = readRuntimeConfigValue(value.url, "workflow.postgres.url")
 
   return {
     ...(namespaceId ? { namespaceId } : {}),
     ...(typeof runMigrations === "boolean" ? { runMigrations } : {}),
     ...(schema ? { schema } : {}),
     ...(url ? { url } : {}),
+  }
+}
+
+function normalizeOpenWorkflowSqliteOptions(value: unknown): OpenWorkflowSqliteOptions | undefined {
+  if (typeof value === "undefined") {
+    return undefined
+  }
+  if (!isPlainObject(value)) {
+    throw new TypeError("`workflow.sqlite` must be a plain object.")
+  }
+
+  const namespaceId = readString(value.namespaceId, "workflow.sqlite.namespaceId")
+  const path = readRuntimeConfigValue(value.path, "workflow.sqlite.path")
+  const runMigrations = readBoolean(value.runMigrations, "workflow.sqlite.runMigrations")
+
+  return {
+    ...(namespaceId ? { namespaceId } : {}),
+    ...(path ? { path } : {}),
+    ...(typeof runMigrations === "boolean" ? { runMigrations } : {}),
   }
 }
 
@@ -74,8 +123,14 @@ function normalizeOpenWorkflowWorkerOptions(value: unknown): OpenWorkflowWorkerO
   return typeof concurrency === "number" ? { concurrency } : {}
 }
 
-function hasOpenWorkflowPostgresConfig(options: Record<string, unknown>): boolean {
-  return isPlainObject(options.postgres) && typeof options.postgres.url === "string" && !!options.postgres.url.trim()
+function hasOpenWorkflowStorageConfig(options: Record<string, unknown>): boolean {
+  return typeof options.database === "string" && !!options.database.trim()
+    || isPlainObject(options.postgres) && isDefinedRuntimeConfigValue(options.postgres.url)
+    || isPlainObject(options.sqlite) && isDefinedRuntimeConfigValue(options.sqlite.path)
+}
+
+function isDefinedRuntimeConfigValue(value: unknown): boolean {
+  return typeof value === "string" && !!value.trim() || isRuntimeEnvDeclaration(value)
 }
 
 function inferProvider(provider: unknown, hosting: string): "cloudflare" | "openworkflow" | "vercel" {
@@ -89,7 +144,7 @@ function inferProvider(provider: unknown, hosting: string): "cloudflare" | "open
 }
 
 function inferProviderFromOptions(options: Record<string, unknown>, hosting: string): "cloudflare" | "openworkflow" | "vercel" {
-  if (typeof options.provider === "undefined" && (hosting.includes("node") || hosting.includes("docker")) && hasOpenWorkflowPostgresConfig(options)) {
+  if (typeof options.provider === "undefined" && (hosting.includes("node") || hosting.includes("docker")) && hasOpenWorkflowStorageConfig(options)) {
     return "openworkflow"
   }
   return inferProvider(options.provider, hosting)
@@ -113,12 +168,26 @@ function resolveProvider(options: Record<string, unknown>, hosting: string): Res
   }
 
   if (resolved === "openworkflow") {
+    const database = readDatabaseName(options.database)
     const postgres = normalizeOpenWorkflowPostgresOptions(options.postgres)
+    const sqlite = normalizeOpenWorkflowSqliteOptions(options.sqlite)
     const worker = normalizeOpenWorkflowWorkerOptions(options.worker)
+
+    if (database && postgres?.url) {
+      throw new TypeError("`workflow.database` and `workflow.postgres.url` cannot both configure OpenWorkflow storage.")
+    }
+    if (database && sqlite?.path) {
+      throw new TypeError("`workflow.database` and `workflow.sqlite.path` cannot both configure OpenWorkflow storage.")
+    }
+    if (postgres?.url && sqlite?.path) {
+      throw new TypeError("`workflow.postgres.url` and `workflow.sqlite.path` cannot both configure OpenWorkflow storage.")
+    }
 
     return defu(
       {
+        ...(database ? { database } : {}),
         ...(postgres ? { postgres } : {}),
+        ...(sqlite ? { sqlite } : {}),
         ...(worker ? { worker } : {}),
       },
       shared,

--- a/packages/workflow/src/config.ts
+++ b/packages/workflow/src/config.ts
@@ -3,7 +3,7 @@ import { defu } from "defu"
 import { normalizeHosting } from "@vite-hub/internal/feature-bridge/hosting"
 import { isPlainObject } from "@vite-hub/internal/object"
 
-import type { OpenWorkflowPostgresOptions, OpenWorkflowSqliteOptions, OpenWorkflowWorkerOptions, ResolvedWorkflowOptions, RuntimeEnvDeclarationLike, WorkflowModuleOptions, WorkflowRuntimeConfigValue, WorkflowSharedOptions } from "./types.ts"
+import type { OpenWorkflowPostgresOptions, OpenWorkflowSqliteOptions, OpenWorkflowWorkerOptions, ResolvedWorkflowOptions, WorkflowModuleOptions, WorkflowRuntimeConfigValue, WorkflowRuntimeEnvDeclarationLike, WorkflowSharedOptions } from "./types.ts"
 
 interface WorkflowResolutionInput {
   hosting?: string
@@ -44,13 +44,13 @@ function readBoolean(value: unknown, label: string): boolean | undefined {
   return value
 }
 
-function isRuntimeEnvDeclaration(value: unknown): value is RuntimeEnvDeclarationLike {
+function isRuntimeEnvDeclaration(value: unknown): value is WorkflowRuntimeEnvDeclarationLike {
   return isPlainObject(value)
     && value.kind === "env-variable"
     && (!("source" in value) || isRuntimeEnvSource(value.source))
 }
 
-function isRuntimeEnvSource(value: unknown): value is RuntimeEnvDeclarationLike["source"] {
+function isRuntimeEnvSource(value: unknown): value is WorkflowRuntimeEnvDeclarationLike["source"] {
   return isPlainObject(value)
     && value.kind === "env"
     && typeof value.name === "string"

--- a/packages/workflow/src/nitro/module.ts
+++ b/packages/workflow/src/nitro/module.ts
@@ -10,11 +10,13 @@ import type { Nitro, NitroModule, NitroRuntimeConfig } from "nitro/types"
 import { normalizeWorkflowOptions } from "../config.ts"
 import { discoverWorkflowDefinitions } from "../discovery.ts"
 import { createCloudflareWorkflowBindings, getCloudflareWorkflowClassName } from "../integrations/cloudflare.ts"
-import type { DiscoveredWorkflowDefinition, ResolvedWorkflowOptions, WorkflowModuleOptions } from "../types.ts"
+import type { DiscoveredWorkflowDefinition, ResolvedWorkflowOptions, WorkflowModuleOptions, WorkflowRuntimeConfigValue } from "../types.ts"
 
 const WORKFLOW_NITRO_IMPORTS_PRESET = { from: "@vite-hub/workflow", imports: ["defineWorkflow", "getWorkflowRun"] }
-const OPENWORKFLOW_NITRO_TRACE_DEPS = ["openworkflow", "postgres"] as const
-const OPENWORKFLOW_NITRO_TRACE_IMPORTS = ["openworkflow", "openworkflow/postgres"] as const
+const OPENWORKFLOW_POSTGRES_NITRO_TRACE_DEPS = ["openworkflow", "postgres"] as const
+const OPENWORKFLOW_POSTGRES_NITRO_TRACE_IMPORTS = ["openworkflow", "openworkflow/postgres"] as const
+const OPENWORKFLOW_SQLITE_NITRO_TRACE_DEPS = ["openworkflow"] as const
+const OPENWORKFLOW_SQLITE_NITRO_TRACE_IMPORTS = ["openworkflow", "openworkflow/sqlite"] as const
 const WORKFLOW_VITE_PLUGIN_NAME = "@vite-hub/workflow/vite"
 
 function resolveRuntimeEntry(srcRelative: string, packageSubpath: string): string {
@@ -43,7 +45,7 @@ function resolveNitroWorkflowScanDirs(rootDir: string, scanDirs: string[] | unde
 
 function createNitroWorkflowPluginContents(file: string, registryFile: string, options: false | ResolvedWorkflowOptions) {
   const openWorkflowTraceImports = options && options.provider === "openworkflow"
-    ? OPENWORKFLOW_NITRO_TRACE_IMPORTS.map(specifier => `import ${JSON.stringify(specifier)}`)
+    ? getOpenWorkflowNitroTraceImports(options).map(specifier => `import ${JSON.stringify(specifier)}`)
     : []
 
   return [
@@ -70,11 +72,11 @@ function createNitroWorkflowPluginContents(file: string, registryFile: string, o
     "globalThis.__vitehubRunNitroWorkflowDefinition = runNitroWorkflowDefinition",
     "",
     "function shouldStartOpenWorkflowWorker(workflowConfig) {",
-    "  return workflowConfig?.provider === \"openworkflow\" && hasOpenWorkflowPostgresConfig(workflowConfig) && globalThis.process?.env?.OPENWORKFLOW_WORKER !== \"false\"",
+    "  return workflowConfig?.provider === \"openworkflow\" && hasOpenWorkflowStorageConfig(workflowConfig) && globalThis.process?.env?.OPENWORKFLOW_WORKER !== \"false\"",
     "}",
     "",
-    "function hasOpenWorkflowPostgresConfig(workflowConfig) {",
-    "  return Boolean(workflowConfig?.postgres?.url || globalThis.process?.env?.OPENWORKFLOW_POSTGRES_URL || globalThis.process?.env?.DATABASE_URL)",
+    "function hasOpenWorkflowStorageConfig(workflowConfig) {",
+    "  return Boolean(workflowConfig?.sqlite?.path || workflowConfig?.postgres?.url || globalThis.process?.env?.OPENWORKFLOW_SQLITE_PATH || globalThis.process?.env?.OPENWORKFLOW_POSTGRES_URL || globalThis.process?.env?.DATABASE_URL)",
     "}",
     "",
     "const workflowNitroPlugin = defineNitroPlugin(async (nitroApp) => {",
@@ -156,10 +158,99 @@ async function writeNitroWorkflowRuntimeFiles(nitro: Nitro, resolved: false | Re
   return { ...runtimeFiles, providerDefinitions }
 }
 
-function addOpenWorkflowNitroTraceDeps(nitro: Nitro): void {
+function getOpenWorkflowNitroTraceDeps(options: ResolvedWorkflowOptions) {
+  return options.provider === "openworkflow" && options.sqlite?.path
+    ? OPENWORKFLOW_SQLITE_NITRO_TRACE_DEPS
+    : OPENWORKFLOW_POSTGRES_NITRO_TRACE_DEPS
+}
+
+function getOpenWorkflowNitroTraceImports(options: ResolvedWorkflowOptions) {
+  return options.provider === "openworkflow" && options.sqlite?.path
+    ? OPENWORKFLOW_SQLITE_NITRO_TRACE_IMPORTS
+    : OPENWORKFLOW_POSTGRES_NITRO_TRACE_IMPORTS
+}
+
+function normalizeDatabaseSqlitePath(url: string, name: string): string {
+  if (url === ":memory:") return url
+  if (/^(?:libsql:|https?:\/\/)/i.test(url)) {
+    throw new Error(`[vitehub] workflow.database "${name}" uses ${JSON.stringify(url)}, but OpenWorkflow SQLite storage requires a local SQLite file path.`)
+  }
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url) && !url.startsWith("file:")) {
+    throw new Error(`[vitehub] workflow.database "${name}" uses unsupported OpenWorkflow storage URL ${JSON.stringify(url)}.`)
+  }
+  return url.startsWith("file:") ? url.slice("file:".length) : url
+}
+
+function normalizeDatabaseSqliteConfigValue(value: WorkflowRuntimeConfigValue, name: string, resolvedUrl: string): WorkflowRuntimeConfigValue {
+  const normalizedResolvedUrl = normalizeDatabaseSqlitePath(resolvedUrl, name)
+  if (typeof value === "string") return normalizedResolvedUrl
+  if (typeof value.default !== "string") return value
+  return {
+    ...value,
+    default: normalizeDatabaseSqlitePath(value.default, name),
+  }
+}
+
+function isPostgresDatabaseUrl(url: string): boolean {
+  return /^postgres(?:ql)?:/i.test(url)
+}
+
+async function resolveOpenWorkflowDatabaseStorage(rootDir: string, options: false | ResolvedWorkflowOptions): Promise<false | ResolvedWorkflowOptions> {
+  if (!options || options.provider !== "openworkflow" || !options.database) {
+    return options
+  }
+
+  const databaseName = options.database
+  let databaseModule: {
+    resolveConfigValue: (value: unknown) => string | undefined
+    resolveDBViteConfig: (options?: unknown, rootDir?: string) => { databases: Record<string, { connection?: { authToken?: unknown, url?: WorkflowRuntimeConfigValue }, dialect: string }> } | undefined
+  }
+  try {
+    databaseModule = await import("@vite-hub/database/config") as typeof databaseModule
+  }
+  catch (error) {
+    throw new Error(`[vitehub] workflow.database requires @vite-hub/database. Install @vite-hub/database and add a Database Definition named "${databaseName}".`, { cause: error })
+  }
+
+  const config = databaseModule.resolveDBViteConfig(undefined, rootDir)
+  const database = config?.databases[databaseName]
+  if (!database) {
+    throw new Error(`[vitehub] workflow.database references missing Database Definition "${databaseName}".`)
+  }
+
+  const url = database.connection?.url
+  const resolvedUrl = databaseModule.resolveConfigValue(url)
+  if (!url || !resolvedUrl) {
+    throw new Error(`[vitehub] workflow.database "${databaseName}" requires a database connection URL.`)
+  }
+
+  if (isPostgresDatabaseUrl(resolvedUrl)) {
+    return {
+      ...options,
+      postgres: {
+        ...options.postgres,
+        url,
+      },
+    }
+  }
+
+  if (typeof database.connection?.authToken !== "undefined") {
+    throw new Error(`[vitehub] workflow.database "${databaseName}" has an auth token, but OpenWorkflow SQLite storage only supports local SQLite files.`)
+  }
+
+  return {
+    ...options,
+    sqlite: {
+      ...options.sqlite,
+      path: normalizeDatabaseSqliteConfigValue(url, databaseName, resolvedUrl),
+    },
+  }
+}
+
+function addOpenWorkflowNitroTraceDeps(nitro: Nitro, resolved: ResolvedWorkflowOptions): void {
   const options = nitro.options as typeof nitro.options & { traceDeps?: string[] }
   options.traceDeps ||= []
-  for (const dependency of OPENWORKFLOW_NITRO_TRACE_DEPS) {
+  for (const dependency of getOpenWorkflowNitroTraceDeps(resolved)) {
     if (!options.traceDeps.includes(dependency)) {
       options.traceDeps.push(dependency)
     }
@@ -171,7 +262,8 @@ const workflowNitroModule: NitroModule = {
   async setup(nitro) {
     await assertNoVitePluginInNitro(nitro, WORKFLOW_VITE_PLUGIN_NAME, "@vite-hub/workflow/nitro")
 
-    const resolved = normalizeWorkflowOptions(nitro.options.workflow, { hosting: nitro.options.preset })
+    const normalized = normalizeWorkflowOptions(nitro.options.workflow, { hosting: nitro.options.preset })
+    const resolved = await resolveOpenWorkflowDatabaseStorage(nitro.options.rootDir, normalized || false)
     const runtimeConfig = (nitro.options.runtimeConfig ||= {} as NitroRuntimeConfig)
     if (nitro.options.preset) runtimeConfig.hosting ||= nitro.options.preset
     runtimeConfig.workflow = resolved || false
@@ -184,8 +276,8 @@ const workflowNitroModule: NitroModule = {
     nitro.options.alias["@vite-hub/workflow/runtime/openworkflow"] = resolveRuntimeEntry("../runtime/openworkflow", "@vite-hub/workflow/runtime/openworkflow")
     nitro.options.alias["@vite-hub/workflow/runtime/openworkflow-worker"] = resolveRuntimeEntry("../runtime/openworkflow-worker", "@vite-hub/workflow/runtime/openworkflow-worker")
 
-    if (resolved?.provider === "openworkflow") {
-      addOpenWorkflowNitroTraceDeps(nitro)
+    if (resolved && resolved.provider === "openworkflow") {
+      addOpenWorkflowNitroTraceDeps(nitro, resolved)
     }
 
     let runtimeFiles = await writeNitroWorkflowRuntimeFiles(nitro, resolved || false)

--- a/packages/workflow/src/runtime/openworkflow.ts
+++ b/packages/workflow/src/runtime/openworkflow.ts
@@ -1,12 +1,13 @@
 import { runWorkflowHandler } from "./execute.ts"
 
 import type { RetryPolicy } from "openworkflow"
-import type { ResolvedWorkflowOptions, WorkflowDefinition, WorkflowDeferOptions, WorkflowProviderStep, WorkflowRun, WorkflowRunStatus, WorkflowStepOptions } from "../types.ts"
+import type { ResolvedWorkflowOptions, RuntimeEnvDeclarationLike, WorkflowDefinition, WorkflowDeferOptions, WorkflowProviderStep, WorkflowRun, WorkflowRunStatus, WorkflowRuntimeConfigValue, WorkflowStepOptions } from "../types.ts"
 
 type OpenWorkflowModule = typeof import("openworkflow")
 type OpenWorkflowPostgresModule = typeof import("openworkflow/postgres")
+type OpenWorkflowSqliteModule = typeof import("openworkflow/sqlite")
 type OpenWorkflowClient = InstanceType<OpenWorkflowModule["OpenWorkflow"]>
-type OpenWorkflowBackend = Awaited<ReturnType<OpenWorkflowPostgresModule["BackendPostgres"]["connect"]>>
+type OpenWorkflowBackend = Awaited<ReturnType<OpenWorkflowPostgresModule["BackendPostgres"]["connect"]>> | ReturnType<OpenWorkflowSqliteModule["BackendSqlite"]["connect"]>
 type OpenWorkflowRunnable = ReturnType<OpenWorkflowClient["defineWorkflow"]>
 type OpenWorkflowRun = Awaited<ReturnType<OpenWorkflowBackend["getWorkflowRun"]>>
 type OpenWorkflowStepApi = Parameters<Parameters<OpenWorkflowClient["defineWorkflow"]>[1]>[0]["step"]
@@ -28,18 +29,59 @@ function readEnv(name: string): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined
 }
 
-function getOpenWorkflowConfig(config: ResolvedWorkflowOptions) {
+function resolveRuntimeConfigValue(value: WorkflowRuntimeConfigValue | undefined): string | undefined {
+  if (typeof value === "string" || typeof value === "undefined") {
+    return value
+  }
+  for (const name of getRuntimeEnvNames(value)) {
+    const resolved = readEnv(name)
+    if (resolved) return resolved
+  }
+  return typeof value.default === "string" && value.default.trim() ? value.default.trim() : undefined
+}
+
+function getRuntimeEnvNames(value: RuntimeEnvDeclarationLike): string[] {
+  return value.source?.names ?? (value.source?.name ? [value.source.name] : [])
+}
+
+function normalizeSqlitePath(path: string): string {
+  if (/^(?:libsql:|https?:\/\/)/i.test(path)) {
+    throw new Error(`OpenWorkflow SQLite storage requires a local SQLite file path, received ${JSON.stringify(path)}.`)
+  }
+  if (/^[a-z][a-z0-9+.-]*:/i.test(path) && !path.startsWith("file:")) {
+    throw new Error(`OpenWorkflow SQLite storage received unsupported storage URL ${JSON.stringify(path)}.`)
+  }
+  return path.startsWith("file:") ? path.slice("file:".length) : path
+}
+
+type OpenWorkflowStorageConfig =
+  | { backend: "postgres", namespaceId: string, runMigrations?: boolean, schema: string, url: string }
+  | { backend: "sqlite", namespaceId: string, path: string, runMigrations?: boolean }
+
+function getOpenWorkflowConfig(config: ResolvedWorkflowOptions): OpenWorkflowStorageConfig {
   if (config.provider !== "openworkflow") {
     throw new Error(`OpenWorkflow runtime requires workflow.provider "openworkflow", received "${config.provider}".`)
   }
 
+  const sqlite = config.sqlite || {}
+  const sqlitePath = resolveRuntimeConfigValue(sqlite.path) || readEnv("OPENWORKFLOW_SQLITE_PATH")
+  if (sqlitePath) {
+    return {
+      backend: "sqlite",
+      namespaceId: sqlite.namespaceId || readEnv("OPENWORKFLOW_NAMESPACE_ID") || "production",
+      path: normalizeSqlitePath(sqlitePath),
+      runMigrations: sqlite.runMigrations,
+    }
+  }
+
   const postgres = config.postgres || {}
-  const url = postgres.url || readEnv("OPENWORKFLOW_POSTGRES_URL") || readEnv("DATABASE_URL")
+  const url = resolveRuntimeConfigValue(postgres.url) || readEnv("OPENWORKFLOW_POSTGRES_URL") || readEnv("DATABASE_URL")
   if (!url) {
-    throw new Error("Missing OpenWorkflow Postgres URL. Set workflow.postgres.url, OPENWORKFLOW_POSTGRES_URL, or DATABASE_URL.")
+    throw new Error("Missing OpenWorkflow storage. Set workflow.database, workflow.sqlite.path, workflow.postgres.url, OPENWORKFLOW_SQLITE_PATH, OPENWORKFLOW_POSTGRES_URL, or DATABASE_URL.")
   }
 
   return {
+    backend: "postgres",
     namespaceId: postgres.namespaceId || readEnv("OPENWORKFLOW_NAMESPACE_ID") || "production",
     runMigrations: postgres.runMigrations,
     schema: postgres.schema || readEnv("OPENWORKFLOW_SCHEMA") || "openworkflow",
@@ -53,15 +95,22 @@ function getRuntimeKey(config: ResolvedWorkflowOptions): string {
 
 async function createOpenWorkflowRuntime(config: ResolvedWorkflowOptions): Promise<OpenWorkflowRuntime> {
   const options = getOpenWorkflowConfig(config)
-  const [{ OpenWorkflow }, { BackendPostgres }] = await Promise.all([
+  const [{ OpenWorkflow }, backendModule] = await Promise.all([
     openWorkflowImporter<OpenWorkflowModule>("openworkflow"),
-    openWorkflowImporter<OpenWorkflowPostgresModule>("openworkflow/postgres"),
+    options.backend === "sqlite"
+      ? openWorkflowImporter<OpenWorkflowSqliteModule>("openworkflow/sqlite")
+      : openWorkflowImporter<OpenWorkflowPostgresModule>("openworkflow/postgres"),
   ])
-  const backend = await BackendPostgres.connect(options.url, {
-    namespaceId: options.namespaceId,
-    ...(typeof options.runMigrations === "boolean" ? { runMigrations: options.runMigrations } : {}),
-    schema: options.schema,
-  })
+  const backend = options.backend === "sqlite"
+    ? (backendModule as OpenWorkflowSqliteModule).BackendSqlite.connect(options.path, {
+        namespaceId: options.namespaceId,
+        ...(typeof options.runMigrations === "boolean" ? { runMigrations: options.runMigrations } : {}),
+      })
+    : await (backendModule as OpenWorkflowPostgresModule).BackendPostgres.connect(options.url, {
+        namespaceId: options.namespaceId,
+        ...(typeof options.runMigrations === "boolean" ? { runMigrations: options.runMigrations } : {}),
+        schema: options.schema,
+      })
 
   return {
     backend,

--- a/packages/workflow/src/runtime/openworkflow.ts
+++ b/packages/workflow/src/runtime/openworkflow.ts
@@ -1,7 +1,7 @@
 import { runWorkflowHandler } from "./execute.ts"
 
 import type { RetryPolicy } from "openworkflow"
-import type { ResolvedWorkflowOptions, RuntimeEnvDeclarationLike, WorkflowDefinition, WorkflowDeferOptions, WorkflowProviderStep, WorkflowRun, WorkflowRunStatus, WorkflowRuntimeConfigValue, WorkflowStepOptions } from "../types.ts"
+import type { ResolvedWorkflowOptions, WorkflowDefinition, WorkflowDeferOptions, WorkflowProviderStep, WorkflowRun, WorkflowRunStatus, WorkflowRuntimeConfigValue, WorkflowRuntimeEnvDeclarationLike, WorkflowStepOptions } from "../types.ts"
 
 type OpenWorkflowModule = typeof import("openworkflow")
 type OpenWorkflowPostgresModule = typeof import("openworkflow/postgres")
@@ -40,7 +40,7 @@ function resolveRuntimeConfigValue(value: WorkflowRuntimeConfigValue | undefined
   return typeof value.default === "string" && value.default.trim() ? value.default.trim() : undefined
 }
 
-function getRuntimeEnvNames(value: RuntimeEnvDeclarationLike): string[] {
+function getRuntimeEnvNames(value: WorkflowRuntimeEnvDeclarationLike): string[] {
   return value.source?.names ?? (value.source?.name ? [value.source.name] : [])
 }
 

--- a/packages/workflow/src/types.ts
+++ b/packages/workflow/src/types.ts
@@ -30,7 +30,7 @@ export interface OpenWorkflowPostgresOptions {
   url?: WorkflowRuntimeConfigValue
 }
 
-export interface RuntimeEnvDeclarationLike {
+export interface WorkflowRuntimeEnvDeclarationLike {
   default?: unknown
   kind: "env-variable"
   source?: {
@@ -40,7 +40,7 @@ export interface RuntimeEnvDeclarationLike {
   }
 }
 
-export type WorkflowRuntimeConfigValue = string | RuntimeEnvDeclarationLike
+export type WorkflowRuntimeConfigValue = string | WorkflowRuntimeEnvDeclarationLike
 
 export interface OpenWorkflowSqliteOptions {
   namespaceId?: string

--- a/packages/workflow/src/types.ts
+++ b/packages/workflow/src/types.ts
@@ -27,7 +27,25 @@ export interface OpenWorkflowPostgresOptions {
   namespaceId?: string
   runMigrations?: boolean
   schema?: string
-  url?: string
+  url?: WorkflowRuntimeConfigValue
+}
+
+export interface RuntimeEnvDeclarationLike {
+  default?: unknown
+  kind: "env-variable"
+  source?: {
+    kind: "env"
+    name: string
+    names?: string[]
+  }
+}
+
+export type WorkflowRuntimeConfigValue = string | RuntimeEnvDeclarationLike
+
+export interface OpenWorkflowSqliteOptions {
+  namespaceId?: string
+  path?: WorkflowRuntimeConfigValue
+  runMigrations?: boolean
 }
 
 export interface OpenWorkflowWorkerOptions {
@@ -35,14 +53,18 @@ export interface OpenWorkflowWorkerOptions {
 }
 
 export interface OpenWorkflowProviderOptions extends WorkflowSharedOptions {
+  database?: string
   postgres?: OpenWorkflowPostgresOptions
   provider: "openworkflow"
+  sqlite?: OpenWorkflowSqliteOptions
   worker?: OpenWorkflowWorkerOptions
 }
 
 export interface InferredWorkflowProviderOptions extends WorkflowSharedOptions {
+  database?: string
   postgres?: OpenWorkflowPostgresOptions
   provider?: undefined
+  sqlite?: OpenWorkflowSqliteOptions
   worker?: OpenWorkflowWorkerOptions
 }
 

--- a/packages/workflow/test/config.test.ts
+++ b/packages/workflow/test/config.test.ts
@@ -44,6 +44,43 @@ describe("workflow config", () => {
     })
   })
 
+  it("infers openworkflow from node hosting with SQLite config", () => {
+    expect(normalizeWorkflowOptions({
+      sqlite: {
+        path: ".data/workflow.sqlite",
+      },
+    }, { hosting: "node-server" })).toEqual({
+      provider: "openworkflow",
+      sqlite: {
+        path: ".data/workflow.sqlite",
+      },
+    })
+  })
+
+  it("accepts runtime env declarations for OpenWorkflow SQLite storage", () => {
+    const path = {
+      default: "file:.data/workflow.sqlite",
+      kind: "env-variable",
+      source: { kind: "env", name: "VITEHUB_WORKFLOW_DATABASE_URL" },
+    } as const
+
+    expect(normalizeWorkflowOptions({
+      sqlite: { path },
+    }, { hosting: "node-server" })).toEqual({
+      provider: "openworkflow",
+      sqlite: { path },
+    })
+  })
+
+  it("infers openworkflow from node hosting with a database reference", () => {
+    expect(normalizeWorkflowOptions({
+      database: "workflow",
+    }, { hosting: "node-server" })).toEqual({
+      database: "workflow",
+      provider: "openworkflow",
+    })
+  })
+
   it("does not infer openworkflow from docker hosting without Postgres config", () => {
     expect(normalizeWorkflowOptions({}, { hosting: "docker" })).toEqual({
       provider: "vercel",
@@ -59,6 +96,15 @@ describe("workflow config", () => {
       provider: "openworkflow",
       worker: { concurrency: 0 },
     } as never)).toThrow(/workflow\.worker\.concurrency/)
+    expect(() => normalizeWorkflowOptions({
+      provider: "openworkflow",
+      sqlite: "file:.data/workflow.sqlite",
+    } as never)).toThrow(/workflow\.sqlite/)
+    expect(() => normalizeWorkflowOptions({
+      database: "workflow",
+      provider: "openworkflow",
+      sqlite: { path: ".data/workflow.sqlite" },
+    } as never)).toThrow(/workflow\.database/)
   })
 
   it("rejects unknown providers", () => {

--- a/packages/workflow/test/nitro.test.ts
+++ b/packages/workflow/test/nitro.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from "node:fs/promises"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -54,5 +54,73 @@ describe("Nitro module", () => {
     await workflowNitroModule.setup(nitro as never)
 
     expect(nitro.options.traceDeps).toEqual(expect.arrayContaining(["openworkflow", "postgres"]))
+  })
+
+  it("marks OpenWorkflow SQLite provider dependencies for Nitro tracing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workflow-nitro-openworkflow-sqlite-"))
+    const nitro = {
+      hooks: { hook: vi.fn() },
+      options: {
+        alias: {},
+        buildDir: join(root, ".nitro"),
+        imports: undefined as { presets?: Array<{ from: string, imports: string[] }> } | undefined,
+        output: { serverDir: join(root, ".output/server") },
+        plugins: [],
+        rootDir: root,
+        scanDirs: [],
+        traceDeps: undefined as string[] | undefined,
+        workflow: { provider: "openworkflow", sqlite: { path: ".data/workflow.sqlite" } },
+      },
+    }
+
+    await workflowNitroModule.setup(nitro as never)
+
+    expect(nitro.options.traceDeps).toContain("openworkflow")
+    expect(nitro.options.traceDeps).not.toContain("postgres")
+  })
+
+  it("resolves OpenWorkflow storage from a Database Definition", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workflow-nitro-database-"))
+    delete process.env.VITEHUB_TEST_WORKFLOW_DATABASE_URL
+    await mkdir(join(root, "server/databases/workflow"), { recursive: true })
+    await writeFile(join(root, "server/databases/workflow/config.ts"), [
+      `import { defineDatabase } from "@vite-hub/database"`,
+      `export default defineDatabase({`,
+      `  connection: { url: process.env.VITEHUB_TEST_WORKFLOW_DATABASE_URL || "file:.data/workflow/openworkflow.sqlite" },`,
+      `  tables: {},`,
+      `})`,
+      ``,
+    ].join("\n"), "utf8")
+    const nitro = {
+      hooks: { hook: vi.fn() },
+      options: {
+        alias: {},
+        buildDir: join(root, ".nitro"),
+        imports: undefined as { presets?: Array<{ from: string, imports: string[] }> } | undefined,
+        output: { serverDir: join(root, ".output/server") },
+        plugins: [],
+        rootDir: root,
+        runtimeConfig: {} as { workflow?: unknown },
+        scanDirs: [],
+        traceDeps: undefined as string[] | undefined,
+        workflow: { database: "workflow", provider: "openworkflow" },
+      },
+    }
+
+    await workflowNitroModule.setup(nitro as never)
+
+    expect(nitro.options.runtimeConfig.workflow).toMatchObject({
+      database: "workflow",
+      provider: "openworkflow",
+      sqlite: {
+        path: {
+          default: ".data/workflow/openworkflow.sqlite",
+          kind: "env-variable",
+          source: { kind: "env", name: "VITEHUB_TEST_WORKFLOW_DATABASE_URL" },
+        },
+      },
+    })
+    expect(nitro.options.traceDeps).toContain("openworkflow")
+    expect(nitro.options.traceDeps).not.toContain("postgres")
   })
 })

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -16,6 +16,10 @@ const openWorkflowMock = vi.hoisted(() => {
     getWorkflowRun: vi.fn(async ({ workflowRunId }: { workflowRunId: string }) => runs.get(workflowRunId) || null),
     stop: vi.fn(),
   }))
+  const sqliteConnect = vi.fn((_path: string, _options?: unknown) => ({
+    getWorkflowRun: vi.fn(async ({ workflowRunId }: { workflowRunId: string }) => runs.get(workflowRunId) || null),
+    stop: vi.fn(),
+  }))
   const newWorker = vi.fn((options?: unknown) => ({
     options,
     start: vi.fn(async () => {}),
@@ -94,6 +98,7 @@ const openWorkflowMock = vi.hoisted(() => {
     OpenWorkflow,
     runOptions,
     runs,
+    sqliteConnect,
   }
 })
 
@@ -107,6 +112,12 @@ vi.mock("openworkflow/postgres", () => ({
   },
 }))
 
+vi.mock("openworkflow/sqlite", () => ({
+  BackendSqlite: {
+    connect: openWorkflowMock.sqliteConnect,
+  },
+}))
+
 beforeEach(async () => {
   resetWorkflowRuntime()
   await resetOpenWorkflowRuntime()
@@ -117,9 +128,13 @@ beforeEach(async () => {
     if (specifier === "openworkflow/postgres") {
       return { BackendPostgres: { connect: openWorkflowMock.connect } } as never
     }
+    if (specifier === "openworkflow/sqlite") {
+      return { BackendSqlite: { connect: openWorkflowMock.sqliteConnect } } as never
+    }
     return await import(specifier) as never
   })
   openWorkflowMock.connect.mockClear()
+  openWorkflowMock.sqliteConnect.mockClear()
   openWorkflowMock.definitions.clear()
   openWorkflowMock.newWorker.mockClear()
   openWorkflowMock.runOptions.length = 0
@@ -129,6 +144,8 @@ beforeEach(async () => {
   delete process.env.OPENWORKFLOW_NAMESPACE_ID
   delete process.env.OPENWORKFLOW_POSTGRES_URL
   delete process.env.OPENWORKFLOW_SCHEMA
+  delete process.env.OPENWORKFLOW_SQLITE_PATH
+  delete process.env.VITEHUB_WORKFLOW_DATABASE_URL
 })
 
 afterEach(() => {
@@ -607,13 +624,73 @@ describe("workflow runtime", () => {
     })
   })
 
-  it("requires a Postgres URL for the OpenWorkflow provider", async () => {
+  it("runs registered definitions through the OpenWorkflow SQLite provider", async () => {
+    setWorkflowRuntimeConfig({
+      provider: "openworkflow",
+      sqlite: {
+        namespaceId: "local",
+        path: ".data/workflow.sqlite",
+        runMigrations: false,
+      },
+    })
+    setWorkflowRuntimeRegistry({
+      welcome: async () => ({ default: { handler: async () => ({ ok: true }) } }),
+    })
+
+    await runWorkflow("welcome", {})
+
+    expect(openWorkflowMock.sqliteConnect).toHaveBeenCalledWith(".data/workflow.sqlite", {
+      namespaceId: "local",
+      runMigrations: false,
+    })
+    expect(openWorkflowMock.connect).not.toHaveBeenCalled()
+  })
+
+  it("reads OpenWorkflow SQLite connection options from runtime environment", async () => {
+    process.env.OPENWORKFLOW_NAMESPACE_ID = "local"
+    process.env.OPENWORKFLOW_SQLITE_PATH = ".data/env-workflow.sqlite"
     setWorkflowRuntimeConfig({ provider: "openworkflow" })
     setWorkflowRuntimeRegistry({
       welcome: async () => ({ default: { handler: async () => ({ ok: true }) } }),
     })
 
-    await expect(runWorkflow("welcome", {})).rejects.toThrow(/Missing OpenWorkflow Postgres URL/)
+    await runWorkflow("welcome", {})
+
+    expect(openWorkflowMock.sqliteConnect).toHaveBeenCalledWith(".data/env-workflow.sqlite", {
+      namespaceId: "local",
+    })
+  })
+
+  it("resolves OpenWorkflow SQLite connection options from runtime config env declarations", async () => {
+    process.env.VITEHUB_WORKFLOW_DATABASE_URL = "file:.data/runtime-workflow.sqlite"
+    setWorkflowRuntimeConfig({
+      provider: "openworkflow",
+      sqlite: {
+        path: {
+          default: "file:.data/default-workflow.sqlite",
+          kind: "env-variable",
+          source: { kind: "env", name: "VITEHUB_WORKFLOW_DATABASE_URL" },
+        },
+      },
+    })
+    setWorkflowRuntimeRegistry({
+      welcome: async () => ({ default: { handler: async () => ({ ok: true }) } }),
+    })
+
+    await runWorkflow("welcome", {})
+
+    expect(openWorkflowMock.sqliteConnect).toHaveBeenCalledWith(".data/runtime-workflow.sqlite", {
+      namespaceId: "production",
+    })
+  })
+
+  it("requires storage for the OpenWorkflow provider", async () => {
+    setWorkflowRuntimeConfig({ provider: "openworkflow" })
+    setWorkflowRuntimeRegistry({
+      welcome: async () => ({ default: { handler: async () => ({ ok: true }) } }),
+    })
+
+    await expect(runWorkflow("welcome", {})).rejects.toThrow(/Missing OpenWorkflow storage/)
   })
 
   it("creates an OpenWorkflow worker from the runtime registry", async () => {

--- a/packages/workflow/tsconfig.json
+++ b/packages/workflow/tsconfig.json
@@ -5,6 +5,9 @@
     "rootDir": "..",
     "baseUrl": "../..",
     "paths": {
+      "@vite-hub/database/config": [
+        "packages/database/src/config.ts"
+      ],
       "@vite-hub/internal/*": [
         "packages/internal/src/*.ts"
       ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1138,9 +1138,6 @@ importers:
       pathe:
         specifier: catalog:unjs
         version: 2.0.3
-      postgres:
-        specifier: catalog:database
-        version: 3.4.9
       workflow:
         specifier: catalog:workflow
         version: 4.2.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.2)
@@ -1148,6 +1145,9 @@ importers:
       '@types/node':
         specifier: catalog:tooling
         version: 25.6.0
+      '@vite-hub/database':
+        specifier: workspace:*
+        version: link:../database
       '@vite-hub/internal':
         specifier: workspace:*
         version: link:../internal
@@ -1160,6 +1160,9 @@ importers:
       openworkflow:
         specifier: catalog:workflow
         version: 0.9.0(postgres@3.4.9)
+      postgres:
+        specifier: catalog:database
+        version: 3.4.9
       publint:
         specifier: catalog:tooling
         version: 0.3.21
@@ -18183,55 +18186,6 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@vitejs/devtools@0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(vite@8.0.8)':
-    dependencies:
-      '@vitejs/devtools-kit': 0.1.19(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@nuxt/kit@4.4.6(magicast@0.5.3))(launch-editor@2.13.2)(typescript@6.0.2)(vite@8.0.8)
-      '@vitejs/devtools-rolldown': 0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(launch-editor@2.13.2)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(vite@8.0.8)(vue@3.5.34(typescript@6.0.2))
-      birpc: 4.0.0
-      cac: 7.0.0
-      devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@nuxt/kit@4.4.6(magicast@0.5.3))(launch-editor@2.13.2)(typescript@6.0.2)
-      h3: 1.15.11
-      immer: 11.1.6
-      launch-editor: 2.13.2
-      logs-sdk: 0.0.6
-      mlly: 1.8.2
-      obug: 2.1.1
-      open: 11.0.0
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      sirv: 3.0.2
-      tinyexec: 1.1.2
-      vite: 8.0.8(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
-      vue: 3.5.34(typescript@6.0.2)
-      ws: 8.20.1
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@modelcontextprotocol/sdk'
-      - '@netlify/blobs'
-      - '@nuxt/kit'
-      - '@planetscale/database'
-      - '@pnpm/logger'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - idb-keyval
-      - ioredis
-      - typescript
-      - uploadthing
-      - utf-8-validate
-    optional: true
-
   '@vitejs/devtools@0.2.0(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(crossws@0.4.5(srvx@0.11.15))(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(vite@8.0.8)':
     dependencies:
       '@vitejs/devtools-kit': 0.2.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(crossws@0.4.5(srvx@0.11.15))(typescript@6.0.2)(vite@8.0.8)
@@ -25836,7 +25790,7 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.6.0
-      '@vitejs/devtools': 0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(vite@8.0.8)
+      '@vitejs/devtools': 0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(vite@8.0.8)
       esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ catalogs:
     drizzle-orm:
       specifier: ^0.44.7
       version: 0.44.7
-    postgres:
-      specifier: ^3.4.9
-      version: 3.4.9
   esbuild-v27:
     esbuild:
       specifier: ^0.27.7
@@ -1160,9 +1157,6 @@ importers:
       openworkflow:
         specifier: catalog:workflow
         version: 0.9.0(postgres@3.4.9)
-      postgres:
-        specifier: catalog:database
-        version: 3.4.9
       publint:
         specifier: catalog:tooling
         version: 0.3.21
@@ -23933,7 +23927,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgres@3.4.9: {}
+  postgres@3.4.9:
+    optional: true
 
   powershell-utils@0.1.0: {}
 


### PR DESCRIPTION
## Summary

- Adds `workflow.database` so the OpenWorkflow provider can resolve a ViteHub database definition for workflow state.
- Wires SQLite and Postgres OpenWorkflow storage through generated Nitro runtime env instead of forcing app-level Postgres setup.
- Exposes `@vite-hub/database/config` for lightweight database config authoring and adds focused config/runtime/module coverage.

## Validation

- `pnpm --dir /private/tmp/vitehub-workflow-database-storage-pr/packages/workflow typecheck`
- `pnpm test` from `/private/tmp/vitehub-workflow-database-storage-pr/packages/workflow`

Note: the workflow Vite fixture tests need the local `@vite-hub/devtools` package built in a fresh worktree; I built it before rerunning the suite.