### PR TITLE
feat(agent): add git capability

### DIFF
--- a/.agents/adr/0066-git-capability-stays-local-to-workspace-git.md
+++ b/.agents/adr/0066-git-capability-stays-local-to-workspace-git.md
@@ -1,0 +1,3 @@
+# Git Capability Stays Local To Workspace Git
+
+ViteHub exposes `git()` as an official Agent Capability for bounded source-history and local Workspace Session git state access rather than hiding Git under `workspaceShell()`. Public authority remains coarse `read`/`write`, and remote publication stays outside this capability until Workspace materialization, source ownership, credentials, and actor trust have a dedicated boundary.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -160,6 +160,18 @@ _Avoid_: Second transcript path, provider audio output
 A Workspace Capability that exposes shell-shaped Workspace inspection and optional structured Workspace mutation tools.
 _Avoid_: Bash, sandbox, raw workspace tools
 
+**Git Capability**:
+An official Capability that gives an Agent bounded Git source-history access and local Workspace Session git state selection.
+_Avoid_: Workspace Shell Capability, unrestricted shell, remote publication
+
+**Local Git State Change**:
+A Workspace Session-local change to Git metadata, refs, index, or working tree used to inspect source history or select a local review state.
+_Avoid_: Remote Git Publication, git history publication, git commit
+
+**Remote Git Publication**:
+A Git operation that creates, rewrites, deletes, or publishes commits, branches, tags, or remote refs outside the local Workspace Session.
+_Avoid_: git write mode, fetch, local checkout
+
 **MCP Capability**:
 A Capability that connects an Agent to external MCP servers and exposes their model-facing tools.
 _Avoid_: MCP server implementation, MCP Resource Source

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -1,0 +1,364 @@
+import {
+  defineCapability,
+  normalizeMode,
+} from "../capability-runtime.ts"
+
+import type {
+  AgentCapabilityDefinition,
+  AgentCapabilityMode,
+  AgentToolPolicyContext,
+  AgentToolPolicyDecision,
+  AgentToolSet,
+  MaybePromise,
+} from "../types.ts"
+import type { WorkspaceSession } from "@vite-hub/workspace"
+
+export type GitCapabilityToolPolicy = AgentToolPolicyDecision | ((context: AgentToolPolicyContext) => MaybePromise<AgentToolPolicyDecision>)
+
+export interface GitCapabilityOptions {
+  maxOutputLength?: number
+  mode?: AgentCapabilityMode
+  policy?: GitCapabilityToolPolicy
+  timeout?: number
+}
+
+interface GitCommandInput {
+  command: string
+  cwd?: string
+}
+
+interface GitCommandResult {
+  args: string[]
+  command: string
+  cwd: string
+  exitCode: number
+  outputTruncated?: boolean
+  stderr: string
+  stdout: string
+}
+
+const readSubcommands = new Set([
+  "blame",
+  "cat-file",
+  "describe",
+  "diff",
+  "for-each-ref",
+  "grep",
+  "log",
+  "ls-files",
+  "merge-base",
+  "rev-list",
+  "rev-parse",
+  "shortlog",
+  "show",
+  "show-ref",
+  "status",
+])
+const writeSubcommands = new Set(["checkout", "fetch", "switch"])
+const blockedSubcommands = new Set(["commit", "push", "reset", "rebase", "tag"])
+const blockedReadOptions = new Set(["--contents", "--ext-diff", "--no-index", "--open-files-in-pager", "--textconv"])
+const blockedCheckoutOptions = new Set(["--force", "--merge", "--orphan", "--patch", "-B", "-b", "-f", "-m", "-p"])
+const blockedFetchOptions = new Set(["--force", "--prune-tags", "--refmap", "--tags", "--update-head-ok", "-f", "-t"])
+const fetchOptionsWithValue = new Set(["--deepen", "--depth", "--filter", "--jobs", "--negotiation-tip", "--refmap", "--recurse-submodules", "--server-option", "--shallow-exclude", "--shallow-since", "--upload-pack"])
+const blockedSwitchOptions = new Set(["--create", "--discard-changes", "--force", "--force-create", "--guess", "--merge", "--orphan", "--track", "-C", "-c", "-f", "-m", "-t"])
+const defaultMaxOutputLength = 30_000
+const gitEnv = {
+  GIT_PAGER: "cat",
+  GIT_TERMINAL_PROMPT: "0",
+  PAGER: "cat",
+}
+
+type GitSessionWorkspace = {
+  startSession: () => Promise<WorkspaceSession>
+}
+
+function isGitSessionWorkspace(workspace: unknown): workspace is GitSessionWorkspace {
+  return typeof workspace === "object"
+    && workspace !== null
+    && typeof (workspace as { startSession?: unknown }).startSession === "function"
+}
+
+function parseGitCommand(command: string): string[] {
+  const words = shellWords(command)
+  if (words[0] !== "git") throw new Error("[vitehub] git commands must start with `git`.")
+  if (!words[1]) throw new Error("[vitehub] git command requires a subcommand.")
+  if (words[1].startsWith("-")) throw new Error("[vitehub] git() does not accept global git flags. Use the tool cwd option instead of `git -C`.")
+  return words.slice(1)
+}
+
+function shellWords(command: string): string[] {
+  const words: string[] = []
+  let current = ""
+  let quote: "'" | "\"" | undefined
+  let escaped = false
+
+  for (const char of command) {
+    if (escaped) {
+      current += char
+      escaped = false
+      continue
+    }
+    if (char === "\\") {
+      escaped = true
+      continue
+    }
+    if (quote) {
+      if (char === quote) quote = undefined
+      else current += char
+      continue
+    }
+    if (char === "'" || char === "\"") {
+      quote = char
+      continue
+    }
+    if (char === "|" || char === ";" || char === "<" || char === ">" || char === "&" || char === "\n") {
+      throw new Error("[vitehub] git() accepts one git command without shell composition.")
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        words.push(current)
+        current = ""
+      }
+      continue
+    }
+    current += char
+  }
+
+  if (escaped) current += "\\"
+  if (quote) throw new Error("[vitehub] git() command has an unterminated quote.")
+  if (current) words.push(current)
+  return words
+}
+
+function assertGitRead(args: string[]): void {
+  const subcommand = args[0]!
+  if (blockedSubcommands.has(subcommand)) {
+    throw new Error(`[vitehub] git ${subcommand} is not available through git().`)
+  }
+  if (!readSubcommands.has(subcommand)) {
+    throw new Error(`[vitehub] git ${subcommand} requires git({ mode: "write" }) or is not supported.`)
+  }
+  if (args.some(arg => arg === "--output" || arg.startsWith("--output="))) {
+    throw new Error("[vitehub] git read commands cannot write output files.")
+  }
+  for (const arg of args.slice(1)) {
+    const option = optionName(arg)
+    if (blockedReadOptions.has(option) || arg === "-O" || arg.startsWith("-O")) {
+      throw new Error(`[vitehub] git ${subcommand} option ${option} is not available through git_read.`)
+    }
+    assertWorkspaceArg(arg)
+  }
+}
+
+function assertGitWrite(args: string[]): void {
+  const subcommand = args[0]!
+  if (!writeSubcommands.has(subcommand)) {
+    assertGitRead(args)
+    return
+  }
+  if (subcommand === "fetch" && args.some(arg => arg.includes("://") || arg.startsWith("git@"))) {
+    throw new Error("[vitehub] git fetch only accepts configured remotes, not arbitrary remote URLs.")
+  }
+  if (subcommand === "fetch") assertGitFetch(args)
+  if (subcommand === "checkout") assertNoBlockedOptions(args, blockedCheckoutOptions)
+  if (subcommand === "switch") assertNoBlockedOptions(args, blockedSwitchOptions)
+}
+
+function optionName(arg: string): string {
+  const equalsIndex = arg.indexOf("=")
+  return equalsIndex === -1 ? arg : arg.slice(0, equalsIndex)
+}
+
+function assertWorkspaceArg(arg: string): void {
+  const value = arg.includes("=") ? arg.slice(arg.indexOf("=") + 1) : arg
+  const normalized = value.replace(/\\/g, "/")
+  if (normalized === ".." || normalized.startsWith("/") || normalized.startsWith("../") || normalized.startsWith("~/") || normalized.includes("/../")) {
+    throw new Error("[vitehub] git arguments must stay inside the workspace.")
+  }
+}
+
+function assertNoBlockedOptions(args: string[], blockedOptions: Set<string>): void {
+  for (const arg of args.slice(1)) {
+    const option = optionName(arg)
+    if (blockedOptions.has(option) || blockedOptions.has(arg.slice(0, 2))) {
+      throw new Error(`[vitehub] git ${args[0]} option ${option} is not available through git_write.`)
+    }
+    assertWorkspaceArg(arg)
+  }
+}
+
+function assertGitFetch(args: string[]): void {
+  for (const arg of args.slice(1)) {
+    const option = optionName(arg)
+    if (blockedFetchOptions.has(option) || blockedFetchOptions.has(arg.slice(0, 2))) {
+      throw new Error(`[vitehub] git fetch option ${option} is not available through git_write.`)
+    }
+  }
+  const [, ...refspecs] = fetchPositionals(args)
+  for (const refspec of refspecs) {
+    assertWorkspaceArg(refspec)
+    if (refspec.startsWith("+") || refspec.includes(":")) {
+      throw new Error("[vitehub] git fetch cannot update local ref destinations through git_write.")
+    }
+  }
+}
+
+function fetchPositionals(args: string[]): string[] {
+  const positionals: string[] = []
+  for (let index = 1; index < args.length; index += 1) {
+    const arg = args[index]!
+    if (arg === "--") return positionals.concat(args.slice(index + 1))
+    if (arg.startsWith("--")) {
+      if (fetchOptionsWithValue.has(optionName(arg)) && !arg.includes("=")) index += 1
+      continue
+    }
+    if (arg === "-j" || arg === "--jobs") {
+      index += 1
+      continue
+    }
+    if (arg.startsWith("-")) continue
+    positionals.push(arg)
+  }
+  return positionals
+}
+
+function fetchRemote(args: string[]): string | undefined {
+  return fetchPositionals(args)[0]
+}
+
+function gitExecOptions(cwd: string, timeout: number | undefined) {
+  return { cwd, env: gitEnv, timeout }
+}
+
+async function assertConfiguredFetchRemote(session: WorkspaceSession, cwd: string, timeout: number | undefined, args: string[]): Promise<void> {
+  const remote = fetchRemote(args)
+  if (!remote) return
+  const result = await session.exec("git", ["remote"], gitExecOptions(cwd, timeout))
+  if (result.exitCode !== 0) throw new Error(result.stderr || result.stdout || "[vitehub] git remote failed.")
+  if (!result.stdout.split(/\r?\n/).filter(Boolean).includes(remote)) {
+    throw new Error("[vitehub] git fetch only accepts configured remotes, not arbitrary remote URLs.")
+  }
+}
+
+function normalizeCwd(cwd: string | undefined): string {
+  const stripped = (cwd || "").replace(/\\/g, "/").replace(/^\/workspace(?:\/|$)/, "")
+  const parts = stripped.split("/").filter(Boolean)
+  if (parts.some(part => part === "." || part === "..")) {
+    throw new Error("[vitehub] git cwd must stay inside the workspace.")
+  }
+  return parts.length ? `/workspace/${parts.join("/")}` : "/workspace"
+}
+
+function limitOutput(output: string, maxOutputLength: number): { output: string, truncated?: boolean } {
+  if (output.length <= maxOutputLength) return { output }
+  return {
+    output: `${output.slice(0, maxOutputLength)}\n[output truncated to ${maxOutputLength} characters]\n`,
+    truncated: true,
+  }
+}
+
+async function cleanWorkingTree(session: WorkspaceSession, cwd: string, timeout: number | undefined): Promise<void> {
+  const result = await session.exec("git", ["status", "--porcelain"], gitExecOptions(cwd, timeout))
+  if (result.exitCode !== 0) throw new Error(result.stderr || result.stdout || "[vitehub] git status failed.")
+  if (result.stdout.trim()) throw new Error("[vitehub] git write commands require a clean working tree.")
+}
+
+function gitTools(
+  mode: AgentCapabilityMode,
+  options: Required<Pick<GitCapabilityOptions, "maxOutputLength">> & Pick<GitCapabilityOptions, "policy" | "timeout">,
+  getSession: () => Promise<WorkspaceSession>,
+): AgentToolSet {
+  async function run(input: GitCommandInput, write: boolean): Promise<GitCommandResult> {
+    if (typeof input?.command !== "string" || !input.command.trim()) {
+      throw new Error("[vitehub] git command must be a non-empty string.")
+    }
+    const args = parseGitCommand(input.command)
+    write ? assertGitWrite(args) : assertGitRead(args)
+    const cwd = normalizeCwd(input.cwd)
+    const session = await getSession()
+    if (write && args[0] === "fetch") await assertConfiguredFetchRemote(session, cwd, options.timeout, args)
+    if (write && writeSubcommands.has(args[0]!)) await cleanWorkingTree(session, cwd, options.timeout)
+    const result = await session.exec("git", args, gitExecOptions(cwd, options.timeout))
+    if (write && writeSubcommands.has(args[0]!) && result.exitCode === 0) {
+      await session.commit({ message: `git ${args[0]}` })
+    }
+    const stdout = limitOutput(result.stdout, options.maxOutputLength)
+    const stderr = limitOutput(result.stderr, options.maxOutputLength)
+    return {
+      args,
+      command: input.command,
+      cwd,
+      exitCode: result.exitCode,
+      outputTruncated: stdout.truncated || stderr.truncated,
+      stderr: stderr.output,
+      stdout: stdout.output,
+    }
+  }
+
+  const tools: AgentToolSet = {
+    git_read: {
+      description: "Run one read-only git command in the workspace.",
+      execute: (input: unknown) => run(input as GitCommandInput, false),
+      inputSchema: gitInputSchema("Read-only git command, for example `git status --short`, `git diff --stat`, or `git log --oneline -n 20`."),
+      name: "git_read",
+    },
+  }
+
+  if (mode === "write") {
+    tools.git_write = {
+      description: "Run one local git write command in the workspace. Supports fetch, checkout, and switch on a clean working tree.",
+      execute: (input: unknown) => run(input as GitCommandInput, true),
+      inputSchema: gitInputSchema("Local git command, for example `git fetch origin pull/123/head` or `git switch main`."),
+      name: "git_write",
+      policy: options.policy || "require-approval",
+    }
+  }
+
+  return tools
+}
+
+function gitInputSchema(commandDescription: string) {
+  return {
+    additionalProperties: false,
+    properties: {
+      command: { description: commandDescription, type: "string" },
+      cwd: { description: "Workspace-relative directory. Defaults to the workspace root.", type: "string" },
+    },
+    required: ["command"],
+    type: "object",
+  }
+}
+
+export function git(options: GitCapabilityOptions = {}): AgentCapabilityDefinition {
+  const mode = normalizeMode(options.mode, "Git")
+  const maxOutputLength = options.maxOutputLength ?? defaultMaxOutputLength
+  let sessionPromise: Promise<WorkspaceSession> | undefined
+
+  async function getSession(workspace: unknown): Promise<WorkspaceSession> {
+    if (!isGitSessionWorkspace(workspace)) {
+      throw new Error("[vitehub] git() requires a git-capable workspace session.")
+    }
+    sessionPromise ??= workspace.startSession().catch((error) => {
+      sessionPromise = undefined
+      throw error
+    })
+    return await sessionPromise
+  }
+
+  return defineCapability({
+    id: "git",
+    mode,
+    metadata: { mode },
+    requires: [{ primitive: "workspace", workspace: { mode, required: true } }],
+    tools: context => gitTools(mode, {
+      maxOutputLength,
+      policy: options.policy,
+      timeout: options.timeout,
+    }, () => getSession(context.workspace)),
+    async close() {
+      const session = await sessionPromise
+      sessionPromise = undefined
+      await session?.close()
+    },
+  })
+}

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -19,6 +19,9 @@ export {
   fetch,
 } from "./fetch.ts"
 export {
+  git,
+} from "./git.ts"
+export {
   inputCommands,
 } from "./input-commands.ts"
 export {
@@ -157,6 +160,10 @@ export type {
   FetchCapabilityToolOptions,
   FetchCapabilityToolRequest,
 } from "./fetch.ts"
+export type {
+  GitCapabilityOptions,
+  GitCapabilityToolPolicy,
+} from "./git.ts"
 export type {
   InputCommand,
   InputCommandRunInput,

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { git } from "../src/capabilities.ts"
+
+import type { AgentToolSet } from "../src/types.ts"
+import type { WorkspaceSession } from "@vite-hub/workspace"
+
+function gitSession(options: { remotes?: string, status?: string } = {}) {
+  const session = {
+    close: vi.fn(),
+    commit: vi.fn(),
+    exec: vi.fn(async (command: string, args: string[] = []) => ({
+      args,
+      command,
+      exitCode: 0,
+      stderr: "",
+      stdout: args.join(" ") === "status --porcelain"
+        ? options.status || ""
+        : args[0] === "remote"
+          ? options.remotes || "origin\n"
+          : "ok\n",
+    })),
+  } as unknown as WorkspaceSession & {
+    close: ReturnType<typeof vi.fn>
+    commit: ReturnType<typeof vi.fn>
+    exec: ReturnType<typeof vi.fn>
+  }
+  return session
+}
+
+async function capabilityTools(capability = git(), session = gitSession()): Promise<{ session: ReturnType<typeof gitSession>, tools: AgentToolSet }> {
+  if (typeof capability.tools !== "function") throw new Error("git capability must expose tool resolver")
+  const tools = await capability.tools({
+    workspace: {
+      startSession: vi.fn(async () => session),
+    },
+  } as never) as AgentToolSet
+  return { session, tools }
+}
+
+describe("git capability", () => {
+  it("defaults to read mode and records write mode", () => {
+    expect(git()).toMatchObject({
+      id: "git",
+      metadata: { mode: "read" },
+      mode: "read",
+      requires: [{ workspace: { mode: "read", required: true } }],
+    })
+    expect(git({ mode: "write" })).toMatchObject({
+      metadata: { mode: "write" },
+      mode: "write",
+      requires: [{ workspace: { mode: "write", required: true } }],
+    })
+    expect(() => git({ mode: "remote-write" as never })).toThrow("Git mode must be \"read\" or \"write\"")
+  })
+
+  it("exposes only read git commands in read mode", async () => {
+    const { session, tools } = await capabilityTools()
+
+    expect(Object.keys(tools)).toEqual(["git_read"])
+    await expect(tools.git_read!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+      args: ["status", "--short"],
+      cwd: "/workspace",
+      stdout: "ok\n",
+    })
+    await expect(tools.git_read!.execute?.({ command: "git switch main" })).rejects.toThrow("requires git({ mode: \"write\" })")
+    expect(session.exec).toHaveBeenCalledWith("git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace", timeout: undefined }))
+  })
+
+  it("blocks git read options that escape inspection boundaries", async () => {
+    const { tools } = await capabilityTools()
+
+    await expect(tools.git_read!.execute?.({ command: "git grep -O=sh TODO" })).rejects.toThrow("not available through git_read")
+    await expect(tools.git_read!.execute?.({ command: "git grep --open-files-in-pager=sh TODO" })).rejects.toThrow("not available through git_read")
+    await expect(tools.git_read!.execute?.({ command: "git diff --no-index /etc/passwd README.md" })).rejects.toThrow("not available through git_read")
+    await expect(tools.git_read!.execute?.({ command: "git show /etc/passwd" })).rejects.toThrow("must stay inside the workspace")
+  })
+
+  it("runs local write commands only on a clean tree", async () => {
+    const session = gitSession()
+    const { tools } = await capabilityTools(git({ mode: "write", policy: "allow" }), session)
+
+    expect(Object.keys(tools)).toEqual(["git_read", "git_write"])
+    expect(tools.git_write!.policy).toBe("allow")
+    await expect(tools.git_write!.execute?.({ command: "git switch feature/pr-1", cwd: "portal" })).resolves.toMatchObject({
+      args: ["switch", "feature/pr-1"],
+      cwd: "/workspace/portal",
+    })
+    expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["status", "--porcelain"], expect.objectContaining({ cwd: "/workspace/portal", timeout: undefined }))
+    expect(session.exec).toHaveBeenNthCalledWith(2, "git", ["switch", "feature/pr-1"], expect.objectContaining({ cwd: "/workspace/portal", timeout: undefined }))
+    expect(session.commit).toHaveBeenCalledWith({ message: "git switch" })
+  })
+
+  it("fetches only configured remotes in write mode", async () => {
+    const session = gitSession({ remotes: "origin\nupstream\n" })
+    const { tools } = await capabilityTools(git({ mode: "write" }), session)
+
+    await expect(tools.git_write!.execute?.({ command: "git fetch origin pull/123/head" })).resolves.toMatchObject({
+      args: ["fetch", "origin", "pull/123/head"],
+    })
+    await expect(tools.git_write!.execute?.({ command: "git fetch /tmp/repo.git main" })).rejects.toThrow("configured remotes")
+    await expect(tools.git_write!.execute?.({ command: "git fetch user@example.com:repo main" })).rejects.toThrow("configured remotes")
+  })
+
+  it("blocks destructive local git write flags and refspec destinations", async () => {
+    const { tools } = await capabilityTools(git({ mode: "write" }))
+
+    await expect(tools.git_write!.execute?.({ command: "git switch -C review HEAD" })).rejects.toThrow("not available through git_write")
+    await expect(tools.git_write!.execute?.({ command: "git checkout -B review HEAD" })).rejects.toThrow("not available through git_write")
+    await expect(tools.git_write!.execute?.({ command: "git fetch origin pull/123/head:review" })).rejects.toThrow("cannot update local ref destinations")
+    await expect(tools.git_write!.execute?.({ command: "git fetch origin +pull/123/head" })).rejects.toThrow("cannot update local ref destinations")
+    await expect(tools.git_write!.execute?.({ command: "git fetch --refmap=refs/*:refs/* origin pull/123/head" })).rejects.toThrow("not available through git_write")
+    await expect(tools.git_write!.execute?.({ command: "git fetch --tags origin" })).rejects.toThrow("not available through git_write")
+  })
+
+  it("rejects dirty write commands and remote publication commands", async () => {
+    const dirty = gitSession({ status: "M README.md\n" })
+    const { tools } = await capabilityTools(git({ mode: "write" }), dirty)
+
+    await expect(tools.git_write!.execute?.({ command: "git checkout main" })).rejects.toThrow("clean working tree")
+    await expect(tools.git_write!.execute?.({ command: "git push origin main" })).rejects.toThrow("git push is not available")
+    await expect(tools.git_write!.execute?.({ command: "git fetch https://example.com/repo.git main" })).rejects.toThrow("configured remotes")
+    expect(dirty.commit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, type AgentActor, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDefinition, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRuntimeConfig, type AgentRuntimeContext } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, stream, teams, telegram, webChat } from "../src/channels.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -54,6 +54,9 @@ describe("agent public types", () => {
             } satisfies FetchCapabilityToolOptions<{ region: string }, { status: string }, string>,
           },
         }),
