### PR TITLE
fix(agent): commit streamed chat before finish follow-ups

### DIFF
--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -30,7 +30,7 @@ import type {
 } from "./types.ts"
 import type { AccessChatIdentity } from "./capabilities/access.ts"
 import type { AudioData, MessagePart } from "./messages.ts"
-import type { Adapter, Attachment, ChatConfig, Lock, Message as ChatSdkMessage, MessageContext, QueueEntry, StateAdapter, Thread, WebhookOptions } from "chat"
+import type { Adapter, Attachment, ChatConfig, Lock, Message as ChatSdkMessage, MessageContext, QueueEntry, SentMessage, StateAdapter, Thread, WebhookOptions } from "chat"
 
 interface ViteAgentRouteRuntimeConfig extends AgentRuntimeConfig {
   agent?: unknown
@@ -275,7 +275,12 @@ async function collectAgentOutput(result: unknown): Promise<string> {
   return text.trim()
 }
 
-function streamAgentOutputToChatText(result: Promise<unknown>): AsyncIterable<string> {
+type ChatTextStream = AsyncIterable<string> & {
+  getText: () => string
+}
+
+function streamAgentOutputToChatText(result: Promise<unknown>): ChatTextStream {
+  let collected = ""
   return {
     async *[Symbol.asyncIterator]() {
       const output = await result
@@ -283,16 +288,22 @@ function streamAgentOutputToChatText(result: Promise<unknown>): AsyncIterable<st
         if (output.headers.get("content-type")?.includes("application/json")) {
           const body = await output.clone().json().catch(() => undefined)
           if (isRecord(body)) {
-            if (typeof body.text === "string") yield body.text
+            if (typeof body.text === "string") {
+              collected += body.text
+              yield body.text
+            }
             return
           }
         }
-        yield await output.text()
+        const bodyText = await output.text()
+        collected += bodyText
+        yield bodyText
         return
       }
 
       for await (const event of streamAgentOutputToEvents(output)) {
         if (event.type === "text-delta") {
+          collected += event.text
           yield event.text
         }
         if (event.type === "error") {
@@ -300,6 +311,19 @@ function streamAgentOutputToChatText(result: Promise<unknown>): AsyncIterable<st
         }
       }
     },
+    getText: () => collected,
+  }
+}
+
+async function commitStreamedChatResponse(
+  thread: Thread,
+  message: SentMessage,
+  response: ChatTextStream,
+): Promise<void> {
+  if (!thread.adapter.stream) return
+  const markdown = response.getText()
+  if (markdown.trim()) {
+    await message.edit({ markdown })
   }
 }
 
@@ -818,7 +842,9 @@ async function handleChatSdkMessage(
       const result = streamAgent(agent as never, runContext as never, invocationInput as never, {
         output: "events",
       })
-      await thread.post(streamAgentOutputToChatText(result))
+      const response = streamAgentOutputToChatText(result)
+      const message = await thread.post(response)
+      await commitStreamedChatResponse(thread, message, response)
       await flushChatFinishExtensionMessages(thread, chatFinish)
     }
   }

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { Message } from "chat"
 import { describe, expect, it, vi } from "vitest"
 
-import type { Adapter, ChatInstance, WebhookOptions } from "chat"
+import type { Adapter, ChatInstance, StreamChunk, WebhookOptions } from "chat"
 
 vi.mock("@vite-hub/internal/build/vercel-runtime-packages", () => ({
   copyVercelFunctionRuntimePackages: vi.fn(async () => undefined),
@@ -57,6 +57,9 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, secr
       const task = chatInstance.processMessage(adapter as unknown as Adapter, message.threadId, message, webhookOptions)
       if (!options.deferMessageProcessing) {
         await task
+      }
+      else {
+        task.catch(() => undefined)
       }
       return Response.json({ ok: true })
     }),
@@ -906,6 +909,111 @@ describe("server helpers", () => {
     expect(finish).toHaveBeenCalledOnce()
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:888", { markdown: "agent answer" })
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:888", { markdown: "side message via telegram" })
+  })
+
+  it("commits native streamed chat responses before flushing finish hook messages", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const adapter = createTestChatAdapter()
+    const order: string[] = []
+    let streamConsumed!: () => void
+    let commitStarted!: () => void
+    let commitResponse!: () => void
+    const streamConsumedPromise = new Promise<void>(resolve => {
+      streamConsumed = resolve
+    })
+    const commitStartedPromise = new Promise<void>(resolve => {
+      commitStarted = resolve
+    })
+    const commitResponsePromise = new Promise<void>(resolve => {
+      commitResponse = resolve
+    })
+    adapter.stream = vi.fn(async (threadId: string, textStream: AsyncIterable<string | StreamChunk>) => {
+      let text = ""
+      for await (const chunk of textStream) {
+        if (typeof chunk === "string") text += chunk
+        else if (chunk.type === "markdown_text") text += chunk.text
+      }
+      order.push(`stream:${text}`)
+      streamConsumed()
+      return { id: "stream-1", raw: { text }, threadId }
+    })
+    adapter.editMessage.mockImplementation(async (threadId: string, messageId: string, message: unknown) => {
+      order.push("commit:start")
+      commitStarted()
+      await commitResponsePromise
+      order.push("commit:done")
+      return { id: messageId, raw: { message }, threadId }
+    })
+    adapter.postMessage.mockImplementation(async (threadId: string, message: unknown) => {
+      order.push("post:follow-up")
+      return { id: "sent-follow-up", raw: { message }, threadId }
+    })
+    const finish = vi.fn(async (event) => {
+      const chat = event.extensions.get("chat") as { sendMessage?: (message: { markdown: string }) => Promise<void> } | undefined
+      await chat?.sendMessage?.({ markdown: "usage ok" })
+      order.push("finish:queued")
+    })
+    const agent = defineAgent({
+      capabilities: [
+        chat({
+          adapters: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({ text: "agent answer" }),
+    })
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+    const responsePromise = handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 89,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 89,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    try {
+      await streamConsumedPromise
+      await expect(Promise.race([
+        commitStartedPromise.then(() => "commit-started"),
+        responsePromise.then(() => "settled"),
+      ])).resolves.toBe("commit-started")
+      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "stream-1", { markdown: "agent answer" })
+      expect(adapter.postMessage).not.toHaveBeenCalled()
+      await expect(Promise.race([
+        responsePromise.then(() => "settled"),
+        Promise.resolve("pending"),
+      ])).resolves.toBe("pending")
+
+      commitResponse()
+      const response = await responsePromise
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ ok: true })
+      expect(adapter.postMessage).toHaveBeenCalledTimes(1)
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "usage ok" })
+      expect(finish).toHaveBeenCalledOnce()
+      expect(order.indexOf("commit:done")).toBeLessThan(order.indexOf("post:follow-up"))
+      expect(order).toContain("stream:agent answer")
+    }
+    finally {
+      commitResponse()
+    }
   })
 
   it("flushes deferred non-streaming chat webhook work before returning", async () => {


### PR DESCRIPTION
Stacked on #275 (`origin/codex/remove-usage-telemetry-chat-option`) so Nuxt Agent consumers should test a pkg.pr.new candidate that includes both #275 and this commit.

This keeps native chat streaming enabled by default, but makes ViteHub treat the streamed assistant response as committed before it flushes finish-hook `chat.sendMessage` follow-ups. For native-stream adapters, the webhook path captures the streamed markdown and performs a final committed edit of the streamed message before draining queued finish-extension messages.

Usage follow-up content and formatting remain downstream-owned; ViteHub only provides the ordering primitive.