### PR TITLE
fix: avoid workspace shell inspection timeouts

### DIFF
--- a/.agents/adr/0043-shell-command-analysis-does-not-own-utility-semantics.md
+++ b/.agents/adr/0043-shell-command-analysis-does-not-own-utility-semantics.md
@@ -1,0 +1,9 @@
+# Shell Command Analysis Does Not Own Utility Semantics
+
+ViteHub may parse shell commands for **Command Analysis**, policy routing, scope enforcement, approval prompts, and guardrails, but Workspace inspection helpers must not implement ad hoc shell utility semantics. Shell command semantics belong inside **Shell Runtime** **Execution Providers**, or in explicitly structured **Workspace Tools** when the operation is not actually shell execution. Provider optimizations for common commands are allowed only when they are boundary-declared, compatibility-tested, and fall back to normal provider execution outside their supported subset.
+
+## Considered Options
+
+- Workspace-level `ls` and `find` fast paths were rejected because they drift into partial shell utility emulation and create recurring compatibility debt around flags, glob expansion, path display, dotfiles, malformed predicates, and shell runtime fallback.
+- Parser-backed **Command Analysis** was kept because it can produce facts for policy and routing without pretending to execute a command.
+- Provider-owned fast paths remain allowed because the **Execution Provider** is the boundary that owns command semantics and can declare its compatibility limits.

--- a/packages/shell/src/workspace/inspection.ts
+++ b/packages/shell/src/workspace/inspection.ts
@@ -228,7 +228,9 @@ function searchNoMatchFeedback(command: string, result: ShellObservation, broadS
   return ""
 }
 
