### PR TITLE
feat: support harness workspace sessions

### DIFF
--- a/.agents/adr/0063-flue-comparison-keeps-vitehub-harness-boundaries.md
+++ b/.agents/adr/0063-flue-comparison-keeps-vitehub-harness-boundaries.md
@@ -1,0 +1,9 @@
+# Flue Comparison Keeps ViteHub Harness Boundaries
+
+Flue's collapsed root config shape was useful comparison material, but ViteHub should not copy root `tools`, `skills`, or `sandbox` fields into Agent Definitions.
+
+ViteHub keeps harness-backed execution in the **Agent Driver** boundary: `defineAgent({ driver: { harness, sandbox?, credentials? }, workspace, capabilities })`. The **Agent Package** adapts the harness and owns **Harness Permission Policy**. The **Workspace Package** owns Harness Workspace Session preparation and sync back through Workspace rules. Capabilities remain the place where tools and Skills are enabled, including `.agents/skills/` through `skills()` when a developer opts into that Capability.
+
+The consequence is a slightly more explicit public API than Flue's collapsed shape, but the ownership lines stay inspectable by agents: harness execution is an Agent Driver concern, file state is a Workspace concern, and optional product abilities are Capability concerns.
+
+Deferred: automatic discovery of `.agents/skills/` may be added behind `skills()` if the Capability needs it. It should not become a root Agent Definition field.

--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -233,6 +233,7 @@ _Avoid_: Fake agent, dummy model, test bot
 ## Flagged Ambiguities
 
 - Raw tools were considered as top-level Agent Definition fields - resolved: tools are contributed by Capabilities.
+- Flue-style root `tools`, `skills`, and `sandbox` fields were considered for harness-backed Agents - resolved: keep `sandbox` under the harness-backed **Agent Driver**, and keep tools or Skills behind Capabilities.
 - Multi-adapter support was considered part of Agent Definition shape - resolved: use one **Agent Driver** boundary rather than public adapter selectors.
 - Top-level `model` and `harness` selectors were considered part of Agent Definition shape - resolved: select model-backed or harness-backed execution through **Agent Driver**.
 - Driver factory wrappers such as `modelDriver()` and `harnessDriver()` were considered for explicitness - resolved: configure the **Agent Driver** as a single object variant and distinguish variants by exclusive keys.

--- a/.agents/contexts/packages/agent/CONTEXT.md
+++ b/.agents/contexts/packages/agent/CONTEXT.md
@@ -87,6 +87,7 @@ _Avoid_: Root Agent Package export, generated adapter barrel, upstream package m
 - The **Agent Package** should allow harness-backed Agent Drivers to produce Agent Usage Records without token counts when the harness reports non-token usage details.
 - The **Agent Package** should preserve raw provider- or harness-reported usage details and the resolved Harness Credential Source label when available without exposing secrets.
 - The **Agent Package** coordinates scoped Workspace Session preparation for harness-backed Agent Drivers through the Workspace Package boundary.
+- The **Agent Package** does not copy Flue-style root `tools`, `skills`, or `sandbox` fields; harness sandbox setup stays under `driver`, and tools or Skills stay Capability-owned.
 - The **Agent Package** resolves explicit Harness Session Keys for harness-backed Agent Drivers and does not infer durable harness reuse from chat or thread metadata by default.
 - An **Agent Driver Boundary** is configured as one object on the Agent Definition, with exactly one concrete driver key such as `model`, `harness`, or `run`.
 - The concrete **Agent Driver Boundary** key holds the implementation value directly; driver-specific options are sibling fields on the same driver object.

--- a/.agents/contexts/packages/workspace/CONTEXT.md
+++ b/.agents/contexts/packages/workspace/CONTEXT.md
@@ -36,6 +36,10 @@ _Avoid_: Source Definition, Source Loader, provider adapter
 The Workspace Package authoring input that normalizes into a Workspace Source Binding.
 _Avoid_: Source Definition, Source Loader options only, provider namespace
 
+**Harness Workspace Session Preparation**:
+The Workspace Package helper that materializes selected Workspace files into a harness sandbox and syncs write-mode additions or updates back through Workspace rules.
+_Avoid_: Agent Package file copier, harness checkout, root sandbox config
+
 ## Relationships
 
 - The **Workspace Package** owns **Workspace Definitions**.
@@ -54,6 +58,8 @@ _Avoid_: Source Definition, Source Loader options only, provider namespace
 - A Workspace Store can be backed by a **Workspace Provider Adapter**.
 - The **Workspace Runtime Surface** enforces Workspace Rules before writes reach the store.
 - The **Workspace Runtime Surface** may expose Source Sync without making normal Workspace reads run Source Sync.
+- The **Workspace Package** owns **Harness Workspace Session Preparation** for harness-backed Agent Drivers.
+- **Harness Workspace Session Preparation** is consumed by the Agent Package; it is not an app-level sandbox workflow surface.
 - Source Sync on the **Workspace Runtime Surface** requires explicit Source selection.
 - The **Workspace Runtime Surface** exposes Source Sync through the Workspace sync lifecycle rather than a separate public Source Sync method.
 - The Workspace sync lifecycle on the **Workspace Runtime Surface** requires explicit selection.
@@ -100,3 +106,4 @@ _Avoid_: Source Definition, Source Loader options only, provider namespace
 - Requiring Workspace authors to choose between a binding object and a Source helper call was considered - resolved: Workspace Source Binding Inputs may infer common Source Loaders from unambiguous plain objects and may still reference reusable or custom Source Definitions.
 - Allowing ambiguous Workspace Source Binding Inputs was considered - resolved: prevent ambiguity with strong TypeScript types and reject remaining ambiguity during runtime normalization.
 - Adding project-specific file consumers to the Workspace Package was considered - resolved: Workspace Package owns durable file-tree primitives, not downstream project consumption of those files.
+- Copying Flue's collapsed harness shape into the Workspace Package was considered - resolved: Workspace owns materialization and writeback only; Agent Driver and Capability shape stay with the Agent Package.

--- a/.agents/contexts/packages/workspace/CONTEXT.md
+++ b/.agents/contexts/packages/workspace/CONTEXT.md
@@ -37,7 +37,7 @@ The Workspace Package authoring input that normalizes into a Workspace Source Bi
 _Avoid_: Source Definition, Source Loader options only, provider namespace
 
 **Harness Workspace Session Preparation**:
-The Workspace Package helper that materializes selected Workspace files into a harness sandbox and syncs write-mode additions or updates back through Workspace rules.
+The Workspace Package helper that materializes selected Workspace files into a harness sandbox and syncs write-mode additions, updates, or deletions back through Workspace rules.
 _Avoid_: Agent Package file copier, harness checkout, root sandbox config
 
 ## Relationships

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -12,11 +12,19 @@ The Workspace is the file boundary. Capabilities decide which model-facing tools
 ## Colocate workspace context
 
 ```ts [server/agents/docs/config.ts]
+import { gateway } from '@ai-sdk/gateway'
 import { defineAgent } from '@vite-hub/agent'
 import { workspaceShell } from '@vite-hub/agent/capabilities'
 import { source } from '@vite-hub/workspace'
 
 export default defineAgent({
+  driver: {
+    model: gateway('openai/gpt-5.1-mini'),
+    instructions: [
+      'Answer from the docs workspace. Say when the answer is not present.',
+      '{{ workspace.sources }}',
+    ],
+  },
   workspace: {
     sources: {
       docs: source.glob({
@@ -32,8 +40,6 @@ export default defineAgent({
   capabilities: [
     workspaceShell({ mode: 'read' }),
   ],
-  instructions: 'Answer from the docs workspace. Say when the answer is not present.',
-  model,
 })
 ```
 
@@ -50,6 +56,36 @@ Only visible sources render. When `access()` selects a Workspace Scope, hidden o
 Start with read mode. It gives the model enough visibility to inspect files without writing changes.
 
 Use write mode only when the Agent is explicitly supposed to mutate Workspace files and the Workspace rules allow the target paths.
