### PR TITLE
fix(vercel): skip traced runtime directories

### DIFF
--- a/packages/internal/src/build/vercel-runtime-packages.ts
+++ b/packages/internal/src/build/vercel-runtime-packages.ts
@@ -116,6 +116,8 @@ async function copyTracedPackageFiles(
   for (const file of fileList) {
     const source = resolve(packageDir, file)
     if (!isInsideDirectory(packageDir, source) || hasNodeModulesSegment(file)) continue
+    const sourceStat = await stat(source)
+    if (!sourceStat.isFile()) continue
     const target = resolve(targetDir, file)
     await mkdir(dirname(target), { recursive: true })
     await copyFile(source, target)

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -285,6 +285,37 @@ describe("provider deployment outputs", () => {
     expect(existsSync(join(serverDir, "node_modules", "optional-peer", "package.json"))).toBe(false)
   })
 
+  it("ignores traced Vercel runtime package directory entries", async () => {
+    vi.resetModules()
+    vi.doMock("@vercel/nft", () => ({
+      nodeFileTrace: vi.fn(async () => ({ fileList: new Set([".", "index.js"]) })),
+    }))
+
+    try {
+      const rootDir = await createTempProject()
+      const {
+        createDefaultVercelOutputRoot,
+      } = await import("../src/build/deployment-output.ts")
+      const { copyVercelFunctionRuntimePackages } = await import("../src/build/vercel-runtime-packages.ts")
+      const outputRoot = createDefaultVercelOutputRoot(rootDir)
+      const serverDir = join(outputRoot, "functions", "__server.func")
+      await writePackage(rootDir, "runtime-with-directory-entry", {
+        exports: { ".": "./index.js" },
+      })
+      await mkdir(serverDir, { recursive: true })
+
+      await copyVercelFunctionRuntimePackages({
+        packages: [{ name: "runtime-with-directory-entry" }],
+        rootDir,
+      })
+
+      expect(existsSync(join(serverDir, "node_modules", "runtime-with-directory-entry", "index.js"))).toBe(true)
+    }
+    finally {
+      vi.doUnmock("@vercel/nft")
+    }
+  })
+
   it("skips optional Vercel function runtime packages when they are not installed", async () => {
     const rootDir = await createTempProject()
     const {


### PR DESCRIPTION
Skips non-file entries returned by `@vercel/nft` when materializing Vercel function runtime packages. This keeps pnpm directory symlinks, such as packages surfaced through dependency node_modules folders, from being passed to `copyFile` while preserving traced file copying and recursive package dependency materialization.

Adds a regression test that forces a traced directory entry so downstream Nitro/Vercel builds can rely on the ViteHub materializer instead of app-level postbuild scripts.