### PR TITLE
fix(agent): define streamed usage telemetry descriptors

### DIFF
--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -332,6 +332,23 @@ function toReadableAsyncIterableStream<T>(iterable: AsyncIterable<T>): AsyncIter
   }))
 }
 
+function defineUsageTelemetryOutput(output: UnknownRecord, usageRecord: AgentUsageRecord) {
+  Object.defineProperties(output, {
+    usage: {
+      configurable: true,
+      enumerable: true,
+      value: usageRecord.usage,
+      writable: true,
+    },
+    usageRecord: {
+      configurable: true,
+      enumerable: true,
+      value: usageRecord,
+      writable: true,
+    },
+  })
+}
+
 function cloneWithUsageTelemetryStream<T extends UnknownRecord>(
   result: T,
   options: UsageTelemetryOptions,
@@ -344,9 +361,7 @@ function cloneWithUsageTelemetryStream<T extends UnknownRecord>(
   const clone = Object.create(Object.getPrototypeOf(result)) as T
   Object.defineProperties(clone, Object.getOwnPropertyDescriptors(result))
   let stream = toReadableAsyncIterableStream(withUsageTelemetryStream(fullStream, options, run, (usageRecord) => {
-    const output = clone as UnknownRecord
-    output.usage = usageRecord.usage
-    output.usageRecord = usageRecord
+    defineUsageTelemetryOutput(clone as UnknownRecord, usageRecord)
   }))
   Object.defineProperty(clone, "fullStream", {
     configurable: true,

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -198,6 +198,72 @@ describe("usage telemetry", () => {
     })
   })
 
+  it("attaches streamed usage telemetry to results with getter-only usage properties", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+
+    class GetterOnlyUsageResult {
+      fullStream = (async function* () {
+        yield { text: "ok", type: "text-delta" }
+        yield {
+          finishReason: "stop",
+          totalUsage: {
+            inputTokens: 2,
+            outputTokens: 3,
+          },
+          type: "finish",
+        }
+      })()
+
+      get usage() {
+        return undefined
+      }
+    }
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry(),
+      ],
+      run: () => new GetterOnlyUsageResult(),
+    })
+
+    const output = await streamAgent(agent, runtime(), {})
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents(output)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: expect.objectContaining({
+          usage: {
+            inputTokens: 2,
+            outputTokens: 3,
+            totalTokens: 5,
+          },
+        }),
+      },
+      { reason: "stop", type: "finish" },
+    ])
+    expect(output).toMatchObject({
+      usage: {
+        inputTokens: 2,
+        outputTokens: 3,
+        totalTokens: 5,
+      },
+      usageRecord: {
+        usage: {
+          inputTokens: 2,
+          outputTokens: 3,
+          totalTokens: 5,
+        },
+      },
+    })
+  })
+
   it("does not fail the invocation when pricing fails", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")


### PR DESCRIPTION
Fixes usageTelemetry wrapping for streamed agent results whose `usage` field is implemented as a getter-only property, such as AI SDK stream text results. The wrapper now defines telemetry fields as own descriptors on the cloned result when the finish chunk is observed instead of assigning through a getter-only accessor.

Adds a focused regression test that streams a result with a getter-only `usage` accessor and asserts the usage event is emitted and the cloned output receives the telemetry record.