### PR TITLE
fix(agent): skip committed native stream final edits

### DIFF
--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -1,6 +1,6 @@
 import { runWithActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { createRuntimeWaitUntilController } from "@vite-hub/runtime"
-import { Chat } from "chat"
+import { Chat, markdownToPlainText, parseMarkdown, stringifyMarkdown } from "chat"
 
 import { resolveAgentTriggerInvocation, resolveAgentTriggers, runAgentInline, streamAgent, streamAgentTrigger } from "./index.ts"
 import { streamAgentOutputToEvents } from "./agent-output.ts"
@@ -66,9 +66,14 @@ type AgentDefinitionWithCapabilities = {
 
 const defaultChatErrorFallbackText = "Sorry, I couldn't process that message."
 const chatFinishMessagesKey = Symbol("vitehub.chat.finish.messages")
+const chatTypingRefreshIntervalMs = 4000
 
 type AgentChatQueuedFinishExtension = AgentChatFinishExtension & {
   [chatFinishMessagesKey]: AgentChatMessage[]
+}
+
+interface ChatTypingRefresh {
+  stop: () => void
 }
 
 async function readJsonBody(request: Request): Promise<AgentChatRouteBody> {
@@ -279,8 +284,16 @@ type ChatTextStream = AsyncIterable<string> & {
   getText: () => string
 }
 
-function streamAgentOutputToChatText(result: Promise<unknown>): ChatTextStream {
+function streamAgentOutputToChatText(result: Promise<unknown>, options: { onFirstText?: () => void } = {}): ChatTextStream {
   let collected = ""
+  let firstText = false
+  const appendText = (text: string) => {
+    collected += text
+    if (!firstText && text) {
+      firstText = true
+      options.onFirstText?.()
+    }
+  }
   return {
     async *[Symbol.asyncIterator]() {
       const output = await result
@@ -289,21 +302,21 @@ function streamAgentOutputToChatText(result: Promise<unknown>): ChatTextStream {
           const body = await output.clone().json().catch(() => undefined)
           if (isRecord(body)) {
             if (typeof body.text === "string") {
-              collected += body.text
+              appendText(body.text)
               yield body.text
             }
             return
           }
         }
         const bodyText = await output.text()
-        collected += bodyText
+        appendText(bodyText)
         yield bodyText
         return
       }
 
       for await (const event of streamAgentOutputToEvents(output)) {
         if (event.type === "text-delta") {
-          collected += event.text
+          appendText(event.text)
           yield event.text
         }
         if (event.type === "error") {
@@ -315,6 +328,15 @@ function streamAgentOutputToChatText(result: Promise<unknown>): ChatTextStream {
   }
 }
 
+function normalizeMarkdown(markdown: string): string {
+  return stringifyMarkdown(parseMarkdown(markdown)).trim()
+}
+
+function isCommittedChatMessage(message: SentMessage, markdown: string): boolean {
+  return message.text === markdownToPlainText(markdown)
+    && stringifyMarkdown(message.formatted).trim() === normalizeMarkdown(markdown)
+}
+
 async function commitStreamedChatResponse(
   thread: Thread,
   message: SentMessage,
@@ -323,7 +345,34 @@ async function commitStreamedChatResponse(
   if (!thread.adapter.stream) return
   const markdown = response.getText()
   if (markdown.trim()) {
+    if (isCommittedChatMessage(message, markdown)) return
     await message.edit({ markdown })
+  }
+}
+
+function startChatTypingRefresh(context: ViteAgentRouteRuntimeContext, thread: Thread): ChatTypingRefresh {
+  let stopped = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const startTyping = () => {
+    context.waitUntil(thread.startTyping().catch(() => undefined))
+  }
+  const schedule = () => {
+    timer = setTimeout(() => {
+      if (stopped) return
+      startTyping()
+      schedule()
+    }, chatTypingRefreshIntervalMs)
+    if (typeof timer === "object" && "unref" in timer) {
+      timer.unref()
+    }
+  }
+  startTyping()
+  schedule()
+  return {
+    stop() {
+      stopped = true
+      if (timer) clearTimeout(timer)
+    },
   }
 }
 
@@ -813,6 +862,7 @@ async function handleChatSdkMessage(
 ): Promise<void> {
   let input: AgentChatMessageTriggerInput | undefined
   let run: AgentRunMetadata | undefined
+  let typing: ChatTypingRefresh | undefined
   try {
     input = createChatTriggerInput(registration.provider, thread, message, messageContext)
     const firstMessage = input.messages[0]
@@ -820,7 +870,7 @@ async function handleChatSdkMessage(
     if (!await isChatMessageAuthorized(agent, context, registration, thread, message, messageContext)) return
 
     if (options?.stream !== false) {
-      context.waitUntil(thread.startTyping().catch(() => undefined))
+      typing = startChatTypingRefresh(context, thread)
     }
     const invocation = await resolveAgentTriggerInvocation(agent as never, context as never, "chat.message", input)
     run = invocation.run
@@ -842,15 +892,22 @@ async function handleChatSdkMessage(
       const result = streamAgent(agent as never, runContext as never, invocationInput as never, {
         output: "events",
       })
-      const response = streamAgentOutputToChatText(result)
+      const response = streamAgentOutputToChatText(result, {
+        onFirstText: () => typing?.stop(),
+      })
       const message = await thread.post(response)
+      typing?.stop()
       await commitStreamedChatResponse(thread, message, response)
       await flushChatFinishExtensionMessages(thread, chatFinish)
     }
   }
   catch (error) {
+    typing?.stop()
     await postChatErrorFallback(error, thread, message, options, input, run)
     throw error
+  }
+  finally {
+    typing?.stop()
   }
 }
 

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -488,6 +488,82 @@ describe("server helpers", () => {
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "ok" })
   })
 
+  it("refreshes chat typing until streamed output starts", async () => {
+    vi.useFakeTimers()
+    try {
+      const { defineAgent } = await import("../src/index.ts")
+      const { chat } = await import("../src/capabilities.ts")
+      const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+      const adapter = createTestChatAdapter()
+      adapter.stream = vi.fn(async (threadId: string, textStream: AsyncIterable<string | StreamChunk>) => {
+        let text = ""
+        for await (const chunk of textStream) {
+          if (typeof chunk === "string") text += chunk
+          else if (chunk.type === "markdown_text") text += chunk.text
+        }
+        return { id: "stream-typing", raw: { text }, threadId }
+      })
+      let runStarted!: () => void
+      let finishRun!: () => void
+      const runStartedPromise = new Promise<void>(resolve => {
+        runStarted = resolve
+      })
+      const finishRunPromise = new Promise<void>(resolve => {
+        finishRun = resolve
+      })
+      const agent = defineAgent({
+        capabilities: [
+          chat({
+            adapters: {
+              telegram: () => adapter as never,
+            },
+            webhooks: {
+              telegram: {},
+            },
+          }),
+        ],
+        run: async () => {
+          runStarted()
+          await finishRunPromise
+          return "ok"
+        },
+      })
+      const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+      const responsePromise = handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+        body: JSON.stringify({
+          update_id: 144,
+          message: {
+            chat: { id: 456, type: "private" },
+            date: 1781092800,
+            from: { first_name: "Maxi", id: 123, username: "maxi" },
+            message_id: 144,
+            text: "hello",
+          },
+        }),
+        method: "POST",
+      }), "telegram")
+
+      await runStartedPromise
+      expect(adapter.startTyping).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(4000)
+      expect(adapter.startTyping).toHaveBeenCalledTimes(2)
+      await vi.advanceTimersByTimeAsync(4000)
+      expect(adapter.startTyping).toHaveBeenCalledTimes(3)
+
+      finishRun()
+      const response = await responsePromise
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ ok: true })
+      const callsAfterFirstOutput = adapter.startTyping.mock.calls.length
+      await vi.advanceTimersByTimeAsync(8000)
+      expect(adapter.startTyping).toHaveBeenCalledTimes(callsAfterFirstOutput)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("posts configured chat fallback while streamed webhook work is still running", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
@@ -918,13 +994,9 @@ describe("server helpers", () => {
     const adapter = createTestChatAdapter()
     const order: string[] = []
     let streamConsumed!: () => void
-    let commitStarted!: () => void
     let commitResponse!: () => void
     const streamConsumedPromise = new Promise<void>(resolve => {
       streamConsumed = resolve
-    })
-    const commitStartedPromise = new Promise<void>(resolve => {
-      commitStarted = resolve
     })
     const commitResponsePromise = new Promise<void>(resolve => {
       commitResponse = resolve
@@ -937,14 +1009,9 @@ describe("server helpers", () => {
       }
       order.push(`stream:${text}`)
       streamConsumed()
-      return { id: "stream-1", raw: { text }, threadId }
-    })
-    adapter.editMessage.mockImplementation(async (threadId: string, messageId: string, message: unknown) => {
-      order.push("commit:start")
-      commitStarted()
       await commitResponsePromise
-      order.push("commit:done")
-      return { id: messageId, raw: { message }, threadId }
+      order.push("stream:committed")
+      return { id: "stream-1", raw: { text }, threadId }
     })
     adapter.postMessage.mockImplementation(async (threadId: string, message: unknown) => {
       order.push("post:follow-up")
@@ -990,10 +1057,10 @@ describe("server helpers", () => {
     try {
       await streamConsumedPromise
       await expect(Promise.race([
-        commitStartedPromise.then(() => "commit-started"),
         responsePromise.then(() => "settled"),
-      ])).resolves.toBe("commit-started")
-      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "stream-1", { markdown: "agent answer" })
+        Promise.resolve("pending"),
+      ])).resolves.toBe("pending")
+      expect(adapter.editMessage).not.toHaveBeenCalled()
       expect(adapter.postMessage).not.toHaveBeenCalled()
       await expect(Promise.race([
         responsePromise.then(() => "settled"),
@@ -1008,11 +1075,78 @@ describe("server helpers", () => {
       expect(adapter.postMessage).toHaveBeenCalledTimes(1)
       expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "usage ok" })
       expect(finish).toHaveBeenCalledOnce()
-      expect(order.indexOf("commit:done")).toBeLessThan(order.indexOf("post:follow-up"))
+      expect(order.indexOf("stream:committed")).toBeLessThan(order.indexOf("post:follow-up"))
       expect(order).toContain("stream:agent answer")
     }
     finally {
       commitResponse()
+    }
+  })
+
+  it("does not fail native streamed chats when the final message is already committed", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatWebhookFetchHandler } = await import("../src/server.ts")
+    const adapter = createTestChatAdapter()
+    adapter.stream = vi.fn(async (threadId: string, textStream: AsyncIterable<string | StreamChunk>) => {
+      let text = ""
+      for await (const chunk of textStream) {
+        if (typeof chunk === "string") text += chunk
+        else if (chunk.type === "markdown_text") text += chunk.text
+      }
+      return { id: "stream-committed", raw: { text }, threadId }
+    })
+    adapter.editMessage.mockRejectedValue(new Error("message is not modified"))
+    adapter.postMessage.mockImplementation(async (threadId: string, message: unknown) => ({ id: "sent-follow-up", raw: { message }, threadId }))
+    const finish = vi.fn(async (event) => {
+      const chat = event.extensions.get("chat") as { sendMessage?: (message: { markdown: string }) => Promise<void> } | undefined
+      await chat?.sendMessage?.({ markdown: "usage ok" })
+    })
+    const agent = defineAgent({
+      capabilities: [
+        chat({
+          adapters: {
+            telegram: () => adapter as never,
+          },
+          errorFallbackText: "Sorry, I couldn't process that message.",
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({ text: "agent `answer`" }),
+    })
+    const handler = defineAgentChatWebhookFetchHandler(agent as never)
+
+    try {
+      const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+        body: JSON.stringify({
+          update_id: 90,
+          message: {
+            chat: { id: 456, type: "private" },
+            date: 1781092800,
+            from: { first_name: "Maxi", id: 123, username: "maxi" },
+            message_id: 90,
+            text: "hello",
+          },
+        }),
+        method: "POST",
+      }), "telegram")
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ ok: true })
+      expect(adapter.editMessage).not.toHaveBeenCalled()
+      expect(adapter.postMessage).toHaveBeenCalledTimes(1)
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "usage ok" })
+      expect(finish).toHaveBeenCalledOnce()
+      expect(consoleError).not.toHaveBeenCalled()
+    }
+    finally {
+      consoleError.mockRestore()
     }
   })
 


### PR DESCRIPTION
Stacked on #275.

This keeps the Agent Package from treating a native Chat Platform Adapter stream as failed when the Chat SDK has already returned the committed final message. ViteHub now compares the returned sent message against the final markdown before issuing a final edit, so adapters that post the final streamed answer themselves do not receive a duplicate no-op edit that can be rejected by the platform.

It also refreshes chat typing every four seconds while a streamed Agent Invocation is waiting for its first output, then stops as soon as text starts streaming so native streaming adapters do not get fallback placeholder text.

Validated with `pnpm -F @vite-hub/agent run typecheck`, `pnpm -F @vite-hub/agent exec vp test run test/providers.test.ts`, and `pnpm -F @vite-hub/agent test`.

Refs #275