-function preflightUnsupportedWorkspaceCommand(command: string, commands: string[] = []): ShellObservation | undefined {
+function preflightUnsupportedWorkspaceCommand(command: string, commands?: string[]): ShellObservation | undefined {
+  if (!commands) return undefined
+  if (usesCompoundShellSyntax(command)) return undefined
   const allowed = new Set([...commands, "cd", "false", "true"])
   for (const segment of analyzeWorkspaceInspectionCommand(command)) {
     const executable = workspaceExecutable(segment.words)
@@ -260,9 +262,39 @@ function workspaceExecutable(words: string[]) {
   }
 }
 
+function usesCompoundShellSyntax(command: string) {
+  return analyzeWorkspaceInspectionCommand(command)
+    .some(segment => isCompoundShellSyntaxWord(segment.words[0] || ""))
+}
+
+function isCompoundShellSyntaxWord(word: string) {
+  return word === "{"
+    || word.startsWith("(")
+    || /^[A-Za-z_][A-Za-z0-9_]*\(\)$/.test(word)
+    || shellSyntaxWords.has(word)
+}
+
 function isAssignmentWord(word: string) {
   return /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(word)
 }
+
+const shellSyntaxWords = new Set([
+  "case",
+  "do",
+  "done",
+  "elif",
+  "else",
+  "esac",
+  "fi",
+  "for",
+  "function",
+  "if",
+  "select",
+  "then",
+  "time",
+  "until",
+  "while",
+])
 
 function isConcreteWorkspacePath(path: string) {
   return isWorkspacePathCandidate(path) && cleanWorkspaceShellPath(path) !== ""

--- a/packages/shell/src/workspace/inspection.ts
+++ b/packages/shell/src/workspace/inspection.ts
@@ -8,7 +8,7 @@ import { cleanWorkspaceShellPath } from "./path.ts"
 
 import type { ShellObservation } from "../runtime/types.ts"
 import type { WorkspaceShellFileSystem } from "./filesystem.ts"
-import type { SearchableShellWorkspace, ShellEntry, ShellStat } from "./types.ts"
+import type { SearchableShellWorkspace } from "./types.ts"
 
 interface WorkspaceInspectionCommandOptions {
   broadSearchPaths?: string[]
@@ -20,7 +20,7 @@ interface WorkspaceInspectionCommandOptions {
 }
 
 export async function runWorkspaceInspectionCommand(
-  input: SearchableShellWorkspace,
+  _input: SearchableShellWorkspace,
   command: string,
   options: WorkspaceInspectionCommandOptions,
 ): Promise<ShellObservation> {
@@ -32,11 +32,6 @@ export async function runWorkspaceInspectionCommand(
   if (missingPath) return missingPath
   const unsupported = preflightUnsupportedWorkspaceCommand(command, options.commands)
   if (unsupported) return unsupported
-  const direct = await runDirectWorkspaceInspectionCommand(input, command, {
-    cwd: options.cwd || workspaceMountPoint,
-    maxOutputLength,
-  })
-  if (direct) return direct
   const runtime = createShellRuntime({
     policy: {
       maxOutputLength,
@@ -52,267 +47,6 @@ export async function runWorkspaceInspectionCommand(
   const noMatchFeedback = searchNoMatchFeedback(command, result, options.broadSearchPaths, options.cwd)
 
   return noMatchFeedback ? { ...result, stdout: noMatchFeedback, workspaceGuardrail: { kind: "no_match" } } : result
-}
-
-async function runDirectWorkspaceInspectionCommand(
-  input: SearchableShellWorkspace,
-  command: string,
-  options: { cwd: string, maxOutputLength: number },
-): Promise<ShellObservation | undefined> {
-  const segments = analyzeWorkspaceInspectionCommand(command)
-  if (segments.length !== 1 || segments[0]?.separatorAfter) return undefined
-  if (hasRedirect(wordsOf(segments[0]))) return undefined
-
-  const started = Date.now()
-  const words = wordsOf(segments[0])
-  const executable = workspaceExecutable(words)
-  if (!executable) return undefined
-
-  if (executable.name === "ls") {
-    const output = await directLs(input, words.slice(executable.index + 1), options.cwd)
-    return finalizeDirectObservation({
-      command,
-      cwd: options.cwd,
-      durationMs: Date.now() - started,
-      maxOutputLength: options.maxOutputLength,
-      stdout: output,
-    })
-  }
-
-  if (executable.name === "find") {
-    const output = await directFind(input, words.slice(executable.index + 1), options.cwd)
-    if (typeof output !== "string") return undefined
-    return finalizeDirectObservation({
-      command,
-      cwd: options.cwd,
-      durationMs: Date.now() - started,
-      maxOutputLength: options.maxOutputLength,
-      stdout: output,
-    })
-  }
-}
-
-function finalizeDirectObservation(input: {
-  command: string
-  cwd: string
-  durationMs: number
-  maxOutputLength: number
-  stderr?: string
-  stdout: string
-}): ShellObservation {
-  return applyOutputLimit({
-    command: input.command,
-    cwd: input.cwd,
-    durationMs: input.durationMs,
-    event: "command_finished",
-    exitCode: 0,
-    stderr: input.stderr || "",
-    stdout: input.stdout,
-  }, input.maxOutputLength)
-}
-
-function applyOutputLimit(result: ShellObservation, maxLength: number): ShellObservation {
-  const next: ShellObservation = { ...result, maxOutputLength: maxLength }
-  let truncated = false
-  if (next.stdout.length > maxLength) {
-    next.stdout = `${next.stdout.slice(0, maxLength)}\n[output truncated to ${maxLength} characters]\n`
-    truncated = true
-  }
-  if (next.stderr.length > maxLength) {
-    next.stderr = `${next.stderr.slice(0, maxLength)}\n[output truncated to ${maxLength} characters]\n`
-    truncated = true
-  }
-  return truncated ? { ...next, outputTruncated: true } : next
-}
-
-async function directLs(input: SearchableShellWorkspace, args: string[], cwd: string) {
-  const parsed = parseLsArgs(args)
-  const chunks: string[] = []
-
-  for (const [index, path] of parsed.paths.entries()) {
-    const resolved = resolveWorkspaceShellPath(cwd, path)
-    const stat = await input.stat(resolved)
-    if (parsed.paths.length > 1) {
-      if (index > 0) chunks.push("\n")
-      chunks.push(`${path}:\n`)
-    }
-    if (stat.type === "file") {
-      chunks.push(formatLsEntries([stat], {
-        all: false,
-        basePath: parentPath(stat.path),
-        long: parsed.long,
-      }))
-      continue
-    }
-    const entries = await input.list(resolved, { recursive: false })
-    chunks.push(formatLsEntries(entries, {
-      all: parsed.all,
-      basePath: resolved,
-      long: parsed.long,
-    }))
-  }
-
-  return chunks.join("")
-}
-
-function parseLsArgs(args: string[]) {
-  const paths: string[] = []
-  let all = false
-  let long = false
-
-  for (let index = 0; index < args.length; index++) {
-    const arg = args[index]!
-    if (arg === "--") {
-      paths.push(...args.slice(index + 1))
-      break
-    }
-    if (arg === "-I" || arg === "--ignore") {
-      index += 1
-      continue
-    }
-    if (arg.startsWith("--ignore=")) continue
-    if (arg.startsWith("-") && arg !== "-") {
-      all ||= arg.includes("a") || arg.includes("A")
-      long ||= arg.includes("l")
-      continue
-    }
-    paths.push(arg)
-  }
-
-  return {
-    all,
-    long,
-    paths: paths.length ? paths : ["."],
-  }
-}
-
-function formatLsEntries(entries: ShellEntry[], options: { all: boolean, basePath: string, long: boolean }) {
-  const sorted = [...entries].sort((left, right) =>
-    Number(left.type === "directory") - Number(right.type === "directory")
-    || left.path.localeCompare(right.path),
-  )
-  if (!options.long) {
-    return sorted.map(entry => lsEntryName(options.basePath, entry)).join("\n") + (sorted.length ? "\n" : "")
-  }
-
-  const rows: string[] = [`total ${sorted.length}`]
-  if (options.all) {
-    rows.push(formatLsLongEntry(".", { path: options.basePath, type: "directory" }))
-    rows.push(formatLsLongEntry("..", { path: parentPath(options.basePath), type: "directory" }))
-  }
-  rows.push(...sorted.map(entry => formatLsLongEntry(lsEntryName(options.basePath, entry), entry)))
-  return `${rows.join("\n")}\n`
-}
-
-function formatLsLongEntry(name: string, entry: ShellEntry | ShellStat) {
-  const directory = entry.type === "directory"
-  const mode = directory ? "drwxr-xr-x" : "-rw-r--r--"
-  const size = String(directory ? 0 : entry.size || 0).padStart(5)
-  return `${mode} 1 user user ${size} Jan  1  1970 ${name}${directory && name !== "." && name !== ".." ? "/" : ""}`
-}
-
-function lsEntryName(basePath: string, entry: ShellEntry | ShellStat) {
-  return basePath ? entry.path.slice(basePath.length + 1) : entry.path
-}
-
-async function directFind(input: SearchableShellWorkspace, args: string[], cwd: string): Promise<string | undefined> {
-  const parsed = parseFindArgs(args)
-  if (!parsed) return undefined
-
-  const matches: string[] = []
-  for (const path of parsed.paths) {
-    const rootPath = resolveWorkspaceShellPath(cwd, path)
-    const root = await input.stat(rootPath)
-    const entries = [root, ...await input.list(rootPath, { recursive: true })]
-    for (const entry of entries) {
-      if (!findEntryWithinDepth(rootPath, entry.path, parsed.maxDepth)) continue
-      if (parsed.type && entry.type !== parsed.type) continue
-      if (parsed.name && !globNameMatches(parsed.name, basename(entry.path))) continue
-      matches.push(entry.path || ".")
-    }
-  }
-
-  return matches.join("\n") + (matches.length ? "\n" : "")
-}
-
-function parseFindArgs(args: string[]) {
-  if (args.some(arg => arg === "-exec" || arg === "-ok" || arg === "-delete" || arg === "-print0")) return undefined
-  if (args[0] === "-H" || args[0] === "-L" || args[0] === "-P") return undefined
-
-  const paths: string[] = []
-  let index = 0
-  if (args[index] === "--") index += 1
-  while (index < args.length) {
-    const arg = args[index]!
-    if (arg.startsWith("-")) break
-    paths.push(arg)
-    index += 1
-  }
-  if (!paths.length) paths.push(".")
-
-  let maxDepth: number | undefined
-  let name: string | undefined
-  let type: "directory" | "file" | undefined
-
-  while (index < args.length) {
-    const arg = args[index]!
-    if (arg === "-name") {
-      name = args[index + 1]
-      index += 2
-      continue
-    }
-    if (arg === "-type") {
-      const value = args[index + 1]
-      if (value === "f") type = "file"
-      else if (value === "d") type = "directory"
-      else return undefined
-      index += 2
-      continue
-    }
-    if (arg === "-maxdepth") {
-      const value = Number(args[index + 1])
-      if (!Number.isInteger(value) || value < 0) return undefined
-      maxDepth = value
-      index += 2
-      continue
-    }
-    if (arg.startsWith("-maxdepth=")) {
-      const value = Number(arg.slice("-maxdepth=".length))
-      if (!Number.isInteger(value) || value < 0) return undefined
-      maxDepth = value
-      index += 1
-      continue
-    }
-    if (arg === "-print") {
-      index += 1
-      continue
-    }
-    return undefined
-  }
-
-  return { maxDepth, name, paths, type }
-}
-
-function findEntryWithinDepth(rootPath: string, entryPath: string, maxDepth: number | undefined) {
-  if (maxDepth === undefined) return true
-  if (entryPath === rootPath) return maxDepth >= 0
-  const relative = rootPath ? entryPath.slice(rootPath.length + 1) : entryPath
-  const depth = relative ? relative.split("/").length : 0
-  return depth <= maxDepth
-}
-
-function globNameMatches(pattern: string, name: string) {
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*").replace(/\?/g, ".")
-  return new RegExp(`^${escaped}$`).test(name)
-}
-
-function basename(path: string) {
-  return path.split("/").filter(Boolean).at(-1) || "."
-}
-
-function parentPath(path: string) {
-  const parent = posix.dirname(path)
-  return parent === "." ? "" : parent
 }
 
 async function preflightWorkspaceInspectionCommand(command: string, fs: WorkspaceShellFileSystem, broadSearchPaths: string[] = [], cwd = workspaceMountPoint): Promise<ShellObservation | undefined> {
@@ -528,14 +262,6 @@ function workspaceExecutable(words: string[]) {
 
 function isAssignmentWord(word: string) {
   return /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(word)
-}
-
-function wordsOf(segment: ReturnType<typeof analyzeWorkspaceInspectionCommand>[number]) {
-  return segment.words
-}
-
-function hasRedirect(words: string[]) {
-  return words.some(word => /^(?:\d*)[<>]/.test(word))
 }
 
 function isConcreteWorkspacePath(path: string) {

--- a/packages/shell/src/workspace/inspection.ts
+++ b/packages/shell/src/workspace/inspection.ts
@@ -8,7 +8,7 @@ import { cleanWorkspaceShellPath } from "./path.ts"
 
 import type { ShellObservation } from "../runtime/types.ts"
 import type { WorkspaceShellFileSystem } from "./filesystem.ts"
-import type { SearchableShellWorkspace } from "./types.ts"
+import type { SearchableShellWorkspace, ShellEntry, ShellStat } from "./types.ts"
 
 interface WorkspaceInspectionCommandOptions {
   broadSearchPaths?: string[]
@@ -20,7 +20,7 @@ interface WorkspaceInspectionCommandOptions {
 }
 
 export async function runWorkspaceInspectionCommand(
-  _input: SearchableShellWorkspace,
+  input: SearchableShellWorkspace,
   command: string,
   options: WorkspaceInspectionCommandOptions,
 ): Promise<ShellObservation> {
@@ -30,6 +30,13 @@ export async function runWorkspaceInspectionCommand(
   if (preflight) return preflight
   const missingPath = await preflightMissingWorkspacePath(command, options.fs, options.cwd)
   if (missingPath) return missingPath
+  const unsupported = preflightUnsupportedWorkspaceCommand(command, options.commands)
+  if (unsupported) return unsupported
+  const direct = await runDirectWorkspaceInspectionCommand(input, command, {
+    cwd: options.cwd || workspaceMountPoint,
+    maxOutputLength,
+  })
+  if (direct) return direct
   const runtime = createShellRuntime({
     policy: {
       maxOutputLength,
@@ -45,6 +52,267 @@ export async function runWorkspaceInspectionCommand(
   const noMatchFeedback = searchNoMatchFeedback(command, result, options.broadSearchPaths, options.cwd)
 
   return noMatchFeedback ? { ...result, stdout: noMatchFeedback, workspaceGuardrail: { kind: "no_match" } } : result
+}
+
+async function runDirectWorkspaceInspectionCommand(
+  input: SearchableShellWorkspace,
+  command: string,
+  options: { cwd: string, maxOutputLength: number },
+): Promise<ShellObservation | undefined> {
+  const segments = analyzeWorkspaceInspectionCommand(command)
+  if (segments.length !== 1 || segments[0]?.separatorAfter) return undefined
+  if (hasRedirect(wordsOf(segments[0]))) return undefined
+
+  const started = Date.now()
+  const words = wordsOf(segments[0])
+  const executable = workspaceExecutable(words)
+  if (!executable) return undefined
+
+  if (executable.name === "ls") {
+    const output = await directLs(input, words.slice(executable.index + 1), options.cwd)
+    return finalizeDirectObservation({
+      command,
+      cwd: options.cwd,
+      durationMs: Date.now() - started,
+      maxOutputLength: options.maxOutputLength,
+      stdout: output,
+    })
+  }
+
+  if (executable.name === "find") {
+    const output = await directFind(input, words.slice(executable.index + 1), options.cwd)
+    if (typeof output !== "string") return undefined
+    return finalizeDirectObservation({
+      command,
+      cwd: options.cwd,
+      durationMs: Date.now() - started,
+      maxOutputLength: options.maxOutputLength,
+      stdout: output,
+    })
+  }
+}
+
+function finalizeDirectObservation(input: {
+  command: string
+  cwd: string
+  durationMs: number
+  maxOutputLength: number
+  stderr?: string
+  stdout: string
+}): ShellObservation {
+  return applyOutputLimit({
+    command: input.command,
+    cwd: input.cwd,
+    durationMs: input.durationMs,
+    event: "command_finished",
+    exitCode: 0,
+    stderr: input.stderr || "",
+    stdout: input.stdout,
+  }, input.maxOutputLength)
+}
+
+function applyOutputLimit(result: ShellObservation, maxLength: number): ShellObservation {
+  const next: ShellObservation = { ...result, maxOutputLength: maxLength }
+  let truncated = false
+  if (next.stdout.length > maxLength) {
+    next.stdout = `${next.stdout.slice(0, maxLength)}\n[output truncated to ${maxLength} characters]\n`
+    truncated = true
+  }
+  if (next.stderr.length > maxLength) {
+    next.stderr = `${next.stderr.slice(0, maxLength)}\n[output truncated to ${maxLength} characters]\n`
+    truncated = true
+  }
+  return truncated ? { ...next, outputTruncated: true } : next
+}
+
+async function directLs(input: SearchableShellWorkspace, args: string[], cwd: string) {
+  const parsed = parseLsArgs(args)
+  const chunks: string[] = []
+
+  for (const [index, path] of parsed.paths.entries()) {
+    const resolved = resolveWorkspaceShellPath(cwd, path)
+    const stat = await input.stat(resolved)
+    if (parsed.paths.length > 1) {
+      if (index > 0) chunks.push("\n")
+      chunks.push(`${path}:\n`)
+    }
+    if (stat.type === "file") {
+      chunks.push(formatLsEntries([stat], {
+        all: false,
+        basePath: parentPath(stat.path),
+        long: parsed.long,
+      }))
+      continue
+    }
+    const entries = await input.list(resolved, { recursive: false })
+    chunks.push(formatLsEntries(entries, {
+      all: parsed.all,
+      basePath: resolved,
+      long: parsed.long,
+    }))
+  }
+
+  return chunks.join("")
+}
+
+function parseLsArgs(args: string[]) {
+  const paths: string[] = []
+  let all = false
+  let long = false
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]!
+    if (arg === "--") {
+      paths.push(...args.slice(index + 1))
+      break
+    }
+    if (arg === "-I" || arg === "--ignore") {
+      index += 1
+      continue
+    }
+    if (arg.startsWith("--ignore=")) continue
+    if (arg.startsWith("-") && arg !== "-") {
+      all ||= arg.includes("a") || arg.includes("A")
+      long ||= arg.includes("l")
+      continue
+    }
+    paths.push(arg)
+  }
+
+  return {
+    all,
+    long,
+    paths: paths.length ? paths : ["."],
+  }
+}
+
+function formatLsEntries(entries: ShellEntry[], options: { all: boolean, basePath: string, long: boolean }) {
+  const sorted = [...entries].sort((left, right) =>
+    Number(left.type === "directory") - Number(right.type === "directory")
+    || left.path.localeCompare(right.path),
+  )
+  if (!options.long) {
+    return sorted.map(entry => lsEntryName(options.basePath, entry)).join("\n") + (sorted.length ? "\n" : "")
+  }
+
+  const rows: string[] = [`total ${sorted.length}`]
+  if (options.all) {
+    rows.push(formatLsLongEntry(".", { path: options.basePath, type: "directory" }))
+    rows.push(formatLsLongEntry("..", { path: parentPath(options.basePath), type: "directory" }))
+  }
+  rows.push(...sorted.map(entry => formatLsLongEntry(lsEntryName(options.basePath, entry), entry)))
+  return `${rows.join("\n")}\n`
+}
+
+function formatLsLongEntry(name: string, entry: ShellEntry | ShellStat) {
+  const directory = entry.type === "directory"
+  const mode = directory ? "drwxr-xr-x" : "-rw-r--r--"
+  const size = String(directory ? 0 : entry.size || 0).padStart(5)
+  return `${mode} 1 user user ${size} Jan  1  1970 ${name}${directory && name !== "." && name !== ".." ? "/" : ""}`
+}
+
+function lsEntryName(basePath: string, entry: ShellEntry | ShellStat) {
+  return basePath ? entry.path.slice(basePath.length + 1) : entry.path
+}
+
+async function directFind(input: SearchableShellWorkspace, args: string[], cwd: string): Promise<string | undefined> {
+  const parsed = parseFindArgs(args)
+  if (!parsed) return undefined
+
+  const matches: string[] = []
+  for (const path of parsed.paths) {
+    const rootPath = resolveWorkspaceShellPath(cwd, path)
+    const root = await input.stat(rootPath)
+    const entries = [root, ...await input.list(rootPath, { recursive: true })]
+    for (const entry of entries) {
+      if (!findEntryWithinDepth(rootPath, entry.path, parsed.maxDepth)) continue
+      if (parsed.type && entry.type !== parsed.type) continue
+      if (parsed.name && !globNameMatches(parsed.name, basename(entry.path))) continue
+      matches.push(entry.path || ".")
+    }
+  }
+
+  return matches.join("\n") + (matches.length ? "\n" : "")
+}
+
+function parseFindArgs(args: string[]) {
+  if (args.some(arg => arg === "-exec" || arg === "-ok" || arg === "-delete" || arg === "-print0")) return undefined
+  if (args[0] === "-H" || args[0] === "-L" || args[0] === "-P") return undefined
+
+  const paths: string[] = []
+  let index = 0
+  if (args[index] === "--") index += 1
+  while (index < args.length) {
+    const arg = args[index]!
+    if (arg.startsWith("-")) break
+    paths.push(arg)
+    index += 1
+  }
+  if (!paths.length) paths.push(".")
+
+  let maxDepth: number | undefined
+  let name: string | undefined
+  let type: "directory" | "file" | undefined
+
+  while (index < args.length) {
+    const arg = args[index]!
+    if (arg === "-name") {
+      name = args[index + 1]
+      index += 2
+      continue
+    }
+    if (arg === "-type") {
+      const value = args[index + 1]
+      if (value === "f") type = "file"
+      else if (value === "d") type = "directory"
+      else return undefined
+      index += 2
+      continue
+    }
+    if (arg === "-maxdepth") {
+      const value = Number(args[index + 1])
+      if (!Number.isInteger(value) || value < 0) return undefined
+      maxDepth = value
+      index += 2
+      continue
+    }
+    if (arg.startsWith("-maxdepth=")) {
+      const value = Number(arg.slice("-maxdepth=".length))
+      if (!Number.isInteger(value) || value < 0) return undefined
+      maxDepth = value
+      index += 1
+      continue
+    }
+    if (arg === "-print") {
+      index += 1
+      continue
+    }
+    return undefined
+  }
+
+  return { maxDepth, name, paths, type }
+}
+
+function findEntryWithinDepth(rootPath: string, entryPath: string, maxDepth: number | undefined) {
+  if (maxDepth === undefined) return true
+  if (entryPath === rootPath) return maxDepth >= 0
+  const relative = rootPath ? entryPath.slice(rootPath.length + 1) : entryPath
+  const depth = relative ? relative.split("/").length : 0
+  return depth <= maxDepth
+}
+
+function globNameMatches(pattern: string, name: string) {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*").replace(/\?/g, ".")
+  return new RegExp(`^${escaped}$`).test(name)
+}
+
+function basename(path: string) {
+  return path.split("/").filter(Boolean).at(-1) || "."
+}
+
+function parentPath(path: string) {
+  const parent = posix.dirname(path)
+  return parent === "." ? "" : parent
 }
 
 async function preflightWorkspaceInspectionCommand(command: string, fs: WorkspaceShellFileSystem, broadSearchPaths: string[] = [], cwd = workspaceMountPoint): Promise<ShellObservation | undefined> {
@@ -224,6 +492,50 @@ function searchNoMatchFeedback(command: string, result: ShellObservation, broadS
     return ""
   }
   return ""
+}
+
+function preflightUnsupportedWorkspaceCommand(command: string, commands: string[] = []): ShellObservation | undefined {
+  const allowed = new Set([...commands, "cd", "false", "true"])
+  for (const segment of analyzeWorkspaceInspectionCommand(command)) {
+    const executable = workspaceExecutable(segment.words)
+    if (!executable || allowed.has(executable.name)) continue
+    return unsupportedWorkspaceCommandFeedback(command, executable.name, commands)
+  }
+}
+
+function unsupportedWorkspaceCommandFeedback(command: string, name: string, commands: string[]): ShellObservation {
+  const available = [...new Set(commands)].sort()
+  const formatted = available.length ? available.map(command => `\`${command}\``).join(", ") : "none"
+  return {
+    command,
+    event: "policy_denied",
+    exitCode: 126,
+    stderr: `[vitehub] Unsupported workspace shell command: ${name}. Available commands: ${available.join(", ") || "none"}.\n`,
+    stdout: [
+      `[vitehub] Workspace shell command is not available: ${name}`,
+      `Use only the available workspace commands: ${formatted}.`,
+      "Rewrite the command with supported workspace commands, or answer from the evidence already collected.",
+    ].join("\n") + "\n",
+  }
+}
+
+function workspaceExecutable(words: string[]) {
+  for (const [index, word] of words.entries()) {
+    if (isAssignmentWord(word)) continue
+    return { index, name: word }
+  }
+}
+
+function isAssignmentWord(word: string) {
+  return /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(word)
+}
+
+function wordsOf(segment: ReturnType<typeof analyzeWorkspaceInspectionCommand>[number]) {
+  return segment.words
+}
+
+function hasRedirect(words: string[]) {
+  return words.some(word => /^(?:\d*)[<>]/.test(word))
 }
 
 function isConcreteWorkspacePath(path: string) {

--- a/packages/shell/test/workspace-inspection.test.ts
+++ b/packages/shell/test/workspace-inspection.test.ts
@@ -11,6 +11,7 @@ import { MemoryWorkspace } from "./workspace-test-utils.ts"
 describe("@vite-hub/shell workspace inspection", () => {
   it("runs workspace inspection through the real shell runtime", async () => {
     const workspace = new MemoryWorkspace({
+      ".secret": "hidden\n",
       "README.md": "# Docs\n",
       "models/customers.sql": "select * from customers\n",
       "models/orders.sql": "select * from orders\n",
@@ -44,21 +45,56 @@ describe("@vite-hub/shell workspace inspection", () => {
       stdout: expect.stringContaining("customers.sql"),
     })
 
-    {
-      const runtimeFs = createReadonlyWorkspaceFs(workspace)
-      runtimeFs.readdirWithFileTypes = async () => {
-        throw new Error("shell runtime should not list simple workspace paths")
-      }
+    await expect(runWorkspaceInspectionCommand(workspace, "ls .", {
+      commands: ["ls"],
+      cwd: workspaceMountPoint,
+      fs,
+    })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "README.md\nmodels\n",
+    })
 
-      await expect(runWorkspaceInspectionCommand(workspace, "ls -la models", {
-        commands: ["ls"],
-        cwd: workspaceMountPoint,
-        fs: runtimeFs,
-      })).resolves.toMatchObject({
-        exitCode: 0,
-        stdout: expect.stringContaining("customers.sql"),
-      })
-    }
+    await expect(runWorkspaceInspectionCommand(workspace, "ls -a .", {
+      commands: ["ls"],
+      cwd: workspaceMountPoint,
+      fs,
+    })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: ".\n..\n.secret\nREADME.md\nmodels\n",
+    })
+
+    await expect(runWorkspaceInspectionCommand(workspace, "ls -d models", {
+      commands: ["ls"],
+      cwd: workspaceMountPoint,
+      fs,
+    })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "models\n",
+    })
+
+    await expect(runWorkspaceInspectionCommand(workspace, "ls *.md", {
+      commands: ["ls"],
+      cwd: workspaceMountPoint,
+      fs,
+    })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "README.md\n",
+    })
+
+    const slowFs = createReadonlyWorkspaceFs(workspace)
+    slowFs.readdirWithFileTypes = async () => await new Promise(() => {})
+
+    await expect(runWorkspaceInspectionCommand(workspace, "ls models", {
+      commands: ["ls"],
+      cwd: workspaceMountPoint,
+      fs: slowFs,
+      timeout: 20,
+    })).resolves.toMatchObject({
+      event: "command_timed_out",
+      exitCode: null,
+      stderr: expect.stringContaining("Workspace shell command timed out after 20ms"),
+      timedOut: true,
+    })
 
     await expect(runWorkspaceInspectionCommand(workspace, "cat", {
       commands: ["cat"],
@@ -410,21 +446,41 @@ describe("@vite-hub/shell workspace inspection", () => {
       stdout: expect.not.stringContaining("Workspace search is too broad"),
     })
 
-    {
-      const runtimeFs = createReadonlyWorkspaceFs(workspace)
-      runtimeFs.readdirWithFileTypes = async () => {
-        throw new Error("shell runtime should not find simple workspace paths")
-      }
+    await expect(runWorkspaceInspectionCommand(workspace, "find -name '*.sql'", {
+      commands: ["find"],
+      cwd: `${workspaceMountPoint}/models`,
+      fs,
+    })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "./customers.sql\n./orders.sql\n",
+    })
 
-      await expect(runWorkspaceInspectionCommand(workspace, "find models -type f -name '*.sql'", {
-        commands: ["find"],
-        cwd: workspaceMountPoint,
-        fs: runtimeFs,
-      })).resolves.toMatchObject({
-        exitCode: 0,
-        stdout: "models/customers.sql\nmodels/orders.sql\n",
-      })
-    }
+    await expect(runWorkspaceInspectionCommand(workspace, "find /workspace/models -name '*.sql'", {
+      commands: ["find"],
+      cwd: `${workspaceMountPoint}/models`,
+      fs,
+    })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "/workspace/models/customers.sql\n/workspace/models/orders.sql\n",
+    })
+
+    await expect(runWorkspaceInspectionCommand(workspace, "find *.md -name README.md", {
+      commands: ["find"],
+      cwd: workspaceMountPoint,
+      fs,
+    })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "README.md\n",
+    })
+
+    await expect(runWorkspaceInspectionCommand(workspace, "find models -name", {
+      commands: ["find"],
+      cwd: workspaceMountPoint,
+      fs,
+    })).resolves.toMatchObject({
+      exitCode: 1,
+      stderr: expect.stringContaining("unknown predicate '-name'"),
+    })
 
     await expect(runWorkspaceInspectionCommand(workspace, "rg customers models && wc -l models/customers.sql", {
       commands: ["rg", "wc"],

--- a/packages/shell/test/workspace-inspection.test.ts
+++ b/packages/shell/test/workspace-inspection.test.ts
@@ -44,6 +44,22 @@ describe("@vite-hub/shell workspace inspection", () => {
       stdout: expect.stringContaining("customers.sql"),
     })
 
+    {
+      const runtimeFs = createReadonlyWorkspaceFs(workspace)
+      runtimeFs.readdirWithFileTypes = async () => {
+        throw new Error("shell runtime should not list simple workspace paths")
+      }
+
+      await expect(runWorkspaceInspectionCommand(workspace, "ls -la models", {
+        commands: ["ls"],
+        cwd: workspaceMountPoint,
+        fs: runtimeFs,
+      })).resolves.toMatchObject({
+        exitCode: 0,
+        stdout: expect.stringContaining("customers.sql"),
+      })
+    }
+
     await expect(runWorkspaceInspectionCommand(workspace, "cat", {
       commands: ["cat"],
       cwd: workspaceMountPoint,
@@ -394,6 +410,22 @@ describe("@vite-hub/shell workspace inspection", () => {
       stdout: expect.not.stringContaining("Workspace search is too broad"),
     })
 
+    {
+      const runtimeFs = createReadonlyWorkspaceFs(workspace)
+      runtimeFs.readdirWithFileTypes = async () => {
+        throw new Error("shell runtime should not find simple workspace paths")
+      }
+
+      await expect(runWorkspaceInspectionCommand(workspace, "find models -type f -name '*.sql'", {
+        commands: ["find"],
+        cwd: workspaceMountPoint,
+        fs: runtimeFs,
+      })).resolves.toMatchObject({
+        exitCode: 0,
+        stdout: "models/customers.sql\nmodels/orders.sql\n",
+      })
+    }
+
     await expect(runWorkspaceInspectionCommand(workspace, "rg customers models && wc -l models/customers.sql", {
       commands: ["rg", "wc"],
       cwd: workspaceMountPoint,
@@ -529,6 +561,17 @@ describe("@vite-hub/shell workspace inspection", () => {
     })).resolves.toMatchObject({
       stderr: expect.not.stringContaining("Workspace path is not mounted"),
       stdout: expect.not.stringContaining("Workspace path is not mounted"),
+    })
+
+    await expect(runWorkspaceInspectionCommand(workspace, "find models -type d -name \"forecast*\" | xargs -I {} rg -i \"class.*Forecast\" {} || true", {
+      commands: ["find", "rg"],
+      cwd: workspaceMountPoint,
+      fs,
+    })).resolves.toMatchObject({
+      event: "policy_denied",
+      exitCode: 126,
+      stderr: expect.stringContaining("Unsupported workspace shell command: xargs"),
+      stdout: expect.stringContaining("Use only the available workspace commands"),
     })
   })
 

--- a/packages/shell/test/workspace-inspection.test.ts
+++ b/packages/shell/test/workspace-inspection.test.ts
@@ -27,6 +27,23 @@ describe("@vite-hub/shell workspace inspection", () => {
       stdout: "# Docs\n/workspace\n",
     })
 
+    await expect(runWorkspaceInspectionCommand(workspace, "cat README.md", {
+      cwd: workspaceMountPoint,
+      fs,
+    })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "# Docs\n",
+    })
+
+    await expect(runWorkspaceInspectionCommand(workspace, "if true; then cat README.md; fi", {
+      commands: ["cat"],
+      cwd: workspaceMountPoint,
+      fs,
+    })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "# Docs\n",
+    })
+
     await expect(runWorkspaceInspectionCommand(workspace, "cat README.md | wc -l", {
       commands: ["cat", "wc"],
       cwd: workspaceMountPoint,

--- a/packages/workspace/src/ai.ts
+++ b/packages/workspace/src/ai.ts
@@ -180,8 +180,10 @@ function describeShellCommands(commands: string[]) {
   return [
     "Run a real Bash-compatible workspace shell command over files mounted at `/workspace`.",
     `Available workspace commands include: ${available.join(", ")}.`,
-    "Pipes, redirects, chaining, quoted patterns, and multiline shell scripts are supported by the shell runtime.",
+    "Only the listed commands are available; other executables are rejected before they run.",
+    "Pipes, redirects, chaining, quoted patterns, and multiline shell scripts are supported when they use available commands.",
     "The workspace filesystem controls whether writes are allowed; read-only tools reject mutation commands at execution time.",
+    "Do not use unsupported helpers such as `xargs`, `awk`, `sed`, `sort`, `cut`, or `python`.",
     "Do not use shell commands such as `echo` to compose assistant replies; answer conversational messages directly.",
     "Examples: `rg 'siff|PLC' ingestion forecasting-engine | head -n 20`; `find ingestion -type f -name '*.sql'`; `cat forecasting-engine/README.md | head -n 40`.",
   ].join(" ")

--- a/packages/workspace/src/ai.ts
+++ b/packages/workspace/src/ai.ts
@@ -176,6 +176,12 @@ function describeShellCommands(commands: string[]) {
     supported.has("tail") && "`tail`",
     supported.has("wc") && "`wc`",
   ].filter(Boolean)
+  const examples = [
+    supported.has("rg") && supported.has("head") && "`rg 'siff|PLC' ingestion forecasting-engine | head -n 20`",
+    supported.has("rg") && !supported.has("head") && "`rg 'siff|PLC' ingestion forecasting-engine`",
+    supported.has("find") && "`find ingestion -type f -name '*.sql'`",
+    supported.has("cat") && supported.has("head") && "`cat forecasting-engine/README.md | head -n 40`",
+  ].filter(Boolean)
 
   return [
     "Run a real Bash-compatible workspace shell command over files mounted at `/workspace`.",
@@ -185,8 +191,8 @@ function describeShellCommands(commands: string[]) {
     "The workspace filesystem controls whether writes are allowed; read-only tools reject mutation commands at execution time.",
     "Do not use unsupported helpers such as `xargs`, `awk`, `sed`, `sort`, `cut`, or `python`.",
     "Do not use shell commands such as `echo` to compose assistant replies; answer conversational messages directly.",
-    "Examples: `rg 'siff|PLC' ingestion forecasting-engine | head -n 20`; `find ingestion -type f -name '*.sql'`; `cat forecasting-engine/README.md | head -n 40`.",
-  ].join(" ")
+    examples.length && `Examples: ${examples.join("; ")}.`,
+  ].filter(Boolean).join(" ")
 }
 
 async function runShellCommand(

--- a/packages/workspace/test/ai.test.ts
+++ b/packages/workspace/test/ai.test.ts
@@ -67,6 +67,8 @@ describe("createWorkspaceTools", () => {
       exitCode: 0,
       stdout: "/workspace\ncustomers.sql\norders.sql\n",
     })
+    expect(tools.shell.description).toContain("Only the listed commands are available")
+    expect(tools.shell.description).toContain("Do not use unsupported helpers such as `xargs`")
   })
 
   it("limits shell commands to the enabled read capabilities", async () => {
@@ -82,12 +84,16 @@ describe("createWorkspaceTools", () => {
 
     await expect(runShell(tools, "ls .")).resolves.toMatchObject({ exitCode: 0, stdout: "README.md\nmodels\n" })
     await expect(runShell(tools, "cat README.md")).resolves.toMatchObject({
-      exitCode: 127,
-      stderr: "bash: cat: command not found\n",
+      event: "policy_denied",
+      exitCode: 126,
+      stderr: expect.stringContaining("Unsupported workspace shell command: cat"),
+      stdout: expect.stringContaining("Use only the available workspace commands"),
     })
     await expect(runShell(tools, "rg orders models")).resolves.toMatchObject({
-      exitCode: 127,
-      stderr: "bash: rg: command not found\n",
+      event: "policy_denied",
+      exitCode: 126,
+      stderr: expect.stringContaining("Unsupported workspace shell command: rg"),
+      stdout: expect.stringContaining("Use only the available workspace commands"),
     })
   })
 
@@ -97,8 +103,10 @@ describe("createWorkspaceTools", () => {
     }))
 
     await expect(runShell(tools, "rm README.md")).resolves.toMatchObject({
-      exitCode: 127,
-      stderr: "bash: rm: command not found\n",
+      event: "policy_denied",
+      exitCode: 126,
+      stderr: expect.stringContaining("Unsupported workspace shell command: rm"),
+      stdout: expect.stringContaining("Use only the available workspace commands"),
     })
     await expect(runShell(tools, "cat README.md | wc -l")).resolves.toMatchObject({
       exitCode: 0,

--- a/packages/workspace/test/ai.test.ts
+++ b/packages/workspace/test/ai.test.ts
@@ -83,6 +83,9 @@ describe("createWorkspaceTools", () => {
     })
 
     await expect(runShell(tools, "ls .")).resolves.toMatchObject({ exitCode: 0, stdout: "README.md\nmodels\n" })
+    expect(tools.shell.description).toContain("`find ingestion -type f -name '*.sql'`")
+    expect(tools.shell.description).not.toContain("`rg")
+    expect(tools.shell.description).not.toContain("cat forecasting-engine")
     await expect(runShell(tools, "cat README.md")).resolves.toMatchObject({
       event: "policy_denied",
       exitCode: 126,


### PR DESCRIPTION
## Summary
- reject executables outside the advertised workspace shell commands before runtime with actionable feedback
- keep shell utility semantics in Shell Runtime execution providers rather than Workspace inspection helpers
- add an ADR documenting that Command Analysis can drive policy/routing, but must not own utility semantics
- clarify shell tool guidance so agents avoid helpers like `xargs` when they are not available

## Test Plan
- `pnpm --dir packages/shell exec vitest run test/workspace-inspection.test.ts`
- `pnpm --dir packages/shell test`
- `pnpm --dir packages/workspace test`
- `pnpm --dir packages/shell typecheck`
- `pnpm --dir packages/workspace typecheck`