### PR TITLE
feat(agent): add rate limit capability

### DIFF
--- a/.agents/adr/0041-rate-limit-capability.md
+++ b/.agents/adr/0041-rate-limit-capability.md
@@ -1,0 +1,22 @@
+# Rate Limit Capability
+
+ViteHub will expose `rateLimit()` as an official Agent Capability imported from `@vite-hub/agent/capabilities`. The capability runs before the main Agent Invocation, resolves a trusted invocation identity, consumes a fixed-window budget, records the result as an Agent Invocation Context Value, and rejects with a structured 429 error when the budget is exhausted.
+
+The first version uses a fixed-window algorithm and ships an in-process `memoryRateLimitStore()` for local development, tests, and single-process hosts. Hosted runtimes require an explicit store choice; production-grade adapters should implement the explicit `RateLimitStore.consume()` contract so the check and increment happen in one store operation.
+
+Identity resolution must use trusted invocation context. `identity: "chat"` reads the Chat Identity context value produced by trusted server-side chat triggers, not client-provided chat user data. `identity: "ip"` reads request headers only when the developer names trusted IP headers for their deployment boundary. `identity: "run"` uses stable Agent Run metadata such as thread or channel ids, not the invocation-unique run id.
+
+Rate limiting is not part of `access()`, because access controls authority over runtime surfaces while rate limiting controls invocation budget. It is also not a model-facing KV/DB/Blob tool, because the model should not participate in enforcement. Current KV `get`/`set` storage is not enough to claim strict distributed rate-limit behavior, so durable adapters should target a backend with atomic increment, compare-and-set, a Durable Object, or an equivalent coordination primitive.
+
+## Considered Options
+
+- Keeping downstream app middleware was rejected because Agent Invocations can start through multiple Agent Trigger Consumers, and the budget should compose through the Agent Definition.
+- Folding rate limits into `access()` was rejected because access roles and budget consumption are separate Pre-Invocation Decisions.
+- Building the first version on plain KV `get`/`set` was rejected because concurrent invocations can pass stale reads unless the store has an atomic consume operation.
+- Trusting generated Chat App Route `user` or `run` request fields was rejected because those fields are client-controlled on public app routes.
+- Reading forwarded IP headers by default was rejected because proxy trust is host-specific and clients can spoof those headers in common deployments.
+- Shipping sliding windows or token buckets in the first version was deferred because fixed windows prove the capability shape while leaving room for later algorithms.
+
+## Consequences
+
+Applications can attach `rateLimit()` beside other Capabilities and customize identity, scope, message, and store behavior. The memory store remains available through explicit configuration but should not be treated as hosted production coordination. Future runtime/provider packages can add durable stores without changing the Agent Package capability surface.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -188,10 +188,14 @@ _Avoid_: Routing Capability, callback routing, model router
 A Capability that asks an LLM to classify a request against developer-defined allow and reject categories and may reject before the main Agent Invocation proceeds.
 _Avoid_: Gate, auth gate, security gate, deterministic guard
 
+**Rate Limit Capability**:
+A Capability created by `rateLimit()` that consumes a trusted invocation budget and may reject before the main Agent Invocation proceeds.
+_Avoid_: App middleware, model-facing counter tool, KV wrapper
+
 ## Relationships
 
 - An Agent attaches zero or more **Capabilities**.
-- Official helpers such as `entry()`, `audience()`, `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `access()`, `sandbox()`, `kv()`, `blob()`, `db()`, `webSearch()`, `llmRoute()`, and `llmGate()` create **Capability Definitions**.
+- Official helpers such as `entry()`, `audience()`, `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `access()`, `sandbox()`, `kv()`, `blob()`, `db()`, `webSearch()`, `llmRoute()`, `llmGate()`, and `rateLimit()` create **Capability Definitions**.
 - Official Capability factories and Capability-owned helper functions are imported from `@vite-hub/agent/capabilities`, not from the root `@vite-hub/agent` Agent Package entry.
 - Official helpers should map to product abilities rather than implementation mechanisms.
 - An official **Capability Definition** may carry a narrow **Capability Type Contract** when it directly consumes typed Agent Definition inputs such as Source keys, trusted Chat Capability origins, or schema-validated invocation context.
