### PR TITLE
fix(agent): load chat devtools metadata asynchronously

### DIFF
--- a/packages/agent/src/chat/devtools.ts
+++ b/packages/agent/src/chat/devtools.ts
@@ -50,6 +50,7 @@ export type {
   ChatDevtoolsFileTreeItem,
   ChatDevtoolsInvokerProfile,
   ChatDevtoolsMetadata,
+  ChatDevtoolsMetadataStatus,
   ChatDevtoolsMessage,
   ChatDevtoolsMessageRole,
   ChatDevtoolsSendInput,

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url"
 import { setWorkspaceRuntimeRegistry } from "@vite-hub/workspace/internal/runtime/state"
 
 import {
+  createAgentDevtoolsMetadata,
   resolveAgentDevtoolsMetadata,
   resolveAgentTriggers,
   streamAgentTrigger,
@@ -13,6 +14,7 @@ import {
 import {
   type ChatDevtoolsConversation,
   type ChatDevtoolsMetadata,
+  type ChatDevtoolsMetadataStatus,
   type ChatDevtoolsStateResult,
   type ChatDevtoolsStreamEvent,
   chatDevtoolsBridgeRoute,
@@ -74,7 +76,13 @@ interface ChatDevtoolsSession {
 
 interface ChatDevtoolsAgentEntry {
   agent: AgentInput<ViteAgentDevtoolsRuntimeContext>
+  defaults?: WorkspaceAgentDefaults
   metadata: ChatDevtoolsMetadata
+  metadataError?: string
+  metadataSelectionKey?: string
+  metadataStaticKey: string
+  metadataStatus: ChatDevtoolsMetadataStatus
+  metadataTask?: Promise<void>
   name: string
 }
 
@@ -209,7 +217,96 @@ function metadataSelectionForAgent(
     : {}
 }
 
-async function discoverChatAgents(server: ViteDevServer, selection: ChatDevtoolsInvokerSelection = {}): Promise<Map<string, ChatDevtoolsAgentEntry>> {
+function metadataSelectionKey(selection: ChatDevtoolsInvokerSelection = {}): string {
+  if (selection.invokerFallback) return "fallback"
+  return selection.invokerProfileId ? `profile:${selection.invokerProfileId}` : "default"
+}
+
+function canResolveWorkspaceMetadata(agent: AgentInput<ViteAgentDevtoolsRuntimeContext>): boolean {
+  return Boolean((agent as { __vitehubWorkspaceAgent?: unknown }).__vitehubWorkspaceAgent)
+}
+
+function createStaticDevtoolsMetadata(agent: AgentInput<ViteAgentDevtoolsRuntimeContext>): ChatDevtoolsMetadata {
+  return createAgentDevtoolsMetadata(agent as never)
+}
+
+function metadataStaticKey(metadata: ChatDevtoolsMetadata): string {
+  return JSON.stringify(metadata)
+}
+
+function createChatDevtoolsAgentEntry(
+  name: string,
+  agent: AgentInput<ViteAgentDevtoolsRuntimeContext>,
+  defaults: WorkspaceAgentDefaults | undefined,
+  previous: ChatDevtoolsAgentEntry | undefined,
+): ChatDevtoolsAgentEntry {
+  const metadata = createStaticDevtoolsMetadata(agent)
+  const staticKey = metadataStaticKey(metadata)
+  if (previous?.metadataStaticKey === staticKey) {
+    previous.agent = agent
+    previous.defaults = defaults
+    previous.name = name
+    return previous
+  }
+  return {
+    agent,
+    defaults,
+    metadata,
+    metadataStaticKey: staticKey,
+    metadataStatus: canResolveWorkspaceMetadata(agent) ? "loading" : "ready",
+    name,
+  }
+}
+
+function metadataErrorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : "Chat DevTools metadata inspection failed."
+}
+
+function startMetadataResolution(
+  entry: ChatDevtoolsAgentEntry,
+  selection: ChatDevtoolsInvokerSelection = {},
+): void {
+  if (!canResolveWorkspaceMetadata(entry.agent)) {
+    entry.metadataError = undefined
+    entry.metadataSelectionKey = "static"
+    entry.metadataStatus = "ready"
+    entry.metadataTask = undefined
+    return
+  }
+
+  const metadataSelection = metadataSelectionForAgent(entry.agent, selection)
+  const selectionKey = metadataSelectionKey(metadataSelection)
+  if (entry.metadataSelectionKey === selectionKey) {
+    return
+  }
+
+  entry.metadata = createStaticDevtoolsMetadata(entry.agent)
+  entry.metadataStaticKey = metadataStaticKey(entry.metadata)
+  entry.metadataError = undefined
+  entry.metadataSelectionKey = selectionKey
+  entry.metadataStatus = "loading"
+
+  const task = resolveAgentDevtoolsMetadata(entry.agent as never, {
+    ...entry.defaults,
+    input: createDevtoolsMetadataInput(metadataSelection),
+  } as never)
+    .then((metadata) => {
+      if (entry.metadataTask !== task || entry.metadataSelectionKey !== selectionKey) return
+      entry.metadata = metadata
+      entry.metadataError = undefined
+      entry.metadataStatus = "ready"
+      entry.metadataTask = undefined
+    })
+    .catch((cause) => {
+      if (entry.metadataTask !== task || entry.metadataSelectionKey !== selectionKey) return
+      entry.metadataError = metadataErrorMessage(cause)
+      entry.metadataStatus = "error"
+      entry.metadataTask = undefined
+    })
+  entry.metadataTask = task
+}
+
+async function discoverChatAgents(server: ViteDevServer, state: ChatDevtoolsBridgeState): Promise<void> {
   const context = createDevtoolsDiscoveryContext()
   const entries = new Map<string, ChatDevtoolsAgentEntry>()
   const definitions = discoverAgentDefinitions({
@@ -225,16 +322,14 @@ async function discoverChatAgents(server: ViteDevServer, selection: ChatDevtools
     const trigger = triggers["chat.message"]
     if (!trigger || trigger.devtools === false) continue
 
-    entries.set(definition.name, {
+    entries.set(definition.name, createChatDevtoolsAgentEntry(
+      definition.name,
       agent,
-      metadata: await resolveAgentDevtoolsMetadata(agent as never, {
-        ...workspaceDefaults(definition),
-        input: createDevtoolsMetadataInput(metadataSelectionForAgent(agent, selection)),
-      } as never),
-      name: definition.name,
-    })
+      workspaceDefaults(definition),
+      state.entries.get(definition.name),
+    ))
   }
-  return entries
+  state.entries = entries
 }
 
 function getSession(state: ChatDevtoolsBridgeState, name: string): ChatDevtoolsSession {
@@ -326,7 +421,8 @@ async function serializeState(
 
   const nextSelected = getSelectedName(state, selected)
   const selectedSession = nextSelected ? getSession(state, nextSelected) : undefined
-  const metadata = nextSelected ? state.entries.get(nextSelected)?.metadata : undefined
+  const entry = nextSelected ? state.entries.get(nextSelected) : undefined
+  const metadata = entry?.metadata
   const title = selectedSession ? sessionTitle(selectedSession) || metadata?.title : metadata?.title
   const invokerProfileId = selectedSession?.invokerProfileId || (!requestedSelection.invokerFallback ? validMetadataInvokerProfileId(metadata, requestedSelection.invokerProfileId) : undefined)
   const invokerFallback = selectedSession?.invokerFallback || (!invokerProfileId && requestedSelection.invokerFallback === true)
@@ -338,6 +434,8 @@ async function serializeState(
     ...(invokerFallback ? { invokerFallback: true } : {}),
     ...(invokerProfileId ? { invokerProfileId } : {}),
     invokerProfiles: metadata?.invokerProfiles || [],
+    ...(entry?.metadataError ? { metadataError: entry.metadataError } : {}),
+    ...(entry?.metadataStatus ? { metadataStatus: entry.metadataStatus } : {}),
     selected: nextSelected,
     thinkingFallback: selectedSession?.thinkingFallback ?? null,
     ...(title ? { title } : {}),
@@ -602,9 +700,14 @@ async function handleChatDevtoolsRequest(
   }
 
   const invokerSelection = normalizeInvokerSelection(body)
-  state.entries = await discoverChatAgents(server, invokerSelection)
+  await discoverChatAgents(server, state)
   if (body.chat && state.entries.has(body.chat)) {
     state.selected = body.chat
+  }
+  const selected = getSelectedName(state, body.chat)
+  const entry = selected ? state.entries.get(selected) : undefined
+  if (entry) {
+    startMetadataResolution(entry, invokerSelection)
   }
 
   const action = normalizeChatDevtoolsAction(body.action)
@@ -631,6 +734,18 @@ async function handleChatDevtoolsRequest(
 
 function routeMatches(req: IncomingMessage): boolean {
   return new URL(req.url || "/", "http://localhost").pathname === chatDevtoolsBridgeRoute
+}
+
+function installChatDevtoolsInvalidation(server: ViteDevServer, state: ChatDevtoolsBridgeState): void {
+  const serverRoot = join(server.config.root, "server")
+  const invalidate = (file: string) => {
+    if (file.startsWith(serverRoot)) {
+      state.entries = new Map()
+    }
+  }
+  server.watcher?.on("add", invalidate)
+  server.watcher?.on("change", invalidate)
+  server.watcher?.on("unlink", invalidate)
 }
 
 async function writeResponse(res: ServerResponse, response: Response): Promise<void> {
@@ -669,6 +784,7 @@ export function registerChatDevtoolsBridge(server: ViteDevServer): void {
     entries: new Map(),
     sessions: new Map(),
   }
+  installChatDevtoolsInvalidation(server, state)
 
   server.middlewares.use((req, res, next) => {
     if (!routeMatches(req)) {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -99,6 +99,24 @@ async function invokeMiddleware(
   return result
 }
 
+async function invokeState(handler: Connect.NextHandleFunction, body: Record<string, unknown>) {
+  return JSON.parse((await invokeMiddleware(handler, body)).body) as Record<string, unknown>
+}
+
+async function waitForMetadataState(
+  handler: Connect.NextHandleFunction,
+  body: Record<string, unknown>,
+  status: "error" | "loading" | "ready" = "ready",
+) {
+  let latest: Record<string, unknown> | undefined
+  for (let attempt = 0; attempt < 50; attempt++) {
+    latest = await invokeState(handler, body)
+    if (latest.metadataStatus === status) return latest
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+  throw new Error(`Expected chat devtools metadata status ${status}, received ${String(latest?.metadataStatus)}`)
+}
+
 describe("agent discovery", () => {
   it("discovers Vite suffix agents without scanning server files", async () => {
     const root = await createTempRoot("vitehub-agent-vite-")
@@ -281,11 +299,11 @@ describe("agent chat capability discovery", () => {
     await configurePluginServer(plugin, server)
     expect(server.middlewares.use).toHaveBeenCalledTimes(1)
 
-    const stateResponse = await invokeMiddleware(handlers[0]!, { action: "get-state", invokerProfileId: "support-technical" })
-    const state = JSON.parse(stateResponse.body)
+    const state = await waitForMetadataState(handlers[0]!, { action: "get-state", invokerProfileId: "support-technical" })
     expect(state).toMatchObject({
       chats: [{ name: "support", uiMessages: [] }],
       instructions: ["# Support\n\nAudience resolved for technical."],
+      metadataStatus: "ready",
       invokerProfileId: "support-technical",
       invokerProfiles: [
         { id: "support-customer", kind: "customer", label: "Customer" },
@@ -333,12 +351,24 @@ describe("agent chat capability discovery", () => {
     })
     const clearedFallbackState = JSON.parse(clearedFallbackResponse.body)
     expect(clearedFallbackState).toMatchObject({
-      instructions: ["# Support\n\nAudience resolved for undefined."],
       invokerFallback: true,
+      metadataStatus: "loading",
       selected: "support",
       uiMessages: [],
     })
     expect(clearedFallbackState.invokerProfileId).toBeUndefined()
+    const resolvedFallbackState = await waitForMetadataState(handlers[0]!, {
+      action: "get-state",
+      chat: "support",
+      invokerFallback: true,
+    })
+    expect(resolvedFallbackState).toMatchObject({
+      instructions: ["# Support\n\nAudience resolved for undefined."],
+      invokerFallback: true,
+      metadataStatus: "ready",
+      selected: "support",
+    })
+    expect(resolvedFallbackState.invokerProfileId).toBeUndefined()
 
     const fallbackSendResponse = await invokeMiddleware(handlers[0]!, {
       action: "send",
@@ -357,6 +387,54 @@ describe("agent chat capability discovery", () => {
     expect(fallbackFinalState.invokerFallback).toBe(true)
     expect(fallbackFinalState.invokerProfileId).toBeUndefined()
     expect(textFromUiMessage(fallbackFinalState.uiMessages[1])).toBe("answered as devtools with workspace")
+  })
+
+  it("serves initial chat devtools state while workspace metadata resolves", async () => {
+    const root = await createTempRoot("vitehub-agent-devtools-metadata-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    let resolveInstructions!: (value: string) => void
+    const instructionsReady = new Promise<string>((resolve) => {
+      resolveInstructions = resolve
+    })
+    const readInstructions = vi.fn(async () => await instructionsReady)
+    const agent = withWorkspaceAgentDefaults(defineAgent({
+      capabilities: [chat()],
+      instructions: readInstructions,
+      model: {} as never,
+      workspace: {
+        sources: {
+          docs: { name: "docs" } as never,
+        },
+      },
+      run: () => "ok",
+    }), { workspace: "support" })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent()
+
+    await configurePluginServer(plugin, server)
+
+    const firstState = await invokeState(handlers[0]!, { action: "get-state" })
+    expect(firstState).toMatchObject({
+      files: [expect.objectContaining({ path: "docs" })],
+      instructions: ["Dynamic system instructions resolver configured."],
+      metadataStatus: "loading",
+      selected: "support",
+    })
+
+    resolveInstructions("Resolved workspace instructions")
+    const resolvedState = await waitForMetadataState(handlers[0]!, { action: "get-state" })
+    expect(resolvedState).toMatchObject({
+      instructions: ["Resolved workspace instructions"],
+      metadataStatus: "ready",
+      selected: "support",
+    })
+
+    await invokeState(handlers[0]!, { action: "get-state" })
+    expect(readInstructions).toHaveBeenCalledTimes(1)
   })
 
   it("omits unfinished tool-call assistant messages from devtools prompt history", async () => {

--- a/packages/devtools/devtools/chat/app/app.vue
+++ b/packages/devtools/devtools/chat/app/app.vue
@@ -56,6 +56,7 @@ const selectedFilePath = ref<string | undefined>()
 const sidebarWidth = ref(340)
 let rpcClient: Awaited<ReturnType<typeof getDevToolsRpcClient>> | undefined
 let currentReader: { cancel: () => unknown } | undefined
+let metadataRefreshTimeout: ReturnType<typeof setTimeout> | undefined
 let stopSidebarResize: (() => void) | undefined
 
 const disconnectedStatusMessage = "Connect through Vite DevTools to inspect a real chat runtime."
@@ -115,6 +116,9 @@ const visibleTools = computed<ChatDevtoolsToolDefinition[]>(() => {
     status: tool.status === "error" ? "disabled" : "available",
   }))
 })
+const metadataStatus = computed(() => state.value.metadataStatus || "ready")
+const isMetadataLoading = computed(() => metadataStatus.value === "loading")
+const metadataError = computed(() => state.value.metadataError)
 
 function clearPendingMessages() {
   const pendingId = pendingUserMessage.value?.id
@@ -156,7 +160,12 @@ function applyState(next: ChatDevtoolsStateResult) {
 
   messages.value = nextMessages
   syncExpandedFiles(state.value.files || [])
-
+  if (isMetadataLoading.value) {
+    scheduleMetadataRefresh()
+  }
+  else {
+    stopMetadataRefresh()
+  }
 }
 
 function syncInvokerSelection(next: ChatDevtoolsStateResult) {
@@ -526,6 +535,22 @@ function appendPendingUserMessage(text: string, chat: string | undefined) {
 
 function waitForFrame() {
   return new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+}
+
+function stopMetadataRefresh() {
+  if (!metadataRefreshTimeout) return
+  clearTimeout(metadataRefreshTimeout)
+  metadataRefreshTimeout = undefined
+}
+
+function scheduleMetadataRefresh() {
+  if (metadataRefreshTimeout || metadataStatus.value !== "loading") return
+  metadataRefreshTimeout = setTimeout(async () => {
+    metadataRefreshTimeout = undefined
+    if (metadataStatus.value === "loading") {
+      await refreshFromBridge(state.value.selected)
+    }
+  }, 700)
 }
 
 function localBridgeRoute() {
@@ -981,6 +1006,7 @@ watch(selectedInvokerProfileId, async (next, previous) => {
   await refreshFromBridge(state.value.selected)
 })
 onBeforeUnmount(() => {
+  stopMetadataRefresh()
   stopSidebarResize?.()
 })
 </script>
@@ -1230,6 +1256,24 @@ onBeforeUnmount(() => {
               }"
             >
               <template #files>
+                <UAlert
+                  v-if="fileRows.length && isMetadataLoading"
+                  color="neutral"
+                  variant="soft"
+                  icon="i-lucide-loader-circle"
+                  title="Loading workspace metadata..."
+                  class="mb-2"
+                  :ui="{ root: 'rounded-md bg-transparent !py-1 !pl-8 !pr-2 gap-0', icon: 'absolute left-3 top-1/2 size-3.5 -translate-y-1/2 opacity-70', wrapper: 'min-w-0', title: 'text-xs font-normal leading-5' }"
+                />
+                <UAlert
+                  v-else-if="fileRows.length && metadataError"
+                  color="error"
+                  variant="soft"
+                  icon="i-lucide-triangle-alert"
+                  :title="metadataError"
+                  class="mb-2"
+                  :ui="{ root: 'rounded-md bg-transparent !py-1 !pl-8 !pr-2 gap-0', icon: 'absolute left-3 top-1/2 size-3.5 -translate-y-1/2 opacity-80', wrapper: 'min-w-0', title: 'text-xs font-normal leading-5' }"
+                />
                 <div v-if="fileRows.length" class="space-y-1">
                   <UButton
                     v-for="file in fileRows"
@@ -1262,6 +1306,20 @@ onBeforeUnmount(() => {
                   </UButton>
                 </div>
                 <UEmpty
+                  v-else-if="isMetadataLoading"
+                  icon="i-lucide-loader-circle"
+                  title="Loading workspace files."
+                  description="Inspecting workspace metadata for this chat."
+                  :ui="{ root: 'border-0 ring-0 shadow-none bg-transparent px-2 py-8' }"
+                />
+                <UEmpty
+                  v-else-if="metadataError"
+                  icon="i-lucide-triangle-alert"
+                  title="Workspace metadata failed."
+                  :description="metadataError"
+                  :ui="{ root: 'border-0 ring-0 shadow-none bg-transparent px-2 py-8' }"
+                />
+                <UEmpty
                   v-else
                   icon="i-lucide-folder-search"
                   title="No files exposed."
@@ -1271,6 +1329,24 @@ onBeforeUnmount(() => {
               </template>
 
               <template #tools>
+                <UAlert
+                  v-if="visibleTools.length && isMetadataLoading"
+                  color="neutral"
+                  variant="soft"
+                  icon="i-lucide-loader-circle"
+                  title="Loading workspace metadata..."
+                  class="mb-2"
+                  :ui="{ root: 'rounded-md bg-transparent !py-1 !pl-8 !pr-2 gap-0', icon: 'absolute left-3 top-1/2 size-3.5 -translate-y-1/2 opacity-70', wrapper: 'min-w-0', title: 'text-xs font-normal leading-5' }"
+                />
+                <UAlert
+                  v-else-if="visibleTools.length && metadataError"
+                  color="error"
+                  variant="soft"
+                  icon="i-lucide-triangle-alert"
+                  :title="metadataError"
+                  class="mb-2"
+                  :ui="{ root: 'rounded-md bg-transparent !py-1 !pl-8 !pr-2 gap-0', icon: 'absolute left-3 top-1/2 size-3.5 -translate-y-1/2 opacity-80', wrapper: 'min-w-0', title: 'text-xs font-normal leading-5' }"
+                />
                 <div v-if="visibleTools.length" class="space-y-2">
                   <div
                     v-for="tool in visibleTools"
@@ -1325,6 +1401,20 @@ onBeforeUnmount(() => {
                   </div>
                 </div>
                 <UEmpty
+                  v-else-if="isMetadataLoading"
+                  icon="i-lucide-loader-circle"
+                  title="Loading tools."
+                  description="Inspecting workspace metadata for this chat."
+                  :ui="{ root: 'border-0 ring-0 shadow-none bg-transparent px-2 py-8' }"
+                />
+                <UEmpty
+                  v-else-if="metadataError"
+                  icon="i-lucide-triangle-alert"
+                  title="Workspace metadata failed."
+                  :description="metadataError"
+                  :ui="{ root: 'border-0 ring-0 shadow-none bg-transparent px-2 py-8' }"
+                />
+                <UEmpty
                   v-else
                   icon="i-lucide-wrench"
                   title="No tools exposed."
@@ -1334,6 +1424,24 @@ onBeforeUnmount(() => {
               </template>
 
               <template #instructions>
+                <UAlert
+                  v-if="state.instructions?.length && isMetadataLoading"
+                  color="neutral"
+                  variant="soft"
+                  icon="i-lucide-loader-circle"
+                  title="Loading workspace metadata..."
+                  class="mb-2"
+                  :ui="{ root: 'rounded-md bg-transparent !py-1 !pl-8 !pr-2 gap-0', icon: 'absolute left-3 top-1/2 size-3.5 -translate-y-1/2 opacity-70', wrapper: 'min-w-0', title: 'text-xs font-normal leading-5' }"
+                />
+                <UAlert
+                  v-else-if="state.instructions?.length && metadataError"
+                  color="error"
+                  variant="soft"
+                  icon="i-lucide-triangle-alert"
+                  :title="metadataError"
+                  class="mb-2"
+                  :ui="{ root: 'rounded-md bg-transparent !py-1 !pl-8 !pr-2 gap-0', icon: 'absolute left-3 top-1/2 size-3.5 -translate-y-1/2 opacity-80', wrapper: 'min-w-0', title: 'text-xs font-normal leading-5' }"
+                />
                 <div v-if="state.instructions?.length" class="min-w-0 space-y-4 px-1">
                   <div
                     v-for="(instruction, index) in state.instructions"
@@ -1353,6 +1461,20 @@ onBeforeUnmount(() => {
                     </Suspense>
                   </div>
                 </div>
+                <UEmpty
+                  v-else-if="isMetadataLoading"
+                  icon="i-lucide-loader-circle"
+                  title="Loading instructions."
+                  description="Inspecting workspace metadata for this chat."
+                  :ui="{ root: 'border-0 ring-0 shadow-none bg-transparent px-2 py-8' }"
+                />
+                <UEmpty
+                  v-else-if="metadataError"
+                  icon="i-lucide-triangle-alert"
+                  title="Workspace metadata failed."
+                  :description="metadataError"
+                  :ui="{ root: 'border-0 ring-0 shadow-none bg-transparent px-2 py-8' }"
+                />
                 <UEmpty
                   v-else
                   icon="i-lucide-scroll-text"

--- a/packages/devtools/src/chat-shared.ts
+++ b/packages/devtools/src/chat-shared.ts
@@ -62,6 +62,8 @@ export interface ChatDevtoolsMetadata {
   version?: string
 }
 
+export type ChatDevtoolsMetadataStatus = "error" | "loading" | "ready"
+
 export interface ChatDevtoolsMessage {
   createdAt: string
   id: string
@@ -87,6 +89,8 @@ export interface ChatDevtoolsStateResult {
   invokerFallback?: boolean
   invokerProfileId?: string
   invokerProfiles?: ChatDevtoolsInvokerProfile[]
+  metadataError?: string
+  metadataStatus?: ChatDevtoolsMetadataStatus
   selected: string
   thinkingFallback?: string | null
   title?: string


### PR DESCRIPTION
This changes Chat DevTools so the bridge returns static agent metadata immediately, then resolves the expensive workspace metadata in the background for the selected chat and invoker profile. The resolved metadata is cached per selection, reused across state polls, and reset when the selected invoker changes so the UI does not show stale scoped files.

The DevTools client now receives `metadataStatus` / `metadataError`, polls only while metadata is loading, and shows loading or error states in the integration tabs instead of presenting an empty panel during long workspace scans.

Validation:
- `pnpm --filter @vite-hub/agent test -- discovery.test.ts`
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --filter @vite-hub/devtools typecheck`
- `pnpm lint` (0 errors, existing warnings outside this change)