### PR TITLE
feat(agent): infer invocation profile run inputs

### DIFF
--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -12,7 +12,7 @@ The Workspace is the file boundary. Capabilities decide which model-facing tools
 ## Colocate workspace context
 
 ```ts [server/agents/docs/config.ts]
-import { defineAgent, defineInvocationProfile } from '@vite-hub/agent'
+import { defineAgent } from '@vite-hub/agent'
 import { workspaceShell } from '@vite-hub/agent/capabilities'
 import { source } from '@vite-hub/workspace'
 
@@ -46,7 +46,7 @@ Use the Access Capability when invocation identity should narrow the visible Wor
 ```ts [server/agents/support/config.ts]
 import { gateway } from '@ai-sdk/gateway'
 import { createTeamsAdapter } from '@chat-adapter/teams'
-import { defineAgent } from '@vite-hub/agent'
+import { defineAgent, defineInvocationProfile, type AgentInvocationProfileRunInputFromSchemas } from '@vite-hub/agent'
 import { access, chat, entry, workspaceShell } from '@vite-hub/agent/capabilities'
 import { source } from '@vite-hub/workspace'
 import { z } from 'zod'
@@ -78,15 +78,17 @@ const portalEntry = entry({
   chat: { capability: supportChat, origin: 'portal' },
 })
 
