### PR TITLE
docs: record agent architecture decisions

### DIFF
--- a/.agents/adr/0038-cloudflare-first-agent-state-provider.md
+++ b/.agents/adr/0038-cloudflare-first-agent-state-provider.md
@@ -1,0 +1,12 @@
+# Cloudflare-First Agent State Provider
+
+ViteHub will design Agent State Provider as a provider-neutral runtime contract, but the first durable implementation may be Cloudflare-first because the immediate production failure is in Cloudflare-hosted Chat Webhook Autowiring. This keeps the API shaped for future providers while allowing the first implementation to replace the current community chat state backend with a built-in durable path.
+
+## Considered Options
+
+- Wrapping the current Chat SDK state adapter shape directly was rejected as the public design center because it would make Chat History the boundary instead of Agent-owned runtime state.
+- Waiting for every provider before shipping durable Agent state was rejected because hosted Chat History and invocation coordination need a reliable first-party production path now.
+
+## Consequences
+
+Cloudflare-specific storage, binding, and coordination details should stay behind Provider Selection and Provider Output. The public Agent State Provider contract must remain suitable for later Vercel, local, database-backed, or other hosted implementations.

--- a/.agents/adr/0039-named-dependency-catalog-taxonomy.md
+++ b/.agents/adr/0039-named-dependency-catalog-taxonomy.md
@@ -1,0 +1,13 @@
+# Named Dependency Catalog Taxonomy
+
+External dependency versions in package manifests should use named pnpm catalogs rather than direct versions or the unnamed `catalog:` namespace. Catalog names should primarily follow package families or clear ownership boundaries, such as `unjs`, `vite`, `nuxt`, `storage`, `database`, `workflow`, `workspace`, `sandbox`, `vercel`, `ai`, and `chat`, while shared development dependencies can live under `tooling`.
+
+## Considered Options
+
+- Broad abstract buckets such as `backend`, `frontend`, `build`, `test`, and `types` were rejected because they hide why a package belongs there and make future additions depend on fuzzy categories.
+- One-package catalogs are discouraged unless they encode an intentional compatibility or version boundary, such as `nitro-compat`, `vite8-compat`, or `esbuild-v27`.
+- `capabilities` was rejected as a catalog name for AI SDK peer ranges because **Capability** is ViteHub product language for model-facing agent abilities, not dependency grouping.
+
+## Consequences
+
+Internal `@vite-hub/*` package links should stay as `workspace:*`. Future dependency changes should add external packages to an existing package-family catalog when the ownership is clear, create a new package-family catalog when a real family emerges, or use a narrowly named `*-compat` or version catalog only when the range itself is the important boundary.

--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -52,6 +52,14 @@ _Avoid_: Chat state, workflow state
 Host-provided metadata naming where an Agent Invocation came from, such as `http`, `devtools`, or a Chat Platform Adapter name.
 _Avoid_: Platform, Agent Trigger, runtime
 
+**Agent State Provider**:
+A configured backend for Agent-owned runtime state that must survive beyond one request, such as Chat History and invocation coordination.
+_Avoid_: Chat adapter state, Workflow Provider, Queue Provider, app database
+
+**Agent State Primitive**:
+A small runtime-facing Agent State Provider operation, such as value storage, list append, compare-and-set, or Lease acquisition.
+_Avoid_: Chat History API, app storage method, provider message
+
 **Chat History**:
 Ordered conversational messages for one chat interaction with an Agent.
 _Avoid_: Agent Memory, Agent Run State
@@ -82,7 +90,7 @@ _Avoid_: Public lock API, Capability
 
 **Development State Provider**:
 An in-memory or local provider used only for single-process Agent development.
-_Avoid_: Production state provider, durable coordination
+_Avoid_: Durable Agent State Provider, production coordination
 
 **Agent Usage**:
 Normalized model usage information produced by an Agent Invocation, including token counts and provider-reported usage details.
@@ -122,11 +130,16 @@ _Avoid_: Fake agent, dummy model, test bot
 - Workspace Tools are derived from an Agent's Colocated Workspace Definition.
 - An **Agent Invocation** can create or update **Agent Run State**.
 - An **Agent Run Origin** is observability metadata for an **Agent Invocation**; it is not the **Agent Trigger** that prepared the invocation.
