### PR TITLE
feat(agent): add named workspace write references

### DIFF
--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -90,6 +90,27 @@ export default defineEventHandler(async (event) => {
 
 Agent Trigger Consumers call the trigger surface. They do not own the Capability behavior that registered the trigger.
 
+## Input lifecycle
+
+Use an Agent Input Hook when an Agent needs to validate trusted invocation context before its Agent Driver runs. Input hooks run once per Agent Invocation after Capabilities prepare input.
+
+```ts [server/agents/review.ts]
+import { defineAgent } from '@vite-hub/agent'
+
+export default defineAgent({
+  driver: {
+    run: () => 'ok',
+  },
+  hooks: {
+    'agent:input'(context) {
+      if (!context.input.context?.pullRequest) {
+        throw new Error('Missing GitHub field: context.pullRequest')
+      }
+    },
+  },
+})
+```
+
 ## Finish lifecycle
 
 Use an Agent Finish Hook to observe the completed invocation. Finish hooks are appropriate for usage export, trace collection, cleanup, or product-side notifications.

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -9,6 +9,16 @@ Workspace context gives an Agent a named Workspace File Tree and optional Source
 
 Use Workspace context when the Agent needs project files, documentation, generated state, Source-backed paths, or controlled file mutation. Do not use it as a hidden prompt bag.
 
+## Add Agent Instructions
+
+Put shared Agent instructions beside the colocated Agent config:
+
+```md [server/agents/docs/instructions.md]
+Answer from the docs workspace. Say when the answer is not present.
+```
+
+ViteHub materializes `server/agents/<name>/instructions.md` into the Agent Workspace as `AGENTS.md`. Model-backed Agent Drivers use it as the default instructions when `driver.instructions` or legacy `instructions` are not configured. Harness-backed Agent Drivers receive the same file in their Workspace session.
+
 ## Declare Sources
 
 Declare a colocated Workspace when the Agent primarily owns the file-tree context. Add Source Instructions when the model-backed driver needs guidance about a Source.
@@ -22,10 +32,6 @@ import { glob } from '@vite-hub/workspace'
 export default defineAgent({
   driver: {
     model: gateway('openai/gpt-5.1-mini'),
-    instructions: [
-      'Answer from the docs workspace. Say when the answer is not present.',
-      '{{ workspace.sources }}',
-    ],
   },
   workspace: {
     sources: {
@@ -66,6 +72,8 @@ ViteHub renders visible Source Instructions into a `## Workspace Sources` block 
 
 Only visible Sources render. If Access selects a Workspace Scope, ViteHub omits hidden Source Instructions along with hidden files.
 
+Explicit `driver.instructions` still wins when the Agent needs custom prompt composition, including manual `{{ workspace.sources }}` placement. Ordinary Workspace files named `AGENTS.md` are just files; only colocated `instructions.md` is the default Agent instructions convention.
+
 ## Start with read access
 
 Use read mode when the Agent only needs to inspect files. Use write mode only when the product expects the Agent to mutate Workspace files and Workspace Rules allow the target paths.
@@ -88,7 +96,6 @@ Harness-backed Agent Drivers receive Workspace state through a Harness Workspace
 import { createCodex } from '@ai-sdk/harness-codex'
 import { defineAgent } from '@vite-hub/agent'
 import { skills } from '@vite-hub/agent/capabilities'
-import { file } from '@vite-hub/workspace'
 
 export default defineAgent({
   driver: {
@@ -98,9 +105,6 @@ export default defineAgent({
   },
   workspace: {
     mode: 'write',
-    sources: {
-      guide: file('AGENTS.md'),
-    },
   },
   capabilities: [
     skills({ path: '.agents/skills/review' }),
@@ -108,7 +112,7 @@ export default defineAgent({
 })
 ```
 
-Read mode materializes the selected Workspace into the harness sandbox and discards sandbox changes. Write mode syncs additions, updates, and deletions back through Workspace rules. Keep Skills behind the `skills()` Capability; ViteHub does not add root `skills`, `tools`, or `sandbox` Agent Definition fields for harness-backed Agents. Put harness guidance in Workspace files such as `AGENTS.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet.
+Read mode materializes the selected Workspace into the harness sandbox and discards sandbox changes. Write mode syncs additions, updates, and deletions back through Workspace rules. Keep Skills behind the `skills()` Capability; ViteHub does not add root `skills`, `tools`, or `sandbox` Agent Definition fields for harness-backed Agents. Put harness guidance in colocated `instructions.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet.
 
 ## Scope by Agent Invoker
 

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -47,6 +47,19 @@ export default defineAgent({
 
 The Workspace supplies files. The Workspace Shell Capability exposes read or write tools to compatible Agent Drivers.
 
+## Reuse a Workspace
+
+Use a string when another Agent should read an existing Workspace. Use `{ name, mode: 'write' }` when it should write artifacts into that same Workspace File Tree.
+
+```ts [server/agents/summary/config.ts]
+export default defineAgent({
+  workspace: { name: 'review', mode: 'write' },
+  capabilities: [
+    workspaceShell({ mode: 'write' }),
+  ],
+})
+```
+
 ## Render Source Instructions
 
 ViteHub renders visible Source Instructions into a `## Workspace Sources` block for model-backed drivers. Put `{{ workspace.sources }}` where that block belongs, or omit the slot and let ViteHub append it.

--- a/docs/content/docs/capabilities/skills.md
+++ b/docs/content/docs/capabilities/skills.md
@@ -7,7 +7,7 @@ navigation.group: Workspace
 icon: i-lucide-scroll-text
 ---
 
-`skills()` adds a Workspace requirement for a skill file.
+`skills()` adds a Workspace requirement and model-facing hint for a skill file.
 Use it when an Agent must have a `SKILL.md` file available before it runs.
 
 ## Installation
@@ -17,9 +17,10 @@ Use the configuration example below as the starting point, then tighten modes, p
 
 ## What it adds
 
-The Capability records the configured skill path in metadata and requires the Workspace path to exist.
-By default it does not expose model-facing tools.
+The Capability records the configured skill path in metadata, requires the Workspace path to exist, and tells model-backed Agents where to read the full skill.
+By default it does not expose model-facing tools beyond the instruction hint.
 When `shellExecution` is set, it also exposes `skill_shell`, which runs commands from the mounted skill instructions through the active Workspace Session.
+When `source` is set, ViteHub adds that source to the Agent Workspace at definition time and mounts it at the skill path.
 
 ## Configuration
 
@@ -39,22 +40,50 @@ export default defineAgent({
 })
 ```
 
+Mount a remote skill source when the Agent should not carry the skill file in the local project:
+
+```ts [server/agents/review/browser.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { skills } from '@vite-hub/agent/capabilities'
+import { github } from '@vite-hub/workspace'
+
+export default defineAgent({
+  driver: { model },
+  workspace: { name: 'review', mode: 'write' },
+  capabilities: [
+    skills({
+      path: 'skills/agent-browser',
+      source: github({
+        repo: 'vercel/vercel-plugin',
+        root: 'skills/agent-browser',
+        include: ['SKILL.md', 'references/**', 'templates/**'],
+        materialize: 'build',
+      }),
+      shellExecution: 'write',
+    }),
+  ],
+})
+```
+
 ## Runtime behavior
 
 ViteHub validates the Workspace read requirement before the Agent Driver runs.
 The Capability metadata includes the directory path and the resolved `SKILL.md` path.
+Generated instructions include the skill path, the frontmatter `name` and `description` when available, and a reminder to read the full `SKILL.md`.
 With `shellExecution: 'write'`, successful `skill_shell` commands commit Workspace Session changes back into the Workspace.
+With `source`, ViteHub still uses normal Workspace Source materialization, visibility, and DevTools metadata. `skills()` does not fetch source files at invocation time.
 
 ## Requirements
 
 `skills()` requires an explicit Workspace with read access to the configured skill file.
 The path can point to a directory or directly to a `SKILL.md` file.
+When `source` is configured, the source mount must match the configured skill directory.
 
 ## Driver support
 
 | Agent Driver | Support |
 | --- | --- |
-| Model-backed | Validates the skill file requirement; reading or rendering the file remains Agent or Workspace behavior. |
+| Model-backed | Validates the skill file requirement, receives the generated skill-read hint, and can read the mounted skill through Workspace tools. |
 | Harness-backed | Validates the skill file requirement before harness execution. |
 | Custom-run-backed | Validates the skill file requirement before `driver.run`. |
 
@@ -70,8 +99,11 @@ Inspect Capability metadata for the normalized `path` and `skillPath` values.
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `maxOutputLength` | `number` | `30000` | Maximum stdout/stderr characters returned from `skill_shell`. |
+| `instructions` | `string \| false` | generated | Override or disable the generated skill-read instructions. |
 | `path` | `string` | `"skills"` | Directory or `SKILL.md` path required in the Workspace. |
 | `shellExecution` | `"read" \| "write"` | none | Optional Workspace Session shell execution mode for commands described by the mounted skill. |
+| `source` | `WorkspaceSourceInput` | none | Workspace Source to mount at the skill directory. |
+| `sourceKey` | `string` | derived from `path` | Workspace source key used when `source` is configured. |
 | `timeout` | `number` | none | Default `skill_shell` timeout in milliseconds. |
 
 ## Reference

--- a/docs/content/docs/capabilities/skills.md
+++ b/docs/content/docs/capabilities/skills.md
@@ -77,7 +77,7 @@ With `source`, ViteHub still uses normal Workspace Source materialization, visib
 
 `skills()` requires an explicit Workspace with read access to the configured skill file.
 The path can point to a directory or directly to a `SKILL.md` file.
-When `source` is configured, the source mount must match the configured skill directory.
+When `source` is configured, `path` is the canonical mount. ViteHub mounts the source at the configured skill directory even when the source helper has its own default mount.
 
 ## Driver support
 

--- a/docs/content/docs/capabilities/skills.md
+++ b/docs/content/docs/capabilities/skills.md
@@ -18,7 +18,8 @@ Use the configuration example below as the starting point, then tighten modes, p
 ## What it adds
 
 The Capability records the configured skill path in metadata and requires the Workspace path to exist.
-It does not expose model-facing tools by itself.
+By default it does not expose model-facing tools.
+When `shellExecution` is set, it also exposes `skill_shell`, which runs commands from the mounted skill instructions through the active Workspace Session.
 
 ## Configuration
 
@@ -42,6 +43,7 @@ export default defineAgent({
 
 ViteHub validates the Workspace read requirement before the Agent Driver runs.
 The Capability metadata includes the directory path and the resolved `SKILL.md` path.
+With `shellExecution: 'write'`, successful `skill_shell` commands commit Workspace Session changes back into the Workspace.
 
 ## Requirements
 
@@ -67,8 +69,10 @@ Inspect Capability metadata for the normalized `path` and `skillPath` values.
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
+| `maxOutputLength` | `number` | `30000` | Maximum stdout/stderr characters returned from `skill_shell`. |
 | `path` | `string` | `"skills"` | Directory or `SKILL.md` path required in the Workspace. |
-| `shellExecution` | `"read" \| "write"` | none | Optional Workspace Shell execution mode declared by the skill requirement. |
+| `shellExecution` | `"read" \| "write"` | none | Optional Workspace Session shell execution mode for commands described by the mounted skill. |
+| `timeout` | `number` | none | Default `skill_shell` timeout in milliseconds. |
 
 ## Reference
 

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -6,10 +6,29 @@ import type { AgentRunResult, AgentUsage, AgentUsageRecord } from "./types.ts"
 
 export { isAsyncIterable } from "./internal/stream-result.ts"
 
+function textFromContent(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return
+
+  const text = content.flatMap((part) => {
+    if (typeof part === "string") return [part]
+    if (!part || typeof part !== "object") return []
+
+    const record = part as Record<string, unknown>
+    if (record.type !== "text" && record.type !== "text-delta") return []
+
+    const value = record.text ?? record.textDelta ?? record.delta
+    return typeof value === "string" ? [value] : []
+  }).join("")
+
+  return text ? text : undefined
+}
+
 function textFromResult(result: Record<string, unknown>): string | undefined {
   if (typeof result.text === "string") return result.text
   if (typeof result.output === "string") return result.output
   if (typeof result._output === "string") return result._output
+  const contentText = textFromContent(result.content)
+  if (contentText) return contentText
 
   const steps = result.steps
   if (Array.isArray(steps)) {
@@ -17,6 +36,8 @@ function textFromResult(result: Record<string, unknown>): string | undefined {
       if (step && typeof step === "object" && typeof (step as { text?: unknown }).text === "string") {
         return (step as { text: string }).text
       }
+      const stepContentText = textFromContent((step as { content?: unknown }).content)
+      if (stepContentText) return stepContentText
     }
   }
 }

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -686,11 +686,10 @@ async function createAgent(options: AiSdkAdapterOptions, context: AgentAdapterRu
   const instrumentedModel = modelInstrumentation
     ? await modelInstrumentation({ ...runtime, actor: context.actor, context: context.context, invoker: context.invoker, model, run: context.runtime.run })
     : model
-  const instructions = context.instructions
-    ?? applyWorkspaceSourceInstructionSlot(
-      applyCapabilityInstructionSlots(await resolveInstructions(options, metadataContext), context.capabilityInstructions),
-      context.sourceInstructions,
-    )
+  const instructions = applyWorkspaceSourceInstructionSlot(
+    applyCapabilityInstructionSlots(context.instructions ?? await resolveInstructions(options, metadataContext), context.capabilityInstructions),
+    context.sourceInstructions,
+  )
   const adapterTools = await resolveTools(options, metadataContext, context.devtools?.reportToolStep)
   const resolvedTools = withDefaultToolInputSchemas(await applyCapabilityToolTransforms({
     ...context.tools,

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -275,9 +275,8 @@ function collectToolResults(
   const parts: string[] = []
 
   for (const step of result.steps || []) {
-    for (const content of step.content || []) {
-      if (content.type !== "tool-result") continue
-      parts.push(JSON.stringify(content.output).slice(0, 4000))
+    for (const output of collectToolResultOutputs(step)) {
+      parts.push(JSON.stringify(output).slice(0, 4000))
       if (parts.length >= maxToolResults) return parts
     }
   }
@@ -286,7 +285,7 @@ function collectToolResults(
 }
 
 function hasToolResults(result: { steps?: Array<{ content?: Array<{ type: string }> }> }) {
-  return result.steps?.some(step => step.content?.some(content => content.type === "tool-result")) || false
+  return result.steps?.some(step => collectToolResultOutputs(step).length > 0) || false
 }
 
 function getPromptText(context: AgentAdapterRunContext) {
@@ -337,16 +336,50 @@ function streamEventText(event: unknown): string | undefined {
   return typeof text === "string" ? text : undefined
 }
 
-function streamToolResultOutput(event: unknown): unknown {
-  if (typeof event !== "object" || event === null) return undefined
-  const record = event as { error?: unknown, errorText?: unknown, output?: unknown, result?: unknown, type?: unknown }
-  if (record.type === "tool-result" || record.type === "tool-output-available") {
-    return record.output ?? record.result
+function recordFrom(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? value as Record<string, unknown> : undefined
+}
+
+function pushDefinedOutput(outputs: unknown[], output: unknown): void {
+  if (output !== undefined) outputs.push(output)
+}
+
+function collectToolResultOutputs(value: unknown): unknown[] {
+  const record = recordFrom(value)
+  if (!record) return []
+  const type = typeof record.type === "string" ? record.type : undefined
+  const outputs: unknown[] = []
+
+  if (type === "tool-result" || type === "tool-output-available") {
+    pushDefinedOutput(outputs, record.output ?? record.result)
   }
-  if (record.type === "tool-error" || record.type === "tool-output-error") {
-    return record.error ?? record.errorText ?? record.output ?? record.result
+  if (type === "tool-error" || type === "tool-output-error") {
+    pushDefinedOutput(outputs, record.error ?? record.errorText ?? record.output ?? record.result)
   }
-  return undefined
+
+  for (const key of ["content", "toolResults", "tool_outputs", "toolOutputs"]) {
+    const items = record[key]
+    if (!Array.isArray(items)) continue
+    for (const item of items) {
+      const itemRecord = recordFrom(item)
+      if (!itemRecord) continue
+      if (key === "toolResults" || key === "tool_outputs" || key === "toolOutputs") {
+        pushDefinedOutput(outputs, itemRecord.output ?? itemRecord.result ?? itemRecord.error ?? itemRecord.errorText)
+        continue
+      }
+      outputs.push(...collectToolResultOutputs(itemRecord))
+    }
+  }
+
+  const stepOutputs = collectToolResultOutputs(record.step)
+  if (stepOutputs.length) outputs.push(...stepOutputs)
+
+  return outputs
+}
+
+function streamToolResultOutputs(event: unknown): unknown[] {
+  if (typeof event !== "object" || event === null) return []
+  return collectToolResultOutputs(event)
 }
 
 function streamEventType(event: unknown): string | undefined {
@@ -399,8 +432,9 @@ function withWorkspaceFallbackFullStream(
       const eventText = streamEventText(event) || ""
       text += eventText
       textAfterLastToolResult += eventText
-      const output = streamToolResultOutput(event)
-      if (output !== undefined && evidence.length < maxToolResults) {
+      const outputs = streamToolResultOutputs(event)
+      for (const output of outputs) {
+        if (evidence.length >= maxToolResults) break
         evidence.push(JSON.stringify(output).slice(0, 4000))
         textAfterLastToolResult = ""
       }

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -2,6 +2,7 @@ import { getMessageText } from "./messages.ts"
 import { jsonSchema } from "ai"
 import {
   cloneWithPropertyDescriptors,
+  isAsyncIterable,
   teeingAsyncIterableStreamDescriptor,
 } from "./internal/stream-result.ts"
 import {
@@ -497,6 +498,9 @@ function withWorkspaceFallbackStreamResult<T extends { fullStream?: AsyncIterabl
     return cloneStreamTextResult(result as object, {
       stream: withWorkspaceFallbackFullStream(result.stream, model, context, fallback.maxToolResults, capturedEvidence),
     }) as T
+  }
+  if (isAsyncIterable(result)) {
+    return withWorkspaceFallbackFullStream(result, model, context, fallback.maxToolResults, capturedEvidence) as unknown as T
   }
   return result
 }

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -327,6 +327,22 @@ async function synthesizeWorkspaceFallbackFromEvidence(
   return summary.text.trim() || undefined
 }
 
+function createWorkspaceFallbackEvidenceCapture(maxToolResults: number) {
+  const evidence: string[] = []
+
+  return {
+    collect(event: unknown) {
+      for (const output of collectToolResultOutputs(event)) {
+        if (evidence.length >= maxToolResults) break
+        evidence.push(JSON.stringify(output).slice(0, 4000))
+      }
+    },
+    evidence() {
+      return evidence.slice()
+    },
+  }
+}
+
 function streamEventText(event: unknown): string | undefined {
   if (typeof event === "string") return event
   if (typeof event !== "object" || event === null) return undefined
@@ -421,6 +437,7 @@ function withWorkspaceFallbackFullStream(
   model: ToolLoopAgentSettings["model"],
   context: AgentAdapterRunContext,
   maxToolResults: number,
+  capturedEvidence?: () => string[],
 ): AsyncIterable<unknown> {
   return (async function* () {
     let text = ""
@@ -446,13 +463,18 @@ function withWorkspaceFallbackFullStream(
       yield event
     }
 
-    const hasFinalText = evidence.length ? textAfterLastToolResult.trim() : text.trim()
-    if ((hasFinalText && finishEventReason(finishEvent) !== "tool-calls") || evidence.length === 0) {
+    const fallbackEvidence = evidence.length ? evidence : capturedEvidence?.() ?? []
+    const hasFinalText = evidence.length
+      ? textAfterLastToolResult.trim()
+      : fallbackEvidence.length
+        ? ""
+        : text.trim()
+    if ((hasFinalText && finishEventReason(finishEvent) !== "tool-calls") || fallbackEvidence.length === 0) {
       if (finishEvent) yield finishEvent
       return
     }
 
-    const synthesized = await synthesizeWorkspaceFallbackFromEvidence(model, context, evidence)
+    const synthesized = await synthesizeWorkspaceFallbackFromEvidence(model, context, fallbackEvidence)
     if (synthesized) {
       yield* workspaceFallbackTextEvents(synthesized)
       yield workspaceFallbackFinishEvent(finishEvent)
@@ -467,9 +489,10 @@ function withWorkspaceFallbackStreamResult<T extends { fullStream?: AsyncIterabl
   model: ToolLoopAgentSettings["model"],
   context: AgentAdapterRunContext,
   fallback: Required<AiSdkWorkspaceFallbackOptions>,
+  capturedEvidence?: () => string[],
 ): T {
   if (!fallback.enabled || !result.fullStream) return result
-  return cloneStreamTextResult(result as object, withWorkspaceFallbackFullStream(result.fullStream, model, context, fallback.maxToolResults)) as T
+  return cloneStreamTextResult(result as object, withWorkspaceFallbackFullStream(result.fullStream, model, context, fallback.maxToolResults, capturedEvidence)) as T
 }
 
 async function resolveValue<T>(value: T | ((context: AgentAdapterMetadataContext) => MaybePromise<T>), context: AgentAdapterMetadataContext): Promise<T> {
@@ -833,15 +856,22 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
     async stream(context) {
       const { agent, model } = await createAgent(options, context)
       const usageCapture = createUsageCapture()
+      const execution = options.execution ?? options.modelExecution
+      const fallback = getFallbackOptions(execution?.workspaceFallback)
+      const fallbackCapture = fallback.enabled
+        ? createWorkspaceFallbackEvidenceCapture(fallback.maxToolResults)
+        : undefined
       const callInput = getCallInput(context) as Record<string, unknown>
       const result = withResolvedModelMetadata(withCapturedUsage(await agent.stream({
         ...callInput,
         onEnd: usageCapture.onEnd,
         onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
-        onStepEnd: usageCapture.onStepEnd,
+        async onStepEnd(event: unknown) {
+          await usageCapture.onStepEnd(event)
+          fallbackCapture?.collect(event)
+        },
       } as never) as StreamTextResult<ToolSet, never, never>, usageCapture), model) as StreamTextResult<ToolSet, never, never>
-      const execution = options.execution ?? options.modelExecution
-      return withWorkspaceFallbackStreamResult(result, model as never, context, getFallbackOptions(execution?.workspaceFallback))
+      return withWorkspaceFallbackStreamResult(result, model as never, context, fallback, fallbackCapture?.evidence)
     },
   }
 }

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -494,11 +494,7 @@ function withWorkspaceFallbackFullStream(
     }
 
     const fallbackEvidence = evidence.length ? evidence : capturedEvidence?.() ?? []
-    const hasFinalText = evidence.length
-      ? textAfterLastToolResult.trim()
-      : fallbackEvidence.length
-        ? ""
-        : text.trim()
+    const hasFinalText = evidence.length ? textAfterLastToolResult.trim() : text.trim()
     if ((hasFinalText && finishEventReason(finishEvent) !== "tool-calls") || fallbackEvidence.length === 0) {
       if (finishEvent) yield finishEvent
       return

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -418,12 +418,7 @@ function finishEventReason(event: unknown): string | undefined {
 }
 
 function workspaceFallbackTextEvents(text: string): unknown[] {
-  const id = "workspace-fallback"
-  return [
-    { id, type: "text-start" },
-    { id, text, type: "text-delta" },
-    { id, type: "text-end" },
-  ]
+  return [{ id: "workspace-fallback", text, type: "text-delta" }]
 }
 
 function cloneStreamTextResult<T extends object>(result: T, fullStream: AsyncIterable<unknown>): T {

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -391,14 +391,18 @@ function withWorkspaceFallbackFullStream(
 ): AsyncIterable<unknown> {
   return (async function* () {
     let text = ""
+    let textAfterLastToolResult = ""
     const evidence: string[] = []
     let finishEvent: unknown
 
     for await (const event of stream) {
-      text += streamEventText(event) || ""
+      const eventText = streamEventText(event) || ""
+      text += eventText
+      textAfterLastToolResult += eventText
       const output = streamToolResultOutput(event)
       if (output !== undefined && evidence.length < maxToolResults) {
         evidence.push(JSON.stringify(output).slice(0, 4000))
+        textAfterLastToolResult = ""
       }
       const type = streamEventType(event)
       if (type === "finish" || type === "abort") {
@@ -408,7 +412,8 @@ function withWorkspaceFallbackFullStream(
       yield event
     }
 
-    if ((text.trim() && finishEventReason(finishEvent) !== "tool-calls") || evidence.length === 0) {
+    const hasFinalText = evidence.length ? textAfterLastToolResult.trim() : text.trim()
+    if ((hasFinalText && finishEventReason(finishEvent) !== "tool-calls") || evidence.length === 0) {
       if (finishEvent) yield finishEvent
       return
     }

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -330,18 +330,51 @@ async function synthesizeWorkspaceFallbackFromEvidence(
 
 function createWorkspaceFallbackEvidenceCapture(maxToolResults: number) {
   const evidence: string[] = []
+  const seen = new Set<string>()
 
   return {
     collect(event: unknown) {
       for (const output of collectToolResultOutputs(event)) {
         if (evidence.length >= maxToolResults) break
-        evidence.push(JSON.stringify(output).slice(0, 4000))
+        const text = JSON.stringify(output).slice(0, 4000)
+        if (seen.has(text)) continue
+        seen.add(text)
+        evidence.push(text)
       }
     },
     evidence() {
       return evidence.slice()
     },
   }
+}
+
+function withWorkspaceFallbackToolEvidence<TTools extends AgentToolSet | undefined>(
+  tools: TTools,
+  capture?: ReturnType<typeof createWorkspaceFallbackEvidenceCapture>,
+): TTools {
+  if (!capture || !tools || typeof tools !== "object") return tools
+
+  return Object.fromEntries(Object.entries(tools).map(([name, tool]) => {
+    if (!tool || typeof tool !== "object" || typeof (tool as { execute?: unknown }).execute !== "function") {
+      return [name, tool]
+    }
+
+    const execute = (tool as { execute: (...args: unknown[]) => unknown }).execute
+    return [name, {
+      ...tool,
+      async execute(input: unknown, ...args: unknown[]) {
+        try {
+          const output = await execute.call(tool, input, ...args)
+          capture.collect({ output, toolName: name, type: "tool-result" })
+          return output
+        }
+        catch (error) {
+          capture.collect({ error: error instanceof Error ? error.message : String(error), toolName: name, type: "tool-error" })
+          throw error
+        }
+      },
+    }]
+  })) as TTools
 }
 
 function streamEventText(event: unknown): string | undefined {
@@ -748,7 +781,11 @@ function withViteHubTelemetry(settings: Record<string, unknown>, context: AgentA
   }
 }
 
-async function createAgent(options: AiSdkAdapterOptions, context: AgentAdapterRunContext) {
+async function createAgent(
+  options: AiSdkAdapterOptions,
+  context: AgentAdapterRunContext,
+  fallbackCapture?: ReturnType<typeof createWorkspaceFallbackEvidenceCapture>,
+) {
   const { ToolLoopAgent, stepCountIs } = await import("ai")
   const execution = options.execution ?? options.modelExecution
   const { runtimeConfig: _runtimeConfig, ...runtime } = context.runtime
@@ -770,10 +807,10 @@ async function createAgent(options: AiSdkAdapterOptions, context: AgentAdapterRu
     context.sourceInstructions,
   )
   const adapterTools = await resolveTools(options, metadataContext, context.devtools?.reportToolStep)
-  const resolvedTools = withDefaultToolInputSchemas(await applyCapabilityToolTransforms({
+  const resolvedTools = withDefaultToolInputSchemas(withWorkspaceFallbackToolEvidence(await applyCapabilityToolTransforms({
     ...context.tools,
     ...adapterTools,
-  }, []))
+  }, []), fallbackCapture))
   const providerTools = Object.fromEntries((context.providerTools || []).map(tool => [tool.name, {
     args: tool.args || {},
     id: tool.id,
@@ -822,12 +859,17 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
     : undefined
   return {
     async generate(context) {
-      const { agent, model, tools } = await createAgent(options, context)
+      const callInput = getCallInput(context) as Record<string, unknown>
+      const execution = options.execution ?? options.modelExecution
+      const fallback = getFallbackOptions(execution?.workspaceFallback)
+      const fallbackCapture = fallback.enabled
+        ? createWorkspaceFallbackEvidenceCapture(fallback.maxToolResults)
+        : undefined
+      const { agent, model, tools } = await createAgent(options, context, fallbackCapture)
       if (context.workspace && tools && "materialize_sources" in tools) {
         await reportWorkspaceMaterialization(tools as AgentToolSet, context.devtools?.reportToolStep)
       }
       const usageCapture = createUsageCapture()
-      const callInput = getCallInput(context) as Record<string, unknown>
       const result = withResolvedModelMetadata(withCapturedUsage(await agent.generate({
         ...callInput,
         onEnd: usageCapture.onEnd,
@@ -835,10 +877,9 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         onStepEnd: usageCapture.onStepEnd,
       } as never) as GenerateTextResult<ToolSet, never, never>, usageCapture), model) as GenerateTextResult<ToolSet, never, never>
       const text = result.text.trim()
-      const execution = options.execution ?? options.modelExecution
-      const fallback = getFallbackOptions(execution?.workspaceFallback)
       if (fallback.enabled && (result.finishReason === "tool-calls" || !text && hasToolResults(result))) {
         const synthesized = await synthesizeWorkspaceFallback(model as never, context, result, fallback.maxToolResults)
+          ?? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [])
         if (synthesized) return { raw: result, text: synthesized }
       }
       if (text) return result as unknown as AgentAdapterResult
@@ -864,13 +905,13 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
     name: "ai-sdk",
     ...(staticTools ? { tools: staticTools } : {}),
     async stream(context) {
-      const { agent, model } = await createAgent(options, context)
       const usageCapture = createUsageCapture()
       const execution = options.execution ?? options.modelExecution
       const fallback = getFallbackOptions(execution?.workspaceFallback)
       const fallbackCapture = fallback.enabled
         ? createWorkspaceFallbackEvidenceCapture(fallback.maxToolResults)
         : undefined
+      const { agent, model } = await createAgent(options, context, fallbackCapture)
       const captureStep = async (event: unknown) => {
         await usageCapture.onStepEnd(event)
         fallbackCapture?.collect(event)

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -421,10 +421,11 @@ function workspaceFallbackTextEvents(text: string): unknown[] {
   return [{ id: "workspace-fallback", text, type: "text-delta" }]
 }
 
-function cloneStreamTextResult<T extends object>(result: T, fullStream: AsyncIterable<unknown>): T {
-  return cloneWithPropertyDescriptors(result, {
-    fullStream: teeingAsyncIterableStreamDescriptor(fullStream),
-  })
+function cloneStreamTextResult<T extends object>(result: T, streams: { fullStream?: AsyncIterable<unknown>, stream?: AsyncIterable<unknown> }): T {
+  return cloneWithPropertyDescriptors(result, Object.fromEntries(Object.entries(streams).map(([key, stream]) => [
+    key,
+    teeingAsyncIterableStreamDescriptor(stream),
+  ])))
 }
 
 function withWorkspaceFallbackFullStream(
@@ -479,15 +480,25 @@ function withWorkspaceFallbackFullStream(
   })()
 }
 
-function withWorkspaceFallbackStreamResult<T extends { fullStream?: AsyncIterable<unknown> }>(
+function withWorkspaceFallbackStreamResult<T extends { fullStream?: AsyncIterable<unknown>, stream?: AsyncIterable<unknown> }>(
   result: T,
   model: ToolLoopAgentSettings["model"],
   context: AgentAdapterRunContext,
   fallback: Required<AiSdkWorkspaceFallbackOptions>,
   capturedEvidence?: () => string[],
 ): T {
-  if (!fallback.enabled || !result.fullStream) return result
-  return cloneStreamTextResult(result as object, withWorkspaceFallbackFullStream(result.fullStream, model, context, fallback.maxToolResults, capturedEvidence)) as T
+  if (!fallback.enabled) return result
+  if (result.fullStream) {
+    return cloneStreamTextResult(result as object, {
+      fullStream: withWorkspaceFallbackFullStream(result.fullStream, model, context, fallback.maxToolResults, capturedEvidence),
+    }) as T
+  }
+  if (result.stream) {
+    return cloneStreamTextResult(result as object, {
+      stream: withWorkspaceFallbackFullStream(result.stream, model, context, fallback.maxToolResults, capturedEvidence),
+    }) as T
+  }
+  return result
 }
 
 async function resolveValue<T>(value: T | ((context: AgentAdapterMetadataContext) => MaybePromise<T>), context: AgentAdapterMetadataContext): Promise<T> {

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -361,6 +361,13 @@ function workspaceFallbackFinishEvent(finishEvent: unknown): unknown {
     : { finishReason: "workspace-fallback", type: "finish" }
 }
 
+function finishEventReason(event: unknown): string | undefined {
+  if (typeof event !== "object" || event === null) return undefined
+  const record = event as { finishReason?: unknown, reason?: unknown }
+  const reason = record.finishReason ?? record.reason
+  return typeof reason === "string" ? reason : undefined
+}
+
 function workspaceFallbackTextEvents(text: string): unknown[] {
   const id = "workspace-fallback"
   return [
@@ -401,7 +408,7 @@ function withWorkspaceFallbackFullStream(
       yield event
     }
 
-    if (text.trim() || evidence.length === 0) {
+    if ((text.trim() && finishEventReason(finishEvent) !== "tool-calls") || evidence.length === 0) {
       if (finishEvent) yield finishEvent
       return
     }
@@ -756,14 +763,13 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         onStepEnd: usageCapture.onStepEnd,
       } as never) as GenerateTextResult<ToolSet, never, never>, usageCapture), model) as GenerateTextResult<ToolSet, never, never>
       const text = result.text.trim()
-      if (text) return result as unknown as AgentAdapterResult
-
       const execution = options.execution ?? options.modelExecution
       const fallback = getFallbackOptions(execution?.workspaceFallback)
-      if (fallback.enabled && (result.finishReason === "tool-calls" || hasToolResults(result))) {
+      if (fallback.enabled && (result.finishReason === "tool-calls" || !text && hasToolResults(result))) {
         const synthesized = await synthesizeWorkspaceFallback(model as never, context, result, fallback.maxToolResults)
         if (synthesized) return { raw: result, text: synthesized }
       }
+      if (text) return result as unknown as AgentAdapterResult
 
       return result as unknown as AgentAdapterResult
     },

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -861,15 +861,17 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       const fallbackCapture = fallback.enabled
         ? createWorkspaceFallbackEvidenceCapture(fallback.maxToolResults)
         : undefined
+      const captureStep = async (event: unknown) => {
+        await usageCapture.onStepEnd(event)
+        fallbackCapture?.collect(event)
+      }
       const callInput = getCallInput(context) as Record<string, unknown>
       const result = withResolvedModelMetadata(withCapturedUsage(await agent.stream({
         ...callInput,
         onEnd: usageCapture.onEnd,
         onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
-        async onStepEnd(event: unknown) {
-          await usageCapture.onStepEnd(event)
-          fallbackCapture?.collect(event)
-        },
+        onStepEnd: captureStep,
+        onStepFinish: captureStep,
       } as never) as StreamTextResult<ToolSet, never, never>, usageCapture), model) as StreamTextResult<ToolSet, never, never>
       return withWorkspaceFallbackStreamResult(result, model as never, context, fallback, fallbackCapture?.evidence)
     },

--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -5,7 +5,7 @@ import type {
   AgentCapabilityMode,
   AgentToolSet,
 } from "../types.ts"
-import type { WorkspaceSession } from "@vite-hub/workspace"
+import type { WorkspaceSession, WorkspaceSessionOptions } from "@vite-hub/workspace"
 
 export interface SkillsCapabilityOptions {
   maxOutputLength?: number
@@ -21,7 +21,7 @@ interface SkillShellInput {
 }
 
 type SkillShellWorkspace = {
-  startSession: () => Promise<WorkspaceSession>
+  startSession: (options?: WorkspaceSessionOptions) => Promise<WorkspaceSession>
 }
 
 const defaultMaxOutputLength = 30_000
@@ -120,7 +120,7 @@ export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDe
       if (!isSkillShellWorkspace(workspace)) {
         throw new Error("[vitehub] skills({ shellExecution }) requires an executable workspace session.")
       }
-      return await workspace.startSession()
+      return await workspace.startSession({ paths: [normalizedPath] })
     }
   }
 

--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -57,9 +57,38 @@ function skillSourceKey(path: string): string {
   return `skill.${suffix}`
 }
 
+function rebaseMountedFileSource(source: WorkspaceSourceInput, mountPath: string): WorkspaceSourceInput {
+  const normalizedMount = normalizeSkillPath(mountPath)
+  if (!normalizedMount) return source
+  if (typeof source === "string") {
+    const workspacePath = workspacePathInsideMount(source, normalizedMount)
+    return workspacePath ? { path: source, workspacePath } : source
+  }
+  if (!isPlainFileSource(source) || typeof source.workspacePath === "string") return source
+  const workspacePath = workspacePathInsideMount(source.path, normalizedMount)
+  return workspacePath ? { ...source, workspacePath } as WorkspaceSourceInput : source
+}
+
+function isPlainFileSource(source: WorkspaceSourceInput): source is { path: string, workspacePath?: string } {
+  if (!source || typeof source !== "object") return false
+  if (!("path" in source) || typeof source.path !== "string") return false
+  return !("repo" in source)
+    && !("root" in source)
+    && !("include" in source)
+    && !("url" in source)
+    && !("source" in source)
+    && !("server" in source)
+    && !("getKeys" in source)
+}
+
+function workspacePathInsideMount(path: string, mountPath: string) {
+  const normalized = normalizeSkillPath(path)
+  return normalized.startsWith(`${mountPath}/`) ? normalized.slice(mountPath.length + 1) : undefined
+}
+
 function sourceBinding(source: WorkspaceSourceInput, mountPath: string): WorkspaceSourceInput {
   return {
-    source,
+    source: rebaseMountedFileSource(source, mountPath),
     mount: mountPath,
   }
 }
@@ -140,6 +169,7 @@ function skillShellInputSchema() {
 function skillShellTools(
   mode: AgentCapabilityMode,
   options: Required<Pick<SkillsCapabilityOptions, "maxOutputLength">> & Pick<SkillsCapabilityOptions, "timeout">,
+  directoryPath: string,
   getSession: () => Promise<WorkspaceSession>,
 ): AgentToolSet {
   return {
@@ -157,7 +187,7 @@ function skillShellTools(
         const session = await getSession()
         try {
           const result = await session.exec("bash", ["-lc", command], {
-            cwd: value.cwd,
+            cwd: value.cwd ?? directoryPath,
             timeout: value.timeout ?? options.timeout,
           })
           if (mode === "write" && result.exitCode === 0) await session.commit({ message: "skill shell" })
@@ -166,7 +196,7 @@ function skillShellTools(
           return {
             args: result.args,
             command,
-            cwd: value.cwd || "",
+            cwd: value.cwd ?? directoryPath,
             exitCode: result.exitCode,
             outputTruncated: stdout.truncated || stderr.truncated,
             stderr: stderr.output,
@@ -188,7 +218,8 @@ export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDe
   const normalizedPath = normalizeSkillPath(path)
   const shellExecution = normalizeShellExecution(options.shellExecution)
   const maxOutputLength = options.maxOutputLength ?? defaultMaxOutputLength
-  const skillPath = normalizedPath.endsWith("/SKILL.md")
+  const workspaceRequirementMode = shellExecution ? "write" : "read"
+  const skillPath = normalizedPath === skillFilename || normalizedPath.endsWith("/SKILL.md")
     ? normalizedPath
     : `${normalizedPath}/SKILL.md`
   const directoryPath = skillDirectory(skillPath)
@@ -204,7 +235,7 @@ export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDe
       if (!isSkillShellWorkspace(workspace)) {
         throw new Error("[vitehub] skills({ shellExecution }) requires an executable workspace session.")
       }
-      return await workspace.startSession({ paths: [directoryPath || normalizedPath] })
+      return await workspace.startSession({ paths: [directoryPath] })
     }
   }
 
@@ -224,14 +255,19 @@ export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDe
       ...(shellExecution ? { shellExecution } : {}),
       ...(workspaceSources ? { sourceKey: Object.keys(workspaceSources)[0] } : {}),
     },
-    requires: [{ primitive: "workspace", workspace: { mode: shellExecution === "write" ? "write" : "read", paths: [skillPath], required: true } }],
+    prepare(context) {
+      if (shellExecution && !isSkillShellWorkspace(context.workspace)) {
+        throw new Error("[vitehub] skills({ shellExecution }) requires an executable workspace session.")
+      }
+    },
+    requires: [{ primitive: "workspace", workspace: { mode: workspaceRequirementMode, paths: [skillPath], required: true } }],
     ...(workspaceSources ? { workspaceSources } : {}),
     ...(shellExecution
       ? {
           tools: context => skillShellTools(shellExecution, {
             maxOutputLength,
             timeout: options.timeout,
-          }, getSessionResolver(context)),
+          }, directoryPath, getSessionResolver(context)),
         }
       : {}),
   })

--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -1,16 +1,22 @@
 import { defineCapability } from "../capability-runtime.ts"
 
 import type {
+  AgentAdapterInstructionsValue,
   AgentCapabilityDefinition,
   AgentCapabilityMode,
+  AgentCapabilityRuntimeContext,
+  AgentRuntimeConfig,
   AgentToolSet,
 } from "../types.ts"
-import type { WorkspaceSession, WorkspaceSessionOptions } from "@vite-hub/workspace"
+import type { WorkspaceName, WorkspaceSession, WorkspaceSessionOptions, WorkspaceSourceInput } from "@vite-hub/workspace"
 
 export interface SkillsCapabilityOptions {
+  instructions?: string | false
   maxOutputLength?: number
   path?: string
   shellExecution?: AgentCapabilityMode
+  source?: WorkspaceSourceInput
+  sourceKey?: string
   timeout?: number
 }
 
@@ -25,11 +31,105 @@ type SkillShellWorkspace = {
 }
 
 const defaultMaxOutputLength = 30_000
+const skillFilename = "SKILL.md"
 
 function normalizeShellExecution(value: unknown): AgentCapabilityMode | undefined {
   if (value === undefined) return undefined
   if (value === "read" || value === "write") return value
   throw new TypeError("[vitehub] skills({ shellExecution }) must be \"read\" or \"write\".")
+}
+
+function normalizeSkillPath(path: string): string {
+  return path.replace(/\/+$/, "")
+}
+
+function skillDirectory(skillPath: string): string {
+  return skillPath.endsWith(`/${skillFilename}`)
+    ? skillPath.slice(0, -1 * (`/${skillFilename}`).length)
+    : skillPath === skillFilename ? "" : skillPath
+}
+
+function normalizeMountPath(path: string): string {
+  return path.replace(/^\/+/, "").replace(/\/+$/, "")
+}
+
+function sourceMountPath(input: WorkspaceSourceInput): string | undefined {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return
+  const record = input as Record<string, unknown>
+  const mount = record.mount
+  if (typeof mount === "string") return normalizeMountPath(mount)
+  if (mount && typeof mount === "object" && typeof (mount as { path?: unknown }).path === "string") {
+    return normalizeMountPath((mount as { path: string }).path)
+  }
+}
+
+function assertSourceMountMatchesPath(source: WorkspaceSourceInput, mountPath: string): void {
+  const explicitMount = sourceMountPath(source)
+  if (explicitMount !== undefined && explicitMount !== mountPath) {
+    throw new Error(`[vitehub] skills({ source }) mount "${explicitMount}" must match path "${mountPath}".`)
+  }
+}
+
+function skillSourceKey(path: string): string {
+  const suffix = (path || "root")
+    .replace(/^skills\//, "")
+    .replace(/[^A-Za-z0-9_.-]+/g, ".")
+    .replace(/^\.+|\.+$/g, "") || "root"
+  return `skill.${suffix}`
+}
+
+function sourceBinding(source: WorkspaceSourceInput, mountPath: string): WorkspaceSourceInput {
+  assertSourceMountMatchesPath(source, mountPath)
+  return {
+    source,
+    mount: mountPath,
+  }
+}
+
+function readFrontmatterValue(frontmatter: string, key: string): string | undefined {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const match = new RegExp(`^${escaped}:\\s*(.+?)\\s*$`, "m").exec(frontmatter)
+  const value = match?.[1]?.trim()
+  if (!value) return
+  return value.replace(/^['"]|['"]$/g, "").trim() || undefined
+}
+
+function parseSkillMetadata(content: string): { description?: string, name?: string } {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content)
+  if (!match) return {}
+  return {
+    description: readFrontmatterValue(match[1] || "", "description"),
+    name: readFrontmatterValue(match[1] || "", "name"),
+  }
+}
+
+async function readSkillMetadata(
+  context: AgentCapabilityRuntimeContext<AgentRuntimeConfig, WorkspaceName>,
+  skillPath: string,
+): Promise<{ description?: string, name?: string }> {
+  try {
+    const content = await context.fs?.readFile(skillPath as never)
+    return typeof content === "string" ? parseSkillMetadata(content) : {}
+  }
+  catch {
+    return {}
+  }
+}
+
+function renderSkillInstructions(options: {
+  directoryPath: string
+  metadata: { description?: string, name?: string }
+  shellExecution?: AgentCapabilityMode
+  skillPath: string
+}): AgentAdapterInstructionsValue {
+  return [
+    `Skill${options.metadata.name ? ` "${options.metadata.name}"` : ""} is mounted at \`${options.directoryPath || "."}\`.`,
+    options.metadata.description ? `Description: ${options.metadata.description}` : "",
+    `Read \`${options.skillPath}\` before using this skill.`,
+    options.shellExecution
+      ? `Use the \`skill_shell\` tool for shell commands described by this skill. It runs inside \`${options.directoryPath || "."}\`${options.shellExecution === "write" ? " and commits successful changes back to the workspace" : ""}.`
+      : "",
+  ].filter(Boolean).join("\n")
 }
 
 function isSkillShellWorkspace(workspace: unknown): workspace is SkillShellWorkspace {
@@ -107,12 +207,18 @@ function skillShellTools(
 
 export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDefinition {
   const path = options.path || "skills"
-  const normalizedPath = path.replace(/\/+$/, "")
+  const normalizedPath = normalizeSkillPath(path)
   const shellExecution = normalizeShellExecution(options.shellExecution)
   const maxOutputLength = options.maxOutputLength ?? defaultMaxOutputLength
   const skillPath = normalizedPath.endsWith("/SKILL.md")
     ? normalizedPath
     : `${normalizedPath}/SKILL.md`
+  const directoryPath = skillDirectory(skillPath)
+  const workspaceSources = options.source
+    ? {
+        [options.sourceKey || skillSourceKey(directoryPath)]: sourceBinding(options.source, directoryPath),
+      }
+    : undefined
 
   function getSessionResolver(context: { workspace?: unknown }): () => Promise<WorkspaceSession> {
     return async () => {
@@ -120,14 +226,28 @@ export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDe
       if (!isSkillShellWorkspace(workspace)) {
         throw new Error("[vitehub] skills({ shellExecution }) requires an executable workspace session.")
       }
-      return await workspace.startSession({ paths: [normalizedPath] })
+      return await workspace.startSession({ paths: [directoryPath || normalizedPath] })
     }
   }
 
   return defineCapability({
     id: "skills",
-    metadata: { path: normalizedPath, skillPath, ...(shellExecution ? { shellExecution } : {}) },
+    instructions: options.instructions === undefined
+      ? async (context: AgentCapabilityRuntimeContext<AgentRuntimeConfig, WorkspaceName>) => renderSkillInstructions({
+          directoryPath,
+          metadata: await readSkillMetadata(context, skillPath),
+          shellExecution,
+          skillPath,
+        })
+      : options.instructions,
+    metadata: {
+      path: normalizedPath,
+      skillPath,
+      ...(shellExecution ? { shellExecution } : {}),
+      ...(workspaceSources ? { sourceKey: Object.keys(workspaceSources)[0] } : {}),
+    },
     requires: [{ primitive: "workspace", workspace: { mode: shellExecution === "write" ? "write" : "read", paths: [skillPath], required: true } }],
+    ...(workspaceSources ? { workspaceSources } : {}),
     ...(shellExecution
       ? {
           tools: context => skillShellTools(shellExecution, {

--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -49,27 +49,6 @@ function skillDirectory(skillPath: string): string {
     : skillPath === skillFilename ? "" : skillPath
 }
 
-function normalizeMountPath(path: string): string {
-  return path.replace(/^\/+/, "").replace(/\/+$/, "")
-}
-
-function sourceMountPath(input: WorkspaceSourceInput): string | undefined {
-  if (!input || typeof input !== "object" || Array.isArray(input)) return
-  const record = input as Record<string, unknown>
-  const mount = record.mount
-  if (typeof mount === "string") return normalizeMountPath(mount)
-  if (mount && typeof mount === "object" && typeof (mount as { path?: unknown }).path === "string") {
-    return normalizeMountPath((mount as { path: string }).path)
-  }
-}
-
-function assertSourceMountMatchesPath(source: WorkspaceSourceInput, mountPath: string): void {
-  const explicitMount = sourceMountPath(source)
-  if (explicitMount !== undefined && explicitMount !== mountPath) {
-    throw new Error(`[vitehub] skills({ source }) mount "${explicitMount}" must match path "${mountPath}".`)
-  }
-}
-
 function skillSourceKey(path: string): string {
   const suffix = (path || "root")
     .replace(/^skills\//, "")
@@ -79,7 +58,6 @@ function skillSourceKey(path: string): string {
 }
 
 function sourceBinding(source: WorkspaceSourceInput, mountPath: string): WorkspaceSourceInput {
-  assertSourceMountMatchesPath(source, mountPath)
   return {
     source,
     mount: mountPath,

--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -3,12 +3,28 @@ import { defineCapability } from "../capability-runtime.ts"
 import type {
   AgentCapabilityDefinition,
   AgentCapabilityMode,
+  AgentToolSet,
 } from "../types.ts"
+import type { WorkspaceSession } from "@vite-hub/workspace"
 
 export interface SkillsCapabilityOptions {
+  maxOutputLength?: number
   path?: string
   shellExecution?: AgentCapabilityMode
+  timeout?: number
 }
+
+interface SkillShellInput {
+  command?: string
+  cwd?: string
+  timeout?: number
+}
+
+type SkillShellWorkspace = {
+  startSession: () => Promise<WorkspaceSession>
+}
+
+const defaultMaxOutputLength = 30_000
 
 function normalizeShellExecution(value: unknown): AgentCapabilityMode | undefined {
   if (value === undefined) return undefined
@@ -16,16 +32,109 @@ function normalizeShellExecution(value: unknown): AgentCapabilityMode | undefine
   throw new TypeError("[vitehub] skills({ shellExecution }) must be \"read\" or \"write\".")
 }
 
+function isSkillShellWorkspace(workspace: unknown): workspace is SkillShellWorkspace {
+  return typeof workspace === "object"
+    && workspace !== null
+    && typeof (workspace as { startSession?: unknown }).startSession === "function"
+}
+
+function limitOutput(value: string, maxLength: number) {
+  if (value.length <= maxLength) return { output: value, truncated: false }
+  return {
+    output: `${value.slice(0, maxLength)}\n[vitehub] Output truncated after ${maxLength} characters.`,
+    truncated: true,
+  }
+}
+
+function skillShellInputSchema() {
+  return {
+    additionalProperties: false,
+    properties: {
+      command: { description: "Shell command from the mounted skill instructions.", type: "string" },
+      cwd: { description: "Workspace-relative directory. Defaults to the workspace root.", type: "string" },
+      timeout: { description: "Optional timeout in milliseconds for this command.", type: "number" },
+    },
+    required: ["command"],
+    type: "object",
+  }
+}
+
+function skillShellTools(
+  mode: AgentCapabilityMode,
+  options: Required<Pick<SkillsCapabilityOptions, "maxOutputLength">> & Pick<SkillsCapabilityOptions, "timeout">,
+  getSession: () => Promise<WorkspaceSession>,
+): AgentToolSet {
+  return {
+    skill_shell: {
+      description: [
+        "Run one shell command from the mounted skill instructions in the active Workspace Session.",
+        mode === "write"
+          ? "Successful commands are committed back to the workspace."
+          : "Workspace changes are discarded in read mode.",
+      ].join(" "),
+      async execute(input: unknown) {
+        const value = input as SkillShellInput
+        const command = value?.command?.trim()
+        if (!command) throw new Error("[vitehub] skill_shell requires a non-empty command.")
+        const session = await getSession()
+        try {
+          const result = await session.exec("bash", ["-lc", command], {
+            cwd: value.cwd,
+            timeout: value.timeout ?? options.timeout,
+          })
+          if (mode === "write" && result.exitCode === 0) await session.commit({ message: "skill shell" })
+          const stdout = limitOutput(result.stdout, options.maxOutputLength)
+          const stderr = limitOutput(result.stderr, options.maxOutputLength)
+          return {
+            args: result.args,
+            command,
+            cwd: value.cwd || "",
+            exitCode: result.exitCode,
+            outputTruncated: stdout.truncated || stderr.truncated,
+            stderr: stderr.output,
+            stdout: stdout.output,
+          }
+        }
+        finally {
+          await session.close()
+        }
+      },
+      inputSchema: skillShellInputSchema(),
+      name: "skill_shell",
+    },
+  }
+}
+
 export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDefinition {
   const path = options.path || "skills"
   const normalizedPath = path.replace(/\/+$/, "")
   const shellExecution = normalizeShellExecution(options.shellExecution)
+  const maxOutputLength = options.maxOutputLength ?? defaultMaxOutputLength
   const skillPath = normalizedPath.endsWith("/SKILL.md")
     ? normalizedPath
     : `${normalizedPath}/SKILL.md`
+
+  function getSessionResolver(context: { workspace?: unknown }): () => Promise<WorkspaceSession> {
+    return async () => {
+      const workspace = context.workspace
+      if (!isSkillShellWorkspace(workspace)) {
+        throw new Error("[vitehub] skills({ shellExecution }) requires an executable workspace session.")
+      }
+      return await workspace.startSession()
+    }
+  }
+
   return defineCapability({
     id: "skills",
     metadata: { path: normalizedPath, skillPath, ...(shellExecution ? { shellExecution } : {}) },
     requires: [{ primitive: "workspace", workspace: { mode: shellExecution === "write" ? "write" : "read", paths: [skillPath], required: true } }],
+    ...(shellExecution
+      ? {
+          tools: context => skillShellTools(shellExecution, {
+            maxOutputLength,
+            timeout: options.timeout,
+          }, getSessionResolver(context)),
+        }
+      : {}),
   })
 }

--- a/packages/agent/src/capabilities/subagents.ts
+++ b/packages/agent/src/capabilities/subagents.ts
@@ -1,4 +1,4 @@
-import { defineCapability } from "../capability-runtime.ts"
+import { capabilityWorkspaceSources, defineCapability } from "../capability-runtime.ts"
 import { withResolvedAgentInvokerInput } from "../invoker.ts"
 
 import type {
@@ -12,7 +12,7 @@ import type {
   AgentToolSet,
 } from "../types.ts"
 import type { Message } from "../messages.ts"
-import type { WorkspaceName } from "@vite-hub/workspace"
+import type { WorkspaceDefinition, WorkspaceName } from "@vite-hub/workspace"
 
 interface JsonSchema {
   additionalProperties?: boolean | JsonSchema
@@ -112,6 +112,28 @@ function renderInstructions(agents: ReturnType<typeof normalizeAgents>, fallback
   ].join("\n")
 }
 
+function subagentWorkspaceSources(
+  agents: ReturnType<typeof normalizeAgents>,
+): WorkspaceDefinition["sources"] | undefined {
+  const sources: NonNullable<WorkspaceDefinition["sources"]> = {}
+  for (const { definition, name } of agents) {
+    const workspaceAgent = definition.agent as Partial<{
+      __vitehubWorkspaceAgentOptions: { capabilities?: AgentCapabilityDefinition[] }
+      capabilities: AgentCapabilityDefinition[]
+    }>
+    const contributed = capabilityWorkspaceSources(
+      workspaceAgent.__vitehubWorkspaceAgentOptions?.capabilities || workspaceAgent.capabilities,
+    )
+    for (const [key, source] of Object.entries(contributed || {})) {
+      if (key in sources) {
+        throw new Error(`[vitehub] subagents() workspace source "${key}" from "${name}" conflicts with another subagent source.`)
+      }
+      sources[key] = source
+    }
+  }
+  return Object.keys(sources).length ? sources : undefined
+}
+
 function randomToken(): string {
   return globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)
 }
@@ -151,10 +173,12 @@ export function subagents<
   const id = options.id || "subagents"
   const agents = normalizeAgents(options)
   const instructions = renderInstructions(agents, options.instructions)
+  const workspaceSources = subagentWorkspaceSources(agents)
 
   return defineCapability({
     id,
     instructions,
+    ...(workspaceSources ? { workspaceSources } : {}),
     tools(context) {
       const tools: AgentToolSet = {}
       for (const { definition, toolName } of agents) {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -163,6 +163,22 @@ export function normalizeCapabilities(
   })
 }
 
+export function capabilityWorkspaceSources(
+  capabilities: AgentCapabilityDefinition[] | undefined,
+): WorkspaceDefinition["sources"] | undefined {
+  const normalized = normalizeCapabilities(capabilities)
+  const sources: NonNullable<WorkspaceDefinition["sources"]> = {}
+  for (const capability of normalized) {
+    for (const [key, source] of Object.entries(capability.workspaceSources || {})) {
+      if (key in sources) {
+        throw new Error(`[vitehub] Duplicate workspace source "${key}" contributed by capabilities.`)
+      }
+      sources[key] = source
+    }
+  }
+  return Object.keys(sources).length ? sources : undefined
+}
+
 function validateAccessCapabilityOrder(capabilities: AgentCapabilityDefinition[]): void {
   const accessIndex = capabilities.findIndex(capability => capability.id === "access")
   if (accessIndex > 0) {

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -26,6 +26,7 @@ import {
 import { createChatDevtoolsStreamResponse } from "../devtools-stream.ts"
 import { createAgentRuntimeContext } from "../../runtime/context.ts"
 import { discoverAgentDefinitions } from "../../discovery.ts"
+import { workspaceAgentOwnsWorkspaceDefinition } from "../../workspace-agent.ts"
 
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http"
 import type { UIMessage } from "ai"
@@ -147,10 +148,13 @@ function resolveWorkspaceSourceRoot(file: string): string {
     : dirname(file)
 }
 
-function installServerAgentWorkspaceRegistry(server: ViteDevServer, definitions: DiscoveredAgentDefinition[]): void {
-  setWorkspaceRuntimeRegistry(Object.fromEntries(definitions
-    .filter(definition => definition.workspace)
-    .map(definition => [
+function installServerAgentWorkspaceRegistry(
+  server: ViteDevServer,
+  entries: Array<{ agent: AgentInput<ViteAgentDevtoolsRuntimeContext>, definition: DiscoveredAgentDefinition }>,
+): void {
+  setWorkspaceRuntimeRegistry(Object.fromEntries(entries
+    .filter(entry => entry.definition.workspace && workspaceAgentOwnsWorkspaceDefinition(entry.agent))
+    .map(({ definition }) => [
       definition.workspace!,
       async () => {
         const mod = await server.ssrLoadModule(pathToFileURL(definition.handler).href)
@@ -374,11 +378,16 @@ async function discoverChatAgents(server: ViteDevServer, state: ChatDevtoolsBrid
     mode: "server-agents",
     scanDirs: [join(server.config.root, "server")],
   }).sort((left, right) => left.name.localeCompare(right.name))
-  installServerAgentWorkspaceRegistry(server, definitions)
 
+  const loaded = []
   for (const definition of definitions) {
     const agent = await loadDiscoveredAgent(server, definition)
     if (!agent) continue
+    loaded.push({ agent, definition })
+  }
+  installServerAgentWorkspaceRegistry(server, loaded)
+
+  for (const { agent, definition } of loaded) {
     const triggers = await resolveAgentTriggers(agent as never, context as never)
     const trigger = triggers["chat.message"]
     if (!trigger || trigger.devtools === false) continue

--- a/packages/agent/src/eval.ts
+++ b/packages/agent/src/eval.ts
@@ -171,6 +171,7 @@ function withSiblingWorkspaceSourceRoot<TRuntimeConfig extends AgentRuntimeConfi
 
   const options = agent.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<TRuntimeConfig>
   if (typeof options.workspace !== "object" || !options.workspace) return agent
+  if ("name" in options.workspace) return agent
   if (options.workspace.sourceRootDir) return agent
 
   return defineAgent({

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -49,6 +49,7 @@ import {
 } from "./trigger-runtime.ts"
 import {
   isWorkspaceAgentOptions,
+  resolveWorkspaceAgentDefaultInstructions,
   resolveWorkspaceSourceInstructionBlock,
   workspaceDefinitionFromOptions,
   workspaceModeFromOptions,
@@ -1060,6 +1061,7 @@ type AgentInvocationContext<
   outputRenderers: AgentCapabilityRegistries["outputRenderers"]
   runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
   sourceInstructions?: string
+  instructions?: string
   startedAt: number
   actor: AgentInvoker
   invoker: AgentInvoker
@@ -1077,7 +1079,7 @@ function toAgentAdapterRunContext<
 ): AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig> {
   return {
     ...context,
-    instructions: undefined,
+    instructions: context.instructions,
     runtime: context.runtimeContext,
     workspace: context.workspace as ReadonlyWorkspaceFacade<WorkspaceName> | undefined,
   }
@@ -1152,6 +1154,9 @@ async function createAgentInvocationContext<
           workspaceScope && !workspaceScope.all ? activeWorkspace as ReadonlyWorkspaceFacade : undefined,
         )
       : undefined
+    const instructions = workspaceOptions && activeWorkspace
+      ? await resolveWorkspaceAgentDefaultInstructions(workspaceOptions, activeWorkspace as ReadonlyWorkspaceFacade)
+      : undefined
 
     const invocation = {
       ...callbackContext,
@@ -1169,6 +1174,7 @@ async function createAgentInvocationContext<
       handledResponse: capabilities.response,
       hooks: definition?.hooks as AgentHookObserverHooks | undefined,
       input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
+      instructions,
       invoker,
       messages: capabilities.messages,
       outputExtensionProviders: capabilities.registries.outputExtensionProviders,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1083,6 +1083,16 @@ function toAgentAdapterRunContext<
   }
 }
 
+async function resolveRegisteredAgentWorkspaceDefinition(name: string): Promise<WorkspaceDefinition | undefined> {
+  try {
+    return await (await import("@vite-hub/workspace")).resolveRegisteredWorkspaceDefinition(name)
+  }
+  catch (error) {
+    if (error instanceof Error && error.name === "WorkspaceNotFoundError") return undefined
+    throw error
+  }
+}
+
 async function createAgentInvocationContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -1105,8 +1115,11 @@ async function createAgentInvocationContext<
       ? workspaceNameFromOptions(workspaceOptions, workspaceDefinition?.__vitehubWorkspaceAgentDefaults)
       : workspaceDefinition?.__vitehubWorkspaceAgentDefaults?.workspace
     const workspaceMode = workspaceOptions ? workspaceModeFromOptions(workspaceOptions) : "read"
-    const resolvedWorkspaceDefinition = workspaceOptions && workspaceName
+    const configuredWorkspaceDefinition = workspaceOptions && workspaceName
       ? { ...workspaceDefinitionFromOptions(workspaceOptions), name: workspaceName }
+      : undefined
+    const resolvedWorkspaceDefinition = workspaceName
+      ? await resolveRegisteredAgentWorkspaceDefinition(workspaceName) || configuredWorkspaceDefinition
       : undefined
     const workspace = workspaceName
       ? workspaceMode === "write"

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1134,6 +1134,12 @@ function mergeAgentWorkspaceDefinition(
   }
 }
 
+function hasWorkspaceDefinitionOverlay(definition: WorkspaceDefinition | undefined): boolean {
+  if (!definition) return false
+  const { name: _name, sources, mode: _mode, ...fields } = definition as WorkspaceDefinition & { mode?: AgentCapabilityMode }
+  return Object.keys(fields).length > 0 || Object.keys(sources || {}).length > 0
+}
+
 async function registerResolvedAgentWorkspaceDefinition(name: string, definition: WorkspaceDefinition | undefined): Promise<void> {
   if (!definition) return
   const { name: _name, ...workspace } = definition
@@ -1179,7 +1185,7 @@ async function createAgentInvocationContext<
     if (workspaceName && ownsWorkspaceDefinition && configuredWorkspaceDefinition && !registeredWorkspaceDefinition) {
       await registerResolvedAgentWorkspaceDefinition(workspaceName, resolvedWorkspaceDefinition)
     }
-    const workspaceUseOptions = !registeredWorkspaceDefinition && !ownsWorkspaceDefinition && resolvedWorkspaceDefinition
+    const workspaceUseOptions = !ownsWorkspaceDefinition && hasWorkspaceDefinitionOverlay(configuredDefinitionForMerge) && resolvedWorkspaceDefinition
       ? { definition: resolvedWorkspaceDefinition }
       : undefined
     const workspaceModule = workspaceName ? await import("@vite-hub/workspace") : undefined

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -51,6 +51,7 @@ import {
   isWorkspaceAgentOptions,
   resolveWorkspaceAgentDefaultInstructions,
   resolveWorkspaceSourceInstructionBlock,
+  workspaceAgentOwnsWorkspaceDefinition,
   workspaceDefinitionFromOptions,
   workspaceModeFromOptions,
   workspaceNameFromOptions,
@@ -1101,10 +1102,14 @@ function mergeWorkspaceSources(
   configured: WorkspaceDefinition["sources"] | undefined,
 ): WorkspaceDefinition["sources"] | undefined {
   if (!registered && !configured) return undefined
-  return {
-    ...registered,
-    ...configured,
+  const sources = { ...registered }
+  for (const [key, source] of Object.entries(configured || {})) {
+    if (key in sources) {
+      throw new Error(`[vitehub] Workspace source "${key}" is already defined.`)
+    }
+    sources[key] = source
   }
+  return sources
 }
 
 function mergeAgentWorkspaceDefinition(
@@ -1114,18 +1119,19 @@ function mergeAgentWorkspaceDefinition(
 ): WorkspaceDefinition | undefined {
   if (!registered && !configured) return undefined
   if (!registered) return configured ? { ...configured, name } : undefined
-  if (!configured) {
-    registered.name ||= name
-    return registered
-  }
+  if (!configured) return { ...registered, name: registered.name || name }
 
   const { name: _configuredName, sources: configuredSources, ...configuredFields } = configured as WorkspaceDefinition & { mode?: AgentCapabilityMode }
   const { mode: _mode, ...configuredDefinitionFields } = configuredFields
-  Object.assign(registered, configuredDefinitionFields, {
+  if (!Object.keys(configuredDefinitionFields).length && !Object.keys(configuredSources || {}).length) {
+    return registered
+  }
+  return {
+    ...registered,
+    ...configuredDefinitionFields,
     name: registered.name || name,
     sources: mergeWorkspaceSources(registered.sources, configuredSources),
-  })
-  return registered
+  }
 }
 
 async function registerResolvedAgentWorkspaceDefinition(name: string, definition: WorkspaceDefinition | undefined): Promise<void> {
@@ -1163,16 +1169,21 @@ async function createAgentInvocationContext<
     const registeredWorkspaceDefinition = workspaceName
       ? await resolveRegisteredAgentWorkspaceDefinition(workspaceName)
       : undefined
+    const ownsWorkspaceDefinition = workspaceDefinition ? workspaceAgentOwnsWorkspaceDefinition(workspaceDefinition) : false
     const resolvedWorkspaceDefinition = workspaceName
-      ? mergeAgentWorkspaceDefinition(workspaceName, registeredWorkspaceDefinition, configuredWorkspaceDefinition)
+      ? mergeAgentWorkspaceDefinition(workspaceName, registeredWorkspaceDefinition, ownsWorkspaceDefinition || registeredWorkspaceDefinition ? configuredWorkspaceDefinition : undefined)
       : undefined
-    if (workspaceName && configuredWorkspaceDefinition && resolvedWorkspaceDefinition !== registeredWorkspaceDefinition) {
+    if (workspaceName && ownsWorkspaceDefinition && configuredWorkspaceDefinition && !registeredWorkspaceDefinition) {
       await registerResolvedAgentWorkspaceDefinition(workspaceName, resolvedWorkspaceDefinition)
     }
-    const workspace = workspaceName
+    const workspaceUseOptions = !ownsWorkspaceDefinition && resolvedWorkspaceDefinition && resolvedWorkspaceDefinition !== registeredWorkspaceDefinition
+      ? { definition: resolvedWorkspaceDefinition }
+      : undefined
+    const workspaceModule = workspaceName ? await import("@vite-hub/workspace") : undefined
+    const workspace = workspaceName && workspaceModule
       ? workspaceMode === "write"
-        ? (await import("@vite-hub/workspace")).useWorkspace(workspaceName, { mode: "write" })
-        : (await import("@vite-hub/workspace")).useWorkspace(workspaceName)
+        ? workspaceModule.useWorkspace(workspaceName, workspaceUseOptions ? { ...workspaceUseOptions, mode: "write" } : { mode: "write" })
+        : workspaceUseOptions ? workspaceModule.useWorkspace(workspaceName, workspaceUseOptions) : workspaceModule.useWorkspace(workspaceName)
       : undefined
     const capabilityOptions = definition?.capabilities?.length
       ? { capabilities: definition.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: definition.hooks as never }
@@ -1187,7 +1198,7 @@ async function createAgentInvocationContext<
       workspaceDefinition: resolvedWorkspaceDefinition,
     })
     const inputHook = definition?.hooks?.["agent:input"]
-    if (inputHook) {
+    if (inputHook && !capabilities.response) {
       try {
         await runObservedAgentHook(definition?.hooks as AgentHookObserverHooks | undefined, {
           name: "agent:input",

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1114,16 +1114,18 @@ function mergeAgentWorkspaceDefinition(
 ): WorkspaceDefinition | undefined {
   if (!registered && !configured) return undefined
   if (!registered) return configured ? { ...configured, name } : undefined
-  if (!configured) return { ...registered, name: registered.name || name }
+  if (!configured) {
+    registered.name ||= name
+    return registered
+  }
 
   const { name: _configuredName, sources: configuredSources, ...configuredFields } = configured as WorkspaceDefinition & { mode?: AgentCapabilityMode }
   const { mode: _mode, ...configuredDefinitionFields } = configuredFields
-  return {
-    ...registered,
-    ...configuredDefinitionFields,
+  Object.assign(registered, configuredDefinitionFields, {
     name: registered.name || name,
     sources: mergeWorkspaceSources(registered.sources, configuredSources),
-  }
+  })
+  return registered
 }
 
 async function registerResolvedAgentWorkspaceDefinition(name: string, definition: WorkspaceDefinition | undefined): Promise<void> {
@@ -1164,7 +1166,7 @@ async function createAgentInvocationContext<
     const resolvedWorkspaceDefinition = workspaceName
       ? mergeAgentWorkspaceDefinition(workspaceName, registeredWorkspaceDefinition, configuredWorkspaceDefinition)
       : undefined
-    if (workspaceName && configuredWorkspaceDefinition) {
+    if (workspaceName && configuredWorkspaceDefinition && resolvedWorkspaceDefinition !== registeredWorkspaceDefinition) {
       await registerResolvedAgentWorkspaceDefinition(workspaceName, resolvedWorkspaceDefinition)
     }
     const workspace = workspaceName

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -80,8 +80,8 @@ import type {
   AgentChatOptions,
   AgentHandlerOptions,
   AgentInput,
+  AgentInputHook,
   AgentInstructionBlock,
-  AgentInvocationHooks,
   AgentInvocationContextStore,
   AgentInvocationContextValues,
   AgentHookObserverHooks,
@@ -196,6 +196,7 @@ export type {
   AgentHarnessSandboxInput,
   AgentHarnessSessionKey,
   AgentInput,
+  AgentInputHook,
   AgentInstructionBlock,
   AgentIntegrationOption,
   AgentHookObserver,
@@ -875,7 +876,7 @@ export interface DefineAgent {
     >,
   >(
     options: TOptions & { capabilities?: TCapabilities } & ValidateWorkspaceAgentOptions<TOptions>,
-  ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>
+  ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>, TCapabilities>
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     CALL_OPTIONS = unknown,
@@ -889,7 +890,7 @@ export interface DefineAgent {
       AgentCapabilitiesInvocationContextValues<TCapabilities>,
       TCapabilities
     > & { capabilities?: TCapabilities, workspace?: never },
-  ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS>
+  ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>>
 }
 
 function createWorkspaceAgentDefinition<
@@ -1140,6 +1141,32 @@ async function createAgentInvocationContext<
       model: agentModel as never,
       workspaceDefinition: resolvedWorkspaceDefinition,
     })
+    const inputHook = definition?.hooks?.["agent:input"]
+    if (inputHook) {
+      try {
+        await runObservedAgentHook(definition?.hooks as AgentHookObserverHooks | undefined, {
+          name: "agent:input",
+          owner: "agent",
+          phase: "input",
+        }, () => inputHook({
+          ...callbackContext,
+          actor: invoker,
+          context: invocationContext,
+          input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
+          invoker,
+          run: context.run,
+        }))
+      }
+      catch (error) {
+        try {
+          await capabilities.close()
+        }
+        catch (closeError) {
+          throw new AggregateError([error, closeError], "[vitehub] Agent input hook failed and cleanup also failed.")
+        }
+        throw error
+      }
+    }
     const transformedTools = await applyCapabilityToolTransforms(capabilities.tools, capabilities.toolTransforms)
     const tools = Object.keys(transformedTools || {}).length
       ? withAgentToolStepReporting(withJsonCompatibleToolOutputs(applyAgentToolPolicies(transformedTools) || {}), context.devtools?.reportToolStep)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1170,13 +1170,16 @@ async function createAgentInvocationContext<
       ? await resolveRegisteredAgentWorkspaceDefinition(workspaceName)
       : undefined
     const ownsWorkspaceDefinition = workspaceDefinition ? workspaceAgentOwnsWorkspaceDefinition(workspaceDefinition) : false
+    const configuredDefinitionForMerge = ownsWorkspaceDefinition && registeredWorkspaceDefinition
+      ? undefined
+      : configuredWorkspaceDefinition
     const resolvedWorkspaceDefinition = workspaceName
-      ? mergeAgentWorkspaceDefinition(workspaceName, registeredWorkspaceDefinition, ownsWorkspaceDefinition || registeredWorkspaceDefinition ? configuredWorkspaceDefinition : undefined)
+      ? mergeAgentWorkspaceDefinition(workspaceName, registeredWorkspaceDefinition, configuredDefinitionForMerge)
       : undefined
     if (workspaceName && ownsWorkspaceDefinition && configuredWorkspaceDefinition && !registeredWorkspaceDefinition) {
       await registerResolvedAgentWorkspaceDefinition(workspaceName, resolvedWorkspaceDefinition)
     }
-    const workspaceUseOptions = !ownsWorkspaceDefinition && resolvedWorkspaceDefinition && resolvedWorkspaceDefinition !== registeredWorkspaceDefinition
+    const workspaceUseOptions = !registeredWorkspaceDefinition && !ownsWorkspaceDefinition && resolvedWorkspaceDefinition
       ? { definition: resolvedWorkspaceDefinition }
       : undefined
     const workspaceModule = workspaceName ? await import("@vite-hub/workspace") : undefined

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1183,7 +1183,7 @@ async function createAgentInvocationContext<
     const workspace = workspaceName && workspaceModule
       ? workspaceMode === "write"
         ? workspaceModule.useWorkspace(workspaceName, workspaceUseOptions ? { ...workspaceUseOptions, mode: "write" } : { mode: "write" })
-        : workspaceUseOptions ? workspaceModule.useWorkspace(workspaceName, workspaceUseOptions) : workspaceModule.useWorkspace(workspaceName)
+        : workspaceUseOptions ? workspaceModule.useWorkspace(workspaceName, { ...workspaceUseOptions, mode: "read" }) : workspaceModule.useWorkspace(workspaceName)
       : undefined
     const capabilityOptions = definition?.capabilities?.length
       ? { capabilities: definition.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: definition.hooks as never }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -282,6 +282,7 @@ export {
   createAgentDevtoolsMetadata,
   materializeAgentDevtoolsSourceMetadata,
   resolveAgentDevtoolsMetadata,
+  workspaceAgentOwnsWorkspaceDefinition,
 } from "./workspace-agent.ts"
 
 export {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1096,6 +1096,43 @@ async function resolveRegisteredAgentWorkspaceDefinition(name: string): Promise<
   }
 }
 
+function mergeWorkspaceSources(
+  registered: WorkspaceDefinition["sources"] | undefined,
+  configured: WorkspaceDefinition["sources"] | undefined,
+): WorkspaceDefinition["sources"] | undefined {
+  if (!registered && !configured) return undefined
+  return {
+    ...registered,
+    ...configured,
+  }
+}
+
+function mergeAgentWorkspaceDefinition(
+  name: string,
+  registered: WorkspaceDefinition | undefined,
+  configured: WorkspaceDefinition | undefined,
+): WorkspaceDefinition | undefined {
+  if (!registered && !configured) return undefined
+  if (!registered) return configured ? { ...configured, name } : undefined
+  if (!configured) return { ...registered, name: registered.name || name }
+
+  const { name: _configuredName, sources: configuredSources, ...configuredFields } = configured as WorkspaceDefinition & { mode?: AgentCapabilityMode }
+  const { mode: _mode, ...configuredDefinitionFields } = configuredFields
+  return {
+    ...registered,
+    ...configuredDefinitionFields,
+    name: registered.name || name,
+    sources: mergeWorkspaceSources(registered.sources, configuredSources),
+  }
+}
+
+async function registerResolvedAgentWorkspaceDefinition(name: string, definition: WorkspaceDefinition | undefined): Promise<void> {
+  if (!definition) return
+  const { name: _name, ...workspace } = definition
+  const { registerWorkspace } = await import("@vite-hub/workspace/runtime")
+  registerWorkspace(name, workspace)
+}
+
 async function createAgentInvocationContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -1121,9 +1158,15 @@ async function createAgentInvocationContext<
     const configuredWorkspaceDefinition = workspaceOptions && workspaceName
       ? { ...workspaceDefinitionFromOptions(workspaceOptions), name: workspaceName }
       : undefined
-    const resolvedWorkspaceDefinition = workspaceName
-      ? await resolveRegisteredAgentWorkspaceDefinition(workspaceName) || configuredWorkspaceDefinition
+    const registeredWorkspaceDefinition = workspaceName
+      ? await resolveRegisteredAgentWorkspaceDefinition(workspaceName)
       : undefined
+    const resolvedWorkspaceDefinition = workspaceName
+      ? mergeAgentWorkspaceDefinition(workspaceName, registeredWorkspaceDefinition, configuredWorkspaceDefinition)
+      : undefined
+    if (workspaceName && configuredWorkspaceDefinition) {
+      await registerResolvedAgentWorkspaceDefinition(workspaceName, resolvedWorkspaceDefinition)
+    }
     const workspace = workspaceName
       ? workspaceMode === "write"
         ? (await import("@vite-hub/workspace")).useWorkspace(workspaceName, { mode: "write" })

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -6,8 +6,8 @@ interface ViteAgentRouteRuntimeConfig extends AgentRuntimeConfig {
   agent?: unknown
 }
 
-import { withAgentDefaults } from "./index.ts"
-import { workspaceNameFromOptions } from "./workspace-agent.ts"
+import { withAgentDefaults, workspaceAgentOwnsWorkspaceDefinition } from "./index.ts"
+import { workspaceDefinitionFromOptions, workspaceNameFromOptions } from "./workspace-agent.ts"
 
 import type { AgentRuntimeConfig } from "./types.ts"
 import type { WorkspaceAgentDefaults, WorkspaceAgentDefinition } from "./workspace-agent.ts"
@@ -32,14 +32,18 @@ export function registerWorkspaceAgent<
     workspace: options.workspace,
   }) as WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>
   const workspaceOptions = preparedAgent.__vitehubWorkspaceAgentOptions
-  if (typeof workspaceOptions.workspace === "string") return preparedAgent
+  if (!workspaceAgentOwnsWorkspaceDefinition(preparedAgent)) return preparedAgent
   const sourceRootDir = preparedAgent.sourceRootDir ?? options.sourceRootDir
   if (sourceRootDir !== undefined) {
+    const configuredWorkspace = workspaceOptions.workspace as Record<string, unknown> & { sourceRootDir?: string }
     const workspace = {
-      ...workspaceOptions.workspace,
-      sourceRootDir: workspaceOptions.workspace.sourceRootDir ?? sourceRootDir,
+      ...configuredWorkspace,
+      sourceRootDir: configuredWorkspace.sourceRootDir ?? sourceRootDir,
     }
-    Object.assign(preparedAgent, workspace, {
+    Object.assign(preparedAgent, workspaceDefinitionFromOptions({
+      ...workspaceOptions,
+      workspace,
+    } as never), {
       __vitehubWorkspaceAgentOptions: {
         ...workspaceOptions,
         workspace,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1058,9 +1058,20 @@ export type AgentToolSet = Record<string, AgentToolDefinition>
 
 export interface WorkspaceAgentWorkspaceOptions extends Omit<WorkspaceDefinitionInput, "name"> {
   mode?: AgentCapabilityMode
+  name?: never
 }
 
-export type WorkspaceAgentWorkspaceConfig = WorkspaceName | WorkspaceAgentWorkspaceOptions
+export type WorkspaceAgentWorkspaceReference<Name extends WorkspaceName = WorkspaceName> = {
+  mode?: AgentCapabilityMode
+  name: Name
+} & {
+  [Key in keyof Omit<WorkspaceAgentWorkspaceOptions, "mode" | "name">]?: never
+}
+
+export type WorkspaceAgentWorkspaceConfig<Name extends WorkspaceName = WorkspaceName> =
+  | Name
+  | WorkspaceAgentWorkspaceReference<Name>
+  | WorkspaceAgentWorkspaceOptions
 
 export interface AgentDevtoolsFileTreeItem {
   children?: AgentDevtoolsFileTreeItem[]

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -546,6 +546,7 @@ export interface AgentCapabilityDefinition<
   resolve?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   tools?: AgentCapabilityToolResolver<TRuntimeConfig, Name>
   triggers?: Record<string, AgentTriggerDefinition<TRuntimeConfig, Name, any, any>>
+  workspaceSources?: WorkspaceDefinition["sources"]
 }
 
 export type AgentCapabilityInput<

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -343,11 +343,19 @@ export type AgentFinishHook<
   CALL_OPTIONS = unknown,
 > = (event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void>
 
+export type AgentInputHook<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+  TContextValues extends object = AgentInvocationContextValues,
+> = (context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>) => MaybePromise<void>
+
 export interface AgentInvocationHooks<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
+  TContextValues extends object = AgentInvocationContextValues,
 > {
   "agent:finish"?: AgentFinishHook<TRuntimeConfig, CALL_OPTIONS>
+  "agent:input"?: AgentInputHook<TRuntimeConfig, CALL_OPTIONS, TContextValues>
 }
 
 export type AgentHookOwner = "agent" | "capability" | "channel" | "runtime" | "integration" | (string & {})
@@ -720,7 +728,7 @@ type AgentSharedSettings<
   capabilities?: TCapabilities
   channels?: AgentChannels<TRuntimeConfig>
   description?: string
-  hooks?: AgentCapabilityHooks<TRuntimeConfig> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig>
+  hooks?: AgentCapabilityHooks<TRuntimeConfig> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   runtime?: AgentRuntimeBinding
@@ -768,7 +776,7 @@ export interface AgentDefinition<
   channels?: AgentChannels<TRuntimeConfig>
   chat?: AgentChatOptions<TRuntimeConfig>
   description?: string
-  hooks?: AgentCapabilityHooks<TRuntimeConfig, WorkspaceName> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS>
+  hooks?: AgentCapabilityHooks<TRuntimeConfig, WorkspaceName> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   runtime?: AgentRuntimeBinding
@@ -779,7 +787,7 @@ export interface AgentDefinition<
 }
 
 export type AgentInput<TContext extends AgentRuntimeContext<any> = AgentRuntimeContext> =
-  AgentDefinition<TContext extends AgentRuntimeContext<infer TRuntimeConfig> ? TRuntimeConfig : AgentRuntimeConfig, any, any>
+  AgentDefinition<TContext extends AgentRuntimeContext<infer TRuntimeConfig> ? TRuntimeConfig : AgentRuntimeConfig, any, any, any>
 
 export type AgentRegistryModule<TContext extends AgentRuntimeContext<any> = AgentRuntimeContext> =
   | { default?: AgentInput<TContext> }

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -214,6 +214,11 @@ function resolveWorkspaceSourceRoot(file: string): string {
     : dirname(file)
 }
 
+function hasColocatedAgentInstructions(sourceRootDir: string): boolean {
+  const file = join(sourceRootDir, "instructions.md")
+  return existsSync(file) && statSync(file).isFile()
+}
+
 function moduleImportSpecifier(fromFile: string, targetFile: string): string {
   const specifier = relative(dirname(fromFile), targetFile).replace(/\\/g, "/")
   return specifier.startsWith(".") ? specifier : `./${specifier}`
@@ -279,14 +284,18 @@ function generateAgentWebhookRouteHandler(
     .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
     .join("\n")
   const workspaceEntries = definitions
-    .map((definition, index) => definition.workspace
-      ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(resolveWorkspaceSourceRoot(definition.handler))})`
-      : undefined)
+    .map((definition, index) => {
+      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
+      return definition.workspace
+        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(hasColocatedAgentInstructions(sourceRootDir))})`
+        : undefined
+    })
     .filter(Boolean)
     .join(",\n  ")
   const agentEntries = definitions
     .map((definition, index) => {
-      const agentExpression = `withAgentDefaults(resolveAgentModule(agent${index}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
+      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
+      const agentExpression = `withAgentDefaults(withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(hasColocatedAgentInstructions(sourceRootDir))}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
       return `${JSON.stringify(definition.name)}: ${agentExpression}`
     })
     .join(",\n  ")
@@ -313,9 +322,20 @@ function generateAgentWebhookRouteHandler(
     "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
     "}",
     "",
-    "function workspaceRegistryEntry(name, module, sourceRootDir) {",
-    "  if (!workspaceAgentOwnsWorkspaceDefinition(resolveAgentModule(module))) return",
-    "  return [name, async () => ({ ...module, default: { ...module.default, sourceRootDir: module.default?.sourceRootDir ?? sourceRootDir } })]",
+    "function withWorkspaceSourceRoot(agent, sourceRootDir, colocatedInstructions) {",
+    "  const options = agent?.__vitehubWorkspaceAgentOptions",
+    "  const workspace = options?.workspace",
+    "  if (!workspace || typeof workspace !== 'object' || 'name' in workspace) return agent",
+    "  const sources = colocatedInstructions && !(workspace.sources && '__vitehubAgentInstructions' in workspace.sources)",
+    "    ? { __vitehubAgentInstructions: { materialize: 'build', mount: '', path: 'instructions.md', workspacePath: 'AGENTS.md' }, ...workspace.sources }",
+    "    : workspace.sources",
+    "  return { ...agent, ...(sources ? { sources } : {}), sourceRootDir: agent.sourceRootDir ?? sourceRootDir, __vitehubWorkspaceAgentOptions: { ...options, workspace: { ...workspace, ...(sources ? { sources } : {}), sourceRootDir: workspace.sourceRootDir ?? sourceRootDir } } }",
+    "}",
+    "",
+    "function workspaceRegistryEntry(name, module, sourceRootDir, colocatedInstructions) {",
+    "  const agent = withWorkspaceSourceRoot(resolveAgentModule(module), sourceRootDir, colocatedInstructions)",
+    "  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return",
+    "  return [name, async () => ({ ...module, default: agent })]",
     "}",
     "",
     "async function toRequest(event) {",
@@ -370,14 +390,18 @@ function generateAgentNetlifyFunctionRouteHandler(
     .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
     .join("\n")
   const workspaceEntries = definitions
-    .map((definition, index) => definition.workspace
-      ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(resolveWorkspaceSourceRoot(definition.handler))})`
-      : undefined)
+    .map((definition, index) => {
+      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
+      return definition.workspace
+        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(hasColocatedAgentInstructions(sourceRootDir))})`
+        : undefined
+    })
     .filter(Boolean)
     .join(",\n  ")
   const agentEntries = definitions
     .map((definition, index) => {
-      const agentExpression = `withAgentDefaults(resolveAgentModule(agent${index}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
+      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
+      const agentExpression = `withAgentDefaults(withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(hasColocatedAgentInstructions(sourceRootDir))}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
       return `${JSON.stringify(definition.name)}: ${agentExpression}`
     })
     .join(",\n  ")
@@ -400,9 +424,20 @@ function generateAgentNetlifyFunctionRouteHandler(
     "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
     "}",
     "",
-    "function workspaceRegistryEntry(name, module, sourceRootDir) {",
-    "  if (!workspaceAgentOwnsWorkspaceDefinition(resolveAgentModule(module))) return",
-    "  return [name, async () => ({ ...module, default: { ...module.default, sourceRootDir: module.default?.sourceRootDir ?? sourceRootDir } })]",
+    "function withWorkspaceSourceRoot(agent, sourceRootDir, colocatedInstructions) {",
+    "  const options = agent?.__vitehubWorkspaceAgentOptions",
+    "  const workspace = options?.workspace",
+    "  if (!workspace || typeof workspace !== 'object' || 'name' in workspace) return agent",
+    "  const sources = colocatedInstructions && !(workspace.sources && '__vitehubAgentInstructions' in workspace.sources)",
+    "    ? { __vitehubAgentInstructions: { materialize: 'build', mount: '', path: 'instructions.md', workspacePath: 'AGENTS.md' }, ...workspace.sources }",
+    "    : workspace.sources",
+    "  return { ...agent, ...(sources ? { sources } : {}), sourceRootDir: agent.sourceRootDir ?? sourceRootDir, __vitehubWorkspaceAgentOptions: { ...options, workspace: { ...workspace, ...(sources ? { sources } : {}), sourceRootDir: workspace.sourceRootDir ?? sourceRootDir } } }",
+    "}",
+    "",
+    "function workspaceRegistryEntry(name, module, sourceRootDir, colocatedInstructions) {",
+    "  const agent = withWorkspaceSourceRoot(resolveAgentModule(module), sourceRootDir, colocatedInstructions)",
+    "  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return",
+    "  return [name, async () => ({ ...module, default: agent })]",
     "}",
     "",
     ...generatedNetlifyRuntimeHelpers(),
@@ -456,14 +491,18 @@ function generateAgentDenoServer(
     .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
     .join("\n")
   const workspaceEntries = definitions
-    .map((definition, index) => definition.workspace
-      ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(resolveWorkspaceSourceRoot(definition.handler))})`
-      : undefined)
+    .map((definition, index) => {
+      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
+      return definition.workspace
+        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(hasColocatedAgentInstructions(sourceRootDir))})`
+        : undefined
+    })
     .filter(Boolean)
     .join(",\n  ")
   const agentEntries = definitions
     .map((definition, index) => {
-      const agentExpression = `withAgentDefaults(resolveAgentModule(agent${index}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
+      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
+      const agentExpression = `withAgentDefaults(withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(hasColocatedAgentInstructions(sourceRootDir))}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
       return `${JSON.stringify(definition.name)}: ${agentExpression}`
     })
     .join(",\n  ")
@@ -499,9 +538,20 @@ function generateAgentDenoServer(
     "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
     "}",
     "",
-    "function workspaceRegistryEntry(name, module, sourceRootDir) {",
-    "  if (!workspaceAgentOwnsWorkspaceDefinition(resolveAgentModule(module))) return",
-    "  return [name, async () => ({ ...module, default: { ...module.default, sourceRootDir: module.default?.sourceRootDir ?? sourceRootDir } })]",
+    "function withWorkspaceSourceRoot(agent, sourceRootDir, colocatedInstructions) {",
+    "  const options = agent?.__vitehubWorkspaceAgentOptions",
+    "  const workspace = options?.workspace",
+    "  if (!workspace || typeof workspace !== 'object' || 'name' in workspace) return agent",
+    "  const sources = colocatedInstructions && !(workspace.sources && '__vitehubAgentInstructions' in workspace.sources)",
+    "    ? { __vitehubAgentInstructions: { materialize: 'build', mount: '', path: 'instructions.md', workspacePath: 'AGENTS.md' }, ...workspace.sources }",
+    "    : workspace.sources",
+    "  return { ...agent, ...(sources ? { sources } : {}), sourceRootDir: agent.sourceRootDir ?? sourceRootDir, __vitehubWorkspaceAgentOptions: { ...options, workspace: { ...workspace, ...(sources ? { sources } : {}), sourceRootDir: workspace.sourceRootDir ?? sourceRootDir } } }",
+    "}",
+    "",
+    "function workspaceRegistryEntry(name, module, sourceRootDir, colocatedInstructions) {",
+    "  const agent = withWorkspaceSourceRoot(resolveAgentModule(module), sourceRootDir, colocatedInstructions)",
+    "  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return",
+    "  return [name, async () => ({ ...module, default: agent })]",
     "}",
     "",
     "function jsonError(status, message) {",

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -280,7 +280,7 @@ function generateAgentWebhookRouteHandler(
     .join("\n")
   const workspaceEntries = definitions
     .map((definition, index) => definition.workspace
-      ? `${JSON.stringify(definition.workspace)}: async () => ({ ...agent${index}, default: { ...agent${index}.default, sourceRootDir: agent${index}.default?.sourceRootDir ?? ${JSON.stringify(resolveWorkspaceSourceRoot(definition.handler))} } })`
+      ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(resolveWorkspaceSourceRoot(definition.handler))})`
       : undefined)
     .filter(Boolean)
     .join(",\n  ")
@@ -297,7 +297,7 @@ function generateAgentWebhookRouteHandler(
   const webhookSelector = webhookRoute.includes("[webhook]") ? "getRouterParam(event, 'webhook')" : "''"
 
   return [
-    "import { withAgentDefaults } from '@vite-hub/agent'",
+    "import { withAgentDefaults, workspaceAgentOwnsWorkspaceDefinition } from '@vite-hub/agent'",
     ...(options.cloudflareState ? ["import { createCloudflareAgentState } from '@vite-hub/agent/cloudflare'"] : []),
     "import { defineAgentChatFetchHandler, defineAgentChatWebhookFetchHandler } from '@vite-hub/agent/server'",
     "import { setWorkspaceRuntimeRegistry } from '@vite-hub/workspace/internal/runtime/state'",
@@ -311,6 +311,11 @@ function generateAgentWebhookRouteHandler(
     "function resolveChatRouteOptions(module) {",
     "  const chatRoute = module && typeof module === 'object' ? module.chatRoute : undefined",
     "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
+    "}",
+    "",
+    "function workspaceRegistryEntry(name, module, sourceRootDir) {",
+    "  if (!workspaceAgentOwnsWorkspaceDefinition(resolveAgentModule(module))) return",
+    "  return [name, async () => ({ ...module, default: { ...module.default, sourceRootDir: module.default?.sourceRootDir ?? sourceRootDir } })]",
     "}",
     "",
     "async function toRequest(event) {",
@@ -328,7 +333,7 @@ function generateAgentWebhookRouteHandler(
     ...generatedRuntimeHelpers(),
     ...(options.cloudflareState ? generatedCloudflareChatStateHelper() : []),
     "",
-    `setWorkspaceRuntimeRegistry({${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}})`,
+    `setWorkspaceRuntimeRegistry(Object.fromEntries([${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}].filter(Boolean)))`,
     "",
     `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
     `const agentModules = {${agentModuleEntries ? `\n  ${agentModuleEntries}\n` : ""}}`,
@@ -366,7 +371,7 @@ function generateAgentNetlifyFunctionRouteHandler(
     .join("\n")
   const workspaceEntries = definitions
     .map((definition, index) => definition.workspace
-      ? `${JSON.stringify(definition.workspace)}: async () => ({ ...agent${index}, default: { ...agent${index}.default, sourceRootDir: agent${index}.default?.sourceRootDir ?? ${JSON.stringify(resolveWorkspaceSourceRoot(definition.handler))} } })`
+      ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(resolveWorkspaceSourceRoot(definition.handler))})`
       : undefined)
     .filter(Boolean)
     .join(",\n  ")
@@ -382,7 +387,7 @@ function generateAgentNetlifyFunctionRouteHandler(
   const webhookSelector = routeUsesParam(options.webhookRoute, "webhook") ? "netlifyParam(context, 'webhook')" : "''"
 
   return [
-    "import { withAgentDefaults } from '@vite-hub/agent'",
+    "import { withAgentDefaults, workspaceAgentOwnsWorkspaceDefinition } from '@vite-hub/agent'",
     "import { defineAgentChatFetchHandler, defineAgentChatWebhookFetchHandler, setWorkspaceRuntimeRegistry } from '@vite-hub/agent/server'",
     imports,
     "",
@@ -395,9 +400,14 @@ function generateAgentNetlifyFunctionRouteHandler(
     "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
     "}",
     "",
+    "function workspaceRegistryEntry(name, module, sourceRootDir) {",
+    "  if (!workspaceAgentOwnsWorkspaceDefinition(resolveAgentModule(module))) return",
+    "  return [name, async () => ({ ...module, default: { ...module.default, sourceRootDir: module.default?.sourceRootDir ?? sourceRootDir } })]",
+    "}",
+    "",
     ...generatedNetlifyRuntimeHelpers(),
     "",
-    `setWorkspaceRuntimeRegistry({${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}})`,
+    `setWorkspaceRuntimeRegistry(Object.fromEntries([${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}].filter(Boolean)))`,
     "",
     `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
     `const agentModules = {${agentModuleEntries ? `\n  ${agentModuleEntries}\n` : ""}}`,
@@ -447,7 +457,7 @@ function generateAgentDenoServer(
     .join("\n")
   const workspaceEntries = definitions
     .map((definition, index) => definition.workspace
-      ? `${JSON.stringify(definition.workspace)}: async () => ({ ...agent${index}, default: { ...agent${index}.default, sourceRootDir: agent${index}.default?.sourceRootDir ?? ${JSON.stringify(resolveWorkspaceSourceRoot(definition.handler))} } })`
+      ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(resolveWorkspaceSourceRoot(definition.handler))})`
       : undefined)
     .filter(Boolean)
     .join(",\n  ")
@@ -464,13 +474,13 @@ function generateAgentDenoServer(
     ? [
         "import { setWorkspaceRuntimeRegistry } from '@vite-hub/workspace/runtime'",
         "",
-        `setWorkspaceRuntimeRegistry({\n  ${workspaceEntries}\n})`,
+        `setWorkspaceRuntimeRegistry(Object.fromEntries([\n  ${workspaceEntries}\n].filter(Boolean)))`,
         "",
       ]
     : []
 
   return [
-    "import { withAgentDefaults } from '@vite-hub/agent'",
+    "import { withAgentDefaults, workspaceAgentOwnsWorkspaceDefinition } from '@vite-hub/agent'",
     "import { defineAgentChatFetchHandler, defineAgentChatWebhookFetchHandler } from '@vite-hub/agent/server/routes'",
     ...workspaceRuntimeLines.slice(0, 1),
     imports,
@@ -487,6 +497,11 @@ function generateAgentDenoServer(
     "function resolveChatRouteOptions(module) {",
     "  const chatRoute = module && typeof module === 'object' ? module.chatRoute : undefined",
     "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
+    "}",
+    "",
+    "function workspaceRegistryEntry(name, module, sourceRootDir) {",
+    "  if (!workspaceAgentOwnsWorkspaceDefinition(resolveAgentModule(module))) return",
+    "  return [name, async () => ({ ...module, default: { ...module.default, sourceRootDir: module.default?.sourceRootDir ?? sourceRootDir } })]",
     "}",
     "",
     "function jsonError(status, message) {",

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -10,6 +10,7 @@ import { uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { discoverAgentDefinitions } from "../discovery.ts"
 import { isResolvedAgentTriggerHandledInvocation, resolveAgentTriggerInvocation, resolveAgentTriggers, streamAgent, withAgentDefaults } from "../index.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
+import { workspaceAgentOwnsWorkspaceDefinition } from "../workspace-agent.ts"
 
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http"
 import type { ViteDevServer } from "vite"
@@ -188,10 +189,10 @@ function agentAliases(definition: DiscoveredAgentDefinition, agent: AgentInput<V
 
 function installServerAgentWorkspaceRegistry(
   server: ViteDevServer,
-  entries: Array<{ aliases?: string[], definition: DiscoveredAgentDefinition }>,
+  entries: Array<{ agent: AgentInput<ViteAgentDevRuntimeContext>, aliases?: string[], definition: DiscoveredAgentDefinition }>,
 ): void {
   setWorkspaceRuntimeRegistry(Object.fromEntries(entries
-    .filter(entry => entry.definition.workspace)
+    .filter(entry => entry.definition.workspace && workspaceAgentOwnsWorkspaceDefinition(entry.agent))
     .flatMap(({ aliases, definition }) => [definition.workspace!, ...(aliases || [])].map(name => [
       name,
       async () => {

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -842,7 +842,8 @@ export async function resolveWorkspaceAgentDefaultInstructions<
   workspace: ReadonlyWorkspaceFacade<Name>,
 ): Promise<string | undefined> {
   if (!shouldUseColocatedAgentInstructions(options)) return undefined
-  if (!hasColocatedAgentInstructions(workspaceDefinitionFromOptions(options).sourceRootDir)) return undefined
+  const definition = workspaceDefinitionFromOptions(options)
+  if (!definition.sources || !(colocatedAgentInstructionsSourceKey in definition.sources)) return undefined
   try {
     const content = (await workspace.fs.readFile(colocatedAgentInstructionsWorkspacePath as never)).trim()
     if (content) return content

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1,5 +1,6 @@
 import {
   applyCapabilityInstructionSlots,
+  capabilityWorkspaceSources,
   capabilityInstructionBlockId,
   normalizeCapabilities,
   normalizeMode,
@@ -178,15 +179,23 @@ export function workspaceDefinitionFromOptions<
 >(
   options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
 ): WorkspaceAgentWorkspaceOptions {
-  if (typeof options.workspace === "string") return { mode: "read" }
+  if (typeof options.workspace === "string") {
+    return withCapabilityWorkspaceSources({ mode: "read" }, options.capabilities as AgentCapabilityDefinition[] | undefined)
+  }
   if (isWorkspaceReference(options.workspace)) {
     assertWorkspaceReference(options.workspace)
-    return normalizeWorkspaceOptions(options.workspace)
+    return withCapabilityWorkspaceSources(
+      normalizeWorkspaceOptions(options.workspace),
+      options.capabilities as AgentCapabilityDefinition[] | undefined,
+    )
   }
   const workspace = normalizeWorkspaceOptions(options.workspace)
   const { mode: _mode, ...definition } = workspace
   assertWorkspaceDefinition(definition)
-  return withColocatedAgentInstructions(workspace)
+  return withColocatedAgentInstructions(withCapabilityWorkspaceSources(
+    workspace,
+    options.capabilities as AgentCapabilityDefinition[] | undefined,
+  ))
 }
 
 function assertWorkspaceDefinition(definition: Record<string, unknown>): void {
@@ -199,6 +208,25 @@ function assertWorkspaceDefinition(definition: Record<string, unknown>): void {
   const unsupported = Object.keys(definition).filter(key => !workspaceDefinitionKeys.has(key))
   if (unsupported.length) {
     throw new TypeError(`[vitehub] defineWorkspace does not support option${unsupported.length === 1 ? "" : "s"}: ${unsupported.join(", ")}.`)
+  }
+}
+
+function withCapabilityWorkspaceSources(
+  workspace: NormalizedWorkspaceOptions,
+  capabilities: AgentCapabilityDefinition[] | undefined,
+): NormalizedWorkspaceOptions {
+  const contributed = capabilityWorkspaceSources(capabilities)
+  if (!contributed) return workspace
+  const sources = { ...workspace.sources }
+  for (const [key, source] of Object.entries(contributed)) {
+    if (key in sources) {
+      throw new Error(`[vitehub] Workspace source "${key}" is already defined.`)
+    }
+    sources[key] = source
+  }
+  return {
+    ...workspace,
+    sources,
   }
 }
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -54,6 +54,9 @@ import type {
 } from "@vite-hub/workspace"
 
 const defaultWorkspaceName = "workspace"
+const colocatedAgentInstructionsPath = "instructions.md"
+const colocatedAgentInstructionsWorkspacePath = "AGENTS.md"
+const colocatedAgentInstructionsSourceKey = "__vitehubAgentInstructions"
 const readCommands = ["pwd", "ls", "find", "rg", "grep", "cat", "head", "tail", "wc"]
 const sourceRequestCommands = ["curl"]
 const writeCommands = [...readCommands, "mkdir", "touch", "cp", "mv", "rm"]
@@ -183,7 +186,7 @@ export function workspaceDefinitionFromOptions<
   const workspace = normalizeWorkspaceOptions(options.workspace)
   const { mode: _mode, ...definition } = workspace
   assertWorkspaceDefinition(definition)
-  return workspace
+  return withColocatedAgentInstructions(workspace)
 }
 
 function assertWorkspaceDefinition(definition: Record<string, unknown>): void {
@@ -196,6 +199,36 @@ function assertWorkspaceDefinition(definition: Record<string, unknown>): void {
   const unsupported = Object.keys(definition).filter(key => !workspaceDefinitionKeys.has(key))
   if (unsupported.length) {
     throw new TypeError(`[vitehub] defineWorkspace does not support option${unsupported.length === 1 ? "" : "s"}: ${unsupported.join(", ")}.`)
+  }
+}
+
+function hasColocatedAgentInstructions(sourceRootDir: string | undefined): boolean {
+  if (!sourceRootDir) return false
+  const fs = getNodeBuiltin<typeof import("node:fs")>("node:fs")
+  const path = getNodeBuiltin<typeof import("node:path")>("node:path")
+  if (!fs || !path) return false
+  try {
+    return fs.statSync(path.join(sourceRootDir, colocatedAgentInstructionsPath)).isFile()
+  }
+  catch {
+    return false
+  }
+}
+
+function withColocatedAgentInstructions(workspace: NormalizedWorkspaceOptions): NormalizedWorkspaceOptions {
+  if (!hasColocatedAgentInstructions(workspace.sourceRootDir)) return workspace
+  if (workspace.sources && colocatedAgentInstructionsSourceKey in workspace.sources) return workspace
+  return {
+    ...workspace,
+    sources: {
+      [colocatedAgentInstructionsSourceKey]: {
+        materialize: "build",
+        mount: "",
+        path: colocatedAgentInstructionsPath,
+        workspacePath: colocatedAgentInstructionsWorkspacePath,
+      },
+      ...workspace.sources,
+    },
   }
 }
 
@@ -244,6 +277,14 @@ function modelDriverInstructions<
       : undefined
   }
   return (options as { instructions?: AgentAdapterInstructions<TRuntimeConfig, Name> }).instructions
+}
+
+function shouldUseColocatedAgentInstructions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(options: WorkspaceAgentOptions<TRuntimeConfig, Name>): boolean {
+  return modelDriverInstructions(options) === undefined
+    && normalizeAgentDriver(options as AgentSettings<TRuntimeConfig>).kind === "model"
 }
 
 function workspaceShellMetadataCommands(mode: AgentCapabilityMode, sourceRequests = false) {
@@ -737,6 +778,9 @@ function workspaceMetadataInstructions<
   options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
 ): string[] {
   const configuredInstructions = modelDriverInstructions(options)
+  const defaultInstructions = shouldUseColocatedAgentInstructions(options)
+    ? readColocatedAgentInstructions(options)
+    : undefined
   const parts = Array.isArray(configuredInstructions) ? configuredInstructions : [configuredInstructions]
   const instructions = parts.flatMap((part) => {
     if (typeof part === "string" && part.trim().length > 0) return [part]
@@ -747,6 +791,7 @@ function workspaceMetadataInstructions<
     }
     return []
   })
+  if (defaultInstructions) instructions.unshift(defaultInstructions)
   const renderedInstructions = applyPassiveCapabilityInstructionSlots(
     instructions.join("\n\n"),
     staticCapabilityInstructionBlocks(options),
@@ -774,6 +819,37 @@ function readLocalWorkspaceInstructions<
   }
 }
 
+function readColocatedAgentInstructions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(options: WorkspaceAgentOptions<TRuntimeConfig, Name>): string | undefined {
+  const fs = getNodeBuiltin<typeof import("node:fs")>("node:fs")
+  const path = getNodeBuiltin<typeof import("node:path")>("node:path")
+  const sourceRootDir = workspaceDefinitionFromOptions(options).sourceRootDir
+  if (!fs || !path || !hasColocatedAgentInstructions(sourceRootDir)) return undefined
+  try {
+    const content = fs.readFileSync(path.join(sourceRootDir!, colocatedAgentInstructionsPath), "utf8").trim()
+    if (content) return content
+  }
+  catch {}
+}
+
+export async function resolveWorkspaceAgentDefaultInstructions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
+  workspace: ReadonlyWorkspaceFacade<Name>,
+): Promise<string | undefined> {
+  if (!shouldUseColocatedAgentInstructions(options)) return undefined
+  if (!hasColocatedAgentInstructions(workspaceDefinitionFromOptions(options).sourceRootDir)) return undefined
+  try {
+    const content = (await workspace.fs.readFile(colocatedAgentInstructionsWorkspacePath as never)).trim()
+    if (content) return content
+  }
+  catch {}
+}
+
 async function resolveWorkspaceMetadataInstructions<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
@@ -789,6 +865,9 @@ async function resolveWorkspaceMetadataInstructions<
     workspace,
   }
   const configuredInstructions = modelDriverInstructions(options)
+  const defaultInstructions = shouldUseColocatedAgentInstructions(options)
+    ? await resolveWorkspaceAgentDefaultInstructions(options, workspace)
+    : undefined
   const parts = Array.isArray(configuredInstructions) ? configuredInstructions : [configuredInstructions]
   const instructions = await Promise.all(parts.map(part => typeof part === "function"
     ? part(instructionContext as never)
@@ -797,6 +876,7 @@ async function resolveWorkspaceMetadataInstructions<
     .flatMap(part => Array.isArray(part) ? part : [part])
     .map(part => part?.trim())
     .filter((part): part is string => Boolean(part))
+  if (defaultInstructions) baseInstructions.unshift(defaultInstructions)
   const renderedInstructions = applyPassiveCapabilityInstructionSlots(
     baseInstructions.join("\n\n"),
     capabilityBlocks,

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -34,7 +34,6 @@ import type {
   AgentInput,
   AgentInstructionBlock,
   AgentModelInput,
-  AgentModelResolver,
   AgentRunInput,
   AgentRuntimeConfig,
   AgentRuntimeContext,
@@ -70,6 +69,7 @@ const workspaceDefinitionKeys = new Set([
   "sources",
   "store",
 ])
+const workspaceReferenceKeys = new Set(["mode", "name"])
 
 type NormalizedWorkspaceOptions = WorkspaceAgentWorkspaceOptions & { mode: AgentCapabilityMode }
 type NormalizedCapability = AgentCapabilityDefinition & { mode?: AgentCapabilityMode }
@@ -83,7 +83,7 @@ export type WorkspaceAgentOptions<
   TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined = AgentCapabilityDefinition<TRuntimeConfig>[] | undefined,
 > = AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities> & {
   name?: string
-  workspace: WorkspaceAgentWorkspaceConfig
+  workspace: WorkspaceAgentWorkspaceConfig<_Name>
 }
 
 export type WorkspaceAgentDefinition<
@@ -122,12 +122,28 @@ export interface AgentDevtoolsSourceMaterializationOptions<
 }
 
 export function normalizeWorkspaceOptions(workspace: WorkspaceAgentWorkspaceConfig): NormalizedWorkspaceOptions {
-  if (typeof workspace === "string") {
-    return { mode: "read" }
-  }
+  if (isWorkspaceReference(workspace)) return { mode: normalizeMode(workspace.mode, "Workspace") }
+  if (typeof workspace === "string") return { mode: "read" }
   return {
     ...workspace,
     mode: normalizeMode(workspace.mode, "Workspace"),
+  }
+}
+
+function isWorkspaceReference(workspace: WorkspaceAgentWorkspaceConfig): workspace is { mode?: AgentCapabilityMode, name: string } {
+  return typeof workspace === "object"
+    && workspace !== null
+    && "name" in workspace
+    && typeof workspace.name === "string"
+}
+
+function assertWorkspaceReference(reference: { name: string }): void {
+  if (!reference.name.trim()) {
+    throw new TypeError("[vitehub] Workspace reference requires a non-empty string name.")
+  }
+  const unsupported = Object.keys(reference).filter(key => !workspaceReferenceKeys.has(key))
+  if (unsupported.length) {
+    throw new TypeError(`[vitehub] Workspace reference does not support option${unsupported.length === 1 ? "" : "s"}: ${unsupported.join(", ")}.`)
   }
 }
 
@@ -139,6 +155,7 @@ export function workspaceNameFromOptions<
   defaults: WorkspaceAgentDefaults<Name> = {},
 ): Name | string {
   if (typeof options.workspace === "string") return options.workspace
+  if (isWorkspaceReference(options.workspace)) return options.workspace.name
   return options.name || defaults.workspace || defaults.name || defaultWorkspaceName
 }
 
@@ -149,6 +166,10 @@ export function workspaceDefinitionFromOptions<
   options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
 ): WorkspaceAgentWorkspaceOptions {
   if (typeof options.workspace === "string") return { mode: "read" }
+  if (isWorkspaceReference(options.workspace)) {
+    assertWorkspaceReference(options.workspace)
+    return normalizeWorkspaceOptions(options.workspace)
+  }
   const workspace = normalizeWorkspaceOptions(options.workspace)
   const { mode: _mode, ...definition } = workspace
   assertWorkspaceDefinition(definition)

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -137,6 +137,16 @@ function isWorkspaceReference(workspace: WorkspaceAgentWorkspaceConfig): workspa
     && typeof workspace.name === "string"
 }
 
+export function workspaceAgentOwnsWorkspaceDefinition(agent: unknown): boolean {
+  const options = typeof agent === "object" && agent !== null
+    ? (agent as { __vitehubWorkspaceAgentOptions?: { workspace?: unknown } }).__vitehubWorkspaceAgentOptions
+    : undefined
+  const workspace = options?.workspace
+  return typeof workspace === "object"
+    && workspace !== null
+    && !isWorkspaceReference(workspace as WorkspaceAgentWorkspaceConfig)
+}
+
 function assertWorkspaceReference(reference: { name: string }): void {
   if (!reference.name.trim()) {
     throw new TypeError("[vitehub] Workspace reference requires a non-empty string name.")

--- a/packages/agent/src/workspace-source-metadata.ts
+++ b/packages/agent/src/workspace-source-metadata.ts
@@ -206,7 +206,7 @@ function hasSourceMethods(input: Record<string, unknown>) {
 
 function fileSourceKey(input: Record<string, unknown>): string {
   if (typeof input.workspacePath === "string") return normalizeAgentSourcePath(input.workspacePath, { allowEmpty: false })
-  if (typeof input.path === "string") return normalizeAgentSourcePath(basename(normalizeAgentSourcePath(input.path, { allowEmpty: false })), { allowEmpty: false })
+  if (typeof input.path === "string") return normalizeAgentSourcePath(input.path, { allowEmpty: false })
   throw new TypeError("[vitehub] file requires a path or workspacePath.")
 }
 

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -52,6 +52,24 @@ describe("agent output helpers", () => {
     expect(toAgentRunResult(value).text).toBe("latest")
   })
 
+  it("falls back to AI SDK v7 step content text", () => {
+    const value = {
+      finishReason: "stop",
+      steps: [
+        { content: [{ text: "older", type: "text" }] },
+        {
+          content: [
+            { output: { ok: true }, toolCallId: "call-1", toolName: "lookup", type: "tool-result" },
+            { text: "latest", type: "text" },
+            { textDelta: " result", type: "text-delta" },
+          ],
+        },
+      ],
+    }
+
+    expect(toAgentRunResult(value).text).toBe("latest result")
+  })
+
   it("tracks tool names across stream events", () => {
     const toolNames = new Map<string, string>()
 

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -25,6 +25,7 @@ const agentGenerate = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ f
 
 vi.mock("@vite-hub/workspace", () => ({
   defineWorkspace: vi.fn(definition => definition),
+  resolveRegisteredWorkspaceDefinition: vi.fn(() => undefined),
   useWorkspace: vi.fn(() => ({
     fs: { list, readFile },
     tools: {

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -46,6 +46,24 @@ describe("inputCommands", () => {
     expect(resolved.input.prompt).toBe("/summary")
   })
 
+  it("keeps command-only message text when a string handler returns empty args", async () => {
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [inputCommands({
+        commands: {
+          review: {
+            description: "Review the request.",
+            run: ({ args }) => args,
+          },
+        },
+      })],
+    }, runtime(), { messages: [createMessage({ role: "user", text: "/review" })] })
+
+    expect(resolved.input.messages?.map(message => getMessageText(message))).toEqual(["/review"])
+  })
+
   it("replaces command text from an initial message", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -542,7 +542,10 @@ describe("agent Vite plugin", () => {
       const denoServer = await readFile(join(root, ".vitehub/agent/deno-server.ts"), "utf8")
 
       expect(denoServer).toContain("import { setWorkspaceRuntimeRegistry } from '@vite-hub/workspace/runtime'")
-      expect(denoServer).toContain("setWorkspaceRuntimeRegistry({\n  \"support\": async () =>")
+      expect(denoServer).toContain("workspaceAgentOwnsWorkspaceDefinition")
+      expect(denoServer).toContain("workspaceRegistryEntry(\"support\", agent0")
+      expect(denoServer).toContain("setWorkspaceRuntimeRegistry(Object.fromEntries([")
+      expect(denoServer).not.toContain("\"support\": async ()")
     }
     finally {
       await rm(root, { force: true, recursive: true })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -474,7 +474,7 @@ describe("agent Vite plugin", () => {
       const webhookRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
 
       expect(webhookRoute).toContain("defineAgentChatFetchHandler")
-      expect(webhookRoute).toContain("withAgentDefaults(resolveAgentModule")
+      expect(webhookRoute).toContain("withAgentDefaults(withWorkspaceSourceRoot(resolveAgentModule")
       expect(webhookRoute).toContain("import { createCloudflareAgentState } from '@vite-hub/agent/cloudflare'")
       expect(webhookRoute).toContain("async function toRequest(event)")
       expect(webhookRoute).toContain("function waitUntilFromEvent(event)")
@@ -534,6 +534,7 @@ describe("agent Vite plugin", () => {
     try {
       await mkdir(join(root, "server", "agents", "support"), { recursive: true })
       await writeFile(join(root, "server", "agents", "support", "config.ts"), "import { defineAgent } from '@vite-hub/agent'\nexport default defineAgent({ workspace: {}, async run() { return 'ok' } })", "utf8")
+      await writeFile(join(root, "server", "agents", "support", "instructions.md"), "Use support instructions.\n", "utf8")
       const plugin = hubAgent({ routes: { chat: true }, runtime: "deno" })
       if (typeof plugin.configResolved === "function") {
         await plugin.configResolved.call({} as never, { root } as never)
@@ -543,7 +544,10 @@ describe("agent Vite plugin", () => {
 
       expect(denoServer).toContain("import { setWorkspaceRuntimeRegistry } from '@vite-hub/workspace/runtime'")
       expect(denoServer).toContain("workspaceAgentOwnsWorkspaceDefinition")
+      expect(denoServer).toContain("withWorkspaceSourceRoot(resolveAgentModule(agent0)")
       expect(denoServer).toContain("workspaceRegistryEntry(\"support\", agent0")
+      expect(denoServer).toContain("__vitehubAgentInstructions")
+      expect(denoServer).toContain(", true)")
       expect(denoServer).toContain("setWorkspaceRuntimeRegistry(Object.fromEntries([")
       expect(denoServer).not.toContain("\"support\": async ()")
     }
@@ -678,6 +682,45 @@ describe("server helpers", () => {
       const workspace = useWorkspace(workspaceName)
 
       expect(preparedAgent.__vitehubWorkspaceAgentOptions.workspace).toBe(workspaceName)
+      expect(await workspace.fs.readFile("AGENTS.md")).toBe("# Registered\n")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("does not register object workspace references as definitions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-runtime-workspace-"))
+    const sourceRoot = join(root, "registered", "workspace")
+    await mkdir(sourceRoot, { recursive: true })
+    await writeFile(join(sourceRoot, "AGENTS.md"), "# Registered\n")
+
+    try {
+      const { defineAgent } = await import("../src/index.ts")
+      const { registerWorkspaceAgent } = await import("../src/server.ts")
+      const { defineWorkspace, file, useWorkspace } = await import("@vite-hub/workspace")
+      const { registerWorkspace } = await import("@vite-hub/workspace/runtime")
+      const workspaceName = "support-runtime-object-reference"
+      registerWorkspace(workspaceName, defineWorkspace({
+        sourceRootDir: sourceRoot,
+        store: { provider: "memory" },
+        sources: {
+          instructions: file("AGENTS.md"),
+        },
+      }))
+      const agent = defineAgent({
+        async run() {
+          return "ok"
+        },
+        workspace: { mode: "write", name: workspaceName },
+      })
+
+      const preparedAgent = registerWorkspaceAgent(agent, {
+        sourceRootDir: join(root, "ignored", "workspace"),
+      })
+      const workspace = useWorkspace(workspaceName)
+
+      expect(preparedAgent.__vitehubWorkspaceAgentOptions.workspace).toEqual({ mode: "write", name: workspaceName })
       expect(await workspace.fs.readFile("AGENTS.md")).toBe("# Registered\n")
     }
     finally {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5,6 +5,8 @@ import { createMessage, getMessageText } from "@vite-hub/agent"
 import { createTraceEventLog, deriveTraceRuns, emitTraceEvent } from "@vite-hub/runtime"
 import { chat, chatTitle, schedule, subagents } from "../src/capabilities.ts"
 
+import type { WritableWorkspaceFacade } from "@vite-hub/workspace"
+
 const harnessAgentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
 const harnessCreateSession = vi.hoisted(() => vi.fn())
 const harnessGenerate = vi.hoisted(() => vi.fn())
@@ -518,6 +520,37 @@ describe("agent message protocol", () => {
       },
       text: "browser report",
     })
+  })
+
+  it("shares named workspace references across subagent runAgent calls", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { registerWorkspaceAgent } = await import("../src/server.ts")
+    const workspaceName = `shared-agent-workspace-${Math.random().toString(36).slice(2)}`
+    const summaryAgent = defineAgent({
+      workspace: { name: workspaceName, mode: "write" },
+      async run({ workspace }) {
+        await (workspace as WritableWorkspaceFacade).fs.writeFile("summary.md", "summary")
+        return "summary written"
+      },
+    })
+    const reviewerAgent = registerWorkspaceAgent(defineAgent({
+      workspace: {
+        mode: "write",
+        store: { provider: "memory" },
+      },
+      async run(context) {
+        const workspace = context.workspace as WritableWorkspaceFacade
+        await workspace.fs.writeFile("review.md", "review")
+        await runAgent(summaryAgent, context as never, { message: "write summary" })
+        return await workspace.fs.readFile("summary.md")
+      },
+    }), { workspace: workspaceName })
+
+    await expect(runAgent(reviewerAgent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { message: "review" })).resolves.toBe("summary")
   })
 
   it("rejects duplicate generated subagent tool names", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -89,6 +89,33 @@ describe("agent message protocol", () => {
     expect(run).toHaveBeenCalledTimes(1)
   })
 
+  it("skips agent input hooks after a capability handles the input", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const handled = new Response("handled")
+    const run = vi.fn(() => "ok")
+    const inputHook = vi.fn(() => {
+      throw new Error("should not run")
+    })
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "handled",
+          input: () => handled,
+        }),
+      ],
+      driver: { run },
+      hooks: {
+        "agent:input": inputHook,
+      },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      prompt: "review",
+    })).resolves.toBe(handled)
+    expect(inputHook).not.toHaveBeenCalled()
+    expect(run).not.toHaveBeenCalled()
+  })
+
   it("emits invocation Trace Events without persisting prompt content", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const traceLog = createTraceEventLog()

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -60,6 +60,35 @@ describe("agent message protocol", () => {
     }))
   })
 
+  it("runs agent input hooks once before driver execution and can abort", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const run = vi.fn(() => "ok")
+    const inputHook = vi.fn((context) => {
+      if (!context.input.context?.pullRequest) {
+        throw new Error("Missing GitHub field: context.pullRequest")
+      }
+    })
+    const agent = defineAgent({
+      driver: { run },
+      hooks: {
+        "agent:input": inputHook,
+      },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      context: { pullRequest: true as never },
+      prompt: "review",
+    })).resolves.toBe("ok")
+    expect(inputHook).toHaveBeenCalledTimes(1)
+    expect(run).toHaveBeenCalledTimes(1)
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      prompt: "review",
+    })).rejects.toThrow("Missing GitHub field: context.pullRequest")
+    expect(inputHook).toHaveBeenCalledTimes(2)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
   it("emits invocation Trace Events without persisting prompt content", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const traceLog = createTraceEventLog()

--- a/packages/agent/test/test-runner.test.ts
+++ b/packages/agent/test/test-runner.test.ts
@@ -22,6 +22,7 @@ vi.mock("ai", () => ({
 
 vi.mock("@vite-hub/workspace", () => ({
   defineWorkspace: vi.fn(definition => definition),
+  resolveRegisteredWorkspaceDefinition: vi.fn(() => undefined),
   useWorkspace: vi.fn(() => ({
     fs: { list, readFile },
     tools: {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -95,6 +95,7 @@ describe("agent public types", () => {
           provider: "github",
         }),
         skills(),
+        skills({ path: "skills/agent-browser", source: githubSource({ repo: "vercel/vercel-plugin", root: "skills/agent-browser" }) }),
         skills({ shellExecution: "read" }),
         skills({ shellExecution: "write" }),
         sandbox({ commands: ["node"] }),

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -777,6 +777,13 @@ describe("agent public types", () => {
           },
         }),
       ],
+      hooks: {
+        "agent:input"({ context }) {
+          const accessContext = context.get("access")
+          expectTypeOf(accessContext).toMatchTypeOf<AccessInvocationContextValue<"demo" | "quiver"> | undefined>()
+          expectTypeOf(accessContext?.workspaceScope?.scope).toEqualTypeOf<"demo" | "quiver" | undefined>()
+        },
+      },
       run({ actor, context }) {
         const accessContext = context.get("access")
         expectTypeOf(actor.id).toEqualTypeOf<string>()

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -297,10 +297,33 @@ describe("agent public types", () => {
       tools: {},
     })
 
-    // @ts-expect-error workspace mode must be read or write
     defineAgent({
       model: {} as never,
+      // @ts-expect-error workspace mode must be read or write
       workspace: { mode: "mutable" },
+    })
+
+    defineAgent({
+      model: {} as never,
+      workspace: "review",
+    })
+
+    defineAgent({
+      capabilities: [workspaceShell({ mode: "write" })],
+      model: {} as never,
+      workspace: { name: "review", mode: "write" },
+    })
+
+    // @ts-expect-error workspace reference mode must be read or write
+    defineAgent({
+      model: {} as never,
+      workspace: { name: "review", mode: "mutable" },
+    })
+
+    // @ts-expect-error named workspace references cannot include colocated Workspace Definition options
+    defineAgent({
+      model: {} as never,
+      workspace: { name: "review", sources: {} },
     })
 
     defineAgent({

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -254,6 +254,52 @@ describe("defineAgent workspace option", () => {
     expect(() => skills({ shellExecution: "execute" as never })).toThrow("skills({ shellExecution })")
   })
 
+  it("exposes opt-in skill shell execution through a workspace session", async () => {
+    const session = {
+      close: vi.fn(),
+      commit: vi.fn(),
+      exec: vi.fn(async () => ({
+        args: ["-lc", "agent-browser snapshot -i"],
+        command: "bash",
+        exitCode: 0,
+        stderr: "",
+        stdout: "snapshot",
+      })),
+    }
+    useWorkspace.mockReturnValueOnce({
+      diff,
+      fs: { exists, list, readFile, writeFile },
+      snapshot,
+      startSession: vi.fn(async () => session),
+      tools: Object.assign(tools, {
+        inspect: inspectTools,
+        none: vi.fn(() => ({})),
+        readonly: inspectTools,
+      }),
+    } as unknown as WritableWorkspaceFacade)
+    agentGenerate.mockImplementationOnce(async function (this: { settings: { tools: Record<string, { execute: (input: unknown) => Promise<unknown> }> } }) {
+      const output = await this.settings.tools.skill_shell.execute({ command: "agent-browser snapshot -i" })
+      return { finishReason: "stop", text: JSON.stringify(output) }
+    })
+    exists.mockResolvedValue(true)
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [skills({ path: "skills/agent-browser", shellExecution: "write" })],
+      model: {} as never,
+      workspace: { mode: "write" },
+    })
+
+    await expect(agent.run!(context())).resolves.toContain("snapshot")
+    expect(session.exec).toHaveBeenCalledWith("bash", ["-lc", "agent-browser snapshot -i"], {
+      cwd: undefined,
+      timeout: undefined,
+    })
+    expect(session.commit).toHaveBeenCalledWith({ message: "skill shell" })
+    expect(session.close).toHaveBeenCalledTimes(1)
+  })
+
   it("requires writable workspace for write-mode skill shell execution", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1336,6 +1336,37 @@ describe("defineAgent workspace option", () => {
     }))
   })
 
+  it("synthesizes streamed answers when tool loops finish with tool calls after pre-tool text", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    agentStream.mockResolvedValueOnce({
+      fullStream: (async function* () {
+        yield { id: "msg-1", text: "I will inspect the workspace first.", type: "text-delta" }
+        yield {
+          output: { stdout: "summary.md:1: final summary from subagent" },
+          toolCallId: "call-1",
+          type: "tool-output-available",
+        }
+        yield { finishReason: "tool-calls", type: "finish" }
+      })(),
+    })
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    const stream = await streamAgent(agent, context(), { messages: [] })
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toContainEqual({ id: "workspace-fallback", text: "fallback answer", type: "text-delta" })
+    expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("summary.md:1"),
+    }))
+  })
+
   it("emits streamed workspace fallback text before finish events", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     agentStream.mockResolvedValueOnce({

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import type { ReadonlyWorkspaceFacade, WritableWorkspaceFacade } from "@vite-hub/workspace"
+import type { ReadonlyWorkspaceFacade, WritableWorkspaceFacade, WorkspaceSourceInput } from "@vite-hub/workspace"
 
 const readFile = vi.fn()
 const writeFile = vi.fn()
@@ -389,9 +389,13 @@ describe("defineAgent workspace option", () => {
   it("registers capability sources on shared named workspace references", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
-    const { registerWorkspace, resolveRegisteredWorkspaceDefinition: resolveRuntimeWorkspaceDefinition } = await import("@vite-hub/workspace/runtime")
+    const { registerWorkspace } = await import("@vite-hub/workspace/runtime")
     const workspaceName = `review-${Math.random().toString(36).slice(2)}`
-    const registeredDefinition = {
+    const registeredDefinition: {
+      name: string
+      sources: Record<string, WorkspaceSourceInput>
+      store: { provider: "memory" }
+    } = {
       name: workspaceName,
       sources: {
         instructions: { path: "AGENTS.md" } as never,
@@ -422,9 +426,8 @@ describe("defineAgent workspace option", () => {
 
     await agent.run!(context())
 
-    const resolved = await resolveRuntimeWorkspaceDefinition(workspaceName)
-    expect(resolved.sources?.instructions).toEqual({ path: "AGENTS.md" })
-    expect(resolved.sources?.["skill.agent-browser"]).toEqual({
+    expect(registeredDefinition.sources?.instructions).toEqual({ path: "AGENTS.md" })
+    expect(registeredDefinition.sources?.["skill.agent-browser"]).toEqual({
       mount: "skills/agent-browser",
       source: {
         materialize: "build",

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1434,6 +1434,45 @@ describe("defineAgent workspace option", () => {
     }))
   })
 
+  it("synthesizes streamed answers from step callback tool results", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    agentStream.mockImplementationOnce(async (input: unknown) => {
+      const callInput = input as { onStepEnd?: (event: unknown) => Promise<void> }
+      await callInput.onStepEnd?.({
+        toolResults: [
+          {
+            output: { text: "Browser evidence from callback: screenshots/login-version-badge-desktop.png" },
+            toolCallId: "call-1",
+            toolName: "run_browser",
+          },
+        ],
+      })
+
+      return {
+        fullStream: (async function* () {
+          yield { id: "msg-1", text: "I will inspect the workspace first.", type: "text-delta" }
+          yield { finishReason: "tool-calls", type: "finish" }
+        })(),
+      }
+    })
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    const stream = await streamAgent(agent, context(), { messages: [] })
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toContainEqual({ id: "workspace-fallback", text: "fallback answer", type: "text-delta" })
+    expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("Browser evidence from callback"),
+    }))
+  })
+
   it("emits streamed workspace fallback text before finish events", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     agentStream.mockResolvedValueOnce({

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -266,11 +266,12 @@ describe("defineAgent workspace option", () => {
         stdout: "snapshot",
       })),
     }
+    const startSession = vi.fn(async () => session)
     useWorkspace.mockReturnValueOnce({
       diff,
       fs: { exists, list, readFile, writeFile },
       snapshot,
-      startSession: vi.fn(async () => session),
+      startSession,
       tools: Object.assign(tools, {
         inspect: inspectTools,
         none: vi.fn(() => ({})),
@@ -292,6 +293,7 @@ describe("defineAgent workspace option", () => {
     })
 
     await expect(agent.run!(context())).resolves.toContain("snapshot")
+    expect(startSession).toHaveBeenCalledWith({ paths: ["skills/agent-browser"] })
     expect(session.exec).toHaveBeenCalledWith("bash", ["-lc", "agent-browser snapshot -i"], {
       cwd: undefined,
       timeout: undefined,

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1559,11 +1559,37 @@ describe("defineAgent workspace option", () => {
       events.push(event)
     }
 
-    expect(events).toEqual([
-      { error: undefined, id: "call-1", name: "tool", output: { stdout: "screenshots/login-version-badge-desktop.png" }, type: "tool-result" },
-      { id: "workspace-fallback", text: "fallback answer", type: "text-delta" },
-      { reason: "workspace-fallback", type: "finish" },
-    ])
+    expect(events).toContainEqual({ id: "workspace-fallback", text: "fallback answer", type: "text-delta" })
+    expect(events).toContainEqual({ reason: "workspace-fallback", type: "finish" })
+    expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("screenshots/login-version-badge-desktop.png"),
+    }))
+  })
+
+  it("synthesizes streamed answers from async iterable AI SDK results", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    agentStream.mockResolvedValueOnce((async function* () {
+      yield {
+        output: { stdout: "screenshots/login-version-badge-desktop.png" },
+        toolCallId: "call-1",
+        type: "tool-output-available",
+      }
+      yield { finishReason: "tool-calls", type: "finish" }
+    })() as never)
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    const stream = await streamAgent(agent, context(), { messages: [] })
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toContainEqual({ id: "workspace-fallback", text: "fallback answer", type: "text-delta" })
+    expect(events).toContainEqual({ finishReason: "workspace-fallback", type: "finish" })
     expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
       prompt: expect.stringContaining("screenshots/login-version-badge-desktop.png"),
     }))

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1535,6 +1535,40 @@ describe("defineAgent workspace option", () => {
     ])
   })
 
+  it("synthesizes streamed answers from stream-only AI SDK results", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    agentStream.mockResolvedValueOnce({
+      stream: (async function* () {
+        yield {
+          output: { stdout: "screenshots/login-version-badge-desktop.png" },
+          toolCallId: "call-1",
+          type: "tool-output-available",
+        }
+        yield { finishReason: "tool-calls", type: "finish" }
+      })(),
+    } as never)
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    const stream = await streamAgent(agent, context(), { messages: [] })
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { error: undefined, id: "call-1", name: "tool", output: { stdout: "screenshots/login-version-badge-desktop.png" }, type: "tool-result" },
+      { id: "workspace-fallback", text: "fallback answer", type: "text-delta" },
+      { reason: "workspace-fallback", type: "finish" },
+    ])
+    expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("screenshots/login-version-badge-desktop.png"),
+    }))
+  })
+
   it("preserves stream result methods when wrapping workspace fallback streams", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     class StreamResult {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -571,6 +571,67 @@ describe("defineAgent workspace option", () => {
     expect(agentSettings.at(-1)?.instructions).toBe("Use colocated workspace instructions.")
   })
 
+  it("keeps source instructions with colocated default model instructions", async () => {
+    const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))
+    tempRoots.push(sourceRootDir)
+    await writeLocalFile(join(sourceRootDir, "instructions.md"), "Use colocated workspace instructions.\n")
+    readFile.mockResolvedValueOnce("Use colocated workspace instructions.\n")
+    const { defineAgent } = await import("../src/index.ts")
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {
+        sourceRootDir,
+        sources: {
+          docs: { instructions: "Use docs for product behavior.", name: "docs" } as never,
+        },
+      },
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    await agent.run!(context())
+
+    expect(agentSettings.at(-1)?.instructions).toBe([
+      "Use colocated workspace instructions.",
+      "## Workspace Sources",
+      "### docs\n\nUse docs for product behavior.",
+    ].join("\n\n"))
+  })
+
+  it("reads materialized colocated instructions without host fs", async () => {
+    const processWithBuiltins = globalThis.process as typeof process & {
+      getBuiltinModule?: (name: string) => unknown
+    }
+    const getBuiltinModule = processWithBuiltins.getBuiltinModule
+    processWithBuiltins.getBuiltinModule = () => undefined
+    readFile.mockResolvedValueOnce("Use materialized workspace instructions.\n")
+
+    try {
+      const { defineAgent } = await import("../src/index.ts")
+      const agent = withAgentDefaults(defineAgent({
+        workspace: {
+          sourceRootDir: "/runtime/server/agents/support",
+          sources: {
+            __vitehubAgentInstructions: {
+              materialize: "build",
+              mount: "",
+              path: "instructions.md",
+              workspacePath: "AGENTS.md",
+            },
+          },
+        },
+        model: {} as never,
+      }), { workspace: "docs" })
+
+      await agent.run!(context())
+
+      expect(readFile).toHaveBeenCalledWith("AGENTS.md")
+      expect(agentSettings.at(-1)?.instructions).toBe("Use materialized workspace instructions.")
+    }
+    finally {
+      processWithBuiltins.getBuiltinModule = getBuiltinModule
+    }
+  })
+
   it("keeps explicit model instructions ahead of colocated instructions.md", async () => {
     const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))
     tempRoots.push(sourceRootDir)

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -386,6 +386,54 @@ describe("defineAgent workspace option", () => {
     })
   })
 
+  it("registers capability sources on shared named workspace references", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    const { registerWorkspace, resolveRegisteredWorkspaceDefinition: resolveRuntimeWorkspaceDefinition } = await import("@vite-hub/workspace/runtime")
+    const workspaceName = `review-${Math.random().toString(36).slice(2)}`
+    const registeredDefinition = {
+      name: workspaceName,
+      sources: {
+        instructions: { path: "AGENTS.md" } as never,
+      },
+      store: { provider: "memory" as const },
+    }
+    registerWorkspace(workspaceName, {
+      sources: registeredDefinition.sources,
+      store: registeredDefinition.store,
+    })
+    resolveRegisteredWorkspaceDefinition.mockResolvedValueOnce(registeredDefinition)
+    exists.mockResolvedValue(true)
+
+    const agent = defineAgent({
+      capabilities: [
+        skills({
+          path: "skills/agent-browser",
+          source: {
+            materialize: "build",
+            repo: "vercel/vercel-plugin",
+            root: "skills/agent-browser",
+          } as never,
+        }),
+      ],
+      model: {} as never,
+      workspace: { name: workspaceName, mode: "write" },
+    })
+
+    await agent.run!(context())
+
+    const resolved = await resolveRuntimeWorkspaceDefinition(workspaceName)
+    expect(resolved.sources?.instructions).toEqual({ path: "AGENTS.md" })
+    expect(resolved.sources?.["skill.agent-browser"]).toEqual({
+      mount: "skills/agent-browser",
+      source: {
+        materialize: "build",
+        repo: "vercel/vercel-plugin",
+        root: "skills/agent-browser",
+      },
+    })
+  })
+
   it("exposes opt-in skill shell execution through a workspace session", async () => {
     const session = {
       close: vi.fn(),

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1367,6 +1367,37 @@ describe("defineAgent workspace option", () => {
     }))
   })
 
+  it("synthesizes streamed answers when tool output follows pre-tool text without final text", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    agentStream.mockResolvedValueOnce({
+      fullStream: (async function* () {
+        yield { id: "msg-1", text: "I will inspect the workspace first.", type: "text-delta" }
+        yield {
+          output: { stdout: "screenshots/login-version-badge-desktop.png" },
+          toolCallId: "call-1",
+          type: "tool-output-available",
+        }
+        yield { finishReason: "stop", type: "finish" }
+      })(),
+    })
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    const stream = await streamAgent(agent, context(), { messages: [] })
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toContainEqual({ id: "workspace-fallback", text: "fallback answer", type: "text-delta" })
+    expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("screenshots/login-version-badge-desktop.png"),
+    }))
+  })
+
   it("emits streamed workspace fallback text before finish events", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     agentStream.mockResolvedValueOnce({

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -267,6 +267,33 @@ describe("defineAgent workspace option", () => {
     await expect(agent.run!(context())).rejects.toThrow("git() requires workspace.mode: \"write\"")
   })
 
+  it("uses write mode for named workspace references", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { workspaceShell } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [workspaceShell({ mode: "write" })],
+      model: {} as never,
+      workspace: { name: "docs", mode: "write" },
+    })
+
+    await agent.run!(context())
+
+    expect(useWorkspace).toHaveBeenCalledWith("docs", { mode: "write" })
+  })
+
+  it("rejects mixed named workspace references and colocated definitions", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+
+    expect(() => defineAgent({
+      model: {} as never,
+      workspace: {
+        name: "docs",
+        sources: {},
+      } as never,
+    })).toThrow("[vitehub] Workspace reference does not support option: sources.")
+  })
+
   it("creates a workspace and agent definition without resolving workspace until run", async () => {
     const { useWorkspace } = await import("@vite-hub/workspace")
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -312,17 +312,33 @@ describe("defineAgent workspace option", () => {
     })
   })
 
-  it("rejects skill sources mounted away from the skill path", async () => {
+  it("mounts skill sources at the configured skill path", async () => {
     const { skills } = await import("../src/capabilities.ts")
+    const { workspaceDefinitionFromOptions } = await import("../src/workspace-agent.ts")
 
-    expect(() => skills({
-      path: "skills/agent-browser",
+    const definition = workspaceDefinitionFromOptions({
+      capabilities: [
+        skills({
+          path: "skills/agent-browser",
+          source: {
+            mount: "vercel-plugin",
+            repo: "vercel/vercel-plugin",
+            root: "skills/agent-browser",
+          } as never,
+        }),
+      ],
+      model: {} as never,
+      workspace: {},
+    })
+
+    expect(definition.sources?.["skill.agent-browser"]).toEqual({
+      mount: "skills/agent-browser",
       source: {
-        mount: "other",
+        mount: "vercel-plugin",
         repo: "vercel/vercel-plugin",
         root: "skills/agent-browser",
-      } as never,
-    })).toThrow("skills({ source }) mount \"other\" must match path \"skills/agent-browser\"")
+      },
+    })
   })
 
   it("bubbles subagent skill sources into the parent workspace definition", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -245,6 +245,33 @@ describe("defineAgent workspace option", () => {
     await expect(agent.run!(context())).resolves.toBe("ok")
   })
 
+  it("adds generic model instructions for mounted skills", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    exists.mockResolvedValue(true)
+    readFile.mockResolvedValueOnce([
+      "---",
+      "name: agent-browser",
+      "description: Browser automation CLI for AI agents.",
+      "---",
+      "# Agent Browser",
+    ].join("\n"))
+
+    const agent = defineAgent({
+      capabilities: [skills({ path: "skills/agent-browser", shellExecution: "write" })],
+      model: {} as never,
+      workspace: { mode: "write" },
+    })
+
+    await agent.run!(context())
+
+    expect(readFile).toHaveBeenCalledWith("skills/agent-browser/SKILL.md")
+    expect(agentSettings.at(-1)?.instructions).toContain("Skill \"agent-browser\" is mounted at `skills/agent-browser`.")
+    expect(agentSettings.at(-1)?.instructions).toContain("Description: Browser automation CLI for AI agents.")
+    expect(agentSettings.at(-1)?.instructions).toContain("Read `skills/agent-browser/SKILL.md` before using this skill.")
+    expect(agentSettings.at(-1)?.instructions).toContain("Use the `skill_shell` tool")
+  })
+
   it("records opt-in skill shell execution mode", async () => {
     const { skills } = await import("../src/capabilities.ts")
 
@@ -252,6 +279,95 @@ describe("defineAgent workspace option", () => {
     expect(skills({ shellExecution: "read" }).metadata).toMatchObject({ shellExecution: "read" })
     expect(skills({ shellExecution: "write" }).metadata).toMatchObject({ shellExecution: "write" })
     expect(() => skills({ shellExecution: "execute" as never })).toThrow("skills({ shellExecution })")
+  })
+
+  it("lets skills() contribute a mounted workspace source", async () => {
+    const { skills } = await import("../src/capabilities.ts")
+    const { workspaceDefinitionFromOptions } = await import("../src/workspace-agent.ts")
+
+    const definition = workspaceDefinitionFromOptions({
+      capabilities: [
+        skills({
+          path: "skills/agent-browser",
+          source: {
+            include: ["SKILL.md", "references/**"],
+            materialize: "build",
+            repo: "vercel/vercel-plugin",
+            root: "skills/agent-browser",
+          } as never,
+        }),
+      ],
+      model: {} as never,
+      workspace: {},
+    })
+
+    expect(definition.sources?.["skill.agent-browser"]).toEqual({
+      mount: "skills/agent-browser",
+      source: {
+        include: ["SKILL.md", "references/**"],
+        materialize: "build",
+        repo: "vercel/vercel-plugin",
+        root: "skills/agent-browser",
+      },
+    })
+  })
+
+  it("rejects skill sources mounted away from the skill path", async () => {
+    const { skills } = await import("../src/capabilities.ts")
+
+    expect(() => skills({
+      path: "skills/agent-browser",
+      source: {
+        mount: "other",
+        repo: "vercel/vercel-plugin",
+        root: "skills/agent-browser",
+      } as never,
+    })).toThrow("skills({ source }) mount \"other\" must match path \"skills/agent-browser\"")
+  })
+
+  it("bubbles subagent skill sources into the parent workspace definition", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills, subagents } = await import("../src/capabilities.ts")
+    const { workspaceDefinitionFromOptions } = await import("../src/workspace-agent.ts")
+
+    const browserAgent = defineAgent({
+      capabilities: [
+        skills({
+          path: "skills/agent-browser",
+          source: {
+            materialize: "build",
+            repo: "vercel/vercel-plugin",
+            root: "skills/agent-browser",
+          } as never,
+        }),
+      ],
+      model: {} as never,
+      workspace: { name: "review", mode: "write" },
+    })
+    const reviewerAgent = defineAgent({
+      capabilities: [
+        subagents({
+          agents: {
+            browser: {
+              agent: browserAgent,
+              description: "Collect browser evidence.",
+            },
+          },
+        }),
+      ],
+      model: {} as never,
+      workspace: { mode: "write" },
+    })
+    const options = (reviewerAgent as unknown as { __vitehubWorkspaceAgentOptions: Parameters<typeof workspaceDefinitionFromOptions>[0] }).__vitehubWorkspaceAgentOptions
+
+    expect(workspaceDefinitionFromOptions(options).sources?.["skill.agent-browser"]).toEqual({
+      mount: "skills/agent-browser",
+      source: {
+        materialize: "build",
+        repo: "vercel/vercel-plugin",
+        root: "skills/agent-browser",
+      },
+    })
   })
 
   it("exposes opt-in skill shell execution through a workspace session", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1,4 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtemp, rm, writeFile as writeLocalFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { ReadonlyWorkspaceFacade, WritableWorkspaceFacade } from "@vite-hub/workspace"
 
@@ -17,6 +21,7 @@ const isWorkspaceSourceRequestOnly = vi.fn((_: unknown): boolean => false)
 const resolveRegisteredWorkspaceDefinition = vi.fn()
 const resolveWorkspaceAutoCommit = vi.fn()
 const workspaceSourceRequestDescriptorPath = vi.fn((source: string) => `.vitehub/sources/${source}.json`)
+const tempRoots: string[] = []
 const useWorkspace = vi.fn<() => ReadonlyWorkspaceFacade | WritableWorkspaceFacade>(() => ({
   diff,
   fs: { exists, list, readFile, writeFile },
@@ -136,6 +141,10 @@ function readonlyWorkspaceFacade(): ReadonlyWorkspaceFacade {
 }
 
 describe("defineAgent workspace option", () => {
+  afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map(root => rm(root, { force: true, recursive: true })))
+  })
+
   beforeEach(() => {
     agentSettings.length = 0
     harnessAgentSettings.length = 0
@@ -486,6 +495,89 @@ describe("defineAgent workspace option", () => {
     await agent.run!(context())
 
     expect(agentSettings.at(-1)?.instructions).toBe("Use workspace sources.")
+  })
+
+  it("uses colocated instructions.md as default model instructions", async () => {
+    const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))
+    tempRoots.push(sourceRootDir)
+    await writeLocalFile(join(sourceRootDir, "instructions.md"), "Use colocated workspace instructions.\n")
+    readFile.mockResolvedValueOnce("Use colocated workspace instructions.\n")
+    const { defineAgent } = await import("../src/index.ts")
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: { sourceRootDir },
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    expect((agent as { sources?: unknown }).sources).toMatchObject({
+      __vitehubAgentInstructions: {
+        mount: "",
+        path: "instructions.md",
+        workspacePath: "AGENTS.md",
+      },
+    })
+
+    await agent.run!(context())
+
+    expect(readFile).toHaveBeenCalledWith("AGENTS.md")
+    expect(agentSettings.at(-1)?.instructions).toBe("Use colocated workspace instructions.")
+  })
+
+  it("keeps explicit model instructions ahead of colocated instructions.md", async () => {
+    const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))
+    tempRoots.push(sourceRootDir)
+    await writeLocalFile(join(sourceRootDir, "instructions.md"), "Use colocated workspace instructions.\n")
+    const { defineAgent } = await import("../src/index.ts")
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: { sourceRootDir },
+      instructions: "Use explicit instructions.",
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    await agent.run!(context())
+
+    expect(readFile).not.toHaveBeenCalledWith("AGENTS.md")
+    expect(agentSettings.at(-1)?.instructions).toBe("Use explicit instructions.")
+  })
+
+  it("keeps explicit model driver instructions ahead of colocated instructions.md", async () => {
+    const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))
+    tempRoots.push(sourceRootDir)
+    await writeLocalFile(join(sourceRootDir, "instructions.md"), "Use colocated workspace instructions.\n")
+    const { defineAgent } = await import("../src/index.ts")
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: { sourceRootDir },
+      driver: {
+        instructions: "Use explicit driver instructions.",
+        model: {} as never,
+      },
+    }), { workspace: "docs" })
+
+    await agent.run!(context())
+
+    expect(readFile).not.toHaveBeenCalledWith("AGENTS.md")
+    expect(agentSettings.at(-1)?.instructions).toBe("Use explicit driver instructions.")
+  })
+
+  it("does not load ordinary workspace AGENTS.md as implicit instructions", async () => {
+    readFile.mockResolvedValueOnce("Ordinary workspace instructions.\n")
+    const { defineAgent } = await import("../src/index.ts")
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {
+        sources: {
+          guide: { path: "AGENTS.md" },
+        },
+      },
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    await agent.run!(context())
+
+    expect(readFile).not.toHaveBeenCalledWith("AGENTS.md")
+    expect(agentSettings.at(-1)?.instructions).toBe("")
   })
 
   it("rebinds synthetic workspace runs when applying discovered defaults", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -557,6 +557,34 @@ describe("defineAgent workspace option", () => {
     expect(agentSettings.at(-1)?.instructions).toBe("Workspace instructions")
   })
 
+  it("uses the registered workspace definition for named reference instructions", async () => {
+    readFile.mockResolvedValueOnce("Summary instructions")
+    const { defineAgent } = await import("../src/index.ts")
+    const { registerWorkspace } = await import("@vite-hub/workspace/runtime")
+    const workspaceName = `shared-reference-${Math.random().toString(36).slice(2)}`
+    registerWorkspace(workspaceName, {
+      sources: {
+        summaryInstructions: { instructions: "Use the summary instructions.", name: "summary" } as never,
+      },
+      store: { provider: "memory" },
+    })
+
+    const agent = defineAgent({
+      workspace: { name: workspaceName, mode: "write" },
+      instructions: async ({ fs }) => await fs.readFile(".agents/summary/AGENTS.md"),
+      model: {} as never,
+    })
+
+    await agent.run!(context())
+
+    expect(readFile).toHaveBeenCalledWith(".agents/summary/AGENTS.md")
+    expect(agentSettings.at(-1)?.instructions).toBe([
+      "Summary instructions",
+      "## Workspace Sources",
+      "### summaryInstructions\n\nUse the summary instructions.",
+    ].join("\n\n"))
+  })
+
   it("appends visible source instructions by default", async () => {
     const { defineAgent } = await import("../src/index.ts")
 

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -248,6 +248,17 @@ describe("defineAgent workspace option", () => {
   it("adds generic model instructions for mounted skills", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
+    useWorkspace.mockReturnValueOnce({
+      diff,
+      fs: { exists, list, readFile, writeFile },
+      snapshot,
+      startSession: vi.fn(),
+      tools: Object.assign(tools, {
+        inspect: inspectTools,
+        none: vi.fn(() => ({})),
+        readonly: inspectTools,
+      }),
+    } as unknown as WritableWorkspaceFacade)
     exists.mockResolvedValue(true)
     readFile.mockResolvedValueOnce([
       "---",
@@ -308,6 +319,30 @@ describe("defineAgent workspace option", () => {
         materialize: "build",
         repo: "vercel/vercel-plugin",
         root: "skills/agent-browser",
+      },
+    })
+  })
+
+  it("rebases file skill sources under the configured skill path", async () => {
+    const { skills } = await import("../src/capabilities.ts")
+    const { workspaceDefinitionFromOptions } = await import("../src/workspace-agent.ts")
+
+    const definition = workspaceDefinitionFromOptions({
+      capabilities: [
+        skills({
+          path: "skills/agent-browser",
+          source: { path: "skills/agent-browser/SKILL.md" },
+        }),
+      ],
+      model: {} as never,
+      workspace: {},
+    })
+
+    expect(definition.sources?.["skill.agent-browser"]).toEqual({
+      mount: "skills/agent-browser",
+      source: {
+        path: "skills/agent-browser/SKILL.md",
+        workspacePath: "SKILL.md",
       },
     })
   })
@@ -386,7 +421,7 @@ describe("defineAgent workspace option", () => {
     })
   })
 
-  it("registers capability sources on shared named workspace references", async () => {
+  it("adds capability sources to shared named workspace references for one invocation", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
     const { registerWorkspace } = await import("@vite-hub/workspace/runtime")
@@ -427,14 +462,54 @@ describe("defineAgent workspace option", () => {
     await agent.run!(context())
 
     expect(registeredDefinition.sources?.instructions).toEqual({ path: "AGENTS.md" })
-    expect(registeredDefinition.sources?.["skill.agent-browser"]).toEqual({
-      mount: "skills/agent-browser",
-      source: {
-        materialize: "build",
-        repo: "vercel/vercel-plugin",
-        root: "skills/agent-browser",
-      },
+    expect(registeredDefinition.sources?.["skill.agent-browser"]).toBeUndefined()
+    expect(useWorkspace).toHaveBeenCalledWith(workspaceName, {
+      definition: expect.objectContaining({
+        sources: {
+          instructions: { path: "AGENTS.md" },
+          "skill.agent-browser": {
+            mount: "skills/agent-browser",
+            source: {
+              materialize: "build",
+              repo: "vercel/vercel-plugin",
+              root: "skills/agent-browser",
+            },
+          },
+        },
+        store: { provider: "memory" },
+      }),
+      mode: "write",
     })
+  })
+
+  it("rejects duplicate capability source keys on shared named workspace references", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    const workspaceName = `review-${Math.random().toString(36).slice(2)}`
+    resolveRegisteredWorkspaceDefinition.mockResolvedValueOnce({
+      name: workspaceName,
+      sources: {
+        instructions: { path: "AGENTS.md" } as never,
+      },
+      store: { provider: "memory" as const },
+    })
+    const agent = defineAgent({
+      capabilities: [
+        skills({
+          path: "skills/agent-browser",
+          source: {
+            materialize: "build",
+            repo: "vercel/vercel-plugin",
+            root: "skills/agent-browser",
+          } as never,
+          sourceKey: "instructions",
+        }),
+      ],
+      model: {} as never,
+      workspace: { name: workspaceName, mode: "write" },
+    })
+
+    await expect(agent.run!(context())).rejects.toThrow('Workspace source "instructions" is already defined.')
   })
 
   it("exposes opt-in skill shell execution through a workspace session", async () => {
@@ -478,11 +553,77 @@ describe("defineAgent workspace option", () => {
     await expect(agent.run!(context())).resolves.toContain("snapshot")
     expect(startSession).toHaveBeenCalledWith({ paths: ["skills/agent-browser"] })
     expect(session.exec).toHaveBeenCalledWith("bash", ["-lc", "agent-browser snapshot -i"], {
-      cwd: undefined,
+      cwd: "skills/agent-browser",
       timeout: undefined,
     })
     expect(session.commit).toHaveBeenCalledWith({ message: "skill shell" })
     expect(session.close).toHaveBeenCalledTimes(1)
+  })
+
+  it("scopes root skill shell sessions to the workspace root", async () => {
+    const session = {
+      close: vi.fn(),
+      commit: vi.fn(),
+      exec: vi.fn(async () => ({
+        args: ["-lc", "echo root"],
+        command: "bash",
+        exitCode: 0,
+        stderr: "",
+        stdout: "root",
+      })),
+    }
+    const startSession = vi.fn(async () => session)
+    useWorkspace.mockReturnValueOnce({
+      diff,
+      fs: { exists, list, readFile, writeFile },
+      snapshot,
+      startSession,
+      tools: Object.assign(tools, {
+        inspect: inspectTools,
+        none: vi.fn(() => ({})),
+        readonly: inspectTools,
+      }),
+    } as unknown as WritableWorkspaceFacade)
+    agentGenerate.mockImplementationOnce(async function (this: { settings: { tools: Record<string, { execute: (input: unknown) => Promise<unknown> }> } }) {
+      const output = await this.settings.tools.skill_shell.execute({ command: "echo root" })
+      return { finishReason: "stop", text: JSON.stringify(output) }
+    })
+    exists.mockResolvedValue(true)
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [skills({ path: "SKILL.md", shellExecution: "write" })],
+      model: {} as never,
+      workspace: { mode: "write" },
+    })
+
+    await expect(agent.run!(context())).resolves.toContain("root")
+    expect(startSession).toHaveBeenCalledWith({ paths: [""] })
+    expect(session.exec).toHaveBeenCalledWith("bash", ["-lc", "echo root"], {
+      cwd: "",
+      timeout: undefined,
+    })
+  })
+
+  it("requires writable workspace mode for read-mode skill shell execution", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [skills({ path: "skills/agent-browser", shellExecution: "read" })],
+      model: {} as never,
+      workspace: {},
+    })
+
+    await expect(agent.run!(context())).rejects.toThrow('skills() requires workspace.mode: "write"')
+    expect(agentGenerate).not.toHaveBeenCalled()
+  })
+
+  it("uses full file source paths as probe keys", async () => {
+    const { normalizeAgentWorkspaceSource } = await import("../src/workspace-source-metadata.ts")
+
+    expect(normalizeAgentWorkspaceSource("summaryInstructions", { path: ".agents/summary/AGENTS.md" } as never).probeKeys).toEqual([".agents/summary/AGENTS.md"])
   })
 
   it("requires writable workspace for write-mode skill shell execution", async () => {
@@ -973,6 +1114,20 @@ describe("defineAgent workspace option", () => {
       "## Workspace Sources",
       "### summaryInstructions\n\nUse the summary instructions.",
     ].join("\n\n"))
+  })
+
+  it("does not create placeholder definitions for unregistered named references", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const workspaceName = `missing-reference-${Math.random().toString(36).slice(2)}`
+
+    const agent = defineAgent({
+      workspace: { name: workspaceName, mode: "write" },
+      model: {} as never,
+    })
+
+    await agent.run!(context())
+
+    expect(useWorkspace).toHaveBeenCalledWith(workspaceName, { mode: "write" })
   })
 
   it("appends visible source instructions by default", async () => {
@@ -1474,6 +1629,44 @@ describe("defineAgent workspace option", () => {
     expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
       prompt: expect.stringContaining("Browser evidence from callback"),
     }))
+  })
+
+  it("keeps final stream text when callback evidence is only supporting evidence", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    agentStream.mockImplementationOnce(async (input: unknown) => {
+      const callInput = input as { onStepFinish?: (event: unknown) => Promise<void> }
+      await callInput.onStepFinish?.({
+        toolResults: [
+          {
+            output: { text: "Browser evidence from callback: screenshots/login-version-badge-desktop.png" },
+            toolCallId: "call-1",
+            toolName: "run_browser",
+          },
+        ],
+      })
+
+      return {
+        fullStream: (async function* () {
+          yield { id: "msg-1", text: "Final review summary.", type: "text-delta" }
+          yield { finishReason: "stop", type: "finish" }
+        })(),
+      }
+    })
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    const stream = await streamAgent(agent, context(), { messages: [] })
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toContainEqual({ id: "msg-1", text: "Final review summary.", type: "text-delta" })
+    expect(events).not.toContainEqual({ id: "workspace-fallback", text: "fallback answer", type: "text-delta" })
+    expect(generateText).not.toHaveBeenCalled()
   })
 
   it("synthesizes streamed answers from captured tool execution results", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -14,6 +14,7 @@ const createWorkspaceTools = vi.fn(() => ({}))
 const createWorkspaceSourceResolutionFacade = vi.fn(async (workspace: ReadonlyWorkspaceFacade | WritableWorkspaceFacade, definition: unknown) => ({ definition, workspace }))
 const getWorkspaceSourceRequestDescriptor = vi.fn((_: unknown): { method: string, url: string } | undefined => undefined)
 const isWorkspaceSourceRequestOnly = vi.fn((_: unknown): boolean => false)
+const resolveRegisteredWorkspaceDefinition = vi.fn()
 const resolveWorkspaceAutoCommit = vi.fn()
 const workspaceSourceRequestDescriptorPath = vi.fn((source: string) => `.vitehub/sources/${source}.json`)
 const useWorkspace = vi.fn<() => ReadonlyWorkspaceFacade | WritableWorkspaceFacade>(() => ({
@@ -104,6 +105,7 @@ vi.mock("@vite-hub/workspace", async (importOriginal) => {
     getWorkspaceSourceRequestDescriptor,
     isWorkspaceSourceRequestOnly,
     prepareHarnessWorkspaceSession,
+    resolveRegisteredWorkspaceDefinition,
     resolveWorkspaceAutoCommit,
     workspaceSourceRequestDescriptorPath,
     useWorkspace,
@@ -170,6 +172,8 @@ describe("defineAgent workspace option", () => {
     readFile.mockReset()
     writeFile.mockReset()
     snapshot.mockReset()
+    resolveRegisteredWorkspaceDefinition.mockReset()
+    resolveRegisteredWorkspaceDefinition.mockResolvedValue(undefined)
     resolveWorkspaceAutoCommit.mockReset()
     resolveWorkspaceAutoCommit.mockReturnValue(undefined)
     tools.mockClear()
@@ -562,12 +566,14 @@ describe("defineAgent workspace option", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { registerWorkspace } = await import("@vite-hub/workspace/runtime")
     const workspaceName = `shared-reference-${Math.random().toString(36).slice(2)}`
-    registerWorkspace(workspaceName, {
+    const workspaceDefinition = {
       sources: {
         summaryInstructions: { instructions: "Use the summary instructions.", name: "summary" } as never,
       },
       store: { provider: "memory" },
-    })
+    }
+    registerWorkspace(workspaceName, workspaceDefinition)
+    resolveRegisteredWorkspaceDefinition.mockResolvedValueOnce(workspaceDefinition)
 
     const agent = defineAgent({
       workspace: { name: workspaceName, mode: "write" },

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1398,6 +1398,42 @@ describe("defineAgent workspace option", () => {
     }))
   })
 
+  it("synthesizes streamed answers from finish-step tool results", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    agentStream.mockResolvedValueOnce({
+      fullStream: (async function* () {
+        yield { id: "msg-1", text: "I will inspect the workspace first.", type: "text-delta" }
+        yield {
+          toolResults: [
+            {
+              output: { text: "Browser evidence: screenshots/login-version-badge-desktop.png" },
+              toolCallId: "call-1",
+              toolName: "run_browser",
+            },
+          ],
+          type: "finish-step",
+        }
+        yield { finishReason: "tool-calls", type: "finish" }
+      })(),
+    })
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    const stream = await streamAgent(agent, context(), { messages: [] })
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toContainEqual({ id: "workspace-fallback", text: "fallback answer", type: "text-delta" })
+    expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("screenshots/login-version-badge-desktop.png"),
+    }))
+  })
+
   it("emits streamed workspace fallback text before finish events", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     agentStream.mockResolvedValueOnce({

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1473,6 +1473,44 @@ describe("defineAgent workspace option", () => {
     }))
   })
 
+  it("synthesizes streamed answers from captured tool execution results", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const runBrowser = vi.fn(async () => ({ text: "Browser evidence from execute: screenshots/login-version-badge-desktop.png" }))
+    agentStream.mockImplementationOnce(async function (this: { settings: { tools: Record<string, { execute: (input: unknown) => Promise<unknown> }> } }) {
+      await this.settings.tools.run_browser.execute({ message: "capture one desktop screenshot" })
+
+      return {
+        fullStream: (async function* () {
+          yield { id: "msg-1", text: "I will capture browser evidence.", type: "text-delta" }
+          yield { finishReason: "tool-calls", type: "finish" }
+        })(),
+      }
+    })
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      model: {} as never,
+      capabilities: [{
+        id: "subagents",
+        tools: {
+          run_browser: { execute: runBrowser },
+        } as never,
+      }],
+    }), { workspace: "docs" })
+
+    const stream = await streamAgent(agent, context(), { messages: [] })
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(runBrowser).toHaveBeenCalledWith({ message: "capture one desktop screenshot" })
+    expect(events).toContainEqual({ id: "workspace-fallback", text: "fallback answer", type: "text-delta" })
+    expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("Browser evidence from execute"),
+    }))
+  })
+
   it("emits streamed workspace fallback text before finish events", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     agentStream.mockResolvedValueOnce({

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1434,11 +1434,11 @@ describe("defineAgent workspace option", () => {
     }))
   })
 
-  it("synthesizes streamed answers from step callback tool results", async () => {
+  it("synthesizes streamed answers from step finish callback tool results", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     agentStream.mockImplementationOnce(async (input: unknown) => {
-      const callInput = input as { onStepEnd?: (event: unknown) => Promise<void> }
-      await callInput.onStepEnd?.({
+      const callInput = input as { onStepFinish?: (event: unknown) => Promise<void> }
+      await callInput.onStepFinish?.({
         toolResults: [
           {
             output: { text: "Browser evidence from callback: screenshots/login-version-badge-desktop.png" },

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -570,7 +570,7 @@ describe("defineAgent workspace option", () => {
       sources: {
         summaryInstructions: { instructions: "Use the summary instructions.", name: "summary" } as never,
       },
-      store: { provider: "memory" },
+      store: { provider: "memory" as const },
     }
     registerWorkspace(workspaceName, workspaceDefinition)
     resolveRegisteredWorkspaceDefinition.mockResolvedValueOnce(workspaceDefinition)

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -76,14 +76,11 @@ export interface CloudflareQueueConfig {
   }
 }
 
-function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, registryFile: string, userAppEntry: string | undefined, queueConfig: unknown, preloadVercelQueue = false) {
+function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, registryFile: string, userAppEntry: string | undefined, queueConfig: unknown) {
   const imports = [
     `import { ${spec.factory} } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(spec.runtimeModule)))}`,
     `import queueRegistry from ${JSON.stringify(`./${generatedRegistryFileName}`)}`,
   ]
-  if (preloadVercelQueue) {
-    imports.unshift("import * as __vitehubVercelQueue from '@vercel/queue'")
-  }
   if (userAppEntry) {
     imports.push(`import queueApp from ${JSON.stringify(createImportPath(entryFile, userAppEntry))}`)
   }
@@ -91,7 +88,6 @@ function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, registr
   return [
     ...imports,
     "",
-    preloadVercelQueue ? "globalThis.__vitehubVercelQueue = __vitehubVercelQueue" : "",
     `const queueConfig = ${JSON.stringify(queueConfig, null, 2)}`,
     "",
     `export default ${spec.factory}({`,
@@ -117,8 +113,7 @@ async function writeProviderEntries(rootDir: string, queue: QueueModuleOptions |
   for (const spec of providerEntrySpecs) {
     const entryFile = resolve(generatedDir, spec.entryFile)
     const queueConfig = normalizeQueueOptions(queue, { hosting: spec.hosting }) || false
-    const preloadVercelQueue = spec.name === "vercel" && isVercelQueueEnabled(queueConfig)
-    await writeFile(entryFile, renderProviderEntry(spec, entryFile, registryFile, userAppEntry, queueConfig, preloadVercelQueue), "utf8")
+    await writeFile(entryFile, renderProviderEntry(spec, entryFile, registryFile, userAppEntry, queueConfig), "utf8")
     entryFiles[spec.name] = entryFile
   }
 

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -81,17 +81,21 @@ export interface CloudflareQueueConfig {
   }
 }
 
-function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, registryFile: string, userAppEntry: string | undefined, queueConfig: unknown) {
+function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, registryFile: string, userAppEntry: string | undefined, queueConfig: unknown, preloadVercelQueue = false) {
   const imports = [
     `import { ${spec.factory} } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(spec.runtimeModule)))}`,
     `import queueRegistry from ${JSON.stringify(`./${generatedRegistryFileName}`)}`,
   ]
+  if (preloadVercelQueue) {
+    imports.unshift("import * as __vitehubVercelQueue from '@vercel/queue'")
+  }
   if (userAppEntry) {
     imports.push(`import queueApp from ${JSON.stringify(createImportPath(entryFile, userAppEntry))}`)
   }
 
   return [
     ...imports,
+    preloadVercelQueue ? "globalThis.__vitehubVercelQueue = __vitehubVercelQueue" : "",
     "",
     `const queueConfig = ${JSON.stringify(queueConfig, null, 2)}`,
     "",
@@ -118,7 +122,8 @@ async function writeProviderEntries(rootDir: string, queue: QueueModuleOptions |
   for (const spec of providerEntrySpecs) {
     const entryFile = resolve(generatedDir, spec.entryFile)
     const queueConfig = resolveOutputQueueConfig(queue, spec.hosting)
-    await writeFile(entryFile, renderProviderEntry(spec, entryFile, registryFile, userAppEntry, queueConfig), "utf8")
+    const preloadVercelQueue = spec.name === "vercel" && definitions.length > 0 && isVercelQueueEnabled(queueConfig)
+    await writeFile(entryFile, renderProviderEntry(spec, entryFile, registryFile, userAppEntry, queueConfig, preloadVercelQueue), "utf8")
     entryFiles[spec.name] = entryFile
   }
 

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -84,8 +84,7 @@ describe("Vite provider outputs", () => {
     expect(vercelConsumerContents).toContain("@vercel/queue")
     expect(vercelConsumerContents).toContain("reportQueueMarker")
     expect(vercelServerContents).toContain("/api/tests/queue")
-    expect(vercelServerContents).not.toContain("import * as __vitehubVercelQueue from")
-    expect(vercelServerContents).not.toContain("globalThis.__vitehubVercelQueue =")
+    expect(vercelServerContents).toContain("globalThis.__vitehubVercelQueue =")
     expect(vercelConsumerTrigger).toEqual({
       consumer: "api_Svitehub_Squeues_Svercel_Swelcome-email_Swelcome-email_Dfunc",
       topic: "topic--77656c636f6d652d656d61696c",
@@ -127,7 +126,7 @@ describe("Vite provider outputs", () => {
 
     expect(await readFile(join(rootDir, ".vercel", "output", "static", "index.html"), "utf8")).toContain("<title>vitehub</title>")
     const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
-    expect(vercelServerContents).not.toContain("globalThis.__vitehubVercelQueue =")
+    expect(vercelServerContents).toContain("globalThis.__vitehubVercelQueue =")
   })
 
   it("does not preload Vercel queue without queue definitions", async () => {

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -81,10 +81,11 @@ describe("Vite provider outputs", () => {
     expect(vercelConsumerContents).toContain("waitUntil")
     expect(vercelConsumerContents).not.toContain("runWithQueueRuntimeEvent({ req, res },")
     expect(vercelConsumerContents).toContain("__vitehubVercelQueue")
+    expect(vercelConsumerContents).toContain("@vercel/queue")
     expect(vercelConsumerContents).toContain("reportQueueMarker")
     expect(vercelServerContents).toContain("/api/tests/queue")
-    expect(vercelServerContents).toContain("__vitehubVercelQueue")
-    expect(vercelServerContents).toContain("@vercel/queue")
+    expect(vercelServerContents).not.toContain("import * as __vitehubVercelQueue from")
+    expect(vercelServerContents).not.toContain("globalThis.__vitehubVercelQueue =")
     expect(vercelConsumerTrigger).toEqual({
       consumer: "api_Svitehub_Squeues_Svercel_Swelcome-email_Swelcome-email_Dfunc",
       topic: "topic--77656c636f6d652d656d61696c",
@@ -126,10 +127,10 @@ describe("Vite provider outputs", () => {
 
     expect(await readFile(join(rootDir, ".vercel", "output", "static", "index.html"), "utf8")).toContain("<title>vitehub</title>")
     const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
-    expect(vercelServerContents).toContain("@vercel/queue")
+    expect(vercelServerContents).not.toContain("globalThis.__vitehubVercelQueue =")
   })
 
-  it("preloads Vercel queue without queue definitions for direct clients", async () => {
+  it("does not preload Vercel queue without queue definitions", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-no-definitions-")
     await mkdir(join(rootDir, "src"), { recursive: true })
     await mkdir(join(rootDir, "dist"), { recursive: true })
@@ -142,7 +143,7 @@ describe("Vite provider outputs", () => {
     })
 
     const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
-    expect(vercelServerContents).toContain("@vercel/queue")
+    expect(vercelServerContents).not.toContain("globalThis.__vitehubVercelQueue =")
   })
 
   it("does not preload or emit Vercel queue functions for a non-Vercel queue provider", async () => {

--- a/packages/source/src/sources/file.ts
+++ b/packages/source/src/sources/file.ts
@@ -25,17 +25,13 @@ export type FileSourceOptions<TKey extends string = string> =
 
 type FileSourceInput<TKey extends string = string> = FileSourceOptions<TKey> | TKey
 
-function basename(path: string) {
-  return path.replace(/\\/g, "/").split("/").filter(Boolean).pop() || path
-}
-
 function normalizeFileSourceOptions<TKey extends string>(input: FileSourceInput<TKey>): FileSourceOptions<TKey> {
   return typeof input === "string" ? { path: input } : input
 }
 
 function sourceKey<TKey extends string>(options: FileSourceOptions<TKey>): TKey {
   if (options.workspacePath) return normalizeSourcePath(options.workspacePath) as TKey
-  if ("path" in options && options.path) return normalizeSourcePath(basename(normalizeSafeSourcePath(options.path))) as TKey
+  if ("path" in options && options.path) return normalizeSourcePath(normalizeSafeSourcePath(options.path)) as TKey
   throw new TypeError("[vitehub] file requires a path or workspacePath.")
 }
 

--- a/packages/source/test/sources/file-glob-markdown.test.ts
+++ b/packages/source/test/sources/file-glob-markdown.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest"
 import {
   clearSources,
   defineSources,
+  file,
   glob,
   markdown,
   registerSources,
@@ -27,6 +28,20 @@ afterEach(async () => {
 })
 
 describe("@vite-hub/source local file sources", () => {
+  it("preserves relative file paths as default workspace paths", async () => {
+    const root = await createRoot()
+    await mkdir(join(root, "docs"), { recursive: true })
+    await writeFile(join(root, "docs", "README.md"), "# Docs\n")
+
+    const readme = file("docs/README.md")
+
+    await expect(readme.getKeys({ rootDir: root })).resolves.toEqual(["docs/README.md"])
+    await expect(readme.getItem("docs/README.md", { rootDir: root })).resolves.toMatchObject({
+      path: "docs/README.md",
+      mediaType: "text/markdown",
+    })
+  })
+
   it("loads file, markdown, and glob providers", async () => {
     const root = await createRoot()
     await mkdir(join(root, "docs"), { recursive: true })

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -46,7 +46,7 @@ export function vitehub(options: ViteHubPresetOptions = {}): PluginOption[] {
   if (options.database !== false) plugins.push(hubDb(options.database))
   if (options.blob !== false) plugins.push(hubBlob(options.blob))
   if (options.kv !== false) plugins.push(hubKv(options.kv))
-  if (options.queue) plugins.push(hubQueue(options.queue === true ? undefined : options.queue))
+  if (options.queue) plugins.push(hubQueue(options.queue === true ? {} : options.queue))
   if (options.sandbox !== false) plugins.push(hubSandbox(options.sandbox))
   if (options.schedule !== false) plugins.push(hubSchedule(options.schedule))
   if (options.workflow !== false) plugins.push(hubWorkflow(options.workflow))

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -32,7 +32,7 @@ export interface ViteHubPresetOptions {
   devtools?: false | HubDevtoolsOptions
   env?: false | EnvIntegrationOptions
   kv?: false | KVModuleOptions
-  queue?: false | QueueModuleOptions
+  queue?: boolean | QueueModuleOptions
   sandbox?: false | SandboxPublicOptions
   schedule?: false | ScheduleVitePluginOptions
   workflow?: false | WorkflowModuleOptions
@@ -46,7 +46,7 @@ export function vitehub(options: ViteHubPresetOptions = {}): PluginOption[] {
   if (options.database !== false) plugins.push(hubDb(options.database))
   if (options.blob !== false) plugins.push(hubBlob(options.blob))
   if (options.kv !== false) plugins.push(hubKv(options.kv))
-  if (options.queue !== false) plugins.push(hubQueue(options.queue))
+  if (options.queue) plugins.push(hubQueue(options.queue === true ? undefined : options.queue))
   if (options.sandbox !== false) plugins.push(hubSandbox(options.sandbox))
   if (options.schedule !== false) plugins.push(hubSchedule(options.schedule))
   if (options.workflow !== false) plugins.push(hubWorkflow(options.workflow))

--- a/packages/vite/test/vite.test.ts
+++ b/packages/vite/test/vite.test.ts
@@ -33,14 +33,13 @@ describe("vitehub", () => {
       "@vite-hub/database/vite",
       "@vite-hub/blob/vite",
       "@vite-hub/kv/vite",
-      "@vite-hub/queue/vite",
       "@vite-hub/sandbox/vite",
       "@vite-hub/schedule/vite",
       "@vite-hub/workflow/vite",
       "@vite-hub/workspace/vite",
       "@vite-hub/devtools",
     ])
-    expect(pluginNames(vitehub({ database: false, devtools: false, kv: false, queue: false }))).toEqual([
+    expect(pluginNames(vitehub({ database: false, devtools: false, kv: false }))).toEqual([
       "@vite-hub/env/vite",
       "@vite-hub/agent/vite",
       "@vite-hub/blob/vite",
@@ -49,6 +48,8 @@ describe("vitehub", () => {
       "@vite-hub/workflow/vite",
       "@vite-hub/workspace/vite",
     ])
+    expect(pluginNames(vitehub({ queue: true }))).toContain("@vite-hub/queue/vite")
+    expect(pluginNames(vitehub({ queue: { provider: "cloudflare" } }))).toContain("@vite-hub/queue/vite")
   })
 
   it("can be used as one nested Vite plugin entry", () => {

--- a/packages/vite/test/vite.test.ts
+++ b/packages/vite/test/vite.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest"
 
+const queueMocks = vi.hoisted(() => ({
+  hubQueue: vi.fn(() => ({ name: "@vite-hub/queue/vite" })),
+}))
+
 vi.mock("@vite-hub/agent", () => ({ defineAgent: "define-agent" }))
 vi.mock("@vite-hub/agent/capabilities", () => ({ workspaceShell: "workspace-shell" }))
 vi.mock("@vite-hub/agent/channels", () => ({ stream: "stream-channel" }))
@@ -9,7 +13,7 @@ vi.mock("@vite-hub/database/vite", () => ({ hubDb: () => ({ name: "@vite-hub/dat
 vi.mock("@vite-hub/devtools", () => ({ hubDevtools: () => ({ name: "@vite-hub/devtools" }) }))
 vi.mock("@vite-hub/env/vite", () => ({ env: "env-helper", hubEnv: () => ({ name: "@vite-hub/env/vite" }) }))
 vi.mock("@vite-hub/kv/vite", () => ({ hubKv: () => ({ name: "@vite-hub/kv/vite" }) }))
-vi.mock("@vite-hub/queue/vite", () => ({ hubQueue: () => ({ name: "@vite-hub/queue/vite" }) }))
+vi.mock("@vite-hub/queue/vite", () => ({ hubQueue: queueMocks.hubQueue }))
 vi.mock("@vite-hub/sandbox/vite", () => ({ hubSandbox: () => ({ name: "@vite-hub/sandbox/vite" }) }))
 vi.mock("@vite-hub/schedule/vite", () => ({ hubSchedule: () => ({ name: "@vite-hub/schedule/vite" }) }))
 vi.mock("@vite-hub/workflow/vite", () => ({ hubWorkflow: () => ({ name: "@vite-hub/workflow/vite" }) }))
@@ -48,8 +52,11 @@ describe("vitehub", () => {
       "@vite-hub/workflow/vite",
       "@vite-hub/workspace/vite",
     ])
+    queueMocks.hubQueue.mockClear()
     expect(pluginNames(vitehub({ queue: true }))).toContain("@vite-hub/queue/vite")
+    expect(queueMocks.hubQueue).toHaveBeenLastCalledWith({})
     expect(pluginNames(vitehub({ queue: { provider: "cloudflare" } }))).toContain("@vite-hub/queue/vite")
+    expect(queueMocks.hubQueue).toHaveBeenLastCalledWith({ provider: "cloudflare" })
   })
 
   it("can be used as one nested Vite plugin entry", () => {

--- a/packages/workspace/src/core/registry.ts
+++ b/packages/workspace/src/core/registry.ts
@@ -100,6 +100,10 @@ async function resolveWorkspaceDefinition(name: string): Promise<WorkspaceDefini
   return definition
 }
 
+export async function resolveRegisteredWorkspaceDefinition(name: string): Promise<WorkspaceDefinition> {
+  return resolveWorkspaceDefinition(name)
+}
+
 export async function useRegisteredWorkspace(name: string): Promise<Workspace> {
   const definition = await resolveWorkspaceDefinition(name)
   return createWorkspace(definition)

--- a/packages/workspace/src/core/rules.ts
+++ b/packages/workspace/src/core/rules.ts
@@ -87,7 +87,8 @@ function matchRule(policy: NormalizedWorkspacePolicy, path: string): ResolvedWor
   const normalized = normalizeWorkspacePath(path)
   let matched: ResolvedWorkspaceRule | undefined
   for (const rule of policy.rules) {
-    if (minimatch(normalized, rule.pattern, { dot: true })) matched = rule
+    const globstarDirectory = rule.pattern.endsWith("/**") ? rule.pattern.slice(0, -3) : undefined
+    if (minimatch(normalized, rule.pattern, { dot: true }) || normalized === globstarDirectory) matched = rule
   }
   return matched
 }

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -132,6 +132,7 @@ export interface WorkspaceSyncOptions {
 }
 
 export interface WorkspaceSessionOptions {
+  paths?: readonly string[]
   runtime?: never
   sandbox?: never
 }

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -581,7 +581,7 @@ export interface WorkspaceDefinition {
   name: string
   rootDir?: string
   sourceRootDir?: string
-  runtime?: "sandbox" | "trusted-host"
+  runtime?: WorkspaceRuntime
   store?: WorkspaceStoreOptions
   sources?: Record<string, WorkspaceSourceInput>
   loaders?: WorkspaceLoader[]
@@ -589,6 +589,21 @@ export interface WorkspaceDefinition {
   plugins?: WorkspacePlugin[]
   rules?: WorkspaceRules
   hooks?: WorkspaceHooks
+}
+
+export type WorkspaceRuntime =
+  | "sandbox"
+  | "trusted-host"
+  | WorkspaceSandboxRuntimeOptions
+  | WorkspaceTrustedHostRuntimeOptions
+
+export interface WorkspaceSandboxRuntimeOptions {
+  type: "sandbox"
+}
+
+export interface WorkspaceTrustedHostRuntimeOptions {
+  type: "trusted-host"
+  allowProduction?: boolean
 }
 
 export type WorkspaceDefinitionInput = Omit<WorkspaceDefinition, "name"> & {

--- a/packages/workspace/src/core/use.ts
+++ b/packages/workspace/src/core/use.ts
@@ -12,6 +12,7 @@ import { WorkspaceError, WorkspaceNotFoundError } from "./errors.ts"
 import { appendWorkspaceFile, copyWorkspacePath } from "../fs-ops.ts"
 import { normalizeSafeWorkspacePath, normalizeSafeWorkspacePattern } from "./path.ts"
 import { useRegisteredWorkspace } from "./registry.ts"
+import { createWorkspace } from "./workspace.ts"
 import { attachWorkspaceSourceRequestExecution, getWorkspaceSourceRequestExecution } from "../sources/request-execution.ts"
 
 import type { Tool, ToolSet } from "ai"
@@ -24,6 +25,7 @@ import type {
   ReadFileResult,
   RmOptions,
   Workspace,
+  WorkspaceDefinition,
   WorkspaceAssetPath,
   WorkspaceAssets,
   WorkspaceContent,
@@ -50,6 +52,7 @@ type WorkspaceWithDefinitionSync = Workspace & {
 }
 
 export interface UseWorkspaceOptions {
+  definition?: WorkspaceDefinition
   mode?: "read" | "write"
 }
 
@@ -154,12 +157,12 @@ async function materializeWorkspaceSources(workspace: Workspace, options?: Works
   return await workspace.materializeSources(options)
 }
 
-function createLazyWorkspace(name: WorkspaceName): Workspace {
+function createLazyWorkspace(name: WorkspaceName, definition?: WorkspaceDefinition): Workspace {
   let workspacePromise: Promise<Workspace> | undefined
   let syncPromise: Promise<void> | undefined
 
   async function resolveWorkspace() {
-    workspacePromise ||= useRegisteredWorkspace(name)
+    workspacePromise ||= definition ? Promise.resolve(createWorkspace(definition)) : useRegisteredWorkspace(name)
     return await workspacePromise
   }
 
@@ -431,7 +434,7 @@ export function useWorkspace<Name extends WorkspaceName>(name: Name, options: { 
 export function useWorkspace<Name extends WorkspaceName>(name: Name, options: { mode: "write" }): WritableWorkspaceFacade<Name>
 export function useWorkspace<Name extends WorkspaceName>(name: Name, options?: UseWorkspaceOptions): ReadonlyWorkspaceFacade<Name> | WritableWorkspaceFacade<Name> {
   if (options?.mode === "write") {
-    const workspace = createLazyWorkspace(name)
+    const workspace = createLazyWorkspace(name, options.definition)
     const createTools = (opts?: WritableWorkspaceFacadeToolOptions) => createWorkspaceTools(workspace, {
       broadSearchPaths: opts?.broadSearchPaths,
       cwd: opts?.cwd,
@@ -466,7 +469,7 @@ export function useWorkspace<Name extends WorkspaceName>(name: Name, options?: U
     }
   }
 
-  const fs = createReadonlyFs(name, createLazyWorkspace(name))
+  const fs = createReadonlyFs(name, createLazyWorkspace(name, options?.definition))
   const createTools = (opts?: WorkspaceFacadeToolOptions) => createWorkspaceTools(fs, {
     broadSearchPaths: opts?.broadSearchPaths,
     cwd: opts?.cwd,

--- a/packages/workspace/src/core/workspace.ts
+++ b/packages/workspace/src/core/workspace.ts
@@ -8,6 +8,7 @@ import type {
   WorkspaceDefinition,
   WorkspaceMount,
   WorkspaceMountOptions,
+  WorkspaceRuntime,
   WorkspaceSession,
 } from "./types.ts"
 
@@ -17,6 +18,10 @@ type WorkspaceWithDefinitionSync = Workspace & {
 
 function getStore(definition: WorkspaceDefinition) {
   return getCachedWorkspaceStore(definition, () => createWorkspaceStoreFromProvider(definition))
+}
+
+function workspaceRuntimeType(runtime: WorkspaceRuntime | undefined) {
+  return typeof runtime === "string" ? runtime : runtime?.type
 }
 
 export function createWorkspace(definition: WorkspaceDefinition): Workspace {
@@ -69,11 +74,12 @@ export function createWorkspace(definition: WorkspaceDefinition): Workspace {
       return await store.diff(options)
     },
     async startSession(options): Promise<WorkspaceSession> {
-      if (definition.runtime === "sandbox") {
+      const runtime = workspaceRuntimeType(definition.runtime)
+      if (runtime === "sandbox") {
         const { createSandboxWorkspaceSession } = await import("../session/sandbox.ts")
         return await createSandboxWorkspaceSession(definition, workspace, options)
       }
-      if (definition.runtime === "trusted-host") {
+      if (runtime === "trusted-host") {
         const { createTrustedHostWorkspaceSession } = await import("../session/trusted-host.ts")
         return await createTrustedHostWorkspaceSession(definition, workspace, options)
       }

--- a/packages/workspace/src/core/workspace.ts
+++ b/packages/workspace/src/core/workspace.ts
@@ -68,14 +68,14 @@ export function createWorkspace(definition: WorkspaceDefinition): Workspace {
     async diff(options) {
       return await store.diff(options)
     },
-    async startSession(_options): Promise<WorkspaceSession> {
+    async startSession(options): Promise<WorkspaceSession> {
       if (definition.runtime === "sandbox") {
         const { createSandboxWorkspaceSession } = await import("../session/sandbox.ts")
-        return await createSandboxWorkspaceSession(definition, workspace)
+        return await createSandboxWorkspaceSession(definition, workspace, options)
       }
       if (definition.runtime === "trusted-host") {
         const { createTrustedHostWorkspaceSession } = await import("../session/trusted-host.ts")
-        return await createTrustedHostWorkspaceSession(definition, workspace)
+        return await createTrustedHostWorkspaceSession(definition, workspace, options)
       }
 
       return createBasicWorkspaceSession(workspace)

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -56,6 +56,7 @@ export type {
 } from "./sources/resolution.ts"
 export type * from "./ai.ts"
 export { resolveWorkspaceAutoCommit } from "./core/rules.ts"
+export { resolveRegisteredWorkspaceDefinition } from "./core/registry.ts"
 export { useWorkspace } from "./core/use.ts"
 export type * from "./core/use.ts"
 export type * from "./core/types.ts"

--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -9,6 +9,7 @@ export {
 export {
   registerWorkspace,
   resetWorkspaceStoreCache,
+  resolveRegisteredWorkspaceDefinition,
   setWorkspaceRuntimeAssetsRegistry,
   setWorkspaceRuntimeRegistry,
   useWorkspace,

--- a/packages/workspace/src/runtime/state.ts
+++ b/packages/workspace/src/runtime/state.ts
@@ -1,4 +1,4 @@
-import { registerWorkspace, setWorkspaceRegistry, type WorkspaceRegistry } from "../core/registry.ts"
+import { registerWorkspace, resolveRegisteredWorkspaceDefinition, setWorkspaceRegistry, type WorkspaceRegistry } from "../core/registry.ts"
 import { setWorkspaceAssetsRegistry } from "../asset-registry.ts"
 import type { WorkspaceAssetsRegistry } from "../core/types.ts"
 export { useWorkspace } from "../core/use.ts"
@@ -7,6 +7,7 @@ export { resetWorkspaceStoreCache } from "../core/workspace-cache.ts"
 export { getWorkspaceHostedStoreLoader, setWorkspaceHostedStoreLoader } from "./hosted-store-loader.ts"
 export { getWorkspaceRuntimeConfig, setWorkspaceRuntimeConfig } from "./config.ts"
 export { registerWorkspace }
+export { resolveRegisteredWorkspaceDefinition }
 
 export function setWorkspaceRuntimeRegistry(registry: WorkspaceRegistry): void {
   setWorkspaceRegistry(registry)

--- a/packages/workspace/src/session/sandbox.ts
+++ b/packages/workspace/src/session/sandbox.ts
@@ -16,6 +16,7 @@ import type {
   WorkspaceFile,
   WorkspaceSearchHit,
   WorkspaceSession,
+  WorkspaceSessionOptions,
   WriteFileOptions,
 } from "../core/types.ts"
 
@@ -99,9 +100,30 @@ async function resetSandboxWorkspaceRoot(sandbox: SandboxClient) {
   await sandbox.mkdir(sandboxCwd, { recursive: true })
 }
 
-async function materializeWorkspace(workspace: Workspace, sandbox: SandboxClient) {
+function normalizeSessionPaths(options?: WorkspaceSessionOptions): string[] | undefined {
+  const paths = [...new Set((options?.paths || []).map(path => normalizeSafeWorkspacePath(path, { allowEmpty: true })))]
+  if (!paths.length || paths.includes("")) return undefined
+  return paths.sort((left, right) => left.length - right.length || left.localeCompare(right))
+}
+
+async function sessionEntries(workspace: Workspace, options?: WorkspaceSessionOptions): Promise<WorkspaceEntry[]> {
+  const paths = normalizeSessionPaths(options)
+  if (!paths) return await workspace.list("", { recursive: true })
+
+  const entries = new Map<string, WorkspaceEntry>()
+  for (const path of paths) {
+    const stat = await workspace.stat(path)
+    entries.set(stat.path, stat)
+    if (stat.type === "directory") {
+      for (const entry of await workspace.list(path, { recursive: true })) entries.set(entry.path, entry)
+    }
+  }
+  return [...entries.values()].sort((left, right) => left.path.localeCompare(right.path))
+}
+
+async function materializeWorkspace(workspace: Workspace, sandbox: SandboxClient, options?: WorkspaceSessionOptions) {
   await resetSandboxWorkspaceRoot(sandbox)
-  const entries = await workspace.list("", { recursive: true })
+  const entries = await sessionEntries(workspace, options)
   for (const entry of entries.filter(entry => entry.type === "directory"))
     await sandbox.mkdir(toSandboxPath(entry.path), { recursive: true })
   for (const entry of entries) {
@@ -148,6 +170,7 @@ async function commitSandboxChanges(
 export async function createSandboxWorkspaceSession(
   definition: WorkspaceDefinition,
   workspace: Workspace,
+  options?: WorkspaceSessionOptions,
 ): Promise<WorkspaceSession> {
   const sandboxPackage = await import(/* @vite-ignore */ sandboxPackageSpecifier).catch((error) => {
     throw new WorkspaceError(`[vitehub] Sandbox workspace runtime requires @vite-hub/sandbox. ${error instanceof Error ? error.message : String(error)}`)
@@ -159,7 +182,7 @@ export async function createSandboxWorkspaceSession(
   }
 
   const sandbox = await sandboxPackage.createSandboxWithConfig(sandboxConfig)
-  let baseline = await materializeWorkspace(workspace, sandbox)
+  let baseline = await materializeWorkspace(workspace, sandbox, options)
   const mediaTypes = new Map<string, string>()
   let closed = false
 

--- a/packages/workspace/src/session/sandbox.ts
+++ b/packages/workspace/src/session/sandbox.ts
@@ -106,6 +106,12 @@ function normalizeSessionPaths(options?: WorkspaceSessionOptions): string[] | un
   return paths.sort((left, right) => left.length - right.length || left.localeCompare(right))
 }
 
+function assertDiffInsideSessionPaths(diff: WorkspaceDiff, paths: string[] | undefined) {
+  if (!paths) return
+  const entry = diff.entries.find(entry => !paths.some(path => entry.path === path || entry.path.startsWith(`${path}/`)))
+  if (entry) throw new WorkspaceError(`[vitehub] Workspace session path ${entry.path} is outside the session scope.`)
+}
+
 async function sessionEntries(workspace: Workspace, options?: WorkspaceSessionOptions): Promise<WorkspaceEntry[]> {
   const paths = normalizeSessionPaths(options)
   if (!paths) return await workspace.list("", { recursive: true })
@@ -182,6 +188,7 @@ export async function createSandboxWorkspaceSession(
   }
 
   const sandbox = await sandboxPackage.createSandboxWithConfig(sandboxConfig)
+  const sessionPaths = normalizeSessionPaths(options)
   let baseline = await materializeWorkspace(workspace, sandbox, options)
   const mediaTypes = new Map<string, string>()
   let closed = false
@@ -254,6 +261,7 @@ export async function createSandboxWorkspaceSession(
     },
     async commit(options) {
       const diff = await currentDiff()
+      assertDiffInsideSessionPaths(diff, sessionPaths)
       await commitSandboxChanges(sandbox, workspace, diff, mediaTypes)
       baseline = await snapshotSandbox(sandbox, options?.message || "sandbox-commit")
     },

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -125,6 +125,12 @@ function normalizeSessionPaths(options?: WorkspaceSessionOptions): string[] | un
   return paths.sort((left, right) => left.length - right.length || left.localeCompare(right))
 }
 
+function assertDiffInsideSessionPaths(diff: WorkspaceDiff, paths: string[] | undefined) {
+  if (!paths) return
+  const entry = diff.entries.find(entry => !paths.some(path => entry.path === path || entry.path.startsWith(`${path}/`)))
+  if (entry) throw new WorkspaceError(`[vitehub] Workspace session path ${entry.path} is outside the session scope.`)
+}
+
 async function sessionEntries(workspace: Workspace, options?: WorkspaceSessionOptions): Promise<WorkspaceEntry[]> {
   const paths = normalizeSessionPaths(options)
   if (!paths) return await workspace.list("", { recursive: true })
@@ -236,6 +242,7 @@ export async function createTrustedHostWorkspaceSession(
 ): Promise<WorkspaceSession> {
   assertTrustedHostWorkspaceRuntimeAllowed(definition)
   const root = await mkdtemp(join(tmpdir(), `vitehub-workspace-${workspace.name.replace(/[^a-zA-Z0-9._-]+/g, "-") || "workspace"}-`))
+  const sessionPaths = normalizeSessionPaths(options)
   let baseline = await materializeWorkspace(workspace, root, options).catch(async (error) => {
     await rm(root, { force: true, recursive: true })
     throw error
@@ -311,6 +318,7 @@ export async function createTrustedHostWorkspaceSession(
     },
     async commit(options) {
       const diff = await currentDiff()
+      assertDiffInsideSessionPaths(diff, sessionPaths)
       await commitLocalChanges(root, workspace, diff, mediaTypes)
       baseline = await snapshotLocal(root, options?.message || "local-commit")
     },

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -25,9 +25,17 @@ import type {
   WorkspaceSessionOptions,
 } from "../core/types.ts"
 
-function assertTrustedHostWorkspaceRuntimeAllowed() {
+function trustedHostRuntimeAllowsProduction(definition: WorkspaceDefinition) {
+  const runtime = definition.runtime
+  return typeof runtime === "object"
+    && runtime !== null
+    && runtime.type === "trusted-host"
+    && runtime.allowProduction === true
+}
+
+function assertTrustedHostWorkspaceRuntimeAllowed(definition: WorkspaceDefinition) {
   const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
-  if (env?.NODE_ENV === "production") {
+  if (env?.NODE_ENV === "production" && !trustedHostRuntimeAllowsProduction(definition)) {
     throw new WorkspaceError("[vitehub] Workspace runtime `trusted-host` is only available outside production. Use `runtime: 'sandbox'` for hosted executable workspaces.")
   }
 }
@@ -222,11 +230,11 @@ async function execLocal(root: string, command: string, args: string[] = [], opt
 }
 
 export async function createTrustedHostWorkspaceSession(
-  _definition: WorkspaceDefinition,
+  definition: WorkspaceDefinition,
   workspace: Workspace,
   options?: WorkspaceSessionOptions,
 ): Promise<WorkspaceSession> {
-  assertTrustedHostWorkspaceRuntimeAllowed()
+  assertTrustedHostWorkspaceRuntimeAllowed(definition)
   const root = await mkdtemp(join(tmpdir(), `vitehub-workspace-${workspace.name.replace(/[^a-zA-Z0-9._-]+/g, "-") || "workspace"}-`))
   let baseline = await materializeWorkspace(workspace, root, options).catch(async (error) => {
     await rm(root, { force: true, recursive: true })

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -22,6 +22,7 @@ import type {
   WorkspaceSearchHit,
   WorkspaceSession,
   WriteFileOptions,
+  WorkspaceSessionOptions,
 } from "../core/types.ts"
 
 function assertTrustedHostWorkspaceRuntimeAllowed() {
@@ -110,8 +111,29 @@ async function snapshotLocal(root: string, name?: string) {
   return await createSnapshotFromEntries(files, name)
 }
 
-async function materializeWorkspace(workspace: Workspace, root: string) {
-  const entries = await workspace.list("", { recursive: true })
+function normalizeSessionPaths(options?: WorkspaceSessionOptions): string[] | undefined {
+  const paths = [...new Set((options?.paths || []).map(path => normalizeLocalWorkspacePath(path, { allowEmpty: true, allowGenerated: true })))]
+  if (!paths.length || paths.includes("")) return undefined
+  return paths.sort((left, right) => left.length - right.length || left.localeCompare(right))
+}
+
+async function sessionEntries(workspace: Workspace, options?: WorkspaceSessionOptions): Promise<WorkspaceEntry[]> {
+  const paths = normalizeSessionPaths(options)
+  if (!paths) return await workspace.list("", { recursive: true })
+
+  const entries = new Map<string, WorkspaceEntry>()
+  for (const path of paths) {
+    const stat = await workspace.stat(path)
+    entries.set(stat.path, stat)
+    if (stat.type === "directory") {
+      for (const entry of await workspace.list(path, { recursive: true })) entries.set(entry.path, entry)
+    }
+  }
+  return [...entries.values()].sort((left, right) => left.path.localeCompare(right.path))
+}
+
+async function materializeWorkspace(workspace: Workspace, root: string, options?: WorkspaceSessionOptions) {
+  const entries = await sessionEntries(workspace, options)
   for (const entry of entries.filter(entry => entry.type === "directory"))
     await mkdir(toLocalPath(root, entry.path, { allowGenerated: true }), { recursive: true })
   for (const entry of entries) {
@@ -202,10 +224,11 @@ async function execLocal(root: string, command: string, args: string[] = [], opt
 export async function createTrustedHostWorkspaceSession(
   _definition: WorkspaceDefinition,
   workspace: Workspace,
+  options?: WorkspaceSessionOptions,
 ): Promise<WorkspaceSession> {
   assertTrustedHostWorkspaceRuntimeAllowed()
   const root = await mkdtemp(join(tmpdir(), `vitehub-workspace-${workspace.name.replace(/[^a-zA-Z0-9._-]+/g, "-") || "workspace"}-`))
-  let baseline = await materializeWorkspace(workspace, root).catch(async (error) => {
+  let baseline = await materializeWorkspace(workspace, root, options).catch(async (error) => {
     await rm(root, { force: true, recursive: true })
     throw error
   })

--- a/packages/workspace/test/public-api.test.ts
+++ b/packages/workspace/test/public-api.test.ts
@@ -191,6 +191,26 @@ describe("workspace public API", () => {
     await expect(workspace.fs.exists("instructions/AGENTS.md")).resolves.toBe(false)
   })
 
+  it("preserves nested local file source paths in the workspace", async () => {
+    const root = await createRoot()
+    const sourceRoot = join(root, "server", "agents", "review", "workspace")
+    await mkdir(join(sourceRoot, ".agents", "summary"), { recursive: true })
+    await writeFile(join(sourceRoot, ".agents", "summary", "AGENTS.md"), "# Summary\n")
+
+    registerWorkspace("nested-source-file", defineWorkspace({
+      rootDir: sourceRoot,
+      store: { provider: "memory" },
+      sources: {
+        summaryInstructions: file(".agents/summary/AGENTS.md"),
+      },
+    }))
+
+    const workspace = useWorkspace("nested-source-file")
+
+    expect(await workspace.fs.readFile(".agents/summary/AGENTS.md")).toBe("# Summary\n")
+    await expect(workspace.fs.exists("AGENTS.md")).resolves.toBe(false)
+  })
+
   it("keeps runtime-injected source roots on colocated agent workspaces", async () => {
     const root = await createRoot()
     const sourceRoot = join(root, "server", "agents", "support", "workspace")

--- a/packages/workspace/test/sandbox-runtime.test.ts
+++ b/packages/workspace/test/sandbox-runtime.test.ts
@@ -222,6 +222,29 @@ describe("sandbox workspace runtime", () => {
     await expect(workspace.exists("old.txt")).resolves.toBe(false)
   })
 
+  it("rejects changes outside scoped sandbox session paths", async () => {
+    const fake = createFakeSandbox("cloudflare")
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "cloudflare", binding: "SANDBOX" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "sandbox",
+        store: { provider: "memory" },
+      }),
+      name: "review",
+    })
+    await workspace.writeFile("skills/browser/SKILL.md", "# Browser\n")
+
+    const session = await workspace.startSession({ paths: ["skills/browser"] })
+    await session.writeFile("screenshots/login-version-badge-desktop.png", "png\n")
+
+    await expect(session.commit()).rejects.toThrow("outside the session scope")
+    await session.close()
+    await expect(workspace.exists("screenshots/login-version-badge-desktop.png")).resolves.toBe(false)
+  })
+
   it("keeps lazy source files out of the initial sandbox sync until materialized", async () => {
     const fake = createFakeSandbox("cloudflare")
     const sandboxPackage = await import("@vite-hub/sandbox")

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -42,7 +42,7 @@ describe("trusted host workspace runtime", () => {
     await expect(workspace.readFile("generated/result.txt")).resolves.toBe("done\n")
   })
 
-  it("commits new files under globstar writable directories from scoped sessions", async () => {
+  it("rejects changes outside scoped session paths", async () => {
     const workspace = createWorkspace({
       ...defineWorkspace({
         runtime: "trusted-host",
@@ -65,10 +65,10 @@ describe("trusted host workspace runtime", () => {
     ])
 
     expect(result.exitCode).toBe(0)
-    await expect(session.commit()).resolves.toBeUndefined()
+    await expect(session.commit()).rejects.toThrow("outside the session scope")
     await session.close()
 
-    await expect(workspace.readFile("screenshots/login-version-badge-desktop.png")).resolves.toBe("png\n")
+    await expect(workspace.exists("screenshots/login-version-badge-desktop.png")).resolves.toBe(false)
   })
 
   it("scopes command cwd inside the materialized workspace", async () => {

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -42,6 +42,35 @@ describe("trusted host workspace runtime", () => {
     await expect(workspace.readFile("generated/result.txt")).resolves.toBe("done\n")
   })
 
+  it("commits new files under globstar writable directories from scoped sessions", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        rules: {
+          "screenshots/**": { write: true },
+          "skills/**": { write: true },
+          "**": { write: false },
+        },
+        store: { provider: "memory" },
+      }),
+      name: "review",
+    })
+    await workspace.writeFile("skills/browser/SKILL.md", "# Browser\n")
+    await workspace.writeFile("screenshots/.gitkeep", "")
+
+    const session = await workspace.startSession({ paths: ["skills/browser"] })
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "const fs = require('node:fs'); fs.mkdirSync('screenshots', { recursive: true }); fs.writeFileSync('screenshots/login-version-badge-desktop.png', 'png\\n')",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    await expect(session.commit()).resolves.toBeUndefined()
+    await session.close()
+
+    await expect(workspace.readFile("screenshots/login-version-badge-desktop.png")).resolves.toBe("png\n")
+  })
+
   it("scopes command cwd inside the materialized workspace", async () => {
     const workspace = createWorkspace({
       ...defineWorkspace({

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -267,4 +267,25 @@ describe("trusted host workspace runtime", () => {
 
     await expect(workspace.startSession()).rejects.toThrow("only available outside production")
   })
+
+  it("allows trusted host sessions in production when explicitly opted in", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: { type: "trusted-host", allowProduction: true },
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    await workspace.writeFile("README.md", "# Docs\n")
+
+    const session = await workspace.startSession()
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "process.stdout.write(require('node:fs').readFileSync('README.md', 'utf8'))",
+    ])
+
+    expect(result).toMatchObject({ exitCode: 0, stdout: "# Docs\n" })
+    await session.close()
+  })
 })

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -131,6 +131,37 @@ describe("trusted host workspace runtime", () => {
     await session.close()
   })
 
+  it("can materialize only selected paths in a local session", async () => {
+    const workspace = {
+      name: "review",
+      async stat(path: string) {
+        if (path === "skills/agent-browser") return { path, type: "directory" as const }
+        if (path === "skills/agent-browser/SKILL.md") return { path, size: 10, type: "file" as const }
+        throw new Error(`unexpected stat: ${path}`)
+      },
+      async list(path: string) {
+        if (path === "") throw new Error("root list should not be used")
+        if (path === "skills/agent-browser") return [{ path: "skills/agent-browser/SKILL.md", size: 10, type: "file" as const }]
+        return []
+      },
+      async readFile(path: string) {
+        if (path === "skills/agent-browser/SKILL.md") return "# Browser\n"
+        throw new Error(`unexpected read: ${path}`)
+      },
+    } as unknown as Workspace
+
+    const session = await createTrustedHostWorkspaceSession({ name: "review", runtime: "trusted-host" }, workspace, {
+      paths: ["skills/agent-browser"],
+    })
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "process.stdout.write(require('node:fs').readFileSync('skills/agent-browser/SKILL.md', 'utf8'))",
+    ])
+
+    expect(result).toMatchObject({ exitCode: 0, stdout: "# Browser\n" })
+    await session.close()
+  })
+
   it("ignores git metadata when committing host session changes", async () => {
     const workspace = createWorkspace({
       ...defineWorkspace({

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -87,6 +87,9 @@ describe("workspace types", () => {
     defineWorkspace({
       runtime: "trusted-host",
     })
+    defineWorkspace({
+      runtime: { type: "trusted-host", allowProduction: true },
+    })
     file({
       workspacePath: "AGENTS.md",
       content: "# Instructions\n",


### PR DESCRIPTION
## Summary
- keep existing `workspace: "name"` behavior as a read-only named Workspace reference
- add explicit write-capable named references with `workspace: { name, mode: "write" }`
- cover same-backing-store artifact sharing across `runAgent(...)` subagent calls
- add colocated `server/agents/<name>/instructions.md` as the preferred workspace instructions file, materialized as `AGENTS.md` and used as default model instructions only when explicit `driver.instructions` or legacy `instructions` are absent
- keep ordinary Workspace `AGENTS.md` files non-implicit while preserving Source Instructions and Capability instruction composition

## Tests
- `pnpm exec vp test test/workspace.test.ts` from `packages/agent`
- `pnpm typecheck` from `packages/agent`
- `pnpm typecheck` from `docs`
- `git diff --check`