### PR TITLE
test(agent): cover eval runtime config

### DIFF
--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -145,6 +145,19 @@ describe("agent eval", () => {
     expect(score.score).toBe(1)
   })
 
+  it("passes eval runtime config into agent invocations", async () => {
+    await import("./fixtures/quiver-sku-runtime.eval.ts")
+
+    expect(evaliteCalls[0]?.name).toBe("quiver-sku-runtime")
+
+    const output = await evaliteCalls[0]!.opts.task(evaliteCalls[0]!.opts.data[0].input)
+    const score = await evaliteCalls[0]!.opts.scorers[0].scorer({ output })
+
+    expect(output.text).toContain("Selected SKU RAIN-042-BLK")
+    expect(output.text).toContain("shortfall of 130")
+    expect(score.score).toBe(1)
+  })
+
   it("infers workspace source roots for sibling workspace agents", async () => {
     readFile.mockResolvedValueOnce("workspace config")
 

--- a/packages/agent/test/fixtures/quiver-sku-runtime.eval.ts
+++ b/packages/agent/test/fixtures/quiver-sku-runtime.eval.ts
@@ -1,0 +1,35 @@
+import { defineEval, textContains } from "../../src/eval.ts"
+import type { QuiverPortalRuntimeConfig } from "./quiver-sku-runtime.ts"
+
+export default defineEval<QuiverPortalRuntimeConfig>({
+  runtimeConfig: () => ({
+    portal: {
+      forecast: {
+        next60DaysDemand: 350,
+        peakMonth: "August",
+      },
+      inventory: {
+        onHand: 300,
+        safetyStock: 200,
+      },
+      planningGroup: "EU Wholesale",
+      purchaseOrders: [{
+        eta: "2026-07-24",
+        quantity: 120,
+        reference: "PO-7721",
+      }],
+      selectedSku: "RAIN-042-BLK",
+    },
+  }),
+  scenarios: [{
+    input: {
+      prompt: "For the selected SKU, should we increase the next purchase order before the August forecast peak, or wait for more sales data?",
+    },
+    name: "selected SKU purchase order forecast",
+    scorers: [
+      textContains("Selected SKU RAIN-042-BLK"),
+      textContains("shortfall of 130"),
+      textContains("PO-7721"),
+    ],
+  }],
+})

--- a/packages/agent/test/fixtures/quiver-sku-runtime.ts
+++ b/packages/agent/test/fixtures/quiver-sku-runtime.ts
@@ -1,0 +1,46 @@
+import type { AgentAdapter } from "../../src/index.ts"
+
+export interface QuiverPortalRuntimeConfig {
+  portal: {
+    forecast: {
+      next60DaysDemand: number
+      peakMonth: string
+    }
+    inventory: {
+      onHand: number
+      safetyStock: number
+    }
+    planningGroup: string
+    purchaseOrders: Array<{
+      eta: string
+      quantity: number
+      reference: string
+    }>
+    selectedSku: string
+  }
+}
+
+const agent: AgentAdapter<never, QuiverPortalRuntimeConfig> = {
+  async generate({ input, runtime }) {
+    const portal = runtime.runtimeConfig.portal
+    const openPurchaseOrderQuantity = portal.purchaseOrders.reduce((total, order) => total + order.quantity, 0)
+    const projectedStock = portal.inventory.onHand + openPurchaseOrderQuantity - portal.forecast.next60DaysDemand
+    const shortfall = Math.max(0, portal.inventory.safetyStock - projectedStock)
+    const firstPurchaseOrder = portal.purchaseOrders[0]
+
+    return {
+      text: [
+        `Selected SKU ${portal.selectedSku} in ${portal.planningGroup}.`,
+        `Question: ${input.prompt || "Should we adjust the purchase plan?"}`,
+        `Projected stock after open purchase orders is ${projectedStock}, leaving a safety-stock shortfall of ${shortfall} for ${portal.forecast.peakMonth}.`,
+        `Recommendation: increase the next purchase order by ${shortfall} units${firstPurchaseOrder ? `, using ${firstPurchaseOrder.reference} due ${firstPurchaseOrder.eta} as the baseline` : ""}.`,
+      ].join(" "),
+    }
+  },
+  name: "quiver-sku-runtime",
+  async stream() {
+    throw new Error("stream is not used by this eval fixture.")
+  },
+}
+
+export default agent


### PR DESCRIPTION
Adds a regression fixture for Agent Eval runtime config so eval scenarios can pass selected runtime facts through to agent invocations.

The fixture uses a Quiver-style selected SKU scenario to prove runtimeConfig reaches the adapter and remains available during scoring.
