### PR TITLE
fix(agent): stream workflow-backed chat inline

### DIFF
--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -93,7 +93,7 @@ A Capability that gives an Agent model-facing access to Workspace files.
 _Avoid_: Bash, raw workspace tools, built-in tool
 
 **Access Capability**:
-A Capability created by `access()` that resolves trusted invocation access and applies allow-only access boundaries to configured runtime surfaces, starting with Workspace Scope.
+A Capability created by `access()` that resolves trusted invocation access and applies allow-only access boundaries to configured runtime surfaces, starting with chat admission and Workspace Scope.
 _Avoid_: Organization Capability, Workspace Definition mutator, dynamic Source, dynamic Capability
 
 **Access Role**:
@@ -239,13 +239,14 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - A **Workspace Capability** contributes Workspace tools without implying unrestricted process execution.
 - An **Access Capability** applies invocation-time access rules without mutating Workspace Definitions or granting new Capabilities dynamically.
 - The `access()` helper creates an **Access Capability**.
-- In the first version, an **Access Capability** applies **Workspace Scope** only.
+- An **Access Capability** can admit or reject normalized chat-origin invocations before the Agent Invocation starts.
+- An **Access Capability** can apply **Workspace Scope** to narrow an already-declared Workspace.
 - An **Access Capability** can record the active Workspace Scope as an Agent Invocation Context Value for later callbacks and instructions.
 - An **Access Capability** owns both Workspace Scope selection and application, but keeps resolver logic separate from grants.
 - An **Access Capability** may consume an **Invocation Profile** to select Workspace Scope without owning the profile resolution.
-- An **Access Capability** may reference a **Chat Capability** for typed origin context instead of asking users to repeat Chat Capability origins in Access configuration.
+- An **Access Capability** may consume normalized chat identity and request context from **Chat Webhook Autowiring** without repeating **Chat Capability** origins in Access configuration.
 - An **Access Capability** can use static named Workspace Scopes or an inline Workspace Scope definition returned by its resolver.
-- An **Access Capability** must be ordered before other Workspace-reading Capabilities so Workspace Scope is applied before they resolve tools or requirements.
+- An **Access Capability** must be ordered before other Capabilities so invocation access is applied before they read scoped runtime surfaces or expose tools.
 - An **Access Capability** provides tiny default **Access Roles** for the first version.
 - The default `viewer` **Access Role** can read granted Source keys and path prefixes through Workspace Scope Grants.
 - The default `admin` **Access Role** can select the explicit all-scopes mode when the developer configured that mode.
@@ -336,7 +337,7 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Trigger handlers were considered for direct Agent execution - resolved: trigger contributions map input and run metadata, while the Agent Package executes the Agent Invocation through the standard lifecycle.
 - Public chat webhook registration helpers were considered for platform adapters - resolved: use **Chat Webhook Autowiring** from the **Chat Capability** so adapter configuration remains the only source of truth.
 - Build-time Chat Platform Adapter detection was considered - resolved: resolve the **Chat Adapter Callback** at request time because platform credentials and adapter construction can depend on Server Env.
-- Repeating Chat Capability origins in `access()` was considered - resolved: Invocation Profiles declare trusted chat origins explicitly, and Access consumes the resolved profile rather than owning chat input configuration.
+- Repeating Chat Capability origins in `access()` was considered - resolved: **Chat Capability** owns adapter/webhook origin configuration, while **Access Capability** consumes normalized chat identity and request context for chat admission.
 - Capability phases, contexts, hooks, and instruction slots were considered glossary terms - resolved: group that detail under **Capability Lifecycle** unless a feature needs a sharper term.
 - Chat History was considered as a standalone Capability - resolved: keep Chat History inside the **Chat Capability** for this stack and revisit during a future Agent Memory pass.
 - Agent Memory was considered dependent on the Chat Capability - resolved: stack Agent Memory directly on the capability runtime because memory and chat are separate Capability concerns.

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -3,6 +3,21 @@ import { ApprovalRequiredError } from "@vite-hub/runtime"
 import type { StreamEvent } from "./messages.ts"
 import type { AgentRunResult, AgentUsageRecord } from "./types.ts"
 
