### PR TITLE
refactor(agent)!: remove defineAgent title metadata

### DIFF
--- a/packages/agent/src/chat/devtools.ts
+++ b/packages/agent/src/chat/devtools.ts
@@ -151,8 +151,8 @@ export interface ChatDevtoolsTypingThread {
 }
 
 type ResolvedChatDevtoolsMetadata =
-  Required<Omit<ChatDevtoolsMetadata, "config" | "title" | "version">>
-  & Pick<ChatDevtoolsMetadata, "config" | "title" | "version">
+  Required<Omit<ChatDevtoolsMetadata, "config" | "name" | "version">>
+  & Pick<ChatDevtoolsMetadata, "config" | "name" | "version">
 
 interface ChatDevtoolsFullStreamToolPart {
   error?: unknown
@@ -478,7 +478,7 @@ function normalizeDevtoolsMetadata(metadata: ChatDevtoolsMetadata | undefined): 
     files: metadata?.files ? [...metadata.files] : [],
     instructions: metadata?.instructions ? [...metadata.instructions] : [],
     invokerProfiles: metadata?.invokerProfiles ? [...metadata.invokerProfiles] : [],
-    title: metadata?.title,
+    name: metadata?.name,
     tools: metadata?.tools ? [...metadata.tools] : [],
     version: metadata?.version,
     ...(metadata?.config ? { config: metadata.config } : {}),
@@ -672,7 +672,7 @@ export function createDevtoolsAdapter(options: ChatDevtoolsAdapterOptions = {}):
         instructions: metadata.instructions,
         invokerProfiles: metadata.invokerProfiles,
         selected: chat && chats.some(item => item.name === chat) ? chat : chats[0]!.name,
-        ...(metadata.title ? { title: metadata.title } : {}),
+        ...(metadata.name ? { title: metadata.name } : {}),
         tools: metadata.tools,
         ...(metadata.version ? { version: metadata.version } : {}),
       }

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -265,8 +265,15 @@ function canResolveWorkspaceMetadata(agent: AgentInput<ViteAgentDevtoolsRuntimeC
   return Boolean((agent as { __vitehubWorkspaceAgent?: unknown }).__vitehubWorkspaceAgent)
 }
 
