### PR TITLE
ci: trim redundant workflow checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
       - run: vp run typecheck
       - run: vp run test:contracts
       - run: vp run test
-      - run: vp run build
 
   docs:
     name: docs

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
-      - run: vp run typecheck
       - run: vp run build
 
       - name: Publish preview packages


### PR DESCRIPTION
## Summary
- remove the redundant root package build from PR CI after tests
- remove the duplicate typecheck step before preview package publishing

## Test plan
- `git diff --check`
- parsed updated workflow YAML with Ruby stdlib YAML parser
