### PR TITLE
feat(agent): add input invocation hook

### DIFF
--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -90,6 +90,27 @@ export default defineEventHandler(async (event) => {
 
 Agent Trigger Consumers call the trigger surface. They do not own the Capability behavior that registered the trigger.
 
+## Input lifecycle
+
+Use an Agent Input Hook when an Agent needs to validate trusted invocation context before its Agent Driver runs. Input hooks run once per Agent Invocation after Capabilities prepare input.
+
+```ts [server/agents/review.ts]
+import { defineAgent } from '@vite-hub/agent'
+
+export default defineAgent({
+  driver: {
+    run: () => 'ok',
+  },
+  hooks: {
+    'agent:input'(context) {
+      if (!context.input.context?.pullRequest) {
+        throw new Error('Missing GitHub field: context.pullRequest')
+      }
+    },
+  },
+})
+```
+
 ## Finish lifecycle
 
 Use an Agent Finish Hook to observe the completed invocation. Finish hooks are appropriate for usage export, trace collection, cleanup, or product-side notifications.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -875,7 +875,7 @@ export interface DefineAgent {
     >,
   >(
     options: TOptions & { capabilities?: TCapabilities } & ValidateWorkspaceAgentOptions<TOptions>,
-  ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>
+  ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>, TCapabilities>
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     CALL_OPTIONS = unknown,
@@ -889,7 +889,7 @@ export interface DefineAgent {
       AgentCapabilitiesInvocationContextValues<TCapabilities>,
       TCapabilities
     > & { capabilities?: TCapabilities, workspace?: never },
-  ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS>
+  ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>>
 }
 
 function createWorkspaceAgentDefinition<

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -79,8 +79,8 @@ import type {
   AgentChatOptions,
   AgentHandlerOptions,
   AgentInput,
+  AgentInputHook,
   AgentInstructionBlock,
-  AgentInvocationHooks,
   AgentInvocationContextStore,
   AgentInvocationContextValues,
   AgentHookObserverHooks,
@@ -195,6 +195,7 @@ export type {
   AgentHarnessSandboxInput,
   AgentHarnessSessionKey,
   AgentInput,
+  AgentInputHook,
   AgentInstructionBlock,
   AgentIntegrationOption,
   AgentHookObserver,
@@ -1124,6 +1125,32 @@ async function createAgentInvocationContext<
       model: agentModel as never,
       workspaceDefinition: resolvedWorkspaceDefinition,
     })
+    const inputHook = definition?.hooks?.["agent:input"]
+    if (inputHook) {
+      try {
+        await runObservedAgentHook(definition?.hooks as AgentHookObserverHooks | undefined, {
+          name: "agent:input",
+          owner: "agent",
+          phase: "input",
+        }, () => inputHook({
+          ...callbackContext,
+          actor: invoker,
+          context: invocationContext,
+          input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
+          invoker,
+          run: context.run,
+        }))
+      }
+      catch (error) {
+        try {
+          await capabilities.close()
+        }
+        catch (closeError) {
+          throw new AggregateError([error, closeError], "[vitehub] Agent input hook failed and cleanup also failed.")
+        }
+        throw error
+      }
+    }
     const transformedTools = await applyCapabilityToolTransforms(capabilities.tools, capabilities.toolTransforms)
     const tools = Object.keys(transformedTools || {}).length
       ? withAgentToolStepReporting(withJsonCompatibleToolOutputs(applyAgentToolPolicies(transformedTools) || {}), context.devtools?.reportToolStep)

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -343,11 +343,17 @@ export type AgentFinishHook<
   CALL_OPTIONS = unknown,
 > = (event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void>
 
+export type AgentInputHook<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> = (context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void>
+
 export interface AgentInvocationHooks<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
 > {
   "agent:finish"?: AgentFinishHook<TRuntimeConfig, CALL_OPTIONS>
+  "agent:input"?: AgentInputHook<TRuntimeConfig, CALL_OPTIONS>
 }
 
 export type AgentHookOwner = "agent" | "capability" | "channel" | "runtime" | "integration" | (string & {})

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -346,14 +346,16 @@ export type AgentFinishHook<
 export type AgentInputHook<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
-> = (context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void>
+  TContextValues extends object = AgentInvocationContextValues,
+> = (context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>) => MaybePromise<void>
 
 export interface AgentInvocationHooks<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
+  TContextValues extends object = AgentInvocationContextValues,
 > {
   "agent:finish"?: AgentFinishHook<TRuntimeConfig, CALL_OPTIONS>
-  "agent:input"?: AgentInputHook<TRuntimeConfig, CALL_OPTIONS>
+  "agent:input"?: AgentInputHook<TRuntimeConfig, CALL_OPTIONS, TContextValues>
 }
 
 export type AgentHookOwner = "agent" | "capability" | "channel" | "runtime" | "integration" | (string & {})
@@ -726,7 +728,7 @@ type AgentSharedSettings<
   capabilities?: TCapabilities
   channels?: AgentChannels<TRuntimeConfig>
   description?: string
-  hooks?: AgentCapabilityHooks<TRuntimeConfig> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig>
+  hooks?: AgentCapabilityHooks<TRuntimeConfig> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   runtime?: AgentRuntimeBinding
@@ -774,7 +776,7 @@ export interface AgentDefinition<
   channels?: AgentChannels<TRuntimeConfig>
   chat?: AgentChatOptions<TRuntimeConfig>
   description?: string
-  hooks?: AgentCapabilityHooks<TRuntimeConfig, WorkspaceName> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS>
+  hooks?: AgentCapabilityHooks<TRuntimeConfig, WorkspaceName> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   runtime?: AgentRuntimeBinding
@@ -785,7 +787,7 @@ export interface AgentDefinition<
 }
 
 export type AgentInput<TContext extends AgentRuntimeContext<any> = AgentRuntimeContext> =
-  AgentDefinition<TContext extends AgentRuntimeContext<infer TRuntimeConfig> ? TRuntimeConfig : AgentRuntimeConfig, any, any>
+  AgentDefinition<TContext extends AgentRuntimeContext<infer TRuntimeConfig> ? TRuntimeConfig : AgentRuntimeConfig, any, any, any>
 
 export type AgentRegistryModule<TContext extends AgentRuntimeContext<any> = AgentRuntimeContext> =
   | { default?: AgentInput<TContext> }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -58,6 +58,35 @@ describe("agent message protocol", () => {
     }))
   })
 
+  it("runs agent input hooks once before driver execution and can abort", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const run = vi.fn(() => "ok")
+    const inputHook = vi.fn((context) => {
+      if (!context.input.context?.pullRequest) {
+        throw new Error("Missing GitHub field: context.pullRequest")
+      }
+    })
+    const agent = defineAgent({
+      driver: { run },
+      hooks: {
+        "agent:input": inputHook,
+      },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      context: { pullRequest: true as never },
+      prompt: "review",
+    })).resolves.toBe("ok")
+    expect(inputHook).toHaveBeenCalledTimes(1)
+    expect(run).toHaveBeenCalledTimes(1)
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      prompt: "review",
+    })).rejects.toThrow("Missing GitHub field: context.pullRequest")
+    expect(inputHook).toHaveBeenCalledTimes(2)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
   it("emits invocation Trace Events without persisting prompt content", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const traceLog = createTraceEventLog()

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -777,6 +777,13 @@ describe("agent public types", () => {
           },
         }),
       ],
+      hooks: {
+        "agent:input"({ context }) {
+          const accessContext = context.get("access")
+          expectTypeOf(accessContext).toMatchTypeOf<AccessInvocationContextValue<"demo" | "quiver"> | undefined>()
+          expectTypeOf(accessContext?.workspaceScope?.scope).toEqualTypeOf<"demo" | "quiver" | undefined>()
+        },
+      },
       run({ actor, context }) {
         const accessContext = context.get("access")
         expectTypeOf(actor.id).toEqualTypeOf<string>()


### PR DESCRIPTION
Adds an Agent-level `agent:input` lifecycle hook that runs once after invocation input, invoker, and Capabilities are prepared, but before the selected Agent Driver executes. This gives apps a clean Agent Definition hook for trusted invocation-context guards without attaching fake Capabilities.

Documents the hook on the invocations page and covers the no-Capability regression case with a focused runtime test.