### PR TITLE
feat(agent): load dev context from JSON

### DIFF
--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -57,14 +57,17 @@ Then attach the Agent Dev Loop from another terminal.
 pnpm vitehub agent dev --agent support --url http://localhost:5173
 ```
 
-Pass a message for a one-shot invocation, or omit the message to enter an interactive session.
+Pass a message or `--prompt` for a one-shot invocation, or omit both to enter an interactive session.
 
 ```bash [Terminal]
 pnpm vitehub agent dev "/summary" --agent support
+pnpm vitehub agent dev --agent support --prompt "/summary"
+pnpm vitehub agent dev --agent support -p "/summary"
 ```
 
 Use `--context` when the invocation needs trusted Agent Invocation Context Values that would normally come from a Channel, route, or webhook.
-The file can live anywhere in the app, but it must contain one JSON object.
+The file can live anywhere in the app, but colocating it as `server/agents/<agent>/dev.context.json` keeps local Agent fixtures next to the Agent Definition without making them part of production behavior.
+It must contain one JSON object.
 
 ```json [server/agents/support/dev.context.json]
 {
@@ -81,6 +84,7 @@ The file can live anywhere in the app, but it must contain one JSON object.
 
 ```bash [Terminal]
 pnpm vitehub agent dev --agent support --context server/agents/support/dev.context.json
+pnpm vitehub agent dev --agent support --context server/agents/support/dev.context.json -p "/summary"
 ```
 
 Expected output includes the resolved context file path before the Agent Invocation starts.

--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -33,6 +33,7 @@ Available namespaces:
 | Command | Status | Owner | Use it for |
 | --- | --- | --- | --- |
 | `vitehub agent eval` | Available | Agent Package | Run discovered Agent Evals through ViteHub defaults. |
+| `vitehub agent dev` | Available | Agent Package | Talk to a discovered Agent through a running Vite Development Server. |
 | `vitehub provision run` | Available | ViteHub CLI plus package Provision Steps | Create missing provider resources idempotently. |
 | Package-specific namespaces | Planned per package | Owning package | Add workflows only when the package has a durable development task. |
 
@@ -45,6 +46,50 @@ The optional path narrows the Agent Eval Target.
 pnpm vitehub agent eval
 pnpm vitehub agent eval server/agents/support.eval.ts --threshold 0.9
 pnpm vitehub agent eval --output .vitehub/evals/support.json --hide-table
+```
+
+## Talk to an Agent during development
+
+Start the app's Vite dev server in one terminal.
+Then attach the Agent Dev Loop from another terminal.
+
+```bash [Terminal]
+pnpm vitehub agent dev --agent support --url http://localhost:5173
+```
+
+Pass a message for a one-shot invocation, or omit the message to enter an interactive session.
+
+```bash [Terminal]
+pnpm vitehub agent dev "/summary" --agent support
+```
+
+Use `--context` when the invocation needs trusted Agent Invocation Context Values that would normally come from a Channel, route, or webhook.
+The file can live anywhere in the app, but it must contain one JSON object.
+
+```json [server/agents/support/dev.context.json]
+{
+  "actor": {
+    "id": "user_123",
+    "kind": "developer",
+    "label": "Local Developer"
+  },
+  "workspace": {
+    "id": "local-review"
+  }
+}
+```
+
+```bash [Terminal]
+pnpm vitehub agent dev --agent support --context server/agents/support/dev.context.json
+```
+
+Expected output includes the resolved context file path before the Agent Invocation starts.
+In interactive mode, type a message or command such as `/summary` at the prompt.
+
+```txt [Output]
+Loaded context: /Users/acme/app/server/agents/support/dev.context.json
+Connected to support at http://localhost:5173
+> /summary
 ```
 
 ## Preview provisioning
@@ -65,6 +110,8 @@ pnpm vitehub provision run --provider vercel --dry-run
 | `Provision requires --provider cloudflare\|vercel` | The provider flag is missing or misspelled. | Pass a supported provider explicitly. |
 | Provision fails before applying actions | Required provider credentials are missing. | Set `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`, or set `VERCEL_TOKEN`. |
 | Agent eval CLI is disabled | `agent.eval` or `agent.cli` disables the Agent Eval Runner. | Re-enable the Agent integration option for local development. |
+| `No Compatible Vite Development Server found` | The app dev server is not running or `--url` points at the wrong port. | Start Vite separately, then pass the dev server URL. |
+| `Agent Dev Loop context file must contain a JSON object` | The `--context` file is not a JSON object. | Replace the file contents with one object whose keys are Agent Invocation Context Value ids. |
 
 ## Next steps
 

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -33,7 +33,6 @@ export type {
 } from "./types.ts"
 export interface AgentChannelOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   adapter?: AgentChannelDefinition<TRuntimeConfig>["adapter"]
-  dev?: AgentChannelDefinition<TRuntimeConfig>["dev"]
   effects?: AgentChannelDefinition<TRuntimeConfig>["effects"]
   identity?: AgentChannelDefinition<TRuntimeConfig>["identity"]
   messages?: false | AgentMessageChannelSettings<TRuntimeConfig>
@@ -175,7 +174,6 @@ declare global {
 }
 
 export interface GitHubPullRequestCommentEventOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
-  dev?: AgentTriggerDefinition<TRuntimeConfig>["dev"]
   ignored?: (reason: string) => Response
   origin?: string
   reply?: boolean | AgentChannelDeliveryFinishEffect
@@ -780,7 +778,6 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
   const options = pullRequestComments === true ? {} : pullRequestComments
   return {
     webhook: {
-      ...(options.dev ? { dev: options.dev } : {}),
       async invoke(context, input): Promise<AgentTriggerInvokeResult> {
         const payload = inputPayloadOrBody(input)
         const command = githubPullRequestCommandFromInput(isRecord(input) ? { ...input, payload } : { payload })

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -176,9 +176,6 @@ function createChatMessageTrigger<TRuntimeConfig extends AgentRuntimeConfig>(
   options: AgentChatOptions<TRuntimeConfig> = {},
 ): AgentTriggerDefinition<TRuntimeConfig, WorkspaceName, AgentChatMessageTriggerInput> {
   return {
-    ...(options.dev?.samples
-      ? { dev: { samples: options.dev.samples as Record<string, AgentChatMessageTriggerInput> } }
-      : {}),
     devtools: true,
     input: "ui-message[]",
     output: "ui-message-stream",

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig, type ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, readAgentInvocationStream } from "./invocation-stream.ts"
 
@@ -54,10 +57,11 @@ interface ParsedEvalArgs {
 
 interface ParsedDevArgs {
   agent?: string
+  context?: Record<string, unknown>
+  contextPath?: string
   help: boolean
   input?: unknown
   message?: string
-  sample?: string
   timeout?: number
   trigger?: string
   url: string
@@ -68,7 +72,7 @@ interface AgentDevCliOptions {
 }
 
 interface AgentDevDiscovery {
-  agents?: Array<{ name?: unknown, samples?: unknown, triggers?: unknown }>
+  agents?: Array<{ name?: unknown, triggers?: unknown }>
   root?: unknown
 }
 
@@ -94,20 +98,24 @@ function writeEvalUsage(context: AgentCliContext): void {
 
 function writeDevUsage(context: AgentCliContext): void {
   context.stdout.write([
-    "Usage: vitehub agent dev [message...] [--agent <name>] [--trigger <id>] [--sample <name>] [--input <json>] [--url <url>] [--timeout <ms>]",
+    "Usage: vitehub agent dev [message...] [--agent <name>] [--trigger <id>] [--context <path>] [--input <json>] [--url <url>] [--timeout <ms>]",
     "",
     "Talk to a discovered Agent through a running Vite Development Server.",
     "",
     "Options:",
-    "  --agent <name>   Agent Dev Loop Target. Required when multiple Agents are compatible.",
-    "  --trigger <id>   Agent Trigger to invoke. Defaults to chat.message when available.",
-    "  --sample <name>  Agent Trigger dev sample to replay.",
-    "  --input <json>   Raw Agent Trigger input JSON for one-shot invocations.",
-    "  --url <url>      Compatible Vite Development Server URL. Defaults to http://localhost:5173.",
-    "  --timeout <ms>   Agent Invocation timeout. Defaults to 90000.",
-    "  -h, --help       Show this help.",
+    "  --agent <name>    Agent Dev Loop Target. Required when multiple Agents are compatible.",
+    "  --trigger <id>    Agent Trigger to invoke. Defaults to chat.message when available.",
+    "  --context <path>  Agent Invocation Context Values JSON file.",
+    "  --input <json>    Raw Agent Trigger input JSON for one-shot invocations.",
+    "  --url <url>       Compatible Vite Development Server URL. Defaults to http://localhost:5173.",
+    "  --timeout <ms>    Agent Invocation timeout. Defaults to 90000.",
+    "  -h, --help        Show this help.",
     "",
   ].join("\n"))
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
 }
 
 function readOptionValue(args: string[], index: number, flag: string): string {
@@ -272,13 +280,13 @@ function parseDevArgs(args: string[], env: NodeJS.ProcessEnv): ParsedDevArgs {
       parsed.trigger = arg.slice("--trigger=".length)
       continue
     }
-    if (arg === "--sample") {
-      parsed.sample = readOptionValue(args, index, arg)
+    if (arg === "--context") {
+      parsed.contextPath = readOptionValue(args, index, arg)
       index++
       continue
     }
-    if (arg.startsWith("--sample=")) {
-      parsed.sample = arg.slice("--sample=".length)
+    if (arg.startsWith("--context=")) {
+      parsed.contextPath = arg.slice("--context=".length)
       continue
     }
     if (arg === "--input") {
@@ -321,6 +329,15 @@ function parseDevArgs(args: string[], env: NodeJS.ProcessEnv): ParsedDevArgs {
   const text = message.join(" ").trim()
   if (text) parsed.message = text
   return parsed
+}
+
+async function loadDevContext(contextPath: string, cwd: string): Promise<{ path: string, value: Record<string, unknown> }> {
+  const path = resolve(cwd, contextPath)
+  const value = JSON.parse(await readFile(path, "utf8")) as unknown
+  if (!isRecord(value)) {
+    throw new Error("Agent Dev Loop context file must contain a JSON object.")
+  }
+  return { path, value }
 }
 
 function endpointUrl(baseUrl: string): string {
@@ -413,9 +430,9 @@ async function sendDevMessage(
     response = await fetchImpl(url, {
       body: JSON.stringify({
         agent,
+        ...(parsed.context ? { context: parsed.context } : {}),
         ...(messages.length ? { messages } : {}),
         ...("input" in parsed ? { input: parsed.input } : {}),
-        ...(parsed.sample ? { sample: parsed.sample } : {}),
         ...(parsed.timeout ? { timeout: parsed.timeout } : {}),
         ...(parsed.trigger ? { trigger: parsed.trigger } : {}),
       }),
@@ -551,12 +568,23 @@ export async function runAgentDevCli(
     writeDevUsage(context)
     return 0
   }
+  if (parsed.contextPath) {
+    try {
+      const loaded = await loadDevContext(parsed.contextPath, context.cwd)
+      parsed.context = loaded.value
+      context.stdout.write(`Loaded context: ${loaded.path}\n`)
+    }
+    catch (error) {
+      context.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+      return 1
+    }
+  }
 
   const fetchImpl = options.fetch || globalThis.fetch
   const target = await readDiscovery(parsed, context, fetchImpl)
   if (!target) return 1
 
-  if (parsed.message || parsed.sample || "input" in parsed) {
+  if (parsed.message || "input" in parsed) {
     return await sendDevMessage(target.url, target.agent, parsed.message || "", [], parsed, context, fetchImpl, new AbortController().signal) ? 0 : 1
   }
   if (!process.stdin.isTTY) {

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -482,7 +482,7 @@ async function sendDevMessage(
         output += event.text
         continue
       }
-      if (event.type === "tool-call") {
+      if (event.type === "tool-call" || event.type === "tool-input-start") {
         context.stderr.write(`\n[tool] ${event.name}\n`)
         continue
       }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -475,6 +475,7 @@ async function sendDevMessage(
 
   let output = ""
   let needsApproval = false
+  const visibleTools = new Set<string>()
   try {
     for await (const event of readAgentInvocationStream(response.body)) {
       if (event.type === "text-delta") {
@@ -483,7 +484,15 @@ async function sendDevMessage(
         continue
       }
       if (event.type === "tool-call" || event.type === "tool-input-start") {
+        visibleTools.add(event.id)
         context.stderr.write(`\n[tool] ${event.name}\n`)
+        continue
+      }
+      if (event.type === "tool-result") {
+        if (!visibleTools.has(event.id)) {
+          visibleTools.add(event.id)
+          context.stderr.write(`\n[tool] ${event.name}\n`)
+        }
         continue
       }
       if (event.type === "approval-request") {

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -98,12 +98,13 @@ function writeEvalUsage(context: AgentCliContext): void {
 
 function writeDevUsage(context: AgentCliContext): void {
   context.stdout.write([
-    "Usage: vitehub agent dev [message...] [--agent <name>] [--trigger <id>] [--context <path>] [--input <json>] [--url <url>] [--timeout <ms>]",
+    "Usage: vitehub agent dev [message...] [--agent <name>] [--prompt <text>] [--trigger <id>] [--context <path>] [--input <json>] [--url <url>] [--timeout <ms>]",
     "",
     "Talk to a discovered Agent through a running Vite Development Server.",
     "",
     "Options:",
     "  --agent <name>    Agent Dev Loop Target. Required when multiple Agents are compatible.",
+    "  -p, --prompt <text>  Prompt text for a one-shot invocation.",
     "  --trigger <id>    Agent Trigger to invoke. Defaults to chat.message when available.",
     "  --context <path>  Agent Invocation Context Values JSON file.",
     "  --input <json>    Raw Agent Trigger input JSON for one-shot invocations.",
@@ -271,6 +272,17 @@ function parseDevArgs(args: string[], env: NodeJS.ProcessEnv): ParsedDevArgs {
       parsed.agent = arg.slice("--agent=".length)
       continue
     }
+    if (arg === "-p" || arg === "--prompt") {
+      parsed.message = readOptionValue(args, index, arg).trim()
+      if (!parsed.message) throw new Error(`${arg} cannot be empty.`)
+      index++
+      continue
+    }
+    if (arg.startsWith("--prompt=")) {
+      parsed.message = arg.slice("--prompt=".length).trim()
+      if (!parsed.message) throw new Error("--prompt cannot be empty.")
+      continue
+    }
     if (arg === "--trigger") {
       parsed.trigger = readOptionValue(args, index, arg)
       index++
@@ -327,6 +339,7 @@ function parseDevArgs(args: string[], env: NodeJS.ProcessEnv): ParsedDevArgs {
   }
 
   const text = message.join(" ").trim()
+  if (text && parsed.message) throw new Error("Pass either --prompt or message text, not both.")
   if (text) parsed.message = text
   return parsed
 }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -344,13 +344,28 @@ function parseDevArgs(args: string[], env: NodeJS.ProcessEnv): ParsedDevArgs {
   return parsed
 }
 
-async function loadDevContext(contextPath: string, cwd: string): Promise<{ path: string, value: Record<string, unknown> }> {
-  const path = resolve(cwd, contextPath)
+function isFileNotFound(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT"
+}
+
+async function readDevContextFile(path: string): Promise<{ path: string, value: Record<string, unknown> }> {
   const value = JSON.parse(await readFile(path, "utf8")) as unknown
   if (!isRecord(value)) {
     throw new Error("Agent Dev Loop context file must contain a JSON object.")
   }
   return { path, value }
+}
+
+async function loadDevContext(contextPath: string, rootDir: string, cwd: string): Promise<{ path: string, value: Record<string, unknown> }> {
+  const rootPath = resolve(rootDir, contextPath)
+  try {
+    return await readDevContextFile(rootPath)
+  }
+  catch (error) {
+    const cwdPath = resolve(cwd, contextPath)
+    if (!isFileNotFound(error) || cwdPath === rootPath) throw error
+    return await readDevContextFile(cwdPath)
+  }
 }
 
 function endpointUrl(baseUrl: string): string {
@@ -592,7 +607,7 @@ export async function runAgentDevCli(
   }
   if (parsed.contextPath) {
     try {
-      const loaded = await loadDevContext(parsed.contextPath, context.cwd)
+      const loaded = await loadDevContext(parsed.contextPath, context.rootDir, context.cwd)
       parsed.context = loaded.value
       context.stdout.write(`Loaded context: ${loaded.path}\n`)
     }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig, type ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, readAgentInvocationStream } from "./invocation-stream.ts"
 
-import type { AgentEvalOptions } from "./types.ts"
+import type { AgentEvalOptions, AgentUsageRecord } from "./types.ts"
 import type { UIMessageLike } from "./chat-message-input.ts"
 
 interface AgentEvaliteRunnerOptions extends ResolvedAgentEvalOptions {
@@ -76,6 +76,8 @@ interface AgentDevDiscovery {
   root?: unknown
 }
 
+const devPayloadMaxLength = 1200
+
 function writeEvalUsage(context: AgentCliContext): void {
   context.stdout.write([
     "Usage: vitehub agent eval [path] [--watch] [--threshold <score>] [--output <path>] [--hide-table] [--no-cache]",
@@ -117,6 +119,59 @@ function writeDevUsage(context: AgentCliContext): void {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+function formatDevPayload(value: unknown): string | undefined {
+  if (value === undefined) return
+  const text = typeof value === "string" ? value : JSON.stringify(value)
+  if (text === undefined) return
+  return text.length > devPayloadMaxLength
+    ? `${text.slice(0, devPayloadMaxLength)}... [truncated ${text.length - devPayloadMaxLength} chars]`
+    : text
+}
+
+function writeDevPayload(context: AgentCliContext, label: string, value: unknown): void {
+  const text = formatDevPayload(value)
+  if (text === undefined) return
+  context.stderr.write(`  ${label}: ${text}\n`)
+}
+
+function usageNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.trunc(value) : undefined
+}
+
+function formatUsageNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value)
+}
+
+function readUsageDetail(...records: Array<Record<string, unknown> | undefined>): number | undefined {
+  const keys = ["reasoningTokens", "reasoning_tokens", "thinkingTokens", "thinking_tokens", "reasoning", "thinking"]
+  for (const record of records) {
+    if (!record) continue
+    for (const key of keys) {
+      const value = usageNumber(record[key])
+      if (value !== undefined) return value
+    }
+  }
+}
+
+function formatUsageRecord(record: AgentUsageRecord): string | undefined {
+  const usage = record.usage
+  const input = usageNumber(usage?.inputTokens)
+  const output = usageNumber(usage?.outputTokens)
+  const total = usageNumber(usage?.totalTokens) ?? (input !== undefined && output !== undefined ? input + output : undefined)
+  const reasoning = readUsageDetail(usage?.outputTokenDetails, usage?.inputTokenDetails, usage?.details)
+  const parts: string[] = []
+  if (total !== undefined) {
+    const tokens = `${formatUsageNumber(total)} tokens`
+    parts.push(input !== undefined && output !== undefined ? `${tokens}: ${formatUsageNumber(input)} in / ${formatUsageNumber(output)} out` : tokens)
+  }
+  else if (input !== undefined || output !== undefined) {
+    parts.push([input !== undefined ? `${formatUsageNumber(input)} in` : undefined, output !== undefined ? `${formatUsageNumber(output)} out` : undefined].filter(Boolean).join(" / "))
+  }
+  if (reasoning !== undefined) parts.push(`${formatUsageNumber(reasoning)} reasoning tokens`)
+  if (!parts.length) return record.summary
+  return parts.join("; ")
 }
 
 function readOptionValue(args: string[], index: number, flag: string): string {
@@ -501,6 +556,7 @@ async function sendDevMessage(
       if (event.type === "tool-call" || event.type === "tool-input-start") {
         visibleTools.add(event.id)
         context.stderr.write(`\n[tool] ${event.name}\n`)
+        writeDevPayload(context, "input", event.input)
         continue
       }
       if (event.type === "tool-result") {
@@ -508,6 +564,13 @@ async function sendDevMessage(
           visibleTools.add(event.id)
           context.stderr.write(`\n[tool] ${event.name}\n`)
         }
+        writeDevPayload(context, "output", event.output)
+        writeDevPayload(context, "error", event.error)
+        continue
+      }
+      if (event.type === "usage") {
+        const usage = formatUsageRecord(event.usageRecord)
+        if (usage) context.stderr.write(`\n[usage] ${usage}\n`)
         continue
       }
       if (event.type === "approval-request") {

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -31,15 +31,6 @@ function hasMessageOverrides<TRuntimeConfig extends AgentRuntimeConfig>(
   return !!messages && Object.keys(messages).length > 0
 }
 
-function addDevSamples(target: Record<string, unknown>, samples: Record<string, unknown> | undefined): void {
-  for (const [name, sample] of Object.entries(samples || {})) {
-    if (Object.prototype.hasOwnProperty.call(target, name)) {
-      throw new TypeError(`[vitehub] Duplicate Agent Channel dev sample: ${name}. Use unique sample names across message-shaped Channels.`)
-    }
-    target[name] = sample
-  }
-}
-
 export function resolveAgentChannelChatOptions<TRuntimeConfig extends AgentRuntimeConfig>(
   channels: AgentChannels<TRuntimeConfig> | undefined,
   messages: AgentMessageChannelSettings<TRuntimeConfig> | undefined,
@@ -54,13 +45,11 @@ export function resolveAgentChannelChatOptions<TRuntimeConfig extends AgentRunti
   let messageChannelCount = 0
   const channelIdentities: NonNullable<AgentChatOptions<TRuntimeConfig>["identity"]>[] = []
   const channelMessageOverrides: AgentMessageChannelSettings<TRuntimeConfig>[] = []
-  const channelDevSamples: Record<string, unknown> = {}
 
   for (const [channelId, channelDefinition] of entries) {
     if (channelDefinition.messages === false) continue
     hasMessageChannel = true
     messageChannelCount += 1
-    addDevSamples(channelDevSamples, channelDefinition.dev?.samples)
     if (hasMessageOverrides(channelDefinition.messages)) {
       channelMessageOverrides.push(channelDefinition.messages)
     }
@@ -96,13 +85,6 @@ export function resolveAgentChannelChatOptions<TRuntimeConfig extends AgentRunti
       throw new TypeError("[vitehub] Channel-local messages options are only supported when an Agent defines one message-shaped Channel. Move shared settings to defineAgent({ messages }) until Channel-scoped chat triggers land.")
     }
     Object.assign(options, channelMessageOverrides[0])
-  }
-  if (Object.keys(channelDevSamples).length) {
-    addDevSamples(channelDevSamples, options.dev?.samples as Record<string, unknown> | undefined)
-    options.dev = {
-      ...options.dev,
-      samples: channelDevSamples,
-    }
   }
   if (Object.keys(platforms).length) options.platforms = platforms
   if (Object.keys(webhooks).length) options.webhooks = webhooks

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -126,7 +126,6 @@ export async function resolveAgentTriggers<
       triggers[id] = {
         capabilityId: capability.id,
         definition: trigger as never,
-        dev: trigger.dev,
         devtools: trigger.devtools,
         id,
         input: trigger.input,
@@ -165,7 +164,6 @@ export async function resolveAgentTriggers<
       triggers[id] = {
         channelId,
         definition: trigger as never,
-        dev: trigger.dev,
         devtools: trigger.devtools,
         id,
         input: trigger.input,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -265,9 +265,6 @@ export interface AgentTriggerDefinition<
   CALL_OPTIONS = unknown,
   TContext extends AgentCallbackContext<TRuntimeConfig> = AgentTriggerContext<TRuntimeConfig, Name>,
 > {
-  dev?: {
-    samples?: Record<string, TInput>
-  }
   devtools?: boolean | Record<string, unknown>
   input?: unknown
   invoke: (context: TContext, input: TInput) => MaybePromise<AgentTriggerInvokeResult<CALL_OPTIONS>>
@@ -283,9 +280,6 @@ export interface ResolvedAgentTriggerDefinition<
   capabilityId?: string
   channelId?: string
   definition: AgentTriggerDefinition<TRuntimeConfig, WorkspaceName, TInput, CALL_OPTIONS>
-  dev?: {
-    samples?: Record<string, TInput>
-  }
   devtools?: boolean | Record<string, unknown>
   id: `${string}.${string}`
   input?: unknown
@@ -982,9 +976,6 @@ export interface AgentChatFinishExtension {
 export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   concurrency?: AgentMessageConcurrency
   dedupeTtlMs?: number
-  dev?: {
-    samples?: Record<string, unknown>
-  }
   errorFallbackText?: string | null | ((context: AgentChatErrorHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   fallbackStreamingPlaceholderText?: string | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   history?: AgentChatAgentBindingOptions["history"]
@@ -1003,9 +994,6 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
 
 export interface AgentChannelDefinition<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   adapter?: AgentChatPlatformResolver<TRuntimeConfig>
-  dev?: {
-    samples?: Record<string, unknown>
-  }
   effects?: AgentChannelDeliveryEffects<TRuntimeConfig>
   identity?: IdentityResolver
   kind: string

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -8,7 +8,7 @@ import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInv
 import { streamAgentOutputToEvents } from "../agent-output.ts"
 import { uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { discoverAgentDefinitions } from "../discovery.ts"
-import { resolveAgentTriggers, streamAgent, streamAgentTrigger, withAgentDefaults } from "../index.ts"
+import { isResolvedAgentTriggerHandledInvocation, resolveAgentTriggerInvocation, resolveAgentTriggers, streamAgent, withAgentDefaults } from "../index.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
 
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http"
@@ -16,6 +16,7 @@ import type { ViteDevServer } from "vite"
 import type { AgentChatMessageTriggerInput } from "../chat-trigger.ts"
 import type {
   AgentInput,
+  AgentRunInput,
   AgentRunMetadata,
   AgentRuntimeConfig,
   AgentRuntimeContext,
@@ -35,12 +36,12 @@ interface ViteAgentDevRuntimeContext extends AgentRuntimeContext<ViteAgentDevRun
 
 interface AgentInvocationStreamBody {
   agent?: string
+  context?: unknown
   input?: unknown
   invokerProfileId?: string
   messages?: AgentChatMessageTriggerInput["messages"]
   meta?: Record<string, unknown>
   run?: AgentRunMetadata
-  sample?: string
   text?: string
   timeout?: number
   trigger?: string
@@ -54,6 +55,23 @@ interface AgentInvocationStreamEntry {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+function contextFromBody(body: AgentInvocationStreamBody): Record<string, unknown> | undefined {
+  if (body.context === undefined) return undefined
+  if (!isRecord(body.context)) {
+    throw new Response("Agent Dev Loop context must be a JSON object.", { status: 400 })
+  }
+  return body.context
+}
+
+function withDevContext<CALL_OPTIONS>(
+  input: AgentRunInput<CALL_OPTIONS>,
+  context: Record<string, unknown> | undefined,
+): AgentRunInput<CALL_OPTIONS> {
+  return context
+    ? { ...input, context: { ...input.context, ...context } }
+    : input
 }
 
 function headersFromNode(headers: IncomingHttpHeaders): Headers {
@@ -203,36 +221,19 @@ function messagesFromBody(body: AgentInvocationStreamBody): AgentChatMessageTrig
   throw new Response("Missing Agent Dev Loop message text.", { status: 400 })
 }
 
-function sampleNames(trigger: ResolvedAgentTriggerDefinition): string[] {
-  return Object.keys(trigger.dev?.samples || {})
-}
-
 function selectedTrigger(entry: AgentInvocationStreamEntry, body: AgentInvocationStreamBody): ResolvedAgentTriggerDefinition | undefined {
   if (typeof body.trigger === "string" && body.trigger.trim()) {
     const trigger = entry.triggers[body.trigger]
     if (!trigger) throw new Response(`Unknown Agent Trigger: ${body.trigger}`, { status: 404 })
     return trigger
   }
-  if (typeof body.sample === "string" && body.sample.trim()) {
-    const matches = Object.values(entry.triggers).filter(trigger => sampleNames(trigger).includes(body.sample!))
-    if (matches.length === 1) return matches[0]
-    if (!matches.length) throw new Response(`Unknown Agent Dev Sample: ${body.sample}`, { status: 404 })
-    throw new Response(`Ambiguous Agent Dev Sample: ${body.sample}. Pass trigger.`, { status: 400 })
-  }
   return entry.triggers["chat.message"]
 }
 
 function triggerInput(trigger: ResolvedAgentTriggerDefinition, body: AgentInvocationStreamBody, signal: AbortSignal, run: AgentRunMetadata, timeout: number): unknown {
-  if (typeof body.sample === "string" && body.sample.trim()) {
-    const samples = trigger.dev?.samples || {}
-    if (!Object.prototype.hasOwnProperty.call(samples, body.sample)) {
-      throw new Response(`Unknown Agent Dev Sample: ${body.sample}`, { status: 404 })
-    }
-    return samples[body.sample]
-  }
   if ("input" in body) return body.input
   if (trigger.id !== "chat.message") {
-    throw new Response("Missing Agent Trigger input. Pass input or sample.", { status: 400 })
+    throw new Response("Missing Agent Trigger input. Pass input.", { status: 400 })
   }
   return {
     abortSignal: signal,
@@ -280,8 +281,6 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
     return Response.json({
       agents: entries.map(entry => ({
         name: entry.name,
-        samples: Object.fromEntries(Object.entries(entry.triggers)
-          .flatMap(([id, trigger]) => sampleNames(trigger).map(sample => [`${id}.${sample}`, { sample, trigger: id }]))),
         triggers: Object.keys(entry.triggers),
       })),
       root: server.config.root,
@@ -292,25 +291,32 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
   const entry = selectedEntry(entries, body.agent)
   const run = body.run || devRun(entry.name)
   const context = createRuntimeContext(server, req, run)
+  const devContext = contextFromBody(body)
   const timeout = typeof body.timeout === "number" && Number.isFinite(body.timeout) ? body.timeout : 90_000
 
   return createAgentInvocationStreamResponse(async (emit, signal) => {
     let output: Awaited<ReturnType<typeof streamAgent>>
     const trigger = selectedTrigger(entry, body)
     if (trigger) {
-      output = await streamAgentTrigger(entry.agent as never, context as never, trigger.id, triggerInput(trigger, body, signal, run, timeout), {
-        async onInvocation(invocation) {
-          if (!signal.aborted) emit({ agent: entry.name, run: invocation.run, trigger: invocation.trigger.id, type: "start" })
-        },
-        output: "events",
-      })
+      const invocation = await resolveAgentTriggerInvocation(entry.agent as never, context as never, trigger.id, triggerInput(trigger, body, signal, run, timeout))
+      if (isResolvedAgentTriggerHandledInvocation(invocation)) {
+        output = invocation.response
+      }
+      else {
+        if (!signal.aborted) emit({ agent: entry.name, run: invocation.run, trigger: invocation.trigger.id, type: "start" })
+        output = await streamAgent(entry.agent as never, { ...context, ...(invocation.run ? { run: invocation.run } : {}) } as never, withDevContext(invocation.input, devContext) as never, {
+          output: "events",
+        })
+      }
     }
     else {
       const messages = messagesFromBody(body)
       if (!signal.aborted) emit({ agent: entry.name, run, type: "start" })
       output = await streamAgent(entry.agent as never, context as never, {
         abortSignal: signal,
-        ...(typeof body.invokerProfileId === "string" ? { context: { invokerProfileId: body.invokerProfileId } } : {}),
+        ...(devContext || typeof body.invokerProfileId === "string"
+          ? { context: { ...devContext, ...(typeof body.invokerProfileId === "string" ? { invokerProfileId: body.invokerProfileId } : {}) } }
+          : {}),
         messages: uiMessagesToAgentMessages(messages),
         timeout,
       }, { output: "events" })

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -69,9 +69,12 @@ function withDevContext<CALL_OPTIONS>(
   input: AgentRunInput<CALL_OPTIONS>,
   context: Record<string, unknown> | undefined,
 ): AgentRunInput<CALL_OPTIONS> {
-  return context
-    ? { ...input, context: { ...input.context, ...context } }
-    : input
+  if (!context) return input
+  const mergedContext: Record<string, unknown> = { ...input.context, ...context }
+  if (context.actor !== undefined && context.invoker === undefined) {
+    mergedContext.invoker = context.actor
+  }
+  return { ...input, context: mergedContext as AgentRunInput<CALL_OPTIONS>["context"] }
 }
 
 function headersFromNode(headers: IncomingHttpHeaders): Headers {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -66,7 +66,7 @@ describe("agent CLI", () => {
       })
     })
 
-    const exitCode = await runAgentDevCli(["hello", "agent"], {
+    const exitCode = await runAgentDevCli(["-p", "hello agent"], {
       cwd: "/repo",
       env: {},
       rootDir: "/repo",
@@ -123,7 +123,7 @@ describe("agent CLI", () => {
         })
       })
 
-      const exitCode = await runAgentDevCli(["--agent", "review", "--context", "context.json", "/summary"], {
+      const exitCode = await runAgentDevCli(["--agent", "review", "--context", "context.json", "--prompt=/summary"], {
         cwd: rootDir,
         env: {},
         rootDir,

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -210,16 +210,18 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain("[approval required] workspace_write: Needs write access.")
   })
 
-  it("surfaces Agent Dev Loop tool starts", async () => {
+  it("renders Agent Dev Loop tool input, truncated output, and usage", async () => {
     const stderr = stream()
+    const longOutput = "x".repeat(1300)
     const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       if (init?.method === "POST") {
         return ndjson([
           { agent: "support", trigger: "chat.message", type: "start" },
-          { id: "tool-1", name: "workspace_read", type: "tool-input-start" },
-          { id: "tool-1", name: "workspace_read", output: { path: "README.md" }, type: "tool-result" },
+          { id: "tool-1", input: { command: "pnpm test" }, name: "shell", type: "tool-call" },
+          { id: "tool-1", name: "shell", output: longOutput, type: "tool-result" },
           { id: "tool-2", name: "workspace_list", output: { path: "." }, type: "tool-result" },
           { text: "done", type: "text-delta" },
+          { type: "usage", usageRecord: { usage: { inputTokens: 10, outputTokenDetails: { reasoningTokens: 3 }, outputTokens: 7, totalTokens: 17 } } },
           { type: "finish" },
           { type: "done" },
         ])
@@ -240,9 +242,14 @@ describe("agent CLI", () => {
     }, { fetch: fetchAgentStream as never })
 
     expect(exitCode).toBe(0)
-    expect(stderr.output()).toContain("[tool] workspace_read")
+    expect(stderr.output()).toContain("[tool] shell")
+    expect(stderr.output()).toContain(`input: {"command":"pnpm test"}`)
+    expect(stderr.output()).toContain("[truncated ")
+    expect(stderr.output()).not.toContain(longOutput)
     expect(stderr.output()).toContain("[tool] workspace_list")
-    expect(stderr.output().match(/\[tool\] workspace_read/g)).toHaveLength(1)
+    expect(stderr.output()).toContain(`output: {"path":"."}`)
+    expect(stderr.output()).toContain("[usage] 17 tokens: 10 in / 7 out; 3 reasoning tokens")
+    expect(stderr.output().match(/\[tool\] shell/g)).toHaveLength(1)
   })
 
   it("runs Evalite through the Node runner with ViteHub defaults", async () => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -98,7 +98,9 @@ describe("agent CLI", () => {
   })
 
   it("loads Agent Invocation Context Values from a JSON file", async () => {
-    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-dev-context-"))
+    const workspaceDir = await mkdtemp(join(tmpdir(), "vitehub-agent-dev-context-"))
+    const rootDir = join(workspaceDir, "app")
+    await mkdir(rootDir)
     try {
       const contextPath = join(rootDir, "context.json")
       await writeFile(contextPath, JSON.stringify({
@@ -124,7 +126,7 @@ describe("agent CLI", () => {
       })
 
       const exitCode = await runAgentDevCli(["--agent", "review", "--context", "context.json", "--prompt=/summary"], {
-        cwd: rootDir,
+        cwd: workspaceDir,
         env: {},
         rootDir,
         spawn: vi.fn(),
@@ -150,7 +152,7 @@ describe("agent CLI", () => {
       })
     }
     finally {
-      await rm(rootDir, { force: true, recursive: true })
+      await rm(workspaceDir, { force: true, recursive: true })
     }
   })
 

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -208,6 +208,38 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain("[approval required] workspace_write: Needs write access.")
   })
 
+  it("surfaces Agent Dev Loop tool starts", async () => {
+    const stderr = stream()
+    const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return ndjson([
+          { agent: "support", trigger: "chat.message", type: "start" },
+          { id: "tool-1", name: "workspace_read", type: "tool-input-start" },
+          { id: "tool-1", name: "workspace_read", output: { path: "README.md" }, type: "tool-result" },
+          { text: "done", type: "text-delta" },
+          { type: "finish" },
+          { type: "done" },
+        ])
+      }
+      return Response.json({
+        agents: [{ name: "support", triggers: ["chat.message"] }],
+        root: "/repo",
+      })
+    })
+
+    const exitCode = await runAgentDevCli(["hello"], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      spawn: vi.fn(),
+      stderr,
+      stdout: stream(),
+    }, { fetch: fetchAgentStream as never })
+
+    expect(exitCode).toBe(0)
+    expect(stderr.output()).toContain("[tool] workspace_read")
+  })
+
   it("runs Evalite through the Node runner with ViteHub defaults", async () => {
     const runner = vi.fn(async () => ({ exitCode: undefined }))
     const exitCode = await runAgentEvalCli(["server/agents/support.eval.ts"], {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -216,6 +216,7 @@ describe("agent CLI", () => {
           { agent: "support", trigger: "chat.message", type: "start" },
           { id: "tool-1", name: "workspace_read", type: "tool-input-start" },
           { id: "tool-1", name: "workspace_read", output: { path: "README.md" }, type: "tool-result" },
+          { id: "tool-2", name: "workspace_list", output: { path: "." }, type: "tool-result" },
           { text: "done", type: "text-delta" },
           { type: "finish" },
           { type: "done" },
@@ -238,6 +239,8 @@ describe("agent CLI", () => {
 
     expect(exitCode).toBe(0)
     expect(stderr.output()).toContain("[tool] workspace_read")
+    expect(stderr.output()).toContain("[tool] workspace_list")
+    expect(stderr.output().match(/\[tool\] workspace_read/g)).toHaveLength(1)
   })
 
   it("runs Evalite through the Node runner with ViteHub defaults", async () => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -97,38 +97,85 @@ describe("agent CLI", () => {
     })
   })
 
-  it("replays an Agent Trigger dev sample without chat text", async () => {
-    const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
-      if (init?.method === "POST") {
-        return ndjson([
-          { agent: "review", trigger: "github.webhook", type: "start" },
-          { text: "summary", type: "text-delta" },
-          { type: "finish" },
-          { type: "done" },
-        ])
-      }
-      return Response.json({
-        agents: [{ name: "review", samples: { "github.webhook.summaryComment": { sample: "summaryComment", trigger: "github.webhook" } }, triggers: ["github.webhook"] }],
-        root: "/repo",
+  it("loads Agent Invocation Context Values from a JSON file", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-dev-context-"))
+    try {
+      const contextPath = join(rootDir, "context.json")
+      await writeFile(contextPath, JSON.stringify({
+        pullRequest: {
+          repository: "acme/repo",
+          trigger: { command: "/summary" },
+        },
+      }), "utf8")
+      const stdout = stream()
+      const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        if (init?.method === "POST") {
+          return ndjson([
+            { agent: "review", trigger: "github.webhook", type: "start" },
+            { text: "summary", type: "text-delta" },
+            { type: "finish" },
+            { type: "done" },
+          ])
+        }
+        return Response.json({
+          agents: [{ name: "review", triggers: ["chat.message"] }],
+          root: rootDir,
+        })
       })
-    })
 
-    const exitCode = await runAgentDevCli(["--agent", "review", "--trigger", "github.webhook", "--sample", "summaryComment"], {
-      cwd: "/repo",
-      env: {},
-      rootDir: "/repo",
-      spawn: vi.fn(),
-      stderr: stream(),
-      stdout: stream(),
-    }, { fetch: fetchAgentStream as never })
+      const exitCode = await runAgentDevCli(["--agent", "review", "--context", "context.json", "/summary"], {
+        cwd: rootDir,
+        env: {},
+        rootDir,
+        spawn: vi.fn(),
+        stderr: stream(),
+        stdout,
+      }, { fetch: fetchAgentStream as never })
 
-    expect(exitCode).toBe(0)
-    const post = fetchAgentStream.mock.calls.find(([, init]) => init?.method === "POST")
-    expect(JSON.parse(String(post?.[1]?.body))).toEqual({
-      agent: "review",
-      sample: "summaryComment",
-      trigger: "github.webhook",
-    })
+      expect(exitCode).toBe(0)
+      expect(stdout.output()).toBe(`Loaded context: ${contextPath}\nsummary\n`)
+      const post = fetchAgentStream.mock.calls.find(([, init]) => init?.method === "POST")
+      expect(JSON.parse(String(post?.[1]?.body))).toMatchObject({
+        agent: "review",
+        context: {
+          pullRequest: {
+            repository: "acme/repo",
+            trigger: { command: "/summary" },
+          },
+        },
+        messages: [{
+          parts: [{ text: "/summary", type: "text" }],
+          role: "user",
+        }],
+      })
+    }
+    finally {
+      await rm(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  it("rejects non-object Agent Dev Loop context files", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-dev-context-"))
+    try {
+      await writeFile(join(rootDir, "context.json"), "[1,2,3]", "utf8")
+      const stderr = stream()
+      const fetchAgentStream = vi.fn()
+      const exitCode = await runAgentDevCli(["--context", "context.json", "hello"], {
+        cwd: rootDir,
+        env: {},
+        rootDir,
+        spawn: vi.fn(),
+        stderr,
+        stdout: stream(),
+      }, { fetch: fetchAgentStream as never })
+
+      expect(exitCode).toBe(1)
+      expect(fetchAgentStream).not.toHaveBeenCalled()
+      expect(stderr.output()).toContain("Agent Dev Loop context file must contain a JSON object.")
+    }
+    finally {
+      await rm(rootDir, { force: true, recursive: true })
+    }
   })
 
   it("surfaces Agent Dev Loop approval requests", async () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -555,8 +555,8 @@ describe("agent chat capability discovery", () => {
     expect(abortSignal).toBeInstanceOf(AbortSignal)
   })
 
-  it("replays Agent Invocation Stream dev samples from message-shaped channels", async () => {
-    const root = await createTempRoot("vitehub-agent-invocation-stream-sample-")
+  it("passes Agent Dev Loop context into message-shaped channel invocations", async () => {
+    const root = await createTempRoot("vitehub-agent-invocation-stream-context-")
     await mkdir(join(root, "server", "agents"), { recursive: true })
     await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
 
@@ -569,21 +569,9 @@ describe("agent chat capability discovery", () => {
     }
     const agent = defineAgent({
       channels: {
-        portal: webChat({
-          dev: {
-            samples: {
-              purchaseOrderQuestion: {
-                messages: [{
-                  id: "sample-user-1",
-                  parts: [{ text: "Review purchase order 42", type: "text" }],
-                  role: "user",
-                }],
-              },
-            },
-          },
-        }),
+        portal: webChat(),
       },
-      run: ({ messages }) => `sample ${getMessageText(messages[0]!)}`,
+      run: ({ context, messages }) => `context ${context.get<{ number: number }>("pullRequest")?.number} ${getMessageText(messages[0]!)}`,
     })
     const { handlers, server } = createFakeServer(root, { default: agent })
     const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
@@ -596,19 +584,18 @@ describe("agent chat capability discovery", () => {
     expect(JSON.parse(discovery.body)).toMatchObject({
       agents: [{
         name: "support",
-        samples: {
-          "chat.message.purchaseOrderQuestion": {
-            sample: "purchaseOrderQuestion",
-            trigger: "chat.message",
-          },
-        },
         triggers: ["chat.message"],
       }],
     })
 
     const response = await invokeMiddleware(handlers[0]!, {
       agent: "support",
-      sample: "purchaseOrderQuestion",
+      context: { pullRequest: { number: 42 } },
+      messages: [{
+        id: "user-1",
+        parts: [{ text: "/summary", type: "text" }],
+        role: "user",
+      }],
     }, agentInvocationStreamRoute, headers)
     const events = response.body
       .trim()
@@ -617,7 +604,7 @@ describe("agent chat capability discovery", () => {
 
     expect(events).toEqual([
       expect.objectContaining({ agent: "support", trigger: "chat.message", type: "start" }),
-      { text: "sample Review purchase order 42", type: "text-delta" },
+      { text: "context 42 /summary", type: "text-delta" },
       { type: "finish" },
       { type: "done" },
     ])

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -571,7 +571,7 @@ describe("agent chat capability discovery", () => {
       channels: {
         portal: webChat(),
       },
-      run: ({ context, messages }) => `context ${context.get<{ number: number }>("pullRequest")?.number} ${getMessageText(messages[0]!)}`,
+      run: ({ context, invoker, messages }) => `context ${context.get<{ number: number }>("pullRequest")?.number} ${invoker.id} ${getMessageText(messages[0]!)}`,
     })
     const { handlers, server } = createFakeServer(root, { default: agent })
     const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
@@ -590,7 +590,10 @@ describe("agent chat capability discovery", () => {
 
     const response = await invokeMiddleware(handlers[0]!, {
       agent: "support",
-      context: { pullRequest: { number: 42 } },
+      context: {
+        actor: { id: "github:onmax", kind: "github" },
+        pullRequest: { number: 42 },
+      },
       messages: [{
         id: "user-1",
         parts: [{ text: "/summary", type: "text" }],
@@ -604,7 +607,7 @@ describe("agent chat capability discovery", () => {
 
     expect(events).toEqual([
       expect.objectContaining({ agent: "support", trigger: "chat.message", type: "start" }),
-      { text: "context 42 /summary", type: "text-delta" },
+      { text: "context 42 github:onmax /summary", type: "text-delta" },
       { type: "finish" },
       { type: "done" },
     ])

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1280,7 +1280,7 @@ describe("agent message protocol", () => {
     }
   })
 
-  it("exposes Agent Trigger dev samples", async () => {
+  it("exposes Agent Trigger metadata", async () => {
     const { entry } = await import("../src/capabilities.ts")
     const { resolveAgentTriggers } = await import("../src/trigger-runtime.ts")
     const agent = {
@@ -1288,11 +1288,6 @@ describe("agent message protocol", () => {
         id: "github",
         triggers: {
           webhook: {
-            dev: {
-              samples: {
-                summaryComment: { body: "/summary", deliveryId: "delivery-1" },
-              },
-            },
             invoke: (_context, input: { body: string, deliveryId: string }) => ({
               input: { prompt: input.body },
               run: { origin: "github", runId: input.deliveryId },
@@ -1305,11 +1300,8 @@ describe("agent message protocol", () => {
 
     await expect(resolveAgentTriggers(agent, { memo: vi.fn(), runtime: "unknown" as const, runtimeConfig: {}, waitUntil: vi.fn() })).resolves.toMatchObject({
       "github.webhook": {
-        dev: {
-          samples: {
-            summaryComment: { body: "/summary", deliveryId: "delivery-1" },
-          },
-        },
+        capabilityId: "github",
+        source: "capability",
       },
     })
   })
@@ -1396,16 +1388,6 @@ describe("agent message protocol", () => {
       channels: {
         support: teams({
           adapter,
-          dev: {
-            samples: {
-              supportThread: {
-                messages: [{
-                  parts: [{ text: "Need help with an invoice", type: "text" }],
-                  role: "user",
-                }],
-              },
-            },
-          },
           webhooks: {
             path: "/api/teams/support",
           },
@@ -1435,16 +1417,6 @@ describe("agent message protocol", () => {
     expect(agent.capabilities?.some(capability => capability.id === "chat")).toBe(true)
     await expect(resolveAgentTriggers(agent, { memo: vi.fn(), runtime: "unknown" as const, runtimeConfig: {}, waitUntil: vi.fn() })).resolves.toMatchObject({
       "chat.message": {
-        dev: {
-          samples: {
-            supportThread: {
-              messages: [{
-                parts: [{ text: "Need help with an invoice", type: "text" }],
-                role: "user",
-              }],
-            },
-          },
-        },
         webhooks: [{
           id: "support",
           method: "POST",
@@ -1558,7 +1530,7 @@ describe("agent message protocol", () => {
     })
   })
 
-  it("keeps GitHub event samples on the channel trigger", async () => {
+  it("keeps GitHub events on the channel trigger", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { github } = await import("../src/channels.ts")
     const { resolveAgentTriggers } = await import("../src/trigger-runtime.ts")
@@ -1566,13 +1538,7 @@ describe("agent message protocol", () => {
       channels: {
         github: github({
           events: {
-            pullRequestComments: {
-              dev: {
-                samples: {
-                  review: { github: { event: "issue_comment" }, payload: { comment: { body: "/review" } } },
-                },
-              },
-            },
+            pullRequestComments: true,
           },
         }),
       },
@@ -1581,11 +1547,6 @@ describe("agent message protocol", () => {
 
     await expect(resolveAgentTriggers(agent, { memo: vi.fn(), runtime: "unknown" as const, runtimeConfig: {}, waitUntil: vi.fn() })).resolves.toMatchObject({
       "github.webhook": {
-        dev: {
-          samples: {
-            review: { github: { event: "issue_comment" }, payload: { comment: { body: "/review" } } },
-          },
-        },
         channelId: "github",
         source: "channel",
       },

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -462,7 +462,6 @@ describe("agent public types", () => {
           app: true,
           events: {
             pullRequestComments: {
-              dev: { samples: { review: { github: { event: "issue_comment" } } } },
               origin: "github-review",
             },
           },

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -44,10 +44,6 @@ function isVercelQueueEnabled(queueConfig: NormalizedQueueOptions) {
   return queueConfig !== false && queueConfig.provider === "vercel"
 }
 
-function shouldPreloadVercelQueue(queueConfig: NormalizedQueueOptions, definitions: DiscoveredQueueDefinition[]) {
-  return isVercelQueueEnabled(queueConfig) && definitions.length > 0
-}
-
 interface GeneratedQueueArtifacts {
   cloudflareWorkerFile: string
   definitions: DiscoveredQueueDefinition[]
@@ -121,7 +117,7 @@ async function writeProviderEntries(rootDir: string, queue: QueueModuleOptions |
   for (const spec of providerEntrySpecs) {
     const entryFile = resolve(generatedDir, spec.entryFile)
     const queueConfig = normalizeQueueOptions(queue, { hosting: spec.hosting }) || false
-    const preloadVercelQueue = spec.name === "vercel" && shouldPreloadVercelQueue(queueConfig, definitions)
+    const preloadVercelQueue = spec.name === "vercel" && isVercelQueueEnabled(queueConfig)
     await writeFile(entryFile, renderProviderEntry(spec, entryFile, registryFile, userAppEntry, queueConfig, preloadVercelQueue), "utf8")
     entryFiles[spec.name] = entryFile
   }

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -38,6 +38,12 @@ const providerEntrySpecs: ProviderEntrySpec[] = [
   { name: "vercel", entryFile: "vercel-server.mjs", runtimeModule: "runtime/vercel-vite", factory: "createQueueVercelServer", hosting: "vercel" },
 ]
 
+type NormalizedQueueOptions = false | NonNullable<ReturnType<typeof normalizeQueueOptions>>
+
+function isVercelQueueEnabled(queueConfig: NormalizedQueueOptions) {
+  return queueConfig !== false && queueConfig.provider === "vercel"
+}
+
 interface GeneratedQueueArtifacts {
   cloudflareWorkerFile: string
   definitions: DiscoveredQueueDefinition[]
@@ -111,7 +117,7 @@ async function writeProviderEntries(rootDir: string, queue: QueueModuleOptions |
   for (const spec of providerEntrySpecs) {
     const entryFile = resolve(generatedDir, spec.entryFile)
     const queueConfig = normalizeQueueOptions(queue, { hosting: spec.hosting }) || false
-    const preloadVercelQueue = spec.name === "vercel" && definitions.length > 0 && queueConfig !== false && queueConfig.provider === "vercel"
+    const preloadVercelQueue = spec.name === "vercel" && definitions.length > 0 && isVercelQueueEnabled(queueConfig)
     await writeFile(entryFile, renderProviderEntry(spec, entryFile, registryFile, userAppEntry, queueConfig, preloadVercelQueue), "utf8")
     entryFiles[spec.name] = entryFile
   }
@@ -195,7 +201,7 @@ function sanitizeVercelConsumerName(functionPath: string) {
   return result
 }
 
-function createVercelQueueWrapperContents(file: string, registryFile: string, name: string, queueConfig: false | ReturnType<typeof normalizeQueueOptions>) {
+function createVercelQueueWrapperContents(file: string, registryFile: string, name: string, queueConfig: NormalizedQueueOptions) {
   return [
     "import * as __vitehubVercelQueue from '@vercel/queue'",
     "import { H3 } from 'h3'",
@@ -242,7 +248,7 @@ async function writeVercelQueueFunctions(rootDir: string, queue: QueueModuleOpti
   const queueConfig = normalizeQueueOptions(queue, { hosting: "vercel" }) || false
 
   await rm(queueRoot, { force: true, recursive: true })
-  if (queueConfig === false) {
+  if (!isVercelQueueEnabled(queueConfig)) {
     return
   }
 

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -44,6 +44,10 @@ function isVercelQueueEnabled(queueConfig: NormalizedQueueOptions) {
   return queueConfig !== false && queueConfig.provider === "vercel"
 }
 
+function shouldPreloadVercelQueue(queueConfig: NormalizedQueueOptions, definitions: DiscoveredQueueDefinition[]) {
+  return isVercelQueueEnabled(queueConfig) && definitions.length > 0
+}
+
 interface GeneratedQueueArtifacts {
   cloudflareWorkerFile: string
   definitions: DiscoveredQueueDefinition[]
@@ -117,7 +121,7 @@ async function writeProviderEntries(rootDir: string, queue: QueueModuleOptions |
   for (const spec of providerEntrySpecs) {
     const entryFile = resolve(generatedDir, spec.entryFile)
     const queueConfig = normalizeQueueOptions(queue, { hosting: spec.hosting }) || false
-    const preloadVercelQueue = spec.name === "vercel" && definitions.length > 0 && isVercelQueueEnabled(queueConfig)
+    const preloadVercelQueue = spec.name === "vercel" && shouldPreloadVercelQueue(queueConfig, definitions)
     await writeFile(entryFile, renderProviderEntry(spec, entryFile, registryFile, userAppEntry, queueConfig, preloadVercelQueue), "utf8")
     entryFiles[spec.name] = entryFile
   }

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -75,9 +75,6 @@ function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, registr
     `import { ${spec.factory} } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(spec.runtimeModule)))}`,
     `import queueRegistry from ${JSON.stringify(`./${generatedRegistryFileName}`)}`,
   ]
-  if (spec.name === "vercel") {
-    imports.unshift("import * as __vitehubVercelQueue from '@vercel/queue'")
-  }
   if (userAppEntry) {
     imports.push(`import queueApp from ${JSON.stringify(createImportPath(entryFile, userAppEntry))}`)
   }
@@ -85,7 +82,6 @@ function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, registr
   return [
     ...imports,
     "",
-    spec.name === "vercel" ? "globalThis.__vitehubVercelQueue = __vitehubVercelQueue" : "",
     `const queueConfig = ${JSON.stringify(queueConfig, null, 2)}`,
     "",
     `export default ${spec.factory}({`,

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -70,11 +70,14 @@ export interface CloudflareQueueConfig {
   }
 }
 
-function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, registryFile: string, userAppEntry: string | undefined, queueConfig: unknown) {
+function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, registryFile: string, userAppEntry: string | undefined, queueConfig: unknown, preloadVercelQueue = false) {
   const imports = [
     `import { ${spec.factory} } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(spec.runtimeModule)))}`,
     `import queueRegistry from ${JSON.stringify(`./${generatedRegistryFileName}`)}`,
   ]
+  if (preloadVercelQueue) {
+    imports.unshift("import * as __vitehubVercelQueue from '@vercel/queue'")
+  }
   if (userAppEntry) {
     imports.push(`import queueApp from ${JSON.stringify(createImportPath(entryFile, userAppEntry))}`)
   }
@@ -82,6 +85,7 @@ function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, registr
   return [
     ...imports,
     "",
+    preloadVercelQueue ? "globalThis.__vitehubVercelQueue = __vitehubVercelQueue" : "",
     `const queueConfig = ${JSON.stringify(queueConfig, null, 2)}`,
     "",
     `export default ${spec.factory}({`,
@@ -107,7 +111,8 @@ async function writeProviderEntries(rootDir: string, queue: QueueModuleOptions |
   for (const spec of providerEntrySpecs) {
     const entryFile = resolve(generatedDir, spec.entryFile)
     const queueConfig = normalizeQueueOptions(queue, { hosting: spec.hosting }) || false
-    await writeFile(entryFile, renderProviderEntry(spec, entryFile, registryFile, userAppEntry, queueConfig), "utf8")
+    const preloadVercelQueue = spec.name === "vercel" && definitions.length > 0 && queueConfig !== false && queueConfig.provider === "vercel"
+    await writeFile(entryFile, renderProviderEntry(spec, entryFile, registryFile, userAppEntry, queueConfig, preloadVercelQueue), "utf8")
     entryFiles[spec.name] = entryFile
   }
 

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -145,6 +145,24 @@ describe("Vite provider outputs", () => {
     expect(vercelServerContents).not.toContain("@vercel/queue")
   })
 
+  it("does not preload or emit Vercel queue functions for a non-Vercel queue provider", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-cloudflare-provider-")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist"), { recursive: true })
+    await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
+    await writeFile(join(rootDir, "dist", "index.html"), "<!doctype html><title>vitehub</title>\n", "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist",
+      queue: { provider: "cloudflare" },
+      rootDir,
+    })
+
+    const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
+    expect(vercelServerContents).not.toContain("@vercel/queue")
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "queues", "vercel"))).toBe(false)
+  })
+
   it("throws when queue names collide after Vercel sanitization", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-collision-")
     await mkdir(join(rootDir, "src"), { recursive: true })

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -129,7 +129,7 @@ describe("Vite provider outputs", () => {
     expect(vercelServerContents).toContain("@vercel/queue")
   })
 
-  it("does not preload Vercel queue without queue definitions", async () => {
+  it("preloads Vercel queue without queue definitions for direct clients", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-no-definitions-")
     await mkdir(join(rootDir, "src"), { recursive: true })
     await mkdir(join(rootDir, "dist"), { recursive: true })
@@ -142,7 +142,7 @@ describe("Vite provider outputs", () => {
     })
 
     const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
-    expect(vercelServerContents).not.toContain("@vercel/queue")
+    expect(vercelServerContents).toContain("@vercel/queue")
   })
 
   it("does not preload or emit Vercel queue functions for a non-Vercel queue provider", async () => {

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -83,8 +83,8 @@ describe("Vite provider outputs", () => {
     expect(vercelConsumerContents).toContain("__vitehubVercelQueue")
     expect(vercelConsumerContents).toContain("reportQueueMarker")
     expect(vercelServerContents).toContain("/api/tests/queue")
-    expect(vercelServerContents).not.toContain("__vitehubVercelQueue")
-    expect(vercelServerContents).not.toContain("@vercel/queue")
+    expect(vercelServerContents).toContain("__vitehubVercelQueue")
+    expect(vercelServerContents).toContain("@vercel/queue")
     expect(vercelConsumerTrigger).toEqual({
       consumer: "api_Svitehub_Squeues_Svercel_Swelcome-email_Swelcome-email_Dfunc",
       topic: "topic--77656c636f6d652d656d61696c",
@@ -125,6 +125,22 @@ describe("Vite provider outputs", () => {
     })
 
     expect(await readFile(join(rootDir, ".vercel", "output", "static", "index.html"), "utf8")).toContain("<title>vitehub</title>")
+    const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
+    expect(vercelServerContents).toContain("@vercel/queue")
+  })
+
+  it("does not preload Vercel queue without queue definitions", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-no-definitions-")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist"), { recursive: true })
+    await writeFile(join(rootDir, "dist", "index.html"), "<!doctype html><title>vitehub</title>\n", "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist",
+      queue: {},
+      rootDir,
+    })
+
     const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
     expect(vercelServerContents).not.toContain("@vercel/queue")
   })

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -83,7 +83,8 @@ describe("Vite provider outputs", () => {
     expect(vercelConsumerContents).toContain("__vitehubVercelQueue")
     expect(vercelConsumerContents).toContain("reportQueueMarker")
     expect(vercelServerContents).toContain("/api/tests/queue")
-    expect(vercelServerContents).toContain("__vitehubVercelQueue")
+    expect(vercelServerContents).not.toContain("__vitehubVercelQueue")
+    expect(vercelServerContents).not.toContain("@vercel/queue")
     expect(vercelConsumerTrigger).toEqual({
       consumer: "api_Svitehub_Squeues_Svercel_Swelcome-email_Swelcome-email_Dfunc",
       topic: "topic--77656c636f6d652d656d61696c",
@@ -124,6 +125,8 @@ describe("Vite provider outputs", () => {
     })
 
     expect(await readFile(join(rootDir, ".vercel", "output", "static", "index.html"), "utf8")).toContain("<title>vitehub</title>")
+    const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
+    expect(vercelServerContents).not.toContain("@vercel/queue")
   })
 
   it("throws when queue names collide after Vercel sanitization", async () => {

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -120,7 +120,7 @@ describe("Vite provider outputs", () => {
 
     await generateProviderOutputs({
       clientOutDir: "dist",
-      queue: {},
+      queue: { provider: "vercel" },
       rootDir,
     })
 


### PR DESCRIPTION
Adds `vitehub agent dev --context <path>` so the Agent Dev Loop can load a JSON object as Agent Invocation Context Values and print a concise `Loaded context: <absolute path>` line before connecting. The loaded context is sent with one-shot and interactive dev-loop messages, while `--input` remains raw trigger input.

Removes the public `dev.samples` path from Agent triggers, message/channel settings, and GitHub event options, so local sample data no longer lives in Agent Definition or channel code. Slash commands such as `/summary` continue to travel as normal user input for `inputCommands()` to handle.

Validated with Agent package typecheck, build, targeted dev-loop/runtime tests, and `git diff --check`.