### PR TITLE
refactor(agent): deepen output normalization

### DIFF
--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -1,0 +1,119 @@
+import { ApprovalRequiredError } from "@vite-hub/runtime"
+
+import type { StreamEvent } from "./messages.ts"
+import type { AgentRunResult, AgentUsageRecord } from "./types.ts"
+
+export function toAgentRunResult(value: unknown): AgentRunResult {
+  if (typeof value !== "object" || value === null) {
+    return { raw: value, text: typeof value === "string" ? value : undefined }
+  }
+
+  const result = value as Record<string, unknown>
+  return {
+    finishReason: result.finishReason,
+    raw: value,
+    text: typeof result.text === "string" ? result.text : undefined,
+    usage: result.usage,
+    usageRecord: result.usageRecord as AgentUsageRecord | undefined,
+    warnings: result.warnings,
+  }
+}
+
+export function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return !!value && typeof value === "object" && Symbol.asyncIterator in value
+}
+
+export function toAgentStreamEvent(chunk: unknown, toolNames?: Map<string, string>): StreamEvent | undefined {
+  if (typeof chunk === "string") {
+    return { text: chunk, type: "text-delta" }
+  }
+  if (!chunk || typeof chunk !== "object") {
+    return undefined
+  }
+
+  const value = chunk as Record<string, unknown>
+  const type = String(value.type || "")
+  if (type === "text-delta" || type === "text") {
+    return { id: value.id as string | undefined, text: String(value.text || value.textDelta || value.delta || ""), type: "text-delta" }
+  }
+  if (type === "data") {
+    return { data: value.data, id: value.id as string | undefined, messageId: value.messageId as string | undefined, type: "data" }
+  }
+  if (type === "tool-input-start") {
+    const id = String(value.id || value.toolCallId)
+    const name = String(value.toolName || value.name || toolNames?.get(id) || "tool")
+    toolNames?.set(id, name)
+    return { id, input: value.input, name, type: "tool-input-start" }
+  }
+  if (type === "tool-call" || type === "tool-input-available") {
+    const id = String(value.toolCallId ?? value.id)
+    const name = String(value.toolName ?? value.name ?? toolNames?.get(id) ?? "tool")
+    toolNames?.set(id, name)
+    return { id, input: value.input ?? value.args, name, type: "tool-call" }
+  }
+  if (type === "tool-result" || type === "tool-output-available") {
+    const id = String(value.toolCallId ?? value.id)
+    return { error: typeof value.error === "string" ? value.error : undefined, id, name: String(value.toolName ?? value.name ?? toolNames?.get(id) ?? "tool"), output: value.output ?? value.result, type: "tool-result" }
+  }
+  if (type === "tool-error" || type === "tool-output-error") {
+    const id = String(value.toolCallId ?? value.id)
+    const error = value.error instanceof Error
+      ? value.error.message
+      : typeof value.errorText === "string"
+        ? value.errorText
+        : String(value.error || "Unknown tool error")
+    return { error, id, name: String(value.toolName ?? value.name ?? toolNames?.get(id) ?? "tool"), output: value.output ?? value.result, type: "tool-result" }
+  }
+  if (type === "error") {
+    if (value.error instanceof ApprovalRequiredError) {
+      const { request } = value.error
+      return { id: request.id, input: request.input, name: request.capability || request.id, reason: request.reason, type: "approval-request" }
+    }
+    return { error: value.error instanceof Error ? value.error.message : String(value.error || "Unknown error"), type: "error" }
+  }
+  if (type === "finish") {
+    return { reason: typeof value.finishReason === "string" ? value.finishReason : undefined, type: "finish" }
+  }
+  return undefined
+}
+
+export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<StreamEvent> {
+  if (typeof value === "string") {
+    if (value) yield { text: value, type: "text-delta" }
+    yield { type: "finish" }
+    return
+  }
+  if (isAsyncIterable(value)) {
+    const toolNames = new Map<string, string>()
+    for await (const chunk of value as AsyncIterable<unknown>) {
+      const event = toAgentStreamEvent(chunk, toolNames)
+      if (event) yield event
+    }
+    return
+  }
+  const result = value as { fullStream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string> }
+  if (result.fullStream) {
+    const toolNames = new Map<string, string>()
+    for await (const chunk of result.fullStream) {
+      const event = toAgentStreamEvent(chunk, toolNames)
+      if (event) yield event
+    }
+    return
+  }
+  if (result.textStream) {
+    for await (const text of result.textStream) {
+      yield { text, type: "text-delta" }
+    }
+    return
+  }
+  if (typeof (value as { text?: unknown } | undefined)?.text === "string") {
+    const text = (value as { text: string }).text
+    if (text) yield { text, type: "text-delta" }
+    yield {
+      reason: typeof (value as { finishReason?: unknown }).finishReason === "string"
+        ? (value as { finishReason: string }).finishReason
+        : undefined,
+      type: "finish",
+    }
+  }
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,9 +1,7 @@
 import agentRegistry from "#vitehub/agent/registry"
 import { getMessageText } from "./messages.ts"
-import {
-  ApprovalRequiredError,
-  resolveRuntimeContext,
-} from "@vite-hub/runtime"
+import { resolveRuntimeContext } from "@vite-hub/runtime"
+import { isAsyncIterable, streamAgentOutputToEvents, toAgentRunResult } from "./agent-output.ts"
 import { getChatCapabilityOptions } from "./chat-trigger.ts"
 import { defineInvocationProfile } from "./invocation-profile.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
@@ -66,7 +64,6 @@ import type {
   AgentRuntimeContext,
   AgentSettings,
   AgentUsageCost,
-  AgentUsageRecord,
   AgentWorkflowRuntimeBinding,
   AgentToolDefinition,
   MaybePromise,
@@ -1045,130 +1042,12 @@ export async function streamAgentTrigger<
   return await streamAgentTriggerWith<TRuntimeConfig, TInput, CALL_OPTIONS>(streamAgent, agent, createResolvedRuntimeContext(context), triggerId, input, options)
 }
 
-function toAgentRunResult(value: unknown): AgentRunResult {
-  if (typeof value !== "object" || value === null) {
-    return { raw: value, text: typeof value === "string" ? value : undefined }
-  }
-
-  const result = value as Record<string, unknown>
-  return {
-    finishReason: result.finishReason,
-    raw: value,
-    text: typeof result.text === "string" ? result.text : undefined,
-    usage: result.usage,
-    usageRecord: result.usageRecord as AgentUsageRecord | undefined,
-    warnings: result.warnings,
-  }
-}
-
-function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
-  return !!value && typeof value === "object" && Symbol.asyncIterator in value
-}
-
 function hasCustomRun<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
   agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
 ): agent is AgentDefinition<TRuntimeConfig, any> & { run: NonNullable<AgentDefinition<TRuntimeConfig, CALL_OPTIONS>["run"]> } {
   return hasAgentDefinition(agent)
     && typeof agent.run === "function"
     && !(syntheticWorkspaceRun in agent.run)
-}
-
-function toStreamEvent(chunk: unknown, toolNames?: Map<string, string>): StreamEvent | undefined {
-  if (typeof chunk === "string") {
-    return { text: chunk, type: "text-delta" }
-  }
-  if (!chunk || typeof chunk !== "object") {
-    return undefined
-  }
-
-  const value = chunk as Record<string, unknown>
-  const type = String(value.type || "")
-  if (type === "text-delta" || type === "text") {
-    return { id: value.id as string | undefined, text: String(value.text || value.textDelta || value.delta || ""), type: "text-delta" }
-  }
-  if (type === "data") {
-    return { data: value.data, id: value.id as string | undefined, messageId: value.messageId as string | undefined, type: "data" }
-  }
-  if (type === "tool-input-start") {
-    const id = String(value.id || value.toolCallId)
-    const name = String(value.toolName || value.name || toolNames?.get(id) || "tool")
-    toolNames?.set(id, name)
-    return { id, input: value.input, name, type: "tool-input-start" }
-  }
-  if (type === "tool-call" || type === "tool-input-available") {
-    const id = String(value.toolCallId ?? value.id)
-    const name = String(value.toolName ?? value.name ?? toolNames?.get(id) ?? "tool")
-    toolNames?.set(id, name)
-    return { id, input: value.input ?? value.args, name, type: "tool-call" }
-  }
-  if (type === "tool-result" || type === "tool-output-available") {
-    const id = String(value.toolCallId ?? value.id)
-    return { error: typeof value.error === "string" ? value.error : undefined, id, name: String(value.toolName ?? value.name ?? toolNames?.get(id) ?? "tool"), output: value.output ?? value.result, type: "tool-result" }
-  }
-  if (type === "tool-error" || type === "tool-output-error") {
-    const id = String(value.toolCallId ?? value.id)
-    const error = value.error instanceof Error
-      ? value.error.message
-      : typeof value.errorText === "string"
-        ? value.errorText
-        : String(value.error || "Unknown tool error")
-    return { error, id, name: String(value.toolName ?? value.name ?? toolNames?.get(id) ?? "tool"), output: value.output ?? value.result, type: "tool-result" }
-  }
-  if (type === "error") {
-    if (value.error instanceof ApprovalRequiredError) {
-      const { request } = value.error
-      return { id: request.id, input: request.input, name: request.capability || request.id, reason: request.reason, type: "approval-request" }
-    }
-    return { error: value.error instanceof Error ? value.error.message : String(value.error || "Unknown error"), type: "error" }
-  }
-  if (type === "finish") {
-    return { reason: typeof value.finishReason === "string" ? value.finishReason : undefined, type: "finish" }
-  }
-  if (type === "data") {
-    return { data: value.data, type: "data" }
-  }
-  return undefined
-}
-
-async function* streamTextResultToEvents(value: unknown): AsyncIterable<StreamEvent> {
-  if (typeof value === "string") {
-    if (value) yield { text: value, type: "text-delta" }
-    yield { type: "finish" }
-    return
-  }
-  if (isAsyncIterable(value)) {
-    const toolNames = new Map<string, string>()
-    for await (const chunk of value as AsyncIterable<unknown>) {
-      const event = toStreamEvent(chunk, toolNames)
-      if (event) yield event
-    }
-    return
-  }
-  const result = value as { fullStream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string> }
-  if (result.fullStream) {
-    const toolNames = new Map<string, string>()
-    for await (const chunk of result.fullStream) {
-      const event = toStreamEvent(chunk, toolNames)
-      if (event) yield event
-    }
-    return
-  }
-  if (result.textStream) {
-    for await (const text of result.textStream) {
-      yield { text, type: "text-delta" }
-    }
-    return
-  }
-  if (typeof (value as { text?: unknown } | undefined)?.text === "string") {
-    const text = (value as { text: string }).text
-    if (text) yield { text, type: "text-delta" }
-    yield {
-      reason: typeof (value as { finishReason?: unknown }).finishReason === "string"
-        ? (value as { finishReason: string }).finishReason
-        : undefined,
-      type: "finish",
-    }
-  }
 }
 
 type AgentInvocationContext<