-function createStaticDevtoolsMetadata(agent: AgentInput<ViteAgentDevtoolsRuntimeContext>): ChatDevtoolsMetadata {
-  return createAgentDevtoolsMetadata(agent as never)
+function metadataWithAgentName(metadata: ChatDevtoolsMetadata, name: string): ChatDevtoolsMetadata {
+  return {
+    ...metadata,
+    name: metadata.name || name,
+  }
+}
+
+function createStaticDevtoolsMetadata(name: string, agent: AgentInput<ViteAgentDevtoolsRuntimeContext>): ChatDevtoolsMetadata {
+  return metadataWithAgentName(createAgentDevtoolsMetadata(agent as never), name)
 }
 
 function metadataStaticKey(metadata: ChatDevtoolsMetadata): string {
@@ -279,7 +286,7 @@ function createChatDevtoolsAgentEntry(
   defaults: WorkspaceAgentDefaults | undefined,
   previous: ChatDevtoolsAgentEntry | undefined,
 ): ChatDevtoolsAgentEntry {
-  const metadata = createStaticDevtoolsMetadata(agent)
+  const metadata = createStaticDevtoolsMetadata(name, agent)
   const staticKey = metadataStaticKey(metadata)
   if (previous?.metadataStaticKey === staticKey) {
     previous.agent = agent
@@ -333,7 +340,7 @@ async function startMetadataResolution(
     return
   }
 
-  entry.metadata = createStaticDevtoolsMetadata(entry.agent)
+  entry.metadata = createStaticDevtoolsMetadata(entry.name, entry.agent)
   entry.metadataStaticKey = metadataStaticKey(entry.metadata)
   entry.metadataError = undefined
   entry.metadataSelectionKey = selectionKey
@@ -345,7 +352,7 @@ async function startMetadataResolution(
   } as never)
     .then((metadata) => {
       if (entry.metadataTask !== task || entry.metadataSelectionKey !== selectionKey) return
-      entry.metadata = metadata
+      entry.metadata = metadataWithAgentName(metadata, entry.name)
       entry.metadataError = undefined
       entry.metadataStatus = "ready"
       entry.metadataTask = undefined
@@ -486,7 +493,7 @@ async function serializeState(
   const selectedSession = nextSelected ? getSession(state, nextSelected) : undefined
   const entry = nextSelected ? state.entries.get(nextSelected) : undefined
   const metadata = entry?.metadata
-  const title = selectedSession ? sessionTitle(selectedSession) || metadata?.title : metadata?.title
+  const title = selectedSession ? sessionTitle(selectedSession) || metadata?.name : metadata?.name
   const invokerProfileId = selectedSession?.invokerProfileId || (!requestedSelection.invokerFallback ? validMetadataInvokerProfileId(metadata, requestedSelection.invokerProfileId) : undefined)
   const invokerFallback = selectedSession?.invokerFallback || (!invokerProfileId && requestedSelection.invokerFallback === true)
 
@@ -748,13 +755,14 @@ async function materializeDevtoolsSource(
   entry.metadataError = undefined
 
   try {
-    entry.metadata = await materializeAgentDevtoolsSourceMetadata(entry.agent as never, {
+    const metadata = await materializeAgentDevtoolsSourceMetadata(entry.agent as never, {
       ...entry.defaults,
       input: createDevtoolsMetadataInput(metadataSelection),
       ...(input.path ? { path: input.path } : {}),
       ...(input.source ? { source: input.source } : {}),
       sources: materializedSourceKeys(entry.metadata),
     } as never)
+    entry.metadata = metadataWithAgentName(metadata, entry.name)
     entry.metadataSelectionKey = metadataSelectionKey(metadataSelection)
     entry.metadataStatus = "ready"
     entry.metadataTask = undefined

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -704,7 +704,7 @@ function defineBaseAgent<
   options: AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile>,
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS> {
   const driver = normalizeAgentDriver(options)
-  const { capabilities, channels, description, hooks, messages, runtime, title, version, workspace } = options
+  const { capabilities, channels, description, hooks, messages, runtime, version, workspace } = options
   const run = driver.kind === "run" ? driver.run : (options as { run?: AgentRunHandler<TRuntimeConfig, CALL_OPTIONS> }).run
   const baseCapabilities = normalizeCapabilities(capabilities as AgentCapabilitiesList | undefined)
   const invoker = normalizeAgentInvokerOptions(options.invoker) as AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS> | undefined
@@ -748,7 +748,6 @@ function defineBaseAgent<
     messages,
     runtime,
     run,
-    title,
     version,
     workspace,
     ...(normalizedCapabilities.length ? { capabilities: normalizedCapabilities } : {}),

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -1220,8 +1220,16 @@ function canResolveAgentDevtoolsMetadata(agent: AgentInput<ViteAgentRouteRuntime
   return Boolean((agent as { __vitehubWorkspaceAgent?: unknown }).__vitehubWorkspaceAgent)
 }
 
-function createStaticAgentDevtoolsMetadata(agent: AgentInput<ViteAgentRouteRuntimeContext>): ChatDevtoolsMetadata {
-  return createAgentDevtoolsMetadata(agent as never)
+function metadataWithAgentName(metadata: ChatDevtoolsMetadata, name: string): ChatDevtoolsMetadata {
+  return {
+    ...metadata,
+    name: metadata.name || name,
+  }
+}
+
+function createStaticAgentDevtoolsMetadata(agent: AgentInput<ViteAgentRouteRuntimeContext>, name?: string): ChatDevtoolsMetadata {
+  const metadata = createAgentDevtoolsMetadata(agent as never)
+  return name ? metadataWithAgentName(metadata, name) : metadata
 }
 
 function chatDevtoolsMetadataStatus(agent: AgentInput<ViteAgentRouteRuntimeContext>): ChatDevtoolsMetadataStatus {
@@ -1333,7 +1341,8 @@ async function startAgentDevtoolsMetadataResolution(
   const selectionKey = metadataSelectionKey(metadataSelection)
   if (!resolution.force && state.metadataSelectionKey === selectionKey) return
 
-  state.metadata = createStaticAgentDevtoolsMetadata(agent)
+  const name = agentChatDevtoolsName(agent, options)
+  state.metadata = createStaticAgentDevtoolsMetadata(agent, name)
   state.metadataError = undefined
   state.metadataSelectionKey = selectionKey
   state.metadataStatus = "loading"
@@ -1345,7 +1354,7 @@ async function startAgentDevtoolsMetadataResolution(
   } as never)
     .then((metadata) => {
       if (state.metadataTask !== task || state.metadataSelectionKey !== selectionKey) return
-      state.metadata = metadata
+      state.metadata = metadataWithAgentName(metadata, name)
       state.metadataError = undefined
       state.metadataStatus = "ready"
       state.metadataTask = undefined
@@ -1394,7 +1403,7 @@ function serializeAgentChatDevtoolsState(
   state: AgentChatDevtoolsFetchState,
   requestedSelection: AgentChatDevtoolsInvokerSelection = {},
 ): ChatDevtoolsStateResult {
-  const title = sessionTitle(state.session) || state.metadata.title
+  const title = sessionTitle(state.session) || state.metadata.name
   const invokerProfileId = state.session.invokerProfileId || (!requestedSelection.invokerFallback ? validMetadataInvokerProfileId(state.metadata, requestedSelection.invokerProfileId) : undefined)
   const invokerFallback = state.session.invokerFallback || (!invokerProfileId && requestedSelection.invokerFallback === true)
   const chats: ChatDevtoolsConversation[] = [{
@@ -1706,7 +1715,7 @@ async function materializeDevtoolsSource(
   state.metadataError = undefined
 
   try {
-    state.metadata = await materializeAgentDevtoolsSourceMetadata(agent as never, {
+    const metadata = await materializeAgentDevtoolsSourceMetadata(agent as never, {
       ...options.defaults,
       input: createDevtoolsMetadataInput(metadataSelection),
       ...(input.path ? { path: input.path } : {}),
@@ -1714,6 +1723,7 @@ async function materializeDevtoolsSource(
       runtime,
       sources: materializedSourceKeys(state.metadata),
     } as never)
+    state.metadata = metadataWithAgentName(metadata, agentChatDevtoolsName(agent, options))
     state.metadataSelectionKey = metadataSelectionKey(metadataSelection)
     state.metadataStatus = "ready"
     state.metadataTask = undefined
@@ -1914,8 +1924,9 @@ export function defineAgentChatDevtoolsFetchHandler(
   agent: AgentInput<ViteAgentRouteRuntimeContext>,
   options: AgentChatDevtoolsFetchHandlerOptions = {},
 ): (request: Request, options?: AgentChatDevtoolsFetchRequestOptions) => Promise<Response> {
+  const name = agentChatDevtoolsName(agent, options)
   const state: AgentChatDevtoolsFetchState = {
-    metadata: createStaticAgentDevtoolsMetadata(agent),
+    metadata: createStaticAgentDevtoolsMetadata(agent, name),
     metadataStatus: chatDevtoolsMetadataStatus(agent),
     session: { uiMessages: [] },
   }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -716,7 +716,6 @@ type AgentSharedSettings<
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   runtime?: AgentRuntimeBinding
-  title?: string
   version?: string
   workspace?: WorkspaceAgentWorkspaceConfig
 }
@@ -767,7 +766,6 @@ export interface AgentDefinition<
   runtime?: AgentRuntimeBinding
   resolve(context: AgentRuntimeContext<TRuntimeConfig>): Promise<AgentAdapter<CALL_OPTIONS>>
   run?(context: AgentRunContext<TRuntimeConfig, CALL_OPTIONS, WorkspaceName, TContextValues>): MaybePromise<Response | AgentRunResult | AsyncIterable<StreamEvent> | unknown>
-  title?: string
   version?: string
   workspace?: WorkspaceAgentWorkspaceConfig
 }
@@ -1125,7 +1123,7 @@ export interface AgentDevtoolsMetadata {
   files?: AgentDevtoolsFileTreeItem[]
   instructions?: string[]
   invokerProfiles?: AgentInvokerProfile[]
-  title?: string
+  name?: string
   tools?: AgentDevtoolsToolDefinition[]
   version?: string
 }

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -418,14 +418,13 @@ function agentDevtoolsMetadata<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
 >(
-  definition: Pick<AgentDefinition<TRuntimeConfig, CALL_OPTIONS>, "invoker" | "title" | "version"> & AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
-): Pick<AgentDevtoolsMetadata, "config" | "invokerProfiles" | "title" | "version"> {
+  definition: Pick<AgentDefinition<TRuntimeConfig, CALL_OPTIONS>, "invoker" | "version"> & AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+): Pick<AgentDevtoolsMetadata, "config" | "invokerProfiles" | "version"> {
   const invokerProfiles = normalizeAgentInvokerProfiles(definition.invoker?.profiles)
   const config = staticConfigMetadata(definition)
   return {
     ...(config ? { config } : {}),
     ...(invokerProfiles.length ? { invokerProfiles } : {}),
-    ...(definition.title ? { title: definition.title } : {}),
     ...(definition.version ? { version: definition.version } : {}),
   }
 }

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -427,6 +427,7 @@ describe("agent chat capability discovery", () => {
         { id: "support-technical", kind: "technical", label: "Technical" },
       ],
       selected: "support",
+      title: "support",
     })
 
     const sendResponse = await invokeMiddleware(handlers[0]!, {
@@ -982,6 +983,7 @@ describe("agent chat capability discovery", () => {
       source: "ingestion",
     })
 
+    expect(materializedState.title).toBe("support")
     expect(materializedState.files).toEqual([
       expect.objectContaining({
         children: [
@@ -1018,6 +1020,7 @@ describe("agent chat capability discovery", () => {
       source: "portal",
     })
 
+    expect(nextState.title).toBe("support")
     expect(nextState.files).toEqual([
       expect.objectContaining({
         children: [

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -410,17 +410,33 @@ describe("server helpers", () => {
   it("serves hosted Chat DevTools state for an explicit agent handler", async () => {
     const { defineAgent, defineAgentInvoker } = await import("../src/index.ts")
     const { defineAgentChatDevtoolsFetchHandler } = await import("../src/server.ts")
+    const { defineWorkspace, source } = await import("@vite-hub/workspace")
+    const profiles: Array<{ id: string, kind?: string, meta?: Record<string, unknown> }> = [{
+      id: "customer:demo:support",
+      kind: "customerPortal",
+      meta: { customer: "demo" },
+    }]
     const agent = defineAgent({
       invoker: defineAgentInvoker({
-        profiles: [{
-          id: "customer:demo:support",
-          kind: "customerPortal",
-          meta: { customer: "demo" },
-        }],
+        profiles,
       }),
       run: () => "unused",
-      title: "Support",
       version: "test-agent",
+      workspace: defineWorkspace({
+        store: { provider: "memory" },
+        sources: {
+          docs: source.custom({
+            materialize: "lazy",
+            mount: "docs",
+            async getKeys() {
+              return ["README.md"]
+            },
+            async getItem(key) {
+              return { content: "# Support\n", key }
+            },
+          }),
+        },
+      }),
     })
     const handler = defineAgentChatDevtoolsFetchHandler(agent as never, {
       meta: { email: "user@example.com" },
@@ -442,7 +458,7 @@ describe("server helpers", () => {
       chats: [{
         invokerProfileId: "customer:demo:support",
         name: "support",
-        title: "Support",
+        title: "support",
         uiMessages: [],
       }],
       invokerProfileId: "customer:demo:support",
@@ -454,9 +470,29 @@ describe("server helpers", () => {
       meta: { email: "user@example.com" },
       metadataStatus: "ready",
       selected: "support",
-      title: "Support",
+      title: "support",
       uiMessages: [],
       version: "test-agent",
+    })
+
+    const materializedResponse = await handler(new Request("https://example.com/__vitehub/agent/chat/devtools", {
+      body: JSON.stringify({
+        action: "materialize-source",
+        invokerProfileId: "customer:demo:support",
+        path: "docs",
+        source: "docs",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }))
+
+    expect(materializedResponse.status).toBe(200)
+    await expect(materializedResponse.json()).resolves.toMatchObject({
+      chats: [{
+        name: "support",
+        title: "support",
+      }],
+      title: "support",
     })
   })
 

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1450,7 +1450,6 @@ describe("defineAgent workspace option", () => {
       },
       instructions: "Answer from the workspace.",
       model: model as never,
-      title: "Support agent",
       version: "1.2.3",
       capabilities: [{ id: "workspace-shell", tools: ({ workspace }) => workspace.tools.inspect() }],
     }), { workspace: "support" })
@@ -1475,7 +1474,6 @@ describe("defineAgent workspace option", () => {
         status: "ready",
       }],
       instructions: ["Answer from the workspace."],
-      title: "Support agent",
       version: "1.2.3",
       tools: expect.arrayContaining([
         expect.objectContaining({

--- a/packages/devtools/src/chat-shared.ts
+++ b/packages/devtools/src/chat-shared.ts
@@ -98,7 +98,7 @@ export interface ChatDevtoolsMetadata {
   files?: ChatDevtoolsFileTreeItem[]
   instructions?: string[]
   invokerProfiles?: ChatDevtoolsInvokerProfile[]
-  title?: string
+  name?: string
   tools?: ChatDevtoolsToolDefinition[]
   version?: string
 }


### PR DESCRIPTION
Removes the Agent Definition `title` option so discovered agent identity remains the only naming source. DevTools metadata now carries `name`, populated from the discovered or handler agent name, while chat conversation `title` remains reserved for `chatTitle()` conversation metadata.

This keeps `defineAgent({ name })` from becoming a display override and avoids colliding with the existing workspace-agent `name` option.