### PR TITLE
refactor(workspace): rename selected scope field

### DIFF
--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -329,9 +329,9 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
             },
             selectedWorkspaceScope: {
               all: scope.all,
+              name: scope.scope,
               paths: scope.paths,
               role: scope.role,
-              scope: scope.scope,
             },
           })
         : { definition: context.workspaceDefinition, workspace: context.workspace }

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -310,9 +310,9 @@ export interface WorkspaceSourceResolutionContextValueReader<TContextMap extends
 
 export interface WorkspaceSelectedScope<TScopeName extends string = string> {
   all: boolean
+  name: TScopeName
   paths?: readonly string[]
   role?: string
-  scope: TScopeName
 }
 
 export interface WorkspaceSourceResolutionInvocation<TContextMap extends object = WorkspaceSourceResolutionContextMap> {

--- a/packages/workspace/src/sources/fetch.ts
+++ b/packages/workspace/src/sources/fetch.ts
@@ -11,6 +11,7 @@ import {
 import type {
   SourceContext,
   WorkspaceContent,
+  WorkspaceSelectedScope,
   WorkspaceSource,
   WorkspaceSourceRequestDescriptor,
   WorkspaceSourceRequestExecutionInput,
@@ -64,7 +65,7 @@ export interface FetchSourceRequestCallbackContext {
     query?: Record<string, unknown>
     url: string
   }
-  selectedWorkspaceScope?: unknown
+  selectedWorkspaceScope?: WorkspaceSelectedScope
   source: {
     key?: string
   }

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -177,10 +177,10 @@ async function resolveWorkspaceSource(
         selectedWorkspaceScope: options.selectedWorkspaceScope
           ? {
               all: options.selectedWorkspaceScope.all,
+              name: options.selectedWorkspaceScope.name,
               paths: options.selectedWorkspaceScope.paths,
               role: options.selectedWorkspaceScope.role,
-              scope: options.selectedWorkspaceScope.scope,
-        }
+            }
           : undefined,
       },
     },

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -27,9 +27,9 @@ function scope(scope: string, paths: string[]): WorkspaceSourceResolutionOptions
     invocation,
     selectedWorkspaceScope: {
       all: false,
+      name: scope,
       paths,
       role: "viewer",
-      scope,
     },
   }
 }
@@ -37,7 +37,7 @@ function scope(scope: string, paths: string[]): WorkspaceSourceResolutionOptions
 function customerSource() {
   return source.custom({
     async resolve({ selectedWorkspaceScope }) {
-      const customer = selectedWorkspaceScope?.scope
+      const customer = selectedWorkspaceScope?.name
       if (!customer) return false
       return source.custom({
         fingerprint: { customer },
@@ -115,9 +115,9 @@ describe("Workspace Source Resolution", () => {
       source: { customer: "acme" },
       sourceResolution: {
         selectedWorkspaceScope: {
+          name: "acme",
           paths: ["ingestion/acme"],
           role: "viewer",
-          scope: "acme",
         },
       },
     })
@@ -148,10 +148,10 @@ describe("Workspace Source Resolution", () => {
 
   it("resolves fetch sources from source.fetch resolvers", async () => {
     const resolveFetch = vi.fn(({ selectedWorkspaceScope }) => ({
-      body: { customer: selectedWorkspaceScope?.scope },
+      body: { customer: selectedWorkspaceScope?.name },
       method: "POST" as const,
       request: {
-        headers: { "x-customer": selectedWorkspaceScope?.scope ?? "unknown" },
+        headers: { "x-customer": selectedWorkspaceScope?.name ?? "unknown" },
       },
       url: "https://portal.example.com/runtime/inventory-health",
     }))
@@ -167,7 +167,7 @@ describe("Workspace Source Resolution", () => {
     const resolvedSource = normalizeWorkspaceSources(resolved.sources).find(source => source.key === "inventoryHealthSummary")?.source
 
     expect(resolveFetch).toHaveBeenCalledWith(expect.objectContaining({
-      selectedWorkspaceScope: expect.objectContaining({ scope: "acme" }),
+      selectedWorkspaceScope: expect.objectContaining({ name: "acme" }),
       source: {
         key: "inventoryHealthSummary",
         mountPath: "inventoryHealthSummary",
@@ -283,7 +283,7 @@ describe("Workspace Source Resolution", () => {
       status: 200,
     }))
     const requestFactory = vi.fn(({ selectedWorkspaceScope }) => ({
-      headers: { "x-scope": selectedWorkspaceScope?.scope },
+      headers: { "x-scope": selectedWorkspaceScope?.name },
     }))
     const base = createWorkspace({ name: "support", store: { provider: "memory" } })
     const querySchema = {
@@ -331,7 +331,7 @@ describe("Workspace Source Resolution", () => {
     expect((init.headers as Headers).get("cookie")).toBe("auth_token=secret")
     expect((init.headers as Headers).get("x-scope")).toBe("support")
     expect(requestFactory).toHaveBeenCalledWith(expect.objectContaining({
-      selectedWorkspaceScope: expect.objectContaining({ scope: "support" }),
+      selectedWorkspaceScope: expect.objectContaining({ name: "support" }),
     }))
   })
 

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -91,7 +91,7 @@ describe("workspace types", () => {
     })
     source.github(({ invocation, selectedWorkspaceScope, source: sourceContext, workspace }) => {
       expectTypeOf(invocation.context.get("support.customerScope")?.customers).toEqualTypeOf<Array<"acme" | "globex"> | undefined>()
-      expectTypeOf(selectedWorkspaceScope?.scope).toEqualTypeOf<"acme" | "globex" | "support" | undefined>()
+      expectTypeOf(selectedWorkspaceScope?.name).toEqualTypeOf<"acme" | "globex" | "support" | undefined>()
       expectTypeOf(sourceContext.key).toEqualTypeOf<string>()
       expectTypeOf(workspace.name).toEqualTypeOf<string>()
       const customer = invocation.context.get("support.customerScope")?.customers[0]
@@ -142,7 +142,7 @@ describe("workspace types", () => {
     })
     source.fetch<{ status: string }, { ok: boolean }>(({ invocation, selectedWorkspaceScope, source: sourceContext, workspace }) => {
       expectTypeOf(invocation.context.get("support.customerScope")?.customers).toEqualTypeOf<Array<"acme" | "globex"> | undefined>()
-      expectTypeOf(selectedWorkspaceScope?.scope).toEqualTypeOf<"acme" | "globex" | "support" | undefined>()
+      expectTypeOf(selectedWorkspaceScope?.name).toEqualTypeOf<"acme" | "globex" | "support" | undefined>()
       expectTypeOf(sourceContext.key).toEqualTypeOf<string>()
       expectTypeOf(workspace.name).toEqualTypeOf<string>()
       if (!selectedWorkspaceScope) return null


### PR DESCRIPTION
Renames the selected Workspace Scope context identity field from `scope` to `name`, so Source Resolution and Source Request callbacks can read `selectedWorkspaceScope?.name` instead of the awkward `selectedWorkspaceScope?.scope`.

The Access Capability resolver contract still accepts existing `scope` selections, then maps the resolved scope into the Workspace callback context as `name`. This keeps the resolver API stable while cleaning up the callback surface that downstream app code uses.