### PR TITLE
fix(agent): restore vite chat devtools bridge

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -36,6 +36,7 @@
     "./memory": "./dist/memory.js",
     "./messages": "./dist/messages.js",
     "./runtime/empty-registry": "./dist/runtime/empty-registry.js",
+    "./server": "./dist/server.js",
     "./state/sqlite": "./dist/state/sqlite.js",
     "./test": "./dist/test.js",
     "./vercel": "./dist/vercel.js",

--- a/packages/agent/src/access-runtime.ts
+++ b/packages/agent/src/access-runtime.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyWorkspaceFacade, WorkspaceName } from "@vite-hub/workspace"
 
-export const workspaceOverrideSymbol: unique symbol = Symbol("vitehub.agent.workspaceOverride")
+export const workspaceOverrideSymbol: unique symbol = Symbol.for("vitehub.agent.workspaceOverride") as never
 
 export interface WorkspaceOverrideRuntime<Name extends WorkspaceName = WorkspaceName> {
   [workspaceOverrideSymbol]: (workspace: ReadonlyWorkspaceFacade<Name>) => void

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -1,0 +1,609 @@
+import { existsSync, statSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { setWorkspaceRuntimeRegistry } from "@vite-hub/workspace/internal/runtime/state"
+
+import {
+  resolveAgentDevtoolsMetadata,
+  resolveAgentTriggers,
+  streamAgentTrigger,
+  withWorkspaceAgentDefaults,
+} from "../../index.ts"
+import {
+  type ChatDevtoolsConversation,
+  type ChatDevtoolsMetadata,
+  type ChatDevtoolsStateResult,
+  type ChatDevtoolsStreamEvent,
+  chatDevtoolsBridgeRoute,
+  chatDevtoolsClearRpc,
+  chatDevtoolsGetStateRpc,
+  chatDevtoolsSendRpc,
+} from "../devtools.ts"
+import { createAgentRuntimeContext } from "../../runtime/context.ts"
+import { discoverAgentDefinitions } from "../../discovery.ts"
+
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http"
+import type { UIMessage } from "ai"
+import type { ViteDevServer } from "vite"
+import type { AgentChatMessageTriggerInput } from "../../chat-trigger.ts"
+import type {
+  AgentInput,
+  AgentRunMetadata,
+  AgentRuntimeConfig,
+  AgentRuntimeContext,
+  DiscoveredAgentDefinition,
+  WorkspaceAgentDefaults,
+} from "../../index.ts"
+
+type ReadUIMessageStream = typeof import("ai").readUIMessageStream
+type ChatDevtoolsAction = "clear" | "get-state" | "send"
+type ChatDevtoolsBridgeBody = {
+  action?: string
+  chat?: string
+  stream?: boolean
+  text?: string
+}
+
+interface ViteAgentDevtoolsRuntimeConfig extends AgentRuntimeConfig {
+  agent?: unknown
+}
+
+interface ViteAgentDevtoolsRuntimeContext extends AgentRuntimeContext<ViteAgentDevtoolsRuntimeConfig> {
+  request?: Request
+  runtime: "vite"
+  runtimeConfig: ViteAgentDevtoolsRuntimeConfig
+}
+
+interface ChatDevtoolsSession {
+  name: string
+  thinkingFallback?: string | null
+  title?: string
+  uiMessages: UIMessage[]
+}
+
+interface ChatDevtoolsAgentEntry {
+  agent: AgentInput<ViteAgentDevtoolsRuntimeContext>
+  metadata: ChatDevtoolsMetadata
+  name: string
+}
+
+interface ChatDevtoolsBridgeState {
+  entries: Map<string, ChatDevtoolsAgentEntry>
+  sessions: Map<string, ChatDevtoolsSession>
+  selected?: string
+}
+
+function normalizeChatDevtoolsAction(action: string): ChatDevtoolsAction | undefined {
+  if (action === "get-state" || action === chatDevtoolsGetStateRpc) return "get-state"
+  if (action === "send" || action === chatDevtoolsSendRpc) return "send"
+  if (action === "clear" || action === chatDevtoolsClearRpc) return "clear"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object"
+}
+
+function resolveAgentModule(module: unknown): AgentInput<ViteAgentDevtoolsRuntimeContext> | undefined {
+  if (isRecord(module) && "default" in module) {
+    return module.default as AgentInput<ViteAgentDevtoolsRuntimeContext> | undefined
+  }
+  return module as AgentInput<ViteAgentDevtoolsRuntimeContext> | undefined
+}
+
+function workspaceDefaults(definition: DiscoveredAgentDefinition): WorkspaceAgentDefaults | undefined {
+  return definition.workspace
+    ? { name: definition.name, workspace: definition.workspace }
+    : undefined
+}
+
+function resolveWorkspaceSourceRoot(file: string): string {
+  const workspaceDirectory = join(dirname(file), "workspace")
+  return existsSync(workspaceDirectory) && statSync(workspaceDirectory).isDirectory()
+    ? workspaceDirectory
+    : dirname(file)
+}
+
+function installServerAgentWorkspaceRegistry(server: ViteDevServer, definitions: DiscoveredAgentDefinition[]): void {
+  setWorkspaceRuntimeRegistry(Object.fromEntries(definitions
+    .filter(definition => definition.workspace)
+    .map(definition => [
+      definition.workspace!,
+      async () => {
+        const mod = await server.ssrLoadModule(pathToFileURL(definition.handler).href)
+        const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
+        return {
+          ...mod,
+          default: {
+            ...mod.default,
+            sourceRootDir: mod.default?.sourceRootDir ?? sourceRootDir,
+          },
+        }
+      },
+    ])))
+}
+
+async function loadDiscoveredAgent(
+  server: ViteDevServer,
+  definition: DiscoveredAgentDefinition,
+): Promise<AgentInput<ViteAgentDevtoolsRuntimeContext> | undefined> {
+  const module = await server.ssrLoadModule(pathToFileURL(definition.handler).href)
+  const agent = resolveAgentModule(module)
+  const defaults = workspaceDefaults(definition)
+  return agent && defaults
+    ? withWorkspaceAgentDefaults(agent as never, defaults as never) as AgentInput<ViteAgentDevtoolsRuntimeContext>
+    : agent
+}
+
+function createDevtoolsDiscoveryContext(): ViteAgentDevtoolsRuntimeContext {
+  return createAgentRuntimeContext({
+    runtime: "vite",
+    runtimeConfig: {},
+    waitUntil: task => void Promise.resolve(task).catch(() => {}),
+  }) as ViteAgentDevtoolsRuntimeContext
+}
+
+function headersFromNode(headers: IncomingHttpHeaders): Headers {
+  const result = new Headers()
+  for (const [name, value] of Object.entries(headers)) {
+    if (typeof value === "string") result.set(name, value)
+    else if (Array.isArray(value)) {
+      for (const item of value) result.append(name, item)
+    }
+  }
+  return result
+}
+
+function createRequest(server: ViteDevServer, req: IncomingMessage): Request {
+  const base = server.resolvedUrls?.local?.[0] || `http://localhost:${server.config.server.port || 5173}/`
+  return new Request(new URL(req.url || chatDevtoolsBridgeRoute, base), {
+    headers: headersFromNode(req.headers),
+    method: req.method || "GET",
+  })
+}
+
+function createRuntimeContext(server: ViteDevServer, req: IncomingMessage, run: AgentRunMetadata): ViteAgentDevtoolsRuntimeContext {
+  return createAgentRuntimeContext({
+    request: createRequest(server, req),
+    run,
+    runtime: "vite",
+    runtimeConfig: {},
+    waitUntil: task => void Promise.resolve(task).catch(() => {}),
+  }) as ViteAgentDevtoolsRuntimeContext
+}
+
+async function discoverChatAgents(server: ViteDevServer): Promise<Map<string, ChatDevtoolsAgentEntry>> {
+  const context = createDevtoolsDiscoveryContext()
+  const entries = new Map<string, ChatDevtoolsAgentEntry>()
+  const definitions = discoverAgentDefinitions({
+    mode: "server-agents",
+    scanDirs: [join(server.config.root, "server")],
+  }).sort((left, right) => left.name.localeCompare(right.name))
+  installServerAgentWorkspaceRegistry(server, definitions)
+
+  for (const definition of definitions) {
+    const agent = await loadDiscoveredAgent(server, definition)
+    if (!agent) continue
+    const triggers = await resolveAgentTriggers(agent as never, context as never)
+    const trigger = triggers["chat.message"]
+    if (!trigger || trigger.devtools === false) continue
+
+    entries.set(definition.name, {
+      agent,
+      metadata: await resolveAgentDevtoolsMetadata(agent as never, workspaceDefaults(definition) as never),
+      name: definition.name,
+    })
+  }
+  return entries
+}
+
+function getSession(state: ChatDevtoolsBridgeState, name: string): ChatDevtoolsSession {
+  let session = state.sessions.get(name)
+  if (!session) {
+    session = { name, uiMessages: [] }
+    state.sessions.set(name, session)
+  }
+  return session
+}
+
+function titleFromUIMessage(message: UIMessage): string | undefined {
+  for (const part of message.parts || []) {
+    const data = (part as { data?: unknown }).data
+    if (
+      (part as { type?: unknown }).type === "data-chat-title"
+      && data
+      && typeof data === "object"
+      && (data as { type?: unknown }).type === "chat-title"
+      && typeof (data as { title?: unknown }).title === "string"
+    ) {
+      const title = (data as { title: string }).title.trim()
+      if (title) return title
+    }
+  }
+}
+
+function titleFromUIMessages(messages: UIMessage[]): string | undefined {
+  for (const message of [...messages].reverse()) {
+    const title = titleFromUIMessage(message)
+    if (title) return title
+  }
+}
+
+function sessionTitle(session: ChatDevtoolsSession): string | undefined {
+  const title = session.title || titleFromUIMessages(session.uiMessages)
+  if (title) session.title = title
+  return title
+}
+
+function getSelectedName(state: ChatDevtoolsBridgeState, selected?: string): string {
+  const names = [...state.entries.keys()]
+  const next = selected && state.entries.has(selected)
+    ? selected
+    : state.selected && state.entries.has(state.selected)
+      ? state.selected
+      : names[0] || ""
+  state.selected = next || undefined
+  return next
+}
+
+async function serializeState(state: ChatDevtoolsBridgeState, selected?: string): Promise<ChatDevtoolsStateResult> {
+  for (const name of state.entries.keys()) getSession(state, name)
+
+  const chats: ChatDevtoolsConversation[] = [...state.entries.keys()].map((name) => {
+    const session = getSession(state, name)
+    const title = sessionTitle(session)
+    return {
+      messages: [],
+      name,
+      ...(title ? { title } : {}),
+      uiMessages: [...session.uiMessages],
+    }
+  })
+
+  const nextSelected = getSelectedName(state, selected)
+  const selectedSession = nextSelected ? getSession(state, nextSelected) : undefined
+  const metadata = nextSelected ? state.entries.get(nextSelected)?.metadata : undefined
+  const title = selectedSession ? sessionTitle(selectedSession) || metadata?.title : metadata?.title
+
+  return {
+    chats,
+    files: metadata?.files || [],
+    instructions: metadata?.instructions || [],
+    selected: nextSelected,
+    thinkingFallback: selectedSession?.thinkingFallback ?? null,
+    ...(title ? { title } : {}),
+    tools: metadata?.tools || [],
+    uiMessages: selectedSession ? [...selectedSession.uiMessages] : [],
+    ...(metadata?.version ? { version: metadata.version } : {}),
+  }
+}
+
+function randomId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+function createRunMetadata(session: ChatDevtoolsSession, userMessageId: string): AgentRunMetadata {
+  return {
+    channelId: `devtools:${session.name}`,
+    messageId: userMessageId,
+    origin: "devtools",
+    runId: globalThis.crypto?.randomUUID?.() || randomId("devtools-run"),
+    threadId: `devtools:${session.name}:thread`,
+  }
+}
+
+function createUserUIMessage(text: string): UIMessage {
+  return {
+    id: randomId("devtools-user"),
+    metadata: {},
+    parts: [{ text, type: "text" }],
+    role: "user",
+  }
+}
+
+function uiMessageMetadata(message: UIMessage): Record<string, unknown> | undefined {
+  return isRecord(message.metadata) ? message.metadata : undefined
+}
+
+function hasCompletedMetadata(message: UIMessage): boolean {
+  const completedAt = uiMessageMetadata(message)?.completedAt
+  return typeof completedAt === "string" && completedAt.trim().length > 0
+}
+
+function isToolUIMessagePart(part: unknown): part is Record<string, unknown> {
+  if (!isRecord(part)) return false
+  return part.type === "dynamic-tool"
+    || (typeof part.type === "string" && part.type.startsWith("tool-"))
+}
+
+function toolPartHasOutput(part: Record<string, unknown>): boolean {
+  return part.state === "output-available"
+    || part.state === "output-denied"
+    || Object.prototype.hasOwnProperty.call(part, "output")
+    || typeof part.errorText === "string"
+}
+
+function hasIncompleteToolParts(message: UIMessage): boolean {
+  return (message.parts || []).some(part => isToolUIMessagePart(part) && !toolPartHasOutput(part))
+}
+
+function isIncompleteAssistantHistoryMessage(message: UIMessage): boolean {
+  return message.role === "assistant" && !hasCompletedMetadata(message) && hasIncompleteToolParts(message)
+}
+
+export function createChatDevtoolsPromptHistory(messages: UIMessage[]): UIMessage[] {
+  return messages.filter(message => !isIncompleteAssistantHistoryMessage(message))
+}
+
+function readableStreamFromResult(value: unknown): ReadableStream<never> {
+  if (value instanceof ReadableStream) return value as ReadableStream<never>
+  if (value instanceof Response && value.body) return value.body as ReadableStream<never>
+  throw new Error("[vitehub] Chat DevTools expected a UI message stream.")
+}
+
+async function sendDevtoolsUIMessage(
+  server: ViteDevServer,
+  req: IncomingMessage,
+  state: ChatDevtoolsBridgeState,
+  input: { chat?: string, stream?: boolean, text?: string },
+  onChange?: (next: ChatDevtoolsStateResult) => void | Promise<void>,
+): Promise<ChatDevtoolsStateResult> {
+  if (!input.stream) {
+    throw new Response("AI SDK Chat DevTools sends require stream: true.", { status: 400 })
+  }
+
+  const text = input.text?.trim()
+  if (!text) {
+    throw new Response("Missing chat message text.", { status: 400 })
+  }
+
+  const selected = getSelectedName(state, input.chat)
+  if (!selected) {
+    throw new Response("No chats are registered for DevTools.", { status: 404 })
+  }
+
+  const entry = state.entries.get(selected)
+  if (!entry) {
+    throw new Response(`Unknown chat: ${selected}`, { status: 404 })
+  }
+
+  const session = getSession(state, selected)
+  state.selected = selected
+  const userMessage = createUserUIMessage(text)
+  const baseMessages = [...createChatDevtoolsPromptHistory(session.uiMessages), userMessage]
+  const run = createRunMetadata(session, userMessage.id)
+  const startedAt = new Date().toISOString()
+  session.uiMessages = baseMessages
+  session.thinkingFallback = null
+  await onChange?.(await serializeState(state, selected))
+
+  const runtimeContext = createRuntimeContext(server, req, run)
+  const triggerInput: AgentChatMessageTriggerInput = {
+    messages: baseMessages,
+    run,
+    timeout: 90_000,
+  }
+  const stream = readableStreamFromResult(await streamAgentTrigger(entry.agent as never, runtimeContext as never, "chat.message", triggerInput, {
+    output: "ui-message-stream",
+    async onInvocation(invocation) {
+      session.thinkingFallback = typeof invocation.metadata?.thinkingFallback === "string"
+        ? invocation.metadata.thinkingFallback
+        : null
+      await onChange?.(await serializeState(state, selected))
+    },
+  }))
+  const { readUIMessageStream } = await import("ai") as { readUIMessageStream: ReadUIMessageStream }
+  let latestAssistant: UIMessage | undefined
+  for await (const assistantMessage of readUIMessageStream({ stream })) {
+    const now = new Date().toISOString()
+    latestAssistant = {
+      ...assistantMessage as UIMessage,
+      metadata: {
+        ...((assistantMessage as UIMessage).metadata as Record<string, unknown> | undefined),
+        createdAt: startedAt,
+        updatedAt: now,
+      },
+    }
+    session.title = titleFromUIMessage(latestAssistant) || session.title
+    session.uiMessages = [...baseMessages, latestAssistant]
+    await onChange?.(await serializeState(state, selected))
+  }
+  if (latestAssistant) {
+    latestAssistant = {
+      ...latestAssistant,
+      metadata: {
+        ...(latestAssistant.metadata as Record<string, unknown> | undefined),
+        completedAt: new Date().toISOString(),
+      },
+    }
+    session.title = titleFromUIMessage(latestAssistant) || session.title
+    session.uiMessages = [...baseMessages, latestAssistant]
+    await onChange?.(await serializeState(state, selected))
+  }
+  return await serializeState(state, selected)
+}
+
+async function clearDevtoolsMessages(state: ChatDevtoolsBridgeState, input: { chat?: string }): Promise<ChatDevtoolsStateResult> {
+  const selected = getSelectedName(state, input.chat)
+  if (!selected) return await serializeState(state)
+  const session = getSession(state, selected)
+  state.selected = selected
+  session.thinkingFallback = null
+  session.title = undefined
+  session.uiMessages = []
+  return await serializeState(state, selected)
+}
+
+function createChatDevtoolsStreamResponse(run: (emit: (event: ChatDevtoolsStreamEvent) => void, signal: AbortSignal) => Promise<void>): Response {
+  const encoder = new TextEncoder()
+  const abortController = new AbortController()
+  let closed = false
+
+  function emit(controller: ReadableStreamDefaultController<Uint8Array>, event: ChatDevtoolsStreamEvent): void {
+    if (closed || abortController.signal.aborted) return
+    try {
+      controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`))
+    }
+    catch {
+      closed = true
+      abortController.abort()
+    }
+  }
+
+  return new Response(new ReadableStream({
+    start(controller) {
+      run(event => emit(controller, event), abortController.signal)
+        .then(() => {
+          if (closed || abortController.signal.aborted) return
+          emit(controller, { type: "done" })
+          if (!closed) {
+            closed = true
+            controller.close()
+          }
+        })
+        .catch((cause) => {
+          if (closed || abortController.signal.aborted) return
+          emit(controller, {
+            message: cause instanceof Error ? cause.message : "Chat DevTools stream failed.",
+            type: "error",
+          })
+          if (!closed) {
+            closed = true
+            controller.close()
+          }
+        })
+    },
+    cancel() {
+      closed = true
+      abortController.abort()
+    },
+  }), {
+    headers: { "content-type": "application/x-ndjson" },
+  })
+}
+
+function parseChatDevtoolsBridgeBody(rawBody: string): ChatDevtoolsBridgeBody | undefined {
+  if (!rawBody.trim()) return undefined
+  try {
+    return JSON.parse(rawBody) as ChatDevtoolsBridgeBody
+  }
+  catch {
+    throw new Response("Malformed chat devtools payload.", { status: 400 })
+  }
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  let body = ""
+  req.setEncoding("utf8")
+  for await (const chunk of req) body += chunk
+  return body
+}
+
+async function handleChatDevtoolsRequest(
+  server: ViteDevServer,
+  req: IncomingMessage,
+  state: ChatDevtoolsBridgeState,
+): Promise<Response> {
+  const body = parseChatDevtoolsBridgeBody(await readRequestBody(req))
+  if (!body || typeof body.action !== "string") {
+    return new Response("Missing chat devtools action.", { status: 400 })
+  }
+
+  state.entries = await discoverChatAgents(server)
+  if (body.chat && state.entries.has(body.chat)) {
+    state.selected = body.chat
+  }
+
+  const action = normalizeChatDevtoolsAction(body.action)
+  if (action === "get-state") {
+    return Response.json(await serializeState(state, body.chat))
+  }
+  if (action === "send") {
+    if (!body.stream) {
+      return new Response("Chat DevTools sends require stream: true.", { status: 400 })
+    }
+    return createChatDevtoolsStreamResponse(async (emit, signal) => {
+      const finalState = await sendDevtoolsUIMessage(server, req, state, body, (next) => {
+        if (!signal.aborted) emit({ state: next, type: "state" })
+      })
+      if (!signal.aborted) emit({ state: finalState, type: "state" })
+    })
+  }
+  if (action === "clear") {
+    return Response.json(await clearDevtoolsMessages(state, body))
+  }
+
+  return new Response(`Unknown chat devtools action: ${body.action}`, { status: 400 })
+}
+
+function routeMatches(req: IncomingMessage): boolean {
+  return new URL(req.url || "/", "http://localhost").pathname === chatDevtoolsBridgeRoute
+}
+
+async function writeResponse(res: ServerResponse, response: Response): Promise<void> {
+  res.statusCode = response.status
+  for (const [name, value] of response.headers) {
+    res.setHeader(name, value)
+  }
+  if (!response.body) {
+    res.end()
+    return
+  }
+
+  const reader = response.body.getReader()
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      res.write(value)
+    }
+    res.end()
+  }
+  catch (error) {
+    res.destroy(error instanceof Error ? error : undefined)
+  }
+}
+
+function errorResponse(error: unknown): Response {
+  if (error instanceof Response) return error
+  return new Response(error instanceof Error ? error.message : "Chat DevTools bridge failed.", {
+    status: 500,
+  })
+}
+
+export function registerChatDevtoolsBridge(server: ViteDevServer): void {
+  const state: ChatDevtoolsBridgeState = {
+    entries: new Map(),
+    sessions: new Map(),
+  }
+
+  server.middlewares.use((req, res, next) => {
+    if (!routeMatches(req)) {
+      next()
+      return
+    }
+    if (req.method === "OPTIONS") {
+      res.statusCode = 204
+      res.setHeader("access-control-allow-origin", "*")
+      res.setHeader("access-control-allow-methods", "POST, OPTIONS")
+      res.setHeader("access-control-allow-headers", "content-type")
+      res.end()
+      return
+    }
+    if (req.method !== "POST") {
+      void writeResponse(res, new Response("Method not allowed.", { status: 405 }))
+      return
+    }
+
+    void handleChatDevtoolsRequest(server, req, state)
+      .then((response) => {
+        response.headers.set("access-control-allow-origin", "*")
+        return writeResponse(res, response)
+      })
+      .catch((error) => {
+        const response = errorResponse(error)
+        response.headers.set("access-control-allow-origin", "*")
+        return writeResponse(res, response)
+      })
+  })
+}

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -1,0 +1,85 @@
+import { streamAgentTrigger } from "./index.ts"
+import { createAgentRuntimeContext } from "./runtime/context.ts"
+import { toHttpErrorResponse } from "./http-error.ts"
+
+import type { AgentChatMessageTriggerInput } from "./chat-trigger.ts"
+import type {
+  AgentInput,
+  AgentRunMetadata,
+  AgentRuntimeConfig,
+  AgentRuntimeContext,
+} from "./types.ts"
+
+interface ViteAgentRouteRuntimeConfig extends AgentRuntimeConfig {
+  agent?: unknown
+}
+
+interface ViteAgentRouteRuntimeContext extends AgentRuntimeContext<ViteAgentRouteRuntimeConfig> {
+  request: Request
+  runtime: "vite"
+  runtimeConfig: ViteAgentRouteRuntimeConfig
+}
+
+type AgentChatRouteBody = AgentChatMessageTriggerInput & {
+  stream?: boolean
+}
+
+async function readJsonBody(request: Request): Promise<AgentChatRouteBody> {
+  const body = await request.json().catch(() => undefined)
+  return typeof body === "object" && body !== null ? body as AgentChatRouteBody : { messages: [] }
+}
+
+function readableStreamFromResult(value: unknown): ReadableStream<unknown> {
+  if (value instanceof ReadableStream) return value
+  if (value instanceof Response && value.body) return value.body
+  throw new Error("[vitehub] Agent chat route expected a UI message stream.")
+}
+
+function createBadRequest(message: string): Response {
+  return Response.json({
+    error: true,
+    status: 400,
+    statusText: message,
+    message,
+  }, { status: 400 })
+}
+
+function createRuntimeContext(request: Request, run: AgentRunMetadata | undefined): ViteAgentRouteRuntimeContext {
+  return createAgentRuntimeContext({
+    request,
+    ...(run ? { run } : {}),
+    runtime: "vite",
+    runtimeConfig: {},
+    waitUntil: task => void Promise.resolve(task).catch(() => {}),
+  }) as ViteAgentRouteRuntimeContext
+}
+
+async function toUiMessageStreamResponse(stream: ReadableStream<unknown>): Promise<Response> {
+  const { createUIMessageStreamResponse } = await import("ai") as {
+    createUIMessageStreamResponse: (options: { stream: ReadableStream<unknown> }) => Response
+  }
+  return createUIMessageStreamResponse({ stream })
+}
+
+export function defineAgentChatFetchHandler(
+  agent: AgentInput<ViteAgentRouteRuntimeContext>,
+): (request: Request) => Promise<Response> {
+  return async (request) => {
+    const body = await readJsonBody(request.clone())
+    if (!Array.isArray(body.messages) || body.messages.length === 0) {
+      return createBadRequest("Agent chat route requires messages.")
+    }
+
+    try {
+      const result = await streamAgentTrigger(agent as never, createRuntimeContext(request, body.run), "chat.message", body, {
+        output: "ui-message-stream",
+      })
+      return await toUiMessageStreamResponse(readableStreamFromResult(result))
+    }
+    catch (error) {
+      const response = toHttpErrorResponse(error)
+      if (response) return response
+      throw error
+    }
+  }
+}

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1,6 +1,7 @@
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored } from "@vite-hub/internal/build/vite"
 
 import { chatDevTools } from "./chat/devtools.ts"
+import { registerChatDevtoolsBridge } from "./chat/vite/devtools-bridge.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig } from "./internal/evalite-config.ts"
 
 import type { Plugin } from "vite"
@@ -33,6 +34,11 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
           return chatDevtoolsPlugin.devtools?.setup?.(ctx)
         }
       },
+    },
+    configureServer(server) {
+      if (agentDevtoolsEnabled(agent)) {
+        registerChatDevtoolsBridge(server)
+      }
     },
     vitehub: {
       cli: async () => {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1,11 +1,17 @@
+import { existsSync, statSync } from "node:fs"
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, join, relative } from "node:path"
+
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored } from "@vite-hub/internal/build/vite"
 
 import { chatDevTools } from "./chat/devtools.ts"
 import { registerChatDevtoolsBridge } from "./chat/vite/devtools-bridge.ts"
+import { normalizeAgentOptions } from "./config.ts"
+import { discoverAgentDefinitions } from "./discovery.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig } from "./internal/evalite-config.ts"
 
 import type { Plugin } from "vite"
-import type { AgentModuleOptions } from "./types.ts"
+import type { AgentModuleOptions, DiscoveredAgentDefinition } from "./types.ts"
 
 interface AgentCliContributingPlugin {
   vitehub?: {
@@ -17,9 +23,84 @@ export type AgentVitePlugin = Plugin & AgentCliContributingPlugin
 
 const agentPackageName = "@vite-hub/agent"
 const mergeNoExternal = createNoExternalMerger(agentPackageName)
+const generatedAgentRouteHandler = ".vitehub/agent/chat-route.ts"
 
 function agentDevtoolsEnabled(agent: AgentModuleOptions | false | undefined): boolean {
   return agent !== false && agent?.devtools !== false
+}
+
+function normalizeNitroRoute(route: string): string {
+  const normalized = route.startsWith("/") ? route : `/${route}`
+  return normalized.replace(/\[agent\]/g, ":agent")
+}
+
+function resolveWorkspaceSourceRoot(file: string): string {
+  const workspaceDirectory = join(dirname(file), "workspace")
+  return existsSync(workspaceDirectory) && statSync(workspaceDirectory).isDirectory()
+    ? workspaceDirectory
+    : dirname(file)
+}
+
+function moduleImportSpecifier(fromFile: string, targetFile: string): string {
+  const specifier = relative(dirname(fromFile), targetFile).replace(/\\/g, "/")
+  return specifier.startsWith(".") ? specifier : `./${specifier}`
+}
+
+function generateAgentRouteHandler(definitions: DiscoveredAgentDefinition[], handlerPath: string): string {
+  const imports = definitions
+    .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
+    .join("\n")
+  const workspaceEntries = definitions
+    .map((definition, index) => definition.workspace
+      ? `${JSON.stringify(definition.workspace)}: async () => ({ ...agent${index}, default: { ...agent${index}.default, sourceRootDir: agent${index}.default?.sourceRootDir ?? ${JSON.stringify(resolveWorkspaceSourceRoot(definition.handler))} } })`
+      : undefined)
+    .filter(Boolean)
+    .join(",\n  ")
+  const agentEntries = definitions
+    .map((definition, index) => {
+      const agentExpression = definition.workspace
+        ? `withWorkspaceAgentDefaults(resolveAgentModule(agent${index}), ${JSON.stringify({ name: definition.name, workspace: definition.workspace })})`
+        : `resolveAgentModule(agent${index})`
+      return `${JSON.stringify(definition.name)}: ${agentExpression}`
+    })
+    .join(",\n  ")
+
+  return [
+    "import { withWorkspaceAgentDefaults } from '@vite-hub/agent'",
+    "import { defineAgentChatFetchHandler } from '@vite-hub/agent/server'",
+    "import { setWorkspaceRuntimeRegistry } from '@vite-hub/workspace/internal/runtime/state'",
+    "import { createError, defineEventHandler, getRouterParam } from 'h3'",
+    imports,
+    "",
+    "function resolveAgentModule(module) {",
+    "  return module && typeof module === 'object' && 'default' in module ? module.default : module",
+    "}",
+    "",
+    `setWorkspaceRuntimeRegistry({${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}})`,
+    "",
+    `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
+    "const handlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, defineAgentChatFetchHandler(agent)]))",
+    "",
+    "export default defineEventHandler(async (event) => {",
+    "  const agent = getRouterParam(event, 'agent')",
+    "  const handler = agent ? handlers[agent] : undefined",
+    "  if (!handler) {",
+    "    throw createError({ statusCode: 404, statusMessage: 'Unknown ViteHub agent.' })",
+    "  }",
+    "  return await handler(event.req)",
+    "})",
+    "",
+  ].join("\n")
+}
+
+async function writeAgentRouteHandler(root: string): Promise<void> {
+  const handlerPath = join(root, generatedAgentRouteHandler)
+  const definitions = discoverAgentDefinitions({
+    mode: "server-agents",
+    scanDirs: [join(root, "server")],
+  })
+  await mkdir(dirname(handlerPath), { recursive: true })
+  await writeFile(handlerPath, generateAgentRouteHandler(definitions, handlerPath), "utf8")
 }
 
 export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
@@ -49,8 +130,21 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     },
     config(config) {
       agent = config.agent ?? agent
+      const resolved = normalizeAgentOptions(agent)
       return {
         ...(typeof agent !== "undefined" ? { agent } : {}),
+        ...(resolved && resolved.route
+          ? {
+              nitro: {
+                handlers: [
+                  {
+                    handler: generatedAgentRouteHandler,
+                    route: normalizeNitroRoute(resolved.route),
+                  },
+                ],
+              },
+            }
+          : {}),
         server: {
           watch: {
             ignored: mergeGeneratedViteHubWatchIgnored(config.server?.watch?.ignored),
@@ -60,6 +154,10 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     },
     async configResolved(config) {
       agent = config.agent ?? agent
+      const resolved = normalizeAgentOptions(agent)
+      if (resolved && resolved.route) {
+        await writeAgentRouteHandler(config.root)
+      }
       if (agent === false || agent?.eval === false) {
         return
       }

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1,14 +1,102 @@
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { Readable } from "node:stream"
 
 import { describe, expect, it, vi } from "vitest"
 
 import { listViteHubDevtoolsFeatures } from "@vite-hub/devtools"
 import { discoverAgentDefinitions } from "../src/discovery.ts"
 
+import type { IncomingMessage, ServerResponse } from "node:http"
+import type { Connect } from "vite"
+
 async function createTempRoot(prefix: string) {
   return await mkdtemp(join(tmpdir(), prefix))
+}
+
+function textFromUiMessage(message: { parts?: Array<Record<string, unknown>> } | undefined) {
+  return (message?.parts || [])
+    .filter(part => part.type === "text" && typeof part.text === "string")
+    .map(part => part.text)
+    .join("")
+}
+
+function responseChunkText(chunk: unknown) {
+  if (typeof chunk === "string") return chunk
+  if (Buffer.isBuffer(chunk)) return chunk.toString("utf8")
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString("utf8")
+  return String(chunk)
+}
+
+function createFakeServer(root: string, module: unknown) {
+  const handlers: Connect.NextHandleFunction[] = []
+  const server = {
+    config: {
+      root,
+      server: { port: 3000 },
+    },
+    middlewares: {
+      use: vi.fn((handler: Connect.NextHandleFunction) => {
+        handlers.push(handler)
+      }),
+    },
+    resolvedUrls: {
+      local: ["http://localhost:3000/"],
+    },
+    ssrLoadModule: vi.fn(async () => module),
+  }
+  return { handlers, server }
+}
+
+async function configurePluginServer(plugin: { configureServer?: unknown }, server: unknown) {
+  const hook = plugin.configureServer
+  if (typeof hook === "function") {
+    await hook(server)
+  }
+  else if (hook && typeof hook === "object" && "handler" in hook && typeof hook.handler === "function") {
+    await hook.handler(server)
+  }
+}
+
+async function invokeMiddleware(
+  handler: Connect.NextHandleFunction,
+  body: Record<string, unknown>,
+  url = "/__vitehub/agent/chat/devtools",
+) {
+  let output = ""
+  const req = Readable.from([JSON.stringify(body)]) as IncomingMessage
+  req.headers = { "content-type": "text/plain" }
+  req.method = "POST"
+  req.url = url
+
+  const result = await new Promise<{ body: string, statusCode: number }>((resolve, reject) => {
+    let statusCode = 200
+    const res = {
+      destroy(error?: Error) {
+        reject(error || new Error("response destroyed"))
+      },
+      end(chunk?: unknown) {
+        if (chunk) output += responseChunkText(chunk)
+        resolve({ body: output, statusCode })
+      },
+      get statusCode() {
+        return statusCode
+      },
+      set statusCode(value: number) {
+        statusCode = value
+      },
+      setHeader: vi.fn(),
+      write(chunk: unknown) {
+        output += responseChunkText(chunk)
+        return true
+      },
+    } as unknown as ServerResponse
+
+    handler(req, res, () => reject(new Error("middleware passed through")))
+  })
+
+  return result
 }
 
 describe("agent discovery", () => {
@@ -146,6 +234,86 @@ describe("agent chat capability discovery", () => {
     expect(ctx.rpc.register).toHaveBeenCalledTimes(3)
   })
 
+  it("serves chat devtools state and send requests from the Vite bridge", async () => {
+    const root = await createTempRoot("vitehub-agent-devtools-bridge-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+
+    const { access, chat } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        access({
+          workspace: {
+            resolve: () => ({ role: "admin", scope: "support" }),
+            scopes: {
+              support: { all: true },
+            },
+          },
+        }),
+        chat(),
+      ],
+      workspace: {},
+      run: (context: { input: { context?: { chat?: { run?: { origin?: string } } } }, workspace?: unknown }) => `answered through ${context.input.context?.chat?.run?.origin} with ${context.workspace ? "workspace" : "no workspace"}`,
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent()
+
+    await configurePluginServer(plugin, server)
+    expect(server.middlewares.use).toHaveBeenCalledTimes(1)
+
+    const stateResponse = await invokeMiddleware(handlers[0]!, { action: "get-state" })
+    const state = JSON.parse(stateResponse.body)
+    expect(state).toMatchObject({
+      chats: [{ name: "support", uiMessages: [] }],
+      selected: "support",
+    })
+
+    const sendResponse = await invokeMiddleware(handlers[0]!, {
+      action: "send",
+      chat: "support",
+      stream: true,
+      text: "hello",
+    })
+    const events = sendResponse.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+    const finalState = events.filter(event => event.type === "state").at(-1)?.state
+
+    expect(events.at(-1)).toEqual({ type: "done" })
+    expect(finalState.selected).toBe("support")
+    expect(finalState.uiMessages.map((message: { role: string }) => message.role)).toEqual(["user", "assistant"])
+    expect(textFromUiMessage(finalState.uiMessages[1])).toBe("answered through devtools with workspace")
+  })
+
+  it("omits unfinished tool-call assistant messages from devtools prompt history", async () => {
+    const { createChatDevtoolsPromptHistory } = await import("../src/chat/vite/devtools-bridge.ts")
+    const history = createChatDevtoolsPromptHistory([
+      {
+        id: "user-1",
+        parts: [{ text: "first", type: "text" }],
+        role: "user",
+      },
+      {
+        id: "assistant-partial",
+        parts: [{ input: { command: "rg forecast" }, state: "input-available", toolCallId: "call-1", type: "tool-shell" }],
+        role: "assistant",
+      },
+      {
+        id: "assistant-complete",
+        metadata: { completedAt: "2026-06-03T08:00:00.000Z" },
+        parts: [
+          { input: { command: "rg forecast" }, output: { stdout: "ok" }, state: "output-available", toolCallId: "call-2", type: "tool-shell" },
+          { text: "done", type: "text" },
+        ],
+        role: "assistant",
+      },
+    ])
+
+    expect(history.map(message => message.id)).toEqual(["user-1", "assistant-complete"])
+  })
+
   it("skips chat devtools feature and bridge when package-local devtools are disabled", async () => {
     const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
     const ctx = {
@@ -161,6 +329,10 @@ describe("agent chat capability discovery", () => {
 
     expect(listViteHubDevtoolsFeatures(ctx as never)).toEqual([])
     expect(ctx.rpc.register).not.toHaveBeenCalled()
+
+    const { server } = createFakeServer(await createTempRoot("vitehub-agent-devtools-disabled-"), {})
+    await configurePluginServer(plugin, server)
+    expect(server.middlewares.use).not.toHaveBeenCalled()
   })
 
 })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -40,6 +40,42 @@ describe("agent Vite plugin", () => {
 
     expect(result).toMatchObject({ agent: { route: true } })
   })
+
+  it("registers configured agent routes with Nitro", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const plugin = hubAgent({ route: "/api/_vitehub/agents/[agent]/chat" })
+    const result = typeof plugin.config === "function"
+      ? await plugin.config.call({} as never, {}, { command: "build", mode: "production" })
+      : undefined
+
+    expect(result).toMatchObject({
+      nitro: {
+        handlers: [{
+          handler: ".vitehub/agent/chat-route.ts",
+          route: "/api/_vitehub/agents/:agent/chat",
+        }],
+      },
+    })
+  })
+})
+
+describe("server helpers", () => {
+  it("rejects chat route requests without messages", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineAgentChatFetchHandler } = await import("../src/server.ts")
+    const handler = defineAgentChatFetchHandler(defineAgent({ run: () => "unused" }) as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({}),
+      method: "POST",
+    }))
+
+    await expect(response.json()).resolves.toMatchObject({
+      message: "Agent chat route requires messages.",
+      status: 400,
+    })
+    expect(response.status).toBe(400)
+  })
 })
 
 describe("Vercel helpers", () => {

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -71,6 +71,9 @@
       "@vite-hub/workspace/*": [
         "packages/workspace/src/*"
       ],
+      "@vite-hub/workspace/internal/runtime/state": [
+        "packages/workspace/src/runtime/state.ts"
+      ],
       "@vite-hub/workflow": [
         "packages/workflow/src/index.ts"
       ],

--- a/packages/agent/tsdown.config.ts
+++ b/packages/agent/tsdown.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     "src/state/sqlite.ts",
     "src/cloudflare/state.ts",
     "src/runtime/empty-registry.ts",
+    "src/server.ts",
     "src/test.ts",
     "src/vercel.ts",
     "src/vite.ts",

--- a/packages/devtools/devtools/chat/app/app.vue
+++ b/packages/devtools/devtools/chat/app/app.vue
@@ -557,23 +557,14 @@ async function refreshFromBridge(chat?: string) {
 }
 
 async function pollFinalBridgeState(input: { chat?: string, text: string }, signal: AbortSignal) {
-  const startedAt = Date.now()
-  let sawSubmittedMessage = false
-
   while (!signal.aborted) {
     await new Promise(resolve => setTimeout(resolve, 700))
     if (signal.aborted) break
 
     const next = await callBridgeState({ action: "get-state", ...(input.chat ? { chat: input.chat } : {}) }, signal)
-    if (!next) {
-      if (!sawSubmittedMessage && Date.now() - startedAt > 3_000) {
-        return false
-      }
-      continue
-    }
+    if (!next) continue
 
     if (hasCurrentUserMessage(next, input.chat, input.text)) {
-      sawSubmittedMessage = true
       if (!signal.aborted) {
         applyState(next)
         error.value = undefined
@@ -642,14 +633,15 @@ async function readDirectBridgeStream(input: { chat?: string, text: string }): P
   currentReader = { cancel: () => abortController.abort() }
 
   let response: Response | undefined
-  let timeoutSignal: AbortSignal | undefined
+  const connectTimeoutController = new AbortController()
+  let connectTimeout: ReturnType<typeof setTimeout> | undefined
   try {
-    timeoutSignal = AbortSignal.timeout(2_000)
+    connectTimeout = setTimeout(() => connectTimeoutController.abort(), 15_000)
     response = await fetch(localBridgeRoute(), {
         method: "POST",
         headers: { "content-type": "text/plain" },
         body: JSON.stringify({ action: "send", ...input, stream: true }),
-        signal: AbortSignal.any([abortController.signal, timeoutSignal]),
+        signal: AbortSignal.any([abortController.signal, connectTimeoutController.signal]),
       })
   }
   catch {
@@ -657,9 +649,13 @@ async function readDirectBridgeStream(input: { chat?: string, text: string }): P
       currentReader = undefined
       return true
     }
-    if (timeoutSignal?.aborted) {
+    if (connectTimeoutController.signal.aborted) {
       try {
-        return await recoverTimedOutBridgeSend(input, abortController.signal)
+        if (await recoverTimedOutBridgeSend(input, abortController.signal)) {
+          return true
+        }
+        error.value = "Chat DevTools bridge timed out before confirming the message."
+        return true
       }
       finally {
         abortController.abort()
@@ -669,6 +665,9 @@ async function readDirectBridgeStream(input: { chat?: string, text: string }): P
 
     currentReader = undefined
     return false
+  }
+  finally {
+    if (connectTimeout) clearTimeout(connectTimeout)
   }
 
   if (!response.ok || !response.body) {
@@ -708,7 +707,7 @@ async function readDirectBridgeStream(input: { chat?: string, text: string }): P
       return "done"
     }
     catch {
-      return abortController.signal.aborted ? "done" : false
+      return abortController.signal.aborted ? "done" : "interrupted"
     }
   }
 
@@ -721,6 +720,13 @@ async function readDirectBridgeStream(input: { chat?: string, text: string }): P
       return true
     }
     if (outcome === "done") {
+      return true
+    }
+    if (outcome === "interrupted") {
+      if (await recoverTimedOutBridgeSend(input, abortController.signal)) {
+        return true
+      }
+      error.value = "Chat DevTools bridge stream disconnected before confirming the message."
       return true
     }
     if (!outcome || hasCompletedResponse(state.value, input.chat, input.text)) {
@@ -993,11 +999,10 @@ onBeforeUnmount(() => {
                               {{ toolMetadataLabel(part.tool) }}
                             </UBadge>
                           </template>
-                          <Suspense v-if="hasToolOutput(part.tool)">
-                            <Comark class="space-y-1 text-toned [&_em]:text-muted [&_h3]:font-medium [&_h3]:text-highlighted [&_p]:my-0 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-elevated [&_pre]:p-2">
-                              {{ renderToolOutput(part.tool) }}
-                            </Comark>
-                          </Suspense>
+                          <pre
+                            v-if="hasToolOutput(part.tool)"
+                            class="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-md bg-elevated p-2 font-mono text-xs/5 text-toned"
+                          >{{ renderToolOutput(part.tool) }}</pre>
                           <p v-else class="italic text-muted">
                             No output
                           </p>


### PR DESCRIPTION
Restores the Agent Package Vite-owned Chat DevTools path by registering the chat DevTools Feature and DevTools Bridge from `hubAgent()`. The bridge discovers server Agent Definitions through Vite SSR loading, filters for chat-capable Agents, preserves workspace-backed defaults, and sends messages through the Agent Trigger API so the hosted ViteHub DevTools Client can inspect and invoke discovered chats without app-owned bridge routes.

Adds the generated Vite chat route surface for configured Agent routes by exporting `@vite-hub/agent/server`, generating `.vitehub/agent/chat-route.ts`, and registering the normalized Nitro handler from the Vite Integration. The route dispatches `/api/_vitehub/agents/:agent/chat` requests to the selected discovered Agent.

This also hardens the chat client around slow or interrupted bridge streams and adds focused coverage for DevTools state and send behavior, generated route registration, server request validation, provider wiring, and prompt history cleanup.