### PR TITLE
feat(agent)!: remove usage telemetry chat option

### DIFF
--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -66,8 +66,6 @@ export {
   mcp,
 } from "./mcp.ts"
 export {
-  formatUsageTelemetryChatMessage,
-  getUsageTelemetryChatOptions,
   normalizeAgentUsage,
   staticModelPricing,
   usageTelemetry,
@@ -245,13 +243,6 @@ export type {
   AgentUsagePricingContext,
   StaticModelPrice,
   UsageTelemetryCallback,
-  UsageTelemetryChatCallback,
-  UsageTelemetryChatCallbackContext,
-  UsageTelemetryChatFormatter,
-  UsageTelemetryChatMessage,
-  UsageTelemetryChatMessageContext,
-  UsageTelemetryChatOptions,
-  UsageTelemetryChatSendMessage,
   UsageTelemetryContext,
   UsageTelemetryOptions,
   VercelAiGatewayPricingOptions,

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -2,11 +2,8 @@ import { defineCapability } from "../capability-runtime.ts"
 
 import type {
   AgentCapabilityDefinition,
-  AgentChatMessage,
-  AgentChatSendMessage,
   AgentFinishEvent,
   AgentRunMetadata,
-  AgentRuntimeConfig,
   AgentUsage,
   AgentUsageCost,
   AgentUsageRecord,
@@ -22,47 +19,16 @@ export interface AgentUsagePricingContext {
 
 export type AgentUsagePricing = (context: AgentUsagePricingContext) => MaybePromise<AgentUsageCost | undefined>
 
-export interface UsageTelemetryChatMessageContext {
-  durationMs?: number
-  provider?: string
-  run?: Partial<AgentRunMetadata>
-}
-
 export interface UsageTelemetryContext {
   run?: Partial<AgentRunMetadata>
 }
-
-export type UsageTelemetryChatMessage = AgentChatMessage
-
-export type UsageTelemetryChatSendMessage = AgentChatSendMessage
-
-export interface UsageTelemetryChatCallbackContext extends UsageTelemetryChatMessageContext {
-  sendMessage: UsageTelemetryChatSendMessage
-}
-
-export type UsageTelemetryChatFormatter = (
-  record: AgentUsageRecord,
-  context: UsageTelemetryChatMessageContext,
-) => MaybePromise<string | undefined>
 
 export type UsageTelemetryCallback = (
   record: AgentUsageRecord,
   context: UsageTelemetryContext,
 ) => MaybePromise<void>
 
-export type UsageTelemetryChatCallback = (
-  record: AgentUsageRecord,
-  context: UsageTelemetryChatCallbackContext,
-) => MaybePromise<void>
-
-export interface UsageTelemetryChatOptions {
-  enabled?: boolean
-  format?: UsageTelemetryChatFormatter
-  onUsage?: UsageTelemetryChatCallback
-}
-
 export interface UsageTelemetryOptions {
-  chat?: boolean | UsageTelemetryChatOptions
   includeRaw?: boolean
   onUsage?: UsageTelemetryCallback
   pricing?: AgentUsagePricing
@@ -99,29 +65,6 @@ function isRecord(value: unknown): value is UnknownRecord {
 
 function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
   return !!value && typeof value === "object" && Symbol.asyncIterator in value
-}
-
-function isUsageTelemetryMetadata(value: unknown): value is UsageTelemetryCapabilityMetadata {
-  return isRecord(value)
-    && value.kind === "usage-telemetry"
-    && isRecord(value.usageTelemetry)
-}
-
-function normalizeChatOptions(value: UsageTelemetryOptions["chat"]): UsageTelemetryChatOptions | undefined {
-  if (value === true) return {}
-  if (!value) return
-  return value.enabled === false ? undefined : value
-}
-
-export function getUsageTelemetryChatOptions<TRuntimeConfig extends AgentRuntimeConfig>(
-  capabilities: AgentCapabilityDefinition<TRuntimeConfig>[],
-): UsageTelemetryChatOptions[] {
-  return capabilities
-    .map((capability) => {
-      if (capability.id !== "usage-telemetry" || !isUsageTelemetryMetadata(capability.metadata)) return undefined
-      return normalizeChatOptions(capability.metadata.usageTelemetry.chat)
-    })
-    .filter((options): options is UsageTelemetryChatOptions => !!options)
 }
 
 function readNumber(record: UnknownRecord, ...keys: string[]): number | undefined {
@@ -403,56 +346,6 @@ export function usageTelemetry(options: UsageTelemetryOptions = {}): AgentCapabi
       })
     },
   })
-}
-
-function formatNumber(value: number | undefined): string | undefined {
-  return typeof value === "number" && Number.isFinite(value)
-    ? new Intl.NumberFormat("en-US").format(value)
-    : undefined
-}
-
-function formatSeconds(value: number | undefined): string | undefined {
-  if (typeof value !== "number" || !Number.isFinite(value)) return
-  return `${(value / 1000).toFixed(value < 10_000 ? 2 : 1)}s`
-}
-
-function formatTokenSummary(usage: AgentUsage | undefined): string {
-  if (!usage) return "`n/a`"
-  const input = formatNumber(usage.inputTokens)
-  const output = formatNumber(usage.outputTokens)
-  const total = formatNumber(usage.totalTokens ?? (usage.inputTokens !== undefined && usage.outputTokens !== undefined ? usage.inputTokens + usage.outputTokens : undefined))
-  const details = [
-    input ? `${input} in` : undefined,
-    output ? `${output} out` : undefined,
-  ].filter(Boolean).join(", ")
-  return `${total ? `\`${total}\`` : "`n/a`"} total${details ? ` (${details})` : ""}`
-}
-
-function formatCost(cost: AgentUsageCost | undefined): string {
-  if (!cost) return "`n/a`"
-  const prefix = cost.estimated ? "~" : ""
-  const suffix = cost.source ? ` ${cost.source}` : ""
-  return `\`${prefix}${cost.amount} ${cost.currency}\`${suffix}`
-}
-
-export function formatUsageTelemetryChatMessage(
-  record: AgentUsageRecord,
-  context: UsageTelemetryChatMessageContext = {},
-): string {
-  const durationMs = record.latency?.durationMs ?? context.durationMs
-  const lines = [
-    "**Usage**",
-    `- Tokens: ${formatTokenSummary(record.usage)}`,
-    `- Time: \`${formatSeconds(durationMs) || "n/a"}\``,
-    `- Price: ${formatCost(record.cost)}`,
-  ]
-  if (record.latency?.tokensPerSecond !== undefined) {
-    lines.push(`- Speed: \`${record.latency.tokensPerSecond.toFixed(1)} tok/s\``)
-  }
-  if (record.model?.id) {
-    lines.push(`- Model: \`${record.model.id}\``)
-  }
-  return lines.join("\n")
 }
 
 function decimalToParts(value: string): { scale: bigint, units: bigint } {

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -5,7 +5,6 @@ import { Chat } from "chat"
 import { resolveAgentTriggerInvocation, resolveAgentTriggers, runAgentInline, streamAgent, streamAgentTrigger } from "./index.ts"
 import { streamAgentOutputToEvents } from "./agent-output.ts"
 import { getAccessCapabilityOptions } from "./capabilities/access.ts"
-import { formatUsageTelemetryChatMessage, getUsageTelemetryChatOptions } from "./capabilities/usage-telemetry.ts"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions } from "./chat-trigger.ts"
 import { uiMessagesToAgentMessages } from "./chat-message-input.ts"
 import { createAgentRuntimeContext } from "./runtime/context.ts"
