### PR TITLE
fix(agent): suppress dev-loop channel delivery effects

### DIFF
--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -573,6 +573,13 @@ async function sendDevMessage(
         if (usage) context.stderr.write(`\n[usage] ${usage}\n`)
         continue
       }
+      if (event.type === "delivery-preview") {
+        context.stderr.write(`\n[delivery preview] would ${event.effect.kind}${event.channelId ? ` on ${event.channelId}` : ""}\n`)
+        writeDevPayload(context, "intent", event.effect.intent)
+        writeDevPayload(context, "payload", event.effect.payload)
+        writeDevPayload(context, "metadata", event.effect.metadata)
+        continue
+      }
       if (event.type === "approval-request") {
         context.stderr.write(`\n[approval required] ${event.name}${event.reason ? `: ${event.reason}` : ""}\n`)
         needsApproval = true

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -1,4 +1,5 @@
 import type { StreamEvent } from "./messages.ts"
+import type { AgentChannelDeliveryEffectIntent, AgentRunMetadata } from "./types.ts"
 
 export const agentInvocationStreamRoute = "/__vitehub/agent/invocation-stream"
 export const agentInvocationStreamHeader = "x-vitehub-agent-dev-loop"
@@ -6,6 +7,7 @@ export const agentInvocationStreamHeaderValue = "1"
 
 export type AgentInvocationStreamEvent =
   | StreamEvent
+  | { channelId?: string, effect: AgentChannelDeliveryEffectIntent, run?: AgentRunMetadata, type: "delivery-preview" }
   | { agent: string, run?: unknown, trigger?: string, type: "start" }
   | { type: "done" }
 

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -6,6 +6,7 @@ import { setWorkspaceRuntimeRegistry } from "@vite-hub/workspace/internal/runtim
 
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, createAgentInvocationStreamResponse } from "../invocation-stream.ts"
 import { streamAgentOutputToEvents } from "../agent-output.ts"
