### PR TITLE
fix(agent): harden rate limit capability

### DIFF
--- a/.agents/adr/0041-rate-limit-capability.md
+++ b/.agents/adr/0041-rate-limit-capability.md
@@ -2,7 +2,9 @@
 
 ViteHub will expose `rateLimit()` as an official Agent Capability imported from `@vite-hub/agent/capabilities`. The capability runs before the main Agent Invocation, resolves a trusted invocation identity, consumes a fixed-window budget, records the result as an Agent Invocation Context Value, and rejects with a structured 429 error when the budget is exhausted.
 
-The first version uses a fixed-window algorithm and ships an in-process `memoryRateLimitStore()` for local development, tests, and single-process hosts. Production-grade adapters should implement the explicit `RateLimitStore.consume()` contract so the check and increment happen in one store operation.
+The first version uses a fixed-window algorithm and ships an in-process `memoryRateLimitStore()` for local development, tests, and single-process hosts. Hosted runtimes require an explicit store choice; production-grade adapters should implement the explicit `RateLimitStore.consume()` contract so the check and increment happen in one store operation.
+
+Identity resolution must use trusted invocation context. `identity: "chat"` reads the Chat Identity context value produced by trusted server-side chat triggers, not client-provided chat user data. `identity: "ip"` reads request headers only when the developer names trusted IP headers for their deployment boundary. `identity: "run"` uses stable Agent Run metadata such as thread or channel ids, not the invocation-unique run id.
 
 Rate limiting is not part of `access()`, because access controls authority over runtime surfaces while rate limiting controls invocation budget. It is also not a model-facing KV/DB/Blob tool, because the model should not participate in enforcement. Current KV `get`/`set` storage is not enough to claim strict distributed rate-limit behavior, so durable adapters should target a backend with atomic increment, compare-and-set, a Durable Object, or an equivalent coordination primitive.
 
@@ -11,8 +13,10 @@ Rate limiting is not part of `access()`, because access controls authority over 
 - Keeping downstream app middleware was rejected because Agent Invocations can start through multiple Agent Trigger Consumers, and the budget should compose through the Agent Definition.
 - Folding rate limits into `access()` was rejected because access roles and budget consumption are separate Pre-Invocation Decisions.
 - Building the first version on plain KV `get`/`set` was rejected because concurrent invocations can pass stale reads unless the store has an atomic consume operation.
+- Trusting generated Chat App Route `user` or `run` request fields was rejected because those fields are client-controlled on public app routes.
+- Reading forwarded IP headers by default was rejected because proxy trust is host-specific and clients can spoof those headers in common deployments.
 - Shipping sliding windows or token buckets in the first version was deferred because fixed windows prove the capability shape while leaving room for later algorithms.
 
 ## Consequences
 
-Applications can attach `rateLimit()` beside other Capabilities and customize identity, scope, message, and store behavior. The default memory store is useful but should not be treated as hosted production coordination. Future runtime/provider packages can add durable stores without changing the Agent Package capability surface.
+Applications can attach `rateLimit()` beside other Capabilities and customize identity, scope, message, and store behavior. The memory store remains available through explicit configuration but should not be treated as hosted production coordination. Future runtime/provider packages can add durable stores without changing the Agent Package capability surface.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -222,8 +222,8 @@ _Avoid_: App middleware, model-facing counter tool, KV wrapper
 - An **LLM Gate Capability** chooses one developer-defined allow or reject category through an LLM and may reject before the main Agent Invocation.
 - Deterministic or callback-based routing is not an official Capability in V1; users can define inline Capabilities or hooks that set named invocation context values.
 - A **Rate Limit Capability** records a typed **Agent Invocation Context Value** with the consumed budget result when an invocation is allowed or rejected.
-- A **Rate Limit Capability** consumes trusted identity from Agent Invocation context, Agent Run metadata, request metadata, or a developer callback, not from model output.
-- A **Rate Limit Capability** uses an explicit rate-limit store contract; model-facing storage Capabilities are not the runtime enforcement mechanism.
+- A **Rate Limit Capability** consumes trusted identity from Chat Identity, stable Agent Run metadata, explicitly trusted request metadata, or a developer callback, not from model output or client-supplied Chat App Route identity fields.
+- A **Rate Limit Capability** uses an explicit rate-limit store contract; model-facing storage Capabilities are not the runtime enforcement mechanism, and hosted runtimes require an explicit store choice.
 - Primitive storage helpers such as `kv()`, `blob()`, and `db()` are first-class official **Capabilities**, not sample raw-tool wrappers.
 - A **Chat Capability** owns Chat History behavior for the current stack.
 - A **Chat Capability** may declare **Chat Platform Adapters** through a **Chat Adapter Callback**.