+
+## Harness Workspace Sessions
+
+Harness-backed Agent Drivers receive Workspace state through a Harness Workspace Session instead of model-facing Workspace Tools by default.
+
+```ts [server/agents/review/config.ts]
+import { createCodex } from '@ai-sdk/harness-codex'
+import { defineAgent } from '@vite-hub/agent'
+import { skills } from '@vite-hub/agent/capabilities'
+import { source } from '@vite-hub/workspace'
+
+export default defineAgent({
+  driver: {
+    harness: createCodex({
+      model: 'gpt-5.5',
+    }),
+  },
+  workspace: {
+    mode: 'write',
+    sources: {
+      guide: source.file('AGENTS.md'),
+    },
+  },
+  capabilities: [
+    skills({ path: '.agents/skills/review' }),
+  ],
+})
+```
+
+Read mode materializes the selected Workspace into the harness sandbox and discards sandbox changes. Write mode syncs additions and updates back through Workspace rules. Keep Skills behind the `skills()` Capability; ViteHub does not add root `skills`, `tools`, or `sandbox` Agent Definition fields for harness-backed Agents. Put harness guidance in Workspace files such as `AGENTS.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet.
 
 ## Access scope
 
@@ -132,6 +168,14 @@ export default defineAgent({
       }),
     },
   },
+  driver: {
+    model: gateway('openai/gpt-5.1-mini'),
+    instructions: [
+      'Answer from the scoped customer workspace.',
+      '{{ capabilities.access.workspace }}',
+      '{{ workspace.sources }}',
+    ],
+  },
   capabilities: [
     access({
       workspace: {
@@ -164,12 +208,6 @@ export default defineAgent({
     workspaceShell({ mode: 'read' }),
     supportChat,
   ],
-  instructions: [
-    'Answer from the scoped customer workspace.',
-    '{{ capabilities.access.workspace }}',
-    '{{ workspace.sources }}',
-  ],
-  model: gateway('openai/gpt-5.1-mini'),
 })
 ```
 

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -85,7 +85,7 @@ export default defineAgent({
 })
 ```
 
-Read mode materializes the selected Workspace into the harness sandbox and discards sandbox changes. Write mode syncs additions and updates back through Workspace rules. Keep Skills behind the `skills()` Capability; ViteHub does not add root `skills`, `tools`, or `sandbox` Agent Definition fields for harness-backed Agents. Put harness guidance in Workspace files such as `AGENTS.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet.
+Read mode materializes the selected Workspace into the harness sandbox and discards sandbox changes. Write mode syncs additions, updates, and deletions back through Workspace rules. Keep Skills behind the `skills()` Capability; ViteHub does not add root `skills`, `tools`, or `sandbox` Agent Definition fields for harness-backed Agents. Put harness guidance in Workspace files such as `AGENTS.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet.
 
 ## Access scope
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -65,6 +65,8 @@ Harness-backed agents use AI SDK `HarnessAgent` behind the ViteHub Agent Driver 
 // server/agents/codex/config.ts
 import { createCodex } from "@ai-sdk/harness-codex"
 import { defineAgent } from "@vite-hub/agent"
+import { skills } from "@vite-hub/agent/capabilities"
+import { source } from "@vite-hub/workspace"
 
 export default defineAgent({
   driver: {
@@ -74,10 +76,19 @@ export default defineAgent({
     }),
     credentials: { label: "local Codex", source: "ambient" },
   },
+  workspace: {
+    mode: "write",
+    sources: {
+      guide: source.file("AGENTS.md"),
+    },
+  },
+  capabilities: [
+    skills({ path: ".agents/skills/review" }),
+  ],
 })
 ```
 
