### PR TITLE
fix(agent): keep devtools metadata passive

### DIFF
--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -2,13 +2,9 @@ import {
   applyCapabilityInstructionSlots,
   normalizeCapabilities,
   normalizeMode,
-  type ResolvedAgentCapabilities,
-  resolveAgentCapabilities,
 } from "./capability-runtime.ts"
-import { createAgentInvocationContextStore } from "./invocation-context.ts"
 import {
   normalizeAgentInvokerProfiles,
-  resolveAgentInvoker,
 } from "./invoker.ts"
 
 import type {
@@ -19,6 +15,7 @@ import type {
   AgentDevtoolsMetadata,
   AgentDevtoolsToolDefinition,
   AgentInput,
+  AgentInstructionBlock,
   AgentRunInput,
   AgentRuntimeConfig,
   AgentRuntimeContext,
@@ -43,9 +40,6 @@ const writeCommands = [...readCommands, "mkdir", "touch", "cp", "mv", "rm"]
 type NormalizedWorkspaceOptions = WorkspaceAgentWorkspaceOptions & { mode: AgentCapabilityMode }
 type NormalizedCapability = AgentCapabilityDefinition & { mode?: AgentCapabilityMode }
 type WorkspaceSourceMap = NonNullable<WorkspaceDefinition["sources"]>
-type ResolvedWorkspaceMetadataCapabilities = ResolvedAgentCapabilities & {
-  workspaceDefinition?: WorkspaceDefinition
-}
 
 export type WorkspaceAgentOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -359,6 +353,33 @@ function workspaceMetadataTools<Name extends WorkspaceName>(
     .sort((left, right) => left.name.localeCompare(right.name))
 }
 
+function staticCapabilityInstructionBlocks<Name extends WorkspaceName>(
+  options: WorkspaceAgentOptions<AgentRuntimeConfig, Name>,
+): AgentInstructionBlock[] {
+  return normalizeCapabilities(options.capabilities)
+    .flatMap((capability) => {
+      if (capability.instructions === undefined || capability.instructions === false) return []
+      const parts = Array.isArray(capability.instructions) ? capability.instructions : [capability.instructions]
+      const instructions = parts
+        .flatMap(part => Array.isArray(part) ? part : [part])
+        .map(part => typeof part === "string" ? part.trim() : "")
+        .filter(Boolean)
+        .join("\n\n")
+      return instructions
+        ? [{ id: `capabilities.${capability.id}`, instructions }]
+        : []
+    })
+}
+
+const capabilityInstructionSlotPattern = /\{\{\s*capabilities(?:\.[a-zA-Z][\w.-]*)?\s*\}\}/g
+
+function applyPassiveCapabilityInstructionSlots(instructions: string, blocks: AgentInstructionBlock[] = []): string {
+  const rendered = blocks.length
+    ? applyCapabilityInstructionSlots(instructions, blocks)
+    : instructions
+  return rendered.replace(capabilityInstructionSlotPattern, "").trim().replace(/\n{3,}/g, "\n\n")
+}
+
 function workspaceMetadataInstructions<Name extends WorkspaceName>(
   options: WorkspaceAgentOptions<AgentRuntimeConfig, Name>,
 ): string[] {
@@ -372,7 +393,14 @@ function workspaceMetadataInstructions<Name extends WorkspaceName>(
     }
     return []
   })
-  return applyWorkspaceSourceInstructionsToParts(instructions, renderWorkspaceSourceInstructionBlock(workspaceDefinitionFromOptions(options).sources))
+  const renderedInstructions = applyPassiveCapabilityInstructionSlots(
+    instructions.join("\n\n"),
+    staticCapabilityInstructionBlocks(options),
+  )
+  return applyWorkspaceSourceInstructionsToParts(
+    renderedInstructions ? [renderedInstructions] : [],
+    renderWorkspaceSourceInstructionBlock(workspaceDefinitionFromOptions(options).sources),
+  )
 }
 
 function readLocalWorkspaceInstructions(options: WorkspaceAgentOptions<AgentRuntimeConfig, WorkspaceName>): string | undefined {
@@ -396,12 +424,10 @@ async function resolveWorkspaceMetadataInstructions<
   options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
   workspace: ReadonlyWorkspaceFacade<Name>,
   resolution: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name> = {},
-  resolvedCapabilities?: ResolvedWorkspaceMetadataCapabilities,
 ) {
-  const metadataWorkspace = (resolvedCapabilities?.workspace || workspace) as ReadonlyWorkspaceFacade<Name>
   const instructionContext = {
-    fs: metadataWorkspace.fs,
-    workspace: metadataWorkspace,
+    fs: workspace.fs,
+    workspace,
   }
   const parts = Array.isArray(options.instructions) ? options.instructions : [options.instructions]
   const instructions = await Promise.all(parts.map(part => typeof part === "function"
@@ -411,17 +437,15 @@ async function resolveWorkspaceMetadataInstructions<
     .flatMap(part => Array.isArray(part) ? part : [part])
     .map(part => part?.trim())
     .filter((part): part is string => Boolean(part))
-  const capabilityInstructions = resolvedCapabilities
-    ? [...resolvedCapabilities.capabilityInstructions]
-    : await resolveWorkspaceMetadataCapabilityInstructions(options, metadataWorkspace, resolution)
-  const renderedInstructions = capabilityInstructions.length
-    ? applyCapabilityInstructionSlots(baseInstructions.join("\n\n"), capabilityInstructions).trim()
-    : baseInstructions.join("\n\n")
+  const renderedInstructions = applyPassiveCapabilityInstructionSlots(
+    baseInstructions.join("\n\n"),
+    staticCapabilityInstructionBlocks(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>),
+  )
   return applyWorkspaceSourceInstructionsToParts(
     renderedInstructions ? [renderedInstructions] : [],
     await resolveWorkspaceSourceInstructionBlock(
-      resolvedCapabilities?.workspaceDefinition || workspaceDefinitionWithNameFromOptions(options, resolution),
-      metadataWorkspace,
+      workspaceDefinitionWithNameFromOptions(options, resolution),
+      workspace,
     ),
   )
 }
@@ -547,74 +571,6 @@ function applyWorkspaceSourceInstructionsToParts(parts: string[], sourceInstruct
   return instructions ? [instructions] : []
 }
 
-function createDevtoolsMetadataRuntime<
-  TRuntimeConfig extends AgentRuntimeConfig,
->(
-  runtime: Partial<ResolvedAgentRuntimeContext<TRuntimeConfig>> = {},
-): ResolvedAgentRuntimeContext<TRuntimeConfig> {
-  const memoValues = new Map<string, unknown>()
-  return {
-    memo(key, create) {
-      if (!memoValues.has(key)) memoValues.set(key, create())
-      return memoValues.get(key) as never
-    },
-    runtime: "vite",
-    runtimeConfig: {} as TRuntimeConfig,
-    waitUntil: () => {},
-    ...runtime,
-  }
-}
-
-async function resolveWorkspaceMetadataCapabilities<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  Name extends WorkspaceName,
->(
-  options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
-  workspace: ReadonlyWorkspaceFacade<Name>,
-  resolution: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name>,
-): Promise<ResolvedWorkspaceMetadataCapabilities | undefined> {
-  const capabilities = normalizeCapabilities(options.capabilities as AgentCapabilityDefinition[] | undefined)
-  if (!capabilities.length) return undefined
-
-  const runtime = createDevtoolsMetadataRuntime(resolution.runtime)
-  const workspaceName = resolution.workspace || resolution.name || workspaceNameFromOptions(options)
-  const input = resolution.input || {}
-  const { runtimeConfig: _runtimeConfig, ...callbackContext } = runtime
-  const invocationContext = createAgentInvocationContextStore(input.context)
-  const invoker = await resolveAgentInvoker(options.invoker, callbackContext, invocationContext, input, runtime.run)
-  const workspaceDefinition = workspaceDefinitionWithNameFromOptions(options, { workspace: workspaceName })
-  const resolved = await resolveAgentCapabilities({
-    capabilities: options.capabilities as AgentCapabilityDefinition<TRuntimeConfig, Name>[] | undefined,
-    hooks: options.hooks as never,
-  }, runtime, input, workspace, workspaceModeFromOptions(options), {
-    context: invocationContext,
-    invoker,
-    model: "model" in options ? options.model as never : undefined,
-    workspaceDefinition,
-  })
-  return Object.assign(resolved, {
-    workspaceDefinition: invocationContext.get<WorkspaceDefinition>("workspace.sourceResolution.definition") || workspaceDefinition,
-  })
-}
-
-async function resolveWorkspaceMetadataCapabilityInstructions<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  Name extends WorkspaceName,
->(
-  options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
-  workspace: ReadonlyWorkspaceFacade<Name>,
-  resolution: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name>,
-) {
-  const resolved = await resolveWorkspaceMetadataCapabilities(options, workspace, resolution)
-  if (!resolved) return []
-  try {
-    return [...resolved.capabilityInstructions]
-  }
-  finally {
-    await resolved.close()
-  }
-}
-
 export function createAgentDevtoolsMetadata<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
@@ -659,17 +615,10 @@ export async function resolveAgentDevtoolsMetadata<
   const { useWorkspace } = await import("@vite-hub/workspace")
   const workspace = useWorkspace(workspaceName)
   const options = workspaceDefinition.__vitehubWorkspaceAgentOptions as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>
-  const resolved = await resolveWorkspaceMetadataCapabilities(options, workspace, defaultsOverride)
-  try {
-    const metadataWorkspace = (resolved?.workspace || workspace) as ReadonlyWorkspaceFacade<Name>
-    return {
-      files: await resolveWorkspaceMetadataFiles(options, defaults, metadataWorkspace),
-      instructions: await resolveWorkspaceMetadataInstructions(options, metadataWorkspace, defaultsOverride, resolved),
-      ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition),
-      tools: workspaceMetadataTools(options),
-    }
-  }
-  finally {
-    await resolved?.close()
+  return {
+    files: await resolveWorkspaceMetadataFiles(options, defaults, workspace),
+    instructions: await resolveWorkspaceMetadataInstructions(options, workspace, defaultsOverride),
+    ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition),
+    tools: workspaceMetadataTools(options),
   }
 }

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -302,7 +302,7 @@ describe("agent chat capability discovery", () => {
     const state = await waitForMetadataState(handlers[0]!, { action: "get-state", invokerProfileId: "support-technical" })
     expect(state).toMatchObject({
       chats: [{ name: "support", uiMessages: [] }],
-      instructions: ["# Support\n\nAudience resolved for technical."],
+      instructions: ["# Support"],
       metadataStatus: "ready",
       invokerProfileId: "support-technical",
       invokerProfiles: [
@@ -338,7 +338,7 @@ describe("agent chat capability discovery", () => {
     })
     const clearedTechnicalState = JSON.parse(clearedTechnicalResponse.body)
     expect(clearedTechnicalState).toMatchObject({
-      instructions: ["# Support\n\nAudience resolved for technical."],
+      instructions: ["# Support"],
       invokerProfileId: "support-technical",
       selected: "support",
       uiMessages: [],
@@ -363,7 +363,7 @@ describe("agent chat capability discovery", () => {
       invokerFallback: true,
     })
     expect(resolvedFallbackState).toMatchObject({
-      instructions: ["# Support\n\nAudience resolved for undefined."],
+      instructions: ["# Support"],
       invokerFallback: true,
       metadataStatus: "ready",
       selected: "support",

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1218,7 +1218,7 @@ describe("defineAgent workspace option", () => {
     expect(readInstructions).toHaveBeenCalledOnce()
   })
 
-  it("renders capability instruction slots in resolved DevTools metadata", async () => {
+  it("renders static capability instruction slots in resolved DevTools metadata", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
     const readInstructions = vi.fn(async ({ fs }) => await fs.readFile("AGENTS.md"))
     readFile.mockResolvedValue("# Workspace instructions\n\n{{ capabilities.audience }}\n")
@@ -1229,25 +1229,70 @@ describe("defineAgent workspace option", () => {
       model: {} as never,
       capabilities: [{
         id: "audience",
-        prepare({ input, instructions }) {
-          const origin = (input.get().context as { chat?: { run?: { origin?: string } } } | undefined)?.chat?.run?.origin
-          instructions.add(`Audience resolved for ${origin}.`)
+        instructions: "Static audience instructions.",
+      }],
+    }), { workspace: "support" })
+
+    expect(await resolveAgentDevtoolsMetadata(agent)).toMatchObject({
+      instructions: ["# Workspace instructions\n\nStatic audience instructions."],
+    })
+    expect(readInstructions).toHaveBeenCalledOnce()
+  })
+
+  it("does not run invocation-scoped capability work while resolving DevTools metadata", async () => {
+    const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const phase = vi.fn()
+    const toolResolver = vi.fn(() => ({}))
+    const invokerResolve = vi.fn(() => ({ id: "resolved" }))
+    exists.mockResolvedValue(true)
+    list.mockResolvedValue([{ path: "docs/guide.md", type: "file" }])
+    readFile.mockResolvedValue("# Workspace instructions\n\n{{ capabilities.tracked }}")
+    const agent = withWorkspaceAgentDefaults(defineAgent({
+      invoker: {
+        profiles: [{ id: "support", kind: "support", label: "Support" }],
+        resolve: invokerResolve,
+      },
+      workspace: {
+        sources: {
+          docs: { instructions: "Use docs for support evidence.", name: "docs" } as never,
         },
+      },
+      instructions: async ({ fs }) => await fs.readFile("AGENTS.md"),
+      hooks: {
+        "capability:prepare": () => phase("hook:prepare"),
+      },
+      model: {} as never,
+      capabilities: [{
+        bind: () => phase("bind"),
+        close: () => phase("close"),
+        configure: () => phase("configure"),
+        id: "tracked",
+        input: () => phase("input"),
+        instructions: () => {
+          phase("instructions")
+          return "Dynamic capability instructions."
+        },
+        output: () => phase("output"),
+        prepare: () => phase("prepare"),
+        resolve: () => phase("resolve"),
+        tools: toolResolver,
       }],
     }), { workspace: "support" })
 
     expect(await resolveAgentDevtoolsMetadata(agent, {
-      input: {
-        context: {
-          chat: {
-            run: { origin: "devtools" },
-          },
-        },
-      },
+      input: { context: { invokerProfileId: "support" } },
     })).toMatchObject({
-      instructions: ["# Workspace instructions\n\nAudience resolved for devtools."],
+      files: [expect.objectContaining({ path: "docs" })],
+      instructions: [[
+        "# Workspace instructions",
+        "## Workspace Sources",
+        "### docs\n\nUse docs for support evidence.",
+      ].join("\n\n")],
+      tools: [expect.objectContaining({ name: "tracked" })],
     })
-    expect(readInstructions).toHaveBeenCalledOnce()
+    expect(phase).not.toHaveBeenCalled()
+    expect(toolResolver).not.toHaveBeenCalled()
+    expect(invokerResolve).not.toHaveBeenCalled()
   })
 
   it("resolves recursive DevTools file metadata for lazy source entries", async () => {
@@ -1292,9 +1337,14 @@ describe("defineAgent workspace option", () => {
     })
   })
 
-  it("filters resolved DevTools file metadata through Access-scoped workspace visibility", async () => {
+  it("does not apply Access-scoped workspace visibility during passive DevTools metadata resolution", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
     const { access } = await import("../src/capabilities.ts")
+    const resolveScope = vi.fn(({ invoker }) => {
+      return invoker.meta?.scope === "support"
+        ? { role: "admin", scope: "support" }
+        : { role: "viewer", scope: "customer" }
+    })
     useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
     list.mockResolvedValue([
       { path: "customers", type: "directory" },
@@ -1320,11 +1370,7 @@ describe("defineAgent workspace option", () => {
       capabilities: [
         access({
           workspace: {
-            resolve({ invoker }) {
-              return invoker.meta?.scope === "support"
-                ? { role: "admin", scope: "support" }
-                : { role: "viewer", scope: "customer" }
-            },
+            resolve: resolveScope,
             scopes: {
               customer: { paths: ["customers/acme"] },
               support: { all: true },
@@ -1342,33 +1388,25 @@ describe("defineAgent workspace option", () => {
     const paths = JSON.stringify(metadata.files)
 
     expect(paths).toContain("customers/acme/orders.sql")
-    expect(paths).not.toContain("customers/globex")
-    expect(paths).not.toContain("portal")
+    expect(paths).toContain("customers/globex")
+    expect(paths).toContain("portal")
+    expect(resolveScope).not.toHaveBeenCalled()
+    expect(createWorkspaceSourceResolutionFacade).not.toHaveBeenCalled()
   })
 
-  it("renders resolved Source Instructions in resolved DevTools metadata", async () => {
+  it("renders static Source Instructions without running Access source resolution for DevTools metadata", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
     const { access } = await import("../src/capabilities.ts")
-    const metadataWorkspace = readonlyWorkspaceFacade()
     useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
     exists.mockImplementation(async path => path === "ingestion/acme")
-    createWorkspaceSourceResolutionFacade.mockResolvedValueOnce({
-      workspace: metadataWorkspace,
-      definition: {
-        name: "support",
-        sources: {
-          ingestion: {
-            instructions: "Use this source for acme ingestion models only.",
-            mount: "ingestion/acme",
-            name: "ingestion",
-          },
-        },
-      },
-    })
     const agent = withWorkspaceAgentDefaults(defineAgent({
       workspace: {
         sources: {
-          ingestion: { name: "ingestion" } as never,
+          ingestion: {
+            instructions: "Use this source for ingestion models.",
+            mount: "ingestion/acme",
+            name: "ingestion",
+          } as never,
         },
       },
       capabilities: [
@@ -1389,9 +1427,10 @@ describe("defineAgent workspace option", () => {
       instructions: [[
         "Answer from the workspace.",
         "## Workspace Sources",
-        "### ingestion\n\nUse this source for acme ingestion models only.",
+        "### ingestion\n\nUse this source for ingestion models.",
       ].join("\n\n")],
     })
+    expect(createWorkspaceSourceResolutionFacade).not.toHaveBeenCalled()
   })
 
   it("flattens virtual workspace AGENTS.md while keeping sibling instruction files", async () => {


### PR DESCRIPTION
Makes Chat DevTools metadata resolution passive by removing the async metadata path that resolved invokers and ran the Capability Lifecycle. Resolved metadata still reads the Workspace file tree and renders static Agent, Source, and Capability instruction metadata, but it no longer executes invocation-scoped Capability phases, tool resolvers, Access source resolution, or `invoker.resolve()` just to inspect DevTools metadata.

This fixes the remaining metadata inspection bug where opening or refreshing Chat DevTools could trigger runtime side effects from application-defined invocation paths. Real Agent Invocations and Chat DevTools sends still use the normal Agent Trigger and Capability Lifecycle paths.

Scoped Access-derived metadata is no longer resolved during passive inspection; DevTools continues to show the static Workspace/source view until a real invocation applies access and source resolution.