### PR TITLE
feat(agent): support trigger dev samples

### DIFF
--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -12,6 +12,7 @@ export type {
 
 export interface AgentChannelOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   adapter?: AgentChannelDefinition<TRuntimeConfig>["adapter"]
+  dev?: AgentChannelDefinition<TRuntimeConfig>["dev"]
   identity?: AgentChannelDefinition<TRuntimeConfig>["identity"]
   messages?: false | AgentMessageChannelSettings<TRuntimeConfig>
   webhooks?: AgentChannelDefinition<TRuntimeConfig>["webhooks"]

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -176,6 +176,9 @@ function createChatMessageTrigger<TRuntimeConfig extends AgentRuntimeConfig>(
   options: AgentChatOptions<TRuntimeConfig> = {},
 ): AgentTriggerDefinition<TRuntimeConfig, WorkspaceName, AgentChatMessageTriggerInput> {
   return {
+    ...(options.dev?.samples
+      ? { dev: { samples: options.dev.samples as Record<string, AgentChatMessageTriggerInput> } }
+      : {}),
     devtools: true,
     input: "ui-message[]",
     output: "ui-message-stream",

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -55,8 +55,11 @@ interface ParsedEvalArgs {
 interface ParsedDevArgs {
   agent?: string
   help: boolean
+  input?: unknown
   message?: string
+  sample?: string
   timeout?: number
+  trigger?: string
   url: string
 }
 
@@ -65,7 +68,7 @@ interface AgentDevCliOptions {
 }
 
 interface AgentDevDiscovery {
-  agents?: Array<{ name?: unknown }>
+  agents?: Array<{ name?: unknown, samples?: unknown, triggers?: unknown }>
   root?: unknown
 }
 
@@ -91,15 +94,18 @@ function writeEvalUsage(context: AgentCliContext): void {
 
 function writeDevUsage(context: AgentCliContext): void {
   context.stdout.write([
-    "Usage: vitehub agent dev [message...] [--agent <name>] [--url <url>] [--timeout <ms>]",
+    "Usage: vitehub agent dev [message...] [--agent <name>] [--trigger <id>] [--sample <name>] [--input <json>] [--url <url>] [--timeout <ms>]",
     "",
     "Talk to a discovered Agent through a running Vite Development Server.",
     "",
     "Options:",
-    "  --agent <name>  Agent Dev Loop Target. Required when multiple Agents are compatible.",
-    "  --url <url>     Compatible Vite Development Server URL. Defaults to http://localhost:5173.",
-    "  --timeout <ms>  Agent Invocation timeout. Defaults to 90000.",
-    "  -h, --help      Show this help.",
+    "  --agent <name>   Agent Dev Loop Target. Required when multiple Agents are compatible.",
+    "  --trigger <id>   Agent Trigger to invoke. Defaults to chat.message when available.",
+    "  --sample <name>  Agent Trigger dev sample to replay.",
+    "  --input <json>   Raw Agent Trigger input JSON for one-shot invocations.",
+    "  --url <url>      Compatible Vite Development Server URL. Defaults to http://localhost:5173.",
+    "  --timeout <ms>   Agent Invocation timeout. Defaults to 90000.",
+    "  -h, --help       Show this help.",
     "",
   ].join("\n"))
 }
@@ -257,6 +263,33 @@ function parseDevArgs(args: string[], env: NodeJS.ProcessEnv): ParsedDevArgs {
       parsed.agent = arg.slice("--agent=".length)
       continue
     }
+    if (arg === "--trigger") {
+      parsed.trigger = readOptionValue(args, index, arg)
+      index++
+      continue
+    }
+    if (arg.startsWith("--trigger=")) {
+      parsed.trigger = arg.slice("--trigger=".length)
+      continue
+    }
+    if (arg === "--sample") {
+      parsed.sample = readOptionValue(args, index, arg)
+      index++
+      continue
+    }
+    if (arg.startsWith("--sample=")) {
+      parsed.sample = arg.slice("--sample=".length)
+      continue
+    }
+    if (arg === "--input") {
+      parsed.input = JSON.parse(readOptionValue(args, index, arg))
+      index++
+      continue
+    }
+    if (arg.startsWith("--input=")) {
+      parsed.input = JSON.parse(arg.slice("--input=".length))
+      continue
+    }
     if (arg === "--url" || arg === "--server") {
       parsed.url = readOptionValue(args, index, arg)
       index++
@@ -374,14 +407,17 @@ async function sendDevMessage(
   fetchImpl: typeof fetch,
   signal?: AbortSignal,
 ): Promise<UIMessageLike[] | undefined> {
-  const messages = [...history, userMessage(text, history.length)]
+  const messages = text ? [...history, userMessage(text, history.length)] : history
   let response: Response
   try {
     response = await fetchImpl(url, {
       body: JSON.stringify({
         agent,
-        messages,
+        ...(messages.length ? { messages } : {}),
+        ...("input" in parsed ? { input: parsed.input } : {}),
+        ...(parsed.sample ? { sample: parsed.sample } : {}),
         ...(parsed.timeout ? { timeout: parsed.timeout } : {}),
+        ...(parsed.trigger ? { trigger: parsed.trigger } : {}),
       }),
       headers: {
         "content-type": "application/json",
@@ -444,7 +480,7 @@ async function sendDevMessage(
   }
   context.stdout.write("\n")
   if (!output && needsApproval) return
-  return [...messages, assistantMessage(output, messages.length)]
+  return messages.length || output ? [...messages, assistantMessage(output, messages.length)] : []
 }
 
 async function runInteractiveDevLoop(
@@ -520,8 +556,8 @@ export async function runAgentDevCli(
   const target = await readDiscovery(parsed, context, fetchImpl)
   if (!target) return 1
 
-  if (parsed.message) {
-    return await sendDevMessage(target.url, target.agent, parsed.message, [], parsed, context, fetchImpl, new AbortController().signal) ? 0 : 1
+  if (parsed.message || parsed.sample || "input" in parsed) {
+    return await sendDevMessage(target.url, target.agent, parsed.message || "", [], parsed, context, fetchImpl, new AbortController().signal) ? 0 : 1
   }
   if (!process.stdin.isTTY) {
     context.stderr.write("Pass a message or run in an interactive terminal.\n")

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -31,6 +31,15 @@ function hasMessageOverrides<TRuntimeConfig extends AgentRuntimeConfig>(
   return !!messages && Object.keys(messages).length > 0
 }
 
+function addDevSamples(target: Record<string, unknown>, samples: Record<string, unknown> | undefined): void {
+  for (const [name, sample] of Object.entries(samples || {})) {
+    if (Object.prototype.hasOwnProperty.call(target, name)) {
+      throw new TypeError(`[vitehub] Duplicate Agent Channel dev sample: ${name}. Use unique sample names across message-shaped Channels.`)
+    }
+    target[name] = sample
+  }
+}
+
 export function resolveAgentChannelChatOptions<TRuntimeConfig extends AgentRuntimeConfig>(
   channels: AgentChannels<TRuntimeConfig> | undefined,
   messages: AgentMessageChannelSettings<TRuntimeConfig> | undefined,
@@ -45,11 +54,13 @@ export function resolveAgentChannelChatOptions<TRuntimeConfig extends AgentRunti
   let messageChannelCount = 0
   const channelIdentities: NonNullable<AgentChatOptions<TRuntimeConfig>["identity"]>[] = []
   const channelMessageOverrides: AgentMessageChannelSettings<TRuntimeConfig>[] = []
+  const channelDevSamples: Record<string, unknown> = {}
 
   for (const [channelId, channelDefinition] of entries) {
     if (channelDefinition.messages === false) continue
     hasMessageChannel = true
     messageChannelCount += 1
+    addDevSamples(channelDevSamples, channelDefinition.dev?.samples)
     if (hasMessageOverrides(channelDefinition.messages)) {
       channelMessageOverrides.push(channelDefinition.messages)
     }
@@ -85,6 +96,13 @@ export function resolveAgentChannelChatOptions<TRuntimeConfig extends AgentRunti
       throw new TypeError("[vitehub] Channel-local messages options are only supported when an Agent defines one message-shaped Channel. Move shared settings to defineAgent({ messages }) until Channel-scoped chat triggers land.")
     }
     Object.assign(options, channelMessageOverrides[0])
+  }
+  if (Object.keys(channelDevSamples).length) {
+    addDevSamples(channelDevSamples, options.dev?.samples as Record<string, unknown> | undefined)
+    options.dev = {
+      ...options.dev,
+      samples: channelDevSamples,
+    }
   }
   if (Object.keys(platforms).length) options.platforms = platforms
   if (Object.keys(webhooks).length) options.webhooks = webhooks

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -72,6 +72,7 @@ export async function resolveAgentTriggers<
       triggers[id] = {
         capabilityId: capability.id,
         definition: trigger as never,
+        dev: trigger.dev,
         devtools: trigger.devtools,
         id,
         input: trigger.input,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -193,6 +193,9 @@ export interface AgentTriggerDefinition<
   TInput = unknown,
   CALL_OPTIONS = unknown,
 > {
+  dev?: {
+    samples?: Record<string, TInput>
+  }
   devtools?: boolean | Record<string, unknown>
   input?: unknown
   invoke: (context: AgentTriggerContext<TRuntimeConfig, Name>, input: TInput) => MaybePromise<AgentTriggerInvokeResult<CALL_OPTIONS>>
@@ -207,6 +210,9 @@ export interface ResolvedAgentTriggerDefinition<
 > {
   capabilityId: string
   definition: AgentTriggerDefinition<TRuntimeConfig, WorkspaceName, TInput, CALL_OPTIONS>
+  dev?: {
+    samples?: Record<string, TInput>
+  }
   devtools?: boolean | Record<string, unknown>
   id: `${string}.${string}`
   input?: unknown
@@ -872,6 +878,9 @@ export interface AgentChatFinishExtension {
 export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   concurrency?: AgentMessageConcurrency
   dedupeTtlMs?: number
+  dev?: {
+    samples?: Record<string, unknown>
+  }
   errorFallbackText?: string | null | ((context: AgentChatErrorHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   fallbackStreamingPlaceholderText?: string | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   history?: AgentChatAgentBindingOptions["history"]
@@ -890,6 +899,9 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
 
 export interface AgentChannelDefinition<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   adapter?: AgentChatPlatformResolver<TRuntimeConfig>
+  dev?: {
+    samples?: Record<string, unknown>
+  }
   identity?: IdentityResolver
   kind: string
   messages?: false | AgentMessageChannelSettings<TRuntimeConfig>

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -20,6 +20,7 @@ import type {
   AgentRuntimeConfig,
   AgentRuntimeContext,
   DiscoveredAgentDefinition,
+  ResolvedAgentTriggerDefinition,
 } from "../index.ts"
 
 interface ViteAgentDevRuntimeConfig extends AgentRuntimeConfig {
@@ -34,18 +35,21 @@ interface ViteAgentDevRuntimeContext extends AgentRuntimeContext<ViteAgentDevRun
 
 interface AgentInvocationStreamBody {
   agent?: string
+  input?: unknown
   invokerProfileId?: string
   messages?: AgentChatMessageTriggerInput["messages"]
   meta?: Record<string, unknown>
   run?: AgentRunMetadata
+  sample?: string
   text?: string
   timeout?: number
+  trigger?: string
 }
 
 interface AgentInvocationStreamEntry {
   agent: AgentInput<ViteAgentDevRuntimeContext>
   name: string
-  trigger?: "chat.message"
+  triggers: Record<string, ResolvedAgentTriggerDefinition<ViteAgentDevRuntimeContext>>
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -168,7 +172,7 @@ async function discoverStreamAgents(server: ViteDevServer): Promise<AgentInvocat
     const agent = await loadDiscoveredAgent(server, definition)
     if (!agent) continue
     const triggers = await resolveAgentTriggers(agent as never, context as never)
-    entries.push({ agent, name: definition.name, ...(triggers["chat.message"] ? { trigger: "chat.message" as const } : {}) })
+    entries.push({ agent, name: definition.name, triggers })
   }
   return entries
 }
@@ -197,6 +201,51 @@ function messagesFromBody(body: AgentInvocationStreamBody): AgentChatMessageTrig
   const text = typeof body.text === "string" ? body.text.trim() : ""
   if (text) return [messageFromText(text)]
   throw new Response("Missing Agent Dev Loop message text.", { status: 400 })
+}
+
+function sampleNames(trigger: ResolvedAgentTriggerDefinition): string[] {
+  return Object.keys(trigger.dev?.samples || {})
+}
+
+function selectedTrigger(entry: AgentInvocationStreamEntry, body: AgentInvocationStreamBody): ResolvedAgentTriggerDefinition | undefined {
+  if (typeof body.trigger === "string" && body.trigger.trim()) {
+    const trigger = entry.triggers[body.trigger]
+    if (!trigger) throw new Response(`Unknown Agent Trigger: ${body.trigger}`, { status: 404 })
+    return trigger
+  }
+  if (typeof body.sample === "string" && body.sample.trim()) {
+    const matches = Object.values(entry.triggers).filter(trigger => sampleNames(trigger).includes(body.sample!))
+    if (matches.length === 1) return matches[0]
+    if (!matches.length) throw new Response(`Unknown Agent Dev Sample: ${body.sample}`, { status: 404 })
+    throw new Response(`Ambiguous Agent Dev Sample: ${body.sample}. Pass trigger.`, { status: 400 })
+  }
+  return entry.triggers["chat.message"]
+}
+
+function triggerInput(trigger: ResolvedAgentTriggerDefinition, body: AgentInvocationStreamBody, signal: AbortSignal, run: AgentRunMetadata, timeout: number): unknown {
+  if (typeof body.sample === "string" && body.sample.trim()) {
+    const samples = trigger.dev?.samples || {}
+    if (!Object.prototype.hasOwnProperty.call(samples, body.sample)) {
+      throw new Response(`Unknown Agent Dev Sample: ${body.sample}`, { status: 404 })
+    }
+    return samples[body.sample]
+  }
+  if ("input" in body) return body.input
+  if (trigger.id !== "chat.message") {
+    throw new Response("Missing Agent Trigger input. Pass input or sample.", { status: 400 })
+  }
+  return {
+    abortSignal: signal,
+    messages: messagesFromBody(body),
+    run,
+    timeout,
+    user: {
+      id: "dev",
+      name: "ViteHub Dev Loop",
+    },
+    ...(typeof body.invokerProfileId === "string" ? { invokerProfileId: body.invokerProfileId } : {}),
+    ...(isRecord(body.meta) ? { meta: body.meta } : {}),
+  } satisfies AgentChatMessageTriggerInput
 }
 
 function parseBody(rawBody: string): AgentInvocationStreamBody {
@@ -229,7 +278,12 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
   const entries = await discoverStreamAgents(server)
   if (req.method === "GET") {
     return Response.json({
-      agents: entries.map(entry => ({ name: entry.name, triggers: entry.trigger ? [entry.trigger] : [] })),
+      agents: entries.map(entry => ({
+        name: entry.name,
+        samples: Object.fromEntries(Object.entries(entry.triggers)
+          .flatMap(([id, trigger]) => sampleNames(trigger).map(sample => [`${id}.${sample}`, { sample, trigger: id }]))),
+        triggers: Object.keys(entry.triggers),
+      })),
       root: server.config.root,
     })
   }
@@ -238,25 +292,13 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
   const entry = selectedEntry(entries, body.agent)
   const run = body.run || devRun(entry.name)
   const context = createRuntimeContext(server, req, run)
-  const messages = messagesFromBody(body)
   const timeout = typeof body.timeout === "number" && Number.isFinite(body.timeout) ? body.timeout : 90_000
 
   return createAgentInvocationStreamResponse(async (emit, signal) => {
     let output: Awaited<ReturnType<typeof streamAgent>>
-    if (entry.trigger) {
-      const input = {
-        abortSignal: signal,
-        messages,
-        run,
-        timeout,
-        user: {
-          id: "dev",
-          name: "ViteHub Dev Loop",
-        },
-        ...(typeof body.invokerProfileId === "string" ? { invokerProfileId: body.invokerProfileId } : {}),
-        ...(isRecord(body.meta) ? { meta: body.meta } : {}),
-      } satisfies AgentChatMessageTriggerInput
-      output = await streamAgentTrigger(entry.agent as never, context as never, entry.trigger, input, {
+    const trigger = selectedTrigger(entry, body)
+    if (trigger) {
+      output = await streamAgentTrigger(entry.agent as never, context as never, trigger.id, triggerInput(trigger, body, signal, run, timeout), {
         async onInvocation(invocation) {
           if (!signal.aborted) emit({ agent: entry.name, run: invocation.run, trigger: invocation.trigger.id, type: "start" })
         },
@@ -264,6 +306,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
       })
     }
     else {
+      const messages = messagesFromBody(body)
       if (!signal.aborted) emit({ agent: entry.name, run, type: "start" })
       output = await streamAgent(entry.agent as never, context as never, {
         abortSignal: signal,

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -97,6 +97,40 @@ describe("agent CLI", () => {
     })
   })
 
+  it("replays an Agent Trigger dev sample without chat text", async () => {
+    const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return ndjson([
+          { agent: "review", trigger: "github.webhook", type: "start" },
+          { text: "summary", type: "text-delta" },
+          { type: "finish" },
+          { type: "done" },
+        ])
+      }
+      return Response.json({
+        agents: [{ name: "review", samples: { "github.webhook.summaryComment": { sample: "summaryComment", trigger: "github.webhook" } }, triggers: ["github.webhook"] }],
+        root: "/repo",
+      })
+    })
+
+    const exitCode = await runAgentDevCli(["--agent", "review", "--trigger", "github.webhook", "--sample", "summaryComment"], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      spawn: vi.fn(),
+      stderr: stream(),
+      stdout: stream(),
+    }, { fetch: fetchAgentStream as never })
+
+    expect(exitCode).toBe(0)
+    const post = fetchAgentStream.mock.calls.find(([, init]) => init?.method === "POST")
+    expect(JSON.parse(String(post?.[1]?.body))).toEqual({
+      agent: "review",
+      sample: "summaryComment",
+      trigger: "github.webhook",
+    })
+  })
+
   it("surfaces Agent Dev Loop approval requests", async () => {
     const stderr = stream()
     const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -443,6 +443,74 @@ describe("agent chat capability discovery", () => {
     expect(abortSignal).toBeInstanceOf(AbortSignal)
   })
 
+  it("replays Agent Invocation Stream dev samples from message-shaped channels", async () => {
+    const root = await createTempRoot("vitehub-agent-invocation-stream-sample-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+
+    const { webChat } = await import("../src/channels.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const headers = {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    }
+    const agent = defineAgent({
+      channels: {
+        portal: webChat({
+          dev: {
+            samples: {
+              purchaseOrderQuestion: {
+                messages: [{
+                  id: "sample-user-1",
+                  parts: [{ text: "Review purchase order 42", type: "text" }],
+                  role: "user",
+                }],
+              },
+            },
+          },
+        }),
+      },
+      run: ({ messages }) => `sample ${getMessageText(messages[0]!)}`,
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
+
+    await configurePluginServer(plugin, server)
+
+    const discovery = await invokeMiddleware(handlers[0]!, {}, agentInvocationStreamRoute, {
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    }, "GET")
+    expect(JSON.parse(discovery.body)).toMatchObject({
+      agents: [{
+        name: "support",
+        samples: {
+          "chat.message.purchaseOrderQuestion": {
+            sample: "purchaseOrderQuestion",
+            trigger: "chat.message",
+          },
+        },
+        triggers: ["chat.message"],
+      }],
+    })
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      agent: "support",
+      sample: "purchaseOrderQuestion",
+    }, agentInvocationStreamRoute, headers)
+    const events = response.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+
+    expect(events).toEqual([
+      expect.objectContaining({ agent: "support", trigger: "chat.message", type: "start" }),
+      { text: "sample Review purchase order 42", type: "text-delta" },
+      { type: "finish" },
+      { type: "done" },
+    ])
+  })
+
   it("serves plain Agent Definitions from the Agent Invocation Stream endpoint", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-plain-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -956,6 +956,40 @@ describe("agent message protocol", () => {
     await expect(runAgentTrigger(agent, runtime, "portal.message", { text: "hello" })).resolves.toBe("received hello")
   })
 
+  it("exposes Agent Trigger dev samples", async () => {
+    const { entry } = await import("../src/capabilities.ts")
+    const { resolveAgentTriggers } = await import("../src/trigger-runtime.ts")
+    const agent = {
+      capabilities: [entry({
+        id: "github",
+        triggers: {
+          webhook: {
+            dev: {
+              samples: {
+                summaryComment: { body: "/summary", deliveryId: "delivery-1" },
+              },
+            },
+            invoke: (_context, input: { body: string, deliveryId: string }) => ({
+              input: { prompt: input.body },
+              run: { origin: "github", runId: input.deliveryId },
+            }),
+          },
+        },
+      })],
+      resolve: vi.fn(),
+    }
+
+    await expect(resolveAgentTriggers(agent, { memo: vi.fn(), runtime: "unknown" as const, runtimeConfig: {}, waitUntil: vi.fn() })).resolves.toMatchObject({
+      "github.webhook": {
+        dev: {
+          samples: {
+            summaryComment: { body: "/summary", deliveryId: "delivery-1" },
+          },
+        },
+      },
+    })
+  })
+
   it("exposes chat webhook registration metadata through agent triggers", async () => {
     const { chat } = await import("../src/chat-trigger.ts")
     const { resolveAgentTriggers } = await import("../src/trigger-runtime.ts")
@@ -1038,6 +1072,16 @@ describe("agent message protocol", () => {
       channels: {
         support: teams({
           adapter,
+          dev: {
+            samples: {
+              supportThread: {
+                messages: [{
+                  parts: [{ text: "Need help with an invoice", type: "text" }],
+                  role: "user",
+                }],
+              },
+            },
+          },
           webhooks: {
             path: "/api/teams/support",
           },
@@ -1067,6 +1111,16 @@ describe("agent message protocol", () => {
     expect(agent.capabilities?.some(capability => capability.id === "chat")).toBe(true)
     await expect(resolveAgentTriggers(agent, { memo: vi.fn(), runtime: "unknown" as const, runtimeConfig: {}, waitUntil: vi.fn() })).resolves.toMatchObject({
       "chat.message": {
+        dev: {
+          samples: {
+            supportThread: {
+              messages: [{
+                parts: [{ text: "Need help with an invoice", type: "text" }],
+                role: "user",
+              }],
+            },
+          },
+        },
         webhooks: [{
           id: "support",
           method: "POST",


### PR DESCRIPTION
## Summary
- add `dev.samples` metadata to Agent Triggers and resolved triggers
- let message-shaped channels provide dev samples that surface on `chat.message`
- teach `vitehub agent dev` and the Vite stream endpoint to invoke `--trigger`, `--sample`, or raw `--input`

## Tests
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --filter @vite-hub/agent test`