@@ -217,6 +221,9 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - An **LLM Route Capability** chooses one developer-defined option through an LLM and records the route decision. It does not apply route effects directly.
 - An **LLM Gate Capability** chooses one developer-defined allow or reject category through an LLM and may reject before the main Agent Invocation.
 - Deterministic or callback-based routing is not an official Capability in V1; users can define inline Capabilities or hooks that set named invocation context values.
+- A **Rate Limit Capability** records a typed **Agent Invocation Context Value** with the consumed budget result when an invocation is allowed or rejected.
+- A **Rate Limit Capability** consumes trusted identity from Chat Identity, stable Agent Run metadata, explicitly trusted request metadata, or a developer callback, not from model output or client-supplied Chat App Route identity fields.
+- A **Rate Limit Capability** uses an explicit rate-limit store contract; model-facing storage Capabilities are not the runtime enforcement mechanism, and hosted runtimes require an explicit store choice.
 - Primitive storage helpers such as `kv()`, `blob()`, and `db()` are first-class official **Capabilities**, not sample raw-tool wrappers.
 - A **Chat Capability** owns Chat History behavior for the current stack.
 - A **Chat Capability** may declare **Chat Platform Adapters** through a **Chat Adapter Callback**.
@@ -362,6 +369,10 @@ _Avoid_: Gate, auth gate, security gate, deterministic guard
 - Multiple route or gate decisions writing the same context key were considered for priority or merging - resolved: **Pre-Invocation Decision** ids are unique per Agent, with duplicate ids failing early.
 - Dynamic Capability activation through route decisions was considered - resolved: Pre-Invocation Decisions can influence conditional contributions but must not attach, remove, or grant **Capabilities** at runtime.
 - A generic `decisionPolicy()` helper and request-refinement Capability were considered - resolved: defer them until **LLM Route Capability**, **LLM Gate Capability**, and Chat Sessions prove the internal primitive.
