### PR TITLE
fix(agent): rebase generated chat route

### DIFF
--- a/packages/agent/src/config.ts
+++ b/packages/agent/src/config.ts
@@ -1,6 +1,12 @@
 import type { AgentModuleOptions, ResolvedAgentModuleOptions } from "./types.ts"
 
+const defaultAgentChatRoute = "/api/_vitehub/agents/[agent]/chat"
 const defaultAgentWebhookRoute = "/api/_vitehub/agents/[agent]/webhooks/[webhook]"
+
+function normalizeAgentRouteOption(value: boolean | string | undefined, defaultRoute: string): false | string {
+  if (value === true) return defaultRoute
+  return value || false
+}
 
 export function normalizeAgentOptions(options: AgentModuleOptions | false | undefined): false | ResolvedAgentModuleOptions {
   if (options === false) {
@@ -26,7 +32,10 @@ export function normalizeAgentOptions(options: AgentModuleOptions | false | unde
         provider: options?.providers?.state?.provider || "auto",
       },
     },
+    routes: {
+      chat: normalizeAgentRouteOption(options?.routes?.chat, defaultAgentChatRoute),
+      webhooks: normalizeAgentRouteOption(options?.routes?.webhooks, defaultAgentWebhookRoute),
+    },
     runtime: options?.runtime || "auto",
-    webhooks: options?.webhooks === true ? defaultAgentWebhookRoute : options?.webhooks ?? false,
   }
 }

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -30,6 +30,7 @@ import type {
   AgentRuntimeName,
   AgentWaitUntil,
   AgentWebhookRegistrationDefinition,
+  MaybePromise,
   MaybeResolvable,
 } from "./types.ts"
 import type { AudioData, MessagePart } from "./messages.ts"
