### PR TITLE
feat: add runtime env and schedule bridges

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -43,18 +43,20 @@ export const appName = publicEnv.appName
 
 ```ts
 // server/sync.ts
-import { useServerEnv } from "#vitehub/env/server"
+import { runWithServerEnv, useServerEnv } from "#vitehub/env/server"
 
-export async function sync() {
-  const { airtableToken } = useServerEnv()
-  await fetch("https://api.airtable.com/v0/app/table", {
-    headers: { Authorization: `Bearer ${airtableToken.unseal()}` },
+export async function sync(event: unknown) {
+  return runWithServerEnv(event, async () => {
+    const { airtableToken } = useServerEnv()
+    await fetch("https://api.airtable.com/v0/app/table", {
+      headers: { Authorization: `Bearer ${airtableToken.unseal()}` },
+    })
   })
 }
 ```
 
 ## Vite Integration
 
-Use `hubEnv()` in Vite to resolve public/build env, generate `#vitehub/env/public` and `#vitehub/env/server`, and keep environment declarations close to the app config. Runtime secrets are read from the host environment at request time and are wrapped in `SecretEnv` until explicitly unsealed.
+Use `hubEnv()` in Vite to resolve public/build env, generate `#vitehub/env/public` and `#vitehub/env/server`, and keep environment declarations close to the app config. Runtime secrets are read from the host environment at request time and are wrapped in `SecretEnv` until explicitly unsealed. `runWithServerEnv(event, callback)` activates host Runtime Env for nested ViteHub runtime helpers that cannot receive the request or scheduled event directly.
 
 Learn more at [vitehub.dev](https://vitehub.dev).

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -2,7 +2,7 @@ export { env } from "./core/declarations.ts"
 export { openWorkflowEnv } from "./presets.ts"
 export { parseSchema } from "./schema.ts"
 export { SecretEnv } from "./secret.ts"
-export { resolveServerEnv } from "./server.ts"
+export { resolveServerEnv, runWithServerEnv } from "./server.ts"
 export type { StandardSchemaV1 } from "./schema.ts"
 export type {
   EnvConfigOptions,

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -90,3 +90,35 @@ export function resolveServerEnv<TServerEnv extends Record<string, unknown> = Re
 ): TServerEnv {
   return resolveRegistryValue(registry, runtimeEnv(event)) as TServerEnv
 }
+
+export function runWithServerEnv<T>(event: unknown, callback: () => T): T {
+  const globals = globalThis as { __env__?: RuntimeEnv }
+  const hadGlobalEnv = Object.prototype.hasOwnProperty.call(globals, "__env__")
+  const previousGlobalEnv = globals.__env__
+  const env = getCloudflareEnv(event)
+  if (env) globals.__env__ = env
+
+  try {
+    const result = callback()
+    if (isPromiseLike(result)) {
+      return result.finally(() => restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)) as T
+    }
+    restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)
+    return result
+  }
+  catch (error) {
+    restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)
+    throw error
+  }
+}
+
+function restoreGlobalEnv(globals: { __env__?: RuntimeEnv }, hadGlobalEnv: boolean, previousGlobalEnv: RuntimeEnv | undefined): void {
+  if (hadGlobalEnv) globals.__env__ = previousGlobalEnv
+  else delete globals.__env__
+}
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return typeof value === "object"
+    && value !== null
+    && typeof (value as { finally?: unknown }).finally === "function"
+}

--- a/packages/env/src/virtual-module.d.ts
+++ b/packages/env/src/virtual-module.d.ts
@@ -9,6 +9,7 @@ declare module "#vitehub/env/server" {
 
   export interface ServerEnv extends Record<string, unknown> {}
   export function useServerEnv(event?: unknown): ServerEnv
+  export function runWithServerEnv<T>(event: unknown, callback: () => T): T
 }
 
 export {}

--- a/packages/env/src/vite.ts
+++ b/packages/env/src/vite.ts
@@ -104,9 +104,10 @@ export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
       }
       if (id === RESOLVED_SERVER_ID) {
         return [
-          "import { resolveServerEnv } from '@vite-hub/env/server';",
+          "import { resolveServerEnv, runWithServerEnv as runWithGeneratedServerEnv } from '@vite-hub/env/server';",
           `const registry = ${JSON.stringify(serverRegistry, null, 2)};`,
           "export function useServerEnv(event) { return resolveServerEnv(registry, event); }",
+          "export function runWithServerEnv(event, callback) { return runWithGeneratedServerEnv(event, callback); }",
         ].join("\n")
       }
     },
