### PR TITLE
refactor(agent): remove workspace agent defaults helper

### DIFF
--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -11,7 +11,6 @@ import {
   resolveAgentTriggers,
   streamAgentTrigger,
   withAgentDefaults,
-  withWorkspaceAgentDefaults,
 } from "../../index.ts"
 import {
   type ChatDevtoolsConversation,
@@ -173,10 +172,7 @@ async function loadDiscoveredAgent(
 ): Promise<AgentInput<ViteAgentDevtoolsRuntimeContext> | undefined> {
   const module = await server.ssrLoadModule(pathToFileURL(definition.handler).href)
   const agent = resolveAgentModule(module)
-  const defaults = workspaceDefaults(definition)
-  return agent && defaults
-    ? withWorkspaceAgentDefaults(agent as never, defaults as never) as AgentInput<ViteAgentDevtoolsRuntimeContext>
-    : withAgentDefaults(agent, { inferredName: definition.name })
+  return withAgentDefaults(agent, { inferredName: definition.name, workspace: definition.workspace }) as AgentInput<ViteAgentDevtoolsRuntimeContext>
 }
 
 function createDevtoolsDiscoveryContext(): ViteAgentDevtoolsRuntimeContext {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -668,13 +668,19 @@ function withAgentWorkflowRuntimeName(runtime: AgentRuntimeBinding | undefined, 
   return { ...runtime, name }
 }
 
-function cloneAgentDefinitionWithRuntime<TContext extends AgentRuntimeContext>(
+function cloneAgentDefinitionWithDefaults<TContext extends AgentRuntimeContext>(
   agent: AgentInput<TContext>,
-  runtime: AgentRuntimeBinding,
+  defaults: WorkspaceAgentDefaults | undefined,
+  runtime: AgentRuntimeBinding | undefined,
 ): AgentInput<TContext> {
   const clone = Object.create(Object.getPrototypeOf(agent)) as AgentDefinition
   Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
-  clone.runtime = runtime
+  if (defaults) {
+    (clone as Partial<WorkspaceAgentDefinition>).__vitehubWorkspaceAgentDefaults = defaults
+  }
+  if (runtime) {
+    clone.runtime = runtime
+  }
   return clone as AgentInput<TContext>
 }
 
@@ -692,11 +698,13 @@ export function withAgentDefaults<TContext extends AgentRuntimeContext>(
 ): AgentInput<TContext> | undefined {
   if (!agent || !hasAgentDefinition(agent)) return agent
   const workspaceDefinition = agent as Partial<WorkspaceAgentDefinition>
-  if (workspaceDefinition.__vitehubWorkspaceAgent && (options.inferredName || options.workspace)) {
-    workspaceDefinition.__vitehubWorkspaceAgentDefaults = { name: options.inferredName, workspace: options.workspace }
-  }
+  const workspaceDefaults = workspaceDefinition.__vitehubWorkspaceAgent && (options.inferredName || options.workspace)
+    ? { name: options.inferredName, workspace: options.workspace }
+    : undefined
   const runtime = withAgentWorkflowRuntimeName(agent.runtime, options.inferredName)
-  return !runtime || runtime === agent.runtime ? agent : cloneAgentDefinitionWithRuntime(agent, runtime)
+  return !workspaceDefaults && (!runtime || runtime === agent.runtime)
+    ? agent
+    : cloneAgentDefinitionWithDefaults(agent, workspaceDefaults, runtime === agent.runtime ? undefined : runtime)
 }
 
 export interface DefineAgent {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -668,6 +668,23 @@ function withAgentWorkflowRuntimeName(runtime: AgentRuntimeBinding | undefined, 
   return { ...runtime, name }
 }
 
+function createSyntheticWorkspaceRun<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS>,
+): NonNullable<AgentDefinition<TRuntimeConfig, CALL_OPTIONS>["run"]> {
+  const run: NonNullable<AgentDefinition<TRuntimeConfig, CALL_OPTIONS>["run"]> = async (context) => {
+    const adapter = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(definition as never, context)
+    const invocationContext = await createAgentInvocationContext(definition as never, context as never, context.input)
+    const result = await adapter.generate(toAgentAdapterRunContext(invocationContext) as never)
+    return typeof result === "object" && result && "text" in result && typeof (result as { text?: unknown }).text === "string"
+      ? (result as { text: string }).text
+      : result
+  }
+  return Object.assign(run, { [syntheticWorkspaceRun]: true })
+}
+
 function cloneAgentDefinitionWithDefaults<TContext extends AgentRuntimeContext>(
   agent: AgentInput<TContext>,
   defaults: WorkspaceAgentDefaults | undefined,
@@ -680,6 +697,9 @@ function cloneAgentDefinitionWithDefaults<TContext extends AgentRuntimeContext>(
   }
   if (runtime) {
     clone.runtime = runtime
+  }
+  if (clone.run && syntheticWorkspaceRun in clone.run) {
+    clone.run = createSyntheticWorkspaceRun(clone as never) as typeof clone.run
   }
   return clone as AgentInput<TContext>
 }
@@ -775,15 +795,7 @@ function createWorkspaceAgentDefinition<
   } as never) as WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>
 
   if (!definition.run) {
-    const run: NonNullable<AgentDefinition<TRuntimeConfig, CALL_OPTIONS>["run"]> = async (context) => {
-      const adapter = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(definition as never, context)
-      const invocationContext = await createAgentInvocationContext(definition as never, context as never, context.input)
-      const result = await adapter.generate(toAgentAdapterRunContext(invocationContext) as never)
-      return typeof result === "object" && result && "text" in result && typeof (result as { text?: unknown }).text === "string"
-        ? (result as { text: string }).text
-        : result
-    }
-    definition.run = Object.assign(run, { [syntheticWorkspaceRun]: true })
+    definition.run = createSyntheticWorkspaceRun(definition)
   }
 
   Object.assign(definition, workspaceDefinition, {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -679,10 +679,22 @@ function cloneAgentDefinitionWithRuntime<TContext extends AgentRuntimeContext>(
 }
 
 export function withAgentDefaults<TContext extends AgentRuntimeContext>(
+  agent: AgentInput<TContext>,
+  options?: AgentHandlerOptions<TContext>,
+): AgentInput<TContext>
+export function withAgentDefaults<TContext extends AgentRuntimeContext>(
   agent: AgentInput<TContext> | undefined,
-  options: AgentHandlerOptions = {},
+  options?: AgentHandlerOptions<TContext>,
+): AgentInput<TContext> | undefined
+export function withAgentDefaults<TContext extends AgentRuntimeContext>(
+  agent: AgentInput<TContext> | undefined,
+  options: AgentHandlerOptions<TContext> = {},
 ): AgentInput<TContext> | undefined {
   if (!agent || !hasAgentDefinition(agent)) return agent
+  const workspaceDefinition = agent as Partial<WorkspaceAgentDefinition>
+  if (workspaceDefinition.__vitehubWorkspaceAgent && (options.inferredName || options.workspace)) {
+    workspaceDefinition.__vitehubWorkspaceAgentDefaults = { name: options.inferredName, workspace: options.workspace }
+  }
   const runtime = withAgentWorkflowRuntimeName(agent.runtime, options.inferredName)
   return !runtime || runtime === agent.runtime ? agent : cloneAgentDefinitionWithRuntime(agent, runtime)
 }
@@ -767,18 +779,6 @@ function createWorkspaceAgentDefinition<
     __vitehubWorkspaceAgentOptions: options,
   })
   return definition
-}
-
-export function withWorkspaceAgentDefaults<
-  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  Name extends WorkspaceName = WorkspaceName,
-  CALL_OPTIONS = unknown,
->(
-  definition: WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>,
-  defaults: WorkspaceAgentDefaults<Name>,
-): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS> {
-  if (!definition?.__vitehubWorkspaceAgent) return definition
-  return createWorkspaceAgentDefinition(definition.__vitehubWorkspaceAgentOptions, defaults)
 }
 
 export const defineAgent: DefineAgent = ((options: unknown) => {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -698,8 +698,13 @@ export function withAgentDefaults<TContext extends AgentRuntimeContext>(
 ): AgentInput<TContext> | undefined {
   if (!agent || !hasAgentDefinition(agent)) return agent
   const workspaceDefinition = agent as Partial<WorkspaceAgentDefinition>
+  const existingWorkspaceDefaults = workspaceDefinition.__vitehubWorkspaceAgentDefaults
   const workspaceDefaults = workspaceDefinition.__vitehubWorkspaceAgent && (options.inferredName || options.workspace)
-    ? { name: options.inferredName, workspace: options.workspace }
+    ? {
+        ...existingWorkspaceDefaults,
+        ...(options.inferredName ? { name: options.inferredName } : {}),
+        ...(options.workspace ? { workspace: options.workspace } : {}),
+      }
     : undefined
   const runtime = withAgentWorkflowRuntimeName(agent.runtime, options.inferredName)
   return !workspaceDefaults && (!runtime || runtime === agent.runtime)

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -2,7 +2,7 @@ import { runWithActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflar
 import { createRuntimeWaitUntilController } from "@vite-hub/runtime"
 import { Chat, StreamingPlan } from "chat"
 
-import { createAgentDevtoolsMetadata, materializeAgentDevtoolsSourceMetadata, resolveAgentDevtoolsMetadata, resolveAgentTriggerInvocation, resolveAgentTriggers, runAgentInline, streamAgent, streamAgentTrigger, withWorkspaceAgentDefaults } from "./index.ts"
+import { createAgentDevtoolsMetadata, materializeAgentDevtoolsSourceMetadata, resolveAgentDevtoolsMetadata, resolveAgentTriggerInvocation, resolveAgentTriggers, runAgentInline, streamAgent, streamAgentTrigger, withAgentDefaults } from "./index.ts"
 import { streamAgentOutputToEvents } from "./agent-output.ts"
 import { getAccessCapabilityOptions } from "./capabilities/access.ts"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions } from "./chat-trigger.ts"
@@ -101,7 +101,10 @@ export function registerWorkspaceAgent<
   agent: WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>,
   options: RegisterWorkspaceAgentOptions<Name> = {},
 ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS> {
-  const preparedAgent = withWorkspaceAgentDefaults(agent, options)
+  const preparedAgent = withAgentDefaults(agent as never, {
+    inferredName: options.name,
+    workspace: options.workspace,
+  }) as WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>
   const workspaceOptions = preparedAgent.__vitehubWorkspaceAgentOptions
   if (typeof workspaceOptions.workspace === "string") return preparedAgent
   const sourceRootDir = preparedAgent.sourceRootDir ?? options.sourceRootDir

--- a/packages/agent/src/test.ts
+++ b/packages/agent/src/test.ts
@@ -1,7 +1,7 @@
 import {
   defineAgent,
   runAgent,
-  withWorkspaceAgentDefaults,
+  withAgentDefaults,
 } from "./index.ts"
 import { createAgentRuntimeContext } from "./runtime/context.ts"
 import { registerWorkspace } from "@vite-hub/workspace/test"
@@ -212,9 +212,9 @@ export function createAgentTestRunner<
   }
 
   const preparedAgent = options.workspace
-    ? withWorkspaceAgentDefaults(
-        withTestModelInstrumentation(agent, options.instrumentModel) as WorkspaceAgentDefinition<TRuntimeConfig>,
-        { name: options.name, workspace: options.workspace },
+    ? withAgentDefaults(
+        withTestModelInstrumentation(agent, options.instrumentModel) as never,
+        { inferredName: options.name, workspace: options.workspace },
       )
     : withTestModelInstrumentation(agent, options.instrumentModel)
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -761,6 +761,7 @@ export interface ResolvedAgentModuleOptions {
 export interface AgentHandlerOptions<TRuntimeContext extends AgentRuntimeContext = AgentRuntimeContext> {
   inferredName?: string
   lifecycleHooks?: AgentRuntimeHooks<TRuntimeContext>
+  workspace?: WorkspaceName
 }
 
 export interface AgentRegistryHandlerOptions<TRuntimeContext extends AgentRuntimeContext = AgentRuntimeContext> {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -201,9 +201,7 @@ function generateAgentWebhookRouteHandler(definitions: DiscoveredAgentDefinition
     .join(",\n  ")
   const agentEntries = definitions
     .map((definition, index) => {
-      const agentExpression = definition.workspace
-        ? `withWorkspaceAgentDefaults(resolveAgentModule(agent${index}), ${JSON.stringify({ name: definition.name, workspace: definition.workspace })})`
-        : `withAgentDefaults(resolveAgentModule(agent${index}), ${JSON.stringify({ inferredName: definition.name })})`
+      const agentExpression = `withAgentDefaults(resolveAgentModule(agent${index}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
       return `${JSON.stringify(definition.name)}: ${agentExpression}`
     })
     .join(",\n  ")
@@ -212,7 +210,7 @@ function generateAgentWebhookRouteHandler(definitions: DiscoveredAgentDefinition
     .join(",\n  ")
 
   return [
-    "import { withAgentDefaults, withWorkspaceAgentDefaults } from '@vite-hub/agent'",
+    "import { withAgentDefaults } from '@vite-hub/agent'",
     ...(options.cloudflareState ? ["import { createCloudflareAgentState } from '@vite-hub/agent/cloudflare'"] : []),
     "import { defineAgentChatFetchHandler, defineAgentChatWebhookFetchHandler } from '@vite-hub/agent/server'",
     "import { setWorkspaceRuntimeRegistry } from '@vite-hub/workspace/internal/runtime/state'",

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -8,7 +8,7 @@ import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInv
 import { streamAgentOutputToEvents } from "../agent-output.ts"
 import { uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { discoverAgentDefinitions } from "../discovery.ts"
-import { resolveAgentTriggers, streamAgent, streamAgentTrigger, withAgentDefaults, withWorkspaceAgentDefaults } from "../index.ts"
+import { resolveAgentTriggers, streamAgent, streamAgentTrigger, withAgentDefaults } from "../index.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
 
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http"
@@ -20,7 +20,6 @@ import type {
   AgentRuntimeConfig,
   AgentRuntimeContext,
   DiscoveredAgentDefinition,
-  WorkspaceAgentDefaults,
 } from "../index.ts"
 
 interface ViteAgentDevRuntimeConfig extends AgentRuntimeConfig {
@@ -123,12 +122,6 @@ function resolveAgentModule(module: unknown): AgentInput<ViteAgentDevRuntimeCont
   return module as AgentInput<ViteAgentDevRuntimeContext> | undefined
 }
 
-function workspaceDefaults(definition: DiscoveredAgentDefinition): WorkspaceAgentDefaults | undefined {
-  return definition.workspace
-    ? { name: definition.name, workspace: definition.workspace }
-    : undefined
-}
-
 function resolveWorkspaceSourceRoot(file: string): string {
   const workspaceDirectory = join(dirname(file), "workspace")
   return existsSync(workspaceDirectory) && statSync(workspaceDirectory).isDirectory()
@@ -160,10 +153,7 @@ async function loadDiscoveredAgent(
 ): Promise<AgentInput<ViteAgentDevRuntimeContext> | undefined> {
   const module = await server.ssrLoadModule(pathToFileURL(definition.handler).href)
   const agent = resolveAgentModule(module)
-  const defaults = workspaceDefaults(definition)
-  return agent && defaults
-    ? withWorkspaceAgentDefaults(agent as never, defaults as never) as AgentInput<ViteAgentDevRuntimeContext>
-    : withAgentDefaults(agent, { inferredName: definition.name })
+  return withAgentDefaults(agent, { inferredName: definition.name, workspace: definition.workspace }) as AgentInput<ViteAgentDevRuntimeContext>
 }
 
 async function discoverStreamAgents(server: ViteDevServer): Promise<AgentInvocationStreamEntry[]> {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -12,6 +12,8 @@ import { getMessageText } from "../src/messages.ts"
 import type { IncomingMessage, ServerResponse } from "node:http"
 import type { Connect } from "vite"
 
+const { withAgentDefaults } = await import("../src/index.ts")
+
 async function createTempRoot(prefix: string) {
   return await mkdtemp(join(tmpdir(), prefix))
 }
@@ -263,10 +265,10 @@ describe("agent chat capability discovery", () => {
     await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
 
     const { access, chat } = await import("../src/capabilities.ts")
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const devtoolsMeta = { email: "maximo@quiver.dk" }
     const technicalEmails = new Set(["maximo@quiver.dk"])
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       invoker: {
         profiles: [
           { id: "support-customer", kind: "customer", label: "Customer", meta: { audience: "customer", scope: "customer" } },
@@ -588,13 +590,13 @@ describe("agent chat capability discovery", () => {
     await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
 
     const { chat } = await import("../src/capabilities.ts")
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     let resolveInstructions!: (value: string) => void
     const instructionsReady = new Promise<string>((resolve) => {
       resolveInstructions = resolve
     })
     const readInstructions = vi.fn(async () => await instructionsReady)
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       capabilities: [chat()],
       instructions: readInstructions,
       model: {} as never,
@@ -636,10 +638,10 @@ describe("agent chat capability discovery", () => {
     await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default {}", "utf8")
 
     const { chat } = await import("../src/capabilities.ts")
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const { source } = await import("@vite-hub/workspace")
     const { registerWorkspace } = await import("@vite-hub/workspace/test")
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       capabilities: [chat()],
       instructions: "Answer from the workspace.",
       model: {} as never,
@@ -723,10 +725,10 @@ describe("agent chat capability discovery", () => {
     await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default {}", "utf8")
 
     const { chat } = await import("../src/capabilities.ts")
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const { source } = await import("@vite-hub/workspace")
     const { registerWorkspace } = await import("@vite-hub/workspace/test")
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       capabilities: [chat()],
       instructions: "Answer from the workspace.",
       model: {} as never,

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2965,6 +2965,21 @@ describe("agent message protocol", () => {
       expect(defaults(supportAgent)).toEqual({ name: "support-agent", workspace: "support" })
     })
 
+    it("preserves existing workspace defaults when applying an inferred registry name", async () => {
+      const { defineAgent } = await import("../src/index.ts")
+      const defaults = (agent: unknown) => (agent as { __vitehubWorkspaceAgentDefaults?: { name?: string, workspace?: string } }).__vitehubWorkspaceAgentDefaults
+      const agent = defineAgent({
+        run: () => "ok",
+        workspace: {},
+      })
+
+      const preparedAgent = withAgentDefaults(agent, { inferredName: "support-agent", workspace: "support" })
+      const registryAgent = withAgentDefaults(preparedAgent, { inferredName: "registry-support" })
+
+      expect(registryAgent).not.toBe(preparedAgent)
+      expect(defaults(registryAgent)).toEqual({ name: "registry-support", workspace: "support" })
+    })
+
     it("uses workspace Agent defaults for unnamed workflow runtime bindings", async () => {
       const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2946,6 +2946,25 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("keeps workspace defaults scoped to each prepared Agent Definition", async () => {
+      const { defineAgent } = await import("../src/index.ts")
+      const defaults = (agent: unknown) => (agent as { __vitehubWorkspaceAgentDefaults?: { name?: string, workspace?: string } }).__vitehubWorkspaceAgentDefaults
+      const agent = defineAgent({
+        run: () => "ok",
+        workspace: {},
+      })
+
+      const docsAgent = withAgentDefaults(agent, { inferredName: "docs-agent", workspace: "docs" })
+      const supportAgent = withAgentDefaults(agent, { inferredName: "support-agent", workspace: "support" })
+
+      expect(docsAgent).not.toBe(agent)
+      expect(supportAgent).not.toBe(agent)
+      expect(docsAgent).not.toBe(supportAgent)
+      expect(defaults(agent)).toEqual({})
+      expect(defaults(docsAgent)).toEqual({ name: "docs-agent", workspace: "docs" })
+      expect(defaults(supportAgent)).toEqual({ name: "support-agent", workspace: "support" })
+    })
+
     it("uses workspace Agent defaults for unnamed workflow runtime bindings", async () => {
       const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -29,6 +29,8 @@ vi.mock("@ai-sdk/harness/agent", () => ({
   },
 }))
 
+const { withAgentDefaults } = await import("../src/index.ts")
+
 afterEach(() => {
   harnessAgentSettings.length = 0
   harnessCreateSession.mockReset()
@@ -1076,7 +1078,7 @@ describe("agent message protocol", () => {
   })
 
   it("keeps channel chat triggers discoverable for workspace agents", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const { webChat } = await import("../src/channels.ts")
     const { resolveAgentTriggers } = await import("../src/trigger-runtime.ts")
     const agent = defineAgent({
@@ -1085,7 +1087,7 @@ describe("agent message protocol", () => {
       run: () => "ok",
       workspace: {},
     })
-    const registered = withWorkspaceAgentDefaults(agent as never, { workspace: "docs" })
+    const registered = withAgentDefaults(agent as never, { workspace: "docs" })
 
     await expect(resolveAgentTriggers(registered, { memo: vi.fn(), runtime: "unknown" as const, runtimeConfig: {}, waitUntil: vi.fn() })).resolves.toMatchObject({
       "chat.message": {
@@ -2945,17 +2947,17 @@ describe("agent message protocol", () => {
     })
 
     it("uses workspace Agent defaults for unnamed workflow runtime bindings", async () => {
-      const { defineAgent, runAgent, withWorkspaceAgentDefaults, workflow } = await import("../src/index.ts")
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")
       const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
       const waitUntilTasks: Array<Promise<unknown>> = []
       setWorkflowRuntimeConfig({ provider: "vercel" })
 
-      const agent = withWorkspaceAgentDefaults(defineAgent({
+      const agent = withAgentDefaults(defineAgent({
         runtime: workflow(),
         run: context => `received ${context.prompt}`,
         workspace: {},
-      }), { name: "reviewer", workspace: "reviewer" })
+      }), { inferredName: "reviewer", workspace: "reviewer" })
       const run = await runAgent(agent, {
         memo: vi.fn(),
         runtime: "vercel",

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -444,6 +444,19 @@ describe("defineAgent workspace option", () => {
     expect(agentSettings.at(-1)?.instructions).toBe("Use workspace sources.")
   })
 
+  it("rebinds synthetic workspace runs when applying discovered defaults", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    await agent.run!(context())
+
+    expect(useWorkspace).toHaveBeenCalledWith("docs")
+  })
+
   it("joins array instructions", async () => {
     const { defineAgent } = await import("../src/index.ts")
 

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -110,6 +110,8 @@ vi.mock("@vite-hub/workspace", async (importOriginal) => {
   }
 })
 
+const { withAgentDefaults } = await import("../src/index.ts")
+
 function context(runtimeConfig: Record<string, unknown> = {}) {
   return {
     input: { messages: [] },
@@ -281,14 +283,14 @@ describe("defineAgent workspace option", () => {
   })
 
   it("prepares Harness Workspace Sessions for workspace-backed harness Agent Drivers", async () => {
-    const { defineAgent, runAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
     const harnessSession = { destroy: vi.fn() }
     const harnessWorkspaceSession = { close: vi.fn() }
     harnessCreateSession.mockResolvedValueOnce(harnessSession)
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
     exists.mockResolvedValue(true)
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       driver: {
         harness: { provider: "codex" },
         sandbox: { provider: "sandbox" },
@@ -336,9 +338,9 @@ describe("defineAgent workspace option", () => {
       message: "chore: archive audio",
       paths: ["inbox/audio.md"],
     })
-    const { defineAgent, runAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         mode: "write",
         rules: {
@@ -373,9 +375,9 @@ describe("defineAgent workspace option", () => {
       message: "chore: archive stream",
       paths: ["inbox/stream.md"],
     })
-    const { defineAgent, streamAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         mode: "write",
         rules: {
@@ -406,9 +408,9 @@ describe("defineAgent workspace option", () => {
       message: "chore: archive response",
       paths: ["inbox/response.md"],
     })
-    const { defineAgent, runAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         mode: "write",
         rules: {
@@ -429,9 +431,9 @@ describe("defineAgent workspace option", () => {
   })
 
   it("uses string instructions", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       instructions: "Use workspace sources.",
       model: {} as never,
@@ -443,9 +445,9 @@ describe("defineAgent workspace option", () => {
   })
 
   it("joins array instructions", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       instructions: [" First ", "", "Second"],
       model: {} as never,
@@ -458,9 +460,9 @@ describe("defineAgent workspace option", () => {
 
   it("joins mixed static and callback instructions", async () => {
     readFile.mockResolvedValueOnce("Workspace instructions")
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       instructions: [
         "Use workspace sources.",
@@ -477,9 +479,9 @@ describe("defineAgent workspace option", () => {
 
   it("uses callback instructions with workspace fs", async () => {
     readFile.mockResolvedValueOnce("Workspace instructions")
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       instructions: async ({ fs }) => await fs.readFile("AGENTS.md"),
       model: {} as never,
@@ -492,9 +494,9 @@ describe("defineAgent workspace option", () => {
   })
 
   it("appends visible source instructions by default", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           docs: { instructions: "Use docs for product behavior.", name: "docs" } as never,
@@ -515,10 +517,10 @@ describe("defineAgent workspace option", () => {
   })
 
   it("applies model Agent Driver instructions and execution settings", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const model = { id: "driver-model" }
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       driver: {
         execution: {
           callSettings: {
@@ -551,9 +553,9 @@ describe("defineAgent workspace option", () => {
   })
 
   it("places source instructions in the workspace sources slot", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           docs: {
@@ -584,9 +586,9 @@ describe("defineAgent workspace option", () => {
   })
 
   it("replaces the workspace sources slot with empty instructions when no source instructions are visible", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           docs: { name: "docs" } as never,
@@ -609,10 +611,10 @@ describe("defineAgent workspace option", () => {
     list.mockImplementation(async path => path === ".vitehub/sources"
       ? [{ path: ".vitehub/sources/inventoryHealthSummary.json", type: "file" }]
       : [])
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const { workspaceShell } = await import("../src/capabilities.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       capabilities: [workspaceShell()],
       instructions: [
@@ -639,10 +641,10 @@ describe("defineAgent workspace option", () => {
   it("filters source instructions through Access-scoped workspace visibility", async () => {
     exists.mockResolvedValue(true)
     useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const { access } = await import("../src/capabilities.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           private: { instructions: "Use private source.", name: "private" } as never,
@@ -675,10 +677,10 @@ describe("defineAgent workspace option", () => {
   it("omits root-mounted source instructions when only another scoped source is visible", async () => {
     exists.mockImplementation(async path => path === "public")
     useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const { access } = await import("../src/capabilities.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           guide: {
@@ -728,10 +730,10 @@ describe("defineAgent workspace option", () => {
     isWorkspaceSourceRequestOnly.mockImplementation(source => source === privateSource)
     exists.mockImplementation(async path => path === "" || path === "public")
     useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const { access } = await import("../src/capabilities.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           private: privateSource as never,
@@ -764,10 +766,10 @@ describe("defineAgent workspace option", () => {
   it("includes root-mounted source instructions when a source path is visible", async () => {
     exists.mockImplementation(async path => path === "AGENTS.md")
     useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const { access } = await import("../src/capabilities.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           guide: {
@@ -802,7 +804,7 @@ describe("defineAgent workspace option", () => {
   })
 
   it("synthesizes an answer when tool loop stops without text after tool results", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     agentGenerate.mockResolvedValueOnce({
       finishReason: "stop",
       steps: [
@@ -815,7 +817,7 @@ describe("defineAgent workspace option", () => {
       text: "",
     })
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       model: {} as never,
     }), { workspace: "docs" })
@@ -827,7 +829,7 @@ describe("defineAgent workspace option", () => {
   })
 
   it("synthesizes streamed answers when tool loops stop without text after AI SDK tool outputs", async () => {
-    const { defineAgent, streamAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
     agentStream.mockResolvedValueOnce({
       fullStream: (async function* () {
         yield {
@@ -838,7 +840,7 @@ describe("defineAgent workspace option", () => {
       })(),
     })
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       model: {} as never,
     }), { workspace: "docs" })
@@ -856,7 +858,7 @@ describe("defineAgent workspace option", () => {
   })
 
   it("emits streamed workspace fallback text before finish events", async () => {
-    const { defineAgent, streamAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
     agentStream.mockResolvedValueOnce({
       fullStream: (async function* () {
         yield {
@@ -868,7 +870,7 @@ describe("defineAgent workspace option", () => {
       })(),
     })
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       model: {} as never,
     }), { workspace: "docs" })
@@ -887,7 +889,7 @@ describe("defineAgent workspace option", () => {
   })
 
   it("emits streamed workspace fallback text before abort events", async () => {
-    const { defineAgent, streamAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
     agentStream.mockResolvedValueOnce({
       fullStream: (async function* () {
         yield {
@@ -899,7 +901,7 @@ describe("defineAgent workspace option", () => {
       })(),
     })
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       model: {} as never,
     }), { workspace: "docs" })
@@ -918,7 +920,7 @@ describe("defineAgent workspace option", () => {
   })
 
   it("preserves stream result methods when wrapping workspace fallback streams", async () => {
-    const { defineAgent, streamAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
     class StreamResult {
       fullStream = (async function* () {
         yield {
@@ -944,7 +946,7 @@ describe("defineAgent workspace option", () => {
     }
     agentStream.mockResolvedValueOnce(new StreamResult())
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       model: {} as never,
     }), { workspace: "docs" })
@@ -962,12 +964,12 @@ describe("defineAgent workspace option", () => {
   })
 
   it("passes AI SDK tool loop settings through workspace agents", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const stopWhen = { custom: true }
     const onStepFinish = vi.fn()
     const experimental_telemetry = { integrations: [], isEnabled: true }
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       modelExecution: {
         callSettings: {
@@ -996,9 +998,9 @@ describe("defineAgent workspace option", () => {
 
   it("passes provider-defined capability tools to AI SDK agents", async () => {
     const { webSearch } = await import("../src/capabilities.ts")
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       capabilities: [webSearch({ mode: "model" })],
       model: {} as never,
@@ -1017,12 +1019,12 @@ describe("defineAgent workspace option", () => {
   })
 
   it("uses custom run for workspace agents on the streaming path", async () => {
-    const { defineAgent, streamAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
     const stream = (async function* () {
       yield { text: "ok", type: "text-delta" }
     })()
     const run = vi.fn(async () => stream)
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       run,
       workspace: {},
     }), { workspace: "docs" })
@@ -1032,12 +1034,12 @@ describe("defineAgent workspace option", () => {
   })
 
   it("wraps workspace agent models with runtime instrumentation", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const baseModel = { id: "base" }
     const wrappedModel = { id: "wrapped" }
     const instrumentModel = vi.fn(() => wrappedModel as never)
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       modelExecution: {
         callSettings: {
@@ -1079,10 +1081,10 @@ describe("defineAgent workspace option", () => {
     inspectTools.mockReturnValueOnce({
       shell: { execute },
     })
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const model = { id: "base" }
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       modelExecution: {
         callSettings: {
@@ -1129,10 +1131,10 @@ describe("defineAgent workspace option", () => {
       observedTemperatures.push(callSettings.temperature)
       ;(callSettings as Record<string, unknown>).temperature = 0.8
     })
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const settingsStart = agentSettings.length
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       modelExecution: {
         callSettings: {
@@ -1162,9 +1164,9 @@ describe("defineAgent workspace option", () => {
     const experimental_onToolCallFinish = vi.fn()
     const onRunToolCallStart = vi.fn()
     const onRunToolCallFinish = vi.fn()
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       modelExecution: {
         callSettings: {
@@ -1205,9 +1207,9 @@ describe("defineAgent workspace option", () => {
   })
 
   it("passes workspace to callback instructions", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       instructions: ({ fs, workspace }) => {
         expect(fs).toBe(workspace.fs)
@@ -1223,9 +1225,9 @@ describe("defineAgent workspace option", () => {
 
   it("does not load AGENTS.md as implicit instructions", async () => {
     readFile.mockResolvedValueOnce("Workspace instructions")
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       model: {} as never,
     }), { workspace: "docs" })
@@ -1238,9 +1240,9 @@ describe("defineAgent workspace option", () => {
 
   it("throws when explicit callback instructions fail", async () => {
     readFile.mockRejectedValueOnce(new Error("missing"))
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       instructions: ({ fs }) => fs.readFile("MISSING.md"),
       model: {} as never,
@@ -1250,9 +1252,9 @@ describe("defineAgent workspace option", () => {
   })
 
   it("does not attach workspace tools unless explicitly requested", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       model: {} as never,
     }), { workspace: "docs" })
@@ -1265,14 +1267,14 @@ describe("defineAgent workspace option", () => {
   })
 
   it("passes workspace facade to workspace tool resolvers", async () => {
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
     const shell = { execute: vi.fn(), inputSchema: {} }
     const toolResolver = vi.fn(({ workspace }) => {
       expect(workspace.fs).toEqual(expect.objectContaining({ readFile }))
       return { shell }
     })
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       model: {} as never,
       capabilities: [{ id: "workspace-tools", tools: toolResolver as never }],
@@ -1296,9 +1298,9 @@ describe("defineAgent workspace option", () => {
       await this.settings.tools.shell.execute({ command: "rg defineAgent" })
       return { finishReason: "stop", text: "ok" }
     })
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       model: {} as never,
       capabilities: [{ id: "workspace-shell", tools: ({ workspace }) => workspace.tools.inspect() }],
@@ -1332,9 +1334,9 @@ describe("defineAgent workspace option", () => {
       await this.settings.tools.shell.execute({ command: "rg PLC forecasting-engine | head -n 20" })
       return { finishReason: "stop", text: "ok" }
     })
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: { sources: { docs: { cache: { maxAge: 60 }, source: {} } as never } },
       model: {} as never,
       capabilities: [{ id: "workspace-shell", tools: ({ workspace }) => workspace.tools.inspect() }],
@@ -1368,9 +1370,9 @@ describe("defineAgent workspace option", () => {
     inspectTools.mockReturnValueOnce({
       materialize_sources: { execute: materialize },
     })
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: { sources: { docs: { cache: { maxAge: 60 }, source: {} } as never } },
       model: {} as never,
       capabilities: [{ id: "bash", tools: ({ workspace }) => workspace.tools.inspect() }],
@@ -1389,9 +1391,9 @@ describe("defineAgent workspace option", () => {
     inspectTools.mockReturnValueOnce({
       materialize_sources: { execute: materialize },
     })
-    const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: { sources: { docs: { cache: { maxAge: 60 }, source: {} } as never } },
       model: {} as never,
       capabilities: [{ id: "workspace-shell", tools: ({ workspace }) => workspace.tools.inspect() }],
@@ -1412,9 +1414,9 @@ describe("defineAgent workspace option", () => {
   })
 
   it("derives DevTools metadata from workspace agents", async () => {
-    const { createAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { createAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const model = { modelId: "openai/gpt-test", provider: "openai" }
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           docs: { name: "docs" } as never,
@@ -1464,9 +1466,9 @@ describe("defineAgent workspace option", () => {
     list.mockImplementation(async path => path === ".vitehub/sources"
       ? [{ path: ".vitehub/sources/inventoryHealthSummary.json", type: "file" }]
       : [])
-    const { defineAgent, resolveAgentDevtoolsMetadata, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent, resolveAgentDevtoolsMetadata } = await import("../src/index.ts")
     const { workspaceShell } = await import("../src/capabilities.ts")
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       model: {} as never,
       capabilities: [workspaceShell()],
@@ -1483,12 +1485,12 @@ describe("defineAgent workspace option", () => {
   })
 
   it("resolves dynamic model metadata for DevTools", async () => {
-    const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const resolveModel = vi.fn((context: { invoker: { kind?: string } }) => ({
       modelId: `test/${context.invoker.kind || "unknown"}`,
       provider: "test",
     }))
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       model: resolveModel as never,
     }), { workspace: "support" })
@@ -1518,9 +1520,9 @@ describe("defineAgent workspace option", () => {
   })
 
   it("marks dynamic DevTools instruction metadata without resolving it", async () => {
-    const { createAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { createAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const readInstructions = vi.fn(async () => "Workspace instructions")
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       instructions: readInstructions,
       model: {} as never,
@@ -1532,11 +1534,11 @@ describe("defineAgent workspace option", () => {
   })
 
   it("resolves dynamic DevTools instruction metadata", async () => {
-    const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const readInstructions = vi.fn(async ({ fs }) => await fs.readFile("AGENTS.md"))
     readFile.mockResolvedValue("# Workspace instructions\n")
     list.mockResolvedValue([{ path: "AGENTS.md", type: "file" }])
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       instructions: readInstructions,
       model: {} as never,
@@ -1555,11 +1557,11 @@ describe("defineAgent workspace option", () => {
   })
 
   it("renders static capability instruction slots in resolved DevTools metadata", async () => {
-    const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const readInstructions = vi.fn(async ({ fs }) => await fs.readFile("AGENTS.md"))
     readFile.mockResolvedValue("# Workspace instructions\n\n{{ capabilities.audience }}\n")
     list.mockResolvedValue([{ path: "AGENTS.md", type: "file" }])
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {},
       instructions: readInstructions,
       model: {} as never,
@@ -1576,14 +1578,14 @@ describe("defineAgent workspace option", () => {
   })
 
   it("resolves prepare-scoped capability instructions while resolving DevTools metadata", async () => {
-    const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const phase = vi.fn()
     const toolResolver = vi.fn(() => ({}))
     const invokerResolve = vi.fn(() => ({ id: "resolved" }))
     exists.mockResolvedValue(true)
     list.mockResolvedValue([{ path: "docs/guide.md", type: "file" }])
     readFile.mockResolvedValue("# Workspace instructions\n\n{{ capabilities.tracked }}")
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       invoker: {
         profiles: [{ id: "support", kind: "support", label: "Support" }],
         resolve: invokerResolve,
@@ -1633,12 +1635,12 @@ describe("defineAgent workspace option", () => {
   })
 
   it("resolves recursive DevTools file metadata for lazy source entries", async () => {
-    const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     list.mockResolvedValue([
       { path: "docs/guides", type: "directory" },
       { path: "docs/guides/start.md", type: "file" },
     ])
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           docs: { cache: { maxAge: 60 }, mount: "docs", name: "docs" } as never,
@@ -1675,7 +1677,7 @@ describe("defineAgent workspace option", () => {
   })
 
   it("applies Access-scoped workspace visibility during DevTools metadata resolution", async () => {
-    const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const { access } = await import("../src/capabilities.ts")
     const resolveScope = vi.fn(({ invoker }) => {
       return invoker.meta?.scope === "support"
@@ -1691,7 +1693,7 @@ describe("defineAgent workspace option", () => {
       { path: "customers/globex/orders.sql", type: "file" },
       { path: "portal", type: "directory" },
     ])
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       invoker: {
         profiles: [
           { id: "customer", kind: "customer", label: "Customer", meta: { scope: "customer" } },
@@ -1732,11 +1734,11 @@ describe("defineAgent workspace option", () => {
   })
 
   it("renders static Source Instructions after Access source resolution for DevTools metadata", async () => {
-    const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const { access } = await import("../src/capabilities.ts")
     useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
     exists.mockImplementation(async path => path === "ingestion/acme")
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           ingestion: {
@@ -1771,7 +1773,7 @@ describe("defineAgent workspace option", () => {
   })
 
   it("flattens virtual workspace AGENTS.md while keeping sibling instruction files", async () => {
-    const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     list.mockResolvedValue([
       { path: "forecasting-engine", type: "directory" },
       { path: "ingestion", type: "directory" },
@@ -1779,7 +1781,7 @@ describe("defineAgent workspace option", () => {
       { path: "instructions/AGENTS.md", type: "file" },
       { path: "instructions/private.md", type: "file" },
     ])
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           "forecasting-engine": { name: "forecasting-engine" } as never,
@@ -1809,11 +1811,11 @@ describe("defineAgent workspace option", () => {
   })
 
   it("marks listed lazy source files as materialized when stored metadata is present", async () => {
-    const { resolveAgentDevtoolsMetadata, defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     list.mockResolvedValue([
       { mtime: 1710000000000, path: "docs/guides/start.md", size: 128, type: "file" },
     ])
-    const agent = withWorkspaceAgentDefaults(defineAgent({
+    const agent = withAgentDefaults(defineAgent({
       workspace: {
         sources: {
           docs: { cache: { maxAge: 60 }, mount: "docs", name: "docs" } as never,


### PR DESCRIPTION
Removes the public `withWorkspaceAgentDefaults` helper and routes discovered Workspace Agent defaults through `withAgentDefaults` instead. This keeps Discovery Identity and Workspace identity handling on the existing Agent default path without carrying a workspace-specific wrapper.

Updates generated Vite route, DevTools, dev-loop, test-runner, and test call sites to use the same default path. The committed diff is net-negative: 147 insertions, 153 deletions.