-`driver.harness` is the AI SDK harness adapter instance. `driver.sandbox` can provide an AI SDK sandbox provider; when omitted, ViteHub uses the AI SDK Vercel Sandbox default for bridge-backed harnesses. V1 configures built-in harness permissions internally with the no-approval policy and does not expose a public permission option.
+`driver.harness` is the AI SDK harness adapter instance. `driver.sandbox` can provide an AI SDK sandbox provider; when omitted, ViteHub uses the AI SDK Vercel Sandbox default for bridge-backed harnesses. Workspace-backed harness drivers receive a Harness Workspace Session prepared from the selected Workspace. Read mode materializes files and discards sandbox changes; write mode syncs additions and updates back through Workspace rules. V1 configures built-in harness permissions internally with the no-approval policy and does not expose a public permission option. Skills stay a Capability through `skills()` rather than becoming a root Agent Definition field. Put harness guidance in Workspace files such as `AGENTS.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet.
 
 ```ts
 // vite.config.ts

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -88,7 +88,7 @@ export default defineAgent({
 })
 ```
 
-`driver.harness` is the AI SDK harness adapter instance. `driver.sandbox` can provide an AI SDK sandbox provider; when omitted, ViteHub uses the AI SDK Vercel Sandbox default for bridge-backed harnesses. Workspace-backed harness drivers receive a Harness Workspace Session prepared from the selected Workspace. Read mode materializes files and discards sandbox changes; write mode syncs additions and updates back through Workspace rules. V1 configures built-in harness permissions internally with the no-approval policy and does not expose a public permission option. Skills stay a Capability through `skills()` rather than becoming a root Agent Definition field. Put harness guidance in Workspace files such as `AGENTS.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet.
+`driver.harness` is the AI SDK harness adapter instance. `driver.sandbox` can provide an AI SDK sandbox provider; when omitted, ViteHub uses the AI SDK Vercel Sandbox default for bridge-backed harnesses. Workspace-backed harness drivers receive a Harness Workspace Session prepared from the selected Workspace. Read mode materializes files and discards sandbox changes; write mode syncs additions, updates, and deletions back through Workspace rules. V1 configures built-in harness permissions internally with the no-approval policy and does not expose a public permission option. Skills stay a Capability through `skills()` rather than becoming a root Agent Definition field. Put harness guidance in Workspace files such as `AGENTS.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet.
 
 ```ts
 // vite.config.ts

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -51,7 +51,6 @@ function assertSupportedHarnessDriverContributions(context: AgentAdapterRunConte
     hasEntries(context.tools) ? "Capability tools" : undefined,
     context.providerTools?.length ? "provider tools" : undefined,
     context.capabilityInstructions?.length ? "Capability instructions" : undefined,
-    context.sourceInstructions ? "Workspace Source Instructions" : undefined,
   ].filter((value): value is string => Boolean(value))
 
   if (unsupported.length) {

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -47,10 +47,6 @@ function hasEntries(value: unknown): value is Record<string, unknown> {
 }
 
 function assertSupportedHarnessDriverContributions(context: AgentAdapterRunContext) {
-  if (context.workspace) {
-    throw new Error("[vitehub] Harness Agent Drivers with workspace are not supported until ViteHub can prepare a Harness Workspace Session for the selected Workspace Scope.")
-  }
-
   const unsupported = [
     hasEntries(context.tools) ? "Capability tools" : undefined,
     context.providerTools?.length ? "provider tools" : undefined,
@@ -152,12 +148,16 @@ async function createHarnessAgent<
 >(
   options: HarnessAgentAdapterOptions<TRuntimeConfig, CALL_OPTIONS>,
   context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>,
+  prepareWorkspaceSession: (session: unknown, sessionWorkDir: string, abortSignal: AbortSignal | undefined) => Promise<void>,
 ): Promise<HarnessAgentLike> {
   assertSupportedHarnessDriverContributions(context)
   const { HarnessAgent } = await import("@ai-sdk/harness/agent") as unknown as { HarnessAgent: HarnessAgentConstructor }
   const sandbox = await resolveHarnessSandbox(options.sandbox, context)
   return new HarnessAgent({
     harness: options.harness,
+    onSandboxSession: async ({ abortSignal, session, sessionWorkDir }: { abortSignal?: AbortSignal, session: unknown, sessionWorkDir: string }) => {
+      await prepareWorkspaceSession(session, sessionWorkDir, abortSignal)
+    },
     permissionMode: "allow-all",
     sandbox,
   })
@@ -242,7 +242,11 @@ export function createHarnessAgentAdapter<
   const resumeStates = getResumeStates(options)
   const usageMetadata = createHarnessUsageMetadata(options.credentials)
 
-  async function createSession(agent: HarnessAgentLike, context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>) {
+  async function createSession(
+    agent: HarnessAgentLike,
+    context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>,
+    getWorkspaceSession: () => { close: (error?: unknown) => MaybePromise<void> } | undefined,
+  ) {
     const sessionId = await resolveHarnessSessionKey(options.sessionKey, context)
     const resumeFrom = sessionId ? resumeStates.get(sessionId) : undefined
     const session = await agent.createSession(sessionId
@@ -252,9 +256,17 @@ export function createHarnessAgentAdapter<
         }
       : undefined)
     const cleanup = async (error?: unknown) => {
-      if (!sessionId || error) {
+      let closeError = error
+      try {
+        await getWorkspaceSession()?.close(error)
+      }
+      catch (nextError) {
+        closeError = nextError
+      }
+      if (!sessionId || closeError) {
         if (sessionId) resumeStates.delete(sessionId)
         await destroySession(session)
+        if (closeError !== error) throw closeError
         return
       }
       if (!hasDetach(session)) {
@@ -264,13 +276,32 @@ export function createHarnessAgentAdapter<
       }
       resumeStates.set(sessionId, await session.detach())
     }
-    return { cleanup, session }
+    return {
+      cleanup,
+      session,
+    }
+  }
+
+  async function createAgentAndSession(context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>) {
+    let workspaceSession: { close: (error?: unknown) => MaybePromise<void> } | undefined
+    const agent = await createHarnessAgent(options, context, async (session, sessionWorkDir, abortSignal) => {
+      if (!context.workspace) return
+      const { prepareHarnessWorkspaceSession } = await import("@vite-hub/workspace")
+      workspaceSession = await prepareHarnessWorkspaceSession(context.workspace, {
+        abortSignal,
+        session: session as never,
+        sessionWorkDir,
+      })
+    })
+    return {
+      agent,
+      ...await createSession(agent, context, () => workspaceSession),
+    }
   }
 
   return {
     async generate(context) {
-      const agent = await createHarnessAgent(options, context)
-      const { cleanup, session } = await createSession(agent, context)
+      const { agent, cleanup, session } = await createAgentAndSession(context)
       try {
         const result = defineAgentUsageMetadata(await agent.generate({
           ...toHarnessCallInput(context),
@@ -286,8 +317,7 @@ export function createHarnessAgentAdapter<
     },
     name: "ai-sdk-harness",
     async stream(context) {
-      const agent = await createHarnessAgent(options, context)
-      const { cleanup, session } = await createSession(agent, context)
+      const { agent, cleanup, session } = await createAgentAndSession(context)
       try {
         const result = defineAgentUsageMetadata(await agent.stream({
           ...toHarnessCallInput(context),

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -7,6 +7,7 @@ import {
 } from "./capability-runtime.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
 import {
+  defineWorkspace,
   getWorkspaceSourceRequestDescriptor,
   isWorkspaceSourceRequestOnly,
   workspaceSourceRequestDescriptorPath,
@@ -134,7 +135,11 @@ export function workspaceDefinitionFromOptions<
 >(
   options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
 ): WorkspaceAgentWorkspaceOptions {
-  return typeof options.workspace === "string" ? { mode: "read" } : options.workspace
+  if (typeof options.workspace === "string") return { mode: "read" }
+  const workspace = normalizeWorkspaceOptions(options.workspace)
+  const { mode: _mode, ...definition } = workspace
+  defineWorkspace(definition as never)
+  return workspace
 }
 
 function workspaceDefinitionWithNameFromOptions<

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -24,6 +24,7 @@ const agentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
 const agentGenerate = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ finishReason: string, text: string, usage?: unknown, warnings?: unknown }>>(async () => ({ finishReason: "stop", text: "ok" })))
 
 vi.mock("@vite-hub/workspace", () => ({
+  defineWorkspace: vi.fn(definition => definition),
   useWorkspace: vi.fn(() => ({
     fs: { list, readFile },
     tools: {

--- a/packages/agent/test/test-runner.test.ts
+++ b/packages/agent/test/test-runner.test.ts
@@ -21,6 +21,7 @@ vi.mock("ai", () => ({
 }))
 
 vi.mock("@vite-hub/workspace", () => ({
+  defineWorkspace: vi.fn(definition => definition),
   useWorkspace: vi.fn(() => ({
     fs: { list, readFile },
     tools: {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -34,6 +34,20 @@ const agentStream = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ ful
     yield { text: "ok", type: "text-delta" }
   })(),
 })))
+const harnessAgentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
+const harnessSandboxSession = vi.hoisted(() => ({
+  readBinaryFile: vi.fn(),
+  run: vi.fn(),
+  writeBinaryFile: vi.fn(),
+}))
+const harnessCreateSession = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ destroy: () => unknown }>>(async () => ({ destroy: vi.fn() })))
+const harnessGenerate = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ finishReason: string, text: string }>>(async () => ({ finishReason: "stop", text: "ok" })))
+const harnessStream = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ fullStream: AsyncIterable<unknown> }>>(async () => ({
+  fullStream: (async function* () {
+    yield { text: "ok", type: "text-delta" }
+  })(),
+})))
+const prepareHarnessWorkspaceSession = vi.fn()
 
 vi.mock("ai", () => ({
   generateText,
@@ -54,6 +68,33 @@ vi.mock("ai", () => ({
   },
 }))
 
+vi.mock("@ai-sdk/harness/agent", () => ({
+  HarnessAgent: class {
+    constructor(public settings: Record<string, unknown>) {
+      harnessAgentSettings.push(settings)
+    }
+
+    async createSession(...args: unknown[]) {
+      const session = await harnessCreateSession.apply(this, args)
+      const options = args[0] as { abortSignal?: AbortSignal } | undefined
+      await (this.settings.onSandboxSession as ((input: Record<string, unknown>) => Promise<void>) | undefined)?.({
+        abortSignal: options?.abortSignal,
+        session: harnessSandboxSession,
+        sessionWorkDir: "/workspace/codex-session",
+      })
+      return session
+    }
+
+    async generate(...args: unknown[]) {
+      return await harnessGenerate.apply(this, args)
+    }
+
+    async stream(...args: unknown[]) {
+      return await harnessStream.apply(this, args)
+    }
+  },
+}))
+
 vi.mock("@vite-hub/workspace", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@vite-hub/workspace")>()
   return {
@@ -62,6 +103,7 @@ vi.mock("@vite-hub/workspace", async (importOriginal) => {
     createWorkspaceTools,
     getWorkspaceSourceRequestDescriptor,
     isWorkspaceSourceRequestOnly,
+    prepareHarnessWorkspaceSession,
     resolveWorkspaceAutoCommit,
     workspaceSourceRequestDescriptorPath,
     useWorkspace,
@@ -92,6 +134,21 @@ function readonlyWorkspaceFacade(): ReadonlyWorkspaceFacade {
 describe("defineAgent workspace option", () => {
   beforeEach(() => {
     agentSettings.length = 0
+    harnessAgentSettings.length = 0
+    harnessCreateSession.mockReset()
+    harnessCreateSession.mockResolvedValue({ destroy: vi.fn() })
+    harnessGenerate.mockReset()
+    harnessGenerate.mockResolvedValue({ finishReason: "stop", text: "ok" })
+    harnessStream.mockReset()
+    harnessStream.mockResolvedValue({
+      fullStream: (async function* () {
+        yield { text: "ok", type: "text-delta" }
+      })(),
+    })
+    harnessSandboxSession.readBinaryFile.mockReset()
+    harnessSandboxSession.run.mockReset()
+    harnessSandboxSession.writeBinaryFile.mockReset()
+    prepareHarnessWorkspaceSession.mockReset()
     agentGenerate.mockReset()
     agentGenerate.mockResolvedValue({ finishReason: "stop", text: "ok" })
     agentStream.mockReset()
@@ -190,8 +247,12 @@ describe("defineAgent workspace option", () => {
     expect(useWorkspace).not.toHaveBeenCalled()
   })
 
-  it("rejects harness-backed workspace agents until Harness Workspace Sessions are available", async () => {
+  it("prepares Harness Workspace Sessions for workspace-backed harness Agent Drivers", async () => {
     const { defineAgent, runAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const harnessSession = { destroy: vi.fn() }
+    const harnessWorkspaceSession = { close: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(harnessSession)
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withWorkspaceAgentDefaults(defineAgent({
       driver: {
@@ -201,8 +262,28 @@ describe("defineAgent workspace option", () => {
       workspace: {},
     }), { workspace: "docs" })
 
-    await expect(runAgent(agent, context(), { prompt: "hello" })).rejects.toThrow("Harness Agent Drivers with workspace")
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
     expect(useWorkspace).toHaveBeenCalledWith("docs")
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
+      abortSignal: undefined,
+      session: harnessSandboxSession,
+      sessionWorkDir: "/workspace/codex-session",
+    })
+    expect(harnessAgentSettings.at(-1)).toMatchObject({
+      harness: { provider: "codex" },
+      permissionMode: "allow-all",
+      sandbox: { provider: "sandbox" },
+    })
+    expect(harnessGenerate).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: "hello",
+      session: harnessSession,
+    }))
+    expect(harnessWorkspaceSession.close).toHaveBeenCalledWith(undefined)
+    expect(harnessSession.destroy).toHaveBeenCalledOnce()
   })
 
   it("auto-commits write-mode workspace changes when rules request it", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -247,19 +247,38 @@ describe("defineAgent workspace option", () => {
     expect(useWorkspace).not.toHaveBeenCalled()
   })
 
+  it("rejects unknown colocated Workspace Definition options", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+
+    expect(() => defineAgent({
+      model: {} as never,
+      workspace: {
+        stroe: { provider: "memory" },
+      } as never,
+    })).toThrow("[vitehub] defineWorkspace does not support option: stroe.")
+  })
+
   it("prepares Harness Workspace Sessions for workspace-backed harness Agent Drivers", async () => {
     const { defineAgent, runAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
     const harnessSession = { destroy: vi.fn() }
     const harnessWorkspaceSession = { close: vi.fn() }
     harnessCreateSession.mockResolvedValueOnce(harnessSession)
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+    exists.mockResolvedValue(true)
 
     const agent = withWorkspaceAgentDefaults(defineAgent({
       driver: {
         harness: { provider: "codex" },
         sandbox: { provider: "sandbox" },
       },
-      workspace: {},
+      workspace: {
+        sources: {
+          guide: {
+            instructions: "Use this guide for operating rules.",
+            path: "AGENTS.md",
+          },
+        },
+      },
     }), { workspace: "docs" })
 
     await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -97,6 +97,8 @@ export default defineConfig({
 
 Need the workspace to run generated code instead of only reading and writing files? Pair it with [`@vite-hub/sandbox`](../sandbox/README.md) so sessions can execute inside an isolated provider runtime.
 
+Harness-backed Agents use the Workspace Package to prepare Harness Workspace Sessions for `defineAgent({ driver: { harness }, workspace })`. The Agent Package keeps the harness inside the Agent Driver boundary, Capabilities keep tools and Skills opt-in, and Workspace owns materializing selected files plus write-mode sync back through Workspace rules.
+
 ## Vite Integration
 
 Use `hubWorkspace()` in Vite to discover workspace definitions, emit the workspace manifest for local development, and make the runtime store available to server code.

--- a/packages/workspace/src/config.ts
+++ b/packages/workspace/src/config.ts
@@ -10,6 +10,13 @@ import type {
 } from "./core/types.ts"
 import type { WorkspaceResolutionInput } from "./storage/provider.ts"
 
+const workspaceConfigKeys = new Set([
+  "assets",
+  "projectRoot",
+  "root",
+  "store",
+])
+
 export {
   MASKED_WORKSPACE_RUNTIME_VALUE,
   hasVercelWorkspaceBlobEnv,
@@ -31,6 +38,11 @@ export function normalizeWorkspaceOptions(
   }
 
   const resolvedOptions = (options || {}) as WorkspaceModuleOptions
+  const unsupported = Object.keys(resolvedOptions).filter(key => !workspaceConfigKeys.has(key))
+  if (unsupported.length) {
+    throw new TypeError(`[vitehub] workspace config does not support option${unsupported.length === 1 ? "" : "s"}: ${unsupported.join(", ")}.`)
+  }
+
   const rootDir = input.rootDir || process.cwd()
   const root = resolvedOptions.root || ".vitehub/workspaces"
   return {

--- a/packages/workspace/src/core/define.ts
+++ b/packages/workspace/src/core/define.ts
@@ -1,5 +1,24 @@
 import type { WorkspaceDefinitionInput } from "./types.ts"
 
+const workspaceDefinitionKeys = new Set([
+  "hooks",
+  "loaders",
+  "plugins",
+  "publish",
+  "rootDir",
+  "rules",
+  "runtime",
+  "sourceRootDir",
+  "sources",
+  "store",
+])
+
+function assertWorkspaceDefinitionKeys(definition: WorkspaceDefinitionInput): void {
+  const unsupported = Object.keys(definition).filter(key => !workspaceDefinitionKeys.has(key))
+  if (!unsupported.length) return
+  throw new TypeError(`[vitehub] defineWorkspace does not support option${unsupported.length === 1 ? "" : "s"}: ${unsupported.join(", ")}.`)
+}
+
 export function defineWorkspace(definition: WorkspaceDefinitionInput): WorkspaceDefinitionInput {
   if (!definition || typeof definition !== "object") {
     throw new TypeError("[vitehub] defineWorkspace requires a workspace definition.")
@@ -7,5 +26,6 @@ export function defineWorkspace(definition: WorkspaceDefinitionInput): Workspace
   if ("name" in definition) {
     throw new TypeError("[vitehub] Workspace names are inferred from definition filenames.")
   }
+  assertWorkspaceDefinitionKeys(definition)
   return definition
 }

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -169,6 +169,7 @@ export interface ExecResult {
 export interface WorkspaceSession {
   readFile<TOptions extends ReadFileOptions | undefined = undefined>(path: string, options?: TOptions): Promise<ReadFileResult<TOptions>>
   writeFile(path: string, content: WorkspaceContent, options?: WriteFileOptions): Promise<void>
+  rm(path: string, options?: RmOptions): Promise<void>
   list(path?: string, options?: ListOptions): Promise<WorkspaceEntry[]>
   glob(pattern: string | string[], options?: GlobOptions): Promise<WorkspaceEntry[]>
   search(query: WorkspaceSearchQuery): Promise<WorkspaceSearchHit[]>

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -169,6 +169,7 @@ export interface ExecResult {
 export interface WorkspaceSession {
   readFile<TOptions extends ReadFileOptions | undefined = undefined>(path: string, options?: TOptions): Promise<ReadFileResult<TOptions>>
   writeFile(path: string, content: WorkspaceContent, options?: WriteFileOptions): Promise<void>
+  mkdir(path: string, options?: MkdirOptions): Promise<void>
   rm(path: string, options?: RmOptions): Promise<void>
   list(path?: string, options?: ListOptions): Promise<WorkspaceEntry[]>
   glob(pattern: string | string[], options?: GlobOptions): Promise<WorkspaceEntry[]>

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -15,6 +15,14 @@ export {
   attachWorkspaceSourceRequestExecution,
   getWorkspaceSourceRequestExecution,
 } from "./sources/request-execution.ts"
+export {
+  prepareHarnessWorkspaceSession,
+} from "./session/harness.ts"
+export type {
+  HarnessSandboxSession,
+  HarnessWorkspaceSession,
+  PrepareHarnessWorkspaceSessionOptions,
+} from "./session/harness.ts"
 export type {
   WorkspaceSourceResolutionFacade,
   WorkspaceSourceResolutionOptions,

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -1,9 +1,11 @@
+import { useWorkspaceAssets } from "./asset-registry.ts"
+import { WorkspaceNotFoundError } from "./core/errors.ts"
 import { files as filesLoader } from "./loaders/files.ts"
 import { normalizeWorkspacePath } from "./core/path.ts"
 import { createSourceContext, normalizeWorkspaceSources, type ResolvedWorkspaceSource } from "./sources/config.ts"
 import { createWorkspaceStoreFromProvider } from "./storage/provider.ts"
 
-import type { LoaderContext, WorkspaceDefinition, WorkspaceLoaderSource, WorkspaceSnapshot, WorkspaceStore } from "./core/types.ts"
+import type { LoaderContext, WorkspaceAssets, WorkspaceDefinition, WorkspaceLoaderSource, WorkspaceSnapshot, WorkspaceStore } from "./core/types.ts"
 
 const buildSourcesMetaKey = "workspace:build-sources"
 
@@ -34,6 +36,11 @@ export async function syncWorkspaceDefinition(definition: WorkspaceDefinition, s
   const buildSources = normalizeWorkspaceSources(definition.sources)
     .filter(source => source.materialize === "build")
   const hasBuildSourceState = await reconcileBuildSourceMounts(store, buildSources)
+  if (!hasExplicitLoaders && await syncRuntimeBuildAssets(definition, store, buildSources)) {
+    const snapshot = await store.snapshot({ name: "sync" })
+    await publishWorkspaceSnapshot(definition, store, snapshot)
+    return
+  }
   if (!hasBuildSourceState && !hasExplicitLoaders) return
 
   const normalizedSources = buildSources.map(source => createMountedBuildSource(source))
@@ -76,6 +83,38 @@ async function reconcileBuildSourceMounts(store: WorkspaceStore, currentSources:
 
   await store.setMeta?.(buildSourcesMetaKey, currentSources.map(({ key, mountPath }) => ({ key, mountPath })))
   return hasBuildSourceState
+}
+
+async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: WorkspaceStore, currentSources: ResolvedWorkspaceSource[]): Promise<boolean> {
+  if (!currentSources.length) return false
+
+  let assets: WorkspaceAssets
+  try {
+    assets = useWorkspaceAssets(definition.name)
+  }
+  catch (error) {
+    if (error instanceof WorkspaceNotFoundError) return false
+    throw error
+  }
+
+  const entries = await assets.list("", { recursive: true })
+  const files = entries.filter(entry => entry.type === "file")
+  for (const entry of files) {
+    const source = findBuildSourceForPath(entry.path, currentSources)
+    await store.writeFile(entry.path, {
+      path: entry.path,
+      content: await assets.readFile(entry.path, { encoding: "binary" }),
+      mediaType: entry.mediaType,
+      metadata: source ? { source: source.key } : undefined,
+    })
+  }
+  return true
+}
+
+function findBuildSourceForPath(path: string, sources: ResolvedWorkspaceSource[]): ResolvedWorkspaceSource | undefined {
+  return sources
+    .filter(source => !source.mountPath || path === source.mountPath || path.startsWith(`${source.mountPath}/`))
+    .sort((left, right) => right.mountPath.length - left.mountPath.length)[0]
 }
 
 async function readSyncedBuildSources(store: WorkspaceStore): Promise<SyncedBuildSource[]> {

--- a/packages/workspace/src/session/basic.ts
+++ b/packages/workspace/src/session/basic.ts
@@ -10,6 +10,7 @@ export function createBasicWorkspaceSession(workspace: Workspace): WorkspaceSess
   return {
     readFile: workspace.readFile,
     writeFile: workspace.writeFile,
+    mkdir: workspace.mkdir,
     rm: workspace.rm,
     list: workspace.list,
     glob: workspace.glob,

--- a/packages/workspace/src/session/basic.ts
+++ b/packages/workspace/src/session/basic.ts
@@ -10,6 +10,7 @@ export function createBasicWorkspaceSession(workspace: Workspace): WorkspaceSess
   return {
     readFile: workspace.readFile,
     writeFile: workspace.writeFile,
+    rm: workspace.rm,
     list: workspace.list,
     glob: workspace.glob,
     search: workspace.search,

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -1,0 +1,141 @@
+import { posix } from "node:path"
+
+import type {
+  ReadonlyWorkspaceFacade,
+  WritableWorkspaceFacade,
+} from "../core/use.ts"
+import type {
+  WorkspaceEntry,
+  WorkspaceSession,
+} from "../core/types.ts"
+
+export interface HarnessSandboxSession {
+  readBinaryFile?(options: { abortSignal?: AbortSignal, path: string }): PromiseLike<Uint8Array | null>
+  run?(options: { abortSignal?: AbortSignal, command: string, workingDirectory?: string }): PromiseLike<{ exitCode: number, stderr: string, stdout: string }>
+  writeBinaryFile(options: { abortSignal?: AbortSignal, content: Uint8Array, path: string }): PromiseLike<void>
+}
+
+export interface HarnessWorkspaceSession {
+  close(error?: unknown): Promise<void>
+}
+
+export interface PrepareHarnessWorkspaceSessionOptions {
+  abortSignal?: AbortSignal
+  session: HarnessSandboxSession
+  sessionWorkDir: string
+}
+
+type WorkspaceFacade = ReadonlyWorkspaceFacade | WritableWorkspaceFacade
+
+function isWritableWorkspaceFacade(workspace: WorkspaceFacade): workspace is WritableWorkspaceFacade {
+  return "startSession" in workspace && typeof workspace.startSession === "function"
+}
+
+function sandboxPath(root: string, path: string) {
+  return posix.join(root, path)
+}
+
+function workspaceFiles(entries: WorkspaceEntry[]) {
+  return entries
+    .filter(entry => entry.type === "file")
+    .map(entry => entry.path)
+    .sort((left, right) => left.localeCompare(right))
+}
+
+function bytesEqual(left: Uint8Array | undefined, right: Uint8Array) {
+  if (!left || left.byteLength !== right.byteLength) return false
+  for (let index = 0; index < left.byteLength; index++) {
+    if (left[index] !== right[index]) return false
+  }
+  return true
+}
+
+function pathsFromFindOutput(stdout: string) {
+  return stdout
+    .split("\n")
+    .map(path => path.trim())
+    .filter(Boolean)
+    .map(path => path.replace(/^\.\//, ""))
+    .filter(path => path && path !== ".")
+    .sort((left, right) => left.localeCompare(right))
+}
+
+async function copyWorkspaceToSandbox(
+  workspace: WorkspaceFacade,
+  sandbox: HarnessSandboxSession,
+  sessionWorkDir: string,
+  abortSignal: AbortSignal | undefined,
+) {
+  const files = workspaceFiles(await workspace.fs.list("", { recursive: true }))
+  const initialFiles = new Map<string, Uint8Array>()
+  for (const path of files) {
+    const content = await workspace.fs.readFile(path, { encoding: "binary" })
+    initialFiles.set(path, content)
+    await sandbox.writeBinaryFile({
+      abortSignal,
+      content,
+      path: sandboxPath(sessionWorkDir, path),
+    })
+  }
+  return initialFiles
+}
+
+async function copySandboxChangesToWorkspace(
+  session: WorkspaceSession,
+  sandbox: HarnessSandboxSession,
+  sessionWorkDir: string,
+  initialFiles: Map<string, Uint8Array>,
+  abortSignal: AbortSignal | undefined,
+) {
+  if (!sandbox.run || !sandbox.readBinaryFile) return
+  const result = await sandbox.run({
+    abortSignal,
+    command: "find . -type f -print",
+    workingDirectory: sessionWorkDir,
+  })
+  if (result.exitCode !== 0) {
+    throw new Error(`[vitehub] Failed to inspect Harness Workspace Session files: ${result.stderr || "find failed"}`)
+  }
+
+  for (const path of pathsFromFindOutput(result.stdout)) {
+    const content = await sandbox.readBinaryFile({
+      abortSignal,
+      path: sandboxPath(sessionWorkDir, path),
+    })
+    if (!content || bytesEqual(initialFiles.get(path), content)) continue
+    await session.writeFile(path, content)
+  }
+
+  // ponytail: deletions wait until WorkspaceSession exposes rm; additions and updates still commit through Workspace rules.
+  const diff = await session.diff()
+  if (diff.entries.length) await session.commit({ message: "harness-workspace-session" })
+}
+
+export async function prepareHarnessWorkspaceSession(
+  workspace: WorkspaceFacade,
+  options: PrepareHarnessWorkspaceSessionOptions,
+): Promise<HarnessWorkspaceSession> {
+  const initialFiles = await copyWorkspaceToSandbox(workspace, options.session, options.sessionWorkDir, options.abortSignal)
+  const workspaceSession = isWritableWorkspaceFacade(workspace)
+    ? await workspace.startSession()
+    : undefined
+
+  return {
+    async close(error?: unknown) {
+      try {
+        if (!error && workspaceSession) {
+          await copySandboxChangesToWorkspace(
+            workspaceSession,
+            options.session,
+            options.sessionWorkDir,
+            initialFiles,
+            options.abortSignal,
+          )
+        }
+      }
+      finally {
+        await workspaceSession?.close()
+      }
+    },
+  }
+}

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -1,17 +1,19 @@
 import { posix } from "node:path"
+import { lookup } from "mrmime"
 
 import type {
   ReadonlyWorkspaceFacade,
   WritableWorkspaceFacade,
 } from "../core/use.ts"
 import type {
+  MkdirOptions,
   WorkspaceEntry,
   WorkspaceSession,
 } from "../core/types.ts"
 
 export interface HarnessSandboxSession {
   readBinaryFile?(options: { abortSignal?: AbortSignal, path: string }): PromiseLike<Uint8Array | null>
-  run?(options: { abortSignal?: AbortSignal, command: string, workingDirectory?: string }): PromiseLike<{ exitCode: number, stderr: string, stdout: string }>
+  run(options: { abortSignal?: AbortSignal, command: string, workingDirectory?: string }): PromiseLike<{ exitCode: number, stderr: string, stdout: string }>
   writeBinaryFile(options: { abortSignal?: AbortSignal, content: Uint8Array, path: string }): PromiseLike<void>
 }
 
@@ -26,6 +28,11 @@ export interface PrepareHarnessWorkspaceSessionOptions {
 }
 
 type WorkspaceFacade = ReadonlyWorkspaceFacade | WritableWorkspaceFacade
+type InitialFile = { content: Uint8Array, mediaType?: string }
+type InitialTree = {
+  directories: Set<string>
+  files: Map<string, InitialFile>
+}
 
 function isWritableWorkspaceFacade(workspace: WorkspaceFacade): workspace is WritableWorkspaceFacade {
   return "startSession" in workspace && typeof workspace.startSession === "function"
@@ -35,9 +42,30 @@ function sandboxPath(root: string, path: string) {
   return posix.join(root, path)
 }
 
+function shellQuote(value: string) {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+async function runSandbox(
+  sandbox: HarnessSandboxSession,
+  options: { abortSignal?: AbortSignal, command: string, workingDirectory?: string },
+) {
+  const result = await sandbox.run(options)
+  if (result.exitCode !== 0) {
+    throw new Error(`[vitehub] Failed to prepare Harness Workspace Session: ${result.stderr || "sandbox command failed"}`)
+  }
+  return result
+}
+
 function workspaceFiles(entries: WorkspaceEntry[]) {
   return entries
     .filter(entry => entry.type === "file")
+    .sort((left, right) => left.path.localeCompare(right.path))
+}
+
+function workspaceDirectories(entries: WorkspaceEntry[]) {
+  return entries
+    .filter(entry => entry.type === "directory")
     .map(entry => entry.path)
     .sort((left, right) => left.localeCompare(right))
 }
@@ -60,54 +88,101 @@ function pathsFromFindOutput(stdout: string) {
     .sort((left, right) => left.localeCompare(right))
 }
 
+async function resetSandboxWorkDir(
+  sandbox: HarnessSandboxSession,
+  sessionWorkDir: string,
+  abortSignal: AbortSignal | undefined,
+) {
+  await runSandbox(sandbox, {
+    abortSignal,
+    command: `rm -rf ${shellQuote(sessionWorkDir)} && mkdir -p ${shellQuote(sessionWorkDir)}`,
+  })
+}
+
+async function mkdirSandboxDirectories(
+  sandbox: HarnessSandboxSession,
+  directories: string[],
+  sessionWorkDir: string,
+  abortSignal: AbortSignal | undefined,
+) {
+  if (!directories.length) return
+  await runSandbox(sandbox, {
+    abortSignal,
+    command: `mkdir -p ${directories.map(path => shellQuote(sandboxPath(sessionWorkDir, path))).join(" ")}`,
+  })
+}
+
+async function listSandboxPaths(
+  sandbox: HarnessSandboxSession,
+  sessionWorkDir: string,
+  type: "d" | "f",
+  abortSignal: AbortSignal | undefined,
+) {
+  const result = await runSandbox(sandbox, {
+    abortSignal,
+    command: `find . -type ${type} -print`,
+    workingDirectory: sessionWorkDir,
+  })
+  return new Set(pathsFromFindOutput(result.stdout))
+}
+
 async function copyWorkspaceToSandbox(
   workspace: WorkspaceFacade,
   sandbox: HarnessSandboxSession,
   sessionWorkDir: string,
   abortSignal: AbortSignal | undefined,
 ) {
-  const files = workspaceFiles(await workspace.fs.list("", { recursive: true }))
-  const initialFiles = new Map<string, Uint8Array>()
-  for (const path of files) {
-    const content = await workspace.fs.readFile(path, { encoding: "binary" })
-    initialFiles.set(path, content)
+  const entries = await workspace.fs.list("", { recursive: true })
+  const initialTree: InitialTree = {
+    directories: new Set(workspaceDirectories(entries)),
+    files: new Map(),
+  }
+  await resetSandboxWorkDir(sandbox, sessionWorkDir, abortSignal)
+  await mkdirSandboxDirectories(sandbox, [...initialTree.directories], sessionWorkDir, abortSignal)
+  for (const entry of workspaceFiles(entries)) {
+    const content = await workspace.fs.readFile(entry.path, { encoding: "binary" })
+    initialTree.files.set(entry.path, { content, mediaType: entry.mediaType })
     await sandbox.writeBinaryFile({
       abortSignal,
       content,
-      path: sandboxPath(sessionWorkDir, path),
+      path: sandboxPath(sessionWorkDir, entry.path),
     })
   }
-  return initialFiles
+  return initialTree
 }
 
 async function copySandboxChangesToWorkspace(
   session: WorkspaceSession,
   sandbox: HarnessSandboxSession,
   sessionWorkDir: string,
-  initialFiles: Map<string, Uint8Array>,
+  initialTree: InitialTree,
   abortSignal: AbortSignal | undefined,
 ) {
-  if (!sandbox.run || !sandbox.readBinaryFile) return
-  const result = await sandbox.run({
-    abortSignal,
-    command: "find . -type f -print",
-    workingDirectory: sessionWorkDir,
-  })
-  if (result.exitCode !== 0) {
-    throw new Error(`[vitehub] Failed to inspect Harness Workspace Session files: ${result.stderr || "find failed"}`)
+  if (!sandbox.readBinaryFile) {
+    throw new Error("[vitehub] Harness Workspace Session write mode requires sandbox.readBinaryFile.")
   }
 
-  const sandboxFiles = new Set(pathsFromFindOutput(result.stdout))
+  const sandboxDirectories = await listSandboxPaths(sandbox, sessionWorkDir, "d", abortSignal)
+  const sandboxFiles = await listSandboxPaths(sandbox, sessionWorkDir, "f", abortSignal)
+  for (const path of initialTree.files.keys()) {
+    if (!sandboxFiles.has(path)) await session.rm(path, { force: true })
+  }
+  for (const path of [...initialTree.directories].sort((left, right) => right.length - left.length)) {
+    if (!sandboxDirectories.has(path)) await session.rm(path, { force: true, recursive: true })
+  }
+  for (const path of sandboxDirectories) {
+    await session.mkdir(path, { recursive: true } satisfies MkdirOptions)
+  }
   for (const path of sandboxFiles) {
     const content = await sandbox.readBinaryFile({
       abortSignal,
       path: sandboxPath(sessionWorkDir, path),
     })
-    if (!content || bytesEqual(initialFiles.get(path), content)) continue
-    await session.writeFile(path, content)
-  }
-  for (const path of initialFiles.keys()) {
-    if (!sandboxFiles.has(path)) await session.rm(path, { force: true })
+    const initial = initialTree.files.get(path)
+    if (!content || bytesEqual(initial?.content, content)) continue
+    await session.writeFile(path, content, {
+      mediaType: initial?.mediaType || lookup(path) || undefined,
+    })
   }
 
   const diff = await session.diff()
@@ -118,7 +193,7 @@ export async function prepareHarnessWorkspaceSession(
   workspace: WorkspaceFacade,
   options: PrepareHarnessWorkspaceSessionOptions,
 ): Promise<HarnessWorkspaceSession> {
-  const initialFiles = await copyWorkspaceToSandbox(workspace, options.session, options.sessionWorkDir, options.abortSignal)
+  const initialTree = await copyWorkspaceToSandbox(workspace, options.session, options.sessionWorkDir, options.abortSignal)
   const workspaceSession = isWritableWorkspaceFacade(workspace)
     ? await workspace.startSession()
     : undefined
@@ -131,7 +206,7 @@ export async function prepareHarnessWorkspaceSession(
             workspaceSession,
             options.session,
             options.sessionWorkDir,
-            initialFiles,
+            initialTree,
             options.abortSignal,
           )
         }

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -97,7 +97,8 @@ async function copySandboxChangesToWorkspace(
     throw new Error(`[vitehub] Failed to inspect Harness Workspace Session files: ${result.stderr || "find failed"}`)
   }
 
-  for (const path of pathsFromFindOutput(result.stdout)) {
+  const sandboxFiles = new Set(pathsFromFindOutput(result.stdout))
+  for (const path of sandboxFiles) {
     const content = await sandbox.readBinaryFile({
       abortSignal,
       path: sandboxPath(sessionWorkDir, path),
@@ -105,8 +106,10 @@ async function copySandboxChangesToWorkspace(
     if (!content || bytesEqual(initialFiles.get(path), content)) continue
     await session.writeFile(path, content)
   }
+  for (const path of initialFiles.keys()) {
+    if (!sandboxFiles.has(path)) await session.rm(path, { force: true })
+  }
 
-  // ponytail: deletions wait until WorkspaceSession exposes rm; additions and updates still commit through Workspace rules.
   const diff = await session.diff()
   if (diff.entries.length) await session.commit({ message: "harness-workspace-session" })
 }

--- a/packages/workspace/src/session/sandbox.ts
+++ b/packages/workspace/src/session/sandbox.ts
@@ -191,6 +191,10 @@ export async function createSandboxWorkspaceSession(
       else
         mediaTypes.delete(workspacePath)
     },
+    async mkdir(path: string, options = {}) {
+      assertOpen()
+      await sandbox.mkdir(toSandboxPath(path), { recursive: options.recursive })
+    },
     async rm(path: string, _options?: RmOptions) {
       assertOpen()
       await sandbox.deleteFile(toSandboxPath(path))

--- a/packages/workspace/src/session/sandbox.ts
+++ b/packages/workspace/src/session/sandbox.ts
@@ -7,6 +7,7 @@ import { createSnapshotFromEntries, diffSnapshots } from "../storage/utils.ts"
 import type {
   ReadFileOptions,
   ReadFileResult,
+  RmOptions,
   Workspace,
   WorkspaceContent,
   WorkspaceDefinition,
@@ -189,6 +190,11 @@ export async function createSandboxWorkspaceSession(
         mediaTypes.set(workspacePath, options.mediaType)
       else
         mediaTypes.delete(workspacePath)
+    },
+    async rm(path: string, _options?: RmOptions) {
+      assertOpen()
+      await sandbox.deleteFile(toSandboxPath(path))
+      mediaTypes.delete(normalizeWorkspacePath(path))
     },
     async list(path = "", options = {}) {
       assertOpen()

--- a/packages/workspace/test/config.test.ts
+++ b/packages/workspace/test/config.test.ts
@@ -1,8 +1,24 @@
 import { describe, expect, it } from "vitest"
 
 import { normalizeWorkspaceOptions, resolveRuntimeVercelBlobWorkspaceStore } from "../src/config.ts"
+import { defineWorkspace } from "../src/core/define.ts"
 
 describe("workspace config", () => {
+  it("rejects unknown workspace definition options", () => {
+    expect(() => defineWorkspace({
+      stroe: { provider: "memory" },
+    } as never)).toThrow("[vitehub] defineWorkspace does not support option: stroe.")
+  })
+
+  it("rejects unknown workspace module config options", () => {
+    expect(() => normalizeWorkspaceOptions({
+      stores: { provider: "memory" },
+    } as never, {
+      env: {},
+      rootDir: "/repo",
+    })).toThrow("[vitehub] workspace config does not support option: stores.")
+  })
+
   it("leaves build assets enabled by default", () => {
     const config = normalizeWorkspaceOptions({}, {
       env: {},

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { prepareHarnessWorkspaceSession } from "../src/session/harness.ts"
+
+function bytes(content: string): Uint8Array {
+  return new TextEncoder().encode(content)
+}
+
+describe("Harness Workspace Session", () => {
+  it("materializes selected Workspace files into the harness sandbox", async () => {
+    const readme = bytes("# Docs\n")
+    const list = vi.fn(async () => [
+      { path: "README.md", type: "file" },
+      { path: "notes", type: "directory" },
+    ])
+    const readFile = vi.fn(async () => readme)
+    const writeBinaryFile = vi.fn(async () => {})
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: { list, readFile },
+      tools: {},
+    } as never, {
+      session: { writeBinaryFile },
+      sessionWorkDir: "/work/agent",
+    })
+
+    expect(list).toHaveBeenCalledWith("", { recursive: true })
+    expect(readFile).toHaveBeenCalledWith("README.md", { encoding: "binary" })
+    expect(writeBinaryFile).toHaveBeenCalledWith({
+      abortSignal: undefined,
+      content: readme,
+      path: "/work/agent/README.md",
+    })
+
+    await session.close()
+  })
+
+  it("commits harness sandbox additions and updates through write-mode Workspace rules", async () => {
+    const initial = bytes("old")
+    const updated = bytes("new")
+    const added = bytes("added")
+    const workspaceSession = {
+      close: vi.fn(async () => {}),
+      commit: vi.fn(async () => {}),
+      diff: vi.fn(async () => ({
+        entries: [{ path: "README.md", type: "modified" }],
+        to: "next",
+      })),
+      writeFile: vi.fn(async () => {}),
+    }
+    const startSession = vi.fn(async () => workspaceSession)
+    const run = vi.fn(async () => ({
+      exitCode: 0,
+      stderr: "",
+      stdout: "./README.md\n./new.txt\n",
+    }))
+    const readBinaryFile = vi.fn(async ({ path }: { path: string }) => path.endsWith("README.md") ? updated : added)
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: {
+        list: vi.fn(async () => [{ path: "README.md", type: "file" }]),
+        readFile: vi.fn(async () => initial),
+      },
+      startSession,
+      tools: {},
+    } as never, {
+      session: {
+        readBinaryFile,
+        run,
+        writeBinaryFile: vi.fn(async () => {}),
+      },
+      sessionWorkDir: "/work/agent",
+    })
+
+    await session.close()
+
+    expect(startSession).toHaveBeenCalledOnce()
+    expect(run).toHaveBeenCalledWith({
+      abortSignal: undefined,
+      command: "find . -type f -print",
+      workingDirectory: "/work/agent",
+    })
+    expect(workspaceSession.writeFile).toHaveBeenCalledWith("README.md", updated)
+    expect(workspaceSession.writeFile).toHaveBeenCalledWith("new.txt", added)
+    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
+    expect(workspaceSession.close).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -85,4 +85,45 @@ describe("Harness Workspace Session", () => {
     expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
     expect(workspaceSession.close).toHaveBeenCalledOnce()
   })
+
+  it("commits harness sandbox deletions through write-mode Workspace rules", async () => {
+    const workspaceSession = {
+      close: vi.fn(async () => {}),
+      commit: vi.fn(async () => {}),
+      diff: vi.fn(async () => ({
+        entries: [{ path: "old.txt", type: "removed" }],
+        to: "next",
+      })),
+      rm: vi.fn(async () => {}),
+      writeFile: vi.fn(async () => {}),
+    }
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: {
+        list: vi.fn(async () => [
+          { path: "README.md", type: "file" },
+          { path: "old.txt", type: "file" },
+        ]),
+        readFile: vi.fn(async (path: string) => bytes(path)),
+      },
+      startSession: vi.fn(async () => workspaceSession),
+      tools: {},
+    } as never, {
+      session: {
+        readBinaryFile: vi.fn(async ({ path }: { path: string }) => bytes(path)),
+        run: vi.fn(async () => ({
+          exitCode: 0,
+          stderr: "",
+          stdout: "./README.md\n",
+        })),
+        writeBinaryFile: vi.fn(async () => {}),
+      },
+      sessionWorkDir: "/work/agent",
+    })
+
+    await session.close()
+
+    expect(workspaceSession.rm).toHaveBeenCalledWith("old.txt", { force: true })
+    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
+  })
 })

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -6,25 +6,46 @@ function bytes(content: string): Uint8Array {
   return new TextEncoder().encode(content)
 }
 
+function ok(stdout = "") {
+  return { exitCode: 0, stderr: "", stdout }
+}
+
+function sandboxRun(files: string[] = [], directories: string[] = []) {
+  return vi.fn(async ({ command }: { command: string }) => {
+    if (command.includes("-type d")) return ok(directories.map(path => `./${path}`).join("\n"))
+    if (command.includes("-type f")) return ok(files.map(path => `./${path}`).join("\n"))
+    return ok()
+  })
+}
+
 describe("Harness Workspace Session", () => {
-  it("materializes selected Workspace files into the harness sandbox", async () => {
+  it("resets and materializes selected Workspace files into the harness sandbox", async () => {
     const readme = bytes("# Docs\n")
     const list = vi.fn(async () => [
       { path: "README.md", type: "file" },
       { path: "notes", type: "directory" },
     ])
     const readFile = vi.fn(async () => readme)
+    const run = sandboxRun()
     const writeBinaryFile = vi.fn(async () => {})
 
     const session = await prepareHarnessWorkspaceSession({
       fs: { list, readFile },
       tools: {},
     } as never, {
-      session: { writeBinaryFile },
+      session: { run, writeBinaryFile },
       sessionWorkDir: "/work/agent",
     })
 
     expect(list).toHaveBeenCalledWith("", { recursive: true })
+    expect(run).toHaveBeenCalledWith({
+      abortSignal: undefined,
+      command: "rm -rf '/work/agent' && mkdir -p '/work/agent'",
+    })
+    expect(run).toHaveBeenCalledWith({
+      abortSignal: undefined,
+      command: "mkdir -p '/work/agent/notes'",
+    })
     expect(readFile).toHaveBeenCalledWith("README.md", { encoding: "binary" })
     expect(writeBinaryFile).toHaveBeenCalledWith({
       abortSignal: undefined,
@@ -46,19 +67,17 @@ describe("Harness Workspace Session", () => {
         entries: [{ path: "README.md", type: "modified" }],
         to: "next",
       })),
+      mkdir: vi.fn(async () => {}),
+      rm: vi.fn(async () => {}),
       writeFile: vi.fn(async () => {}),
     }
     const startSession = vi.fn(async () => workspaceSession)
-    const run = vi.fn(async () => ({
-      exitCode: 0,
-      stderr: "",
-      stdout: "./README.md\n./new.txt\n",
-    }))
+    const run = sandboxRun(["README.md", "new.json"])
     const readBinaryFile = vi.fn(async ({ path }: { path: string }) => path.endsWith("README.md") ? updated : added)
 
     const session = await prepareHarnessWorkspaceSession({
       fs: {
-        list: vi.fn(async () => [{ path: "README.md", type: "file" }]),
+        list: vi.fn(async () => [{ mediaType: "text/markdown", path: "README.md", type: "file" }]),
         readFile: vi.fn(async () => initial),
       },
       startSession,
@@ -80,8 +99,8 @@ describe("Harness Workspace Session", () => {
       command: "find . -type f -print",
       workingDirectory: "/work/agent",
     })
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("README.md", updated)
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("new.txt", added)
+    expect(workspaceSession.writeFile).toHaveBeenCalledWith("README.md", updated, { mediaType: "text/markdown" })
+    expect(workspaceSession.writeFile).toHaveBeenCalledWith("new.json", added, { mediaType: "application/json" })
     expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
     expect(workspaceSession.close).toHaveBeenCalledOnce()
   })
@@ -94,6 +113,7 @@ describe("Harness Workspace Session", () => {
         entries: [{ path: "old.txt", type: "removed" }],
         to: "next",
       })),
+      mkdir: vi.fn(async () => {}),
       rm: vi.fn(async () => {}),
       writeFile: vi.fn(async () => {}),
     }
@@ -111,11 +131,7 @@ describe("Harness Workspace Session", () => {
     } as never, {
       session: {
         readBinaryFile: vi.fn(async ({ path }: { path: string }) => bytes(path)),
-        run: vi.fn(async () => ({
-          exitCode: 0,
-          stderr: "",
-          stdout: "./README.md\n",
-        })),
+        run: sandboxRun(["README.md"]),
         writeBinaryFile: vi.fn(async () => {}),
       },
       sessionWorkDir: "/work/agent",
@@ -124,6 +140,47 @@ describe("Harness Workspace Session", () => {
     await session.close()
 
     expect(workspaceSession.rm).toHaveBeenCalledWith("old.txt", { force: true })
+    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
+  })
+
+  it("commits harness sandbox directory and file transitions through Workspace rules", async () => {
+    const workspaceSession = {
+      close: vi.fn(async () => {}),
+      commit: vi.fn(async () => {}),
+      diff: vi.fn(async () => ({
+        entries: [{ path: "node/result.txt", type: "added" }],
+        to: "next",
+      })),
+      mkdir: vi.fn(async () => {}),
+      rm: vi.fn(async () => {}),
+      writeFile: vi.fn(async () => {}),
+    }
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: {
+        list: vi.fn(async () => [
+          { path: "empty", type: "directory" },
+          { path: "node", type: "file" },
+        ]),
+        readFile: vi.fn(async (path: string) => bytes(path)),
+      },
+      startSession: vi.fn(async () => workspaceSession),
+      tools: {},
+    } as never, {
+      session: {
+        readBinaryFile: vi.fn(async ({ path }: { path: string }) => bytes(path)),
+        run: sandboxRun(["node/result.txt"], ["empty", "node"]),
+        writeBinaryFile: vi.fn(async () => {}),
+      },
+      sessionWorkDir: "/work/agent",
+    })
+
+    await session.close()
+
+    expect(workspaceSession.rm).toHaveBeenCalledWith("node", { force: true })
+    expect(workspaceSession.mkdir).toHaveBeenCalledWith("empty", { recursive: true })
+    expect(workspaceSession.mkdir).toHaveBeenCalledWith("node", { recursive: true })
+    expect(workspaceSession.writeFile).toHaveBeenCalledWith("node/result.txt", bytes("/work/agent/node/result.txt"), { mediaType: "text/plain" })
     expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
   })
 })

--- a/packages/workspace/test/sandbox-runtime.test.ts
+++ b/packages/workspace/test/sandbox-runtime.test.ts
@@ -196,6 +196,32 @@ describe("sandbox workspace runtime", () => {
     await expect(workspace.exists("stale.txt")).resolves.toBe(false)
   })
 
+  it("commits sandbox session deletions", async () => {
+    const fake = createFakeSandbox("cloudflare")
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "cloudflare", binding: "SANDBOX" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "sandbox",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    await workspace.writeFile("old.txt", "old")
+
+    const session = await workspace.startSession()
+    await session.rm("old.txt", { force: true })
+    expect((await session.diff()).entries).toEqual([
+      expect.objectContaining({ path: "old.txt", type: "removed" }),
+    ])
+    await session.commit()
+    await session.close()
+
+    await expect(workspace.exists("old.txt")).resolves.toBe(false)
+  })
+
   it("keeps lazy source files out of the initial sandbox sync until materialized", async () => {
     const fake = createFakeSandbox("cloudflare")
     const sandboxPackage = await import("@vite-hub/sandbox")

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -10,11 +10,14 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { collectWorkspaceStoreAssetBundle, syncDiscoveredWorkspaceAssetBundles, writeWorkspaceAssetsRegistry } from "../src/build/assets.ts"
 import { initializeWorkspaceAssetRegistry, syncWorkspaceBuildAssets } from "../src/build/integration.ts"
+import { resetWorkspaceAssetsRegistry } from "../src/asset-registry.ts"
 import { defineWorkspace, source, useWorkspace } from "../src/index.ts"
 import * as loader from "../src/loader.ts"
 import * as publish from "../src/publish.ts"
 import { registerWorkspace } from "../src/test.ts"
 import { syncWorkspaceDefinition } from "../src/lifecycle.ts"
+import { setWorkspaceRuntimeAssetsRegistry } from "../src/runtime/state.ts"
+import { createWorkspaceAssets } from "../src/runtime/assets.ts"
 import { useRegisteredWorkspace } from "../src/core/registry.ts"
 import { createLocalWorkspaceStore } from "../src/storage/local.ts"
 import { createMemoryWorkspaceStore } from "../src/storage/memory.ts"
@@ -33,6 +36,7 @@ afterEach(async () => {
   delete process.env.GITHUB_TOKEN
   delete (globalThis as { __env__?: Record<string, unknown> }).__env__
   setStorage(createMemoryStorage())
+  resetWorkspaceAssetsRegistry()
   vi.unstubAllGlobals()
   await Promise.all(tempDirs.splice(0).map(path => rm(path, { recursive: true, force: true })))
 })
@@ -595,6 +599,55 @@ describe("sources, loaders, and publishers", () => {
       name: "support",
     })
     expect(Buffer.from(bundles[0]!.files[0]!.content)).toEqual(Buffer.from("# Support\n"))
+  })
+
+  it("syncs explicit file sources from bundled assets when the original source root is absent", async () => {
+    const root = await createRoot()
+    const directory = join(root, "server", "agents", "support")
+    const sourceRoot = join(directory, "workspace")
+    await mkdir(sourceRoot, { recursive: true })
+    await writeFile(join(sourceRoot, "AGENTS.md"), "# Bundled Support\n")
+    await writeFile(join(directory, "config.mjs"), [
+      `import { source } from '${workspaceSourceImport}'`,
+      "export default {",
+      "  sources: { instructions: source.file('AGENTS.md') },",
+      "}",
+      "",
+    ].join("\n"))
+
+    const [bundle] = await syncDiscoveredWorkspaceAssetBundles([{
+      handler: join(directory, "config.mjs"),
+      name: "support",
+      path: join(directory, "config.mjs"),
+      source: "test",
+      sourceRootDir: sourceRoot,
+    }], root, {
+      root: join(root, ".vitehub", "workspaces"),
+      store: { provider: "memory" },
+      assets: true,
+    })
+    await rm(sourceRoot, { recursive: true, force: true })
+    setWorkspaceRuntimeAssetsRegistry({
+      support: createWorkspaceAssets(Object.fromEntries(bundle!.files.map(file => [
+        file.path,
+        {
+          load: async () => file.content,
+          mediaType: file.mediaType,
+        },
+      ]))),
+    })
+
+    const store = createMemoryWorkspaceStore()
+    await syncWorkspaceDefinition({
+      name: "support",
+      rootDir: root,
+      sourceRootDir: sourceRoot,
+      sources: { instructions: source.file("AGENTS.md") },
+    }, store)
+
+    await expect(store.readFile("AGENTS.md")).resolves.toMatchObject({
+      content: new TextEncoder().encode("# Bundled Support\n"),
+    })
   })
 
   it("purges stale build source files when source maps change", async () => {

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -195,6 +195,7 @@ describe("workspace types", () => {
     // @ts-expect-error runtime selection belongs in workspace config, not open options
     await writable.startSession({ runtime: "local" })
     expectTypeOf(session.exec).toBeFunction()
+    expectTypeOf(session.rm).toBeFunction()
     expectTypeOf(session.commit).toBeFunction()
     expectTypeOf(session.close).toBeFunction()
     expectTypeOf(await readonly.fs.readFile("AGENTS.md")).toEqualTypeOf<string>()

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -195,6 +195,7 @@ describe("workspace types", () => {
     // @ts-expect-error runtime selection belongs in workspace config, not open options
     await writable.startSession({ runtime: "local" })
     expectTypeOf(session.exec).toBeFunction()
+    expectTypeOf(session.mkdir).toBeFunction()
     expectTypeOf(session.rm).toBeFunction()
     expectTypeOf(session.commit).toBeFunction()
     expectTypeOf(session.close).toBeFunction()


### PR DESCRIPTION
Adds the ViteHub-owned Harness Workspace Session path for workspace-backed harness Agent Drivers. The agent adapter now prepares the selected Workspace through `@vite-hub/workspace` when the harness sandbox session starts, keeps `permissionMode: "allow-all"` internal, and syncs write-mode additions, updates, and deletions back through Workspace rules.

Also preserves build-time Workspace Sources by hydrating explicit file sources from bundled assets when the original source root is unavailable at runtime. That keeps discovered Workspaces usable after build materialization without copying Flue's collapsed root config shape.

The PR also tightens low-cost Workspace Definition and workspace config unknown-field validation, and updates docs plus `.agents` context so the Flue comparison preserves ViteHub boundaries: Agent Driver for harness execution, Workspace for file state, and Capabilities for tools and Skills.