### PR TITLE
fix: resolve workspace git aliases from isomorphic-git

### DIFF
--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -137,6 +137,10 @@ function resolveIsomorphicGitHttpWebEsmEntry() {
   return resolve(dirname(resolvePackageDependency(workspacePackageDir, "isomorphic-git/http/web")), "index.js")
 }
 
+function resolveIsomorphicGitDependency(specifier: string) {
+  return createRequire(resolveIsomorphicGitEsmEntry()).resolve(specifier)
+}
+
 function resolveSandboxClassName(config: { className?: unknown } | undefined) {
   return typeof config?.className === "string" ? config.className : defaultCloudflareSandboxClassName
 }
@@ -759,7 +763,7 @@ async function prepareFeatureArtifacts(options: ViteE2EComposerOptions) {
     alias["isomorphic-git/http/web"] = resolveIsomorphicGitHttpWebEsmEntry()
     alias["isomorphic-git"] = resolveIsomorphicGitEsmEntry()
     for (const dependency of ["async-lock", "clean-git-ref", "crc-32", "diff3", "ignore", "inherits", "minimisted", "pako", "pify", "readable-stream", "sha.js/sha1.js", "simple-get"]) {
-      alias[dependency] = resolvePackageDependency(workspacePackageDir, dependency)
+      alias[dependency] = resolveIsomorphicGitDependency(dependency)
     }
     runtimeWrites.push(
       writeFile(workspaceAssetsRuntimeFile, renderWorkspaceAssetsRuntimeModule(), "utf8"),


### PR DESCRIPTION
Resolves the playground Workspace Package aliases for `isomorphic-git` transitive dependencies from the installed `isomorphic-git` package instead of from `@vite-hub/workspace`.

The scheduled Live Smoke build was asking Node to resolve `async-lock` through `packages/workspace/package.json`, but that dependency belongs to `isomorphic-git` and is not available from the Workspace Package root under the package boundary. This keeps the Provider Output aliases explicit without adding transitive dependencies to `@vite-hub/workspace`.