### PR TITLE
feat(workspace): add github store provider

### DIFF
--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -87,6 +87,23 @@ Need the workspace to run generated code instead of only reading and writing fil
 
 Use `hubWorkspace()` in Vite to discover workspace definitions, emit the workspace manifest for local development, and make the runtime store available to server code.
 
+## GitHub-backed persistence
+
+Use the GitHub Workspace Store when a hosted runtime needs durable Workspace file-tree state without a provider-specific artifact store:
+
+```ts
+export default defineWorkspace({
+  store: {
+    provider: "github",
+    repository: "owner/repo",
+    branch: "main",
+    root: ".vitehub/workspaces/<workspace>",
+  },
+})
+```
+
+Set `WORKSPACE_GITHUB_TOKEN`, `VITEHUB_WORKSPACE_GITHUB_TOKEN`, `GITHUB_TOKEN`, or a `GITHUB_TOKEN` runtime binding with permission to read and write the repository contents. Reads and snapshots call the GitHub API, so this Store trades provider independence for GitHub API latency and rate limits. `workspace.snapshot()` writes changed Workspace Store files as a GitHub commit. If the target branch moves after the Workspace Store loaded local changes, snapshot fails with a conflict so the caller can retry from a fresh Workspace Store.
+
 Built on [`@vite-hub/source`](../source/README.md), [`@vite-hub/shell`](../shell/README.md), [files-sdk](https://files-sdk.dev/), and [isomorphic-git](https://isomorphic-git.org/).
 
 Learn more at [vitehub.dev](https://vitehub.dev).

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -48,6 +48,7 @@
     "./internal/runtime/empty-registry": "./dist/runtime/empty-registry.js",
     "./internal/runtime/state": "./dist/runtime/state.js",
     "./internal/stores/cloudflare-artifacts": "./dist/providers/cloudflare/artifacts-store.js",
+    "./internal/stores/github": "./dist/providers/github/store.js",
     "./internal/stores/vercel-blob": "./dist/providers/vercel/blob-store.js"
   },
   "scripts": {

--- a/packages/workspace/src/config.ts
+++ b/packages/workspace/src/config.ts
@@ -16,6 +16,7 @@ export {
   isMaskedWorkspaceRuntimeValue,
   normalizeWorkspaceStoreOptions,
   resolveCloudflareArtifactsStore,
+  resolveGitHubWorkspaceStore,
   resolveRuntimeVercelBlobWorkspaceStore,
   resolveVercelBlobWorkspaceStore,
 } from "./storage/provider.ts"

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -409,11 +409,21 @@ export interface VercelBlobWorkspaceStoreOptions {
   access?: "private" | "public"
 }
 
+export interface GitHubWorkspaceStoreOptions {
+  provider: "github"
+  branch?: string
+  repo?: string
+  repository?: string
+  root?: string
+  token?: string
+}
+
 export type WorkspaceStoreOptions =
   | LocalWorkspaceStoreOptions
   | MemoryWorkspaceStoreOptions
   | CloudflareArtifactsWorkspaceStoreOptions
   | VercelBlobWorkspaceStoreOptions
+  | GitHubWorkspaceStoreOptions
   | WorkspaceStore
 
 export interface WorkspaceDefinition {

--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -1,0 +1,369 @@
+import { getActiveCloudflareBinding } from "@vite-hub/internal/runtime/cloudflare-env";
+
+import { WorkspaceError } from "../../core/errors.ts";
+import { contentToBytes, normalizeWorkspacePath } from "../../core/path.ts";
+
+import type { WorkspaceEntry } from "../../core/types.ts";
+
+export type GitHubWorkspaceOption = string | (() => string | undefined);
+
+export interface GitHubWorkspaceOptions {
+  branch?: GitHubWorkspaceOption;
+  repo?: GitHubWorkspaceOption;
+  repository?: GitHubWorkspaceOption;
+  root?: GitHubWorkspaceOption;
+  token?: GitHubWorkspaceOption;
+}
+
+export interface GitHubTreeEntry {
+  mode?: string;
+  path: string;
+  sha?: string | null;
+  size?: number;
+  type: string;
+}
+
+export interface GitHubTreeResponse {
+  tree: GitHubTreeEntry[];
+  truncated?: boolean;
+}
+
+export interface GitHubBranchState {
+  files: Map<string, GitHubTreeEntry>;
+  refSha: string;
+  treeSha: string;
+}
+
+export interface GitHubFileUpdate {
+  bytes: Uint8Array;
+  fullPath: string;
+  gitSha: string;
+}
+
+export interface GitHubCommitResult {
+  commitSha: string;
+  treeSha: string;
+}
+
+function processEnv(
+  env: Record<string, string | undefined>,
+  ...keys: string[]
+): string | undefined {
+  return keys.map((key) => env[key]).find((value) => typeof value === "string" && value.length > 0);
+}
+
+export function resolveGitHubOption(value: GitHubWorkspaceOption | undefined): string | undefined {
+  return typeof value === "function" ? value() : value;
+}
+
+export function requireGitHubOption(
+  kind: "publisher" | "store",
+  label: string,
+  value: string | undefined,
+): string {
+  if (!value) throw new WorkspaceError(`[vitehub] GitHub workspace ${kind} requires ${label}.`);
+  return value;
+}
+
+export function splitGitHubRepository(
+  repository: string,
+  kind: "publisher" | "store",
+): { owner: string; repo: string } {
+  const [owner, repo] = repository.split("/");
+  if (!owner || !repo) {
+    throw new WorkspaceError(
+      `[vitehub] GitHub workspace ${kind} requires a repository in owner/repo format.`,
+    );
+  }
+  return { owner: owner, repo: repo };
+}
+
+export function joinGitPath(...parts: string[]): string {
+  return parts.join("/").replaceAll("\\", "/").split("/").filter(Boolean).join("/");
+}
+
+export function resolveGitHubWorkspaceRoot(root: string, workspaceName: string): string {
+  return joinGitPath(root.replaceAll("<workspace>", workspaceName));
+}
+
+export function workspacePathFromGitPath(path: string, root: string): string | undefined {
+  const normalized = joinGitPath(path);
+  const normalizedRoot = joinGitPath(root);
+  if (!normalizedRoot) return normalizeWorkspacePath(normalized);
+  if (!normalized.startsWith(`${normalizedRoot}/`)) return undefined;
+  return normalizeWorkspacePath(normalized.slice(normalizedRoot.length + 1));
+}
+
+export function isWorkspaceFileEntry(
+  entry: WorkspaceEntry,
+): entry is WorkspaceEntry & { type: "file" } {
+  return entry.type === "file";
+}
+
+function toHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function gitBlobSha(bytes: Uint8Array): Promise<string> {
+  const prefix = new TextEncoder().encode(`blob ${bytes.byteLength}\0`);
+  const input = new Uint8Array(prefix.byteLength + bytes.byteLength);
+  input.set(prefix);
+  input.set(bytes, prefix.byteLength);
+  return toHex(new Uint8Array(await globalThis.crypto.subtle.digest("SHA-1", input)));
+}
+
+export function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let index = 0; index < bytes.length; index += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + 0x8000));
+  }
+  const encode = (globalThis as { btoa?: (input: string) => string }).btoa;
+  return encode ? encode(binary) : Buffer.from(bytes).toString("base64");
+}
+
+export function fromBase64(input: string): Uint8Array {
+  const normalized = input.replace(/\s/g, "");
+  const decode = (globalThis as { atob?: (value: string) => string }).atob;
+  if (!decode) return new Uint8Array(Buffer.from(normalized, "base64"));
+  const binary = decode(normalized);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) bytes[index] = binary.charCodeAt(index);
+  return bytes;
+}
+
+export function resolveGitHubRepositoryOption(
+  options: GitHubWorkspaceOptions,
+  env: Record<string, string | undefined> = typeof process !== "undefined" ? process.env : {},
+): string | undefined {
+  return (
+    resolveGitHubOption(options.repository) ||
+    resolveGitHubOption(options.repo) ||
+    processEnv(
+      env,
+      "WORKSPACE_GITHUB_REPOSITORY",
+      "VITEHUB_WORKSPACE_GITHUB_REPOSITORY",
+      "GITHUB_REPOSITORY",
+    )
+  );
+}
+
+export function resolveGitHubBranchOption(
+  options: GitHubWorkspaceOptions,
+  env: Record<string, string | undefined> = typeof process !== "undefined" ? process.env : {},
+): string {
+  return (
+    resolveGitHubOption(options.branch) ||
+    processEnv(
+      env,
+      "WORKSPACE_GITHUB_BRANCH",
+      "VITEHUB_WORKSPACE_GITHUB_BRANCH",
+      "GITHUB_BRANCH",
+    ) ||
+    "main"
+  );
+}
+
+export function resolveGitHubRootOption(
+  options: GitHubWorkspaceOptions,
+  workspaceName: string,
+  env: Record<string, string | undefined> = typeof process !== "undefined" ? process.env : {},
+): string {
+  return resolveGitHubWorkspaceRoot(
+    resolveGitHubOption(options.root) ||
+      processEnv(env, "WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT") ||
+      ".vitehub/workspaces/<workspace>",
+    workspaceName,
+  );
+}
+
+export function resolveGitHubTokenOption(
+  options: GitHubWorkspaceOptions,
+  env: Record<string, string | undefined> = typeof process !== "undefined" ? process.env : {},
+): string | undefined {
+  const token = resolveGitHubOption(options.token);
+  if (token && token !== "********") return token;
+  return (
+    getActiveCloudflareBinding<string>("GITHUB_TOKEN") ||
+    processEnv(env, "WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN")
+  );
+}
+
+export async function requestGitHubJson<T>(
+  repository: string,
+  token: string,
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "user-agent": "vitehub-workspace",
+      "x-github-api-version": "2022-11-28",
+      ...init?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new WorkspaceError(
+      `[vitehub] GitHub workspace request failed for ${repository}: ${response.status} ${response.statusText} ${await response.text().catch(() => "")}`,
+    );
+  }
+  return (await response.json()) as T;
+}
+
+export function findGitHubRemoteFiles(
+  tree: GitHubTreeResponse,
+  root: string,
+  kind: "publisher" | "store",
+): Map<string, GitHubTreeEntry> {
+  if (tree.truncated) {
+    throw new WorkspaceError(
+      `[vitehub] GitHub workspace ${kind} could not compare the remote tree because GitHub returned a truncated tree.`,
+    );
+  }
+
+  const files = new Map<string, GitHubTreeEntry>();
+  for (const entry of tree.tree) {
+    if (entry.type !== "blob" || !entry.sha) continue;
+    const path = workspacePathFromGitPath(entry.path, root);
+    if (path) files.set(path, entry);
+  }
+  return files;
+}
+
+export async function readGitHubBranchState(input: {
+  branch: string;
+  kind: "publisher" | "store";
+  repository: string;
+  root: string;
+  token: string;
+}): Promise<GitHubBranchState> {
+  const { owner, repo } = splitGitHubRepository(input.repository, input.kind);
+  const ref = await requestGitHubJson<{ object: { sha: string } }>(
+    input.repository,
+    input.token,
+    `/repos/${owner}/${repo}/git/ref/heads/${input.branch}`,
+  );
+  const current = await requestGitHubJson<{ tree: { sha: string } }>(
+    input.repository,
+    input.token,
+    `/repos/${owner}/${repo}/git/commits/${ref.object.sha}`,
+  );
+  const tree = await requestGitHubJson<GitHubTreeResponse>(
+    input.repository,
+    input.token,
+    `/repos/${owner}/${repo}/git/trees/${current.tree.sha}?recursive=1`,
+  );
+  return {
+    files: findGitHubRemoteFiles(tree, input.root, input.kind),
+    refSha: ref.object.sha,
+    treeSha: current.tree.sha,
+  };
+}
+
+export async function readGitHubBlob(input: {
+  kind: "publisher" | "store";
+  repository: string;
+  sha: string;
+  token: string;
+}): Promise<Uint8Array> {
+  const { owner, repo } = splitGitHubRepository(input.repository, input.kind);
+  const blob = await requestGitHubJson<{ content: string; encoding: string }>(
+    input.repository,
+    input.token,
+    `/repos/${owner}/${repo}/git/blobs/${input.sha}`,
+  );
+  if (blob.encoding !== "base64") {
+    throw new WorkspaceError(
+      `[vitehub] GitHub workspace ${input.kind} cannot read blob encoding: ${blob.encoding}.`,
+    );
+  }
+  return fromBase64(blob.content);
+}
+
+export async function commitGitHubChanges(input: {
+  baseTreeSha: string;
+  branch: string;
+  deletePaths: string[];
+  files: GitHubFileUpdate[];
+  kind?: "publisher" | "store";
+  message: string;
+  parentSha: string;
+  repository: string;
+  token: string;
+}): Promise<GitHubCommitResult> {
+  const kind = input.kind || "store";
+  const { owner, repo } = splitGitHubRepository(input.repository, kind);
+  const blobs = await Promise.all(
+    input.files.map((file) =>
+      requestGitHubJson<{ sha: string }>(
+        input.repository,
+        input.token,
+        `/repos/${owner}/${repo}/git/blobs`,
+        {
+          body: JSON.stringify({ content: toBase64(file.bytes), encoding: "base64" }),
+          method: "POST",
+        },
+      ),
+    ),
+  );
+  const tree = await requestGitHubJson<{ sha: string }>(
+    input.repository,
+    input.token,
+    `/repos/${owner}/${repo}/git/trees`,
+    {
+      body: JSON.stringify({
+        base_tree: input.baseTreeSha,
+        tree: [
+          ...input.files.map((file, index) => ({
+            mode: "100644",
+            path: file.fullPath,
+            sha: blobs[index]!.sha,
+            type: "blob",
+          })),
+          ...input.deletePaths.map((path) => ({ mode: "100644", path, sha: null, type: "blob" })),
+        ],
+      }),
+      method: "POST",
+    },
+  );
+  const commit = await requestGitHubJson<{ sha: string }>(
+    input.repository,
+    input.token,
+    `/repos/${owner}/${repo}/git/commits`,
+    {
+      body: JSON.stringify({
+        message: input.message,
+        parents: [input.parentSha],
+        tree: tree.sha,
+      }),
+      method: "POST",
+    },
+  );
+  await requestGitHubJson(
+    input.repository,
+    input.token,
+    `/repos/${owner}/${repo}/git/refs/heads/${input.branch}`,
+    {
+      body: JSON.stringify({ force: false, sha: commit.sha }),
+      method: "PATCH",
+    },
+  );
+  return { commitSha: commit.sha, treeSha: tree.sha };
+}
+
+export async function createGitHubFileUpdate(
+  path: string,
+  root: string,
+  content: string | Uint8Array,
+): Promise<GitHubFileUpdate> {
+  const bytes = contentToBytes(content);
+  return {
+    bytes,
+    fullPath: joinGitPath(root, path),
+    gitSha: await gitBlobSha(bytes),
+  };
+}

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -1,0 +1,388 @@
+import { WorkspaceError } from "../../core/errors.ts";
+import {
+  matchesAny,
+  normalizeSafeWorkspacePath,
+  normalizeSafeWorkspacePattern,
+  normalizeWorkspacePath,
+} from "../../core/path.ts";
+import { createSnapshotFromEntries, diffSnapshots } from "../../storage/utils.ts";
+import {
+  commitGitHubChanges,
+  createGitHubFileUpdate,
+  gitBlobSha,
+  joinGitPath,
+  readGitHubBlob,
+  readGitHubBranchState,
+  requireGitHubOption,
+  resolveGitHubBranchOption,
+  resolveGitHubRepositoryOption,
+  resolveGitHubRootOption,
+  resolveGitHubTokenOption,
+  type GitHubTreeEntry,
+} from "./shared.ts";
+
+import type {
+  DiffOptions,
+  GitHubWorkspaceStoreOptions,
+  GlobOptions,
+  ListOptions,
+  MkdirOptions,
+  RmOptions,
+  SnapshotOptions,
+  WorkspaceDiff,
+  WorkspaceEntry,
+  WorkspaceFile,
+  WorkspaceSnapshot,
+  WorkspaceStat,
+  WorkspaceStore,
+} from "../../core/types.ts";
+
+interface GitHubWorkspaceStoreFile {
+  bytes?: Uint8Array;
+  gitSha: string;
+  mediaType?: string;
+  metadata?: Record<string, unknown>;
+  path: string;
+  size?: number;
+}
+
+function isReservedWorkspacePath(path: string): boolean {
+  const root = normalizeWorkspacePath(path).split("/")[0];
+  return root === ".git" || root === ".vitehub";
+}
+
+function contentLength(content: string | Uint8Array): number {
+  return typeof content === "string"
+    ? new TextEncoder().encode(content).byteLength
+    : content.byteLength;
+}
+
+function parentDirectories(path: string): string[] {
+  const parts = normalizeWorkspacePath(path).split("/").filter(Boolean);
+  const directories: string[] = [];
+  for (let index = 1; index < parts.length; index++)
+    directories.push(parts.slice(0, index).join("/"));
+  return directories;
+}
+
+class GitHubWorkspaceStore implements WorkspaceStore {
+  #baseline: WorkspaceSnapshot | undefined;
+  #baselineRefSha: string | undefined;
+  #baselineTreeSha: string | undefined;
+  #branch: string;
+  #dirty = false;
+  #files = new Map<string, GitHubWorkspaceStoreFile>();
+  #ready: Promise<void> | undefined;
+  #remoteFiles = new Map<string, GitHubTreeEntry>();
+  #repository: string;
+  #root: string;
+  #token: string;
+
+  constructor(
+    options: GitHubWorkspaceStoreOptions,
+    private workspaceName: string,
+  ) {
+    this.#repository = requireGitHubOption(
+      "store",
+      "a repository",
+      resolveGitHubRepositoryOption(options),
+    );
+    this.#branch = resolveGitHubBranchOption(options);
+    this.#root = resolveGitHubRootOption(options, workspaceName);
+    this.#token = requireGitHubOption("store", "a token", resolveGitHubTokenOption(options));
+  }
+
+  async readFile(path: string): Promise<WorkspaceFile | undefined> {
+    const normalized = normalizeSafeWorkspacePath(path);
+    await this.#ensure({ refresh: true });
+    return await this.#readWorkspaceFile(normalized);
+  }
+
+  async writeFile(path: string, file: WorkspaceFile): Promise<void> {
+    const normalized = normalizeSafeWorkspacePath(path);
+    await this.#ensure({ refresh: false });
+    const update = await createGitHubFileUpdate(normalized, this.#root, file.content);
+    this.#files.set(normalized, {
+      bytes: update.bytes,
+      gitSha: update.gitSha,
+      mediaType: file.mediaType,
+      metadata: file.metadata,
+      path: normalized,
+      size: contentLength(file.content),
+    });
+    this.#dirty = true;
+  }
+
+  async list(prefix = "", options: ListOptions = {}): Promise<WorkspaceEntry[]> {
+    const normalizedPrefix = normalizeSafeWorkspacePath(prefix, { allowEmpty: true });
+    await this.#ensure({ refresh: true });
+    return await this.#listEntries(normalizedPrefix, options);
+  }
+
+  async glob(pattern: string | string[], _options: GlobOptions = {}): Promise<WorkspaceEntry[]> {
+    const patterns = Array.isArray(pattern)
+      ? pattern.map(normalizeSafeWorkspacePattern)
+      : normalizeSafeWorkspacePattern(pattern);
+    const entries = await this.list("", { recursive: true });
+    return entries.filter((entry) => entry.type === "file" && matchesAny(entry.path, patterns));
+  }
+
+  async stat(path: string): Promise<WorkspaceStat | undefined> {
+    const normalized = normalizeSafeWorkspacePath(path);
+    await this.#ensure({ refresh: true });
+    const file = this.#files.get(normalized);
+    if (file && !isReservedWorkspacePath(normalized)) return this.#fileEntry(file);
+    if (this.#directoryExists(normalized)) return { path: normalized, type: "directory" };
+  }
+
+  async mkdir(path: string, _options: MkdirOptions = {}): Promise<void> {
+    normalizeSafeWorkspacePath(path);
+  }
+
+  async rm(path: string, options: RmOptions = {}): Promise<void> {
+    const normalized = normalizeSafeWorkspacePath(path);
+    await this.#ensure({ refresh: false });
+    const file = this.#files.get(normalized);
+    if (file && !isReservedWorkspacePath(normalized)) {
+      this.#files.delete(normalized);
+      this.#dirty = true;
+      return;
+    }
+
+    const children = this.#publicDescendants(normalized);
+    const hasDirectory = children.length > 0;
+    if (!hasDirectory) {
+      if (options.force) return;
+      throw new WorkspaceError(`[vitehub] Workspace path does not exist: ${path}.`);
+    }
+    if (children.length && !options.recursive) {
+      throw new WorkspaceError(`[vitehub] Workspace directory is not empty: ${path}.`);
+    }
+
+    for (const child of children) this.#files.delete(child);
+    this.#dirty = true;
+  }
+
+  async snapshot(options: SnapshotOptions = {}): Promise<WorkspaceSnapshot> {
+    await this.#ensure({ refresh: false });
+    const snapshot = await createSnapshotFromEntries(
+      await this.#listEntries("", { recursive: true }),
+      options.name,
+    );
+
+    if (!this.#dirty) {
+      this.#baseline = snapshot;
+      return snapshot;
+    }
+
+    const remote = await readGitHubBranchState({
+      branch: this.#branch,
+      kind: "store",
+      repository: this.#repository,
+      root: this.#root,
+      token: this.#token,
+    });
+    if (this.#baselineRefSha && remote.refSha !== this.#baselineRefSha) {
+      throw new WorkspaceError(
+        `[vitehub] GitHub Workspace Store conflict for ${this.#repository}@${this.#branch}: the branch changed after this Workspace Store loaded. Retry with a fresh Workspace Store before snapshotting.`,
+      );
+    }
+    this.#remoteFiles = remote.files;
+    this.#baselineRefSha = remote.refSha;
+    this.#baselineTreeSha = remote.treeSha;
+
+    const changedFiles = [...this.#files.values()].filter(
+      (file) => this.#remoteFiles.get(file.path)?.sha !== file.gitSha,
+    );
+    const deletePaths = [...this.#remoteFiles]
+      .filter(([path]) => !this.#files.has(path))
+      .map(([, entry]) => entry.path);
+
+    if (!changedFiles.length && !deletePaths.length) {
+      this.#dirty = false;
+      this.#baseline = snapshot;
+      return snapshot;
+    }
+
+    const files = changedFiles.map((file) => {
+      if (!file.bytes) {
+        throw new WorkspaceError(
+          `[vitehub] GitHub Workspace Store cannot commit ${file.path} because its content was not loaded.`,
+        );
+      }
+      return {
+        bytes: file.bytes,
+        fullPath: joinGitPath(this.#root, file.path),
+        gitSha: file.gitSha,
+      };
+    });
+    const commit = await commitGitHubChanges({
+      baseTreeSha: this.#baselineTreeSha,
+      branch: this.#branch,
+      deletePaths,
+      files,
+      message: options.name || "chore: update workspace snapshot",
+      parentSha: this.#baselineRefSha,
+      repository: this.#repository,
+      token: this.#token,
+    });
+
+    this.#dirty = false;
+    this.#baselineRefSha = commit.commitSha;
+    this.#baselineTreeSha = commit.treeSha;
+    this.#remoteFiles = this.#toRemoteFiles();
+    this.#baseline = { ...snapshot, id: commit.commitSha };
+    return this.#baseline;
+  }
+
+  async diff(options: DiffOptions = {}): Promise<WorkspaceDiff> {
+    const from = options.from || this.#baseline;
+    const to = await createSnapshotFromEntries(await this.list("", { recursive: true }));
+    return diffSnapshots(from, to);
+  }
+
+  async getMeta(key: string): Promise<unknown> {
+    await this.#ensure({ refresh: true });
+    const file = await this.#readWorkspaceFile(this.#metaPath(key));
+    if (!file) return undefined;
+    return JSON.parse(new TextDecoder().decode(file.bytes));
+  }
+
+  async setMeta(key: string, value: unknown): Promise<void> {
+    const path = this.#metaPath(key);
+    const content = JSON.stringify(value);
+    const bytes = new TextEncoder().encode(content);
+    await this.#ensure({ refresh: false });
+    this.#files.set(path, {
+      bytes,
+      gitSha: await gitBlobSha(bytes),
+      path,
+      size: bytes.byteLength,
+    });
+    this.#dirty = true;
+  }
+
+  async #ensure(options: { refresh: boolean }): Promise<void> {
+    const wasReady = !!this.#ready;
+    this.#ready ||= this.#load();
+    await this.#ready;
+    if (wasReady && options.refresh && !this.#dirty) await this.#load();
+  }
+
+  async #load(): Promise<void> {
+    const remote = await readGitHubBranchState({
+      branch: this.#branch,
+      kind: "store",
+      repository: this.#repository,
+      root: this.#root,
+      token: this.#token,
+    });
+    this.#baselineRefSha = remote.refSha;
+    this.#baselineTreeSha = remote.treeSha;
+    this.#remoteFiles = remote.files;
+    if (!this.#dirty) {
+      this.#files = new Map(
+        [...remote.files].map(([path, entry]) => [
+          path,
+          {
+            gitSha: entry.sha!,
+            path,
+            size: entry.size,
+          },
+        ]),
+      );
+    }
+  }
+
+  async #readWorkspaceFile(
+    path: string,
+  ): Promise<(WorkspaceFile & { bytes: Uint8Array }) | undefined> {
+    const current = this.#files.get(path);
+    if (!current) return undefined;
+    if (!current.bytes) {
+      current.bytes = await readGitHubBlob({
+        kind: "store",
+        repository: this.#repository,
+        sha: current.gitSha,
+        token: this.#token,
+      });
+      current.size = current.bytes.byteLength;
+    }
+    return {
+      content: current.bytes,
+      bytes: current.bytes,
+      mediaType: current.mediaType,
+      metadata: current.metadata,
+      path,
+    };
+  }
+
+  async #listEntries(prefix: string, options: ListOptions): Promise<WorkspaceEntry[]> {
+    const entries = new Map<string, WorkspaceEntry>();
+    for (const file of this.#files.values()) {
+      if (isReservedWorkspacePath(file.path)) continue;
+      for (const dir of parentDirectories(file.path)) {
+        if (this.#entryInPrefix(dir, prefix, options))
+          entries.set(dir, { path: dir, type: "directory" });
+      }
+      if (this.#entryInPrefix(file.path, prefix, options))
+        entries.set(file.path, await this.#fileEntry(file));
+    }
+    return [...entries.values()].sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  #entryInPrefix(path: string, prefix: string, options: ListOptions): boolean {
+    if (!prefix) return options.recursive || !path.includes("/");
+    if (path === prefix) return false;
+    if (!path.startsWith(`${prefix}/`)) return false;
+    return options.recursive || !path.slice(prefix.length + 1).includes("/");
+  }
+
+  #fileEntry(file: GitHubWorkspaceStoreFile): WorkspaceEntry {
+    return {
+      digest: file.gitSha,
+      mediaType: file.mediaType,
+      path: file.path,
+      size: file.size,
+      type: "file",
+    };
+  }
+
+  #directoryExists(path: string): boolean {
+    return this.#publicDescendants(path).length > 0;
+  }
+
+  #publicDescendants(path: string): string[] {
+    return [...this.#files.keys()].filter(
+      (key) => !isReservedWorkspacePath(key) && key.startsWith(`${path}/`),
+    );
+  }
+
+  #metaPath(key: string): string {
+    const normalized = normalizeSafeWorkspacePath(key.endsWith(".json") ? key : `${key}.json`, {
+      allowReserved: true,
+    });
+    return normalizeSafeWorkspacePath(`.vitehub/meta/${normalized}`, { allowReserved: true });
+  }
+
+  #toRemoteFiles(): Map<string, GitHubTreeEntry> {
+    return new Map(
+      [...this.#files.values()].map((file) => [
+        file.path,
+        {
+          path: joinGitPath(this.#root, file.path),
+          sha: file.gitSha,
+          size: file.size,
+          type: "blob",
+        },
+      ]),
+    );
+  }
+}
+
+export function createGitHubWorkspaceStore(
+  options: GitHubWorkspaceStoreOptions,
+  workspaceName: string,
+): WorkspaceStore {
+  return new GitHubWorkspaceStore(options, workspaceName);
+}

