### PR TITLE
feat(agent): read extension fields

### DIFF
--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -545,8 +545,11 @@ export async function createAgentInvocationExtensions(
 ): Promise<AgentFinishEvent["extensions"]> {
   const values = new Map<string, unknown>()
   const extensions: AgentFinishEvent["extensions"] = {
-    get<T = unknown>(capabilityId: string): T | undefined {
-      return values.get(capabilityId) as T | undefined
+    get<T = unknown>(capabilityId: string, key?: string): T | undefined {
+      const value = values.get(capabilityId)
+      if (key === undefined) return value as T | undefined
+      if (typeof value !== "object" || value === null) return undefined
+      return (value as Record<string, unknown>)[key] as T | undefined
     },
   }
   const finishEvent = { ...event, extensions } as AgentFinishEvent

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -209,6 +209,7 @@ export interface AgentRunResult {
 
 export interface AgentInvocationExtensions {
   get<T = unknown>(capabilityId: string): T | undefined
+  get<T = unknown>(capabilityId: string, key: string): T | undefined
 }
 
 export interface AgentFinishEvent<

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -557,7 +557,7 @@ describe("agent message protocol", () => {
         {
           id: "second",
           output(context) {
-            context.finish.provide("second-value")
+            context.finish.provide({ value: "second-value" })
           },
         },
       ],
@@ -586,7 +586,9 @@ describe("agent message protocol", () => {
     }))
     const event = finish.mock.calls[0]![0]
     expect(event.extensions.get("first")).toBe("ok:first")
-    expect(event.extensions.get("second")).toBe("second-value")
+    expect(event.extensions.get("second")).toEqual({ value: "second-value" })
+    expect(event.extensions.get("second", "value")).toBe("second-value")
+    expect(event.extensions.get("first", "length")).toBeUndefined()
     expect(event.extensions.get("missing")).toBeUndefined()
   })
 

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -208,6 +208,7 @@ describe("agent public types", () => {
           expectTypeOf(event.extensions.get<AgentChatFinishExtension>("chat")).toEqualTypeOf<AgentChatFinishExtension | undefined>()
           expectTypeOf(event.extensions.get<TranscriptionResult[]>("transcribe")).toEqualTypeOf<TranscriptionResult[] | undefined>()
           expectTypeOf(event.extensions.get<AgentUsageRecord>("usage-telemetry")).toEqualTypeOf<AgentUsageRecord | undefined>()
+          expectTypeOf(event.extensions.get<string>("usage-telemetry", "transcription")).toEqualTypeOf<string | undefined>()
         },
       },
     })


### PR DESCRIPTION
Adds a small `extensions.get(id, key)` overload so finish hooks can read one field from object-valued extension payloads without casting the whole record.

This keeps the existing `extensions.get(id)` behavior intact and adds runtime/type coverage for field reads.