### PR TITLE
feat(source): add MCP resource sources

### DIFF
--- a/.agents/adr/0016-mcp-capability-ai-sdk-boundary.md
+++ b/.agents/adr/0016-mcp-capability-ai-sdk-boundary.md
@@ -2,4 +2,8 @@
 
 The `mcp()` helper remains an Agent Capability that consumes external MCP Servers and exposes their model-facing tools through the Capability Lifecycle. ViteHub will build this as a thin layer over AI SDK MCP instead of reimplementing MCP client or protocol behavior: ViteHub owns capability composition, tool namespacing, metadata redaction, default instructions, and lifecycle cleanup, while AI SDK owns MCP client behavior.
 
-`@ai-sdk/mcp` stays optional and lazily loaded. The root and `@vite-hub/agent/capabilities` surfaces may expose `mcp()` but must not eagerly import MCP client helper code; explicit MCP client/server helper construction belongs behind a dedicated `@vite-hub/agent/mcp` export path. MCP resources and prompts are intentionally deferred to the Dynamic Source design rather than being hidden behind the MCP Capability.
+`@ai-sdk/mcp` stays optional and lazily loaded. The root and `@vite-hub/agent/capabilities` surfaces may expose `mcp()` but must not eagerly import MCP client helper code; explicit MCP client/server helper construction belongs behind a dedicated `@vite-hub/agent/mcp` export path.
+
+Read-only MCP resources belong to Source design as MCP Resource Sources rather than being hidden behind the MCP Capability.
+
+MCP Prompt Templates belong to Capability prompt or input behavior by default, not Workspace. If a host should let users invoke named MCP prompts before an Agent runs, expose those prompts as Input Command behavior. If an MCP Prompt Template references read-only MCP resources, expose the referenced resources separately through MCP Resource Sources.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -40,6 +40,10 @@ _Avoid_: Dynamic prompt, hardcoded prompt, prompt callback
 A named value available when rendering a Prompt Template.
 _Avoid_: Placeholder, interpolation value, prompt arg
 
+**MCP Prompt Template**:
+A prompt template exposed by an MCP Server and consumed through Capability prompt or input behavior.
+_Avoid_: MCP Resource Source, Workspace file, model tool
+
 **Audience Capability**:
 A Capability created by `audience()` that contributes model-facing instruction blocks for the selected invocation audience.
 _Avoid_: Access Role, model role, user profile, prompt middleware
@@ -158,7 +162,7 @@ _Avoid_: Bash, sandbox, raw workspace tools
 
 **MCP Capability**:
 A Capability that connects an Agent to external MCP servers and exposes their model-facing tools.
-_Avoid_: MCP server implementation, MCP Source
+_Avoid_: MCP server implementation, MCP Resource Source
 
 **MCP Server**:
 An external Model Context Protocol server consumed by an Agent through the MCP Capability.
@@ -199,6 +203,9 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - An **Entry Capability** is the official small helper for app-owned product events when a full product-specific Capability has not earned a name yet.
 - An **Entry Capability** may expose a trusted Chat App Route origin without adding app-route fields to Chat Capability options.
 - A **Prompt Template** belongs to the Capability that renders it and should expose only the **Prompt Template Variables** that are stable for that Capability.
+- An **MCP Prompt Template** is Capability behavior, not Workspace content by default.
+- An **MCP Prompt Template** can be exposed as an **Input Command** when the host should let users invoke a named prompt before the Agent runs.
+- If an **MCP Prompt Template** references read-only MCP resources, those resources can be exposed separately through an **MCP Resource Source**.
 - An **Audience Capability** contributes prompt instructions; it does not apply access boundaries.
 - Standard Schema validation is the preferred runtime boundary for app-owned invocation metadata that an official **Capability** directly consumes.
 - An **Input Command** is a **Capability** concern resolved before model-facing Agent behavior.
@@ -244,6 +251,7 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - The default `admin` **Access Role** can select the explicit all-scopes mode when the developer configured that mode.
 - A **Workspace Shell Capability** contributes shell-shaped Workspace tools without implying Sandbox execution.
 - An **MCP Capability** consumes one or more external **MCP Servers**.
+- An **MCP Capability** exposes executable MCP tools; read-only MCP resources belong to Source design.
 - A **Web Search Capability** hides its underlying search library from users and model-facing labels.
 - A **Web Search Capability** requires an explicit **Web Search Mode** in the first version.
 - A tool-based **Web Search Mode** exposes web search and URL reading as ordinary ViteHub tools.

--- a/.agents/contexts/packages/source/CONTEXT.md
+++ b/.agents/contexts/packages/source/CONTEXT.md
@@ -24,12 +24,18 @@ _Avoid_: Filesystem path, mount path
 The source-specific retrieval behavior for files, globs, markdown, GitHub, or custom data.
 _Avoid_: Workspace loader, build plugin
 
+**MCP Resource Source Loader**:
+A Source Loader that retrieves read-only MCP resources from an external MCP Server as Source items.
+_Avoid_: MCP tool bridge, Agent Capability, MCP server implementation
+
 ## Relationships
 
 - The **Source Package** owns **Source Definitions**.
 - A **Source Registry** contains named Source Definitions.
 - A **Source Path** is validated before source retrieval.
 - A **Source Loader** retrieves items for a Source Definition.
+- An **MCP Resource Source Loader** belongs in Source Package language when MCP resources are used as read-only retrievable content.
+- An **MCP Resource Source Loader** does not expose executable MCP tools; those belong to the MCP Capability.
 - Workspace can consume source retrieval concepts, but Workspace owns file-tree placement and persistence.
 
 ## Example Dialogue
@@ -40,3 +46,4 @@ _Avoid_: Workspace loader, build plugin
 ## Flagged Ambiguities
 
 - Source retrieval and Workspace file placement were considered one concept - resolved: Source Package owns retrieval, Workspace owns file-tree placement.
+- MCP resources and MCP tools were considered one ViteHub integration surface - resolved: read-only MCP resources belong to Source retrieval, while executable MCP tools belong to the MCP Capability.

--- a/.agents/contexts/workspace/CONTEXT.md
+++ b/.agents/contexts/workspace/CONTEXT.md
@@ -31,6 +31,10 @@ _Avoid_: Stored connector, synced files
 A Source whose items are fetched on demand without being written into the Workspace Store by default.
 _Avoid_: Virtual Source, Ephemeral Source, query tool
 
+**MCP Resource Source**:
+A Source that exposes read-only MCP resources from an external MCP Server as addressable Source-Backed Paths.
+_Avoid_: MCP Capability, MCP tool bridge, query-only MCP wrapper
+
 **Source Map**:
 The keyed object that declares a Workspace's Sources.
 _Avoid_: Source list, source array
@@ -122,6 +126,8 @@ _Avoid_: Open workspace, sandbox, mount
 - A **Source** has zero or one **Mount**.
 - A **Source** can expose local or external read-only information when that information has addressable files or items.
 - A **Source** must expose addressable files or items; query-only read tools belong outside the Source concept.
+- An **MCP Resource Source** is appropriate when an MCP Server mostly exposes read-only resources that can be addressed as files or items.
+- MCP tools remain Capability behavior; an **MCP Resource Source** should not turn executable MCP tools into Source-Backed Paths.
 - A **Materialized Source** persists its items in the **Workspace Store**.
 - A **Live Source** resolves Source-Backed Paths directly from its origin unless an explicit cache or materialization policy says otherwise.
 - A **Live Source** cache is separate from the **Workspace Store** and is opt-in.

