### PR TITLE
fix(vercel): materialize runtime packages

### DIFF
--- a/fallow.toml
+++ b/fallow.toml
@@ -78,6 +78,7 @@ ignoreDependencies = [
   "docus",
   "@cloudflare/sandbox",
   "@vercel/blob",
+  "@vercel/nft",
   "@vercel/queue",
   "@vercel/sandbox",
   "async-retry",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -66,6 +66,7 @@
     "@vite-hub/workspace": "workspace:*",
     "@vite-hub/devtools": "workspace:*",
     "@vercel/functions": "catalog:vercel",
+    "@vercel/nft": "catalog:vercel",
     "@vitejs/devtools-kit": "catalog:vite",
     "chat": "catalog:chat",
     "hookable": "catalog:unjs"

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from "node:fs"
 import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, join, relative } from "node:path"
 
+import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/deployment-output"
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored } from "@vite-hub/internal/build/vite"
 
 import { chatDevTools } from "./chat/devtools.ts"
@@ -10,7 +11,7 @@ import { normalizeAgentOptions } from "./config.ts"
 import { discoverAgentDefinitions } from "./discovery.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig } from "./internal/evalite-config.ts"
 
-import type { Plugin } from "vite"
+import type { Plugin, ResolvedConfig } from "vite"
 import type { AgentModuleOptions, DiscoveredAgentDefinition } from "./types.ts"
 
 interface AgentCliContributingPlugin {
@@ -105,6 +106,7 @@ async function writeAgentRouteHandler(root: string): Promise<void> {
 
 export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
   let agent: AgentModuleOptions | false | undefined = options
+  let resolved: ResolvedConfig | undefined
   const chatDevtoolsPlugin = chatDevTools()
 
   return {
@@ -153,9 +155,10 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       }
     },
     async configResolved(config) {
+      resolved = config
       agent = config.agent ?? agent
-      const resolved = normalizeAgentOptions(agent)
-      if (resolved && resolved.route) {
+      const normalized = normalizeAgentOptions(agent)
+      if (normalized && normalized.route) {
         await writeAgentRouteHandler(config.root)
       }
       if (agent === false || agent?.eval === false) {
@@ -178,6 +181,16 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
           noExternal: mergeNoExternal(config.resolve?.noExternal),
         },
       }
+    },
+    closeBundle: {
+      order: "post",
+      async handler() {
+        if (!resolved || resolved.command !== "build") return
+        await copyVercelFunctionRuntimePackages({
+          packages: [{ includePeerDependencies: true, name: "@ai-sdk/mcp", optional: true }],
+          rootDir: resolved.root,
+        })
+      },
     },
   }
 }

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -2,7 +2,7 @@ import { existsSync, statSync } from "node:fs"
 import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, join, relative } from "node:path"
 