+- App-level rate-limit middleware was considered for agent chat routes - resolved: use a **Rate Limit Capability** so invocation budgets compose through Agent Definitions and can run before model execution on every Agent Invocation path.
+- Plain KV `get`/`set` counters were considered for **Rate Limit Capability** storage - resolved: rate limiting needs an explicit consume contract because distributed enforcement depends on atomic store behavior.
+- Client-provided Chat App Route user/run fields were considered for **Rate Limit Capability** defaults - resolved: do not trust them as budget identity; official chat triggers should produce Chat Identity from trusted server-side inputs.
+- Forwarded request headers were considered for default IP identity - resolved: require explicit trusted header names because proxy trust is deployment-specific.
 - Typed capability preparation was considered as a runtime lifecycle phase - resolved: use narrow **Capability Type Contracts** for type-only Agent Definition checks on official Capabilities, and keep runtime validation inside the **Capability Lifecycle**.
 - A generic custom-Capability contract framework was considered - resolved: defer it until user-defined Capabilities prove a stable story; the current contract exists for official Capabilities that directly consume Agent Definition inputs.
 - Input Command display metadata was considered capability-level - resolved: Capability id owns identity, while command descriptions are the user-facing metadata hosts may render.

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -27,6 +27,11 @@ export {
   llmGate,
 } from "./llm-gate.ts"
 export {
+  memoryRateLimitStore,
+  RateLimitRejectedError,
+  rateLimit,
+} from "./rate-limit.ts"
+export {
   llmRoute,
 } from "./llm-route.ts"
 export {
@@ -164,6 +169,18 @@ export type {
   LlmGateDecision,
   LlmGateOptions,
 } from "./llm-gate.ts"
+export type {
+  MemoryRateLimitStore,
+  MemoryRateLimitStoreOptions,
+  RateLimitConsumeInput,
+  RateLimitConsumeResult,
+  RateLimitDecision,
+  RateLimitIdentity,
+  RateLimitIdentityResolver,
+  RateLimitOptions,
+  RateLimitStore,
+  RateLimitWindow,
+} from "./rate-limit.ts"
 export type {
   LlmRouteDecision,
   LlmRouteOptions,

--- a/packages/agent/src/capabilities/rate-limit.ts
+++ b/packages/agent/src/capabilities/rate-limit.ts
@@ -1,0 +1,382 @@
+import { defineCapability } from "../capability-runtime.ts"
+
+import type {
+  AgentCapabilityDefinition,
+  AgentCapabilityRuntimeContext,
+  AgentRuntimeConfig,
+  MaybePromise,
+} from "../types.ts"
+
+export type RateLimitWindow =
+  | `${number}ms`
+  | `${number}s`
+  | `${number}m`
+  | `${number}h`
+  | `${number}d`
+
+export type RateLimitIdentity =
+  | "auto"
+  | "chat"
+  | "ip"
+  | "run"
+  | RateLimitIdentityResolver
+
+export type RateLimitIdentityResolver = (
+  context: AgentCapabilityRuntimeContext,
+) => MaybePromise<string | null | undefined>
+
+export interface RateLimitConsumeInput {
+  key: string
+  limit: number
+  now: number
+  windowMs: number
+}
+
+export interface RateLimitConsumeResult {
+  allowed: boolean
+  limit: number
+  remaining: number
+  resetAt: number
+}
+
+export interface RateLimitStore {
+  consume: (input: RateLimitConsumeInput) => MaybePromise<RateLimitConsumeResult>
+}
+
+export interface MemoryRateLimitStore extends RateLimitStore {
+  clear: () => void
+  size: () => number
+}
+
+export interface MemoryRateLimitStoreOptions {
+  maxEntries?: number
+}
+
+export interface RateLimitDecision {
+  allowed: boolean
+  capabilityId: string
+  identity: string
+  identitySource: string
+  key: string
+  limit: number
+  remaining: number
+  resetAt: number
+  retryAfter: number
+  windowMs: number
+}
+
+export interface RateLimitOptions {
+  id?: string
+  identity?: RateLimitIdentity
+  limit: number
+  message?: string | ((decision: RateLimitDecision) => string)
+  scope?: string | ((context: AgentCapabilityRuntimeContext) => MaybePromise<string>)
+  store?: RateLimitStore | "memory" | ((context: AgentCapabilityRuntimeContext) => MaybePromise<RateLimitStore | "memory">)
+  trustedIpHeaders?: string[]
+  window: RateLimitWindow
+}
+
+interface MemoryEntry {
+  count: number
+  resetAt: number
+}
+
+const DEFAULT_MEMORY_MAX_ENTRIES = 100_000
+
+export class RateLimitRejectedError extends Error {
+  capabilityId: string
+  decision: RateLimitDecision
+  headers: Record<string, string>
+  retryAfter: number
+
+  constructor(capabilityId: string, decision: RateLimitDecision, message?: string) {
+    super(message || "Rate limit exceeded. Try again later.")
+    this.capabilityId = capabilityId
+    this.decision = decision
+    this.headers = {
+      "retry-after": String(decision.retryAfter),
+      "x-retry-after": String(decision.retryAfter),
+    }
+    this.name = "RateLimitRejectedError"
+    this.retryAfter = decision.retryAfter
+    Object.defineProperty(this, "statusCode", {
+      enumerable: true,
+      value: 429,
+    })
+  }
+}
+
+export function memoryRateLimitStore(options: MemoryRateLimitStoreOptions = {}): MemoryRateLimitStore {
+  const entries = new Map<string, MemoryEntry>()
+  const maxEntries = Math.max(1, Math.floor(options.maxEntries ?? DEFAULT_MEMORY_MAX_ENTRIES))
+
+  function prune(now: number) {
+    for (const [key, entry] of entries) {
+      if (entry.resetAt <= now) entries.delete(key)
+    }
+    if (entries.size <= maxEntries) return
+    const overflow = entries.size - maxEntries
+    let removed = 0
+    for (const key of entries.keys()) {
+      entries.delete(key)
+      removed += 1
+      if (removed >= overflow) return
+    }
+  }
+
+  return {
+    clear() {
+      entries.clear()
+    },
+    async consume(input) {
+      prune(input.now)
+      const windowStart = Math.floor(input.now / input.windowMs) * input.windowMs
+      const resetAt = windowStart + input.windowMs
+      const current = entries.get(input.key)
+      const active = current && current.resetAt > input.now
+        ? current
+        : { count: 0, resetAt }
+      const nextCount = active.count + 1
+      if (nextCount > input.limit) {
+        return {
+          allowed: false,
+          limit: input.limit,
+          remaining: 0,
+          resetAt: active.resetAt,
+        }
+      }
+      entries.set(input.key, { count: nextCount, resetAt: active.resetAt })
+      return {
+        allowed: true,
+        limit: input.limit,
+        remaining: Math.max(0, input.limit - nextCount),
+        resetAt: active.resetAt,
+      }
+    },
+    size() {
+      return entries.size
+    },
+  }
+}
+
+function parseRateLimitWindow(value: RateLimitWindow): number {
+  const match = /^(\d+(?:\.\d+)?)(ms|s|m|h|d)$/.exec(value)
+  if (!match) {
+    throw new TypeError(`[vitehub] rateLimit({ window }) must use a unit such as "500ms", "60s", "15m", "1h", or "1d".`)
+  }
+  const amount = Number(match[1])
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new TypeError("[vitehub] rateLimit({ window }) must be greater than zero.")
+  }
+  const unit = match[2]
+  const multiplier = unit === "ms"
+    ? 1
+    : unit === "s"
+      ? 1_000
+      : unit === "m"
+        ? 60_000
+        : unit === "h"
+          ? 3_600_000
+          : 86_400_000
+  return Math.ceil(amount * multiplier)
+}
+
+function normalizeLimit(value: number): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError("[vitehub] rateLimit({ limit }) must be a positive integer.")
+  }
+  return value
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === "string" && value.length > 0)
+}
+
+function resolveChatIdentity(context: AgentCapabilityRuntimeContext): string | undefined {
+  return firstString(context.context.get("chat.identity"))
+}
+
+function resolveRunIdentity(context: AgentCapabilityRuntimeContext): string | undefined {
+  const run = context.run
+  if (!run) return
+  return firstString(
+    run.threadId && run.origin ? `${run.origin}:thread:${run.threadId}` : undefined,
+    run.threadId ? `thread:${run.threadId}` : undefined,
+    run.channelId && run.origin ? `${run.origin}:channel:${run.channelId}` : undefined,
+    run.channelId ? `channel:${run.channelId}` : undefined,
+  )
+}
+
+function forwardedFor(value: string): string | undefined {
+  const first = value.split(",")[0]?.trim()
+  return first || undefined
+}
+
+function forwardedHeader(value: string): string | undefined {
+  const first = value.split(",")[0]?.trim()
+  const match = /(?:^|;)\s*for=(?:"?\[?)([^;,"\]]+)/i.exec(first || "")
+  return match?.[1]
+}
+
+function resolveIpIdentity(context: AgentCapabilityRuntimeContext, trustedIpHeaders: string[] | undefined): string | undefined {
+  const headers = context.request?.headers
+  if (!headers || !trustedIpHeaders?.length) return
+  for (const name of trustedIpHeaders) {
+    const value = headers.get(name)
+    if (!value) continue
+    if (name.toLowerCase() === "x-forwarded-for") return forwardedFor(value)
+    if (name.toLowerCase() === "forwarded") return forwardedHeader(value)
+    return value.trim() || undefined
+  }
+}
+
+async function resolveIdentity(
+  identity: RateLimitIdentity,
+  context: AgentCapabilityRuntimeContext,
+  trustedIpHeaders: string[] | undefined,
+): Promise<{ source: string, value: string }> {
+  if (typeof identity === "function") {
+    const value = await identity(context)
+    if (value) return { source: "custom", value }
+    throw new Error("[vitehub] rateLimit({ identity }) returned no identity.")
+  }
+  if (identity === "chat") {
+    const value = resolveChatIdentity(context)
+    if (value) return { source: "chat", value }
+    throw new Error("[vitehub] rateLimit({ identity: \"chat\" }) could not resolve a Chat Identity.")
+  }
+  if (identity === "run") {
+    const value = resolveRunIdentity(context)
+    if (value) return { source: "run", value }
+    throw new Error("[vitehub] rateLimit({ identity: \"run\" }) could not resolve Agent Run metadata.")
+  }
+  if (identity === "ip") {
+    const value = resolveIpIdentity(context, trustedIpHeaders)
+    if (value) return { source: "ip", value }
+    throw new Error("[vitehub] rateLimit({ identity: \"ip\" }) requires trustedIpHeaders and a matching request header.")
+  }
+  return resolveAutoIdentity(context, trustedIpHeaders)
+}
+
+function resolveAutoIdentity(context: AgentCapabilityRuntimeContext, trustedIpHeaders: string[] | undefined): { source: string, value: string } {
+  const chat = resolveChatIdentity(context)
+  if (chat) return { source: "chat", value: chat }
+  const run = resolveRunIdentity(context)
+  if (run) return { source: "run", value: run }
+  const ip = resolveIpIdentity(context, trustedIpHeaders)
+  if (ip) return { source: "ip", value: ip }
+  return { source: "anonymous", value: "anonymous" }
+}
+
+function fallbackHash(value: string): string {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+async function hashKeyPart(value: string): Promise<string> {
+  if (globalThis.crypto?.subtle) {
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(value))
+    return Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, "0")).join("")
+  }
+  return fallbackHash(value)
+}
+
+function stableKeyPart(value: string): string {
+  return value.trim().replace(/[^a-zA-Z0-9_.:-]+/g, "-").replace(/^-+|-+$/g, "") || "default"
+}
+
+async function resolveScope(
+  scope: RateLimitOptions["scope"],
+  context: AgentCapabilityRuntimeContext,
+  id: string,
+): Promise<string> {
+  if (typeof scope === "function") return stableKeyPart(await scope(context))
+  if (typeof scope === "string") return stableKeyPart(scope)
+  return stableKeyPart(id)
+}
+
+async function resolveStore(
+  store: RateLimitOptions["store"],
+  context: AgentCapabilityRuntimeContext,
+  fallback: RateLimitStore,
+): Promise<RateLimitStore> {
+  if (!store) {
+    if (isHostedRuntime(context.runtime)) {
+      throw new Error(`[vitehub] rateLimit() requires an explicit store on hosted runtime "${context.runtime}". Use store: "memory" only for local development, tests, or single-process hosts.`)
+    }
+    return fallback
+  }
+  const resolved = typeof store === "function" ? await store(context) : store
+  if (resolved === "memory") return fallback
+  if (!resolved || typeof resolved.consume !== "function") {
+    throw new TypeError("[vitehub] rateLimit({ store }) must provide a consume() function.")
+  }
+  return resolved
+}
+
+function isHostedRuntime(runtime: string): boolean {
+  return runtime === "vercel" || runtime === "cloudflare-agents"
+}
+
+function retryAfterSeconds(resetAt: number, now: number): number {
+  return Math.max(1, Math.ceil((resetAt - now) / 1_000))
+}
+
+function resolveRejectedMessage(
+  option: RateLimitOptions["message"],
+  decision: RateLimitDecision,
+): string | undefined {
+  return typeof option === "function" ? option(decision) : option
+}
+
+export function rateLimit(
+  options: RateLimitOptions,
+): AgentCapabilityDefinition<AgentRuntimeConfig> {
+  const id = options.id || "rate-limit"
+  const limit = normalizeLimit(options.limit)
+  const windowMs = parseRateLimitWindow(options.window)
+  const fallbackStore = memoryRateLimitStore()
+  const identity = options.identity || "auto"
+  const trustedIpHeaders = options.trustedIpHeaders?.map(header => header.trim()).filter(Boolean)
+
+  return defineCapability({
+    id,
+    metadata: {
+      kind: "rate-limit",
+    },
+    configure(context) {
+      context.finish.provide(() => context.context.get(id))
+    },
+    async input(context) {
+      if (context.context.has(id)) {
+        throw new Error(`[vitehub] Invocation context value "${id}" is already set.`)
+      }
+      const now = Date.now()
+      const resolvedIdentity = await resolveIdentity(identity, context, trustedIpHeaders)
+      const scope = await resolveScope(options.scope, context, id)
+      const key = `vitehub:rate-limit:${stableKeyPart(id)}:${scope}:${await hashKeyPart(`${resolvedIdentity.source}:${resolvedIdentity.value}`)}`
+      const store = await resolveStore(options.store, context, fallbackStore)
+      const consumed = await store.consume({ key, limit, now, windowMs })
+      const decision: RateLimitDecision = {
+        allowed: consumed.allowed,
+        capabilityId: id,
+        identity: resolvedIdentity.value,
+        identitySource: resolvedIdentity.source,
+        key,
+        limit: consumed.limit,
+        remaining: Math.max(0, consumed.remaining),
+        resetAt: consumed.resetAt,
+        retryAfter: consumed.allowed ? 0 : retryAfterSeconds(consumed.resetAt, now),
+        windowMs,
+      }
+      context.context.set(id, decision)
+      if (!decision.allowed) {
+        throw new RateLimitRejectedError(id, decision, resolveRejectedMessage(options.message, decision))
+      }
+    },
+  })
+}

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -48,6 +48,12 @@ function firstString(...values: unknown[]): string | undefined {
   return values.find((value): value is string => typeof value === "string" && value.length > 0)
 }
 
