### PR TITLE
fix: show agent dev thinking fallback

### DIFF
--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -103,7 +103,7 @@ function responseFromResult(result: unknown): AgentUsageRecord["response"] | und
   }
 }
 
-function usageRecordFromUsage(rawUsage: unknown, metadataSource?: unknown): AgentUsageRecord | undefined {
+function usageRecordFromUsage(rawUsage: unknown, metadataSource?: unknown, fallbackMetadataSource?: unknown): AgentUsageRecord | undefined {
   if (!isRecord(rawUsage)) return
   const inputTokens = readNumber(rawUsage, "inputTokens", "promptTokens", "input_tokens", "prompt_tokens")
   const outputTokens = readNumber(rawUsage, "outputTokens", "completionTokens", "output_tokens", "completion_tokens")
@@ -119,8 +119,8 @@ function usageRecordFromUsage(rawUsage: unknown, metadataSource?: unknown): Agen
     ...(outputTokenDetails ? { outputTokenDetails } : {}),
   }
   if (!Object.keys(usage).length) return
-  const model = modelFromResult(metadataSource)
-  const response = responseFromResult(metadataSource)
+  const model = modelFromResult(metadataSource) ?? modelFromResult(fallbackMetadataSource)
+  const response = responseFromResult(metadataSource) ?? responseFromResult(fallbackMetadataSource)
   return {
     ...(model ? { model } : {}),
     ...(response ? { response } : {}),
@@ -128,14 +128,26 @@ function usageRecordFromUsage(rawUsage: unknown, metadataSource?: unknown): Agen
   }
 }
 