+        git(),
+        git({ mode: "read" }),
+        git({ mode: "write", policy: "require-approval" }),
         inputCommands({
           commands: {
             review: {
@@ -128,6 +131,9 @@ describe("agent public types", () => {
 
     // @ts-expect-error skills shell execution mode must be read or write
     skills({ shellExecution: "allow" })
+
+    // @ts-expect-error git mode must be read or write
+    git({ mode: "remote-write" })
 
     const invocationContext: AgentInvocationContextStore = {
       entries: () => new Map<string, unknown>().entries(),

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -252,6 +252,19 @@ describe("defineAgent workspace option", () => {
     await expect(agent.run!(context())).rejects.toThrow("skills() requires workspace.mode: \"write\"")
   })
 
+  it("requires writable workspace for write-mode git commands", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { git } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [git({ mode: "write" })],
+      model: {} as never,
+      workspace: { mode: "read" },
+    })
+
+    await expect(agent.run!(context())).rejects.toThrow("git() requires workspace.mode: \"write\"")
+  })
+
   it("creates a workspace and agent definition without resolving workspace until run", async () => {
     const { useWorkspace } = await import("@vite-hub/workspace")
     const { defineAgent } = await import("../src/index.ts")


### PR DESCRIPTION
Adds a Git capability for workspace agents so they can inspect repository state with `git_read` and opt into local git state changes with `git_write`.

The write mode follows the existing coarse read/write capability shape while staying local: it allows configured-remote `fetch`, `checkout`, and `switch` on a clean workspace, blocks history publication and remote publication, and hardens Git argument boundaries against pager execution, workspace path escapes, arbitrary fetch remotes, destructive branch creation flags, and refspec destination updates.

Stacked on #337 because Quiver Review already uses the channel-owned trigger APIs from that branch.

Research and review artifacts were written locally under `/var/folders/85/68jgd5r148j98t_nq6w1r5mh0000gn/T/evidence-research/vitehub/git-capability/`.