--- a/fallow.toml
+++ b/fallow.toml
@@ -87,6 +87,7 @@ ignoreDependencies = [
   "chat-state-cloudflare-do",
   "agents",
   "ai",
+  "@ai-sdk/mcp",
   "publint",
   "@iconify-json/lucide",
   "@iconify-json/simple-icons",

--- a/fallow.toml
+++ b/fallow.toml
@@ -87,7 +87,6 @@ ignoreDependencies = [
   "chat-state-cloudflare-do",
   "agents",
   "ai",
-  "@ai-sdk/mcp",
   "publint",
   "@iconify-json/lucide",
   "@iconify-json/simple-icons",

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -29,6 +29,7 @@
     "./sources/github": "./dist/sources/github.js",
     "./sources/glob": "./dist/sources/glob.js",
     "./sources/markdown": "./dist/sources/markdown.js",
+    "./sources/mcp-resources": "./dist/sources/mcp-resources.js",
     "./package.json": "./package.json"
   },
   "files": [
@@ -48,7 +49,16 @@
     "picomatch": "catalog:workspace",
     "tinyglobby": "catalog:workspace"
   },
+  "peerDependencies": {
+    "@ai-sdk/mcp": "catalog:ai"
+  },
+  "peerDependenciesMeta": {
+    "@ai-sdk/mcp": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@ai-sdk/mcp": "catalog:ai",
     "@types/node": "catalog:tooling",
     "@types/picomatch": "catalog:tooling",
     "publint": "catalog:tooling",

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -50,15 +50,15 @@
     "tinyglobby": "catalog:workspace"
   },
   "peerDependencies": {
-    "@ai-sdk/mcp": "catalog:ai"
+    "@modelcontextprotocol/sdk": "catalog:ai"
   },
   "peerDependenciesMeta": {
-    "@ai-sdk/mcp": {
+    "@modelcontextprotocol/sdk": {
       "optional": true
     }
   },
   "devDependencies": {
-    "@ai-sdk/mcp": "catalog:ai",
+    "@modelcontextprotocol/sdk": "catalog:ai",
     "@types/node": "catalog:tooling",
     "@types/picomatch": "catalog:tooling",
     "publint": "catalog:tooling",

--- a/packages/source/src/index.ts
+++ b/packages/source/src/index.ts
@@ -18,10 +18,18 @@ export {
   github,
   glob,
   markdown,
+  mcpResources,
 } from "./sources/index.ts"
 export * as source from "./sources/index.ts"
 export type {
   FileSourceOptions,
   GitHubSourceOptions,
   GlobSourceOptions,
+  McpResourceContent,
+  McpResourceDescriptor,
+  McpResourcesClient,
+  McpResourcesClientConfig,
+  McpResourcesRequestOptions,
+  McpResourcesServer,
+  McpResourcesSourceOptions,
 } from "./sources/index.ts"

--- a/packages/source/src/sources/index.ts
+++ b/packages/source/src/sources/index.ts
@@ -6,3 +6,13 @@ export type { GitHubSourceOptions } from "./github/types.ts"
 export { glob } from "./glob.ts"
 export type { GlobSourceOptions } from "./glob.ts"
 export { markdown } from "./markdown.ts"
+export { mcpResources } from "./mcp-resources.ts"
+export type {
+  McpResourceContent,
+  McpResourceDescriptor,
+  McpResourcesClient,
+  McpResourcesClientConfig,
+  McpResourcesRequestOptions,
+  McpResourcesServer,
+  McpResourcesSourceOptions,
+} from "./mcp-resources.ts"

--- a/packages/source/src/sources/mcp-resources.ts
+++ b/packages/source/src/sources/mcp-resources.ts
@@ -1,0 +1,324 @@
+import { SourceError } from "../core/errors.ts"
+import { matchesAny, normalizeSafeSourcePath, normalizeSourcePath } from "../core/path.ts"
+
+import type { Source, SourceCacheOptions, SourceContent, SourceContext } from "../core/types.ts"
+
+export interface McpResourcesRequestOptions {
+  maxTotalTimeout?: number
+  signal?: AbortSignal
+  timeout?: number
+}
+
+export interface McpResourceDescriptor {
+  uri: string
+  name: string
+  title?: string
+  description?: string
+  mimeType?: string
+  size?: number
+}
+
+export interface McpResourceContent {
+  uri: string
+  name?: string
+  title?: string
+  mimeType?: string
+  text?: string
+  blob?: string
+}
+
+export interface McpResourcesClient {
+  close?: () => void | Promise<void>
+  listResources: (options?: {
+    params?: { cursor?: string }
+    options?: McpResourcesRequestOptions
+  }) => Promise<{
+    nextCursor?: string
+    resources: McpResourceDescriptor[]
+  }>
+  readResource: (args: {
+    options?: McpResourcesRequestOptions
+    uri: string
+  }) => Promise<{
+    contents: McpResourceContent[]
+  }>
+  serverInfo?: unknown
+}
+
+export interface McpResourcesClientConfig {
+  transport: unknown
+}
+
+export type McpResourcesServer =
+  | McpResourcesClient
+  | McpResourcesClientConfig
+  | ((ctx: SourceContext) => McpResourcesClient | McpResourcesClientConfig | Promise<McpResourcesClient | McpResourcesClientConfig>)
+
+export interface McpResourcesSourceOptions<TKey extends string = string> {
+  cache?: false | SourceCacheOptions
+  exclude?: string | string[]
+  include?: string | string[]
+  path?: (resource: McpResourceDescriptor) => TKey | string | undefined
+  request?: McpResourcesRequestOptions
+  server: McpResourcesServer
+}
+
+interface ResourceEntry<TKey extends string = string> {
+  key: TKey
+  resource: McpResourceDescriptor
+}
+
+function isMcpResourcesClient(value: unknown): value is McpResourcesClient {
+  return typeof value === "object"
+    && value !== null
+    && typeof (value as { listResources?: unknown }).listResources === "function"
+    && typeof (value as { readResource?: unknown }).readResource === "function"
+}
+
+function isMcpResourcesClientConfig(value: unknown): value is McpResourcesClientConfig {
+  return typeof value === "object"
+    && value !== null
+    && "transport" in value
+}
+
+async function createMcpClient(config: McpResourcesClientConfig): Promise<McpResourcesClient> {
+  const specifier = ["@ai-sdk", "mcp"].join("/")
+  const runtime = await import(specifier) as {
+    createMCPClient: (config: unknown) => Promise<McpResourcesClient>
+  }
+  return await runtime.createMCPClient(config as never)
+}
+
+async function resolveMcpClient(server: McpResourcesServer, ctx: SourceContext) {
+  const resolved = typeof server === "function" ? await server(ctx) : server
+  if (isMcpResourcesClient(resolved)) {
+    return { client: resolved, ownsClient: false }
+  }
+  if (isMcpResourcesClientConfig(resolved)) {
+    return { client: await createMcpClient(resolved), ownsClient: true }
+  }
+  throw new TypeError("[vitehub] source.mcpResources({ server }) must resolve to an MCP client or MCP client config.")
+}
+
+async function withMcpClient<T>(server: McpResourcesServer, ctx: SourceContext, callback: (client: McpResourcesClient) => Promise<T>) {
+  const { client, ownsClient } = await resolveMcpClient(server, ctx)
+  try {
+    return await callback(client)
+  }
+  finally {
+    if (ownsClient) await client.close?.()
+  }
+}
+
+function extensionForMimeType(mimeType: string | undefined) {
+  if (!mimeType) return
+  if (mimeType === "application/json") return "json"
+  if (mimeType === "text/markdown") return "md"
+  if (mimeType === "text/plain") return "txt"
+  if (mimeType === "text/html") return "html"
+  if (mimeType === "application/xml" || mimeType === "text/xml") return "xml"
+  if (mimeType === "application/octet-stream") return "bin"
+}
+
+function normalizePathSegment(input: string) {
+  return input
+    .normalize("NFKD")
+    .replace(/\\/g, "/")
+    .replace(/[^\w./-]+/g, "-")
+    .replace(/\/+/g, "/")
+    .replace(/(^|\/)\.+(?=\/|$)/g, "")
+    .replace(/^-+|-+$/g, "")
+}
+
+function defaultResourcePath(resource: McpResourceDescriptor) {
+  let path = ""
+  try {
+    const url = new URL(resource.uri)
+    const protocol = url.protocol.replace(/:$/, "")
+    const host = url.hostname || url.host
+    const pathname = decodeURIComponent(url.pathname).replace(/^\/+/, "")
+    path = [host, pathname || resource.name || protocol].filter(Boolean).join("/")
+  }
+  catch {
+    path = resource.name || resource.uri
+  }
+
+  let normalized = normalizePathSegment(path)
+  if (!normalized) normalized = normalizePathSegment(resource.name || resource.uri)
+  const extension = extensionForMimeType(resource.mimeType)
+  if (extension && !normalized.split("/").at(-1)?.includes(".")) {
+    normalized = `${normalized}.${extension}`
+  }
+  return normalizeSafeSourcePath(normalized)
+}
+
+function resourceKey<TKey extends string>(resource: McpResourceDescriptor, options: McpResourcesSourceOptions<TKey>) {
+  const resolved = options.path?.(resource) ?? defaultResourcePath(resource)
+  return normalizeSafeSourcePath(resolved) as TKey
+}
+
+function shouldInclude(path: string, options: Pick<McpResourcesSourceOptions, "include" | "exclude">) {
+  if (options.include && !matchesAny(path, options.include)) return false
+  if (options.exclude && matchesAny(path, options.exclude)) return false
+  return true
+}
+
+async function listAllResources(client: McpResourcesClient, request: McpResourcesRequestOptions | undefined) {
+  const resources: McpResourceDescriptor[] = []
+  let cursor: string | undefined
+  do {
+    const page = await client.listResources({
+      ...(cursor ? { params: { cursor } } : {}),
+      ...(request ? { options: request } : {}),
+    })
+    resources.push(...page.resources)
+    cursor = page.nextCursor
+  } while (cursor)
+  return resources
+}
+
+function createEntries<TKey extends string>(resources: McpResourceDescriptor[], options: McpResourcesSourceOptions<TKey>) {
+  const entries: ResourceEntry<TKey>[] = []
+  const seen = new Map<string, string>()
+  for (const resource of resources) {
+    const key = resourceKey(resource, options)
+    if (!shouldInclude(key, options)) continue
+    const existingUri = seen.get(key)
+    if (existingUri) {
+      throw new SourceError(`[vitehub] source.mcpResources produced duplicate path ${JSON.stringify(key)} for ${JSON.stringify(existingUri)} and ${JSON.stringify(resource.uri)}.`)
+    }
+    seen.set(key, resource.uri)
+    entries.push({ key, resource })
+  }
+  return entries
+}
+
+function decodeBase64(value: string) {
+  if (typeof Buffer !== "undefined") return new Uint8Array(Buffer.from(value, "base64"))
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+  return bytes
+}
+
+function contentToSourceContent(content: McpResourceContent): SourceContent {
+  if (typeof content.text === "string") return content.text
+  if (typeof content.blob === "string") return decodeBase64(content.blob)
+  return ""
+}
+
+function createResourceItem<TKey extends string>(
+  key: TKey,
+  resource: McpResourceDescriptor,
+  contents: McpResourceContent[],
+) {
+  const content = contents.find(item => item.uri === resource.uri) || contents[0]
+  if (!content) {
+    throw new SourceError(`[vitehub] source.mcpResources could not read resource ${JSON.stringify(resource.uri)}.`)
+  }
+  const multipleContents = contents.length > 1
+  return {
+    key,
+    path: key,
+    content: multipleContents ? JSON.stringify(contents, null, 2) : contentToSourceContent(content),
+    mediaType: multipleContents ? "application/json" : content.mimeType || resource.mimeType,
+    metadata: {
+      description: resource.description,
+      name: resource.name,
+      serverResourceCount: contents.length,
+      size: resource.size,
+      title: resource.title,
+      uri: resource.uri,
+    },
+  }
+}
+
+export function mcpResources<const TKey extends string = string>(options: McpResourcesSourceOptions<TKey>): Source<TKey> {
+  if (!options || typeof options !== "object" || !options.server) {
+    throw new TypeError("[vitehub] source.mcpResources({ server }) requires an MCP server.")
+  }
+
+  async function getEntries(ctx: SourceContext) {
+    return await withMcpClient(options.server, ctx, async (client) => {
+      return createEntries(await listAllResources(client, options.request), options)
+    })
+  }
+
+  async function getItems(ctx: SourceContext) {
+    return await withMcpClient(options.server, ctx, async (client) => {
+      const entries = createEntries(await listAllResources(client, options.request), options)
+      return await Promise.all(entries.map(async ({ key, resource }) => {
+        const result = await client.readResource({ uri: resource.uri, ...(options.request ? { options: options.request } : {}) })
+        return createResourceItem(key, resource, result.contents)
+      }))
+    })
+  }
+
+  return {
+    cache: options.cache,
+    fingerprint: {
+      exclude: options.exclude,
+      include: options.include,
+      server: typeof options.server === "function"
+        ? "[function]"
+        : isMcpResourcesClient(options.server)
+          ? { client: true, serverInfo: options.server.serverInfo }
+          : options.server,
+    },
+    name: "mcpResources",
+    async getKeys(ctx) {
+      return (await getEntries(ctx)).map(entry => entry.key)
+    },
+    async getItems(ctx) {
+      return await getItems(ctx)
+    },
+    async getMeta(key, ctx) {
+      const entry = (await getEntries(ctx)).find(entry => entry.key === key)
+      if (!entry) return
+      return {
+        description: entry.resource.description,
+        mimeType: entry.resource.mimeType,
+        name: entry.resource.name,
+        size: entry.resource.size,
+        title: entry.resource.title,
+        uri: entry.resource.uri,
+      }
+    },
+    async getItem(key, ctx) {
+      return await withMcpClient(options.server, ctx, async (client) => {
+        const entry = createEntries(await listAllResources(client, options.request), options).find(entry => entry.key === key)
+        if (!entry) {
+          throw new SourceError(`[vitehub] source.mcpResources could not find ${JSON.stringify(key)}.`)
+        }
+        const result = await client.readResource({ uri: entry.resource.uri, ...(options.request ? { options: options.request } : {}) })
+        return createResourceItem(key, entry.resource, result.contents)
+      })
+    },
+    async search(query, ctx) {
+      const pattern = query.regex ? new RegExp(query.pattern, query.caseSensitive ? "g" : "gi") : undefined
+      const search = query.caseSensitive ? query.pattern : query.pattern.toLowerCase()
+      const results = []
+      for (const item of await getItems(ctx)) {
+        if (typeof item.content !== "string") continue
+        if (query.paths?.length && !query.paths.some(path => item.path && normalizeSourcePath(item.path).startsWith(normalizeSourcePath(path)))) continue
+        const lines = item.content.split(/\r?\n/)
+        for (const [index, line] of lines.entries()) {
+          const matchIndex = pattern
+            ? line.search(pattern)
+            : (query.caseSensitive ? line : line.toLowerCase()).indexOf(search)
+          if (matchIndex === -1) continue
+          results.push({
+            column: matchIndex + 1,
+            line: index + 1,
+            path: item.path || item.key,
+            text: line,
+          })
+          if (query.limit && results.length >= query.limit) return results
+        }
+      }
+      return results
+    },
+  }
+}

--- a/packages/source/src/sources/mcp-resources.ts
+++ b/packages/source/src/sources/mcp-resources.ts
@@ -2,51 +2,34 @@ import { SourceError } from "../core/errors.ts"
 import { matchesAny, normalizeSafeSourcePath, normalizeSourcePath } from "../core/path.ts"
 
 import type { Source, SourceCacheOptions, SourceContent, SourceContext } from "../core/types.ts"
+import type { Client as SdkMcpClient } from "@modelcontextprotocol/sdk/client/index.js"
+import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js"
+import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js"
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
+import type { BlobResourceContents, Resource, TextResourceContents } from "@modelcontextprotocol/sdk/types.js"
 
-export interface McpResourcesRequestOptions {
-  maxTotalTimeout?: number
-  signal?: AbortSignal
-  timeout?: number
-}
+export type McpResourcesRequestOptions = RequestOptions
 
-export interface McpResourceDescriptor {
-  uri: string
-  name: string
-  title?: string
-  description?: string
-  mimeType?: string
-  size?: number
-}
+export type McpResourceDescriptor = Resource
 
-export interface McpResourceContent {
-  uri: string
-  name?: string
-  title?: string
-  mimeType?: string
-  text?: string
-  blob?: string
-}
+export type McpResourceContent = TextResourceContents | BlobResourceContents
 
 export interface McpResourcesClient {
   close?: () => void | Promise<void>
-  listResources: (options?: {
-    params?: { cursor?: string }
-    options?: McpResourcesRequestOptions
-  }) => Promise<{
-    nextCursor?: string
-    resources: McpResourceDescriptor[]
-  }>
-  readResource: (args: {
-    options?: McpResourcesRequestOptions
-    uri: string
-  }) => Promise<{
-    contents: McpResourceContent[]
-  }>
+  getServerVersion?: SdkMcpClient["getServerVersion"]
+  listResources: SdkMcpClient["listResources"]
+  readResource: SdkMcpClient["readResource"]
   serverInfo?: unknown
 }
 
+export type McpResourcesTransportConfig =
+  | Transport
+  | ({ type?: "http", url: string | URL } & StreamableHTTPClientTransportOptions)
+  | ({ type: "sse", url: string | URL } & SSEClientTransportOptions)
+
 export interface McpResourcesClientConfig {
-  transport: unknown
+  transport: McpResourcesTransportConfig
 }
 
 export type McpResourcesServer =
@@ -82,12 +65,36 @@ function isMcpResourcesClientConfig(value: unknown): value is McpResourcesClient
     && "transport" in value
 }
 
-async function createMcpClient(config: McpResourcesClientConfig): Promise<McpResourcesClient> {
-  const specifier = ["@ai-sdk", "mcp"].join("/")
-  const runtime = await import(specifier) as {
-    createMCPClient: (config: unknown) => Promise<McpResourcesClient>
+function isMcpTransport(value: unknown): value is Transport {
+  return typeof value === "object"
+    && value !== null
+    && typeof (value as { close?: unknown }).close === "function"
+    && typeof (value as { send?: unknown }).send === "function"
+    && typeof (value as { start?: unknown }).start === "function"
+}
+
+async function createMcpTransport(config: McpResourcesTransportConfig): Promise<Transport> {
+  if (isMcpTransport(config)) return config
+  const { type = "http", url, ...options } = config
+  if (type === "sse") {
+    const { SSEClientTransport } = await import("@modelcontextprotocol/sdk/client/sse.js")
+    return new SSEClientTransport(new URL(url), options)
   }
-  return await runtime.createMCPClient(config as never)
+  const { StreamableHTTPClientTransport } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js")
+  return new StreamableHTTPClientTransport(new URL(url), options)
+}
+
+async function createMcpClient(config: McpResourcesClientConfig): Promise<McpResourcesClient> {
+  const [{ Client }, transport] = await Promise.all([
+    import("@modelcontextprotocol/sdk/client/index.js"),
+    createMcpTransport(config.transport),
+  ])
+  const client = new Client({
+    name: "vitehub-source",
+    version: "0.0.1",
+  })
+  await client.connect(transport)
+  return client
 }
 
 async function resolveMcpClient(server: McpResourcesServer, ctx: SourceContext) {
@@ -181,21 +188,19 @@ async function listAllResources(client: McpResourcesClient, request: McpResource
   const resources: McpResourceDescriptor[] = []
   let cursor: string | undefined
   do {
-    const page = await client.listResources({
-      ...(cursor ? { params: { cursor } } : {}),
-      ...(request ? { options: request } : {}),
-    })
+    const page = await client.listResources(cursor ? { cursor } : undefined, request)
     resources.push(...page.resources)
     cursor = page.nextCursor
   } while (cursor)
   return resources
 }
 
-function readResourceInput(resource: McpResourceDescriptor, request: McpResourcesRequestOptions | undefined) {
-  return {
-    uri: resource.uri,
-    ...(request ? { options: request } : {}),
-  }
+async function readResourceContents(
+  client: McpResourcesClient,
+  resource: McpResourceDescriptor,
+  request: McpResourcesRequestOptions | undefined,
+) {
+  return (await client.readResource({ uri: resource.uri }, request)).contents
 }
 
 async function createEntries<TKey extends string>(
@@ -209,7 +214,7 @@ async function createEntries<TKey extends string>(
     let contents: McpResourceContent[] | undefined
     let resolvedResource = resource
     if (client && resourcePathNeedsContentMimeType(resource, options)) {
-      contents = (await client.readResource(readResourceInput(resource, options.request))).contents
+      contents = await readResourceContents(client, resource, options.request)
       resolvedResource = resourceWithContentMimeType(resource, contents)
     }
     const key = resourceKey(resolvedResource, options)
@@ -235,8 +240,8 @@ function decodeBase64(value: string) {
 }
 
 function contentToSourceContent(content: McpResourceContent): SourceContent {
-  if (typeof content.text === "string") return content.text
-  if (typeof content.blob === "string") return decodeBase64(content.blob)
+  if ("text" in content && typeof content.text === "string") return content.text
+  if ("blob" in content && typeof content.blob === "string") return decodeBase64(content.blob)
   return ""
 }
 
@@ -281,7 +286,7 @@ export function mcpResources<const TKey extends string = string>(options: McpRes
     return await withMcpClient(options.server, ctx, async (client) => {
       const entries = await createEntries(await listAllResources(client, options.request), options, client)
       return await Promise.all(entries.map(async ({ contents, key, resource }) => {
-        const result = contents ?? (await client.readResource(readResourceInput(resource, options.request))).contents
+        const result = contents ?? await readResourceContents(client, resource, options.request)
         return createResourceItem(key, resource, result)
       }))
     })
@@ -323,7 +328,7 @@ export function mcpResources<const TKey extends string = string>(options: McpRes
         if (!entry) {
           throw new SourceError(`[vitehub] source.mcpResources could not find ${JSON.stringify(key)}.`)
         }
-        const result = entry.contents ?? (await client.readResource(readResourceInput(entry.resource, options.request))).contents
+        const result = entry.contents ?? await readResourceContents(client, entry.resource, options.request)
         return createResourceItem(key, entry.resource, result)
       })
     },

--- a/packages/source/src/sources/mcp-resources.ts
+++ b/packages/source/src/sources/mcp-resources.ts
@@ -64,6 +64,7 @@ export interface McpResourcesSourceOptions<TKey extends string = string> {
 }
 
 interface ResourceEntry<TKey extends string = string> {
+  contents?: McpResourceContent[]
   key: TKey
   resource: McpResourceDescriptor
 }
@@ -152,6 +153,19 @@ function defaultResourcePath(resource: McpResourceDescriptor) {
   return normalizeSafeSourcePath(normalized)
 }
 
+function resourcePathNeedsContentMimeType(resource: McpResourceDescriptor, options: McpResourcesSourceOptions) {
+  if (options.path || resource.mimeType) return false
+  const path = defaultResourcePath(resource)
+  return !path.split("/").at(-1)?.includes(".")
+}
+
+function resourceWithContentMimeType(resource: McpResourceDescriptor, contents: McpResourceContent[]) {
+  if (resource.mimeType) return resource
+  const content = contents.find(item => item.uri === resource.uri) || contents[0]
+  const mimeType = contents.length > 1 ? "application/json" : content?.mimeType
+  return mimeType ? { ...resource, mimeType } : resource
+}
+
 function resourceKey<TKey extends string>(resource: McpResourceDescriptor, options: McpResourcesSourceOptions<TKey>) {
   const resolved = options.path?.(resource) ?? defaultResourcePath(resource)
   return normalizeSafeSourcePath(resolved) as TKey
@@ -177,18 +191,35 @@ async function listAllResources(client: McpResourcesClient, request: McpResource
   return resources
 }
 
-function createEntries<TKey extends string>(resources: McpResourceDescriptor[], options: McpResourcesSourceOptions<TKey>) {
+function readResourceInput(resource: McpResourceDescriptor, request: McpResourcesRequestOptions | undefined) {
+  return {
+    uri: resource.uri,
+    ...(request ? { options: request } : {}),
+  }
+}
+
+async function createEntries<TKey extends string>(
+  resources: McpResourceDescriptor[],
+  options: McpResourcesSourceOptions<TKey>,
+  client?: McpResourcesClient,
+) {
   const entries: ResourceEntry<TKey>[] = []
   const seen = new Map<string, string>()
   for (const resource of resources) {
-    const key = resourceKey(resource, options)
+    let contents: McpResourceContent[] | undefined
+    let resolvedResource = resource
+    if (client && resourcePathNeedsContentMimeType(resource, options)) {
+      contents = (await client.readResource(readResourceInput(resource, options.request))).contents
+      resolvedResource = resourceWithContentMimeType(resource, contents)
+    }
+    const key = resourceKey(resolvedResource, options)
     if (!shouldInclude(key, options)) continue
     const existingUri = seen.get(key)
     if (existingUri) {
       throw new SourceError(`[vitehub] source.mcpResources produced duplicate path ${JSON.stringify(key)} for ${JSON.stringify(existingUri)} and ${JSON.stringify(resource.uri)}.`)
     }
     seen.set(key, resource.uri)
-    entries.push({ key, resource })
+    entries.push({ contents, key, resource: resolvedResource })
   }
   return entries
 }
@@ -242,16 +273,16 @@ export function mcpResources<const TKey extends string = string>(options: McpRes
 
   async function getEntries(ctx: SourceContext) {
     return await withMcpClient(options.server, ctx, async (client) => {
-      return createEntries(await listAllResources(client, options.request), options)
+      return await createEntries(await listAllResources(client, options.request), options, client)
     })
   }
 
   async function getItems(ctx: SourceContext) {
     return await withMcpClient(options.server, ctx, async (client) => {
-      const entries = createEntries(await listAllResources(client, options.request), options)
-      return await Promise.all(entries.map(async ({ key, resource }) => {
-        const result = await client.readResource({ uri: resource.uri, ...(options.request ? { options: options.request } : {}) })
-        return createResourceItem(key, resource, result.contents)
+      const entries = await createEntries(await listAllResources(client, options.request), options, client)
+      return await Promise.all(entries.map(async ({ contents, key, resource }) => {
+        const result = contents ?? (await client.readResource(readResourceInput(resource, options.request))).contents
+        return createResourceItem(key, resource, result)
       }))
     })
   }
@@ -288,12 +319,12 @@ export function mcpResources<const TKey extends string = string>(options: McpRes
     },
     async getItem(key, ctx) {
       return await withMcpClient(options.server, ctx, async (client) => {
-        const entry = createEntries(await listAllResources(client, options.request), options).find(entry => entry.key === key)
+        const entry = (await createEntries(await listAllResources(client, options.request), options, client)).find(entry => entry.key === key)
         if (!entry) {
           throw new SourceError(`[vitehub] source.mcpResources could not find ${JSON.stringify(key)}.`)
         }
-        const result = await client.readResource({ uri: entry.resource.uri, ...(options.request ? { options: options.request } : {}) })
-        return createResourceItem(key, entry.resource, result.contents)
+        const result = entry.contents ?? (await client.readResource(readResourceInput(entry.resource, options.request))).contents
+        return createResourceItem(key, entry.resource, result)
       })
     },
     async search(query, ctx) {

--- a/packages/source/test/sources/mcp-resources.test.ts
+++ b/packages/source/test/sources/mcp-resources.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { mcpResources } from "../../src/index.ts"
+
+import type { McpResourcesClient } from "../../src/index.ts"
+
+function createClient(): McpResourcesClient {
+  return {
+    serverInfo: { name: "Nuxt", version: "test" },
+    async listResources(options) {
+      if (!options?.params?.cursor) {
+        return {
+          nextCursor: "next",
+          resources: [{
+            description: "Complete list of available Nuxt documentation pages",
+            mimeType: "application/json",
+            name: "documentation-pages",
+            title: "Nuxt documentation pages",
+            uri: "resource://nuxt-com/documentation-pages",
+          }],
+        }
+      }
+      return {
+        resources: [{
+          description: "Complete list of Nuxt blog posts",
+          mimeType: "application/json",
+          name: "blog-posts",
+          uri: "resource://nuxt-com/blog-posts",
+        }],
+      }
+    },
+    async readResource({ uri }) {
+      return {
+        contents: [{
+          mimeType: "application/json",
+          text: JSON.stringify([{ title: uri.includes("blog") ? "Nuxt blog" : "Nuxt docs" }], null, 2),
+          uri,
+        }],
+      }
+    },
+  }
+}
+
+describe("source.mcpResources", () => {
+  it("lists paginated MCP resources as source paths", async () => {
+    const source = mcpResources({ server: createClient() })
+
+    await expect(source.getKeys({ rootDir: "/tmp" })).resolves.toEqual([
+      "nuxt-com/documentation-pages.json",
+      "nuxt-com/blog-posts.json",
+    ])
+  })
+
+  it("reads MCP resource contents and metadata", async () => {
+    const source = mcpResources({ server: createClient() })
+
+    await expect(source.getItem("nuxt-com/documentation-pages.json", { rootDir: "/tmp" })).resolves.toMatchObject({
+      content: JSON.stringify([{ title: "Nuxt docs" }], null, 2),
+      mediaType: "application/json",
+      metadata: {
+        description: "Complete list of available Nuxt documentation pages",
+        title: "Nuxt documentation pages",
+        uri: "resource://nuxt-com/documentation-pages",
+      },
+    })
+    await expect(source.getMeta?.("nuxt-com/blog-posts.json", { rootDir: "/tmp" })).resolves.toMatchObject({
+      mimeType: "application/json",
+      uri: "resource://nuxt-com/blog-posts",
+    })
+  })
+
+  it("filters resources and supports custom paths", async () => {
+    const source = mcpResources({
+      exclude: "**/blog-posts.json",
+      path: resource => `mcp/${resource.name}.json`,
+      server: createClient(),
+    })
+
+    await expect(source.getKeys({ rootDir: "/tmp" })).resolves.toEqual([
+      "mcp/documentation-pages.json",
+    ])
+  })
+
+  it("closes owned MCP clients created from config", async () => {
+    const close = vi.fn()
+    vi.doMock("@ai-sdk/mcp", () => ({
+      createMCPClient: vi.fn(async () => ({
+        close,
+        async listResources() {
+          return {
+            resources: [{
+              mimeType: "text/plain",
+              name: "resource.txt",
+              uri: "file:///mock/resource.txt",
+            }],
+          }
+        },
+        async readResource() {
+          return {
+            contents: [{ text: "hello", uri: "file:///mock/resource.txt" }],
+          }
+        },
+      })),
+    }))
+    vi.resetModules()
+    const { mcpResources } = await import("../../src/sources/mcp-resources.ts")
+    const source = mcpResources({ server: { transport: { type: "http", url: "https://example.com/mcp" } } })
+
+    await expect(source.getItem("mock/resource.txt", { rootDir: "/tmp" })).resolves.toMatchObject({
+      content: "hello",
+    })
+    expect(close).toHaveBeenCalledTimes(1)
+    vi.doUnmock("@ai-sdk/mcp")
+    vi.resetModules()
+  })
+})

--- a/packages/source/test/sources/mcp-resources.test.ts
+++ b/packages/source/test/sources/mcp-resources.test.ts
@@ -8,7 +8,7 @@ function createClient(): McpResourcesClient {
   return {
     serverInfo: { name: "Nuxt", version: "test" },
     async listResources(options) {
-      if (!options?.params?.cursor) {
+      if (!options?.cursor) {
         return {
           nextCursor: "next",
           resources: [{
@@ -81,24 +81,44 @@ describe("source.mcpResources", () => {
 
   it("closes owned MCP clients created from config", async () => {
     const close = vi.fn()
-    vi.doMock("@ai-sdk/mcp", () => ({
-      createMCPClient: vi.fn(async () => ({
-        close,
-        async listResources() {
-          return {
-            resources: [{
-              mimeType: "text/plain",
-              name: "resource.txt",
-              uri: "file:///mock/resource.txt",
-            }],
-          }
-        },
-        async readResource() {
-          return {
-            contents: [{ text: "hello", uri: "file:///mock/resource.txt" }],
-          }
-        },
-      })),
+    const connect = vi.fn()
+    const transport = {
+      close: vi.fn(),
+      send: vi.fn(),
+      start: vi.fn(),
+    }
+    vi.doMock("@modelcontextprotocol/sdk/client/index.js", () => ({
+      Client: vi.fn(function () {
+        return {
+          close,
+          connect,
+          getServerVersion: () => ({ name: "mock", version: "test" }),
+          async listResources() {
+            return {
+              resources: [{
+                mimeType: "text/plain",
+                name: "resource.txt",
+                uri: "file:///mock/resource.txt",
+              }],
+            }
+          },
+          async readResource() {
+            return {
+              contents: [{ text: "hello", uri: "file:///mock/resource.txt" }],
+            }
+          },
+        }
+      }),
+    }))
+    vi.doMock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+      StreamableHTTPClientTransport: vi.fn(function () {
+        return transport
+      }),
+    }))
+    vi.doMock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+      SSEClientTransport: vi.fn(function () {
+        return transport
+      }),
     }))
     vi.resetModules()
     const { mcpResources } = await import("../../src/sources/mcp-resources.ts")
@@ -107,8 +127,11 @@ describe("source.mcpResources", () => {
     await expect(source.getItem("mock/resource.txt", { rootDir: "/tmp" })).resolves.toMatchObject({
       content: "hello",
     })
+    expect(connect).toHaveBeenCalledWith(transport)
     expect(close).toHaveBeenCalledTimes(1)
-    vi.doUnmock("@ai-sdk/mcp")
+    vi.doUnmock("@modelcontextprotocol/sdk/client/index.js")
+    vi.doUnmock("@modelcontextprotocol/sdk/client/streamableHttp.js")
+    vi.doUnmock("@modelcontextprotocol/sdk/client/sse.js")
     vi.resetModules()
   })
 })

--- a/packages/source/test/sources/mcp-resources.test.ts
+++ b/packages/source/test/sources/mcp-resources.test.ts
@@ -13,7 +13,6 @@ function createClient(): McpResourcesClient {
           nextCursor: "next",
           resources: [{
             description: "Complete list of available Nuxt documentation pages",
-            mimeType: "application/json",
             name: "documentation-pages",
             title: "Nuxt documentation pages",
             uri: "resource://nuxt-com/documentation-pages",
@@ -23,7 +22,6 @@ function createClient(): McpResourcesClient {
       return {
         resources: [{
           description: "Complete list of Nuxt blog posts",
-          mimeType: "application/json",
           name: "blog-posts",
           uri: "resource://nuxt-com/blog-posts",
         }],
@@ -43,7 +41,7 @@ function createClient(): McpResourcesClient {
 
 describe("source.mcpResources", () => {
   it("lists paginated MCP resources as source paths", async () => {
-    const source = mcpResources({ server: createClient() })
+    const source = mcpResources({ include: "**/*.json", server: createClient() })
 
     await expect(source.getKeys({ rootDir: "/tmp" })).resolves.toEqual([
       "nuxt-com/documentation-pages.json",

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -6,6 +6,7 @@ import {
   defineSources,
   file,
   github,
+  mcpResources,
   registerSources,
   source,
   type Source,
@@ -28,6 +29,15 @@ describe("@vite-hub/source types", () => {
   it("types registered source names and keys", async () => {
     const staticSource = file({ content: "# Docs\n", workspacePath: "README.md" })
     expectTypeOf(source.file({ content: "# Docs\n", workspacePath: "README.md" })).toMatchTypeOf<Source<"README.md">>()
+    expectTypeOf(source.mcpResources({ server: {
+      async listResources() {
+        return { resources: [] }
+      },
+      async readResource() {
+        return { contents: [] }
+      },
+    } })).toMatchTypeOf<Source<string>>()
+    expectTypeOf(mcpResources({ server: { transport: { type: "http", url: "https://example.com/mcp" } } })).toMatchTypeOf<Source<string>>()
     const sources = defineSources({
       docs: staticSource,
       dynamic: github({ repo: "acme/app" }),

--- a/packages/source/tsdown.config.ts
+++ b/packages/source/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "src/sources/glob.ts",
     "src/sources/index.ts",
     "src/sources/markdown.ts",
+    "src/sources/mcp-resources.ts",
   ],
   exports: {
     inlinedDependencies: false,

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -250,7 +250,9 @@ export interface WorkspaceStore {
 }
 
 export interface SourceContext {
+  mountPath?: string
   rootDir: string
+  source?: string
   sourceRootDir?: string
   workspace: string
 }

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -101,14 +101,21 @@ function isSyncedBuildSource(value: unknown): value is SyncedBuildSource {
 }
 
 function createMountedBuildSource(source: ResolvedWorkspaceSource): WorkspaceLoaderSource {
+  function getSourceContext(ctx: Parameters<WorkspaceLoaderSource["getKeys"]>[0]) {
+    return { ...ctx, mountPath: source.mountPath, source: source.key }
+  }
+
   return {
     ...source.source,
     key: source.key,
+    async prepare(ctx) {
+      await source.source.prepare?.(getSourceContext(ctx))
+    },
     async getKeys(ctx) {
-      return await source.source.getKeys(ctx)
+      return await source.source.getKeys(getSourceContext(ctx))
     },
     async getItem(key, ctx) {
-      const item = await source.source.getItem(key, ctx)
+      const item = await source.source.getItem(key, getSourceContext(ctx))
       const path = normalizeWorkspacePath(`${source.mountPath}/${item.path || item.key}`)
       return { ...item, path, metadata: { ...item.metadata, source: source.key } }
     },

--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -29,9 +29,11 @@ export function markLiveWorkspaceSource(source: WorkspaceSource, paths: Record<s
   return source
 }
 
-export function createSourceContext(definition: WorkspaceDefinition): SourceContext {
+export function createSourceContext(definition: WorkspaceDefinition, source?: { key: string, mountPath: string }): SourceContext {
   return {
+    mountPath: source?.mountPath,
     rootDir: definition.rootDir || process.cwd(),
+    source: source?.key,
     sourceRootDir: definition.sourceRootDir,
     workspace: definition.name,
   }

--- a/packages/workspace/src/sources/index.ts
+++ b/packages/workspace/src/sources/index.ts
@@ -8,3 +8,13 @@ export type { GitHubSourceOptions } from "./github.ts"
 export { glob } from "./glob.ts"
 export type { GlobSourceOptions } from "./glob.ts"
 export { markdown } from "./markdown.ts"
+export { mcpResources } from "./mcp-resources.ts"
+export type {
+  McpResourceContent,
+  McpResourceDescriptor,
+  McpResourcesClient,
+  McpResourcesClientConfig,
+  McpResourcesRequestOptions,
+  McpResourcesServer,
+  McpResourcesSourceOptions,
+} from "./mcp-resources.ts"

--- a/packages/workspace/src/sources/materialization.ts
+++ b/packages/workspace/src/sources/materialization.ts
@@ -128,7 +128,6 @@ export async function materializeWorkspaceSources(
   options: WorkspaceMaterializeSourcesOptions = {},
 ): Promise<WorkspaceMaterializeSourcesResult> {
   const started = Date.now()
-  const ctx = createSourceContext(definition)
   const sources = normalizeWorkspaceSources(definition.sources).filter(source => source.materialize === "lazy" && sourcePathMatches("", source, options))
   const resultSources: WorkspaceSourceMaterializationStatus[] = []
   let files = 0
@@ -162,6 +161,7 @@ export async function materializeWorkspaceSources(
     })
 
     try {
+      const ctx = createSourceContext(definition, source)
       await source.source.prepare?.(ctx)
       const items = source.source.getItems
         ? await source.source.getItems(ctx)

--- a/packages/workspace/src/sources/mcp-resources.ts
+++ b/packages/workspace/src/sources/mcp-resources.ts
@@ -1,5 +1,8 @@
 import { mcpResources as createMcpResourcesSource } from "@vite-hub/source"
 
+import { normalizeSafeWorkspacePath } from "../core/path.ts"
+import { markLiveWorkspaceSource } from "./config.ts"
+
 import type { WorkspaceSource } from "../core/types.ts"
 import type { McpResourcesSourceOptions as SourcePackageMcpResourcesSourceOptions } from "@vite-hub/source"
 
@@ -9,17 +12,37 @@ export interface McpResourcesSourceOptions<TKey extends string = string>
   extends Omit<SourcePackageMcpResourcesSourceOptions<TKey>, "cache">, SourceRuntimeOptions {}
 
 export function mcpResources<const TKey extends string = string>(options: McpResourcesSourceOptions<TKey>): WorkspaceSource {
+  const livePaths: Record<string, string> = {}
   const baseSource = createMcpResourcesSource({
     ...options,
     cache: options.cache,
   })
 
-  return {
+  return markLiveWorkspaceSource({
     ...baseSource,
     cache: options.cache,
     materialize: options.materialize || "lazy",
     mount: options.mount,
+    async prepare(ctx) {
+      await baseSource.prepare?.(ctx)
+      const mountPath = resolveMountPath(options.mount, ctx)
+      const keys = await baseSource.getKeys(ctx)
+      resetLivePaths(livePaths, mountPath, keys)
+    },
     validate: options.validate,
+  }, livePaths)
+}
+
+function resolveMountPath(mount: WorkspaceSource["mount"], ctx: { mountPath?: string, source?: string }) {
+  const explicit = typeof mount === "string" ? mount : mount?.path
+  return normalizeSafeWorkspacePath(explicit ?? ctx.mountPath ?? ctx.source ?? "", { allowEmpty: true })
+}
+
+function resetLivePaths(paths: Record<string, string>, mountPath: string, keys: string[]) {
+  for (const path of Object.keys(paths)) delete paths[path]
+  for (const key of keys) {
+    const path = normalizeSafeWorkspacePath(`${mountPath}/${key}`.replace(/\/+/g, "/"), { allowEmpty: false })
+    paths[path] = key
   }
 }
 

--- a/packages/workspace/src/sources/mcp-resources.ts
+++ b/packages/workspace/src/sources/mcp-resources.ts
@@ -1,0 +1,33 @@
+import { mcpResources as createMcpResourcesSource } from "@vite-hub/source"
+
+import type { WorkspaceSource } from "../core/types.ts"
+import type { McpResourcesSourceOptions as SourcePackageMcpResourcesSourceOptions } from "@vite-hub/source"
+
+type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "materialize" | "mount" | "validate">
+
+export interface McpResourcesSourceOptions<TKey extends string = string>
+  extends Omit<SourcePackageMcpResourcesSourceOptions<TKey>, "cache">, SourceRuntimeOptions {}
+
+export function mcpResources<const TKey extends string = string>(options: McpResourcesSourceOptions<TKey>): WorkspaceSource {
+  const baseSource = createMcpResourcesSource({
+    ...options,
+    cache: options.cache,
+  })
+
+  return {
+    ...baseSource,
+    cache: options.cache,
+    materialize: options.materialize || "lazy",
+    mount: options.mount,
+    validate: options.validate,
+  }
+}
+
+export type {
+  McpResourceContent,
+  McpResourceDescriptor,
+  McpResourcesClient,
+  McpResourcesClientConfig,
+  McpResourcesRequestOptions,
+  McpResourcesServer,
+} from "@vite-hub/source"

--- a/packages/workspace/src/sources/view.ts
+++ b/packages/workspace/src/sources/view.ts
@@ -49,6 +49,10 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
   const prepareBySource = new Map<string, Promise<void>>()
   const materializeBySource = new Map<string, Promise<void>>()
 
+  function getSourceContext(source: { key: string, mountPath: string }) {
+    return createSourceContext(definition, source)
+  }
+
   function isLazySourcePath(path: string) {
     return sources.some(source => sourceMountContainsPath(source, path))
   }
@@ -62,11 +66,11 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
   }
 
   async function ensurePrepared(sourceKey: string) {
-    const source = sources.find(item => item.key === sourceKey)?.source
-    if (!source?.prepare) return
+    const source = sources.find(item => item.key === sourceKey)
+    if (!source?.source.prepare) return
     let pending = prepareBySource.get(sourceKey)
     if (!pending) {
-      pending = source.prepare(sourceContext)
+      pending = source.source.prepare(getSourceContext(source))
       prepareBySource.set(sourceKey, pending)
     }
     await pending
@@ -101,7 +105,7 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
       }
       if (!path && options.recursive && !await hasCurrentSourceSnapshot(store, source)) {
         if ([...result.keys()].some(key => sourceMountContainsPath(source, key))) {
-          const allowed = await currentSourceTreePaths(source, sourceContext)
+          const allowed = await currentSourceTreePaths(source, getSourceContext(source))
           for (const key of result.keys()) {
             if (sourceMountContainsPath(source, key) && !allowed.has(key)) result.delete(key)
           }
@@ -167,7 +171,7 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
         for (const entry of liveEntries) {
           const sourcePath = source.livePaths[entry.path]
           if (typeof sourcePath !== "string") continue
-          const item = await source.source.getItem(sourcePath, sourceContext)
+          const item = await source.source.getItem(sourcePath, getSourceContext(source))
           const content = item.content ?? (typeof item.data === "undefined" ? "" : JSON.stringify(item.data, null, 2))
           const text = typeof content === "string" ? content : new TextDecoder().decode(content)
           results.push(...searchText(entry.path, text, { ...query, limit: limit - results.length }))
@@ -235,7 +239,7 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
       if (resolution.type === "source") {
         await ensurePrepared(resolution.sourceKey)
         if (isLiveSource(resolution.sourceKey)) {
-          const item = await resolution.source.source.getItem(resolution.sourcePath, sourceContext)
+          const item = await resolution.source.source.getItem(resolution.sourcePath, getSourceContext(resolution.source))
           return decodeFile(item.content ?? (typeof item.data === "undefined" ? "" : JSON.stringify(item.data, null, 2)), options)
         }
         await ensureMaterialized(resolution.sourceKey)
@@ -301,7 +305,7 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
           return result
         }
         await ensureMaterialized(resolution.sourceKey)
-        const result = await statVirtualSourcePath(resolution.source, resolution.workspacePath, store, sourceContext)
+        const result = await statVirtualSourcePath(resolution.source, resolution.workspacePath, store, getSourceContext(resolution.source))
         if (!result) throw new WorkspaceError(`[vitehub] Workspace path does not exist: ${path}.`)
         return result
       }
@@ -328,7 +332,7 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
           return Boolean(liveSourceStat(resolution.source, resolution.workspacePath))
         }
         await ensureMaterialized(resolution.sourceKey)
-        return Boolean(await statVirtualSourcePath(resolution.source, resolution.workspacePath, store, sourceContext))
+        return Boolean(await statVirtualSourcePath(resolution.source, resolution.workspacePath, store, getSourceContext(resolution.source)))
       }
       if (await store.stat(resolution.workspacePath)) return true
       if (!resolution.workspacePath && sources.some(source => !source.mountPath && source.livePaths)) return true

--- a/packages/workspace/test/mcp-resources-source.test.ts
+++ b/packages/workspace/test/mcp-resources-source.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { defineWorkspace, source } from "../src/index.ts"
+import { resetWorkspaceRegistry, useRegisteredWorkspace } from "../src/core/registry.ts"
+import { registerWorkspace } from "../src/test.ts"
+
+import type { McpResourcesClient } from "../src/sources/index.ts"
+
+const client: McpResourcesClient = {
+  async listResources() {
+    return {
+      resources: [{
+        description: "Complete list of available Nuxt documentation pages",
+        mimeType: "application/json",
+        name: "documentation-pages",
+        uri: "resource://nuxt-com/documentation-pages",
+      }],
+    }
+  },
+  async readResource({ uri }) {
+    return {
+      contents: [{
+        mimeType: "application/json",
+        text: JSON.stringify([{ path: "/docs/getting-started/introduction" }], null, 2),
+        uri,
+      }],
+    }
+  },
+}
+
+afterEach(() => {
+  resetWorkspaceRegistry()
+})
+
+describe("MCP resource workspace sources", () => {
+  it("exposes MCP resources through the workspace file tree", async () => {
+    registerWorkspace("nuxt-mcp", defineWorkspace({
+      store: { provider: "memory" },
+      sources: {
+        nuxt: source.mcpResources({
+          mount: "nuxt",
+          server: client,
+        }),
+      },
+    }))
+
+    const workspace = await useRegisteredWorkspace("nuxt-mcp")
+
+    await expect(workspace.readFile("nuxt/nuxt-com/documentation-pages.json")).resolves.toBe(
+      JSON.stringify([{ path: "/docs/getting-started/introduction" }], null, 2),
+    )
+    await expect(workspace.diff()).resolves.toMatchObject({
+      entries: [
+        expect.objectContaining({ path: "nuxt", type: "added" }),
+        expect.objectContaining({ path: "nuxt/nuxt-com", type: "added" }),
+        expect.objectContaining({ path: "nuxt/nuxt-com/documentation-pages.json", type: "added" }),
+      ],
+    })
+  })
+})

--- a/packages/workspace/test/mcp-resources-source.test.ts
+++ b/packages/workspace/test/mcp-resources-source.test.ts
@@ -11,7 +11,6 @@ const client: McpResourcesClient = {
     return {
       resources: [{
         description: "Complete list of available Nuxt documentation pages",
-        mimeType: "application/json",
         name: "documentation-pages",
         uri: "resource://nuxt-com/documentation-pages",
       }],
@@ -49,6 +48,9 @@ describe("MCP resource workspace sources", () => {
     await expect(workspace.readFile("nuxt/nuxt-com/documentation-pages.json")).resolves.toBe(
       JSON.stringify([{ path: "/docs/getting-started/introduction" }], null, 2),
     )
+    await expect(workspace.diff()).resolves.toMatchObject({ entries: [] })
+
+    await workspace.materializeSources?.({ sources: ["nuxt"] })
     await expect(workspace.diff()).resolves.toMatchObject({
       entries: [
         expect.objectContaining({ path: "nuxt", type: "added" }),

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -83,6 +83,17 @@ describe("workspace types", () => {
       },
       url: "https://status.example.com/api/summary",
     })
+    source.mcpResources({
+      mount: "nuxt",
+      server: {
+        async listResources() {
+          return { resources: [] }
+        },
+        async readResource() {
+          return { contents: [] }
+        },
+      },
+    })
     // @ts-expect-error source.fetch does not expose public lifecycle hooks
     source.fetch({ url: "https://status.example.com/api/summary", beforeRequest() {} })
     // @ts-expect-error source.fetch uses path as its only Workspace-facing address

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@ai-sdk/mcp':
       specifier: ^1.0.36
       version: 1.0.36
+    '@modelcontextprotocol/sdk':
+      specifier: ^1.29.0
+      version: 1.29.0
     agents:
       specifier: ^0.12.3
       version: 0.12.3
@@ -971,9 +974,9 @@ importers:
         specifier: catalog:workspace
         version: 0.2.16
     devDependencies:
-      '@ai-sdk/mcp':
+      '@modelcontextprotocol/sdk':
         specifier: catalog:ai
-        version: 1.0.36(zod@4.4.3)
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@types/node':
         specifier: catalog:tooling
         version: 25.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -971,6 +971,9 @@ importers:
         specifier: catalog:workspace
         version: 0.2.16
     devDependencies:
+      '@ai-sdk/mcp':
+        specifier: catalog:ai
+        version: 1.0.36(zod@4.4.3)
       '@types/node':
         specifier: catalog:tooling
         version: 25.6.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalogMode: prefer
 catalogs:
   ai:
     '@ai-sdk/mcp': ^1.0.36
+    '@modelcontextprotocol/sdk': ^1.29.0
     agents: ^0.12.3
     ai: ^6.0.172
     evalite: 1.0.0-beta.16


### PR DESCRIPTION
Adds source.mcpResources() for read-only MCP resources, with a Source Package retriever and Workspace source wrapper so agents can mount MCP resources as addressable Workspace files.\n\nThis keeps executable MCP tools in the existing mcp() Capability while moving read-only MCP resources into Source design, and records that boundary in the agent-facing docs.