@@ -27,11 +26,9 @@ import type {
   AgentRuntimeName,
   AgentWaitUntil,
   AgentWebhookRegistrationDefinition,
-  AgentUsageRecord,
   MaybeResolvable,
 } from "./types.ts"
 import type { AccessChatIdentity } from "./capabilities/access.ts"
-import type { UsageTelemetryChatCallbackContext, UsageTelemetryChatMessage } from "./capabilities/usage-telemetry.ts"
 import type { AudioData, MessagePart } from "./messages.ts"
 import type { Adapter, Attachment, ChatConfig, Lock, Message as ChatSdkMessage, MessageContext, QueueEntry, StateAdapter, Thread, WebhookOptions } from "chat"
 
@@ -68,6 +65,11 @@ type AgentDefinitionWithCapabilities = {
 }
 
 const defaultChatErrorFallbackText = "Sorry, I couldn't process that message."
+const chatFinishMessagesKey = Symbol("vitehub.chat.finish.messages")
+
+type AgentChatQueuedFinishExtension = AgentChatFinishExtension & {
+  [chatFinishMessagesKey]: AgentChatMessage[]
+}
 
 async function readJsonBody(request: Request): Promise<AgentChatRouteBody> {
   const body = await request.json().catch(() => undefined)
@@ -250,48 +252,30 @@ function fallbackWebhookFromRequest(request: Request): string | undefined {
   return new URL(request.url).pathname.split("/").filter(Boolean).at(-1) || undefined
 }
 
-interface CollectedAgentOutput {
-  text: string
-  usageRecord?: AgentUsageRecord
-}
-
-async function collectAgentOutput(result: unknown): Promise<CollectedAgentOutput> {
+async function collectAgentOutput(result: unknown): Promise<string> {
   if (result instanceof Response) {
     if (result.headers.get("content-type")?.includes("application/json")) {
       const body = await result.clone().json().catch(() => undefined)
       if (isRecord(body) && typeof body.text === "string") {
-        return {
-          text: body.text,
-          ...(isRecord(body.usageRecord) ? { usageRecord: body.usageRecord as AgentUsageRecord } : {}),
-        }
+        return body.text
       }
     }
-    return { text: await result.text() }
+    return await result.text()
   }
 
   let text = ""
-  let usageRecord: AgentUsageRecord | undefined
   for await (const event of streamAgentOutputToEvents(result)) {
     if (event.type === "text-delta") {
       text += event.text
-    }
-    if (event.type === "usage") {
-      usageRecord = event.usageRecord
     }
     if (event.type === "error") {
       throw new Error(event.error)
     }
   }
-  return {
-    ...(usageRecord ? { usageRecord } : {}),
-    text: text.trim(),
-  }
+  return text.trim()
 }
 
-function streamAgentOutputToChatText(
-  result: Promise<unknown>,
-  onUsageRecord: (usageRecord: AgentUsageRecord) => void,
-): AsyncIterable<string> {
+function streamAgentOutputToChatText(result: Promise<unknown>): AsyncIterable<string> {
   return {
     async *[Symbol.asyncIterator]() {
       const output = await result
@@ -299,7 +283,6 @@ function streamAgentOutputToChatText(
         if (output.headers.get("content-type")?.includes("application/json")) {
           const body = await output.clone().json().catch(() => undefined)
           if (isRecord(body)) {
-            if (isRecord(body.usageRecord)) onUsageRecord(body.usageRecord as AgentUsageRecord)
             if (typeof body.text === "string") yield body.text
             return
           }
@@ -311,9 +294,6 @@ function streamAgentOutputToChatText(
       for await (const event of streamAgentOutputToEvents(output)) {
         if (event.type === "text-delta") {
           yield event.text
-        }
-        if (event.type === "usage") {
-          onUsageRecord(event.usageRecord)
         }
         if (event.type === "error") {
           throw new Error(event.error)
@@ -740,14 +720,25 @@ async function postChatErrorFallback(
 function createChatFinishExtension(
   input: AgentChatMessageTriggerInput,
   registration: AgentWebhookRegistrationDefinition,
-  thread: Thread,
-): AgentChatFinishExtension {
+): AgentChatQueuedFinishExtension {
+  const messages: AgentChatMessage[] = []
   return {
+    [chatFinishMessagesKey]: messages,
     provider: registration.provider,
     ...(input.run ? { run: input.run } : {}),
     sendMessage: async (message) => {
-      await postChatMessage(thread, message)
+      messages.push(message)
     },
+  }
+}
+
+async function flushChatFinishExtensionMessages(
+  thread: Thread,
+  chat: AgentChatQueuedFinishExtension,
+): Promise<void> {
+  const messages = chat[chatFinishMessagesKey].splice(0)
+  for (const message of messages) {
+    await postChatMessage(thread, message)
   }
 }
 
@@ -787,35 +778,6 @@ async function isChatMessageAuthorized(
   return true
 }
 
-async function postUsageTelemetry(
-  agent: AgentInput<ViteAgentRouteRuntimeContext>,
-  durationMs: number,
-  input: AgentChatMessageTriggerInput,
-  registration: AgentWebhookRegistrationDefinition,
-  thread: Thread,
-  usageRecord: AgentUsageRecord | undefined,
-): Promise<void> {
-  if (!usageRecord) return
-  for (const options of getUsageTelemetryChatOptions(getAgentCapabilities(agent))) {
-    const context: UsageTelemetryChatCallbackContext = {
-      durationMs,
-      provider: registration.provider,
-      ...(input.run ? { run: input.run } : {}),
-      sendMessage: async (message: UsageTelemetryChatMessage) => {
-        await postChatMessage(thread, message)
-      },
-    }
-    if (options.onUsage) {
-      await options.onUsage(usageRecord, context)
-      continue
-    }
-    const markdown = options.format
-      ? await options.format(usageRecord, context)
-      : formatUsageTelemetryChatMessage(usageRecord, context)
-    if (markdown) await thread.post({ markdown })
-  }
-}
-
 async function handleChatSdkMessage(
   agent: AgentInput<ViteAgentRouteRuntimeContext>,
   context: ViteAgentRouteRuntimeContext,
@@ -833,7 +795,6 @@ async function handleChatSdkMessage(
     if (!firstMessage || !Array.isArray(firstMessage.parts) || firstMessage.parts.length === 0) return
     if (!await isChatMessageAuthorized(agent, context, registration, thread, message, messageContext)) return
 
-    const startedAt = Date.now()
     if (options?.stream !== false) {
       context.waitUntil(thread.startTyping().catch(() => undefined))
     }
@@ -843,28 +804,23 @@ async function handleChatSdkMessage(
       ...context,
       ...(invocation.run ? { run: invocation.run } : {}),
     }
-    const invocationInput = withChatFinishExtension(
-      invocation.input as AgentRunInput,
-      createChatFinishExtension(input, registration, thread),
-    )
-    let usageRecord: AgentUsageRecord | undefined
+    const chatFinish = createChatFinishExtension(input, registration)
+    const invocationInput = withChatFinishExtension(invocation.input as AgentRunInput, chatFinish)
     if (options?.stream === false) {
       const result = await runAgentInline(agent as never, runContext as never, invocationInput as never)
-      const collected = await collectAgentOutput(result)
-      usageRecord = collected.usageRecord
-      if (collected.text) {
-        await thread.post({ markdown: collected.text })
+      const text = await collectAgentOutput(result)
+      if (text) {
+        await thread.post({ markdown: text })
       }
+      await flushChatFinishExtensionMessages(thread, chatFinish)
     }
     else {
       const result = streamAgent(agent as never, runContext as never, invocationInput as never, {
         output: "events",
       })
-      await thread.post(streamAgentOutputToChatText(result, record => {
-        usageRecord = record
-      }))
+      await thread.post(streamAgentOutputToChatText(result))
+      await flushChatFinishExtensionMessages(thread, chatFinish)
     }
-    await postUsageTelemetry(agent, Date.now() - startedAt, input, registration, thread, usageRecord)
   }
   catch (error) {
     await postChatErrorFallback(error, thread, message, options, input, run)

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -30,7 +30,7 @@ import type {
 } from "./types.ts"
 import type { AccessChatIdentity } from "./capabilities/access.ts"
 import type { AudioData, MessagePart } from "./messages.ts"
-import type { Adapter, Attachment, ChatConfig, Lock, Message as ChatSdkMessage, MessageContext, QueueEntry, StateAdapter, Thread, WebhookOptions } from "chat"
+import type { Adapter, Attachment, ChatConfig, Lock, Message as ChatSdkMessage, MessageContext, QueueEntry, SentMessage, StateAdapter, Thread, WebhookOptions } from "chat"
 
 interface ViteAgentRouteRuntimeConfig extends AgentRuntimeConfig {
   agent?: unknown
@@ -275,7 +275,12 @@ async function collectAgentOutput(result: unknown): Promise<string> {
   return text.trim()
 }
 
-function streamAgentOutputToChatText(result: Promise<unknown>): AsyncIterable<string> {
+type ChatTextStream = AsyncIterable<string> & {
+  getText: () => string
+}
+
+function streamAgentOutputToChatText(result: Promise<unknown>): ChatTextStream {
+  let collected = ""
   return {
     async *[Symbol.asyncIterator]() {
       const output = await result
@@ -283,16 +288,22 @@ function streamAgentOutputToChatText(result: Promise<unknown>): AsyncIterable<st
         if (output.headers.get("content-type")?.includes("application/json")) {
           const body = await output.clone().json().catch(() => undefined)
           if (isRecord(body)) {
-            if (typeof body.text === "string") yield body.text
+            if (typeof body.text === "string") {
+              collected += body.text
+              yield body.text
+            }
             return
           }
         }
-        yield await output.text()
+        const bodyText = await output.text()
+        collected += bodyText
+        yield bodyText
         return
       }
 
       for await (const event of streamAgentOutputToEvents(output)) {
         if (event.type === "text-delta") {
+          collected += event.text
           yield event.text
         }
         if (event.type === "error") {
@@ -300,6 +311,19 @@ function streamAgentOutputToChatText(result: Promise<unknown>): AsyncIterable<st
         }
       }
     },
+    getText: () => collected,
+  }
+}
+
+async function commitStreamedChatResponse(
+  thread: Thread,
+  message: SentMessage,
+  response: ChatTextStream,
+): Promise<void> {
+  if (!thread.adapter.stream) return
+  const markdown = response.getText()
+  if (markdown.trim()) {
+    await message.edit({ markdown })
   }
 }
 
@@ -818,7 +842,9 @@ async function handleChatSdkMessage(
       const result = streamAgent(agent as never, runContext as never, invocationInput as never, {
         output: "events",
       })
-      await thread.post(streamAgentOutputToChatText(result))
+      const response = streamAgentOutputToChatText(result)
+      const message = await thread.post(response)
+      await commitStreamedChatResponse(thread, message, response)
       await flushChatFinishExtensionMessages(thread, chatFinish)
     }
   }

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -366,7 +366,6 @@ describe("server helpers", () => {
           },
         }),
         usageTelemetry({
-          chat: true,
           pricing: staticModelPricing({
             "openai/gpt-test": {
               input: "0.00000010",
@@ -398,19 +397,8 @@ describe("server helpers", () => {
     await expect(response.json()).resolves.toEqual({ ok: true })
     expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "...")
+    expect(adapter.postMessage).toHaveBeenCalledTimes(1)
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "echo: hello" })
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", {
-      markdown: expect.stringContaining("**Usage**"),
-    })
-    expect(adapter.postMessage.mock.calls[1]![1]).toEqual({
-      markdown: expect.stringContaining("`15` total (10 in, 5 out)"),
-    })
-    expect(adapter.postMessage.mock.calls[1]![1]).toEqual({
-      markdown: expect.stringContaining("`1.20s`"),
-    })
-    expect(adapter.postMessage.mock.calls[1]![1]).toEqual({
-      markdown: expect.stringContaining("`~0.000002 USD`"),
-    })
     expect(admitChat).toHaveBeenCalledWith(expect.objectContaining({
       identity: expect.objectContaining({
         id: "123",
@@ -768,14 +756,18 @@ describe("server helpers", () => {
     }
   })
 
-  it("posts usage telemetry callbacks for non-streaming model chat webhooks", async () => {
+  it("lets agent finish hooks post usage telemetry for non-streaming model chat webhooks", async () => {
     const { chat, staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
     const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
     const adapter = createTestChatAdapter()
-    const onUsage = vi.fn(async (record, context) => {
-      await context.sendMessage({
-        markdown: `Custom usage: \`${record.usage.totalTokens}\` tokens via ${context.provider}`,
-      })
+    const finish = vi.fn(async (event) => {
+      const chat = event.extensions.get("chat") as { provider?: string, sendMessage?: (message: { markdown: string }) => Promise<void> } | undefined
+      const usage = event.extensions.get("usage-telemetry") as { usage?: { totalTokens?: number } } | undefined
+      if (chat && usage) {
+        await chat.sendMessage?.({
+          markdown: `Custom usage: \`${usage.usage?.totalTokens}\` tokens via ${chat.provider}`,
+        })
+      }
     })
     const model = {
       generate: vi.fn(async () => ({
@@ -808,7 +800,6 @@ describe("server helpers", () => {
           },
         }),
         usageTelemetry({
-          chat: { onUsage },
           pricing: staticModelPricing({
             "openai/gpt-test": {
               input: "0.00000010",
@@ -817,6 +808,9 @@ describe("server helpers", () => {
           }),
         }),
       ],
+      hooks: {
+        "agent:finish": finish,
+      },
       resolve: vi.fn(async () => model),
     }
     const handler = defineAgentChatWebhookFetchHandler(agent as never)
@@ -841,7 +835,8 @@ describe("server helpers", () => {
     expect(model.stream).not.toHaveBeenCalled()
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", { markdown: "generated ok" })
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Custom usage: `15` tokens via telegram" })
-    expect(onUsage).toHaveBeenCalledWith(expect.objectContaining({
+    expect(finish).toHaveBeenCalledOnce()
+    expect(finish.mock.calls[0]![0].extensions.get("usage-telemetry")).toEqual(expect.objectContaining({
       cost: expect.objectContaining({
         amount: "0.0000018",
         currency: "USD",
@@ -857,8 +852,8 @@ describe("server helpers", () => {
         outputTokens: 3,
         totalTokens: 15,
       },
-    }), expect.objectContaining({
-      durationMs: expect.any(Number),
+    }))
+    expect(finish.mock.calls[0]![0].extensions.get("chat")).toEqual(expect.objectContaining({
       provider: "telegram",
       sendMessage: expect.any(Function),
     }))
@@ -909,8 +904,8 @@ describe("server helpers", () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ ok: true })
     expect(finish).toHaveBeenCalledOnce()
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:888", { markdown: "side message via telegram" })
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:888", { markdown: "agent answer" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:888", { markdown: "agent answer" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:888", { markdown: "side message via telegram" })
   })
 
   it("flushes deferred non-streaming chat webhook work before returning", async () => {
@@ -938,8 +933,12 @@ describe("server helpers", () => {
         },
       }
     })
-    const onUsage = vi.fn(async (_record, context) => {
-      await context.sendMessage({ markdown: "usage ok" })
+    const finish = vi.fn(async (event) => {
+      const chat = event.extensions.get("chat") as { sendMessage?: (message: { markdown: string }) => Promise<void> } | undefined
+      const usage = event.extensions.get("usage-telemetry")
+      if (chat && usage) {
+        await chat.sendMessage?.({ markdown: "usage ok" })
+      }
     })
     const agent = defineAgent({
       capabilities: [
@@ -952,10 +951,11 @@ describe("server helpers", () => {
             telegram: {},
           },
         }),
-        usageTelemetry({
-          chat: { onUsage },
-        }),
+        usageTelemetry(),
       ],
+      hooks: {
+        "agent:finish": finish,
+      },
       run,
     })
     const handler = defineAgentChatWebhookFetchHandler(agent as never)
@@ -989,17 +989,22 @@ describe("server helpers", () => {
     expect(adapter.startTyping).not.toHaveBeenCalled()
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", { markdown: "ok" })
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "usage ok" })
+    expect(finish).toHaveBeenCalledOnce()
   })
 
-  it("lets usageTelemetry chat callbacks post custom follow-up messages", async () => {
+  it("lets agent finish hooks compose usage telemetry and chat follow-up messages", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { access, chat, staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
     const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
     const adapter = createTestChatAdapter()
-    const onUsage = vi.fn(async (record, context) => {
-      await context.sendMessage({
-        markdown: `Custom usage: \`${record.usage.totalTokens}\` tokens via ${context.provider}`,
-      })
+    const finish = vi.fn(async (event) => {
+      const chat = event.extensions.get("chat") as { provider?: string, sendMessage?: (message: { markdown: string }) => Promise<void> } | undefined
+      const usage = event.extensions.get("usage-telemetry") as { usage?: { totalTokens?: number } } | undefined
+      if (chat && usage) {
+        await chat.sendMessage?.({
+          markdown: `Custom usage: \`${usage.usage?.totalTokens}\` tokens via ${chat.provider}`,
+        })
+      }
     })
     const agent = defineAgent({
       capabilities: [
@@ -1017,7 +1022,6 @@ describe("server helpers", () => {
           },
         }),
         usageTelemetry({
-          chat: { onUsage },
           pricing: staticModelPricing({
             "openai/gpt-test": {
               input: "0.00000010",
@@ -1026,6 +1030,9 @@ describe("server helpers", () => {
           }),
         }),
       ],
+      hooks: {
+        "agent:finish": finish,
+      },
       run: () => ({
         response: {
           modelId: "openai/gpt-test",
@@ -1058,13 +1065,15 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:789", "...")
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:789", "sent-1", { markdown: "ok" })
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:789", { markdown: "Custom usage: `15` tokens via telegram" })
-    expect(onUsage).toHaveBeenCalledWith(expect.objectContaining({
+    expect(finish).toHaveBeenCalledOnce()
+    expect(finish.mock.calls[0]![0].extensions.get("usage-telemetry")).toEqual(expect.objectContaining({
       usage: {
         inputTokens: 10,
         outputTokens: 5,
         totalTokens: 15,
       },
-    }), expect.objectContaining({
+    }))
+    expect(finish.mock.calls[0]![0].extensions.get("chat")).toEqual(expect.objectContaining({
       provider: "telegram",
       sendMessage: expect.any(Function),
     }))

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { Message } from "chat"
 import { describe, expect, it, vi } from "vitest"
 
-import type { Adapter, ChatInstance, WebhookOptions } from "chat"
+import type { Adapter, ChatInstance, StreamChunk, WebhookOptions } from "chat"
 
 vi.mock("@vite-hub/internal/build/vercel-runtime-packages", () => ({
   copyVercelFunctionRuntimePackages: vi.fn(async () => undefined),
@@ -57,6 +57,9 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, secr
       const task = chatInstance.processMessage(adapter as unknown as Adapter, message.threadId, message, webhookOptions)
       if (!options.deferMessageProcessing) {
         await task
+      }
+      else {
+        task.catch(() => undefined)
       }
       return Response.json({ ok: true })
     }),
@@ -906,6 +909,111 @@ describe("server helpers", () => {
     expect(finish).toHaveBeenCalledOnce()
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:888", { markdown: "agent answer" })
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:888", { markdown: "side message via telegram" })
+  })
+
+  it("commits native streamed chat responses before flushing finish hook messages", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const adapter = createTestChatAdapter()
+    const order: string[] = []
+    let streamConsumed!: () => void
+    let commitStarted!: () => void
+    let commitResponse!: () => void
+    const streamConsumedPromise = new Promise<void>(resolve => {
+      streamConsumed = resolve
+    })
+    const commitStartedPromise = new Promise<void>(resolve => {
+      commitStarted = resolve
+    })
+    const commitResponsePromise = new Promise<void>(resolve => {
+      commitResponse = resolve
+    })
+    adapter.stream = vi.fn(async (threadId: string, textStream: AsyncIterable<string | StreamChunk>) => {
+      let text = ""
+      for await (const chunk of textStream) {
+        if (typeof chunk === "string") text += chunk
+        else if (chunk.type === "markdown_text") text += chunk.text
+      }
+      order.push(`stream:${text}`)
+      streamConsumed()
+      return { id: "stream-1", raw: { text }, threadId }
+    })
+    adapter.editMessage.mockImplementation(async (threadId: string, messageId: string, message: unknown) => {
+      order.push("commit:start")
+      commitStarted()
+      await commitResponsePromise
+      order.push("commit:done")
+      return { id: messageId, raw: { message }, threadId }
+    })
+    adapter.postMessage.mockImplementation(async (threadId: string, message: unknown) => {
+      order.push("post:follow-up")
+      return { id: "sent-follow-up", raw: { message }, threadId }
+    })
+    const finish = vi.fn(async (event) => {
+      const chat = event.extensions.get("chat") as { sendMessage?: (message: { markdown: string }) => Promise<void> } | undefined
+      await chat?.sendMessage?.({ markdown: "usage ok" })
+      order.push("finish:queued")
+    })
+    const agent = defineAgent({
+      capabilities: [
+        chat({
+          adapters: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({ text: "agent answer" }),
+    })
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+    const responsePromise = handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 89,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 89,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    try {
+      await streamConsumedPromise
+      await expect(Promise.race([
+        commitStartedPromise.then(() => "commit-started"),
+        responsePromise.then(() => "settled"),
+      ])).resolves.toBe("commit-started")
+      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "stream-1", { markdown: "agent answer" })
+      expect(adapter.postMessage).not.toHaveBeenCalled()
+      await expect(Promise.race([
+        responsePromise.then(() => "settled"),
+        Promise.resolve("pending"),
+      ])).resolves.toBe("pending")
+
+      commitResponse()
+      const response = await responsePromise
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ ok: true })
+      expect(adapter.postMessage).toHaveBeenCalledTimes(1)
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "usage ok" })
+      expect(finish).toHaveBeenCalledOnce()
+      expect(order.indexOf("commit:done")).toBeLessThan(order.indexOf("post:follow-up"))
+      expect(order).toContain("stream:agent answer")
+    }
+    finally {
+      commitResponse()
+    }
   })
 
   it("flushes deferred non-streaming chat webhook work before returning", async () => {

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -13,27 +13,6 @@ const runtime = () => ({
 })
 
 describe("usage telemetry", () => {
-  it("exposes opt-in chat telemetry options and formats a chat summary", async () => {
-    const { formatUsageTelemetryChatMessage, getUsageTelemetryChatOptions, usageTelemetry } = await import("../src/capabilities.ts")
-    const capability = usageTelemetry({ chat: true })
-
-    expect(getUsageTelemetryChatOptions([capability])).toEqual([{}])
-    expect(formatUsageTelemetryChatMessage({
-      cost: {
-        amount: "0.000002",
-        currency: "USD",
-        estimated: true,
-        source: "vercel-ai-gateway",
-      },
-      model: { id: "openai/gpt-test" },
-      usage: {
-        inputTokens: 10,
-        outputTokens: 5,
-        totalTokens: 15,
-      },
-    }, { durationMs: 1234 })).toContain("`15` total (10 in, 5 out)")
-  })
-
   it("normalizes usage and attaches a priced usage record", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")


### PR DESCRIPTION
Removes the chat-specific `usageTelemetry` API surface from `@vite-hub/agent`, including the `chat` option, chat formatter/helper exports, and the automatic chat webhook usage follow-up path.

Apps that need chat usage messages should now compose the `usage-telemetry` and `chat` finish extensions in `agent:finish`, which keeps usage collection and the finish extension provider intact while removing capability-level chat coupling.

BREAKING CHANGE: `usageTelemetry` no longer accepts `{ chat: ... }` or exports `UsageTelemetryChat*` helpers.