### PR TITLE
fix(agent): harden git capability session access

### DIFF
--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -58,7 +58,7 @@ const writeSubcommands = new Set(["checkout", "fetch", "switch"])
 const blockedSubcommands = new Set(["commit", "push", "reset", "rebase", "tag"])
 const blockedReadOptions = new Set(["--contents", "--ext-diff", "--no-index", "--open-files-in-pager", "--textconv"])
 const blockedCheckoutOptions = new Set(["--force", "--merge", "--orphan", "--patch", "-B", "-b", "-f", "-m", "-p"])
-const blockedFetchOptions = new Set(["--force", "--prune-tags", "--refmap", "--tags", "--update-head-ok", "-f", "-t"])
+const blockedFetchOptions = new Set(["--force", "--prune-tags", "--refmap", "--tags", "--update-head-ok", "--upload-pack", "-f", "-t"])
 const fetchOptionsWithValue = new Set(["--deepen", "--depth", "--filter", "--jobs", "--negotiation-tip", "--refmap", "--recurse-submodules", "--server-option", "--shallow-exclude", "--shallow-since", "--upload-pack"])
 const blockedSwitchOptions = new Set(["--create", "--discard-changes", "--force", "--force-create", "--guess", "--merge", "--orphan", "--track", "-C", "-c", "-f", "-m", "-t"])
 const defaultMaxOutputLength = 30_000
@@ -349,7 +349,7 @@ export function git(options: GitCapabilityOptions = {}): AgentCapabilityDefiniti
     id: "git",
     mode,
     metadata: { mode },
-    requires: [{ primitive: "workspace", workspace: { mode, required: true } }],
+    requires: [{ primitive: "workspace", workspace: { mode: "write", required: true } }],
     tools: context => gitTools(mode, {
       maxOutputLength,
       policy: options.policy,

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -44,7 +44,7 @@ describe("git capability", () => {
       id: "git",
       metadata: { mode: "read" },
       mode: "read",
-      requires: [{ workspace: { mode: "read", required: true } }],
+      requires: [{ workspace: { mode: "write", required: true } }],
     })
     expect(git({ mode: "write" })).toMatchObject({
       metadata: { mode: "write" },
@@ -110,6 +110,8 @@ describe("git capability", () => {
     await expect(tools.git_write!.execute?.({ command: "git fetch origin pull/123/head:review" })).rejects.toThrow("cannot update local ref destinations")
     await expect(tools.git_write!.execute?.({ command: "git fetch origin +pull/123/head" })).rejects.toThrow("cannot update local ref destinations")
     await expect(tools.git_write!.execute?.({ command: "git fetch --refmap=refs/*:refs/* origin pull/123/head" })).rejects.toThrow("not available through git_write")
+    await expect(tools.git_write!.execute?.({ command: "git fetch --upload-pack=\"sh -c whoami\" origin" })).rejects.toThrow("not available through git_write")
+    await expect(tools.git_write!.execute?.({ command: "git fetch --upload-pack sh origin" })).rejects.toThrow("not available through git_write")
     await expect(tools.git_write!.execute?.({ command: "git fetch --tags origin" })).rejects.toThrow("not available through git_write")
   })
 

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -252,12 +252,12 @@ describe("defineAgent workspace option", () => {
     await expect(agent.run!(context())).rejects.toThrow("skills() requires workspace.mode: \"write\"")
   })
 
-  it("requires writable workspace for write-mode git commands", async () => {
+  it("requires writable workspace for git commands", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { git } = await import("../src/capabilities.ts")
 
     const agent = defineAgent({
-      capabilities: [git({ mode: "write" })],
+      capabilities: [git()],
       model: {} as never,
       workspace: { mode: "read" },
     })


### PR DESCRIPTION
Addresses the Codex review comments from #338 by blocking `git fetch --upload-pack` in `git_write` and declaring that `git()` needs the session-capable Workspace surface even when it exposes only `git_read`.

Stacked on #337 because #338 is already merged into `codex/channels-api-grill`, not `main`.