### PR TITLE
feat(agent): add repository host capability

### DIFF
--- a/.agents/adr/0068-repository-host-capability.md
+++ b/.agents/adr/0068-repository-host-capability.md
@@ -1,6 +1,6 @@
 # Repository Host Capability
 
-ViteHub adds a **Repository Host Capability** through `repositoryHost()` for provider-hosted repository collaboration objects: repository metadata, issues, Change Requests, comments, and read-only check/status signals. The capability is not raw git, not `gh`, not Source retrieval, not MCP, and not raw provider API passthrough; write mode starts with narrow comment and reaction effects behind normal tool policy while approvals, merges, branch updates, status/check writes, issue edits, repository settings, content, secrets, workflows, and arbitrary provider mutations stay out of this first boundary.
+ViteHub adds a **Repository Host Capability** through `repositoryHost()` for provider-hosted repository collaboration objects: repository metadata, issues, Change Requests, Change Request file metadata, comments, and read-only check/status signals. The capability is not raw git, not `gh`, not Source retrieval, not MCP, and not raw provider API passthrough; write mode starts with narrow comment and reaction effects behind normal tool policy while approvals, merges, branch updates, status/check writes, issue edits, repository settings, content, secrets, workflows, and arbitrary provider mutations stay out of this first boundary.
 
 ## Considered Options
 
@@ -10,4 +10,4 @@ ViteHub adds a **Repository Host Capability** through `repositoryHost()` for pro
 
 ## Consequences
 
-`repositoryHost()` lives on `@vite-hub/agent/capabilities` and may use an app-owned or runtime-provided Repository Host Client. Provider adapters should preserve native ids, URLs, and raw metadata while exposing ViteHub's normalized repository, issue, Change Request, comment, and check/status read vocabulary.
+`repositoryHost()` lives on `@vite-hub/agent/capabilities` and may use an app-owned or runtime-provided Repository Host Client. Provider adapters should preserve native ids, URLs, and raw metadata while exposing ViteHub's normalized repository, issue, Change Request, Change Request file-list, comment, and check/status read vocabulary.

--- a/.agents/adr/0068-repository-host-capability.md
+++ b/.agents/adr/0068-repository-host-capability.md
@@ -1,0 +1,13 @@
+# Repository Host Capability
+
+ViteHub adds a **Repository Host Capability** through `repositoryHost()` for provider-hosted repository collaboration objects: repository metadata, issues, Change Requests, comments, and read-only check/status signals. The capability is not raw git, not `gh`, not Source retrieval, not MCP, and not raw provider API passthrough; write mode starts with narrow comment and reaction effects behind normal tool policy while approvals, merges, branch updates, status/check writes, issue edits, repository settings, content, secrets, workflows, and arbitrary provider mutations stay out of this first boundary.
+
+## Considered Options
+
+- `gh()` or `github()` were rejected because the capability is provider-neutral across GitHub, GitLab, Bitbucket, and similar Repository Host Providers.
+- `forge()` and `scm()` were rejected because `forge` is not obvious enough and collides with Atlassian Forge, while SCM over-implies raw source control and local git behavior.
+- Source, Workspace, MCP, and generic `fetch()` were rejected because they do not own the provider-hosted collaboration object vocabulary or the externally visible write-effect policy.
+
+## Consequences
+
+`repositoryHost()` lives on `@vite-hub/agent/capabilities` and may use an app-owned or runtime-provided Repository Host Client. Provider adapters should preserve native ids, URLs, and raw metadata while exposing ViteHub's normalized repository, issue, Change Request, comment, and check/status read vocabulary.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -136,6 +136,22 @@ _Avoid_: Model-selected read provider, search provider requirement
 An allowed origin for a Web Search Capability provider credential.
 _Avoid_: Vite env var, Nitro env var, browser env
 