@@ -1547,7 +1426,7 @@ export async function streamAgent<
     if (output === "ui-message-stream") {
       return finalizeUiMessageStreamOutput(rendered, shouldDeferFinish(adapterContext), error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error))
     }
-    const events = streamTextResultToEvents(rendered)
+    const events = streamAgentOutputToEvents(rendered)
     const shouldWrapOutput = shouldDeferFinish(adapterContext)
     return {
       deferFinish: shouldWrapOutput,

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  streamAgentOutputToEvents,
+  toAgentRunResult,
+  toAgentStreamEvent,
+} from "../src/agent-output.ts"
+
+describe("agent output helpers", () => {
+  it("normalizes primitive values into Agent run results", () => {
+    expect(toAgentRunResult("ok")).toEqual({ raw: "ok", text: "ok" })
+    expect(toAgentRunResult(42)).toEqual({ raw: 42, text: undefined })
+  })
+
+  it("normalizes model output objects into Agent run results", () => {
+    const value = { finishReason: "stop", text: "ok", usage: { inputTokens: 1 }, warnings: [] }
+
+    expect(toAgentRunResult(value)).toEqual({
+      finishReason: "stop",
+      raw: value,
+      text: "ok",
+      usage: { inputTokens: 1 },
+      usageRecord: undefined,
+      warnings: [],
+    })
+  })
+
+  it("tracks tool names across stream events", () => {
+    const toolNames = new Map<string, string>()
+
+    expect(toAgentStreamEvent({ input: false, toolCallId: "call-1", toolName: "confirm", type: "tool-input-available" }, toolNames)).toEqual({
+      id: "call-1",
+      input: false,
+      name: "confirm",
+      type: "tool-call",
+    })
+    expect(toAgentStreamEvent({ output: 0, toolCallId: "call-1", type: "tool-output-available" }, toolNames)).toEqual({
+      error: undefined,
+      id: "call-1",
+      name: "confirm",
+      output: 0,
+      type: "tool-result",
+    })
+  })
+
+  it("converts text outputs into stream events", async () => {
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents({ finishReason: "stop", text: "ok" })) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      { reason: "stop", type: "finish" },
+    ])
+  })
+})


### PR DESCRIPTION
Moves AgentRunResult shaping, async-output detection, and stream-event normalization into a dedicated Agent output Module. `runAgent` and `streamAgent` now consume that small Interface instead of keeping output parsing mixed into the root Agent Package entry.\n\nAdds focused coverage for primitive and model-object run results, tool event name tracking, falsy tool input/output preservation, and text output stream conversion while preserving existing Agent runtime behavior.