### PR TITLE
feat(agent): run agents with workflow runtime

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -36,6 +36,7 @@
     "./memory": "./dist/memory.js",
     "./messages": "./dist/messages.js",
     "./runtime/empty-registry": "./dist/runtime/empty-registry.js",
+    "./runtime/workflow": "./dist/runtime/workflow.js",
     "./state/sqlite": "./dist/state/sqlite.js",
     "./test": "./dist/test.js",
     "./vercel": "./dist/vercel.js",

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -381,7 +381,7 @@ async function getAgentWorkflowHandle<
   const { createWorkflow } = await import("@vite-hub/workflow")
   const handle = createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>(name, async (workflowContext) => {
     const { runAgentWorkflowDefinition } = await import("./runtime/workflow.ts")
-    return await runAgentWorkflowDefinition(agent as never, workflowContext as never)
+    return await runAgentWorkflowDefinition(agent as never, workflowContext as never, runAgentInline as never)
   })
   handles.set(name, handle as WorkflowHandle<AgentWorkflowInvocationPayload, unknown>)
   agentWorkflowHandles.set(agent as object, handles)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -64,6 +64,7 @@ import type {
   AgentRequestBody,
   AgentRunContext,
   AgentRunInput,
+  AgentRunMetadata,
   AgentRunResult,
   AgentRuntimeBinding,
   AgentRuntimeConfig,
@@ -89,6 +90,7 @@ import type {
   WorkspaceDefinition,
   WorkspaceName,
 } from "@vite-hub/workspace"
+import type { WorkflowHandle } from "@vite-hub/workflow"
 
 export type {
   AgentAdapter,
@@ -293,6 +295,11 @@ type AgentDefinitionWithBaseResolve<
   [baseAgentResolve]?: BaseAgentResolver<TRuntimeConfig, CALL_OPTIONS>
   [baseAgentModel]?: AgentModelResolver<TRuntimeConfig>
 }
+interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
+  input: AgentRunInput<CALL_OPTIONS>
+  run?: AgentRunMetadata
+  runtime?: AgentRuntimeContext["runtime"]
+}
 interface ScheduleRunContextLike {
   attemptId?: string
   id: string
@@ -301,6 +308,8 @@ interface ScheduleRunContextLike {
   scheduledAt: Date
   target?: string
 }
+
+const agentWorkflowHandles = new WeakMap<object, Map<string, WorkflowHandle<AgentWorkflowInvocationPayload, unknown>>>()
 
 function hasAgentMethods(value: unknown): value is AgentAdapter {
   return typeof value === "object"
@@ -341,6 +350,71 @@ function hasAgentDefinition(value: unknown): value is AgentDefinition {
     && value !== null
     && "resolve" in value
     && typeof (value as { resolve?: unknown }).resolve === "function"
+}
+
+function resolveAgentWorkflowRuntimeBinding<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+): AgentWorkflowRuntimeBinding | undefined {
+  if (!hasAgentDefinition(agent)) return undefined
+  return agent.runtime?.kind === "workflow" ? agent.runtime : undefined
+}
+
+function resolveAgentWorkflowName(binding: AgentWorkflowRuntimeBinding): string {
+  if (binding.name) return binding.name
+  throw new Error("[vitehub] Agent runtime workflow() requires a name when invoked directly. Use workflow(\"name\") so the Agent Invocation can target a stable Workflow Definition.")
+}
+
+async function getAgentWorkflowHandle<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  name: string,
+): Promise<WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>> {
+  const handles = agentWorkflowHandles.get(agent as object) || new Map<string, WorkflowHandle<AgentWorkflowInvocationPayload, unknown>>()
+  const existing = handles.get(name)
+  if (existing) return existing as WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>
+
+  const { createWorkflow } = await import("@vite-hub/workflow")
+  const handle = createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>(name, async (workflowContext) => {
+    const { runAgentWorkflowDefinition } = await import("./runtime/workflow.ts")
+    return await runAgentWorkflowDefinition(agent as never, workflowContext as never)
+  })
+  handles.set(name, handle as WorkflowHandle<AgentWorkflowInvocationPayload, unknown>)
+  agentWorkflowHandles.set(agent as object, handles)
+  return handle
+}
+
+async function runAgentAsWorkflow<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  context: AgentRuntimeContext<TRuntimeConfig>,
+  input: AgentRunInput<CALL_OPTIONS>,
+) {
+  const binding = resolveAgentWorkflowRuntimeBinding<TRuntimeConfig, CALL_OPTIONS>(agent)
+  if (!binding) return undefined
+
+  const handle = await getAgentWorkflowHandle<TRuntimeConfig, CALL_OPTIONS>(agent, resolveAgentWorkflowName(binding))
+  const payload: AgentWorkflowInvocationPayload<CALL_OPTIONS> = {
+    input,
+    runtime: context.runtime,
+    ...(context.run ? { run: context.run } : {}),
+  }
+  const workflowEvent = {
+    ...(context.cloudflare?.env ? { env: context.cloudflare.env } : {}),
+    waitUntil: context.waitUntil,
+    context: {
+      ...(context.cloudflare ? { cloudflare: context.cloudflare } : {}),
+      waitUntil: context.waitUntil,
+    },
+  }
+  const { runWithWorkflowRuntimeEvent } = await import("@vite-hub/workflow/runtime/state")
+  return await runWithWorkflowRuntimeEvent(workflowEvent, () => handle.run(payload, context.run?.runId ? { id: context.run.runId } : {}))
 }
 
 function resolveRegistryModule<TContext extends AgentRuntimeContext>(
@@ -887,7 +961,7 @@ async function finalizeAgentInvocationResult<
   }
 }
 
