### PR TITLE
fix(vite): support nested vitehub preset

### DIFF
--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Add ViteHub packages to your app and register the Vite Integrations you use.
+description: Add ViteHub packages to your app and register the Vite Integrations or preset you use.
 navigation.order: 2
 icon: i-lucide-download
 ---
@@ -11,8 +11,8 @@ icon: i-lucide-download
 Install ViteHub in my app.
 
 - Choose whether I need server primitives, agents, or both.
-- Install only the packages I use.
-- Register each installed package in `vite.config.ts`.
+- Install the common ViteHub preset or only the packages I use.
+- Register the preset or package-owned integrations in `vite.config.ts`.
 - Keep host credentials in environment variables or deployment configuration.
 - Start with KV for a small server primitive, or start with Agent definitions for model-backed behavior.
 ```
@@ -86,6 +86,40 @@ export default defineConfig({
 ::tip
 Keep the installed set small. The docs show the complete primitive list so you can see the shape, but most apps should start with one or two packages.
 ::
+
+## Install the common ViteHub preset
+
+Use the ViteHub preset when the app needs the common agent runtime surface and you do not want to wire each package-owned Vite Integration by hand.
+
+```bash [Terminal]
+pnpm add @vite-hub/vite @ai-sdk/gateway
+```
+
+Register the preset as one Vite plugin entry.
+
+```ts [vite.config.ts]
+import { vitehub } from "@vite-hub/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    vitehub(),
+  ],
+});
+```
+
+Disable package integrations the app does not use.
+
+```ts [vite.config.ts]
+export default defineConfig({
+  plugins: [
+    vitehub({
+      database: false,
+      workflow: false,
+    }),
+  ],
+});
+```
 
 ## Install agents
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -11,7 +11,9 @@ import type { HubDevtoolsOptions } from "@vite-hub/devtools"
 import type { EnvIntegrationOptions } from "@vite-hub/env"
 import type { WorkflowModuleOptions } from "@vite-hub/workflow"
 import type { WorkspaceModuleOptions } from "@vite-hub/workspace"
-import type { Plugin } from "vite"
+import type { PluginOption } from "vite"
+
+export { env } from "@vite-hub/env/vite"
 
 export interface ViteHubPresetOptions {
   agent?: false | AgentModuleOptions
@@ -22,7 +24,7 @@ export interface ViteHubPresetOptions {
   workspace?: false | WorkspaceModuleOptions
 }
 
-export function vitehub(options: ViteHubPresetOptions = {}): Plugin[] {
+export function vitehub(options: ViteHubPresetOptions = {}): PluginOption[] {
   const plugins: unknown[] = []
   if (options.env !== false) plugins.push(hubEnv(options.env))
   if (options.agent !== false) plugins.push(hubAgent(options.agent))
@@ -30,5 +32,5 @@ export function vitehub(options: ViteHubPresetOptions = {}): Plugin[] {
   if (options.workflow !== false) plugins.push(hubWorkflow(options.workflow))
   if (options.workspace !== false) plugins.push(hubWorkspace(options.workspace))
   if (options.devtools !== false) plugins.push(hubDevtools(options.devtools))
-  return plugins as Plugin[]
+  return plugins as PluginOption[]
 }

--- a/packages/vite/test/vite.test.ts
+++ b/packages/vite/test/vite.test.ts
@@ -3,15 +3,20 @@ import { describe, expect, it, vi } from "vitest"
 vi.mock("@vite-hub/agent/vite", () => ({ hubAgent: () => ({ name: "@vite-hub/agent/vite" }) }))
 vi.mock("@vite-hub/database/vite", () => ({ hubDb: () => ({ name: "@vite-hub/database/vite" }) }))
 vi.mock("@vite-hub/devtools", () => ({ hubDevtools: () => ({ name: "@vite-hub/devtools" }) }))
-vi.mock("@vite-hub/env/vite", () => ({ hubEnv: () => ({ name: "@vite-hub/env/vite" }) }))
+vi.mock("@vite-hub/env/vite", () => ({ env: "env-helper", hubEnv: () => ({ name: "@vite-hub/env/vite" }) }))
 vi.mock("@vite-hub/workflow/vite", () => ({ hubWorkflow: () => ({ name: "@vite-hub/workflow/vite" }) }))
 vi.mock("@vite-hub/workspace/vite", () => ({ hubWorkspace: () => ({ name: "@vite-hub/workspace/vite" }) }))
 
-import { vitehub } from "../src/index.ts"
+import type { Plugin, PluginOption } from "vite"
+import { env, vitehub } from "../src/index.ts"
+
+function pluginNames(plugins: PluginOption[]): string[] {
+  return plugins.map(plugin => (plugin as Plugin).name)
+}
 
 describe("vitehub", () => {
   it("composes ViteHub primitive integrations explicitly", () => {
-    expect(vitehub().map(plugin => plugin.name)).toEqual([
+    expect(pluginNames(vitehub())).toEqual([
       "@vite-hub/env/vite",
       "@vite-hub/agent/vite",
       "@vite-hub/database/vite",
@@ -19,11 +24,20 @@ describe("vitehub", () => {
       "@vite-hub/workspace/vite",
       "@vite-hub/devtools",
     ])
-    expect(vitehub({ database: false, devtools: false }).map(plugin => plugin.name)).toEqual([
+    expect(pluginNames(vitehub({ database: false, devtools: false }))).toEqual([
       "@vite-hub/env/vite",
       "@vite-hub/agent/vite",
       "@vite-hub/workflow/vite",
       "@vite-hub/workspace/vite",
     ])
+  })
+
+  it("can be used as one nested Vite plugin entry", () => {
+    const plugins: PluginOption[] = [vitehub()]
+    expect(plugins).toHaveLength(1)
+  })
+
+  it("re-exports the env declaration helper for Vite config", () => {
+    expect(env).toBe("env-helper")
   })
 })


### PR DESCRIPTION
Updates the `@vite-hub/vite` preset so `vitehub()` is typed as a Vite plugin-array preset and can be used directly as `plugins: [vitehub()]`, avoiding downstream spread syntax while keeping the package-owned integrations composed internally.

Also re-exports the Env declaration helper from the preset package for Vite config ergonomics and documents the common preset path on the installation page. Verified with `pnpm --filter @vite-hub/vite typecheck`, `pnpm --filter @vite-hub/vite test`, and the downstream `/Users/maxi/quiver/chat` `pnpm typecheck`.