+function chatIdentity(user: Record<string, unknown> | undefined, run: AgentRunMetadata | undefined): string | undefined {
+  const identity = firstString(user?.id, user?.sub, user?.email, user?.username)
+  if (!identity) return
+  return run?.origin ? `${run.origin}:${identity}` : identity
+}
+
 function uiToolName(part: Record<string, unknown>): string {
   if (part.type === "dynamic-tool") {
     return firstString(part.toolName, part.name) || "tool"
@@ -256,10 +262,12 @@ export function createChatMessageTriggerInput<TRuntimeConfig extends AgentRuntim
   }
   const selectedMessages = selectChatHistory(messages, triggerInput?.history ?? options.history, options.sessions, triggerInput?.session)
   const hookArgs = createChatTriggerHookArgs<TRuntimeConfig>(selectedMessages, triggerInput?.run, triggerInput?.session)
+  const identity = chatIdentity(triggerInput?.user, triggerInput?.run)
   return {
     hookArgs,
     input: {
       context: {
+        ...(identity ? { "chat.identity": identity } : {}),
         chat: {
           message: hookArgs.message,
           run: triggerInput?.run,

--- a/packages/agent/src/http-error.ts
+++ b/packages/agent/src/http-error.ts
@@ -17,8 +17,20 @@ export function getHttpErrorMessage(error: unknown): string {
   return error instanceof Error && error.message ? error.message : "Agent request failed."
 }
 
+function readHeaders(error: unknown): Headers | Record<string, string> | undefined {
+  if (typeof error !== "object" || error === null) return
+  const headers = (error as { headers?: unknown }).headers
+  if (headers instanceof Headers) return headers
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) return
+  const entries = Object.entries(headers).filter((entry): entry is [string, string] => typeof entry[1] === "string")
+  return entries.length ? Object.fromEntries(entries) : undefined
+}
+
 export function toHttpErrorResponse(error: unknown): Response | undefined {
   const statusCode = getHttpErrorStatusCode(error)
   if (!statusCode) return
-  return Response.json({ error: getHttpErrorMessage(error) }, { status: statusCode })
+  return Response.json({ error: getHttpErrorMessage(error) }, {
+    headers: readHeaders(error),
+    status: statusCode,
+  })
 }

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -64,6 +64,15 @@ async function readJsonBody(request: Request): Promise<AgentChatRouteBody> {
   return typeof body === "object" && body !== null ? body as AgentChatRouteBody : { messages: [] }
 }
 
+function chatAppRouteTriggerInput(body: AgentChatRouteBody): AgentChatMessageTriggerInput {
+  return {
+    ...(body.history !== undefined ? { history: body.history } : {}),
+    messages: body.messages,
+    ...(body.session !== undefined ? { session: body.session } : {}),
+    ...(body.timeout !== undefined ? { timeout: body.timeout } : {}),
+  }
+}
+
 function readableStreamFromResult(value: unknown): ReadableStream<unknown> {
   if (value instanceof ReadableStream) return value
   if (value instanceof Response && value.body) return value.body
@@ -708,8 +717,8 @@ export function defineAgentChatFetchHandler(
     }
 
     try {
-      const context = createRuntimeContext(request, body.run, await resolveRuntimeWaitUntil(handlerOptions.waitUntil))
-      const result = await streamAgentTrigger(agent as never, context, "chat.message", body, {
+      const context = createRuntimeContext(request, undefined, await resolveRuntimeWaitUntil(handlerOptions.waitUntil))
+      const result = await streamAgentTrigger(agent as never, context, "chat.message", chatAppRouteTriggerInput(body), {
         output: "ui-message-stream",
       })
       return await toUiMessageStreamResponse(readableStreamFromResult(result))

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -20,6 +20,7 @@ describe("chat message trigger input", () => {
       session: { id: "b" },
       user: { id: "user_1" },
     })
+    expect(result.input.context?.["chat.identity"]).toBe("user_1")
     expect(result.input.messages?.map(message => message.parts
       .filter((part): part is { text: string, type: "text" } => part.type === "text")
       .map(part => part.text)

--- a/packages/agent/test/rate-limit.test.ts
+++ b/packages/agent/test/rate-limit.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createMessage } from "@vite-hub/agent"
+import {
+  memoryRateLimitStore,
+  rateLimit,
+  RateLimitRejectedError,
+} from "../src/capabilities.ts"
+import { toHttpErrorResponse } from "../src/http-error.ts"
+
+import type { AgentRunMetadata, AgentRuntimeName } from "../src/index.ts"
+
+const runtime = (options: {
+  request?: Request
+  run?: AgentRunMetadata
+  runtime?: AgentRuntimeName
+} = {}) => ({
+  memo: vi.fn(),
+  ...(options.request ? { request: options.request } : {}),
+  ...(options.run ? { run: options.run } : {}),
+  runtime: options.runtime || "unknown" as const,
+  runtimeConfig: {},
+  waitUntil: vi.fn(),
+})
+
+describe("rateLimit capability", () => {
+  it("rejects before the agent run when an identity exhausts its window", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const run = vi.fn((context: { context: { get: (id: string) => unknown } }) => context.context.get("rate-limit"))
+    const agent = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: () => "user_1",
+          limit: 2,
+          window: "1m",
+        }),
+      ],
+      run,
+    })
+
+    await expect(runAgent(agent, runtime(), {
+      messages: [createMessage({ role: "user", text: "first" })],
+    })).resolves.toMatchObject({
+      allowed: true,
+      identity: "user_1",
+      limit: 2,
+      remaining: 1,
+    })
+    await expect(runAgent(agent, runtime(), {
+      messages: [createMessage({ role: "user", text: "second" })],
+    })).resolves.toMatchObject({
+      allowed: true,
+      remaining: 0,
+    })
+    await expect(runAgent(agent, runtime(), {
+      messages: [createMessage({ role: "user", text: "third" })],
+    })).rejects.toMatchObject({
+      decision: {
+        allowed: false,
+        identity: "user_1",
+        limit: 2,
+        remaining: 0,
+      },
+      name: "RateLimitRejectedError",
+      retryAfter: expect.any(Number),
+      statusCode: 429,
+    })
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it("uses trusted chat input identity when configured for chat", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: "chat",
+          limit: 1,
+          window: "1m",
+        }),
+      ],
+      run: () => "ok",
+    })
+
+    await expect(runAgent(agent, runtime(), {
+      context: { "chat.identity": "user_1" },
+    })).resolves.toBe("ok")
+    await expect(runAgent(agent, runtime(), {
+      context: { "chat.identity": "user_2" },
+    })).resolves.toBe("ok")
+    await expect(runAgent(agent, runtime(), {
+      context: { "chat.identity": "user_1" },
+    })).rejects.toBeInstanceOf(RateLimitRejectedError)
+  })
+
+  it("does not treat untrusted chat user context as Chat Identity", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: "chat",
+          limit: 1,
+          window: "1m",
+        }),
+      ],
+      run: () => "ok",
+    })
+
+    await expect(runAgent(agent, runtime(), {
+      context: { chat: { user: { id: "user_1" } } },
+    })).rejects.toThrow("could not resolve a Chat Identity")
+  })
+
+  it("resets the memory store after the fixed window elapses", async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(0)
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const store = memoryRateLimitStore()
+      const agent = defineAgent({
+        capabilities: [
+          rateLimit({
+            identity: () => "user_1",
+            limit: 1,
+            store,
+            window: "1s",
+          }),
+        ],
+        run: () => "ok",
+      })
+
+      await expect(runAgent(agent, runtime(), {})).resolves.toBe("ok")
+      await expect(runAgent(agent, runtime(), {})).rejects.toBeInstanceOf(RateLimitRejectedError)
+
+      vi.setSystemTime(1_000)
+      await expect(runAgent(agent, runtime(), {})).resolves.toBe("ok")
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("preserves retry headers on HTTP error responses", async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(0)
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const agent = defineAgent({
+        capabilities: [
+          rateLimit({
+            identity: "ip",
+            limit: 1,
+            message: decision => `Try again in ${decision.retryAfter}s.`,
+            trustedIpHeaders: ["x-forwarded-for"],
+            window: "1m",
+          }),
+        ],
+        run: () => "ok",
+      })
+      const request = new Request("https://example.com/api/agent", {
+        headers: {
+          "x-forwarded-for": "203.0.113.10",
+        },
+      })
+
+      await expect(runAgent(agent, runtime({ request }), {})).resolves.toBe("ok")
+      const error = await runAgent(agent, runtime({ request }), {}).catch(error => error)
+      const response = toHttpErrorResponse(error)
+
+      expect(response?.status).toBe(429)
+      expect(response?.headers.get("retry-after")).toBe("60")
+      expect(response?.headers.get("x-retry-after")).toBe("60")
+      await expect(response?.json()).resolves.toEqual({ error: "Try again in 60s." })
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("requires explicit trusted IP headers for IP identity", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: "ip",
+          limit: 1,
+          window: "1m",
+        }),
+      ],
+      run: () => "ok",
+    })
+
+    await expect(runAgent(agent, runtime({
+      request: new Request("https://example.com", {
+        headers: { "x-forwarded-for": "203.0.113.10" },
+      }),
+    }), {})).rejects.toThrow("requires trustedIpHeaders")
+  })
+
+  it("requires an explicit store for hosted runtimes", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const withoutStore = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: () => "user_1",
+          limit: 1,
+          window: "1m",
+        }),
+      ],
+      run: () => "ok",
+    })
+    const withMemoryOptIn = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: () => "user_1",
+          limit: 1,
+          store: "memory",
+          window: "1m",
+        }),
+      ],
+      run: () => "ok",
+    })
+
+    await expect(runAgent(withoutStore, runtime({ runtime: "vercel" }), {})).rejects.toThrow("requires an explicit store")
+    await expect(runAgent(withMemoryOptIn, runtime({ runtime: "vercel" }), {})).resolves.toBe("ok")
+  })
+
+  it("requires stable run metadata for run identity", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        rateLimit({
+          identity: "run",
+          limit: 1,
+          window: "1m",
+        }),
+      ],
+      run: () => "ok",
+    })
+
+    await expect(runAgent(agent, runtime({ run: { runId: "run_1" } }), {})).rejects.toThrow("could not resolve Agent Run metadata")
+    await expect(runAgent(agent, runtime({ run: { runId: "run_2", threadId: "thread_1" } }), {})).resolves.toBe("ok")
+  })
+})


### PR DESCRIPTION
Reintroduces `rateLimit()` as an official Agent Capability after reverting the accidental #253 merge from `main`. This version includes the review hardening from the start: Chat Identity is server-created, generated chat app routes strip client-supplied `user` and `run` identity fields, IP identity only reads developer-named trusted headers, hosted runtimes require an explicit store choice, and run identity uses stable thread/channel metadata rather than per-invocation run ids.

The capability keeps the fixed-window budget model, structured 429 rejection metadata, invocation context recording, and pluggable `RateLimitStore.consume()` contract from the original direction.

Refs #253. Supersedes #254.