### PR TITLE
feat(env)!: remove runWithServerEnv

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -43,21 +43,20 @@ export const appName = publicEnv.appName
 
 ```ts
 // server/sync.ts
-import { runWithServerEnv, useServerEnv } from "#vitehub/env/server"
+import { useServerEnv } from "#vitehub/env/server"
 
 export async function sync(event: unknown) {
-  return runWithServerEnv(event, async () => {
-    const { airtableToken } = useServerEnv()
-    await fetch("https://api.airtable.com/v0/app/table", {
-      headers: { Authorization: `Bearer ${airtableToken.unseal()}` },
-    })
+  const { airtableToken } = useServerEnv(event)
+
+  await fetch("https://api.airtable.com/v0/app/table", {
+    headers: { Authorization: `Bearer ${airtableToken.unseal()}` },
   })
 }
 ```
 
 ## Vite Integration
 
-Use `hubEnv()` in Vite to resolve public/build env, generate `#vitehub/env/public` and `#vitehub/env/server`, and keep environment declarations close to the app config. Runtime secrets are read from the host environment at request time and are wrapped in `SecretEnv` until explicitly unsealed. `runWithServerEnv(event, callback)` activates host Runtime Env for nested ViteHub runtime helpers that cannot receive the request or scheduled event directly.
+Use `hubEnv()` in Vite to resolve public/build env, generate `#vitehub/env/public` and `#vitehub/env/server`, and keep environment declarations close to the app config. Runtime secrets are read from the host environment at request time and are wrapped in `SecretEnv` until explicitly unsealed.
 
 `hubEnv()` writes generated env runtime modules to `.vitehub/env/` and generated env types to `.vitehub/types/env.d.ts`. Add `.vitehub/types/**/*.d.ts` to your `tsconfig.json` include list when TypeScript should see app-specific Public Env and Server Env fields.
 

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -2,7 +2,7 @@ export { env } from "./core/declarations.ts"
 export { openWorkflowEnv } from "./presets.ts"
 export { parseSchema } from "./schema.ts"
 export { SecretEnv } from "./secret.ts"
-export { resolveServerEnv, runWithServerEnv } from "./server.ts"
+export { resolveServerEnv } from "./server.ts"
 export type { StandardSchemaV1 } from "./schema.ts"
 export type {
   EnvConfigOptions,

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -90,35 +90,3 @@ export function resolveServerEnv<TServerEnv extends Record<string, unknown> = Re
 ): TServerEnv {
   return resolveRegistryValue(registry, runtimeEnv(event)) as TServerEnv
 }
-
-export function runWithServerEnv<T>(event: unknown, callback: () => T): T {
-  const globals = globalThis as { __env__?: RuntimeEnv }
-  const hadGlobalEnv = Object.prototype.hasOwnProperty.call(globals, "__env__")
-  const previousGlobalEnv = globals.__env__
-  const env = getCloudflareEnv(event)
-  if (env) globals.__env__ = env
-
-  try {
-    const result = callback()
-    if (isPromiseLike(result)) {
-      return result.finally(() => restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)) as T
-    }
-    restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)
-    return result
-  }
-  catch (error) {
-    restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)
-    throw error
-  }
-}
-
-function restoreGlobalEnv(globals: { __env__?: RuntimeEnv }, hadGlobalEnv: boolean, previousGlobalEnv: RuntimeEnv | undefined): void {
-  if (hadGlobalEnv) globals.__env__ = previousGlobalEnv
-  else delete globals.__env__
-}
-
-function isPromiseLike(value: unknown): value is Promise<unknown> {
-  return typeof value === "object"
-    && value !== null
-    && typeof (value as { finally?: unknown }).finally === "function"
-}

--- a/packages/env/src/virtual-module.d.ts
+++ b/packages/env/src/virtual-module.d.ts
@@ -9,7 +9,6 @@ declare module "#vitehub/env/server" {
 
   export interface ServerEnv extends Record<string, unknown> {}
   export function useServerEnv(event?: unknown): ServerEnv
-  export function runWithServerEnv<T>(event: unknown, callback: () => T): T
 }
 
 export {}

--- a/packages/env/src/vite.ts
+++ b/packages/env/src/vite.ts
@@ -187,10 +187,9 @@ function createPublicEnvModuleTypes(publicConfig: Record<string, unknown>): stri
 
 function createServerEnvModule(serverRegistry: EnvRuntimeRegistry): string {
   return [
-    "import { resolveServerEnv, runWithServerEnv as runWithGeneratedServerEnv } from '@vite-hub/env/server';",
+    "import { resolveServerEnv } from '@vite-hub/env/server';",
     `const registry = ${JSON.stringify(serverRegistry, null, 2)};`,
     "export function useServerEnv(event) { return resolveServerEnv(registry, event); }",
-    "export function runWithServerEnv(event, callback) { return runWithGeneratedServerEnv(event, callback); }",
     "",
   ].join("\n")
 }