+import { channelDeliveryEffectsContextKey, channelDeliveryFinishEffectsContextKey } from "../capability-runtime.ts"
 import { uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { discoverAgentDefinitions } from "../discovery.ts"
 import { isResolvedAgentTriggerHandledInvocation, resolveAgentTriggerInvocation, resolveAgentTriggers, streamAgent, withAgentDefaults } from "../index.ts"
@@ -69,9 +70,10 @@ function withDevContext<CALL_OPTIONS>(
   input: AgentRunInput<CALL_OPTIONS>,
   context: Record<string, unknown> | undefined,
 ): AgentRunInput<CALL_OPTIONS> {
-  if (!context) return input
   const mergedContext: Record<string, unknown> = { ...input.context, ...context }
-  if (context.actor !== undefined && context.invoker === undefined) {
+  delete mergedContext[channelDeliveryEffectsContextKey]
+  delete mergedContext[channelDeliveryFinishEffectsContextKey]
+  if (context?.actor !== undefined && context.invoker === undefined) {
     mergedContext.invoker = context.actor
   }
   return { ...input, context: mergedContext as AgentRunInput<CALL_OPTIONS>["context"] }

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -79,6 +79,12 @@ function withDevContext<CALL_OPTIONS>(
   return { ...input, context: mergedContext as AgentRunInput<CALL_OPTIONS>["context"] }
 }
 
+function withoutDeliveryChannels(agent: AgentInput<ViteAgentDevRuntimeContext>): AgentInput<ViteAgentDevRuntimeContext> {
+  return isRecord(agent) && "channels" in agent
+    ? { ...agent, channels: undefined } as AgentInput<ViteAgentDevRuntimeContext>
+    : agent
+}
+
 function headersFromNode(headers: IncomingHttpHeaders): Headers {
   const result = new Headers()
   for (const [name, value] of Object.entries(headers)) {
@@ -309,7 +315,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
       }
       else {
         if (!signal.aborted) emit({ agent: entry.name, run: invocation.run, trigger: invocation.trigger.id, type: "start" })
-        output = await streamAgent(entry.agent as never, { ...context, ...(invocation.run ? { run: invocation.run } : {}) } as never, withDevContext(invocation.input, devContext) as never, {
+        output = await streamAgent(withoutDeliveryChannels(entry.agent) as never, { ...context, ...(invocation.run ? { run: invocation.run } : {}) } as never, withDevContext(invocation.input, devContext) as never, {
           output: "events",
         })
       }
@@ -317,7 +323,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
     else {
       const messages = messagesFromBody(body)
       if (!signal.aborted) emit({ agent: entry.name, run, type: "start" })
-      output = await streamAgent(entry.agent as never, context as never, {
+      output = await streamAgent(withoutDeliveryChannels(entry.agent) as never, context as never, {
         abortSignal: signal,
         ...(devContext || typeof body.invokerProfileId === "string"
           ? { context: { ...devContext, ...(typeof body.invokerProfileId === "string" ? { invokerProfileId: body.invokerProfileId } : {}) } }

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -6,7 +6,6 @@ import { setWorkspaceRuntimeRegistry } from "@vite-hub/workspace/internal/runtim
 
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, createAgentInvocationStreamResponse } from "../invocation-stream.ts"
 import { streamAgentOutputToEvents } from "../agent-output.ts"
-import { channelDeliveryEffectsContextKey, channelDeliveryFinishEffectsContextKey } from "../capability-runtime.ts"
 import { uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { discoverAgentDefinitions } from "../discovery.ts"
 import { isResolvedAgentTriggerHandledInvocation, resolveAgentTriggerInvocation, resolveAgentTriggers, streamAgent, withAgentDefaults } from "../index.ts"
@@ -15,7 +14,9 @@ import { createAgentRuntimeContext } from "../runtime/context.ts"
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http"
 import type { ViteDevServer } from "vite"
 import type { AgentChatMessageTriggerInput } from "../chat-trigger.ts"
+import type { AgentInvocationStreamEvent } from "../invocation-stream.ts"
 import type {
+  AgentChannelDeliveryEffectContext,
   AgentInput,
   AgentRunInput,
   AgentRunMetadata,
@@ -71,18 +72,30 @@ function withDevContext<CALL_OPTIONS>(
   context: Record<string, unknown> | undefined,
 ): AgentRunInput<CALL_OPTIONS> {
   const mergedContext: Record<string, unknown> = { ...input.context, ...context }
-  delete mergedContext[channelDeliveryEffectsContextKey]
-  delete mergedContext[channelDeliveryFinishEffectsContextKey]
   if (context?.actor !== undefined && context.invoker === undefined) {
     mergedContext.invoker = context.actor
   }
   return { ...input, context: mergedContext as AgentRunInput<CALL_OPTIONS>["context"] }
 }
 
-function withoutDeliveryChannels(agent: AgentInput<ViteAgentDevRuntimeContext>): AgentInput<ViteAgentDevRuntimeContext> {
-  return isRecord(agent) && "channels" in agent
-    ? { ...agent, channels: undefined } as AgentInput<ViteAgentDevRuntimeContext>
-    : agent
+function withDeliveryPreviewChannels(
+  agent: AgentInput<ViteAgentDevRuntimeContext>,
+  preview: (event: Extract<AgentInvocationStreamEvent, { type: "delivery-preview" }>) => void,
+): AgentInput<ViteAgentDevRuntimeContext> {
+  if (!isRecord(agent) || !isRecord(agent.channels)) return agent
+  const channels = Object.fromEntries(Object.entries(agent.channels).map(([channelId, channel]) => {
+    if (!isRecord(channel) || !isRecord(channel.effects)) return [channelId, channel]
+    const effects = Object.fromEntries(Object.keys(channel.effects).map(kind => [kind, (context: AgentChannelDeliveryEffectContext<ViteAgentDevRuntimeConfig>) => {
+      preview({
+        channelId: context.trigger?.channelId || context.run?.channelId || channelId,
+        effect: context.effect,
+        ...(context.run ? { run: context.run } : {}),
+        type: "delivery-preview",
+      })
+    }]))
+    return [channelId, { ...channel, effects }]
+  }))
+  return { ...agent, channels } as AgentInput<ViteAgentDevRuntimeContext>
 }
 
 function headersFromNode(headers: IncomingHttpHeaders): Headers {
@@ -315,7 +328,10 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
       }
       else {
         if (!signal.aborted) emit({ agent: entry.name, run: invocation.run, trigger: invocation.trigger.id, type: "start" })
-        output = await streamAgent(withoutDeliveryChannels(entry.agent) as never, { ...context, ...(invocation.run ? { run: invocation.run } : {}) } as never, withDevContext(invocation.input, devContext) as never, {
+        const previewAgent = withDeliveryPreviewChannels(entry.agent, event => {
+          if (!signal.aborted) emit(event)
+        })
+        output = await streamAgent(previewAgent as never, { ...context, ...(invocation.run ? { run: invocation.run } : {}) } as never, withDevContext(invocation.input, devContext) as never, {
           output: "events",
         })
       }
@@ -323,7 +339,10 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
     else {
       const messages = messagesFromBody(body)
       if (!signal.aborted) emit({ agent: entry.name, run, type: "start" })
-      output = await streamAgent(withoutDeliveryChannels(entry.agent) as never, context as never, {
+      const previewAgent = withDeliveryPreviewChannels(entry.agent, event => {
+        if (!signal.aborted) emit(event)
+      })
+      output = await streamAgent(previewAgent as never, context as never, {
         abortSignal: signal,
         ...(devContext || typeof body.invokerProfileId === "string"
           ? { context: { ...devContext, ...(typeof body.invokerProfileId === "string" ? { invokerProfileId: body.invokerProfileId } : {}) } }

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -252,6 +252,38 @@ describe("agent CLI", () => {
     expect(stderr.output().match(/\[tool\] shell/g)).toHaveLength(1)
   })
 
+  it("renders Agent Dev Loop delivery previews", async () => {
+    const stderr = stream()
+    const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return ndjson([
+          { agent: "review", trigger: "github.webhook", type: "start" },
+          { text: "summary", type: "text-delta" },
+          { channelId: "github", effect: { kind: "reply", payload: "summary" }, type: "delivery-preview" },
+          { type: "finish" },
+          { type: "done" },
+        ])
+      }
+      return Response.json({
+        agents: [{ name: "review", triggers: ["github.webhook"] }],
+        root: "/repo",
+      })
+    })
+
+    const exitCode = await runAgentDevCli(["--agent", "review", "--trigger", "github.webhook", "--input", "{}"], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      spawn: vi.fn(),
+      stderr,
+      stdout: stream(),
+    }, { fetch: fetchAgentStream as never })
+
+    expect(exitCode).toBe(0)
+    expect(stderr.output()).toContain("[delivery preview] would reply on github")
+    expect(stderr.output()).toContain("payload: summary")
+  })
+
   it("runs Evalite through the Node runner with ViteHub defaults", async () => {
     const runner = vi.fn(async () => ({ exitCode: undefined }))
     const exitCode = await runAgentEvalCli(["server/agents/support.eval.ts"], {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -613,6 +613,67 @@ describe("agent chat capability discovery", () => {
     ])
   })
 
+  it("suppresses trigger Channel Delivery Effects for Agent Dev Loop channel invocations", async () => {
+    const root = await createTempRoot("vitehub-agent-invocation-stream-effects-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "review.ts"), "export default {}", "utf8")
+
+    const { defineChannel } = await import("../src/channels.ts")
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const effect = vi.fn()
+    const agent = defineAgent({
+      channels: {
+        github: defineChannel("github", {
+          effects: { reply: effect },
+          messages: false,
+          triggers: {
+            webhook: {
+              invoke: context => ({
+                delivery: {
+                  finishEffects: () => ({ kind: "reply", payload: "finished" }),
+                },
+                input: { prompt: "review" },
+                run: { channelId: context.trigger.channelId, origin: "github", runId: "github-run" },
+              }),
+            },
+          },
+        }),
+      },
+      run: () => "Review completed.",
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "github.webhook", {})).resolves.toBe("Review completed.")
+    expect(effect).toHaveBeenCalledOnce()
+    effect.mockClear()
+
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
+
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      agent: "review",
+      input: {},
+      trigger: "github.webhook",
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    })
+    const events = response.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+
+    expect(events).toEqual([
+      expect.objectContaining({ agent: "review", trigger: "github.webhook", type: "start" }),
+      { text: "Review completed.", type: "text-delta" },
+      { type: "finish" },
+      { type: "done" },
+    ])
+    expect(effect).not.toHaveBeenCalled()
+  })
+
   it("serves plain Agent Definitions from the Agent Invocation Stream endpoint", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-plain-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -619,13 +619,23 @@ describe("agent chat capability discovery", () => {
     await writeFile(join(root, "server", "agents", "review.ts"), "export default {}", "utf8")
 
     const { defineChannel } = await import("../src/channels.ts")
-    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
-    const effect = vi.fn()
+    const reactionEffect = vi.fn()
+    const replyEffect = vi.fn()
     const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "review-output",
+          prepare: context => {
+            context.delivery.effect({ kind: "reaction", payload: "queued" })
+            context.delivery.finishEffect(() => ({ kind: "reply", payload: "capability-finished" }))
+          },
+        }),
+      ],
       channels: {
         github: defineChannel("github", {
-          effects: { reply: effect },
+          effects: { reaction: reactionEffect, reply: replyEffect },
           messages: false,
           triggers: {
             webhook: {
@@ -644,8 +654,10 @@ describe("agent chat capability discovery", () => {
     })
 
     await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "github.webhook", {})).resolves.toBe("Review completed.")
-    expect(effect).toHaveBeenCalledOnce()
-    effect.mockClear()
+    expect(reactionEffect).toHaveBeenCalledOnce()
+    expect(replyEffect).toHaveBeenCalledTimes(2)
+    reactionEffect.mockClear()
+    replyEffect.mockClear()
 
     const { handlers, server } = createFakeServer(root, { default: agent })
     const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
@@ -671,7 +683,8 @@ describe("agent chat capability discovery", () => {
       { type: "finish" },
       { type: "done" },
     ])
-    expect(effect).not.toHaveBeenCalled()
+    expect(reactionEffect).not.toHaveBeenCalled()
+    expect(replyEffect).not.toHaveBeenCalled()
   })
 
   it("serves plain Agent Definitions from the Agent Invocation Stream endpoint", async () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -613,7 +613,7 @@ describe("agent chat capability discovery", () => {
     ])
   })
 
-  it("suppresses trigger Channel Delivery Effects for Agent Dev Loop channel invocations", async () => {
+  it("previews trigger Channel Delivery Effects for Agent Dev Loop channel invocations", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-effects-")
     await mkdir(join(root, "server", "agents"), { recursive: true })
     await writeFile(join(root, "server", "agents", "review.ts"), "export default {}", "utf8")
@@ -677,12 +677,15 @@ describe("agent chat capability discovery", () => {
       .split("\n")
       .map(line => JSON.parse(line))
 
-    expect(events).toEqual([
+    expect(events).toEqual(expect.arrayContaining([
       expect.objectContaining({ agent: "review", trigger: "github.webhook", type: "start" }),
+      expect.objectContaining({ channelId: "github", effect: { kind: "reaction", payload: "queued" }, type: "delivery-preview" }),
+      expect.objectContaining({ channelId: "github", effect: { kind: "reply", payload: "finished" }, type: "delivery-preview" }),
+      expect.objectContaining({ channelId: "github", effect: { kind: "reply", payload: "capability-finished" }, type: "delivery-preview" }),
       { text: "Review completed.", type: "text-delta" },
       { type: "finish" },
       { type: "done" },
-    ])
+    ]))
     expect(reactionEffect).not.toHaveBeenCalled()
     expect(replyEffect).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
Strips trigger-provided channel delivery effect context from Agent Dev Loop invocations before they call `streamAgent`, so local dev-loop replays can run the Agent without posting channel replies or other delivery effects.

Normal trigger/webhook runtime behavior is unchanged because the suppression lives only in the Agent Invocation Stream endpoint.