### PR TITLE
refactor(agent): deepen host response handling

### DIFF
--- a/packages/agent/src/cloudflare.ts
+++ b/packages/agent/src/cloudflare.ts
@@ -1,7 +1,8 @@
-import type { AgentInput, AgentRequestBody, AgentRuntimeContext, CloudflareExportedHandlerFetchHandler } from "./types.ts"
+import type { AgentInput, AgentRuntimeContext, CloudflareExportedHandlerFetchHandler } from "./types.ts"
 
 import { runAgent, streamAgent } from "./index.ts"
 import { toHttpErrorResponse } from "./http-error.ts"
+import { readAgentRequestBody, toAgentFetchResponse } from "./http-response.ts"
 import { createAgentRuntimeContext } from "./runtime/context.ts"
 export { createCloudflareAgentState, ViteHubAgentStateAdapter } from "./state/providers/cloudflare.ts"
 export type {
@@ -15,76 +16,6 @@ type RouteAgentRequest = (request: Request, env: Record<string, unknown>, option
 async function loadRouteAgentRequest(): Promise<RouteAgentRequest> {
   const mod = await import("agents")
   return mod.routeAgentRequest as RouteAgentRequest
-}
-
-async function readJsonBody(request: Request): Promise<AgentRequestBody> {
-  const body = await request.json().catch(() => undefined)
-  return typeof body === "object" && body !== null ? body as AgentRequestBody : {}
-}
-
-function isStreamResult(value: unknown): value is { toUIMessageStreamResponse?: () => Response, toTextStreamResponse?: () => Response } {
-  return typeof value === "object"
-    && value !== null
-    && (typeof (value as { toUIMessageStreamResponse?: unknown }).toUIMessageStreamResponse === "function"
-      || typeof (value as { toTextStreamResponse?: unknown }).toTextStreamResponse === "function")
-}
-
-function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
-  return !!value && typeof value === "object" && Symbol.asyncIterator in value
-}
-
-function toEventStreamResponse(stream: AsyncIterable<unknown>): Response {
-  const encoder = new TextEncoder()
-  return new Response(new ReadableStream({
-    async start(controller) {
-      try {
-        for await (const event of stream) {
-          controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`))
-        }
-        controller.close()
-      }
-      catch (error) {
-        controller.error(error)
-      }
-    },
-  }), {
-    headers: {
-      "content-type": "application/x-ndjson; charset=utf-8",
-    },
-  })
-}
-
-function toJsonSafeResult(value: unknown) {
-  if (typeof value !== "object" || value === null) {
-    return value
-  }
-
-  const result = value as Record<string, unknown>
-  return {
-    finishReason: result.finishReason,
-    raw: result.raw,
-    text: result.text,
-    usage: result.usage,
-    usageRecord: result.usageRecord,
-    warnings: result.warnings,
-  }
-}
-
-function toResponse(value: unknown, stream: boolean): Response {
-  if (value instanceof Response) {
-    return value
-  }
-  if (stream && isStreamResult(value)) {
-    if (value.toUIMessageStreamResponse) {
-      return value.toUIMessageStreamResponse()
-    }
-    const response = value.toTextStreamResponse?.()
-    if (response) return response
-  }
-  if (stream && isAsyncIterable(value)) {
-    return toEventStreamResponse(value)
-  }
-  return Response.json(toJsonSafeResult(value))
 }
 
 export function defineCloudflareAgentHandler(
@@ -101,13 +32,13 @@ export function defineCloudflareAgentHandler(
       waitUntil: task => executionContext.waitUntil?.(task),
     })
     try {
-      const body = await readJsonBody(request.clone())
+      const body = await readAgentRequestBody(request.clone())
       const stream = body.stream !== false
       const result = stream
         ? await streamAgent(agent, context, body)
         : await runAgent(agent, context, body)
 
-      return toResponse(result, stream)
+      return toAgentFetchResponse(result, stream)
     }
     catch (error) {
       const response = toHttpErrorResponse(error)

--- a/packages/agent/src/http-response.ts
+++ b/packages/agent/src/http-response.ts
@@ -1,0 +1,81 @@
+import type { AgentRequestBody } from "./types.ts"
+
+interface AgentStreamResult {
+  toTextStreamResponse?: () => Response
+  toUIMessageStreamResponse?: () => Response
+}
+
+export async function readAgentRequestBody(request: Request): Promise<AgentRequestBody> {
+  const body = await request.json().catch(() => undefined)
+  return typeof body === "object" && body !== null ? body as AgentRequestBody : {}
+}
+
+function isAgentStreamResult(value: unknown): value is AgentStreamResult {
+  return typeof value === "object"
+    && value !== null
+    && (typeof (value as { toUIMessageStreamResponse?: unknown }).toUIMessageStreamResponse === "function"
+      || typeof (value as { toTextStreamResponse?: unknown }).toTextStreamResponse === "function")
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return !!value && typeof value === "object" && Symbol.asyncIterator in value
+}
+
+export function toAgentEventStreamResponse(stream: AsyncIterable<unknown>): Response {
+  const encoder = new TextEncoder()
+  return new Response(new ReadableStream({
+    async start(controller) {
+      try {
+        for await (const event of stream) {
+          controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`))
+        }
+        controller.close()
+      }
+      catch (error) {
+        controller.error(error)
+      }
+    },
+  }), {
+    headers: {
+      "content-type": "application/x-ndjson; charset=utf-8",
+    },
+  })
+}
+
+export function toJsonSafeAgentResult(value: unknown) {
+  if (typeof value !== "object" || value === null) {
+    return value
+  }
+
+  const result = value as Record<string, unknown>
+  return {
+    finishReason: result.finishReason,
+    raw: result.raw,
+    text: result.text,
+    usage: result.usage,
+    usageRecord: result.usageRecord,
+    warnings: result.warnings,
+  }
+}
+
+export function toAgentHttpResult(value: unknown, stream: boolean): Response | unknown {
+  if (value instanceof Response) {
+    return value
+  }
+  if (stream && isAgentStreamResult(value)) {
+    if (value.toUIMessageStreamResponse) {
+      return value.toUIMessageStreamResponse()
+    }
+    const response = value.toTextStreamResponse?.()
+    if (response) return response
+  }
+  if (stream && isAsyncIterable(value)) {
+    return toAgentEventStreamResponse(value)
+  }
+  return toJsonSafeAgentResult(value)
+}
+
+export function toAgentFetchResponse(value: unknown, stream: boolean): Response {
+  const result = toAgentHttpResult(value, stream)
+  return result instanceof Response ? result : Response.json(result)
+}