-export async function runAgent<
+export async function runAgentInline<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
 >(
@@ -937,6 +1011,19 @@ export async function runAgent<
   }, "[vitehub] Agent run failed and finish lifecycle also failed.")
 }
 
+export async function runAgent<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+>(
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  context: AgentRuntimeContext<TRuntimeConfig>,
+  input: AgentRunInput<CALL_OPTIONS>,
+): Promise<Response | AgentRunResult | unknown> {
+  const workflowRun = await runAgentAsWorkflow(agent, context, input)
+  if (workflowRun) return workflowRun
+  return await runAgentInline(agent, context, input)
+}
+
 export async function runScheduledAgent(
   agent: AgentInput<AgentRuntimeContext>,
   context: ScheduleRunContextLike,
@@ -968,7 +1055,7 @@ export async function runScheduledAgent(
   })
 }
 
-export async function streamAgent<
+export async function streamAgentInline<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
 >(
@@ -1039,6 +1126,20 @@ export async function streamAgent<
       value: shouldWrapOutput ? withCapabilityCleanup(events, error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error)) : events,
     }
   }, "[vitehub] Agent stream failed and finish lifecycle also failed.", { finalizeRawStreams: output === "ui-message-stream" })
+}
+
+export async function streamAgent<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+>(
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  context: AgentRuntimeContext<TRuntimeConfig>,
+  input: AgentRunInput<CALL_OPTIONS>,
+  options: { output?: "events" | "ui-message-stream" } = {},
+): Promise<Response | AsyncIterable<StreamEvent> | unknown> {
+  const workflowRun = await runAgentAsWorkflow(agent, context, input)
+  if (workflowRun) return workflowRun
+  return await streamAgentInline(agent, context, input, options)
 }
 
 export async function getAgent<TContext extends AgentRuntimeContext>(

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -1,0 +1,58 @@
+import { getActiveCloudflareEnv, getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
+import { getWorkflowRuntimeEvent } from "@vite-hub/workflow/runtime/state"
+
+import { runAgentInline } from "../index.ts"
+
+import { createAgentRuntimeContext } from "./context.ts"
+
+import type {
+  AgentInput,
+  AgentRunInput,
+  AgentRunMetadata,
+  AgentRuntimeConfig,
+  AgentRuntimeName,
+} from "../types.ts"
+import type { WorkflowExecutionContext, WorkflowProvider } from "@vite-hub/workflow"
+
+export interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
+  input?: AgentRunInput<CALL_OPTIONS>
+  run?: AgentRunMetadata
+  runtime?: AgentRuntimeName
+}
+
+function agentRuntimeFromWorkflowProvider(provider: WorkflowProvider): AgentRuntimeName {
+  if (provider === "cloudflare") return "cloudflare-agents"
+  if (provider === "vercel") return "vercel"
+  return "unknown"
+}
+
+function waitUntil(promise: Promise<unknown>): void {
+  void Promise.resolve(promise).catch(() => {})
+}
+
+export async function runAgentWorkflowDefinition<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+>(
+  agent: AgentInput,
+  context: WorkflowExecutionContext<AgentWorkflowInvocationPayload<CALL_OPTIONS> | undefined>,
+): Promise<Response | unknown> {
+  const payload = context.payload || {}
+  const cloudflareEnv = context.provider === "cloudflare"
+    ? getActiveCloudflareEnv() || getCloudflareEnv(getWorkflowRuntimeEvent())
+    : undefined
+  const runtimeContext = createAgentRuntimeContext<TRuntimeConfig>({
+    ...(cloudflareEnv ? { cloudflare: { env: cloudflareEnv } } : {}),
+    ...(payload.run || context.id
+      ? { run: payload.run || { origin: `workflow:${context.provider}`, runId: context.id! } }
+      : {}),
+    runtime: payload.runtime || agentRuntimeFromWorkflowProvider(context.provider),
+    waitUntil,
+  } as never)
+
+  return await runAgentInline(
+    agent as AgentInput<typeof runtimeContext>,
+    runtimeContext,
+    (payload.input || {}) as AgentRunInput<CALL_OPTIONS>,
+  )
+}

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -1,8 +1,6 @@
 import { getActiveCloudflareEnv, getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { getWorkflowRuntimeEvent } from "@vite-hub/workflow/runtime/state"
 
-import { runAgentInline } from "../index.ts"
-
 import { createAgentRuntimeContext } from "./context.ts"
 
 import type {
@@ -20,6 +18,12 @@ export interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
   runtime?: AgentRuntimeName
 }
 
+export type AgentWorkflowRunner = (
+  agent: any,
+  context: any,
+  input: any,
+) => Promise<Response | unknown>
+
 function agentRuntimeFromWorkflowProvider(provider: WorkflowProvider): AgentRuntimeName {
   if (provider === "cloudflare") return "cloudflare-agents"
   if (provider === "vercel") return "vercel"
@@ -36,6 +40,7 @@ export async function runAgentWorkflowDefinition<
 >(
   agent: AgentInput,
   context: WorkflowExecutionContext<AgentWorkflowInvocationPayload<CALL_OPTIONS> | undefined>,
+  runAgentInline: AgentWorkflowRunner,
 ): Promise<Response | unknown> {
   const payload = context.payload || {}
   const cloudflareEnv = context.provider === "cloudflare"
@@ -51,8 +56,8 @@ export async function runAgentWorkflowDefinition<
   } as never)
 
   return await runAgentInline(
-    agent as AgentInput<typeof runtimeContext>,
+    agent,
     runtimeContext,
-    (payload.input || {}) as AgentRunInput<CALL_OPTIONS>,
+    payload.input || {},
   )
 }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createMessage, getMessageText } from "@vite-hub/agent"
 import { chat, chatTitle, schedule } from "../src/capabilities.ts"