@@ -203,7 +202,6 @@ function createServerEnvModuleTypes(serverRegistry: EnvRuntimeRegistry): string 
     ...createServerTypeFields(serverRegistry, 2),
     "}",
     "export function useServerEnv(event?: unknown): ServerEnv",
-    "export function runWithServerEnv<T>(event: unknown, callback: () => T): T",
     "",
   ].join("\n")
 }
@@ -223,7 +221,6 @@ function createViteTypes(publicConfig: Record<string, unknown>, serverRegistry: 
     ...createServerTypeFields(serverRegistry, 4),
     "  }",
     "  export function useServerEnv(event?: unknown): ServerEnv",
-    "  export function runWithServerEnv<T>(event: unknown, callback: () => T): T",
     "}",
     "export {}",
     "",

--- a/packages/env/test/vite.test.ts
+++ b/packages/env/test/vite.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { describe, expect, it, vi } from "vitest"
 
 import { createRuntimeRegistry } from "../src/core/resolve.ts"
-import { resolveServerEnv, runWithServerEnv } from "../src/server.ts"
+import { resolveServerEnv } from "../src/server.ts"
 import { createEnvImportAliases, createEnvTypeScriptPaths, env, hubEnv } from "../src/vite.ts"
 
 import { booleanSchema, stringSchema } from "./helpers.ts"
@@ -127,6 +127,7 @@ describe("Vite plugin", () => {
     expect(types).toContain("\"appType\": \"SingleTenant\"")
     expect(types).toContain("usePublicEnv(): PublicEnv")
     expect(types).toContain("useServerEnv(event?: unknown): ServerEnv")
+    expect(types).not.toContain("runWithServerEnv")
     expect(types).not.toContain("import(\"@vite-hub/env/secret\")")
     expect(types).not.toContain("serverEnv")
     expect(types).not.toContain("buildConfig")
@@ -141,6 +142,7 @@ describe("Vite plugin", () => {
     expect(serverModuleTypes).toContain("export interface ServerEnv")
     expect(serverModuleTypes).toContain("\"airtableToken\": SecretEnv<string>")
     expect(serverModuleTypes).toContain("export function useServerEnv(event?: unknown): ServerEnv")
+    expect(serverModuleTypes).not.toContain("runWithServerEnv")
 
     const loadHook = plugin.load as (id: string) => string | undefined
     const loaded = loadHook("\0#vitehub/env/public")
@@ -157,7 +159,7 @@ describe("Vite plugin", () => {
     expect(serverLoaded).not.toContain("SERVER_OPTIONAL_TOKEN")
     expect(serverLoaded).not.toContain("serverEnv")
     expect(serverLoaded).toContain("useServerEnv")
-    expect(serverLoaded).toContain("runWithServerEnv")
+    expect(serverLoaded).not.toContain("runWithServerEnv")
   })
 
   it("applies prefixes to inferred Vite env names", async () => {
@@ -333,18 +335,4 @@ describe("Vite plugin", () => {
     })).toThrow("Missing Runtime Env from env:VITEHUB_AIRTABLE_TOKEN.")
   })
 
-  it("runs callbacks with Server Env active for nested runtime helpers", () => {
-    const registry = createRuntimeRegistry({
-      airtableToken: env({ secret: true }),
-    }, { prefix: "VITEHUB_" })
-
-    const resolved = runWithServerEnv({
-      env: {
-        VITEHUB_AIRTABLE_TOKEN: "callback-secret",
-      },
-    }, () => resolveServerEnv<{ airtableToken: { unseal(): string } }>(registry))
-
-    expect(resolved.airtableToken.unseal()).toBe("callback-secret")
-    expect(() => resolveServerEnv(registry)).toThrow("Missing Runtime Env from env:VITEHUB_AIRTABLE_TOKEN.")
-  })
 })


### PR DESCRIPTION
Removes the public `runWithServerEnv` wrapper from Env and stops generating it for `#vitehub/env/server`. Server Runtime Env access now stays on direct `useServerEnv(event?)`, matching the existing Server Env surface without activating request env through a public global wrapper.

This is a breaking Env API cleanup for callers importing `runWithServerEnv`; pass the host event to `useServerEnv(event)` instead.