@@ -137,6 +138,7 @@ function createViteTypes(publicConfig: Record<string, unknown>, serverRegistry: 
     ...createServerTypeFields(serverRegistry, 4),
     "  }",
     "  export function useServerEnv(event?: unknown): ServerEnv",
+    "  export function runWithServerEnv<T>(event: unknown, callback: () => T): T",
     "}",
     "export {}",
     "",

--- a/packages/env/test/vite.test.ts
+++ b/packages/env/test/vite.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { describe, expect, it, vi } from "vitest"
 
 import { createRuntimeRegistry } from "../src/core/resolve.ts"
-import { resolveServerEnv } from "../src/server.ts"
+import { resolveServerEnv, runWithServerEnv } from "../src/server.ts"
 import { env, hubEnv } from "../src/vite.ts"
 
 import { booleanSchema, stringSchema } from "./helpers.ts"
@@ -134,6 +134,7 @@ describe("Vite plugin", () => {
     expect(serverLoaded).not.toContain("SERVER_OPTIONAL_TOKEN")
     expect(serverLoaded).not.toContain("serverEnv")
     expect(serverLoaded).toContain("useServerEnv")
+    expect(serverLoaded).toContain("runWithServerEnv")
   })
 
   it("applies prefixes to inferred Vite env names", async () => {
@@ -204,5 +205,20 @@ describe("Vite plugin", () => {
         WEBHOOK_URL: "https://example.test/hook",
       },
     })).toThrow("Missing Runtime Env from env:VITEHUB_AIRTABLE_TOKEN.")
+  })
+
+  it("runs callbacks with Server Env active for nested runtime helpers", () => {
+    const registry = createRuntimeRegistry({
+      airtableToken: env({ secret: true }),
+    }, { prefix: "VITEHUB_" })
+
+    const resolved = runWithServerEnv({
+      env: {
+        VITEHUB_AIRTABLE_TOKEN: "callback-secret",
+      },
+    }, () => resolveServerEnv<{ airtableToken: { unseal(): string } }>(registry))
+
+    expect(resolved.airtableToken.unseal()).toBe("callback-secret")
+    expect(() => resolveServerEnv(registry)).toThrow("Missing Runtime Env from env:VITEHUB_AIRTABLE_TOKEN.")
   })
 })