-import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/deployment-output"
+import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored } from "@vite-hub/internal/build/vite"
 
 import { chatDevTools } from "./chat/devtools.ts"

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-vi.mock("@vite-hub/internal/build/deployment-output", () => ({
+vi.mock("@vite-hub/internal/build/vercel-runtime-packages", () => ({
   copyVercelFunctionRuntimePackages: vi.fn(async () => undefined),
 }))
 
@@ -63,7 +63,7 @@ describe("agent Vite plugin", () => {
   })
 
   it("materializes the MCP runtime package for Vercel build output", async () => {
-    const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/deployment-output")
+    const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/vercel-runtime-packages")
     const { hubAgent } = await import("../src/vite.ts")
     const plugin = hubAgent({ eval: false })
     const configResolved = plugin.configResolved as (config: { agent?: unknown, command: "build", root: string }) => Promise<void>

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest"
 
+vi.mock("@vite-hub/internal/build/deployment-output", () => ({
+  copyVercelFunctionRuntimePackages: vi.fn(async () => undefined),
+}))
+
 describe("agent Vite plugin", () => {
   it("ignores generated ViteHub files in the Vite dev watcher", async () => {
     const { hubAgent } = await import("../src/vite.ts")
@@ -55,6 +59,23 @@ describe("agent Vite plugin", () => {
           route: "/api/_vitehub/agents/:agent/chat",
         }],
       },
+    })
+  })
+
+  it("materializes the MCP runtime package for Vercel build output", async () => {
+    const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/deployment-output")
+    const { hubAgent } = await import("../src/vite.ts")
+    const plugin = hubAgent({ eval: false })
+    const configResolved = plugin.configResolved as (config: { agent?: unknown, command: "build", root: string }) => Promise<void>
+    const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
+    vi.mocked(copyVercelFunctionRuntimePackages).mockClear()
+
+    await configResolved({ command: "build", root: "/app" })
+    await closeBundle.handler()
+
+    expect(copyVercelFunctionRuntimePackages).toHaveBeenCalledWith({
+      packages: [{ includePeerDependencies: true, name: "@ai-sdk/mcp", optional: true }],
+      rootDir: "/app",
     })
   })
 })

--- a/packages/agent/tsdown.config.ts
+++ b/packages/agent/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   clean: true,
   deps: {
     alwaysBundle: [/^@vite-hub\/(devtools|internal)/],
-    neverBundle: ["#vitehub/agent/registry", "cloudflare:workers", /^@chat-adapter\/telegram$/, /^evalite/, /^vitest/],
+    neverBundle: ["#vitehub/agent/registry", "@vercel/nft", "cloudflare:workers", /^@chat-adapter\/telegram$/, /^evalite/, /^vitest/],
     onlyBundle: false,
   },
   dts: true,

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -47,6 +47,7 @@
     "typecheck": "tsc --noEmit -p ./tsconfig.json"
   },
   "dependencies": {
+    "@vercel/nft": "catalog:vercel",
     "@vite-hub/runtime": "workspace:*",
     "esbuild": "catalog:esbuild-v27",
     "exsolve": "catalog:unjs",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -33,6 +33,7 @@
     "./build/esbuild": "./dist/build/esbuild.js",
     "./build/client-output": "./dist/build/client-output.js",
     "./build/vercel-config": "./dist/build/vercel-config.js",
+    "./build/vercel-runtime-packages": "./dist/build/vercel-runtime-packages.js",
     "./build/user-entry": "./dist/build/user-entry.js",
     "./build/vite": "./dist/build/vite.js",
     "./workspace-inventory": "./dist/workspace-inventory.js",

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -65,14 +65,14 @@ interface ResolvedClientOutput {
   staticIndex: boolean
 }
 
-export interface VercelFunctionRuntimePackage {
+interface VercelFunctionRuntimePackage {
   includePeerDependencies?: boolean
   name: string
   optional?: boolean
   resolveFrom?: string
 }
 
-export interface VercelFunctionRuntimePackagesOptions {
+interface VercelFunctionRuntimePackagesOptions {
   outputRoot?: string
   packages: VercelFunctionRuntimePackage[]
   rootDir: string

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -1,5 +1,6 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
-import { resolve } from "node:path"
+import { access, cp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { createRequire } from "node:module"
+import { dirname, join, relative, resolve, sep } from "node:path"
 
 import { copyClientOutput, hasStaticIndex } from "./client-output.ts"
 import { bundleEsmEntry } from "./esbuild.ts"
@@ -30,6 +31,7 @@ interface VercelDeploymentOutputOptions extends SharedDeploymentOptions {
   configKeys?: string[]
   functionConfig?: object
   outputRoot?: string
+  runtimePackages?: VercelFunctionRuntimePackage[]
   serverFunctionName?: string
   staticOutputDir?: string
 }
@@ -61,6 +63,20 @@ interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
 interface ResolvedClientOutput {
   clientDir: string
   staticIndex: boolean
+}
+
+export interface VercelFunctionRuntimePackage {
+  includePeerDependencies?: boolean
+  name: string
+  optional?: boolean
+  resolveFrom?: string
+}
+
+export interface VercelFunctionRuntimePackagesOptions {
+  outputRoot?: string
+  packages: VercelFunctionRuntimePackage[]
+  rootDir: string
+  serverFunctionName?: string
 }
 
 function resolveClientOutput(rootDir: string, clientOutDir: string): ResolvedClientOutput {
@@ -139,6 +155,125 @@ export function createDefaultVercelOutputRoot(rootDir: string): string {
   return resolve(rootDir, ".vercel", "output")
 }
 
+export async function copyVercelFunctionRuntimePackages(options: VercelFunctionRuntimePackagesOptions): Promise<void> {
+  if (!options.packages.length) return
+
+  const outputRoot = options.outputRoot ?? createDefaultVercelOutputRoot(options.rootDir)
+  const serverFunctionName = options.serverFunctionName ?? "__server.func"
+  const serverDir = resolve(outputRoot, "functions", serverFunctionName)
+  try {
+    await access(serverDir)
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    throw error
+  }
+
+  const copied = new Set<string>()
+  const outputNodeModules = resolve(serverDir, "node_modules")
+  for (const runtimePackage of options.packages) {
+    const resolver = createRequire(runtimePackage.resolveFrom ?? join(options.rootDir, "package.json"))
+    await copyPackageToNodeModules(runtimePackage.name, resolver, options.rootDir, outputNodeModules, copied, runtimePackage)
+  }
+}
+
+async function copyPackageToNodeModules(
+  name: string,
+  resolver: NodeJS.Require,
+  fromDir: string,
+  outputNodeModules: string,
+  copied: Set<string>,
+  options: VercelFunctionRuntimePackage = { name },
+): Promise<void> {
+  const packageJsonPath = await resolvePackageJson(name, resolver, fromDir)
+  if (!packageJsonPath) {
+    if (options.optional) return
+    throw new Error(`Could not resolve package.json for ${name}.`)
+  }
+
+  const packageDir = dirname(packageJsonPath)
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+    dependencies?: Record<string, string>
+    name?: string
+    peerDependencies?: Record<string, string>
+    peerDependenciesMeta?: Record<string, { optional?: boolean }>
+  }
+  const packageKey = `${name}\0${packageJsonPath}`
+
+  if (!copied.has(packageKey)) {
+    copied.add(packageKey)
+    const targetDir = join(outputNodeModules, ...name.split("/"))
+    await rm(targetDir, { force: true, recursive: true })
+    await mkdir(dirname(targetDir), { recursive: true })
+    await cp(packageDir, targetDir, {
+      dereference: true,
+      filter: source => !relative(packageDir, source).split(sep).includes("node_modules"),
+      recursive: true,
+    })
+  }
+
+  const packageRequire = createRequire(packageJsonPath)
+  const dependencyNames = new Set(Object.keys(packageJson.dependencies || {}))
+  if (options.includePeerDependencies) {
+    for (const dependencyName of Object.keys(packageJson.peerDependencies || {})) {
+      if (!packageJson.peerDependenciesMeta?.[dependencyName]?.optional) dependencyNames.add(dependencyName)
+    }
+  }
+
+  for (const dependencyName of dependencyNames) {
+    await copyPackageToNodeModules(dependencyName, packageRequire, packageDir, outputNodeModules, copied, {
+      includePeerDependencies: options.includePeerDependencies,
+      name: dependencyName,
+    })
+  }
+}
+
+async function resolvePackageJson(name: string, resolver: NodeJS.Require, fromDir: string): Promise<string | undefined> {
+  try {
+    return resolver.resolve(`${name}/package.json`)
+  }
+  catch (error) {
+    if (!isPackageResolutionMiss(error)) throw error
+  }
+
+  try {
+    let current = dirname(resolver.resolve(name))
+    while (current !== dirname(current)) {
+      const candidate = join(current, "package.json")
+      try {
+        await access(candidate)
+        const packageJson = JSON.parse(await readFile(candidate, "utf8")) as { name?: string }
+        if (packageJson.name === name) return candidate
+      }
+      catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+      }
+      current = dirname(current)
+    }
+  }
+  catch (error) {
+    if (!isPackageResolutionMiss(error)) throw error
+  }
+
+  let current = fromDir
+  while (current !== dirname(current)) {
+    const candidate = join(current, "node_modules", ...name.split("/"), "package.json")
+    try {
+      await access(candidate)
+      return candidate
+    }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    }
+    current = dirname(current)
+  }
+}
+
+function isPackageResolutionMiss(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code
+  return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND" || code === "ERR_PACKAGE_PATH_NOT_EXPORTED"
+}
+
 async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutputOptions): Promise<void> {
   const { clientDir, staticIndex } = resolveClientOutput(options.rootDir, options.clientOutDir)
   const outputRoot = options.outputRoot ?? createDefaultCloudflareOutputRoot(options.rootDir)
@@ -168,6 +303,12 @@ async function writeVercelDeploymentOutput(options: VercelDeploymentOutputOption
 
   await Promise.all([
     bundleEsmEntry(options.bundleEntry, serverEntry, options.bundleOptions),
+    copyVercelFunctionRuntimePackages({
+      outputRoot,
+      packages: options.runtimePackages ?? [],
+      rootDir: options.rootDir,
+      serverFunctionName,
+    }),
     writeFile(resolve(serverDir, ".vc-config.json"), `${JSON.stringify(options.functionConfig ?? createNodeFunctionConfig(), null, 2)}\n`, "utf8"),
     writeMergedJsonObject(resolve(outputRoot, "config.json"), options.config ?? createVercelConfigJson(), options.configKeys),
     staticIndex

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -1,6 +1,5 @@
-import { access, cp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
-import { createRequire } from "node:module"
-import { dirname, join, relative, resolve, sep } from "node:path"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { resolve } from "node:path"
 
 import { copyClientOutput, hasStaticIndex } from "./client-output.ts"
 import { bundleEsmEntry } from "./esbuild.ts"
@@ -31,7 +30,6 @@ interface VercelDeploymentOutputOptions extends SharedDeploymentOptions {
   configKeys?: string[]
   functionConfig?: object
   outputRoot?: string
-  runtimePackages?: VercelFunctionRuntimePackage[]
   serverFunctionName?: string
   staticOutputDir?: string
 }
@@ -63,20 +61,6 @@ interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
 interface ResolvedClientOutput {
   clientDir: string
   staticIndex: boolean
-}
-
-interface VercelFunctionRuntimePackage {
-  includePeerDependencies?: boolean
-  name: string
-  optional?: boolean
-  resolveFrom?: string
-}
-
-interface VercelFunctionRuntimePackagesOptions {
-  outputRoot?: string
-  packages: VercelFunctionRuntimePackage[]
-  rootDir: string
-  serverFunctionName?: string
 }
 
 function resolveClientOutput(rootDir: string, clientOutDir: string): ResolvedClientOutput {
@@ -155,125 +139,6 @@ export function createDefaultVercelOutputRoot(rootDir: string): string {
   return resolve(rootDir, ".vercel", "output")
 }
 
-export async function copyVercelFunctionRuntimePackages(options: VercelFunctionRuntimePackagesOptions): Promise<void> {
-  if (!options.packages.length) return
-
-  const outputRoot = options.outputRoot ?? createDefaultVercelOutputRoot(options.rootDir)
-  const serverFunctionName = options.serverFunctionName ?? "__server.func"
-  const serverDir = resolve(outputRoot, "functions", serverFunctionName)
-  try {
-    await access(serverDir)
-  }
-  catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
-    throw error
-  }
-
-  const copied = new Set<string>()
-  const outputNodeModules = resolve(serverDir, "node_modules")
-  for (const runtimePackage of options.packages) {
-    const resolver = createRequire(runtimePackage.resolveFrom ?? join(options.rootDir, "package.json"))
-    await copyPackageToNodeModules(runtimePackage.name, resolver, options.rootDir, outputNodeModules, copied, runtimePackage)
-  }
-}
-
-async function copyPackageToNodeModules(
-  name: string,
-  resolver: NodeJS.Require,
-  fromDir: string,
-  outputNodeModules: string,
-  copied: Set<string>,
-  options: VercelFunctionRuntimePackage = { name },
-): Promise<void> {
-  const packageJsonPath = await resolvePackageJson(name, resolver, fromDir)
-  if (!packageJsonPath) {
-    if (options.optional) return
-    throw new Error(`Could not resolve package.json for ${name}.`)
-  }
-
-  const packageDir = dirname(packageJsonPath)
-  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
-    dependencies?: Record<string, string>
-    name?: string
-    peerDependencies?: Record<string, string>
-    peerDependenciesMeta?: Record<string, { optional?: boolean }>
-  }
-  const packageKey = `${name}\0${packageJsonPath}`
-
-  if (!copied.has(packageKey)) {
-    copied.add(packageKey)
-    const targetDir = join(outputNodeModules, ...name.split("/"))
-    await rm(targetDir, { force: true, recursive: true })
-    await mkdir(dirname(targetDir), { recursive: true })
-    await cp(packageDir, targetDir, {
-      dereference: true,
-      filter: source => !relative(packageDir, source).split(sep).includes("node_modules"),
-      recursive: true,
-    })
-  }
-
-  const packageRequire = createRequire(packageJsonPath)
-  const dependencyNames = new Set(Object.keys(packageJson.dependencies || {}))
-  if (options.includePeerDependencies) {
-    for (const dependencyName of Object.keys(packageJson.peerDependencies || {})) {
-      if (!packageJson.peerDependenciesMeta?.[dependencyName]?.optional) dependencyNames.add(dependencyName)
-    }
-  }
-
-  for (const dependencyName of dependencyNames) {
-    await copyPackageToNodeModules(dependencyName, packageRequire, packageDir, outputNodeModules, copied, {
-      includePeerDependencies: options.includePeerDependencies,
-      name: dependencyName,
-    })
-  }
-}
-
-async function resolvePackageJson(name: string, resolver: NodeJS.Require, fromDir: string): Promise<string | undefined> {
-  try {
-    return resolver.resolve(`${name}/package.json`)
-  }
-  catch (error) {
-    if (!isPackageResolutionMiss(error)) throw error
-  }
-
-  try {
-    let current = dirname(resolver.resolve(name))
-    while (current !== dirname(current)) {
-      const candidate = join(current, "package.json")
-      try {
-        await access(candidate)
-        const packageJson = JSON.parse(await readFile(candidate, "utf8")) as { name?: string }
-        if (packageJson.name === name) return candidate
-      }
-      catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
-      }
-      current = dirname(current)
-    }
-  }
-  catch (error) {
-    if (!isPackageResolutionMiss(error)) throw error
-  }
-
-  let current = fromDir
-  while (current !== dirname(current)) {
-    const candidate = join(current, "node_modules", ...name.split("/"), "package.json")
-    try {
-      await access(candidate)
-      return candidate
-    }
-    catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
-    }
-    current = dirname(current)
-  }
-}
-
-function isPackageResolutionMiss(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException | undefined)?.code
-  return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND" || code === "ERR_PACKAGE_PATH_NOT_EXPORTED"
-}
-
 async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutputOptions): Promise<void> {
   const { clientDir, staticIndex } = resolveClientOutput(options.rootDir, options.clientOutDir)
   const outputRoot = options.outputRoot ?? createDefaultCloudflareOutputRoot(options.rootDir)
@@ -303,12 +168,6 @@ async function writeVercelDeploymentOutput(options: VercelDeploymentOutputOption
 
   await Promise.all([
     bundleEsmEntry(options.bundleEntry, serverEntry, options.bundleOptions),
-    copyVercelFunctionRuntimePackages({
-      outputRoot,
-      packages: options.runtimePackages ?? [],
-      rootDir: options.rootDir,
-      serverFunctionName,
-    }),
     writeFile(resolve(serverDir, ".vc-config.json"), `${JSON.stringify(options.functionConfig ?? createNodeFunctionConfig(), null, 2)}\n`, "utf8"),
     writeMergedJsonObject(resolve(outputRoot, "config.json"), options.config ?? createVercelConfigJson(), options.configKeys),
     staticIndex

--- a/packages/internal/src/build/vercel-runtime-packages.ts
+++ b/packages/internal/src/build/vercel-runtime-packages.ts
@@ -1,8 +1,11 @@
-import { access, cp, mkdir, readFile, rm } from "node:fs/promises"
+import { access, copyFile, cp, mkdir, readFile, rm, stat } from "node:fs/promises"
 import { createRequire } from "node:module"
-import { dirname, join, relative, resolve, sep } from "node:path"
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path"
 
 import { createDefaultVercelOutputRoot } from "./deployment-output.ts"
+
+const runtimeExportConditions = new Set(["default", "import", "module", "node", "node-addons", "require"])
+let nodeFileTracePromise: Promise<typeof import("@vercel/nft").nodeFileTrace> | undefined
 
 interface VercelFunctionRuntimePackage {
   includePeerDependencies?: boolean
@@ -57,6 +60,9 @@ async function copyPackageToNodeModules(
   const packageDir = dirname(packageJsonPath)
   const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
     dependencies?: Record<string, string>
+    exports?: unknown
+    main?: string
+    module?: string
     name?: string
     peerDependencies?: Record<string, string>
     peerDependenciesMeta?: Record<string, { optional?: boolean }>
@@ -67,12 +73,8 @@ async function copyPackageToNodeModules(
     copied.add(packageKey)
     const targetDir = join(outputNodeModules, ...name.split("/"))
     await rm(targetDir, { force: true, recursive: true })
-    await mkdir(dirname(targetDir), { recursive: true })
-    await cp(packageDir, targetDir, {
-      dereference: true,
-      filter: source => !relative(packageDir, source).split(sep).includes("node_modules"),
-      recursive: true,
-    })
+    const copiedTrace = await copyTracedPackageFiles(name, resolver, packageDir, packageJsonPath, packageJson, targetDir)
+    if (!copiedTrace) await copyPackageDirectory(packageDir, targetDir)
   }
 
   const packageRequire = createRequire(packageJsonPath)
@@ -89,6 +91,129 @@ async function copyPackageToNodeModules(
       name: dependencyName,
     })
   }
+}
+
+async function copyTracedPackageFiles(
+  name: string,
+  resolver: NodeJS.Require,
+  packageDir: string,
+  packageJsonPath: string,
+  packageJson: { exports?: unknown, main?: string, module?: string },
+  targetDir: string,
+): Promise<boolean> {
+  const entries = await resolvePackageTraceEntries(name, resolver, packageDir, packageJson)
+  if (!entries) return false
+
+  const nodeFileTrace = await loadNodeFileTrace()
+  const { fileList } = await nodeFileTrace([...entries], {
+    base: packageDir,
+    conditions: ["node"],
+    exportsOnly: true,
+    processCwd: packageDir,
+  })
+
+  fileList.add(relative(packageDir, packageJsonPath))
+  for (const file of fileList) {
+    const source = resolve(packageDir, file)
+    if (!isInsideDirectory(packageDir, source) || hasNodeModulesSegment(file)) continue
+    const target = resolve(targetDir, file)
+    await mkdir(dirname(target), { recursive: true })
+    await copyFile(source, target)
+  }
+
+  return true
+}
+
+async function copyPackageDirectory(packageDir: string, targetDir: string): Promise<void> {
+  await mkdir(dirname(targetDir), { recursive: true })
+  await cp(packageDir, targetDir, {
+    dereference: true,
+    filter: source => !hasNodeModulesSegment(relative(packageDir, source)),
+    recursive: true,
+  })
+}
+
+async function loadNodeFileTrace(): Promise<typeof import("@vercel/nft").nodeFileTrace> {
+  nodeFileTracePromise ??= import("@vercel/nft").then(({ nodeFileTrace }) => nodeFileTrace)
+  return nodeFileTracePromise
+}
+
+async function resolvePackageTraceEntries(
+  name: string,
+  resolver: NodeJS.Require,
+  packageDir: string,
+  packageJson: { exports?: unknown, main?: string, module?: string },
+): Promise<string[] | undefined> {
+  const entryCandidates = new Set<string>()
+
+  if (packageJson.exports) {
+    const exportedTargets = collectRuntimeExportTargets(packageJson.exports)
+    if (!exportedTargets) return undefined
+    for (const target of exportedTargets) entryCandidates.add(resolve(packageDir, target))
+  } else {
+    try {
+      entryCandidates.add(resolver.resolve(name))
+    }
+    catch (error) {
+      if (!isPackageResolutionMiss(error)) throw error
+    }
+    if (packageJson.main) entryCandidates.add(resolve(packageDir, packageJson.main))
+    if (packageJson.module) entryCandidates.add(resolve(packageDir, packageJson.module))
+    entryCandidates.add(resolve(packageDir, "index.js"))
+  }
+
+  const entries: string[] = []
+  for (const candidate of entryCandidates) {
+    try {
+      const candidateStat = await stat(candidate)
+      if (candidateStat.isFile()) entries.push(candidate)
+      else if (candidateStat.isDirectory()) return undefined
+    }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    }
+  }
+
+  return entries.length ? entries : undefined
+}
+
+function collectRuntimeExportTargets(exportsValue: unknown, condition?: string): Set<string> | undefined {
+  if (typeof exportsValue === "string") {
+    if (condition === "types") return new Set()
+    if (exportsValue.includes("*")) return undefined
+    return exportsValue.startsWith("./") ? new Set([exportsValue]) : new Set()
+  }
+
+  if (Array.isArray(exportsValue)) {
+    const targets = new Set<string>()
+    for (const entry of exportsValue) {
+      const entryTargets = collectRuntimeExportTargets(entry, condition)
+      if (!entryTargets) return undefined
+      for (const target of entryTargets) targets.add(target)
+    }
+    return targets
+  }
+
+  if (typeof exportsValue !== "object" || exportsValue === null) return new Set()
+
+  const targets = new Set<string>()
+  for (const [key, value] of Object.entries(exportsValue)) {
+    if (key === "types") continue
+    if (!key.startsWith(".") && !runtimeExportConditions.has(key)) continue
+    const entryTargets = collectRuntimeExportTargets(value, key)
+    if (!entryTargets) return undefined
+    for (const target of entryTargets) targets.add(target)
+  }
+  return targets
+}
+
+function hasNodeModulesSegment(path: string): boolean {
+  return path.split(/[\\/]/).includes("node_modules")
+}
+
+function isInsideDirectory(parent: string, child: string): boolean {
+  const childRelativePath = relative(parent, child)
+  return childRelativePath === "" || (!childRelativePath.startsWith(`..${sep}`) && childRelativePath !== ".." && !isAbsolute(childRelativePath))
 }
 
 async function resolvePackageJson(name: string, resolver: NodeJS.Require, fromDir: string): Promise<string | undefined> {

--- a/packages/internal/src/build/vercel-runtime-packages.ts
+++ b/packages/internal/src/build/vercel-runtime-packages.ts
@@ -1,0 +1,138 @@
+import { access, cp, mkdir, readFile, rm } from "node:fs/promises"
+import { createRequire } from "node:module"
+import { dirname, join, relative, resolve, sep } from "node:path"
+
+import { createDefaultVercelOutputRoot } from "./deployment-output.ts"
+
+interface VercelFunctionRuntimePackage {
+  includePeerDependencies?: boolean
+  name: string
+  optional?: boolean
+  resolveFrom?: string
+}
+
+interface VercelFunctionRuntimePackagesOptions {
+  outputRoot?: string
+  packages: VercelFunctionRuntimePackage[]
+  rootDir: string
+  serverFunctionName?: string
+}
+
+export async function copyVercelFunctionRuntimePackages(options: VercelFunctionRuntimePackagesOptions): Promise<void> {
+  if (!options.packages.length) return
+
+  const outputRoot = options.outputRoot ?? createDefaultVercelOutputRoot(options.rootDir)
+  const serverFunctionName = options.serverFunctionName ?? "__server.func"
+  const serverDir = resolve(outputRoot, "functions", serverFunctionName)
+  try {
+    await access(serverDir)
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    throw error
+  }
+
+  const copied = new Set<string>()
+  const outputNodeModules = resolve(serverDir, "node_modules")
+  for (const runtimePackage of options.packages) {
+    const resolver = createRequire(runtimePackage.resolveFrom ?? join(options.rootDir, "package.json"))
+    await copyPackageToNodeModules(runtimePackage.name, resolver, options.rootDir, outputNodeModules, copied, runtimePackage)
+  }
+}
+
+async function copyPackageToNodeModules(
+  name: string,
+  resolver: NodeJS.Require,
+  fromDir: string,
+  outputNodeModules: string,
+  copied: Set<string>,
+  options: VercelFunctionRuntimePackage = { name },
+): Promise<void> {
+  const packageJsonPath = await resolvePackageJson(name, resolver, fromDir)
+  if (!packageJsonPath) {
+    if (options.optional) return
+    throw new Error(`Could not resolve package.json for ${name}.`)
+  }
+
+  const packageDir = dirname(packageJsonPath)
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+    dependencies?: Record<string, string>
+    name?: string
+    peerDependencies?: Record<string, string>
+    peerDependenciesMeta?: Record<string, { optional?: boolean }>
+  }
+  const packageKey = `${name}\0${packageJsonPath}`
+
+  if (!copied.has(packageKey)) {
+    copied.add(packageKey)
+    const targetDir = join(outputNodeModules, ...name.split("/"))
+    await rm(targetDir, { force: true, recursive: true })
+    await mkdir(dirname(targetDir), { recursive: true })
+    await cp(packageDir, targetDir, {
+      dereference: true,
+      filter: source => !relative(packageDir, source).split(sep).includes("node_modules"),
+      recursive: true,
+    })
+  }
+
+  const packageRequire = createRequire(packageJsonPath)
+  const dependencyNames = new Set(Object.keys(packageJson.dependencies || {}))
+  if (options.includePeerDependencies) {
+    for (const dependencyName of Object.keys(packageJson.peerDependencies || {})) {
+      if (!packageJson.peerDependenciesMeta?.[dependencyName]?.optional) dependencyNames.add(dependencyName)
+    }
+  }
+
+  for (const dependencyName of dependencyNames) {
+    await copyPackageToNodeModules(dependencyName, packageRequire, packageDir, outputNodeModules, copied, {
+      includePeerDependencies: options.includePeerDependencies,
+      name: dependencyName,
+    })
+  }
+}
+
+async function resolvePackageJson(name: string, resolver: NodeJS.Require, fromDir: string): Promise<string | undefined> {
+  try {
+    return resolver.resolve(`${name}/package.json`)
+  }
+  catch (error) {
+    if (!isPackageResolutionMiss(error)) throw error
+  }
+
+  try {
+    let current = dirname(resolver.resolve(name))
+    while (current !== dirname(current)) {
+      const candidate = join(current, "package.json")
+      try {
+        await access(candidate)
+        const packageJson = JSON.parse(await readFile(candidate, "utf8")) as { name?: string }
+        if (packageJson.name === name) return candidate
+      }
+      catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+      }
+      current = dirname(current)
+    }
+  }
+  catch (error) {
+    if (!isPackageResolutionMiss(error)) throw error
+  }
+
+  let current = fromDir
+  while (current !== dirname(current)) {
+    const candidate = join(current, "node_modules", ...name.split("/"), "package.json")
+    try {
+      await access(candidate)
+      return candidate
+    }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    }
+    current = dirname(current)
+  }
+}
+
+function isPackageResolutionMiss(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code
+  return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND" || code === "ERR_PACKAGE_PATH_NOT_EXPORTED"
+}

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -17,6 +17,18 @@ async function createTempProject() {
   return rootDir
 }
 
+async function writePackage(rootDir: string, name: string, packageJson: Record<string, unknown> = {}) {
+  const packageDir = join(rootDir, "node_modules", ...name.split("/"))
+  await mkdir(packageDir, { recursive: true })
+  await writeFile(join(packageDir, "index.js"), "export default {}\n", "utf8")
+  await writeFile(join(packageDir, "package.json"), `${JSON.stringify({
+    name,
+    version: "1.0.0",
+    ...packageJson,
+  }, null, 2)}\n`, "utf8")
+  return packageDir
+}
+
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
 })
@@ -223,5 +235,62 @@ describe("provider deployment outputs", () => {
     await expect(readFile(join(cloudflareDir, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       triggers: { crons: ["0 0 * * *"] },
     })
+  })
+
+  it("copies Vercel function runtime package dependency closures", async () => {
+    const rootDir = await createTempProject()
+    const {
+      copyVercelFunctionRuntimePackages,
+      createDefaultVercelOutputRoot,
+    } = await import("../src/build/deployment-output.ts")
+    const outputRoot = createDefaultVercelOutputRoot(rootDir)
+    const serverDir = join(outputRoot, "functions", "__server.func")
+    const runtimePackageDir = await writePackage(rootDir, "@scope/runtime", {
+      dependencies: { "runtime-dependency": "1.0.0" },
+      exports: { ".": "./index.js" },
+      peerDependencies: {
+        "optional-peer": "1.0.0",
+        "runtime-peer": "1.0.0",
+      },
+      peerDependenciesMeta: {
+        "optional-peer": { optional: true },
+      },
+    })
+    await writePackage(rootDir, "runtime-dependency", {
+      peerDependencies: { "transitive-peer": "1.0.0" },
+    })
+    await writePackage(rootDir, "runtime-peer")
+    await writePackage(rootDir, "transitive-peer")
+    await writePackage(rootDir, "optional-peer")
+    await writePackage(runtimePackageDir, "nested-ignored")
+    await mkdir(serverDir, { recursive: true })
+
+    await copyVercelFunctionRuntimePackages({
+      packages: [{ includePeerDependencies: true, name: "@scope/runtime" }],
+      rootDir,
+    })
+
+    await expect(readFile(join(serverDir, "node_modules", "@scope", "runtime", "package.json"), "utf8").then(JSON.parse)).resolves.toMatchObject({
+      name: "@scope/runtime",
+    })
+    expect(existsSync(join(serverDir, "node_modules", "@scope", "runtime", "node_modules", "nested-ignored"))).toBe(false)
+    expect(existsSync(join(serverDir, "node_modules", "runtime-dependency", "package.json"))).toBe(true)
+    expect(existsSync(join(serverDir, "node_modules", "runtime-peer", "package.json"))).toBe(true)
+    expect(existsSync(join(serverDir, "node_modules", "transitive-peer", "package.json"))).toBe(true)
+    expect(existsSync(join(serverDir, "node_modules", "optional-peer", "package.json"))).toBe(false)
+  })
+
+  it("skips optional Vercel function runtime packages when they are not installed", async () => {
+    const rootDir = await createTempProject()
+    const {
+      copyVercelFunctionRuntimePackages,
+      createDefaultVercelOutputRoot,
+    } = await import("../src/build/deployment-output.ts")
+    await mkdir(join(createDefaultVercelOutputRoot(rootDir), "functions", "__server.func"), { recursive: true })
+
+    await expect(copyVercelFunctionRuntimePackages({
+      packages: [{ name: "missing-runtime", optional: true }],
+      rootDir,
+    })).resolves.toBeUndefined()
   })
 })

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -240,9 +240,9 @@ describe("provider deployment outputs", () => {
   it("copies Vercel function runtime package dependency closures", async () => {
     const rootDir = await createTempProject()
     const {
-      copyVercelFunctionRuntimePackages,
       createDefaultVercelOutputRoot,
     } = await import("../src/build/deployment-output.ts")
+    const { copyVercelFunctionRuntimePackages } = await import("../src/build/vercel-runtime-packages.ts")
     const outputRoot = createDefaultVercelOutputRoot(rootDir)
     const serverDir = join(outputRoot, "functions", "__server.func")
     const runtimePackageDir = await writePackage(rootDir, "@scope/runtime", {
@@ -283,9 +283,9 @@ describe("provider deployment outputs", () => {
   it("skips optional Vercel function runtime packages when they are not installed", async () => {
     const rootDir = await createTempProject()
     const {
-      copyVercelFunctionRuntimePackages,
       createDefaultVercelOutputRoot,
     } = await import("../src/build/deployment-output.ts")
+    const { copyVercelFunctionRuntimePackages } = await import("../src/build/vercel-runtime-packages.ts")
     await mkdir(join(createDefaultVercelOutputRoot(rootDir), "functions", "__server.func"), { recursive: true })
 
     await expect(copyVercelFunctionRuntimePackages({

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -263,6 +263,9 @@ describe("provider deployment outputs", () => {
     await writePackage(rootDir, "transitive-peer")
     await writePackage(rootDir, "optional-peer")
     await writePackage(runtimePackageDir, "nested-ignored")
+    await writeFile(join(runtimePackageDir, "index.js"), "import './runtime-file.js'\nexport default {}\n", "utf8")
+    await writeFile(join(runtimePackageDir, "runtime-file.js"), "export const runtime = true\n", "utf8")
+    await writeFile(join(runtimePackageDir, "unused-file.js"), "export const unused = true\n", "utf8")
     await mkdir(serverDir, { recursive: true })
 
     await copyVercelFunctionRuntimePackages({
@@ -273,6 +276,8 @@ describe("provider deployment outputs", () => {
     await expect(readFile(join(serverDir, "node_modules", "@scope", "runtime", "package.json"), "utf8").then(JSON.parse)).resolves.toMatchObject({
       name: "@scope/runtime",
     })
+    expect(existsSync(join(serverDir, "node_modules", "@scope", "runtime", "runtime-file.js"))).toBe(true)
+    expect(existsSync(join(serverDir, "node_modules", "@scope", "runtime", "unused-file.js"))).toBe(false)
     expect(existsSync(join(serverDir, "node_modules", "@scope", "runtime", "node_modules", "nested-ignored"))).toBe(false)
     expect(existsSync(join(serverDir, "node_modules", "runtime-dependency", "package.json"))).toBe(true)
     expect(existsSync(join(serverDir, "node_modules", "runtime-peer", "package.json"))).toBe(true)

--- a/packages/internal/tsdown.config.ts
+++ b/packages/internal/tsdown.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     "src/build/paths.ts",
     "src/build/user-entry.ts",
     "src/build/vercel-config.ts",
+    "src/build/vercel-runtime-packages.ts",
     "src/build/vite.ts",
     "src/feature-bridge/feature-engine.ts",
     "src/feature-bridge/hosting.ts",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -58,6 +58,7 @@
     "test": "pnpm --filter @vite-hub/workspace... build && vitest run"
   },
   "dependencies": {
+    "@vercel/nft": "catalog:vercel",
     "@vite-hub/shell": "workspace:*",
     "@vite-hub/source": "workspace:*",
     "defu": "catalog:unjs",

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path"
 
+import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/deployment-output"
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored } from "@vite-hub/internal/build/vite"
 
 import { initializeWorkspaceAssetRegistry, refreshWorkspaceBuildState, syncWorkspaceBuildAssets } from "../../build/integration.ts"
@@ -108,6 +109,16 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
 
       const definitions = discoverViteWorkspaceDefinitions(resolved.root)
       await syncWorkspaceBuildAssets(definitions, resolved.root, resolvedOptions, assetsRegistryFile)
+    },
+    closeBundle: {
+      order: "post",
+      async handler() {
+        if (!resolved || resolved.command !== "build") return
+        await copyVercelFunctionRuntimePackages({
+          packages: [{ name: WORKSPACE_PACKAGE_NAME, resolveFrom: import.meta.url }],
+          rootDir: resolved.root,
+        })
+      },
     },
     configureServer(devServer) {
       server = devServer

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path"
 
-import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/deployment-output"
+import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored } from "@vite-hub/internal/build/vite"
 
 import { initializeWorkspaceAssetRegistry, refreshWorkspaceBuildState, syncWorkspaceBuildAssets } from "../../build/integration.ts"

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@vite-hub/internal/build/deployment-output", () => ({
+  copyVercelFunctionRuntimePackages: vi.fn(async () => undefined),
+}))
 
 const tempDirs: string[] = []
 
@@ -90,6 +94,24 @@ describe("hubWorkspace", () => {
     const registryId = resolveId("#vitehub-workspace-registry")!
     expect(load(registryId)).toContain('"docs": async () => {')
     expect(load(registryId)).toContain("sourceRootDir")
+  })
+
+  it("materializes the workspace runtime package for Vercel build output", async () => {
+    const root = await createViteRoot()
+    const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/deployment-output")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace()
+    const configResolved = plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>
+    const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
+    vi.mocked(copyVercelFunctionRuntimePackages).mockClear()
+
+    await configResolved({ command: "build", root })
+    await closeBundle.handler()
+
+    expect(copyVercelFunctionRuntimePackages).toHaveBeenCalledWith({
+      packages: [{ name: "@vite-hub/workspace", resolveFrom: expect.any(String) }],
+      rootDir: root,
+    })
   })
 
   it("emits build-time workspace assets for Vite builds", async () => {

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url"
 
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-vi.mock("@vite-hub/internal/build/deployment-output", () => ({
+vi.mock("@vite-hub/internal/build/vercel-runtime-packages", () => ({
   copyVercelFunctionRuntimePackages: vi.fn(async () => undefined),
 }))
 
@@ -98,7 +98,7 @@ describe("hubWorkspace", () => {
 
   it("materializes the workspace runtime package for Vercel build output", async () => {
     const root = await createViteRoot()
-    const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/deployment-output")
+    const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/vercel-runtime-packages")
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace()
     const configResolved = plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>

--- a/packages/workspace/tsdown.config.ts
+++ b/packages/workspace/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   clean: true,
   deps: {
     alwaysBundle: [/^@vite-hub\/internal/],
-    neverBundle: ["#vitehub-workspace-assets-registry", "#vitehub-workspace-registry", /^@vite-hub\/sandbox/],
+    neverBundle: ["#vitehub-workspace-assets-registry", "#vitehub-workspace-registry", "@vercel/nft", /^@vite-hub\/sandbox/],
   },
   dts: true,
   entry: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ catalogs:
     '@vercel/functions':
       specifier: ^3.4.3
       version: 3.4.3
+    '@vercel/nft':
+      specifier: ^1.5.0
+      version: 1.5.0
     '@vercel/queue':
       specifier: ^0.0.0-alpha.23
       version: 0.0.0-alpha.40
@@ -318,6 +321,9 @@ importers:
       '@vercel/functions':
         specifier: catalog:vercel
         version: 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38)
+      '@vercel/nft':
+        specifier: catalog:vercel
+        version: 1.5.0(rollup@4.60.4)
       '@vite-hub/devtools':
         specifier: workspace:*
         version: link:../devtools
@@ -637,6 +643,9 @@ importers:
 
   packages/internal:
     dependencies:
+      '@vercel/nft':
+        specifier: catalog:vercel
+        version: 1.5.0(rollup@4.60.4)
       '@vite-hub/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -1065,6 +1074,9 @@ importers:
 
   packages/workspace:
     dependencies:
+      '@vercel/nft':
+        specifier: catalog:vercel
+        version: 1.5.0(rollup@4.60.4)
       '@vite-hub/shell':
         specifier: workspace:*
         version: link:../shell

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,6 +90,7 @@ catalogs:
     unimport: ^6.0.2
   vercel:
     '@vercel/functions': ^3.4.3
+    '@vercel/nft': ^1.5.0
     '@vercel/queue': ^0.0.0-alpha.23
   vite:
     '@vitejs/devtools': ^0.2.0


### PR DESCRIPTION
Materializes Vercel function runtime packages from the ViteHub Workspace and Agent Vite plugins, so consumers no longer need app-level scripts like `scripts/prepare-vercel-output.mjs` to copy `@vite-hub/workspace` or `@ai-sdk/mcp` into `.vercel/output/functions/__server.func/node_modules`.

The implementation copies package dependency closures, handles exported-package resolution, required peer dependencies, and optional runtime packages. The Node-only materializer now lives behind `@vite-hub/internal/build/vercel-runtime-packages`, keeping shared deployment-output code provider-safe for Cloudflare and queue builds.