### PR TITLE
feat: add trusted host workspace runtime

### DIFF
--- a/.agents/contexts/packages/workspace/CONTEXT.md
+++ b/.agents/contexts/packages/workspace/CONTEXT.md
@@ -40,6 +40,10 @@ _Avoid_: Source Definition, Source Loader options only, provider namespace
 The Workspace Package helper that materializes selected Workspace files into a harness sandbox and syncs write-mode additions, updates, or deletions back through Workspace rules.
 _Avoid_: Agent Package file copier, harness checkout, root sandbox config
 
+**Trusted Host Workspace Runtime**:
+The Workspace Package-owned runtime that backs explicit trusted local development and test Workspace Sessions.
+_Avoid_: CLI execution mode, Agent Dev Loop option, hosted runtime
+
 ## Relationships
 
 - The **Workspace Package** owns **Workspace Definitions**.
@@ -60,6 +64,8 @@ _Avoid_: Agent Package file copier, harness checkout, root sandbox config
 - The **Workspace Runtime Surface** may expose Source Sync without making normal Workspace reads run Source Sync.
 - The **Workspace Package** owns **Harness Workspace Session Preparation** for harness-backed Agent Drivers.
 - **Harness Workspace Session Preparation** is consumed by the Agent Package; it is not an app-level sandbox workflow surface.
+- The **Workspace Package** owns the **Trusted Host Workspace Runtime** because Workspace Session materialization and commit behavior stay inside the Workspace Runtime Surface.
+- The **Trusted Host Workspace Runtime** is selected from a Workspace Definition, not from the ViteHub CLI or Agent Package.
 - Source Sync on the **Workspace Runtime Surface** requires explicit Source selection.
 - The **Workspace Runtime Surface** exposes Source Sync through the Workspace sync lifecycle rather than a separate public Source Sync method.
 - The Workspace sync lifecycle on the **Workspace Runtime Surface** requires explicit selection.

--- a/.agents/contexts/workspace/CONTEXT.md
+++ b/.agents/contexts/workspace/CONTEXT.md
@@ -195,6 +195,10 @@ _Avoid_: Asset workspace, runtime workspace, merged workspace
 A runtime materialization of a Workspace that can execute commands and commit file changes back to the Workspace Store.
 _Avoid_: Open workspace, sandbox, mount
 
+**Trusted Host Workspace Runtime**:
+A trusted development and test Workspace Session runtime that materializes the Workspace on the host machine and executes commands there.
+_Avoid_: Agent Dev Loop runtime, production shell, sandbox replacement
+
 **Harness Workspace Session**:
 A scoped Workspace Session prepared for a harness-backed Agent Driver, exposing a materialized filesystem and session boundary instead of model-facing Workspace Tools by default.
 _Avoid_: Workspace Tools, prompt context, unscoped checkout
@@ -375,6 +379,8 @@ _Avoid_: Chat Session, thread id, implicit conversation state
 - A missing **Selected Workspace Scope** fails the Agent Invocation unless the developer declared a **Default Workspace Scope**.
 - A **Default Workspace Scope** is explicit configuration and never implies **All-Scopes Workspace Scope**.
 - A **Workspace Session** starts from a Workspace runtime surface and may use a Sandbox provider behind the boundary.
+- A **Workspace Session** can use the **Trusted Host Workspace Runtime** only through an explicit trusted development or test opt-in.
+- The **Trusted Host Workspace Runtime** is not implied by the **Agent Dev Loop**.
 - A **Harness Workspace Session** starts after the **Selected Workspace Scope** is resolved, so harness-backed Agent Drivers see only scoped Workspace state.
 - A **Harness Workspace Session** is invocation-scoped by default.
 - A **Harness Workspace Session** is reused across Agent Invocations only when a driver option or Capability provides an explicit **Harness Session Key**.

--- a/docs/content/docs/server-primitives/workspace.md
+++ b/docs/content/docs/server-primitives/workspace.md
@@ -242,6 +242,7 @@ Build and dev integrations own build-time Source materialization. Runtime `sync(
 ## Sessions and Shell
 
 Use a Workspace Session when execution should operate on a materialized file tree and then produce a diff.
+`session.exec()` currently requires `runtime: 'sandbox'` on the Workspace Definition and app-level Sandbox config. `vitehub agent dev` does not add a trusted host execution runtime yet.
 
 ```ts [server/tasks/test-docs.ts]
 import { useWorkspace } from '@vite-hub/workspace'

--- a/docs/content/docs/server-primitives/workspace.md
+++ b/docs/content/docs/server-primitives/workspace.md
@@ -242,7 +242,7 @@ Build and dev integrations own build-time Source materialization. Runtime `sync(
 ## Sessions and Shell
 
 Use a Workspace Session when execution should operate on a materialized file tree and then produce a diff.
-`session.exec()` currently requires `runtime: 'sandbox'` on the Workspace Definition and app-level Sandbox config. `vitehub agent dev` does not add a trusted host execution runtime yet.
+`session.exec()` requires an executable Workspace runtime. Use `runtime: 'sandbox'` for hosted or untrusted execution, or `runtime: 'trusted-host'` for trusted local development and tests.
 
 ```ts [server/tasks/test-docs.ts]
 import { useWorkspace } from '@vite-hub/workspace'
