### PR TITLE
feat(agent): add skills shell execution mode

### DIFF
--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -43,6 +43,9 @@ export {
 export {
   skills,
 } from "./skills.ts"
+export type {
+  SkillsCapabilityOptions,
+} from "./skills.ts"
 export {
   audioBytes,
   getTranscriptionResults,

--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -1,15 +1,31 @@
 import { defineCapability } from "../capability-runtime.ts"
 
-import type { AgentCapabilityDefinition } from "../types.ts"
+import type {
+  AgentCapabilityDefinition,
+  AgentCapabilityMode,
+} from "../types.ts"
 
-export function skills(options: { path?: string } = {}): AgentCapabilityDefinition {
+export interface SkillsCapabilityOptions {
+  path?: string
+  shellExecution?: AgentCapabilityMode
+}
+
+function normalizeShellExecution(value: unknown): AgentCapabilityMode | undefined {
+  if (value === undefined) return undefined
+  if (value === "read" || value === "write") return value
+  throw new TypeError("[vitehub] skills({ shellExecution }) must be \"read\" or \"write\".")
+}
+
+export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDefinition {
   const path = options.path || "skills"
-  const skillPath = path.replace(/\/+$/, "").endsWith("/SKILL.md")
-    ? path.replace(/\/+$/, "")
-    : `${path.replace(/\/+$/, "")}/SKILL.md`
+  const normalizedPath = path.replace(/\/+$/, "")
+  const shellExecution = normalizeShellExecution(options.shellExecution)
+  const skillPath = normalizedPath.endsWith("/SKILL.md")
+    ? normalizedPath
+    : `${normalizedPath}/SKILL.md`
   return defineCapability({
     id: "skills",
-    metadata: { path: path.replace(/\/+$/, ""), skillPath },
-    requires: [{ primitive: "workspace", workspace: { mode: "read", paths: [skillPath], required: true } }],
+    metadata: { path: normalizedPath, skillPath, ...(shellExecution ? { shellExecution } : {}) },
+    requires: [{ primitive: "workspace", workspace: { mode: shellExecution === "write" ? "write" : "read", paths: [skillPath], required: true } }],
   })
 }

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -71,6 +71,8 @@ describe("agent public types", () => {
           },
         }),
         skills(),
+        skills({ shellExecution: "read" }),
+        skills({ shellExecution: "write" }),
         sandbox({ commands: ["node"] }),
         schedule({ mode: "read", targets: ["daily-reports"] as const }),
         schedule({ allowSelfTarget: true, mode: "write", policy: "require-approval", selfTarget: "agent/digest", targets: ["agent/digest", "daily-reports"] as const }),
@@ -122,6 +124,9 @@ describe("agent public types", () => {
 
     // @ts-expect-error tool mode requires one explicit provider
     webSearch({ mode: "tool" })
+
+    // @ts-expect-error skills shell execution mode must be read or write
+    skills({ shellExecution: "allow" })
 
     const invocationContext: AgentInvocationContextStore = {
       entries: () => new Map<string, unknown>().entries(),

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -173,6 +173,28 @@ describe("defineAgent workspace option", () => {
     await expect(agent.run!(context())).resolves.toBe("ok")
   })
 
+  it("records opt-in skill shell execution mode", async () => {
+    const { skills } = await import("../src/capabilities.ts")
+
+    expect(skills().metadata).not.toHaveProperty("shellExecution")
+    expect(skills({ shellExecution: "read" }).metadata).toMatchObject({ shellExecution: "read" })
+    expect(skills({ shellExecution: "write" }).metadata).toMatchObject({ shellExecution: "write" })
+    expect(() => skills({ shellExecution: "execute" as never })).toThrow("skills({ shellExecution })")
+  })
+
+  it("requires writable workspace for write-mode skill shell execution", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [skills({ path: "agent-skills/support", shellExecution: "write" })],
+      model: {} as never,
+      workspace: { mode: "read" },
+    })
+
+    await expect(agent.run!(context())).rejects.toThrow("skills() requires workspace.mode: \"write\"")
+  })
+
   it("creates a workspace and agent definition without resolving workspace until run", async () => {
     const { useWorkspace } = await import("@vite-hub/workspace")
     const { defineAgent } = await import("../src/index.ts")


### PR DESCRIPTION
Adds `shellExecution: "read" | "write"` to the Skills Capability so agents can opt into skill shell expansion by mode without exposing per-command allowlists.

The option is recorded in capability metadata, exported as `SkillsCapabilityOptions`, and write mode now requires a writable Workspace. Actual command rendering can stay behind the Shell/Sandbox boundary when that path is wired.