+- An **Agent State Provider** stores Agent-owned runtime state across requests.
+- An **Agent State Provider** is runtime-facing and does not expose model-facing tools or arbitrary app data storage.
+- An **Agent State Provider** exposes **Agent State Primitives** rather than product-shaped stores such as `chatHistory`, `invocationRuns`, or `dedupe`.
+- Agent Package and Capability behavior build named state services on top of **Agent State Primitives**.
+- Agent State Provider selection should fail at build time when hosted production requires durable state and no durable provider can be inferred or configured.
 - **Chat History** is conversation-scoped and is not **Agent Memory**.
 - A **Chat Session** is part of Chat History behavior and is not **Agent Memory**.
 - The Chat Capability resolves the active **Chat Session** before applying the **Chat History Window**.
 - A **Chat History Window** is configured by the Agent Definition when the application wants bounded Chat History.
-- The Chat Capability can require state for **Chat History** through the Agent State Provider.
+- The Chat Capability can require state for **Chat History** through an **Agent State Provider**.
 - The Chat Capability can produce **Chat Identity** before later Capabilities resolve.
 - **Chat Identity** is available through Agent Invocation Context Values and is not model-facing by default.
 - Chat History is explicit application behavior and is not enabled by default.
@@ -134,8 +147,8 @@ _Avoid_: Fake agent, dummy model, test bot
 - **Agent Invocation Context Values** do not grant Capabilities dynamically.
 - **Agent Invocation Context Value** ids must be unique per Agent so every invocation has one writer per context value.
 - **Agent Memory** can outlive one conversation.
-- A **Concurrent Invocation Guard** protects **Agent Run State**.
-- A **Development State Provider** is not acceptable for hosted production runtimes.
+- A **Concurrent Invocation Guard** protects **Agent Run State** through a Runtime Package **Lease**, not a public lock API.
+- A **Development State Provider** is not acceptable where hosted production needs durable Chat History or a **Concurrent Invocation Guard**.
 - **Agent Usage** belongs to one **Agent Invocation**.
 - **Agent Usage Telemetry** observes **Agent Usage Records**.
 - **Agent Usage Telemetry** can expose an **Agent Usage Record** as an **Agent Invocation Extension**.

--- a/.agents/contexts/framework-integrations/CONTEXT.md
+++ b/.agents/contexts/framework-integrations/CONTEXT.md
@@ -56,6 +56,14 @@ _Avoid_: User options, provider output
 An Integration Option that chooses the provider used for generated output, bindings, imports, or deployment behavior.
 _Avoid_: Invocation option, runtime helper option
 
+**Build-Time Diagnostic**:
+A framework integration error emitted before deployment when ViteHub can prove configuration, discovery, provider selection, or provider output is invalid.
+_Avoid_: Runtime guard, warning, linter rule
+
+**Runtime Diagnostic**:
+A runtime error emitted when ViteHub can only prove the invalid state from runtime facts such as request input, deployed bindings, or provider environment.
+_Avoid_: Build validation, deploy check, generic exception
+
 **Runtime Helper**:
 A runtime API used by application code to call, inspect, or use a configured ViteHub primitive.
 _Avoid_: Composable, Vite plugin, Nitro module
@@ -94,6 +102,8 @@ _Avoid_: Virtual module path, generated file path, framework import path
 - First-class discovered definition files use a **Discovered Definition Export**.
 - A direct default-exported **Definition Boundary Helper** is the only source shape eligible for Build-Extracted Definition Options.
 - **Provider Selection** belongs in Integration Options when it changes generated output, bindings, imports, or deployment behavior.
+- Prefer a **Build-Time Diagnostic** whenever Integration Options, Definition Options, discovered Definitions, hosting detection, or Provider Output make an invalid state knowable before deployment.
+- Use a **Runtime Diagnostic** only for invalid states that depend on runtime-only facts.
 - Options should live as late as possible unless static analysis, type generation, provider binding, generated files, or deployment output require earlier placement.
 - A **Stable ViteHub Import Path** can resolve to a Runtime Registry, Provider Output, virtual module, or generated file.
 - Application code should import generated or integration-backed ViteHub surfaces through **Stable ViteHub Import Paths** unless an ADR makes another import path public.


### PR DESCRIPTION
Records the remaining agent architecture decision notes and framework integration context that still live on the agent-state-provider docs branch.