+**Repository Host Capability**:
+An Official Capability created by `repositoryHost()` for provider-hosted repository collaboration objects such as repository metadata, issues, Change Requests, comments, and read-only check/status signals.
+_Avoid_: gh, Git Capability, Source, Workspace Source, Forge Capability, SCM Capability
+
+**Repository Host Provider**:
+The configured repository hosting service behind a Repository Host Capability, such as GitHub, GitLab, Bitbucket, Forgejo, Gitea, Gerrit, SourceHut, or Azure DevOps.
+_Avoid_: Git provider, SCM provider, platform
+
+**Repository Host Client**:
+The app-owned or runtime-provided adapter that executes normalized Repository Host Capability read and write requests against one Repository Host Provider.
+_Avoid_: Provider SDK passthrough, raw API client, gh wrapper
+
+**Change Request**:
+A provider-hosted proposed repository change, called a pull request by GitHub and Bitbucket and a merge request by GitLab.
+_Avoid_: PR as canonical term, MR as canonical term, change
+
 **Transcription**:
 An Official Capability that turns audio input parts into transcript text before an Agent runs.
 _Avoid_: Voice Input, audio support, voice plugin
@@ -196,7 +212,7 @@ _Avoid_: KV Store, hubKv, model-facing storage
 
 - An Agent attaches zero or more **Capabilities**.
 - Capabilities attach above the **Agent Driver** in the Agent Definition shape.
