### PR TITLE
feat(runtime): default local state under vitehub data

### DIFF
--- a/packages/database/src/config.ts
+++ b/packages/database/src/config.ts
@@ -232,7 +232,7 @@ function normalizeCloudflareConfig(
 function getDefaultConnection(name: string) {
   return {
     authToken: undefined,
-    url: name === "default" ? "file:.data/database/sqlite.db" : `file:.data/database/${name}.sqlite.db`,
+    url: name === "default" ? "file:.vitehub/data/database/sqlite.db" : `file:.vitehub/data/database/${name}.sqlite.db`,
   }
 }
 

--- a/packages/database/test/config-value.test.ts
+++ b/packages/database/test/config-value.test.ts
@@ -27,8 +27,8 @@ describe("database config values", () => {
     expect(renderConfigValueExpression(createRuntimeEnvConfigValue([
       "VITEHUB_PRIMARY_DATABASE_URL",
       "VITEHUB_FALLBACK_DATABASE_URL",
-    ], "file:.data/database/sqlite.db"))).toBe(
-      'process.env["VITEHUB_PRIMARY_DATABASE_URL"] || process.env["VITEHUB_FALLBACK_DATABASE_URL"] || "file:.data/database/sqlite.db"',
+    ], "file:.vitehub/data/database/sqlite.db"))).toBe(
+      'process.env["VITEHUB_PRIMARY_DATABASE_URL"] || process.env["VITEHUB_FALLBACK_DATABASE_URL"] || "file:.vitehub/data/database/sqlite.db"',
     )
   })
 })

