### PR TITLE
fix(agent): ignore helper files in agent discovery

### DIFF
--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -33,6 +33,19 @@ function isWorkspaceAgentConfig(source: string): boolean {
   return /\bdefineAgent\s*\(\s*\{[\s\S]*?\bworkspace\s*:/.test(stripComments(source))
 }
 
+function isInsideConfiguredAgent(file: string, configuredAgentDirs: Set<string>): boolean {
+  const directory = dirname(file)
+  for (const agentDir of configuredAgentDirs) {
+    const path = relative(agentDir, directory)
+    if (path === "" || (!path.startsWith("..") && path !== "..")) return true
+  }
+  return false
+}
+
+function isWorkspaceSourceConfig(agent: string): boolean {
+  return agent.split("/").slice(1).includes("workspace")
+}
+
 function discoverDirectoryAgentConfigs(scanDirs: string[]): DiscoveredAgentDefinition[] {
   const definitions: DiscoveredAgentDefinition[] = []
 
@@ -57,6 +70,7 @@ function discoverDirectoryAgentConfigs(scanDirs: string[]): DiscoveredAgentDefin
       const source = readFileSync(file, "utf8")
       const agent = relative(agentsRoot, dirname(file)).replace(/\\/g, "/")
       if (!agent || agent === ".") continue
+      if (isWorkspaceSourceConfig(agent)) continue
       const workspace = isWorkspaceAgentConfig(source)
       definitions.push({
         handler: file,
@@ -79,10 +93,13 @@ export function discoverAgentDefinitions(options:
   | { mode: "server-agents", scanDirs: string[] }
 ): DiscoveredAgentDefinition[] {
   if (options.mode === "server-agents") {
+    const configDefinitions = discoverDirectoryAgentConfigs(options.scanDirs)
+    const configuredAgentDirs = new Set(configDefinitions.map(definition => dirname(definition.handler)))
     const directoryDefinitions = discoverDefinitions("agent", [
       createDirectoryDefinitionSource<DiscoveredAgentDefinition>("server-agents", options.scanDirs, "agents", {
         normalizeName(directory, file) {
           if (configPattern.test(basename(file)) || isEvalDefinitionFile(file)) return
+          if (isInsideConfiguredAgent(file, configuredAgentDirs)) return
           return relative(directory, file).replace(/\.(?:c|m)?[jt]s$/i, "").replace(/\/index$/i, "")
         },
         createDefinition({ file, name }) {
@@ -94,9 +111,8 @@ export function discoverAgentDefinitions(options:
         },
       }),
     ])
-    const workspaceDefinitions = discoverDirectoryAgentConfigs(options.scanDirs)
 
-    return mergeDefinitions("agent", directoryDefinitions, workspaceDefinitions)
+    return mergeDefinitions("agent", directoryDefinitions, configDefinitions)
   }
 
   const roots = new Set([options.rootDir, ...(options.scanDirs || [])].filter(Boolean))

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -34,9 +34,15 @@ function isWorkspaceAgentConfig(source: string): boolean {
   return /\bdefineAgent\s*\(\s*\{[\s\S]*?\bworkspace\s*:/.test(stripComments(source))
 }
 
+function isAgentDefinitionSource(source: string): boolean {
+  const stripped = stripComments(source)
+  return /\bdefineAgent\s*\(/.test(stripped) || /\bexport\s+default\b/.test(stripped)
+}
+
 function isInsideConfiguredAgent(file: string, configuredAgentDirs: Set<string>): boolean {
   const directory = dirname(file)
   if (configuredAgentDirs.has(directory) && indexDefinitionPattern.test(basename(file))) return false
+  if (isAgentDefinitionSource(readFileSync(file, "utf8"))) return false
   for (const agentDir of configuredAgentDirs) {
     const path = relative(agentDir, directory)
     if (path === "" || (!path.startsWith("..") && path !== "..")) return true

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -44,12 +44,18 @@ function isInsideConfiguredAgent(file: string, configuredAgentDirs: Set<string>)
   return false
 }
 
-function isWorkspaceSourceConfig(agent: string): boolean {
-  return agent.split("/").slice(1).includes("workspace")
+function isWorkspaceSourceConfig(file: string, configuredAgentDirs: Set<string>): boolean {
+  const directory = dirname(file)
+  for (const agentDir of configuredAgentDirs) {
+    const path = relative(agentDir, directory).replace(/\\/g, "/")
+    if (!path || path.startsWith("../") || path === "..") continue
+    if (path.split("/")[0] === "workspace") return true
+  }
+  return false
 }
 
 function discoverDirectoryAgentConfigs(scanDirs: string[]): DiscoveredAgentDefinition[] {
-  const definitions: DiscoveredAgentDefinition[] = []
+  const candidates: DiscoveredAgentDefinition[] = []
 
   const walk = (agentsRoot: string, current: string) => {
     let entries
@@ -72,9 +78,8 @@ function discoverDirectoryAgentConfigs(scanDirs: string[]): DiscoveredAgentDefin
       const source = readFileSync(file, "utf8")
       const agent = relative(agentsRoot, dirname(file)).replace(/\\/g, "/")
       if (!agent || agent === ".") continue
-      if (isWorkspaceSourceConfig(agent)) continue
       const workspace = isWorkspaceAgentConfig(source)
-      definitions.push({
+      candidates.push({
         handler: file,
         name: agent,
         source: workspace ? "server-agent-workspace" : "server-agents",
@@ -87,7 +92,8 @@ function discoverDirectoryAgentConfigs(scanDirs: string[]): DiscoveredAgentDefin
     walk(resolve(scanDir, "agents"), resolve(scanDir, "agents"))
   }
 
-  return definitions
+  const configuredAgentDirs = new Set(candidates.map(definition => dirname(definition.handler)))
+  return candidates.filter(definition => !isWorkspaceSourceConfig(definition.handler, configuredAgentDirs))
 }
 
 export function discoverAgentDefinitions(options:

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -13,6 +13,7 @@ import type { DiscoveredAgentDefinition } from "./types.ts"
 const agentSuffixPattern = /\.agent\.(?:c|m)?[jt]s$/i
 const configPattern = /^config\.(?:c|m)?[jt]s$/i
 const evalDefinitionPattern = /^(?:.+\.)?eval\.(?:c|m)?[jt]s$/i
+const indexDefinitionPattern = /^index\.(?:c|m)?[jt]s$/i
 
 function isEvalDefinitionFile(file: string): boolean {
   return evalDefinitionPattern.test(basename(file))
@@ -37,6 +38,7 @@ function isInsideConfiguredAgent(file: string, configuredAgentDirs: Set<string>)
   const directory = dirname(file)
   for (const agentDir of configuredAgentDirs) {
     const path = relative(agentDir, directory)
+    if (path === "" && indexDefinitionPattern.test(basename(file))) return false
     if (path === "" || (!path.startsWith("..") && path !== "..")) return true
   }
   return false

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -92,7 +92,9 @@ function discoverDirectoryAgentConfigs(scanDirs: string[]): DiscoveredAgentDefin
     walk(resolve(scanDir, "agents"), resolve(scanDir, "agents"))
   }
 
-  const configuredAgentDirs = new Set(candidates.map(definition => dirname(definition.handler)))
+  const configuredAgentDirs = new Set(candidates
+    .filter(definition => definition.source === "server-agent-workspace")
+    .map(definition => dirname(definition.handler)))
   return candidates.filter(definition => !isWorkspaceSourceConfig(definition.handler, configuredAgentDirs))
 }
 

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -35,7 +35,10 @@ function isWorkspaceAgentConfig(source: string): boolean {
 }
 
 function isAgentDefinitionSource(source: string): boolean {
-  return /\bdefineAgent\s*\(/.test(stripComments(source))
+  const stripped = stripComments(source)
+  return /\bdefineAgent\s*\(/.test(stripped)
+    || /\bexport\s*\{\s*default\s*\}\s*from\b/.test(stripped)
+    || /\bexport\s+default\s+\w*Agent\b/.test(stripped)
 }
 
 function isInsideConfiguredAgent(file: string, configuredAgentDirs: Set<string>): boolean {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -35,8 +35,7 @@ function isWorkspaceAgentConfig(source: string): boolean {
 }
 
 function isAgentDefinitionSource(source: string): boolean {
-  const stripped = stripComments(source)
-  return /\bdefineAgent\s*\(/.test(stripped) || /\bexport\s+default\b/.test(stripped)
+  return /\bdefineAgent\s*\(/.test(stripComments(source))
 }
 
 function isInsideConfiguredAgent(file: string, configuredAgentDirs: Set<string>): boolean {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -36,9 +36,9 @@ function isWorkspaceAgentConfig(source: string): boolean {
 
 function isInsideConfiguredAgent(file: string, configuredAgentDirs: Set<string>): boolean {
   const directory = dirname(file)
+  if (configuredAgentDirs.has(directory) && indexDefinitionPattern.test(basename(file))) return false
   for (const agentDir of configuredAgentDirs) {
     const path = relative(agentDir, directory)
-    if (path === "" && indexDefinitionPattern.test(basename(file))) return false
     if (path === "" || (!path.startsWith("..") && path !== "..")) return true
   }
   return false

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -250,6 +250,25 @@ describe("agent discovery", () => {
     ]))
   })
 
+  it("discovers nested re-exported file agents below configured agents", async () => {
+    const root = await createTempRoot("vitehub-agent-nested-reexport-agent-")
+    await mkdir(join(root, "server", "agents", "team"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "team", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "prompts.ts"), "export default { system: 'help' }", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "review.ts"), "export { default } from './review-agent'", "utf8")
+
+    const definitions = discoverAgentDefinitions({
+      mode: "server-agents",
+      scanDirs: [join(root, "server")],
+    })
+
+    expect(definitions).toHaveLength(2)
+    expect(definitions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "team", source: "server-agent-workspace", workspace: "team" }),
+      expect.objectContaining({ name: "team/review", source: "server-agents" }),
+    ]))
+  })
+
   it("throws on duplicate server agent names", async () => {
     const root = await createTempRoot("vitehub-agent-duplicate-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -213,6 +213,18 @@ describe("agent discovery", () => {
       scanDirs: [join(root, "server")],
     })).toThrow("Duplicate agent name")
   })
+
+  it("throws when a configured server agent also has an index definition", async () => {
+    const root = await createTempRoot("vitehub-agent-config-index-duplicate-")
+    await mkdir(join(root, "server", "agents", "support"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "index.ts"), "export default defineAgent({ model })", "utf8")
+
+    expect(() => discoverAgentDefinitions({
+      mode: "server-agents",
+      scanDirs: [join(root, "server")],
+    })).toThrow("Duplicate agent name")
+  })
 })
 
 describe("agent chat capability discovery", () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -253,6 +253,19 @@ describe("agent discovery", () => {
       scanDirs: [join(root, "server")],
     })).toThrow("Duplicate agent name")
   })
+
+  it("throws when a nested configured server agent also has an index definition", async () => {
+    const root = await createTempRoot("vitehub-agent-nested-config-index-duplicate-")
+    await mkdir(join(root, "server", "agents", "team", "review"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "team", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "review", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "review", "index.ts"), "export default defineAgent({ model })", "utf8")
+
+    expect(() => discoverAgentDefinitions({
+      mode: "server-agents",
+      scanDirs: [join(root, "server")],
+    })).toThrow("Duplicate agent name")
+  })
 })
 
 describe("agent chat capability discovery", () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -202,6 +202,19 @@ describe("agent discovery", () => {
     ])
   })
 
+  it("discovers nested agents named workspace when no parent agent owns the source root", async () => {
+    const root = await createTempRoot("vitehub-agent-nested-workspace-")
+    await mkdir(join(root, "server", "agents", "team", "workspace"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "team", "workspace", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
+
+    expect(discoverAgentDefinitions({
+      mode: "server-agents",
+      scanDirs: [join(root, "server")],
+    })).toEqual([
+      expect.objectContaining({ name: "team/workspace", source: "server-agent-workspace", workspace: "team/workspace" }),
+    ])
+  })
+
   it("throws on duplicate server agent names", async () => {
     const root = await createTempRoot("vitehub-agent-duplicate-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -652,7 +652,7 @@ describe("agent chat capability discovery", () => {
   it("refreshes chat devtools workspace metadata after source materialization", async () => {
     const root = await createTempRoot("vitehub-agent-devtools-materialized-source-")
     await mkdir(join(root, "server", "agents", "support"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default {}", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
 
     const { chat } = await import("../src/capabilities.ts")
     const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")
@@ -739,7 +739,7 @@ describe("agent chat capability discovery", () => {
   it("materializes resolver-backed lazy sources from the chat devtools file tree", async () => {
     const root = await createTempRoot("vitehub-agent-devtools-click-source-")
     await mkdir(join(root, "server", "agents", "support"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default {}", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
 
     const { chat } = await import("../src/capabilities.ts")
     const { defineAgent, withWorkspaceAgentDefaults } = await import("../src/index.ts")

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -177,6 +177,7 @@ describe("agent discovery", () => {
     await writeFile(join(root, "server", "agents", "chat", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
     await writeFile(join(root, "server", "agents", "chat", "access.ts"), "export const access = {}", "utf8")
     await writeFile(join(root, "server", "agents", "chat", "audience.test.ts"), "export const test = {}", "utf8")
+    await writeFile(join(root, "server", "agents", "chat", "prompts.ts"), "export default { system: 'help' }", "utf8")
     await writeFile(join(root, "server", "agents", "chat", "workspace", "config.ts"), "export const sources = {}", "utf8")
     await writeFile(join(root, "server", "agents", "review", "config.ts"), "export default defineAgent({ model })", "utf8")
 

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -215,6 +215,21 @@ describe("agent discovery", () => {
     ])
   })
 
+  it("discovers nested agents named workspace below plain config agents", async () => {
+    const root = await createTempRoot("vitehub-agent-plain-parent-workspace-")
+    await mkdir(join(root, "server", "agents", "team", "workspace"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "team", "config.ts"), "export default defineAgent({ run: () => 'ok' })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "workspace", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
+
+    expect(discoverAgentDefinitions({
+      mode: "server-agents",
+      scanDirs: [join(root, "server")],
+    })).toEqual([
+      expect.objectContaining({ name: "team", source: "server-agents", workspace: undefined }),
+      expect.objectContaining({ name: "team/workspace", source: "server-agent-workspace", workspace: "team/workspace" }),
+    ])
+  })
+
   it("throws on duplicate server agent names", async () => {
     const root = await createTempRoot("vitehub-agent-duplicate-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -230,6 +230,25 @@ describe("agent discovery", () => {
     ])
   })
 
+  it("discovers nested file agents below configured agents", async () => {
+    const root = await createTempRoot("vitehub-agent-nested-file-agent-")
+    await mkdir(join(root, "server", "agents", "team"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "team", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "access.ts"), "export const access = {}", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "review.ts"), "export default defineAgent({ model })", "utf8")
+
+    const definitions = discoverAgentDefinitions({
+      mode: "server-agents",
+      scanDirs: [join(root, "server")],
+    })
+
+    expect(definitions).toHaveLength(2)
+    expect(definitions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "team", source: "server-agent-workspace", workspace: "team" }),
+      expect.objectContaining({ name: "team/review", source: "server-agents" }),
+    ]))
+  })
+
   it("throws on duplicate server agent names", async () => {
     const root = await createTempRoot("vitehub-agent-duplicate-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -170,6 +170,25 @@ describe("agent discovery", () => {
     ])
   })
 
+  it("ignores helper files inside configured server agents", async () => {
+    const root = await createTempRoot("vitehub-agent-server-helpers-")
+    await mkdir(join(root, "server", "agents", "chat", "workspace"), { recursive: true })
+    await mkdir(join(root, "server", "agents", "review"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "chat", "config.ts"), "export default defineAgent({ workspace: {}, model })", "utf8")
+    await writeFile(join(root, "server", "agents", "chat", "access.ts"), "export const access = {}", "utf8")
+    await writeFile(join(root, "server", "agents", "chat", "audience.test.ts"), "export const test = {}", "utf8")
+    await writeFile(join(root, "server", "agents", "chat", "workspace", "config.ts"), "export const sources = {}", "utf8")
+    await writeFile(join(root, "server", "agents", "review", "config.ts"), "export default defineAgent({ model })", "utf8")
+
+    expect(discoverAgentDefinitions({
+      mode: "server-agents",
+      scanDirs: [join(root, "server")],
+    })).toEqual([
+      expect.objectContaining({ name: "chat", source: "server-agent-workspace", workspace: "chat" }),
+      expect.objectContaining({ name: "review", source: "server-agents" }),
+    ])
+  })
+
   it("uses folder identity for colocated workspace agents", async () => {
     const root = await createTempRoot("vitehub-agent-workspace-name-")
     await mkdir(join(root, "server", "agents", "docs"), { recursive: true })


### PR DESCRIPTION
Narrows server agent discovery so directory config files only register when they actually define an agent, and helper files under configured agent folders are not treated as separate agents.

This fixes the Quiver-style layout where `server/agents/chat/config.ts` is the agent, while sibling files such as `access.ts`, tests, and `workspace/config.ts` are support code. Generated ViteHub routes should now import the actual agents instead of every helper module under `server/agents/**`.