@@ -1721,5 +1721,109 @@ describe("agent message protocol", () => {
     })
 
     await expect(agent.resolve({ memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() })).rejects.toThrow("requires the kv primitive")
+  })
+
+  describe("workflow-backed agents", () => {
+    afterEach(async () => {
+      const { resetWorkflowRuntime } = await import("@vite-hub/workflow/runtime/state")
+      resetWorkflowRuntime()
+    })
+
+    it("queues direct agent runs as Workflow Runs", async () => {
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = defineAgent({
+        runtime: workflow("support-agent"),
+        run: context => `received ${context.prompt}`,
+      })
+      const run = await runAgent(agent, {
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "hello" }) as { id: string }
+
+      expect(run).toMatchObject({
+        provider: "vercel",
+        status: "queued",
+      })
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("support-agent", run.id)).resolves.toMatchObject({
+        result: "received hello",
+        status: "completed",
+      })
+    })
+
+    it("uses trigger run ids as workflow run ids", async () => {
+      const { defineAgent, runAgentTrigger, workflow } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = defineAgent({
+        capabilities: [{
+          id: "portal",
+          triggers: {
+            message: {
+              invoke: (_context, input: { text: string }) => ({
+                input: { prompt: input.text },
+                run: { origin: "portal", runId: "portal-run" },
+              }),
+            },
+          },
+        }],
+        runtime: workflow("portal-agent"),
+        run: context => `received ${context.prompt}`,
+      })
+      const run = await runAgentTrigger(agent, {
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, "portal.message", { text: "hello" }) as { id: string }
+
+      expect(run).toMatchObject({
+        id: "portal-run",
+        provider: "vercel",
+        status: "queued",
+      })
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("portal-agent", "portal-run")).resolves.toMatchObject({
+        result: "received hello",
+        status: "completed",
+      })
+    })
+
+    it("passes Cloudflare env through workflow inline fallback", async () => {
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "cloudflare" })
+
+      const agent = defineAgent({
+        runtime: workflow("cloudflare-agent"),
+        run: context => context.cloudflare?.env?.NUXT_SITE,
+      })
+      const run = await runAgent(agent, {
+        cloudflare: { env: { NUXT_SITE: "nuxt.com" } },
+        memo: vi.fn(),
+        runtime: "cloudflare-agents",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, {}) as { id: string }
+
+      expect(run).toMatchObject({
+        provider: "cloudflare",
+        status: "queued",
+      })
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("cloudflare-agent", run.id)).resolves.toMatchObject({
+        result: "nuxt.com",
+        status: "completed",
+      })
+    })
   })
 })

