### PR TITLE
feat(agent): add subagent invocation API

### DIFF
--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -41,6 +41,9 @@ export {
   schedule,
 } from "./schedule.ts"
 export {
+  subagents,
+} from "./subagents.ts"
+export {
   skills,
 } from "./skills.ts"
 export {
@@ -192,6 +195,11 @@ export type {
   RuntimeScheduleCapabilityOptions,
   ScheduleCapabilityToolPolicy,
 } from "./schedule.ts"
+export type {
+  SubagentDefinition,
+  SubagentsOptions,
+  SubagentToolInput,
+} from "./subagents.ts"
 export type {
   TranscribeArtifactTemplateInput,
   TranscribeArtifactsOptions,

--- a/packages/agent/src/capabilities/subagents.ts
+++ b/packages/agent/src/capabilities/subagents.ts
@@ -1,0 +1,159 @@
+import { defineCapability } from "../capability-runtime.ts"
+
+import type {
+  AgentCapabilityDefinition,
+  AgentInput,
+  AgentRunInput,
+  AgentRuntimeConfig,
+  AgentRuntimeContext,
+  AgentToolDefinition,
+  AgentToolSet,
+} from "../types.ts"
+import type { Message } from "../messages.ts"
+import type { WorkspaceName } from "@vite-hub/workspace"
+
+interface JsonSchema {
+  additionalProperties?: boolean | JsonSchema
+  description?: string
+  properties?: Record<string, JsonSchema>
+  required?: string[]
+  type?: string
+}
+
+export interface SubagentToolInput<
+  CALL_OPTIONS = unknown,
+  TContext extends object = Record<string, unknown>,
+> {
+  context?: TContext
+  message: string | Message
+  options?: CALL_OPTIONS
+  runId?: string
+  timeout?: number
+}
+
+export interface SubagentDefinition<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+  TContext extends object = Record<string, unknown>,
+> {
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>
+  description: string
+  instructions?: string
+  toolName?: string
+}
+
+export interface SubagentsOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  TAgents extends Record<string, SubagentDefinition<TRuntimeConfig, any, any>> = Record<string, SubagentDefinition<TRuntimeConfig>>,
+> {
+  agents: TAgents
+  id?: string
+  instructions?: string | false
+}
+
+function assertSubagentName(name: string): void {
+  if (!/^[a-z][a-z0-9_-]*$/.test(name)) {
+    throw new TypeError(`[vitehub] subagents() key "${name}" must be a lowercase stable identifier.`)
+  }
+}
+
+function toolNameFor(name: string, definition: SubagentDefinition): string {
+  const toolName = definition.toolName || `run_${name.replaceAll("-", "_")}`
+  if (!/^[a-z][a-z0-9_]*$/.test(toolName)) {
+    throw new TypeError(`[vitehub] subagents() tool name "${toolName}" must be lowercase and use underscores instead of dashes.`)
+  }
+  return toolName
+}
+
+function inputSchema(description: string): JsonSchema {
+  return {
+    additionalProperties: false,
+    properties: {
+      context: { additionalProperties: true, description: "Structured task context for the subagent.", type: "object" },
+      message: { description, type: "string" },
+      options: { additionalProperties: true, description: "Agent call options for the subagent.", type: "object" },
+      runId: { description: "Optional run id for this subagent invocation.", type: "string" },
+      timeout: { description: "Optional timeout in milliseconds.", type: "number" },
+    },
+    required: ["message"],
+    type: "object",
+  }
+}
+
+function normalizeAgents<TRuntimeConfig extends AgentRuntimeConfig>(
+  options: SubagentsOptions<TRuntimeConfig>,
+) {
+  if (!options?.agents || typeof options.agents !== "object" || Array.isArray(options.agents) || !Object.keys(options.agents).length) {
+    throw new TypeError("[vitehub] subagents({ agents }) requires at least one subagent.")
+  }
+  return Object.entries(options.agents).map(([name, definition]) => {
+    assertSubagentName(name)
+    if (!definition?.agent) throw new TypeError(`[vitehub] subagents() "${name}" requires an agent.`)
+    if (!definition.description?.trim()) throw new TypeError(`[vitehub] subagents() "${name}" requires a description.`)
+    return { definition, name, toolName: toolNameFor(name, definition) }
+  })
+}
+
+function renderInstructions(agents: ReturnType<typeof normalizeAgents>, fallback?: string | false): string | false {
+  if (fallback === false) return false
+  return fallback || [
+    "Use subagents for bounded delegated work. Call the matching subagent tool with a clear message and structured context.",
+    "",
+    ...agents.map(({ definition, name, toolName }) => [
+      `- ${name}: ${definition.description} Tool: ${toolName}.`,
+      definition.instructions ? `  Instructions: ${definition.instructions}` : "",
+    ].filter(Boolean).join("\n")),
+  ].join("\n")
+}
+
+function randomToken(): string {
+  return globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)
+}
+
+function childRunId(parentRunId: string | undefined, name: string, runId: string | undefined): string | undefined {
+  return runId || (parentRunId ? `${parentRunId}:${name}:${randomToken()}` : undefined)
+}
+
+function createTool<TRuntimeConfig extends AgentRuntimeConfig>(
+  definition: SubagentDefinition<TRuntimeConfig>,
+  name: string,
+  parentContext: AgentRuntimeContext<TRuntimeConfig>,
+): AgentToolDefinition {
+  return {
+    description: definition.description,
+    async execute(input: unknown) {
+      const { runAgent } = await import("../index.ts")
+      const { runId, ...agentInput } = input as SubagentToolInput
+      const nextRunId = childRunId(parentContext.run?.runId, name, runId)
+      return await runAgent(definition.agent, nextRunId
+        ? { ...parentContext, run: { ...parentContext.run, runId: nextRunId } }
+        : parentContext, agentInput as AgentRunInput)
+    },
+    inputSchema: inputSchema(definition.description),
+    name,
+  }
+}
+
+export function subagents<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  const TAgents extends Record<string, SubagentDefinition<TRuntimeConfig, any, any>> = Record<string, SubagentDefinition<TRuntimeConfig>>,
+>(
+  options: SubagentsOptions<TRuntimeConfig, TAgents>,
+): AgentCapabilityDefinition<TRuntimeConfig, Name> {
+  const id = options.id || "subagents"
+  const agents = normalizeAgents(options)
+  const instructions = renderInstructions(agents, options.instructions)
+
+  return defineCapability({
+    id,
+    instructions,
+    tools(context) {
+      const tools: AgentToolSet = {}
+      for (const { definition, toolName } of agents) {
+        tools[toolName] = createTool(definition, toolName, context)
+      }
+      return tools
+    },
+  })
+}

--- a/packages/agent/src/capabilities/subagents.ts
+++ b/packages/agent/src/capabilities/subagents.ts
@@ -1,6 +1,8 @@
 import { defineCapability } from "../capability-runtime.ts"
+import { withResolvedAgentInvokerInput } from "../invoker.ts"
 
 import type {
+  AgentCapabilityContext,
   AgentCapabilityDefinition,
   AgentInput,
   AgentRunInput,
@@ -86,11 +88,15 @@ function normalizeAgents<TRuntimeConfig extends AgentRuntimeConfig>(
   if (!options?.agents || typeof options.agents !== "object" || Array.isArray(options.agents) || !Object.keys(options.agents).length) {
     throw new TypeError("[vitehub] subagents({ agents }) requires at least one subagent.")
   }
+  const toolNames = new Set<string>()
   return Object.entries(options.agents).map(([name, definition]) => {
     assertSubagentName(name)
     if (!definition?.agent) throw new TypeError(`[vitehub] subagents() "${name}" requires an agent.`)
     if (!definition.description?.trim()) throw new TypeError(`[vitehub] subagents() "${name}" requires a description.`)
-    return { definition, name, toolName: toolNameFor(name, definition) }
+    const toolName = toolNameFor(name, definition)
+    if (toolNames.has(toolName)) throw new TypeError(`[vitehub] Duplicate subagent tool name "${toolName}". Use explicit toolName values to disambiguate.`)
+    toolNames.add(toolName)
+    return { definition, name, toolName }
   })
 }
 
@@ -117,17 +123,18 @@ function childRunId(parentRunId: string | undefined, name: string, runId: string
 function createTool<TRuntimeConfig extends AgentRuntimeConfig>(
   definition: SubagentDefinition<TRuntimeConfig>,
   name: string,
-  parentContext: AgentRuntimeContext<TRuntimeConfig>,
+  parentContext: AgentCapabilityContext<TRuntimeConfig>,
 ): AgentToolDefinition {
   return {
     description: definition.description,
     async execute(input: unknown) {
       const { runAgent } = await import("../index.ts")
       const { runId, ...agentInput } = input as SubagentToolInput
-      const nextRunId = childRunId(parentContext.run?.runId, name, runId)
+      const runtimeContext = (parentContext.runtimeContext || parentContext) as AgentRuntimeContext<TRuntimeConfig>
+      const nextRunId = childRunId(runtimeContext.run?.runId, name, runId)
       return await runAgent(definition.agent, nextRunId
-        ? { ...parentContext, run: { ...parentContext.run, runId: nextRunId } }
-        : parentContext, agentInput as AgentRunInput)
+        ? { ...runtimeContext, run: { ...runtimeContext.run, runId: nextRunId } }
+        : runtimeContext, withResolvedAgentInvokerInput(agentInput as AgentRunInput, parentContext.invoker))
     },
     inputSchema: inputSchema(definition.description),
     name,

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -457,6 +457,7 @@ export async function resolveStaticCapabilityTools<
       fs: workspace?.fs,
       invoker,
       mode: capability.mode,
+      runtimeContext: runtime,
       workspace,
     } as unknown as AgentCapabilityContext<TRuntimeConfig, Name>
     const resolved = await resolveRuntimeValue(capability.tools as never, capabilityContext as never) as unknown

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1,6 +1,7 @@
 import { resolveRuntimeValue } from "@vite-hub/runtime"
 
 import { workspaceOverrideSymbol } from "./access-runtime.ts"
+import { createMessage } from "./messages.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
 import {
   createFallbackAgentInvoker,
@@ -153,7 +154,13 @@ function validateAccessCapabilityOrder(capabilities: AgentCapabilityDefinition[]
 function getRunMessages(input: AgentRunInput): Message[] {
   if (input.messages) return input.messages
   if (Array.isArray(input.prompt)) return input.prompt
+  if (input.message !== undefined) return [typeof input.message === "string" ? createMessage({ role: "user", text: input.message }) : input.message]
   return []
+}
+
+function normalizeRunInput(input: AgentRunInput): AgentRunInput {
+  if (input.messages || Array.isArray(input.prompt) || input.message === undefined) return input
+  return { ...input, messages: getRunMessages(input) }
 }
 
 function withMessages(input: AgentRunInput, messages: Message[]): AgentRunInput {
@@ -237,7 +244,7 @@ export async function resolveAgentCapabilities<
   ensureAgentInvokerContext(invocationContext, invoker)
   const capabilities = normalizeCapabilities(options?.capabilities as AgentCapabilityDefinition[] | undefined) as AgentCapabilityDefinition<TRuntimeConfig, Name>[]
   validateAccessCapabilityOrder(capabilities)
-  let currentInput = input
+  let currentInput = normalizeRunInput(input)
   let currentWorkspace = workspace as ReadonlyWorkspaceFacade<Name> | undefined
   let messages = getRunMessages(currentInput)
   let tools: AgentToolSet | undefined
@@ -297,7 +304,7 @@ export async function resolveAgentCapabilities<
           get: () => currentInput,
           messages: () => messages,
           set(value) {
-            currentInput = value
+            currentInput = normalizeRunInput(value)
             messages = getRunMessages(currentInput)
           },
           setMessages(value) {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -282,6 +282,7 @@ export async function resolveAgentCapabilities<
         context: invocationContext,
         fs: currentWorkspace?.fs,
         invoker,
+        runtimeContext: runtime,
         workspace: currentWorkspace,
         workspaceDefinition: invocationOptions.workspaceDefinition,
       }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -160,7 +160,8 @@ function getRunMessages(input: AgentRunInput): Message[] {
 
 function normalizeRunInput(input: AgentRunInput): AgentRunInput {
   if (input.messages || Array.isArray(input.prompt) || input.message === undefined) return input
-  return { ...input, messages: getRunMessages(input) }
+  const { message: _message, ...next } = input
+  return { ...next, messages: getRunMessages(input) }
 }
 
 function withMessages(input: AgentRunInput, messages: Message[]): AgentRunInput {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -346,6 +346,7 @@ interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
   input: AgentRunInput<CALL_OPTIONS>
   run?: AgentRunMetadata
   runtime?: AgentRuntimeContext["runtime"]
+  runtimeConfig?: AgentRuntimeConfig
 }
 interface ScheduleRunContextLike {
   attemptId?: string
@@ -452,9 +453,11 @@ async function runAgentAsWorkflow<
   if (!binding) return undefined
 
   const handle = await getAgentWorkflowHandle<TRuntimeConfig, CALL_OPTIONS>(agent, resolveAgentWorkflowName(binding))
+  const resolvedContext = createResolvedRuntimeContext(context)
   const payload: AgentWorkflowInvocationPayload<CALL_OPTIONS> = {
     input,
     runtime: context.runtime,
+    runtimeConfig: resolvedContext.runtimeConfig,
     ...(context.run ? { run: context.run } : {}),
   }
   const workflowEvent = {

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -16,6 +16,7 @@ export interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
   input?: AgentRunInput<CALL_OPTIONS>
   run?: AgentRunMetadata
   runtime?: AgentRuntimeName
+  runtimeConfig?: AgentRuntimeConfig
 }
 
 export type AgentWorkflowRunner = (
@@ -52,6 +53,7 @@ export async function runAgentWorkflowDefinition<
       ? { run: payload.run || { origin: `workflow:${context.provider}`, runId: context.id! } }
       : {}),
     runtime: payload.runtime || agentRuntimeFromWorkflowProvider(context.provider),
+    runtimeConfig: (payload.runtimeConfig || {}) as TRuntimeConfig,
     waitUntil,
   } as never)
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -127,6 +127,7 @@ export interface AgentRunInput<
 > {
   abortSignal?: AbortSignal
   context?: TContext
+  message?: string | Message
   messages?: Message[]
   options?: CALL_OPTIONS
   prompt?: string | Message[]

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -318,6 +318,7 @@ export interface AgentCapabilityContext<
   Name extends WorkspaceName = WorkspaceName,
 > extends AgentAdapterMetadataContext<TRuntimeConfig, Name> {
   mode?: AgentCapabilityMode
+  runtimeContext?: ResolvedAgentRuntimeContext
   workspaceDefinition?: WorkspaceDefinition
 }
 

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -44,6 +44,7 @@ describe("inputCommands", () => {
     }, runtime(), { message: "/review auth changes" })
 
     expect(resolved.input.messages?.map(message => getMessageText(message))).toEqual(["Review this: auth changes"])
+    expect(resolved.input.message).toBeUndefined()
   })
 
   it("replaces command text in the latest user message", async () => {

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -28,6 +28,24 @@ describe("inputCommands", () => {
     expect(resolved.input.prompt).toBe("Review this: auth changes")
   })
 
+  it("replaces command text from an initial message", async () => {
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [inputCommands({
+        commands: {
+          review: {
+            description: "Review the request.",
+            run: ({ args }) => `Review this: ${args}`,
+          },
+        },
+      })],
+    }, runtime(), { message: "/review auth changes" })
+
+    expect(resolved.input.messages?.map(message => getMessageText(message))).toEqual(["Review this: auth changes"])
+  })
+
   it("replaces command text in the latest user message", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createMessage, getMessageText } from "@vite-hub/agent"
-import { chat, chatTitle, schedule } from "../src/capabilities.ts"
+import { chat, chatTitle, schedule, subagents } from "../src/capabilities.ts"
 
 const harnessAgentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
 const harnessCreateSession = vi.hoisted(() => vi.fn())
@@ -47,6 +47,84 @@ describe("agent message protocol", () => {
     expect(run).toHaveBeenCalledWith(expect.objectContaining({
       prompt: "hello",
     }))
+  })
+
+  it("runs agents with an initial message and structured context", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const run = vi.fn(({ input, messages, run }) => ({
+      raw: {
+        context: input.context,
+        message: getMessageText(messages[0]!),
+        runId: run?.runId,
+      },
+      text: "browser report",
+    }))
+    const agent = defineAgent({ run })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "review-run" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {
+      context: { previewUrl: "https://preview.local" },
+      message: "Check the product card.",
+    })).resolves.toEqual({
+      raw: {
+        context: { previewUrl: "https://preview.local" },
+        message: "Check the product card.",
+        runId: "review-run",
+      },
+      text: "browser report",
+    })
+  })
+
+  it("registers subagent tools", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const browserAgent = defineAgent({
+      run: ({ input, messages, run }) => ({
+        raw: {
+          context: input.context,
+          message: getMessageText(messages[0]!),
+          runId: run?.runId,
+        },
+        text: "browser report",
+      }),
+    })
+    const reviewerAgent = defineAgent({
+      capabilities: [
+        subagents({
+          agents: {
+            browser: {
+              agent: browserAgent,
+              description: "Collect browser evidence.",
+            },
+          },
+        }),
+      ],
+      async run({ tools }) {
+        const tool = tools?.run_browser
+        if (!tool?.execute) throw new Error("Missing browser subagent tool.")
+        return await tool.execute({
+          context: { previewUrl: "https://preview.local" },
+          message: "Check the product card.",
+        })
+      },
+    })
+
+    await expect(runAgent(reviewerAgent, {
+      memo: vi.fn(),
+      run: { runId: "review-run" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { message: "Review the PR." })).resolves.toEqual({
+      raw: {
+        context: { previewUrl: "https://preview.local" },
+        message: "Check the product card.",
+        runId: expect.stringMatching(/^review-run:run_browser:/),
+      },
+      text: "browser report",
+    })
   })
 
   it("runs harness Agent Drivers through AI SDK HarnessAgent", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -71,7 +71,7 @@ describe("agent message protocol", () => {
       message: "Check the product card.",
     })).resolves.toEqual({
       raw: {
-        context: { previewUrl: "https://preview.local" },
+        context: expect.objectContaining({ previewUrl: "https://preview.local" }),
         message: "Check the product card.",
         runId: "review-run",
       },
@@ -82,9 +82,10 @@ describe("agent message protocol", () => {
   it("registers subagent tools", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const browserAgent = defineAgent({
-      run: ({ input, messages, run }) => ({
+      run: ({ input, invoker, messages, run }) => ({
         raw: {
           context: input.context,
+          invokerId: invoker.id,
           message: getMessageText(messages[0]!),
           runId: run?.runId,
         },
@@ -117,11 +118,94 @@ describe("agent message protocol", () => {
       run: { runId: "review-run" },
       runtime: "unknown",
       waitUntil: vi.fn(),
-    }, { message: "Review the PR." })).resolves.toEqual({
+    }, {
+      context: {
+        invoker: { id: "github:onmax", kind: "github" },
+      },
+      message: "Review the PR.",
+    })).resolves.toEqual({
       raw: {
-        context: { previewUrl: "https://preview.local" },
+        context: expect.objectContaining({ previewUrl: "https://preview.local" }),
+        invokerId: "github:onmax",
         message: "Check the product card.",
         runId: expect.stringMatching(/^review-run:run_browser:/),
+      },
+      text: "browser report",
+    })
+  })
+
+  it("rejects duplicate generated subagent tool names", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+
+    expect(() => subagents({
+      agents: {
+        "code-review": {
+          agent: defineAgent({ run: () => "ok" }),
+          description: "Review code.",
+        },
+        code_review: {
+          agent: defineAgent({ run: () => "ok" }),
+          description: "Review code again.",
+        },
+      },
+    })).toThrow('Duplicate subagent tool name "run_code_review"')
+  })
+
+  it("runs subagent tools with the resolved parent runtime context", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const browserAgent = {
+      async resolve(context) {
+        return {
+          async generate({ invoker, runtime }) {
+            return {
+              raw: {
+                invokerId: invoker.id,
+                resolveRuntimeConfig: context.runtimeConfig,
+                runtimeConfig: runtime.runtimeConfig,
+              },
+              text: "browser report",
+            }
+          },
+          name: "browser",
+        }
+      },
+    } as ReturnType<typeof defineAgent>
+    const reviewerAgent = defineAgent({
+      capabilities: [
+        subagents({
+          agents: {
+            browser: {
+              agent: browserAgent,
+              description: "Collect browser evidence.",
+            },
+          },
+        }),
+      ],
+      async run({ tools }) {
+        const tool = tools?.run_browser
+        if (!tool?.execute) throw new Error("Missing browser subagent tool.")
+        return await tool.execute({ message: "Check the product card." })
+      },
+    })
+
+    await expect(runAgent(reviewerAgent, {
+      memo: vi.fn(),
+      run: { runId: "review-run" },
+      runtime: "unknown",
+      runtimeConfig: { region: "iad" },
+      waitUntil: vi.fn(),
+    }, {
+      context: {
+        invoker: { id: "github:onmax", kind: "github" },
+      },
+      message: "Review the PR.",
+    })).resolves.toMatchObject({
+      raw: {
+        raw: {
+          invokerId: "github:onmax",
+          resolveRuntimeConfig: { region: "iad" },
+          runtimeConfig: { region: "iad" },
+        },
       },
       text: "browser report",
     })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2026,6 +2026,56 @@ describe("agent message protocol", () => {
     expect(resolved).toEqual(expect.any(Object))
   })
 
+  it("resolves static subagent tools with the resolved runtime context", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const browserAgent = {
+      async resolve(context) {
+        return {
+          async generate({ runtime }) {
+            return {
+              raw: {
+                resolveRuntimeConfig: context.runtimeConfig,
+                runtimeConfig: runtime.runtimeConfig,
+              },
+              text: "browser report",
+            }
+          },
+          name: "browser",
+        }
+      },
+    } as ReturnType<typeof defineAgent>
+    const reviewerAgent = defineAgent({
+      capabilities: [
+        subagents({
+          agents: {
+            browser: {
+              agent: browserAgent,
+              description: "Collect browser evidence.",
+            },
+          },
+        }),
+      ],
+      model: {} as never,
+    })
+
+    const resolved = await reviewerAgent.resolve({
+      memo: vi.fn(),
+      runtime: "unknown",
+      runtimeConfig: { region: "iad" },
+      waitUntil: vi.fn(),
+    }) as unknown as { tools: Record<string, { execute: (input: unknown) => Promise<unknown> }> }
+
+    await expect(resolved.tools.run_browser!.execute({ message: "Check the product card." })).resolves.toMatchObject({
+      raw: {
+        raw: {
+          resolveRuntimeConfig: { region: "iad" },
+          runtimeConfig: { region: "iad" },
+        },
+      },
+      text: "browser report",
+    })
+  })
+
   it("prevents denied tools from executing", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const execute = vi.fn()
@@ -2190,6 +2240,50 @@ describe("agent message protocol", () => {
       await Promise.all(waitUntilTasks)
       await expect(getWorkflowRun("support-agent", run.id)).resolves.toMatchObject({
         result: "received hello",
+        status: "completed",
+      })
+    })
+
+    it("passes runtimeConfig through Workflow Runs", async () => {
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = {
+        runtime: workflow("configured-agent"),
+        async resolve(context) {
+          return {
+            async generate({ runtime }) {
+              return {
+                raw: {
+                  resolveRuntimeConfig: context.runtimeConfig,
+                  runtimeConfig: runtime.runtimeConfig,
+                },
+              }
+            },
+            name: "configured",
+          }
+        },
+      } as ReturnType<typeof defineAgent>
+      const run = await runAgent(agent, {
+        memo: vi.fn(),
+        runtime: "vercel",
+        runtimeConfig: { region: "iad" },
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "hello" }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("configured-agent", run.id)).resolves.toMatchObject({
+        result: {
+          raw: {
+            raw: {
+              resolveRuntimeConfig: { region: "iad" },
+              runtimeConfig: { region: "iad" },
+            },
+          },
+        },
         status: "completed",
       })
     })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, type AgentDriver, type AgentInvoker, type AgentRunInput, type AgentRuntimeConfig, type AgentRuntimeContext } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, transcribe, webSearch, workspaceShell } from "../src/capabilities.ts"
+import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
@@ -476,6 +476,29 @@ describe("agent public types", () => {
     ]
     expectTypeOf(supportProfiles[0]?.meta?.customer).toEqualTypeOf<"acme" | undefined>()
     expectTypeOf({} as AgentRunInput<unknown, SupportInputContext>["context"]).toEqualTypeOf<SupportInputContext | undefined>()
+    type BrowserSubagentContext = { previewUrl: string }
+    const browserAgentInput: AgentRunInput<{ mode: "fast" }, BrowserSubagentContext> = {
+      context: { previewUrl: "https://preview.local" },
+      message: "Check the product card.",
+      options: { mode: "fast" },
+    }
+    expectTypeOf(browserAgentInput.context?.previewUrl).toEqualTypeOf<string | undefined>()
+    expectTypeOf(browserAgentInput.options?.mode).toEqualTypeOf<"fast" | undefined>()
+    const browserToolInput: SubagentToolInput<{ mode: "fast" }, BrowserSubagentContext> = {
+      context: { previewUrl: "https://preview.local" },
+      message: "Check the product card.",
+      options: { mode: "fast" },
+      runId: "review-run:browser",
+    }
+    expectTypeOf(browserToolInput.runId).toEqualTypeOf<string | undefined>()
+    subagents({
+      agents: {
+        browser: {
+          agent: defineAgent({ run: () => "ok" }),
+          description: "Collect browser evidence.",
+        },
+      },
+    })
     const supportAccess: AccessWorkspaceOptionsFor<typeof workspace, SupportInputContext> = {
       resolve({ input, invoker }) {
         const chat = input.get().context?.chat


### PR DESCRIPTION
## Summary
- allow `runAgent` calls to pass a single initial `message` alongside structured context/options
- add a `subagents()` capability that injects delegate instructions and exposes `run_<name>` tools for registered agents
- generate child run ids for subagent tool calls when the caller omits `runId`
- normalize `message` into canonical input messages before capability phases run
- keep result schemas, artifacts, and tracing app-owned so Quiver Review can define its own Browser Agent contract

## Checks
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --filter @vite-hub/agent test -- --run test/runtime.test.ts test/input-commands.test.ts test/types.test-d.ts`
- `git diff --check`
- Quiver Review: `pnpm typecheck`
