### PR TITLE
fix(devtools): collapse chat workspace files by default

### DIFF
--- a/packages/devtools/devtools/chat/app/app.vue
+++ b/packages/devtools/devtools/chat/app/app.vue
@@ -17,6 +17,7 @@ import {
   type ChatDevtoolsToolDefinition,
 } from "../../../src/chat-shared.js"
 import { resolveChatBridgeRoute } from "./bridge-route"
+import { flattenFiles, syncExpandedFilePaths, type FileRow } from "./file-tree"
 
 type ChatStatus = "ready" | "submitted" | "streaming" | "error"
 type ChatMessage = UIMessage & { chat?: string }
@@ -66,7 +67,6 @@ const integrationTabs = [
   { icon: "i-lucide-scroll-text", label: "Instructions", slot: "instructions" as const },
 ]
 
-type FileRow = ChatDevtoolsFileTreeItem & { depth: number, expanded?: boolean }
 type FileMaterialization = {
   materialize?: string
   materialized?: boolean
@@ -322,31 +322,7 @@ function renderToolOutput(tool: ChatDevtoolsTool) {
 }
 
 function syncExpandedFiles(files: ChatDevtoolsFileTreeItem[]) {
-  const expanded = new Set(expandedFilePaths.value)
-  const isInitialExpansion = expanded.size === 0
-  const visit = (items: ChatDevtoolsFileTreeItem[]) => {
-    for (const file of items) {
-      if (file.kind !== "directory") continue
-      if (file.path === "" || file.path === "/" || isInitialExpansion) {
-        expanded.add(file.path)
-      }
-      if (isInitialExpansion) {
-        visit(file.children || [])
-      }
-    }
-  }
-  visit(files)
-  expandedFilePaths.value = expanded
-}
-
-function flattenFiles(files: ChatDevtoolsFileTreeItem[], expanded: Set<string>, depth = 0): FileRow[] {
-  return files.flatMap((file) => {
-    const isExpanded = file.kind === "directory" && expanded.has(file.path)
-    return [
-      { ...file, depth, expanded: isExpanded },
-      ...(isExpanded ? flattenFiles(file.children || [], expanded, depth + 1) : []),
-    ]
-  })
+  expandedFilePaths.value = syncExpandedFilePaths(files, expandedFilePaths.value)
 }
 
 function fileLabel(file: ChatDevtoolsFileTreeItem) {
@@ -1257,16 +1233,7 @@ onBeforeUnmount(() => {
             >
               <template #files>
                 <UAlert
-                  v-if="fileRows.length && isMetadataLoading"
-                  color="neutral"
-                  variant="soft"
-                  icon="i-lucide-loader-circle"
-                  title="Loading workspace metadata..."
-                  class="mb-2"
-                  :ui="{ root: 'rounded-md bg-transparent !py-1 !pl-8 !pr-2 gap-0', icon: 'absolute left-3 top-1/2 size-3.5 -translate-y-1/2 opacity-70', wrapper: 'min-w-0', title: 'text-xs font-normal leading-5' }"
-                />
-                <UAlert
-                  v-else-if="fileRows.length && metadataError"
+                  v-if="fileRows.length && metadataError"
                   color="error"
                   variant="soft"
                   icon="i-lucide-triangle-alert"
@@ -1305,13 +1272,16 @@ onBeforeUnmount(() => {
                     </template>
                   </UButton>
                 </div>
-                <UEmpty
+                <div
                   v-else-if="isMetadataLoading"
-                  icon="i-lucide-loader-circle"
-                  title="Loading workspace files."
-                  description="Inspecting workspace metadata for this chat."
-                  :ui="{ root: 'border-0 ring-0 shadow-none bg-transparent px-2 py-8' }"
-                />
+                  class="flex flex-col items-center gap-2 px-2 py-8 text-center"
+                >
+                  <UIcon name="i-lucide-loader-circle" class="size-5 animate-spin text-muted" />
+                  <div>
+                    <p class="text-sm font-medium text-toned">Loading workspace files.</p>
+                    <p class="text-xs/5 text-muted">Inspecting workspace metadata for this chat.</p>
+                  </div>
+                </div>
                 <UEmpty
                   v-else-if="metadataError"
                   icon="i-lucide-triangle-alert"
@@ -1330,16 +1300,7 @@ onBeforeUnmount(() => {
 
               <template #tools>
                 <UAlert
-                  v-if="visibleTools.length && isMetadataLoading"
-                  color="neutral"
-                  variant="soft"
-                  icon="i-lucide-loader-circle"
-                  title="Loading workspace metadata..."
-                  class="mb-2"
-                  :ui="{ root: 'rounded-md bg-transparent !py-1 !pl-8 !pr-2 gap-0', icon: 'absolute left-3 top-1/2 size-3.5 -translate-y-1/2 opacity-70', wrapper: 'min-w-0', title: 'text-xs font-normal leading-5' }"
-                />
-                <UAlert
-                  v-else-if="visibleTools.length && metadataError"
+                  v-if="visibleTools.length && metadataError"
                   color="error"
                   variant="soft"
                   icon="i-lucide-triangle-alert"
@@ -1400,13 +1361,16 @@ onBeforeUnmount(() => {
                     </div>
                   </div>
                 </div>
-                <UEmpty
+                <div
                   v-else-if="isMetadataLoading"
-                  icon="i-lucide-loader-circle"
-                  title="Loading tools."
-                  description="Inspecting workspace metadata for this chat."
-                  :ui="{ root: 'border-0 ring-0 shadow-none bg-transparent px-2 py-8' }"
-                />
+                  class="flex flex-col items-center gap-2 px-2 py-8 text-center"
+                >
+                  <UIcon name="i-lucide-loader-circle" class="size-5 animate-spin text-muted" />
+                  <div>
+                    <p class="text-sm font-medium text-toned">Loading tools.</p>
+                    <p class="text-xs/5 text-muted">Inspecting workspace metadata for this chat.</p>
+                  </div>
+                </div>
                 <UEmpty
                   v-else-if="metadataError"
                   icon="i-lucide-triangle-alert"
@@ -1425,16 +1389,7 @@ onBeforeUnmount(() => {
 
               <template #instructions>
                 <UAlert
-                  v-if="state.instructions?.length && isMetadataLoading"
-                  color="neutral"
-                  variant="soft"
-                  icon="i-lucide-loader-circle"
-                  title="Loading workspace metadata..."
-                  class="mb-2"
-                  :ui="{ root: 'rounded-md bg-transparent !py-1 !pl-8 !pr-2 gap-0', icon: 'absolute left-3 top-1/2 size-3.5 -translate-y-1/2 opacity-70', wrapper: 'min-w-0', title: 'text-xs font-normal leading-5' }"
-                />
-                <UAlert
-                  v-else-if="state.instructions?.length && metadataError"
+                  v-if="state.instructions?.length && metadataError"
                   color="error"
                   variant="soft"
                   icon="i-lucide-triangle-alert"
@@ -1461,13 +1416,16 @@ onBeforeUnmount(() => {
                     </Suspense>
                   </div>
                 </div>
-                <UEmpty
+                <div
                   v-else-if="isMetadataLoading"
-                  icon="i-lucide-loader-circle"
-                  title="Loading instructions."
-                  description="Inspecting workspace metadata for this chat."
-                  :ui="{ root: 'border-0 ring-0 shadow-none bg-transparent px-2 py-8' }"
-                />
+                  class="flex flex-col items-center gap-2 px-2 py-8 text-center"
+                >
+                  <UIcon name="i-lucide-loader-circle" class="size-5 animate-spin text-muted" />
+                  <div>
+                    <p class="text-sm font-medium text-toned">Loading instructions.</p>
+                    <p class="text-xs/5 text-muted">Inspecting workspace metadata for this chat.</p>
+                  </div>
+                </div>
                 <UEmpty
                   v-else-if="metadataError"
                   icon="i-lucide-triangle-alert"

--- a/packages/devtools/devtools/chat/app/file-tree.ts
+++ b/packages/devtools/devtools/chat/app/file-tree.ts
@@ -1,0 +1,28 @@
+import type { ChatDevtoolsFileTreeItem } from "../../../src/chat-shared.js"
+
+export type FileRow = ChatDevtoolsFileTreeItem & { depth: number, expanded?: boolean }
+
+function isSyntheticRoot(file: ChatDevtoolsFileTreeItem) {
+  return file.kind === "directory" && (file.path === "" || file.path === "/")
+}
+
+export function syncExpandedFilePaths(files: ChatDevtoolsFileTreeItem[], current: ReadonlySet<string>) {
+  const expanded = new Set(current)
+  const roots = files.filter(isSyntheticRoot)
+
+  if (roots.length === 1) {
+    expanded.add(roots[0]!.path)
+  }
+
+  return expanded
+}
+
+export function flattenFiles(files: ChatDevtoolsFileTreeItem[], expanded: ReadonlySet<string>, depth = 0): FileRow[] {
+  return files.flatMap((file) => {
+    const isExpanded = file.kind === "directory" && expanded.has(file.path)
+    return [
+      { ...file, depth, expanded: isExpanded },
+      ...(isExpanded ? flattenFiles(file.children || [], expanded, depth + 1) : []),
+    ]
+  })
+}

--- a/packages/devtools/test/chat-file-tree.test.ts
+++ b/packages/devtools/test/chat-file-tree.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import type { ChatDevtoolsFileTreeItem } from "../src/chat-shared.ts"
+import { flattenFiles, syncExpandedFilePaths } from "../devtools/chat/app/file-tree.ts"
+
+function directory(path: string, children: ChatDevtoolsFileTreeItem[] = []): ChatDevtoolsFileTreeItem {
+  return { children, kind: "directory", path }
+}
+
+function file(path: string): ChatDevtoolsFileTreeItem {
+  return { kind: "file", path }
+}
+
+describe("chat file tree", () => {
+  it("keeps workspace folders collapsed by default", () => {
+    const files = [
+      directory("forecasting-engine", [file("forecasting-engine/README.md")]),
+      directory("ingestion", [file("ingestion/README.md")]),
+      directory("instructions", [file("instructions/AGENTS.md")]),
+    ]
+
+    const expanded = syncExpandedFilePaths(files, new Set())
+
+    expect([...expanded]).toEqual([])
+    expect(flattenFiles(files, expanded).map(row => row.path)).toEqual([
+      "forecasting-engine",
+      "ingestion",
+      "instructions",
+    ])
+  })
+
+  it("opens a single synthetic root without recursively expanding workspace folders", () => {
+    const files = [
+      directory("", [
+        directory("forecasting-engine", [file("forecasting-engine/README.md")]),
+        directory("ingestion", [file("ingestion/README.md")]),
+      ]),
+    ]
+
+    const expanded = syncExpandedFilePaths(files, new Set())
+
+    expect([...expanded]).toEqual([""])
+    expect(flattenFiles(files, expanded).map(row => [row.path, row.depth, row.expanded])).toEqual([
+      ["", 0, true],
+      ["forecasting-engine", 1, false],
+      ["ingestion", 1, false],
+    ])
+  })
+
+  it("preserves explicit folder toggles across metadata refreshes", () => {
+    const files = [
+      directory("forecasting-engine", [file("forecasting-engine/README.md")]),
+      directory("ingestion", [file("ingestion/README.md")]),
+    ]
+
+    const expanded = syncExpandedFilePaths(files, new Set(["ingestion"]))
+
+    expect([...expanded]).toEqual(["ingestion"])
+    expect(flattenFiles(files, expanded).map(row => row.path)).toEqual([
+      "forecasting-engine",
+      "ingestion",
+      "ingestion/README.md",
+    ])
+  })
+})


### PR DESCRIPTION
Fixes the Chat DevTools Files tab behavior seen from Quiver Chat, where workspace folders were visible but a prominent "Loading workspace metadata..." row still sat above them.

The root cause was that the ViteHub DevTools Client treated an empty expanded-path set as an initial recursive expansion signal. The file tree now keeps top-level workspace folders collapsed by default, preserves explicit user expansion paths across metadata refreshes, and only auto-opens a single synthetic root when needed to reveal top-level entries. Metadata loading UI is now limited to empty states with an animated spinner, so usable Files/Tools/Instructions lists are not displaced by a lingering loading alert.

The fix is scoped to the DevTools Package client surface; Agent-owned DevTools Bridge metadata contracts are unchanged.