--- a/packages/database/test/config.test.ts
+++ b/packages/database/test/config.test.ts
@@ -114,7 +114,7 @@ describe("resolveDBViteConfig", () => {
 
     expect(resolved?.databaseNames).toEqual(["default"])
     expect(resolved?.databases.default).toMatchObject({
-      connection: { url: "file:.data/database/sqlite.db" },
+      connection: { url: "file:.vitehub/data/database/sqlite.db" },
       dialect: "sqlite",
       migrationsDir: "server/databases/migrations",
       mode: "default",
@@ -133,7 +133,7 @@ describe("resolveDBViteConfig", () => {
     const resolved = resolveDBViteConfig(undefined, rootDir)
 
     expect(resolved?.databases.analytics).toMatchObject({
-      connection: { url: "file:.data/database/analytics.sqlite.db" },
+      connection: { url: "file:.vitehub/data/database/analytics.sqlite.db" },
       migrationsDir: "server/databases/analytics/migrations",
       mode: "named",
     })
@@ -156,7 +156,7 @@ describe("resolveDBViteConfig", () => {
 
       expect(resolveDBViteConfig(undefined, rootDir)?.databases.default.connection).toEqual({
         authToken: undefined,
-        url: "file:.data/database/sqlite.db",
+        url: "file:.vitehub/data/database/sqlite.db",
       })
     }
     finally {

--- a/packages/database/test/vite.test.ts
+++ b/packages/database/test/vite.test.ts
@@ -56,7 +56,7 @@ describe("hubDb", () => {
       databaseNames: ["default"],
       databases: {
         default: {
-          connection: { url: "file:.data/database/sqlite.db" },
+          connection: { url: "file:.vitehub/data/database/sqlite.db" },
           migrationsDir: "server/databases/migrations",
           mode: "default",
         },
@@ -65,7 +65,7 @@ describe("hubDb", () => {
     await expect(readFile(join(rootDir, ".vitehub/database/schema/default.ts"), "utf8")).resolves.toContain("export const notes")
     await expect(readFile(join(rootDir, ".vitehub/database/drizzle.config.ts"), "utf8")).resolves.toContain("server/databases/migrations")
     await expect(readFile(join(rootDir, ".vitehub/database/drizzle.config.ts"), "utf8")).resolves.toContain("dbCredentials")
-    await expect(readFile(join(rootDir, ".vitehub/database/drizzle/default.config.ts"), "utf8")).resolves.toContain("file:.data/database/sqlite.db")
+    await expect(readFile(join(rootDir, ".vitehub/database/drizzle/default.config.ts"), "utf8")).resolves.toContain("file:.vitehub/data/database/sqlite.db")
   })
 
   it("writes one Drizzle config per named database migrations directory", async () => {
@@ -81,9 +81,9 @@ describe("hubDb", () => {
     const primaryConfig = await readFile(join(rootDir, ".vitehub/database/drizzle/primary.config.ts"), "utf8")
 
     expect(analyticsConfig).toContain("server/databases/analytics/migrations")
-    expect(analyticsConfig).toContain("file:.data/database/analytics.sqlite.db")
+    expect(analyticsConfig).toContain("file:.vitehub/data/database/analytics.sqlite.db")
     expect(primaryConfig).toContain("server/databases/primary/migrations")
-    expect(primaryConfig).toContain("file:.data/database/primary.sqlite.db")
+    expect(primaryConfig).toContain("file:.vitehub/data/database/primary.sqlite.db")
   })
 
   it("keeps env-sourced Drizzle credentials as runtime expressions", async () => {

--- a/packages/workflow/src/runtime/openworkflow.ts
+++ b/packages/workflow/src/runtime/openworkflow.ts
@@ -16,6 +16,7 @@ type OpenWorkflowStepApi = Parameters<Parameters<OpenWorkflowClient["defineWorkf
 type OpenWorkflowImporter = <T>(specifier: string) => Promise<T>
 const defaultImporter = new Function("specifier", "return import(specifier)") as OpenWorkflowImporter
 let openWorkflowImporter = defaultImporter
+const defaultOpenWorkflowSqlitePath = ".vitehub/data/openworkflow.sqlite.db"
 
 interface OpenWorkflowRuntime {
   backend: OpenWorkflowBackend
@@ -89,16 +90,21 @@ function getOpenWorkflowConfig(config: ResolvedWorkflowOptions): OpenWorkflowSto
 
   const postgres = config.postgres || {}
   const url = resolveRuntimeConfigValue(postgres.url) || readEnv("OPENWORKFLOW_POSTGRES_URL") || readEnv("DATABASE_URL")
-  if (!url) {
-    throw new Error("Missing OpenWorkflow storage. Set workflow.database, workflow.sqlite.path, workflow.postgres.url, OPENWORKFLOW_SQLITE_PATH, OPENWORKFLOW_POSTGRES_URL, or DATABASE_URL.")
+  if (url) {
+    return {
+      backend: "postgres",
+      namespaceId: postgres.namespaceId || readEnv("OPENWORKFLOW_NAMESPACE_ID") || "production",
+      runMigrations: postgres.runMigrations,
+      schema: postgres.schema || readEnv("OPENWORKFLOW_SCHEMA") || "openworkflow",
+      url,
+    }
   }
 
   return {
-    backend: "postgres",
-    namespaceId: postgres.namespaceId || readEnv("OPENWORKFLOW_NAMESPACE_ID") || "production",
-    runMigrations: postgres.runMigrations,
-    schema: postgres.schema || readEnv("OPENWORKFLOW_SCHEMA") || "openworkflow",
-    url,
+    backend: "sqlite",
+    namespaceId: sqlite.namespaceId || readEnv("OPENWORKFLOW_NAMESPACE_ID") || "production",
+    path: defaultOpenWorkflowSqlitePath,
+    runMigrations: sqlite.runMigrations,
   }
 }
 

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -713,13 +713,17 @@ describe("workflow runtime", () => {
     })
   })
 
-  it("requires storage for the OpenWorkflow provider", async () => {
+  it("uses local SQLite storage for the OpenWorkflow provider by default", async () => {
     setWorkflowRuntimeConfig({ provider: "openworkflow" })
     setWorkflowRuntimeRegistry({
       welcome: async () => ({ default: { handler: async () => ({ ok: true }) } }),
     })
 
-    await expect(runWorkflow("welcome", {})).rejects.toThrow(/Missing OpenWorkflow storage/)
+    await runWorkflow("welcome", {})
+
+    expect(openWorkflowMock.sqliteConnect).toHaveBeenCalledWith(".vitehub/data/openworkflow.sqlite.db", {
+      namespaceId: "production",
+    })
   })
 
   it("creates an OpenWorkflow worker from the runtime registry", async () => {


### PR DESCRIPTION
Default local ViteHub state now lands in `.vitehub/data`: database SQLite files resolve under `.vitehub/data/database`, and OpenWorkflow falls back to `.vitehub/data/openworkflow.sqlite.db` when no storage is configured. Explicit SQLite and Postgres configuration still take precedence, so apps stay in control when they opt into a different path or backend.

Checked locally with `pnpm --filter @vite-hub/database test` and `pnpm --filter @vite-hub/workflow test`.