--- a/packages/schedule/README.md
+++ b/packages/schedule/README.md
@@ -59,6 +59,19 @@ export default defineConfig({
 
 Use `hubSchedule()` in Vite to discover `server/schedules/<name>.ts` and `src/<name>.schedule.ts`. Static schedules can produce provider cron output, including [Vercel Cron Jobs](https://vercel.com/docs/cron-jobs/). For Nitro apps on Cloudflare, Schedule Provider Wake writes generated `server/plugins/vitehub-schedule.ts` and `server/modules/vitehub-schedule.ts` files so Nitro can register the `cloudflare:scheduled` runtime hook and emit `cloudflare.wrangler.triggers.crons` during standalone `nitro build`. In automatic mode, `server/schedules/*` routes through Nitro Provider Wake while suffix schedules keep standalone provider output.
 
+When a host owns its own Cloudflare scheduled-event bridge, use the runtime helper instead of reimplementing registry matching:
+
+```ts
+import scheduleRegistry from "#vitehub/schedule/registry"
+import { executeCloudflareStaticSchedules } from "@vite-hub/schedule/runtime/static"
+
+export default {
+  async scheduled(event) {
+    await executeCloudflareStaticSchedules(event, { registry: scheduleRegistry })
+  },
+}
+```
+
 Cron parsing uses [`cron-schedule`](https://github.com/P4sca1/cron-schedule).
 
 Learn more at [vitehub.dev](https://vitehub.dev).

--- a/packages/schedule/src/runtime/static.ts
+++ b/packages/schedule/src/runtime/static.ts
@@ -1,4 +1,4 @@
-import type { ScheduleDefinition, ScheduleRunContext } from "../types.ts"
+import type { ScheduleDefinition, ScheduleDefinitionRegistry, ScheduleRunContext } from "../types.ts"
 
 export interface ExecuteStaticScheduleOptions {
   cron: string
@@ -6,6 +6,28 @@ export interface ExecuteStaticScheduleOptions {
   name: string
   scheduledAt?: Date
 }
+
+export interface ExecuteMatchingStaticSchedulesOptions {
+  cron: string
+  registry: ScheduleDefinitionRegistry
+  scheduledAt?: Date
+}
+
+export interface ExecuteCloudflareStaticSchedulesOptions {
+  registry: ScheduleDefinitionRegistry
+}
+
+interface CloudflareScheduledEventLike {
+  [key: string]: unknown
+  controller?: {
+    cron?: string
+    scheduledTime?: number | string | Date
+  }
+  cron?: string
+  scheduledTime?: number | string | Date
+}
+
+type LoadedScheduleModule = ScheduleDefinition | { default?: ScheduleDefinition }
 
 export interface StaticScheduleRun extends ScheduleRunContext {
   cron: string
@@ -24,4 +46,105 @@ export function createStaticScheduleRun(options: Omit<ExecuteStaticScheduleOptio
 
 export async function executeStaticSchedule(options: ExecuteStaticScheduleOptions): Promise<unknown> {
   return await options.definition.handler(createStaticScheduleRun(options))
+}
+
+export async function executeMatchingStaticSchedules(options: ExecuteMatchingStaticSchedulesOptions): Promise<unknown[]> {
+  const scheduledAt = options.scheduledAt ?? new Date()
+  const runs: Array<Promise<unknown>> = []
+  for (const [name, load] of Object.entries(options.registry)) {
+    const definition = unwrapScheduleDefinition(await load())
+    if (!definition || definition.cron !== options.cron) continue
+    runs.push(executeStaticSchedule({ cron: options.cron, definition, name, scheduledAt }))
+  }
+  return await Promise.all(runs)
+}
+
+export async function executeCloudflareStaticSchedules(
+  event: CloudflareScheduledEventLike,
+  options: ExecuteCloudflareStaticSchedulesOptions,
+): Promise<unknown[]> {
+  const scheduled = readCloudflareScheduledEvent(event)
+  return await runWithCloudflareServerEnv(event, async () => {
+    return await executeMatchingStaticSchedules({
+      cron: scheduled.cron,
+      registry: options.registry,
+      scheduledAt: scheduled.scheduledAt,
+    })
+  })
+}
+
+function readCloudflareScheduledEvent(event: CloudflareScheduledEventLike): { cron: string, scheduledAt: Date } {
+  const cron = event.controller?.cron ?? event.cron
+  if (!cron) {
+    throw new TypeError("[vitehub:schedule] Cloudflare scheduled event is missing a cron string.")
+  }
+  const scheduledTime = event.controller?.scheduledTime ?? event.scheduledTime
+  const scheduledAt = scheduledTime instanceof Date
+    ? scheduledTime
+    : typeof scheduledTime === "number" || typeof scheduledTime === "string"
+      ? new Date(scheduledTime)
+      : new Date()
+  if (Number.isNaN(scheduledAt.getTime())) {
+    throw new TypeError("[vitehub:schedule] Cloudflare scheduled event has an invalid scheduledTime.")
+  }
+  return { cron, scheduledAt }
+}
+
+function runWithCloudflareServerEnv<T>(event: CloudflareScheduledEventLike, callback: () => T): T {
+  const globals = globalThis as { __env__?: Record<string, unknown> }
+  const hadGlobalEnv = Object.prototype.hasOwnProperty.call(globals, "__env__")
+  const previousGlobalEnv = globals.__env__
+  const env = readCloudflareEventEnv(event)
+  if (env) globals.__env__ = env
+
+  try {
+    const result = callback()
+    if (isPromiseLike(result)) {
+      return result.finally(() => restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)) as T
+    }
+    restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)
+    return result
+  }
+  catch (error) {
+    restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)
+    throw error
+  }
+}
+
+function restoreGlobalEnv(
+  globals: { __env__?: Record<string, unknown> },
+  hadGlobalEnv: boolean,
+  previousGlobalEnv: Record<string, unknown> | undefined,
+): void {
+  if (hadGlobalEnv) globals.__env__ = previousGlobalEnv
+  else delete globals.__env__
+}
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return typeof value === "object"
+    && value !== null
+    && typeof (value as { finally?: unknown }).finally === "function"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readCloudflareEventEnv(event: CloudflareScheduledEventLike): Record<string, unknown> | undefined {
+  if (isRecord(event.env)) return event.env
+  const context = isRecord(event.context) ? event.context : undefined
+  const cloudflareContext = isRecord(context?.cloudflare) ? context.cloudflare : undefined
+  if (isRecord(cloudflareContext?.env)) return cloudflareContext.env
+  const platformContext = isRecord(context?._platform) ? context._platform : undefined
+  const platformCloudflareContext = isRecord(platformContext?.cloudflare) ? platformContext.cloudflare : undefined
+  if (isRecord(platformCloudflareContext?.env)) return platformCloudflareContext.env
+  const request = isRecord(event.req) ? event.req : undefined
+  const runtime = isRecord(request?.runtime) ? request.runtime : undefined
+  const runtimeCloudflare = isRecord(runtime?.cloudflare) ? runtime.cloudflare : undefined
+  return isRecord(runtimeCloudflare?.env) ? runtimeCloudflare.env : undefined
+}
+
+function unwrapScheduleDefinition(loaded: LoadedScheduleModule): ScheduleDefinition | undefined {
+  if (typeof loaded === "object" && loaded !== null && "default" in loaded) return loaded.default
+  return loaded as ScheduleDefinition
 }

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -18,8 +18,8 @@ const SCHEDULE_REGISTRY_ID = "#vitehub/schedule/registry"
 const RESOLVED_SCHEDULE_REGISTRY_ID = "\0#vitehub/schedule/registry"
 const RESOLVED_SCHEDULE_TARGETS_ID = `\0${SCHEDULE_TARGETS_ID}`
 const registryImportAnchor = ".vitehub/schedule/registry.js"
-const generatedNitroCloudflarePlugin = "server/plugins/vitehub-schedule.ts"
-const generatedNitroCloudflareModule = "server/modules/vitehub-schedule.ts"
+const generatedNitroCloudflarePlugin = ".vitehub/nitro/schedule/plugin.ts"
+const generatedNitroCloudflareModule = "./.vitehub/nitro/schedule/module.ts"
 const mergeNoExternal = createNoExternalMerger(schedulePackageName)
 
 export interface ScheduleVitePluginOptions {
@@ -39,6 +39,7 @@ type NitroConfig = Record<string, unknown> & {
       } & Record<string, unknown>
     } & Record<string, unknown>
   } & Record<string, unknown>
+  modules?: unknown[]
   plugins?: unknown[]
 }
 
@@ -93,6 +94,9 @@ function mergeNitroScheduleConfig(value: unknown, options: { crons: string[], pl
   nitro.plugins = Array.isArray(nitro.plugins) && nitro.plugins.includes(options.plugin)
     ? nitro.plugins
     : [...(Array.isArray(nitro.plugins) ? nitro.plugins : []), options.plugin]
+  nitro.modules = Array.isArray(nitro.modules) && nitro.modules.includes(generatedNitroCloudflareModule)
+    ? nitro.modules
+    : [...(Array.isArray(nitro.modules) ? nitro.modules : []), generatedNitroCloudflareModule]
   nitro.cloudflare ||= {}
   nitro.cloudflare.wrangler ||= {}
   const wrangler = nitro.cloudflare.wrangler
@@ -112,45 +116,12 @@ function renderNitroCloudflarePlugin(definitions: DiscoveredScheduleDefinition[]
   const scheduleRuntimeImport = "@vite-hub/schedule/runtime/static"
   return [
     "import { definePlugin } from 'nitro'",
-    "import type { ScheduleDefinition } from '@vite-hub/schedule'",
     `import scheduleRegistry from ${JSON.stringify(registryImport)}`,
-    `import { executeStaticSchedule } from ${JSON.stringify(scheduleRuntimeImport)}`,
-    "",
-    "interface NitroCloudflareScheduledEvent {",
-    "  controller: {",
-    "    cron: string",
-    "    scheduledTime: number | string | Date",
-    "  }",
-    "}",
-    "",
-    "type LoadedScheduleModule = ScheduleDefinition | { default?: ScheduleDefinition }",
-    "",
-    "function unwrapScheduleDefinition(loaded: LoadedScheduleModule): ScheduleDefinition | undefined {",
-    "  if (typeof loaded === 'object' && loaded !== null && 'default' in loaded) return loaded.default",
-    "  return loaded as ScheduleDefinition",
-    "}",
-    "",
-    "async function loadScheduleDefinition(name: string): Promise<ScheduleDefinition | undefined> {",
-    "  const loader = scheduleRegistry[name]",
-    "  if (!loader) return undefined",
-    "  const loaded = await loader() as LoadedScheduleModule",
-    "  return unwrapScheduleDefinition(loaded)",
-    "}",
-    "",
-    "async function runMatchingSchedules(event: NitroCloudflareScheduledEvent): Promise<void> {",
-    "  const cron = event.controller.cron",
-    "  const scheduledAt = new Date(event.controller.scheduledTime)",
-    "  const tasks = Object.entries(scheduleRegistry).map(async ([name]) => {",
-    "    const definition = await loadScheduleDefinition(name)",
-    "    if (!definition || definition.cron !== cron) return",
-    "    await executeStaticSchedule({ cron, definition, name, scheduledAt })",
-    "  })",
-    "  await Promise.all(tasks)",
-    "}",
+    `import { executeCloudflareStaticSchedules } from ${JSON.stringify(scheduleRuntimeImport)}`,
     "",
     "export default definePlugin((nitroApp) => {",
     "  nitroApp.hooks.hook('cloudflare:scheduled', async (event) => {",
-    "    await runMatchingSchedules(event)",
+    "    await executeCloudflareStaticSchedules(event, { registry: scheduleRegistry })",
     "  })",
     "})",
     "",
@@ -165,26 +136,19 @@ function renderNitroCloudflareModule(crons: string[]): string {
     "",
     `const crons = ${JSON.stringify(crons)}`,
     "",
-    "interface WranglerScheduleConfig {",
-    "  triggers?: {",
-    "    crons?: string[]",
-    "    [key: string]: unknown",
-    "  }",
-    "  [key: string]: unknown",
-    "}",
-    "",
-    "function getWranglerConfig(nitro: Nitro): WranglerScheduleConfig {",
-    "  nitro.options.cloudflare ??= {}",
-    "  const cloudflare = nitro.options.cloudflare as { wrangler?: WranglerScheduleConfig }",
-    "  cloudflare.wrangler ??= {}",
-    "  return cloudflare.wrangler",
+    "function dedupeCloudflareCrons(nitro: Nitro): void {",
+    "  const wrangler = nitro.options.cloudflare?.wrangler",
+    "  if (!wrangler?.triggers || !Array.isArray(wrangler.triggers.crons)) return",
+    "  wrangler.triggers.crons = [...new Set(wrangler.triggers.crons.filter((cron): cron is string => typeof cron === 'string'))]",
     "}",
     "",
     "export default function vitehubScheduleModule(nitro: Nitro): void {",
-    "  const wrangler = getWranglerConfig(nitro)",
-    "  wrangler.triggers ??= {}",
-    "  const existingCrons = Array.isArray(wrangler.triggers.crons) ? wrangler.triggers.crons : []",
-    "  wrangler.triggers.crons = [...new Set([...existingCrons, ...crons])]",
+    "  nitro.options.cloudflare ??= {}",
+    "  nitro.options.cloudflare.wrangler ??= {}",
+    "  nitro.options.cloudflare.wrangler.triggers ??= {}",
+    "  const existingCrons = Array.isArray(nitro.options.cloudflare.wrangler.triggers.crons) ? nitro.options.cloudflare.wrangler.triggers.crons : []",
+    "  nitro.options.cloudflare.wrangler.triggers.crons = [...new Set([...existingCrons, ...crons])]",
+    "  nitro.hooks.hook('build:before', dedupeCloudflareCrons)",
     "}",
     "",
   ].join("\n")
@@ -263,8 +227,18 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
     })
   }
 
+  function discoverRegistrySchedules() {
+    if (!resolved) {
+      return []
+    }
+
+    return discoverScheduleDefinitions({
+      rootDir: resolved.root,
+    })
+  }
+
   function createRegistryContents() {
-    const definitions = discoverViteSchedules()
+    const definitions = discoverRegistrySchedules()
     const registryImport = resolved ? resolve(resolved.root, registryImportAnchor) : registryImportAnchor
     return createRuntimeRegistryContents(registryImport, definitions)
   }
@@ -275,6 +249,7 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
 
   const plugin: Plugin = {
     name: SCHEDULE_VITE_PLUGIN_NAME,
+    enforce: "pre",
     async config(config, env) {
       const root = resolve(config.root || process.cwd())
       const definitions = discoverScheduleDefinitions({ rootDir: root })
@@ -291,10 +266,8 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
         ? [...new Set((await readDefinitionCrons(nitroDefinitions)).values())]
         : []
       const plugin = await writeNitroCloudflarePlugin(root, nitroDefinitions, crons)
-      const viteConfig: ViteConfigWithNitro = {
-        nitro: mergeNitroScheduleConfig((config as { nitro?: unknown }).nitro, { crons, plugin }),
-      }
-      return viteConfig
+      ;(config as ViteConfigWithNitro).nitro = mergeNitroScheduleConfig((config as { nitro?: unknown }).nitro, { crons, plugin })
+      return null
     },
     configResolved(config) {
       resolved = config

--- a/packages/schedule/test/static-runtime.test.ts
+++ b/packages/schedule/test/static-runtime.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+
+import { executeCloudflareStaticSchedules, executeMatchingStaticSchedules } from "../src/runtime/static.ts"
+
+import type { ScheduleDefinitionRegistry } from "../src/types.ts"
+
+describe("Static Schedule runtime", () => {
+  it("executes all static schedules matching a cron", async () => {
+    const calls: string[] = []
+    const registry: ScheduleDefinitionRegistry = {
+      cleanup: async () => ({
+        default: {
+          cron: "0 4 * * *",
+          handler: async ({ scheduledAt }) => calls.push(`cleanup:${scheduledAt.toISOString()}`),
+        },
+      }),
+      report: async () => ({
+        cron: "0 4 * * *",
+        handler: async ({ scheduledAt }) => calls.push(`report:${scheduledAt.toISOString()}`),
+      }),
+      skipped: async () => ({
+        default: {
+          cron: "0 5 * * *",
+          handler: async () => calls.push("skipped"),
+        },
+      }),
+    }
+
+    await executeMatchingStaticSchedules({
+      cron: "0 4 * * *",
+      registry,
+      scheduledAt: new Date("2026-06-12T04:00:00.000Z"),
+    })
+
+    expect(calls).toEqual([
+      "cleanup:2026-06-12T04:00:00.000Z",
+      "report:2026-06-12T04:00:00.000Z",
+    ])
+  })
+
+  it("executes Cloudflare scheduled events with runtime env active", async () => {
+    const seen: Array<string | undefined> = []
+    const registry: ScheduleDefinitionRegistry = {
+      sync: async () => ({
+        default: {
+          cron: "0 4 * * *",
+          handler: async () => {
+            seen.push((globalThis as { __env__?: Record<string, unknown> }).__env__?.AIRTABLE_TOKEN as string | undefined)
+          },
+        },
+      }),
+    }
+
+    await executeCloudflareStaticSchedules({
+      controller: {
+        cron: "0 4 * * *",
+        scheduledTime: "2026-06-12T04:00:00.000Z",
+      },
+      env: {
+        AIRTABLE_TOKEN: "airtable-secret",
+      },
+    }, { registry })
+
+    expect(seen).toEqual(["airtable-secret"])
+    expect((globalThis as { __env__?: Record<string, unknown> }).__env__).toBeUndefined()
+  })
+})

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -29,8 +29,14 @@ function resolvePluginConfig(plugin: ReturnType<typeof hubSchedule>, root: strin
 }
 
 describe("Vite schedule integration", () => {
-  it("contributes discovered schedules to Nitro Cloudflare cron output", async () => {
-    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-nitro-"))
+  it("runs before downstream framework integrations that consume Provider Output config", () => {
+    const plugin = hubSchedule()
+
+    expect(plugin.enforce).toBe("pre")
+  })
+
+  it("contributes discovered schedules to the in-flight Nitro config before framework plugins consume it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-nitro-config-"))
     await mkdir(join(root, "server", "schedules"), { recursive: true })
     await writeFile(join(root, "server", "schedules", "mirror.ts"), [
       "import { defineSchedule } from '@vite-hub/schedule'",
@@ -38,8 +44,7 @@ describe("Vite schedule integration", () => {
       "",
     ].join("\n"), "utf8")
 
-    const plugin = hubSchedule()
-    const config = await (plugin.config as (config: Record<string, unknown>, env: { command: "build" | "serve", mode: string }) => unknown)({
+    const userConfig: Record<string, unknown> = {
       root,
       nitro: {
         cloudflare: {
@@ -48,21 +53,29 @@ describe("Vite schedule integration", () => {
           },
         },
       },
-    }, { command: "build", mode: "production" })
+    }
+    const plugin = hubSchedule()
+    await (plugin.config as (config: Record<string, unknown>, env: { command: "build" | "serve", mode: string }) => unknown)(
+      userConfig,
+      { command: "build", mode: "production" },
+    )
 
-    expect(config).toMatchObject({
+    expect(userConfig).toMatchObject({
       nitro: {
         cloudflare: {
           wrangler: {
             triggers: { crons: ["0 0 * * *", "*/10 * * * *"] },
           },
         },
-        plugins: ["server/plugins/vitehub-schedule.ts"],
+        modules: ["./.vitehub/nitro/schedule/module.ts"],
+        plugins: [".vitehub/nitro/schedule/plugin.ts"],
       },
     })
-    await expect(readFile(join(root, "server", "plugins", "vitehub-schedule.ts"), "utf8")).resolves.toContain("cloudflare:scheduled")
-    await expect(readFile(join(root, "server", "plugins", "vitehub-schedule.ts"), "utf8")).resolves.toContain("../../.vitehub/schedule/registry.js")
-    await expect(readFile(join(root, "server", "modules", "vitehub-schedule.ts"), "utf8")).resolves.toContain("\"*/10 * * * *\"")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "plugin.ts"), "utf8")).resolves.toContain("cloudflare:scheduled")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "plugin.ts"), "utf8")).resolves.toContain("../../schedule/registry.js")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("build:before")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("dedupeCloudflareCrons")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("\"*/10 * * * *\"")
     await expect(readFile(join(root, ".vitehub", "schedule", "registry.js"), "utf8")).resolves.toContain("\"mirror\": async () => import(")
     await expect(readFile(join(root, ".vitehub", "schedule", "registry.d.ts"), "utf8")).resolves.toContain("ScheduleDefinition")
   })
@@ -82,8 +95,8 @@ describe("Vite schedule integration", () => {
     }, { command: "build", mode: "production" })
 
     expect(config).toBeNull()
-    await expect(readFile(join(root, "server", "plugins", "vitehub-schedule.ts"), "utf8")).rejects.toThrow()
-    await expect(readFile(join(root, "server", "modules", "vitehub-schedule.ts"), "utf8")).rejects.toThrow()
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "plugin.ts"), "utf8")).rejects.toThrow()
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).rejects.toThrow()
   })
 
   it("can force Nitro plugin output for suffix schedules", async () => {
@@ -96,18 +109,60 @@ describe("Vite schedule integration", () => {
     ].join("\n"), "utf8")
 
     const plugin = hubSchedule({ providerOutput: "nitro" })
-    const config = await (plugin.config as (config: Record<string, unknown>, env: { command: "build" | "serve", mode: string }) => unknown)({
+    const userConfig: Record<string, unknown> = {
       root,
-    }, { command: "build", mode: "production" })
+    }
+    const config = await (plugin.config as (config: Record<string, unknown>, env: { command: "build" | "serve", mode: string }) => unknown)(
+      userConfig,
+      { command: "build", mode: "production" },
+    )
 
-    expect(config).toMatchObject({
+    expect(config).toBeNull()
+    expect(userConfig).toMatchObject({
       nitro: {
         cloudflare: {
           wrangler: {
             triggers: { crons: ["0 0 * * *"] },
           },
         },
-        plugins: ["server/plugins/vitehub-schedule.ts"],
+        modules: ["./.vitehub/nitro/schedule/module.ts"],
+        plugins: [".vitehub/nitro/schedule/plugin.ts"],
+      },
+    })
+  })
+
+  it("preserves existing Nitro build hooks while adding schedule Provider Output", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-nitro-hooks-"))
+    await mkdir(join(root, "server", "schedules"), { recursive: true })
+    await writeFile(join(root, "server", "schedules", "mirror.ts"), [
+      "import { defineSchedule } from '@vite-hub/schedule'",
+      "export default defineSchedule({ cron: '0 4 * * *', handler: () => {} })",
+      "",
+    ].join("\n"), "utf8")
+    const calls: string[] = []
+    const userConfig: Record<string, unknown> = {
+      root,
+      nitro: {
+        hooks: {
+          "build:before": () => calls.push("existing"),
+        },
+      },
+    }
+    const plugin = hubSchedule()
+    await (plugin.config as (config: Record<string, unknown>, env: { command: "build" | "serve", mode: string }) => unknown)(
+      userConfig,
+      { command: "build", mode: "production" },
+    )
+
+    const buildBefore = ((userConfig.nitro as { hooks?: Record<string, unknown> }).hooks?.["build:before"]) as () => void
+    buildBefore()
+
+    expect(calls).toEqual(["existing"])
+    expect(userConfig).toMatchObject({
+      nitro: {
+        hooks: { "build:before": buildBefore },
+        modules: ["./.vitehub/nitro/schedule/module.ts"],
+        plugins: [".vitehub/nitro/schedule/plugin.ts"],
       },
     })
   })
@@ -154,9 +209,13 @@ describe("Vite schedule integration", () => {
     ].join("\n"), "utf8")
 
     const plugin = hubSchedule()
-    const config = await (plugin.config as (config: Record<string, unknown>, env: { command: "build" | "serve", mode: string }) => unknown)({
+    const userConfig: Record<string, unknown> = {
       root,
-    }, { command: "build", mode: "production" })
+    }
+    await (plugin.config as (config: Record<string, unknown>, env: { command: "build" | "serve", mode: string }) => unknown)(
+      userConfig,
+      { command: "build", mode: "production" },
+    )
     ;(plugin.configResolved as (config: Record<string, unknown>) => void)({
       build: { outDir: "dist/client" },
       command: "build",
@@ -165,7 +224,7 @@ describe("Vite schedule integration", () => {
     })
     await (plugin.closeBundle as () => Promise<void>)()
 
-    expect(config).toMatchObject({
+    expect(userConfig).toMatchObject({
       nitro: {
         cloudflare: {
           wrangler: {
@@ -174,8 +233,8 @@ describe("Vite schedule integration", () => {
         },
       },
     })
-    await expect(readFile(join(root, "server", "modules", "vitehub-schedule.ts"), "utf8")).resolves.toContain("\"0 4 * * *\"")
-    await expect(readFile(join(root, "server", "modules", "vitehub-schedule.ts"), "utf8")).resolves.not.toContain("\"0 0 * * *\"")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("\"0 4 * * *\"")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.not.toContain("\"0 0 * * *\"")
     await expect(readFile(join(root, ".vitehub", "schedule", "registry.mjs"), "utf8")).resolves.toContain("\"cleanup\"")
     await expect(readFile(join(root, ".vitehub", "schedule", "registry.mjs"), "utf8")).resolves.not.toContain("\"sync\"")
     await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).resolves.toContain("\"0 0 * * *\"")
@@ -196,6 +255,19 @@ describe("Vite schedule integration", () => {
     expect(registry).toContain("\"cleanup\": async () => import(")
     expect(registry).toContain("\"reports\": async () => import(")
     expect(registry).toContain("../../src/cleanup.schedule.ts")
+  })
+
+  it("serves server schedules from the stable lazy registry", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-registry-server-"))
+    await mkdir(join(root, "server", "schedules"), { recursive: true })
+    await writeFile(join(root, "server", "schedules", "sync.ts"), "export default defineSchedule({ cron: \"0 4 * * *\", handler: () => {} })\n", "utf8")
+
+    const plugin = hubSchedule({ providerOutput: false })
+    resolvePluginConfig(plugin, root)
+    const registry = await loadScheduleRegistry(plugin)
+
+    expect(registry).toContain("\"sync\": async () => import(")
+    expect(registry).toContain("../../server/schedules/sync.ts")
   })
 
   it("serves generated runtime schedule target names behind a stable import", async () => {

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1,4 +1,5 @@
-import { resolve } from "node:path"
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
 
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored } from "@vite-hub/internal/build/vite"
@@ -8,9 +9,9 @@ import { normalizeWorkspaceOptions } from "../../config.ts"
 import { discoverViteWorkspaceDefinitions } from "../../build/discovery.ts"
 import { workspaceSuffixPattern } from "../../build/workspace-config.ts"
 
-import type { HmrContext, Plugin, ResolvedConfig, ViteDevServer } from "vite"
+import type { HmrContext, Plugin, ResolvedConfig, UserConfig, ViteDevServer } from "vite"
 import type { WorkspaceBuildState } from "../../build/integration.ts"
-import type { WorkspaceModuleOptions } from "../../core/types.ts"
+import type { ResolvedWorkspaceModuleOptions, WorkspaceModuleOptions } from "../../core/types.ts"
 
 const WORKSPACE_PACKAGE_NAME = "@vite-hub/workspace"
 const WORKSPACES_ID = "#vitehub/workspaces"
@@ -20,8 +21,17 @@ const WORKSPACE_REGISTRY_ID = "#vitehub-workspace-registry"
 const RESOLVED_WORKSPACES_ID = `\0${WORKSPACES_ID}`
 const RESOLVED_WORKSPACE_PREFIX = `\0${WORKSPACE_PREFIX}`
 const RESOLVED_WORKSPACE_REGISTRY_ID = `\0${WORKSPACE_REGISTRY_ID}`
+const generatedNitroWorkspacePlugin = ".vitehub/nitro/workspace/plugin.ts"
 const mergeNoExternal = createNoExternalMerger(WORKSPACE_PACKAGE_NAME)
 const workspacesDirSegment = /[\\/](?:server[\\/])?workspaces(?:[\\/]|$)/
+
+type NitroConfig = {
+  plugins?: unknown[]
+} & Record<string, unknown>
+
+type ViteConfigWithWorkspaceNitro = Omit<UserConfig, "plugins"> & {
+  nitro?: NitroConfig
+}
 
 function mergeDedupe(current: string[] | undefined): string[] {
   if (!current) return [WORKSPACE_PACKAGE_NAME]
@@ -30,6 +40,39 @@ function mergeDedupe(current: string[] | undefined): string[] {
 
 function isWorkspaceFile(file: string) {
   return workspaceSuffixPattern.test(file) || workspacesDirSegment.test(file)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function isHostedWorkspaceStore(store: ResolvedWorkspaceModuleOptions["store"]): boolean {
+  return store.provider === "cloudflare-artifacts" || store.provider === "github"
+}
+
+function mergeNitroWorkspaceConfig(value: unknown): NitroConfig {
+  const nitro: NitroConfig = isRecord(value) ? { ...value } : {}
+  const plugins = Array.isArray(nitro.plugins) ? [...nitro.plugins] : []
+  if (!plugins.includes(generatedNitroWorkspacePlugin)) plugins.push(generatedNitroWorkspacePlugin)
+  return { ...nitro, plugins }
+}
+
+function renderNitroWorkspacePlugin(config: ResolvedWorkspaceModuleOptions): string {
+  return [
+    "import { configureCloudflareWorkspaceRuntime } from '@vite-hub/workspace/cloudflare'",
+    "import { definePlugin } from 'nitro'",
+    "",
+    "export default definePlugin(() => {",
+    `  configureCloudflareWorkspaceRuntime(${JSON.stringify({ root: config.root, store: config.store }, null, 2)})`,
+    "})",
+    "",
+  ].join("\n")
+}
+
+async function writeNitroWorkspacePlugin(root: string, config: ResolvedWorkspaceModuleOptions): Promise<void> {
+  const pluginFile = resolve(root, generatedNitroWorkspacePlugin)
+  await mkdir(dirname(pluginFile), { recursive: true })
+  await writeFile(pluginFile, renderNitroWorkspacePlugin(config), "utf8")
 }
 
 export interface WorkspaceVitePluginAPI {
@@ -71,17 +114,30 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
 
   return {
     name: "@vite-hub/workspace/vite",
+    enforce: "pre",
     api: {
       getWorkspaces: () => manifest.workspaces,
     },
-    config(config) {
-      return {
+    async config(config, env) {
+      const root = resolve(config.root || process.cwd())
+      const normalized = normalizeWorkspaceOptions((config as UserConfig & { workspace?: false | WorkspaceModuleOptions }).workspace ?? options, {
+        dev: env?.command !== "build",
+        env: process.env,
+        hosting: process.env.VITEHUB_HOSTING,
+        rootDir: root,
+      })
+      const viteConfig: ViteConfigWithWorkspaceNitro = {
         server: {
           watch: {
             ignored: mergeGeneratedViteHubWatchIgnored(config.server?.watch?.ignored),
           },
         },
       }
+      if (normalized && isHostedWorkspaceStore(normalized.store)) {
+        await writeNitroWorkspacePlugin(root, normalized)
+        viteConfig.nitro = mergeNitroWorkspaceConfig((config as ViteConfigWithWorkspaceNitro).nitro)
+      }
+      return viteConfig
     },
     async configResolved(config) {
       resolved = config

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -70,17 +70,24 @@ afterEach(async () => {
 })
 
 describe("hubWorkspace", () => {
+  it("runs before downstream framework integrations that consume Provider Output config", async () => {
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace()
+
+    expect(plugin.enforce).toBe("pre")
+  })
+
   it("ignores generated workspace files in the Vite dev watcher", async () => {
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace()
-    const config = plugin.config as (config: { server?: { watch?: { ignored?: string | string[] } } }) => { server?: { watch?: { ignored?: string[] } } }
+    const config = plugin.config as (config: { server?: { watch?: { ignored?: string | string[] } } }) => Promise<{ server?: { watch?: { ignored?: string[] } } }>
 
-    expect(config({}).server?.watch?.ignored).toEqual(["**/.vitehub/**"])
-    expect(config({ server: { watch: { ignored: ["**/node_modules/**"] } } }).server?.watch?.ignored).toEqual([
+    await expect(config({})).resolves.toMatchObject({ server: { watch: { ignored: ["**/.vitehub/**"] } } })
+    await expect(config({ server: { watch: { ignored: ["**/node_modules/**"] } } })).resolves.toMatchObject({ server: { watch: { ignored: [
       "**/node_modules/**",
       "**/.vitehub/**",
-    ])
-    expect(config({ server: { watch: { ignored: ["**/.vitehub/**"] } } }).server?.watch?.ignored).toEqual(["**/.vitehub/**"])
+    ] } } })
+    await expect(config({ server: { watch: { ignored: ["**/.vitehub/**"] } } })).resolves.toMatchObject({ server: { watch: { ignored: ["**/.vitehub/**"] } } })
   })
 
   it("attaches noExternal and virtual workspace manifests", async () => {
@@ -157,6 +164,38 @@ describe("hubWorkspace", () => {
     await expect(readFile(join(root, ".vitehub", "types", "workspace.d.ts"), "utf8")).resolves.toContain('"tasks": true')
     expect(load(resolveId("#vitehub-workspace-registry")!)).toContain('"tasks": async () => {')
     expect(load(resolveId("#vitehub/workspaces")!)).toContain('"tasks"')
+  })
+
+  it("emits Nitro runtime setup for hosted workspace stores outside server plugins", async () => {
+    const root = await createViteRoot()
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace()
+    const config = plugin.config as (
+      config: { root: string, workspace?: { store?: { branch?: string, provider: "github", repository: string, root: string } } },
+      env: { command: "build", mode: string },
+    ) => Promise<{ nitro?: { plugins?: string[] } }>
+
+    await expect(config({
+      root,
+      workspace: {
+        store: {
+          branch: "main",
+          provider: "github",
+          repository: "onmax/quiver-airtable",
+          root: "app/server/workspaces/mirror",
+        },
+      },
+    }, { command: "build", mode: "production" })).resolves.toMatchObject({
+      nitro: {
+        plugins: [".vitehub/nitro/workspace/plugin.ts"],
+      },
+    })
+
+    const pluginSource = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(pluginSource).toContain("configureCloudflareWorkspaceRuntime")
+    expect(pluginSource).toContain('"provider": "github"')
+    expect(pluginSource).toContain('"repository": "onmax/quiver-airtable"')
+    await expect(readFile(join(root, "server", "plugins", "vitehub-workspace.ts"), "utf8")).rejects.toThrow()
   })
 
   it("materializes the workspace runtime package for Vercel build output", async () => {


### PR DESCRIPTION
Adds Server Env, Schedule, and Workspace runtime bridges so hosted apps do not need hand-authored Nitro plugins for common ViteHub runtime glue.

Env generated #vitehub/env/server now exports runWithServerEnv() beside useServerEnv(). Schedule static runtime can execute matching Cloudflare static schedules from a registry, and Schedule Vite generated Nitro glue now lives under .vitehub/nitro instead of app server/plugins. The stable #vitehub/schedule/registry import includes server/schedules definitions as well as Vite-suffix definitions.

Schedule and Workspace Vite integrations now run early enough for downstream framework integrations like Nitro to consume generated Provider Output regardless of their order in the Vite plugins array. Schedule also emits a generated Nitro build module that preserves existing Nitro build hooks while deduping Cloudflare cron output caused by Vite/Nitro config merging.

Workspace Vite now emits hosted-store Nitro runtime setup under .vitehub/nitro/workspace for hosted workspace stores, so apps can rely on workspace.store config instead of calling setWorkspaceRuntimeConfig()/setWorkspaceHostedStoreLoader() from their own server plugin.

Focused validation passed: Env package typecheck, Schedule package typecheck, targeted Schedule Vite/static-runtime tests, and the Workspace Vite integration test suite. Workspace package tsc still reports missing local optional peer type packages h3/mrmime in this checkout, unrelated to the edited Vite integration path.
