### PR TITLE
fix: expose controlled curl and chat identity

### DIFF
--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -620,6 +620,7 @@ function createChatSdkConfig(
     concurrency: chatSdkOption<ChatConfig["concurrency"]>(options, "concurrency"),
     dedupeTtlMs: chatSdkOption<number>(options, "dedupeTtlMs"),
     fallbackStreamingPlaceholderText,
+    identity: options?.identity,
     lockScope: chatSdkOption<ChatConfig["lockScope"]>(options, "lockScope"),
     logger: chatSdkOption<ChatConfig["logger"]>(options, "logger"),
     messageHistory: chatSdkOption<ChatConfig["messageHistory"]>(options, "messageHistory"),

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1,5 +1,5 @@
 import type { Message, StreamEvent } from "./messages.ts"
-import type { Adapter, AdapterPostableMessage, StateAdapter, TranscriptsConfig } from "chat"
+import type { Adapter, AdapterPostableMessage, IdentityResolver, StateAdapter, TranscriptsConfig } from "chat"
 import type {
   MaybePromise,
   MaybeResolvable,
@@ -853,7 +853,7 @@ export interface AgentChatOptions<TRuntimeConfig extends AgentRuntimeConfig = Ag
   fallbackStreamingPlaceholderText?: string | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   history?: AgentChatAgentBindingOptions["history"]
   hooks?: AgentChatEventHooks<TRuntimeConfig>
-  identity?: never
+  identity?: IdentityResolver
   lifecycleHooks?: Record<string, unknown>
   platforms?: AgentChatPlatformsResolver<TRuntimeConfig>
   sessions?: boolean | AgentChatSessionOptions

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -436,8 +436,13 @@ describe("server helpers", () => {
           },
         }),
         chat({
+          identity: ({ adapter, author }) => `${adapter}:${author.userId}`,
           platforms: {
             telegram: () => adapter as never,
+          },
+          transcripts: {
+            maxPerUser: 50,
+            retention: "30d",
           },
           webhooks: {
             telegram: {},

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -449,6 +449,7 @@ describe("agent public types", () => {
     }
     const teamsAdapter = {} as AgentChatPlatformResolver
     const supportChat = chat({
+      identity: ({ adapter, author }) => `${adapter}:${author.userId}`,
       platforms: () => ({ teams: teamsAdapter }),
       transcripts: {
         maxPerUser: 50,
@@ -458,10 +459,6 @@ describe("agent public types", () => {
     chat({
       // @ts-expect-error adapters was removed; public Chat config uses platforms
       adapters: () => ({ teams: teamsAdapter }),
-    })
-    chat({
-      // @ts-expect-error chat identity was removed; use defineAgent({ invoker }) instead
-      identity: () => "teams:user",
     })
     const workspace = {
       sources: {

--- a/packages/workspace/src/ai.ts
+++ b/packages/workspace/src/ai.ts
@@ -168,7 +168,7 @@ function shellCommandsFor(operations: ReturnType<typeof resolveReadOperations>) 
   return commands
 }
 
-function describeShellCommands(commands: string[]) {
+function describeShellCommands(commands: string[], options: { sourceRequests?: boolean } = {}) {
   const supported = new Set(commands)
   const available = [
     supported.has("pwd") && "`pwd`",
@@ -179,18 +179,21 @@ function describeShellCommands(commands: string[]) {
     supported.has("head") && "`head`",
     supported.has("tail") && "`tail`",
     supported.has("wc") && "`wc`",
+    options.sourceRequests && "controlled `curl` for API-backed Sources listed under `.vitehub/sources/*.json`",
   ].filter(Boolean)
   const examples = [
     supported.has("rg") && supported.has("head") && "`rg 'siff|PLC' ingestion forecasting-engine | head -n 20`",
     supported.has("rg") && !supported.has("head") && "`rg 'siff|PLC' ingestion forecasting-engine`",
     supported.has("find") && "`find ingestion -type f -name '*.sql'`",
     supported.has("cat") && supported.has("head") && "`cat forecasting-engine/README.md | head -n 40`",
+    options.sourceRequests && "`curl --json '{\"region\":\"eu\"}' https://example.com/api/source`",
   ].filter(Boolean)
 
   return [
     "Run a real Bash-compatible workspace shell command over files mounted at `/workspace`.",
     `Available workspace commands include: ${available.join(", ")}.`,
     "Only the listed commands are available; other executables are rejected before they run.",
+    options.sourceRequests && "For controlled `curl`, inspect the matching `.vitehub/sources/<sourceKey>.json` descriptor first; ViteHub validates the request against the Source Request Shape and injects Source credentials.",
     "Pipes, redirects, chaining, quoted patterns, and multiline shell scripts are supported when they use available commands.",
     "The workspace filesystem controls whether writes are allowed; read-only tools reject mutation commands at execution time.",
     "Do not use unsupported helpers such as `xargs`, `awk`, `sed`, `sort`, `cut`, or `python`.",
@@ -690,7 +693,9 @@ export function createWorkspaceTools<Operations extends WorkspaceToolOperations 
 
   if (resolved.commands.length) {
     result.shell = tool({
-      description: describeShellCommands(resolved.commands),
+      description: describeShellCommands(resolved.commands, {
+        sourceRequests: Boolean(getWorkspaceSourceRequestExecution(input)),
+      }),
       inputSchema: jsonSchema<{ command: string }>({
         additionalProperties: false,
         properties: {

--- a/packages/workspace/test/ai.test.ts
+++ b/packages/workspace/test/ai.test.ts
@@ -70,6 +70,7 @@ describe("createWorkspaceTools", () => {
     })
     expect(tools.shell.description).toContain("Only the listed commands are available")
     expect(tools.shell.description).toContain("Do not use unsupported helpers such as `xargs`")
+    expect(tools.shell.description).not.toContain("controlled `curl`")
   })
 
   it("limits shell commands to the enabled read capabilities", async () => {
@@ -197,6 +198,10 @@ describe("createWorkspaceTools", () => {
       store: { provider: "memory" },
     })
     const tools = createWorkspaceTools(workspace)
+
+    expect(tools.shell.description).toContain("controlled `curl`")
+    expect(tools.shell.description).toContain(".vitehub/sources/*.json")
+    expect(tools.shell.description).toContain("Source Request Shape")
 
     await expect(runShell(tools, "curl -sS 'https://portal.example.com/runtime/inventory-health?region=eu'")).resolves.toMatchObject({
       event: "command_finished",


### PR DESCRIPTION
Makes two ViteHub agent-facing fixes used by Quiver Chat.\n\n- Workspace shell descriptions now mention controlled `curl` when API-backed Source request descriptors are available, so agents know to inspect `.vitehub/sources/*.json` and use the controlled fetch path.\n- Agent chat options now expose and pass `identity` through to Chat SDK, which is required when `transcripts` is configured.\n\nTests cover controlled curl discoverability and chat webhook construction with transcripts plus identity.