### PR TITLE
chore(workspace): drop unused source type export

### DIFF
--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -1,6 +1,5 @@
 export { defineWorkspace } from "./core/define.ts"
 export * as source from "./sources/index.ts"
-export type * from "./sources/index.ts"
 export { createWorkspaceTools } from "./ai.ts"
 export {
   createWorkspaceSourceResolutionFacade,

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -4,7 +4,6 @@ import { describe, expectTypeOf, it } from "vitest"
 
 import {
   defineWorkspace,
-  type FetchSourceOptions,
   useWorkspace,
 } from "../src/index.ts"
 import { createWorkspaceTools, type WorkspaceMaterializeSourcesResult, type WorkspaceShellResult } from "../src/ai.ts"
@@ -129,7 +128,6 @@ describe("workspace types", () => {
       url: "https://status.example.com/api/summary",
       workspacePath: "status/summary.json",
     })
-    expectTypeOf<FetchSourceOptions["url"]>().toEqualTypeOf<string | URL>()
     source.fetch({
       body: { scope: "all" },
       cookies: { auth_token: "secret" },


### PR DESCRIPTION
Removes the root `export type * from "./sources/index.ts"` that was only needed for a Quiver-side schema cast.

Quiver now relies on typed source-resolution context directly, so keeping source option types exported from the package root is unnecessary API surface.