+function textFromResult(result: Record<string, unknown>): string | undefined {
+  if (typeof result.text === "string") return result.text
+  if (typeof result.output === "string") return result.output
+  if (typeof result._output === "string") return result._output
+
+  const steps = result.steps
+  if (Array.isArray(steps)) {
+    for (const step of steps.slice().reverse()) {
+      if (step && typeof step === "object" && typeof (step as { text?: unknown }).text === "string") {
+        return (step as { text: string }).text
+      }
+    }
+  }
+}
+
 export function toAgentRunResult(value: unknown): AgentRunResult {
   if (typeof value !== "object" || value === null) {
     return { raw: value, text: typeof value === "string" ? value : undefined }
@@ -12,7 +27,7 @@ export function toAgentRunResult(value: unknown): AgentRunResult {
   return {
     finishReason: result.finishReason,
     raw: value,
-    text: typeof result.text === "string" ? result.text : undefined,
+    text: textFromResult(result),
     usage: result.usage,
     usageRecord: result.usageRecord as AgentUsageRecord | undefined,
     warnings: result.warnings,
@@ -21,6 +36,10 @@ export function toAgentRunResult(value: unknown): AgentRunResult {
 
 export function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
   return !!value && typeof value === "object" && Symbol.asyncIterator in value
+}
+
+function isUsageRecord(value: unknown): value is AgentUsageRecord {
+  return typeof value === "object" && value !== null
 }
 
 export function toAgentStreamEvent(chunk: unknown, toolNames?: Map<string, string>): StreamEvent | undefined {
@@ -71,6 +90,9 @@ export function toAgentStreamEvent(chunk: unknown, toolNames?: Map<string, strin
     }
     return { error: value.error instanceof Error ? value.error.message : String(value.error || "Unknown error"), type: "error" }
   }
+  if (type === "usage" && isUsageRecord(value.usageRecord)) {
+    return { messageId: value.messageId as string | undefined, type: "usage", usageRecord: value.usageRecord }
+  }
   if (type === "finish") {
     return { reason: typeof value.finishReason === "string" ? value.finishReason : undefined, type: "finish" }
   }
@@ -92,9 +114,10 @@ export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<
     return
   }
   const result = value as { fullStream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string> }
-  if (result.fullStream) {
+  const fullStream = result.fullStream
+  if (fullStream) {
     const toolNames = new Map<string, string>()
-    for await (const chunk of result.fullStream) {
+    for await (const chunk of fullStream) {
       const event = toAgentStreamEvent(chunk, toolNames)
       if (event) yield event
     }
@@ -106,9 +129,14 @@ export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<
     }
     return
   }
-  if (typeof (value as { text?: unknown } | undefined)?.text === "string") {
-    const text = (value as { text: string }).text
+  const text = typeof value === "object" && value !== null
+    ? textFromResult(value as Record<string, unknown>)
+    : undefined
+  if (typeof text === "string") {
     if (text) yield { text, type: "text-delta" }
+    if (isUsageRecord((value as { usageRecord?: unknown }).usageRecord)) {
+      yield { type: "usage", usageRecord: (value as { usageRecord: AgentUsageRecord }).usageRecord }
+    }
     yield {
       reason: typeof (value as { finishReason?: unknown }).finishReason === "string"
         ? (value as { finishReason: string }).finishReason

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -4,11 +4,13 @@ import { resolveInvocationProfile } from "../invocation-profile.ts"
 import { createWorkspaceTools } from "@vite-hub/workspace"
 
 import type {
+  AgentCallbackContext,
   AgentCapabilityDefinition,
   AgentCapabilityRuntimeContext,
   AgentCapabilityTypeContract,
   AgentRunInput,
   AgentRuntimeConfig,
+  AgentWebhookRegistrationDefinition,
   MaybePromise,
 } from "../types.ts"
 import type {
@@ -125,6 +127,31 @@ export interface AccessWorkspaceOptions<
   scopes?: Record<string, AccessWorkspaceScopeDefinition<TSourceName>>
 }
 
+export interface AccessChatIdentity {
+  id?: string
+  metadata?: Record<string, unknown>
+  name?: string
+  provider: string
+  username?: string
+}
+
+export interface AccessChatContext<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
+  extends AgentCallbackContext<TRuntimeConfig> {
+  identity?: AccessChatIdentity
+  input?: unknown
+  provider: string
+  request: Request
+  webhook: AgentWebhookRegistrationDefinition
+}
+
+export type AccessDecision = boolean | void
+export type AccessChatResolver<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> =
+  (context: AccessChatContext<TRuntimeConfig>) => MaybePromise<AccessDecision>
+
+export interface AccessChatOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  resolve: AccessChatResolver<TRuntimeConfig>
+}
+
 export interface AccessCapabilityOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
@@ -132,8 +159,9 @@ export interface AccessCapabilityOptions<
   TInputContext extends object = Record<string, unknown>,
   TProfile = undefined,
 > {
+  chat?: AccessChatOptions<TRuntimeConfig>
   profile?: AgentInvocationProfileDefinition<TProfile, TRuntimeConfig, Name, TInputContext>
-  workspace: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext, TProfile>
+  workspace?: AccessWorkspaceOptions<TRuntimeConfig, Name, TSourceName, TInputContext, TProfile>
 }
 
 export type AccessWorkspaceSourceName<TWorkspace extends { sources?: Record<string, WorkspaceSource> }> =
@@ -160,6 +188,29 @@ interface NormalizedWorkspaceScopeSelection<TSourceName extends string = string>
   scope: string
 }
 
+interface AccessCapabilityMetadata<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  access: AccessCapabilityOptions<TRuntimeConfig>
+  chat: boolean
+  kind: "access"
+  workspace: boolean
+}
+
+function isAccessMetadata(value: unknown): value is AccessCapabilityMetadata {
+  return typeof value === "object"
+    && value !== null
+    && (value as { kind?: unknown }).kind === "access"
+    && typeof (value as { access?: unknown }).access === "object"
+    && (value as { access?: unknown }).access !== null
+}
+
+export function getAccessCapabilityOptions<TRuntimeConfig extends AgentRuntimeConfig>(
+  capabilities: AgentCapabilityDefinition[],
+): AccessCapabilityOptions<TRuntimeConfig>[] {
+  return capabilities
+    .map(capability => capability.id === "access" && isAccessMetadata(capability.metadata) ? capability.metadata.access : undefined)
+    .filter((options): options is AccessCapabilityOptions<TRuntimeConfig> => !!options)
+}
+
 function setWorkspaceOverride<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
@@ -180,22 +231,37 @@ export function access<
   TProfile = unknown,
   TInputContext extends object = Record<string, unknown>,
   const TWorkspace extends AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext, TProfile> = AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext, TProfile>,
->(options: { input?: undefined, profile: AgentInvocationProfileDefinition<TProfile, TRuntimeConfig, Name, TInputContext>, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext>>
+>(options: { chat?: AccessChatOptions<TRuntimeConfig>, input?: undefined, profile: AgentInvocationProfileDefinition<TProfile, TRuntimeConfig, Name, TInputContext>, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext>>
 export function access<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
   TInputContext extends object = Record<string, unknown>,
   const TWorkspace extends AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext> = AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext>,
->(options: { input?: undefined, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext>>
+>(options: { chat?: AccessChatOptions<TRuntimeConfig>, input?: undefined, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext>>
+export function access<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+>(options: { chat: AccessChatOptions<TRuntimeConfig>, input?: undefined }): AgentCapabilityDefinition<TRuntimeConfig, Name>
 export function access(options: AccessCapabilityOptions): AgentCapabilityDefinition {
-  if (!options || typeof options !== "object" || !options.workspace) {
-    throw new TypeError("[vitehub] access() requires workspace options.")
+  if (!options || typeof options !== "object") {
+    throw new TypeError("[vitehub] access() requires options.")
+  }
+  if (!options.chat && !options.workspace) {
+    throw new TypeError("[vitehub] access() requires at least one access surface.")
   }
   return defineCapability({
     id: "access",
-    metadata: { kind: "access", workspace: true },
-    requires: [{ primitive: "workspace", workspace: { required: true } }],
+    metadata: {
+      access: options,
+      chat: !!options.chat,
+      kind: "access",
+      workspace: !!options.workspace,
+    } satisfies AccessCapabilityMetadata,
+    requires: options.workspace
+      ? [{ primitive: "workspace", workspace: { required: true } }]
+      : undefined,
     async prepare(context) {
+      if (!options.workspace) return
       if (!context.workspace) {
         throw new Error("[vitehub] access({ workspace }) requires an explicit workspace.")
       }

--- a/packages/agent/src/capabilities/audience.ts
+++ b/packages/agent/src/capabilities/audience.ts
@@ -56,7 +56,10 @@ export function audience<
       const instructions = typeof options.instructions === "function"
         ? await options.instructions({ ...context, profile } as AgentCapabilityRuntimeContext<TRuntimeConfig, Name> & { profile: TProfile })
         : options.instructions
-      context.instructions.add(instructions, { id })
+      context.instructions.add(instructions, {
+        ...(id === "audience" ? {} : { aliases: ["audience"] }),
+        id,
+      })
     },
   })
 }

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -64,6 +64,8 @@ export {
   mcp,
 } from "./mcp.ts"
 export {
+  formatUsageTelemetryChatMessage,
+  getUsageTelemetryChatOptions,
   normalizeAgentUsage,
   staticModelPricing,
   usageTelemetry,
@@ -78,7 +80,12 @@ export type {
   AudienceInstructionsResolver,
 } from "./audience.ts"
 export type {
+  AccessChatContext,
+  AccessChatIdentity,
+  AccessChatOptions,
+  AccessChatResolver,
   AccessCapabilityOptions,
+  AccessDecision,
   AccessRoleName,
   AccessWorkspaceOptions,
   AccessWorkspaceOptionsFor,
@@ -219,6 +226,15 @@ export type {
   AgentUsagePricing,
   AgentUsagePricingContext,
   StaticModelPrice,
+  UsageTelemetryCallback,
+  UsageTelemetryChatCallback,
+  UsageTelemetryChatCallbackContext,
+  UsageTelemetryChatFormatter,
+  UsageTelemetryChatMessage,
+  UsageTelemetryChatMessageContext,
+  UsageTelemetryChatOptions,
+  UsageTelemetryChatSendMessage,
+  UsageTelemetryContext,
   UsageTelemetryOptions,
   VercelAiGatewayPricingOptions,
 } from "./usage-telemetry.ts"

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -4,6 +4,7 @@ import type {
   AgentCapabilityDefinition,
   AgentFinishEvent,
   AgentRunMetadata,
+  AgentRuntimeConfig,
   AgentUsage,
   AgentUsageCost,
   AgentUsageRecord,
@@ -19,8 +20,53 @@ export interface AgentUsagePricingContext {
 
 export type AgentUsagePricing = (context: AgentUsagePricingContext) => MaybePromise<AgentUsageCost | undefined>
 
+export interface UsageTelemetryChatMessageContext {
+  durationMs?: number
+  provider?: string
+  run?: Partial<AgentRunMetadata>
+}
+
+export interface UsageTelemetryContext {
+  run?: Partial<AgentRunMetadata>
+}
+
+export type UsageTelemetryChatMessage =
+  | { markdown: string }
+  | { text: string }
+
+export interface UsageTelemetryChatSendMessage {
+  (message: UsageTelemetryChatMessage): Promise<void>
+}
+
+export interface UsageTelemetryChatCallbackContext extends UsageTelemetryChatMessageContext {
+  sendMessage: UsageTelemetryChatSendMessage
+}
+
+export type UsageTelemetryChatFormatter = (
+  record: AgentUsageRecord,
+  context: UsageTelemetryChatMessageContext,
+) => MaybePromise<string | undefined>
+
+export type UsageTelemetryCallback = (
+  record: AgentUsageRecord,
+  context: UsageTelemetryContext,
+) => MaybePromise<void>
+
+export type UsageTelemetryChatCallback = (
+  record: AgentUsageRecord,
+  context: UsageTelemetryChatCallbackContext,
+) => MaybePromise<void>
+
+export interface UsageTelemetryChatOptions {
+  enabled?: boolean
+  format?: UsageTelemetryChatFormatter
+  onUsage?: UsageTelemetryChatCallback
+}
+
 export interface UsageTelemetryOptions {
+  chat?: boolean | UsageTelemetryChatOptions
   includeRaw?: boolean
+  onUsage?: UsageTelemetryCallback
   pricing?: AgentUsagePricing
 }
 
@@ -40,10 +86,44 @@ export interface VercelAiGatewayPricingOptions {
 
 type UnknownRecord = Record<string, unknown>
 
+interface UsageTelemetryCapabilityMetadata {
+  kind: "usage-telemetry"
+  usageTelemetry: UsageTelemetryOptions
+}
+
+const usageTelemetryWrapped = Symbol("vitehub.usageTelemetryWrapped")
+
 const vercelAiGatewayModelsUrl = "https://ai-gateway.vercel.sh/v1/models"
 
 function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === "object" && value !== null
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return !!value && typeof value === "object" && Symbol.asyncIterator in value
+}
+
+function isUsageTelemetryMetadata(value: unknown): value is UsageTelemetryCapabilityMetadata {
+  return isRecord(value)
+    && value.kind === "usage-telemetry"
+    && isRecord(value.usageTelemetry)
+}
+
+function normalizeChatOptions(value: UsageTelemetryOptions["chat"]): UsageTelemetryChatOptions | undefined {
+  if (value === true) return {}
+  if (!value) return
+  return value.enabled === false ? undefined : value
+}
+
+export function getUsageTelemetryChatOptions<TRuntimeConfig extends AgentRuntimeConfig>(
+  capabilities: AgentCapabilityDefinition<TRuntimeConfig>[],
+): UsageTelemetryChatOptions[] {
+  return capabilities
+    .map((capability) => {
+      if (capability.id !== "usage-telemetry" || !isUsageTelemetryMetadata(capability.metadata)) return undefined
+      return normalizeChatOptions(capability.metadata.usageTelemetry.chat)
+    })
+    .filter((options): options is UsageTelemetryChatOptions => !!options)
 }
 
 function readNumber(record: UnknownRecord, ...keys: string[]): number | undefined {
@@ -175,16 +255,132 @@ function removeRawUsage(usage: AgentUsage): AgentUsage {
   return rest
 }
 
+async function recordUsage(
+  result: UnknownRecord,
+  options: UsageTelemetryOptions,
+  run?: Partial<AgentRunMetadata>,
+): Promise<AgentUsageRecord | undefined> {
+  const usageRecord = await createAgentUsageRecord(result, options, run)
+  if (usageRecord) await options.onUsage?.(usageRecord, run ? { run } : {})
+  return usageRecord
+}
+
+async function* withUsageTelemetryStream(
+  stream: AsyncIterable<unknown>,
+  options: UsageTelemetryOptions,
+  run?: Partial<AgentRunMetadata>,
+  onRecord?: (record: AgentUsageRecord) => void,
+): AsyncIterable<unknown> {
+  for await (const chunk of stream) {
+    if (isRecord(chunk) && chunk.type === "finish") {
+      const usageRecord = await recordUsage(chunk, options, run)
+      if (usageRecord) {
+        onRecord?.(usageRecord)
+        yield { type: "usage", usageRecord }
+      }
+    }
+    yield chunk
+  }
+}
+
+function withAsyncIterator<T>(stream: ReadableStream<T>): AsyncIterable<T> & ReadableStream<T> {
+  if (typeof (stream as AsyncIterable<T>)[Symbol.asyncIterator] === "function") {
+    return stream as AsyncIterable<T> & ReadableStream<T>
+  }
+
+  Object.defineProperty(stream, Symbol.asyncIterator, {
+    configurable: true,
+    value: async function* () {
+      const reader = stream.getReader()
+      try {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) return
+          yield value
+        }
+      }
+      finally {
+        reader.releaseLock()
+      }
+    },
+  })
+  return stream as AsyncIterable<T> & ReadableStream<T>
+}
+
+function toReadableAsyncIterableStream<T>(iterable: AsyncIterable<T>): AsyncIterable<T> & ReadableStream<T> {
+  if (typeof (iterable as ReadableStream<T>).pipeThrough === "function") {
+    return withAsyncIterator(iterable as ReadableStream<T>)
+  }
+
+  const iterator = iterable[Symbol.asyncIterator]()
+  return withAsyncIterator(new ReadableStream<T>({
+    async cancel() {
+      await iterator.return?.()
+    },
+    async pull(controller) {
+      try {
+        const { done, value } = await iterator.next()
+        if (done) {
+          controller.close()
+        }
+        else {
+          controller.enqueue(value)
+        }
+      }
+      catch (error) {
+        controller.error(error)
+      }
+    },
+  }))
+}
+
+function cloneWithUsageTelemetryStream<T extends UnknownRecord>(
+  result: T,
+  options: UsageTelemetryOptions,
+  run?: Partial<AgentRunMetadata>,
+): T {
+  if ((result as UnknownRecord & { [usageTelemetryWrapped]?: boolean })[usageTelemetryWrapped]) return result
+  const fullStream = result.fullStream
+  if (!isAsyncIterable(fullStream)) return result
+
+  const clone = Object.create(Object.getPrototypeOf(result)) as T
+  Object.defineProperties(clone, Object.getOwnPropertyDescriptors(result))
+  let stream = toReadableAsyncIterableStream(withUsageTelemetryStream(fullStream, options, run, (usageRecord) => {
+    const output = clone as UnknownRecord
+    output.usage = usageRecord.usage
+    output.usageRecord = usageRecord
+  }))
+  Object.defineProperty(clone, "fullStream", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      const [next, branch] = stream.tee()
+      stream = withAsyncIterator(next)
+      return withAsyncIterator(branch)
+    },
+  })
+  Object.defineProperty(clone, usageTelemetryWrapped, {
+    value: true,
+  })
+  return clone
+}
+
 export function usageTelemetry(options: UsageTelemetryOptions = {}): AgentCapabilityDefinition {
   return defineCapability({
     id: "usage-telemetry",
+    metadata: {
+      kind: "usage-telemetry",
+      usageTelemetry: options,
+    } satisfies UsageTelemetryCapabilityMetadata,
     output(context) {
       context.finish.provide((event: AgentFinishEvent) => isRecord(event.result)
         ? event.result.usageRecord
         : undefined)
       context.output.render(async (result) => {
+        if (isAsyncIterable(result)) return withUsageTelemetryStream(result, options, context.run)
         if (!isRecord(result)) return result
-        const usageRecord = await createAgentUsageRecord(result, options, context.run)
+        if (isAsyncIterable(result.fullStream)) return cloneWithUsageTelemetryStream(result, options, context.run)
+        const usageRecord = await recordUsage(result, options, context.run)
         if (!usageRecord) return result
         return {
           ...result,
@@ -194,6 +390,56 @@ export function usageTelemetry(options: UsageTelemetryOptions = {}): AgentCapabi
       })
     },
   })
+}
+
+function formatNumber(value: number | undefined): string | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? new Intl.NumberFormat("en-US").format(value)
+    : undefined
+}
+
+function formatSeconds(value: number | undefined): string | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return
+  return `${(value / 1000).toFixed(value < 10_000 ? 2 : 1)}s`
+}
+
+function formatTokenSummary(usage: AgentUsage | undefined): string {
+  if (!usage) return "`n/a`"
+  const input = formatNumber(usage.inputTokens)
+  const output = formatNumber(usage.outputTokens)
+  const total = formatNumber(usage.totalTokens ?? (usage.inputTokens !== undefined && usage.outputTokens !== undefined ? usage.inputTokens + usage.outputTokens : undefined))
+  const details = [
+    input ? `${input} in` : undefined,
+    output ? `${output} out` : undefined,
+  ].filter(Boolean).join(", ")
+  return `${total ? `\`${total}\`` : "`n/a`"} total${details ? ` (${details})` : ""}`
+}
+
+function formatCost(cost: AgentUsageCost | undefined): string {
+  if (!cost) return "`n/a`"
+  const prefix = cost.estimated ? "~" : ""
+  const suffix = cost.source ? ` ${cost.source}` : ""
+  return `\`${prefix}${cost.amount} ${cost.currency}\`${suffix}`
+}
+
+export function formatUsageTelemetryChatMessage(
+  record: AgentUsageRecord,
+  context: UsageTelemetryChatMessageContext = {},
+): string {
+  const durationMs = record.latency?.durationMs ?? context.durationMs
+  const lines = [
+    "**Usage**",
+    `- Tokens: ${formatTokenSummary(record.usage)}`,
+    `- Time: \`${formatSeconds(durationMs) || "n/a"}\``,
+    `- Price: ${formatCost(record.cost)}`,
+  ]
+  if (record.latency?.tokensPerSecond !== undefined) {
+    lines.push(`- Speed: \`${record.latency.tokensPerSecond.toFixed(1)} tok/s\``)
+  }
+  if (record.model?.id) {
+    lines.push(`- Model: \`${record.model.id}\``)
+  }
+  return lines.join("\n")
 }
 
 function decimalToParts(value: string): { scale: bigint, units: bigint } {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -134,7 +134,7 @@ export function normalizeCapabilities(
 function validateAccessCapabilityOrder(capabilities: AgentCapabilityDefinition[]): void {
   const accessIndex = capabilities.findIndex(capability => capability.id === "access")
   if (accessIndex > 0) {
-    throw new Error("[vitehub] access() must be the first capability so Workspace Scope is applied before other capabilities can read the workspace or expose tools.")
+    throw new Error("[vitehub] access() must be the first capability so invocation access is applied before other capabilities can read scoped runtime surfaces or expose tools.")
   }
 }
 
@@ -166,7 +166,7 @@ function addInstructionBlock(
   capabilityInstructions: AgentInstructionBlock[],
   capabilityId: string,
   value: AgentAdapterInstructionsValue | false | undefined,
-  options?: { id?: string },
+  options?: { aliases?: string[], id?: string },
 ) {
   if (value === false || value === undefined) return
   const instructions = (Array.isArray(value) ? value : [value])
@@ -175,6 +175,7 @@ function addInstructionBlock(
     .join("\n\n")
   if (instructions) {
     capabilityInstructions.push({
+      ...(options?.aliases?.length ? { aliases: options.aliases } : {}),
       id: options?.id || capabilityId,
       instructions,
     })
@@ -465,21 +466,24 @@ export function applyCapabilityInstructionSlots(instructions: string, blocks: Ag
   if (!blocks.length) return instructions
 
   const remaining = [...blocks]
-  const known = new Set(blocks.map(block => block.id))
   const used = new Set<string>()
   const slotPattern = /\{\{\s*([a-zA-Z][\w.-]*)\s*\}\}/g
   const rendered = instructions.replace(slotPattern, (match, slot: string) => {
     if (slot === "capabilities") {
       return remaining.splice(0).map(block => block.instructions).join("\n\n")
     }
-    if (!known.has(slot)) {
+
+    const selected = blocks.filter(block => instructionBlockMatchesSlot(block, slot))
+    if (!selected.length) {
       return match
     }
     if (used.has(slot)) {
       throw new Error(`[vitehub] Duplicate capability instruction slot "${slot}". Use {{ capabilities }} for repeated catch-all insertion.`)
     }
+    if (selected.some(block => !remaining.includes(block))) {
+      throw new Error(`[vitehub] Capability instruction slot "${slot}" references instructions that were already inserted by another slot.`)
+    }
     used.add(slot)
-    const selected = remaining.filter(block => block.id === slot)
     for (const block of selected) {
       const index = remaining.indexOf(block)
       if (index >= 0) remaining.splice(index, 1)
@@ -489,6 +493,10 @@ export function applyCapabilityInstructionSlots(instructions: string, blocks: Ag
 
   const appendix = remaining.map(block => block.instructions).join("\n\n")
   return [rendered.trim(), appendix.trim()].filter(Boolean).join("\n\n")
+}
+
+function instructionBlockMatchesSlot(block: AgentInstructionBlock, slot: string): boolean {
+  return block.id === slot || !!block.aliases?.includes(slot)
 }
 
 export async function applyCapabilityToolTransforms(

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -29,6 +29,7 @@ import type { ViteDevServer } from "vite"
 import type { AgentChatMessageTriggerInput } from "../../chat-trigger.ts"
 import type {
   AgentInput,
+  AgentRunInput,
   AgentRunMetadata,
   AgentRuntimeConfig,
   AgentRuntimeContext,
@@ -172,6 +173,18 @@ function createRuntimeContext(server: ViteDevServer, req: IncomingMessage, run: 
   }) as ViteAgentDevtoolsRuntimeContext
 }
 
+function createDevtoolsMetadataInput(): AgentRunInput {
+  return {
+    context: {
+      chat: {
+        message: { metadata: {} },
+        run: { origin: "devtools" },
+      },
+    },
+    messages: [],
+  }
+}
+
 async function discoverChatAgents(server: ViteDevServer): Promise<Map<string, ChatDevtoolsAgentEntry>> {
   const context = createDevtoolsDiscoveryContext()
   const entries = new Map<string, ChatDevtoolsAgentEntry>()
@@ -190,7 +203,10 @@ async function discoverChatAgents(server: ViteDevServer): Promise<Map<string, Ch
 
     entries.set(definition.name, {
       agent,
-      metadata: await resolveAgentDevtoolsMetadata(agent as never, workspaceDefaults(definition) as never),
+      metadata: await resolveAgentDevtoolsMetadata(agent as never, {
+        ...workspaceDefaults(definition),
+        input: createDevtoolsMetadataInput(),
+      } as never),
       name: definition.name,
     })
   }

--- a/packages/agent/src/config.ts
+++ b/packages/agent/src/config.ts
@@ -1,6 +1,7 @@
 import type { AgentModuleOptions, ResolvedAgentModuleOptions } from "./types.ts"
 
 const defaultAgentRoute = "/agents/[agent]"
+const defaultAgentWebhookRoute = "/api/_vitehub/agents/[agent]/webhooks/[webhook]"
 
 export function normalizeAgentOptions(options: AgentModuleOptions | false | undefined): false | ResolvedAgentModuleOptions {
   if (options === false) {
@@ -28,5 +29,6 @@ export function normalizeAgentOptions(options: AgentModuleOptions | false | unde
     },
     route: options?.route === true ? defaultAgentRoute : options?.route ?? false,
     runtime: options?.runtime || "auto",
+    webhooks: options?.webhooks === true ? defaultAgentWebhookRoute : options?.webhooks ?? false,
   }
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -310,6 +310,7 @@ interface ScheduleRunContextLike {
 }
 
 const agentWorkflowHandles = new WeakMap<object, Map<string, WorkflowHandle<AgentWorkflowInvocationPayload, unknown>>>()
+const agentWorkflowNames = new Set<string>()
 
 function hasAgentMethods(value: unknown): value is AgentAdapter {
   return typeof value === "object"
@@ -379,10 +380,14 @@ async function getAgentWorkflowHandle<
   if (existing) return existing as WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>
 
   const { createWorkflow } = await import("@vite-hub/workflow")
-  const handle = createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>(name, async (workflowContext) => {
-    const { runAgentWorkflowDefinition } = await import("./runtime/workflow.ts")
-    return await runAgentWorkflowDefinition(agent as never, workflowContext as never, runAgentInline as never)
-  })
+  const { getInlineWorkflowDefinitions } = await import("@vite-hub/workflow/runtime/state")
+  const handle = agentWorkflowNames.has(name) && getInlineWorkflowDefinitions().has(name)
+    ? createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>(name)
+    : createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>(name, async (workflowContext) => {
+        const { runAgentWorkflowDefinition } = await import("./runtime/workflow.ts")
+        return await runAgentWorkflowDefinition(agent as never, workflowContext as never, runAgentInline as never)
+      })
+  agentWorkflowNames.add(name)
   handles.set(name, handle as WorkflowHandle<AgentWorkflowInvocationPayload, unknown>)
   agentWorkflowHandles.set(agent as object, handles)
   return handle
@@ -477,10 +482,18 @@ function validateWorkspaceCapabilities<Name extends WorkspaceName>(options: Work
   }
 }
 
+function accessCapabilityRequiresWorkspace(capability: NormalizedCapability): boolean {
+  if (capability.id !== "access") return false
+  const metadata = capability.metadata
+  return typeof metadata === "object"
+    && metadata !== null
+    && (metadata as { workspace?: unknown }).workspace === true
+}
+
 function validateNonWorkspaceCapabilities(capabilities: NormalizedCapability[], hasWorkspace: boolean): void {
   if (hasWorkspace) return
   for (const capability of capabilities) {
-    if (capability.id === "workspace-shell" || capability.id === "sandbox" || capability.id === "access") {
+    if (capability.id === "workspace-shell" || capability.id === "sandbox" || accessCapabilityRequiresWorkspace(capability)) {
       const name = capability.id === "workspace-shell" ? "workspaceShell" : capability.id
       throw new Error(`[vitehub] ${name}() requires an explicit workspace.`)
     }
@@ -1137,8 +1150,6 @@ export async function streamAgent<
   input: AgentRunInput<CALL_OPTIONS>,
   options: { output?: "events" | "ui-message-stream" } = {},
 ): Promise<Response | AsyncIterable<StreamEvent> | unknown> {
-  const workflowRun = await runAgentAsWorkflow(agent, context, input)
-  if (workflowRun) return workflowRun
   return await streamAgentInline(agent, context, input, options)
 }
 

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -1,3 +1,5 @@
+import type { AgentUsageRecord } from "./types.ts"
+
 export type MessageRole = "assistant" | "system" | "tool" | "user"
 
 export interface MessageMetadata {
@@ -116,6 +118,7 @@ export type StreamEvent =
   | { id: string, input?: unknown, messageId?: string, name: string, reason?: string, type: "approval-request" }
   | { approved: boolean, decidedAt?: Date | string, id: string, messageId?: string, reason?: string, type: "approval-decision" }
   | { error: string, id?: string, messageId?: string, recoverable?: boolean, type: "error" }
+  | { messageId?: string, usageRecord: AgentUsageRecord, type: "usage" }
   | { messageId?: string, reason?: string, type: "finish" }
 
 export type RunEvent = StreamEvent
@@ -351,7 +354,7 @@ function findOrCreateMessage(messages: Message[], event: StreamEvent): Message {
 
 export function applyStreamEvent(messages: Message[], event: StreamEvent): Message[] {
   const next = messages.map(message => ({ ...message, parts: [...message.parts] }))
-  if (event.type === "finish") {
+  if (event.type === "finish" || event.type === "usage") {
     return next
   }
 

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -1,14 +1,33 @@
-import { streamAgentTrigger } from "./index.ts"
+import { createRuntimeWaitUntilController } from "@vite-hub/runtime"
+import { Chat } from "chat"
+
+import { resolveAgentTriggerInvocation, resolveAgentTriggers, runAgentInline, streamAgentTrigger } from "./index.ts"
+import { streamAgentOutputToEvents } from "./agent-output.ts"
+import { getAccessCapabilityOptions } from "./capabilities/access.ts"
+import { formatUsageTelemetryChatMessage, getUsageTelemetryChatOptions } from "./capabilities/usage-telemetry.ts"
+import { getChatCapabilityOptions } from "./chat-trigger.ts"
 import { createAgentRuntimeContext } from "./runtime/context.ts"
 import { toHttpErrorResponse } from "./http-error.ts"
 
 import type { AgentChatMessageTriggerInput } from "./chat-trigger.ts"
 import type {
+  AgentChatStateResolver,
+  AgentCapabilityDefinition,
+  AgentChatOptions,
   AgentInput,
   AgentRunMetadata,
   AgentRuntimeConfig,
   AgentRuntimeContext,
+  AgentRuntimeName,
+  AgentWaitUntil,
+  AgentWebhookRegistrationDefinition,
+  AgentUsageRecord,
+  MaybeResolvable,
 } from "./types.ts"
+import type { AccessChatIdentity } from "./capabilities/access.ts"
+import type { UsageTelemetryChatCallbackContext, UsageTelemetryChatMessage } from "./capabilities/usage-telemetry.ts"
+import type { AudioData, MessagePart } from "./messages.ts"
+import type { Adapter, Attachment, ChatConfig, Lock, Message as ChatSdkMessage, MessageContext, QueueEntry, StateAdapter, Thread, WebhookOptions } from "chat"
 
 interface ViteAgentRouteRuntimeConfig extends AgentRuntimeConfig {
   agent?: unknown
@@ -16,12 +35,28 @@ interface ViteAgentRouteRuntimeConfig extends AgentRuntimeConfig {
 
 interface ViteAgentRouteRuntimeContext extends AgentRuntimeContext<ViteAgentRouteRuntimeConfig> {
   request: Request
-  runtime: "vite"
+  runtime: AgentRuntimeName
   runtimeConfig: ViteAgentRouteRuntimeConfig
 }
 
 type AgentChatRouteBody = AgentChatMessageTriggerInput & {
   stream?: boolean
+}
+
+export interface AgentChatFetchOptions {
+  waitUntil?: AgentWaitUntil
+}
+
+export interface AgentChatWebhookFetchOptions extends AgentChatFetchOptions {
+  agentName?: string
+}
+
+type AgentDefinitionWithCapabilities = {
+  __vitehubWorkspaceAgentOptions?: {
+    capabilities?: AgentCapabilityDefinition[]
+  }
+  capabilities?: AgentCapabilityDefinition[]
+  chat?: AgentChatOptions
 }
 
 async function readJsonBody(request: Request): Promise<AgentChatRouteBody> {
@@ -35,23 +70,46 @@ function readableStreamFromResult(value: unknown): ReadableStream<unknown> {
   throw new Error("[vitehub] Agent chat route expected a UI message stream.")
 }
 
-function createBadRequest(message: string): Response {
+function createJsonErrorResponse(status: number, message: string): Response {
   return Response.json({
     error: true,
-    status: 400,
+    status,
     statusText: message,
     message,
-  }, { status: 400 })
+  }, { status })
 }
 
-function createRuntimeContext(request: Request, run: AgentRunMetadata | undefined): ViteAgentRouteRuntimeContext {
+function createBadRequest(message: string): Response {
+  return createJsonErrorResponse(400, message)
+}
+
+function detectRuntime(): AgentRuntimeName {
+  const env = typeof process === "object" && process ? process.env : undefined
+  if (env?.VERCEL) return "vercel"
+  return "vite"
+}
+
+function createRuntimeContext(
+  request: Request,
+  run: AgentRunMetadata | undefined,
+  waitUntil?: AgentWaitUntil,
+): ViteAgentRouteRuntimeContext {
+  const waitUntilController = createRuntimeWaitUntilController({ forward: waitUntil })
   return createAgentRuntimeContext({
+    flushWaitUntil: waitUntilController.flushWaitUntil,
     request,
     ...(run ? { run } : {}),
-    runtime: "vite",
+    runtime: detectRuntime(),
     runtimeConfig: {},
-    waitUntil: task => void Promise.resolve(task).catch(() => {}),
+    ...(waitUntil ? { vercel: { waitUntil } } : {}),
+    waitUntil: waitUntilController.waitUntil,
   }) as ViteAgentRouteRuntimeContext
+}
+
+async function resolveRuntimeWaitUntil(waitUntil: AgentWaitUntil | undefined): Promise<AgentWaitUntil | undefined> {
+  if (detectRuntime() !== "vercel") return waitUntil
+  const vercel = await import("@vercel/functions").catch(() => undefined) as { waitUntil?: AgentWaitUntil } | undefined
+  return vercel?.waitUntil || waitUntil
 }
 
 async function toUiMessageStreamResponse(stream: ReadableStream<unknown>): Promise<Response> {
@@ -61,20 +119,643 @@ async function toUiMessageStreamResponse(stream: ReadableStream<unknown>): Promi
   return createUIMessageStreamResponse({ stream })
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function isResolvableObject<T, TContext extends AgentRuntimeContext>(
+  value: unknown,
+): value is { resolve: (context: TContext) => T | Promise<T> } {
+  return isRecord(value) && typeof value.resolve === "function"
+}
+
+async function resolveMaybe<T, TContext extends AgentRuntimeContext>(
+  value: MaybeResolvable<T, TContext> | undefined,
+  context: TContext,
+): Promise<T | undefined> {
+  if (value === undefined) return undefined
+  if (typeof value === "function") {
+    return await (value as (context: TContext) => T | Promise<T>)(context)
+  }
+  if (isResolvableObject<T, TContext>(value)) {
+    return await value.resolve(context)
+  }
+  return value as T
+}
+
+function getAgentCapabilities(agent: unknown): AgentCapabilityDefinition[] {
+  if (!isRecord(agent)) return []
+  const definition = agent as AgentDefinitionWithCapabilities
+  return definition.__vitehubWorkspaceAgentOptions?.capabilities || definition.capabilities || []
+}
+
+function getAgentChatOptions(agent: unknown): AgentChatOptions | undefined {
+  if (!isRecord(agent)) return undefined
+  const definition = agent as AgentDefinitionWithCapabilities
+  return getChatCapabilityOptions(getAgentCapabilities(agent)) || definition.chat
+}
+
+async function findChatWebhookRegistration(
+  agent: AgentInput<ViteAgentRouteRuntimeContext>,
+  context: ViteAgentRouteRuntimeContext,
+  webhook: string,
+): Promise<AgentWebhookRegistrationDefinition | undefined> {
+  const triggers = await resolveAgentTriggers(agent as never, context as never)
+  const registrations = triggers["chat.message"]?.webhooks || []
+  return registrations.find(registration => registration.id === webhook || registration.provider === webhook)
+}
+
+async function resolveChatAdapters(
+  options: AgentChatOptions | undefined,
+  context: ViteAgentRouteRuntimeContext,
+): Promise<Record<string, Adapter>> {
+  const adapters = await resolveMaybe(
+    options?.adapters as MaybeResolvable<Record<string, MaybeResolvable<Adapter, ViteAgentRouteRuntimeContext>>, ViteAgentRouteRuntimeContext> | undefined,
+    context,
+  )
+  const resolved: Record<string, Adapter> = {}
+  for (const [name, adapter] of Object.entries(adapters || {})) {
+    const value = await resolveMaybe(adapter, context)
+    if (value) resolved[name] = value
+  }
+  return resolved
+}
+
+function resolveChatAdapterName(adapters: Record<string, Adapter>, registration: AgentWebhookRegistrationDefinition): string | undefined {
+  if (adapters[registration.provider]) return registration.provider
+  if (registration.id && adapters[registration.id]) return registration.id
+  return undefined
+}
+
+function objectWithoutUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as T
+}
+
+function fallbackWebhookFromRequest(request: Request): string | undefined {
+  return new URL(request.url).pathname.split("/").filter(Boolean).at(-1) || undefined
+}
+
+interface CollectedAgentOutput {
+  text: string
+  usageRecord?: AgentUsageRecord
+}
+
+async function collectAgentOutput(result: unknown): Promise<CollectedAgentOutput> {
+  if (result instanceof Response) {
+    if (result.headers.get("content-type")?.includes("application/json")) {
+      const body = await result.clone().json().catch(() => undefined)
+      if (isRecord(body) && typeof body.text === "string") {
+        return {
+          text: body.text,
+          ...(isRecord(body.usageRecord) ? { usageRecord: body.usageRecord as AgentUsageRecord } : {}),
+        }
+      }
+    }
+    return { text: await result.text() }
+  }
+
+  let text = ""
+  let usageRecord: AgentUsageRecord | undefined
+  for await (const event of streamAgentOutputToEvents(result)) {
+    if (event.type === "text-delta") {
+      text += event.text
+    }
+    if (event.type === "usage") {
+      usageRecord = event.usageRecord
+    }
+    if (event.type === "error") {
+      throw new Error(event.error)
+    }
+  }
+  return {
+    ...(usageRecord ? { usageRecord } : {}),
+    text: text.trim(),
+  }
+}
+
+function randomToken(): string {
+  return globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function isExpired(expiresAt: number | null | undefined): boolean {
+  return typeof expiresAt === "number" && expiresAt <= Date.now()
+}
+
+class ViteHubInMemoryChatStateAdapter implements StateAdapter {
+  private cache = new Map<string, { expiresAt?: number, value: unknown }>()
+  private connected = false
+  private lists = new Map<string, Array<{ expiresAt?: number, value: unknown }>>()
+  private locks = new Map<string, Lock>()
+  private queues = new Map<string, QueueEntry[]>()
+  private subscriptions = new Set<string>()
+
+  async acquireLock(threadId: string, ttlMs: number): Promise<Lock | null> {
+    this.ensureConnected()
+    const existing = this.locks.get(threadId)
+    if (existing && !isExpired(existing.expiresAt)) return null
+    const lock = { expiresAt: Date.now() + ttlMs, threadId, token: randomToken() }
+    this.locks.set(threadId, lock)
+    return lock
+  }
+
+  async appendToList(key: string, value: unknown, options?: { maxLength?: number, ttlMs?: number }): Promise<void> {
+    this.ensureConnected()
+    const expiresAt = options?.ttlMs ? Date.now() + options.ttlMs : undefined
+    const list = (this.lists.get(key) || []).filter(item => !isExpired(item.expiresAt))
+    list.push({ expiresAt, value })
+    if (options?.maxLength && options.maxLength > 0) {
+      this.lists.set(key, list.slice(-options.maxLength))
+      return
+    }
+    this.lists.set(key, list)
+  }
+
+  async connect(): Promise<void> {
+    this.connected = true
+  }
+
+  async delete(key: string): Promise<void> {
+    this.ensureConnected()
+    this.cache.delete(key)
+    this.lists.delete(key)
+  }
+
+  async dequeue(threadId: string): Promise<QueueEntry | null> {
+    this.ensureConnected()
+    const queue = (this.queues.get(threadId) || []).filter(entry => !isExpired(entry.expiresAt))
+    const entry = queue.shift() || null
+    this.queues.set(threadId, queue)
+    return entry
+  }
+
+  async disconnect(): Promise<void> {
+    this.connected = false
+  }
+
+  async enqueue(threadId: string, entry: QueueEntry, maxSize: number): Promise<number> {
+    this.ensureConnected()
+    const queue = (this.queues.get(threadId) || []).filter(item => !isExpired(item.expiresAt))
+    queue.push(entry)
+    const trimmed = maxSize > 0 ? queue.slice(-maxSize) : queue
+    this.queues.set(threadId, trimmed)
+    return trimmed.length
+  }
+
+  async extendLock(lock: Lock, ttlMs: number): Promise<boolean> {
+    this.ensureConnected()
+    const existing = this.locks.get(lock.threadId)
+    if (!existing || existing.token !== lock.token || isExpired(existing.expiresAt)) return false
+    existing.expiresAt = Date.now() + ttlMs
+    return true
+  }
+
+  async forceReleaseLock(threadId: string): Promise<void> {
+    this.ensureConnected()
+    this.locks.delete(threadId)
+  }
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    this.ensureConnected()
+    const item = this.cache.get(key)
+    if (!item || isExpired(item.expiresAt)) {
+      this.cache.delete(key)
+      return null
+    }
+    return item.value as T
+  }
+
+  async getList<T = unknown>(key: string): Promise<T[]> {
+    this.ensureConnected()
+    const list = (this.lists.get(key) || []).filter(item => !isExpired(item.expiresAt))
+    this.lists.set(key, list)
+    return list.map(item => item.value as T)
+  }
+
+  async isSubscribed(threadId: string): Promise<boolean> {
+    this.ensureConnected()
+    return this.subscriptions.has(threadId)
+  }
+
+  async queueDepth(threadId: string): Promise<number> {
+    this.ensureConnected()
+    const queue = (this.queues.get(threadId) || []).filter(entry => !isExpired(entry.expiresAt))
+    this.queues.set(threadId, queue)
+    return queue.length
+  }
+
+  async releaseLock(lock: Lock): Promise<void> {
+    this.ensureConnected()
+    const existing = this.locks.get(lock.threadId)
+    if (existing?.token === lock.token) this.locks.delete(lock.threadId)
+  }
+
+  async set<T = unknown>(key: string, value: T, ttlMs?: number): Promise<void> {
+    this.ensureConnected()
+    this.cache.set(key, { expiresAt: ttlMs ? Date.now() + ttlMs : undefined, value })
+  }
+
+  async setIfNotExists(key: string, value: unknown, ttlMs?: number): Promise<boolean> {
+    this.ensureConnected()
+    const existing = this.cache.get(key)
+    if (existing && !isExpired(existing.expiresAt)) return false
+    this.cache.set(key, { expiresAt: ttlMs ? Date.now() + ttlMs : undefined, value })
+    return true
+  }
+
+  async subscribe(threadId: string): Promise<void> {
+    this.ensureConnected()
+    this.subscriptions.add(threadId)
+  }
+
+  async unsubscribe(threadId: string): Promise<void> {
+    this.ensureConnected()
+    this.subscriptions.delete(threadId)
+  }
+
+  private ensureConnected(): void {
+    if (!this.connected) {
+      throw new Error("[vitehub] In-memory Chat State is not connected. Call connect() before using state.")
+    }
+  }
+}
+
+const inMemoryChatStates = new Map<string, StateAdapter>()
+
+function getInMemoryChatState(key: string): StateAdapter {
+  let state = inMemoryChatStates.get(key)
+  if (!state) {
+    state = new ViteHubInMemoryChatStateAdapter()
+    inMemoryChatStates.set(key, state)
+  }
+  return state
+}
+
+async function resolveChatState(
+  options: AgentChatOptions | undefined,
+  context: ViteAgentRouteRuntimeContext,
+  registration: AgentWebhookRegistrationDefinition,
+  handlerOptions: AgentChatWebhookFetchOptions,
+): Promise<StateAdapter> {
+  const agentName = handlerOptions.agentName || "agent"
+  const state = await resolveMaybe(
+    options?.state as AgentChatStateResolver<ViteAgentRouteRuntimeConfig> | undefined,
+    {
+      ...context,
+      chat: {
+        agentName,
+        stateKeyPrefix: `chat:${agentName}:${registration.provider}:`,
+      },
+    } as never,
+  )
+  return state || getInMemoryChatState(`${agentName}:${registration.provider}`)
+}
+
+function chatSdkOption<T>(options: AgentChatOptions | undefined, key: string): T | undefined {
+  return isRecord(options) ? options[key] as T | undefined : undefined
+}
+
+function createChatSdkConfig(
+  adapters: Record<string, Adapter>,
+  state: StateAdapter,
+  options: AgentChatOptions | undefined,
+): ChatConfig {
+  const fallbackStreamingPlaceholderText = typeof options?.fallbackStreamingPlaceholderText === "function"
+    ? undefined
+    : options?.fallbackStreamingPlaceholderText
+  return objectWithoutUndefined({
+    adapters,
+    concurrency: chatSdkOption<ChatConfig["concurrency"]>(options, "concurrency"),
+    dedupeTtlMs: chatSdkOption<number>(options, "dedupeTtlMs"),
+    fallbackStreamingPlaceholderText,
+    identity: options?.identity,
+    lockScope: chatSdkOption<ChatConfig["lockScope"]>(options, "lockScope"),
+    logger: chatSdkOption<ChatConfig["logger"]>(options, "logger"),
+    messageHistory: chatSdkOption<ChatConfig["messageHistory"]>(options, "messageHistory"),
+    state,
+    streamingUpdateIntervalMs: chatSdkOption<number>(options, "streamingUpdateIntervalMs"),
+    threadHistory: chatSdkOption<ChatConfig["threadHistory"]>(options, "threadHistory"),
+    transcripts: options?.transcripts,
+    userName: options?.userName || "vitehub",
+  }) as ChatConfig
+}
+
+function isoDate(value: unknown): string | undefined {
+  return value instanceof Date ? value.toISOString() : undefined
+}
+
+function accessChatIdentity(provider: string, message: ChatSdkMessage): AccessChatIdentity {
+  return objectWithoutUndefined({
+    id: message.author.userId,
+    metadata: objectWithoutUndefined({
+      isBot: message.author.isBot,
+      isMe: message.author.isMe,
+      userKey: message.userKey,
+    }),
+    name: message.author.fullName,
+    provider,
+    username: message.author.userName,
+  })
+}
+
+function audioData(value: unknown): AudioData | undefined {
+  if (typeof value === "string") return value
+  if (value instanceof ArrayBuffer) return value
+  if (value instanceof Blob) return value
+  if (value instanceof Uint8Array) return value
+  return undefined
+}
+
+function audioPartFromAttachment(attachment: Attachment, index: number): MessagePart | undefined {
+  if (attachment.type !== "audio") return undefined
+  const mediaType = typeof attachment.mimeType === "string" && attachment.mimeType.startsWith("audio/")
+    ? attachment.mimeType
+    : "audio/ogg"
+  const base = objectWithoutUndefined({
+    fetchMetadata: attachment.fetchMetadata,
+    id: `audio-${index + 1}`,
+    mediaType,
+    name: attachment.name,
+    size: attachment.size,
+    type: "audio" as const,
+  })
+  if (typeof attachment.fetchData === "function") {
+    return {
+      ...base,
+      fetchData: async () => {
+        const data = audioData(await attachment.fetchData?.())
+        if (!data) {
+          throw new Error("[vitehub] Chat attachment fetchData() did not return supported audio data.")
+        }
+        return data
+      },
+    }
+  }
+  if (typeof attachment.url === "string" && attachment.url) {
+    return { ...base, url: attachment.url }
+  }
+  const data = audioData(attachment.data)
+  if (data) {
+    return { ...base, data }
+  }
+  return undefined
+}
+
+function chatMessageParts(message: ChatSdkMessage): MessagePart[] {
+  const parts: MessagePart[] = []
+  if (message.text) {
+    parts.push({ id: "text-0", text: message.text, type: "text" })
+  }
+  for (const [index, attachment] of message.attachments.entries()) {
+    const part = audioPartFromAttachment(attachment, index)
+    if (part) parts.push(part)
+  }
+  return parts
+}
+
+function createChatTriggerInput(
+  provider: string,
+  thread: Thread,
+  message: ChatSdkMessage,
+  messageContext?: MessageContext,
+): AgentChatMessageTriggerInput {
+  const metadata = objectWithoutUndefined({
+    chat: objectWithoutUndefined({
+      edited: message.metadata.edited,
+      editedAt: isoDate(message.metadata.editedAt),
+      isMention: message.isMention,
+      messageId: message.id,
+      skippedCount: messageContext?.skipped.length,
+      threadId: message.threadId,
+      totalSinceLastHandler: messageContext?.totalSinceLastHandler,
+    }),
+  })
+  const user = objectWithoutUndefined({
+    id: message.author.userId,
+    isBot: message.author.isBot,
+    isMe: message.author.isMe,
+    name: message.author.fullName,
+    username: message.author.userName,
+  })
+  return {
+    messages: [{
+      createdAt: isoDate(message.metadata.dateSent),
+      id: message.id,
+      metadata,
+      parts: chatMessageParts(message),
+      role: "user",
+    }],
+    run: {
+      channelId: thread.adapter.channelIdFromThreadId(message.threadId),
+      messageId: message.id,
+      origin: provider,
+      runId: `${provider}:${message.id}`,
+      threadId: message.threadId,
+    },
+    user,
+  }
+}
+
+function accessChatInput(thread: Thread, message: ChatSdkMessage, messageContext?: MessageContext): Record<string, unknown> {
+  return {
+    message: objectWithoutUndefined({
+      attachmentCount: message.attachments.length,
+      id: message.id,
+      isMention: message.isMention,
+      text: message.text,
+      threadId: message.threadId,
+    }),
+    queue: objectWithoutUndefined({
+      skippedCount: messageContext?.skipped.length,
+      totalSinceLastHandler: messageContext?.totalSinceLastHandler,
+    }),
+    thread: {
+      id: thread.id,
+      isDM: thread.isDM,
+    },
+  }
+}
+
+async function isChatMessageAuthorized(
+  agent: AgentInput<ViteAgentRouteRuntimeContext>,
+  context: ViteAgentRouteRuntimeContext,
+  registration: AgentWebhookRegistrationDefinition,
+  thread: Thread,
+  message: ChatSdkMessage,
+  messageContext?: MessageContext,
+): Promise<boolean> {
+  for (const options of getAccessCapabilityOptions(getAgentCapabilities(agent))) {
+    if (!options.chat) continue
+    const result = await options.chat.resolve({
+      ...context,
+      identity: accessChatIdentity(registration.provider, message),
+      input: accessChatInput(thread, message, messageContext),
+      provider: registration.provider,
+      request: context.request,
+      webhook: registration,
+    })
+    if (result === false) return false
+  }
+  return true
+}
+
+async function postUsageTelemetry(
+  agent: AgentInput<ViteAgentRouteRuntimeContext>,
+  durationMs: number,
+  input: AgentChatMessageTriggerInput,
+  registration: AgentWebhookRegistrationDefinition,
+  thread: Thread,
+  usageRecord: AgentUsageRecord | undefined,
+): Promise<void> {
+  if (!usageRecord) return
+  for (const options of getUsageTelemetryChatOptions(getAgentCapabilities(agent))) {
+    const context: UsageTelemetryChatCallbackContext = {
+      durationMs,
+      provider: registration.provider,
+      ...(input.run ? { run: input.run } : {}),
+      sendMessage: async (message: UsageTelemetryChatMessage) => {
+        await thread.post("text" in message ? message.text : message)
+      },
+    }
+    if (options.onUsage) {
+      await options.onUsage(usageRecord, context)
+      continue
+    }
+    const markdown = options.format
+      ? await options.format(usageRecord, context)
+      : formatUsageTelemetryChatMessage(usageRecord, context)
+    if (markdown) await thread.post({ markdown })
+  }
+}
+
+async function handleChatSdkMessage(
+  agent: AgentInput<ViteAgentRouteRuntimeContext>,
+  context: ViteAgentRouteRuntimeContext,
+  registration: AgentWebhookRegistrationDefinition,
+  thread: Thread,
+  message: ChatSdkMessage,
+  options: AgentChatOptions | undefined,
+  messageContext?: MessageContext,
+): Promise<void> {
+  const input = createChatTriggerInput(registration.provider, thread, message, messageContext)
+  const firstMessage = input.messages[0]
+  if (!firstMessage || !Array.isArray(firstMessage.parts) || firstMessage.parts.length === 0) return
+  if (!await isChatMessageAuthorized(agent, context, registration, thread, message, messageContext)) return
+
+  const startedAt = Date.now()
+  if (options?.stream !== false) {
+    context.waitUntil(thread.startTyping().catch(() => undefined))
+  }
+  const result = options?.stream === false
+    ? await runChatAgentTriggerInline(agent, context, input)
+    : await streamAgentTrigger(agent as never, context as never, "chat.message", input, {
+        output: "events",
+      })
+  const { text, usageRecord } = await collectAgentOutput(result)
+  if (text) {
+    await thread.post({ markdown: text })
+  }
+  await postUsageTelemetry(agent, Date.now() - startedAt, input, registration, thread, usageRecord)
+}
+
+async function runChatAgentTriggerInline(
+  agent: AgentInput<ViteAgentRouteRuntimeContext>,
+  context: ViteAgentRouteRuntimeContext,
+  input: AgentChatMessageTriggerInput,
+): Promise<Response | unknown> {
+  const invocation = await resolveAgentTriggerInvocation(agent as never, context as never, "chat.message", input)
+  return await runAgentInline(agent as never, {
+    ...context,
+    ...(invocation.run ? { run: invocation.run } : {}),
+  }, invocation.input as never)
+}
+
+async function createChatWebhookHandler(
+  agent: AgentInput<ViteAgentRouteRuntimeContext>,
+  context: ViteAgentRouteRuntimeContext,
+  registration: AgentWebhookRegistrationDefinition,
+  adapterName: string,
+  adapter: Adapter,
+  options: AgentChatOptions | undefined,
+  handlerOptions: AgentChatWebhookFetchOptions,
+): Promise<(request: Request, webhookOptions: WebhookOptions) => Promise<Response>> {
+  const chat = new Chat(createChatSdkConfig({
+    [adapterName]: adapter,
+  }, await resolveChatState(options, context, registration, handlerOptions), options))
+
+  chat.onDirectMessage((thread, message, _channel, messageContext) =>
+    handleChatSdkMessage(agent, context, registration, thread, message, options, messageContext))
+  chat.onNewMention(async (thread, message, messageContext) => {
+    await thread.subscribe().catch(() => undefined)
+    await handleChatSdkMessage(agent, context, registration, thread, message, options, messageContext)
+  })
+  chat.onSubscribedMessage((thread, message, messageContext) =>
+    handleChatSdkMessage(agent, context, registration, thread, message, options, messageContext))
+
+  const handler = chat.webhooks[adapterName]
+  if (!handler) {
+    throw new Error(`[vitehub] Chat adapter "${adapterName}" did not expose a webhook handler.`)
+  }
+  return handler
+}
+
 export function defineAgentChatFetchHandler(
   agent: AgentInput<ViteAgentRouteRuntimeContext>,
-): (request: Request) => Promise<Response> {
-  return async (request) => {
+): (request: Request, options?: AgentChatFetchOptions) => Promise<Response> {
+  return async (request, handlerOptions = {}) => {
     const body = await readJsonBody(request.clone())
     if (!Array.isArray(body.messages) || body.messages.length === 0) {
       return createBadRequest("Agent chat route requires messages.")
     }
 
     try {
-      const result = await streamAgentTrigger(agent as never, createRuntimeContext(request, body.run), "chat.message", body, {
+      const context = createRuntimeContext(request, body.run, await resolveRuntimeWaitUntil(handlerOptions.waitUntil))
+      const result = await streamAgentTrigger(agent as never, context, "chat.message", body, {
         output: "ui-message-stream",
       })
       return await toUiMessageStreamResponse(readableStreamFromResult(result))
+    }
+    catch (error) {
+      const response = toHttpErrorResponse(error)
+      if (response) return response
+      throw error
+    }
+  }
+}
+
+export function defineAgentChatWebhookFetchHandler(
+  agent: AgentInput<ViteAgentRouteRuntimeContext>,
+): (request: Request, webhook?: string, options?: AgentChatWebhookFetchOptions) => Promise<Response> {
+  return async (request, webhook, handlerOptions = {}) => {
+    if (request.method !== "POST") {
+      return createJsonErrorResponse(405, "Agent chat webhook route only accepts POST requests.")
+    }
+
+    const webhookId = webhook || fallbackWebhookFromRequest(request)
+    if (!webhookId) {
+      return createBadRequest("Agent chat webhook route requires a webhook id.")
+    }
+
+    const context = createRuntimeContext(request, undefined, await resolveRuntimeWaitUntil(handlerOptions.waitUntil))
+    const registration = await findChatWebhookRegistration(agent, context, webhookId)
+    if (!registration) {
+      return createJsonErrorResponse(404, "Unknown ViteHub agent chat webhook.")
+    }
+
+    const chatOptions = getAgentChatOptions(agent)
+    const adapters = await resolveChatAdapters(chatOptions, context)
+    const adapterName = resolveChatAdapterName(adapters, registration)
+    const adapter = adapterName ? adapters[adapterName] : undefined
+    if (!adapter) {
+      return createJsonErrorResponse(500, `Agent chat webhook "${webhookId}" does not have a matching chat adapter.`)
+    }
+
+    try {
+      const handler = await createChatWebhookHandler(agent, context, registration, adapterName!, adapter, chatOptions, handlerOptions)
+      const response = await handler(request, { waitUntil: context.waitUntil })
+      if (chatOptions?.stream === false) {
+        await context.flushWaitUntil?.()
+      }
+      return response
     }
     catch (error) {
       const response = toHttpErrorResponse(error)

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -264,6 +264,7 @@ export type AgentCapabilityPhase = "configure" | "prepare" | "bind" | "input" | 
 export type AgentCapabilityHookName = `capability:${AgentCapabilityPhase}` | `capability:${AgentCapabilityPhase}:after`
 
 export interface AgentInstructionBlock {
+  aliases?: string[]
   id: string
   instructions: string
 }
@@ -296,7 +297,7 @@ export interface AgentCapabilityRuntimeContext<
 > extends AgentCapabilityContext<TRuntimeConfig, Name> {
   capability: AgentCapabilityDefinition<TRuntimeConfig, Name>
   instructions: {
-    add: (instructions: AgentAdapterInstructionsValue | false | undefined, options?: { id?: string }) => void
+    add: (instructions: AgentAdapterInstructionsValue | false | undefined, options?: { aliases?: string[], id?: string }) => void
   }
   input: {
     get: () => AgentRunInput
@@ -548,6 +549,7 @@ export interface AgentModuleOptions {
   providers?: AgentProvidersOptions
   route?: boolean | string
   runtime?: AgentRuntime
+  webhooks?: boolean | string
 }
 
 export interface ResolvedAgentModuleOptions {
@@ -561,6 +563,7 @@ export interface ResolvedAgentModuleOptions {
   }
   route: false | string
   runtime: AgentRuntime
+  webhooks: false | string
 }
 
 export interface AgentHandlerOptions<TRuntimeContext extends AgentRuntimeContext = AgentRuntimeContext> {
@@ -669,6 +672,7 @@ export interface AgentChatOptions<TRuntimeConfig extends AgentRuntimeConfig = Ag
   lifecycleHooks?: Record<string, unknown>
   sessions?: boolean | AgentChatSessionOptions
   state?: AgentChatStateResolver<TRuntimeConfig>
+  stream?: boolean
   transcripts?: TranscriptsConfig
   userName?: string
   webhooks?: Record<string, AgentChatWebhookRegistrationDefinition | AgentChatWebhookRegistrationDefinition[]>

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -25,6 +25,7 @@ export type AgentVitePlugin = Plugin & AgentCliContributingPlugin
 const agentPackageName = "@vite-hub/agent"
 const mergeNoExternal = createNoExternalMerger(agentPackageName)
 const generatedAgentRouteHandler = ".vitehub/agent/chat-route.ts"
+const generatedAgentWebhookRouteHandler = ".vitehub/agent/chat-webhook-route.ts"
 
 function agentDevtoolsEnabled(agent: AgentModuleOptions | false | undefined): boolean {
   return agent !== false && agent?.devtools !== false
@@ -32,7 +33,7 @@ function agentDevtoolsEnabled(agent: AgentModuleOptions | false | undefined): bo
 
 function normalizeNitroRoute(route: string): string {
   const normalized = route.startsWith("/") ? route : `/${route}`
-  return normalized.replace(/\[agent\]/g, ":agent")
+  return normalized.replace(/\[([^\]]+)\]/g, ":$1")
 }
 
 function resolveWorkspaceSourceRoot(file: string): string {
@@ -70,11 +71,27 @@ function generateAgentRouteHandler(definitions: DiscoveredAgentDefinition[], han
     "import { withWorkspaceAgentDefaults } from '@vite-hub/agent'",
     "import { defineAgentChatFetchHandler } from '@vite-hub/agent/server'",
     "import { setWorkspaceRuntimeRegistry } from '@vite-hub/workspace/internal/runtime/state'",
-    "import { createError, defineEventHandler, getRouterParam } from 'h3'",
+    "import { createError, defineEventHandler, getRequestHeaders, getRequestURL, getRouterParam, readRawBody } from 'h3'",
     imports,
     "",
     "function resolveAgentModule(module) {",
     "  return module && typeof module === 'object' && 'default' in module ? module.default : module",
+    "}",
+    "",
+    "async function toRequest(event) {",
+    "  if (event.request instanceof Request) {",
+    "    return event.request",
+    "  }",
+    "  const body = await readRawBody(event)",
+    "  return new Request(getRequestURL(event), {",
+    "    body: body || undefined,",
+    "    headers: getRequestHeaders(event),",
+    "    method: event.method || 'POST',",
+    "  })",
+    "}",
+    "",
+    "function waitUntilFromEvent(event) {",
+    "  return typeof event.waitUntil === 'function' ? event.waitUntil.bind(event) : undefined",
     "}",
     "",
     `setWorkspaceRuntimeRegistry({${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}})`,
@@ -88,7 +105,71 @@ function generateAgentRouteHandler(definitions: DiscoveredAgentDefinition[], han
     "  if (!handler) {",
     "    throw createError({ statusCode: 404, statusMessage: 'Unknown ViteHub agent.' })",
     "  }",
-    "  return await handler(event.req)",
+    "  return await handler(await toRequest(event), { waitUntil: waitUntilFromEvent(event) })",
+    "})",
+    "",
+  ].join("\n")
+}
+
+function generateAgentWebhookRouteHandler(definitions: DiscoveredAgentDefinition[], handlerPath: string): string {
+  const imports = definitions
+    .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
+    .join("\n")
+  const workspaceEntries = definitions
+    .map((definition, index) => definition.workspace
+      ? `${JSON.stringify(definition.workspace)}: async () => ({ ...agent${index}, default: { ...agent${index}.default, sourceRootDir: agent${index}.default?.sourceRootDir ?? ${JSON.stringify(resolveWorkspaceSourceRoot(definition.handler))} } })`
+      : undefined)
+    .filter(Boolean)
+    .join(",\n  ")
+  const agentEntries = definitions
+    .map((definition, index) => {
+      const agentExpression = definition.workspace
+        ? `withWorkspaceAgentDefaults(resolveAgentModule(agent${index}), ${JSON.stringify({ name: definition.name, workspace: definition.workspace })})`
+        : `resolveAgentModule(agent${index})`
+      return `${JSON.stringify(definition.name)}: ${agentExpression}`
+    })
+    .join(",\n  ")
+
+  return [
+    "import { withWorkspaceAgentDefaults } from '@vite-hub/agent'",
+    "import { defineAgentChatWebhookFetchHandler } from '@vite-hub/agent/server'",
+    "import { setWorkspaceRuntimeRegistry } from '@vite-hub/workspace/internal/runtime/state'",
+    "import { createError, defineEventHandler, getRequestHeaders, getRequestURL, getRouterParam, readRawBody } from 'h3'",
+    imports,
+    "",
+    "function resolveAgentModule(module) {",
+    "  return module && typeof module === 'object' && 'default' in module ? module.default : module",
+    "}",
+    "",
+    "async function toRequest(event) {",
+    "  if (event.request instanceof Request) {",
+    "    return event.request",
+    "  }",
+    "  const body = await readRawBody(event)",
+    "  return new Request(getRequestURL(event), {",
+    "    body: body || undefined,",
+    "    headers: getRequestHeaders(event),",
+    "    method: event.method || 'POST',",
+    "  })",
+    "}",
+    "",
+    "function waitUntilFromEvent(event) {",
+    "  return typeof event.waitUntil === 'function' ? event.waitUntil.bind(event) : undefined",
+    "}",
+    "",
+    `setWorkspaceRuntimeRegistry({${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}})`,
+    "",
+    `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
+    "const handlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, defineAgentChatWebhookFetchHandler(agent)]))",
+    "",
+    "export default defineEventHandler(async (event) => {",
+    "  const agent = getRouterParam(event, 'agent')",
+    "  const webhook = getRouterParam(event, 'webhook')",
+    "  const handler = agent ? handlers[agent] : undefined",
+    "  if (!handler) {",
+    "    throw createError({ statusCode: 404, statusMessage: 'Unknown ViteHub agent.' })",
+    "  }",
+    "  return await handler(await toRequest(event), webhook, { agentName: agent, waitUntil: waitUntilFromEvent(event) })",
     "})",
     "",
   ].join("\n")
@@ -102,6 +183,16 @@ async function writeAgentRouteHandler(root: string): Promise<void> {
   })
   await mkdir(dirname(handlerPath), { recursive: true })
   await writeFile(handlerPath, generateAgentRouteHandler(definitions, handlerPath), "utf8")
+}
+
+async function writeAgentWebhookRouteHandler(root: string): Promise<void> {
+  const handlerPath = join(root, generatedAgentWebhookRouteHandler)
+  const definitions = discoverAgentDefinitions({
+    mode: "server-agents",
+    scanDirs: [join(root, "server")],
+  })
+  await mkdir(dirname(handlerPath), { recursive: true })
+  await writeFile(handlerPath, generateAgentWebhookRouteHandler(definitions, handlerPath), "utf8")
 }
 
 export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
@@ -133,17 +224,26 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     config(config) {
       agent = config.agent ?? agent
       const resolved = normalizeAgentOptions(agent)
+      const nitroHandlers = [
+        ...(resolved && resolved.route
+          ? [{
+              handler: generatedAgentRouteHandler,
+              route: normalizeNitroRoute(resolved.route),
+            }]
+          : []),
+        ...(resolved && resolved.webhooks
+          ? [{
+              handler: generatedAgentWebhookRouteHandler,
+              route: normalizeNitroRoute(resolved.webhooks),
+            }]
+          : []),
+      ]
       return {
         ...(typeof agent !== "undefined" ? { agent } : {}),
-        ...(resolved && resolved.route
+        ...(nitroHandlers.length
           ? {
               nitro: {
-                handlers: [
-                  {
-                    handler: generatedAgentRouteHandler,
-                    route: normalizeNitroRoute(resolved.route),
-                  },
-                ],
+                handlers: nitroHandlers,
               },
             }
           : {}),
@@ -160,6 +260,9 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       const normalized = normalizeAgentOptions(agent)
       if (normalized && normalized.route) {
         await writeAgentRouteHandler(config.root)
+      }
+      if (normalized && normalized.webhooks) {
+        await writeAgentWebhookRouteHandler(config.root)
       }
       if (agent === false || agent?.eval === false) {
         return

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1,4 +1,9 @@
-import { normalizeCapabilities, normalizeMode } from "./capability-runtime.ts"
+import {
+  applyCapabilityInstructionSlots,
+  normalizeCapabilities,
+  normalizeMode,
+  resolveAgentCapabilities,
+} from "./capability-runtime.ts"
 
 import type {
   AgentCapabilityDefinition,
@@ -8,9 +13,11 @@ import type {
   AgentDevtoolsMetadata,
   AgentDevtoolsToolDefinition,
   AgentInput,
+  AgentRunInput,
   AgentRuntimeConfig,
   AgentRuntimeContext,
   AgentSettings,
+  ResolvedAgentRuntimeContext,
   WorkspaceAgentWorkspaceConfig,
   WorkspaceAgentWorkspaceOptions,
 } from "./types.ts"
@@ -49,6 +56,14 @@ export interface WorkspaceAgentDefaults<Name extends WorkspaceName = WorkspaceNa
   workspace?: Name
 }
 
+export interface AgentDevtoolsMetadataResolutionOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> extends WorkspaceAgentDefaults<Name> {
+  input?: AgentRunInput
+  runtime?: Partial<ResolvedAgentRuntimeContext<TRuntimeConfig>>
+}
+
 export function normalizeWorkspaceOptions(workspace: WorkspaceAgentWorkspaceConfig): NormalizedWorkspaceOptions {
   if (typeof workspace === "string") {
     return { mode: "read" }
@@ -59,22 +74,31 @@ export function normalizeWorkspaceOptions(workspace: WorkspaceAgentWorkspaceConf
   }
 }
 
-export function workspaceNameFromOptions<Name extends WorkspaceName>(
-  options: WorkspaceAgentOptions<AgentRuntimeConfig, Name>,
+export function workspaceNameFromOptions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
   defaults: WorkspaceAgentDefaults<Name> = {},
 ): Name | string {
   if (typeof options.workspace === "string") return options.workspace
   return options.name || defaults.workspace || defaults.name || defaultWorkspaceName
 }
 
-export function workspaceDefinitionFromOptions<Name extends WorkspaceName>(
-  options: WorkspaceAgentOptions<AgentRuntimeConfig, Name>,
+export function workspaceDefinitionFromOptions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
 ): WorkspaceAgentWorkspaceOptions {
   return typeof options.workspace === "string" ? { mode: "read" } : options.workspace
 }
 
-export function workspaceModeFromOptions<Name extends WorkspaceName>(
-  options: WorkspaceAgentOptions<AgentRuntimeConfig, Name>,
+export function workspaceModeFromOptions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
 ): AgentCapabilityMode {
   return normalizeWorkspaceOptions(options.workspace).mode
 }
@@ -341,6 +365,7 @@ async function resolveWorkspaceMetadataInstructions<
 >(
   options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
   workspace: ReadonlyWorkspaceFacade<Name>,
+  resolution: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name> = {},
 ) {
   const instructionContext = {
     fs: workspace.fs,
@@ -350,10 +375,64 @@ async function resolveWorkspaceMetadataInstructions<
   const instructions = await Promise.all(parts.map(part => typeof part === "function"
     ? part(instructionContext as never)
     : part))
-  return instructions
+  const resolved = instructions
     .flatMap(part => Array.isArray(part) ? part : [part])
     .map(part => part?.trim())
     .filter((part): part is string => Boolean(part))
+  const capabilityInstructions = await resolveWorkspaceMetadataCapabilityInstructions(options, workspace, resolution)
+  if (!capabilityInstructions.length) return resolved
+
+  const rendered = applyCapabilityInstructionSlots(resolved.join("\n\n"), capabilityInstructions).trim()
+  return rendered ? [rendered] : []
+}
+
+function createDevtoolsMetadataRuntime<
+  TRuntimeConfig extends AgentRuntimeConfig,
+>(
+  runtime: Partial<ResolvedAgentRuntimeContext<TRuntimeConfig>> = {},
+): ResolvedAgentRuntimeContext<TRuntimeConfig> {
+  const memoValues = new Map<string, unknown>()
+  return {
+    memo(key, create) {
+      if (!memoValues.has(key)) memoValues.set(key, create())
+      return memoValues.get(key) as never
+    },
+    runtime: "vite",
+    runtimeConfig: {} as TRuntimeConfig,
+    waitUntil: () => {},
+    ...runtime,
+  }
+}
+
+async function resolveWorkspaceMetadataCapabilityInstructions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
+  workspace: ReadonlyWorkspaceFacade<Name>,
+  resolution: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name>,
+) {
+  const capabilities = normalizeCapabilities(options.capabilities as AgentCapabilityDefinition[] | undefined)
+  if (!capabilities.length) return []
+
+  const runtime = createDevtoolsMetadataRuntime(resolution.runtime)
+  const workspaceName = resolution.workspace || resolution.name || workspaceNameFromOptions(options)
+  const resolved = await resolveAgentCapabilities({
+    capabilities: options.capabilities as AgentCapabilityDefinition<TRuntimeConfig, Name>[] | undefined,
+    hooks: options.hooks as never,
+  }, runtime, resolution.input || {}, workspace, workspaceModeFromOptions(options), {
+    model: "model" in options ? options.model as never : undefined,
+    workspaceDefinition: {
+      ...workspaceDefinitionFromOptions(options),
+      name: workspaceName,
+    },
+  })
+  try {
+    return [...resolved.capabilityInstructions]
+  }
+  finally {
+    await resolved.close()
+  }
 }
 
 export function createAgentDevtoolsMetadata<
@@ -381,7 +460,7 @@ export async function resolveAgentDevtoolsMetadata<
   Name extends WorkspaceName = WorkspaceName,
 >(
   definition: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
-  defaultsOverride: WorkspaceAgentDefaults<Name> = {},
+  defaultsOverride: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name> = {},
 ): Promise<AgentDevtoolsMetadata> {
   const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig, Name>>
   if (!workspaceDefinition.__vitehubWorkspaceAgent || !workspaceDefinition.__vitehubWorkspaceAgentOptions) {
@@ -402,7 +481,7 @@ export async function resolveAgentDevtoolsMetadata<
   const options = workspaceDefinition.__vitehubWorkspaceAgentOptions as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>
   return {
     files: await resolveWorkspaceMetadataFiles(options, defaults, workspace),
-    instructions: await resolveWorkspaceMetadataInstructions(options, workspace),
+    instructions: await resolveWorkspaceMetadataInstructions(options, workspace, defaultsOverride),
     ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition),
     tools: workspaceMetadataTools(options),
   }

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -83,6 +83,30 @@ function createWorkspace(): ReadonlyWorkspaceFacade {
 }
 
 describe("access capability", () => {
+  it("accepts chat admission without requiring a workspace", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          chat: {
+            resolve: ({ identity }) => identity?.id === "123",
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" })
+
+    expect(resolved.tools).toBeUndefined()
+    expect(resolved.workspace).toBeUndefined()
+  })
+
+  it("fails fast when no access surface is configured", async () => {
+    const { access } = await import("../src/capabilities.ts")
+
+    expect(() => access({} as never)).toThrow("access() requires at least one access surface")
+  })
+
   it("applies the selected Workspace Scope before later capabilities resolve tools", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -25,6 +25,33 @@ describe("agent output helpers", () => {
     })
   })
 
+  it("normalizes AI SDK v6 output objects into Agent run results", () => {
+    const value = {
+      _output: "ok from output",
+      finishReason: "stop",
+      steps: [{ text: "older" }],
+      usage: { inputTokens: 1 },
+    }
+
+    expect(toAgentRunResult(value)).toEqual({
+      finishReason: "stop",
+      raw: value,
+      text: "ok from output",
+      usage: { inputTokens: 1 },
+      usageRecord: undefined,
+      warnings: undefined,
+    })
+  })
+
+  it("falls back to the latest step text for AI SDK result objects", () => {
+    const value = {
+      finishReason: "stop",
+      steps: [{ text: "older" }, { text: "latest" }],
+    }
+
+    expect(toAgentRunResult(value).text).toBe("latest")
+  })
+
   it("tracks tool names across stream events", () => {
     const toolNames = new Map<string, string>()
 
@@ -49,6 +76,44 @@ describe("agent output helpers", () => {
       events.push(event)
     }
 
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      { reason: "stop", type: "finish" },
+    ])
+  })
+
+  it("converts AI SDK v6 output objects into stream events", async () => {
+    const usageRecord = { usage: { totalTokens: 1 } }
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents({ _output: "ok from output", finishReason: "stop", usageRecord })) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok from output", type: "text-delta" },
+      { type: "usage", usageRecord },
+      { reason: "stop", type: "finish" },
+    ])
+  })
+
+  it("reads fullStream getters once while converting stream events", async () => {
+    let reads = 0
+    const output = {
+      get fullStream() {
+        reads++
+        return (async function* () {
+          yield { text: "ok", type: "text-delta" }
+          yield { finishReason: "stop", type: "finish" }
+        })()
+      },
+    }
+
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents(output)) {
+      events.push(event)
+    }
+
+    expect(reads).toBe(1)
     expect(events).toEqual([
       { text: "ok", type: "text-delta" },
       { reason: "stop", type: "finish" },

--- a/packages/agent/test/config.test.ts
+++ b/packages/agent/test/config.test.ts
@@ -18,6 +18,7 @@ describe("agent config", () => {
       },
       route: false,
       runtime: "auto",
+      webhooks: false,
     })
   })
 
@@ -32,12 +33,27 @@ describe("agent config", () => {
       providers: { state: { provider: "sqlite", tablePrefix: "agent_state_", url: "file:agent-state.sqlite" } },
       route: false,
       runtime: "cloudflare-agents",
+      webhooks: false,
     })
   })
 
   it("uses the default route when route is true", () => {
     expect(normalizeAgentOptions({ route: true })).toMatchObject({
       route: "/agents/[agent]",
+    })
+  })
+
+  it("uses the default webhook route when webhooks is true", () => {
+    expect(normalizeAgentOptions({ webhooks: true })).toMatchObject({
+      route: false,
+      webhooks: "/api/_vitehub/agents/[agent]/webhooks/[webhook]",
+    })
+  })
+
+  it("preserves a custom webhook route", () => {
+    expect(normalizeAgentOptions({ webhooks: "/hooks/[agent]/[webhook]" })).toMatchObject({
+      route: false,
+      webhooks: "/hooks/[agent]/[webhook]",
     })
   })
 })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -239,9 +239,28 @@ describe("agent chat capability discovery", () => {
     await mkdir(join(root, "server", "agents"), { recursive: true })
     await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
 
-    const { access, chat } = await import("../src/capabilities.ts")
-    const { defineAgent } = await import("../src/index.ts")
-    const agent = defineAgent({
+    const { access, audience, chat } = await import("../src/capabilities.ts")
+    const { defineAgent, defineInvocationProfile, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const metadataSchema = {
+      "~standard": {
+        validate(input: unknown) {
+          return typeof input === "object" && input !== null
+            ? { value: input }
+            : { issues: ["missing metadata"] }
+        },
+      },
+    }
+    const supportProfile = defineInvocationProfile({
+      id: "bridge-support",
+      input: {
+        chat: {
+          message: { metadata: metadataSchema },
+          run: { origin: ["devtools"] },
+        },
+      },
+      resolve: ({ input }) => ({ origin: input.get().context?.chat?.run?.origin }),
+    })
+    const agent = withWorkspaceAgentDefaults(defineAgent({
       capabilities: [
         access({
           workspace: {
@@ -251,11 +270,17 @@ describe("agent chat capability discovery", () => {
             },
           },
         }),
+        audience({
+          id: "support-audience",
+          profile: supportProfile,
+          instructions: ({ profile }) => `Audience resolved for ${profile.origin}.`,
+        }),
         chat(),
       ],
+      instructions: "# Support\n\n{{ audience }}",
       workspace: {},
       run: (context: { input: { context?: { chat?: { run?: { origin?: string } } } }, workspace?: unknown }) => `answered through ${context.input.context?.chat?.run?.origin} with ${context.workspace ? "workspace" : "no workspace"}`,
-    })
+    }), { workspace: "support" })
     const { handlers, server } = createFakeServer(root, { default: agent })
     const plugin = (await import("../src/vite.ts")).hubAgent()
 
@@ -266,6 +291,7 @@ describe("agent chat capability discovery", () => {
     const state = JSON.parse(stateResponse.body)
     expect(state).toMatchObject({
       chats: [{ name: "support", uiMessages: [] }],
+      instructions: ["# Support\n\nAudience resolved for devtools."],
       selected: "support",
     })
 

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1,8 +1,80 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { Message } from "chat"
 import { describe, expect, it, vi } from "vitest"
+
+import type { Adapter, ChatInstance, WebhookOptions } from "chat"
 
 vi.mock("@vite-hub/internal/build/vercel-runtime-packages", () => ({
   copyVercelFunctionRuntimePackages: vi.fn(async () => undefined),
 }))
+
+function createTestChatAdapter(options: { deferMessageProcessing?: boolean, secret?: string } = {}) {
+  let chatInstance: ChatInstance | undefined
+  const adapter = {
+    channelIdFromThreadId: vi.fn((threadId: string) => threadId),
+    handleWebhook: vi.fn(async (request: Request, webhookOptions?: WebhookOptions) => {
+      if (options.secret && request.headers.get("x-test-secret") !== options.secret) {
+        return Response.json({ ok: false }, { status: 401 })
+      }
+      const body = await request.json().catch(() => undefined) as { message?: Record<string, unknown>, update_id?: number } | undefined
+      const rawMessage = body?.message
+      if (!rawMessage || !chatInstance) {
+        return Response.json({ ignored: true, ok: true })
+      }
+      const chat = rawMessage.chat as { id?: number | string } | undefined
+      const from = rawMessage.from as { id?: number | string, username?: string } | undefined
+      const date = typeof rawMessage.date === "number"
+        ? new Date(rawMessage.date * 1000)
+        : new Date("2026-06-10T12:00:00.000Z")
+      const message = new Message({
+        attachments: rawMessage.audio
+          ? [{
+              fetchData: async () => Buffer.from([1, 2, 3]),
+              fetchMetadata: { fileId: "audio-file" },
+              mimeType: "audio/ogg",
+              name: "voice.ogg",
+              size: 3,
+              type: "audio",
+            }]
+          : [],
+        author: {
+          fullName: "Maxi",
+          isBot: false,
+          isMe: false,
+          userId: String(from?.id ?? "123"),
+          userName: String(from?.username ?? "maxi"),
+        },
+        formatted: { children: [], type: "root" },
+        id: String(rawMessage.message_id ?? "7"),
+        metadata: { dateSent: date, edited: false },
+        raw: body,
+        text: typeof rawMessage.text === "string" ? rawMessage.text : "",
+        threadId: `telegram:${String(chat?.id ?? "456")}`,
+      })
+      const task = chatInstance.processMessage(adapter as unknown as Adapter, message.threadId, message, webhookOptions)
+      if (!options.deferMessageProcessing) {
+        await task
+      }
+      return Response.json({ ok: true })
+    }),
+    initialize: vi.fn(async (chat: ChatInstance) => {
+      chatInstance = chat
+    }),
+    isDM: vi.fn(() => true),
+    name: "telegram",
+    postMessage: vi.fn(async (threadId: string, message: unknown) => ({ id: "sent-1", raw: { message }, threadId })),
+    startTyping: vi.fn(async () => {}),
+    userName: "vitehub",
+  }
+  return adapter as unknown as Adapter & {
+    handleWebhook: ReturnType<typeof vi.fn>
+    postMessage: ReturnType<typeof vi.fn>
+    startTyping: ReturnType<typeof vi.fn>
+  }
+}
 
 describe("agent Vite plugin", () => {
   it("ignores generated ViteHub files in the Vite dev watcher", async () => {
@@ -78,6 +150,74 @@ describe("agent Vite plugin", () => {
       rootDir: "/app",
     })
   })
+
+  it("registers configured agent webhook routes with Nitro", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const plugin = hubAgent({ webhooks: true })
+    const result = typeof plugin.config === "function"
+      ? await plugin.config.call({} as never, {}, { command: "build", mode: "production" })
+      : undefined
+
+    expect(result).toMatchObject({
+      nitro: {
+        handlers: [{
+          handler: ".vitehub/agent/chat-webhook-route.ts",
+          route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
+        }],
+      },
+    })
+  })
+
+  it("keeps chat routes and webhook routes independent", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const plugin = hubAgent({
+      route: "/api/_vitehub/agents/[agent]/chat",
+      webhooks: "/hooks/[agent]/[webhook]",
+    })
+    const result = typeof plugin.config === "function"
+      ? await plugin.config.call({} as never, {}, { command: "build", mode: "production" })
+      : undefined
+
+    expect(result).toMatchObject({
+      nitro: {
+        handlers: [
+          {
+            handler: ".vitehub/agent/chat-route.ts",
+            route: "/api/_vitehub/agents/:agent/chat",
+          },
+          {
+            handler: ".vitehub/agent/chat-webhook-route.ts",
+            route: "/hooks/:agent/:webhook",
+          },
+        ],
+      },
+    })
+  })
+
+  it("writes generated Nitro handlers that pass Web Requests to agent routes", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-routes-"))
+    try {
+      const plugin = hubAgent({ route: true, webhooks: true })
+      if (typeof plugin.configResolved === "function") {
+        await plugin.configResolved.call({} as never, { root } as never)
+      }
+
+      const chatRoute = await readFile(join(root, ".vitehub/agent/chat-route.ts"), "utf8")
+      const webhookRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
+
+      expect(chatRoute).toContain("async function toRequest(event)")
+      expect(chatRoute).toContain("function waitUntilFromEvent(event)")
+      expect(chatRoute).toContain("return await handler(await toRequest(event), { waitUntil: waitUntilFromEvent(event) })")
+      expect(webhookRoute).toContain("async function toRequest(event)")
+      expect(webhookRoute).toContain("function waitUntilFromEvent(event)")
+      expect(webhookRoute).toContain("waitUntil: waitUntilFromEvent(event)")
+      expect(webhookRoute).toContain("return await handler(await toRequest(event), webhook")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
 })
 
 describe("server helpers", () => {
@@ -96,6 +236,598 @@ describe("server helpers", () => {
       status: 400,
     })
     expect(response.status).toBe(400)
+  })
+
+  it("handles Chat SDK webhooks through the chat capability", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { access, chat, staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const adapter = createTestChatAdapter()
+    const admitChat = vi.fn(({ identity }) => identity?.id === "123")
+    const run = vi.fn(({ messages }) => {
+      const text = messages[0]?.parts.find((part: { type?: string }) => part.type === "text") as { text?: string } | undefined
+      return {
+        durationMs: 1200,
+        response: {
+          modelId: "openai/gpt-test",
+        },
+        text: `echo: ${text?.text}`,
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+        },
+      }
+    })
+    const agent = defineAgent({
+      capabilities: [
+        access({
+          chat: {
+            resolve: admitChat,
+          },
+        }),
+        chat({
+          adapters: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+        usageTelemetry({
+          chat: true,
+          pricing: staticModelPricing({
+            "openai/gpt-test": {
+              input: "0.00000010",
+              output: "0.00000020",
+            },
+          }),
+        }),
+      ],
+      run,
+    })
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 42,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 7,
+          audio: { file_id: "audio-file" },
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", { markdown: "echo: hello" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", {
+      markdown: expect.stringContaining("**Usage**"),
+    })
+    expect(adapter.postMessage.mock.calls[1]![1]).toEqual({
+      markdown: expect.stringContaining("`15` total (10 in, 5 out)"),
+    })
+    expect(adapter.postMessage.mock.calls[1]![1]).toEqual({
+      markdown: expect.stringContaining("`1.20s`"),
+    })
+    expect(adapter.postMessage.mock.calls[1]![1]).toEqual({
+      markdown: expect.stringContaining("`~0.000002 USD`"),
+    })
+    expect(admitChat).toHaveBeenCalledWith(expect.objectContaining({
+      identity: expect.objectContaining({
+        id: "123",
+        provider: "telegram",
+        username: "maxi",
+      }),
+      input: expect.objectContaining({
+        message: expect.objectContaining({
+          attachmentCount: 1,
+          id: "7",
+          text: "hello",
+        }),
+      }),
+    }))
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({
+        get: expect.any(Function),
+      }),
+      messages: [expect.objectContaining({
+        metadata: expect.objectContaining({
+          chat: expect.objectContaining({
+            messageId: "7",
+            threadId: "telegram:456",
+          }),
+        }),
+        parts: [
+          expect.objectContaining({ text: "hello", type: "text" }),
+          expect.objectContaining({
+            fetchData: expect.any(Function),
+            mediaType: "audio/ogg",
+            type: "audio",
+          }),
+        ],
+      })],
+      run: expect.objectContaining({
+        origin: "telegram",
+        runId: "telegram:7",
+      }),
+    }))
+  })
+
+  it("does not block chat webhook handling on typing status", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const adapter = createTestChatAdapter()
+    adapter.startTyping.mockImplementation(() => new Promise(() => {}))
+    const agent = defineAgent({
+      capabilities: [
+        chat({
+          adapters: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      run: () => ({ text: "ok" }),
+    })
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+    const response = await Promise.race([
+      handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+        body: JSON.stringify({
+          update_id: 44,
+          message: {
+            chat: { id: 456, type: "private" },
+            date: 1781092800,
+            from: { first_name: "Maxi", id: 123, username: "maxi" },
+            message_id: 9,
+            text: "hello",
+          },
+        }),
+        method: "POST",
+      }), "telegram"),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("webhook blocked on typing status")), 100)),
+    ])
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "ok" })
+  })
+
+  it("lets chat webhooks opt out of streaming model execution", async () => {
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const adapter = createTestChatAdapter()
+    const model = {
+      generate: vi.fn(async () => ({ finishReason: "stop", text: "generated ok" })),
+      stream: vi.fn(async () => {
+        throw new Error("stream should not be used")
+      }),
+      tools: {},
+      version: "agent-v1",
+    }
+    const agent = {
+      capabilities: [
+        chat({
+          adapters: {
+            telegram: () => adapter as never,
+          },
+          stream: false,
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      resolve: vi.fn(async () => model),
+    }
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 45,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 10,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(model.generate).toHaveBeenCalledOnce()
+    expect(model.stream).not.toHaveBeenCalled()
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "generated ok" })
+  })
+
+  it("runs non-streaming chat webhooks inline for workflow-backed agents", async () => {
+    const { workflow } = await import("../src/index.ts")
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const { resetWorkflowRuntime, setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+    const adapter = createTestChatAdapter()
+    const model = {
+      generate: vi.fn(async () => ({ finishReason: "stop", text: "generated ok" })),
+      stream: vi.fn(),
+      tools: {},
+      version: "agent-v1",
+    }
+    const agent = {
+      capabilities: [
+        chat({
+          adapters: {
+            telegram: () => adapter as never,
+          },
+          stream: false,
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      resolve: vi.fn(async () => model),
+      runtime: workflow("support-agent"),
+    }
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+    setWorkflowRuntimeConfig({ provider: "vercel" })
+
+    try {
+      const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+        body: JSON.stringify({
+          update_id: 46,
+          message: {
+            chat: { id: 456, type: "private" },
+            date: 1781092800,
+            from: { first_name: "Maxi", id: 123, username: "maxi" },
+            message_id: 11,
+            text: "hello",
+          },
+        }),
+        method: "POST",
+      }), "telegram")
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ ok: true })
+      expect(model.generate).toHaveBeenCalledOnce()
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "generated ok" })
+    }
+    finally {
+      resetWorkflowRuntime()
+    }
+  })
+
+  it("posts usage telemetry callbacks for non-streaming model chat webhooks", async () => {
+    const { chat, staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const adapter = createTestChatAdapter()
+    const onUsage = vi.fn(async (record, context) => {
+      await context.sendMessage({
+        markdown: `Custom usage: \`${record.usage.totalTokens}\` tokens via ${context.provider}`,
+      })
+    })
+    const model = {
+      generate: vi.fn(async () => ({
+        durationMs: 900,
+        finishReason: "stop",
+        response: {
+          modelId: "openai/gpt-test",
+        },
+        text: "generated ok",
+        usage: {
+          inputTokens: 12,
+          outputTokens: 3,
+        },
+      })),
+      stream: vi.fn(async () => {
+        throw new Error("stream should not be used")
+      }),
+      tools: {},
+      version: "agent-v1",
+    }
+    const agent = {
+      capabilities: [
+        chat({
+          adapters: {
+            telegram: () => adapter as never,
+          },
+          stream: false,
+          webhooks: {
+            telegram: {},
+          },
+        }),
+        usageTelemetry({
+          chat: { onUsage },
+          pricing: staticModelPricing({
+            "openai/gpt-test": {
+              input: "0.00000010",
+              output: "0.00000020",
+            },
+          }),
+        }),
+      ],
+      resolve: vi.fn(async () => model),
+    }
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 47,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 12,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(model.generate).toHaveBeenCalledOnce()
+    expect(model.stream).not.toHaveBeenCalled()
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", { markdown: "generated ok" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Custom usage: `15` tokens via telegram" })
+    expect(onUsage).toHaveBeenCalledWith(expect.objectContaining({
+      cost: expect.objectContaining({
+        amount: "0.0000018",
+        currency: "USD",
+      }),
+      latency: expect.objectContaining({
+        durationMs: 900,
+      }),
+      model: {
+        id: "openai/gpt-test",
+      },
+      usage: {
+        inputTokens: 12,
+        outputTokens: 3,
+        totalTokens: 15,
+      },
+    }), expect.objectContaining({
+      durationMs: expect.any(Number),
+      provider: "telegram",
+      sendMessage: expect.any(Function),
+    }))
+  })
+
+  it("flushes deferred non-streaming chat webhook work before returning", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chat, usageTelemetry } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const adapter = createTestChatAdapter({ deferMessageProcessing: true })
+    adapter.startTyping.mockImplementation(() => new Promise(() => {}))
+    let runStarted!: () => void
+    let finishRun!: () => void
+    const runStartedPromise = new Promise<void>(resolve => {
+      runStarted = resolve
+    })
+    const finishRunPromise = new Promise<void>(resolve => {
+      finishRun = resolve
+    })
+    const run = vi.fn(async () => {
+      runStarted()
+      await finishRunPromise
+      return {
+        text: "ok",
+        usage: {
+          inputTokens: 1,
+          outputTokens: 1,
+        },
+      }
+    })
+    const onUsage = vi.fn(async (_record, context) => {
+      await context.sendMessage({ markdown: "usage ok" })
+    })
+    const agent = defineAgent({
+      capabilities: [
+        chat({
+          adapters: {
+            telegram: () => adapter as never,
+          },
+          stream: false,
+          webhooks: {
+            telegram: {},
+          },
+        }),
+        usageTelemetry({
+          chat: { onUsage },
+        }),
+      ],
+      run,
+    })
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+    const responsePromise = handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 48,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 13,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    await runStartedPromise
+    await Promise.resolve()
+    await expect(Promise.race([
+      responsePromise.then(() => "settled"),
+      Promise.resolve("pending"),
+    ])).resolves.toBe("pending")
+
+    finishRun()
+    const response = await responsePromise
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(adapter.startTyping).not.toHaveBeenCalled()
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", { markdown: "ok" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "usage ok" })
+  })
+
+  it("lets usageTelemetry chat callbacks post custom follow-up messages", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { access, chat, staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const adapter = createTestChatAdapter()
+    const onUsage = vi.fn(async (record, context) => {
+      await context.sendMessage({
+        markdown: `Custom usage: \`${record.usage.totalTokens}\` tokens via ${context.provider}`,
+      })
+    })
+    const agent = defineAgent({
+      capabilities: [
+        access({
+          chat: {
+            resolve: () => true,
+          },
+        }),
+        chat({
+          adapters: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+        usageTelemetry({
+          chat: { onUsage },
+          pricing: staticModelPricing({
+            "openai/gpt-test": {
+              input: "0.00000010",
+              output: "0.00000020",
+            },
+          }),
+        }),
+      ],
+      run: () => ({
+        response: {
+          modelId: "openai/gpt-test",
+        },
+        text: "ok",
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+        },
+      }),
+    })
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 43,
+        message: {
+          chat: { id: 789, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 8,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:789", { markdown: "ok" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:789", { markdown: "Custom usage: `15` tokens via telegram" })
+    expect(onUsage).toHaveBeenCalledWith(expect.objectContaining({
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      },
+    }), expect.objectContaining({
+      provider: "telegram",
+      sendMessage: expect.any(Function),
+    }))
+  })
+
+  it("lets access() reject app-specific chat identities", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { access, chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const adapter = createTestChatAdapter()
+    const run = vi.fn(() => "unused")
+    const agent = defineAgent({
+      capabilities: [
+        access({
+          chat: {
+            resolve: ({ identity }) => identity?.id === "123",
+          },
+        }),
+        chat({
+          adapters: { telegram: () => adapter as never },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      run,
+    })
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 42,
+        message: {
+          chat: { id: 456, type: "private" },
+          from: { id: 999 },
+          message_id: 7,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(run).not.toHaveBeenCalled()
+    expect(adapter.postMessage).not.toHaveBeenCalled()
+  })
+
+  it("returns Chat SDK adapter webhook responses", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const adapter = createTestChatAdapter({ secret: "secret" })
+    const run = vi.fn(() => "unused")
+    const agent = defineAgent({
+      capabilities: [
+        chat({
+          adapters: {
+            telegram: () => adapter as never,
+          },
+        }),
+      ],
+      run,
+    })
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({ update_id: 42 }),
+      headers: { "x-test-secret": "wrong" },
+      method: "POST",
+    }), "telegram")
+
+    expect(response.status).toBe(401)
+    expect(run).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1729,6 +1729,45 @@ describe("agent message protocol", () => {
       resetWorkflowRuntime()
     })
 
+    it("streams workflow-backed chat triggers inline for DevTools", async () => {
+      const { createUIMessageStream, readUIMessageStream } = await import("ai")
+      const { defineAgent, streamAgentTrigger, workflow } = await import("../src/index.ts")
+
+      const agent = defineAgent({
+        capabilities: [chat()],
+        runtime: workflow("support-agent"),
+        run: () => ({
+          toUIMessageStream() {
+            return createUIMessageStream({
+              execute({ writer }) {
+                writer.write({ type: "start", messageId: "assistant-1" })
+                writer.write({ type: "text-start", id: "text-1" })
+                writer.write({ type: "text-delta", id: "text-1", delta: "pong" })
+                writer.write({ type: "text-end", id: "text-1" })
+                writer.write({ type: "finish", finishReason: "stop" })
+              },
+            })
+          },
+        }),
+      })
+
+      const stream = await streamAgentTrigger(agent, {
+        memo: vi.fn(),
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, "chat.message", {
+        messages: [createMessage({ role: "user", text: "Say pong only." })],
+      }, { output: "ui-message-stream" }) as ReadableStream<never>
+      const messages = []
+      for await (const message of readUIMessageStream({ stream })) {
+        messages.push(message)
+      }
+
+      expect(messages.at(-1)?.parts).toEqual([
+        { providerMetadata: undefined, state: "done", text: "pong", type: "text" },
+      ])
+    })
+
     it("queues direct agent runs as Workflow Runs", async () => {
       const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")
@@ -1753,6 +1792,45 @@ describe("agent message protocol", () => {
       await Promise.all(waitUntilTasks)
       await expect(getWorkflowRun("support-agent", run.id)).resolves.toMatchObject({
         result: "received hello",
+        status: "completed",
+      })
+    })
+
+    it("reuses generated workflow definitions across equivalent agent instances", async () => {
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const run = (context: { prompt?: string }) => `received ${context.prompt}`
+      const firstAgent = defineAgent({
+        runtime: workflow("support-agent"),
+        run,
+      })
+      const secondAgent = defineAgent({
+        runtime: workflow("support-agent"),
+        run,
+      })
+
+      const first = await runAgent(firstAgent, {
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "first" }) as { id: string }
+      const second = await runAgent(secondAgent, {
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "second" }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("support-agent", first.id)).resolves.toMatchObject({
+        result: "received first",
+        status: "completed",
+      })
+      await expect(getWorkflowRun("support-agent", second.id)).resolves.toMatchObject({
+        result: "received second",
         status: "completed",
       })
     })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -14,6 +14,15 @@ describe("agent public types", () => {
   it("accepts capabilities from the capabilities entry", () => {
     defineAgent({
       capabilities: [
+        access({
+          chat: {
+            resolve({ identity, provider }) {
+              expectTypeOf(identity?.id).toEqualTypeOf<string | undefined>()
+              expectTypeOf(provider).toEqualTypeOf<string>()
+              return true
+            },
+          },
+        }),
         workspaceShell(),
         blob({ mode: "write", policy: () => "allow", store: "assets" }),
         db({ database: "analytics", mode: "write", policy: "allow", schemaMode: "write" }),

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -13,6 +13,27 @@ const runtime = () => ({
 })
 
 describe("usage telemetry", () => {
+  it("exposes opt-in chat telemetry options and formats a chat summary", async () => {
+    const { formatUsageTelemetryChatMessage, getUsageTelemetryChatOptions, usageTelemetry } = await import("../src/capabilities.ts")
+    const capability = usageTelemetry({ chat: true })
+
+    expect(getUsageTelemetryChatOptions([capability])).toEqual([{}])
+    expect(formatUsageTelemetryChatMessage({
+      cost: {
+        amount: "0.000002",
+        currency: "USD",
+        estimated: true,
+        source: "vercel-ai-gateway",
+      },
+      model: { id: "openai/gpt-test" },
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      },
+    }, { durationMs: 1234 })).toContain("`15` total (10 in, 5 out)")
+  })
+
   it("normalizes usage and attaches a priced usage record", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
@@ -87,6 +108,94 @@ describe("usage telemetry", () => {
     expect(finish).toHaveBeenCalledTimes(1)
     const usageRecord = (result as { usageRecord?: unknown }).usageRecord
     expect(finish.mock.calls[0]![0].extensions.get("usage-telemetry")).toEqual(usageRecord)
+  })
+
+  it("emits usage records from streamed finish chunks", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")
+    const { staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
+    const onUsage = vi.fn()
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({
+          onUsage,
+          pricing: staticModelPricing({
+            "openai/gpt-test": {
+              input: "0.00000010",
+              output: "0.00000020",
+            },
+          }),
+        }),
+      ],
+      run: () => ({
+        fullStream: (async function* () {
+          yield { text: "ok", type: "text-delta" }
+          yield {
+            finishReason: "stop",
+            response: {
+              id: "response-1",
+              modelId: "openai/gpt-test",
+              timestamp: "2026-05-21T00:00:00.000Z",
+            },
+            totalUsage: {
+              inputTokens: 10,
+              outputTokens: 5,
+            },
+            type: "finish",
+          }
+        })(),
+      }),
+    })
+
+    const output = await streamAgent(agent, runtime(), {})
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents(output)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: expect.objectContaining({
+          cost: {
+            amount: "0.000002",
+            currency: "USD",
+            estimated: true,
+            source: "custom",
+          },
+          usage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            totalTokens: 15,
+          },
+        }),
+      },
+      { reason: "stop", type: "finish" },
+    ])
+    expect(output).toMatchObject({
+      usageRecord: {
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        },
+      },
+    })
+    expect(onUsage).toHaveBeenCalledWith(expect.objectContaining({
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      },
+    }), {
+      run: {
+        messageId: "message-1",
+        runId: "run-1",
+        threadId: "thread-1",
+      },
+    })
   })
 
   it("does not fail the invocation when pricing fails", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1004,6 +1004,38 @@ describe("defineAgent workspace option", () => {
     expect(readInstructions).toHaveBeenCalledOnce()
   })
 
+  it("renders capability instruction slots in resolved DevTools metadata", async () => {
+    const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const readInstructions = vi.fn(async ({ fs }) => await fs.readFile("AGENTS.md"))
+    readFile.mockResolvedValue("# Workspace instructions\n\n{{ audience }}\n")
+    list.mockResolvedValue([{ path: "AGENTS.md", type: "file" }])
+    const agent = withWorkspaceAgentDefaults(defineAgent({
+      workspace: {},
+      instructions: readInstructions,
+      model: {} as never,
+      capabilities: [{
+        id: "audience",
+        prepare({ input, instructions }) {
+          const origin = (input.get().context as { chat?: { run?: { origin?: string } } } | undefined)?.chat?.run?.origin
+          instructions.add(`Audience resolved for ${origin}.`)
+        },
+      }],
+    }), { workspace: "support" })
+
+    expect(await resolveAgentDevtoolsMetadata(agent, {
+      input: {
+        context: {
+          chat: {
+            run: { origin: "devtools" },
+          },
+        },
+      },
+    })).toMatchObject({
+      instructions: ["# Workspace instructions\n\nAudience resolved for devtools."],
+    })
+    expect(readInstructions).toHaveBeenCalledOnce()
+  })
+
   it("resolves recursive DevTools file metadata for lazy source entries", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
     list.mockResolvedValue([


### PR DESCRIPTION
## Summary
- keep streamAgent inline so workflow-backed agents can still return live streams
- forward Nitro waitUntil from generated agent chat and webhook routes so Vercel workflow-backed agents do not need app-local wrappers
- add regression coverage for DevTools chat.message UI message streams and generated waitUntil route plumbing

## Verification
- pnpm --filter @vite-hub/agent test -- runtime.test.ts
- pnpm --filter @vite-hub/agent exec vitest run test/providers.test.ts
- pnpm exec tsc --noEmit --ignoreConfig --pretty false --skipLibCheck --moduleResolution bundler --module ESNext --target ES2022 --allowImportingTsExtensions --verbatimModuleSyntax --types node,vitest packages/agent/src/server.ts packages/agent/src/vite.ts packages/agent/test/providers.test.ts
