### PR TITLE
fix(cli): keep private internals out of runtime deps

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,12 +38,12 @@
     "test": "vp run -t @vite-hub/cli#build && vp test"
   },
   "dependencies": {
-    "@vite-hub/internal": "workspace:*",
     "pathe": "catalog:unjs"
   },
   "devDependencies": {
     "@types/node": "catalog:tooling",
     "@vite-hub/agent": "workspace:*",
+    "@vite-hub/internal": "workspace:*",
     "typescript": "catalog:tooling",
     "vite": "catalog:vite",
     "vite-plus": "catalog:tooling",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,9 +520,6 @@ importers:
 
   packages/cli:
     dependencies:
-      '@vite-hub/internal':
-        specifier: workspace:*
-        version: link:../internal
       pathe:
         specifier: catalog:unjs
         version: 2.0.3
@@ -536,6 +533,9 @@ importers:
       '@vite-hub/agent':
         specifier: workspace:*
         version: link:../agent
+      '@vite-hub/internal':
+        specifier: workspace:*
+        version: link:../internal
       typescript:
         specifier: catalog:tooling
         version: 6.0.2


### PR DESCRIPTION
Moves `@vite-hub/internal` out of `@vite-hub/cli` runtime dependencies while keeping it available as a dev/build dependency for local package work. The CLI build already bundles those private helpers into `dist/index.js`, so external installs should not try to fetch the unpublished internal package.

This fixes the pkg.pr.new preview install path for external consumers like Quiver without changing the CLI runtime surface; the packed CLI tarball now depends only on `pathe` at runtime.