--- a/packages/workspace/src/publishers/github.ts
+++ b/packages/workspace/src/publishers/github.ts
@@ -1,16 +1,26 @@
-import { getActiveCloudflareBinding } from "@vite-hub/internal/runtime/cloudflare-env"
-
 import { WorkspaceError } from "../core/errors.ts"
-import { contentToBytes, normalizeWorkspacePath } from "../core/path.ts"
+import { normalizeWorkspacePath } from "../core/path.ts"
+import {
+  commitGitHubChanges,
+  createGitHubFileUpdate,
+  isWorkspaceFileEntry,
+  readGitHubBranchState,
+  requireGitHubOption,
+  resolveGitHubBranchOption,
+  resolveGitHubOption,
+  resolveGitHubRepositoryOption,
+  resolveGitHubRootOption,
+  resolveGitHubTokenOption,
+  type GitHubWorkspaceOption,
+} from "../providers/github/shared.ts"
 
 import type {
   PublishContext,
-  WorkspaceEntry,
   WorkspaceFile,
   WorkspacePublisher,
 } from "../core/types.ts"
 
-export type GitHubPublisherOption = string | (() => string | undefined)
+export type GitHubPublisherOption = GitHubWorkspaceOption
 
 export interface GitHubPublisherOptions {
   branch?: GitHubPublisherOption
@@ -27,213 +37,55 @@ interface GitHubPublisherFile extends WorkspaceFile {
   gitSha: string
 }
 
-interface GitHubTreeEntry {
-  mode?: string
-  path: string
-  sha?: string | null
-  type: string
-}
-
-interface GitHubTreeResponse {
-  tree: GitHubTreeEntry[]
-  truncated?: boolean
-}
-
-function processEnv(...keys: string[]): string | undefined {
-  const env = typeof process !== "undefined" ? process.env : undefined
-  return keys.map(key => env?.[key]).find(value => typeof value === "string" && value.length > 0)
-}
-
-function resolveOption(value: GitHubPublisherOption | undefined): string | undefined {
-  return typeof value === "function" ? value() : value
-}
-
-function requireOption(label: string, value: string | undefined): string {
-  if (!value) throw new WorkspaceError(`[vitehub] GitHub workspace publisher requires ${label}.`)
-  return value
-}
-
-function splitRepository(repository: string) {
-  const [owner, repo] = repository.split("/")
-  if (!owner || !repo) {
-    throw new WorkspaceError("[vitehub] GitHub workspace publisher requires a repository in owner/repo format.")
-  }
-  return { owner, repo }
-}
-
-function joinGitPath(...parts: string[]) {
-  return parts.join("/").replaceAll("\\", "/").split("/").filter(Boolean).join("/")
-}
-
-function workspacePathFromGitPath(path: string, root: string): string | undefined {
-  const normalized = joinGitPath(path)
-  const normalizedRoot = joinGitPath(root)
-  if (!normalizedRoot) return normalizeWorkspacePath(normalized)
-  if (!normalized.startsWith(`${normalizedRoot}/`)) return undefined
-  return normalizeWorkspacePath(normalized.slice(normalizedRoot.length + 1))
-}
-
-function isFileEntry(entry: WorkspaceEntry): entry is WorkspaceEntry & { type: "file" } {
-  return entry.type === "file"
-}
-
-function toHex(bytes: Uint8Array): string {
-  return [...bytes].map(byte => byte.toString(16).padStart(2, "0")).join("")
-}
-
-async function gitBlobSha(bytes: Uint8Array): Promise<string> {
-  const prefix = new TextEncoder().encode(`blob ${bytes.byteLength}\0`)
-  const input = new Uint8Array(prefix.byteLength + bytes.byteLength)
-  input.set(prefix)
-  input.set(bytes, prefix.byteLength)
-  return toHex(new Uint8Array(await globalThis.crypto.subtle.digest("SHA-1", input)))
-}
-
-function toBase64(bytes: Uint8Array): string {
-  let binary = ""
-  for (let index = 0; index < bytes.length; index += 0x8000) {
-    binary += String.fromCharCode(...bytes.subarray(index, index + 0x8000))
-  }
-  const encode = (globalThis as { btoa?: (input: string) => string }).btoa
-  return encode ? encode(binary) : Buffer.from(bytes).toString("base64")
-}
-
-function resolveRepository(options: GitHubPublisherOptions): string | undefined {
-  return resolveOption(options.repository)
-    || resolveOption(options.repo)
-    || processEnv("WORKSPACE_GITHUB_REPOSITORY", "VITEHUB_WORKSPACE_GITHUB_REPOSITORY", "GITHUB_REPOSITORY")
-}
-
-function resolveBranch(options: GitHubPublisherOptions): string {
-  return resolveOption(options.branch)
-    || processEnv("WORKSPACE_GITHUB_BRANCH", "VITEHUB_WORKSPACE_GITHUB_BRANCH", "GITHUB_BRANCH")
-    || "main"
-}
-
-function resolveRoot(options: GitHubPublisherOptions, workspaceName: string): string {
-  return resolveOption(options.root)
-    || processEnv("WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT")
-    || `.vitehub/workspaces/${workspaceName}`
-}
-
-function resolveToken(options: GitHubPublisherOptions): string | undefined {
-  return resolveOption(options.token)
-    || getActiveCloudflareBinding<string>("GITHUB_TOKEN")
-    || processEnv("WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN")
-}
-
 function resolveMessage(options: GitHubPublisherOptions, ctx: PublishContext): string {
   return ctx.snapshot?.name
-    || resolveOption(options.message)
+    || resolveGitHubOption(options.message)
     || "chore: update workspace snapshot"
 }
 
 async function readFiles(ctx: PublishContext, root: string): Promise<GitHubPublisherFile[]> {
   const entries = await ctx.store.list("", { recursive: true })
-  return await Promise.all(entries.filter(isFileEntry).map(async (entry) => {
+  return await Promise.all(entries.filter(isWorkspaceFileEntry).map(async (entry) => {
     const file = await ctx.store.readFile(entry.path)
     if (!file) throw new WorkspaceError(`[vitehub] Workspace file disappeared before GitHub publish: ${entry.path}.`)
-    const bytes = contentToBytes(file.content)
+    const update = await createGitHubFileUpdate(entry.path, root, file.content)
     return {
       ...file,
-      bytes,
       path: normalizeWorkspacePath(entry.path),
-      fullPath: joinGitPath(root, entry.path),
-      gitSha: await gitBlobSha(bytes),
+      ...update,
     }
   }))
-}
-
-async function requestGitHubJson<T>(repo: string, token: string, path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(`https://api.github.com${path}`, {
-    ...init,
-    headers: {
-      accept: "application/vnd.github+json",
-      authorization: `Bearer ${token}`,
-      "content-type": "application/json",
-      "user-agent": "vitehub-workspace",
-      "x-github-api-version": "2022-11-28",
-      ...init?.headers,
-    },
-  })
-
-  if (!response.ok) {
-    throw new WorkspaceError(`[vitehub] GitHub workspace publisher request failed for ${repo}: ${response.status} ${response.statusText} ${await response.text().catch(() => "")}`)
-  }
-  return await response.json() as T
-}
-
-function findRemoteFiles(tree: GitHubTreeResponse, root: string): Map<string, GitHubTreeEntry> {
-  if (tree.truncated) {
-    throw new WorkspaceError("[vitehub] GitHub workspace publisher could not compare the remote tree because GitHub returned a truncated tree.")
-  }
-
-  const files = new Map<string, GitHubTreeEntry>()
-  for (const entry of tree.tree) {
-    if (entry.type !== "blob" || !entry.sha) continue
-    const path = workspacePathFromGitPath(entry.path, root)
-    if (path) files.set(path, entry)
-  }
-  return files
 }
 
 export function github(options: GitHubPublisherOptions = {}): WorkspacePublisher {
   return {
     name: "github",
     async publish(ctx) {
-      const repository = requireOption("a repository", resolveRepository(options))
-      const branch = resolveBranch(options)
-      const root = resolveRoot(options, ctx.workspace.name)
-      const token = requireOption("a token", resolveToken(options))
+      const repository = requireGitHubOption("publisher", "a repository", resolveGitHubRepositoryOption(options))
+      const branch = resolveGitHubBranchOption(options)
+      const root = resolveGitHubRootOption(options, ctx.workspace.name)
+      const token = requireGitHubOption("publisher", "a token", resolveGitHubTokenOption(options))
       const files = await readFiles(ctx, root)
       const nextPaths = new Set(files.map(file => file.path))
 
-      const { owner, repo } = splitRepository(repository)
-      const refPath = `/repos/${owner}/${repo}/git/ref/heads/${branch}`
-      const refsPath = `/repos/${owner}/${repo}/git/refs/heads/${branch}`
-      const ref = await requestGitHubJson<{ object: { sha: string } }>(repository, token, refPath)
-      const current = await requestGitHubJson<{ tree: { sha: string } }>(repository, token, `/repos/${owner}/${repo}/git/commits/${ref.object.sha}`)
-      const remoteFiles = findRemoteFiles(
-        await requestGitHubJson<GitHubTreeResponse>(repository, token, `/repos/${owner}/${repo}/git/trees/${current.tree.sha}?recursive=1`),
-        root,
-      )
-      const changedFiles = files.filter(file => remoteFiles.get(file.path)?.sha !== file.gitSha)
-      const deletedEntries = [...remoteFiles]
+      const remote = await readGitHubBranchState({ branch, kind: "publisher", repository, root, token })
+      const changedFiles = files.filter(file => remote.files.get(file.path)?.sha !== file.gitSha)
+      const deletePaths = [...remote.files]
         .filter(([path]) => !nextPaths.has(path))
-        .map(([, entry]) => ({ mode: "100644", path: entry.path, sha: null, type: "blob" }))
+        .map(([, entry]) => entry.path)
 
-      if (!changedFiles.length && !deletedEntries.length) return
+      if (!changedFiles.length && !deletePaths.length) return
 
-      const blobs = await Promise.all(changedFiles.map(file => requestGitHubJson<{ sha: string }>(repository, token, `/repos/${owner}/${repo}/git/blobs`, {
-        body: JSON.stringify({ content: toBase64(file.bytes), encoding: "base64" }),
-        method: "POST",
-      })))
-      const tree = await requestGitHubJson<{ sha: string }>(repository, token, `/repos/${owner}/${repo}/git/trees`, {
-        body: JSON.stringify({
-          base_tree: current.tree.sha,
-          tree: [
-            ...changedFiles.map((file, index) => ({
-              mode: "100644",
-              path: file.fullPath,
-              sha: blobs[index]!.sha,
-              type: "blob",
-            })),
-            ...deletedEntries,
-          ],
-        }),
-        method: "POST",
-      })
-      const commit = await requestGitHubJson<{ sha: string }>(repository, token, `/repos/${owner}/${repo}/git/commits`, {
-        body: JSON.stringify({
-          message: resolveMessage(options, ctx),
-          parents: [ref.object.sha],
-          tree: tree.sha,
-        }),
-        method: "POST",
-      })
-      await requestGitHubJson(repository, token, refsPath, {
-        body: JSON.stringify({ sha: commit.sha }),
-        method: "PATCH",
+      await commitGitHubChanges({
+        baseTreeSha: remote.treeSha,
+        branch,
+        deletePaths,
+        files: changedFiles,
+        kind: "publisher",
+        message: resolveMessage(options, ctx),
+        parentSha: remote.refSha,
+        repository,
+        token,
       })
     },
   }

--- a/packages/workspace/src/runtime/hosted-store-loader.ts
+++ b/packages/workspace/src/runtime/hosted-store-loader.ts
@@ -1,6 +1,6 @@
-import type { CloudflareArtifactsWorkspaceStoreOptions, VercelBlobWorkspaceStoreOptions, WorkspaceStore } from "../core/types.ts"
+import type { CloudflareArtifactsWorkspaceStoreOptions, GitHubWorkspaceStoreOptions, VercelBlobWorkspaceStoreOptions, WorkspaceStore } from "../core/types.ts"
 
-export type HostedWorkspaceStoreOptions = CloudflareArtifactsWorkspaceStoreOptions | VercelBlobWorkspaceStoreOptions
+export type HostedWorkspaceStoreOptions = CloudflareArtifactsWorkspaceStoreOptions | GitHubWorkspaceStoreOptions | VercelBlobWorkspaceStoreOptions
 export type WorkspaceHostedStoreLoader = (options: HostedWorkspaceStoreOptions, workspaceName: string) => WorkspaceStore
 
 let workspaceHostedStoreLoader: WorkspaceHostedStoreLoader | undefined

--- a/packages/workspace/src/storage/provider.ts
+++ b/packages/workspace/src/storage/provider.ts
@@ -11,6 +11,7 @@ import { createMemoryWorkspaceStore } from "./memory.ts"
 
 import type {
   CloudflareArtifactsWorkspaceStoreOptions,
+  GitHubWorkspaceStoreOptions,
   VercelBlobWorkspaceStoreOptions,
   WorkspaceDefinition,
   WorkspaceStore,
@@ -71,6 +72,21 @@ export function resolveVercelBlobWorkspaceStore(
   }
 }
 
+export function resolveGitHubWorkspaceStore(
+  config: Partial<GitHubWorkspaceStoreOptions> = {},
+  env: Record<string, string | undefined> = process.env,
+): GitHubWorkspaceStoreOptions {
+  return {
+    branch: trimmed(config.branch) ?? readEnv(env, "WORKSPACE_GITHUB_BRANCH", "VITEHUB_WORKSPACE_GITHUB_BRANCH", "GITHUB_BRANCH") ?? "main",
+    provider: "github",
+    repository: trimmed(config.repository)
+      ?? trimmed(config.repo)
+      ?? readEnv(env, "WORKSPACE_GITHUB_REPOSITORY", "VITEHUB_WORKSPACE_GITHUB_REPOSITORY", "GITHUB_REPOSITORY"),
+    root: trimmed(config.root) ?? readEnv(env, "WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT") ?? ".vitehub/workspaces/<workspace>",
+    token: MASKED_WORKSPACE_RUNTIME_VALUE,
+  }
+}
+
 export function hasVercelWorkspaceBlobEnv(env: Record<string, string | undefined>): boolean {
   return Boolean(readEnv(env, "BLOB_READ_WRITE_TOKEN"))
 }
@@ -87,6 +103,7 @@ export function normalizeWorkspaceStoreOptions(
   const hosting = input.hosting || ""
 
   if (store?.provider === "cloudflare-artifacts") return resolveCloudflareArtifactsStore(store, env)
+  if (store?.provider === "github") return resolveGitHubWorkspaceStore(store, env)
   if (store?.provider === "memory") return store
   if (store?.provider === "vercel-blob") return resolveVercelBlobWorkspaceStore(store, env)
   if (store?.provider === "local" || store?.root) return defu(store, { provider: "local" as const }) as ResolvedWorkspaceStoreOptions
@@ -113,7 +130,7 @@ export function createWorkspaceStoreFromProvider(definition: WorkspaceDefinition
   })
 
   if (store?.provider === "memory") return createMemoryWorkspaceStore()
-  if (store?.provider === "cloudflare-artifacts" || store?.provider === "vercel-blob") {
+  if (store?.provider === "cloudflare-artifacts" || store?.provider === "github" || store?.provider === "vercel-blob") {
     const loader = getWorkspaceHostedStoreLoader()
     if (!loader) throw new WorkspaceError(`[vitehub] Hosted workspace store "${store.provider}" is not available in this runtime.`)
     return loader(store, definition.name)

--- a/packages/workspace/test/config.test.ts
+++ b/packages/workspace/test/config.test.ts
@@ -173,16 +173,50 @@ describe("workspace config", () => {
     })
   })
 
-  it("rejects GitHub as a workspace store provider", () => {
-    expect(() => normalizeWorkspaceOptions({
+  it("preserves explicit GitHub stores and masks tokens", () => {
+    const config = normalizeWorkspaceOptions({
       store: {
+        branch: "workspace-state",
         provider: "github",
-        repo: "acme/app",
+        repository: "acme/app",
+        root: ".vitehub/workspaces/<workspace>",
         token: "secret-token",
-      } as never,
+      },
     }, {
       rootDir: "/repo",
-    })).toThrow("Unsupported workspace store provider: github")
+    })
+
+    expect(JSON.stringify(config)).not.toContain("secret-token")
+    expect(config && config.store).toEqual({
+      branch: "workspace-state",
+      provider: "github",
+      repository: "acme/app",
+      root: ".vitehub/workspaces/<workspace>",
+      token: "********",
+    })
+  })
+
+  it("resolves GitHub store options from the environment", () => {
+    const config = normalizeWorkspaceOptions({
+      store: {
+        provider: "github",
+      },
+    }, {
+      env: {
+        VITEHUB_WORKSPACE_GITHUB_BRANCH: "workspace-state",
+        VITEHUB_WORKSPACE_GITHUB_REPOSITORY: "acme/app",
+        VITEHUB_WORKSPACE_GITHUB_ROOT: "state/<workspace>",
+      },
+      rootDir: "/repo",
+    })
+
+    expect(config && config.store).toEqual({
+      branch: "workspace-state",
+      provider: "github",
+      repository: "acme/app",
+      root: "state/<workspace>",
+      token: "********",
+    })
   })
 
   it("rehydrates masked Vercel Blob tokens at runtime", () => {

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -1,0 +1,311 @@
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const requests: Array<{ body?: unknown; headers: Headers; method: string; path: string }> = [];
+let refSha = "base-sha";
+let remoteTreeSha = "base-tree";
+let remoteTree: Array<{ path: string; sha: string; size?: number; type: "blob" }> = [];
+let commitIndex = 0;
+let treeIndex = 0;
+const blobs = new Map<string, Uint8Array>();
+
+function gitBlobSha(bytes: Uint8Array): string {
+  return createHash("sha1").update(`blob ${bytes.byteLength}\0`).update(bytes).digest("hex");
+}
+
+function textBytes(content: string): Uint8Array {
+  return new TextEncoder().encode(content);
+}
+
+function textSha(content: string): string {
+  return gitBlobSha(textBytes(content));
+}
+
+function seedRemote(path: string, content: string) {
+  const bytes = textBytes(content);
+  const sha = gitBlobSha(bytes);
+  blobs.set(sha, bytes);
+  remoteTree.push({ path, sha, size: bytes.byteLength, type: "blob" });
+}
+
+function jsonResponse(value: unknown) {
+  return new Response(JSON.stringify(value), {
+    headers: { "content-type": "application/json" },
+    status: 200,
+  });
+}
+
+beforeEach(() => {
+  requests.length = 0;
+  refSha = "base-sha";
+  remoteTreeSha = "base-tree";
+  remoteTree = [];
+  commitIndex = 0;
+  treeIndex = 0;
+  blobs.clear();
+  delete process.env.WORKSPACE_GITHUB_TOKEN;
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request, init: RequestInit = {}) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      const method = init.method || "GET";
+      const body =
+        typeof init.body === "string"
+          ? (JSON.parse(init.body) as {
+              content?: string;
+              force?: boolean;
+              sha?: string | null;
+              tree?: Array<{ path: string; sha: string | null; type: "blob" }>;
+            })
+          : undefined;
+      requests.push({ body, headers: new Headers(init.headers), method, path: url.pathname });
+
+      if (url.pathname === "/repos/onmax/repo/git/ref/heads/main")
+        return jsonResponse({ object: { sha: refSha } });
+      if (url.pathname.startsWith("/repos/onmax/repo/git/commits/"))
+        return jsonResponse({ tree: { sha: remoteTreeSha } });
+      if (url.pathname === `/repos/onmax/repo/git/trees/${remoteTreeSha}` && method === "GET")
+        return jsonResponse({ tree: remoteTree });
+      if (url.pathname.startsWith("/repos/onmax/repo/git/blobs/") && method === "GET") {
+        const sha = url.pathname.split("/").at(-1)!;
+        const bytes = blobs.get(sha);
+        return bytes
+          ? jsonResponse({ content: Buffer.from(bytes).toString("base64"), encoding: "base64" })
+          : new Response("not found", { status: 404 });
+      }
+      if (url.pathname === "/repos/onmax/repo/git/blobs" && method === "POST" && body?.content) {
+        const bytes = new Uint8Array(Buffer.from(body.content, "base64"));
+        const sha = gitBlobSha(bytes);
+        blobs.set(sha, bytes);
+        return jsonResponse({ sha });
+      }
+      if (url.pathname === "/repos/onmax/repo/git/trees" && method === "POST") {
+        for (const entry of body?.tree || []) {
+          remoteTree = remoteTree.filter((item) => item.path !== entry.path);
+          if (entry.sha) {
+            const bytes = blobs.get(entry.sha);
+            remoteTree.push({
+              path: entry.path,
+              sha: entry.sha,
+              size: bytes?.byteLength,
+              type: "blob",
+            });
+          }
+        }
+        remoteTreeSha = `tree-sha-${++treeIndex}`;
+        return jsonResponse({ sha: remoteTreeSha });
+      }
+      if (url.pathname === "/repos/onmax/repo/git/commits" && method === "POST")
+        return jsonResponse({ sha: `commit-sha-${++commitIndex}` });
+      if (url.pathname === "/repos/onmax/repo/git/refs/heads/main" && method === "PATCH") {
+        if (body?.sha) refSha = body.sha;
+        return jsonResponse({});
+      }
+
+      return new Response("not found", { status: 404 });
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.WORKSPACE_GITHUB_TOKEN;
+});
+
+describe("GitHub workspace store", () => {
+  it("reads, lists, stats, writes, snapshots, and persists metadata through GitHub", async () => {
+    seedRemote(".vitehub/workspaces/docs/data/existing.json", '{"ok":true}\n');
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await expect(store.readFile("data/existing.json")).resolves.toMatchObject({
+      content: textBytes('{"ok":true}\n'),
+      path: "data/existing.json",
+    });
+    await expect(store.list("", { recursive: true })).resolves.toEqual([
+      expect.objectContaining({ path: "data", type: "directory" }),
+      expect.objectContaining({
+        digest: textSha('{"ok":true}\n'),
+        path: "data/existing.json",
+        type: "file",
+      }),
+    ]);
+    await expect(store.stat("data/existing.json")).resolves.toMatchObject({
+      digest: textSha('{"ok":true}\n'),
+      path: "data/existing.json",
+      type: "file",
+    });
+
+    await store.writeFile("tasks/todo.md", {
+      path: "tasks/todo.md",
+      content: "ship it\n",
+      mediaType: "text/markdown",
+    });
+    await store.setMeta!("loader", { digest: "abc" });
+
+    const snapshot = await store.snapshot({ name: "sync workspace" });
+    expect(snapshot.id).toBe("commit-sha-1");
+    expect(await store.getMeta!("loader")).toEqual({ digest: "abc" });
+    expect(
+      requests.find((request) => request.path.endsWith("/git/trees") && request.method === "POST")
+        ?.body,
+    ).toMatchObject({
+      base_tree: "base-tree",
+      tree: expect.arrayContaining([
+        {
+          mode: "100644",
+          path: ".vitehub/workspaces/docs/tasks/todo.md",
+          sha: textSha("ship it\n"),
+          type: "blob",
+        },
+        {
+          mode: "100644",
+          path: ".vitehub/workspaces/docs/.vitehub/meta/loader.json",
+          sha: textSha('{"digest":"abc"}'),
+          type: "blob",
+        },
+      ]),
+    });
+    expect(
+      requests.find((request) => request.path.endsWith("/git/commits") && request.method === "POST")
+        ?.body,
+    ).toMatchObject({
+      message: "sync workspace",
+      parents: ["base-sha"],
+      tree: "tree-sha-1",
+    });
+    expect(
+      requests.find(
+        (request) => request.path.endsWith("/git/refs/heads/main") && request.method === "PATCH",
+      )?.body,
+    ).toMatchObject({
+      force: false,
+      sha: "commit-sha-1",
+    });
+
+    const freshStore = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+    await expect(freshStore.getMeta!("loader")).resolves.toEqual({ digest: "abc" });
+  });
+
+  it("deletes files and directories through snapshot commits", async () => {
+    seedRemote(".vitehub/workspaces/docs/tasks/a.md", "a\n");
+    seedRemote(".vitehub/workspaces/docs/tasks/b.md", "b\n");
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await expect(store.rm("tasks")).rejects.toThrow("Workspace directory is not empty");
+    await store.rm("tasks", { recursive: true });
+    await store.snapshot({ name: "delete tasks" });
+
+    expect(
+      requests.find((request) => request.path.endsWith("/git/trees") && request.method === "POST")
+        ?.body,
+    ).toMatchObject({
+      tree: expect.arrayContaining([
+        { mode: "100644", path: ".vitehub/workspaces/docs/tasks/a.md", sha: null, type: "blob" },
+        { mode: "100644", path: ".vitehub/workspaces/docs/tasks/b.md", sha: null, type: "blob" },
+      ]),
+    });
+  });
+
+  it("skips no-op snapshots after comparing the remote tree", async () => {
+    seedRemote(".vitehub/workspaces/docs/README.md", "# Docs\n");
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await store.writeFile("README.md", { path: "README.md", content: "# Docs\n" });
+    await store.snapshot({ name: "unchanged" });
+
+    expect(requests.filter((request) => request.method !== "GET")).toEqual([]);
+  });
+
+  it("fails dirty snapshots when the branch moved after load", async () => {
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await store.writeFile("README.md", { path: "README.md", content: "# Docs\n" });
+    refSha = "other-commit";
+
+    await expect(store.snapshot({ name: "conflict" })).rejects.toThrow(
+      "GitHub Workspace Store conflict",
+    );
+    expect(
+      requests.filter((request) => request.method === "POST" || request.method === "PATCH"),
+    ).toEqual([]);
+  });
+
+  it("requires repository and token configuration", async () => {
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+
+    expect(() =>
+      createGitHubWorkspaceStore(
+        {
+          provider: "github",
+          repository: "onmax/repo",
+          token: "",
+        },
+        "docs",
+      ),
+    ).toThrow("requires a token");
+    expect(() =>
+      createGitHubWorkspaceStore(
+        {
+          provider: "github",
+          repository: "malformed",
+          token: "token",
+        },
+        "docs",
+      ),
+    ).not.toThrow();
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "malformed",
+        token: "token",
+      },
+      "docs",
+    );
+    await expect(store.list()).rejects.toThrow("requires a repository in owner/repo format");
+  });
+});

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -145,9 +145,11 @@ describe("workspace types", () => {
     expectTypeOf(writable.tools.write().writeFile).toMatchTypeOf<Tool<{ content: string, mediaType?: string, path: string }, { path: string }>>()
     expectTypeOf(writable.startSession).toBeFunction()
     const workspaceOptions: WorkspaceModuleOptions = { assets: ["typed"], store: { provider: "memory" } }
+    const githubWorkspaceOptions: WorkspaceModuleOptions = { store: { branch: "main", provider: "github", repository: "acme/app", root: ".vitehub/workspaces/<workspace>" } }
     // @ts-expect-error syncOnBuild was removed in favor of assets
     const removedOptions: WorkspaceModuleOptions = { syncOnBuild: true }
     expectTypeOf(workspaceOptions).toMatchTypeOf<WorkspaceModuleOptions>()
+    expectTypeOf(githubWorkspaceOptions).toMatchTypeOf<WorkspaceModuleOptions>()
     expectTypeOf(removedOptions).toMatchTypeOf<WorkspaceModuleOptions>()
     const session = null as unknown as Awaited<ReturnType<typeof writable.startSession>>
     // @ts-expect-error runtime selection belongs in workspace config, not open options

--- a/packages/workspace/vite.config.ts
+++ b/packages/workspace/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       "src/runtime/assets.ts",
       "src/runtime/state.ts",
       "src/providers/cloudflare/artifacts-store.ts",
+      "src/providers/github/store.ts",
       "src/providers/vercel/blob-store.ts",
       "src/test.ts",
       "src/vite.ts",
@@ -35,6 +36,7 @@ export default defineConfig({
         "runtime/empty-registry",
         "runtime/state",
         "providers/cloudflare/artifacts-store",
+        "providers/github/store",
         "providers/vercel/blob-store",
       ],
       customExports(exports) {
@@ -45,6 +47,7 @@ export default defineConfig({
         exports["./internal/runtime/state"] = "./dist/runtime/state.js";
         exports["./internal/stores/cloudflare-artifacts"] =
           "./dist/providers/cloudflare/artifacts-store.js";
+        exports["./internal/stores/github"] = "./dist/providers/github/store.js";
         exports["./internal/stores/vercel-blob"] = "./dist/providers/vercel/blob-store.js";
 
         return exports;

--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -570,6 +570,9 @@ function renderCloudflareEntry(file: string, options: ViteE2EComposerOptions, ar
   if (workspaceProvider === "cloudflare-artifacts") {
     imports.push(`import { createCloudflareArtifactsWorkspaceStore } from ${JSON.stringify(createImportPath(file, resolve(workspacePackageDir, "src/providers/cloudflare/artifacts-store.ts")))}`)
   }
+  if (workspaceProvider === "github") {
+    imports.push(`import { createGitHubWorkspaceStore } from ${JSON.stringify(createImportPath(file, resolve(workspacePackageDir, "src/providers/github/store.ts")))}`)
+  }
 
   if (artifacts.queueRegistryFile) {
     imports.push(`import queueRegistry from ${JSON.stringify(createImportPath(file, artifacts.queueRegistryFile))}`)
@@ -628,6 +631,13 @@ function renderCloudflareEntry(file: string, options: ViteE2EComposerOptions, ar
           "  return createCloudflareArtifactsWorkspaceStore(store, workspaceName)",
           "})",
         ]
+      : workspaceProvider === "github"
+        ? [
+            "setWorkspaceHostedStoreLoader((store, workspaceName) => {",
+            "  if (store.provider !== 'github') throw new Error(`[vitehub] Unsupported workspace store for Cloudflare build: ${store.provider}`)",
+            "  return createGitHubWorkspaceStore(store, workspaceName)",
+            "})",
+          ]
       : ["setWorkspaceHostedStoreLoader(undefined)"]),
     `setWorkspaceRuntimeRegistry(${artifacts.workspaceRegistryFile ? "workspaceRegistry" : "{ }"})`,
     "const defaultHandler = toWebHandler(new H3())",
@@ -715,6 +725,9 @@ function renderVercelEntry(file: string, options: ViteE2EComposerOptions, artifa
   if (workspaceProvider === "vercel-blob") {
     imports.push(`import { createVercelBlobWorkspaceStore } from ${JSON.stringify(createImportPath(file, resolve(workspacePackageDir, "src/providers/vercel/blob-store.ts")))}`)
   }
+  if (workspaceProvider === "github") {
+    imports.push(`import { createGitHubWorkspaceStore } from ${JSON.stringify(createImportPath(file, resolve(workspacePackageDir, "src/providers/github/store.ts")))}`)
+  }
 
   if (artifacts.queueRegistryFile) {
     imports.push(`import queueRegistry from ${JSON.stringify(createImportPath(file, artifacts.queueRegistryFile))}`)
@@ -753,6 +766,13 @@ function renderVercelEntry(file: string, options: ViteE2EComposerOptions, artifa
           "  return createVercelBlobWorkspaceStore(store, workspaceName)",
           "})",
         ]
+      : workspaceProvider === "github"
+        ? [
+            "setWorkspaceHostedStoreLoader((store, workspaceName) => {",
+            "  if (store.provider !== 'github') throw new Error(`[vitehub] Unsupported workspace store for Vercel build: ${store.provider}`)",
+            "  return createGitHubWorkspaceStore(store, workspaceName)",
+            "})",
+          ]
       : ["setWorkspaceHostedStoreLoader(undefined)"]),
     `setWorkspaceRuntimeRegistry(${artifacts.workspaceRegistryFile ? "workspaceRegistry" : "{ }"})`,
     "const appInstance = new H3()",


### PR DESCRIPTION
## Summary

- Adds a first-class GitHub Workspace Store provider for durable Workspace file-tree persistence without Cloudflare Artifacts.
- Shares GitHub tree/blob/commit helpers between the existing GitHub Publisher and the new Store adapter.
- Wires `provider: "github"` through store normalization, hosted runtime loaders, package exports, docs, and public types.

## Validation

- `pnpm --filter @vite-hub/workspace test`
- `pnpm exec vp test run test/contracts.test.ts`
- `pnpm exec vp check --no-fmt packages/workspace/README.md packages/workspace/package.json packages/workspace/src/config.ts packages/workspace/src/core/types.ts packages/workspace/src/publishers/github.ts packages/workspace/src/providers/github/shared.ts packages/workspace/src/providers/github/store.ts packages/workspace/src/runtime/hosted-store-loader.ts packages/workspace/src/storage/provider.ts packages/workspace/test/config.test.ts packages/workspace/test/github-store.test.ts packages/workspace/test/types.test-d.ts packages/workspace/vite.config.ts playground/vite/build/vite-e2e.ts`