--- a/packages/agent/src/vercel.ts
+++ b/packages/agent/src/vercel.ts
@@ -2,79 +2,10 @@ import { waitUntil as vercelWaitUntil } from "@vercel/functions"
 
 import { runAgent, streamAgent } from "./index.ts"
 import { toHttpErrorResponse } from "./http-error.ts"
+import { readAgentRequestBody, toAgentFetchResponse } from "./http-response.ts"
 import { createAgentRuntimeContext } from "./runtime/context.ts"
 
-import type { AgentInput, AgentRequestBody, AgentRuntimeContext, AgentWaitUntil } from "./types.ts"
-
-async function readJsonBody(request: Request): Promise<AgentRequestBody> {
-  const body = await request.json().catch(() => undefined)
-  return typeof body === "object" && body !== null ? body as AgentRequestBody : {}
-}
-
-function isStreamResult(value: unknown): value is { toUIMessageStreamResponse?: () => Response, toTextStreamResponse?: () => Response } {
-  return typeof value === "object"
-    && value !== null
-    && (typeof (value as { toUIMessageStreamResponse?: unknown }).toUIMessageStreamResponse === "function"
-      || typeof (value as { toTextStreamResponse?: unknown }).toTextStreamResponse === "function")
-}
-
-function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
-  return !!value && typeof value === "object" && Symbol.asyncIterator in value
-}
-
-function toEventStreamResponse(stream: AsyncIterable<unknown>): Response {
-  const encoder = new TextEncoder()
-  return new Response(new ReadableStream({
-    async start(controller) {
-      try {
-        for await (const event of stream) {
-          controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`))
-        }
-        controller.close()
-      }
-      catch (error) {
-        controller.error(error)
-      }
-    },
-  }), {
-    headers: {
-      "content-type": "application/x-ndjson; charset=utf-8",
-    },
-  })
-}
-
-function toJsonSafeResult(value: unknown) {
-  if (typeof value !== "object" || value === null) {
-    return value
-  }
-
-  const result = value as Record<string, unknown>
-  return {
-    finishReason: result.finishReason,
-    raw: result.raw,
-    text: result.text,
-    usage: result.usage,
-    usageRecord: result.usageRecord,
-    warnings: result.warnings,
-  }
-}
-
-function toResponse(value: unknown, stream: boolean): Response {
-  if (value instanceof Response) {
-    return value
-  }
-  if (stream && isStreamResult(value)) {
-    if (value.toUIMessageStreamResponse) {
-      return value.toUIMessageStreamResponse()
-    }
-    const response = value.toTextStreamResponse?.()
-    if (response) return response
-  }
-  if (stream && isAsyncIterable(value)) {
-    return toEventStreamResponse(value)
-  }
-  return Response.json(toJsonSafeResult(value))
-}
+import type { AgentInput, AgentRuntimeContext, AgentWaitUntil } from "./types.ts"
 
 export function defineVercelAgentHandler(
   agent: AgentInput<AgentRuntimeContext>,
@@ -89,13 +20,13 @@ export function defineVercelAgentHandler(
       waitUntil,
     })
     try {
-      const body = await readJsonBody(request.clone())
+      const body = await readAgentRequestBody(request.clone())
       const stream = body.stream !== false
       const result = stream
         ? await streamAgent(agent, context, body)
         : await runAgent(agent, context, body)
 
-      return toResponse(result, stream)
+      return toAgentFetchResponse(result, stream)
     }
     catch (error) {
       const response = toHttpErrorResponse(error)

--- a/packages/agent/test/http-response.test.ts
+++ b/packages/agent/test/http-response.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  readAgentRequestBody,
+  toAgentEventStreamResponse,
+  toAgentFetchResponse,
+  toAgentHttpResult,
+  toJsonSafeAgentResult,
+} from "../src/http-response.ts"
+
+describe("agent HTTP response helpers", () => {
+  it("reads object request bodies and falls back to an empty request body", async () => {
+    await expect(readAgentRequestBody(new Request("https://example.com", {
+      body: JSON.stringify({ prompt: "hello", stream: false }),
+      method: "POST",
+    }))).resolves.toEqual({ prompt: "hello", stream: false })
+
+    await expect(readAgentRequestBody(new Request("https://example.com", {
+      body: "not-json",
+      method: "POST",
+    }))).resolves.toEqual({})
+  })
+
+  it("keeps only JSON-safe Agent run result fields", () => {
+    expect(toJsonSafeAgentResult({
+      extra: "private",
+      raw: { answer: 42 },
+      text: "ok",
+      usage: { inputTokens: 1 },
+    })).toEqual({
+      finishReason: undefined,
+      raw: { answer: 42 },
+      text: "ok",
+      usage: { inputTokens: 1 },
+      usageRecord: undefined,
+      warnings: undefined,
+    })
+  })
+
+  it("returns host-native Response objects unchanged", () => {
+    const response = Response.json({ ok: true })
+
+    expect(toAgentHttpResult(response, true)).toBe(response)
+    expect(toAgentFetchResponse(response, true)).toBe(response)
+  })
+
+  it("uses AI SDK stream response helpers when streaming Agent results provide them", async () => {
+    const response = new Response("hello")
+    const result = {
+      toTextStreamResponse: () => response,
+    }
+
+    expect(toAgentHttpResult(result, true)).toBe(response)
+    expect(await toAgentFetchResponse(result, true).text()).toBe("hello")
+  })
+
+  it("renders async iterable events as newline-delimited JSON", async () => {
+    async function* events() {
+      yield { type: "start" }
+      yield { type: "done", text: "ok" }
+    }
+
+    const response = toAgentEventStreamResponse(events())
+
+    expect(response.headers.get("content-type")).toBe("application/x-ndjson; charset=utf-8")
+    await expect(response.text()).resolves.toBe("{\"type\":\"start\"}\n{\"type\":\"done\",\"text\":\"ok\"}\n")
+  })
+
+  it("wraps non-streaming results in fetch JSON responses", async () => {
+    const response = toAgentFetchResponse({ extra: "private", text: "ok" }, false)
+
+    await expect(response.json()).resolves.toEqual({ text: "ok" })
+  })
+})


### PR DESCRIPTION
Moves Agent request-body parsing, stream result detection, event stream rendering, JSON-safe result shaping, and fetch Response wrapping into a shared Agent Package HTTP response Module. The Vercel and Cloudflare Agent Route Owners now stay focused on host runtime context and error mapping instead of carrying parallel response pipelines.

Adds focused Module coverage for request parsing, JSON-safe Agent run output, host-native Response passthrough, AI SDK stream response helpers, async event streams, and fetch JSON wrapping, while preserving the existing provider handler behavior.