### PR TITLE
feat(agent): infer workflow runtime names

### DIFF
--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -10,6 +10,7 @@ import {
   resolveAgentDevtoolsMetadata,
   resolveAgentTriggers,
   streamAgentTrigger,
+  withAgentDefaults,
   withWorkspaceAgentDefaults,
 } from "../../index.ts"
 import {
@@ -175,7 +176,7 @@ async function loadDiscoveredAgent(
   const defaults = workspaceDefaults(definition)
   return agent && defaults
     ? withWorkspaceAgentDefaults(agent as never, defaults as never) as AgentInput<ViteAgentDevtoolsRuntimeContext>
-    : agent
+    : withAgentDefaults(agent, { inferredName: definition.name })
 }
 
 function createDevtoolsDiscoveryContext(): ViteAgentDevtoolsRuntimeContext {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -634,13 +634,23 @@ function withAgentWorkflowRuntimeName(runtime: AgentRuntimeBinding | undefined, 
   return { ...runtime, name }
 }
 
+function cloneAgentDefinitionWithRuntime<TContext extends AgentRuntimeContext>(
+  agent: AgentInput<TContext>,
+  runtime: AgentRuntimeBinding,
+): AgentInput<TContext> {
+  const clone = Object.create(Object.getPrototypeOf(agent)) as AgentDefinition
+  Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
+  clone.runtime = runtime
+  return clone as AgentInput<TContext>
+}
+
 export function withAgentDefaults<TContext extends AgentRuntimeContext>(
   agent: AgentInput<TContext> | undefined,
   options: AgentHandlerOptions = {},
 ): AgentInput<TContext> | undefined {
   if (!agent || !hasAgentDefinition(agent)) return agent
   const runtime = withAgentWorkflowRuntimeName(agent.runtime, options.inferredName)
-  return runtime === agent.runtime ? agent : { ...agent, runtime } as AgentInput<TContext>
+  return !runtime || runtime === agent.runtime ? agent : cloneAgentDefinitionWithRuntime(agent, runtime)
 }
 
 export interface DefineAgent {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -60,6 +60,7 @@ import type {
   AgentDefinition,
   AgentFinishEvent,
   AgentChatOptions,
+  AgentHandlerOptions,
   AgentInput,
   AgentInstructionBlock,
   AgentInvocationHooks,
@@ -628,6 +629,20 @@ export function workflow(name?: string): AgentWorkflowRuntimeBinding {
   }
 }
 
+function withAgentWorkflowRuntimeName(runtime: AgentRuntimeBinding | undefined, name: string | undefined): AgentRuntimeBinding | undefined {
+  if (!name || runtime?.kind !== "workflow" || runtime.name) return runtime
+  return { ...runtime, name }
+}
+
+export function withAgentDefaults<TContext extends AgentRuntimeContext>(
+  agent: AgentInput<TContext> | undefined,
+  options: AgentHandlerOptions = {},
+): AgentInput<TContext> | undefined {
+  if (!agent || !hasAgentDefinition(agent)) return agent
+  const runtime = withAgentWorkflowRuntimeName(agent.runtime, options.inferredName)
+  return runtime === agent.runtime ? agent : { ...agent, runtime } as AgentInput<TContext>
+}
+
 export interface DefineAgent {
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -685,7 +700,7 @@ function createWorkspaceAgentDefinition<
     description: options.description,
     hooks: options.hooks,
     run: options.run,
-    runtime: options.runtime,
+    runtime: withAgentWorkflowRuntimeName(options.runtime, defaults.name),
     version: options.version,
     workspace: workspaceDefinition,
   } as never) as WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>
@@ -772,7 +787,7 @@ export async function getAgentFromRegistry<TContext extends AgentRuntimeContext>
     throw new Error(`[vitehub] Agent "${name}" did not export a valid default agent.`)
   }
 
-  return agent
+  return withAgentDefaults(agent, { inferredName: name }) as AgentInput<TContext>
 }
 
 export async function resolveAgentTriggers<

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -203,7 +203,7 @@ function generateAgentWebhookRouteHandler(definitions: DiscoveredAgentDefinition
     .map((definition, index) => {
       const agentExpression = definition.workspace
         ? `withWorkspaceAgentDefaults(resolveAgentModule(agent${index}), ${JSON.stringify({ name: definition.name, workspace: definition.workspace })})`
-        : `resolveAgentModule(agent${index})`
+        : `withAgentDefaults(resolveAgentModule(agent${index}), ${JSON.stringify({ inferredName: definition.name })})`
       return `${JSON.stringify(definition.name)}: ${agentExpression}`
     })
     .join(",\n  ")
@@ -212,7 +212,7 @@ function generateAgentWebhookRouteHandler(definitions: DiscoveredAgentDefinition
     .join(",\n  ")
 
   return [
-    "import { withWorkspaceAgentDefaults } from '@vite-hub/agent'",
+    "import { withAgentDefaults, withWorkspaceAgentDefaults } from '@vite-hub/agent'",
     ...(options.cloudflareState ? ["import { createCloudflareAgentState } from '@vite-hub/agent/cloudflare'"] : []),
     "import { defineAgentChatFetchHandler, defineAgentChatWebhookFetchHandler } from '@vite-hub/agent/server'",
     "import { setWorkspaceRuntimeRegistry } from '@vite-hub/workspace/internal/runtime/state'",

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -7,7 +7,7 @@ import { setWorkspaceRuntimeRegistry } from "@vite-hub/workspace/internal/runtim
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, createAgentInvocationStreamResponse } from "../invocation-stream.ts"
 import { streamAgentOutputToEvents } from "../agent-output.ts"
 import { discoverAgentDefinitions } from "../discovery.ts"
-import { resolveAgentTriggers, streamAgentTrigger, withWorkspaceAgentDefaults } from "../index.ts"
+import { resolveAgentTriggers, streamAgentTrigger, withAgentDefaults, withWorkspaceAgentDefaults } from "../index.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
 
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http"
@@ -161,7 +161,7 @@ async function loadDiscoveredAgent(
   const defaults = workspaceDefaults(definition)
   return agent && defaults
     ? withWorkspaceAgentDefaults(agent as never, defaults as never) as AgentInput<ViteAgentDevRuntimeContext>
-    : agent
+    : withAgentDefaults(agent, { inferredName: definition.name })
 }
 
 async function discoverStreamAgents(server: ViteDevServer): Promise<AgentInvocationStreamEntry[]> {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -262,6 +262,8 @@ describe("agent Vite plugin", () => {
     const { hubAgent } = await import("../src/vite.ts")
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-routes-"))
     try {
+      await mkdir(join(root, "server", "agents"), { recursive: true })
+      await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
       const plugin = hubAgent({ routes: { chat: true, webhooks: true } })
       if (typeof plugin.configResolved === "function") {
         await plugin.configResolved.call({} as never, { root } as never)
@@ -270,6 +272,7 @@ describe("agent Vite plugin", () => {
       const webhookRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
 
       expect(webhookRoute).toContain("defineAgentChatFetchHandler")
+      expect(webhookRoute).toContain("withAgentDefaults(resolveAgentModule")
       expect(webhookRoute).toContain("import { createCloudflareAgentState } from '@vite-hub/agent/cloudflare'")
       expect(webhookRoute).toContain("async function toRequest(event)")
       expect(webhookRoute).toContain("function waitUntilFromEvent(event)")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2268,6 +2268,23 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("preserves Agent Definition metadata when applying discovered defaults", async () => {
+      const { createAgentDevtoolsMetadata, defineAgent, withAgentDefaults, workflow } = await import("../src/index.ts")
+      const agent = withAgentDefaults(defineAgent({
+        model: { id: "test-model" } as never,
+        runtime: workflow(),
+      }), { inferredName: "browser" })
+
+      expect(createAgentDevtoolsMetadata(agent!)).toMatchObject({
+        config: {
+          driver: {
+            kind: "model",
+            model: { id: "test-model" },
+          },
+        },
+      })
+    })
+
     it("uses workspace Agent defaults for unnamed workflow runtime bindings", async () => {
       const { defineAgent, runAgent, withWorkspaceAgentDefaults, workflow } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2244,6 +2244,72 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("uses discovered Agent identity for unnamed workflow runtime bindings", async () => {
+      const { defineAgent, runAgent, withAgentDefaults, workflow } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = withAgentDefaults(defineAgent({
+        runtime: workflow(),
+        run: context => `received ${context.prompt}`,
+      }), { inferredName: "browser" })
+      const run = await runAgent(agent!, {
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "hello" }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("browser", run.id)).resolves.toMatchObject({
+        result: "received hello",
+        status: "completed",
+      })
+    })
+
+    it("uses workspace Agent defaults for unnamed workflow runtime bindings", async () => {
+      const { defineAgent, runAgent, withWorkspaceAgentDefaults, workflow } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = withWorkspaceAgentDefaults(defineAgent({
+        runtime: workflow(),
+        run: context => `received ${context.prompt}`,
+        workspace: {},
+      }), { name: "reviewer", workspace: "reviewer" })
+      const run = await runAgent(agent, {
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "hello" }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("reviewer", run.id)).resolves.toMatchObject({
+        result: "received hello",
+        status: "completed",
+      })
+    })
+
+    it("requires direct unnamed workflow runtime bindings to provide a name", async () => {
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = defineAgent({
+        runtime: workflow(),
+        run: () => "ok",
+      })
+
+      await expect(runAgent(agent, {
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: vi.fn(),
+      }, { prompt: "hello" })).rejects.toThrow("requires a name")
+    })
+
     it("passes runtimeConfig through Workflow Runs", async () => {
       const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")


### PR DESCRIPTION
Lets discovered Agent Definitions use `runtime: workflow()` without repeating the Agent File Name. Vite generated routes, Chat DevTools discovery, the agent dev stream endpoint, and registry lookups now pass the discovered identity into Agent runtime defaults; direct non-discovered usage still requires `workflow("name")`.

Workspace Agent defaults use the same identity, so `server/agents/<name>/config.ts` keeps one source of truth for Agent and Workflow names.