@@ -259,6 +259,8 @@ export async function testDocs() {
 ```
 
 Workspace owns the file tree and commit behavior. [Shell](/docs/server-primitives/shell) owns controlled command sessions, and [Sandbox](/docs/server-primitives/sandbox) owns isolated execution providers.
+
+`runtime: 'trusted-host'` runs commands on the host machine in a temporary materialized Workspace directory and is rejected when `NODE_ENV=production`. Use it only for projects and Sources you trust.
 
 ## Provider output
 

--- a/packages/sandbox/src/runtime/providers/cloudflare.ts
+++ b/packages/sandbox/src/runtime/providers/cloudflare.ts
@@ -1,4 +1,3 @@
-import { getSandbox as getCloudflareSandbox } from '@cloudflare/sandbox'
 import type { CloudflareSandboxDefinitionProviderOptions, SandboxDefinitionOptions } from '../../module-types'
 import { getCloudflareEnv } from '../../internal/shared/provider-detection'
 import type { CloudflareSandboxOptions, CloudflareSandboxStub, DurableObjectNamespaceLike } from '../../sandbox/types'
@@ -15,6 +14,15 @@ type SandboxEvent = {
   }
 }
 
+async function loadCloudflareSandbox() {
+  try {
+    return (await import('@cloudflare/sandbox')).getSandbox
+  }
+  catch (error) {
+    throw new Error(`@cloudflare/sandbox load failed. Install it to use the Cloudflare provider. Original error: ${error instanceof Error ? error.message : error}`)
+  }
+}
+
 export async function resolveSandboxProvider(options: SandboxOptions, context: { event?: SandboxEvent } = {}) {
   const env = getCloudflareEnv(context.event)
   const bindingName = options.provider.binding || 'SANDBOX'
@@ -23,6 +31,8 @@ export async function resolveSandboxProvider(options: SandboxOptions, context: {
   if (!namespace) {
     throw new Error(`Cloudflare sandbox requires the "${bindingName}" binding. Set sandbox.binding or run inside Cloudflare.`)
   }
+
+  const getCloudflareSandbox = await loadCloudflareSandbox()
 
   return {
     provider: 'cloudflare' as const,

--- a/packages/sandbox/src/sandbox/providers/cloudflare.ts
+++ b/packages/sandbox/src/sandbox/providers/cloudflare.ts
@@ -1,14 +1,23 @@
-import { getSandbox as getCloudflareSandbox } from '@cloudflare/sandbox'
 import type { CloudflareSandboxClient, CloudflareSandboxProviderOptions, CloudflareSandboxStub } from '../types'
 import { CloudflareSandboxAdapter } from '../adapters/cloudflare'
 import { SandboxError } from '../errors'
+
+async function loadCloudflareSandbox() {
+  try {
+    return (await import('@cloudflare/sandbox')).getSandbox
+  }
+  catch (error) {
+    throw new SandboxError(`@cloudflare/sandbox load failed. Install it to use the Cloudflare provider. Original error: ${error instanceof Error ? error.message : error}`)
+  }
+}
 
 export async function createCloudflareSandboxClient(provider: CloudflareSandboxProviderOptions): Promise<CloudflareSandboxClient> {
   if (!provider.namespace)
     throw new SandboxError('Cloudflare sandbox requires a Durable Objects binding namespace.')
 
   const id = provider.sandboxId ?? `cloudflare-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-  const getSandbox = provider.getSandbox ?? ((ns, sandboxId, opts) => getCloudflareSandbox(ns as never, sandboxId, opts) as unknown as CloudflareSandboxStub)
+  const cloudflareSandbox = provider.getSandbox ? undefined : await loadCloudflareSandbox()
+  const getSandbox = provider.getSandbox ?? ((ns, sandboxId, opts) => cloudflareSandbox!(ns as never, sandboxId, opts) as unknown as CloudflareSandboxStub)
   const stub = getSandbox(provider.namespace, id, provider.cloudflare)
   return new CloudflareSandboxAdapter(id, stub)
 }

--- a/packages/sandbox/test/provider-detection.test.ts
+++ b/packages/sandbox/test/provider-detection.test.ts
@@ -59,4 +59,26 @@ describe("provider detection", () => {
     expect(isSandboxAvailable("vercel")).toBe(true)
     expect(isSandboxAvailable("cloudflare")).toBe(true)
   })
+
+  it("does not load the Cloudflare SDK when a sandbox getter is injected", async () => {
+    vi.resetModules()
+    vi.doMock("@cloudflare/sandbox", () => {
+      throw new Error("unexpected Cloudflare SDK load")
+    })
+
+    try {
+      const { createCloudflareSandboxClient } = await import("../src/sandbox/providers/cloudflare.ts")
+      const client = await createCloudflareSandboxClient({
+        getSandbox: () => ({}) as never,
+        namespace: {} as never,
+        provider: "cloudflare",
+      })
+
+      expect(client.provider).toBe("cloudflare")
+    }
+    finally {
+      vi.doUnmock("@cloudflare/sandbox")
+      vi.resetModules()
+    }
+  })
 })

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -580,7 +580,7 @@ export interface WorkspaceDefinition {
   name: string
   rootDir?: string
   sourceRootDir?: string
-  runtime?: "sandbox"
+  runtime?: "sandbox" | "trusted-host"
   store?: WorkspaceStoreOptions
   sources?: Record<string, WorkspaceSourceInput>
   loaders?: WorkspaceLoader[]

--- a/packages/workspace/src/core/workspace.ts
+++ b/packages/workspace/src/core/workspace.ts
@@ -73,6 +73,10 @@ export function createWorkspace(definition: WorkspaceDefinition): Workspace {
         const { createSandboxWorkspaceSession } = await import("../session/sandbox.ts")
         return await createSandboxWorkspaceSession(definition, workspace)
       }
+      if (definition.runtime === "trusted-host") {
+        const { createTrustedHostWorkspaceSession } = await import("../session/trusted-host.ts")
+        return await createTrustedHostWorkspaceSession(definition, workspace)
+      }
 
       return createBasicWorkspaceSession(workspace)
     },

