### PR TITLE
chore: simplify model-facing prompt text

### DIFF
--- a/packages/agent/src/capabilities/mcp.ts
+++ b/packages/agent/src/capabilities/mcp.ts
@@ -117,8 +117,8 @@ export function mcp<
       if (options.instructions !== false) {
         const serverNames = Object.keys(options.servers)
         context.instructions.add(options.instructions || [
-          "MCP servers provide external model-facing tools.",
-          `Configured MCP servers: ${serverNames.length ? serverNames.join(", ") : "none"}.`,
+          `MCP tools are available from: ${serverNames.length ? serverNames.join(", ") : "none"}.`,
+          "Use them when they fit the request.",
         ].join("\n"))
       }
     },

--- a/packages/agent/src/capabilities/memory.ts
+++ b/packages/agent/src/capabilities/memory.ts
@@ -633,7 +633,7 @@ export function memory(options: MemoryCapabilityOptions): AgentCapabilityDefinit
       }
       context.tools.add(tools)
       if (options.instructions !== false) {
-        context.instructions.add(options.instructions || "Memory tools operate on durable scoped records. Treat recalled memory as advisory and prefer the current user request when they conflict.", { id: "memory" })
+        context.instructions.add(options.instructions || "Use memory for durable facts that may matter later. Current requests win when memory conflicts.", { id: "memory" })
       }
     },
   })

--- a/packages/agent/src/capabilities/workspace-shell.ts
+++ b/packages/agent/src/capabilities/workspace-shell.ts
@@ -26,12 +26,12 @@ async function sourceRequestHint(context: AgentCapabilityContext): Promise<strin
   if (!descriptors.length) return false
 
   return [
-    "API-backed Sources with controlled curl access:",
+    "API-backed Sources you can inspect with curl:",
     ...descriptors.map((entry) => {
       const source = entry.path.slice(".vitehub/sources/".length, -".json".length)
-      return `- ${source}: inspect \`${entry.path}\` for method, URL, allowed query/body shape, workspace path behavior, and redacted credential names before using curl.`
+      return `- ${source}: read \`${entry.path}\` before using curl.`
     }),
-    "Use normal curl syntax; ViteHub validates the final request against the Source Request Shape and Source Network Grant.",
+    "Use normal curl syntax that matches the descriptor.",
   ].join("\n")
 }
 

--- a/packages/agent/test/mcp-capability.test.ts
+++ b/packages/agent/test/mcp-capability.test.ts
@@ -53,7 +53,7 @@ describe("mcp capability", () => {
       },
       name: "mcp_docs_read_doc",
     })
-    expect(resolved.capabilityInstructions.at(-1)?.instructions).toContain("Configured MCP servers: docs.")
+    expect(resolved.capabilityInstructions.at(-1)?.instructions).toContain("MCP tools are available from: docs.")
 
     await resolved.close()
     expect(client.close).toHaveBeenCalledTimes(1)

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -506,9 +506,9 @@ describe("defineAgent workspace option", () => {
     expect(agentSettings.at(-1)?.instructions).toBe([
       "Answer from the workspace.",
       [
-        "API-backed Sources with controlled curl access:",
-        "- inventoryHealthSummary: inspect `.vitehub/sources/inventoryHealthSummary.json` for method, URL, allowed query/body shape, workspace path behavior, and redacted credential names before using curl.",
-        "Use normal curl syntax; ViteHub validates the final request against the Source Request Shape and Source Network Grant.",
+        "API-backed Sources you can inspect with curl:",
+        "- inventoryHealthSummary: read `.vitehub/sources/inventoryHealthSummary.json` before using curl.",
+        "Use normal curl syntax that matches the descriptor.",
       ].join("\n"),
       "Keep replies short.",
     ].join("\n\n"))

--- a/packages/workspace/src/ai.ts
+++ b/packages/workspace/src/ai.ts
@@ -188,13 +188,11 @@ function describeShellCommands(commands: string[]) {
   ].filter(Boolean)
 
   return [
-    "Run a real Bash-compatible workspace shell command over files mounted at `/workspace`.",
-    `Available workspace commands include: ${available.join(", ")}.`,
-    "Only the listed commands are available; other executables are rejected before they run.",
-    "Pipes, redirects, chaining, quoted patterns, and multiline shell scripts are supported when they use available commands.",
-    "The workspace filesystem controls whether writes are allowed; read-only tools reject mutation commands at execution time.",
-    "Do not use unsupported helpers such as `xargs`, `awk`, `sed`, `sort`, `cut`, or `python`.",
-    "Do not use shell commands such as `echo` to compose assistant replies; answer conversational messages directly.",
+    "Inspect files in `/workspace` with a Bash-compatible shell.",
+    `Use these commands: ${available.join(", ")}.`,
+    "Pipes, redirects, chaining, quoted patterns, and multiline scripts are supported.",
+    "Skip unsupported helpers such as `xargs`, `awk`, `sed`, `sort`, `cut`, or `python`.",
+    "Answer conversational messages directly; do not use shell commands such as `echo` to compose replies.",
     examples.length && `Examples: ${examples.join("; ")}.`,
   ].filter(Boolean).join(" ")
 }

--- a/packages/workspace/test/ai.test.ts
+++ b/packages/workspace/test/ai.test.ts
@@ -68,8 +68,8 @@ describe("createWorkspaceTools", () => {
       exitCode: 0,
       stdout: "/workspace\ncustomers.sql\norders.sql\n",
     })
-    expect(tools.shell.description).toContain("Only the listed commands are available")
-    expect(tools.shell.description).toContain("Do not use unsupported helpers such as `xargs`")
+    expect(tools.shell.description).toContain("Use these commands")
+    expect(tools.shell.description).toContain("Skip unsupported helpers such as `xargs`")
   })
 
   it("limits shell commands to the enabled read capabilities", async () => {


### PR DESCRIPTION
Simplifies default model-facing prompt fragments for Workspace Shell, API-backed Source curl hints, MCP, and Memory so agents see plain behavior guidance instead of runtime enforcement details.

The tool schemas and runtime checks still enforce the same boundaries; this only changes the natural-language instructions and their assertions.