+const supportInput = {
+  chat: {
+    message: { metadata: portalMetadataSchema, runOrigin: ['portal'] },
+    run: { origin: ['portal', 'teams'] },
+    user: portalUserSchema,
+  },
+} as const
+
 const supportProfile = defineInvocationProfile({
   id: 'support',
-  input: {
-    chat: {
-      message: { metadata: portalMetadataSchema, runOrigin: ['portal'] },
-      run: { origin: ['portal', 'teams'] },
-      user: portalUserSchema,
-    },
-  },
+  input: supportInput,
   resolve({ input }) {
     const chat = input.get().context?.chat
     if (chat?.run?.origin !== 'portal')
@@ -141,6 +143,14 @@ export default defineAgent({
 ```
 
 The Invocation Profile sees the parsed schema output. In this example, portal chat requests must include a customer in message metadata, while non-portal chat surfaces can use the explicit all-scopes Workspace Scope. The resolver returns inline Workspace Scope definitions, so the app does not need to pre-register one scope per customer.
+
+If a helper used by the Invocation Profile needs the parsed run input, infer it from the input schema:
+
+```ts
+type SupportRunInput = AgentInvocationProfileRunInputFromSchemas<typeof supportInput>
+```
+
+After the profile value exists, `typeof supportProfile.$Infer.RunInput` and `AgentInvocationProfileRunInput<typeof supportProfile, CallOptions>` can infer from the profile directly.
 
 The Chat App Route origin is configured in `entry({ chat })` so the access decision does not trust a browser-controlled payload. A request body may repeat the same `run.origin`, but it cannot override the configured entry origin; mismatches are rejected as bad requests so app-level proxies fail closed when their contract drifts. The Invocation Profile declares accepted `chat.run.origin` values explicitly and uses `message.runOrigin` when a message metadata schema applies to only some origins.
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -188,15 +188,20 @@ export type {
   AgentInvocationProfileChatMessageInputSchemaOptions,
   AgentInvocationProfileChatRunInputOptions,
   AgentInvocationProfileContextValueId,
+  AgentInvocationProfileInputContext,
   AgentInvocationProfileDefinition,
+  AgentInvocationProfileInfer,
   AgentInvocationProfileInputContextFromSchemas,
   AgentInvocationProfileInputSchemaOptions,
   AgentInvocationProfileOptions,
   AgentInvocationProfileResolver,
   AgentInvocationProfileResolverContext,
+  AgentInvocationProfileRunInput,
+  AgentInvocationProfileRunInputFromSchemas,
   AgentInvocationProfileStandardSchemaResultFailure,
   AgentInvocationProfileStandardSchemaResultSuccess,
   AgentInvocationProfileStandardSchemaV1,
+  DefinedAgentInvocationProfile,
 } from "./invocation-profile.ts"
 
 export type {

--- a/packages/agent/src/invocation-profile.ts
+++ b/packages/agent/src/invocation-profile.ts
@@ -80,6 +80,32 @@ export type AgentInvocationProfileInputContextFromSchemas<TInputSchemas> =
       >
     : Record<string, unknown>
 
+export interface AgentInvocationProfileInfer<
+  TProfile,
+  TInputContext extends object = Record<string, unknown>,
+> {
+  InputContext: TInputContext
+  Profile: TProfile
+  RunInput: AgentRunInput<unknown, TInputContext>
+}
+
+export type AgentInvocationProfileInputContext<
+  TDefinition extends AgentInvocationProfileDefinition<any, any, any, any>,
+> =
+  TDefinition extends AgentInvocationProfileDefinition<any, any, any, infer TInputContext>
+    ? TInputContext
+    : Record<string, unknown>
+
+export type AgentInvocationProfileRunInput<
+  TDefinition extends AgentInvocationProfileDefinition<any, any, any, any>,
+  CALL_OPTIONS = unknown,
+> = AgentRunInput<CALL_OPTIONS, AgentInvocationProfileInputContext<TDefinition>>
+
+export type AgentInvocationProfileRunInputFromSchemas<
+  TInputSchemas extends AgentInvocationProfileInputSchemaOptions,
+  CALL_OPTIONS = unknown,
+> = AgentRunInput<CALL_OPTIONS, AgentInvocationProfileInputContextFromSchemas<TInputSchemas>>
+
 export type AgentInvocationProfileContextValueId<TId extends string = string> = `invocationProfile.${TId}`
 
 export type AgentInvocationProfileResolverContext<
@@ -110,6 +136,15 @@ export interface AgentInvocationProfileDefinition<
   id: string
   input?: AgentInvocationProfileInputSchemaOptions
   resolve: AgentInvocationProfileResolver<TProfile, TRuntimeConfig, Name, TInputContext>
+}
+
+export type DefinedAgentInvocationProfile<
+  TProfile = unknown,
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  TInputContext extends object = Record<string, unknown>,
+> = AgentInvocationProfileDefinition<TProfile, TRuntimeConfig, Name, TInputContext> & {
+  readonly $Infer: AgentInvocationProfileInfer<TProfile, TInputContext>
 }
 
 export interface AgentInvocationProfileOptions<
@@ -210,7 +245,7 @@ export function defineInvocationProfile<
   const TInputSchemas extends AgentInvocationProfileInputSchemaOptions | undefined = undefined,
 >(
   options: AgentInvocationProfileOptions<TProfile, TRuntimeConfig, Name, TInputSchemas>,
-): AgentInvocationProfileDefinition<
+): DefinedAgentInvocationProfile<
   TProfile,
   TRuntimeConfig,
   Name,

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineInvocationProfile, type AgentInvocationProfileStandardSchemaV1, type AgentRuntimeContext } from "../src/index.ts"
+import { defineAgent, defineInvocationProfile, type AgentInvocationProfileInputContext, type AgentInvocationProfileRunInput, type AgentInvocationProfileRunInputFromSchemas, type AgentInvocationProfileStandardSchemaV1, type AgentRunInput, type AgentRuntimeContext } from "../src/index.ts"
 import { access, audience, blob, chat, chatTitle, db, entry, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, transcribe, webSearch, workspaceShell } from "../src/capabilities.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -364,15 +364,16 @@ describe("agent public types", () => {
       },
     })
     const portalEntry = entry({ id: "portal", chat: { capability: supportChat, origin: "portal" } })
+    const supportInput = {
+      chat: {
+        message: { metadata: metadataSchema, runOrigin: ["portal"] },
+        run: { origin: ["portal", "teams"] },
+        user: userSchema,
+      },
+    } as const
     const supportProfile = defineInvocationProfile({
       id: "support",
-      input: {
-        chat: {
-          message: { metadata: metadataSchema, runOrigin: ["portal"] },
-          run: { origin: ["portal", "teams"] },
-          user: userSchema,
-        },
-      },
+      input: supportInput,
       resolve({ input }) {
         const chat = input.get().context?.chat
         expectTypeOf(chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<string | undefined>()
@@ -381,6 +382,28 @@ describe("agent public types", () => {
         return { customer: chat?.message?.metadata?.quiver?.customer || "customer" }
       },
     })
+    type SupportInputContext = typeof supportProfile.$Infer.InputContext
+    expectTypeOf({} as SupportInputContext).toEqualTypeOf<AgentChatRunContext<SupportMessageMetadata, SupportChatUser, "portal" | "teams">>()
+    expectTypeOf({} as typeof supportProfile.$Infer.Profile).toEqualTypeOf<{ customer: string }>()
+    expectTypeOf({} as typeof supportProfile.$Infer.RunInput).toEqualTypeOf<AgentRunInput<unknown, SupportInputContext>>()
+    expectTypeOf({} as AgentInvocationProfileInputContext<typeof supportProfile>).toEqualTypeOf<SupportInputContext>()
+    expectTypeOf({} as AgentInvocationProfileRunInput<typeof supportProfile, { stream: boolean }>).toEqualTypeOf<AgentRunInput<{ stream: boolean }, SupportInputContext>>()
+    expectTypeOf({} as AgentInvocationProfileRunInputFromSchemas<typeof supportInput>).toEqualTypeOf<typeof supportProfile.$Infer.RunInput>()
+
+    type SupportRunInput = AgentInvocationProfileRunInputFromSchemas<typeof supportInput>
+    function resolveSupportProfile(input: SupportRunInput) {
+      const chat = input.context?.chat
+      expectTypeOf(chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<string | undefined>()
+      expectTypeOf(chat?.run?.origin).toEqualTypeOf<"portal" | "teams" | undefined>()
+      expectTypeOf(chat?.user?.email).toEqualTypeOf<string | undefined>()
+      return { customer: chat?.message?.metadata?.quiver?.customer || "customer" }
+    }
+    const externalResolverProfile = defineInvocationProfile({
+      id: "support-external",
+      input: supportInput,
+      resolve: ({ input }) => resolveSupportProfile(input.get()),
+    })
+    expectTypeOf({} as typeof externalResolverProfile.$Infer.Profile).toEqualTypeOf<{ customer: string }>()
 
     defineAgent({
       capabilities: [


### PR DESCRIPTION
Adds Invocation Profile inference helpers so apps can derive typed run inputs from a profile or its input schema without manually composing `AgentRunInput` and `AgentInvocationProfileInputContextFromSchemas`.

The schema-derived helper covers resolver functions used during profile construction, while the profile value also exposes a Better Auth-style `$Infer` bag for consumers that already have the profile object.
