### PR TITLE
fix(workspace): hydrate build sources from bundled assets

### DIFF
--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -1,9 +1,11 @@
+import { useWorkspaceAssets } from "./asset-registry.ts"
+import { WorkspaceNotFoundError } from "./core/errors.ts"
 import { files as filesLoader } from "./loaders/files.ts"
 import { normalizeWorkspacePath } from "./core/path.ts"
 import { createSourceContext, normalizeWorkspaceSources, type ResolvedWorkspaceSource } from "./sources/config.ts"
 import { createWorkspaceStoreFromProvider } from "./storage/provider.ts"
 
-import type { LoaderContext, WorkspaceDefinition, WorkspaceLoaderSource, WorkspaceSnapshot, WorkspaceStore } from "./core/types.ts"
+import type { LoaderContext, WorkspaceAssets, WorkspaceDefinition, WorkspaceLoaderSource, WorkspaceSnapshot, WorkspaceStore } from "./core/types.ts"
 
 const buildSourcesMetaKey = "workspace:build-sources"
 
@@ -34,6 +36,11 @@ export async function syncWorkspaceDefinition(definition: WorkspaceDefinition, s
   const buildSources = normalizeWorkspaceSources(definition.sources)
     .filter(source => source.materialize === "build")
   const hasBuildSourceState = await reconcileBuildSourceMounts(store, buildSources)
+  if (!hasExplicitLoaders && await syncRuntimeBuildAssets(definition, store, buildSources)) {
+    const snapshot = await store.snapshot({ name: "sync" })
+    await publishWorkspaceSnapshot(definition, store, snapshot)
+    return
+  }
   if (!hasBuildSourceState && !hasExplicitLoaders) return
 
   const normalizedSources = buildSources.map(source => createMountedBuildSource(source))
@@ -76,6 +83,38 @@ async function reconcileBuildSourceMounts(store: WorkspaceStore, currentSources:
 
   await store.setMeta?.(buildSourcesMetaKey, currentSources.map(({ key, mountPath }) => ({ key, mountPath })))
   return hasBuildSourceState
+}
+
+async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: WorkspaceStore, currentSources: ResolvedWorkspaceSource[]): Promise<boolean> {
+  if (!currentSources.length) return false
+
+  let assets: WorkspaceAssets
+  try {
+    assets = useWorkspaceAssets(definition.name)
+  }
+  catch (error) {
+    if (error instanceof WorkspaceNotFoundError) return false
+    throw error
+  }
+
+  const entries = await assets.list("", { recursive: true })
+  const files = entries.filter(entry => entry.type === "file")
+  for (const entry of files) {
+    const source = findBuildSourceForPath(entry.path, currentSources)
+    await store.writeFile(entry.path, {
+      path: entry.path,
+      content: await assets.readFile(entry.path, { encoding: "binary" }),
+      mediaType: entry.mediaType,
+      metadata: source ? { source: source.key } : undefined,
+    })
+  }
+  return true
+}
+
+function findBuildSourceForPath(path: string, sources: ResolvedWorkspaceSource[]): ResolvedWorkspaceSource | undefined {
+  return sources
+    .filter(source => !source.mountPath || path === source.mountPath || path.startsWith(`${source.mountPath}/`))
+    .sort((left, right) => right.mountPath.length - left.mountPath.length)[0]
 }
 
 async function readSyncedBuildSources(store: WorkspaceStore): Promise<SyncedBuildSource[]> {

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -10,11 +10,14 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { collectWorkspaceStoreAssetBundle, syncDiscoveredWorkspaceAssetBundles, writeWorkspaceAssetsRegistry } from "../src/build/assets.ts"
 import { initializeWorkspaceAssetRegistry, syncWorkspaceBuildAssets } from "../src/build/integration.ts"
+import { resetWorkspaceAssetsRegistry } from "../src/asset-registry.ts"
 import { defineWorkspace, source, useWorkspace } from "../src/index.ts"
 import * as loader from "../src/loader.ts"
 import * as publish from "../src/publish.ts"
 import { registerWorkspace } from "../src/test.ts"
 import { syncWorkspaceDefinition } from "../src/lifecycle.ts"
+import { setWorkspaceRuntimeAssetsRegistry } from "../src/runtime/state.ts"
+import { createWorkspaceAssets } from "../src/runtime/assets.ts"
 import { useRegisteredWorkspace } from "../src/core/registry.ts"
 import { createLocalWorkspaceStore } from "../src/storage/local.ts"
 import { createMemoryWorkspaceStore } from "../src/storage/memory.ts"
@@ -33,6 +36,7 @@ afterEach(async () => {
   delete process.env.GITHUB_TOKEN
   delete (globalThis as { __env__?: Record<string, unknown> }).__env__
   setStorage(createMemoryStorage())
+  resetWorkspaceAssetsRegistry()
   vi.unstubAllGlobals()
   await Promise.all(tempDirs.splice(0).map(path => rm(path, { recursive: true, force: true })))
 })
@@ -595,6 +599,55 @@ describe("sources, loaders, and publishers", () => {
       name: "support",
     })
     expect(Buffer.from(bundles[0]!.files[0]!.content)).toEqual(Buffer.from("# Support\n"))
+  })
+
+  it("syncs explicit file sources from bundled assets when the original source root is absent", async () => {
+    const root = await createRoot()
+    const directory = join(root, "server", "agents", "support")
+    const sourceRoot = join(directory, "workspace")
+    await mkdir(sourceRoot, { recursive: true })
+    await writeFile(join(sourceRoot, "AGENTS.md"), "# Bundled Support\n")
+    await writeFile(join(directory, "config.mjs"), [
+      `import { source } from '${workspaceSourceImport}'`,
+      "export default {",
+      "  sources: { instructions: source.file('AGENTS.md') },",
+      "}",
+      "",
+    ].join("\n"))
+
+    const [bundle] = await syncDiscoveredWorkspaceAssetBundles([{
+      handler: join(directory, "config.mjs"),
+      name: "support",
+      path: join(directory, "config.mjs"),
+      source: "test",
+      sourceRootDir: sourceRoot,
+    }], root, {
+      root: join(root, ".vitehub", "workspaces"),
+      store: { provider: "memory" },
+      assets: true,
+    })
+    await rm(sourceRoot, { recursive: true, force: true })
+    setWorkspaceRuntimeAssetsRegistry({
+      support: createWorkspaceAssets(Object.fromEntries(bundle!.files.map(file => [
+        file.path,
+        {
+          load: async () => file.content,
+          mediaType: file.mediaType,
+        },
+      ]))),
+    })
+
+    const store = createMemoryWorkspaceStore()
+    await syncWorkspaceDefinition({
+      name: "support",
+      rootDir: root,
+      sourceRootDir: sourceRoot,
+      sources: { instructions: source.file("AGENTS.md") },
+    }, store)
+
+    await expect(store.readFile("AGENTS.md")).resolves.toMatchObject({
+      content: new TextEncoder().encode("# Bundled Support\n"),
+    })
   })
 
   it("purges stale build source files when source maps change", async () => {


### PR DESCRIPTION
Hydrates default build-source sync from generated Workspace asset bundles when they are available, so explicit source.file(...) entries do not depend on the original sourceRootDir still existing inside serverless runtime bundles.

Adds a regression test that builds an explicit file source asset, deletes the original source root, and verifies syncWorkspaceDefinition() can still load the file.