-- Official helpers such as `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `access()`, `sandbox()`, `kv()`, `blob()`, `db()`, `webSearch()`, `llmRoute()`, `llmGate()`, and `rateLimit()` create **Capability Definitions**.
+- Official helpers such as `skills()`, `transcribe()`, `mcp()`, `workspaceShell()`, `access()`, `sandbox()`, `kv()`, `blob()`, `db()`, `webSearch()`, `repositoryHost()`, `llmRoute()`, `llmGate()`, and `rateLimit()` create **Capability Definitions**.
 - Official Capability factories and Capability-owned helper functions are imported from `@vite-hub/agent/capabilities`, not from the root `@vite-hub/agent` Agent Package entry.
 - Channel Kind helpers are not Capability factories and are imported from `@vite-hub/agent/channels`.
 - Official helpers should map to product abilities rather than implementation mechanisms.
@@ -285,6 +301,10 @@ _Avoid_: KV Store, hubKv, model-facing storage
 - A **Web Read Result** defaults to normalized Markdown content, with plain text available when requested.
 - **Model Web Search Mode** is model-execution-gated; TanStack AI is not supported for model mode in the first version.
 - A tool search provider and **Web Search Mode** are separate axes; provider is only used by tool-based **Web Search Mode**.
+- The **Repository Host Capability** is for provider-hosted collaboration objects and externally visible collaboration effects, not raw git checkout/history, `gh` command execution, repository file Source retrieval, or arbitrary provider API passthrough.
+- A **Repository Host Client** preserves provider-native ids, URLs, and raw metadata behind normalized Repository Host Capability requests.
+- **Change Request** is the cross-provider term for pull-request and merge-request shaped objects; provider-native names stay in provider metadata.
+- Repository Host Capability write mode starts with narrow comment and reaction effects; approval, merge, branch update, status/check write, issue edit, repository settings, content, secrets, workflow, and raw API mutations need separate future design.
 - Chat History is not a standalone **Capability** in the current stack.
 - Agent Memory is separate from Chat History and Chat Sessions.
 - User-defined Capabilities use the same **Capability Definition** shape as official helpers.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -137,7 +137,7 @@ An allowed origin for a Web Search Capability provider credential.
 _Avoid_: Vite env var, Nitro env var, browser env
 
 **Repository Host Capability**:
-An Official Capability created by `repositoryHost()` for provider-hosted repository collaboration objects such as repository metadata, issues, Change Requests, comments, and read-only check/status signals.
+An Official Capability created by `repositoryHost()` for provider-hosted repository collaboration objects such as repository metadata, issues, Change Requests, Change Request file metadata, comments, and read-only check/status signals.
 _Avoid_: gh, Git Capability, Source, Workspace Source, Forge Capability, SCM Capability
 
 **Repository Host Provider**:
@@ -303,6 +303,7 @@ _Avoid_: KV Store, hubKv, model-facing storage
 - A tool search provider and **Web Search Mode** are separate axes; provider is only used by tool-based **Web Search Mode**.
 - The **Repository Host Capability** is for provider-hosted collaboration objects and externally visible collaboration effects, not raw git checkout/history, `gh` command execution, repository file Source retrieval, or arbitrary provider API passthrough.
 - A **Repository Host Client** preserves provider-native ids, URLs, and raw metadata behind normalized Repository Host Capability requests.
+- **Change Request** file-list reads are Repository Host reads; repository source diffs and git history still belong to Source, Workspace Source, or Git-aware capabilities.
 - **Change Request** is the cross-provider term for pull-request and merge-request shaped objects; provider-native names stay in provider metadata.
 - Repository Host Capability write mode starts with narrow comment and reaction effects; approval, merge, branch update, status/check write, issue edit, repository settings, content, secrets, workflow, and raw API mutations need separate future design.
 - Chat History is not a standalone **Capability** in the current stack.

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -31,6 +31,9 @@ export {
   rateLimit,
 } from "./rate-limit.ts"
 export {
+  repositoryHost,
+} from "./repository-host.ts"
+export {
   llmRoute,
 } from "./llm-route.ts"
 export {
@@ -186,6 +189,18 @@ export type {
   RateLimitStoreResult,
   RateLimitWindow,
 } from "./rate-limit.ts"
+export type {
+  RepositoryHostClient,
+  RepositoryHostOptions,
+  RepositoryHostProvider,
+  RepositoryHostReadOperation,
+  RepositoryHostReadRequest,
+  RepositoryHostTarget,
+  RepositoryHostTargetKind,
+  RepositoryHostToolPolicy,
+  RepositoryHostWriteOperation,
+  RepositoryHostWriteRequest,
+} from "./repository-host.ts"
 export type {
   LlmRouteDecision,
   LlmRouteOptions,

--- a/packages/agent/src/capabilities/repository-host.ts
+++ b/packages/agent/src/capabilities/repository-host.ts
@@ -1,0 +1,155 @@
+import { defineCapability, normalizeMode } from "../capability-runtime.ts"
+import {
+  assertString,
+  createTool,
+  jsonObjectSchema,
+  requirePrimitive,
+} from "./storage/shared.ts"
+
+import type {
+  AgentCapabilityContext,
+  AgentCapabilityDefinition,
+  AgentCapabilityMode,
+  AgentToolPolicyContext,
+  AgentToolPolicyDecision,
+  AgentToolSet,
+  MaybePromise,
+} from "../types.ts"
+
+export type RepositoryHostProvider = "github" | "gitlab" | "bitbucket" | (string & {})
+export type RepositoryHostTargetKind = "repository" | "changeRequest" | "issue" | "comment"
+export type RepositoryHostReadOperation = "repository" | "changeRequests" | "changeRequest" | "issues" | "issue" | "comments" | "checks" | "statuses"
+export type RepositoryHostWriteOperation = "comment" | "reaction"
+export type RepositoryHostToolPolicy = AgentToolPolicyDecision | ((context: AgentToolPolicyContext) => MaybePromise<AgentToolPolicyDecision>)
+
+export interface RepositoryHostTarget {
+  host?: string
+  id?: number | string
+  kind?: RepositoryHostTargetKind
+  owner?: string
+  repository: string
+}
+
+export interface RepositoryHostReadRequest {
+  operation: RepositoryHostReadOperation
+  params?: Record<string, unknown>
+  target: RepositoryHostTarget
+}
+
+export interface RepositoryHostWriteRequest {
+  body?: string
+  operation: RepositoryHostWriteOperation
+  params?: Record<string, unknown>
+  target: RepositoryHostTarget
+}
+
+export interface RepositoryHostClient {
+  provider?: RepositoryHostProvider
+  read: (request: RepositoryHostReadRequest) => MaybePromise<unknown>
+  write?: (request: RepositoryHostWriteRequest) => MaybePromise<unknown>
+}
+
+export interface RepositoryHostOptions {
+  client?: RepositoryHostClient | ((context: AgentCapabilityContext) => MaybePromise<RepositoryHostClient>)
+  mode?: AgentCapabilityMode
+  policy?: RepositoryHostToolPolicy
+  provider?: RepositoryHostProvider
+}
+
+const readOperations = new Set<RepositoryHostReadOperation>(["repository", "changeRequests", "changeRequest", "issues", "issue", "comments", "checks", "statuses"])
+const writeOperations = new Set<RepositoryHostWriteOperation>(["comment", "reaction"])
+
+const repositoryHostTargetSchema = jsonObjectSchema({
+  host: { description: "Provider host, such as github.com or a self-hosted GitLab domain.", type: "string" },
+  id: { oneOf: [{ type: "string" }, { type: "number" }] },
+  kind: { enum: ["repository", "changeRequest", "issue", "comment"], type: "string" },
+  owner: { description: "Repository owner, organization, group, workspace, or project namespace.", type: "string" },
+  repository: { description: "Repository name or provider-native repository path.", type: "string" },
+}, ["repository"])
+
+const repositoryHostReadInputSchema = jsonObjectSchema({
+  operation: { enum: [...readOperations], type: "string" },
+  params: { additionalProperties: true, type: "object" },
+  target: repositoryHostTargetSchema,
+}, ["operation", "target"])
+
+const repositoryHostWriteInputSchema = jsonObjectSchema({
+  body: { type: "string" },
+  operation: { enum: [...writeOperations], type: "string" },
+  params: { additionalProperties: true, type: "object" },
+  target: repositoryHostTargetSchema,
+}, ["operation", "target"])
+
+async function resolveRepositoryHostClient(options: RepositoryHostOptions, context: AgentCapabilityContext): Promise<RepositoryHostClient> {
+  const client = options.client
+    ? typeof options.client === "function" ? await options.client(context) : options.client
+    : requirePrimitive(context, "repository-host")
+  if (!client || typeof client !== "object" || typeof (client as RepositoryHostClient).read !== "function") {
+    throw new Error("[vitehub] repositoryHost() requires a Repository Host client with read().")
+  }
+  return client as RepositoryHostClient
+}
+
+function assertTarget(target: RepositoryHostTarget | undefined, operation: string): RepositoryHostTarget {
+  if (!target || typeof target !== "object") throw new TypeError(`[vitehub] ${operation} target must be an object.`)
+  assertString(target.repository, `${operation} target.repository`)
+  if (target.id !== undefined && typeof target.id !== "string" && typeof target.id !== "number") {
+    throw new TypeError(`[vitehub] ${operation} target.id must be a string or number.`)
+  }
+  return target
+}
+
+function assertReadRequest(input: RepositoryHostReadRequest): RepositoryHostReadRequest {
+  if (!readOperations.has(input?.operation)) throw new Error(`[vitehub] Unsupported repository_host_read operation: ${String(input?.operation)}`)
+  const target = assertTarget(input.target, "repository_host_read")
+  if (!["repository", "changeRequests", "issues"].includes(input.operation) && target.id === undefined) {
+    throw new TypeError(`[vitehub] repository_host_read ${input.operation} requires target.id.`)
+  }
+  return { ...input, target }
+}
+
+function assertWriteRequest(input: RepositoryHostWriteRequest): RepositoryHostWriteRequest {
+  if (!writeOperations.has(input?.operation)) throw new Error(`[vitehub] Unsupported repository_host_write operation: ${String(input?.operation)}`)
+  const target = assertTarget(input.target, "repository_host_write")
+  if (target.id === undefined) throw new TypeError(`[vitehub] repository_host_write ${input.operation} requires target.id.`)
+  if (input.operation === "comment") assertString(input.body, "repository_host_write comment body")
+  return { ...input, target }
+}
+
+function repositoryHostTools(mode: AgentCapabilityMode, options: RepositoryHostOptions): AgentCapabilityDefinition["tools"] {
+  return async (context) => {
+    const client = await resolveRepositoryHostClient(options, context as never)
+    const tools: AgentToolSet = {
+      repository_host_read: createTool<RepositoryHostReadRequest>({
+        description: "Read repository-hosted metadata for repositories, Change Requests, issues, comments, checks, or statuses.",
+        execute: input => client.read(assertReadRequest(input)),
+        inputSchema: repositoryHostReadInputSchema,
+        name: "repository_host_read",
+      }),
+    }
+    if (mode === "write") {
+      tools.repository_host_write = createTool<RepositoryHostWriteRequest>({
+        description: "Create repository-hosted comments or reactions through the configured provider client.",
+        execute(input) {
+          if (!client.write) throw new Error("[vitehub] repository_host_write requires the Repository Host client to expose write().")
+          return client.write(assertWriteRequest(input))
+        },
+        inputSchema: repositoryHostWriteInputSchema,
+        name: "repository_host_write",
+        policy: options.policy || "require-approval",
+      })
+    }
+    return tools
+  }
+}
+
+export function repositoryHost(options: RepositoryHostOptions = {}): AgentCapabilityDefinition {
+  const mode = normalizeMode(options.mode, "Repository Host")
+  return defineCapability({
+    id: "repository-host",
+    metadata: { kind: "repository-host", mode, ...(options.provider ? { provider: options.provider } : {}) },
+    mode,
+    requires: options.client ? undefined : [{ primitive: "repository-host" }],
+    tools: repositoryHostTools(mode, options),
+  })
+}

--- a/packages/agent/src/capabilities/repository-host.ts
+++ b/packages/agent/src/capabilities/repository-host.ts
@@ -18,7 +18,7 @@ import type {
 
 export type RepositoryHostProvider = "github" | "gitlab" | "bitbucket" | (string & {})
 export type RepositoryHostTargetKind = "repository" | "changeRequest" | "issue" | "comment"
-export type RepositoryHostReadOperation = "repository" | "changeRequests" | "changeRequest" | "issues" | "issue" | "comments" | "checks" | "statuses"
+export type RepositoryHostReadOperation = "repository" | "changeRequests" | "changeRequest" | "changeRequestFiles" | "issues" | "issue" | "comments" | "checks" | "statuses"
 export type RepositoryHostWriteOperation = "comment" | "reaction"
 export type RepositoryHostToolPolicy = AgentToolPolicyDecision | ((context: AgentToolPolicyContext) => MaybePromise<AgentToolPolicyDecision>)
 
@@ -56,7 +56,7 @@ export interface RepositoryHostOptions {
   provider?: RepositoryHostProvider
 }
 
-const readOperations = new Set<RepositoryHostReadOperation>(["repository", "changeRequests", "changeRequest", "issues", "issue", "comments", "checks", "statuses"])
+const readOperations = new Set<RepositoryHostReadOperation>(["repository", "changeRequests", "changeRequest", "changeRequestFiles", "issues", "issue", "comments", "checks", "statuses"])
 const writeOperations = new Set<RepositoryHostWriteOperation>(["comment", "reaction"])
 
 const repositoryHostTargetSchema = jsonObjectSchema({
@@ -121,7 +121,7 @@ function repositoryHostTools(mode: AgentCapabilityMode, options: RepositoryHostO
     const client = await resolveRepositoryHostClient(options, context as never)
     const tools: AgentToolSet = {
       repository_host_read: createTool<RepositoryHostReadRequest>({
-        description: "Read repository-hosted metadata for repositories, Change Requests, issues, comments, checks, or statuses.",
+        description: "Read repository-hosted metadata for repositories, Change Requests, Change Request files, issues, comments, checks, or statuses.",
         execute: input => client.read(assertReadRequest(input)),
         inputSchema: repositoryHostReadInputSchema,
         name: "repository_host_read",

--- a/packages/agent/test/repository-host-capability.test.ts
+++ b/packages/agent/test/repository-host-capability.test.ts
@@ -56,6 +56,14 @@ describe("repositoryHost capability", () => {
       operation: "changeRequest",
       target: { id: 12, owner: "vite-hub", repository: "vitehub" },
     })
+    await expect(tools.repository_host_read!.execute?.({
+      operation: "changeRequestFiles",
+      target: { id: 12, owner: "vite-hub", repository: "vitehub" },
+    })).resolves.toMatchObject({
+      request: {
+        operation: "changeRequestFiles",
+      },
+    })
   })
 
   it("uses runtime primitive clients", async () => {

--- a/packages/agent/test/repository-host-capability.test.ts
+++ b/packages/agent/test/repository-host-capability.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { resolveAgentCapabilities } from "../src/capability-runtime.ts"
+import { repositoryHost } from "../src/capabilities.ts"
+
+import type { RepositoryHostClient } from "../src/capabilities.ts"
+
+function runtime(capabilities: Record<string, unknown> = {}) {
+  return {
+    capabilities,
+    memo: vi.fn(),
+    runtime: "unknown" as const,
+    runtimeConfig: {},
+    waitUntil: vi.fn(),
+  }
+}
+
+async function resolveTools(capability = repositoryHost(), capabilities: Record<string, unknown> = {}) {
+  const resolved = await resolveAgentCapabilities({ capabilities: [capability] }, runtime(capabilities), {})
+  return resolved.tools!
+}
+
+describe("repositoryHost capability", () => {
+  it("defaults to read mode and uses a repository-host runtime primitive", () => {
+    expect(repositoryHost()).toMatchObject({
+      id: "repository-host",
+      metadata: { kind: "repository-host", mode: "read" },
+      mode: "read",
+      requires: [{ primitive: "repository-host" }],
+    })
+    expect(repositoryHost({ client: { read: vi.fn() }, mode: "write", provider: "github" })).toMatchObject({
+      metadata: { mode: "write", provider: "github" },
+      mode: "write",
+      requires: undefined,
+    })
+    expect(() => repositoryHost({ mode: "admin" as never })).toThrow("Repository Host mode must be \"read\" or \"write\"")
+  })
+
+  it("exposes a normalized read tool", async () => {
+    const client: RepositoryHostClient = {
+      read: vi.fn(async request => ({ request })),
+    }
+    const tools = await resolveTools(repositoryHost({ client }))
+
+    expect(Object.keys(tools)).toEqual(["repository_host_read"])
+    await expect(tools.repository_host_read!.execute?.({
+      operation: "changeRequest",
+      target: { id: 12, owner: "vite-hub", repository: "vitehub" },
+    })).resolves.toEqual({
+      request: {
+        operation: "changeRequest",
+        target: { id: 12, owner: "vite-hub", repository: "vitehub" },
+      },
+    })
+    expect(client.read).toHaveBeenCalledWith({
+      operation: "changeRequest",
+      target: { id: 12, owner: "vite-hub", repository: "vitehub" },
+    })
+  })
+
+  it("uses runtime primitive clients", async () => {
+    const client: RepositoryHostClient = {
+      read: vi.fn(async () => "ok"),
+    }
+    const tools = await resolveTools(repositoryHost(), { "repository-host": client })
+
+    await expect(tools.repository_host_read!.execute?.({
+      operation: "repository",
+      target: { repository: "vitehub" },
+    })).resolves.toBe("ok")
+  })
+
+  it("exposes writes only in write mode and requires write support", async () => {
+    const readOnly: RepositoryHostClient = {
+      read: vi.fn(),
+    }
+    const readTools = await resolveTools(repositoryHost({ client: readOnly }))
+    expect(Object.keys(readTools)).toEqual(["repository_host_read"])
+
+    const writeTools = await resolveTools(repositoryHost({ client: readOnly, mode: "write", policy: "allow" }))
+    expect(Object.keys(writeTools).sort()).toEqual(["repository_host_read", "repository_host_write"])
+    expect(writeTools.repository_host_write!.policy).toBe("allow")
+    await expect(Promise.resolve().then(() => writeTools.repository_host_write!.execute?.({
+      body: "Queued review.",
+      operation: "comment",
+      target: { id: 12, repository: "vitehub" },
+    }))).rejects.toThrow("client to expose write")
+  })
+
+  it("validates normalized write requests before calling the client", async () => {
+    const client: RepositoryHostClient = {
+      read: vi.fn(),
+      write: vi.fn(async request => ({ request })),
+    }
+    const tools = await resolveTools(repositoryHost({ client, mode: "write" }))
+
+    await expect(tools.repository_host_write!.execute?.({
+      body: "Looks good.",
+      operation: "comment",
+      target: { id: "17", kind: "changeRequest", owner: "vite-hub", repository: "vitehub" },
+    })).resolves.toEqual({
+      request: {
+        body: "Looks good.",
+        operation: "comment",
+        target: { id: "17", kind: "changeRequest", owner: "vite-hub", repository: "vitehub" },
+      },
+    })
+    await expect(Promise.resolve().then(() => tools.repository_host_write!.execute?.({
+      operation: "comment",
+      target: { id: "17", repository: "vitehub" },
+    }))).rejects.toThrow("comment body")
+    await expect(Promise.resolve().then(() => tools.repository_host_write!.execute?.({
+      body: "Missing id.",
+      operation: "comment",
+      target: { repository: "vitehub" },
+    }))).rejects.toThrow("requires target.id")
+  })
+})

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, type AgentChannelDefinition, type AgentDriver, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRuntimeConfig, type AgentRuntimeContext } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, inputCommands, kv, mcp, repositoryHost, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { http, teams, webChat } from "../src/channels.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -9,7 +9,7 @@ import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentUsageRecord } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
 import { source } from "@vite-hub/workspace"
-import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatPlatformResolver, AgentChatRunContext, FetchCapabilityToolOptions, TranscriptionResult } from "../src/capabilities.ts"
+import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatPlatformResolver, AgentChatRunContext, FetchCapabilityToolOptions, RepositoryHostClient, TranscriptionResult } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
   it("accepts capabilities from the capabilities entry", () => {
@@ -70,6 +70,26 @@ describe("agent public types", () => {
             remote: remoteMcpServer({ url: "https://example.com/mcp" }),
             stdio: stdioMcpServer({ command: "node", args: ["server.js"] }),
           },
+        }),
+        repositoryHost({
+          client: ({ invoker }) => {
+            expectTypeOf(invoker.id).toEqualTypeOf<string>()
+            return {
+              provider: "github",
+              read(request) {
+                expectTypeOf(request.operation).toEqualTypeOf<"repository" | "changeRequests" | "changeRequest" | "issues" | "issue" | "comments" | "checks" | "statuses">()
+                expectTypeOf(request.target.repository).toEqualTypeOf<string>()
+                return request
+              },
+              write(request) {
+                expectTypeOf(request.operation).toEqualTypeOf<"comment" | "reaction">()
+                return request
+              },
+            } satisfies RepositoryHostClient
+          },
+          mode: "write",
+          policy: "require-approval",
+          provider: "github",
         }),
         skills(),
         skills({ shellExecution: "read" }),

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -77,7 +77,7 @@ describe("agent public types", () => {
             return {
               provider: "github",
               read(request) {
-                expectTypeOf(request.operation).toEqualTypeOf<"repository" | "changeRequests" | "changeRequest" | "issues" | "issue" | "comments" | "checks" | "statuses">()
+                expectTypeOf(request.operation).toEqualTypeOf<"repository" | "changeRequests" | "changeRequest" | "changeRequestFiles" | "issues" | "issue" | "comments" | "checks" | "statuses">()
                 expectTypeOf(request.target.repository).toEqualTypeOf<string>()
                 return request
               },


### PR DESCRIPTION
Adds a provider-neutral Repository Host Capability for repository-hosted collaboration objects such as issues, Change Requests, comments, and read-only check/status metadata.

The new `repositoryHost()` helper exposes normalized read/write tools through an app-owned or runtime-provided Repository Host Client, with write mode limited to comments and reactions. The accompanying .agents updates record the language boundary so this stays separate from raw git, `gh`, Source retrieval, and provider API passthrough.
