### PR TITLE
fix: refresh devtools materialized source tree

### DIFF
--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -485,11 +485,35 @@ function isToolUIMessagePart(part: unknown): part is Record<string, unknown> {
     || (typeof part.type === "string" && part.type.startsWith("tool-"))
 }
 
+function uiToolPartName(part: Record<string, unknown>): string | undefined {
+  if (part.type === "dynamic-tool") {
+    return typeof part.toolName === "string" && part.toolName ? part.toolName : undefined
+  }
+  if (typeof part.type === "string" && part.type.startsWith("tool-")) {
+    const name = part.type.slice("tool-".length)
+    return name || undefined
+  }
+}
+
+function uiToolPartId(part: Record<string, unknown>, name: string, index: number): string {
+  if (typeof part.toolCallId === "string" && part.toolCallId) return part.toolCallId
+  if (typeof part.id === "string" && part.id) return part.id
+  return `${name}-${index}`
+}
+
 function toolPartHasOutput(part: Record<string, unknown>): boolean {
   return part.state === "output-available"
     || part.state === "output-denied"
     || Object.prototype.hasOwnProperty.call(part, "output")
     || typeof part.errorText === "string"
+}
+
+function completedMaterializeSourceToolIds(message: UIMessage): string[] {
+  return (message.parts || []).flatMap((part, index) => {
+    if (!isToolUIMessagePart(part) || !toolPartHasOutput(part)) return []
+    const name = uiToolPartName(part)
+    return name === "materialize_sources" ? [uiToolPartId(part, name, index)] : []
+  })
 }
 
 function hasIncompleteToolParts(message: UIMessage): boolean {
@@ -535,12 +559,13 @@ async function sendDevtoolsUIMessage(
   if (!entry) {
     throw new Response(`Unknown chat: ${selected}`, { status: 404 })
   }
+  const selectedEntry: ChatDevtoolsAgentEntry = entry
 
   const session = getSession(state, selected)
   state.selected = selected
   const requestedSelection = normalizeInvokerSelection(input)
   const requestedProfileId = requestedSelection.invokerProfileId
-  assertKnownInvokerProfile(entry.metadata, requestedProfileId)
+  assertKnownInvokerProfile(selectedEntry.metadata, requestedProfileId)
   if (
     session.uiMessages.length > 0
     && ((requestedSelection.invokerFallback && !session.invokerFallback)
@@ -552,7 +577,7 @@ async function sendDevtoolsUIMessage(
     session.invokerFallback = requestedSelection.invokerFallback === true
     session.invokerProfileId = session.invokerFallback
       ? undefined
-      : requestedProfileId || entry.metadata.invokerProfiles?.[0]?.id
+      : requestedProfileId || selectedEntry.metadata.invokerProfiles?.[0]?.id
   }
   const userMessage = createUserUIMessage(text)
   const baseMessages = [...createChatDevtoolsPromptHistory(session.uiMessages), userMessage]
@@ -569,7 +594,7 @@ async function sendDevtoolsUIMessage(
     run,
     timeout: 90_000,
   }
-  const stream = readableStreamFromResult(await streamAgentTrigger(entry.agent as never, runtimeContext as never, "chat.message", triggerInput, {
+  const stream = readableStreamFromResult(await streamAgentTrigger(selectedEntry.agent as never, runtimeContext as never, "chat.message", triggerInput, {
     output: "ui-message-stream",
     async onInvocation(invocation) {
       session.thinkingFallback = typeof invocation.metadata?.thinkingFallback === "string"
@@ -580,6 +605,16 @@ async function sendDevtoolsUIMessage(
   }))
   const { readUIMessageStream } = await import("ai") as { readUIMessageStream: ReadUIMessageStream }
   let latestAssistant: UIMessage | undefined
+  const refreshedMaterializationToolIds = new Set<string>()
+  async function refreshCompletedMaterializations(message: UIMessage): Promise<void> {
+    const completedIds = completedMaterializeSourceToolIds(message)
+      .filter(id => !refreshedMaterializationToolIds.has(id))
+    if (!completedIds.length) return
+
+    for (const id of completedIds) refreshedMaterializationToolIds.add(id)
+    await startMetadataResolution(selectedEntry, requestedSelection, { force: true })
+  }
+
   for await (const assistantMessage of readUIMessageStream({ stream })) {
     const now = new Date().toISOString()
     latestAssistant = {
@@ -592,6 +627,7 @@ async function sendDevtoolsUIMessage(
     }
     session.title = titleFromUIMessage(latestAssistant) || session.title
     session.uiMessages = [...baseMessages, latestAssistant]
+    await refreshCompletedMaterializations(latestAssistant)
     await onChange?.(await serializeState(state, selected))
   }
   if (latestAssistant) {
@@ -606,7 +642,7 @@ async function sendDevtoolsUIMessage(
     session.uiMessages = [...baseMessages, latestAssistant]
     await onChange?.(await serializeState(state, selected))
   }
-  await startMetadataResolution(entry, requestedSelection, { force: true })
+  await startMetadataResolution(selectedEntry, requestedSelection, { force: true })
   return await serializeState(state, selected)
 }
 

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -262,10 +262,11 @@ function metadataErrorMessage(cause: unknown): string {
   return cause instanceof Error ? cause.message : "Chat DevTools metadata inspection failed."
 }
 
-function startMetadataResolution(
+async function startMetadataResolution(
   entry: ChatDevtoolsAgentEntry,
   selection: ChatDevtoolsInvokerSelection = {},
-): void {
+  options: { force?: boolean } = {},
+): Promise<void> {
   if (!canResolveWorkspaceMetadata(entry.agent)) {
     entry.metadataError = undefined
     entry.metadataSelectionKey = "static"
@@ -276,7 +277,7 @@ function startMetadataResolution(
 
   const metadataSelection = metadataSelectionForAgent(entry.agent, selection)
   const selectionKey = metadataSelectionKey(metadataSelection)
-  if (entry.metadataSelectionKey === selectionKey) {
+  if (!options.force && entry.metadataSelectionKey === selectionKey) {
     return
   }
 
@@ -304,6 +305,7 @@ function startMetadataResolution(
       entry.metadataTask = undefined
     })
   entry.metadataTask = task
+  if (options.force) await task
 }
 
 async function discoverChatAgents(server: ViteDevServer, state: ChatDevtoolsBridgeState): Promise<void> {
@@ -604,6 +606,7 @@ async function sendDevtoolsUIMessage(
     session.uiMessages = [...baseMessages, latestAssistant]
     await onChange?.(await serializeState(state, selected))
   }
+  await startMetadataResolution(entry, requestedSelection, { force: true })
   return await serializeState(state, selected)
 }
 
@@ -707,7 +710,7 @@ async function handleChatDevtoolsRequest(
   const selected = getSelectedName(state, body.chat)
   const entry = selected ? state.entries.get(selected) : undefined
   if (entry) {
-    startMetadataResolution(entry, invokerSelection)
+    await startMetadataResolution(entry, invokerSelection)
   }
 
   const action = normalizeChatDevtoolsAction(body.action)

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -437,6 +437,93 @@ describe("agent chat capability discovery", () => {
     expect(readInstructions).toHaveBeenCalledTimes(1)
   })
 
+  it("refreshes chat devtools workspace metadata after source materialization", async () => {
+    const root = await createTempRoot("vitehub-agent-devtools-materialized-source-")
+    await mkdir(join(root, "server", "agents", "support"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default {}", "utf8")
+
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { source } = await import("@vite-hub/workspace")
+    const { registerWorkspace } = await import("@vite-hub/workspace/test")
+    const agent = withWorkspaceAgentDefaults(defineAgent({
+      capabilities: [chat()],
+      instructions: "Answer from the workspace.",
+      model: {} as never,
+      workspace: {
+        store: { provider: "memory" },
+        sources: {
+          ingestion: source.custom({
+            cache: { maxAge: 60 },
+            materialize: "lazy",
+            mount: "ingestion",
+            async getKeys() {
+              return ["customers/acme.csv"]
+            },
+            async getItem(key) {
+              return { content: "sku,demand\nA,4\n", key }
+            },
+          }),
+        },
+      },
+      async run({ workspace }) {
+        const fs = workspace?.fs as { materializeSources?: (options: { sources: string[] }) => Promise<unknown> } | undefined
+        await fs?.materializeSources?.({ sources: ["ingestion"] })
+        return "materialized ingestion"
+      },
+    }), { workspace: "support" })
+    registerWorkspace("support", agent as never)
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent()
+
+    await configurePluginServer(plugin, server)
+    const initialState = await waitForMetadataState(handlers[0]!, { action: "get-state", chat: "support" })
+    expect(initialState.files).toEqual([
+      expect.objectContaining({
+        materialized: false,
+        path: "ingestion",
+        source: "ingestion",
+        status: "lazy",
+      }),
+    ])
+
+    const sendResponse = await invokeMiddleware(handlers[0]!, {
+      action: "send",
+      chat: "support",
+      stream: true,
+      text: "load ingestion",
+    })
+    const events = sendResponse.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+    const finalState = events.filter(event => event.type === "state").at(-1)?.state
+
+    expect(finalState.files).toEqual([
+      expect.objectContaining({
+        children: [
+          expect.objectContaining({
+            children: [
+              expect.objectContaining({
+                kind: "file",
+                path: "ingestion/customers/acme.csv",
+                source: "ingestion",
+              }),
+            ],
+            kind: "directory",
+            path: "ingestion/customers",
+            source: "ingestion",
+          }),
+        ],
+        materialized: true,
+        path: "ingestion",
+        source: "ingestion",
+        status: "ready",
+      }),
+    ])
+    expect(textFromUiMessage(finalState.uiMessages[1])).toBe("materialized ingestion")
+  })
+
   it("omits unfinished tool-call assistant messages from devtools prompt history", async () => {
     const { createChatDevtoolsPromptHistory } = await import("../src/chat/vite/devtools-bridge.ts")
     const history = createChatDevtoolsPromptHistory([

--- a/packages/devtools/devtools/chat/app/app.vue
+++ b/packages/devtools/devtools/chat/app/app.vue
@@ -17,7 +17,7 @@ import {
   type ChatDevtoolsToolDefinition,
 } from "../../../src/chat-shared.js"
 import { resolveChatBridgeRoute } from "./bridge-route"
-import { flattenFiles, syncExpandedFilePaths, type FileRow } from "./file-tree"
+import { flattenFiles, sourceRootStates, syncExpandedFilePaths, type FileRow, type SourceRootState } from "./file-tree"
 
 type ChatStatus = "ready" | "submitted" | "streaming" | "error"
 type ChatMessage = UIMessage & { chat?: string }
@@ -53,6 +53,7 @@ const chatMessages = computed(() => {
 })
 const pendingUserMessage = ref<ChatMessage | undefined>()
 const expandedFilePaths = ref(new Set<string>())
+const previousSourceRootStates = ref(new Map<string, SourceRootState>())
 const selectedFilePath = ref<string | undefined>()
 const sidebarWidth = ref(340)
 let rpcClient: Awaited<ReturnType<typeof getDevToolsRpcClient>> | undefined
@@ -322,7 +323,8 @@ function renderToolOutput(tool: ChatDevtoolsTool) {
 }
 
 function syncExpandedFiles(files: ChatDevtoolsFileTreeItem[]) {
-  expandedFilePaths.value = syncExpandedFilePaths(files, expandedFilePaths.value)
+  expandedFilePaths.value = syncExpandedFilePaths(files, expandedFilePaths.value, previousSourceRootStates.value)
+  previousSourceRootStates.value = sourceRootStates(files)
 }
 
 function fileLabel(file: ChatDevtoolsFileTreeItem) {
@@ -346,7 +348,6 @@ function toggleFile(file: ChatDevtoolsFileTreeItem) {
 
 function fileMaterialization(file: ChatDevtoolsFileTreeItem): "lazy" | "materialized" | undefined {
   const meta = file as ChatDevtoolsFileTreeItem & FileMaterialization
-  if (meta.source && meta.kind === "directory" && meta.children?.length) return "materialized"
   if (meta.status === "ready" || meta.materialized || meta.materializedAt) return "materialized"
   if (meta.status === "lazy" || (meta.materialized === false && meta.materialize === "lazy")) return "lazy"
   return undefined

--- a/packages/devtools/devtools/chat/app/app.vue
+++ b/packages/devtools/devtools/chat/app/app.vue
@@ -346,6 +346,7 @@ function toggleFile(file: ChatDevtoolsFileTreeItem) {
 
 function fileMaterialization(file: ChatDevtoolsFileTreeItem): "lazy" | "materialized" | undefined {
   const meta = file as ChatDevtoolsFileTreeItem & FileMaterialization
+  if (meta.source && meta.kind === "directory" && meta.children?.length) return "materialized"
   if (meta.status === "ready" || meta.materialized || meta.materializedAt) return "materialized"
   if (meta.status === "lazy" || (meta.materialized === false && meta.materialize === "lazy")) return "lazy"
   return undefined
@@ -1050,14 +1051,14 @@ onBeforeUnmount(() => {
               class="min-h-full px-3 py-2"
             >
               <template #content="{ content, message, parts }">
-                <div class="flex min-w-0 flex-col gap-2 text-sm/5">
+                <div class="flex w-full min-w-0 flex-col gap-2 text-sm/5">
                   <UCollapsible
                     v-if="isLoadingMessage(message) || hasToolParts(parts)"
                     :default-open="isLoadingMessage(message) || hasRunningTool(parts)"
                     :unmount-on-hide="false"
                     :ui="{
-                      root: 'min-w-0',
-                      content: 'overflow-visible',
+                      root: 'w-full min-w-0',
+                      content: 'w-full overflow-visible',
                     }"
                   >
                     <button
@@ -1080,7 +1081,7 @@ onBeforeUnmount(() => {
                     </button>
 
                     <template #content>
-                      <div class="flex min-w-0 flex-col gap-2 px-px pb-px pt-2 text-xs/5">
+                      <div class="flex w-full min-w-0 flex-col gap-2 px-px pb-px pt-2 text-xs/5">
                         <UChatTool
                           v-for="part in chatToolParts(parts)"
                           :key="part.tool.id"
@@ -1090,8 +1091,8 @@ onBeforeUnmount(() => {
                           variant="card"
                           :default-open="false"
                           :ui="{
-                            root: 'min-w-0 rounded-md',
-                            trigger: 'min-h-7 px-2 py-1 text-xs focus-visible:ring-1 focus-visible:ring-muted focus-visible:outline-none',
+                            root: 'w-full min-w-0 self-stretch rounded-md',
+                            trigger: 'min-h-7 w-full px-2 py-1 text-xs focus-visible:ring-1 focus-visible:ring-muted focus-visible:outline-none',
                             leading: 'size-3.5',
                             leadingIcon: 'size-3.5 opacity-70',
                             label: 'min-w-0 truncate',

--- a/packages/devtools/devtools/chat/app/file-tree.ts
+++ b/packages/devtools/devtools/chat/app/file-tree.ts
@@ -6,12 +6,25 @@ function isSyntheticRoot(file: ChatDevtoolsFileTreeItem) {
   return file.kind === "directory" && (file.path === "" || file.path === "/")
 }
 
+function hasMaterializedChildren(file: ChatDevtoolsFileTreeItem): boolean {
+  return file.kind === "directory" && Boolean(file.children?.length) && Boolean(file.source)
+}
+
 export function syncExpandedFilePaths(files: ChatDevtoolsFileTreeItem[], current: ReadonlySet<string>) {
   const expanded = new Set(current)
   const roots = files.filter(isSyntheticRoot)
 
   if (roots.length === 1) {
     expanded.add(roots[0]!.path)
+  }
+
+  const pending = [...files]
+  while (pending.length) {
+    const file = pending.shift()!
+    if (hasMaterializedChildren(file)) {
+      expanded.add(file.path)
+    }
+    pending.push(...(file.children || []))
   }
 
   return expanded

--- a/packages/devtools/devtools/chat/app/file-tree.ts
+++ b/packages/devtools/devtools/chat/app/file-tree.ts
@@ -1,16 +1,36 @@
 import type { ChatDevtoolsFileTreeItem } from "../../../src/chat-shared.js"
 
 export type FileRow = ChatDevtoolsFileTreeItem & { depth: number, expanded?: boolean }
+export type SourceRootState = NonNullable<ChatDevtoolsFileTreeItem["status"]>
 
 function isSyntheticRoot(file: ChatDevtoolsFileTreeItem) {
   return file.kind === "directory" && (file.path === "" || file.path === "/")
 }
 
-function hasMaterializedChildren(file: ChatDevtoolsFileTreeItem): boolean {
-  return file.kind === "directory" && Boolean(file.children?.length) && Boolean(file.source)
+function sourceRootState(file: ChatDevtoolsFileTreeItem): SourceRootState | undefined {
+  if (file.kind !== "directory" || !file.source) return undefined
+  return file.status
 }
 
-export function syncExpandedFilePaths(files: ChatDevtoolsFileTreeItem[], current: ReadonlySet<string>) {
+export function sourceRootStates(files: ChatDevtoolsFileTreeItem[]): Map<string, SourceRootState> {
+  const states = new Map<string, SourceRootState>()
+  const pending = [...files]
+  while (pending.length) {
+    const file = pending.shift()!
+    const state = sourceRootState(file)
+    if (state) {
+      states.set(file.path, state)
+    }
+    pending.push(...(file.children || []))
+  }
+  return states
+}
+
+export function syncExpandedFilePaths(
+  files: ChatDevtoolsFileTreeItem[],
+  current: ReadonlySet<string>,
+  previousSourceRootStates: ReadonlyMap<string, SourceRootState> = new Map(),
+) {
   const expanded = new Set(current)
   const roots = files.filter(isSyntheticRoot)
 
@@ -18,13 +38,11 @@ export function syncExpandedFilePaths(files: ChatDevtoolsFileTreeItem[], current
     expanded.add(roots[0]!.path)
   }
 
-  const pending = [...files]
-  while (pending.length) {
-    const file = pending.shift()!
-    if (hasMaterializedChildren(file)) {
-      expanded.add(file.path)
+  for (const [path, state] of sourceRootStates(files)) {
+    const previousState = previousSourceRootStates.get(path)
+    if (state === "ready" && previousState !== undefined && previousState !== "ready") {
+      expanded.add(path)
     }
-    pending.push(...(file.children || []))
   }
 
   return expanded

--- a/packages/devtools/src/chat-shared.ts
+++ b/packages/devtools/src/chat-shared.ts
@@ -33,6 +33,7 @@ export interface ChatDevtoolsFileTreeItem {
   materializedAt?: string
   path: string
   source?: string
+  status?: "lazy" | "updating" | "ready" | "error"
   updatedAt?: string
 }
 

--- a/packages/devtools/test/chat-file-tree.test.ts
+++ b/packages/devtools/test/chat-file-tree.test.ts
@@ -29,6 +29,25 @@ describe("chat file tree", () => {
     ])
   })
 
+  it("opens materialized source folders when children arrive", () => {
+    const files = [
+      { ...directory("forecasting-engine", [file("forecasting-engine/README.md")]), source: "forecasting-engine" },
+      { ...directory("ingestion", [file("ingestion/README.md")]), source: "ingestion" },
+      directory("instructions", [file("instructions/AGENTS.md")]),
+    ]
+
+    const expanded = syncExpandedFilePaths(files, new Set())
+
+    expect([...expanded]).toEqual(["forecasting-engine", "ingestion"])
+    expect(flattenFiles(files, expanded).map(row => row.path)).toEqual([
+      "forecasting-engine",
+      "forecasting-engine/README.md",
+      "ingestion",
+      "ingestion/README.md",
+      "instructions",
+    ])
+  })
+
   it("opens a single synthetic root without recursively expanding workspace folders", () => {
     const files = [
       directory("", [

--- a/packages/devtools/test/chat-file-tree.test.ts
+++ b/packages/devtools/test/chat-file-tree.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import type { ChatDevtoolsFileTreeItem } from "../src/chat-shared.ts"
-import { flattenFiles, syncExpandedFilePaths } from "../devtools/chat/app/file-tree.ts"
+import { flattenFiles, sourceRootStates, syncExpandedFilePaths } from "../devtools/chat/app/file-tree.ts"
 
 function directory(path: string, children: ChatDevtoolsFileTreeItem[] = []): ChatDevtoolsFileTreeItem {
   return { children, kind: "directory", path }
@@ -31,12 +31,15 @@ describe("chat file tree", () => {
 
   it("opens materialized source folders when children arrive", () => {
     const files = [
-      { ...directory("forecasting-engine", [file("forecasting-engine/README.md")]), source: "forecasting-engine" },
-      { ...directory("ingestion", [file("ingestion/README.md")]), source: "ingestion" },
+      { ...directory("forecasting-engine", [file("forecasting-engine/README.md")]), source: "forecasting-engine", status: "ready" as const },
+      { ...directory("ingestion", [file("ingestion/README.md")]), source: "ingestion", status: "ready" as const },
       directory("instructions", [file("instructions/AGENTS.md")]),
     ]
 
-    const expanded = syncExpandedFilePaths(files, new Set())
+    const expanded = syncExpandedFilePaths(files, new Set(), new Map([
+      ["forecasting-engine", "lazy"],
+      ["ingestion", "lazy"],
+    ]))
 
     expect([...expanded]).toEqual(["forecasting-engine", "ingestion"])
     expect(flattenFiles(files, expanded).map(row => row.path)).toEqual([
@@ -46,6 +49,37 @@ describe("chat file tree", () => {
       "ingestion/README.md",
       "instructions",
     ])
+  })
+
+  it("does not recursively open nested materialized source folders", () => {
+    const files = [
+      {
+        ...directory("ingestion", [
+          { ...directory("ingestion/customers", [file("ingestion/customers/acme.csv")]), source: "ingestion" },
+        ]),
+        source: "ingestion",
+        status: "ready" as const,
+      },
+    ]
+
+    const expanded = syncExpandedFilePaths(files, new Set(), new Map([["ingestion", "lazy"]]))
+
+    expect([...expanded]).toEqual(["ingestion"])
+    expect(flattenFiles(files, expanded).map(row => row.path)).toEqual([
+      "ingestion",
+      "ingestion/customers",
+    ])
+  })
+
+  it("preserves manual source root collapse after auto-opening it", () => {
+    const files = [
+      { ...directory("ingestion", [file("ingestion/README.md")]), source: "ingestion", status: "ready" as const },
+    ]
+    const expanded = syncExpandedFilePaths(files, new Set(), new Map([["ingestion", "lazy"]]))
+    const collapsed = syncExpandedFilePaths(files, new Set(), sourceRootStates(files))
+
+    expect([...expanded]).toEqual(["ingestion"])
+    expect([...collapsed]).toEqual([])
   })
 
   it("opens a single synthetic root without recursively expanding workspace folders", () => {


### PR DESCRIPTION
Refreshes the Agent Package DevTools Bridge metadata after a DevTools chat run completes, so Source materialization performed during the run is reflected in the ViteHub DevTools Client Files panel instead of leaving stale Lazy Source roots in place.

The Files panel now auto-expands Source directories once materialized children are present and treats those directories as materialized for the badge state. Tool-call cards in the chat content slot also stretch to the full available message width immediately, avoiding the narrow-to-wide jump while streaming.

Validated with focused and package-level checks in the touched packages: DevTools tests, Agent tests, and both package typechecks.