--- a/packages/agent/tsdown.config.ts
+++ b/packages/agent/tsdown.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     "src/state/sqlite.ts",
     "src/cloudflare/state.ts",
     "src/runtime/empty-registry.ts",
+    "src/runtime/workflow.ts",
     "src/test.ts",
     "src/vercel.ts",
     "src/vite.ts",

--- a/packages/workflow/src/discovery.ts
+++ b/packages/workflow/src/discovery.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync } from "node:fs"
+import { readFileSync, readdirSync, statSync } from "node:fs"
 import { relative } from "node:path"
 
 import { normalize, resolve } from "pathe"
@@ -18,12 +18,20 @@ import {
 import type { DiscoveredWorkflowDefinition } from "./types.ts"
 
 const workflowSuffixPattern = /\.workflow\.(?:c|m)?[jt]s$/i
+const agentSuffixPattern = /\.agent\.(?:c|m)?[jt]s$/i
 const sourceFilePattern = /\.(?:c|m)?[jt]s$/i
 const declarationFilePattern = /\.d\.(?:c|m)?[jt]s$/i
 const stepFilePattern = /^\d+[.-].*\.(?:c|m)?[jt]s$/i
+const agentConfigFilePattern = /^config\.(?:c|m)?[jt]s$/i
+const agentEvalFilePattern = /\.eval\.(?:c|m)?[jt]s$/i
 
 function normalizeSuffixWorkflowName(rootDir: string, file: string) {
   return normalizeSuffixDefinitionName(rootDir, file, workflowSuffixPattern, { stripPrefix: "src/" })
+}
+
+function normalizeSuffixAgentName(rootDir: string, file: string) {
+  const name = normalizeSuffixDefinitionName(rootDir, file, agentSuffixPattern, { stripPrefix: "src/" })
+  return name.startsWith("server/") ? undefined : name
 }
 
 function readDirEntries(root: string) {
@@ -40,6 +48,23 @@ function readDirEntries(root: string) {
 
 function isSourceFile(file: string) {
   return sourceFilePattern.test(file) && !declarationFilePattern.test(file)
+}
+
+function stripSourceComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1")
+}
+
+function extractAgentWorkflowName(file: string, fallbackName: string): string | undefined {
+  const source = stripSourceComments(readFileSync(file, "utf8"))
+  const match = /\bruntime\s*:\s*workflow\s*\(([^)]*)\)/m.exec(source)
+  if (!match) return undefined
+  const literal = /^\s*(["'`])([^"'`]+)\1\s*$/.exec(match[1] || "")
+  return literal?.[2] || fallbackName
+}
+
+function toAgentWorkflowDefinition(file: string, fallbackName: string): DiscoveredWorkflowDefinition | undefined {
+  const name = extractAgentWorkflowName(file, fallbackName)
+  return name ? { handler: file, name, source: "agent-workflow" } : undefined
 }
 
 function isWorkflowFolder(directory: string) {
@@ -63,6 +88,90 @@ function findWorkflowFolders(workflowsDir: string): string[] {
   }
 
   return folders.sort()
+}
+
+function hasConfigAgentDefinition(directory: string): boolean {
+  return readDirEntries(directory).some(entry => entry.isFile() && agentConfigFilePattern.test(entry.name) && isSourceFile(entry.name))
+}
+
+function findAgentConfigFiles(agentsDir: string): string[] {
+  const files: string[] = []
+  for (const entry of readDirEntries(agentsDir)) {
+    if (entry.name.startsWith(".")) {
+      continue
+    }
+    const absolute = resolve(agentsDir, entry.name)
+    if (entry.isDirectory() && !entry.isSymbolicLink()) {
+      files.push(...findAgentConfigFiles(absolute))
+      continue
+    }
+    if (entry.isFile() && agentConfigFilePattern.test(entry.name) && isSourceFile(entry.name)) {
+      files.push(absolute)
+    }
+  }
+  return files.sort()
+}
+
+function discoverSuffixAgentWorkflowDefinitions(roots: string[]): DiscoveredWorkflowDefinition[] {
+  return discoverDefinitions("agent workflow", [
+    createSuffixDefinitionSource<DiscoveredWorkflowDefinition>("agent-workflow", roots, agentSuffixPattern, normalizeSuffixAgentName, {
+      createDefinition: ({ file, name }) => ({ handler: file, name, source: "agent-workflow" }),
+    }),
+  ]).flatMap((definition) => {
+    const workflowDefinition = toAgentWorkflowDefinition(definition.handler, definition.name)
+    return workflowDefinition ? [workflowDefinition] : []
+  })
+}
+
+function discoverFlatServerAgentWorkflowDefinitions(scanDirs: string[]): DiscoveredWorkflowDefinition[] {
+  return discoverDefinitions("agent workflow", [
+    createDirectoryDefinitionSource<DiscoveredWorkflowDefinition>("agent-workflow", scanDirs, "agents", {
+      normalizeName(directory, file) {
+        const fileName = normalize(file).split("/").pop()!
+        if (agentConfigFilePattern.test(fileName) || agentEvalFilePattern.test(fileName)) {
+          return undefined
+        }
+        const parent = normalize(resolve(file, ".."))
+        if (parent !== normalize(directory) && hasConfigAgentDefinition(parent)) {
+          return undefined
+        }
+        return normalizePathDefinitionName(directory, file)
+      },
+      createDefinition: ({ file, name }) => ({ handler: file, name, source: "agent-workflow" }),
+    }),
+  ]).flatMap((definition) => {
+    const workflowDefinition = toAgentWorkflowDefinition(definition.handler, definition.name)
+    return workflowDefinition ? [workflowDefinition] : []
+  })
+}
+
+function discoverConfiguredServerAgentWorkflowDefinitions(scanDirs: string[]): DiscoveredWorkflowDefinition[] {
+  const definitions = new Map<string, DiscoveredWorkflowDefinition>()
+
+  for (const scanDir of scanDirs) {
+    const agentsDir = resolve(scanDir, "agents")
+    for (const file of findAgentConfigFiles(agentsDir)) {
+      const name = normalize(relative(agentsDir, resolve(file, "..")))
+      if (!name || name === ".") {
+        continue
+      }
+      const definition = toAgentWorkflowDefinition(file, name)
+      if (definition) {
+        registerDefinition(definitions, definition, "agent workflow")
+      }
+    }
+  }
+
+  return sortDefinitions(definitions)
+}
+
+function discoverAgentWorkflowDefinitions(roots: string[], serverScanDirs: string[]): DiscoveredWorkflowDefinition[] {
+  return mergeDefinitions(
+    "agent workflow",
+    discoverSuffixAgentWorkflowDefinitions(roots),
+    discoverFlatServerAgentWorkflowDefinitions(serverScanDirs),
+    discoverConfiguredServerAgentWorkflowDefinitions(serverScanDirs),
+  )
 }
 
 function discoverWorkflowFolders(scanDirs: string[], source: NonNullable<DiscoveredWorkflowDefinition["source"]>): DiscoveredWorkflowDefinition[] {
@@ -139,5 +248,6 @@ export function discoverWorkflowDefinitions(options:
     ]),
     discoverFlatServerWorkflowDefinitions(serverScanDirs, "server-workflows"),
     folderDefinitions,
+    discoverAgentWorkflowDefinitions(roots, serverScanDirs),
   )
 }

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -87,7 +87,7 @@ function renderAgentWorkflowRegistryEntry(registryFile: string, definition: Disc
     "    if (cached) return cached",
     `    const loaded = await ${renderRegistryImport(registryFile, definition.handler)}`,
     "    const agent = \"default\" in loaded ? loaded.default : loaded",
-    "    const entry = { handler: async (context) => await runAgentWorkflowDefinition(agent, context) }",
+    "    const entry = { handler: async (context) => await runAgentWorkflowDefinition(agent, context, runAgentInline) }",
     `    registryEntryCache.set(${JSON.stringify(definition.name)}, entry)`,
     "    return entry",
     "  },",
@@ -141,7 +141,12 @@ function createWorkflowRegistryContents(registryFile: string, definitions: Disco
   const needsAgentRuntime = definitions.some(definition => definition.source === "agent-workflow")
   const needsRegistryEntryCache = needsWorkflowRuntime || needsAgentRuntime
   const imports = [
-    ...(needsAgentRuntime ? [`import { runAgentWorkflowDefinition } from "@vite-hub/agent/runtime/workflow"`] : []),
+    ...(needsAgentRuntime
+      ? [
+          `import { runAgentInline } from "@vite-hub/agent"`,
+          `import { runAgentWorkflowDefinition } from "@vite-hub/agent/runtime/workflow"`,
+        ]
+      : []),
     ...(needsWorkflowRuntime
       ? [
           `import { createWorkflowSteps } from "@vite-hub/workflow/runtime/execute"`,

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -1,12 +1,12 @@
 import { mkdir, writeFile } from "node:fs/promises"
-import { resolve } from "node:path"
+import { builtinModules } from "node:module"
+import { dirname, relative, resolve } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
 import { createDefaultCloudflareOutputRoot, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { VITEHUB_MODES, getViteMode } from "@vite-hub/internal/build/mode"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
-import { createRuntimeRegistryContents } from "@vite-hub/internal/definition-catalog"
 
 import { normalizeWorkflowOptions } from "../config.ts"
 import { discoverWorkflowDefinitions } from "../discovery.ts"
@@ -21,6 +21,8 @@ const productName = "workflow"
 const generatedRegistryFileName = "registry.mjs"
 const packageDir = computePackageDir(import.meta.url)
 const resolveRuntimeModule = (modulePath: string) => resolveRuntimeFromPkg(packageDir, modulePath)
+const nodeBuiltinExternals = [...new Set(["node:*", ...builtinModules, ...builtinModules.map(module => `node:${module}`)])]
+const optionalAgentRuntimeExternals = ["@vite-hub/workspace", "@vite-hub/workspace/*"]
 const WORKFLOW_ENTRY_BASE_NAMES = ["server.ts", "server.mts", "server.js", "server.mjs", "worker.ts", "worker.mts", "worker.js", "worker.mjs"] as const
 const WORKFLOW_PRIORITY_NAMES = ["server-workflow.ts", "server-workflow.mts", "server-workflow.js", "server-workflow.mjs"] as const
 
@@ -72,6 +74,93 @@ interface CloudflareWorkflowConfig {
   name?: string
   observability: { enabled: true }
   workflows?: Array<{ binding: string, class_name: string, name: string }>
+}
+
+function renderRegistryImport(registryFile: string, file: string): string {
+  return `import(${JSON.stringify(createImportPath(registryFile, file))})`
+}
+
+function renderAgentWorkflowRegistryEntry(registryFile: string, definition: DiscoveredWorkflowDefinition) {
+  return [
+    `  ${JSON.stringify(definition.name)}: async () => {`,
+    `    const cached = registryEntryCache.get(${JSON.stringify(definition.name)})`,
+    "    if (cached) return cached",
+    `    const loaded = await ${renderRegistryImport(registryFile, definition.handler)}`,
+    "    const agent = \"default\" in loaded ? loaded.default : loaded",
+    "    const entry = { handler: async (context) => await runAgentWorkflowDefinition(agent, context) }",
+    `    registryEntryCache.set(${JSON.stringify(definition.name)}, entry)`,
+    "    return entry",
+    "  },",
+  ].join("\n")
+}
+
+function renderWorkflowRegistryEntry(registryFile: string, definition: DiscoveredWorkflowDefinition) {
+  if (definition.source === "agent-workflow") {
+    return renderAgentWorkflowRegistryEntry(registryFile, definition)
+  }
+
+  if (!definition.steps?.length) {
+    return `  ${JSON.stringify(definition.name)}: async () => ${renderRegistryImport(registryFile, definition.handler)},`
+  }
+
+  const workflowDirectory = /\.(?:c|m)?[jt]s$/i.test(definition.handler) ? dirname(definition.handler) : definition.handler
+  const stepImports = definition.steps.map((step) => {
+    const stepName = relative(workflowDirectory, step)
+    return `{ name: ${JSON.stringify(stepName)}, run: (await ${renderRegistryImport(registryFile, step)}).default }`
+  })
+
+  const hasIndex = /\.(?:c|m)?[jt]s$/i.test(definition.handler)
+  const indexImport = hasIndex ? `const index = await ${renderRegistryImport(registryFile, definition.handler)}` : ""
+  const handler = hasIndex
+    ? `index.default?.handler ? index.default : takeInlineWorkflowDefinitionForModule(${JSON.stringify(definition.name)}, index) || { handler: index.default }`
+    : "{ handler: async (context) => { let value = context.payload; for (const step of Object.values(context.steps || {})) value = await step(value); return value } }"
+
+  return [
+    `  ${JSON.stringify(definition.name)}: async () => {`,
+    `    const cached = registryEntryCache.get(${JSON.stringify(definition.name)})`,
+    "    if (cached) return cached",
+    indexImport ? `    ${indexImport}` : "",
+    `    const steps = [${stepImports.join(", ")}]`,
+    `    const definition = ${handler}`,
+    "    const entry = {",
+    "      ...definition,",
+    "      options: { ...definition.options, rootStep: false },",
+    "      handler: async (context) => {",
+    "        const workflowSteps = createWorkflowSteps(context, steps)",
+    "        return await definition.handler({ ...context, steps: workflowSteps })",
+    "      },",
+    "    }",
+    `    registryEntryCache.set(${JSON.stringify(definition.name)}, entry)`,
+    "    return entry",
+    "  },",
+  ].filter(Boolean).join("\n")
+}
+
+function createWorkflowRegistryContents(registryFile: string, definitions: DiscoveredWorkflowDefinition[]): string {
+  const needsWorkflowRuntime = definitions.some(definition => definition.steps?.length)
+  const needsAgentRuntime = definitions.some(definition => definition.source === "agent-workflow")
+  const needsRegistryEntryCache = needsWorkflowRuntime || needsAgentRuntime
+  const imports = [
+    ...(needsAgentRuntime ? [`import { runAgentWorkflowDefinition } from "@vite-hub/agent/runtime/workflow"`] : []),
+    ...(needsWorkflowRuntime
+      ? [
+          `import { createWorkflowSteps } from "@vite-hub/workflow/runtime/execute"`,
+          `import { takeInlineWorkflowDefinitionForModule } from "@vite-hub/workflow/runtime/state"`,
+        ]
+      : []),
+  ]
+
+  return [
+    ...imports,
+    imports.length ? "" : "",
+    ...(needsRegistryEntryCache ? ["const registryEntryCache = new Map()", ""] : []),
+    "const registry = {",
+    ...definitions.map(definition => renderWorkflowRegistryEntry(registryFile, definition)),
+    "}",
+    "",
+    "export default registry",
+    "",
+  ].join("\n")
 }
 
 function renderCloudflareWorkerWrapper(definitions: DiscoveredWorkflowDefinition[]) {
@@ -153,7 +242,7 @@ async function writeProviderEntries(rootDir: string, workflow: WorkflowModuleOpt
   const userAppEntry = resolveWorkflowUserAppEntry(rootDir)
   const cloudflareWorkflowConfig = resolveWorkflowConfig(workflow, "cloudflare")
 
-  await writeFile(registryFile, createRuntimeRegistryContents(registryFile, definitions), "utf8")
+  await writeFile(registryFile, createWorkflowRegistryContents(registryFile, definitions), "utf8")
 
   const entryFiles: Record<WorkflowProvider, string> = { cloudflare: "", openworkflow: "", vercel: "" }
   await Promise.all(providerEntrySpecs.map(async (spec) => {
@@ -202,8 +291,9 @@ function createCloudflareOutput(rootDir: string, artifacts: GeneratedWorkflowArt
         "@vercel/functions",
         "@vercel/queue",
         "@vercel/sandbox",
+        ...optionalAgentRuntimeExternals,
         "cloudflare:workers",
-        "node:async_hooks",
+        ...nodeBuiltinExternals,
         "workflow",
         "workflow/api",
         "workflow/runtime",
@@ -231,7 +321,7 @@ function createVercelOutput(artifacts: GeneratedWorkflowArtifacts): VercelProvid
   return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
-      external: ["@cloudflare/sandbox", "cloudflare:workers", "workflow", "workflow/api", "workflow/runtime"],
+      external: ["@cloudflare/sandbox", ...optionalAgentRuntimeExternals, "cloudflare:workers", ...nodeBuiltinExternals, "workflow", "workflow/api", "workflow/runtime"],
       format: "esm",
       platform: "node",
     },

--- a/packages/workflow/src/types.ts
+++ b/packages/workflow/src/types.ts
@@ -174,6 +174,6 @@ export interface WorkflowDefinitionRegistry {
 export interface DiscoveredWorkflowDefinition {
   handler: string
   name: string
-  source?: "inline" | "server-workflows" | "vite-suffix"
+  source?: "agent-workflow" | "inline" | "server-workflows" | "vite-suffix"
   steps?: string[]
 }

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -1,12 +1,12 @@
 import { existsSync } from "node:fs"
-import { cp, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import { cp, mkdir, mkdtemp, readdir, readFile, realpath, rm, stat, symlink, writeFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
 import { execFile } from "node:child_process"
 import { promisify } from "node:util"
 
 import { afterAll, describe, expect, it } from "vitest"
 
-import { getCloudflareWorkflowClassName } from "../src/integrations/cloudflare.ts"
+import { getCloudflareWorkflowBindingName, getCloudflareWorkflowClassName, getCloudflareWorkflowName } from "../src/integrations/cloudflare.ts"
 
 const execFileAsync = promisify(execFile)
 const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
@@ -33,8 +33,23 @@ async function linkNodeModules(sourceDir: string, targetDir: string) {
     if (tempNodeModuleBuildDirs.has(entry.name)) {
       continue
     }
-    await symlink(join(sourceDir, entry.name), join(targetDir, entry.name), entry.isDirectory() ? "dir" : "file")
+    const source = join(sourceDir, entry.name)
+    const target = join(targetDir, entry.name)
+    if (entry.isDirectory() && entry.name.startsWith("@")) {
+      await mkdir(target, { recursive: true })
+      for (const scopedEntry of await readdir(source, { withFileTypes: true })) {
+        await linkNodeModuleEntry(join(source, scopedEntry.name), join(target, scopedEntry.name))
+      }
+      continue
+    }
+    await linkNodeModuleEntry(source, target)
   }
+}
+
+async function linkNodeModuleEntry(source: string, target: string) {
+  const resolved = await realpath(source)
+  const info = await stat(resolved)
+  await symlink(resolved, target, info.isDirectory() ? "dir" : "file")
 }
 
 async function createPlaygroundCopy(prefix: string) {
@@ -61,6 +76,17 @@ afterAll(async () => {
 describe("Vite workflow provider outputs", () => {
   it("builds the playground and emits cloudflare and vercel workflow outputs", async () => {
     const rootDir = await createPlaygroundCopy("vitehub-workflow-vite-playground-")
+    const agentDir = join(rootDir, "server", "agents", "nuxt")
+    await mkdir(agentDir, { recursive: true })
+    await writeFile(join(agentDir, "config.ts"), [
+      `import { defineAgent, workflow } from "@vite-hub/agent"`,
+      "",
+      "export default defineAgent({",
+      `  runtime: workflow("nuxt-agent"),`,
+      `  run: () => "nuxt agent",`,
+      "})",
+      "",
+    ].join("\n"))
 
     await execFileAsync(viteBin, ["build"], {
       cwd: rootDir,
@@ -74,6 +100,7 @@ describe("Vite workflow provider outputs", () => {
     const vercelServer = join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs")
     const wrangler = JSON.parse(await readFile(cloudflareConfig, "utf8"))
     const className = getCloudflareWorkflowClassName("welcome")
+    const agentClassName = getCloudflareWorkflowClassName("nuxt-agent")
 
     expect(existsSync(cloudflareWorker)).toBe(true)
     expect(existsSync(cloudflareWorkerBundle)).toBe(true)
@@ -82,12 +109,20 @@ describe("Vite workflow provider outputs", () => {
       class_name: className,
       name: "workflow--77656c636f6d65",
     })
-    expect(wrangler.workflows).toHaveLength(1)
+    expect(wrangler.workflows).toContainEqual({
+      binding: getCloudflareWorkflowBindingName("nuxt-agent"),
+      class_name: agentClassName,
+      name: getCloudflareWorkflowName("nuxt-agent"),
+    })
+    expect(wrangler.workflows).toHaveLength(2)
     const cloudflareWorkerContents = await readFile(cloudflareWorker, "utf8")
     expect(cloudflareWorkerContents).toContain("waitUntil as viteHubWaitUntil")
     expect(cloudflareWorkerContents).toContain(`export class ${className} extends WorkflowEntrypoint`)
+    expect(cloudflareWorkerContents).toContain(`export class ${agentClassName} extends WorkflowEntrypoint`)
     expect(cloudflareWorkerContents).toContain('runViteHubWorkflowDefinition("welcome"')
+    expect(cloudflareWorkerContents).toContain('runViteHubWorkflowDefinition("nuxt-agent"')
     expect(await readFile(cloudflareWorkerBundle, "utf8")).toContain("runViteHubWorkflowDefinition")
+    expect(await readFile(join(rootDir, ".vitehub", "workflow", "registry.mjs"), "utf8")).toContain("runAgentWorkflowDefinition")
     expect(await readFile(vercelConfig, "utf8")).toContain("\"/__server\"")
     expect(existsSync(vercelServer)).toBe(true)
   }, buildOutputTestTimeout)


### PR DESCRIPTION
## Summary
- queue `runtime: workflow("name")` Agent Invocations through `@vite-hub/workflow` while preserving inline execution for non-workflow agents
- add `@vite-hub/agent/runtime/workflow` so generated Workflow Definitions can execute agents without recursing through public `runAgent`
- discover workflow-backed agent definitions in workflow provider output and emit Vercel/Cloudflare registry entries and Cloudflare workflow bindings

## Validation
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --filter @vite-hub/workflow typecheck`
- `pnpm --filter @vite-hub/agent test -- test/runtime.test.ts`
- `pnpm --filter @vite-hub/workflow test -- test/vite-output.test.ts`