### PR TITLE
chore: trim package cleanup surfaces

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -76,7 +76,6 @@
     "@types/node": "catalog:tooling",
     "@vite-hub/internal": "workspace:*",
     "@vite-hub/workflow": "workspace:*",
-    "@vitejs/devtools-kit": "catalog:vite",
     "ai": "catalog:ai",
     "evalite": "catalog:ai",
     "publint": "catalog:tooling",

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -1,6 +1,7 @@
 import { workspaceOverrideSymbol } from "../access-runtime.ts"
 import { defineCapability } from "../capability-runtime.ts"
 import { normalizeAgentWorkspaceSource } from "../workspace-source-metadata.ts"
+import { isPlainObject as isRecord } from "@vite-hub/internal/object"
 import { createWorkspaceSourceResolutionFacade, createWorkspaceTools } from "@vite-hub/workspace"
 
 import type {
@@ -285,10 +286,6 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
       setWorkspaceOverride(context, scopedWorkspace)
     },
   })
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 async function resolveWorkspaceScope<

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -141,7 +141,7 @@ async function renderChatTitleTemplate(options: ChatTitleOptions, input: ChatTit
   }
   const variables = await resolveTemplateVariables(options, input)
   return template.replace(/\{\{\s*([a-zA-Z][\w.-]*)\s*\}\}/g, (match, name: string) => {
-    if (!Object.prototype.hasOwnProperty.call(variables, name)) return match
+    if (!Object.hasOwn(variables, name)) return match
     const value = variables[name]
     return value === null || value === undefined ? "" : String(value)
   })

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -110,7 +110,7 @@ function isKnownChatWebhookPlatform(platform: string): platform is KnownChatWebh
 }
 
 function hasExplicitChatWebhook(options: AgentChatOptions, platform: string): boolean {
-  return !!options.webhooks && Object.prototype.hasOwnProperty.call(options.webhooks, platform)
+  return !!options.webhooks && Object.hasOwn(options.webhooks, platform)
 }
 
 function normalizeChatWebhookRegistrations(

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -522,7 +522,7 @@ function uiToolPartId(part: Record<string, unknown>, name: string, index: number
 function toolPartHasOutput(part: Record<string, unknown>): boolean {
   return part.state === "output-available"
     || part.state === "output-denied"
-    || Object.prototype.hasOwnProperty.call(part, "output")
+    || Object.hasOwn(part, "output")
     || typeof part.errorText === "string"
 }
 

--- a/packages/agent/src/invoker.ts
+++ b/packages/agent/src/invoker.ts
@@ -1,3 +1,5 @@
+import { isPlainObject as isRecord } from "@vite-hub/internal/object"
+
 import type {
   AgentCallbackContext,
   AgentInvocationContextStore,
@@ -17,10 +19,6 @@ const profileSelectorKeys = [
   "invoker.profile",
   "invokerProfile",
 ]
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-}
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined

--- a/packages/agent/src/workspace-source-metadata.ts
+++ b/packages/agent/src/workspace-source-metadata.ts
@@ -1,3 +1,5 @@
+import { isPlainObject as isPlainRecord } from "@vite-hub/internal/object"
+
 import type {
   WorkspaceCacheOptions,
   WorkspaceDefinition,
@@ -89,24 +91,24 @@ function describeWorkspaceSourceInput(input: WorkspaceSourceInput): WorkspaceSou
 
 function inferWorkspaceSourceFamily(input: Record<string, unknown>): WorkspaceSourceFamily | undefined {
   const providerFamilies: WorkspaceSourceFamily[] = []
-  if (hasOwn(input, "repo")) providerFamilies.push("github")
-  if (hasOwn(input, "url")) providerFamilies.push("fetch")
-  if (hasOwn(input, "server")) providerFamilies.push("mcpResources")
+  if (Object.hasOwn(input, "repo")) providerFamilies.push("github")
+  if (Object.hasOwn(input, "url")) providerFamilies.push("fetch")
+  if (Object.hasOwn(input, "server")) providerFamilies.push("mcpResources")
 
   if (providerFamilies.length > 1) {
     throw ambiguousSourceConfiguration(providerFamilies)
   }
 
   if (providerFamilies[0]) {
-    if (providerFamilies[0] === "github" && (hasOwn(input, "path") || hasOwn(input, "workspacePath") || hasOwn(input, "content"))) {
+    if (providerFamilies[0] === "github" && (Object.hasOwn(input, "path") || Object.hasOwn(input, "workspacePath") || Object.hasOwn(input, "content"))) {
       throw ambiguousSourceConfiguration(["github", "file"])
     }
     return providerFamilies[0]
   }
 
   const localFamilies: WorkspaceSourceFamily[] = []
-  if (hasOwn(input, "include")) localFamilies.push("glob")
-  if (hasOwn(input, "path") || hasOwn(input, "workspacePath") || hasOwn(input, "content")) localFamilies.push("file")
+  if (Object.hasOwn(input, "include")) localFamilies.push("glob")
+  if (Object.hasOwn(input, "path") || Object.hasOwn(input, "workspacePath") || Object.hasOwn(input, "content")) localFamilies.push("file")
 
   if (localFamilies.length > 1) {
     throw ambiguousSourceConfiguration(localFamilies)
@@ -120,7 +122,7 @@ function ambiguousSourceConfiguration(families: WorkspaceSourceFamily[]): TypeEr
 }
 
 function fileSourceDefaults(input: Record<string, unknown>): WorkspaceSourceMetadataDescriptor {
-  const mount = typeof input.mount === "object" && input.mount && !hasOwn(input.mount as Record<string, unknown>, "path")
+  const mount = typeof input.mount === "object" && input.mount && !Object.hasOwn(input.mount as Record<string, unknown>, "path")
     ? { ...input.mount as object, path: "" } as WorkspaceSourceMount
     : input.mount as WorkspaceSourceMount | undefined ?? ""
   return {
@@ -173,11 +175,11 @@ function applyWorkspaceSourceBinding(
 ): WorkspaceSourceMetadataDescriptor {
   return {
     ...descriptor,
-    cache: hasOwn(input, "cache") ? input.cache as WorkspaceSourceMetadataDescriptor["cache"] : descriptor.cache,
-    instructions: hasOwn(input, "instructions") ? input.instructions as WorkspaceSourceInstructions | undefined : descriptor.instructions,
-    materialize: hasOwn(input, "materialize") ? input.materialize as WorkspaceMaterializeMode | undefined : descriptor.materialize,
-    mount: hasOwn(input, "mount") ? input.mount as WorkspaceSourceMount | undefined : descriptor.mount,
-    sync: hasOwn(input, "sync") ? input.sync as WorkspaceSourceSyncConfig | undefined : descriptor.sync,
+    cache: Object.hasOwn(input, "cache") ? input.cache as WorkspaceSourceMetadataDescriptor["cache"] : descriptor.cache,
+    instructions: Object.hasOwn(input, "instructions") ? input.instructions as WorkspaceSourceInstructions | undefined : descriptor.instructions,
+    materialize: Object.hasOwn(input, "materialize") ? input.materialize as WorkspaceMaterializeMode | undefined : descriptor.materialize,
+    mount: Object.hasOwn(input, "mount") ? input.mount as WorkspaceSourceMount | undefined : descriptor.mount,
+    sync: Object.hasOwn(input, "sync") ? input.sync as WorkspaceSourceSyncConfig | undefined : descriptor.sync,
   }
 }
 
@@ -197,7 +199,7 @@ function normalizeSourceSync(sync: WorkspaceSourceSyncConfig | undefined): false
 }
 
 function isExplicitSourceBinding(input: Record<string, unknown>): input is Record<string, unknown> & { source: WorkspaceSourceInput } {
-  return hasOwn(input, "source")
+  return Object.hasOwn(input, "source")
 }
 
 function hasSourceMethods(input: Record<string, unknown>) {
@@ -260,12 +262,4 @@ function normalizeSafePath(path: string, label: string, options: { allowEmpty: b
     throw new Error(`[vitehub] ${label} must not be empty.`)
   }
   return normalized
-}
-
-function isPlainRecord(input: unknown): input is Record<string, unknown> {
-  return !!input && typeof input === "object" && !Array.isArray(input)
-}
-
-function hasOwn(input: Record<string, unknown>, key: string) {
-  return Object.prototype.hasOwnProperty.call(input, key)
 }

--- a/packages/auth/src/agent.ts
+++ b/packages/auth/src/agent.ts
@@ -1,3 +1,5 @@
+import { isPlainObject as isRecord } from "@vite-hub/internal/object"
+
 import { getAuth } from "./server.ts"
 
 import type {
@@ -254,8 +256,4 @@ function normalizeMeta(value: Record<string, unknown> | null | undefined): Recor
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }

--- a/packages/auth/src/definition.ts
+++ b/packages/auth/src/definition.ts
@@ -1,3 +1,5 @@
+import { isPlainObject } from "@vite-hub/internal/object"
+
 import { normalizeAuthBasePath } from "./shared.ts"
 
 import type {
@@ -11,10 +13,6 @@ import type {
 const authRuntimeOptionNames = new Set(["baseURL", "secret", "secrets"])
 const databaseReferenceKeys = new Set(["dedicated", "name"])
 const secondaryStorageReferenceKeys = new Set(["store"])
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
-}
 
 function validateNamedString(value: unknown, label: string): void {
   if (typeof value !== "string" || value.trim().length === 0 || value !== value.trim()) {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -11,10 +11,6 @@ import type {
   ViteHubAuth,
 } from "./types.ts"
 
-function hasRuntimeOptions(options: AuthRuntimeOptions | undefined): boolean {
-  return Boolean(options && Object.keys(options).length > 0)
-}
-
 const authRuntimeStateKey = Symbol.for("vitehub.auth.runtime")
 
 interface AuthRuntimeState {
@@ -79,7 +75,7 @@ export function getAuthForDefinition(
   definition: AuthDefinition,
   runtimeOptions?: AuthRuntimeOptions,
 ): ViteHubAuth {
-  if (hasRuntimeOptions(runtimeOptions)) {
+  if (runtimeOptions && Object.keys(runtimeOptions).length > 0) {
     return createAuth(definition, runtimeOptions) as unknown as ViteHubAuth
   }
 

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -69,7 +69,6 @@
   "dependencies": {
     "defu": "catalog:unjs",
     "esbuild": "catalog:esbuild-v27",
-    "exsolve": "catalog:unjs",
     "h3": "catalog:unjs",
     "pathe": "catalog:unjs"
   },

--- a/packages/ci/src/errors.ts
+++ b/packages/ci/src/errors.ts
@@ -40,13 +40,6 @@ export class CIMalformedResponseError extends CIProviderError {
   }
 }
 
-export class CIUnsupportedCapabilityError extends CIProviderError {
-  constructor(message = "CI provider does not support this capability.", options: { provider?: string, statusCode?: number, cause?: unknown } = {}) {
-    super(message, options)
-    this.name = "CIUnsupportedCapabilityError"
-  }
-}
-
 export function normalizeProviderError(error: unknown, provider: string): CIProviderError {
   if (error instanceof CIProviderError) {
     return error

--- a/packages/ci/src/providers/cloudflare.ts
+++ b/packages/ci/src/providers/cloudflare.ts
@@ -11,9 +11,7 @@ import {
 import type { CIContext, CILogPage, CILogQuery, CIProvider, CIRun, CIRunQuery } from "../types.ts"
 
 interface CloudflareEnvelope<T> {
-  success?: boolean
   result?: T
-  errors?: Array<{ message?: string }>
 }
 
 interface CloudflareBuild {
@@ -35,7 +33,6 @@ interface CloudflareTriggerMetadata {
   author?: string
   build_trigger_source?: string
   provider_account_name?: string
-  provider_type?: string
   repo_name?: string
 }
 
@@ -91,10 +88,6 @@ export const cloudflareCIProvider: CIProvider = {
     }
     return normalizeCloudflareLogs(envelope.result, query)
   },
-}
-
-export function createCloudflareCIProvider(): CIProvider {
-  return cloudflareCIProvider
 }
 
 function createCloudflareClient(context: CIContext) {

--- a/packages/ci/src/providers/github.ts
+++ b/packages/ci/src/providers/github.ts
@@ -34,7 +34,6 @@ interface GithubRunsResponse {
 }
 
 interface GithubRepository {
-  name?: string
   full_name?: string
   archived?: boolean
   disabled?: boolean
@@ -42,16 +41,8 @@ interface GithubRepository {
 
 interface GithubJob {
   id?: number
-  run_id?: number
   name?: string
-  status?: string
   conclusion?: string | null
-  html_url?: string
-  head_sha?: string
-  head_branch?: string
-  workflow_name?: string
-  started_at?: string
-  completed_at?: string
 }
 
 interface GithubJobsResponse {
@@ -116,10 +107,6 @@ export const githubCIProvider: CIProvider = {
       raw: { jobs },
     }
   },
-}
-
-export function createGithubCIProvider(): CIProvider {
-  return githubCIProvider
 }
 
 function createGithubClient(context: CIContext) {

--- a/packages/ci/src/providers/vercel.ts
+++ b/packages/ci/src/providers/vercel.ts
@@ -35,7 +35,7 @@ interface VercelListDeploymentsResponse {
 interface VercelEvent {
   created?: number
   date?: number
-  payload?: { text?: string, deploymentId?: string, info?: { type?: string } }
+  payload?: { text?: string, info?: { type?: string } }
   text?: string
   type?: string
   level?: string
@@ -85,10 +85,6 @@ export const vercelCIProvider: CIProvider = {
       raw: response,
     }
   },
-}
-
-export function createVercelCIProvider(): CIProvider {
-  return vercelCIProvider
 }
 
 function createVercelClient(context: CIContext) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,12 +37,8 @@
     "typecheck": "tsc --noEmit -p ./tsconfig.json",
     "test": "vp run -t @vite-hub/cli#build && vp test"
   },
-  "dependencies": {
-    "pathe": "catalog:unjs"
-  },
   "devDependencies": {
     "@types/node": "catalog:tooling",
-    "@vite-hub/agent": "workspace:*",
     "@vite-hub/internal": "workspace:*",
     "typescript": "catalog:tooling",
     "vite": "catalog:vite",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,69 +1,16 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process"
 import { realpathSync } from "node:fs"
+import { resolve } from "node:path"
 import process from "node:process"
 import { fileURLToPath } from "node:url"
 
-import { collectViteHubProvisionSteps } from "@vite-hub/internal/cli"
-import { resolve } from "pathe"
+import { collectViteHubCliNamespaces, collectViteHubProvisionSteps } from "@vite-hub/internal/cli"
 
 import { runProvision } from "./provision.ts"
 
+import type { ViteHubCliCommandNamespace, ViteHubCliContext, ViteHubCliSpawn, ViteHubCliSpawnOptions } from "@vite-hub/internal/cli"
 import type { InlineConfig, ResolvedConfig } from "vite"
-
-interface ViteHubCliSpawnResult {
-  exitCode: number | null
-  signal?: NodeJS.Signals | null
-}
-
-interface ViteHubCliSpawnOptions {
-  cwd?: string
-  env?: NodeJS.ProcessEnv
-  stderr?: "inherit" | "pipe"
-  stdout?: "inherit" | "pipe"
-}
-
-type ViteHubCliSpawn = (
-  command: string,
-  args: string[],
-  options?: ViteHubCliSpawnOptions,
-) => Promise<ViteHubCliSpawnResult>
-
-interface ViteHubCliContext {
-  cwd: string
-  env: NodeJS.ProcessEnv
-  rootDir: string
-  spawn: ViteHubCliSpawn
-  stderr: { write: (chunk: string | Uint8Array) => unknown }
-  stdout: { write: (chunk: string | Uint8Array) => unknown }
-}
-
-interface ViteHubCliFeature {
-  description?: string
-  name: string
-  run: (args: string[], context: ViteHubCliContext) => Promise<number | void> | number | void
-  usage?: string
-}
-
-interface ViteHubCliCommandNamespace {
-  description?: string
-  features: ViteHubCliFeature[]
-  name: string
-}
-
-interface ViteHubCliContributor {
-  namespaces: ViteHubCliCommandNamespace[]
-}
-
-type ViteHubCliContributorFactory = () => ViteHubCliContributor | undefined | Promise<ViteHubCliContributor | undefined>
-
-interface ViteHubCliPluginMetadata {
-  cli?: ViteHubCliContributor | ViteHubCliContributorFactory
-}
-
-interface ViteHubCliContributingPlugin {
-  vitehub?: ViteHubCliPluginMetadata
-}
 
 export interface RunViteHubCliOptions {
   args?: string[]
@@ -96,37 +43,6 @@ async function loadViteConfig(rootDir: string): Promise<Pick<ResolvedConfig, "pl
   const { resolveConfig } = await import("vite")
   const inlineConfig: InlineConfig = { root: rootDir }
   return await resolveConfig(inlineConfig, "serve", "development")
-}
-
-async function resolveContributor(value: ViteHubCliPluginMetadata["cli"]): Promise<ViteHubCliContributor | undefined> {
-  return typeof value === "function" ? await value() : value
-}
-
-async function collectViteHubCliNamespaces(plugins: readonly unknown[]): Promise<ViteHubCliCommandNamespace[]> {
-  const namespaces = new Map<string, ViteHubCliCommandNamespace>()
-
-  for (const plugin of plugins) {
-    if (!plugin || typeof plugin !== "object") continue
-    const metadata = (plugin as ViteHubCliContributingPlugin).vitehub
-    const contributor = await resolveContributor(metadata?.cli)
-    if (!contributor) continue
-
-    for (const namespace of contributor.namespaces) {
-      const existing = namespaces.get(namespace.name)
-      if (!existing) {
-        namespaces.set(namespace.name, { ...namespace, features: [...namespace.features] })
-        continue
-      }
-
-      const features = new Map(existing.features.map(feature => [feature.name, feature]))
-      for (const feature of namespace.features) {
-        features.set(feature.name, feature)
-      }
-      existing.features = [...features.values()]
-    }
-  }
-
-  return [...namespaces.values()]
 }
 
 // Built-in namespace that orchestrates package-contributed Provision Steps.

--- a/packages/cli/src/provision.ts
+++ b/packages/cli/src/provision.ts
@@ -89,10 +89,10 @@ export async function runProvision(args: string[], context: ProvisionFeatureCont
     },
   }
 
-  const actions: Array<{ stepId: string, action: ProvisionAction }> = []
+  const actions: ProvisionAction[] = []
   for (const step of steps) {
     for (const action of await step.plan(provisionContext)) {
-      actions.push({ stepId: step.id, action })
+      actions.push(action)
     }
   }
 
@@ -101,7 +101,7 @@ export async function runProvision(args: string[], context: ProvisionFeatureCont
     return 0
   }
 
-  for (const { action } of actions) {
+  for (const action of actions) {
     context.stdout.write(`${action.exists ? "exists" : "create"}\t${action.kind}\t${action.name}\n`)
   }
 
@@ -109,7 +109,7 @@ export async function runProvision(args: string[], context: ProvisionFeatureCont
 
   // apply() is idempotent: it skips creation when the resource exists but still returns its ids.
   let state: ProvisionState = {}
-  for (const { action } of actions) {
+  for (const action of actions) {
     const result = await action.apply()
     if (result.ids) state = mergeProvisionState(state, result.ids)
   }

--- a/packages/database/src/internal/cloudflare.ts
+++ b/packages/database/src/internal/cloudflare.ts
@@ -2,13 +2,13 @@ import { resolveConfigValue } from "../config-value.ts"
 
 import type { DatabaseConfigValue, ResolvedDBViteConfig } from "../types.ts"
 
-export interface CloudflareD1ProvisionState {
+interface CloudflareD1ProvisionState {
   cloudflare?: {
     d1?: Record<string, string>
   }
 }
 
-export interface CloudflareD1WranglerBinding {
+interface CloudflareD1WranglerBinding {
   binding: string
   database_id: string
   database_name: string
@@ -17,9 +17,9 @@ export interface CloudflareD1WranglerBinding {
   preview_database_id?: string
 }
 
-export type CloudflareD1UnresolvedBindingReason = "missing-database-id" | "missing-database-name"
+type CloudflareD1UnresolvedBindingReason = "missing-database-id" | "missing-database-name"
 
-export interface CloudflareD1UnresolvedBinding {
+interface CloudflareD1UnresolvedBinding {
   binding: string
   database: string
   databaseName?: string
@@ -29,7 +29,7 @@ export interface CloudflareD1UnresolvedBinding {
   reason: CloudflareD1UnresolvedBindingReason
 }
 
-export interface CloudflareD1BindingInput {
+interface CloudflareD1BindingInput {
   binding?: string
   database?: string
   databaseId?: DatabaseConfigValue
@@ -39,18 +39,18 @@ export interface CloudflareD1BindingInput {
   previewDatabaseId?: DatabaseConfigValue
 }
 
-export interface ResolvedCloudflareD1Binding {
+interface ResolvedCloudflareD1Binding {
   bindingName: string
   d1Database?: CloudflareD1WranglerBinding
   unresolved?: CloudflareD1UnresolvedBinding
 }
 
-export interface ResolvedCloudflareD1Bindings {
+interface ResolvedCloudflareD1Bindings {
   d1Databases: CloudflareD1WranglerBinding[]
   unresolved: CloudflareD1UnresolvedBinding[]
 }
 
-export interface ResolveCloudflareD1BindingsOptions {
+interface ResolveCloudflareD1BindingsOptions {
   provisionState?: CloudflareD1ProvisionState
 }
 
@@ -58,7 +58,7 @@ function resolveProvisionedD1Id(provisionState: CloudflareD1ProvisionState | und
   return provisionState?.cloudflare?.d1?.[name]
 }
 
-export function resolveCloudflareD1BindingName(database: string, binding: string | undefined) {
+function resolveCloudflareD1BindingName(database: string, binding: string | undefined) {
   const trimmed = typeof binding === "string" ? binding.trim() : ""
   if (trimmed) return trimmed
   if (database === "default") return "DB"

--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path"
 
 import { resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
+import { isPlainObject as isRecord } from "@vite-hub/internal/object"
 
 import { mergeCloudflareD1Bindings, resolveCloudflareD1Binding } from "./internal/cloudflare.ts"
 import { hubDb as hubDbVite } from "./vite.ts"
@@ -212,8 +213,4 @@ function ensureRecord(parent: Record<string, unknown>, key: string): Record<stri
   const record: Record<string, unknown> = {}
   parent[key] = record
   return record
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -37,9 +37,6 @@
     "test": "vp run -t @vite-hub/devtools#build && vp test",
     "typecheck": "tsc --noEmit -p ./tsconfig.json"
   },
-  "dependencies": {
-    "pathe": "catalog:unjs"
-  },
   "devDependencies": {
     "@comark/vue": "catalog:ui",
     "@iconify-json/lucide": "catalog:ui",
@@ -52,8 +49,7 @@
     "typescript": "catalog:tooling",
     "vite": "catalog:vite",
     "vite-plus": "catalog:tooling",
-    "vitest": "catalog:tooling",
-    "vue-tsc": "catalog:tooling"
+    "vitest": "catalog:tooling"
   },
   "peerDependencies": {
     "@vitejs/devtools-kit": "catalog:devtools-compat",

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -32,7 +32,7 @@ export const viteHubDevtoolsGetFeaturesRpc = "@vite-hub/devtools:get-features"
 const devtoolsShellPublicDirectory = fileURLToPath(new URL("../devtools/chat/.output/public", import.meta.url))
 const devtoolsShellRoute = viteHubDevtoolsDefaultUrl
 const devtoolsShellRouteWithoutSlash = devtoolsShellRoute.replace(/\/$/, "")
-const textFileTypes: Record<string, string> = {
+const fileTypes: Record<string, string> = {
   ".css": "text/css; charset=utf-8",
   ".html": "text/html; charset=utf-8",
   ".js": "text/javascript; charset=utf-8",
@@ -40,9 +40,6 @@ const textFileTypes: Record<string, string> = {
   ".map": "application/json; charset=utf-8",
   ".svg": "image/svg+xml; charset=utf-8",
   ".txt": "text/plain; charset=utf-8",
-}
-
-const binaryFileTypes: Record<string, string> = {
   ".ico": "image/x-icon",
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
@@ -82,7 +79,7 @@ function resolveDevtoolsUrl(options: Pick<HubDevtoolsOptions, "url">): string {
 
 function getContentType(filePath: string): string {
   const extension = extname(filePath)
-  return textFileTypes[extension] || binaryFileTypes[extension] || "application/octet-stream"
+  return fileTypes[extension] || "application/octet-stream"
 }
 
 function rewriteDevtoolsShellIndex(html: string): string {

--- a/packages/devtools/test/panel.test.ts
+++ b/packages/devtools/test/panel.test.ts
@@ -26,9 +26,6 @@ function createContext() {
     rpc: {
       register: vi.fn(),
     },
-    views: {
-      hostStatic: vi.fn(),
-    },
   }
 }
 
@@ -39,7 +36,6 @@ describe("hubDevtools", () => {
     hubDevtools().devtools?.setup?.(ctx as never)
 
     expect(viteHubDevtoolsDefaultUrl).toBe("/__vitehub/devtools/")
-    expect(ctx.views.hostStatic).not.toHaveBeenCalled()
     expect(ctx.docks.register).toHaveBeenCalledWith(expect.objectContaining({
       id: viteHubDevtoolsPanelId,
       remote: false,
@@ -60,7 +56,6 @@ describe("hubDevtools", () => {
     plugin.devtools?.setup?.(ctx as never)
     plugin.devtools?.setup?.(ctx as never)
 
-    expect(ctx.views.hostStatic).not.toHaveBeenCalled()
     expect(ctx.docks.register).toHaveBeenCalledTimes(1)
     expect(ctx.rpc.register).toHaveBeenCalledTimes(1)
   })
@@ -84,7 +79,6 @@ describe("hubDevtools", () => {
 
     hubDevtools().devtools?.setup?.(ctx as never)
 
-    expect(ctx.views.hostStatic).not.toHaveBeenCalled()
     expect(ctx.docks.register).toHaveBeenCalledWith(expect.objectContaining({
       id: viteHubDevtoolsPanelId,
       remote: true,

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -1,3 +1,4 @@
+import { isPlainObject as isRecord } from "@vite-hub/internal/object"
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 
 import { SecretEnv } from "./secret.ts"
@@ -20,10 +21,6 @@ interface RuntimeEnvEntry {
 interface RuntimeLiteralEntry {
   kind: "literal"
   value: unknown
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function isRuntimeLiteralEntry(value: unknown): value is RuntimeLiteralEntry {
@@ -93,7 +90,7 @@ export function resolveServerEnv<TServerEnv extends Record<string, unknown> = Re
 
 export function runWithServerEnv<T>(event: unknown, callback: () => T): T {
   const globals = globalThis as { __env__?: RuntimeEnv }
-  const hadGlobalEnv = Object.prototype.hasOwnProperty.call(globals, "__env__")
+  const hadGlobalEnv = Object.hasOwn(globals, "__env__")
   const previousGlobalEnv = globals.__env__
   const env = getCloudflareEnv(event)
   if (env) globals.__env__ = env

--- a/packages/env/src/vite.ts
+++ b/packages/env/src/vite.ts
@@ -2,6 +2,7 @@ import { rm } from "node:fs/promises"
 import { relative, resolve } from "node:path"
 
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
+import { isPlainObject as isRecord } from "@vite-hub/internal/object"
 import {
   createViteHubEnvImportAliases,
   resolveViteHubProjectRoot,
@@ -37,13 +38,6 @@ const RESOLVED_SERVER_ID = `\0${ENV_SERVER_ID}`
 
 export { env }
 
-export interface EnvVitePluginAPI {
-  getPublicEnv: () => Record<string, unknown>
-  getServerEnvRegistry: () => EnvRuntimeRegistry
-}
-
-export type EnvVitePlugin = Plugin & { api: EnvVitePluginAPI }
-
 export interface EnvGeneratedPathOptions {
   projectRoot?: string
   relativeTo?: string
@@ -62,16 +56,13 @@ export function createEnvTypeScriptPaths(options: EnvGeneratedPathOptions = {}):
   }
 }
 
-export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
+export function hubEnv(options: EnvIntegrationOptions = {}): Plugin {
   let buildPublicConfig: Record<string, unknown> = {}
   let serverRegistry: EnvRuntimeRegistry = {}
   let diagnosticsText: string | undefined
-  const getPublicEnv = () => buildPublicConfig
-  const getServerEnvRegistry = () => serverRegistry
 
   return {
     name: ENV_VITE_PLUGIN_NAME,
-    api: { getPublicEnv, getServerEnvRegistry },
     async config(config, env) {
       const envConfig = (config as UserConfig & EnvViteUserConfig).env
       validateEnvConfigShape(envConfig, "vite")
@@ -148,12 +139,6 @@ function stripModuleExtension(path: string): string {
   return path.replace(/\.mjs$/, "")
 }
 
-function legacyEnvAmbientTypesPaths(root: string) {
-  return [
-    resolve(root, ".vitehub", "env", "vite.d.ts"),
-  ]
-}
-
 async function refreshEnvGeneratedFiles(root: string, publicConfig: Record<string, unknown>, serverRegistry: EnvRuntimeRegistry): Promise<void> {
   await Promise.all([
     writeFileIfChanged(viteHubEnvAmbientTypesPath(root), createViteTypes(publicConfig, serverRegistry)),
@@ -161,7 +146,7 @@ async function refreshEnvGeneratedFiles(root: string, publicConfig: Record<strin
     writeFileIfChanged(viteHubEnvPublicModuleTypesPath(root), createPublicEnvModuleTypes(publicConfig)),
     writeFileIfChanged(viteHubEnvServerModulePath(root), createServerEnvModule(serverRegistry)),
     writeFileIfChanged(viteHubEnvServerModuleTypesPath(root), createServerEnvModuleTypes(serverRegistry)),
-    ...legacyEnvAmbientTypesPaths(root).map(path => rm(path, { force: true })),
+    rm(resolve(root, ".vitehub", "env", "vite.d.ts"), { force: true }),
   ])
 }
 
@@ -285,10 +270,6 @@ function isEnvEntry(value: EnvRuntimeRegistryValue): value is Extract<EnvRuntime
   return isRecord(record.source)
     && typeof record.required === "boolean"
     && typeof record.secret === "boolean"
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 declare module "vite" {

--- a/packages/env/test/vite.test.ts
+++ b/packages/env/test/vite.test.ts
@@ -81,31 +81,6 @@ describe("Vite plugin", () => {
       "#vitehub/env/public": ["../.vitehub/env/public"],
       "#vitehub/env/server": ["../.vitehub/env/server"],
     })
-    expect(plugin.api.getPublicEnv()).toEqual({
-      appName: "Quiver",
-    })
-    expect(plugin.api.getServerEnvRegistry()).toMatchObject({
-      app: {
-        name: {
-          kind: "literal",
-          value: "Telegram Audio",
-        },
-      },
-      airtableToken: {
-        secret: true,
-        source: { name: "AIRTABLE_TOKEN" },
-      },
-      optionalToken: {
-        source: { name: "OPTIONAL_TOKEN" },
-      },
-      teams: {
-        appType: {
-          kind: "literal",
-          value: "SingleTenant",
-        },
-      },
-    })
-
     const configResolvedHook = plugin.configResolved as (config: unknown) => Promise<void> | void
     await configResolvedHook({
       logger: { info: vi.fn() },
@@ -178,9 +153,8 @@ describe("Vite plugin", () => {
       root,
     }, { command: "build", mode: "production" })
 
-    expect(plugin.api.getPublicEnv()).toEqual({
-      appName: "Quiver",
-    })
+    const loadHook = plugin.load as (id: string) => string | undefined
+    expect(loadHook("\0#vitehub/env/public")).toContain("Quiver")
   })
 
   it("keeps generated env files in project ViteHub state when Vite root is app", async () => {

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "defu": "catalog:unjs",
-    "exsolve": "catalog:unjs",
     "unstorage": "catalog:storage"
   },
   "devDependencies": {

--- a/packages/kv/src/runtime/storage.ts
+++ b/packages/kv/src/runtime/storage.ts
@@ -50,16 +50,6 @@ async function resolveHostedConfig(): Promise<false | ResolvedKVModuleOptions | 
 async function resolveStorage(name = "default") {
   const existing = storagePromises.get(name)
   if (existing) return existing
-  const env = typeof process !== "undefined" ? process.env : {}
-  if (inferHosting(env) === "vercel") {
-    const promise = resolveHostedConfig().then(config =>
-      name === "default"
-        ? createHostedKVStorage(config)
-        : createNamedHostedKVStorage(config, name),
-    )
-    storagePromises.set(name, promise)
-    return promise
-  }
   const promise = resolveHostedConfig().then(config =>
     name === "default"
       ? createHostedKVStorage(config)

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -45,7 +45,6 @@
     "@vercel/functions": "catalog:vercel",
     "defu": "catalog:unjs",
     "esbuild": "catalog:esbuild-v27",
-    "exsolve": "catalog:unjs",
     "h3": "catalog:unjs",
     "pathe": "catalog:unjs"
   },

--- a/packages/queue/src/enqueue.ts
+++ b/packages/queue/src/enqueue.ts
@@ -9,16 +9,8 @@ const envelopeKeys = new Set([
   "retentionSeconds",
 ])
 
-let fallbackCounter = 0
-
 export function createQueueMessageId(prefix = "queue"): string {
-  const uuid = globalThis.crypto?.randomUUID?.()
-  if (uuid) {
-    return `${prefix}_${uuid}`
-  }
-
-  fallbackCounter = (fallbackCounter + 1) >>> 0
-  return `${prefix}_${Date.now().toString(36)}_${fallbackCounter.toString(36)}`
+  return `${prefix}_${globalThis.crypto.randomUUID()}`
 }
 
 function isQueueEnvelope<TPayload = unknown>(input: QueueEnqueueInput<TPayload>): input is QueueEnqueueEnvelope<TPayload> {

--- a/packages/queue/src/integrations/cloudflare.ts
+++ b/packages/queue/src/integrations/cloudflare.ts
@@ -1,15 +1,15 @@
-import { decodeQueueNameHex, encodeQueueNameHex } from "../internal/hex.ts"
+import { decodeNameHex, encodeNameHex } from "@vite-hub/internal/integrations/hex"
 
 const cloudflareQueueNamePrefix = "queue--"
 const defaultCloudflareQueueBindingPrefix = "QUEUE"
 const encodedCloudflareQueueNamePattern = /^queue--([0-9a-f]{2})+$/i
 
 export function getCloudflareQueueName(name: string): string {
-  return `${cloudflareQueueNamePrefix}${encodeQueueNameHex(name)}`
+  return `${cloudflareQueueNamePrefix}${encodeNameHex(name)}`
 }
 
 export function getCloudflareQueueBindingName(name: string): string {
-  const encoded = encodeQueueNameHex(name).toUpperCase()
+  const encoded = encodeNameHex(name).toUpperCase()
   return encoded ? `${defaultCloudflareQueueBindingPrefix}_${encoded}` : defaultCloudflareQueueBindingPrefix
 }
 
@@ -18,5 +18,5 @@ export function getCloudflareQueueDefinitionName(name: string): string {
     return name
   }
 
-  return decodeQueueNameHex(name.slice(cloudflareQueueNamePrefix.length)) || name
+  return decodeNameHex(name.slice(cloudflareQueueNamePrefix.length)) || name
 }

--- a/packages/queue/src/integrations/vercel.ts
+++ b/packages/queue/src/integrations/vercel.ts
@@ -1,7 +1,7 @@
-import { encodeQueueNameHex } from "../internal/hex.ts"
+import { encodeNameHex } from "@vite-hub/internal/integrations/hex"
 
 const vercelQueueTopicPrefix = "topic--"
 
 export function getVercelQueueTopicName(name: string): string {
-  return `${vercelQueueTopicPrefix}${encodeQueueNameHex(name)}`
+  return `${vercelQueueTopicPrefix}${encodeNameHex(name)}`
 }

--- a/packages/queue/src/internal/hex.ts
+++ b/packages/queue/src/internal/hex.ts
@@ -1,1 +1,0 @@
-export { encodeNameHex as encodeQueueNameHex, decodeNameHex as decodeQueueNameHex } from "@vite-hub/internal/integrations/hex"

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "esbuild": "catalog:tooling",
-    "exsolve": "catalog:unjs",
     "h3": "catalog:unjs",
     "local-pkg": "catalog:tooling",
     "mlly": "catalog:unjs",
@@ -65,7 +64,6 @@
     "scule": "catalog:unjs",
     "typescript": "catalog:tooling",
     "ufo": "catalog:unjs",
-    "unctx": "catalog:unjs",
     "unimport": "catalog:unjs"
   },
   "devDependencies": {

--- a/packages/schedule/src/runtime/static.ts
+++ b/packages/schedule/src/runtime/static.ts
@@ -1,3 +1,5 @@
+import { isPlainObject as isRecord } from "@vite-hub/internal/object"
+
 import type { ScheduleDefinition, ScheduleDefinitionRegistry, ScheduleRunContext } from "../types.ts"
 
 export interface ExecuteStaticScheduleOptions {
@@ -92,7 +94,7 @@ function readCloudflareScheduledEvent(event: CloudflareScheduledEventLike): { cr
 
 function runWithCloudflareServerEnv<T>(event: CloudflareScheduledEventLike, callback: () => T): T {
   const globals = globalThis as { __env__?: Record<string, unknown> }
-  const hadGlobalEnv = Object.prototype.hasOwnProperty.call(globals, "__env__")
+  const hadGlobalEnv = Object.hasOwn(globals, "__env__")
   const previousGlobalEnv = globals.__env__
   const env = readCloudflareEventEnv(event)
   if (env) globals.__env__ = env
@@ -124,10 +126,6 @@ function isPromiseLike(value: unknown): value is Promise<unknown> {
   return typeof value === "object"
     && value !== null
     && typeof (value as { finally?: unknown }).finally === "function"
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function readCloudflareEventEnv(event: CloudflareScheduledEventLike): Record<string, unknown> | undefined {

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -57,7 +57,6 @@
     "@types/node": "catalog:tooling",
     "@vite-hub/database": "workspace:*",
     "@vite-hub/internal": "workspace:*",
-    "ofetch": "catalog:unjs",
     "openworkflow": "catalog:workflow",
     "publint": "catalog:tooling",
     "typescript": "catalog:tooling",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -61,7 +61,6 @@
     "test": "vp run -t @vite-hub/workspace#build && vp test"
   },
   "dependencies": {
-    "@vercel/nft": "catalog:vercel",
     "@vite-hub/source": "workspace:*",
     "defu": "catalog:unjs",
     "exsolve": "catalog:unjs",

--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -1,4 +1,5 @@
 import { defu } from "defu"
+import { isPlainObject as isPlainRecord } from "@vite-hub/internal/object"
 
 import { normalizeSafeWorkspacePath } from "../core/path.ts"
 import { getLiveWorkspaceSourcePaths, markLiveWorkspaceSource } from "./live.ts"
@@ -112,24 +113,24 @@ function inferWorkspaceSource(input: WorkspaceSourceInput): WorkspaceSourceInput
   if (hasSourceMethods(input)) return input
 
   const providerFamilies: WorkspaceSourceFamily[] = []
-  if (hasOwn(input, "repo")) providerFamilies.push("github")
-  if (hasOwn(input, "url")) providerFamilies.push("fetch")
-  if (hasOwn(input, "server")) providerFamilies.push("mcpResources")
+  if (Object.hasOwn(input, "repo")) providerFamilies.push("github")
+  if (Object.hasOwn(input, "url")) providerFamilies.push("fetch")
+  if (Object.hasOwn(input, "server")) providerFamilies.push("mcpResources")
 
   if (providerFamilies.length > 1) {
     throw ambiguousSourceConfiguration(providerFamilies)
   }
 
   if (providerFamilies[0]) {
-    if (providerFamilies[0] === "github" && (hasOwn(input, "path") || hasOwn(input, "workspacePath") || hasOwn(input, "content"))) {
+    if (providerFamilies[0] === "github" && (Object.hasOwn(input, "path") || Object.hasOwn(input, "workspacePath") || Object.hasOwn(input, "content"))) {
       throw ambiguousSourceConfiguration(["github", "file"])
     }
     return createInferredWorkspaceSource(providerFamilies[0], input)
   }
 
   const localFamilies: WorkspaceSourceFamily[] = []
-  if (hasOwn(input, "include")) localFamilies.push("glob")
-  if (hasOwn(input, "path") || hasOwn(input, "workspacePath") || hasOwn(input, "content")) localFamilies.push("file")
+  if (Object.hasOwn(input, "include")) localFamilies.push("glob")
+  if (Object.hasOwn(input, "path") || Object.hasOwn(input, "workspacePath") || Object.hasOwn(input, "content")) localFamilies.push("file")
 
   if (localFamilies.length === 0) return input
   if (localFamilies.length > 1) {
@@ -314,17 +315,9 @@ function copyDefinedWorkspaceBindingOption<TKey extends "cache" | "instructions"
 }
 
 function isExplicitSourceBinding(input: WorkspaceSourceInput): input is WorkspaceSourceInput & { source: WorkspaceSourceInput } {
-  return isPlainRecord(input) && hasOwn(input, "source")
+  return isPlainRecord(input) && Object.hasOwn(input, "source")
 }
 
 function hasSourceMethods(input: Record<string, unknown>) {
   return typeof input.getKeys === "function" && typeof input.getItem === "function"
-}
-
-function isPlainRecord(input: unknown): input is Record<string, unknown> {
-  return !!input && typeof input === "object" && !Array.isArray(input)
-}
-
-function hasOwn(input: Record<string, unknown>, key: string) {
-  return Object.prototype.hasOwnProperty.call(input, key)
 }

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -1,5 +1,6 @@
 import { createWorkspaceTools } from "../ai.ts"
 import { normalizeWorkspacePath } from "../core/path.ts"
+import { isPlainObject as isPlainRecord } from "@vite-hub/internal/object"
 import { createMemoryWorkspaceStore } from "../storage/memory.ts"
 import { normalizeWorkspaceSource, normalizeWorkspaceSources } from "./config.ts"
 import { resolveWorkspacePath } from "./resolver.ts"
@@ -208,10 +209,6 @@ function withResolvedSourceRuntimeDefaults(source: WorkspaceSource): WorkspaceSo
   }
   if (source.sync) return source
   return { ...source, materialize: "lazy" }
-}
-
-function isPlainRecord(input: unknown): input is Record<string, unknown> {
-  return !!input && typeof input === "object" && !Array.isArray(input)
 }
 
 function isSourcePath(definition: WorkspaceDefinition, path: string): boolean {

--- a/packages/workspace/vite.config.ts
+++ b/packages/workspace/vite.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
         "vite",
         "#vitehub-workspace-assets-registry",
         "#vitehub-workspace-registry",
-        "@vercel/nft",
         /^@vite-hub\/sandbox/,
       ],
       onlyBundle: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,9 +196,6 @@ catalogs:
     ufo:
       specifier: ^1.6.1
       version: 1.6.4
-    unctx:
-      specifier: ^2.4.1
-      version: 2.5.0
     unimport:
       specifier: ^6.0.2
       version: 6.3.0
@@ -514,9 +511,6 @@ importers:
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7
-      exsolve:
-        specifier: catalog:unjs
-        version: 1.0.8
       h3:
         specifier: catalog:unjs
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
@@ -576,9 +570,6 @@ importers:
 
   packages/cli:
     dependencies:
-      pathe:
-        specifier: catalog:unjs
-        version: 2.0.3
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
         version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
@@ -586,9 +577,6 @@ importers:
       '@types/node':
         specifier: catalog:tooling
         version: 24.13.2
-      '@vite-hub/agent':
-        specifier: workspace:*
-        version: link:../agent
       '@vite-hub/internal':
         specifier: workspace:*
         version: link:../internal
@@ -643,10 +631,6 @@ importers:
         version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
 
   packages/devtools:
-    dependencies:
-      pathe:
-        specifier: catalog:unjs
-        version: 2.0.3
     devDependencies:
       '@comark/vue':
         specifier: catalog:ui
@@ -668,7 +652,7 @@ importers:
         version: 7.0.0-canary.173(zod@4.4.3)
       nuxt:
         specifier: catalog:nuxt
-        version: 4.4.6(3a874c4f50455501f484b03e499c124d)
+        version: 4.4.6(2bb65d5499f186b933fb990219d06b8a)
       tailwindcss:
         specifier: catalog:ui
         version: 4.3.0
@@ -684,9 +668,6 @@ importers:
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
         version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.0)))(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
-      vue-tsc:
-        specifier: catalog:tooling
-        version: 3.2.6(typescript@6.0.2)
 
   packages/env:
     dependencies:
@@ -755,9 +736,6 @@ importers:
       defu:
         specifier: catalog:unjs
         version: 6.1.7
-      exsolve:
-        specifier: catalog:unjs
-        version: 1.0.8
       unstorage:
         specifier: catalog:storage
         version: 2.0.0-alpha.7(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@netlify/blobs@10.7.5)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(lru-cache@11.3.5)(ofetch@1.5.1)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.0))
@@ -798,9 +776,6 @@ importers:
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7
-      exsolve:
-        specifier: catalog:unjs
-        version: 1.0.8
       h3:
         specifier: catalog:unjs
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
@@ -853,9 +828,6 @@ importers:
       esbuild:
         specifier: catalog:tooling
         version: 0.28.0
-      exsolve:
-        specifier: catalog:unjs
-        version: 1.0.8
       h3:
         specifier: catalog:unjs
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
@@ -883,9 +855,6 @@ importers:
       ufo:
         specifier: catalog:unjs
         version: 1.6.4
-      unctx:
-        specifier: catalog:unjs
-        version: 2.5.0
       unimport:
         specifier: catalog:unjs
         version: 6.3.0(oxc-parser@0.132.0)(rolldown@1.0.3)
@@ -1047,9 +1016,6 @@ importers:
       '@vite-hub/internal':
         specifier: workspace:*
         version: link:../internal
-      ofetch:
-        specifier: catalog:unjs
-        version: 1.5.1
       openworkflow:
         specifier: catalog:workflow
         version: 0.9.0(postgres@3.4.9)
@@ -1068,9 +1034,6 @@ importers:
 
   packages/workspace:
     dependencies:
-      '@vercel/nft':
-        specifier: catalog:vercel
-        version: 1.5.0(rollup@4.60.4)
       '@vite-hub/source':
         specifier: workspace:*
         version: link:../source
@@ -15472,7 +15435,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.6(bee60cc85b068c307fc38abef7604df9)':
+  '@nuxt/nitro-server@4.4.6(aecd4856fc6410a122c0b0c6c3a215fb)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
@@ -15490,7 +15453,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.4(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@libsql/client@0.15.15)(@netlify/blobs@10.7.5)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1))(oxc-parser@0.131.0)(rolldown@1.0.3)(srvx@0.11.15)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.0))
-      nuxt: 4.4.6(3a874c4f50455501f484b03e499c124d)
+      nuxt: 4.4.6(2bb65d5499f186b933fb990219d06b8a)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -15794,12 +15757,12 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.6(7920a33eda0cccaf3ed4e826676f792e)':
+  '@nuxt/vite-builder@4.4.6(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(eslint@10.2.0(jiti@2.7.0))(magicast@0.5.3)(nuxt@4.4.6(40152e257350b2b63a05a480db13712b))(optionator@0.9.4)(oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)))(publint@0.3.21)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.34(typescript@6.0.2))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
-      '@vitejs/plugin-vue': 6.0.7(@voidzero-dev/vite-plus-core@0.1.24)(vue@3.5.34(typescript@6.0.2))
-      '@vitejs/plugin-vue-jsx': 5.1.5(@voidzero-dev/vite-plus-core@0.1.24)(vue@3.5.34(typescript@6.0.2))
+      '@vitejs/plugin-vue': 6.0.7(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.2))
+      '@vitejs/plugin-vue-jsx': 5.1.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.2))
       autoprefixer: 10.5.0(postcss@8.5.15)
       consola: 3.4.2
       cssnano: 8.0.1(postcss@8.5.15)
@@ -15812,7 +15775,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.6(3a874c4f50455501f484b03e499c124d)
+      nuxt: 4.4.6(40152e257350b2b63a05a480db13712b)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -15821,9 +15784,9 @@ snapshots:
       std-env: 4.1.0
       ufo: 1.6.4
       unenv: 2.0.0-rc.24
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.0)))(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
-      vite-node: 5.3.0(@types/node@24.13.2)(@vitejs/devtools@0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.0)))(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
-      vite-plugin-checker: 0.13.0(@voidzero-dev/vite-plus-core@0.1.24)(eslint@10.2.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.67.0(8133cffe63919a3961cd70bed72f51a4))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+      vite-node: 5.3.0(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
+      vite-plugin-checker: 0.13.0(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0))(eslint@10.2.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
       vue: 3.5.34(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -15863,12 +15826,12 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.6(@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(eslint@10.2.0(jiti@2.7.0))(magicast@0.5.3)(nuxt@4.4.6(40152e257350b2b63a05a480db13712b))(optionator@0.9.4)(oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)))(publint@0.3.21)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.60.4))(rollup@4.60.4)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vue-tsc@3.2.6(typescript@6.0.2))(vue@3.5.34(typescript@6.0.2))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.4.6(df1b477fd53685d0d97b843b81cb53e0)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.4)
-      '@vitejs/plugin-vue': 6.0.7(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.2))
-      '@vitejs/plugin-vue-jsx': 5.1.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.2))
+      '@vitejs/plugin-vue': 6.0.7(@voidzero-dev/vite-plus-core@0.1.24)(vue@3.5.34(typescript@6.0.2))
+      '@vitejs/plugin-vue-jsx': 5.1.5(@voidzero-dev/vite-plus-core@0.1.24)(vue@3.5.34(typescript@6.0.2))
       autoprefixer: 10.5.0(postcss@8.5.15)
       consola: 3.4.2
       cssnano: 8.0.1(postcss@8.5.15)
@@ -15881,7 +15844,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.6(40152e257350b2b63a05a480db13712b)
+      nuxt: 4.4.6(2bb65d5499f186b933fb990219d06b8a)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -15890,9 +15853,9 @@ snapshots:
       std-env: 4.1.0
       ufo: 1.6.4
       unenv: 2.0.0-rc.24
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
-      vite-node: 5.3.0(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
-      vite-plugin-checker: 0.13.0(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0))(eslint@10.2.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2))
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.0)))(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+      vite-node: 5.3.0(@types/node@24.13.2)(@vitejs/devtools@0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.0)))(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
+      vite-plugin-checker: 0.13.0(@voidzero-dev/vite-plus-core@0.1.24)(eslint@10.2.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.67.0(8133cffe63919a3961cd70bed72f51a4))(typescript@6.0.2)
       vue: 3.5.34(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -24020,16 +23983,16 @@ snapshots:
       - vue
       - zod
 
-  nuxt@4.4.6(3a874c4f50455501f484b03e499c124d):
+  nuxt@4.4.6(2bb65d5499f186b933fb990219d06b8a):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.2)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.3.3)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.0)))(@voidzero-dev/vite-plus-core@0.1.24)(vue@3.5.34(typescript@6.0.2))
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.6(bee60cc85b068c307fc38abef7604df9)
+      '@nuxt/nitro-server': 4.4.6(aecd4856fc6410a122c0b0c6c3a215fb)
       '@nuxt/schema': 4.4.6
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.6(7920a33eda0cccaf3ed4e826676f792e)
+      '@nuxt/vite-builder': 4.4.6(df1b477fd53685d0d97b843b81cb53e0)
       '@unhead/vue': 2.1.15(vue@3.5.34(typescript@6.0.2))
       '@vue/shared': 3.5.34
       chokidar: 5.0.0
@@ -27173,7 +27136,7 @@ snapshots:
       typescript: 6.0.2
       vue-tsc: 3.2.6(typescript@6.0.2)
 
-  vite-plugin-checker@0.13.0(@voidzero-dev/vite-plus-core@0.1.24)(eslint@10.2.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.67.0(8133cffe63919a3961cd70bed72f51a4))(typescript@6.0.2)(vue-tsc@3.2.6(typescript@6.0.2)):
+  vite-plugin-checker@0.13.0(@voidzero-dev/vite-plus-core@0.1.24)(eslint@10.2.0(jiti@2.7.0))(optionator@0.9.4)(oxlint@1.67.0(8133cffe63919a3961cd70bed72f51a4))(typescript@6.0.2):
     dependencies:
       '@babel/code-frame': 7.29.0
       chokidar: 4.0.3
@@ -27190,7 +27153,6 @@ snapshots:
       optionator: 0.9.4
       oxlint: 1.67.0(8133cffe63919a3961cd70bed72f51a4)
       typescript: 6.0.2
-      vue-tsc: 3.2.6(typescript@6.0.2)
 
   vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.6(magicast@0.5.3))(@voidzero-dev/vite-plus-core@0.1.24):
     dependencies:


### PR DESCRIPTION
Trims package-level over-engineering from the Ponytail review pass: the CLI now uses the shared internal CLI primitives instead of carrying duplicate type and namespace collection code, Env no longer exposes a test-only plugin API, queue name encoding uses the shared internal hex helper, and small provider/test wrappers that had no callers are removed.

Also drops unused package dependencies and stale lockfile entries where the build and tests proved they were not part of the runtime contract. Larger public-surface removals from the package review, such as Blob driver exports and compatibility aliases, are intentionally left for follow-up PRs because they need a separate API decision.

Validated with focused typechecks and the touched package test suite for Agent, Auth, Blob, CI, CLI, Database, DevTools, Env, KV, Queue, Sandbox, Schedule, Workflow, and Workspace.