@@ -371,6 +371,8 @@ _Avoid_: App middleware, model-facing counter tool, KV wrapper
 - A generic `decisionPolicy()` helper and request-refinement Capability were considered - resolved: defer them until **LLM Route Capability**, **LLM Gate Capability**, and Chat Sessions prove the internal primitive.
 - App-level rate-limit middleware was considered for agent chat routes - resolved: use a **Rate Limit Capability** so invocation budgets compose through Agent Definitions and can run before model execution on every Agent Invocation path.
 - Plain KV `get`/`set` counters were considered for **Rate Limit Capability** storage - resolved: rate limiting needs an explicit consume contract because distributed enforcement depends on atomic store behavior.
+- Client-provided Chat App Route user/run fields were considered for **Rate Limit Capability** defaults - resolved: do not trust them as budget identity; official chat triggers should produce Chat Identity from trusted server-side inputs.
+- Forwarded request headers were considered for default IP identity - resolved: require explicit trusted header names because proxy trust is deployment-specific.
 - Typed capability preparation was considered as a runtime lifecycle phase - resolved: use narrow **Capability Type Contracts** for type-only Agent Definition checks on official Capabilities, and keep runtime validation inside the **Capability Lifecycle**.
 - A generic custom-Capability contract framework was considered - resolved: defer it until user-defined Capabilities prove a stable story; the current contract exists for official Capabilities that directly consume Agent Definition inputs.
 - Input Command display metadata was considered capability-level - resolved: Capability id owns identity, while command descriptions are the user-facing metadata hosts may render.

--- a/packages/agent/src/capabilities/rate-limit.ts
+++ b/packages/agent/src/capabilities/rate-limit.ts
@@ -71,7 +71,8 @@ export interface RateLimitOptions {
   limit: number
   message?: string | ((decision: RateLimitDecision) => string)
   scope?: string | ((context: AgentCapabilityRuntimeContext) => MaybePromise<string>)
-  store?: RateLimitStore | ((context: AgentCapabilityRuntimeContext) => MaybePromise<RateLimitStore>)
+  store?: RateLimitStore | "memory" | ((context: AgentCapabilityRuntimeContext) => MaybePromise<RateLimitStore | "memory">)
+  trustedIpHeaders?: string[]
   window: RateLimitWindow
 }
 
@@ -192,20 +193,7 @@ function firstString(...values: unknown[]): string | undefined {
 }
 
 function resolveChatIdentity(context: AgentCapabilityRuntimeContext): string | undefined {
-  const input = context.input.get()
-  const chat = typeof input.context?.chat === "object" && input.context.chat !== null
-    ? input.context.chat as Record<string, unknown>
-    : undefined
-  const user = typeof chat?.user === "object" && chat.user !== null
-    ? chat.user as Record<string, unknown>
-    : undefined
-  return firstString(
-    context.context.get("chat.identity"),
-    user?.id,
-    user?.sub,
-    user?.email,
-    user?.username,
-  )
+  return firstString(context.context.get("chat.identity"))
 }
 
 function resolveRunIdentity(context: AgentCapabilityRuntimeContext): string | undefined {
@@ -216,8 +204,6 @@ function resolveRunIdentity(context: AgentCapabilityRuntimeContext): string | un
     run.threadId ? `thread:${run.threadId}` : undefined,
     run.channelId && run.origin ? `${run.origin}:channel:${run.channelId}` : undefined,
     run.channelId ? `channel:${run.channelId}` : undefined,
-    run.origin && run.runId ? `${run.origin}:run:${run.runId}` : undefined,
-    run.runId,
   )
 }
 
@@ -232,20 +218,22 @@ function forwardedHeader(value: string): string | undefined {
   return match?.[1]
 }
 
