### PR TITLE
docs: clarify Vite-only integration setup

### DIFF
--- a/docs/content/docs/getting-started/index.md
+++ b/docs/content/docs/getting-started/index.md
@@ -16,7 +16,7 @@ Use **Agents** when your app needs model-backed actors with instructions, invoca
   :::u-page-card
   ---
   title: Installation
-  description: Add the packages you need and register their ViteHub integrations.
+  description: Add the packages you need and register their Vite Integrations.
   icon: i-lucide-download
   to: /docs/getting-started/installation
   ---

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Add ViteHub packages to your app and register the integrations you use.
+description: Add ViteHub packages to your app and register the Vite Integrations you use.
 navigation.order: 2
 icon: i-lucide-download
 ---
@@ -52,7 +52,7 @@ Add more primitives only when your app needs them.
 pnpm add @vite-hub/env @vite-hub/database @vite-hub/blob @vite-hub/queue @vite-hub/workflow @vite-hub/schedule @vite-hub/sandbox @vite-hub/workspace
 ```
 
-Each package exports its own ViteHub integration.
+Each package exports its own Vite Integration.
 
 ```ts [vite.config.ts]
 import { hubBlob } from '@vite-hub/blob/vite'
@@ -122,4 +122,3 @@ Confirm the app starts without missing integration errors. If a page imports `kv
 - Continue with [First agent](/docs/getting-started/first-agent) to define and run an Agent.
 - Open [Server primitives](/docs/server-primitives) when you already know which primitive your app needs.
 - Open [Agents](/docs/agents) when the main product value is model-backed behavior.
-

--- a/docs/content/docs/index.md
+++ b/docs/content/docs/index.md
@@ -58,7 +58,7 @@ Most ViteHub features follow the same shape:
 
 1. Start with [Installation](/docs/getting-started/installation).
 2. Install the package that owns the primitive or Agent surface.
-3. Register the ViteHub integration for your server runtime.
+3. Register the package's Vite Integration in `vite.config.ts`.
 4. Define named work when the primitive needs a Definition.
 5. Keep host-specific output and credentials in configuration.
 6. Call a stable Runtime Helper from server code.


### PR DESCRIPTION
Tightens the getting started docs so setup points to package-owned Vite Integrations in `vite.config.ts` instead of generic ViteHub or server-runtime integration language.

This keeps the docs aligned with the Vite-only Framework Integration direction from ADR 0040 and avoids implying Nuxt or Nitro package integrations remain supported.