@@ -75,6 +76,17 @@ export interface AgentChatWebhookFetchOptions extends AgentRouteRuntimeOptions {
 
 export interface AgentChatFetchOptions extends AgentRouteRuntimeOptions {
   agentName?: string
+}
+
+export interface AgentChatFetchMapInputContext {
+  agentName: string
+  body: AgentChatFetchBody
+  input: AgentChatMessageTriggerInput
+  request: Request
+}
+
+export interface AgentChatFetchHandlerOptions {
+  mapInput?: (context: AgentChatFetchMapInputContext) => MaybePromise<Partial<AgentChatMessageTriggerInput> | undefined | void>
 }
 
 export interface RegisterWorkspaceAgentOptions<Name extends WorkspaceName = WorkspaceName> extends WorkspaceAgentDefaults<Name> {
@@ -1004,11 +1016,15 @@ type AgentChatDevtoolsAction = "clear" | "get-state" | "materialize-source" | "s
 type CreateUIMessageStreamResponse = typeof import("ai").createUIMessageStreamResponse
 type ReadUIMessageStream = typeof import("ai").readUIMessageStream
 
-type AgentChatFetchBody = {
+export type AgentChatFetchBody = {
   history?: AgentChatMessageTriggerInput["history"]
   id?: string
+  invoker?: unknown
+  invokerProfileId?: unknown
   messageId?: string
+  meta?: unknown
   messages?: unknown
+  run?: unknown
   session?: unknown
   trigger?: string
   user?: unknown
@@ -1341,11 +1357,11 @@ function optionalBodyString(value: unknown, label: string): string | undefined {
   return trimmed || undefined
 }
 
-function agentChatFetchInput(body: AgentChatFetchBody, agentName: string): AgentChatMessageTriggerInput {
+function agentChatFetchInput(body: AgentChatFetchBody, agentName: string, allowTrustedInput = false): AgentChatMessageTriggerInput {
   if (!Array.isArray(body.messages)) {
     throw createRouteBodyError("Agent chat payload requires a messages array.")
   }
-  if ("invoker" in body || "invokerProfileId" in body || "meta" in body || "run" in body || "user" in body) {
+  if (!allowTrustedInput && ("invoker" in body || "invokerProfileId" in body || "meta" in body || "run" in body || "user" in body)) {
     throw createRouteBodyError("Agent chat route identity must be derived server-side with defineAgent({ invoker }).")
   }
   const messages = body.messages as UIMessage[]
@@ -1355,6 +1371,20 @@ function agentChatFetchInput(body: AgentChatFetchBody, agentName: string): Agent
     messages,
     run: createHttpChatRunMetadata(agentName, body, messages),
     ...(session ? { session } : {}),
+  }
+}
+
+function mergeAgentChatFetchInput(
+  input: AgentChatMessageTriggerInput,
+  patch: Partial<AgentChatMessageTriggerInput> | undefined | void,
+): AgentChatMessageTriggerInput {
+  if (patch === undefined) return input
+  if (!isRecord(patch)) throw createRouteBodyError("Agent chat route input mapper must return an object.")
+  return {
+    ...input,
+    ...patch,
+    ...(patch.run ? { run: { ...input.run, ...patch.run } } : {}),
+    ...(patch.session ? { session: { ...input.session, ...patch.session } } : {}),
   }
 }
 
@@ -1777,6 +1807,7 @@ function agentChatFetchErrorResponse(error: unknown): Response {
 
 export function defineAgentChatFetchHandler(
   agent: AgentInput<ViteAgentRouteRuntimeContext>,
+  options: AgentChatFetchHandlerOptions = {},
 ): (request: Request, options?: AgentChatFetchOptions) => Promise<Response> {
   return async (request, handlerOptions = {}) => {
     if (request.method !== "POST") {
@@ -1792,7 +1823,11 @@ export function defineAgentChatFetchHandler(
         await resolveRuntimeWaitUntil(handlerOptions.waitUntil),
         handlerOptions.cloudflare,
       )
-      const triggerInput = agentChatFetchInput(body, agentName)
+      const baseInput = agentChatFetchInput(body, agentName, Boolean(options.mapInput))
+      const triggerInput = mergeAgentChatFetchInput(
+        baseInput,
+        await options.mapInput?.({ agentName, body, input: baseInput, request }),
+      )
       const result = await runWithRuntimeCloudflareEnv(context, async () => await streamAgentTrigger(agent as never, context as never, "chat.message", triggerInput, {
         output: "ui-message-stream",
       }))

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -73,6 +73,10 @@ export interface AgentChatWebhookFetchOptions extends AgentRouteRuntimeOptions {
   state?: AgentChatStateResolver<ViteAgentRouteRuntimeConfig>
 }
 
+export interface AgentChatFetchOptions extends AgentRouteRuntimeOptions {
+  agentName?: string
+}
+
 export interface RegisterWorkspaceAgentOptions<Name extends WorkspaceName = WorkspaceName> extends WorkspaceAgentDefaults<Name> {
   sourceRootDir?: string
 }
@@ -997,7 +1001,18 @@ async function createChatWebhookHandler(
 }
 
 type AgentChatDevtoolsAction = "clear" | "get-state" | "materialize-source" | "send"
+type CreateUIMessageStreamResponse = typeof import("ai").createUIMessageStreamResponse
 type ReadUIMessageStream = typeof import("ai").readUIMessageStream
+
+type AgentChatFetchBody = {
+  history?: AgentChatMessageTriggerInput["history"]
+  id?: string
+  messageId?: string
+  messages?: unknown
+  session?: unknown
+  trigger?: string
+  user?: unknown
+}
 
 type AgentChatDevtoolsBridgeBody = {
   action?: string
@@ -1284,6 +1299,62 @@ function createUserUIMessage(text: string): UIMessage {
     metadata: {},
     parts: [{ text, type: "text" }],
     role: "user",
+  }
+}
+
+function createHttpChatRunMetadata(agentName: string, body: AgentChatFetchBody, messages: UIMessage[]): AgentRunMetadata {
+  const chatId = optionalBodyString(body.id, "id") || "default"
+  const messageId = optionalBodyString(body.messageId, "messageId") || messages.at(-1)?.id || randomToken()
+  return {
+    channelId: `http:${agentName}`,
+    messageId,
+    origin: "http",
+    runId: globalThis.crypto?.randomUUID?.() || `http-run-${randomToken()}`,
+    threadId: `http:${agentName}:${chatId}`,
+  }
+}
+
+async function parseAgentChatFetchBody(request: Request): Promise<AgentChatFetchBody> {
+  const raw = await request.text()
+  if (!raw.trim()) throw createRouteBodyError("Missing agent chat payload.")
+  try {
+    const body = JSON.parse(raw) as AgentChatFetchBody
+    if (!isRecord(body)) throw createRouteBodyError("Agent chat payload must be a JSON object.")
+    return body
+  }
+  catch (error) {
+    if (error instanceof Error && "statusCode" in error) throw error
+    throw createRouteBodyError("Malformed agent chat payload.")
+  }
+}
+
+function optionalBodyRecord(value: unknown, label: string): Record<string, unknown> | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value)) throw createRouteBodyError(`${label} must be an object when provided.`)
+  return { ...value }
+}
+
+function optionalBodyString(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== "string") throw createRouteBodyError(`${label} must be a string when provided.`)
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+function agentChatFetchInput(body: AgentChatFetchBody, agentName: string): AgentChatMessageTriggerInput {
+  if (!Array.isArray(body.messages)) {
+    throw createRouteBodyError("Agent chat payload requires a messages array.")
+  }
+  if ("invoker" in body || "invokerProfileId" in body || "meta" in body || "run" in body || "user" in body) {
+    throw createRouteBodyError("Agent chat route identity must be derived server-side with defineAgent({ invoker }).")
+  }
+  const messages = body.messages as UIMessage[]
+  const session = optionalBodyRecord(body.session, "session") as AgentChatMessageTriggerInput["session"] | undefined
+  return {
+    ...(body.history !== undefined ? { history: body.history } : {}),
+    messages,
+    run: createHttpChatRunMetadata(agentName, body, messages),
+    ...(session ? { session } : {}),
   }
 }
 
@@ -1687,6 +1758,50 @@ export function defineAgentChatDevtoolsFetchHandler(
     session: { uiMessages: [] },
   }
   return async (request, requestOptions = {}) => await handleAgentChatDevtoolsFetchRequest(agent, request, state, options, requestOptions)
+}
+
+async function toAgentChatFetchResponse(result: unknown): Promise<Response> {
+  if (result instanceof Response) return result
+  const { createUIMessageStreamResponse } = await import("ai") as { createUIMessageStreamResponse: CreateUIMessageStreamResponse }
+  return createUIMessageStreamResponse({ stream: readableStreamFromResult(result) as never })
+}
+
+function agentChatFetchErrorResponse(error: unknown): Response {
+  const response = toHttpErrorResponse(error)
+  if (response) return response
+  if (error instanceof TypeError) {
+    return createJsonErrorResponse(400, error.message)
+  }
+  return createJsonErrorResponse(500, error instanceof Error ? error.message : "Agent chat request failed.")
+}
+
+export function defineAgentChatFetchHandler(
+  agent: AgentInput<ViteAgentRouteRuntimeContext>,
+): (request: Request, options?: AgentChatFetchOptions) => Promise<Response> {
+  return async (request, handlerOptions = {}) => {
+    if (request.method !== "POST") {
+      return createJsonErrorResponse(405, "Agent chat route only accepts POST requests.")
+    }
+
+    try {
+      const body = await parseAgentChatFetchBody(request)
+      const agentName = handlerOptions.agentName || "agent"
+      const context = createRuntimeContext(
+        request,
+        undefined,
+        await resolveRuntimeWaitUntil(handlerOptions.waitUntil),
+        handlerOptions.cloudflare,
+      )
+      const triggerInput = agentChatFetchInput(body, agentName)
+      const result = await runWithRuntimeCloudflareEnv(context, async () => await streamAgentTrigger(agent as never, context as never, "chat.message", triggerInput, {
+        output: "ui-message-stream",
+      }))
+      return await toAgentChatFetchResponse(result)
+    }
+    catch (error) {
+      return agentChatFetchErrorResponse(error)
+    }
+  }
 }
 
 export function defineAgentChatWebhookFetchHandler(

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -713,6 +713,18 @@ export interface AgentEvalOptions {
 
 export type AgentCliOptions = Record<never, never>
 
+export type AgentRouteOption = boolean | string
+
+export interface AgentRoutesOptions {
+  chat?: AgentRouteOption
+  webhooks?: AgentRouteOption
+}
+
+export interface ResolvedAgentRoutesOptions {
+  chat: false | string
+  webhooks: false | string
+}
+
 export interface AgentModuleOptions {
   cli?: false | AgentCliOptions
   devtools?: false | { meta?: Record<string, unknown> }
@@ -721,8 +733,8 @@ export interface AgentModuleOptions {
   imports?: boolean
   integrations?: AgentIntegrationsOptions
   providers?: AgentProvidersOptions
+  routes?: AgentRoutesOptions
   runtime?: AgentRuntime
-  webhooks?: boolean | string
 }
 
 export interface ResolvedAgentModuleOptions {
@@ -734,8 +746,8 @@ export interface ResolvedAgentModuleOptions {
     scheduler: Required<AgentSchedulerProviderOptions>
     state: ResolvedAgentStateProviderOptions
   }
+  routes: ResolvedAgentRoutesOptions
   runtime: AgentRuntime
-  webhooks: false | string
 }
 
 export interface AgentHandlerOptions<TRuntimeContext extends AgentRuntimeContext = AgentRuntimeContext> {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -31,7 +31,6 @@ export type AgentVitePlugin = Plugin & AgentCliContributingPlugin
 
 const agentPackageName = "@vite-hub/agent"
 const mergeNoExternal = createNoExternalMerger(agentPackageName)
-const defaultAgentChatRoute = "/api/_vitehub/agents/[agent]/chat"
 const generatedAgentWebhookRouteHandler = ".vitehub/agent/chat-webhook-route.ts"
 
 type NitroConfig = Record<string, unknown> & CloudflareAgentStateRollupTarget & CloudflareAgentStateTarget
@@ -42,7 +41,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function shouldInstallCloudflareAgentState(options: false | ResolvedAgentModuleOptions): options is ResolvedAgentModuleOptions {
-  if (!options || !options.webhooks) return false
+  if (!options || !options.routes.webhooks) return false
   const provider = options.providers.state.provider
   return provider === "auto" || provider === "cloudflare" || provider === "cloudflare-agents"
 }
@@ -207,6 +206,9 @@ function generateAgentWebhookRouteHandler(definitions: DiscoveredAgentDefinition
       return `${JSON.stringify(definition.name)}: ${agentExpression}`
     })
     .join(",\n  ")
+  const agentModuleEntries = definitions
+    .map((definition, index) => `${JSON.stringify(definition.name)}: agent${index}`)
+    .join(",\n  ")
 
   return [
     "import { withWorkspaceAgentDefaults } from '@vite-hub/agent'",
@@ -218,6 +220,11 @@ function generateAgentWebhookRouteHandler(definitions: DiscoveredAgentDefinition
     "",
     "function resolveAgentModule(module) {",
     "  return module && typeof module === 'object' && 'default' in module ? module.default : module",
+    "}",
+    "",
+    "function resolveChatRouteOptions(module) {",
+    "  const chatRoute = module && typeof module === 'object' ? module.chatRoute : undefined",
+    "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
     "}",
     "",
     "async function toRequest(event) {",
@@ -238,7 +245,8 @@ function generateAgentWebhookRouteHandler(definitions: DiscoveredAgentDefinition
     `setWorkspaceRuntimeRegistry({${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}})`,
     "",
     `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
-    "const chatHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, defineAgentChatFetchHandler(agent)]))",
+    `const agentModules = {${agentModuleEntries ? `\n  ${agentModuleEntries}\n` : ""}}`,
+    "const chatHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, defineAgentChatFetchHandler(agent, resolveChatRouteOptions(agentModules[name]))]))",
     "const webhookHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, defineAgentChatWebhookFetchHandler(agent)]))",
     "",
     "export default defineEventHandler(async (event) => {",
@@ -297,13 +305,16 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       const resolved = normalizeAgentOptions(agent)
       const installCloudflareState = shouldInstallCloudflareAgentState(resolved)
       const nitroHandlers = [
-        ...(resolved && resolved.webhooks
+        ...(resolved && resolved.routes.chat
           ? [{
               handler: generatedAgentWebhookRouteHandler,
-              route: normalizeNitroRoute(defaultAgentChatRoute),
-            }, {
+              route: normalizeNitroRoute(resolved.routes.chat),
+            }]
+          : []),
+        ...(resolved && resolved.routes.webhooks
+          ? [{
               handler: generatedAgentWebhookRouteHandler,
-              route: normalizeNitroRoute(resolved.webhooks),
+              route: normalizeNitroRoute(resolved.routes.webhooks),
             }]
           : []),
       ]
@@ -329,7 +340,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       resolved = config
       agent = config.agent ?? agent
       const normalized = normalizeAgentOptions(agent)
-      if (normalized && normalized.webhooks) {
+      if (normalized && (normalized.routes.chat || normalized.routes.webhooks)) {
         await writeAgentWebhookRouteHandler(config.root, { cloudflareState: shouldInstallCloudflareAgentState(normalized) })
       }
       if (agent === false || agent?.eval === false) {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -31,6 +31,7 @@ export type AgentVitePlugin = Plugin & AgentCliContributingPlugin
 
 const agentPackageName = "@vite-hub/agent"
 const mergeNoExternal = createNoExternalMerger(agentPackageName)
+const defaultAgentChatRoute = "/api/_vitehub/agents/[agent]/chat"
 const generatedAgentWebhookRouteHandler = ".vitehub/agent/chat-webhook-route.ts"
 
 type NitroConfig = Record<string, unknown> & CloudflareAgentStateRollupTarget & CloudflareAgentStateTarget
@@ -210,7 +211,7 @@ function generateAgentWebhookRouteHandler(definitions: DiscoveredAgentDefinition
   return [
     "import { withWorkspaceAgentDefaults } from '@vite-hub/agent'",
     ...(options.cloudflareState ? ["import { createCloudflareAgentState } from '@vite-hub/agent/cloudflare'"] : []),
-    "import { defineAgentChatWebhookFetchHandler } from '@vite-hub/agent/server'",
+    "import { defineAgentChatFetchHandler, defineAgentChatWebhookFetchHandler } from '@vite-hub/agent/server'",
     "import { setWorkspaceRuntimeRegistry } from '@vite-hub/workspace/internal/runtime/state'",
     "import { createError, defineEventHandler, getRequestHeaders, getRequestURL, getRouterParam, readRawBody } from 'h3'",
     imports,
@@ -237,19 +238,20 @@ function generateAgentWebhookRouteHandler(definitions: DiscoveredAgentDefinition
     `setWorkspaceRuntimeRegistry({${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}})`,
     "",
     `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
-    "const handlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, defineAgentChatWebhookFetchHandler(agent)]))",
+    "const chatHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, defineAgentChatFetchHandler(agent)]))",
+    "const webhookHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, defineAgentChatWebhookFetchHandler(agent)]))",
     "",
     "export default defineEventHandler(async (event) => {",
     "  const agent = getRouterParam(event, 'agent')",
     "  const webhook = getRouterParam(event, 'webhook')",
-    "  const handler = agent ? handlers[agent] : undefined",
+    "  const handler = agent ? (webhook ? webhookHandlers[agent] : chatHandlers[agent]) : undefined",
     "  if (!handler) {",
     "    throw createError({ statusCode: 404, statusMessage: 'Unknown ViteHub agent.' })",
     "  }",
     "  const cloudflare = cloudflareFromEvent(event)",
     options.cloudflareState
-      ? "  return await handler(await toRequest(event), webhook, { agentName: agent, cloudflare, state: chatStateFromCloudflare(cloudflare), waitUntil: waitUntilFromEvent(event) })"
-      : "  return await handler(await toRequest(event), webhook, { agentName: agent, cloudflare, waitUntil: waitUntilFromEvent(event) })",
+      ? "  return webhook ? await handler(await toRequest(event), webhook, { agentName: agent, cloudflare, state: chatStateFromCloudflare(cloudflare), waitUntil: waitUntilFromEvent(event) }) : await handler(await toRequest(event), { agentName: agent, cloudflare, waitUntil: waitUntilFromEvent(event) })"
+      : "  return webhook ? await handler(await toRequest(event), webhook, { agentName: agent, cloudflare, waitUntil: waitUntilFromEvent(event) }) : await handler(await toRequest(event), { agentName: agent, cloudflare, waitUntil: waitUntilFromEvent(event) })",
     "})",
     "",
   ].join("\n")
@@ -297,6 +299,9 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       const nitroHandlers = [
         ...(resolved && resolved.webhooks
           ? [{
+              handler: generatedAgentWebhookRouteHandler,
+              route: normalizeNitroRoute(defaultAgentChatRoute),
+            }, {
               handler: generatedAgentWebhookRouteHandler,
               route: normalizeNitroRoute(resolved.webhooks),
             }]

--- a/packages/agent/test/config.test.ts
+++ b/packages/agent/test/config.test.ts
@@ -16,8 +16,11 @@ describe("agent config", () => {
         scheduler: { provider: "auto" },
         state: { provider: "auto" },
       },
+      routes: {
+        chat: false,
+        webhooks: false,
+      },
       runtime: "auto",
-      webhooks: false,
     })
   })
 
@@ -29,20 +32,26 @@ describe("agent config", () => {
     })).toMatchObject({
       integrations: { sandbox: false, workflow: "auto" },
       providers: { state: { provider: "sqlite", tablePrefix: "agent_state_", url: "file:agent-state.sqlite" } },
+      routes: { chat: false, webhooks: false },
       runtime: "cloudflare-agents",
-      webhooks: false,
     })
   })
 
-  it("uses the default webhook route when webhooks is true", () => {
-    expect(normalizeAgentOptions({ webhooks: true })).toMatchObject({
-      webhooks: "/api/_vitehub/agents/[agent]/webhooks/[webhook]",
+  it("uses the default routes when routes are true", () => {
+    expect(normalizeAgentOptions({ routes: { chat: true, webhooks: true } })).toMatchObject({
+      routes: {
+        chat: "/api/_vitehub/agents/[agent]/chat",
+        webhooks: "/api/_vitehub/agents/[agent]/webhooks/[webhook]",
+      },
     })
   })
 
-  it("preserves a custom webhook route", () => {
-    expect(normalizeAgentOptions({ webhooks: "/hooks/[agent]/[webhook]" })).toMatchObject({
-      webhooks: "/hooks/[agent]/[webhook]",
+  it("preserves custom routes", () => {
+    expect(normalizeAgentOptions({ routes: { chat: "/chat/[agent]", webhooks: "/hooks/[agent]/[webhook]" } })).toMatchObject({
+      routes: {
+        chat: "/chat/[agent]",
+        webhooks: "/hooks/[agent]/[webhook]",
+      },
     })
   })
 })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -117,12 +117,12 @@ describe("agent Vite plugin", () => {
 
   it("exposes hubAgent options through Vite config", async () => {
     const { hubAgent } = await import("../src/vite.ts")
-    const plugin = hubAgent({ webhooks: true })
+    const plugin = hubAgent({ routes: { chat: true } })
     const result = typeof plugin.config === "function"
       ? await plugin.config.call({} as never, {}, { command: "build", mode: "production" })
       : undefined
 
-    expect(result).toMatchObject({ agent: { webhooks: true } })
+    expect(result).toMatchObject({ agent: { routes: { chat: true } } })
   })
 
   it("materializes the MCP runtime package for Vercel build output", async () => {
@@ -144,30 +144,41 @@ describe("agent Vite plugin", () => {
 
   it("registers configured agent webhook routes with Nitro", async () => {
     const { hubAgent } = await import("../src/vite.ts")
-    const plugin = hubAgent({ webhooks: true })
+    const plugin = hubAgent({ routes: { webhooks: true } })
     const result = typeof plugin.config === "function"
       ? await plugin.config.call({} as never, {}, { command: "build", mode: "production" })
       : undefined
 
     expect(result).toMatchObject({
       nitro: {
-        handlers: [
-          {
-            handler: ".vitehub/agent/chat-webhook-route.ts",
-            route: "/api/_vitehub/agents/:agent/chat",
-          },
-          {
-            handler: ".vitehub/agent/chat-webhook-route.ts",
-            route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
-          },
-        ],
+        handlers: [{
+          handler: ".vitehub/agent/chat-webhook-route.ts",
+          route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
+        }],
+      },
+    })
+  })
+
+  it("registers configured agent chat routes with Nitro", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const plugin = hubAgent({ routes: { chat: true } })
+    const result = typeof plugin.config === "function"
+      ? await plugin.config.call({} as never, {}, { command: "build", mode: "production" })
+      : undefined
+
+    expect(result).toMatchObject({
+      nitro: {
+        handlers: [{
+          handler: ".vitehub/agent/chat-webhook-route.ts",
+          route: "/api/_vitehub/agents/:agent/chat",
+        }],
       },
     })
   })
 
   it("installs Cloudflare chat state bindings for generated webhook routes", async () => {
     const { hubAgent } = await import("../src/vite.ts")
-    const plugin = hubAgent({ webhooks: true })
+    const plugin = hubAgent({ routes: { webhooks: true } })
     const result = typeof plugin.config === "function"
       ? await plugin.config.call({} as never, {
           build: {
@@ -221,7 +232,7 @@ describe("agent Vite plugin", () => {
 
   it("keeps Cloudflare chat state opt-out when the state provider is memory", async () => {
     const { hubAgent } = await import("../src/vite.ts")
-    const plugin = hubAgent({ providers: { state: { provider: "memory" } }, webhooks: true })
+    const plugin = hubAgent({ providers: { state: { provider: "memory" } }, routes: { chat: true, webhooks: true } })
     const result = typeof plugin.config === "function"
       ? await plugin.config.call({} as never, {}, { command: "build", mode: "production" })
       : undefined
@@ -251,7 +262,7 @@ describe("agent Vite plugin", () => {
     const { hubAgent } = await import("../src/vite.ts")
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-routes-"))
     try {
-      const plugin = hubAgent({ webhooks: true })
+      const plugin = hubAgent({ routes: { chat: true, webhooks: true } })
       if (typeof plugin.configResolved === "function") {
         await plugin.configResolved.call({} as never, { root } as never)
       }
@@ -263,9 +274,12 @@ describe("agent Vite plugin", () => {
       expect(webhookRoute).toContain("async function toRequest(event)")
       expect(webhookRoute).toContain("function waitUntilFromEvent(event)")
       expect(webhookRoute).toContain("function chatStateFromCloudflare(cloudflare)")
+      expect(webhookRoute).toContain("function resolveChatRouteOptions(module)")
       expect(webhookRoute).toContain("waitUntil: waitUntilFromEvent(event)")
       expect(webhookRoute).toContain("state: chatStateFromCloudflare(cloudflare)")
+      expect(webhookRoute).toContain("const agentModules")
       expect(webhookRoute).toContain("const chatHandlers")
+      expect(webhookRoute).toContain("defineAgentChatFetchHandler(agent, resolveChatRouteOptions(agentModules[name]))")
       expect(webhookRoute).toContain("const webhookHandlers")
       expect(webhookRoute).toContain("return webhook ? await handler(await toRequest(event), webhook")
     }
@@ -516,6 +530,62 @@ describe("server helpers", () => {
     await expect(response.json()).resolves.toMatchObject({
       error: "Agent chat route identity must be derived server-side with defineAgent({ invoker }).",
     })
+  })
+
+  it("maps trusted AI SDK chat route input before invoking the chat trigger", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatFetchHandler } = await import("../src/server.ts")
+    const run = vi.fn(({ context, invoker, run }) => {
+      const chatContext = context.get("chat") as { meta?: { audience?: string }, user?: { email?: string } } | undefined
+      return `portal ${run.origin} ${invoker.id} ${invoker.meta.scope} ${chatContext?.user?.email} ${chatContext?.meta?.audience}`
+    })
+    const handler = defineAgentChatFetchHandler(defineAgent({
+      capabilities: [chat()],
+      invoker: {
+        profiles: [{
+          id: "customer:acme",
+          kind: "customerPortal",
+          meta: { scope: "acme" },
+        }],
+      },
+      run,
+    }) as never, {
+      mapInput({ body, request }) {
+        if (request.headers.get("x-quiver-chat-token") !== "trusted") {
+          throw new Error("Invalid Quiver Chat token.")
+        }
+        return {
+          invokerProfileId: "customer:acme",
+          meta: body.meta as Record<string, unknown>,
+          run: body.run as never,
+          user: body.user as Record<string, unknown>,
+        }
+      },
+    })
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        messages: [{
+          id: "user-1",
+          parts: [{ text: "hello", type: "text" }],
+          role: "user",
+        }],
+        meta: { audience: "technical", customer: "acme", source: "portal" },
+        run: { origin: "portal" },
+        user: { email: "user@example.com" },
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-quiver-chat-token": "trusted",
+      },
+      method: "POST",
+    }), { agentName: "support" })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
+    await expect(response.text()).resolves.toContain("portal portal customer:acme acme user@example.com technical")
+    expect(run).toHaveBeenCalled()
   })
 
   it("handles Chat SDK webhooks through the chat capability", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -151,10 +151,16 @@ describe("agent Vite plugin", () => {
 
     expect(result).toMatchObject({
       nitro: {
-        handlers: [{
-          handler: ".vitehub/agent/chat-webhook-route.ts",
-          route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
-        }],
+        handlers: [
+          {
+            handler: ".vitehub/agent/chat-webhook-route.ts",
+            route: "/api/_vitehub/agents/:agent/chat",
+          },
+          {
+            handler: ".vitehub/agent/chat-webhook-route.ts",
+            route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
+          },
+        ],
       },
     })
   })
@@ -230,6 +236,10 @@ describe("agent Vite plugin", () => {
 
     expect(output.nitro?.handlers).toContainEqual({
       handler: ".vitehub/agent/chat-webhook-route.ts",
+      route: "/api/_vitehub/agents/:agent/chat",
+    })
+    expect(output.nitro?.handlers).toContainEqual({
+      handler: ".vitehub/agent/chat-webhook-route.ts",
       route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
     })
     expect(output.nitro?.cloudflare).toBeUndefined()
@@ -248,13 +258,16 @@ describe("agent Vite plugin", () => {
 
       const webhookRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
 
+      expect(webhookRoute).toContain("defineAgentChatFetchHandler")
       expect(webhookRoute).toContain("import { createCloudflareAgentState } from '@vite-hub/agent/cloudflare'")
       expect(webhookRoute).toContain("async function toRequest(event)")
       expect(webhookRoute).toContain("function waitUntilFromEvent(event)")
       expect(webhookRoute).toContain("function chatStateFromCloudflare(cloudflare)")
       expect(webhookRoute).toContain("waitUntil: waitUntilFromEvent(event)")
       expect(webhookRoute).toContain("state: chatStateFromCloudflare(cloudflare)")
-      expect(webhookRoute).toContain("return await handler(await toRequest(event), webhook")
+      expect(webhookRoute).toContain("const chatHandlers")
+      expect(webhookRoute).toContain("const webhookHandlers")
+      expect(webhookRoute).toContain("return webhook ? await handler(await toRequest(event), webhook")
     }
     finally {
       await rm(root, { force: true, recursive: true })
@@ -398,6 +411,110 @@ describe("server helpers", () => {
       title: "Support",
       uiMessages: [],
       version: "test-agent",
+    })
+  })
+
+  it("serves AI SDK UI message chat requests through the chat trigger", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatFetchHandler } = await import("../src/server.ts")
+    const resolveInvoker = vi.fn(({ defaultInvoker, request }) => ({
+      id: `customer:${request.headers.get("x-customer")}`,
+      kind: "customer",
+      meta: {
+        fallback: defaultInvoker.id,
+        user: request.headers.get("x-user"),
+      },
+    }))
+    const run = vi.fn(({ context, invoker, messages, run }) => {
+      const text = messages[0]?.parts.find((part: { type?: string }) => part.type === "text") as { text?: string } | undefined
+      return `echo ${text?.text} for ${invoker.id} via ${run.origin} from ${invoker.meta.user} after ${invoker.meta.fallback}`
+    })
+    const agent = defineAgent({
+      capabilities: [chat()],
+      invoker: { resolve: resolveInvoker },
+      run,
+    })
+    const handler = defineAgentChatFetchHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        id: "portal-thread",
+        messages: [{
+          id: "user-1",
+          parts: [{ text: "hello", type: "text" }],
+          role: "user",
+        }],
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-customer": "acme",
+        "x-user": "portal-user",
+      },
+      method: "POST",
+    }), { agentName: "support" })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
+    await expect(response.text()).resolves.toContain("echo hello for customer:acme via http from portal-user after anonymous:http")
+    expect(resolveInvoker).toHaveBeenCalledWith(expect.objectContaining({
+      defaultInvoker: expect.objectContaining({
+        id: "anonymous:http",
+        kind: "anonymous",
+      }),
+      request: expect.any(Request),
+      run: expect.objectContaining({
+        channelId: "http:support",
+        origin: "http",
+        threadId: "http:support:portal-thread",
+      }),
+    }))
+  })
+
+  it("returns a validation error for malformed AI SDK chat requests", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatFetchHandler } = await import("../src/server.ts")
+    const handler = defineAgentChatFetchHandler(defineAgent({
+      capabilities: [chat()],
+      run: () => "unused",
+    }) as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({ text: "hello" }),
+      method: "POST",
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Agent chat payload requires a messages array.",
+    })
+  })
+
+  it("rejects client-provided identity on generated AI SDK chat routes", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgentChatFetchHandler } = await import("../src/server.ts")
+    const handler = defineAgentChatFetchHandler(defineAgent({
+      capabilities: [chat()],
+      run: () => "unused",
+    }) as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        messages: [{
+          id: "user-1",
+          parts: [{ text: "hello", type: "text" }],
+          role: "user",
+        }],
+        user: { id: "spoofed" },
+      }),
+      method: "POST",
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Agent chat route identity must be derived server-side with defineAgent({ invoker }).",
     })
   })
 


### PR DESCRIPTION
Rebases the generated AI SDK chat route work onto current `main` so consumers can use a single pkg.pr.new build with the latest workspace-scope API.

This keeps the route generation changes from #318, but avoids the stale package build that passed `selectedWorkspaceScope.name` instead of the current `selectedWorkspaceScope.scope` shape.

Validated with `pnpm --filter @vite-hub/agent test`.