### PR TITLE
fix: use provisioned d1 bindings in live smoke output

### DIFF
--- a/packages/internal/test/vite-e2e-output.test.ts
+++ b/packages/internal/test/vite-e2e-output.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs"
-import { cp, mkdtemp, mkdir, readFile, readdir, rm, symlink } from "node:fs/promises"
+import { cp, mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises"
 import { execFile } from "node:child_process"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
@@ -144,6 +144,50 @@ describe("unified vite e2e hosted outputs", () => {
     expect(cloudflareConfig.durable_objects?.bindings).toBeTruthy()
     expect(cloudflareConfig.migrations).toBeTruthy()
     expect(cloudflareConfig.artifacts).toBeUndefined()
+  }, 45_000)
+
+  it("uses provision state for cloudflare D1 bindings", async () => {
+    const rootDir = await createPlaygroundCopy("vitehub-internal-vite-e2e-cf-provision-")
+    await mkdir(join(rootDir, ".vitehub"), { recursive: true })
+    await writeFile(join(rootDir, ".vitehub", "provision.json"), `${JSON.stringify({
+      cloudflare: {
+        d1: {
+          analytics: "analytics-d1-id",
+          primary: "primary-d1-id",
+        },
+      },
+    }, null, 2)}\n`)
+
+    await execFileAsync("vp", ["build"], {
+      cwd: rootDir,
+      env: {
+        ...process.env,
+        BLOB_BUCKET_NAME: "assets",
+        KV_NAMESPACE_ID: "kv-namespace",
+        TURSO_AUTH_TOKEN: "token",
+        TURSO_DATABASE_URL: "libsql://db.example.turso.io",
+        TURSO_ANALYTICS_DATABASE_URL: "libsql://analytics.example.turso.io",
+        VITEHUB_CLOUDFLARE_WORKER_NAME: "vitehub-playground-vite",
+        VITEHUB_HOSTING: "cloudflare",
+        VITEHUB_VITE_MODE: "e2e",
+      },
+      maxBuffer: execMaxBuffer,
+    })
+
+    const cloudflareConfig = JSON.parse(await readFile(join(rootDir, "dist", "vite", "wrangler.json"), "utf8"))
+
+    expect(cloudflareConfig.d1_databases).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        binding: "DB",
+        database_id: "primary-d1-id",
+        database_name: "vitehub-playground-db",
+      }),
+      expect.objectContaining({
+        binding: "DB_ANALYTICS",
+        database_id: "analytics-d1-id",
+        database_name: "vitehub-playground-analytics",
+      }),
+    ]))
   }, 45_000)
 
   it("keeps the vercel artifact unified while preserving queue server outputs", async () => {

--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -4,8 +4,8 @@ import { dirname, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { normalizeBlobOptions } from "../../../packages/blob/src/config.ts"
-import { resolveConfigValue } from "../../../packages/database/src/config-value.ts"
 import { resolveDBViteConfig } from "../../../packages/database/src/config.ts"
+import { resolveCloudflareD1Bindings } from "../../../packages/database/src/internal/cloudflare.ts"
 import { configureCloudflareKV } from "../../../packages/kv/src/integrations/cloudflare.ts"
 import { normalizeKVOptions } from "../../../packages/kv/src/config.ts"
 import { normalizeQueueOptions } from "../../../packages/queue/src/config.ts"
@@ -34,6 +34,7 @@ import { createImportPath, ensureGeneratedDir } from "@vite-hub/internal/build/p
 import { toSafeAppName } from "@vite-hub/internal/build/user-entry"
 import { createNodeFunctionConfig, createVercelConfigJson } from "@vite-hub/internal/build/vercel-config"
 import { createRuntimeRegistryContents } from "@vite-hub/internal/definition-discovery"
+import { readProvisionStateSync } from "@vite-hub/internal/provision-state"
 
 import type { ResolvedBlobModuleOptions } from "../../../packages/blob/src/types.ts"
 import type { ResolvedDBViteConfig } from "../../../packages/database/src/types.ts"
@@ -1191,22 +1192,14 @@ function createCloudflareR2Bindings(config: false | ResolvedBlobModuleOptions | 
   return [{ binding: config.store.binding, bucket_name: config.store.bucketName }]
 }
 
-function createCloudflareD1Bindings(config: ResolvedDBViteConfig | undefined) {
+function createCloudflareD1Bindings(rootDir: string, config: ResolvedDBViteConfig | undefined) {
   if (!config) {
     return undefined
   }
 
-  const bindings = config.databaseNames
-    .map(name => config.databases[name]?.cloudflare)
-    .filter(database => Boolean(resolveConfigValue(database?.databaseId)))
-    .map(database => ({
-      binding: database!.binding,
-      database_id: resolveConfigValue(database!.databaseId),
-      ...(resolveConfigValue(database!.databaseName) ? { database_name: resolveConfigValue(database!.databaseName) } : {}),
-      ...(database!.migrationsDir ? { migrations_dir: database!.migrationsDir } : {}),
-      ...(database!.migrationsTable ? { migrations_table: database!.migrationsTable } : {}),
-      ...(resolveConfigValue(database!.previewDatabaseId) ? { preview_database_id: resolveConfigValue(database!.previewDatabaseId) } : {}),
-    }))
+  const bindings = resolveCloudflareD1Bindings(config, {
+    provisionState: readProvisionStateSync(rootDir),
+  }).d1Databases
 
   return bindings.length ? bindings : undefined
 }
@@ -1271,7 +1264,7 @@ async function writeCloudflareOutput(options: ViteE2EComposerOptions, artifacts:
     platform: "neutral",
   })
 
-  const d1Databases = createCloudflareD1Bindings(options.db)
+  const d1Databases = createCloudflareD1Bindings(options.rootDir, options.db)
   const queueBindings = createCloudflareQueueBindings(artifacts.queueDefinitions)
   const r2Buckets = createCloudflareR2Bindings(options.blob)
 

--- a/test/output/cloudflare.test.ts
+++ b/test/output/cloudflare.test.ts
@@ -39,6 +39,13 @@ describe.runIf(providerEnabled("cloudflare"))("cloudflare provider output", () =
     expect(wrangler().kv_namespaces.length).toBeGreaterThan(0)
   })
 
+  it("wrangler.json declares D1 databases", () => {
+    expect(wrangler().d1_databases).toEqual(expect.arrayContaining([
+      expect.objectContaining({ binding: "DB" }),
+      expect.objectContaining({ binding: "DB_ANALYTICS" }),
+    ]))
+  })
+
   it("wrangler.json has no Workspace Artifacts bindings", () => {
     expect(wrangler().artifacts).toBeUndefined()
   })


### PR DESCRIPTION
Uses the Database Package Cloudflare D1 binding resolver in the playground e2e composer so Cloudflare Provider Output reads provisioned D1 IDs from `.vitehub/provision.json`. The Live Smoke workflow provisions D1 before build but does not export `VITEHUB_D1_*` IDs, so the generated Worker could omit `d1_databases` and the database runtime could fall back to the remote libSQL URL.

Adds output-contract coverage for the provision-state path and makes the Cloudflare Provider Output Contract assert that `wrangler.json` declares the expected D1 bindings.