--- a/packages/workspace/src/session/basic.ts
+++ b/packages/workspace/src/session/basic.ts
@@ -3,7 +3,7 @@ import { WorkspaceError } from "../core/errors.ts"
 import type { ExecOptions, ExecResult, Workspace, WorkspaceSession } from "../core/types.ts"
 
 function unsupportedExec(): never {
-  throw new WorkspaceError("[vitehub] Workspace does not configure an executable runtime. Set `runtime: 'sandbox'` in the workspace definition.")
+  throw new WorkspaceError("[vitehub] Workspace exec is sandbox-only today. Set `runtime: 'sandbox'` in the workspace definition and configure the Sandbox integration, or avoid session.exec(). Trusted host execution for `vitehub agent dev` is not implemented yet.")
 }
 
 export function createBasicWorkspaceSession(workspace: Workspace): WorkspaceSession {

--- a/packages/workspace/src/session/basic.ts
+++ b/packages/workspace/src/session/basic.ts
@@ -3,7 +3,7 @@ import { WorkspaceError } from "../core/errors.ts"
 import type { ExecOptions, ExecResult, Workspace, WorkspaceSession } from "../core/types.ts"
 
 function unsupportedExec(): never {
-  throw new WorkspaceError("[vitehub] Workspace exec is sandbox-only today. Set `runtime: 'sandbox'` in the workspace definition and configure the Sandbox integration, or avoid session.exec(). Trusted host execution for `vitehub agent dev` is not implemented yet.")
+  throw new WorkspaceError("[vitehub] Workspace exec requires an executable runtime. Set `runtime: 'sandbox'` for hosted or untrusted execution, set `runtime: 'trusted-host'` for trusted local development and tests, or avoid session.exec().")
 }
 
 export function createBasicWorkspaceSession(workspace: Workspace): WorkspaceSession {

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -35,17 +35,31 @@ function toWorkspacePath(root: string, path: string) {
   return normalizeWorkspacePath(relative(root, path).split(sep).join("/"))
 }
 
-function normalizeLocalWorkspacePath(path = "", options: { allowEmpty?: boolean } = {}) {
+function isGeneratedSourceDescriptorPath(path: string): boolean {
+  return path === ".vitehub" || path === ".vitehub/sources" || /^\.vitehub\/sources\/[^/]+\.json$/.test(path)
+}
+
+function normalizeLocalWorkspacePath(path = "", options: { allowEmpty?: boolean, allowGenerated?: boolean } = {}) {
   const normalized = posix.normalize(path.replace(/\\/g, "/"))
-  return normalized === "." ? "" : normalizeSafeWorkspacePath(normalized, options)
+  const workspacePath = normalized === "." ? "" : normalized
+  const { allowGenerated, ...safeOptions } = options
+  if (allowGenerated && isGeneratedSourceDescriptorPath(workspacePath)) {
+    return normalizeSafeWorkspacePath(workspacePath, { ...safeOptions, allowReserved: true })
+  }
+  return normalizeSafeWorkspacePath(workspacePath, safeOptions)
 }
 
-function toLocalPath(root: string, path = "") {
-  return resolveInside(root, normalizeLocalWorkspacePath(path, { allowEmpty: true }))
+function normalizeSessionCwd(path = "") {
+  const normalized = path.replace(/\\/g, "/")
+  return normalizeLocalWorkspacePath(normalized.replace(/^\/workspace(?:\/|$)/, ""), { allowEmpty: true })
 }
 
-async function listLocalEntries(root: string, path = "", recursive = false): Promise<WorkspaceEntry[]> {
-  const base = toLocalPath(root, path)
+function toLocalPath(root: string, path = "", options: { allowGenerated?: boolean } = {}) {
+  return resolveInside(root, normalizeLocalWorkspacePath(path, { allowEmpty: true, allowGenerated: options.allowGenerated }))
+}
+
+async function listLocalEntries(root: string, path = "", recursive = false, options: { allowGenerated?: boolean, skipGenerated?: boolean } = {}): Promise<WorkspaceEntry[]> {
+  const base = toLocalPath(root, path, options)
   const dirents = await readdir(base, { withFileTypes: true }).catch((error) => {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
     throw error
@@ -54,9 +68,10 @@ async function listLocalEntries(root: string, path = "", recursive = false): Pro
   for (const dirent of dirents) {
     const entryPath = join(base, dirent.name)
     const workspacePath = toWorkspacePath(root, entryPath)
+    if (options.skipGenerated && isGeneratedSourceDescriptorPath(workspacePath)) continue
     if (dirent.isDirectory()) {
       entries.push({ path: workspacePath, type: "directory" })
-      if (recursive) entries.push(...await listLocalEntries(root, workspacePath, true))
+      if (recursive) entries.push(...await listLocalEntries(root, workspacePath, true, options))
       continue
     }
     if (!dirent.isFile()) continue
@@ -66,8 +81,8 @@ async function listLocalEntries(root: string, path = "", recursive = false): Pro
   return entries.sort((left, right) => left.path.localeCompare(right.path))
 }
 
-async function readLocalFile(root: string, path: string): Promise<WorkspaceFile | undefined> {
-  const target = toLocalPath(root, path)
+async function readLocalFile(root: string, path: string, options: { allowGenerated?: boolean } = {}): Promise<WorkspaceFile | undefined> {
+  const target = toLocalPath(root, path, options)
   try {
     return { content: await readFile(target), path: normalizeWorkspacePath(path) }
   }
@@ -78,7 +93,7 @@ async function readLocalFile(root: string, path: string): Promise<WorkspaceFile 
 }
 
 async function snapshotLocal(root: string, name?: string) {
-  const entries = await listLocalEntries(root, "", true)
+  const entries = await listLocalEntries(root, "", true, { allowGenerated: true, skipGenerated: true })
   const files = await Promise.all(entries.map(async (entry) => {
     if (entry.type !== "file") return entry
     const content = await readFile(toLocalPath(root, entry.path))
@@ -94,10 +109,10 @@ async function snapshotLocal(root: string, name?: string) {
 async function materializeWorkspace(workspace: Workspace, root: string) {
   const entries = await workspace.list("", { recursive: true })
   for (const entry of entries.filter(entry => entry.type === "directory"))
-    await mkdir(toLocalPath(root, entry.path), { recursive: true })
+    await mkdir(toLocalPath(root, entry.path, { allowGenerated: true }), { recursive: true })
   for (const entry of entries) {
     if (entry.type !== "file") continue
-    const target = toLocalPath(root, entry.path)
+    const target = toLocalPath(root, entry.path, { allowGenerated: true })
     await mkdir(dirname(target), { recursive: true })
     await writeFile(target, await workspace.readFile(entry.path, { encoding: "binary" }))
   }
@@ -111,6 +126,7 @@ async function commitLocalChanges(
   mediaTypes: Map<string, string>,
 ) {
   for (const entry of diff.entries) {
+    if (isGeneratedSourceDescriptorPath(entry.path)) continue
     if (entry.after?.type === "directory") {
       if (entry.before?.type === "file")
         await workspace.rm(entry.path, { force: true })
@@ -136,7 +152,7 @@ async function commitLocalChanges(
 }
 
 async function execLocal(root: string, command: string, args: string[] = [], options: ExecOptions = {}): Promise<ExecResult> {
-  const cwd = toLocalPath(root, options.cwd || "")
+  const cwd = toLocalPath(root, normalizeSessionCwd(options.cwd))
   return await new Promise((resolve) => {
     const child = spawn(command, args, {
       cwd,
@@ -146,22 +162,28 @@ async function execLocal(root: string, command: string, args: string[] = [], opt
     let stdout = ""
     let stderr = ""
     let settled = false
+    let killTimer: NodeJS.Timeout | undefined
     const timer = options.timeout
       ? setTimeout(() => {
           settled = true
           child.kill("SIGTERM")
+          killTimer = setTimeout(() => child.kill("SIGKILL"), 100)
         }, options.timeout)
       : undefined
+    const clearTimers = () => {
+      if (timer) clearTimeout(timer)
+      if (killTimer) clearTimeout(killTimer)
+    }
     child.stdout?.setEncoding("utf8")
     child.stderr?.setEncoding("utf8")
     child.stdout?.on("data", chunk => stdout += chunk)
     child.stderr?.on("data", chunk => stderr += chunk)
     child.on("error", error => {
-      if (timer) clearTimeout(timer)
+      clearTimers()
       resolve({ args, command, exitCode: 127, stderr: error instanceof Error ? error.message : String(error), stdout })
     })
     child.on("close", (code, signal) => {
-      if (timer) clearTimeout(timer)
+      clearTimers()
       resolve({
         args,
         command,
@@ -178,7 +200,7 @@ export async function createTrustedHostWorkspaceSession(
   workspace: Workspace,
 ): Promise<WorkspaceSession> {
   assertTrustedHostWorkspaceRuntimeAllowed()
-  const root = await mkdtemp(join(tmpdir(), `vitehub-workspace-${workspace.name}-`))
+  const root = await mkdtemp(join(tmpdir(), `vitehub-workspace-${workspace.name.replace(/[^a-zA-Z0-9._-]+/g, "-") || "workspace"}-`))
   let baseline = await materializeWorkspace(workspace, root)
   const mediaTypes = new Map<string, string>()
   let closed = false
@@ -196,7 +218,7 @@ export async function createTrustedHostWorkspaceSession(
   return {
     async readFile<TOptions extends ReadFileOptions | undefined = undefined>(path: string, options?: TOptions): Promise<ReadFileResult<TOptions>> {
       assertOpen()
-      const file = await readLocalFile(root, normalizeLocalWorkspacePath(path))
+      const file = await readLocalFile(root, normalizeLocalWorkspacePath(path, { allowGenerated: true }), { allowGenerated: true })
       if (!file) throw new WorkspaceError(`[vitehub] Workspace file does not exist: ${path}.`)
       return decodeFile(file.content, options)
     },
@@ -223,24 +245,24 @@ export async function createTrustedHostWorkspaceSession(
     },
     async list(path = "", options = {}) {
       assertOpen()
-      return await listLocalEntries(root, path, options.recursive)
+      return await listLocalEntries(root, path, options.recursive, { allowGenerated: true })
     },
     async glob(pattern, _options = {}) {
       assertOpen()
       const patterns = Array.isArray(pattern) ? pattern : [pattern]
-      return (await listLocalEntries(root, "", true))
+      return (await listLocalEntries(root, "", true, { allowGenerated: true }))
         .filter(entry => entry.type === "file" && patterns.some(item => matchesAny(entry.path, item)))
     },
     async search(query) {
       assertOpen()
       const { searchText } = await import("../core/search.ts")
-      const searchRoots = [...new Set((query.paths?.length ? query.paths : [query.cwd || ""]).map(path => normalizeLocalWorkspacePath(path, { allowEmpty: true })))]
+      const searchRoots = [...new Set((query.paths?.length ? query.paths : [query.cwd || ""]).map(path => normalizeLocalWorkspacePath(path, { allowEmpty: true, allowGenerated: true })))]
       const scopedSearchRoots = searchRoots.filter(Boolean)
       const limit = query.limit ?? 100
       const hits: WorkspaceSearchHit[] = []
-      for (const entry of (await listLocalEntries(root, "", true)).filter(item => item.type === "file")) {
+      for (const entry of (await listLocalEntries(root, "", true, { allowGenerated: true })).filter(item => item.type === "file")) {
         if (scopedSearchRoots.length && !scopedSearchRoots.some(path => entry.path === path || entry.path.startsWith(`${path}/`))) continue
-        const text = await readFile(toLocalPath(root, entry.path), "utf8")
+        const text = await readFile(toLocalPath(root, entry.path, { allowGenerated: true }), "utf8")
         hits.push(...searchText(entry.path, text, { ...query, limit: limit - hits.length }))
         if (hits.length >= limit) break
       }

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -39,6 +39,10 @@ function isGeneratedSourceDescriptorPath(path: string): boolean {
   return path === ".vitehub" || path === ".vitehub/sources" || /^\.vitehub\/sources\/[^/]+\.json$/.test(path)
 }
 
+function isUncommittedSessionPath(path: string): boolean {
+  return isGeneratedSourceDescriptorPath(path) || path.split("/").includes(".git")
+}
+
 function normalizeLocalWorkspacePath(path = "", options: { allowEmpty?: boolean, allowGenerated?: boolean } = {}) {
   const normalized = posix.normalize(path.replace(/\\/g, "/"))
   const workspacePath = normalized === "." ? "" : normalized
@@ -51,14 +55,14 @@ function normalizeLocalWorkspacePath(path = "", options: { allowEmpty?: boolean,
 
 function normalizeSessionCwd(path = "") {
   const normalized = path.replace(/\\/g, "/")
-  return normalizeLocalWorkspacePath(normalized.replace(/^\/workspace(?:\/|$)/, ""), { allowEmpty: true })
+  return normalizeLocalWorkspacePath(normalized.replace(/^\/workspace(?:\/|$)/, ""), { allowEmpty: true, allowGenerated: true })
 }
 
 function toLocalPath(root: string, path = "", options: { allowGenerated?: boolean } = {}) {
   return resolveInside(root, normalizeLocalWorkspacePath(path, { allowEmpty: true, allowGenerated: options.allowGenerated }))
 }
 
-async function listLocalEntries(root: string, path = "", recursive = false, options: { allowGenerated?: boolean, skipGenerated?: boolean } = {}): Promise<WorkspaceEntry[]> {
+async function listLocalEntries(root: string, path = "", recursive = false, options: { allowGenerated?: boolean, skipUncommitted?: boolean } = {}): Promise<WorkspaceEntry[]> {
   const base = toLocalPath(root, path, options)
   const dirents = await readdir(base, { withFileTypes: true }).catch((error) => {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
@@ -68,7 +72,7 @@ async function listLocalEntries(root: string, path = "", recursive = false, opti
   for (const dirent of dirents) {
     const entryPath = join(base, dirent.name)
     const workspacePath = toWorkspacePath(root, entryPath)
-    if (options.skipGenerated && isGeneratedSourceDescriptorPath(workspacePath)) continue
+    if (options.skipUncommitted && isUncommittedSessionPath(workspacePath)) continue
     if (dirent.isDirectory()) {
       entries.push({ path: workspacePath, type: "directory" })
       if (recursive) entries.push(...await listLocalEntries(root, workspacePath, true, options))
@@ -93,7 +97,7 @@ async function readLocalFile(root: string, path: string, options: { allowGenerat
 }
 
 async function snapshotLocal(root: string, name?: string) {
-  const entries = await listLocalEntries(root, "", true, { allowGenerated: true, skipGenerated: true })
+  const entries = await listLocalEntries(root, "", true, { allowGenerated: true, skipUncommitted: true })
   const files = await Promise.all(entries.map(async (entry) => {
     if (entry.type !== "file") return entry
     const content = await readFile(toLocalPath(root, entry.path))
@@ -126,7 +130,7 @@ async function commitLocalChanges(
   mediaTypes: Map<string, string>,
 ) {
   for (const entry of diff.entries) {
-    if (isGeneratedSourceDescriptorPath(entry.path)) continue
+    if (isUncommittedSessionPath(entry.path)) continue
     if (entry.after?.type === "directory") {
       if (entry.before?.type === "file")
         await workspace.rm(entry.path, { force: true })
@@ -152,7 +156,7 @@ async function commitLocalChanges(
 }
 
 async function execLocal(root: string, command: string, args: string[] = [], options: ExecOptions = {}): Promise<ExecResult> {
-  const cwd = toLocalPath(root, normalizeSessionCwd(options.cwd))
+  const cwd = toLocalPath(root, normalizeSessionCwd(options.cwd), { allowGenerated: true })
   return await new Promise((resolve) => {
     const child = spawn(command, args, {
       cwd,
@@ -201,7 +205,10 @@ export async function createTrustedHostWorkspaceSession(
 ): Promise<WorkspaceSession> {
   assertTrustedHostWorkspaceRuntimeAllowed()
   const root = await mkdtemp(join(tmpdir(), `vitehub-workspace-${workspace.name.replace(/[^a-zA-Z0-9._-]+/g, "-") || "workspace"}-`))
-  let baseline = await materializeWorkspace(workspace, root)
+  let baseline = await materializeWorkspace(workspace, root).catch(async (error) => {
+    await rm(root, { force: true, recursive: true })
+    throw error
+  })
   const mediaTypes = new Map<string, string>()
   let closed = false
 

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -1,0 +1,267 @@
+import { spawn } from "node:child_process"
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, posix, relative, sep } from "node:path"
+
+import { WorkspaceError } from "../core/errors.ts"
+import { contentToBytes, decodeFile, matchesAny, normalizeSafeWorkspacePath, normalizeWorkspacePath, resolveInside, sha256 } from "../core/path.ts"
+import { createSnapshotFromEntries, diffSnapshots } from "../storage/utils.ts"
+
+import type {
+  ExecOptions,
+  ExecResult,
+  ReadFileOptions,
+  ReadFileResult,
+  RmOptions,
+  Workspace,
+  WorkspaceContent,
+  WorkspaceDefinition,
+  WorkspaceDiff,
+  WorkspaceEntry,
+  WorkspaceFile,
+  WorkspaceSearchHit,
+  WorkspaceSession,
+  WriteFileOptions,
+} from "../core/types.ts"
+
+function assertTrustedHostWorkspaceRuntimeAllowed() {
+  const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
+  if (env?.NODE_ENV === "production") {
+    throw new WorkspaceError("[vitehub] Workspace runtime `trusted-host` is only available outside production. Use `runtime: 'sandbox'` for hosted executable workspaces.")
+  }
+}
+
+function toWorkspacePath(root: string, path: string) {
+  return normalizeWorkspacePath(relative(root, path).split(sep).join("/"))
+}
+
+function normalizeLocalWorkspacePath(path = "", options: { allowEmpty?: boolean } = {}) {
+  const normalized = posix.normalize(path.replace(/\\/g, "/"))
+  return normalized === "." ? "" : normalizeSafeWorkspacePath(normalized, options)
+}
+
+function toLocalPath(root: string, path = "") {
+  return resolveInside(root, normalizeLocalWorkspacePath(path, { allowEmpty: true }))
+}
+
+async function listLocalEntries(root: string, path = "", recursive = false): Promise<WorkspaceEntry[]> {
+  const base = toLocalPath(root, path)
+  const dirents = await readdir(base, { withFileTypes: true }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
+    throw error
+  })
+  const entries: WorkspaceEntry[] = []
+  for (const dirent of dirents) {
+    const entryPath = join(base, dirent.name)
+    const workspacePath = toWorkspacePath(root, entryPath)
+    if (dirent.isDirectory()) {
+      entries.push({ path: workspacePath, type: "directory" })
+      if (recursive) entries.push(...await listLocalEntries(root, workspacePath, true))
+      continue
+    }
+    if (!dirent.isFile()) continue
+    const item = await stat(entryPath)
+    entries.push({ path: workspacePath, size: item.size, type: "file" })
+  }
+  return entries.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+async function readLocalFile(root: string, path: string): Promise<WorkspaceFile | undefined> {
+  const target = toLocalPath(root, path)
+  try {
+    return { content: await readFile(target), path: normalizeWorkspacePath(path) }
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined
+    throw error
+  }
+}
+
+async function snapshotLocal(root: string, name?: string) {
+  const entries = await listLocalEntries(root, "", true)
+  const files = await Promise.all(entries.map(async (entry) => {
+    if (entry.type !== "file") return entry
+    const content = await readFile(toLocalPath(root, entry.path))
+    return {
+      ...entry,
+      digest: await sha256(content),
+      size: contentToBytes(content).byteLength,
+    }
+  }))
+  return await createSnapshotFromEntries(files, name)
+}
+
+async function materializeWorkspace(workspace: Workspace, root: string) {
+  const entries = await workspace.list("", { recursive: true })
+  for (const entry of entries.filter(entry => entry.type === "directory"))
+    await mkdir(toLocalPath(root, entry.path), { recursive: true })
+  for (const entry of entries) {
+    if (entry.type !== "file") continue
+    const target = toLocalPath(root, entry.path)
+    await mkdir(dirname(target), { recursive: true })
+    await writeFile(target, await workspace.readFile(entry.path, { encoding: "binary" }))
+  }
+  return await snapshotLocal(root, "local-open")
+}
+
+async function commitLocalChanges(
+  root: string,
+  workspace: Workspace,
+  diff: WorkspaceDiff,
+  mediaTypes: Map<string, string>,
+) {
+  for (const entry of diff.entries) {
+    if (entry.after?.type === "directory") {
+      if (entry.before?.type === "file")
+        await workspace.rm(entry.path, { force: true })
+      await workspace.mkdir(entry.path, { recursive: true })
+      continue
+    }
+    if (entry.type === "removed") {
+      await workspace.rm(entry.path, { force: true, recursive: true })
+      continue
+    }
+    if (entry.after?.type === "file") {
+      if (entry.before?.type === "directory")
+        await workspace.rm(entry.path, { force: true, recursive: true })
+      const before = entry.before?.type === "file"
+        ? await workspace.stat(entry.path).catch(() => undefined)
+        : undefined
+      const file = await readLocalFile(root, entry.path)
+      if (file)
+        await workspace.writeFile(entry.path, file.content, { mediaType: file.mediaType || mediaTypes.get(entry.path) || before?.mediaType })
+    }
+  }
+  await workspace.snapshot({ name: "local-commit" })
+}
+
+async function execLocal(root: string, command: string, args: string[] = [], options: ExecOptions = {}): Promise<ExecResult> {
+  const cwd = toLocalPath(root, options.cwd || "")
+  return await new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: { ...process.env, ...options.env },
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    let stdout = ""
+    let stderr = ""
+    let settled = false
+    const timer = options.timeout
+      ? setTimeout(() => {
+          settled = true
+          child.kill("SIGTERM")
+        }, options.timeout)
+      : undefined
+    child.stdout?.setEncoding("utf8")
+    child.stderr?.setEncoding("utf8")
+    child.stdout?.on("data", chunk => stdout += chunk)
+    child.stderr?.on("data", chunk => stderr += chunk)
+    child.on("error", error => {
+      if (timer) clearTimeout(timer)
+      resolve({ args, command, exitCode: 127, stderr: error instanceof Error ? error.message : String(error), stdout })
+    })
+    child.on("close", (code, signal) => {
+      if (timer) clearTimeout(timer)
+      resolve({
+        args,
+        command,
+        exitCode: settled ? 124 : code ?? 1,
+        stderr: settled ? `${stderr}${stderr ? "\n" : ""}Command timed out${signal ? ` (${signal})` : ""}` : stderr,
+        stdout,
+      })
+    })
+  })
+}
+
+export async function createTrustedHostWorkspaceSession(
+  _definition: WorkspaceDefinition,
+  workspace: Workspace,
+): Promise<WorkspaceSession> {
+  assertTrustedHostWorkspaceRuntimeAllowed()
+  const root = await mkdtemp(join(tmpdir(), `vitehub-workspace-${workspace.name}-`))
+  let baseline = await materializeWorkspace(workspace, root)
+  const mediaTypes = new Map<string, string>()
+  let closed = false
+
+  function assertOpen() {
+    if (closed)
+      throw new WorkspaceError("[vitehub] Workspace trusted-host session is already closed.")
+  }
+
+  async function currentDiff() {
+    assertOpen()
+    return diffSnapshots(baseline, await snapshotLocal(root))
+  }
+
+  return {
+    async readFile<TOptions extends ReadFileOptions | undefined = undefined>(path: string, options?: TOptions): Promise<ReadFileResult<TOptions>> {
+      assertOpen()
+      const file = await readLocalFile(root, normalizeLocalWorkspacePath(path))
+      if (!file) throw new WorkspaceError(`[vitehub] Workspace file does not exist: ${path}.`)
+      return decodeFile(file.content, options)
+    },
+    async writeFile(path: string, content: WorkspaceContent, options?: WriteFileOptions) {
+      assertOpen()
+      const workspacePath = normalizeLocalWorkspacePath(path)
+      const target = toLocalPath(root, workspacePath)
+      await mkdir(dirname(target), { recursive: true })
+      await writeFile(target, content)
+      if (options?.mediaType)
+        mediaTypes.set(workspacePath, options.mediaType)
+      else
+        mediaTypes.delete(workspacePath)
+    },
+    async mkdir(path: string, options = {}) {
+      assertOpen()
+      await mkdir(toLocalPath(root, path), { recursive: options.recursive })
+    },
+    async rm(path: string, options?: RmOptions) {
+      assertOpen()
+      const workspacePath = normalizeLocalWorkspacePath(path)
+      await rm(toLocalPath(root, workspacePath), { force: options?.force, recursive: options?.recursive })
+      mediaTypes.delete(workspacePath)
+    },
+    async list(path = "", options = {}) {
+      assertOpen()
+      return await listLocalEntries(root, path, options.recursive)
+    },
+    async glob(pattern, _options = {}) {
+      assertOpen()
+      const patterns = Array.isArray(pattern) ? pattern : [pattern]
+      return (await listLocalEntries(root, "", true))
+        .filter(entry => entry.type === "file" && patterns.some(item => matchesAny(entry.path, item)))
+    },
+    async search(query) {
+      assertOpen()
+      const { searchText } = await import("../core/search.ts")
+      const searchRoots = [...new Set((query.paths?.length ? query.paths : [query.cwd || ""]).map(path => normalizeLocalWorkspacePath(path, { allowEmpty: true })))]
+      const scopedSearchRoots = searchRoots.filter(Boolean)
+      const limit = query.limit ?? 100
+      const hits: WorkspaceSearchHit[] = []
+      for (const entry of (await listLocalEntries(root, "", true)).filter(item => item.type === "file")) {
+        if (scopedSearchRoots.length && !scopedSearchRoots.some(path => entry.path === path || entry.path.startsWith(`${path}/`))) continue
+        const text = await readFile(toLocalPath(root, entry.path), "utf8")
+        hits.push(...searchText(entry.path, text, { ...query, limit: limit - hits.length }))
+        if (hits.length >= limit) break
+      }
+      return hits
+    },
+    async diff() {
+      return await currentDiff()
+    },
+    async commit(options) {
+      const diff = await currentDiff()
+      await commitLocalChanges(root, workspace, diff, mediaTypes)
+      baseline = await snapshotLocal(root, options?.message || "local-commit")
+    },
+    async exec(command, args = [], options = {}) {
+      assertOpen()
+      return await execLocal(root, command, args, options)
+    },
+    async close() {
+      if (closed) return
+      closed = true
+      await rm(root, { force: true, recursive: true })
+    },
+  }
+}

--- a/packages/workspace/test/sandbox-runtime.test.ts
+++ b/packages/workspace/test/sandbox-runtime.test.ts
@@ -433,6 +433,6 @@ describe("sandbox workspace runtime", () => {
     expect(session.exec).toBeTypeOf("function")
     expect(session.commit).toBeTypeOf("function")
     expect(session.close).toBeTypeOf("function")
-    await expect(session.exec("pnpm", ["test"])).rejects.toThrow("runtime")
+    await expect(session.exec("pnpm", ["test"])).rejects.toThrow("Workspace exec is sandbox-only today")
   })
 })

--- a/packages/workspace/test/sandbox-runtime.test.ts
+++ b/packages/workspace/test/sandbox-runtime.test.ts
@@ -433,6 +433,6 @@ describe("sandbox workspace runtime", () => {
     expect(session.exec).toBeTypeOf("function")
     expect(session.commit).toBeTypeOf("function")
     expect(session.close).toBeTypeOf("function")
-    await expect(session.exec("pnpm", ["test"])).rejects.toThrow("Workspace exec is sandbox-only today")
+    await expect(session.exec("pnpm", ["test"])).rejects.toThrow("Workspace exec requires an executable runtime")
   })
 })

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { defineWorkspace } from "../src/index.ts"
+import { createWorkspace } from "../src/core/workspace.ts"
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe("trusted host workspace runtime", () => {
+  it("runs commands in a trusted local workspace session and commits changes", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    await workspace.writeFile("README.md", "# Docs\n")
+
+    const session = await workspace.startSession()
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "require('node:fs').mkdirSync('generated', { recursive: true }); require('node:fs').writeFileSync('generated/result.txt', 'done\\n')",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect((await session.diff()).entries).toEqual([
+      expect.objectContaining({ path: "generated", type: "added" }),
+      expect.objectContaining({ path: "generated/result.txt", type: "added" }),
+    ])
+
+    await session.commit()
+    await session.close()
+
+    await expect(workspace.readFile("generated/result.txt")).resolves.toBe("done\n")
+  })
+
+  it("scopes command cwd inside the materialized workspace", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    await workspace.writeFile("docs/input.txt", "scoped\n")
+
+    const session = await workspace.startSession()
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "process.stdout.write(require('node:fs').readFileSync('input.txt', 'utf8'))",
+    ], { cwd: "./docs/" })
+
+    expect(result).toMatchObject({ exitCode: 0, stdout: "scoped\n" })
+    await session.close()
+  })
+
+  it("rejects local workspace sessions in production", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+
+    await expect(workspace.startSession()).rejects.toThrow("only available outside production")
+  })
+})

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { defineWorkspace } from "../src/index.ts"
+import { defineWorkspace, fetch as fetchSource } from "../src/index.ts"
 import { createWorkspace } from "../src/core/workspace.ts"
 
 afterEach(() => {
@@ -53,6 +53,95 @@ describe("trusted host workspace runtime", () => {
     ], { cwd: "./docs/" })
 
     expect(result).toMatchObject({ exitCode: 0, stdout: "scoped\n" })
+    await session.close()
+  })
+
+  it("accepts sandbox-style workspace cwd paths", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    await workspace.writeFile("docs/input.txt", "scoped\n")
+
+    const session = await workspace.startSession()
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "process.stdout.write(require('node:fs').readFileSync('input.txt', 'utf8'))",
+    ], { cwd: "/workspace/docs" })
+
+    expect(result).toMatchObject({ exitCode: 0, stdout: "scoped\n" })
+    await session.close()
+  })
+
+  it("hard-stops commands that ignore SIGTERM after timeout", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+
+    const session = await workspace.startSession()
+    const startedAt = Date.now()
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)",
+    ], { timeout: 20 })
+
+    expect(result.exitCode).toBe(124)
+    expect(result.stderr).toContain("Command timed out")
+    expect(Date.now() - startedAt).toBeLessThan(2000)
+    await session.close()
+  })
+
+  it("materializes generated source descriptors for shell inspection", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        sources: {
+          inventory: fetchSource({ url: "https://api.example.com/inventory" }),
+        },
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+
+    const session = await workspace.startSession()
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "process.stdout.write(require('node:fs').readFileSync('.vitehub/sources/inventory.json', 'utf8'))",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      sourceKey: "inventory",
+      url: "https://api.example.com/inventory",
+    })
+    await expect(session.writeFile(".vitehub/sources/inventory.json", "{}")).rejects.toThrow()
+    await session.close()
+  })
+
+  it("sanitizes nested workspace names in temporary directory prefixes", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "emails/welcome",
+    })
+    await workspace.writeFile("README.md", "# Welcome\n")
+
+    const session = await workspace.startSession()
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "process.stdout.write(require('node:fs').readFileSync('README.md', 'utf8'))",
+    ])
+
+    expect(result).toMatchObject({ exitCode: 0, stdout: "# Welcome\n" })
     await session.close()
   })
 

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -1,7 +1,13 @@
+import { readdir } from "node:fs/promises"
+import { tmpdir } from "node:os"
+
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { defineWorkspace, fetch as fetchSource } from "../src/index.ts"
 import { createWorkspace } from "../src/core/workspace.ts"
+import { createTrustedHostWorkspaceSession } from "../src/session/trusted-host.ts"
+
+import type { Workspace } from "../src/core/types.ts"
 
 afterEach(() => {
   vi.unstubAllEnvs()
@@ -113,8 +119,8 @@ describe("trusted host workspace runtime", () => {
     const session = await workspace.startSession()
     const result = await session.exec(process.execPath, [
       "-e",
-      "process.stdout.write(require('node:fs').readFileSync('.vitehub/sources/inventory.json', 'utf8'))",
-    ])
+      "process.stdout.write(require('node:fs').readFileSync('inventory.json', 'utf8'))",
+    ], { cwd: "/workspace/.vitehub/sources" })
 
     expect(result.exitCode).toBe(0)
     expect(JSON.parse(result.stdout)).toMatchObject({
@@ -123,6 +129,50 @@ describe("trusted host workspace runtime", () => {
     })
     await expect(session.writeFile(".vitehub/sources/inventory.json", "{}")).rejects.toThrow()
     await session.close()
+  })
+
+  it("ignores git metadata when committing host session changes", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+
+    const session = await workspace.startSession()
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "const fs = require('node:fs'); fs.mkdirSync('.git', { recursive: true }); fs.writeFileSync('.git/config', 'ignored\\n'); fs.writeFileSync('tracked.txt', 'kept\\n')",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect((await session.diff()).entries).toEqual([
+      expect.objectContaining({ path: "tracked.txt", type: "added" }),
+    ])
+    await session.commit()
+    await session.close()
+
+    await expect(workspace.readFile("tracked.txt")).resolves.toBe("kept\n")
+  })
+
+  it("removes the temporary root when materialization fails", async () => {
+    const name = `cleanup-${Date.now()}`
+    const before = new Set(await readdir(tmpdir()))
+    const workspace = {
+      name,
+      async list() {
+        return [{ path: "seed.txt", type: "file" as const }]
+      },
+      async readFile() {
+        throw new Error("source failed")
+      },
+    } as unknown as Workspace
+
+    await expect(createTrustedHostWorkspaceSession({ name } as never, workspace)).rejects.toThrow("source failed")
+    const leaked = (await readdir(tmpdir()))
+      .filter(entry => entry.startsWith(`vitehub-workspace-${name}-`) && !before.has(entry))
+    expect(leaked).toEqual([])
   })
 
   it("sanitizes nested workspace names in temporary directory prefixes", async () => {

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -84,6 +84,9 @@ describe("workspace types", () => {
         rules: { "/docs/**": { write: "update" } },
       } satisfies WorkspacePlugin],
     })
+    defineWorkspace({
+      runtime: "trusted-host",
+    })
     file({
       workspacePath: "AGENTS.md",
       content: "# Instructions\n",


### PR DESCRIPTION
Adds a `runtime: "trusted-host"` Workspace Definition opt-in for local development and tests. Trusted-host sessions materialize the Workspace into a temporary host directory, run `session.exec()` there, and commit changes back through the normal Workspace Runtime Surface. The runtime is rejected when `NODE_ENV=production`; hosted or untrusted executable workspaces should keep using `runtime: "sandbox"`.

This also keeps the clearer unsupported-runtime diagnostic, documents the runtime choice, records the Workspace Package boundary in `.agents`, and lazy-loads the Cloudflare sandbox SDK so the optional provider package is only needed when Cloudflare sandbox execution is used.

Closes #359