-function usageFromStreamChunk(chunk: unknown): AgentUsageRecord | undefined {
+function withFallbackUsageMetadata(record: AgentUsageRecord, fallbackMetadataSource: unknown): AgentUsageRecord {
+  const model = record.model ?? modelFromResult(fallbackMetadataSource)
+  const response = record.response ?? responseFromResult(fallbackMetadataSource)
+  return model || response
+    ? {
+        ...record,
+        ...(model ? { model } : {}),
+        ...(response ? { response } : {}),
+      }
+    : record
+}
+
+function usageFromStreamChunk(chunk: unknown, fallbackMetadataSource?: unknown): AgentUsageRecord | undefined {
   if (!isRecord(chunk)) return
   const type = String(chunk.type || "")
   return usageRecordFromUsage(type === "finish-step"
     ? chunk.usage
     : type === "finish"
       ? chunk.totalUsage ?? chunk.usage
-      : undefined, chunk)
+      : undefined, chunk, fallbackMetadataSource)
 }
 
 async function usageFromResult(result: unknown): Promise<AgentUsageRecord | undefined> {
@@ -218,11 +230,11 @@ async function* streamChunksToEvents(chunks: AsyncIterable<unknown>, usageSource
   let explicitUsageEvent = false
   let finishEvent: StreamEvent | undefined
   for await (const chunk of chunks) {
-    if (!explicitUsageEvent) usageRecord = usageFromStreamChunk(chunk) ?? usageRecord
+    if (!explicitUsageEvent) usageRecord = usageFromStreamChunk(chunk, usageSource) ?? usageRecord
     const event = toAgentStreamEvent(chunk, toolNames)
     if (!event) continue
     if (event.type === "usage") {
-      usageRecord = event.usageRecord
+      usageRecord = withFallbackUsageMetadata(event.usageRecord, usageSource)
       explicitUsageEvent = true
       continue
     }

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -229,6 +229,11 @@ export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<
     for await (const text of result.textStream) {
       yield { text, type: "text-delta" }
     }
+    let usageRecord = isUsageRecord((value as { usageRecord?: unknown }).usageRecord)
+      ? (value as { usageRecord: AgentUsageRecord }).usageRecord
+      : await usageFromResult(value)
+    if (!usageRecord && isRecord(value)) usageRecord = await usageFromResult(value.raw)
+    if (usageRecord) yield { type: "usage", usageRecord }
     yield { type: "finish" }
     return
   }

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -61,16 +61,16 @@ function readDetails(value: unknown): Record<string, number> | undefined {
   return Object.keys(details).length ? details : undefined
 }
 
-function usageFromStreamChunk(chunk: unknown): AgentUsageRecord | undefined {
-  if (!isRecord(chunk)) return
-  const type = String(chunk.type || "")
-  const rawUsage = type === "finish-step"
-    ? chunk.usage
-    : type === "finish"
-      ? chunk.totalUsage ?? chunk.usage
-      : undefined
-  if (!isRecord(rawUsage)) return
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return isRecord(value) && typeof value.then === "function"
+}
 
+async function resolveUsageValue(value: unknown): Promise<unknown> {
+  return isPromiseLike(value) ? await value : value
+}
+
+function usageRecordFromUsage(rawUsage: unknown): AgentUsageRecord | undefined {
+  if (!isRecord(rawUsage)) return
   const inputTokens = readNumber(rawUsage, "inputTokens", "promptTokens", "input_tokens", "prompt_tokens")
   const outputTokens = readNumber(rawUsage, "outputTokens", "completionTokens", "output_tokens", "completion_tokens")
   const totalTokens = readNumber(rawUsage, "totalTokens", "tokens", "total_tokens")
@@ -85,6 +85,21 @@ function usageFromStreamChunk(chunk: unknown): AgentUsageRecord | undefined {
     ...(outputTokenDetails ? { outputTokenDetails } : {}),
   }
   return Object.keys(usage).length ? { usage } : undefined
+}
+
+function usageFromStreamChunk(chunk: unknown): AgentUsageRecord | undefined {
+  if (!isRecord(chunk)) return
+  const type = String(chunk.type || "")
+  return usageRecordFromUsage(type === "finish-step"
+    ? chunk.usage
+    : type === "finish"
+      ? chunk.totalUsage ?? chunk.usage
+      : undefined)
+}
+
+async function usageFromResult(result: unknown): Promise<AgentUsageRecord | undefined> {
+  if (!isRecord(result)) return
+  return usageRecordFromUsage(await resolveUsageValue(result.totalUsage ?? result.usage))
 }
 
 function optionalMessageId(messageId: string | undefined): { messageId?: string } {
@@ -156,10 +171,10 @@ export function toAgentStreamEvent(chunk: unknown, toolNames?: Map<string, strin
   return undefined
 }
 
-async function* streamChunksToEvents(chunks: AsyncIterable<unknown>): AsyncIterable<StreamEvent> {
+async function* streamChunksToEvents(chunks: AsyncIterable<unknown>, usageSource?: unknown): AsyncIterable<StreamEvent> {
   const toolNames = new Map<string, string>()
   let emittedUsage = false
-  let finished = false
+  let finishEvent: StreamEvent | undefined
   for await (const chunk of chunks) {
     if (!emittedUsage) {
       const usageRecord = usageFromStreamChunk(chunk)
@@ -171,10 +186,17 @@ async function* streamChunksToEvents(chunks: AsyncIterable<unknown>): AsyncItera
     const event = toAgentStreamEvent(chunk, toolNames)
     if (!event) continue
     if (event.type === "usage") emittedUsage = true
-    if (event.type === "finish") finished = true
+    if (event.type === "finish") {
+      finishEvent = event
+      continue
+    }
     yield event
   }
-  if (!finished) yield { type: "finish" }
+  if (!emittedUsage) {
+    const usageRecord = await usageFromResult(usageSource)
+    if (usageRecord) yield { type: "usage", usageRecord }
+  }
+  yield finishEvent ?? { type: "finish" }
 }
 
 export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<StreamEvent> {
@@ -196,11 +218,11 @@ export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<
   const result = value as { fullStream?: AsyncIterable<unknown>, stream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string> }
   const fullStream = result.fullStream
   if (fullStream) {
-    yield* streamChunksToEvents(fullStream)
+    yield* streamChunksToEvents(fullStream, result)
     return
   }
   if (result.stream) {
-    yield* streamChunksToEvents(result.stream)
+    yield* streamChunksToEvents(result.stream, result)
     return
   }
   if (result.textStream) {

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -237,8 +237,14 @@ export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<
     : undefined
   if (typeof text === "string") {
     if (text) yield { text, type: "text-delta" }
-    if (isUsageRecord((value as { usageRecord?: unknown }).usageRecord)) {
-      yield { type: "usage", usageRecord: (value as { usageRecord: AgentUsageRecord }).usageRecord }
+    let usageRecord = isUsageRecord((value as { usageRecord?: unknown }).usageRecord)
+      ? (value as { usageRecord: AgentUsageRecord }).usageRecord
+      : await usageFromResult(value)
+    if (!usageRecord && isRecord(value)) {
+      usageRecord = await usageFromResult((value as { raw?: unknown }).raw)
+    }
+    if (usageRecord) {
+      yield { type: "usage", usageRecord }
     }
     yield {
       reason: typeof (value as { finishReason?: unknown }).finishReason === "string"

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -211,21 +211,19 @@ export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<
     yield { type: "finish" }
     return
   }
-  if (isAsyncIterable(value)) {
-    yield* streamChunksToEvents(value as AsyncIterable<unknown>)
-    return
-  }
-  const result = value as { fullStream?: AsyncIterable<unknown>, stream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string> }
-  const fullStream = result.fullStream
-  if (fullStream) {
+  const result = value && typeof value === "object"
+    ? value as { fullStream?: unknown, stream?: unknown, textStream?: unknown }
+    : undefined
+  const fullStream = result?.fullStream
+  if (isAsyncIterable(fullStream)) {
     yield* streamChunksToEvents(fullStream, result)
     return
   }
-  if (result.stream) {
+  if (isAsyncIterable(result?.stream)) {
     yield* streamChunksToEvents(result.stream, result)
     return
   }
-  if (result.textStream) {
+  if (isAsyncIterable<string>(result?.textStream)) {
     for await (const text of result.textStream) {
       yield { text, type: "text-delta" }
     }
@@ -235,6 +233,10 @@ export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<
     if (!usageRecord && isRecord(value)) usageRecord = await usageFromResult(value.raw)
     if (usageRecord) yield { type: "usage", usageRecord }
     yield { type: "finish" }
+    return
+  }
+  if (isAsyncIterable(value)) {
+    yield* streamChunksToEvents(value as AsyncIterable<unknown>)
     return
   }
   const text = typeof value === "object" && value !== null

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -2,7 +2,7 @@ import { ApprovalRequiredError } from "@vite-hub/runtime"
 import { isAsyncIterable } from "./internal/stream-result.ts"
 
 import type { StreamEvent } from "./messages.ts"
-import type { AgentRunResult, AgentUsageRecord } from "./types.ts"
+import type { AgentRunResult, AgentUsage, AgentUsageRecord } from "./types.ts"
 
 export { isAsyncIterable } from "./internal/stream-result.ts"
 
@@ -39,6 +39,52 @@ export function toAgentRunResult(value: unknown): AgentRunResult {
 
 function isUsageRecord(value: unknown): value is AgentUsageRecord {
   return typeof value === "object" && value !== null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function readNumber(record: Record<string, unknown>, ...keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === "number" && Number.isFinite(value)) return value
+  }
+}
+
+function readDetails(value: unknown): Record<string, number> | undefined {
+  if (!isRecord(value)) return
+  const details: Record<string, number> = {}
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === "number" && Number.isFinite(item)) details[key] = item
+  }
+  return Object.keys(details).length ? details : undefined
+}
+
+function usageFromStreamChunk(chunk: unknown): AgentUsageRecord | undefined {
+  if (!isRecord(chunk)) return
+  const type = String(chunk.type || "")
+  const rawUsage = type === "finish-step"
+    ? chunk.usage
+    : type === "finish"
+      ? chunk.totalUsage ?? chunk.usage
+      : undefined
+  if (!isRecord(rawUsage)) return
+
+  const inputTokens = readNumber(rawUsage, "inputTokens", "promptTokens", "input_tokens", "prompt_tokens")
+  const outputTokens = readNumber(rawUsage, "outputTokens", "completionTokens", "output_tokens", "completion_tokens")
+  const totalTokens = readNumber(rawUsage, "totalTokens", "tokens", "total_tokens")
+    ?? (inputTokens !== undefined && outputTokens !== undefined ? inputTokens + outputTokens : undefined)
+  const inputTokenDetails = readDetails(rawUsage.inputTokenDetails || rawUsage.input_token_details || rawUsage.promptTokenDetails || rawUsage.prompt_token_details)
+  const outputTokenDetails = readDetails(rawUsage.outputTokenDetails || rawUsage.output_token_details || rawUsage.completionTokenDetails || rawUsage.completion_token_details)
+  const usage: AgentUsage = {
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+    ...(inputTokenDetails ? { inputTokenDetails } : {}),
+    ...(outputTokenDetails ? { outputTokenDetails } : {}),
+  }
+  return Object.keys(usage).length ? { usage } : undefined
 }
 
 function optionalMessageId(messageId: string | undefined): { messageId?: string } {
@@ -110,6 +156,27 @@ export function toAgentStreamEvent(chunk: unknown, toolNames?: Map<string, strin
   return undefined
 }
 
+async function* streamChunksToEvents(chunks: AsyncIterable<unknown>): AsyncIterable<StreamEvent> {
+  const toolNames = new Map<string, string>()
+  let emittedUsage = false
+  let finished = false
+  for await (const chunk of chunks) {
+    if (!emittedUsage) {
+      const usageRecord = usageFromStreamChunk(chunk)
+      if (usageRecord) {
+        emittedUsage = true
+        yield { type: "usage", usageRecord }
+      }
+    }
+    const event = toAgentStreamEvent(chunk, toolNames)
+    if (!event) continue
+    if (event.type === "usage") emittedUsage = true
+    if (event.type === "finish") finished = true
+    yield event
+  }
+  if (!finished) yield { type: "finish" }
+}
+
 export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<StreamEvent> {
   if (typeof value === "string") {
     if (value) yield { text: value, type: "text-delta" }
@@ -123,41 +190,17 @@ export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<
     return
   }
   if (isAsyncIterable(value)) {
-    const toolNames = new Map<string, string>()
-    let finished = false
-    for await (const chunk of value as AsyncIterable<unknown>) {
-      const event = toAgentStreamEvent(chunk, toolNames)
-      if (!event) continue
-      if (event.type === "finish") finished = true
-      yield event
-    }
-    if (!finished) yield { type: "finish" }
+    yield* streamChunksToEvents(value as AsyncIterable<unknown>)
     return
   }
   const result = value as { fullStream?: AsyncIterable<unknown>, stream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string> }
   const fullStream = result.fullStream
   if (fullStream) {
-    const toolNames = new Map<string, string>()
-    let finished = false
-    for await (const chunk of fullStream) {
-      const event = toAgentStreamEvent(chunk, toolNames)
-      if (!event) continue
-      if (event.type === "finish") finished = true
-      yield event
-    }
-    if (!finished) yield { type: "finish" }
+    yield* streamChunksToEvents(fullStream)
     return
   }
   if (result.stream) {
-    const toolNames = new Map<string, string>()
-    let finished = false
-    for await (const chunk of result.stream) {
-      const event = toAgentStreamEvent(chunk, toolNames)
-      if (!event) continue
-      if (event.type === "finish") finished = true
-      yield event
-    }
-    if (!finished) yield { type: "finish" }
+    yield* streamChunksToEvents(result.stream)
     return
   }
   if (result.textStream) {

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -52,6 +52,14 @@ function readNumber(record: Record<string, unknown>, ...keys: string[]): number 
   }
 }
 
+function readString(record: Record<string, unknown> | undefined, ...keys: string[]): string | undefined {
+  if (!record) return
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === "string" && value) return value
+  }
+}
+
 function readDetails(value: unknown): Record<string, number> | undefined {
   if (!isRecord(value)) return
   const details: Record<string, number> = {}
@@ -69,7 +77,33 @@ async function resolveUsageValue(value: unknown): Promise<unknown> {
   return isPromiseLike(value) ? await value : value
 }
 
-function usageRecordFromUsage(rawUsage: unknown): AgentUsageRecord | undefined {
+function modelFromResult(result: unknown): AgentUsageRecord["model"] | undefined {
+  if (!isRecord(result)) return
+  const response = isRecord(result.response) ? result.response : undefined
+  const id = readString(response, "modelId", "model") ?? readString(result, "modelId", "model")
+  const provider = readString(result, "provider")
+  if (id === undefined && provider === undefined) return
+  return {
+    ...(id !== undefined ? { id } : {}),
+    ...(provider !== undefined ? { provider } : {}),
+  }
+}
+
+function responseFromResult(result: unknown): AgentUsageRecord["response"] | undefined {
+  if (!isRecord(result)) return
+  const response = isRecord(result.response) ? result.response : undefined
+  const id = readString(response, "id")
+  const timestamp = response?.timestamp
+  const finishReason = result.finishReason
+  if (id === undefined && timestamp === undefined) return
+  return {
+    ...(finishReason !== undefined ? { finishReason } : {}),
+    ...(id !== undefined ? { id } : {}),
+    ...((timestamp instanceof Date || typeof timestamp === "string") ? { timestamp } : {}),
+  }
+}
+
+function usageRecordFromUsage(rawUsage: unknown, metadataSource?: unknown): AgentUsageRecord | undefined {
   if (!isRecord(rawUsage)) return
   const inputTokens = readNumber(rawUsage, "inputTokens", "promptTokens", "input_tokens", "prompt_tokens")
   const outputTokens = readNumber(rawUsage, "outputTokens", "completionTokens", "output_tokens", "completion_tokens")
@@ -84,7 +118,14 @@ function usageRecordFromUsage(rawUsage: unknown): AgentUsageRecord | undefined {
     ...(inputTokenDetails ? { inputTokenDetails } : {}),
     ...(outputTokenDetails ? { outputTokenDetails } : {}),
   }
-  return Object.keys(usage).length ? { usage } : undefined
+  if (!Object.keys(usage).length) return
+  const model = modelFromResult(metadataSource)
+  const response = responseFromResult(metadataSource)
+  return {
+    ...(model ? { model } : {}),
+    ...(response ? { response } : {}),
+    usage,
+  }
 }
 
 function usageFromStreamChunk(chunk: unknown): AgentUsageRecord | undefined {
@@ -94,12 +135,12 @@ function usageFromStreamChunk(chunk: unknown): AgentUsageRecord | undefined {
     ? chunk.usage
     : type === "finish"
       ? chunk.totalUsage ?? chunk.usage
-      : undefined)
+      : undefined, chunk)
 }
 
 async function usageFromResult(result: unknown): Promise<AgentUsageRecord | undefined> {
   if (!isRecord(result)) return
-  return usageRecordFromUsage(await resolveUsageValue(result.totalUsage ?? result.usage))
+  return usageRecordFromUsage(await resolveUsageValue(result.totalUsage ?? result.usage), result)
 }
 
 function optionalMessageId(messageId: string | undefined): { messageId?: string } {

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -173,29 +173,26 @@ export function toAgentStreamEvent(chunk: unknown, toolNames?: Map<string, strin
 
 async function* streamChunksToEvents(chunks: AsyncIterable<unknown>, usageSource?: unknown): AsyncIterable<StreamEvent> {
   const toolNames = new Map<string, string>()
-  let emittedUsage = false
+  let usageRecord: AgentUsageRecord | undefined
+  let explicitUsageEvent = false
   let finishEvent: StreamEvent | undefined
   for await (const chunk of chunks) {
-    if (!emittedUsage) {
-      const usageRecord = usageFromStreamChunk(chunk)
-      if (usageRecord) {
-        emittedUsage = true
-        yield { type: "usage", usageRecord }
-      }
-    }
+    if (!explicitUsageEvent) usageRecord = usageFromStreamChunk(chunk) ?? usageRecord
     const event = toAgentStreamEvent(chunk, toolNames)
     if (!event) continue
-    if (event.type === "usage") emittedUsage = true
+    if (event.type === "usage") {
+      usageRecord = event.usageRecord
+      explicitUsageEvent = true
+      continue
+    }
     if (event.type === "finish") {
       finishEvent = event
       continue
     }
     yield event
   }
-  if (!emittedUsage) {
-    const usageRecord = await usageFromResult(usageSource)
-    if (usageRecord) yield { type: "usage", usageRecord }
-  }
+  usageRecord ??= await usageFromResult(usageSource)
+  if (usageRecord) yield { type: "usage", usageRecord }
   yield finishEvent ?? { type: "finish" }
 }
 

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -95,6 +95,15 @@ function toTextModelMessageContent(parts: MessagePart[]): string {
 type AssistantContentPart = Exclude<AssistantContent, string>[number]
 type ToolContentPart = ToolContent[number]
 
+function toJsonCompatibleValue(value: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(value))
+  }
+  catch {
+    return String(value)
+  }
+}
+
 function toToolResultOutput(part: Extract<MessagePart, { type: "tool-result" }>): ToolResultPart["output"] {
   if (part.error) {
     return { type: "error-text", value: part.error } as ToolResultPart["output"]
@@ -103,7 +112,7 @@ function toToolResultOutput(part: Extract<MessagePart, { type: "tool-result" }>)
   if (typeof output === "string") {
     return { type: "text", value: output } as ToolResultPart["output"]
   }
-  return { type: "json", value: output } as ToolResultPart["output"]
+  return { type: "json", value: toJsonCompatibleValue(output) } as ToolResultPart["output"]
 }
 
 function toToolResultModelPart(part: Extract<MessagePart, { type: "tool-result" }>): ToolResultPart {

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -550,6 +550,9 @@ function createUsageCapture() {
     async onStepEnd(event: unknown) {
       capture(event)
     },
+    async onLanguageModelCallEnd(event: unknown) {
+      capture(event)
+    },
     get captured() {
       return captured
     },
@@ -562,12 +565,21 @@ function createUsageCapture() {
 function withCapturedUsage(result: unknown, capture: ReturnType<typeof createUsageCapture>): unknown {
   if (result && typeof result === "object") {
     const record = result as Record<string, unknown>
-    if (record.usage === undefined && record.totalUsage === undefined) {
-      Object.defineProperty(record, "usage", {
+    const usage = record.usage
+    const totalUsage = record.totalUsage
+    Object.defineProperty(record, "usage", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return capture.usage ?? usage
+      },
+    })
+    if (totalUsage !== undefined) {
+      Object.defineProperty(record, "totalUsage", {
         configurable: true,
         enumerable: true,
         get() {
-          return capture.usage
+          return capture.usage ?? totalUsage
         },
       })
     }
@@ -705,6 +717,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       const result = withCapturedUsage(await agent.generate({
         ...callInput,
         onEnd: usageCapture.onEnd,
+        onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
         onStepEnd: usageCapture.onStepEnd,
       } as never) as GenerateTextResult<ToolSet, never, never>, usageCapture) as GenerateTextResult<ToolSet, never, never>
       const text = result.text.trim()
@@ -744,6 +757,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       const result = withCapturedUsage(await agent.stream({
         ...callInput,
         onEnd: usageCapture.onEnd,
+        onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
         onStepEnd: usageCapture.onStepEnd,
       } as never) as StreamTextResult<ToolSet, never, never>, usageCapture) as StreamTextResult<ToolSet, never, never>
       const execution = options.execution ?? options.modelExecution

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -597,6 +597,40 @@ function withCapturedUsage(result: unknown, capture: ReturnType<typeof createUsa
   }
 }
 
+function readModelString(value: unknown, ...keys: string[]): string | undefined {
+  if (!value || typeof value !== "object") return
+  const record = value as Record<string, unknown>
+  for (const key of keys) {
+    const item = record[key]
+    if (typeof item === "string" && item) return item
+  }
+}
+
+function withResolvedModelMetadata(result: unknown, model: unknown): unknown {
+  const modelId = readModelString(model, "modelId", "model")
+  const provider = readModelString(model, "provider", "providerId")
+  if ((modelId === undefined && provider === undefined) || !result || typeof result !== "object") {
+    return result
+  }
+
+  const record = result as Record<string, unknown>
+  if (modelId !== undefined && record.modelId === undefined) {
+    Object.defineProperty(record, "modelId", {
+      configurable: true,
+      enumerable: true,
+      value: modelId,
+    })
+  }
+  if (provider !== undefined && record.provider === undefined) {
+    Object.defineProperty(record, "provider", {
+      configurable: true,
+      enumerable: true,
+      value: provider,
+    })
+  }
+  return result
+}
+
 function arrayFrom(value: unknown): unknown[] {
   if (Array.isArray(value)) return value
   return value === undefined ? [] : [value]
@@ -716,12 +750,12 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       }
       const usageCapture = createUsageCapture()
       const callInput = getCallInput(context) as Record<string, unknown>
-      const result = withCapturedUsage(await agent.generate({
+      const result = withResolvedModelMetadata(withCapturedUsage(await agent.generate({
         ...callInput,
         onEnd: usageCapture.onEnd,
         onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
         onStepEnd: usageCapture.onStepEnd,
-      } as never) as GenerateTextResult<ToolSet, never, never>, usageCapture) as GenerateTextResult<ToolSet, never, never>
+      } as never) as GenerateTextResult<ToolSet, never, never>, usageCapture), model) as GenerateTextResult<ToolSet, never, never>
       const text = result.text.trim()
       if (text) return result as unknown as AgentAdapterResult
 
@@ -756,12 +790,12 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       const { agent, model } = await createAgent(options, context)
       const usageCapture = createUsageCapture()
       const callInput = getCallInput(context) as Record<string, unknown>
-      const result = withCapturedUsage(await agent.stream({
+      const result = withResolvedModelMetadata(withCapturedUsage(await agent.stream({
         ...callInput,
         onEnd: usageCapture.onEnd,
         onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
         onStepEnd: usageCapture.onStepEnd,
-      } as never) as StreamTextResult<ToolSet, never, never>, usageCapture) as StreamTextResult<ToolSet, never, never>
+      } as never) as StreamTextResult<ToolSet, never, never>, usageCapture), model) as StreamTextResult<ToolSet, never, never>
       const execution = options.execution ?? options.modelExecution
       return withWorkspaceFallbackStreamResult(result, model as never, context, getFallbackOptions(execution?.workspaceFallback))
     },

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -531,6 +531,50 @@ function withRunCallbacks(settings: Record<string, unknown>, context: AgentAdapt
   }
 }
 
+function createUsageCapture() {
+  let resolveUsage: (usage: unknown) => void
+  let captured = false
+  let capturedUsage: unknown
+  const usage = new Promise<unknown>((resolve) => {
+    resolveUsage = resolve
+  })
+
+  return {
+    async onEnd(event: unknown) {
+      const record = typeof event === "object" && event !== null ? event as { totalUsage?: unknown, usage?: unknown } : undefined
+      capturedUsage = record?.totalUsage ?? record?.usage
+      captured = true
+      resolveUsage(capturedUsage)
+    },
+    get captured() {
+      return captured
+    },
+    usage,
+  }
+}
+
+function withCapturedUsage(result: unknown, capture: ReturnType<typeof createUsageCapture>): unknown {
+  if (result && typeof result === "object") {
+    const record = result as Record<string, unknown>
+    if (record.usage === undefined && record.totalUsage === undefined) {
+      Object.defineProperty(record, "usage", {
+        configurable: true,
+        enumerable: true,
+        value: capture.usage,
+      })
+    }
+    return result
+  }
+
+  if (!capture.captured) return result
+
+  return {
+    raw: result,
+    text: typeof result === "string" ? result : undefined,
+    usage: capture.usage,
+  }
+}
+
 function arrayFrom(value: unknown): unknown[] {
   if (Array.isArray(value)) return value
   return value === undefined ? [] : [value]
@@ -648,7 +692,12 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       if (context.workspace && tools && "materialize_sources" in tools) {
         await reportWorkspaceMaterialization(tools as AgentToolSet, context.devtools?.reportToolStep)
       }
-      const result = await agent.generate(getCallInput(context) as never) as GenerateTextResult<ToolSet, never, never>
+      const usageCapture = createUsageCapture()
+      const callInput = getCallInput(context) as Record<string, unknown>
+      const result = withCapturedUsage(await agent.generate({
+        ...callInput,
+        onEnd: usageCapture.onEnd,
+      } as never) as GenerateTextResult<ToolSet, never, never>, usageCapture) as GenerateTextResult<ToolSet, never, never>
       const text = result.text.trim()
       if (text) return result as unknown as AgentAdapterResult
 
@@ -681,7 +730,12 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
     ...(staticTools ? { tools: staticTools } : {}),
     async stream(context) {
       const { agent, model } = await createAgent(options, context)
-      const result = await agent.stream(getCallInput(context) as never) as StreamTextResult<ToolSet, never, never>
+      const usageCapture = createUsageCapture()
+      const callInput = getCallInput(context) as Record<string, unknown>
+      const result = withCapturedUsage(await agent.stream({
+        ...callInput,
+        onEnd: usageCapture.onEnd,
+      } as never) as StreamTextResult<ToolSet, never, never>, usageCapture) as StreamTextResult<ToolSet, never, never>
       const execution = options.execution ?? options.modelExecution
       return withWorkspaceFallbackStreamResult(result, model as never, context, getFallbackOptions(execution?.workspaceFallback))
     },

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -13,6 +13,8 @@ import {
   applyAgentToolPolicies,
   reportWorkspaceMaterialization,
   withAgentToolStepReporting,
+  withJsonCompatibleToolOutputs,
+  toJsonCompatibleValue,
 } from "./tool-runtime.ts"
 import {
   aiSdkTelemetryIntegration,
@@ -94,15 +96,6 @@ function toTextModelMessageContent(parts: MessagePart[]): string {
 
 type AssistantContentPart = Exclude<AssistantContent, string>[number]
 type ToolContentPart = ToolContent[number]
-
-function toJsonCompatibleValue(value: unknown): unknown {
-  try {
-    return JSON.parse(JSON.stringify(value))
-  }
-  catch {
-    return String(value)
-  }
-}
 
 function toToolResultOutput(part: Extract<MessagePart, { type: "tool-result" }>): ToolResultPart["output"] {
   if (part.error) {
@@ -457,7 +450,7 @@ async function resolveInstructions(options: AiSdkAdapterOptions, context: AgentA
 async function resolveTools(options: AiSdkAdapterOptions, context: AgentAdapterMetadataContext, reportToolStep?: AgentAdapterRunContext["devtools"] extends infer T ? T extends { reportToolStep?: infer R } ? R : never : never) {
   if (!options.tools) return undefined
   const resolved = await resolveValue(options.tools as never, context)
-  const tools = applyAgentToolPolicies(resolved as AgentToolSet | undefined) || {}
+  const tools = withJsonCompatibleToolOutputs(applyAgentToolPolicies(resolved as AgentToolSet | undefined) || {})
   const { materialize_sources: materializeSources, ...reportableTools } = tools
   return {
     ...withAgentToolStepReporting(reportableTools, reportToolStep as never),
@@ -713,7 +706,7 @@ async function createAgent(options: AiSdkAdapterOptions, context: AgentAdapterRu
 
 export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
   const staticTools = typeof options.tools === "object" && options.tools
-    ? withAgentToolStepReporting(applyAgentToolPolicies(options.tools as AgentToolSet) || {})
+    ? withAgentToolStepReporting(withJsonCompatibleToolOutputs(applyAgentToolPolicies(options.tools as AgentToolSet) || {}))
     : undefined
   return {
     async generate(context) {

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -532,24 +532,30 @@ function withRunCallbacks(settings: Record<string, unknown>, context: AgentAdapt
 }
 
 function createUsageCapture() {
-  let resolveUsage: (usage: unknown) => void
   let captured = false
   let capturedUsage: unknown
-  const usage = new Promise<unknown>((resolve) => {
-    resolveUsage = resolve
-  })
+
+  const capture = (event: unknown) => {
+    const record = typeof event === "object" && event !== null ? event as { totalUsage?: unknown, usage?: unknown } : undefined
+    const usage = record?.totalUsage ?? record?.usage
+    if (usage === undefined) return
+    capturedUsage = usage
+    captured = true
+  }
 
   return {
     async onEnd(event: unknown) {
-      const record = typeof event === "object" && event !== null ? event as { totalUsage?: unknown, usage?: unknown } : undefined
-      capturedUsage = record?.totalUsage ?? record?.usage
-      captured = true
-      resolveUsage(capturedUsage)
+      capture(event)
+    },
+    async onStepEnd(event: unknown) {
+      capture(event)
     },
     get captured() {
       return captured
     },
-    usage,
+    get usage() {
+      return captured ? Promise.resolve(capturedUsage) : undefined
+    },
   }
 }
 
@@ -560,7 +566,9 @@ function withCapturedUsage(result: unknown, capture: ReturnType<typeof createUsa
       Object.defineProperty(record, "usage", {
         configurable: true,
         enumerable: true,
-        value: capture.usage,
+        get() {
+          return capture.usage
+        },
       })
     }
     return result
@@ -697,6 +705,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       const result = withCapturedUsage(await agent.generate({
         ...callInput,
         onEnd: usageCapture.onEnd,
+        onStepEnd: usageCapture.onStepEnd,
       } as never) as GenerateTextResult<ToolSet, never, never>, usageCapture) as GenerateTextResult<ToolSet, never, never>
       const text = result.text.trim()
       if (text) return result as unknown as AgentAdapterResult
@@ -735,6 +744,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       const result = withCapturedUsage(await agent.stream({
         ...callInput,
         onEnd: usageCapture.onEnd,
+        onStepEnd: usageCapture.onStepEnd,
       } as never) as StreamTextResult<ToolSet, never, never>, usageCapture) as StreamTextResult<ToolSet, never, never>
       const execution = options.execution ?? options.modelExecution
       return withWorkspaceFallbackStreamResult(result, model as never, context, getFallbackOptions(execution?.workspaceFallback))

--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -237,6 +237,13 @@ function removeInputCommandText(input: AgentRunInput, target: InputCommandTarget
   })
 }
 
+function commandReplacementText(targetText: string, invocation: InputCommandInvocation, replacement: string): string {
+  if (replacement || targetText.slice(0, invocation.start).trim() || targetText.slice(invocation.end).trim()) {
+    return replacement
+  }
+  return invocation.text
+}
+
 function mergeInputCommandResult(input: AgentRunInput, result: Partial<AgentRunInput>): AgentRunInput {
   const next: AgentRunInput = {
     ...input,
@@ -301,17 +308,18 @@ export function inputCommands(options: InputCommandsOptions): AgentCapabilityDef
             cursor = text === previousText ? invocation.end : 0
             continue
           }
-          text = `${text.slice(0, invocation.start)}${result}${text.slice(invocation.end)}`
+          const replacement = commandReplacementText(text, invocation, result)
+          text = `${text.slice(0, invocation.start)}${replacement}${text.slice(invocation.end)}`
           input = replaceTargetText(input, target, text, {
             end: invocation.end,
-            replacement: result,
+            replacement,
             start: invocation.start,
           })
           context.input.set(input)
           target = getInputCommandTarget(input)
           if (!target) return
           maxRuns = Math.max(maxRuns, text.length + 1)
-          cursor = result === invocation.text ? invocation.end : invocation.start
+          cursor = replacement === invocation.text ? invocation.end : invocation.start
           continue
         }
 

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -558,6 +558,34 @@ function normalizeVercelPrice(value: unknown): string | undefined {
   return typeof value === "string" && value ? value : undefined
 }
 
+function addModelIdCandidate(candidates: string[], value: string | undefined) {
+  if (value && !candidates.includes(value)) candidates.push(value)
+}
+
+function normalizeAnthropicGatewayModelId(id: string): string {
+  return id
+    .replace(/^anthropic\//, "")
+    .replace(/^claude-(\d+)-(\d+)-/, "claude-$1.$2-")
+    .replace(/(.+-\d+)-(\d+)$/, "$1.$2")
+}
+
+function vercelGatewayModelIdCandidates(model: AgentUsageRecord["model"] | undefined): string[] {
+  const modelId = typeof model?.id === "string" ? model.id.trim() : ""
+  if (!modelId) return []
+  const candidates: string[] = []
+  addModelIdCandidate(candidates, modelId)
+
+  const unscoped = modelId.includes("/") ? modelId.slice(modelId.lastIndexOf("/") + 1) : modelId
+  const provider = typeof model?.provider === "string" ? model.provider.toLowerCase() : ""
+  const isAnthropic = modelId.startsWith("anthropic/") || unscoped.startsWith("claude-") || provider.includes("anthropic")
+  if (isAnthropic) {
+    addModelIdCandidate(candidates, `anthropic/${unscoped}`)
+    addModelIdCandidate(candidates, `anthropic/${normalizeAnthropicGatewayModelId(unscoped)}`)
+  }
+
+  return candidates
+}
+
 export function vercelAiGatewayPricing(options: VercelAiGatewayPricingOptions = {}): AgentUsagePricing {
   const fetcher = options.fetch || globalThis.fetch
   const modelsUrl = options.modelsUrl || vercelAiGatewayModelsUrl
@@ -586,9 +614,10 @@ export function vercelAiGatewayPricing(options: VercelAiGatewayPricingOptions = 
 
   return async ({ model, usage }) => {
     if (!hasTokenUsage(usage)) return
-    const modelId = model?.id
-    if (!modelId) return
-    const price = (await loadPrices())[modelId]
+    const catalog = await loadPrices()
+    const price = vercelGatewayModelIdCandidates(model)
+      .map(modelId => catalog[modelId])
+      .find((item): item is StaticModelPrice => Boolean(item))
     if (!price) return
     return {
       amount: pricedTokens(usage, price),

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -97,7 +97,8 @@ function readNumber(record: UnknownRecord, ...keys: string[]): number | undefine
   }
 }
 
-function readString(record: UnknownRecord, ...keys: string[]): string | undefined {
+function readString(record: UnknownRecord | undefined, ...keys: string[]): string | undefined {
+  if (!record) return
   for (const key of keys) {
     const value = record[key]
     if (typeof value === "string" && value) return value
@@ -189,7 +190,7 @@ function responseFromResult(result: UnknownRecord): AgentUsageRecord["response"]
 
 function modelFromResult(result: UnknownRecord): AgentUsageRecord["model"] | undefined {
   const response = isRecord(result.response) ? result.response : undefined
-  const id = response ? readString(response, "modelId", "model") : readString(result, "modelId", "model")
+  const id = readString(response, "modelId", "model") ?? readString(result, "modelId", "model")
   const provider = readString(result, "provider")
   if (id === undefined && provider === undefined) return
   return {

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -468,9 +468,9 @@ export function usageTelemetry(options: UsageTelemetryOptions = {}): AgentCapabi
         return usageRecord ? await usageRecordForOutput(usageRecord, options) : undefined
       })
       context.output.render(async (result, renderContext) => {
+        if (isRecord(result) && hasUsageTelemetryStream(result)) return cloneWithUsageTelemetryStream(result, options, context.run)
         if (isAsyncIterable(result)) return withUsageTelemetryStream(result, options, context.run)
         if (!isRecord(result)) return result
-        if (hasUsageTelemetryStream(result)) return cloneWithUsageTelemetryStream(result, options, context.run)
         const usageRecord = renderContext.output.extensions.get<UsageTelemetryOutputExtension>("usage-telemetry")?.usageRecord
         if (!usageRecord) return result
         return {

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -113,6 +113,14 @@ function readDetails(value: unknown): Record<string, number> | undefined {
   return Object.keys(details).length ? details : undefined
 }
 
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return isRecord(value) && typeof value.then === "function"
+}
+
+async function resolveUsageValue(value: unknown): Promise<unknown> {
+  return isPromiseLike(value) ? await value : value
+}
+
 function hasTokenUsage(usage: AgentUsage): boolean {
   return usage.inputTokens !== undefined
     || usage.outputTokens !== undefined
@@ -144,6 +152,13 @@ export function normalizeAgentUsage(value: unknown): AgentUsage | undefined {
   return Object.keys(value).length
     ? { details: value, raw: value }
     : undefined
+}
+
+async function usageFromResult(result: UnknownRecord, fallback?: unknown): Promise<AgentUsage | undefined> {
+  const usage = normalizeAgentUsage(await resolveUsageValue(result.totalUsage ?? result.usage))
+  if (usage) return usage
+  if (!isRecord(fallback)) return
+  return normalizeAgentUsage(await resolveUsageValue(fallback.totalUsage ?? fallback.usage))
 }
 
 function credentialSourceFromMetadata(metadata: unknown): AgentUsageRecord["credentialSource"] | undefined {
@@ -203,7 +218,7 @@ export async function createAgentUsageRecord(
   metadataSource?: unknown,
 ): Promise<AgentUsageRecord | undefined> {
   if (!isRecord(result)) return
-  const usage = normalizeAgentUsage(result.totalUsage ?? result.usage)
+  const usage = await usageFromResult(result, metadataSource)
   if (!usage) return
   const model = modelFromResult(result)
   const response = responseFromResult(result)

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -384,8 +384,8 @@ async function* withUsageTelemetryStream(
     }
     yield chunk
   }
-  if (!recorded && fallbackResult) {
-    const usageRecord = await recordUsage(fallbackResult, options, run, metadataSource)
+  if (!recorded && isRecord(metadataSource)) {
+    const usageRecord = await recordUsage(fallbackResult ?? metadataSource, options, run, metadataSource)
     if (usageRecord) {
       onRecord?.(usageRecord)
       yield { type: "usage", usageRecord }

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -384,7 +384,7 @@ async function* withUsageTelemetryStream(
   let recorded = false
   for await (const chunk of stream) {
     if (isRecord(chunk) && chunk.type === "finish") {
-      const usageRecord = await recordUsage(chunk, options, run)
+      const usageRecord = await recordUsage(chunk, options, run, chunk.totalUsage !== undefined || chunk.usage !== undefined ? metadataSource : undefined)
       if (usageRecord) {
         recorded = true
         onRecord?.(usageRecord)
@@ -397,7 +397,7 @@ async function* withUsageTelemetryStream(
     yield chunk
   }
   if (!recorded && isRecord(metadataSource)) {
-    const usageRecord = await recordUsage(fallbackResult ?? metadataSource, options, run, metadataSource)
+    const usageRecord = await recordUsage(fallbackResult ? { ...metadataSource, ...fallbackResult } : metadataSource, options, run, metadataSource)
     if (usageRecord) {
       onRecord?.(usageRecord)
       yield { type: "usage", usageRecord }

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -368,15 +368,28 @@ async function* withUsageTelemetryStream(
   onRecord?: (record: AgentUsageRecord) => void,
   metadataSource?: unknown,
 ): AsyncIterable<unknown> {
+  let fallbackResult: UnknownRecord | undefined
+  let recorded = false
   for await (const chunk of stream) {
     if (isRecord(chunk) && chunk.type === "finish") {
-      const usageRecord = await recordUsage(chunk, options, run, metadataSource)
+      const usageRecord = await recordUsage(chunk, options, run)
       if (usageRecord) {
+        recorded = true
         onRecord?.(usageRecord)
         yield { type: "usage", usageRecord }
       }
+      else if (isRecord(metadataSource)) {
+        fallbackResult = chunk
+      }
     }
     yield chunk
+  }
+  if (!recorded && fallbackResult) {
+    const usageRecord = await recordUsage(fallbackResult, options, run, metadataSource)
+    if (usageRecord) {
+      onRecord?.(usageRecord)
+      yield { type: "usage", usageRecord }
+    }
   }
 }
 

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -293,6 +293,17 @@ function formatUsageDuration(durationMs: unknown): string | undefined {
   return `${(finite / 1000).toFixed(1)}s`
 }
 
+function formatUsageSpeed(record: AgentUsageRecord): string | undefined {
+  const explicit = finiteUsageNumber(record.latency?.tokensPerSecond)
+  const durationMs = finiteUsageNumber(record.latency?.durationMs)
+  const input = finiteUsageNumber(record.usage?.inputTokens)
+  const output = finiteUsageNumber(record.usage?.outputTokens)
+  const total = finiteUsageNumber(record.usage?.totalTokens)
+  const outputOrTotal = output ?? (input !== undefined && total !== undefined ? total - input : total)
+  const derived = explicit ?? (durationMs && durationMs > 0 ? (outputOrTotal ?? 0) / (durationMs / 1000) : undefined)
+  return derived && Number.isFinite(derived) ? `${derived.toFixed(1)} tok/s` : undefined
+}
+
 function normalizeUsageSummaryOptions(summary: UsageTelemetryOptions["summary"]): UsageTelemetrySummaryOptions | undefined {
   if (!summary) return
   return typeof summary === "object" && summary !== null ? summary : {}
@@ -308,7 +319,8 @@ async function formatUsageSummary(record: AgentUsageRecord, options: UsageTeleme
   const tokens = formatUsageTokens(record.usage)
   const model = record.model?.id
   const duration = formatUsageDuration(record.latency?.durationMs)
-  const run = [model ? `using ${model}` : undefined, duration ? `in ${duration}` : undefined].filter(Boolean).join(" ")
+  const speed = formatUsageSpeed(record)
+  const run = [model ? `using ${model}` : undefined, duration ? `in ${duration}` : undefined, speed ? `at ${speed}` : undefined].filter(Boolean).join(" ")
   if (cost) return `${subject} cost ${record.cost?.estimated ? "about " : ""}${cost}${run ? ` ${run}` : ""}${tokens ? ` (${tokens})` : ""}.`
   if (tokens) return `${subject} used ${tokens}${run ? ` ${run}` : ""}.`
   if (run) return `${subject} ran ${run}.`

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -644,7 +644,7 @@ export async function applyOutputRenderers(
     }
     current = await renderer(current, extensions)
   }
-  return current
+  return withOutputExtensionProperties(current, values)
 }
 
 function createAgentExtensionReader(values: Map<string, unknown>): AgentInvocationExtensions {
@@ -656,6 +656,24 @@ function createAgentExtensionReader(values: Map<string, unknown>): AgentInvocati
       return (value as Record<string, unknown>)[key] as T | undefined
     },
   }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function withOutputExtensionProperties(result: unknown, values: Map<string, unknown>): unknown {
+  if (!isObjectRecord(result)) return result
+
+  const usageTelemetry = values.get("usage-telemetry")
+  if (!isObjectRecord(usageTelemetry)) return result
+
+  const usageRecord = usageTelemetry.usageRecord
+  if (!isObjectRecord(usageRecord)) return result
+
+  if (result.usageRecord === undefined) result.usageRecord = usageRecord
+  if (result.usage === undefined) result.usage = usageRecord.usage
+  return result
 }
 
 export async function createAgentInvocationExtensions(

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -649,6 +649,10 @@ function finishUsageSummary(event: AgentFinishEvent): string | undefined {
   return isRecord(usage) ? maybeString(usage.summary) : undefined
 }
 
+function githubNote(body: string): string {
+  return `> [!NOTE]\n${body.split("\n").map(line => `> ${line}`).join("\n")}`
+}
+
 function githubPullRequestCommentReplyEffect(event: AgentFinishEvent): AgentChannelDeliveryEffectIntent | undefined {
   const text = finishResultText(event.result)
   if (!text) return
@@ -656,7 +660,7 @@ function githubPullRequestCommentReplyEffect(event: AgentFinishEvent): AgentChan
   const summary = finishUsageSummary(event)
   return {
     kind: "reply",
-    payload: summary ? `${body}\n\n> ${summary}` : body,
+    payload: summary ? `${body}\n\n${githubNote(summary)}` : body,
   }
 }
 

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -108,12 +108,13 @@ export function getAgentChatContext<
 async function resolveChatThinkingFallback<TRuntimeConfig extends AgentRuntimeConfig>(
   options: AgentChatOptions<TRuntimeConfig>,
   args: AgentChatAgentHookArgs<TRuntimeConfig>,
-): Promise<string | undefined> {
+): Promise<string | null | undefined> {
   const fallback = options.fallbackStreamingPlaceholderText
-  if (fallback === null) return undefined
+  if (fallback === null) return null
   if (typeof fallback === "function") {
     const resolved = await fallback(args)
-    return resolved || undefined
+    if (resolved === null) return null
+    return typeof resolved === "string" ? resolved : undefined
   }
   if (typeof fallback === "string") return fallback
   return undefined
@@ -182,11 +183,10 @@ function createChatMessageTrigger<TRuntimeConfig extends AgentRuntimeConfig>(
     webhooks: chatWebhookRegistrations(options),
     async invoke(_context, triggerInput) {
       const { hookArgs, input } = createChatMessageTriggerInput(options, triggerInput)
+      const thinkingFallback = await resolveChatThinkingFallback(options, hookArgs)
       return {
         input,
-        metadata: {
-          thinkingFallback: await resolveChatThinkingFallback(options, hookArgs),
-        },
+        ...(thinkingFallback !== undefined ? { metadata: { thinkingFallback } } : {}),
         run: triggerInput.run,
       }
     },

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -136,6 +136,13 @@ function writeDevPayload(context: AgentCliContext, label: string, value: unknown
   context.stderr.write(`  ${label}: ${text}\n`)
 }
 
+function writeDevText(context: AgentCliContext, value: unknown): boolean {
+  const text = formatDevPayload(value)
+  if (text === undefined) return false
+  context.stderr.write(text.endsWith("\n") ? text : `${text}\n`)
+  return true
+}
+
 function thinkingFallback(metadata: Record<string, unknown> | undefined): string | undefined {
   if (!metadata) return "Thinking..."
   const value = metadata?.thinkingFallback
@@ -178,6 +185,32 @@ function formatUsageRecord(record: AgentUsageRecord): string | undefined {
   if (reasoning !== undefined) parts.push(`${formatUsageNumber(reasoning)} reasoning tokens`)
   if (!parts.length) return record.summary
   return parts.join("; ")
+}
+
+function formatUsageNote(summary: string): string {
+  return ["> [!NOTE]", `> Usage: ${summary}`].join("\n")
+}
+
+function shellCommand(value: unknown): string | undefined {
+  if (!isRecord(value) || typeof value.command !== "string") return
+  const command = value.command.trim()
+  return command && !command.includes("\n") ? command : undefined
+}
+
+function toolHeader(name: string, input?: unknown, output?: unknown): string {
+  return `[tool] ${shellCommand(input) ?? shellCommand(output) ?? name}`
+}
+
+function writeShellOutput(context: AgentCliContext, output: unknown, error: unknown): boolean {
+  if (!isRecord(output)) return false
+  const stdout = typeof output.stdout === "string" && output.stdout ? output.stdout : undefined
+  const stderr = typeof output.stderr === "string" && output.stderr ? output.stderr : undefined
+  if (!stdout && !stderr && error === undefined) return false
+  if (stdout) writeDevText(context, stdout)
+  if (stderr) writeDevPayload(context, "stderr", stderr)
+  writeDevPayload(context, "error", error)
+  context.stderr.write("---\n")
+  return true
 }
 
 function readOptionValue(args: string[], index: number, flag: string): string {
@@ -564,22 +597,43 @@ async function sendDevMessage(
   let needsApproval = false
   let pendingFallback = false
   let wroteFallback = false
+  let fallbackTimer: ReturnType<typeof setInterval> | undefined
   let lastUsageText: string | undefined
+  let wroteUsageNote = false
+  let finishSeen = false
   const visibleTools = new Set<string>()
+  const writeUsageNote = () => {
+    if (!lastUsageText || wroteUsageNote) return
+    context.stdout.write(`${output && !output.endsWith("\n") ? "\n" : ""}\n${formatUsageNote(lastUsageText)}\n`)
+    wroteUsageNote = true
+  }
   const clearPendingFallback = () => {
+    if (fallbackTimer) {
+      clearInterval(fallbackTimer)
+      fallbackTimer = undefined
+    }
     if (!pendingFallback) return
     context.stderr.write("\r\u001b[K")
     pendingFallback = false
+  }
+  const startFallback = (fallback: string) => {
+    const base = fallback.trim().replace(/\.+$/, "")
+    const frames = [".", "..", "..."]
+    let frame = 2
+    const write = () => {
+      context.stderr.write(`\r${base}${frames[frame++ % frames.length]}`)
+    }
+    write()
+    fallbackTimer = setInterval(write, 250)
+    ;(fallbackTimer as { unref?: () => void }).unref?.()
+    pendingFallback = true
   }
   try {
     for await (const event of readAgentInvocationStream(response.body)) {
       if (event.type === "start") {
         if (wroteFallback) continue
         const fallback = thinkingFallback(event.metadata)
-        if (fallback) {
-          context.stderr.write(fallback)
-          pendingFallback = true
-        }
+        if (fallback) startFallback(fallback)
         wroteFallback = true
         continue
       }
@@ -591,30 +645,37 @@ async function sendDevMessage(
       }
       if (event.type === "tool-call" || event.type === "tool-input-start") {
         clearPendingFallback()
+        if (event.type === "tool-input-start" && event.input === undefined) continue
         if (!visibleTools.has(event.id)) {
           visibleTools.add(event.id)
-          context.stderr.write(`\n[tool] ${event.name}\n`)
+          context.stderr.write(`\n${toolHeader(event.name, event.input)}\n`)
         }
-        writeDevPayload(context, "input", event.input)
+        if (!shellCommand(event.input)) writeDevPayload(context, "input", event.input)
         continue
       }
       if (event.type === "tool-result") {
         clearPendingFallback()
         if (!visibleTools.has(event.id)) {
           visibleTools.add(event.id)
-          context.stderr.write(`\n[tool] ${event.name}\n`)
+          context.stderr.write(`\n${toolHeader(event.name, undefined, event.output)}\n`)
         }
-        writeDevPayload(context, "output", event.output)
-        writeDevPayload(context, "error", event.error)
+        if (!writeShellOutput(context, event.output, event.error)) {
+          writeDevPayload(context, "output", event.output)
+          writeDevPayload(context, "error", event.error)
+        }
         continue
       }
       if (event.type === "usage") {
         clearPendingFallback()
         const usage = formatUsageRecord(event.usageRecord)
-        if (usage && usage !== lastUsageText) {
-          context.stderr.write(`\n[usage] ${usage}\n`)
-          lastUsageText = usage
-        }
+        if (usage) lastUsageText = usage
+        if (finishSeen) writeUsageNote()
+        continue
+      }
+      if (event.type === "finish" || event.type === "done") {
+        clearPendingFallback()
+        finishSeen = true
+        writeUsageNote()
         continue
       }
       if (event.type === "delivery-preview") {

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -143,6 +143,16 @@ function writeDevText(context: AgentCliContext, value: unknown): boolean {
   return true
 }
 
+function toolTextOutput(value: unknown, seen = new Set<unknown>()): string | undefined {
+  if (!isRecord(value) || seen.has(value)) return
+  seen.add(value)
+  if (typeof value.text === "string" && value.text.trim()) return value.text
+  for (const key of ["output", "result", "raw"]) {
+    const text = toolTextOutput(value[key], seen)
+    if (text) return text
+  }
+}
+
 function thinkingFallback(metadata: Record<string, unknown> | undefined): string | undefined {
   if (!metadata || !Object.hasOwn(metadata, "thinkingFallback")) return "Thinking..."
   const value = metadata.thinkingFallback
@@ -241,6 +251,14 @@ function writeShellOutput(context: AgentCliContext, output: unknown, error: unkn
   if (stdout) writeDevText(context, stdout)
   if (stderr) writeDevPayload(context, "stderr", stderr)
   writeDevPayload(context, "error", error)
+  context.stderr.write("---\n")
+  return true
+}
+
+function writeToolTextOutput(context: AgentCliContext, output: unknown): boolean {
+  const text = toolTextOutput(output)
+  if (!text) return false
+  writeDevText(context, text)
   context.stderr.write("---\n")
   return true
 }
@@ -695,7 +713,7 @@ async function sendDevMessage(
           visibleTools.add(event.id)
           context.stderr.write(`\n${toolHeader(event.name, undefined, event.output)}\n`)
         }
-        if (!writeShellOutput(context, event.output, event.error)) {
+        if (!writeShellOutput(context, event.output, event.error) && !writeToolTextOutput(context, event.output)) {
           writeDevPayload(context, "output", event.output)
           writeDevPayload(context, "error", event.error)
         }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -136,9 +136,10 @@ function writeDevPayload(context: AgentCliContext, label: string, value: unknown
   context.stderr.write(`  ${label}: ${text}\n`)
 }
 
-function thinkingFallback(metadata: Record<string, unknown> | undefined): string {
+function thinkingFallback(metadata: Record<string, unknown> | undefined): string | undefined {
+  if (!metadata) return "Thinking..."
   const value = metadata?.thinkingFallback
-  return typeof value === "string" && value.trim() ? value : "Thinking..."
+  return typeof value === "string" && value.trim() ? value : undefined
 }
 
 function usageNumber(value: unknown): number | undefined {
@@ -562,8 +563,11 @@ async function sendDevMessage(
     for await (const event of readAgentInvocationStream(response.body)) {
       if (event.type === "start") {
         if (wroteFallback) continue
-        context.stderr.write(thinkingFallback(event.metadata))
-        pendingFallback = true
+        const fallback = thinkingFallback(event.metadata)
+        if (fallback) {
+          context.stderr.write(fallback)
+          pendingFallback = true
+        }
         wroteFallback = true
         continue
       }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -564,6 +564,7 @@ async function sendDevMessage(
   let needsApproval = false
   let pendingFallback = false
   let wroteFallback = false
+  let lastUsageText: string | undefined
   const visibleTools = new Set<string>()
   const clearPendingFallback = () => {
     if (!pendingFallback) return
@@ -590,8 +591,10 @@ async function sendDevMessage(
       }
       if (event.type === "tool-call" || event.type === "tool-input-start") {
         clearPendingFallback()
-        visibleTools.add(event.id)
-        context.stderr.write(`\n[tool] ${event.name}\n`)
+        if (!visibleTools.has(event.id)) {
+          visibleTools.add(event.id)
+          context.stderr.write(`\n[tool] ${event.name}\n`)
+        }
         writeDevPayload(context, "input", event.input)
         continue
       }
@@ -608,7 +611,10 @@ async function sendDevMessage(
       if (event.type === "usage") {
         clearPendingFallback()
         const usage = formatUsageRecord(event.usageRecord)
-        if (usage) context.stderr.write(`\n[usage] ${usage}\n`)
+        if (usage && usage !== lastUsageText) {
+          context.stderr.write(`\n[usage] ${usage}\n`)
+          lastUsageText = usage
+        }
         continue
       }
       if (event.type === "delivery-preview") {

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -144,8 +144,8 @@ function writeDevText(context: AgentCliContext, value: unknown): boolean {
 }
 
 function thinkingFallback(metadata: Record<string, unknown> | undefined): string | undefined {
-  if (!metadata) return "Thinking..."
-  const value = metadata?.thinkingFallback
+  if (!metadata || !Object.hasOwn(metadata, "thinkingFallback")) return "Thinking..."
+  const value = metadata.thinkingFallback
   return typeof value === "string" && value.trim() ? value : undefined
 }
 

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -72,7 +72,7 @@ interface AgentDevCliOptions {
 }
 
 interface AgentDevDiscovery {
-  agents?: Array<{ name?: unknown, triggers?: unknown }>
+  agents?: Array<{ aliases?: unknown, name?: unknown, triggers?: unknown }>
   root?: unknown
 }
 
@@ -470,12 +470,23 @@ async function readDiscovery(
     return
   }
   const agents = (discovery.agents || []).flatMap(agent => typeof agent.name === "string" ? [agent.name] : [])
+  const agentTargets = new Map<string, string>()
+  for (const agent of discovery.agents || []) {
+    if (typeof agent.name !== "string") continue
+    agentTargets.set(agent.name, agent.name)
+    if (Array.isArray(agent.aliases)) {
+      for (const alias of agent.aliases) {
+        if (typeof alias === "string") agentTargets.set(alias, alias)
+      }
+    }
+  }
   if (parsed.agent) {
-    if (!agents.includes(parsed.agent)) {
+    const target = agentTargets.get(parsed.agent)
+    if (!target) {
       context.stderr.write(`Unknown Agent Dev Loop Target: ${parsed.agent}\n`)
       return
     }
-    return { agent: parsed.agent, url }
+    return { agent: target, url }
   }
   if (agents.length === 1) {
     return { agent: agents[0]!, url }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 
+import { vercelAiGatewayPricing, type AgentUsagePricing } from "./capabilities/usage-telemetry.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig, type ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, readAgentInvocationStream } from "./invocation-stream.ts"
 
@@ -77,6 +78,12 @@ interface AgentDevDiscovery {
 }
 
 const devPayloadMaxLength = 1200
+
+let devUsagePricing: AgentUsagePricing | undefined
+
+function defaultDevUsagePricing() {
+  return devUsagePricing ??= vercelAiGatewayPricing()
+}
 
 function writeEvalUsage(context: AgentCliContext): void {
   context.stdout.write([
@@ -231,6 +238,22 @@ function formatUsageRecord(record: AgentUsageRecord, fallbackDurationMs?: number
 
 function formatUsageNote(summary: string): string {
   return ["> [!NOTE]", `> Usage: ${summary}`].join("\n")
+}
+
+async function enrichUsageCost(record: AgentUsageRecord): Promise<AgentUsageRecord> {
+  if (record.cost || !record.usage) return record
+  try {
+    const cost = await defaultDevUsagePricing()({
+      model: record.model,
+      response: record.response,
+      run: record.run,
+      usage: record.usage,
+    })
+    return cost ? { ...record, cost } : record
+  }
+  catch {
+    return record
+  }
 }
 
 function shellCommand(value: unknown): string | undefined {
@@ -721,7 +744,7 @@ async function sendDevMessage(
       }
       if (event.type === "usage") {
         clearPendingFallback()
-        lastUsageRecord = event.usageRecord
+        lastUsageRecord = await enrichUsageCost(event.usageRecord)
         if (finishSeen) writeUsageNote()
         continue
       }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -136,6 +136,11 @@ function writeDevPayload(context: AgentCliContext, label: string, value: unknown
   context.stderr.write(`  ${label}: ${text}\n`)
 }
 
+function thinkingFallback(metadata: Record<string, unknown> | undefined): string {
+  const value = metadata?.thinkingFallback
+  return typeof value === "string" && value.trim() ? value : "Thinking..."
+}
+
 function usageNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.trunc(value) : undefined
 }
@@ -545,21 +550,38 @@ async function sendDevMessage(
 
   let output = ""
   let needsApproval = false
+  let pendingFallback = false
+  let wroteFallback = false
   const visibleTools = new Set<string>()
+  const clearPendingFallback = () => {
+    if (!pendingFallback) return
+    context.stderr.write("\r\u001b[K")
+    pendingFallback = false
+  }
   try {
     for await (const event of readAgentInvocationStream(response.body)) {
+      if (event.type === "start") {
+        if (wroteFallback) continue
+        context.stderr.write(thinkingFallback(event.metadata))
+        pendingFallback = true
+        wroteFallback = true
+        continue
+      }
       if (event.type === "text-delta") {
+        clearPendingFallback()
         context.stdout.write(event.text)
         output += event.text
         continue
       }
       if (event.type === "tool-call" || event.type === "tool-input-start") {
+        clearPendingFallback()
         visibleTools.add(event.id)
         context.stderr.write(`\n[tool] ${event.name}\n`)
         writeDevPayload(context, "input", event.input)
         continue
       }
       if (event.type === "tool-result") {
+        clearPendingFallback()
         if (!visibleTools.has(event.id)) {
           visibleTools.add(event.id)
           context.stderr.write(`\n[tool] ${event.name}\n`)
@@ -569,11 +591,13 @@ async function sendDevMessage(
         continue
       }
       if (event.type === "usage") {
+        clearPendingFallback()
         const usage = formatUsageRecord(event.usageRecord)
         if (usage) context.stderr.write(`\n[usage] ${usage}\n`)
         continue
       }
       if (event.type === "delivery-preview") {
+        clearPendingFallback()
         context.stderr.write(`\n[delivery preview] would ${event.effect.kind}${event.channelId ? ` on ${event.channelId}` : ""}\n`)
         writeDevPayload(context, "intent", event.effect.intent)
         writeDevPayload(context, "payload", event.effect.payload)
@@ -581,15 +605,18 @@ async function sendDevMessage(
         continue
       }
       if (event.type === "approval-request") {
+        clearPendingFallback()
         context.stderr.write(`\n[approval required] ${event.name}${event.reason ? `: ${event.reason}` : ""}\n`)
         needsApproval = true
         continue
       }
       if (event.type === "approval-decision") {
+        clearPendingFallback()
         context.stderr.write(`\n[approval ${event.approved ? "approved" : "rejected"}]${event.reason ? ` ${event.reason}` : ""}\n`)
         continue
       }
       if (event.type === "error") {
+        clearPendingFallback()
         context.stderr.write(`\n${event.error}\n`)
         return
       }
@@ -602,6 +629,7 @@ async function sendDevMessage(
     }
     throw error
   }
+  clearPendingFallback()
   context.stdout.write("\n")
   if (!output && needsApproval) return
   return messages.length || output ? [...messages, assistantMessage(output, messages.length)] : []

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -168,13 +168,43 @@ function readUsageDetail(...records: Array<Record<string, unknown> | undefined>)
   }
 }
 
-function formatUsageRecord(record: AgentUsageRecord): string | undefined {
+function formatUsageDuration(durationMs: unknown): string | undefined {
+  const finite = usageNumber(durationMs)
+  if (finite === undefined) return
+  return `${(finite / 1000).toFixed(1)}s`
+}
+
+function formatUsageCost(cost: AgentUsageRecord["cost"]): string | undefined {
+  if (!cost?.amount) return
+  const amount = cost.amount.replace(/(\.\d*?[1-9])0+$/, "$1").replace(/\.0+$/, "")
+  return `${cost.estimated ? "~" : ""}${cost.currency === "USD" ? `$${amount}` : `${amount} ${cost.currency}`}`
+}
+
+function formatUsageSpeed(record: AgentUsageRecord, durationMs?: number): string | undefined {
+  const explicit = typeof record.latency?.tokensPerSecond === "number" && Number.isFinite(record.latency.tokensPerSecond)
+    ? record.latency.tokensPerSecond
+    : undefined
+  const duration = usageNumber(record.latency?.durationMs) ?? durationMs
+  const durationSeconds = duration === undefined ? undefined : duration / 1000
+  const input = usageNumber(record.usage?.inputTokens)
+  const output = usageNumber(record.usage?.outputTokens)
+  const total = usageNumber(record.usage?.totalTokens)
+  const outputOrTotal = output ?? (input !== undefined && total !== undefined ? total - input : total)
+  const derived = explicit ?? (durationSeconds !== undefined && durationSeconds > 0 ? (outputOrTotal ?? 0) / durationSeconds : undefined)
+  return derived && Number.isFinite(derived) ? `${derived.toFixed(1)} tok/s` : undefined
+}
+
+function formatUsageRecord(record: AgentUsageRecord, fallbackDurationMs?: number): string | undefined {
   const usage = record.usage
   const input = usageNumber(usage?.inputTokens)
   const output = usageNumber(usage?.outputTokens)
   const total = usageNumber(usage?.totalTokens) ?? (input !== undefined && output !== undefined ? input + output : undefined)
   const reasoning = readUsageDetail(usage?.outputTokenDetails, usage?.inputTokenDetails, usage?.details)
+  const cost = formatUsageCost(record.cost)
+  const duration = formatUsageDuration(record.latency?.durationMs ?? fallbackDurationMs)
+  const speed = formatUsageSpeed(record, fallbackDurationMs)
   const parts: string[] = []
+  if (cost) parts.push(`cost ${cost}`)
   if (total !== undefined) {
     const tokens = `${formatUsageNumber(total)} tokens`
     parts.push(input !== undefined && output !== undefined ? `${tokens}: ${formatUsageNumber(input)} in / ${formatUsageNumber(output)} out` : tokens)
@@ -183,6 +213,8 @@ function formatUsageRecord(record: AgentUsageRecord): string | undefined {
     parts.push([input !== undefined ? `${formatUsageNumber(input)} in` : undefined, output !== undefined ? `${formatUsageNumber(output)} out` : undefined].filter(Boolean).join(" / "))
   }
   if (reasoning !== undefined) parts.push(`${formatUsageNumber(reasoning)} reasoning tokens`)
+  if (duration) parts.push(`time ${duration}`)
+  if (speed) parts.push(`speed ${speed}`)
   if (!parts.length) return record.summary
   return parts.join("; ")
 }
@@ -558,6 +590,7 @@ async function sendDevMessage(
   signal?: AbortSignal,
 ): Promise<UIMessageLike[] | undefined> {
   const messages = text ? [...history, userMessage(text, history.length)] : history
+  const startedAt = Date.now()
   let response: Response
   try {
     response = await fetchImpl(url, {
@@ -598,13 +631,15 @@ async function sendDevMessage(
   let pendingFallback = false
   let wroteFallback = false
   let fallbackTimer: ReturnType<typeof setInterval> | undefined
-  let lastUsageText: string | undefined
+  let lastUsageRecord: AgentUsageRecord | undefined
   let wroteUsageNote = false
   let finishSeen = false
   const visibleTools = new Set<string>()
   const writeUsageNote = () => {
-    if (!lastUsageText || wroteUsageNote) return
-    context.stdout.write(`${output && !output.endsWith("\n") ? "\n" : ""}\n${formatUsageNote(lastUsageText)}\n`)
+    if (!lastUsageRecord || wroteUsageNote) return
+    const usage = formatUsageRecord(lastUsageRecord, Date.now() - startedAt)
+    if (!usage) return
+    context.stdout.write(`${output && !output.endsWith("\n") ? "\n" : ""}\n${formatUsageNote(usage)}\n`)
     wroteUsageNote = true
   }
   const clearPendingFallback = () => {
@@ -613,7 +648,7 @@ async function sendDevMessage(
       fallbackTimer = undefined
     }
     if (!pendingFallback) return
-    context.stderr.write("\r\u001b[K")
+    context.stderr.write("\r\u001b[K\u001B[?25h")
     pendingFallback = false
   }
   const startFallback = (fallback: string) => {
@@ -623,6 +658,7 @@ async function sendDevMessage(
     const write = () => {
       context.stderr.write(`\r${base}${frames[frame++ % frames.length]}`)
     }
+    context.stderr.write("\u001B[?25l")
     write()
     fallbackTimer = setInterval(write, 250)
     ;(fallbackTimer as { unref?: () => void }).unref?.()
@@ -667,8 +703,7 @@ async function sendDevMessage(
       }
       if (event.type === "usage") {
         clearPendingFallback()
-        const usage = formatUsageRecord(event.usageRecord)
-        if (usage) lastUsageText = usage
+        lastUsageRecord = event.usageRecord
         if (finishSeen) writeUsageNote()
         continue
       }
@@ -705,6 +740,7 @@ async function sendDevMessage(
     }
   }
   catch (error) {
+    clearPendingFallback()
     if (signal?.aborted || error instanceof DOMException && error.name === "AbortError") {
       context.stderr.write("\n[aborted]\n")
       return history

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1235,6 +1235,16 @@ function hasTraceableStreamResult(value: unknown): boolean {
   return isAsyncIterable(result.fullStream) || isAsyncIterable(result.stream) || isAsyncIterable(result.textStream)
 }
 
+function withStreamResultProperties<T extends AsyncIterable<StreamEvent>>(stream: T, result: unknown): T {
+  if (typeof stream !== "object" || stream === null || typeof result !== "object" || result === null) return stream
+  Object.defineProperties(stream, Object.fromEntries(["usage", "usageRecord"].map(key => [key, {
+    configurable: true,
+    enumerable: true,
+    get: () => (result as Record<string, unknown>)[key],
+  }])))
+  return stream
+}
+
 function traceUiMessageStream<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -1617,15 +1627,20 @@ export async function streamAgentInline<
       if (output === "ui-message-stream") {
         return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, runContext), shouldWrapInvocationOutput(runContext), error => finishAgentInvocation(runContext, error === undefined ? rendered : undefined, error))
       }
-      const isStream = isAsyncIterable(rendered)
-      const stream = hasTraceableStreamResult(rendered)
+      const isStreamResult = hasTraceableStreamResult(rendered)
+      const isStream = isAsyncIterable(rendered) || isStreamResult
+      const stream = isStreamResult
         ? streamAgentOutputToEvents(rendered)
         : rendered as AsyncIterable<StreamEvent>
+      const shouldWrapOutput = shouldWrapInvocationOutput(runContext)
+      const tracedStream = maybeTraceAgentStream(stream, runContext)
       return {
-        deferFinish: isStream && shouldWrapInvocationOutput(runContext),
+        deferFinish: isStream && shouldWrapOutput,
         finishResult: rendered,
         value: isStream
-          ? maybeTraceAgentStream(stream, runContext)
+          ? withStreamResultProperties(shouldWrapOutput
+              ? withCapabilityCleanup(tracedStream, error => finishAgentInvocation(runContext, error === undefined ? rendered : undefined, error)) as AsyncIterable<StreamEvent>
+              : tracedStream, rendered)
           : rendered,
       }
     }, "[vitehub] Agent run failed and finish lifecycle also failed.", {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -30,6 +30,7 @@ import { finalizeUiMessageStreamOutput, isUIMessageStreamResult } from "./stream
 import {
   applyAgentToolPolicies,
   withAgentToolStepReporting,
+  withJsonCompatibleToolOutputs,
 } from "./tool-runtime.ts"
 import {
   traceAgentInvocationError,
@@ -761,7 +762,7 @@ function defineBaseAgent<
         ? await resolveStaticCapabilityTools({ capabilities: normalizedCapabilities }, resolvedContext)
         : undefined
       const capabilityTools = Object.keys(resolvedTools || {}).length
-        ? withAgentToolStepReporting(applyAgentToolPolicies(resolvedTools) || {}, context.devtools?.reportToolStep)
+        ? withAgentToolStepReporting(withJsonCompatibleToolOutputs(applyAgentToolPolicies(resolvedTools) || {}), context.devtools?.reportToolStep)
         : undefined
       return capabilityTools
         ? { ...adapterInstance, tools: capabilityTools }
@@ -1125,7 +1126,7 @@ async function createAgentInvocationContext<
     })
     const transformedTools = await applyCapabilityToolTransforms(capabilities.tools, capabilities.toolTransforms)
     const tools = Object.keys(transformedTools || {}).length
-      ? withAgentToolStepReporting(applyAgentToolPolicies(transformedTools) || {}, context.devtools?.reportToolStep)
+      ? withAgentToolStepReporting(withJsonCompatibleToolOutputs(applyAgentToolPolicies(transformedTools) || {}), context.devtools?.reportToolStep)
       : undefined
     const activeWorkspace = capabilities.workspace || workspace
     const sourceResolvedWorkspaceDefinition = invocationContext.get<WorkspaceDefinition>("workspace.sourceResolution.definition")

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -315,7 +315,7 @@ export type {
   AgentChatRunContext,
 } from "./chat-trigger.ts"
 
-const syntheticWorkspaceRun = Symbol("vitehub.syntheticWorkspaceRun")
+const syntheticWorkspaceRun = Symbol.for("vitehub.syntheticWorkspaceRun")
 const baseAgentResolve = Symbol("vitehub.baseAgentResolve")
 const baseAgentModel = Symbol("vitehub.baseAgentModel")
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1460,7 +1460,7 @@ async function finalizeAgentInvocationResult<
       finishLifecycleStarted = shouldWrapOutput
       return response
     }
-    if (isAsyncIterable(result) && !options.finalizeRawStreams) {
+    if (isAsyncIterable(result) && !hasTraceableStreamResult(result) && !options.finalizeRawStreams) {
       finishLifecycleStarted = shouldWrapOutput
       const stream = options.wrapStream?.(result) || result
       return shouldWrapOutput ? withCapabilityCleanup(stream, error => finishAgentInvocation(context, error === undefined ? result : undefined, error)) : stream
@@ -1617,11 +1617,14 @@ export async function streamAgentInline<
         return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, runContext), shouldWrapInvocationOutput(runContext), error => finishAgentInvocation(runContext, error === undefined ? rendered : undefined, error))
       }
       const isStream = isAsyncIterable(rendered)
+      const stream = hasTraceableStreamResult(rendered)
+        ? streamAgentOutputToEvents(rendered)
+        : rendered as AsyncIterable<StreamEvent>
       return {
         deferFinish: isStream && shouldWrapInvocationOutput(runContext),
         finishResult: rendered,
         value: isStream
-          ? maybeTraceAgentStream(rendered as AsyncIterable<StreamEvent>, runContext)
+          ? maybeTraceAgentStream(stream, runContext)
           : rendered,
       }
     }, "[vitehub] Agent run failed and finish lifecycle also failed.", {

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -8,7 +8,7 @@ export const agentInvocationStreamHeaderValue = "1"
 export type AgentInvocationStreamEvent =
   | StreamEvent
   | { channelId?: string, effect: AgentChannelDeliveryEffectIntent, run?: AgentRunMetadata, type: "delivery-preview" }
-  | { agent: string, run?: unknown, trigger?: string, type: "start" }
+  | { agent: string, metadata?: Record<string, unknown>, run?: unknown, trigger?: string, type: "start" }
   | { type: "done" }
 
 export async function* readAgentInvocationStream(body: ReadableStream<Uint8Array>): AsyncGenerator<AgentInvocationStreamEvent> {

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -16,6 +16,7 @@ function isAgentToolDefinition(value: unknown): value is AgentToolDefinition {
 }
 
 export function toJsonCompatibleValue(value: unknown): unknown {
+  if (value === undefined) return null
   try {
     return JSON.parse(JSON.stringify(value))
   }

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -15,6 +15,15 @@ function isAgentToolDefinition(value: unknown): value is AgentToolDefinition {
   return typeof value === "object" && value !== null && "name" in value && typeof (value as { name?: unknown }).name === "string"
 }
 
+export function toJsonCompatibleValue(value: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(value))
+  }
+  catch {
+    return String(value)
+  }
+}
+
 function createApprovalRequest(name: string, input: unknown, reason?: string) {
   return {
     capability: name,
@@ -74,6 +83,24 @@ export function applyAgentToolPolicies<TTools extends Record<string, unknown>>(t
       return [name, tool]
     }
     return [name, withToolPolicy(tool)]
+  })) as TTools
+}
+
+export function withJsonCompatibleToolOutputs<TTools extends AgentToolSet>(tools: TTools): TTools {
+  if (!tools || typeof tools !== "object") return tools
+
+  return Object.fromEntries(Object.entries(tools).map(([name, tool]) => {
+    if (!tool || typeof tool !== "object" || typeof (tool as { execute?: unknown }).execute !== "function") {
+      return [name, tool]
+    }
+
+    const execute = (tool as { execute: (...args: unknown[]) => unknown }).execute
+    return [name, {
+      ...tool,
+      async execute(input: unknown, ...args: unknown[]) {
+        return toJsonCompatibleValue(await execute.call(tool, input, ...args))
+      },
+    }]
   })) as TTools
 }
 

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url"
 import { setWorkspaceRuntimeRegistry } from "@vite-hub/workspace/internal/runtime/state"
 
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, createAgentInvocationStreamResponse } from "../invocation-stream.ts"
-import { streamAgentOutputToEvents } from "../agent-output.ts"
+import { isAsyncIterable, streamAgentOutputToEvents } from "../agent-output.ts"
 import { uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { discoverAgentDefinitions } from "../discovery.ts"
 import { isResolvedAgentTriggerHandledInvocation, resolveAgentTriggerInvocation, resolveAgentTriggers, streamAgent, withAgentDefaults } from "../index.ts"
@@ -370,7 +370,10 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
         timeout,
       }, { output: "events" })
     }
-    for await (const event of streamAgentOutputToEvents(output)) {
+    const events = isAsyncIterable(output)
+      ? output as AsyncIterable<AgentInvocationStreamEvent>
+      : streamAgentOutputToEvents(output)
+    for await (const event of events) {
       if (signal.aborted) return
       emit(event)
     }

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url"
 import { setWorkspaceRuntimeRegistry } from "@vite-hub/workspace/internal/runtime/state"
 
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, createAgentInvocationStreamResponse } from "../invocation-stream.ts"
-import { isAsyncIterable, streamAgentOutputToEvents } from "../agent-output.ts"
+import { streamAgentOutputToEvents } from "../agent-output.ts"
 import { uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { discoverAgentDefinitions } from "../discovery.ts"
 import { isResolvedAgentTriggerHandledInvocation, resolveAgentTriggerInvocation, resolveAgentTriggers, streamAgent, withAgentDefaults } from "../index.ts"
@@ -370,10 +370,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
         timeout,
       }, { output: "events" })
     }
-    const events = isAsyncIterable(output)
-      ? output as AsyncIterable<AgentInvocationStreamEvent>
-      : streamAgentOutputToEvents(output)
-    for await (const event of events) {
+    for await (const event of streamAgentOutputToEvents(output)) {
       if (signal.aborted) return
       emit(event)
     }

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -239,7 +239,8 @@ async function discoverStreamAgents(server: ViteDevServer): Promise<AgentInvocat
 
 function selectedEntry(entries: AgentInvocationStreamEntry[], name: string | undefined): AgentInvocationStreamEntry {
   if (name) {
-    const entry = entries.find(item => item.name === name || item.aliases?.includes(name))
+    const entry = entries.find(item => item.name === name)
+      ?? entries.find(item => item.aliases?.includes(name))
     if (!entry) throw new Response(`Unknown Agent Dev Loop Target: ${name}`, { status: 404 })
     return entry
   }

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -51,6 +51,7 @@ interface AgentInvocationStreamBody {
 
 interface AgentInvocationStreamEntry {
   agent: AgentInput<ViteAgentDevRuntimeContext>
+  aliases?: string[]
   name: string
   triggers: Record<string, ResolvedAgentTriggerDefinition<ViteAgentDevRuntimeContext>>
 }
@@ -175,11 +176,24 @@ function resolveWorkspaceSourceRoot(file: string): string {
     : dirname(file)
 }
 
-function installServerAgentWorkspaceRegistry(server: ViteDevServer, definitions: DiscoveredAgentDefinition[]): void {
-  setWorkspaceRuntimeRegistry(Object.fromEntries(definitions
-    .filter(definition => definition.workspace)
-    .map(definition => [
-      definition.workspace!,
+function declaredWorkspaceAgentName(agent: AgentInput<ViteAgentDevRuntimeContext> | undefined): string | undefined {
+  const options = isRecord(agent) && isRecord(agent.__vitehubWorkspaceAgentOptions) ? agent.__vitehubWorkspaceAgentOptions : undefined
+  return typeof options?.name === "string" && options.name ? options.name : undefined
+}
+
+function agentAliases(definition: DiscoveredAgentDefinition, agent: AgentInput<ViteAgentDevRuntimeContext>): string[] | undefined {
+  const declaredName = declaredWorkspaceAgentName(agent)
+  return declaredName && declaredName !== definition.name ? [declaredName] : undefined
+}
+
+function installServerAgentWorkspaceRegistry(
+  server: ViteDevServer,
+  entries: Array<{ aliases?: string[], definition: DiscoveredAgentDefinition }>,
+): void {
+  setWorkspaceRuntimeRegistry(Object.fromEntries(entries
+    .filter(entry => entry.definition.workspace)
+    .flatMap(({ aliases, definition }) => [definition.workspace!, ...(aliases || [])].map(name => [
+      name,
       async () => {
         const mod = await server.ssrLoadModule(pathToFileURL(definition.handler).href)
         return {
@@ -190,7 +204,7 @@ function installServerAgentWorkspaceRegistry(server: ViteDevServer, definitions:
           },
         }
       },
-    ])))
+    ]))))
 }
 
 async function loadDiscoveredAgent(
@@ -207,21 +221,25 @@ async function discoverStreamAgents(server: ViteDevServer): Promise<AgentInvocat
     mode: "server-agents",
     scanDirs: [join(server.config.root, "server")],
   })
-  installServerAgentWorkspaceRegistry(server, definitions)
-  const context = createDiscoveryContext()
-  const entries: AgentInvocationStreamEntry[] = []
+  const loaded = []
   for (const definition of definitions) {
     const agent = await loadDiscoveredAgent(server, definition)
     if (!agent) continue
+    loaded.push({ agent, aliases: agentAliases(definition, agent), definition })
+  }
+  installServerAgentWorkspaceRegistry(server, loaded)
+  const context = createDiscoveryContext()
+  const entries: AgentInvocationStreamEntry[] = []
+  for (const { agent, aliases, definition } of loaded) {
     const triggers = await resolveAgentTriggers(agent as never, context as never)
-    entries.push({ agent, name: definition.name, triggers })
+    entries.push({ agent, ...(aliases ? { aliases } : {}), name: definition.name, triggers })
   }
   return entries
 }
 
 function selectedEntry(entries: AgentInvocationStreamEntry[], name: string | undefined): AgentInvocationStreamEntry {
   if (name) {
-    const entry = entries.find(item => item.name === name)
+    const entry = entries.find(item => item.name === name || item.aliases?.includes(name))
     if (!entry) throw new Response(`Unknown Agent Dev Loop Target: ${name}`, { status: 404 })
     return entry
   }
@@ -304,6 +322,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
   if (req.method === "GET") {
     return Response.json({
       agents: entries.map(entry => ({
+        ...(entry.aliases?.length ? { aliases: entry.aliases } : {}),
         name: entry.name,
         triggers: Object.keys(entry.triggers),
       })),

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -327,7 +327,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
         output = invocation.response
       }
       else {
-        if (!signal.aborted) emit({ agent: entry.name, run: invocation.run, trigger: invocation.trigger.id, type: "start" })
+        if (!signal.aborted) emit({ agent: entry.name, ...(invocation.metadata ? { metadata: invocation.metadata } : {}), run: invocation.run, trigger: invocation.trigger.id, type: "start" })
         const previewAgent = withDeliveryPreviewChannels(entry.agent, event => {
           if (!signal.aborted) emit(event)
         })

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -214,6 +214,52 @@ describe("agent output helpers", () => {
     ])
   })
 
+  it("includes model metadata in derived raw-result usage records", async () => {
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents({
+      raw: {
+        durationMs: 1000,
+        provider: "googleVertex.anthropic.messages",
+        response: {
+          id: "resp_1",
+          modelId: "claude-opus-4-8",
+          timestamp: "2026-06-22T20:00:00.000Z",
+        },
+        usage: Promise.resolve({
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        }),
+      },
+      text: "ok",
+    })) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: {
+          model: {
+            id: "claude-opus-4-8",
+            provider: "googleVertex.anthropic.messages",
+          },
+          response: {
+            id: "resp_1",
+            timestamp: "2026-06-22T20:00:00.000Z",
+          },
+          usage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            totalTokens: 15,
+          },
+        },
+      },
+      { type: "finish" },
+    ])
+  })
+
   it("adds a terminal finish event to fullStream output", async () => {
     const output = {
       fullStream: (async function* () {

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -278,12 +278,12 @@ describe("agent output helpers", () => {
         yield {
           type: "finish-step",
           usage: {
-            inputTokens: 16,
+            inputTokens: 4,
             outputTokenDetails: {
               reasoningTokens: 2,
             },
-            outputTokens: 4,
-            totalTokens: 20,
+            outputTokens: 1,
+            totalTokens: 5,
           },
         }
         yield {
@@ -309,9 +309,6 @@ describe("agent output helpers", () => {
         usageRecord: {
           usage: {
             inputTokens: 16,
-            outputTokenDetails: {
-              reasoningTokens: 2,
-            },
             outputTokens: 4,
             totalTokens: 20,
           },

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -364,6 +364,48 @@ describe("agent output helpers", () => {
     ])
   })
 
+  it("inherits model metadata from stream result usage records", async () => {
+    const output = {
+      fullStream: (async function* () {
+        yield { text: "ok", type: "text-delta" }
+        yield {
+          totalUsage: {
+            inputTokens: 16,
+            outputTokens: 4,
+            totalTokens: 20,
+          },
+          type: "finish",
+        }
+      })(),
+      modelId: "claude-opus-4-8",
+      provider: "googleVertex.anthropic.messages",
+    }
+
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents(output)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: {
+          model: {
+            id: "claude-opus-4-8",
+            provider: "googleVertex.anthropic.messages",
+          },
+          usage: {
+            inputTokens: 16,
+            outputTokens: 4,
+            totalTokens: 20,
+          },
+        },
+      },
+      { type: "finish" },
+    ])
+  })
+
   it("adds a terminal finish event to textStream output", async () => {
     const output = {
       textStream: (async function* () {

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -302,6 +302,39 @@ describe("agent output helpers", () => {
     ])
   })
 
+  it("emits usage from promise-backed textStream results", async () => {
+    const output = {
+      textStream: (async function* () {
+        yield "ok"
+      })(),
+      usage: Promise.resolve({
+        inputTokens: 8,
+        outputTokens: 2,
+        totalTokens: 10,
+      }),
+    }
+
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents(output)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: {
+          usage: {
+            inputTokens: 8,
+            outputTokens: 2,
+            totalTokens: 10,
+          },
+        },
+      },
+      { type: "finish" },
+    ])
+  })
+
   it("reads fullStream getters once while converting stream events", async () => {
     let reads = 0
     const output = {

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -232,6 +232,45 @@ describe("agent output helpers", () => {
     ])
   })
 
+  it("prefers fullStream over async iterable stream result surfaces", async () => {
+    class StreamResult {
+      fullStream = (async function* () {
+        yield { text: "ok", type: "text-delta" }
+        yield { finishReason: "stop", type: "finish" }
+      })()
+
+      usage = Promise.resolve({
+        inputTokens: 8,
+        outputTokens: 2,
+        totalTokens: 10,
+      })
+
+      async *[Symbol.asyncIterator]() {
+        yield { text: "wrong", type: "text-delta" }
+      }
+    }
+
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents(new StreamResult())) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: {
+          usage: {
+            inputTokens: 8,
+            outputTokens: 2,
+            totalTokens: 10,
+          },
+        },
+      },
+      { reason: "stop", type: "finish" },
+    ])
+  })
+
   it("emits usage from AI SDK finish-step chunks before finish", async () => {
     const output = {
       fullStream: (async function* () {

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -199,6 +199,56 @@ describe("agent output helpers", () => {
     ])
   })
 
+  it("emits usage from AI SDK finish-step chunks before finish", async () => {
+    const output = {
+      fullStream: (async function* () {
+        yield { text: "ok", type: "text-delta" }
+        yield {
+          type: "finish-step",
+          usage: {
+            inputTokens: 16,
+            outputTokenDetails: {
+              reasoningTokens: 2,
+            },
+            outputTokens: 4,
+            totalTokens: 20,
+          },
+        }
+        yield {
+          totalUsage: {
+            inputTokens: 16,
+            outputTokens: 4,
+            totalTokens: 20,
+          },
+          type: "finish",
+        }
+      })(),
+    }
+
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents(output)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: {
+          usage: {
+            inputTokens: 16,
+            outputTokenDetails: {
+              reasoningTokens: 2,
+            },
+            outputTokens: 4,
+            totalTokens: 20,
+          },
+        },
+      },
+      { type: "finish" },
+    ])
+  })
+
   it("adds a terminal finish event to textStream output", async () => {
     const output = {
       textStream: (async function* () {

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -181,6 +181,39 @@ describe("agent output helpers", () => {
     ])
   })
 
+  it("emits usage from raw results wrapped by text output renderers", async () => {
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents({
+      raw: {
+        usage: Promise.resolve({
+          inputTokens: 10,
+          outputTokenDetails: { reasoningTokens: 3 },
+          outputTokens: 7,
+          totalTokens: 17,
+        }),
+      },
+      text: "ok",
+    })) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: {
+          usage: {
+            inputTokens: 10,
+            outputTokenDetails: { reasoningTokens: 3 },
+            outputTokens: 7,
+            totalTokens: 17,
+          },
+        },
+      },
+      { type: "finish" },
+    ])
+  })
+
   it("adds a terminal finish event to fullStream output", async () => {
     const output = {
       fullStream: (async function* () {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -344,10 +344,12 @@ describe("agent CLI", () => {
       if (init?.method === "POST") {
         return ndjson([
           { agent: "support", trigger: "chat.message", type: "start" },
+          { id: "tool-1", name: "shell", type: "tool-input-start" },
           { id: "tool-1", input: { command: "pnpm test" }, name: "shell", type: "tool-call" },
           { id: "tool-1", name: "shell", output: longOutput, type: "tool-result" },
           { id: "tool-2", name: "workspace_list", output: { path: "." }, type: "tool-result" },
           { text: "done", type: "text-delta" },
+          { type: "usage", usageRecord: { usage: { inputTokens: 10, outputTokenDetails: { reasoningTokens: 3 }, outputTokens: 7, totalTokens: 17 } } },
           { type: "usage", usageRecord: { usage: { inputTokens: 10, outputTokenDetails: { reasoningTokens: 3 }, outputTokens: 7, totalTokens: 17 } } },
           { type: "finish" },
           { type: "done" },
@@ -377,6 +379,7 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain(`output: {"path":"."}`)
     expect(stderr.output()).toContain("[usage] 17 tokens: 10 in / 7 out; 3 reasoning tokens")
     expect(stderr.output().match(/\[tool\] shell/g)).toHaveLength(1)
+    expect(stderr.output().match(/\[usage\] 17 tokens/g)).toHaveLength(1)
   })
 
   it("renders Agent Dev Loop delivery previews", async () => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -54,7 +54,7 @@ describe("agent CLI", () => {
     const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       if (init?.method === "POST") {
         return ndjson([
-          { agent: "support", trigger: "chat.message", type: "start" },
+          { agent: "support", metadata: {}, trigger: "chat.message", type: "start" },
           { text: "hello from agent", type: "text-delta" },
           { type: "finish" },
           { type: "done" },
@@ -199,7 +199,7 @@ describe("agent CLI", () => {
     const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       if (init?.method === "POST") {
         return ndjson([
-          { agent: "support", metadata: {}, trigger: "chat.message", type: "start" },
+          { agent: "support", metadata: { thinkingFallback: null }, trigger: "chat.message", type: "start" },
           { text: "done", type: "text-delta" },
           { type: "finish" },
           { type: "done" },

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -349,6 +349,7 @@ describe("agent CLI", () => {
           { id: "tool-1", input: { command: "cat file.md" }, name: "shell", type: "tool-call" },
           { id: "tool-1", name: "shell", output: { command: "cat file.md", exitCode: 0, stderr: "", stdout: longOutput }, type: "tool-result" },
           { id: "tool-2", name: "workspace_list", output: { path: "." }, type: "tool-result" },
+          { id: "tool-3", name: "run_summary", output: { raw: { raw: { steps: longOutput } }, text: "summary body" }, type: "tool-result" },
           { text: "done", type: "text-delta" },
           { type: "usage", usageRecord: { cost: { amount: "0.00000400", currency: "USD", estimated: true, source: "estimated" }, latency: { durationMs: 2000, tokensPerSecond: 3.5 }, usage: { inputTokens: 10, outputTokenDetails: { reasoningTokens: 3 }, outputTokens: 7, totalTokens: 17 } } },
           { type: "usage", usageRecord: { cost: { amount: "0.00000400", currency: "USD", estimated: true, source: "estimated" }, latency: { durationMs: 2000, tokensPerSecond: 3.5 }, usage: { inputTokens: 10, outputTokenDetails: { reasoningTokens: 3 }, outputTokens: 7, totalTokens: 17 } } },
@@ -379,6 +380,9 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain("---")
     expect(stderr.output()).toContain("[tool] workspace_list")
     expect(stderr.output()).toContain(`output: {"path":"."}`)
+    expect(stderr.output()).toContain("[tool] run_summary")
+    expect(stderr.output()).toContain("summary body")
+    expect(stderr.output()).not.toContain(`output: {"raw"`)
     expect(stderr.output()).not.toContain("[usage]")
     expect(stderr.output().match(/\[tool\] cat file\.md/g)).toHaveLength(1)
     expect(stdout.output()).toContain("done\n\n> [!NOTE]\n> Usage: cost ~$0.000004; 17 tokens: 10 in / 7 out; 3 reasoning tokens; time 2.0s; speed 3.5 tok/s")

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -388,6 +388,53 @@ describe("agent CLI", () => {
     expect(stdout.output()).toContain("done\n\n> [!NOTE]\n> Usage: cost ~$0.000004; 17 tokens: 10 in / 7 out; 3 reasoning tokens; time 2.0s; speed 3.5 tok/s")
   })
 
+  it("adds best-effort pricing to Agent Dev Loop usage notes", async () => {
+    const stderr = stream()
+    const stdout = stream()
+    const pricingFetch = vi.fn(async () => Response.json({
+      data: [{
+        id: "anthropic/claude-opus-4.8",
+        pricing: {
+          input: "0.000005",
+          output: "0.000025",
+        },
+      }],
+    }))
+    vi.stubGlobal("fetch", pricingFetch)
+    try {
+      const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        if (init?.method === "POST") {
+          return ndjson([
+            { agent: "support", trigger: "chat.message", type: "start" },
+            { text: "done", type: "text-delta" },
+            { type: "usage", usageRecord: { latency: { durationMs: 1000 }, model: { id: "claude-opus-4-8", provider: "googleVertex.anthropic.messages" }, usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } },
+            { type: "finish" },
+          ])
+        }
+        return Response.json({
+          agents: [{ name: "support", triggers: ["chat.message"] }],
+          root: "/repo",
+        })
+      })
+
+      const exitCode = await runAgentDevCli(["hello"], {
+        cwd: "/repo",
+        env: {},
+        rootDir: "/repo",
+        spawn: vi.fn(),
+        stderr,
+        stdout,
+      }, { fetch: fetchAgentStream as never })
+
+      expect(exitCode).toBe(0)
+      expect(stdout.output()).toContain("> Usage: cost ~$0.000175; 15 tokens: 10 in / 5 out; time 1.0s; speed 5.0 tok/s")
+      expect(pricingFetch).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it("renders Agent Dev Loop delivery previews", async () => {
     const stderr = stream()
     const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -97,6 +97,69 @@ describe("agent CLI", () => {
     })
   })
 
+  it("renders and clears the default Agent Dev Loop thinking fallback", async () => {
+    const stderr = stream()
+    const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return ndjson([
+          { agent: "support", trigger: "chat.message", type: "start" },
+          { text: "done", type: "text-delta" },
+          { type: "finish" },
+          { type: "done" },
+        ])
+      }
+      return Response.json({
+        agents: [{ name: "support", triggers: ["chat.message"] }],
+        root: "/repo",
+      })
+    })
+
+    const exitCode = await runAgentDevCli(["hello"], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      spawn: vi.fn(),
+      stderr,
+      stdout: stream(),
+    }, { fetch: fetchAgentStream as never })
+
+    expect(exitCode).toBe(0)
+    expect(stderr.output()).toBe("Thinking...\r\u001b[K")
+  })
+
+  it("uses Agent Dev Loop thinking fallback metadata", async () => {
+    const stderr = stream()
+    const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return ndjson([
+          { agent: "support", metadata: { thinkingFallback: "Reading PR..." }, trigger: "chat.message", type: "start" },
+          { id: "tool-1", input: { command: "ls" }, name: "workspaceShell", type: "tool-call" },
+          { text: "done", type: "text-delta" },
+          { type: "finish" },
+          { type: "done" },
+        ])
+      }
+      return Response.json({
+        agents: [{ name: "support", triggers: ["chat.message"] }],
+        root: "/repo",
+      })
+    })
+
+    const exitCode = await runAgentDevCli(["hello"], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      spawn: vi.fn(),
+      stderr,
+      stdout: stream(),
+    }, { fetch: fetchAgentStream as never })
+
+    expect(exitCode).toBe(0)
+    expect(stderr.output()).toContain("Reading PR...\r\u001b[K")
+    expect(stderr.output()).toContain("[tool] workspaceShell")
+    expect(stderr.output()).not.toContain("Thinking...")
+  })
+
   it("loads Agent Invocation Context Values from a JSON file", async () => {
     const workspaceDir = await mkdtemp(join(tmpdir(), "vitehub-agent-dev-context-"))
     const rootDir = join(workspaceDir, "app")

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -97,6 +97,40 @@ describe("agent CLI", () => {
     })
   })
 
+  it("accepts Agent Dev Loop discovery aliases", async () => {
+    const stdout = stream()
+    const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return ndjson([
+          { agent: "review", type: "start" },
+          { text: "summary", type: "text-delta" },
+          { type: "finish" },
+          { type: "done" },
+        ])
+      }
+      return Response.json({
+        agents: [{ aliases: ["summary"], name: "review", triggers: ["github.webhook"] }],
+        root: "/repo",
+      })
+    })
+
+    const exitCode = await runAgentDevCli(["--agent", "summary", "-p", "/summary"], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      spawn: vi.fn(),
+      stderr: stream(),
+      stdout,
+    }, { fetch: fetchAgentStream as never })
+
+    expect(exitCode).toBe(0)
+    expect(stdout.output()).toBe("summary\n")
+    const post = fetchAgentStream.mock.calls[1]
+    expect(JSON.parse(String(post?.[1]?.body))).toMatchObject({
+      agent: "summary",
+    })
+  })
+
   it("renders and clears the default Agent Dev Loop thinking fallback", async () => {
     const stderr = stream()
     const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -158,7 +158,7 @@ describe("agent CLI", () => {
     }, { fetch: fetchAgentStream as never })
 
     expect(exitCode).toBe(0)
-    expect(stderr.output()).toBe("\rThinking...\r\u001b[K")
+    expect(stderr.output()).toBe("\u001B[?25l\rThinking...\r\u001b[K\u001B[?25h")
   })
 
   it("uses Agent Dev Loop thinking fallback metadata", async () => {
@@ -189,7 +189,7 @@ describe("agent CLI", () => {
     }, { fetch: fetchAgentStream as never })
 
     expect(exitCode).toBe(0)
-    expect(stderr.output()).toContain("\rReading PR...\r\u001b[K")
+    expect(stderr.output()).toContain("\u001B[?25l\rReading PR...\r\u001b[K\u001B[?25h")
     expect(stderr.output()).toContain("[tool] ls")
     expect(stderr.output()).not.toContain("Thinking...")
   })
@@ -350,8 +350,8 @@ describe("agent CLI", () => {
           { id: "tool-1", name: "shell", output: { command: "cat file.md", exitCode: 0, stderr: "", stdout: longOutput }, type: "tool-result" },
           { id: "tool-2", name: "workspace_list", output: { path: "." }, type: "tool-result" },
           { text: "done", type: "text-delta" },
-          { type: "usage", usageRecord: { usage: { inputTokens: 10, outputTokenDetails: { reasoningTokens: 3 }, outputTokens: 7, totalTokens: 17 } } },
-          { type: "usage", usageRecord: { usage: { inputTokens: 10, outputTokenDetails: { reasoningTokens: 3 }, outputTokens: 7, totalTokens: 17 } } },
+          { type: "usage", usageRecord: { cost: { amount: "0.00000400", currency: "USD", estimated: true, source: "estimated" }, latency: { durationMs: 2000, tokensPerSecond: 3.5 }, usage: { inputTokens: 10, outputTokenDetails: { reasoningTokens: 3 }, outputTokens: 7, totalTokens: 17 } } },
+          { type: "usage", usageRecord: { cost: { amount: "0.00000400", currency: "USD", estimated: true, source: "estimated" }, latency: { durationMs: 2000, tokensPerSecond: 3.5 }, usage: { inputTokens: 10, outputTokenDetails: { reasoningTokens: 3 }, outputTokens: 7, totalTokens: 17 } } },
           { type: "finish" },
           { type: "done" },
         ])
@@ -381,7 +381,7 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain(`output: {"path":"."}`)
     expect(stderr.output()).not.toContain("[usage]")
     expect(stderr.output().match(/\[tool\] cat file\.md/g)).toHaveLength(1)
-    expect(stdout.output()).toContain("done\n\n> [!NOTE]\n> Usage: 17 tokens: 10 in / 7 out; 3 reasoning tokens")
+    expect(stdout.output()).toContain("done\n\n> [!NOTE]\n> Usage: cost ~$0.000004; 17 tokens: 10 in / 7 out; 3 reasoning tokens; time 2.0s; speed 3.5 tok/s")
   })
 
   it("renders Agent Dev Loop delivery previews", async () => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -160,6 +160,36 @@ describe("agent CLI", () => {
     expect(stderr.output()).not.toContain("Thinking...")
   })
 
+  it("respects disabled Agent Dev Loop thinking fallback metadata", async () => {
+    const stderr = stream()
+    const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return ndjson([
+          { agent: "support", metadata: {}, trigger: "chat.message", type: "start" },
+          { text: "done", type: "text-delta" },
+          { type: "finish" },
+          { type: "done" },
+        ])
+      }
+      return Response.json({
+        agents: [{ name: "support", triggers: ["chat.message"] }],
+        root: "/repo",
+      })
+    })
+
+    const exitCode = await runAgentDevCli(["hello"], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      spawn: vi.fn(),
+      stderr,
+      stdout: stream(),
+    }, { fetch: fetchAgentStream as never })
+
+    expect(exitCode).toBe(0)
+    expect(stderr.output()).toBe("")
+  })
+
   it("loads Agent Invocation Context Values from a JSON file", async () => {
     const workspaceDir = await mkdtemp(join(tmpdir(), "vitehub-agent-dev-context-"))
     const rootDir = join(workspaceDir, "app")

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -158,7 +158,7 @@ describe("agent CLI", () => {
     }, { fetch: fetchAgentStream as never })
 
     expect(exitCode).toBe(0)
-    expect(stderr.output()).toBe("Thinking...\r\u001b[K")
+    expect(stderr.output()).toBe("\rThinking...\r\u001b[K")
   })
 
   it("uses Agent Dev Loop thinking fallback metadata", async () => {
@@ -189,8 +189,8 @@ describe("agent CLI", () => {
     }, { fetch: fetchAgentStream as never })
 
     expect(exitCode).toBe(0)
-    expect(stderr.output()).toContain("Reading PR...\r\u001b[K")
-    expect(stderr.output()).toContain("[tool] workspaceShell")
+    expect(stderr.output()).toContain("\rReading PR...\r\u001b[K")
+    expect(stderr.output()).toContain("[tool] ls")
     expect(stderr.output()).not.toContain("Thinking...")
   })
 
@@ -337,16 +337,17 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain("[approval required] workspace_write: Needs write access.")
   })
 
-  it("renders Agent Dev Loop tool input, truncated output, and usage", async () => {
+  it("renders Agent Dev Loop tool output and final usage note", async () => {
     const stderr = stream()
+    const stdout = stream()
     const longOutput = "x".repeat(1300)
     const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       if (init?.method === "POST") {
         return ndjson([
           { agent: "support", trigger: "chat.message", type: "start" },
           { id: "tool-1", name: "shell", type: "tool-input-start" },
-          { id: "tool-1", input: { command: "pnpm test" }, name: "shell", type: "tool-call" },
-          { id: "tool-1", name: "shell", output: longOutput, type: "tool-result" },
+          { id: "tool-1", input: { command: "cat file.md" }, name: "shell", type: "tool-call" },
+          { id: "tool-1", name: "shell", output: { command: "cat file.md", exitCode: 0, stderr: "", stdout: longOutput }, type: "tool-result" },
           { id: "tool-2", name: "workspace_list", output: { path: "." }, type: "tool-result" },
           { text: "done", type: "text-delta" },
           { type: "usage", usageRecord: { usage: { inputTokens: 10, outputTokenDetails: { reasoningTokens: 3 }, outputTokens: 7, totalTokens: 17 } } },
@@ -367,19 +368,20 @@ describe("agent CLI", () => {
       rootDir: "/repo",
       spawn: vi.fn(),
       stderr,
-      stdout: stream(),
+      stdout,
     }, { fetch: fetchAgentStream as never })
 
     expect(exitCode).toBe(0)
-    expect(stderr.output()).toContain("[tool] shell")
-    expect(stderr.output()).toContain(`input: {"command":"pnpm test"}`)
+    expect(stderr.output()).toContain("[tool] cat file.md")
+    expect(stderr.output()).not.toContain(`input: {"command":"cat file.md"}`)
     expect(stderr.output()).toContain("[truncated ")
     expect(stderr.output()).not.toContain(longOutput)
+    expect(stderr.output()).toContain("---")
     expect(stderr.output()).toContain("[tool] workspace_list")
     expect(stderr.output()).toContain(`output: {"path":"."}`)
-    expect(stderr.output()).toContain("[usage] 17 tokens: 10 in / 7 out; 3 reasoning tokens")
-    expect(stderr.output().match(/\[tool\] shell/g)).toHaveLength(1)
-    expect(stderr.output().match(/\[usage\] 17 tokens/g)).toHaveLength(1)
+    expect(stderr.output()).not.toContain("[usage]")
+    expect(stderr.output().match(/\[tool\] cat file\.md/g)).toHaveLength(1)
+    expect(stdout.output()).toContain("done\n\n> [!NOTE]\n> Usage: 17 tokens: 10 in / 7 out; 3 reasoning tokens")
   })
 
   it("renders Agent Dev Loop delivery previews", async () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -555,6 +555,49 @@ describe("agent chat capability discovery", () => {
     expect(abortSignal).toBeInstanceOf(AbortSignal)
   })
 
+  it("normalizes Agent Invocation Stream usage before serializing endpoint events", async () => {
+    const root = await createTempRoot("vitehub-agent-invocation-stream-usage-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const usage = { inputTokens: 2, outputTokens: 3, totalTokens: 5 }
+    const agent = defineAgent({
+      async * run() {
+        yield { text: "hello from stream", type: "text-delta" }
+        yield { finishReason: "stop", totalUsage: usage, type: "finish" }
+      },
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
+
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      messages: [{
+        id: "user-1",
+        parts: [{ text: "hello", type: "text" }],
+        role: "user",
+      }],
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    })
+    const events = response.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+
+    expect(events).toEqual([
+      expect.objectContaining({ agent: "support", type: "start" }),
+      { text: "hello from stream", type: "text-delta" },
+      { type: "usage", usageRecord: { usage } },
+      { reason: "stop", type: "finish" },
+      { type: "done" },
+    ])
+  })
+
   it("passes Agent Dev Loop context into message-shaped channel invocations", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-context-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -710,6 +710,55 @@ describe("agent chat capability discovery", () => {
     }
   })
 
+  it("prefers exact dev loop agent names over aliases", async () => {
+    const root = await createTempRoot("vitehub-agent-invocation-stream-exact-name-")
+    await mkdir(join(root, "server", "agents", "review"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "review", "config.ts"), "export default {}", "utf8")
+    await writeFile(join(root, "server", "agents", "summary.ts"), "export default {}", "utf8")
+
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const headers = {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    }
+    const aliasAgent = defineAgent({
+      name: "summary",
+      run: () => "alias",
+      workspace: {},
+    })
+    const exactAgent = defineAgent({
+      run: () => "exact",
+    })
+    const { handlers, server } = createFakeServer(root, { default: aliasAgent })
+    server.ssrLoadModule.mockImplementation(async (...args: unknown[]) => String(args[0] || "").includes("/summary.ts")
+      ? { default: exactAgent }
+      : { default: aliasAgent })
+    const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
+
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      agent: "summary",
+      messages: [{
+        id: "user-1",
+        parts: [{ text: "hello", type: "text" }],
+        role: "user",
+      }],
+    }, agentInvocationStreamRoute, headers)
+    const events = response.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+
+    expect(events).toEqual([
+      expect.objectContaining({ agent: "summary", type: "start" }),
+      { text: "exact", type: "text-delta" },
+      { type: "finish" },
+      { type: "done" },
+    ])
+  })
+
   it("previews trigger Channel Delivery Effects for Agent Dev Loop channel invocations", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-effects-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -613,6 +613,60 @@ describe("agent chat capability discovery", () => {
     ])
   })
 
+  it("accepts declared workspace agent names as dev loop aliases", async () => {
+    const root = await createTempRoot("vitehub-agent-invocation-stream-alias-")
+    await mkdir(join(root, "server", "agents", "review"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "review", "config.ts"), "export default {}", "utf8")
+
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const headers = {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    }
+    const agent = defineAgent({
+      name: "summary",
+      run: () => "ok",
+      workspace: {},
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
+
+    await configurePluginServer(plugin, server)
+
+    const discovery = await invokeMiddleware(handlers[0]!, {}, agentInvocationStreamRoute, {
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    }, "GET")
+    expect(JSON.parse(discovery.body)).toMatchObject({
+      agents: [{
+        aliases: ["summary"],
+        name: "review",
+      }],
+    })
+
+    for (const name of ["summary", "review"]) {
+      const response = await invokeMiddleware(handlers[0]!, {
+        agent: name,
+        messages: [{
+          id: "user-1",
+          parts: [{ text: "hello", type: "text" }],
+          role: "user",
+        }],
+      }, agentInvocationStreamRoute, headers)
+      const events = response.body
+        .trim()
+        .split("\n")
+        .map(line => JSON.parse(line))
+
+      expect(events).toEqual([
+        expect.objectContaining({ agent: "review", type: "start" }),
+        { text: "ok", type: "text-delta" },
+        { type: "finish" },
+        { type: "done" },
+      ])
+    }
+  })
+
   it("previews trigger Channel Delivery Effects for Agent Dev Loop channel invocations", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-effects-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -28,6 +28,24 @@ describe("inputCommands", () => {
     expect(resolved.input.prompt).toBe("Review this: auth changes")
   })
 
+  it("keeps command-only text when a string handler returns empty args", async () => {
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [inputCommands({
+        commands: {
+          summary: {
+            description: "Summarize the request.",
+            run: ({ args }) => args,
+          },
+        },
+      })],
+    }, runtime(), { prompt: "/summary" })
+
+    expect(resolved.input.prompt).toBe("/summary")
+  })
+
   it("replaces command text from an initial message", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -927,6 +927,21 @@ describe("agent message protocol", () => {
     ])
   })
 
+  it("converts live tool execution results to JSON-compatible values", async () => {
+    const { withJsonCompatibleToolOutputs } = await import("../src/tool-runtime.ts")
+
+    const tools = withJsonCompatibleToolOutputs({
+      lookup: {
+        execute: (_input: unknown) => ({ timestamp: new Date("2026-06-22T19:30:00.000Z") }),
+        name: "lookup",
+      },
+    })
+
+    await expect(tools.lookup.execute?.({})).resolves.toEqual({
+      timestamp: "2026-06-22T19:30:00.000Z",
+    })
+  })
+
   it("splits assistant tool result history into valid model messages", async () => {
     const { toAiSdkModelMessages } = await import("../src/ai-sdk.ts")
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3567,6 +3567,28 @@ describe("agent message protocol", () => {
     expect(resolved).toEqual(expect.any(Object))
   })
 
+  it("converts static capability tool execution results to JSON-compatible values", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+
+    const agent = defineAgent({
+      model: {} as never,
+      capabilities: [{
+        id: "lookup-tools",
+        tools: {
+          lookup: {
+            execute: (_input: unknown) => ({ timestamp: new Date("2026-06-22T19:30:00.000Z") }),
+            name: "lookup",
+          },
+        },
+      }],
+    })
+    const resolved = await agent.resolve({ memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }) as unknown as { tools: Record<string, { execute: (input: unknown) => Promise<unknown> }> }
+
+    await expect(resolved.tools.lookup!.execute({})).resolves.toEqual({
+      timestamp: "2026-06-22T19:30:00.000Z",
+    })
+  })
+
   it("resolves static subagent tools with the resolved runtime context", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const browserAgent = {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { createMessage, getMessageText } from "@vite-hub/agent"
 import { createTraceEventLog, deriveTraceRuns, emitTraceEvent } from "@vite-hub/runtime"
 import { chat, chatTitle, schedule, subagents } from "../src/capabilities.ts"
+import { toJsonCompatibleValue } from "../src/tool-runtime.ts"
 
 const harnessAgentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
 const harnessCreateSession = vi.hoisted(() => vi.fn())
@@ -40,6 +41,10 @@ afterEach(() => {
 })
 
 describe("agent message protocol", () => {
+  it("normalizes undefined tool output to JSON null", () => {
+    expect(toJsonCompatibleValue(undefined)).toBeNull()
+  })
+
   it("runs custom Agent Drivers through the invocation lifecycle", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const run = vi.fn(context => `received ${context.prompt}`)
@@ -2310,6 +2315,29 @@ describe("agent message protocol", () => {
     for await (const _event of stream as AsyncIterable<unknown>) {}
 
     expect(order).toEqual(["stream:done", "finish"])
+  })
+
+  it("streams custom run fullStream results", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      run: () => ({
+        fullStream: (async function* () {
+          yield { text: "ok", type: "text-delta" }
+          yield { type: "finish" }
+        })(),
+      }),
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})
+
+    const events = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      { type: "finish" },
+    ])
   })
 
   it("runs finish lifecycle when async stream output renderer setup fails", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3304,6 +3304,44 @@ describe("agent message protocol", () => {
     ])
   })
 
+  it("omits chat thinking fallback metadata when the placeholder is unset", async () => {
+    const { defineAgent, resolveAgentTriggerInvocation } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [chat()],
+      run: () => "ok",
+    })
+
+    const invocation = await resolveAgentTriggerInvocation(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, "chat.message", {
+      messages: [createMessage({ role: "user", text: "hello" })],
+    })
+
+    if ("response" in invocation) throw new Error("Expected chat trigger invocation input.")
+    expect(invocation.metadata).toBeUndefined()
+  })
+
+  it("preserves disabled chat thinking fallback metadata", async () => {
+    const { defineAgent, resolveAgentTriggerInvocation } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [chat({ fallbackStreamingPlaceholderText: null })],
+      run: () => "ok",
+    })
+
+    const invocation = await resolveAgentTriggerInvocation(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, "chat.message", {
+      messages: [createMessage({ role: "user", text: "hello" })],
+    })
+
+    if ("response" in invocation) throw new Error("Expected chat trigger invocation input.")
+    expect(invocation.metadata).toEqual({ thinkingFallback: null })
+  })
+
   it("converts async stream events to AI SDK UI message streams", async () => {
     const { readUIMessageStream } = await import("ai")
     const { defineAgent, streamAgent } = await import("../src/index.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1555,7 +1555,7 @@ describe("agent message protocol", () => {
 
   it("feeds GitHub PR comment commands through input commands and write-back effects", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
-    const { inputCommands } = await import("../src/capabilities.ts")
+    const { inputCommands, usageTelemetry } = await import("../src/capabilities.ts")
     const { github } = await import("../src/channels.ts")
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
     const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
@@ -1648,7 +1648,7 @@ describe("agent message protocol", () => {
             },
           },
         },
-      })],
+      }), usageTelemetry({ summary: { subject: "Review run" } })],
       channels: {
         github: github({
           app: {
@@ -1668,11 +1668,16 @@ describe("agent message protocol", () => {
       },
       run: (context) => {
         expect(context.prompt).toBe("")
-        return "Review completed."
+        return {
+          text: "Review completed.",
+          totalUsage: { inputTokens: 10, outputTokens: 5 },
+        }
       },
     })
 
-    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "github.webhook", input)).resolves.toBe("Review completed.")
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "github.webhook", input)).resolves.toMatchObject({
+      text: "Review completed.",
+    })
 
     expect(fetcher).toHaveBeenCalledWith(
       "https://api.github.test/app/installations/123/access_tokens",
@@ -1699,7 +1704,7 @@ describe("agent message protocol", () => {
     expect(fetcher).toHaveBeenCalledWith(
       "https://api.github.test/repos/vite-hub/vitehub/issues/42/comments",
       expect.objectContaining({
-        body: JSON.stringify({ body: "Review completed." }),
+        body: expect.stringContaining("\"body\":\"Review completed.\\n\\n> [!NOTE]\\n> Review run used 15 tokens: 10 in / 5 out"),
         method: "POST",
       }),
     )

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -906,6 +906,27 @@ describe("agent message protocol", () => {
     ])
   })
 
+  it("converts structured tool history to JSON-compatible model messages", async () => {
+    const { toAiSdkModelMessages } = await import("../src/ai-sdk.ts")
+
+    const messages = [
+      {
+        id: "m1",
+        parts: [
+          { id: "call-1", name: "lookup", output: { timestamp: new Date("2026-06-22T19:30:00.000Z") }, state: "completed", type: "tool-result" },
+        ],
+        role: "tool",
+      },
+    ] as unknown as Parameters<typeof toAiSdkModelMessages>[0]
+
+    expect(toAiSdkModelMessages(messages)).toEqual([
+      {
+        content: [{ output: { type: "json", value: { timestamp: "2026-06-22T19:30:00.000Z" } }, toolCallId: "call-1", toolName: "lookup", type: "tool-result" }],
+        role: "tool",
+      },
+    ])
+  })
+
   it("splits assistant tool result history into valid model messages", async () => {
     const { toAiSdkModelMessages } = await import("../src/ai-sdk.ts")
 

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -366,6 +366,62 @@ describe("usage telemetry", () => {
     })
   })
 
+  it("emits streamed usage from promise-backed stream result usage", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry(),
+      ],
+      run: () => ({
+        fullStream: (async function* () {
+          yield { text: "ok", type: "text-delta" }
+          yield { finishReason: "stop", type: "finish" }
+        })(),
+        usage: Promise.resolve({
+          inputTokens: 10,
+          outputTokenDetails: { reasoningTokens: 3 },
+          outputTokens: 7,
+          totalTokens: 17,
+        }),
+      }),
+    })
+
+    const output = await streamAgent(agent, runtime(), {})
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents(output)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: expect.objectContaining({
+          usage: {
+            inputTokens: 10,
+            outputTokenDetails: { reasoningTokens: 3 },
+            outputTokens: 7,
+            totalTokens: 17,
+          },
+        }),
+      },
+      { reason: "stop", type: "finish" },
+    ])
+    expect(output).toMatchObject({
+      usageRecord: {
+        usage: {
+          inputTokens: 10,
+          outputTokenDetails: { reasoningTokens: 3 },
+          outputTokens: 7,
+          totalTokens: 17,
+        },
+      },
+    })
+  })
+
   it("records streamed usage when ui-message-stream consumes result.stream", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -370,6 +370,10 @@ describe("usage telemetry", () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")
+    let resolveUsage: (usage: unknown) => void
+    const usage = new Promise(resolve => {
+      resolveUsage = resolve
+    })
 
     const agent = defineAgent({
       capabilities: [
@@ -379,24 +383,32 @@ describe("usage telemetry", () => {
         fullStream: (async function* () {
           yield { text: "ok", type: "text-delta" }
           yield { finishReason: "stop", type: "finish" }
+          resolveUsage({
+            inputTokens: 10,
+            outputTokenDetails: { reasoningTokens: 3 },
+            outputTokens: 7,
+            totalTokens: 17,
+          })
         })(),
-        usage: Promise.resolve({
-          inputTokens: 10,
-          outputTokenDetails: { reasoningTokens: 3 },
-          outputTokens: 7,
-          totalTokens: 17,
-        }),
+        usage,
       }),
     })
 
     const output = await streamAgent(agent, runtime(), {})
-    const events: unknown[] = []
-    for await (const event of streamAgentOutputToEvents(output)) {
-      events.push(event)
-    }
+    const events = await Promise.race([
+      (async () => {
+        const items: unknown[] = []
+        for await (const event of streamAgentOutputToEvents(output)) {
+          items.push(event)
+        }
+        return items
+      })(),
+      new Promise<"timeout">(resolve => setTimeout(() => resolve("timeout"), 100)),
+    ])
 
     expect(events).toEqual([
       { text: "ok", type: "text-delta" },
+      { reason: "stop", type: "finish" },
       {
         type: "usage",
         usageRecord: expect.objectContaining({
@@ -408,7 +420,6 @@ describe("usage telemetry", () => {
           },
         }),
       },
-      { reason: "stop", type: "finish" },
     ])
     expect(output).toMatchObject({
       usageRecord: {

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -653,6 +653,64 @@ describe("usage telemetry", () => {
     }
   })
 
+  it("emits ToolLoopAgent model call end usage over empty stream result usage", async () => {
+    vi.doMock("ai", () => ({
+      jsonSchema: vi.fn(schema => schema),
+      stepCountIs: () => () => false,
+      ToolLoopAgent: class {
+        async stream(options: { onLanguageModelCallEnd?: (event: unknown) => unknown }) {
+          return {
+            fullStream: (async function* () {
+              yield { text: "ok", type: "text-delta" }
+              yield { finishReason: "stop", type: "finish" }
+              await options.onLanguageModelCallEnd?.({
+                usage: {
+                  inputTokens: 10,
+                  outputTokenDetails: { reasoningTokens: 3 },
+                  outputTokens: 7,
+                  totalTokens: 17,
+                },
+              })
+            })(),
+            usage: Promise.resolve({}),
+          }
+        }
+      },
+    }))
+
+    try {
+      const { defineAgent, streamAgent } = await import("../src/index.ts")
+
+      const agent = defineAgent({
+        model: {} as never,
+      })
+      const output = await streamAgent(agent, runtime(), {})
+      const events: unknown[] = []
+      for await (const event of output as AsyncIterable<unknown>) {
+        events.push(event)
+      }
+
+      expect(events).toEqual([
+        { text: "ok", type: "text-delta" },
+        {
+          type: "usage",
+          usageRecord: {
+            usage: {
+              inputTokens: 10,
+              outputTokenDetails: { reasoningTokens: 3 },
+              outputTokens: 7,
+              totalTokens: 17,
+            },
+          },
+        },
+        { reason: "stop", type: "finish" },
+      ])
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
   it("emits streamed usage from outer usage when the stream has no finish chunk", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -539,6 +539,63 @@ describe("usage telemetry", () => {
     }
   })
 
+  it("emits ToolLoopAgent onEnd usage when the stream result omits usage", async () => {
+    vi.doMock("ai", () => ({
+      jsonSchema: vi.fn(schema => schema),
+      stepCountIs: () => () => false,
+      ToolLoopAgent: class {
+        async stream(options: { onEnd?: (event: unknown) => unknown }) {
+          return {
+            fullStream: (async function* () {
+              yield { text: "ok", type: "text-delta" }
+              yield { finishReason: "stop", type: "finish" }
+              await options.onEnd?.({
+                totalUsage: {
+                  inputTokens: 10,
+                  outputTokenDetails: { reasoningTokens: 3 },
+                  outputTokens: 7,
+                  totalTokens: 17,
+                },
+              })
+            })(),
+          }
+        }
+      },
+    }))
+
+    try {
+      const { defineAgent, streamAgent } = await import("../src/index.ts")
+
+      const agent = defineAgent({
+        model: {} as never,
+      })
+      const output = await streamAgent(agent, runtime(), {})
+      const events: unknown[] = []
+      for await (const event of output as AsyncIterable<unknown>) {
+        events.push(event)
+      }
+
+      expect(events).toEqual([
+        { text: "ok", type: "text-delta" },
+        {
+          type: "usage",
+          usageRecord: {
+            usage: {
+              inputTokens: 10,
+              outputTokenDetails: { reasoningTokens: 3 },
+              outputTokens: 7,
+              totalTokens: 17,
+            },
+          },
+        },
+        { reason: "stop", type: "finish" },
+      ])
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
   it("emits streamed usage from outer usage when the stream has no finish chunk", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -1132,6 +1132,13 @@ describe("usage telemetry", () => {
     const fetch = vi.fn(async () => Response.json({
       data: [
         {
+          id: "anthropic/claude-opus-4.8",
+          pricing: {
+            input: "0.000005",
+            output: "0.000025",
+          },
+        },
+        {
           id: "openai/gpt-test",
           pricing: {
             input: "0.00000010",
@@ -1161,6 +1168,18 @@ describe("usage telemetry", () => {
         outputTokens: 1,
       },
     })).resolves.toMatchObject({ amount: "0.0000003" })
+    await expect(pricing({
+      model: { id: "claude-opus-4-8", provider: "googleVertex.anthropic.messages" },
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+      },
+    })).resolves.toEqual({
+      amount: "0.000175",
+      currency: "USD",
+      estimated: true,
+      source: "vercel-ai-gateway",
+    })
     expect(fetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -433,6 +433,51 @@ describe("usage telemetry", () => {
     })
   })
 
+  it("emits streamed usage from outer usage when the stream has no finish chunk", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry(),
+      ],
+      run: () => ({
+        fullStream: (async function* () {
+          yield { text: "ok", type: "text-delta" }
+        })(),
+        usage: Promise.resolve({
+          inputTokens: 10,
+          outputTokenDetails: { reasoningTokens: 3 },
+          outputTokens: 7,
+          totalTokens: 17,
+        }),
+      }),
+    })
+
+    const output = await streamAgent(agent, runtime(), {})
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents(output)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: expect.objectContaining({
+          usage: {
+            inputTokens: 10,
+            outputTokenDetails: { reasoningTokens: 3 },
+            outputTokens: 7,
+            totalTokens: 17,
+          },
+        }),
+      },
+      { type: "finish" },
+    ])
+  })
+
   it("records streamed usage when ui-message-stream consumes result.stream", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -756,6 +756,58 @@ describe("usage telemetry", () => {
     ])
   })
 
+  it("preserves usage on stream result objects that are also async iterable", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+
+    class StreamResult {
+      fullStream = (async function* () {
+        yield { text: "ok", type: "text-delta" }
+        yield { finishReason: "stop", type: "finish" }
+      })()
+
+      usage = Promise.resolve({
+        inputTokens: 10,
+        outputTokenDetails: { reasoningTokens: 3 },
+        outputTokens: 7,
+        totalTokens: 17,
+      })
+
+      async *[Symbol.asyncIterator]() {
+        yield { text: "wrong", type: "text-delta" }
+      }
+    }
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry(),
+      ],
+      run: () => new StreamResult(),
+    })
+
+    const output = await streamAgent(agent, runtime(), {})
+    const events: unknown[] = []
+    for await (const event of output as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: expect.objectContaining({
+          usage: {
+            inputTokens: 10,
+            outputTokenDetails: { reasoningTokens: 3 },
+            outputTokens: 7,
+            totalTokens: 17,
+          },
+        }),
+      },
+      { reason: "stop", type: "finish" },
+    ])
+  })
+
   it("records streamed usage when ui-message-stream consumes result.stream", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -206,6 +206,57 @@ describe("usage telemetry", () => {
     expect(onUsage).toHaveBeenCalledTimes(1)
   })
 
+  it("preserves usage telemetry when later renderers wrap text output", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry(),
+        defineCapability({
+          id: "summary-output",
+          output(context) {
+            context.output.render((result) => {
+              const text = typeof result === "object" && result !== null && "text" in result
+                ? (result as { text?: unknown }).text
+                : result
+
+              return {
+                raw: text,
+                text,
+              }
+            })
+          },
+        }),
+      ],
+      run: () => ({
+        text: "ok",
+        totalUsage: {
+          inputTokens: 8,
+          outputTokens: 2,
+          totalTokens: 10,
+        },
+      }),
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+      raw: "ok",
+      text: "ok",
+      usage: {
+        inputTokens: 8,
+        outputTokens: 2,
+        totalTokens: 10,
+      },
+      usageRecord: {
+        usage: {
+          inputTokens: 8,
+          outputTokens: 2,
+          totalTokens: 10,
+        },
+      },
+    })
+  })
+
   it("uses app-owned usage summary formatting", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -137,7 +137,7 @@ describe("usage telemetry", () => {
       latency: {
         durationMs: expect.any(Number),
       },
-      summary: expect.stringMatching(/^Review run cost about \$0\.00015 using openai\/gpt-test in \d+\.\ds \(1,250 tokens: 1,000 in \/ 250 out\)\.$/),
+      summary: expect.stringMatching(/^Review run cost about \$0\.00015 using openai\/gpt-test in \d+\.\ds at \d+\.\d tok\/s \(1,250 tokens: 1,000 in \/ 250 out\)\.$/),
     })
   })
 
@@ -306,6 +306,7 @@ describe("usage telemetry", () => {
       },
       run: () => ({
         text: "ok",
+        durationMs: 2000,
         totalUsage: {
           inputTokens: 1000,
           totalTokens: 1250,
@@ -325,7 +326,7 @@ describe("usage telemetry", () => {
     expect(finish).toHaveBeenCalledTimes(1)
     const usageRecord = finish.mock.calls[0]![0].extensions.get("usage-telemetry")
     expect(usageRecord).toMatchObject({
-      summary: expect.stringMatching(/^Review run used 1,250 tokens: 1,000 in \/ 250 out in \d+\.\ds\.$/),
+      summary: expect.stringMatching(/^Review run used 1,250 tokens: 1,000 in \/ 250 out in \d+\.\ds at \d+\.\d tok\/s\.$/),
     })
   })
 

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -89,6 +89,40 @@ describe("usage telemetry", () => {
     expect(finish.mock.calls[0]![0].extensions.get("usage-telemetry")).toEqual(usageRecord)
   })
 
+  it("uses root model metadata when response only has an id", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({
+          pricing: staticModelPricing({
+            "openai/gpt-test": {
+              input: "0.00000010",
+              output: "0.00000020",
+            },
+          }),
+        }),
+      ],
+      run: () => ({
+        modelId: "openai/gpt-test",
+        response: { id: "response-1" },
+        text: "ok",
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+        },
+      }),
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+      usageRecord: {
+        cost: { amount: "0.000002" },
+        model: { id: "openai/gpt-test" },
+      },
+    })
+  })
+
   it("summarizes usage telemetry for finish hooks", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -408,7 +408,6 @@ describe("usage telemetry", () => {
 
     expect(events).toEqual([
       { text: "ok", type: "text-delta" },
-      { reason: "stop", type: "finish" },
       {
         type: "usage",
         usageRecord: expect.objectContaining({
@@ -420,6 +419,7 @@ describe("usage telemetry", () => {
           },
         }),
       },
+      { reason: "stop", type: "finish" },
     ])
     expect(output).toMatchObject({
       usageRecord: {
@@ -431,6 +431,61 @@ describe("usage telemetry", () => {
         },
       },
     })
+  })
+
+  it("emits ToolLoopAgent stream result usage when chunks only contain finish", async () => {
+    vi.doMock("ai", () => ({
+      jsonSchema: vi.fn(schema => schema),
+      stepCountIs: () => () => false,
+      ToolLoopAgent: class {
+        async stream() {
+          return {
+            fullStream: (async function* () {
+              yield { text: "ok", type: "text-delta" }
+              yield { finishReason: "stop", type: "finish" }
+            })(),
+            usage: Promise.resolve({
+              inputTokens: 10,
+              outputTokenDetails: { reasoningTokens: 3 },
+              outputTokens: 7,
+              totalTokens: 17,
+            }),
+          }
+        }
+      },
+    }))
+
+    try {
+      const { defineAgent, streamAgent } = await import("../src/index.ts")
+
+      const agent = defineAgent({
+        model: {} as never,
+      })
+      const output = await streamAgent(agent, runtime(), {})
+      const events: unknown[] = []
+      for await (const event of output as AsyncIterable<unknown>) {
+        events.push(event)
+      }
+
+      expect(events).toEqual([
+        { text: "ok", type: "text-delta" },
+        {
+          type: "usage",
+          usageRecord: {
+            usage: {
+              inputTokens: 10,
+              outputTokenDetails: { reasoningTokens: 3 },
+              outputTokens: 7,
+              totalTokens: 17,
+            },
+          },
+        },
+        { reason: "stop", type: "finish" },
+      ])
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
   })
 
   it("emits streamed usage from outer usage when the stream has no finish chunk", async () => {

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -596,6 +596,63 @@ describe("usage telemetry", () => {
     }
   })
 
+  it("emits ToolLoopAgent onStepEnd usage when the stream result omits usage", async () => {
+    vi.doMock("ai", () => ({
+      jsonSchema: vi.fn(schema => schema),
+      stepCountIs: () => () => false,
+      ToolLoopAgent: class {
+        async stream(options: { onStepEnd?: (event: unknown) => unknown }) {
+          return {
+            fullStream: (async function* () {
+              yield { text: "ok", type: "text-delta" }
+              yield { finishReason: "stop", type: "finish" }
+              await options.onStepEnd?.({
+                usage: {
+                  inputTokens: 10,
+                  outputTokenDetails: { reasoningTokens: 3 },
+                  outputTokens: 7,
+                  totalTokens: 17,
+                },
+              })
+            })(),
+          }
+        }
+      },
+    }))
+
+    try {
+      const { defineAgent, streamAgent } = await import("../src/index.ts")
+
+      const agent = defineAgent({
+        model: {} as never,
+      })
+      const output = await streamAgent(agent, runtime(), {})
+      const events: unknown[] = []
+      for await (const event of output as AsyncIterable<unknown>) {
+        events.push(event)
+      }
+
+      expect(events).toEqual([
+        { text: "ok", type: "text-delta" },
+        {
+          type: "usage",
+          usageRecord: {
+            usage: {
+              inputTokens: 10,
+              outputTokenDetails: { reasoningTokens: 3 },
+              outputTokens: 7,
+              totalTokens: 17,
+            },
+          },
+        },
+        { reason: "stop", type: "finish" },
+      ])
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
   it("emits streamed usage from outer usage when the stream has no finish chunk", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -334,6 +334,7 @@ describe("usage telemetry", () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")
     const { staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
+    const { defineAgentUsageMetadata } = await import("../src/internal/agent-usage-metadata.ts")
     const onUsage = vi.fn()
 
     const agent = defineAgent({
@@ -348,7 +349,7 @@ describe("usage telemetry", () => {
           }),
         }),
       ],
-      run: () => ({
+      run: () => defineAgentUsageMetadata({
         fullStream: (async function* () {
           yield { text: "ok", type: "text-delta" }
           yield {
@@ -365,7 +366,7 @@ describe("usage telemetry", () => {
             type: "finish",
           }
         })(),
-      }),
+      }, { credentialSource: { label: "local Codex", source: "ambient" } }),
     })
 
     const output = await streamAgent(agent, runtime(), {})
@@ -384,6 +385,10 @@ describe("usage telemetry", () => {
             currency: "USD",
             estimated: true,
             source: "custom",
+          },
+          credentialSource: {
+            label: "local Codex",
+            source: "ambient",
           },
           usage: {
             inputTokens: 10,
@@ -421,7 +426,7 @@ describe("usage telemetry", () => {
   it("emits streamed usage from promise-backed stream result usage", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { streamAgentOutputToEvents } = await import("../src/agent-output.ts")
-    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const { staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
     let resolveUsage: (usage: unknown) => void
     const usage = new Promise(resolve => {
       resolveUsage = resolve
@@ -429,7 +434,14 @@ describe("usage telemetry", () => {
 
     const agent = defineAgent({
       capabilities: [
-        usageTelemetry(),
+        usageTelemetry({
+          pricing: staticModelPricing({
+            "openai/gpt-test": {
+              input: "0.00000010",
+              output: "0.00000020",
+            },
+          }),
+        }),
       ],
       run: () => ({
         fullStream: (async function* () {
@@ -442,6 +454,7 @@ describe("usage telemetry", () => {
             totalTokens: 17,
           })
         })(),
+        modelId: "openai/gpt-test",
         usage,
       }),
     })
@@ -463,6 +476,15 @@ describe("usage telemetry", () => {
       {
         type: "usage",
         usageRecord: expect.objectContaining({
+          cost: {
+            amount: "0.0000024",
+            currency: "USD",
+            estimated: true,
+            source: "custom",
+          },
+          model: {
+            id: "openai/gpt-test",
+          },
           usage: {
             inputTokens: 10,
             outputTokenDetails: { reasoningTokens: 3 },

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -470,6 +470,17 @@ describe("defineAgent workspace option", () => {
     expect(useWorkspace).toHaveBeenCalledWith("docs")
   })
 
+  it("marks synthetic workspace runs with the shared runtime symbol", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+
+    const agent = defineAgent({
+      workspace: {},
+      model: {} as never,
+    })
+
+    expect(agent.run && Symbol.for("vitehub.syntheticWorkspaceRun") in agent.run).toBe(true)
+  })
+
   it("joins array instructions", async () => {
     const { defineAgent } = await import("../src/index.ts")
 

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1320,7 +1320,10 @@ describe("defineAgent workspace option", () => {
     await agent.run!(context({ vertex: { model: "gemini" } }))
 
     expect(toolResolver).toHaveBeenCalledTimes(1)
-    expect(agentSettings.at(-1)?.tools).toEqual({ shell })
+    const resolvedShell = (agentSettings.at(-1)?.tools as { shell?: typeof shell } | undefined)?.shell
+    expect(resolvedShell).toEqual(expect.objectContaining({ inputSchema: {} }))
+    await resolvedShell?.execute({ command: "rg defineAgent" })
+    expect(shell.execute).toHaveBeenCalledWith({ command: "rg defineAgent" })
   })
 
   it("reports explicitly attached workspace tool usage when execution starts and finishes", async () => {

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -44,6 +44,11 @@ function isVercelQueueEnabled(queueConfig: NormalizedQueueOptions) {
   return queueConfig !== false && queueConfig.provider === "vercel"
 }
 
+function resolveOutputQueueConfig(queue: QueueModuleOptions | undefined, hosting: string): NormalizedQueueOptions {
+  if (typeof queue === "undefined") return false
+  return normalizeQueueOptions(queue, { hosting }) || false
+}
+
 interface GeneratedQueueArtifacts {
   cloudflareWorkerFile: string
   definitions: DiscoveredQueueDefinition[]
@@ -116,7 +121,7 @@ async function writeProviderEntries(rootDir: string, queue: QueueModuleOptions |
   const entryFiles: Record<QueueProvider, string> = { cloudflare: "", vercel: "" }
   for (const spec of providerEntrySpecs) {
     const entryFile = resolve(generatedDir, spec.entryFile)
-    const queueConfig = normalizeQueueOptions(queue, { hosting: spec.hosting }) || false
+    const queueConfig = resolveOutputQueueConfig(queue, spec.hosting)
     const preloadVercelQueue = spec.name === "vercel" && isVercelQueueEnabled(queueConfig)
     await writeFile(entryFile, renderProviderEntry(spec, entryFile, registryFile, userAppEntry, queueConfig, preloadVercelQueue), "utf8")
     entryFiles[spec.name] = entryFile
@@ -147,7 +152,7 @@ function createCloudflareQueueBindings(definitions: DiscoveredQueueDefinition[])
 
 export async function createCloudflareQueueConfig(options: CloudflareQueueConfigOptions = {}): Promise<CloudflareQueueConfig> {
   const rootDir = resolve(process.cwd(), options.rootDir || ".")
-  const artifacts = await writeProviderEntries(rootDir, undefined)
+  const artifacts = await writeProviderEntries(rootDir, { provider: "cloudflare" })
   const queues = createCloudflareQueueBindings(artifacts.definitions)
   return {
     assets: { run_worker_first: ["/api/*"] },
@@ -245,7 +250,7 @@ function createVercelOutput(artifacts: GeneratedQueueArtifacts): VercelProviderD
 async function writeVercelQueueFunctions(rootDir: string, queue: QueueModuleOptions | undefined, artifacts: GeneratedQueueArtifacts) {
   const outputRoot = createDefaultVercelOutputRoot(rootDir)
   const queueRoot = resolve(outputRoot, "functions", "api", "vitehub", "queues", "vercel")
-  const queueConfig = normalizeQueueOptions(queue, { hosting: "vercel" }) || false
+  const queueConfig = resolveOutputQueueConfig(queue, "vercel")
 
   await rm(queueRoot, { force: true, recursive: true })
   if (!isVercelQueueEnabled(queueConfig)) {

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -145,6 +145,24 @@ describe("Vite provider outputs", () => {
     expect(vercelServerContents).toContain("@vercel/queue")
   })
 
+  it("does not preload or emit Vercel queue functions when queue config is omitted", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-omitted-provider-")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist"), { recursive: true })
+    await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
+    await writeFile(join(rootDir, "dist", "index.html"), "<!doctype html><title>vitehub</title>\n", "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist",
+      queue: undefined,
+      rootDir,
+    })
+
+    const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
+    expect(vercelServerContents).not.toContain("@vercel/queue")
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "queues", "vercel"))).toBe(false)
+  })
+
   it("does not preload or emit Vercel queue functions for a non-Vercel queue provider", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-cloudflare-provider-")
     await mkdir(join(rootDir, "src"), { recursive: true })


### PR DESCRIPTION
Adds a host-side pending thinking fallback to `vitehub agent dev` so the CLI shows existing trigger `thinkingFallback` metadata, or `Thinking...` by default, until the first visible stream output arrives.

The Vite dev stream now carries trigger invocation metadata on `start`, and the CLI clears the pending fallback before rendering text, tool, usage, delivery, approval, or error events so it never becomes assistant history.
