### PR TITLE
fix(agent): namespace instruction slots

### DIFF
--- a/.agents/adr/0001-agent-capabilities.md
+++ b/.agents/adr/0001-agent-capabilities.md
@@ -14,4 +14,4 @@ ViteHub agents will use agent-scoped Capabilities created with `defineCapability
 
 ## Consequences
 
-The first official capabilities are `skills()`, `mcp()`, `workspaceShell()`, `sandbox()`, `kv()`, `blob()`, and `db()`. Capabilities are single-instance by default, run in user-provided order, and may contribute named instruction blocks that users place with instruction slots such as `{{ skills }}`, `{{ mcp }}`, and `{{ capabilities }}`. Capability definitions keep generic structured `metadata` for runtime configuration details, but do not carry capability-level display metadata.
+The first official capabilities are `skills()`, `mcp()`, `workspaceShell()`, `sandbox()`, `kv()`, `blob()`, and `db()`. Capabilities are single-instance by default, run in user-provided order, and may contribute named instruction blocks that users place with namespaced instruction slots such as `{{ capabilities.skills }}`, `{{ capabilities.mcp }}`, and the catch-all `{{ capabilities }}`. Bare Capability ids are not instruction slots. Capability definitions keep generic structured `metadata` for runtime configuration details, but do not carry capability-level display metadata.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -281,6 +281,8 @@ _Avoid_: App middleware, model-facing counter tool, KV wrapper
 - User-defined Capabilities use the same **Capability Definition** shape as official helpers.
 - A **Capability Definition** can contribute instructions, tools, policy, and metadata.
 - A **Capability Definition** uses `id` as its only capability-level identity and display label.
+- Capability-specific instruction placement uses the `capabilities.<id>` namespace, such as `capabilities.mcp`.
+- Bare Capability ids are not instruction placement slots.
 - A **Capability** can declare **Capability Requirements**.
 - The **Capability Lifecycle** validates **Capability Requirements** as early as possible.
 - Tools are exposed through **Capability Definitions**, not through top-level Agent Definition fields.
@@ -346,6 +348,7 @@ _Avoid_: App middleware, model-facing counter tool, KV wrapper
 - Build-time Chat Platform Adapter detection was considered - resolved: resolve the **Chat Adapter Callback** at request time because platform credentials and adapter construction can depend on Server Env.
 - Repeating Chat Capability origins in `access()` was considered - resolved: **Chat Capability** owns adapter/webhook origin configuration, while **Access Capability** consumes normalized chat identity and request context for chat admission.
 - Capability phases, contexts, hooks, and instruction slots were considered glossary terms - resolved: group that detail under **Capability Lifecycle** unless a feature needs a sharper term.
+- Bare Capability id instruction slots such as `mcp` were considered - resolved: use `capabilities.<id>` without backwards compatibility aliases.
 - Chat History was considered as a standalone Capability - resolved: keep Chat History inside the **Chat Capability** for this stack and revisit during a future Agent Memory pass.
 - Agent Memory was considered dependent on the Chat Capability - resolved: stack Agent Memory directly on the capability runtime because memory and chat are separate Capability concerns.
 - Workspace inspection was considered a hand-written raw tool contribution or Bash concern - resolved: expose it through a **Workspace Capability**.

--- a/.agents/contexts/workspace/CONTEXT.md
+++ b/.agents/contexts/workspace/CONTEXT.md
@@ -124,14 +124,15 @@ _Avoid_: Open workspace, sandbox, mount
 - A **Workspace** has zero or more **Sources**.
 - A **Workspace** declares Sources through one **Source Map**.
 - A **Source Namespace** contains local, inline, tree, and provider Source helpers.
+- A **Source Map** key is ordinary Source identity; a key such as `instructions` does not make Source content into Agent instructions.
 - A **Source** may have **Source Instructions**.
 - **Source Instructions** are static strings or string arrays on a Source declaration.
 - **Source Instructions** are explicit developer-authored Source configuration, not inferred provider metadata.
 - **Source Instructions** guide Agent behavior, but they do not grant access to hidden Sources or change Workspace Scope.
 - An Agent should receive **Source Instructions** only for Sources visible through the **Selected Workspace Scope**.
 - If any visible Source has **Source Instructions**, the Agent should receive them by default at the end of its instructions unless the **Agent Definition** explicitly places the source guidance.
-- If an **Agent Definition** places Source guidance but no visible Source has **Source Instructions**, the placement should render as empty instructions.
-- Explicit Source Instruction placement renders the complete generated Source guidance block, including its heading.
+- If an **Agent Definition** places `workspace.sources` but no visible Source has **Source Instructions**, the placement should render as empty instructions.
+- Explicit Source Instruction placement uses `workspace.sources` and renders the complete generated Source guidance block, including its heading.
 - The generated Source guidance block should render each Source under a Source Map key heading and should not add generated descriptions or Mount summaries when the Source already has **Source Instructions**.
 - Sources without **Source Instructions** should be omitted from the generated Source guidance block.
 - A **Colocated Workspace Definition** has a **Workspace Source Root**.
@@ -201,6 +202,8 @@ _Avoid_: Open workspace, sandbox, mount
 - Live Source search was considered mandatory - resolved: search is optional, and any search hit must resolve to a readable Source-Backed Path.
 - "mount" was considered as the name for `workspace.sources` - resolved: **Mount** is only the placement of a Source inside the Workspace.
 - `workspace.sources` was considered as an array for simple one-off Sources - resolved: use a **Source Map** so every Source has stable identity.
+- A Source Map key named `instructions` was considered as a special prompt signal - resolved: keep it an ordinary Source key and use explicit **Source Instructions** for model-facing guidance.
+- A broad `workspace` instruction placement slot was considered for **Source Instructions** - resolved: use `workspace.sources` so Source guidance is precise and does not imply all Workspace behavior.
 - Agent `workspace: { ... }` shorthand was considered as Agent-owned configuration - resolved: treat it as a **Colocated Workspace Definition**.
 - Sibling files next to a **Colocated Workspace Definition** were considered for automatic ingestion - resolved: require explicit **Sources** instead.
 - Single-file Source root mounting was considered equivalent to tree Source root mounting - resolved: **Single-File Source** can use basename-at-root defaults because it contributes one build-time materialized file.

--- a/docs/content/blog/build-ai-chatbot.md
+++ b/docs/content/blog/build-ai-chatbot.md
@@ -110,7 +110,7 @@ export default defineAgent({
   ],
   instructions: [
     'Answer support requests from the connected workspace.',
-    '{{ sources }}',
+    '{{ workspace.sources }}',
     '{{ capabilities }}',
   ].join('\n\n'),
   model: gateway('openai/gpt-5.1-mini'),
@@ -182,8 +182,8 @@ export default defineAgent({
   adapter: 'ai-sdk',
   instructions: [
     'Answer support requests from the connected workspace.',
+    '{{ capabilities.tickets }}',
     '{{ capabilities }}',
-    '{{ tickets }}',
   ].join('\n\n'),
   capabilities: [
     workspaceShell({ mode: 'read' }),

--- a/docs/content/docs/agents/capabilities/custom-capabilities.md
+++ b/docs/content/docs/agents/capabilities/custom-capabilities.md
@@ -40,7 +40,7 @@ import { tickets } from './capabilities/tickets'
 export default defineAgent({
   instructions: [
     'Triage support requests.',
-    '{{ tickets }}',
+    '{{ capabilities.tickets }}',
   ].join('\n\n'),
   capabilities: [
     tickets(),

--- a/docs/content/docs/agents/instructions.md
+++ b/docs/content/docs/agents/instructions.md
@@ -24,13 +24,13 @@ Do not document tool syntax in instructions when a Capability can expose that sy
 
 ## Capability slots
 
-Capabilities may contribute named instruction blocks.
+Capabilities may contribute named instruction blocks. Place one Capability with `{{ capabilities.<id> }}`, or place every remaining Capability block with `{{ capabilities }}`.
 
 ```ts
 export default defineAgent({
   instructions: [
     'Answer from source files first.',
-    '{{ workspace }}',
+    '{{ workspace.sources }}',
     '{{ capabilities }}',
   ].join('\n\n'),
   capabilities: [

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -41,7 +41,7 @@ export default defineAgent({
 
 Sources can include Source Instructions. They are static developer-authored guidance for how the agent should use that source; ViteHub does not infer them from provider metadata.
 
-When at least one visible source has instructions, ViteHub renders a `## Workspace Sources` block into the model instructions. Put `{{ sources }}` where that block belongs, or omit the slot and ViteHub appends it at the end. If the slot is present but no visible source has instructions, the slot is replaced with an empty string.
+When at least one visible source has instructions, ViteHub renders a `## Workspace Sources` block into the model instructions. Put `{{ workspace.sources }}` where that block belongs, or omit the slot and ViteHub appends it at the end. If the slot is present but no visible source has instructions, the slot is replaced with an empty string.
 
 Only visible sources render. When `access()` selects a Workspace Scope, hidden or scoped-out source instructions are omitted along with the hidden files.
 
@@ -159,7 +159,7 @@ export default defineAgent({
   ],
   instructions: [
     'Answer from the scoped customer workspace.',
-    '{{ sources }}',
+    '{{ workspace.sources }}',
   ],
   model: gateway('openai/gpt-5.1-mini'),
 })

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -35,7 +35,7 @@ export default defineAgent({
   model: gateway("openai/gpt-5.1-mini"),
   instructions: [
     "Answer support questions from the workspace.",
-    "{{ sources }}",
+    "{{ workspace.sources }}",
   ],
   capabilities: [chat(), workspaceShell()],
   workspace: {

--- a/packages/agent/src/capabilities/audience.ts
+++ b/packages/agent/src/capabilities/audience.ts
@@ -56,10 +56,7 @@ export function audience<
       const instructions = typeof options.instructions === "function"
         ? await options.instructions({ ...context, profile } as AgentCapabilityRuntimeContext<TRuntimeConfig, Name> & { profile: TProfile })
         : options.instructions
-      context.instructions.add(instructions, {
-        ...(id === "audience" ? {} : { aliases: ["audience"] }),
-        id,
-      })
+      context.instructions.add(instructions, { id })
     },
   })
 }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -166,7 +166,7 @@ function addInstructionBlock(
   capabilityInstructions: AgentInstructionBlock[],
   capabilityId: string,
   value: AgentAdapterInstructionsValue | false | undefined,
-  options?: { aliases?: string[], id?: string },
+  options?: { id?: string },
 ) {
   if (value === false || value === undefined) return
   const instructions = (Array.isArray(value) ? value : [value])
@@ -175,8 +175,7 @@ function addInstructionBlock(
     .join("\n\n")
   if (instructions) {
     capabilityInstructions.push({
-      ...(options?.aliases?.length ? { aliases: options.aliases } : {}),
-      id: options?.id || capabilityId,
+      id: `capabilities.${options?.id || capabilityId}`,
       instructions,
     })
   }
@@ -473,7 +472,7 @@ export function applyCapabilityInstructionSlots(instructions: string, blocks: Ag
       return remaining.splice(0).map(block => block.instructions).join("\n\n")
     }
 
-    const selected = blocks.filter(block => instructionBlockMatchesSlot(block, slot))
+    const selected = blocks.filter(block => block.id === slot)
     if (!selected.length) {
       return match
     }
@@ -493,10 +492,6 @@ export function applyCapabilityInstructionSlots(instructions: string, blocks: Ag
 
   const appendix = remaining.map(block => block.instructions).join("\n\n")
   return [rendered.trim(), appendix.trim()].filter(Boolean).join("\n\n")
-}
-
-function instructionBlockMatchesSlot(block: AgentInstructionBlock, slot: string): boolean {
-  return block.id === slot || !!block.aliases?.includes(slot)
 }
 
 export async function applyCapabilityToolTransforms(

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -264,7 +264,6 @@ export type AgentCapabilityPhase = "configure" | "prepare" | "bind" | "input" | 
 export type AgentCapabilityHookName = `capability:${AgentCapabilityPhase}` | `capability:${AgentCapabilityPhase}:after`
 
 export interface AgentInstructionBlock {
-  aliases?: string[]
   id: string
   instructions: string
 }
@@ -297,7 +296,7 @@ export interface AgentCapabilityRuntimeContext<
 > extends AgentCapabilityContext<TRuntimeConfig, Name> {
   capability: AgentCapabilityDefinition<TRuntimeConfig, Name>
   instructions: {
-    add: (instructions: AgentAdapterInstructionsValue | false | undefined, options?: { aliases?: string[], id?: string }) => void
+    add: (instructions: AgentAdapterInstructionsValue | false | undefined, options?: { id?: string }) => void
   }
   input: {
     get: () => AgentRunInput

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -506,7 +506,7 @@ export async function resolveWorkspaceSourceInstructionBlock(
   return renderWorkspaceSourceInstructionBlock(sources, visible)
 }
 
-const sourceInstructionSlotPattern = /\{\{\s*sources\s*\}\}/g
+const sourceInstructionSlotPattern = /\{\{\s*workspace\.sources\s*\}\}/g
 
 export function applyWorkspaceSourceInstructionSlot(instructions: string, sourceInstructions: string | undefined): string {
   const sourceBlock = sourceInstructions?.trim()
@@ -523,7 +523,7 @@ export function applyWorkspaceSourceInstructionSlot(instructions: string, source
 }
 
 function applyWorkspaceSourceInstructionsToParts(parts: string[], sourceInstructions: string | undefined): string[] {
-  const hasSourceSlot = parts.some(part => /\{\{\s*sources\s*\}\}/.test(part))
+  const hasSourceSlot = parts.some(part => /\{\{\s*workspace\.sources\s*\}\}/.test(part))
   if (!hasSourceSlot && !sourceInstructions?.trim()) return parts
   const instructions = applyWorkspaceSourceInstructionSlot(parts.join("\n\n"), sourceInstructions)
   return instructions ? [instructions] : []

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -242,7 +242,7 @@ describe("access capability", () => {
     expect(profileResolver).toHaveBeenCalledOnce()
     await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(true)
     await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(false)
-    expect(applyCapabilityInstructionSlots("{{ audience }}", resolved.capabilityInstructions)).toBe("Prefer product-level support answers.")
+    expect(applyCapabilityInstructionSlots("{{ capabilities.audience }}", resolved.capabilityInstructions)).toBe("Prefer product-level support answers.")
   })
 
   it("can resolve an inline Workspace Scope definition", async () => {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -99,8 +99,9 @@ describe("agent capability runtime", () => {
     expect(resolved.messages.map(message => message.parts[0])).toEqual([
       expect.objectContaining({ text: "rewritten" }),
     ])
-    expect(applyCapabilityInstructionSlots("Base\n{{ skills }}", resolved.capabilityInstructions)).toBe("Base\nSkill instructions.")
-    expect(applyCapabilityInstructionSlots("Base {{ user_name }}\n{{ skills }}", resolved.capabilityInstructions)).toBe("Base {{ user_name }}\nSkill instructions.")
+    expect(resolved.capabilityInstructions.map(block => block.id)).toEqual(["capabilities.skills"])
+    expect(applyCapabilityInstructionSlots("Base\n{{ capabilities.skills }}", resolved.capabilityInstructions)).toBe("Base\nSkill instructions.")
+    expect(applyCapabilityInstructionSlots("Base {{ user_name }}\n{{ capabilities.skills }}", resolved.capabilityInstructions)).toBe("Base {{ user_name }}\nSkill instructions.")
     await expect(applyCapabilityToolTransforms(resolved.tools, resolved.toolTransforms)).resolves.toEqual({
       added: { name: "added" },
       original: { name: "original" },

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -277,7 +277,7 @@ describe("agent chat capability discovery", () => {
         }),
         chat(),
       ],
-      instructions: "# Support\n\n{{ audience }}",
+      instructions: "# Support\n\n{{ capabilities.support-audience }}",
       workspace: {},
       run: (context: { input: { context?: { chat?: { run?: { origin?: string } } } }, workspace?: unknown }) => `answered through ${context.input.context?.chat?.run?.origin} with ${context.workspace ? "workspace" : "no workspace"}`,
     }), { workspace: "support" })

--- a/packages/agent/test/memory.test.ts
+++ b/packages/agent/test/memory.test.ts
@@ -110,7 +110,7 @@ describe("agent memory capability", () => {
       ],
     }, { ...runtime(), runtimeConfig: {} }, {})
 
-    const preload = capabilities.capabilityInstructions.find(block => block.id === "memory.agent")
+    const preload = capabilities.capabilityInstructions.find(block => block.id === "capabilities.memory.agent")
     expect(preload?.instructions).toContain("New workflow.")
     expect(preload?.instructions).not.toContain("Old workflow.")
   })

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -356,7 +356,7 @@ describe("defineAgent workspace option", () => {
     ].join("\n\n"))
   })
 
-  it("places source instructions in the sources slot", async () => {
+  it("places source instructions in the workspace sources slot", async () => {
     const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
 
     const agent = withWorkspaceAgentDefaults(defineAgent({
@@ -373,7 +373,7 @@ describe("defineAgent workspace option", () => {
       },
       instructions: [
         "Answer from the workspace.",
-        "{{ sources }}",
+        "{{ workspace.sources }}",
         "Keep replies short.",
       ],
       model: {} as never,
@@ -389,7 +389,7 @@ describe("defineAgent workspace option", () => {
     ].join("\n\n"))
   })
 
-  it("replaces the sources slot with empty instructions when no source instructions are visible", async () => {
+  it("replaces the workspace sources slot with empty instructions when no source instructions are visible", async () => {
     const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
 
     const agent = withWorkspaceAgentDefaults(defineAgent({
@@ -400,7 +400,7 @@ describe("defineAgent workspace option", () => {
       },
       instructions: [
         "Answer from the workspace.",
-        "{{ sources }}",
+        "{{ workspace.sources }}",
         "Keep replies short.",
       ],
       model: {} as never,
@@ -1217,7 +1217,7 @@ describe("defineAgent workspace option", () => {
   it("renders capability instruction slots in resolved DevTools metadata", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
     const readInstructions = vi.fn(async ({ fs }) => await fs.readFile("AGENTS.md"))
-    readFile.mockResolvedValue("# Workspace instructions\n\n{{ audience }}\n")
+    readFile.mockResolvedValue("# Workspace instructions\n\n{{ capabilities.audience }}\n")
     list.mockResolvedValue([{ path: "AGENTS.md", type: "file" }])
     const agent = withWorkspaceAgentDefaults(defineAgent({
       workspace: {},


### PR DESCRIPTION
Namespaces model instruction placement so capability-owned blocks use `capabilities.<id>` and Workspace Source Instructions use `workspace.sources`. Bare capability-id slots are removed instead of kept as compatibility aliases, and source-map keys such as `instructions` remain ordinary source identity.

Updates the agent runtime, Source Instruction slot handling, focused tests, docs, and `.agents` domain records so future work follows the same primitive boundary.