-function resolveIpIdentity(context: AgentCapabilityRuntimeContext): string | undefined {
+function resolveIpIdentity(context: AgentCapabilityRuntimeContext, trustedIpHeaders: string[] | undefined): string | undefined {
   const headers = context.request?.headers
-  if (!headers) return
-  return firstString(
-    headers.get("cf-connecting-ip"),
-    headers.get("x-real-ip"),
-    headers.get("x-forwarded-for") ? forwardedFor(headers.get("x-forwarded-for")!) : undefined,
-    headers.get("forwarded") ? forwardedHeader(headers.get("forwarded")!) : undefined,
-  )
+  if (!headers || !trustedIpHeaders?.length) return
+  for (const name of trustedIpHeaders) {
+    const value = headers.get(name)
+    if (!value) continue
+    if (name.toLowerCase() === "x-forwarded-for") return forwardedFor(value)
+    if (name.toLowerCase() === "forwarded") return forwardedHeader(value)
+    return value.trim() || undefined
+  }
 }
 
 async function resolveIdentity(
   identity: RateLimitIdentity,
   context: AgentCapabilityRuntimeContext,
+  trustedIpHeaders: string[] | undefined,
 ): Promise<{ source: string, value: string }> {
   if (typeof identity === "function") {
     const value = await identity(context)
@@ -263,19 +251,19 @@ async function resolveIdentity(
     throw new Error("[vitehub] rateLimit({ identity: \"run\" }) could not resolve Agent Run metadata.")
   }
   if (identity === "ip") {
-    const value = resolveIpIdentity(context)
+    const value = resolveIpIdentity(context, trustedIpHeaders)
     if (value) return { source: "ip", value }
-    throw new Error("[vitehub] rateLimit({ identity: \"ip\" }) could not resolve a request IP.")
+    throw new Error("[vitehub] rateLimit({ identity: \"ip\" }) requires trustedIpHeaders and a matching request header.")
   }
-  return resolveAutoIdentity(context)
+  return resolveAutoIdentity(context, trustedIpHeaders)
 }
 
-function resolveAutoIdentity(context: AgentCapabilityRuntimeContext): { source: string, value: string } {
+function resolveAutoIdentity(context: AgentCapabilityRuntimeContext, trustedIpHeaders: string[] | undefined): { source: string, value: string } {
   const chat = resolveChatIdentity(context)
   if (chat) return { source: "chat", value: chat }
   const run = resolveRunIdentity(context)
   if (run) return { source: "run", value: run }
-  const ip = resolveIpIdentity(context)
+  const ip = resolveIpIdentity(context, trustedIpHeaders)
   if (ip) return { source: "ip", value: ip }
   return { source: "anonymous", value: "anonymous" }
 }
@@ -316,12 +304,22 @@ async function resolveStore(
   context: AgentCapabilityRuntimeContext,
   fallback: RateLimitStore,
 ): Promise<RateLimitStore> {
-  if (!store) return fallback
+  if (!store) {
+    if (isHostedRuntime(context.runtime)) {
+      throw new Error(`[vitehub] rateLimit() requires an explicit store on hosted runtime "${context.runtime}". Use store: "memory" only for local development, tests, or single-process hosts.`)
+    }
+    return fallback
+  }
   const resolved = typeof store === "function" ? await store(context) : store
+  if (resolved === "memory") return fallback
   if (!resolved || typeof resolved.consume !== "function") {
     throw new TypeError("[vitehub] rateLimit({ store }) must provide a consume() function.")
   }
   return resolved
+}
+
+function isHostedRuntime(runtime: string): boolean {
+  return runtime === "vercel" || runtime === "cloudflare-agents"
 }
 
 function retryAfterSeconds(resetAt: number, now: number): number {
@@ -343,6 +341,7 @@ export function rateLimit(
   const windowMs = parseRateLimitWindow(options.window)
   const fallbackStore = memoryRateLimitStore()
   const identity = options.identity || "auto"
+  const trustedIpHeaders = options.trustedIpHeaders?.map(header => header.trim()).filter(Boolean)
 
   return defineCapability({
     id,
@@ -357,7 +356,7 @@ export function rateLimit(
         throw new Error(`[vitehub] Invocation context value "${id}" is already set.`)
       }
       const now = Date.now()
-      const resolvedIdentity = await resolveIdentity(identity, context)
+      const resolvedIdentity = await resolveIdentity(identity, context, trustedIpHeaders)
       const scope = await resolveScope(options.scope, context, id)
       const key = `vitehub:rate-limit:${stableKeyPart(id)}:${scope}:${await hashKeyPart(`${resolvedIdentity.source}:${resolvedIdentity.value}`)}`
       const store = await resolveStore(options.store, context, fallbackStore)

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -48,6 +48,12 @@ function firstString(...values: unknown[]): string | undefined {
   return values.find((value): value is string => typeof value === "string" && value.length > 0)
 }
 
+function chatIdentity(user: Record<string, unknown> | undefined, run: AgentRunMetadata | undefined): string | undefined {
+  const identity = firstString(user?.id, user?.sub, user?.email, user?.username)
+  if (!identity) return
+  return run?.origin ? `${run.origin}:${identity}` : identity
+}
+
 function uiToolName(part: Record<string, unknown>): string {
   if (part.type === "dynamic-tool") {
     return firstString(part.toolName, part.name) || "tool"
@@ -256,10 +262,12 @@ export function createChatMessageTriggerInput<TRuntimeConfig extends AgentRuntim
   }
   const selectedMessages = selectChatHistory(messages, triggerInput?.history ?? options.history, options.sessions, triggerInput?.session)
   const hookArgs = createChatTriggerHookArgs<TRuntimeConfig>(selectedMessages, triggerInput?.run, triggerInput?.session)
+  const identity = chatIdentity(triggerInput?.user, triggerInput?.run)
   return {
     hookArgs,
     input: {
       context: {
+        ...(identity ? { "chat.identity": identity } : {}),
         chat: {
           message: hookArgs.message,
           run: triggerInput?.run,

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -64,6 +64,15 @@ async function readJsonBody(request: Request): Promise<AgentChatRouteBody> {
   return typeof body === "object" && body !== null ? body as AgentChatRouteBody : { messages: [] }
 }
 
+function chatAppRouteTriggerInput(body: AgentChatRouteBody): AgentChatMessageTriggerInput {
+  return {
+    ...(body.history !== undefined ? { history: body.history } : {}),
+    messages: body.messages,
+    ...(body.session !== undefined ? { session: body.session } : {}),
+    ...(body.timeout !== undefined ? { timeout: body.timeout } : {}),
+  }
+}
+
 function readableStreamFromResult(value: unknown): ReadableStream<unknown> {
   if (value instanceof ReadableStream) return value
   if (value instanceof Response && value.body) return value.body
@@ -708,8 +717,8 @@ export function defineAgentChatFetchHandler(
     }
 
     try {
-      const context = createRuntimeContext(request, body.run, await resolveRuntimeWaitUntil(handlerOptions.waitUntil))
-      const result = await streamAgentTrigger(agent as never, context, "chat.message", body, {
+      const context = createRuntimeContext(request, undefined, await resolveRuntimeWaitUntil(handlerOptions.waitUntil))
+      const result = await streamAgentTrigger(agent as never, context, "chat.message", chatAppRouteTriggerInput(body), {
         output: "ui-message-stream",
       })
       return await toUiMessageStreamResponse(readableStreamFromResult(result))

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -20,6 +20,7 @@ describe("chat message trigger input", () => {
       session: { id: "b" },
       user: { id: "user_1" },
     })
+    expect(result.input.context?.["chat.identity"]).toBe("user_1")
     expect(result.input.messages?.map(message => message.parts
       .filter((part): part is { text: string, type: "text" } => part.type === "text")
       .map(part => part.text)

--- a/packages/agent/test/rate-limit.test.ts
+++ b/packages/agent/test/rate-limit.test.ts
@@ -8,10 +8,17 @@ import {
 } from "../src/capabilities.ts"
 import { toHttpErrorResponse } from "../src/http-error.ts"
 
-const runtime = (request?: Request) => ({
+import type { AgentRunMetadata, AgentRuntimeName } from "../src/index.ts"
+
+const runtime = (options: {
+  request?: Request
+  run?: AgentRunMetadata
+  runtime?: AgentRuntimeName
+} = {}) => ({
   memo: vi.fn(),
-  ...(request ? { request } : {}),
-  runtime: "unknown" as const,
+  ...(options.request ? { request: options.request } : {}),
+  ...(options.run ? { run: options.run } : {}),
+  runtime: options.runtime || "unknown" as const,
   runtimeConfig: {},
   waitUntil: vi.fn(),
 })
@@ -75,14 +82,32 @@ describe("rateLimit capability", () => {
     })
 
     await expect(runAgent(agent, runtime(), {
-      context: { chat: { user: { id: "user_1" } } },
+      context: { "chat.identity": "user_1" },
     })).resolves.toBe("ok")
     await expect(runAgent(agent, runtime(), {
-      context: { chat: { user: { id: "user_2" } } },
+      context: { "chat.identity": "user_2" },
     })).resolves.toBe("ok")
     await expect(runAgent(agent, runtime(), {
-      context: { chat: { user: { id: "user_1" } } },
+      context: { "chat.identity": "user_1" },
     })).rejects.toBeInstanceOf(RateLimitRejectedError)
+  })
+
+  it("does not treat untrusted chat user context as Chat Identity", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: "chat",
+          limit: 1,
+          window: "1m",
+        }),
+      ],
+      run: () => "ok",
+    })
+
+    await expect(runAgent(agent, runtime(), {
+      context: { chat: { user: { id: "user_1" } } },
+    })).rejects.toThrow("could not resolve a Chat Identity")
   })
 
   it("resets the memory store after the fixed window elapses", async () => {
@@ -125,6 +150,7 @@ describe("rateLimit capability", () => {
             identity: "ip",
             limit: 1,
             message: decision => `Try again in ${decision.retryAfter}s.`,
+            trustedIpHeaders: ["x-forwarded-for"],
             window: "1m",
           }),
         ],
@@ -136,8 +162,8 @@ describe("rateLimit capability", () => {
         },
       })
 
-      await expect(runAgent(agent, runtime(request), {})).resolves.toBe("ok")
-      const error = await runAgent(agent, runtime(request), {}).catch(error => error)
+      await expect(runAgent(agent, runtime({ request }), {})).resolves.toBe("ok")
+      const error = await runAgent(agent, runtime({ request }), {}).catch(error => error)
       const response = toHttpErrorResponse(error)
 
       expect(response?.status).toBe(429)
@@ -148,5 +174,70 @@ describe("rateLimit capability", () => {
     finally {
       vi.useRealTimers()
     }
+  })
+
+  it("requires explicit trusted IP headers for IP identity", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: "ip",
+          limit: 1,
+          window: "1m",
+        }),
+      ],
+      run: () => "ok",
+    })
+
+    await expect(runAgent(agent, runtime({
+      request: new Request("https://example.com", {
+        headers: { "x-forwarded-for": "203.0.113.10" },
+      }),
+    }), {})).rejects.toThrow("requires trustedIpHeaders")
+  })
+
+  it("requires an explicit store for hosted runtimes", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const withoutStore = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: () => "user_1",
+          limit: 1,
+          window: "1m",
+        }),
+      ],
+      run: () => "ok",
+    })
+    const withMemoryOptIn = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: () => "user_1",
+          limit: 1,
+          store: "memory",
+          window: "1m",
+        }),
+      ],
+      run: () => "ok",
+    })
+
+    await expect(runAgent(withoutStore, runtime({ runtime: "vercel" }), {})).rejects.toThrow("requires an explicit store")
+    await expect(runAgent(withMemoryOptIn, runtime({ runtime: "vercel" }), {})).resolves.toBe("ok")
+  })
+
+  it("requires stable run metadata for run identity", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: "run",
+          limit: 1,
+          window: "1m",
+        }),
+      ],
+      run: () => "ok",
+    })
+
+    await expect(runAgent(agent, runtime({ run: { runId: "run_1" } }), {})).rejects.toThrow("could not resolve Agent Run metadata")
+    await expect(runAgent(agent, runtime({ run: { runId: "run_2", threadId: "thread_1" } }), {})).resolves.toBe("ok")
   })
 })


### PR DESCRIPTION
Hardens the rate limit capability after #253 by narrowing identity trust boundaries and requiring explicit production coordination choices. Chat identity now comes from server-created Chat Identity context, generated chat app routes strip client-supplied user/run fields, IP identity reads only developer-named trusted headers, and run identity requires stable thread/channel metadata instead of per-invocation run ids.

Hosted runtimes now require an explicit store choice, with `store: "memory"` kept as an opt-in for local development, tests, or single-process hosts. The ADR and capability context now capture those trust boundaries.

Refs #253