### PR TITLE
fix(env): sync generated env package imports

### DIFF
--- a/packages/env/src/vite.ts
+++ b/packages/env/src/vite.ts
@@ -1,5 +1,5 @@
-import { rm } from "node:fs/promises"
-import { relative, resolve } from "node:path"
+import { readFile, rm, stat } from "node:fs/promises"
+import { dirname, relative, resolve } from "node:path"
 
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
 import {
@@ -119,7 +119,9 @@ export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
       if (diagnosticsText) {
         config.logger.info(diagnosticsText)
       }
-      await refreshEnvGeneratedFiles(resolveViteHubProjectRoot(config.root, { projectRoot: options.projectRoot }), buildPublicConfig, serverRegistry)
+      const projectRoot = resolveViteHubProjectRoot(config.root, { projectRoot: options.projectRoot })
+      const packageRoot = await resolvePackageImportRoot(config.root, projectRoot)
+      await refreshEnvGeneratedFiles(projectRoot, packageRoot, buildPublicConfig, serverRegistry)
     },
     load(id) {
       if (id === RESOLVED_PUBLIC_ID) {
@@ -154,8 +156,17 @@ function legacyEnvAmbientTypesPaths(root: string) {
   ]
 }
 
-async function refreshEnvGeneratedFiles(root: string, publicConfig: Record<string, unknown>, serverRegistry: EnvRuntimeRegistry): Promise<void> {
+async function refreshEnvGeneratedFiles(
+  root: string,
+  packageRoot: string | undefined,
+  publicConfig: Record<string, unknown>,
+  serverRegistry: EnvRuntimeRegistry,
+): Promise<void> {
   await Promise.all([
+    ...(packageRoot ? [
+      syncEnvPackageImports(packageRoot),
+      ...(packageRoot === root ? [] : packageEnvModuleWrites(packageRoot, publicConfig, serverRegistry)),
+    ] : []),
     writeFileIfChanged(viteHubEnvAmbientTypesPath(root), createViteTypes(publicConfig, serverRegistry)),
     writeFileIfChanged(viteHubEnvPublicModulePath(root), createPublicEnvModule(publicConfig)),
     writeFileIfChanged(viteHubEnvPublicModuleTypesPath(root), createPublicEnvModuleTypes(publicConfig)),
@@ -163,6 +174,76 @@ async function refreshEnvGeneratedFiles(root: string, publicConfig: Record<strin
     writeFileIfChanged(viteHubEnvServerModuleTypesPath(root), createServerEnvModuleTypes(serverRegistry)),
     ...legacyEnvAmbientTypesPaths(root).map(path => rm(path, { force: true })),
   ])
+}
+
+function packageEnvModuleWrites(root: string, publicConfig: Record<string, unknown>, serverRegistry: EnvRuntimeRegistry): Promise<void>[] {
+  return [
+    writeFileIfChanged(viteHubEnvPublicModulePath(root), createPublicEnvModule(publicConfig)),
+    writeFileIfChanged(viteHubEnvPublicModuleTypesPath(root), createPublicEnvModuleTypes(publicConfig)),
+    writeFileIfChanged(viteHubEnvServerModulePath(root), createServerEnvModule(serverRegistry)),
+    writeFileIfChanged(viteHubEnvServerModuleTypesPath(root), createServerEnvModuleTypes(serverRegistry)),
+  ]
+}
+
+async function resolvePackageImportRoot(viteRoot: string, projectRoot: string): Promise<string | undefined> {
+  const stop = resolve(projectRoot)
+  let current = resolve(viteRoot)
+
+  while (true) {
+    if (await hasPackageManifest(current)) return current
+    if (current === stop) return undefined
+
+    const parent = dirname(current)
+    if (parent === current) return undefined
+    current = parent
+  }
+}
+
+async function hasPackageManifest(root: string): Promise<boolean> {
+  try {
+    return (await stat(resolve(root, "package.json"))).isFile()
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false
+    throw error
+  }
+}
+
+async function syncEnvPackageImports(root: string): Promise<void> {
+  const packageJsonPath = resolve(root, "package.json")
+  let source: string
+  try {
+    source = await readFile(packageJsonPath, "utf8")
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    throw error
+  }
+
+  const manifest = JSON.parse(source) as Record<string, unknown>
+  const imports = isRecord(manifest.imports) ? { ...manifest.imports } : {}
+  const expectedImports = {
+    [ENV_PUBLIC_ID]: {
+      types: "./.vitehub/env/public.d.ts",
+      default: "./.vitehub/env/public.mjs",
+    },
+    [ENV_SERVER_ID]: {
+      types: "./.vitehub/env/server.d.ts",
+      default: "./.vitehub/env/server.mjs",
+    },
+  }
+
+  let changed = !isRecord(manifest.imports)
+  for (const [id, target] of Object.entries(expectedImports)) {
+    if (JSON.stringify(imports[id]) !== JSON.stringify(target)) {
+      imports[id] = target
+      changed = true
+    }
+  }
+  if (!changed) return
+
+  manifest.imports = imports
+  await writeFileIfChanged(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`)
 }
 
 function createPublicEnvModule(publicConfig: Record<string, unknown>): string {

--- a/packages/env/test/vite.test.ts
+++ b/packages/env/test/vite.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { pathToFileURL } from "node:url"
 
 import { describe, expect, it, vi } from "vitest"
 
@@ -160,6 +161,18 @@ describe("Vite plugin", () => {
       root,
     } as never)
 
+    const packageJson = JSON.parse(await readFile(join(root, "package.json"), "utf8"))
+    expect(packageJson.imports).toMatchObject({
+      "#vitehub/env/public": {
+        types: "./.vitehub/env/public.d.ts",
+        default: "./.vitehub/env/public.mjs",
+      },
+      "#vitehub/env/server": {
+        types: "./.vitehub/env/server.d.ts",
+        default: "./.vitehub/env/server.mjs",
+      },
+    })
+
     const types = await readFile(join(root, ".vitehub/types/env.d.ts"), "utf8")
     expect(types).toContain("declare module \"#vitehub/env/public\"")
     expect(types).toContain("declare module \"#vitehub/env/server\"")
@@ -282,6 +295,66 @@ describe("Vite plugin", () => {
 
     await expect(readFile(join(root, ".vitehub", "types", "env.d.ts"), "utf8")).resolves.toContain("\"airtableToken\": SecretEnv<string>")
     await expect(readFile(join(root, "app", ".vitehub", "types", "env.d.ts"), "utf8")).rejects.toThrow()
+  })
+
+  it("writes package imports and local targets for nested package roots", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-env-vite-nested-package-"))
+    const appRoot = join(root, "app")
+    await mkdir(join(appRoot, "src"), { recursive: true })
+    await mkdir(join(root, "server", "workspaces"), { recursive: true })
+    await writeFile(join(root, ".env.production"), "PUBLIC_APP_NAME=Quiver\n", "utf8")
+    await writeFile(join(appRoot, "package.json"), JSON.stringify({
+      imports: {
+        "#app/config": "./config.mjs",
+      },
+      name: "nested-app",
+      type: "module",
+    }), "utf8")
+
+    const plugin = hubEnv()
+    const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "build" | "serve", mode: string }) => Promise<unknown>
+    await configHook({
+      env: {
+        public: {
+          appName: env({
+            mode: "build",
+            schema: stringSchema(),
+          }),
+        },
+      },
+      root: appRoot,
+    }, { command: "build", mode: "production" })
+
+    const configResolvedHook = plugin.configResolved as (config: unknown) => Promise<void> | void
+    await configResolvedHook({
+      logger: { info: vi.fn() },
+      root: appRoot,
+    } as never)
+
+    const packageJson = JSON.parse(await readFile(join(appRoot, "package.json"), "utf8"))
+    expect(packageJson.imports).toMatchObject({
+      "#app/config": "./config.mjs",
+      "#vitehub/env/public": {
+        types: "./.vitehub/env/public.d.ts",
+        default: "./.vitehub/env/public.mjs",
+      },
+      "#vitehub/env/server": {
+        types: "./.vitehub/env/server.d.ts",
+        default: "./.vitehub/env/server.mjs",
+      },
+    })
+    expect(JSON.stringify(packageJson.imports)).not.toContain("../.vitehub")
+    await expect(readFile(join(root, ".vitehub", "env", "public.mjs"), "utf8")).resolves.toContain("Quiver")
+    await expect(readFile(join(appRoot, ".vitehub", "env", "public.mjs"), "utf8")).resolves.toContain("Quiver")
+
+    const checkModule = join(appRoot, "src", "check.mjs")
+    await writeFile(checkModule, [
+      "import { usePublicEnv } from '#vitehub/env/public';",
+      "export const appName = usePublicEnv().appName;",
+      "",
+    ].join("\n"), "utf8")
+    const imported = await import(pathToFileURL(checkModule).href)
+    expect(imported.appName).toBe("Quiver")
   })
 
   it("keeps generated env files in project ViteHub state when Vite root is nested", async () => {


### PR DESCRIPTION
Updates `hubEnv()` to keep the ViteHub-owned `#vitehub/env/public` and `#vitehub/env/server` package imports in the project `package.json` when generated env files are refreshed.

This removes the need for apps to hand-write duplicate env declaration shims or import-map entries just to make TypeScript's `moduleResolution: "Bundler"` resolve the stable ViteHub env import paths.