### PR TITLE
fix(schedule): alias definition imports in provider output

### DIFF
--- a/packages/internal/src/build/esbuild.ts
+++ b/packages/internal/src/build/esbuild.ts
@@ -1,4 +1,4 @@
-import { build as bundle } from "esbuild"
+import { build as bundle, type Plugin } from "esbuild"
 
 interface BundleEsmEntryOptions {
   alias?: Record<string, string>
@@ -6,6 +6,7 @@ interface BundleEsmEntryOptions {
   external?: string[]
   format?: "esm" | "cjs"
   platform?: "browser" | "node" | "neutral"
+  plugins?: Plugin[]
 }
 
 export async function bundleEsmEntry(
@@ -31,6 +32,7 @@ export async function bundleEsmEntry(
     logLevel: "silent",
     outfile,
     platform,
+    plugins: options.plugins,
     sourcemap: false,
     target: "es2022",
     write: true,

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -26,7 +26,6 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
-    "./definition": "./dist/definition.js",
     "./runtime": "./dist/runtime.js",
     "./runtime/state": "./dist/runtime/state.js",
     "./runtime/static": "./dist/runtime/static.js",

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -26,6 +26,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./definition": "./dist/definition.js",
     "./runtime": "./dist/runtime.js",
     "./runtime/state": "./dist/runtime/state.js",
     "./runtime/static": "./dist/runtime/static.js",

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -13,6 +13,7 @@ import { createRuntimeRegistryContents } from "@vite-hub/internal/definition-cat
 import { discoverScheduleDefinitions } from "../discovery.ts"
 import { getVercelSchedulePath } from "../integrations/vercel.ts"
 
+import type { Plugin } from "esbuild"
 import type { DiscoveredScheduleDefinition } from "../types.ts"
 
 export const schedulePackageName = "@vite-hub/schedule"
@@ -33,7 +34,22 @@ export function resolveScheduleRuntimeEntry(metaUrl = import.meta.url) {
     : resolve(dirname(file), "dist/runtime/static.js")
 }
 
+export function resolveScheduleDefinitionEntry(metaUrl = import.meta.url) {
+  const file = fileURLToPath(metaUrl)
+  const normalizedFile = file.replace(/\\/g, "/")
+  if (normalizedFile.endsWith("/src/internal/provider-output.ts")) {
+    return resolve(dirname(file), "../definition.ts")
+  }
+  if (normalizedFile.endsWith("/dist/internal/provider-output.js")) {
+    return resolve(dirname(file), "../definition.js")
+  }
+  return normalizedFile.includes("/dist/")
+    ? resolve(dirname(file), "definition.js")
+    : resolve(dirname(file), "dist/definition.js")
+}
+
 const scheduleRuntimeEntry = resolveScheduleRuntimeEntry()
+const scheduleDefinitionEntry = resolveScheduleDefinitionEntry()
 
 interface GeneratedScheduleArtifacts {
   cloudflareWorkerFile: string
@@ -469,6 +485,17 @@ function renderProviderEntry(file: string, registryFile: string, provider: "clou
   ].join("\n")
 }
 
+function createScheduleDefinitionAliasPlugin(): Plugin {
+  return {
+    name: "vitehub-schedule-definition-alias",
+    setup(build) {
+      build.onResolve({ filter: /^@vite-hub\/schedule(?:\/definition)?$/ }, () => ({
+        path: scheduleDefinitionEntry,
+      }))
+    },
+  }
+}
+
 async function writeProviderEntries(rootDir: string): Promise<GeneratedScheduleArtifacts> {
   const generatedDir = ensureGeneratedDir(rootDir, productName)
   await mkdir(generatedDir, { recursive: true })
@@ -521,7 +548,12 @@ export async function writeVercelScheduleFunctions(options: {
     const wrapperFile = resolve(functionDir, "index.source.mjs")
     await mkdir(functionDir, { recursive: true })
     await writeFile(wrapperFile, renderProviderEntry(wrapperFile, options.registryFile, "vercel", definition.name), "utf8")
-    await bundleEsmEntry(wrapperFile, functionFile, { alias: options.bundleAlias, format: "esm", platform: "node" })
+    await bundleEsmEntry(wrapperFile, functionFile, {
+      alias: options.bundleAlias,
+      format: "esm",
+      platform: "node",
+      plugins: [createScheduleDefinitionAliasPlugin()],
+    })
     await rm(wrapperFile, { force: true })
     await writeFile(resolve(functionDir, ".vc-config.json"), `${JSON.stringify(createNodeFunctionConfig(), null, 2)}\n`, "utf8")
   }
@@ -585,6 +617,7 @@ async function writeCloudflareScheduleOutput(options: {
       conditions: ["workerd", "worker", "browser", "default"],
       format: "esm",
       platform: "neutral",
+      plugins: [createScheduleDefinitionAliasPlugin()],
     }),
     writeFile(configFile, `${JSON.stringify(wranglerConfig, null, 2)}\n`, "utf8"),
   ])

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -489,7 +489,7 @@ function createScheduleDefinitionAliasPlugin(): Plugin {
   return {
     name: "vitehub-schedule-definition-alias",
     setup(build) {
-      build.onResolve({ filter: /^@vite-hub\/schedule(?:\/definition)?$/ }, () => ({
+      build.onResolve({ filter: /^@vite-hub\/schedule$/ }, () => ({
         path: scheduleDefinitionEntry,
       }))
     },

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -40,6 +40,12 @@ describe("schedule provider output", () => {
     expect(output).not.toContain("esbuildCommandAndArgs")
   })
 
+  it("keeps the definition entry out of public package exports", async () => {
+    const packageJson = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")) as { exports: Record<string, unknown> }
+
+    expect(packageJson.exports).not.toHaveProperty("./definition")
+  })
+
   it("emits Cloudflare and Vercel schedule provider wake output", async () => {
     const rootDir = await createTempProject("vitehub-schedule-output-")
 
@@ -61,25 +67,6 @@ describe("schedule provider output", () => {
       schedule: "0 0 * * *",
     }])
     expect(await readFile(vercelFunction, "utf8")).toContain("executeStaticSchedule")
-  })
-
-  it("bundles schedule definitions imported from root and definition subpaths", async () => {
-    const rootDir = await createTempProject("vitehub-schedule-definition-subpath-")
-    await writeFile(join(rootDir, "src", "reports.schedule.ts"), [
-      "import { defineSchedule } from '@vite-hub/schedule/definition'",
-      "",
-      "export default defineSchedule({ cron: '0 1 * * *', handler: () => 'reports' })",
-      "",
-    ].join("\n"), "utf8")
-
-    await generateProviderOutputs({
-      clientOutDir: "dist/client",
-      rootDir,
-    })
-
-    const cloudflareWorker = await readFile(join(createDefaultCloudflareOutputRoot(rootDir), "index.js"), "utf8")
-    expect(cloudflareWorker).toContain("\"cleanup\"")
-    expect(cloudflareWorker).toContain("\"reports\"")
   })
 
   it("preserves existing provider output files when adding schedule output", async () => {

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url"
 import { afterAll, describe, expect, it } from "vitest"
 import { createDefaultCloudflareOutputRoot } from "@vite-hub/internal/build/deployment-output"
 
-import { generateProviderOutputs, resolveScheduleRuntimeEntry, validateProviderCron, writeVercelScheduleFunctions } from "../src/internal/provider-output.ts"
+import { generateProviderOutputs, resolveScheduleDefinitionEntry, resolveScheduleRuntimeEntry, validateProviderCron, writeVercelScheduleFunctions } from "../src/internal/provider-output.ts"
 
 const tempDirs: string[] = []
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)))
@@ -18,6 +18,8 @@ async function createTempProject(prefix: string) {
   await mkdir(join(rootDir, "src"), { recursive: true })
   await mkdir(join(rootDir, "dist", "client"), { recursive: true })
   await writeFile(join(rootDir, "src", "cleanup.schedule.ts"), [
+    "import { defineSchedule } from '@vite-hub/schedule'",
+    "",
     "export default defineSchedule({ cron: '0 0 * * *', handler: () => 'ok' })",
     "",
   ].join("\n"), "utf8")
@@ -61,6 +63,25 @@ describe("schedule provider output", () => {
     expect(await readFile(vercelFunction, "utf8")).toContain("executeStaticSchedule")
   })
 
+  it("bundles schedule definitions imported from root and definition subpaths", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-definition-subpath-")
+    await writeFile(join(rootDir, "src", "reports.schedule.ts"), [
+      "import { defineSchedule } from '@vite-hub/schedule/definition'",
+      "",
+      "export default defineSchedule({ cron: '0 1 * * *', handler: () => 'reports' })",
+      "",
+    ].join("\n"), "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    const cloudflareWorker = await readFile(join(createDefaultCloudflareOutputRoot(rootDir), "index.js"), "utf8")
+    expect(cloudflareWorker).toContain("\"cleanup\"")
+    expect(cloudflareWorker).toContain("\"reports\"")
+  })
+
   it("preserves existing provider output files when adding schedule output", async () => {
     const rootDir = await createTempProject("vitehub-schedule-output-preserve-")
     const cloudflareRoot = createDefaultCloudflareOutputRoot(rootDir)
@@ -97,6 +118,15 @@ describe("schedule provider output", () => {
     expect(resolveScheduleRuntimeEntry("file:///repo/packages/schedule/dist/vite.js")).toBe("/repo/packages/schedule/dist/runtime/static.js")
     expect(resolveScheduleRuntimeEntry("file:///repo/packages/schedule/vite.js")).toBe("/repo/packages/schedule/dist/runtime/static.js")
     expect(resolveScheduleRuntimeEntry("file:///home/user/src/app/node_modules/@vite-hub/schedule/dist/internal/provider-output.js")).toBe("/home/user/src/app/node_modules/@vite-hub/schedule/dist/runtime/static.js")
+  })
+
+  it("resolves the static schedule definition entry from package source and dist layouts", () => {
+    expect(resolveScheduleDefinitionEntry("file:///repo/packages/schedule/src/internal/provider-output.ts")).toBe("/repo/packages/schedule/src/definition.ts")
+    expect(resolveScheduleDefinitionEntry("file:///C:/repo/packages/schedule/src/internal/provider-output.ts")).toBe("/C:/repo/packages/schedule/src/definition.ts")
+    expect(resolveScheduleDefinitionEntry("file:///repo/packages/schedule/dist/internal/provider-output.js")).toBe("/repo/packages/schedule/dist/definition.js")
+    expect(resolveScheduleDefinitionEntry("file:///repo/packages/schedule/dist/vite.js")).toBe("/repo/packages/schedule/dist/definition.js")
+    expect(resolveScheduleDefinitionEntry("file:///repo/packages/schedule/vite.js")).toBe("/repo/packages/schedule/dist/definition.js")
+    expect(resolveScheduleDefinitionEntry("file:///home/user/src/app/node_modules/@vite-hub/schedule/dist/internal/provider-output.js")).toBe("/home/user/src/app/node_modules/@vite-hub/schedule/dist/definition.js")
   })
 
   it("writes Cloudflare schedule output to an existing Wrangler main", async () => {

--- a/packages/schedule/tsdown.config.ts
+++ b/packages/schedule/tsdown.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   },
   dts: true,
   entry: [
+    "src/definition.ts",
     "src/index.ts",
     "src/runtime.ts",
     "src/runtime/state.ts",

--- a/packages/schedule/tsdown.config.ts
+++ b/packages/schedule/tsdown.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
     "src/vite.ts",
   ],
   exports: {
+    customExports(exports) {
+      return Object.fromEntries(Object.entries(exports).filter(([key]) => key !== "./definition"))
+    },
     inlinedDependencies: false,
   },
   format: ["esm"],


### PR DESCRIPTION
## Summary
- alias @vite-hub/schedule to the lightweight definition entry while bundling provider output
- add provider-output coverage for schedule files that import defineSchedule from @vite-hub/schedule
- add definition-entry path resolution coverage alongside runtime-entry coverage

## Validation
- pnpm --filter @vite-hub/schedule typecheck
- pnpm --filter @vite-hub/schedule test