### PR TITLE
feat(agent): add usage telemetry summaries

### DIFF
--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -256,6 +256,7 @@ export type {
   UsageTelemetryCallback,
   UsageTelemetryContext,
   UsageTelemetryOptions,
+  UsageTelemetrySummaryOptions,
   VercelAiGatewayPricingOptions,
 } from "./usage-telemetry.ts"
 export type {

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -236,11 +236,18 @@ function formatUsageNumber(value: number): string {
 function formatUsageTokens(usage: AgentUsageRecord["usage"]): string | undefined {
   const input = finiteUsageNumber(usage?.inputTokens)
   const output = finiteUsageNumber(usage?.outputTokens)
-  const total = finiteUsageNumber(usage?.totalTokens) ?? (input !== undefined || output !== undefined ? (input || 0) + (output || 0) : undefined)
-  if (total === undefined) return
+  const total = finiteUsageNumber(usage?.totalTokens) ?? (input !== undefined && output !== undefined ? input + output : undefined)
+  if (total === undefined) {
+    if (input !== undefined) return `${formatUsageNumber(input)} input tokens`
+    if (output !== undefined) return `${formatUsageNumber(output)} output tokens`
+    return
+  }
   const totalText = `${formatUsageNumber(total)} tokens`
   if (input === undefined && output === undefined) return totalText
-  return `${totalText}: ${formatUsageNumber(input || 0)} in / ${formatUsageNumber(output || 0)} out`
+  const splitInput = input ?? (output !== undefined && total >= output ? total - output : undefined)
+  const splitOutput = output ?? (input !== undefined && total >= input ? total - input : undefined)
+  if (splitInput === undefined || splitOutput === undefined) return totalText
+  return `${totalText}: ${formatUsageNumber(splitInput)} in / ${formatUsageNumber(splitOutput)} out`
 }
 
 function formatUsageCost(cost: AgentUsageRecord["cost"]): string | undefined {

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -38,6 +38,11 @@ export interface UsageTelemetryOptions {
   includeRaw?: boolean
   onUsage?: UsageTelemetryCallback
   pricing?: AgentUsagePricing
+  summary?: boolean | UsageTelemetrySummaryOptions
+}
+
+export interface UsageTelemetrySummaryOptions {
+  subject?: string
 }
 
 export interface StaticModelPrice {
@@ -220,6 +225,76 @@ function removeRawUsage(usage: AgentUsage): AgentUsage {
   return rest
 }
 
+function finiteUsageNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.trunc(value) : undefined
+}
+
+function formatUsageNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value)
+}
+
+function formatUsageTokens(usage: AgentUsageRecord["usage"]): string | undefined {
+  const input = finiteUsageNumber(usage?.inputTokens)
+  const output = finiteUsageNumber(usage?.outputTokens)
+  const total = finiteUsageNumber(usage?.totalTokens) ?? (input !== undefined || output !== undefined ? (input || 0) + (output || 0) : undefined)
+  if (total === undefined) return
+  const totalText = `${formatUsageNumber(total)} tokens`
+  if (input === undefined && output === undefined) return totalText
+  return `${totalText}: ${formatUsageNumber(input || 0)} in / ${formatUsageNumber(output || 0)} out`
+}
+
+function formatUsageCost(cost: AgentUsageRecord["cost"]): string | undefined {
+  if (!cost?.amount) return
+  const amount = cost.amount.replace(/(\.\d*?[1-9])0+$/, "$1").replace(/\.0+$/, "")
+  return cost.currency === "USD" ? `$${amount}` : `${amount} ${cost.currency}`
+}
+
+function formatUsageDuration(durationMs: unknown): string | undefined {
+  const finite = finiteUsageNumber(durationMs)
+  if (finite === undefined) return
+  return `${(finite / 1000).toFixed(1)}s`
+}
+
+function normalizeUsageSummaryOptions(summary: UsageTelemetryOptions["summary"]): UsageTelemetrySummaryOptions | undefined {
+  if (!summary) return
+  return typeof summary === "object" && summary !== null ? summary : {}
+}
+
+function formatUsageSummary(record: AgentUsageRecord, options: UsageTelemetrySummaryOptions = {}): string | undefined {
+  const subject = typeof options.subject === "string" && options.subject.trim() ? options.subject.trim() : "This invocation"
+  const cost = formatUsageCost(record.cost)
+  const tokens = formatUsageTokens(record.usage)
+  const model = record.model?.id
+  const duration = formatUsageDuration(record.latency?.durationMs)
+  const run = [model ? `using ${model}` : undefined, duration ? `in ${duration}` : undefined].filter(Boolean).join(" ")
+  if (cost) return `${subject} cost ${record.cost?.estimated ? "about " : ""}${cost}${run ? ` ${run}` : ""}${tokens ? ` (${tokens})` : ""}.`
+  if (tokens) return `${subject} used ${tokens}${run ? ` ${run}` : ""}.`
+  if (run) return `${subject} ran ${run}.`
+}
+
+function usageRecordForFinish(
+  record: unknown,
+  event: AgentFinishEvent,
+  options: UsageTelemetryOptions,
+): AgentUsageRecord | undefined {
+  if (!isRecord(record)) return
+  const usageRecord = record as AgentUsageRecord
+  const summaryOptions = normalizeUsageSummaryOptions(options.summary)
+  if (!summaryOptions) return usageRecord
+  const durationMs = finiteUsageNumber(usageRecord.latency?.durationMs) ?? finiteUsageNumber(event.invocation.durationMs)
+  const withDuration = durationMs === undefined
+    ? usageRecord
+    : {
+        ...usageRecord,
+        latency: {
+          ...(isRecord(usageRecord.latency) ? usageRecord.latency : {}),
+          durationMs,
+        },
+      }
+  const summary = formatUsageSummary(withDuration, summaryOptions)
+  return summary ? { ...withDuration, summary } : withDuration
+}
+
 async function recordUsage(
   result: UnknownRecord,
   options: UsageTelemetryOptions,
@@ -314,9 +389,9 @@ export function usageTelemetry(options: UsageTelemetryOptions = {}): AgentCapabi
       usageTelemetry: options,
     } satisfies UsageTelemetryCapabilityMetadata,
     output(context) {
-      context.finish.provide((event: AgentFinishEvent) => isRecord(event.result)
+      context.finish.provide((event: AgentFinishEvent) => usageRecordForFinish(isRecord(event.result)
         ? event.result.usageRecord
-        : undefined)
+        : undefined, event, options))
       context.output.render(async (result) => {
         if (isAsyncIterable(result)) return withUsageTelemetryStream(result, options, context.run)
         if (!isRecord(result)) return result

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1064,6 +1064,7 @@ export interface AgentUsageRecord {
     timestamp?: Date | string
   }
   run?: Partial<AgentRunMetadata>
+  summary?: string
   usage?: AgentUsage
 }
 

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, type AgentChannelDefinition, type AgentDriver, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRuntimeConfig, type AgentRuntimeContext } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { http, teams, webChat } from "../src/channels.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -9,7 +9,7 @@ import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentUsageRecord } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
 import { source } from "@vite-hub/workspace"
-import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatPlatformResolver, AgentChatRunContext, FetchCapabilityToolOptions, TranscriptionResult } from "../src/capabilities.ts"
+import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatPlatformResolver, AgentChatRunContext, FetchCapabilityToolOptions, TranscriptionResult, UsageTelemetrySummaryOptions } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
   it("accepts capabilities from the capabilities entry", () => {
@@ -83,6 +83,8 @@ describe("agent public types", () => {
             return "transcript"
           },
         }),
+        usageTelemetry({ summary: true }),
+        usageTelemetry({ summary: { subject: "Review run" } satisfies UsageTelemetrySummaryOptions }),
         chatTitle({
           model: () => ({}),
           template({ fallback, maxLength, text, trigger }) {

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -141,6 +141,45 @@ describe("usage telemetry", () => {
     })
   })
 
+  it("summarizes partial token splits without rendering missing counts as zero", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const finish = vi.fn()
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({
+          summary: { subject: "Review run" },
+        }),
+      ],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({
+        text: "ok",
+        totalUsage: {
+          inputTokens: 1000,
+          totalTokens: 1250,
+        },
+      }),
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+      text: "ok",
+      usageRecord: {
+        usage: {
+          inputTokens: 1000,
+          totalTokens: 1250,
+        },
+      },
+    })
+    expect(finish).toHaveBeenCalledTimes(1)
+    const usageRecord = finish.mock.calls[0]![0].extensions.get("usage-telemetry")
+    expect(usageRecord).toMatchObject({
+      summary: expect.stringMatching(/^Review run used 1,250 tokens: 1,000 in \/ 250 out in \d+\.\ds\.$/),
+    })
+  })
+
   it("emits usage records from streamed finish chunks", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -89,6 +89,58 @@ describe("usage telemetry", () => {
     expect(finish.mock.calls[0]![0].extensions.get("usage-telemetry")).toEqual(usageRecord)
   })
 
+  it("summarizes usage telemetry for finish hooks", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
+    const finish = vi.fn()
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({
+          pricing: staticModelPricing({
+            "openai/gpt-test": {
+              input: "0.00000010",
+              output: "0.00000020",
+            },
+          }),
+          summary: { subject: "Review run" },
+        }),
+      ],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({
+        response: {
+          modelId: "openai/gpt-test",
+        },
+        text: "ok",
+        totalUsage: {
+          inputTokens: 1000,
+          outputTokens: 250,
+        },
+      }),
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+      text: "ok",
+      usageRecord: {
+        usage: {
+          inputTokens: 1000,
+          outputTokens: 250,
+          totalTokens: 1250,
+        },
+      },
+    })
+    expect(finish).toHaveBeenCalledTimes(1)
+    const usageRecord = finish.mock.calls[0]![0].extensions.get("usage-telemetry")
+    expect(usageRecord).toMatchObject({
+      latency: {
+        durationMs: expect.any(Number),
+      },
+      summary: expect.stringMatching(/^Review run cost about \$0\.00015 using openai\/gpt-test in \d+\.\ds \(1,250 tokens: 1,000 in \/ 250 out\)\.$/),
+    })
+  })
+
   it("emits usage records from streamed finish chunks", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")


### PR DESCRIPTION
Adds an opt-in `usageTelemetry({ summary: true })` finish-extension summary so agents can report cost, token usage, model, and invocation duration from the capability instead of app-side formatting.

Existing finish extension records stay unchanged unless `summary` is enabled. The PR also exports `UsageTelemetrySummaryOptions` and types `AgentUsageRecord.summary` for consumers that read the finish extension.