### PR TITLE
feat(agent): add capability output extensions

### DIFF
--- a/docs/content/docs/capabilities/usage-telemetry.md
+++ b/docs/content/docs/capabilities/usage-telemetry.md
@@ -19,6 +19,7 @@ Use the configuration example below as the starting point, then tighten modes, p
 
 The Capability wraps compatible streams and output results.
 It emits `usage` stream events when a finish chunk contains usage, attaches `usage` and `usageRecord` to final results, and calls an optional `onUsage` callback.
+Later output renderers can read `context.output.extensions.get('usage-telemetry')` for `{ usageRecord, summary }`.
 
 ## Configuration
 

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -279,6 +279,7 @@ export type {
   UsageTelemetryCallback,
   UsageTelemetryContext,
   UsageTelemetryOptions,
+  UsageTelemetryOutputExtension,
   UsageTelemetrySummaryFormatContext,
   UsageTelemetrySummaryFormatter,
   UsageTelemetrySummaryOptions,

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -9,6 +9,7 @@ import {
 import type {
   AgentCapabilityDefinition,
   AgentFinishEvent,
+  AgentOutputExtensionEvent,
   AgentRunMetadata,
   AgentUsage,
   AgentUsageCost,
@@ -44,6 +45,11 @@ export interface UsageTelemetryOptions {
 export interface UsageTelemetrySummaryOptions {
   format?: UsageTelemetrySummaryFormatter
   subject?: string
+}
+
+export interface UsageTelemetryOutputExtension {
+  summary?: string
+  usageRecord: AgentUsageRecord
 }
 
 export interface UsageTelemetrySummaryFormatContext {
@@ -316,6 +322,19 @@ async function usageRecordForFinish(
   return summary ? { ...withDuration, summary } : withDuration
 }
 
+async function usageRecordForOutput(
+  record: AgentUsageRecord,
+  options: UsageTelemetryOptions,
+): Promise<UsageTelemetryOutputExtension> {
+  const summaryOptions = normalizeUsageSummaryOptions(options.summary)
+  if (!summaryOptions) return { usageRecord: record }
+  const summary = await formatUsageSummary(record, summaryOptions)
+  return {
+    ...(summary ? { summary } : {}),
+    usageRecord: record,
+  }
+}
+
 async function recordUsage(
   result: UnknownRecord,
   options: UsageTelemetryOptions,
@@ -413,11 +432,18 @@ export function usageTelemetry(options: UsageTelemetryOptions = {}): AgentCapabi
       context.finish.provide((event: AgentFinishEvent) => usageRecordForFinish(isRecord(event.result)
         ? event.result.usageRecord
         : undefined, event, options))
-      context.output.render(async (result) => {
+      context.output.provide(async (event: AgentOutputExtensionEvent) => {
+        if (!isRecord(event.result) || hasUsageTelemetryStream(event.result)) return
+        const usageRecord = isRecord(event.result.usageRecord)
+          ? event.result.usageRecord as AgentUsageRecord
+          : await recordUsage(event.result, options, context.run)
+        return usageRecord ? await usageRecordForOutput(usageRecord, options) : undefined
+      })
+      context.output.render(async (result, renderContext) => {
         if (isAsyncIterable(result)) return withUsageTelemetryStream(result, options, context.run)
         if (!isRecord(result)) return result
         if (hasUsageTelemetryStream(result)) return cloneWithUsageTelemetryStream(result, options, context.run)
-        const usageRecord = await recordUsage(result, options, context.run)
+        const usageRecord = renderContext.output.extensions.get<UsageTelemetryOutputExtension>("usage-telemetry")?.usageRecord
         if (!usageRecord) return result
         return {
           ...result,

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -25,6 +25,8 @@ import type {
   AgentFinishExtensionProvider,
   AgentHookObserverHooks,
   AgentInstructionBlock,
+  AgentInvocationExtensions,
+  AgentOutputExtensionProvider,
   AgentInvocationContextStore,
   AgentInvoker,
   AgentModelResolver,
@@ -42,7 +44,9 @@ import type { WorkspaceOverrideRuntime } from "./access-runtime.ts"
 import type { Message } from "./messages.ts"
 import type { ReadonlyWorkspaceFacade, WorkspaceDefinition, WorkspaceName } from "@vite-hub/workspace"
 
-type ResolvedAgentOutputRenderer = (result: unknown) => MaybePromise<unknown>
+type ResolvedAgentOutputRenderer = ((result: unknown, extensions?: AgentInvocationExtensions) => MaybePromise<unknown>) & {
+  providerCount: number
+}
 const defaultCapabilityRuntimePhases = ["configure", "prepare", "bind", "input", "resolve", "output"] as const
 export const channelDeliveryEffectsContextKey = "channel.delivery.effects"
 export const channelDeliveryFinishEffectsContextKey = "channel.delivery.finishEffects"
@@ -53,10 +57,16 @@ export interface ResolvedAgentFinishExtensionProvider {
   resolve: AgentFinishExtensionProvider
 }
 
+export interface ResolvedAgentOutputExtensionProvider {
+  id: string
+  resolve: AgentOutputExtensionProvider
+}
+
 export interface AgentCapabilityRegistries {
   deliveryEffectIntents: AgentChannelDeliveryEffectIntent[]
   finishDeliveryEffectProviders: AgentChannelDeliveryFinishEffect[]
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
+  outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
   outputRenderers: ResolvedAgentOutputRenderer[]
   providerTools: AgentProviderToolContribution[]
   stateRequirements: Array<{ name: string, optional?: boolean }>
@@ -275,6 +285,7 @@ export async function resolveAgentCapabilities<
     deliveryEffectIntents: [...initialDeliveryEffectIntents],
     finishDeliveryEffectProviders: [...initialFinishDeliveryEffectProviders],
     finishExtensionProviders: [],
+    outputExtensionProviders: [],
     outputRenderers: [],
     providerTools: [],
     stateRequirements: [],
@@ -364,8 +375,25 @@ export async function resolveAgentCapabilities<
           },
         },
         output: {
+          extensions: createAgentExtensionReader(new Map()),
+          provide(value) {
+            registries.outputExtensionProviders.push({
+              id: capability.id,
+              resolve: typeof value === "function"
+                ? value as AgentOutputExtensionProvider
+                : () => value,
+            })
+          },
           render(renderer: AgentOutputRenderer) {
-            registries.outputRenderers.push(result => renderer(result, capabilityContext))
+            const resolved = ((result: unknown, extensions = createAgentExtensionReader(new Map())) => renderer(result, {
+              ...capabilityContext,
+              output: {
+                ...capabilityContext.output,
+                extensions,
+              },
+            })) as ResolvedAgentOutputRenderer
+            resolved.providerCount = registries.outputExtensionProviders.length
+            registries.outputRenderers.push(resolved)
           },
         },
         providerTools: {
@@ -602,20 +630,25 @@ export async function applyCapabilityToolTransforms(
 export async function applyOutputRenderers(
   result: unknown,
   renderers: ResolvedAgentOutputRenderer[] = [],
+  providers: ResolvedAgentOutputExtensionProvider[] = [],
 ): Promise<unknown> {
   let current = result
+  let providerIndex = 0
+  const values = new Map<string, unknown>()
+  const extensions = createAgentExtensionReader(values)
   for (const renderer of renderers) {
-    current = await renderer(current)
+    while (providerIndex < renderer.providerCount) {
+      const provider = providers[providerIndex++]
+      const value = await provider.resolve({ extensions, result: current })
+      if (value !== undefined) values.set(provider.id, value)
+    }
+    current = await renderer(current, extensions)
   }
   return current
 }
 
-export async function createAgentInvocationExtensions(
-  event: Omit<AgentFinishEvent, "extensions">,
-  providers: ResolvedAgentFinishExtensionProvider[] = [],
-): Promise<AgentFinishEvent["extensions"]> {
-  const values = new Map<string, unknown>()
-  const extensions: AgentFinishEvent["extensions"] = {
+function createAgentExtensionReader(values: Map<string, unknown>): AgentInvocationExtensions {
+  return {
     get<T = unknown>(capabilityId: string, key?: string): T | undefined {
       const value = values.get(capabilityId)
       if (key === undefined) return value as T | undefined
@@ -623,6 +656,14 @@ export async function createAgentInvocationExtensions(
       return (value as Record<string, unknown>)[key] as T | undefined
     },
   }
+}
+
+export async function createAgentInvocationExtensions(
+  event: Omit<AgentFinishEvent, "extensions">,
+  providers: ResolvedAgentFinishExtensionProvider[] = [],
+): Promise<AgentFinishEvent["extensions"]> {
+  const values = new Map<string, unknown>()
+  const extensions = createAgentExtensionReader(values)
   const finishEvent = { ...event, extensions } as AgentFinishEvent
   for (const provider of providers) {
     const value = await provider.resolve(finishEvent)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -24,7 +24,7 @@ import {
   withCapabilityCleanup,
   withResponseCleanup,
 } from "./capability-runtime.ts"
-import type { ResolvedAgentFinishExtensionProvider } from "./capability-runtime.ts"
+import type { AgentCapabilityRegistries, ResolvedAgentFinishExtensionProvider, ResolvedAgentOutputExtensionProvider } from "./capability-runtime.ts"
 import { formatUnknownAgentMessage } from "./registry-error.ts"
 import { finalizeUiMessageStreamOutput, isUIMessageStreamResult } from "./stream-output.ts"
 import {
@@ -222,6 +222,8 @@ export type {
   AgentModelResolver,
   AgentModelInstrumentationContext,
   AgentModuleOptions,
+  AgentOutputExtensionEvent,
+  AgentOutputExtensionProvider,
   AgentProvidersOptions,
   AgentRegistryHandlerOptions,
   AgentRegistry,
@@ -1052,7 +1054,8 @@ type AgentInvocationContext<
   finishHook?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS> extends infer TEvent ? (event: TEvent) => MaybePromise<void> : never
   hasCapabilityCleanup: boolean
   hooks?: AgentHookObserverHooks
-  outputRenderers: Array<(result: unknown) => MaybePromise<unknown>>
+  outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
+  outputRenderers: AgentCapabilityRegistries["outputRenderers"]
   runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
   sourceInstructions?: string
   startedAt: number
@@ -1153,6 +1156,7 @@ async function createAgentInvocationContext<
       input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
       invoker,
       messages: capabilities.messages,
+      outputExtensionProviders: capabilities.registries.outputExtensionProviders,
       outputRenderers: capabilities.registries.outputRenderers,
       prompt: typeof capabilities.input.prompt === "string" ? capabilities.input.prompt : undefined,
       providerTools: capabilities.registries.providerTools,
@@ -1497,14 +1501,14 @@ export async function runAgentInline<
     }
     try {
       if (isAsyncIterable(result)) {
-        result = await applyOutputRenderers(result, runContext.outputRenderers)
+        result = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
       }
     }
     catch (error) {
       return await finishFailedAgentInvocation(runContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
     }
     return await finalizeAgentInvocationResult(runContext, result, async (result) => {
-      const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
+      const rendered = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
       return { finishResult: rendered, value: rendered }
     }, "[vitehub] Agent run failed and finish lifecycle also failed.", {
       wrapStream: stream => maybeTraceAgentStream(stream as AsyncIterable<StreamEvent>, runContext),
@@ -1526,7 +1530,7 @@ export async function runAgentInline<
     return await finishFailedAgentInvocation(adapterContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
   }
   return await finalizeAgentInvocationResult(adapterContext, result, async (result) => {
-    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
+    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders)
     const runResult = toAgentRunResult(rendered)
     return { finishResult: rendered, value: runResult }
   }, "[vitehub] Agent run failed and finish lifecycle also failed.")
@@ -1601,14 +1605,14 @@ export async function streamAgentInline<
     }
     try {
       if (isAsyncIterable(result) && output !== "ui-message-stream") {
-        result = await applyOutputRenderers(result, runContext.outputRenderers)
+        result = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
       }
     }
     catch (error) {
       return await finishFailedAgentInvocation(runContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
     }
     return await finalizeAgentInvocationResult(runContext, result, async (result) => {
-      const rendered = await applyOutputRenderers(result, runContext.outputRenderers)
+      const rendered = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
       if (output === "ui-message-stream") {
         return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, runContext), shouldWrapInvocationOutput(runContext), error => finishAgentInvocation(runContext, error === undefined ? rendered : undefined, error))
       }
@@ -1644,14 +1648,14 @@ export async function streamAgentInline<
   }
   try {
     if (isAsyncIterable(result) && output !== "ui-message-stream") {
-      result = await applyOutputRenderers(result, adapterContext.outputRenderers)
+      result = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders)
     }
   }
   catch (error) {
     return await finishFailedAgentInvocation(adapterContext, error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
   }
   return await finalizeAgentInvocationResult(adapterContext, result, async (result) => {
-    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers)
+    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders)
     if (output === "ui-message-stream") {
       return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, adapterContext), shouldWrapInvocationOutput(adapterContext), error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error))
     }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -316,6 +316,11 @@ export interface AgentInvocationExtensions {
   get<T = unknown>(capabilityId: string, key: string): T | undefined
 }
 
+export interface AgentOutputExtensionEvent {
+  extensions: AgentInvocationExtensions
+  result: unknown
+}
+
 export interface AgentFinishEvent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -449,6 +454,7 @@ export type AgentOutputRenderer = (
   result: unknown,
   context: AgentCapabilityRuntimeContext,
 ) => MaybePromise<unknown>
+export type AgentOutputExtensionProvider = (event: AgentOutputExtensionEvent) => MaybePromise<unknown>
 export type AgentFinishExtensionProvider = (event: AgentFinishEvent) => MaybePromise<unknown>
 
 export interface AgentCapabilityStateRequirement {
@@ -483,6 +489,8 @@ export interface AgentCapabilityRuntimeContext<
     resolve: (model?: AgentModelResolver<TRuntimeConfig, Name>) => Promise<AgentModelInput>
   }
   output: {
+    extensions: AgentInvocationExtensions
+    provide: (value: unknown | AgentOutputExtensionProvider) => void
     render: (renderer: AgentOutputRenderer) => void
   }
   providerTools: {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2159,6 +2159,51 @@ describe("agent message protocol", () => {
     }
   })
 
+  it("exposes capability output extensions to later renderers by capability id", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "usage-note",
+          output(context) {
+            context.output.provide({ summary: "12 tokens", usageRecord: { id: "usage-1" } })
+          },
+        }),
+        defineCapability({
+          id: "summary-output",
+          output(context) {
+            context.output.render((result, renderContext) => {
+              const usage = renderContext.output.extensions.get<{ summary: string }>("usage-note")
+              const summary = renderContext.output.extensions.get<string>("usage-note", "summary")
+              const missing = renderContext.output.extensions.get("missing")
+              return `${result}:${usage?.summary}:${summary}:${String(missing)}`
+            })
+          },
+        }),
+      ],
+      run: () => "ok",
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok:12 tokens:12 tokens:undefined")
+  })
+
+  it("keeps one-argument output render callbacks working", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "legacy-render",
+          output(context) {
+            context.output.render(result => `${result}:rendered`)
+          },
+        }),
+      ],
+      run: () => "ok",
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok:rendered")
+  })
+
   it("runs stream finish hooks with rendered model-backed object results", async () => {
     vi.doMock("ai", () => ({
       jsonSchema: vi.fn(schema => schema),

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -6,10 +6,10 @@ import { defineChannel, github, http, stream, teams, telegram, webChat, type Git
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
-import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentUsageRecord } from "../src/index.ts"
+import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentUsageRecord } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
 import { file, github as githubSource } from "@vite-hub/workspace"
-import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatPlatformResolver, AgentChatRunContext, FetchCapabilityToolOptions, RepositoryHostClient, TranscriptionResult, UsageTelemetrySummaryOptions } from "../src/capabilities.ts"
+import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatPlatformResolver, AgentChatRunContext, FetchCapabilityToolOptions, RepositoryHostClient, TranscriptionResult, UsageTelemetryOutputExtension, UsageTelemetrySummaryOptions } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
   it("accepts capabilities from the capabilities entry", () => {
@@ -265,6 +265,27 @@ describe("agent public types", () => {
           context.finish.provide("ok")
           // @ts-expect-error finish extensions are registered through context.finish
           context.extensions.provide("agent:finish", "ok")
+        },
+      }],
+      model: {} as never,
+    })
+
+    defineAgent({
+      capabilities: [{
+        id: "output-extension",
+        output(context) {
+          context.output.provide({ summary: "ok" })
+          context.output.provide(((event) => {
+            expectTypeOf(event.result).toEqualTypeOf<unknown>()
+            expectTypeOf(event.extensions.get("output-extension")).toEqualTypeOf<unknown>()
+            return { summary: "ok" }
+          }) satisfies AgentOutputExtensionProvider)
+          context.output.render((result, renderContext) => {
+            expectTypeOf(renderContext.output.extensions.get<{ summary: string }>("output-extension")).toEqualTypeOf<{ summary: string } | undefined>()
+            expectTypeOf(renderContext.output.extensions.get<string>("output-extension", "summary")).toEqualTypeOf<string | undefined>()
+            expectTypeOf(renderContext.output.extensions.get<UsageTelemetryOutputExtension>("usage-telemetry")).toEqualTypeOf<UsageTelemetryOutputExtension | undefined>()
+            return result
+          })
         },
       }],
       model: {} as never,

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -141,6 +141,71 @@ describe("usage telemetry", () => {
     })
   })
 
+  it("exposes usage summaries through output extensions", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const { staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
+    const onUsage = vi.fn()
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({
+          onUsage,
+          pricing: staticModelPricing({
+            "openai/gpt-test": {
+              input: "0.00000010",
+              output: "0.00000020",
+            },
+          }),
+          summary: { subject: "Review run" },
+        }),
+        defineCapability({
+          id: "usage-footer",
+          output(context) {
+            context.output.render((result, renderContext) => {
+              const usage = renderContext.output.extensions.get<{
+                summary?: string
+                usageRecord?: { usage?: { totalTokens?: number } }
+              }>("usage-telemetry")
+              return {
+                ...result as Record<string, unknown>,
+                extensionTokens: usage?.usageRecord?.usage?.totalTokens,
+                text: `${(result as { text?: string }).text}\n${usage?.summary}`,
+              }
+            })
+          },
+        }),
+      ],
+      run: () => ({
+        response: {
+          modelId: "openai/gpt-test",
+        },
+        text: "ok",
+        totalUsage: {
+          inputTokens: 1000,
+          outputTokens: 250,
+        },
+      }),
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+      extensionTokens: 1250,
+      text: "ok\nReview run cost about $0.00015 using openai/gpt-test (1,250 tokens: 1,000 in / 250 out).",
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 250,
+        totalTokens: 1250,
+      },
+      usageRecord: {
+        usage: {
+          inputTokens: 1000,
+          outputTokens: 250,
+          totalTokens: 1250,
+        },
+      },
+    })
+    expect(onUsage).toHaveBeenCalledTimes(1)
+  })
+
   it("uses app-owned usage summary formatting", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")


### PR DESCRIPTION
Adds a capability-owned output extension surface so earlier output-phase capabilities can publish invocation-scoped data under their capability id and later renderers can read it through `context.output.extensions.get(...)`. `usageTelemetry()` now publishes `{ usageRecord, summary }` there while keeping `usage`/`usageRecord` result enrichment and finish extensions intact.

Checked with focused Agent Package runtime tests and typecheck.