### PR TITLE
feat(agent): add pull request context capability

### DIFF
--- a/.agents/adr/0069-review-context-capability-workspace-contributions.md
+++ b/.agents/adr/0069-review-context-capability-workspace-contributions.md
@@ -19,6 +19,6 @@ The output boundary remains structured JSON from the Agent. Markdown rendering, 
 
 The public helper name remains unresolved. Prefer obvious nouns such as Pull Request Context Capability or Review Context Capability; avoid `prSummary`.
 
-Implementations need a small runtime extension point for Capability Workspace Contributions, with DevTools/inspection output that shows contributed Source keys, rules, and conflict failures before the Agent Driver receives Workspace surfaces.
+The Agent Package exposes a small runtime extension point for Capability Workspace Contributions. Runtime inspection can show contributed Source keys and rules, while Source key, rule, Mount, and path conflicts fail before the Agent Driver receives Workspace surfaces.
 
 Consumers keep structured result schemas and publication hooks local. A review agent can write `artifacts/review/result.json`, render markdown, or publish to GitHub, but those are sinks layered after the context capability.

--- a/.agents/adr/0069-review-context-capability-workspace-contributions.md
+++ b/.agents/adr/0069-review-context-capability-workspace-contributions.md
@@ -1,0 +1,24 @@
+# Review Context Capability Workspace Contributions
+
+ViteHub will model pull-request and review automation as a **Pull Request Context Capability**, not as `prSummary()` and not as a larger `repositoryHost()` surface. The capability owns reusable intake: Agent Trigger behavior for trusted pull-request product events, typed Agent Invocation Context Values for trusted pull-request metadata, and invocation-scoped Workspace inputs for review material. A broader review-context helper name remains open.
+
+The Workspace input primitive is a **Capability Workspace Contribution**. It is add-only, invocation-scoped, inspectable, and resolved after Agent Triggers and pre-invocation context exist but before driver-facing Workspace Tools, Source Instructions, and Workspace Sessions are built. It may contribute Sources such as `pullRequest`, `pullRequestFiles`, `pullRequestReviews`, and `pullRequestChecks`, and it may contribute explicit Workspace Rules for artifact paths such as `artifacts/review/**`. It does not mutate the Colocated Workspace Definition, grant new Capabilities, broaden an Access-selected Workspace Scope, or bypass Workspace Rules. Source key, rule, Mount, and path conflicts fail loudly.
+
+Pull-request and review data should default to lazy Live Sources or Request-Only Sources. Small trusted facts such as repository id, pull-request number, head/base refs, actor, delivery id, and provider-native ids belong in typed Agent Invocation Context Values. Heavy or changing material such as body, comments, files, reviews, review comments, checks, and diffs belongs in Sources.
+
+The output boundary remains structured JSON from the Agent. Markdown rendering, GitHub comments, pull-request reviews, check runs, and Workspace publication are consumer-owned sinks through Agent Finish Hooks, Channel Delivery Effects, or app code. The context capability may make those sinks easier to wire later, but it must not make publication its core responsibility.
+
+## Considered Options
+
+- `prSummary()` was rejected because it names one consumer workflow and invites markdown, publication, and Quiver Review policy into the reusable primitive.
+- Expanding `repositoryHost()` was rejected because Repository Host Capability is model-facing collaboration-object access, while review context intake needs triggers, trusted invocation context, and Workspace Sources before the Agent Driver runs.
+- Arbitrary hidden Workspace mutation from Capabilities was rejected because ADR 0009 and ADR 0033 keep Sources, rules, write policy, and Workspace Scope visible at their boundaries.
+- Eagerly stuffing full pull-request context into invocation context was rejected because review material is large, mutable, and better represented as lazy Live Sources or Request-Only Sources.
+
+## Consequences
+
+The public helper name remains unresolved. Prefer obvious nouns such as Pull Request Context Capability or Review Context Capability; avoid `prSummary`.
+
+Implementations need a small runtime extension point for Capability Workspace Contributions, with DevTools/inspection output that shows contributed Source keys, rules, and conflict failures before the Agent Driver receives Workspace surfaces.
+
+Consumers keep structured result schemas and publication hooks local. A review agent can write `artifacts/review/result.json`, render markdown, or publish to GitHub, but those are sinks layered after the context capability.

--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -327,6 +327,7 @@ _Avoid_: Fake agent, dummy model, test bot
 - DevTools can select configured **Agent Invoker Profiles** before a new Chat Session starts, but does not switch invokers in the middle of one conversation.
 - Chat History is explicit application behavior and is not enabled by default.
 - **Agent Invocation Context Values** can be produced by Pre-Invocation Decisions and read by later Agent or Capability callbacks.
+- **Agent Invocation Context Values** can carry small trusted product metadata, such as pull-request identity facts, while larger review material stays in Workspace Sources.
 - **Agent Invocation Context Values** do not grant Capabilities dynamically.
 - **Agent Invocation Context Value** ids must be unique per Agent so every invocation has one writer per context value.
 - **Agent Memory** can outlive one conversation.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -28,6 +28,10 @@ _Avoid_: Chat helper, DevTools bridge, raw server route, server-only bucket
 A Capability-owned contribution that may feed the active Agent Driver, such as model-facing instructions, model-facing tools, or an explicitly supported harness-compatible input.
 _Avoid_: Raw tool, root instructions, implicit harness prompt, dynamic Capability
 
+**Capability Workspace Contribution**:
+An add-only, invocation-scoped Capability contribution that adds inspectable Workspace Source Bindings or Workspace Rules before driver-facing Workspace surfaces are built.
+_Avoid_: Workspace Definition mutator, hidden Source, dynamic Capability, output sink
+
 **Capability Requirement**:
 A primitive, workspace mode, or workspace path that a Capability needs before it can be applied to an Agent.
 _Avoid_: Capability dependency, plugin dependency
@@ -156,6 +160,10 @@ _Avoid_: Provider SDK passthrough, raw API client, gh wrapper
 A provider-hosted proposed repository change, called a pull request by GitHub and Bitbucket and a merge request by GitLab.
 _Avoid_: PR as canonical term, MR as canonical term, change
 
+**Pull Request Context Capability**:
+A Capability for pull-request and review product events that contributes Agent Triggers, typed Agent Invocation Context Values, and lazy Workspace Sources for review material.
+_Avoid_: prSummary, Repository Host Capability, markdown renderer, GitHub publication sink
+
 **Transcription**:
 An Official Capability that turns audio input parts into transcript text before an Agent runs.
 _Avoid_: Voice Input, audio support, voice plugin
@@ -243,6 +251,8 @@ _Avoid_: KV Store, hubKv, model-facing storage
 - A model-backed **Agent Driver** may receive model-facing tools and model-facing instructions from **Capability Driver Contributions**.
 - A harness-backed **Agent Driver** receives only explicitly supported harness-compatible **Capability Driver Contributions**; model-facing prompt and tool assumptions must not be silently passed into the harness.
 - A custom-run-backed **Agent Driver** receives prepared invocation context and Capability runtime effects; custom `run` code decides which Capability outputs to consume.
+- A **Capability Definition** may provide **Capability Workspace Contributions** when trusted invocation context should add review, artifact, or other product-specific Workspace inputs before the Agent Driver sees Workspace surfaces.
+- **Capability Workspace Contributions** are add-only and invocation-scoped; they fail on Source key, rule, Mount, and path conflicts instead of merging silently.
 - A **Capability** may contribute **Agent Invocation Context Values** or Channel Delivery Effect Intents, but it does not execute Channel Delivery Effects or call platform-specific Channel APIs directly.
 - Capabilities model reusable Agent abilities; app-owned product reachability belongs to **Channels** unless the product event has earned a reusable Capability name.
 - The **Access Capability** may contribute **Workspace Scope Instructions** from a static Workspace Scope or Workspace Scope Resolver result.
@@ -327,6 +337,10 @@ _Avoid_: KV Store, hubKv, model-facing storage
 - **Change Request** file-list reads are Repository Host reads; repository source diffs and git history still belong to Source, Workspace Source, or Git-aware capabilities.
 - **Change Request** is the cross-provider term for pull-request and merge-request shaped objects; provider-native names stay in provider metadata.
 - Repository Host Capability write mode starts with narrow comment and reaction effects; approval, merge, branch update, status/check write, issue edit, repository settings, content, secrets, workflow, and raw API mutations need separate future design.
+- A **Pull Request Context Capability** owns trusted review intake, not model-facing repository collaboration tools or publication sinks.
+- A **Pull Request Context Capability** can contribute Sources such as `pullRequest`, `pullRequestFiles`, `pullRequestReviews`, and `pullRequestChecks`, but those Sources remain Workspace inputs governed by Workspace Scope and Workspace Rules.
+- A **Pull Request Context Capability** should keep full review material in lazy Live Sources or Request-Only Sources and keep only small trusted pull-request metadata in Agent Invocation Context Values.
+- A **Pull Request Context Capability** can require explicit Workspace Rules for artifact writes such as `artifacts/review/**`, but it cannot grant new Capabilities or broaden Access-selected Workspace Scope.
 - Chat History is not a standalone **Capability** in the current stack.
 - Agent Memory is separate from Chat History and Chat Sessions.
 - User-defined Capabilities use the same **Capability Definition** shape as official helpers.

--- a/.agents/contexts/workspace/CONTEXT.md
+++ b/.agents/contexts/workspace/CONTEXT.md
@@ -103,6 +103,10 @@ _Avoid_: Raw Source Definition, provider options only, namespace helper imports
 A direct public import of a Source Loader helper such as `file`, `glob`, or `github`.
 _Avoid_: Source namespace, Workspace-owned provider namespace
 
+**Capability Workspace Contribution**:
+An invocation-scoped contribution from a Capability that adds inspectable Workspace Source Bindings or Workspace Rules without mutating the Colocated Workspace Definition.
+_Avoid_: Hidden Workspace mutation, dynamic Source, Capability Workspace, publication sink
+
 **Mount**:
 The placement of a Source inside a Workspace file tree.
 _Avoid_: Source
@@ -297,6 +301,10 @@ _Avoid_: Chat Session, thread id, implicit conversation state
 - A **Source Map** may accept **Workspace Source Binding Inputs** that normalize into Workspace Source Bindings.
 - A **Workspace Source Binding** can reference a Source Package **Source Definition**.
 - A **Workspace Source Binding** owns Mount, Source Instructions, materialization mode, validation, and Source Sync Policy for that Source inside one Workspace.
+- A **Capability Workspace Contribution** can add Workspace Source Bindings for one Agent Invocation before Workspace Tools, Source Instructions, or Workspace Sessions are built.
+- A **Capability Workspace Contribution** is inspectable runtime input, not hidden mutation of the Colocated Workspace Definition.
+- A **Capability Workspace Contribution** fails loudly on Source key, rule, Mount, and path conflicts.
+- A **Capability Workspace Contribution** cannot broaden the Selected Workspace Scope or make hidden Sources visible.
 - A **Workspace Source Binding Input** may infer a Source Loader from unambiguous Source Loader options.
 - A **Workspace Source Binding Input** should use TypeScript types to prevent ambiguous Source Loader option combinations.
 - Runtime normalization of a **Workspace Source Binding Input** should reject ambiguous Source Loader option combinations.
@@ -308,6 +316,7 @@ _Avoid_: Chat Session, thread id, implicit conversation state
 - A **Single-File Source** can default its Mount to the Workspace root and its Source-Backed Path to the source file basename.
 - Current workspace writes target normal Workspace paths, not Source-Backed Paths.
 - Capability-persisted artifacts, such as Transcription Artifacts, target normal Workspace paths and remain subject to Workspace Rules.
+- Capability-contributed artifact paths require explicit Workspace Rules; a Capability Workspace Contribution does not make writes allowed by default.
 - **Source Sync** is distinct from normal workspace writes.
 - **Source Sync** is a lifecycle operation over existing Sources, not a separate Source kind.
 - **Source Sync** requires explicit Source selection.

--- a/packages/agent/src/access-runtime.ts
+++ b/packages/agent/src/access-runtime.ts
@@ -3,6 +3,7 @@ import type { AgentInvocationContextStore } from "./types.ts"
 
 export const workspaceOverrideSymbol: unique symbol = Symbol.for("vitehub.agent.workspaceOverride") as never
 const trustedSourceResolutionDefinitions = new WeakSet<AgentInvocationContextStore>()
+const trustedWorkspaceAccessScopes = new WeakSet<AgentInvocationContextStore>()
 
 export interface WorkspaceOverrideRuntime<Name extends WorkspaceName = WorkspaceName> {
   [workspaceOverrideSymbol]: (workspace: ReadonlyWorkspaceFacade<Name>) => void
@@ -14,4 +15,12 @@ export function markTrustedWorkspaceSourceResolutionDefinition(context: AgentInv
 
 export function hasTrustedWorkspaceSourceResolutionDefinition(context: AgentInvocationContextStore): boolean {
   return trustedSourceResolutionDefinitions.has(context)
+}
+
+export function markTrustedWorkspaceAccessScope(context: AgentInvocationContextStore): void {
+  trustedWorkspaceAccessScopes.add(context)
+}
+
+export function hasTrustedWorkspaceAccessScope(context: AgentInvocationContextStore): boolean {
+  return trustedWorkspaceAccessScopes.has(context)
 }

--- a/packages/agent/src/access-runtime.ts
+++ b/packages/agent/src/access-runtime.ts
@@ -1,7 +1,17 @@
 import type { ReadonlyWorkspaceFacade, WorkspaceName } from "@vite-hub/workspace"
+import type { AgentInvocationContextStore } from "./types.ts"
 
 export const workspaceOverrideSymbol: unique symbol = Symbol.for("vitehub.agent.workspaceOverride") as never
+const trustedSourceResolutionDefinitions = new WeakSet<AgentInvocationContextStore>()
 
 export interface WorkspaceOverrideRuntime<Name extends WorkspaceName = WorkspaceName> {
   [workspaceOverrideSymbol]: (workspace: ReadonlyWorkspaceFacade<Name>) => void
+}
+
+export function markTrustedWorkspaceSourceResolutionDefinition(context: AgentInvocationContextStore): void {
+  trustedSourceResolutionDefinitions.add(context)
+}
+
+export function hasTrustedWorkspaceSourceResolutionDefinition(context: AgentInvocationContextStore): boolean {
+  return trustedSourceResolutionDefinitions.has(context)
 }

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -1,4 +1,4 @@
-import { workspaceOverrideSymbol } from "../access-runtime.ts"
+import { markTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "../access-runtime.ts"
 import { defineCapability } from "../capability-runtime.ts"
 import { normalizeAgentWorkspaceSource } from "../workspace-source-metadata.ts"
 import type { AccessCapabilityMetadata } from "./access-metadata.ts"
@@ -339,6 +339,7 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
       context.instructions.add(finalScope.instructions, { id: "access.workspace" })
       if (sourceResolution.definition && sourceResolution.definition !== context.workspaceDefinition) {
         context.context.set("workspace.sourceResolution.definition", sourceResolution.definition)
+        markTrustedWorkspaceSourceResolutionDefinition(context.context)
       }
       setWorkspaceOverride(context, scopedWorkspace)
     },

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -1,4 +1,4 @@
-import { markTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "../access-runtime.ts"
+import { markTrustedWorkspaceAccessScope, markTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "../access-runtime.ts"
 import { defineCapability } from "../capability-runtime.ts"
 import { normalizeAgentWorkspaceSource } from "../workspace-source-metadata.ts"
 import type { AccessCapabilityMetadata } from "./access-metadata.ts"
@@ -336,6 +336,7 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
           scope: finalScope.scope,
         },
       })
+      markTrustedWorkspaceAccessScope(context.context)
       context.instructions.add(finalScope.instructions, { id: "access.workspace" })
       if (sourceResolution.definition && sourceResolution.definition !== context.workspaceDefinition) {
         context.context.set("workspace.sourceResolution.definition", sourceResolution.definition)

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -40,6 +40,7 @@ type WorkspaceAccessRuntime = Pick<
   | "createWorkspaceSourceResolutionFacade"
   | "createWorkspaceTools"
   | "getWorkspaceSourceRequestExecution"
+  | "hasWorkspaceSourceResolvers"
   | "isWorkspaceSourceRequestOnly"
   | "workspaceSourceRequestDescriptorPath"
 >
@@ -310,6 +311,9 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
       }
       const workspaceRuntime = await loadWorkspaceAccessRuntime()
       const scope = await resolveWorkspaceScope(options.workspace, context, workspaceRuntime)
+      const hasSourceResolvers = context.workspaceDefinition
+        ? workspaceRuntime.hasWorkspaceSourceResolvers(context.workspaceDefinition)
+        : false
       const sourceResolution = context.workspaceDefinition
         ? await workspaceRuntime.createWorkspaceSourceResolutionFacade(context.workspace, context.workspaceDefinition, {
             invocation: {
@@ -325,9 +329,10 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
           })
         : { definition: context.workspaceDefinition, workspace: context.workspace }
       const finalScope = finalizeResolvedWorkspaceScope(scope, sourceResolution.definition, workspaceRuntime)
+      const workspaceForScope = hasSourceResolvers ? sourceResolution.workspace : context.workspace
       const scopedWorkspace = finalScope.all
-        ? sourceResolution.workspace
-        : createScopedWorkspaceFacade(sourceResolution.workspace, finalScope, workspaceRuntime)
+        ? workspaceForScope
+        : createScopedWorkspaceFacade(workspaceForScope, finalScope, workspaceRuntime)
       context.context.set("access", {
         workspaceScope: {
           all: finalScope.all,

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -37,6 +37,9 @@ export {
   repositoryHost,
 } from "./repository-host.ts"
 export {
+  pullRequestContext,
+} from "./pull-request-context.ts"
+export {
   llmRoute,
 } from "./llm-route.ts"
 export {
@@ -209,6 +212,13 @@ export type {
   RepositoryHostWriteOperation,
   RepositoryHostWriteRequest,
 } from "./repository-host.ts"
+export type {
+  PullRequestContextOptions,
+  PullRequestContextResolver,
+  PullRequestContextRules,
+  PullRequestContextSources,
+  PullRequestContextValue,
+} from "./pull-request-context.ts"
 export type {
   LlmRouteDecision,
   LlmRouteOptions,

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -84,27 +84,37 @@ export function pullRequestContext<
   options: PullRequestContextOptions<TRuntimeConfig, Name> & { contextKey?: TContextKey, sources?: TSourceMap | PullRequestContextSources<TRuntimeConfig, Name> } = {},
 ): AgentCapabilityDefinition<TRuntimeConfig, Name, PullRequestContextCapabilityTypeContract<Extract<keyof NonNullable<TSourceMap>, string>, TContextKey>> {
   const contextKey = options.contextKey || "pullRequest"
+  const hasWorkspaceContribution = options.sources !== undefined || options.rules !== undefined
+
+  async function recordContext(context: AgentCapabilityContext<TRuntimeConfig, Name>) {
+    if (context.context.has(contextKey)) return
+    const value = await resolveMaybeFunction(options.context, context)
+    if (value !== undefined) {
+      context.context.set(contextKey, value)
+    }
+  }
+
   return defineCapability({
     id: options.id || "pull-request-context",
     metadata: {
       contextKey,
       kind: "pull-request-context",
     },
-    prepare: async (context) => {
-      const value = await resolveMaybeFunction(options.context, context)
-      if (value !== undefined && !context.context.has(contextKey)) {
-        context.context.set(contextKey, value)
-      }
-    },
+    prepare: recordContext,
     triggers: options.triggers,
-    workspace: async (context): Promise<AgentCapabilityWorkspaceContribution | undefined> => {
-      const sources = await resolveMaybeFunction(options.sources, context)
-      const rules = await resolveMaybeFunction(options.rules, context)
-      if (!sources && !rules) return
-      return {
-        ...(rules ? { rules } : {}),
-        ...(sources ? { sources } : {}),
-      }
-    },
+    ...(hasWorkspaceContribution
+      ? {
+          workspace: async (context): Promise<AgentCapabilityWorkspaceContribution | undefined> => {
+            await recordContext(context)
+            const sources = await resolveMaybeFunction(options.sources, context)
+            const rules = await resolveMaybeFunction(options.rules, context)
+            if (!sources && !rules) return
+            return {
+              ...(rules ? { rules } : {}),
+              ...(sources ? { sources } : {}),
+            }
+          },
+        }
+      : {}),
   })
 }

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -1,0 +1,110 @@
+import { defineCapability } from "../capability-runtime.ts"
+
+import type {
+  AgentCapabilityContext,
+  AgentCapabilityDefinition,
+  AgentCapabilityTypeContract,
+  AgentCapabilityWorkspaceContribution,
+  AgentRuntimeConfig,
+  AgentTriggerDefinition,
+  MaybePromise,
+} from "../types.ts"
+import type {
+  WorkspaceName,
+  WorkspaceRules,
+  WorkspaceSourceInput,
+} from "@vite-hub/workspace"
+
+export interface PullRequestContextValue {
+  actor?: string
+  baseRef?: string
+  deliveryId?: string
+  headRef?: string
+  id?: number | string
+  number: number | string
+  provider?: string
+  repository: string
+}
+
+export type PullRequestContextResolver<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> = (context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<PullRequestContextValue | false | null | undefined>
+
+export type PullRequestContextSources<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> =
+  | Record<string, WorkspaceSourceInput>
+  | ((context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<Record<string, WorkspaceSourceInput> | false | null | undefined>)
+
+export type PullRequestContextRules<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> =
+  | WorkspaceRules
+  | ((context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<WorkspaceRules | false | null | undefined>)
+
+export interface PullRequestContextOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> {
+  context?: PullRequestContextValue | PullRequestContextResolver<TRuntimeConfig, Name>
+  contextKey?: string
+  id?: string
+  rules?: PullRequestContextRules<TRuntimeConfig, Name>
+  sources?: PullRequestContextSources<TRuntimeConfig, Name>
+  triggers?: Record<string, AgentTriggerDefinition<TRuntimeConfig, Name, any, any>>
+}
+
+type PullRequestContextCapabilityTypeContract<
+  TSourceName extends string = string,
+  TContextKey extends string = "pullRequest",
+> = AgentCapabilityTypeContract & {
+  invocationContext: Record<TContextKey, PullRequestContextValue>
+  workspaceSources: TSourceName
+}
+
+async function resolveMaybeFunction<TValue, TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
+  value: TValue | ((context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<TValue | false | null | undefined>) | undefined,
+  context: AgentCapabilityContext<TRuntimeConfig, Name>,
+): Promise<TValue | undefined> {
+  const resolved = typeof value === "function"
+    ? await (value as (context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<TValue | false | null | undefined>)(context)
+    : value
+  return resolved || undefined
+}
+
+export function pullRequestContext<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  const TSourceMap extends Record<string, WorkspaceSourceInput> | undefined = undefined,
+  const TContextKey extends string = "pullRequest",
+>(
+  options: PullRequestContextOptions<TRuntimeConfig, Name> & { contextKey?: TContextKey, sources?: TSourceMap | PullRequestContextSources<TRuntimeConfig, Name> } = {},
+): AgentCapabilityDefinition<TRuntimeConfig, Name, PullRequestContextCapabilityTypeContract<Extract<keyof NonNullable<TSourceMap>, string>, TContextKey>> {
+  const contextKey = options.contextKey || "pullRequest"
+  return defineCapability({
+    id: options.id || "pull-request-context",
+    metadata: {
+      contextKey,
+      kind: "pull-request-context",
+    },
+    prepare: async (context) => {
+      const value = await resolveMaybeFunction(options.context, context)
+      if (value !== undefined && !context.context.has(contextKey)) {
+        context.context.set(contextKey, value)
+      }
+    },
+    triggers: options.triggers,
+    workspace: async (context): Promise<AgentCapabilityWorkspaceContribution | undefined> => {
+      const sources = await resolveMaybeFunction(options.sources, context)
+      const rules = await resolveMaybeFunction(options.rules, context)
+      if (!sources && !rules) return
+      return {
+        ...(rules ? { rules } : {}),
+        ...(sources ? { sources } : {}),
+      }
+    },
+  })
+}

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -58,11 +58,9 @@ export interface PullRequestContextOptions<
 }
 
 type PullRequestContextCapabilityTypeContract<
-  TSourceName extends string = string,
   TContextKey extends string = "pullRequest",
 > = AgentCapabilityTypeContract & {
   invocationContext: Record<TContextKey, PullRequestContextValue>
-  workspaceSources: TSourceName
 }
 
 async function resolveMaybeFunction<TValue, TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
@@ -82,7 +80,7 @@ export function pullRequestContext<
   const TContextKey extends string = "pullRequest",
 >(
   options: PullRequestContextOptions<TRuntimeConfig, Name> & { contextKey?: TContextKey, sources?: TSourceMap | PullRequestContextSources<TRuntimeConfig, Name> } = {},
-): AgentCapabilityDefinition<TRuntimeConfig, Name, PullRequestContextCapabilityTypeContract<Extract<keyof NonNullable<TSourceMap>, string>, TContextKey>> {
+): AgentCapabilityDefinition<TRuntimeConfig, Name, PullRequestContextCapabilityTypeContract<TContextKey>> {
   const contextKey = options.contextKey || "pullRequest"
   const hasWorkspaceContribution = options.sources !== undefined || options.rules !== undefined
   const recordedContexts = new WeakSet<AgentCapabilityContext<TRuntimeConfig, Name>["context"]>()

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -85,12 +85,14 @@ export function pullRequestContext<
 ): AgentCapabilityDefinition<TRuntimeConfig, Name, PullRequestContextCapabilityTypeContract<Extract<keyof NonNullable<TSourceMap>, string>, TContextKey>> {
   const contextKey = options.contextKey || "pullRequest"
   const hasWorkspaceContribution = options.sources !== undefined || options.rules !== undefined
+  const recordedContexts = new WeakSet<AgentCapabilityContext<TRuntimeConfig, Name>["context"]>()
 
   async function recordContext(context: AgentCapabilityContext<TRuntimeConfig, Name>) {
-    if (context.context.has(contextKey)) return
+    if (recordedContexts.has(context.context)) return
     const value = await resolveMaybeFunction(options.context, context)
     if (value !== undefined) {
       context.context.set(contextKey, value)
+      recordedContexts.add(context.context)
     }
   }
 

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1,8 +1,10 @@
 import { resolveRuntimeValue } from "@vite-hub/runtime"
+import { createWorkspaceSourceResolutionFacade } from "@vite-hub/workspace"
 
 import { workspaceOverrideSymbol } from "./access-runtime.ts"
 import { createMessage } from "./messages.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
+import { normalizeAgentWorkspaceSource } from "./workspace-source-metadata.ts"
 import {
   createFallbackAgentInvoker,
   ensureAgentInvokerContext,
@@ -14,6 +16,7 @@ import type {
   AgentCallbackContext,
   AgentCapabilityContext,
   AgentCapabilityDefinition,
+  AgentCapabilityWorkspaceContribution,
   AgentCapabilityTypeContract,
   AgentCapabilityHookName,
   AgentCapabilityHooks,
@@ -71,6 +74,7 @@ export interface AgentCapabilityRegistries {
   providerTools: AgentProviderToolContribution[]
   stateRequirements: Array<{ name: string, optional?: boolean }>
   triggers: ResolvedAgentTriggerDefinition[]
+  workspaceContributions: Array<{ capabilityId: string, rules: string[], sources: string[] }>
 }
 
 export interface AgentCapabilityOptions<
@@ -105,6 +109,7 @@ export interface ResolvedAgentCapabilities {
   toolTransforms: AgentToolTransform[]
   tools?: AgentToolSet
   workspace?: ReadonlyWorkspaceFacade
+  workspaceDefinition?: WorkspaceDefinition
 }
 
 function assertCapabilityId(id: unknown): asserts id is string {
@@ -254,6 +259,97 @@ function toAgentCallbackContext<TRuntimeConfig extends AgentRuntimeConfig>(
   return context
 }
 
+function pathContains(container: string, path: string): boolean {
+  return !container || path === container || path.startsWith(`${container}/`)
+}
+
+function pathsConflict(left: string, right: string): boolean {
+  return pathContains(left, right) || pathContains(right, left)
+}
+
+function assertWorkspaceContribution(
+  capabilityId: string,
+  contribution: AgentCapabilityWorkspaceContribution,
+  definition: WorkspaceDefinition,
+) {
+  const sources = contribution.sources || {}
+  const rules = contribution.rules || {}
+  const sourceEntries = Object.entries(sources)
+  const rulePatterns = Object.keys(rules)
+
+  for (const [key, source] of sourceEntries) {
+    if (definition.sources?.[key]) {
+      throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with an existing Workspace Source.`)
+    }
+    const mountPath = normalizeAgentWorkspaceSource(key, source).mountPath
+    for (const [existingKey, existingSource] of Object.entries(definition.sources || {})) {
+      const existingMountPath = normalizeAgentWorkspaceSource(existingKey, existingSource).mountPath
+      if (pathsConflict(existingMountPath, mountPath)) {
+        throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with Workspace Source "${existingKey}" at mount "${mountPath || "."}".`)
+      }
+    }
+  }
+
+  for (const pattern of rulePatterns) {
+    if (definition.rules?.[pattern]) {
+      throw new Error(`[vitehub] ${capabilityId}() workspace contribution rule "${pattern}" conflicts with an existing Workspace Rule.`)
+    }
+  }
+}
+
+async function applyCapabilityWorkspaceContributions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  capabilities: AgentCapabilityDefinition<TRuntimeConfig, Name>[],
+  context: Omit<AgentCapabilityContext<TRuntimeConfig, Name>, "capability" | "mode"> & {
+    workspace: ReadonlyWorkspaceFacade<Name>
+    workspaceDefinition: WorkspaceDefinition
+  },
+): Promise<{ definition: WorkspaceDefinition, registries: AgentCapabilityRegistries["workspaceContributions"], workspace: ReadonlyWorkspaceFacade<Name> } | undefined> {
+  let definition = context.workspaceDefinition
+  const registries: AgentCapabilityRegistries["workspaceContributions"] = []
+
+  for (const capability of capabilities) {
+    if (!capability.workspace) continue
+    const resolved = typeof capability.workspace === "function"
+      ? await capability.workspace({
+          ...context,
+          mode: capability.mode,
+        })
+      : capability.workspace
+    if (!resolved) continue
+
+    assertWorkspaceContribution(capability.id, resolved, definition)
+    const sources = resolved.sources || {}
+    const rules = resolved.rules || {}
+    definition = {
+      ...definition,
+      rules: Object.keys(rules).length ? { ...definition.rules, ...rules } : definition.rules,
+      sources: Object.keys(sources).length ? { ...definition.sources, ...sources } : definition.sources,
+    }
+    registries.push({
+      capabilityId: capability.id,
+      rules: Object.keys(rules),
+      sources: Object.keys(sources),
+    })
+  }
+
+  if (!registries.length) return
+  const sourceResolution = await createWorkspaceSourceResolutionFacade(context.workspace, definition, {
+    invocation: {
+      context: context.context,
+      run: context.run,
+    },
+    overlay: true,
+  })
+  return {
+    definition: sourceResolution.definition,
+    registries,
+    workspace: sourceResolution.workspace,
+  }
+}
+
 async function resolveInstructionValue<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
@@ -289,6 +385,7 @@ export async function resolveAgentCapabilities<
   validateAccessCapabilityOrder(capabilities)
   let currentInput = normalizeRunInput(input)
   let currentWorkspace = workspace as ReadonlyWorkspaceFacade<Name> | undefined
+  let currentWorkspaceDefinition = invocationOptions.workspaceDefinition
   let messages = getRunMessages(currentInput)
   let tools: AgentToolSet | undefined
   const capabilityInstructions: AgentInstructionBlock[] = []
@@ -306,6 +403,7 @@ export async function resolveAgentCapabilities<
     providerTools: [],
     stateRequirements: [],
     triggers: [],
+    workspaceContributions: [],
   }
 
   async function closeRegisteredCallbacks() {
@@ -323,6 +421,24 @@ export async function resolveAgentCapabilities<
   }
 
   try {
+    if (currentWorkspace && currentWorkspaceDefinition) {
+      const workspaceContribution = await applyCapabilityWorkspaceContributions(capabilities, {
+        ...runtimeContext,
+        actor: invoker,
+        context: invocationContext,
+        fs: currentWorkspace.fs,
+        invoker,
+        runtimeContext: runtime,
+        workspace: currentWorkspace,
+        workspaceDefinition: currentWorkspaceDefinition,
+      })
+      if (workspaceContribution) {
+        currentWorkspace = workspaceContribution.workspace
+        currentWorkspaceDefinition = workspaceContribution.definition
+        registries.workspaceContributions = workspaceContribution.registries
+      }
+    }
+
     for (const capability of capabilities) {
       await validateCapabilityRuntimeRequirement(capability as AgentCapabilityDefinition, currentWorkspace, workspaceMode)
       const phases = invocationOptions.phases || defaultCapabilityRuntimePhases
@@ -334,7 +450,7 @@ export async function resolveAgentCapabilities<
         invoker,
         runtimeContext: runtime,
         workspace: currentWorkspace,
-        workspaceDefinition: invocationOptions.workspaceDefinition,
+        workspaceDefinition: currentWorkspaceDefinition,
       }
       let capabilityContext: AgentCapabilityRuntimeContext<TRuntimeConfig, Name> & WorkspaceOverrideRuntime<Name>
       capabilityContext = {
@@ -533,6 +649,7 @@ export async function resolveAgentCapabilities<
     toolTransforms,
     tools,
     workspace: currentWorkspace,
+    workspaceDefinition: currentWorkspaceDefinition,
   }
 }
 

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -44,7 +44,7 @@ import type {
 } from "./types.ts"
 import type { WorkspaceOverrideRuntime } from "./access-runtime.ts"
 import type { Message } from "./messages.ts"
-import type { ReadonlyWorkspaceFacade, WorkspaceDefinition, WorkspaceName, WorkspaceSelectedScope } from "@vite-hub/workspace"
+import type { ReadonlyWorkspaceFacade, WorkspaceDefinition, WorkspaceName, WorkspaceSelectedScope, WorkspaceSourceInput } from "@vite-hub/workspace"
 
 type ResolvedAgentOutputRenderer = ((result: unknown, extensions?: AgentInvocationExtensions) => MaybePromise<unknown>) & {
   providerCount: number
@@ -266,6 +266,10 @@ function pathsConflict(left: string, right: string): boolean {
   return pathContains(left, right) || pathContains(right, left)
 }
 
+function isPlainRecord(input: unknown): input is Record<string, unknown> {
+  return !!input && typeof input === "object" && !Array.isArray(input)
+}
+
 function ruleConflictBase(pattern: string): string {
   const wildcard = pattern.search(/[*{[(?]/)
   const base = wildcard === -1 ? pattern : pattern.slice(0, wildcard)
@@ -319,7 +323,14 @@ function assertWorkspaceContribution(
 }
 
 async function workspacePathExists(workspace: ReadonlyWorkspaceFacade, path: string): Promise<boolean> {
-  if (!path) return false
+  if (!path) {
+    try {
+      return Boolean((await workspace.fs.list("" as never)).length)
+    }
+    catch {
+      return false
+    }
+  }
   if (await workspace.fs.exists(path as never)) return true
   try {
     return Boolean((await workspace.fs.list(path as never)).length)
@@ -332,6 +343,7 @@ async function workspacePathExists(workspace: ReadonlyWorkspaceFacade, path: str
 async function assertResolvedWorkspaceContributionSources(
   registries: AgentCapabilityRegistries["workspaceContributions"],
   definition: WorkspaceDefinition,
+  selectedWorkspaceScope: WorkspaceSelectedScope | undefined,
   workspace: ReadonlyWorkspaceFacade,
 ) {
   const contributed = new Map<string, string>()
@@ -343,6 +355,9 @@ async function assertResolvedWorkspaceContributionSources(
     const source = definition.sources?.[key]
     if (!source) continue
     const mountPath = normalizeAgentWorkspaceSource(key, source).mountPath
+    if (!selectedScopeContainsMount(selectedWorkspaceScope, mountPath)) {
+      throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" is outside the selected Workspace Scope.`)
+    }
     for (const [existingKey, existingSource] of Object.entries(definition.sources || {})) {
       if (existingKey === key) continue
       const existingMountPath = normalizeAgentWorkspaceSource(existingKey, existingSource).mountPath
@@ -369,6 +384,26 @@ function selectedWorkspaceScopeFromContext(context: AgentInvocationContextStore)
   }
 }
 
+function selectedScopeContainsMount(scope: WorkspaceSelectedScope | undefined, mountPath: string): boolean {
+  if (!scope || scope.all) return true
+  if (!mountPath) return Boolean(scope.paths?.includes(""))
+  return Boolean(scope.paths?.some(path => pathContains(path, mountPath)))
+}
+
+function withInvocationReadableSource(input: WorkspaceSourceInput): WorkspaceSourceInput {
+  if (typeof input === "string") return { source: input, materialize: "lazy" }
+  if (!isPlainRecord(input)) return input
+  const mount = input.mount
+  if (input.materialize !== undefined || input.sync !== undefined || isPlainRecord(mount) && mount.materialize !== undefined) {
+    return input
+  }
+  return { ...input, materialize: "lazy" } as WorkspaceSourceInput
+}
+
+function withInvocationReadableSources(sources: Record<string, WorkspaceSourceInput>): Record<string, WorkspaceSourceInput> {
+  return Object.fromEntries(Object.entries(sources).map(([key, source]) => [key, withInvocationReadableSource(source)]))
+}
+
 async function applyCapabilityWorkspaceContributions<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
@@ -393,7 +428,7 @@ async function applyCapabilityWorkspaceContributions<
     if (!resolved) continue
 
     assertWorkspaceContribution(capability.id, resolved, definition)
-    const sources = resolved.sources || {}
+    const sources = withInvocationReadableSources(resolved.sources || {})
     const rules = resolved.rules || {}
     definition = {
       ...definition,
@@ -409,15 +444,16 @@ async function applyCapabilityWorkspaceContributions<
 
   if (!registries.length) return
   const { createWorkspaceSourceResolutionFacade } = await import("@vite-hub/workspace")
+  const selectedWorkspaceScope = selectedWorkspaceScopeFromContext(context.context)
   const sourceResolution = await createWorkspaceSourceResolutionFacade(context.workspace, definition, {
     invocation: {
       context: context.context,
       run: context.run,
     },
     overlay: true,
-    selectedWorkspaceScope: selectedWorkspaceScopeFromContext(context.context),
+    selectedWorkspaceScope,
   })
-  await assertResolvedWorkspaceContributionSources(registries, sourceResolution.definition, context.workspace)
+  await assertResolvedWorkspaceContributionSources(registries, sourceResolution.definition, selectedWorkspaceScope, context.workspace)
   return {
     definition: sourceResolution.definition,
     registries,

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1,5 +1,4 @@
 import { resolveRuntimeValue } from "@vite-hub/runtime"
-import { isWorkspaceSourceRequestOnly, workspaceSourceRequestDescriptorPath } from "@vite-hub/workspace"
 
 import { hasTrustedWorkspaceAccessScope, hasTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "./access-runtime.ts"
 import { createMessage } from "./messages.ts"
@@ -45,7 +44,7 @@ import type {
 } from "./types.ts"
 import type { WorkspaceOverrideRuntime } from "./access-runtime.ts"
 import type { Message } from "./messages.ts"
-import type { ReadonlyWorkspaceFacade, WorkspaceDefinition, WorkspaceName, WorkspaceSelectedScope, WorkspaceSourceInput } from "@vite-hub/workspace"
+import type { ReadonlyWorkspaceFacade, WorkspaceDefinition, WorkspaceName, WorkspaceSelectedScope, WorkspaceSource, WorkspaceSourceInput } from "@vite-hub/workspace"
 
 type ResolvedAgentOutputRenderer = ((result: unknown, extensions?: AgentInvocationExtensions) => MaybePromise<unknown>) & {
   providerCount: number
@@ -291,16 +290,31 @@ function workspaceRulePatterns(definition: WorkspaceDefinition): string[] {
   ]
 }
 
-function normalizedContributionSource(key: string, source: WorkspaceSourceInput): { mountPath: string, requestOnly: boolean } {
+type WorkspaceContributionRuntime = Pick<
+  typeof import("@vite-hub/workspace"),
+  | "createWorkspaceSourceResolutionFacade"
+  | "isWorkspaceSourceRequestOnly"
+  | "workspaceSourceRequestDescriptorPath"
+>
+
+function isRequestOnlyWorkspaceSource(runtime: WorkspaceContributionRuntime, source: WorkspaceSource | undefined): boolean {
+  return Boolean(source && runtime.isWorkspaceSourceRequestOnly(source))
+}
+
+function normalizedContributionSource(
+  key: string,
+  source: WorkspaceSourceInput,
+  runtime: WorkspaceContributionRuntime,
+): { mountPath: string, requestOnly: boolean } {
   const metadata = normalizeAgentWorkspaceSource(key, source)
   return {
     mountPath: metadata.mountPath,
-    requestOnly: Boolean(metadata.source && isWorkspaceSourceRequestOnly(metadata.source)),
+    requestOnly: isRequestOnlyWorkspaceSource(runtime, metadata.source),
   }
 }
 
-function sourceScopePath(key: string, source: { mountPath: string, requestOnly: boolean }): string {
-  return source.requestOnly ? workspaceSourceRequestDescriptorPath(key) : source.mountPath
+function sourceScopePath(runtime: WorkspaceContributionRuntime, key: string, source: { mountPath: string, requestOnly: boolean }): string {
+  return source.requestOnly ? runtime.workspaceSourceRequestDescriptorPath(key) : source.mountPath
 }
 
 function sourcesConflict(left: { mountPath: string, requestOnly: boolean }, right: { mountPath: string, requestOnly: boolean }): boolean {
@@ -312,6 +326,7 @@ function assertWorkspaceContribution(
   capabilityId: string,
   contribution: AgentCapabilityWorkspaceContribution,
   definition: WorkspaceDefinition,
+  runtime: WorkspaceContributionRuntime,
 ) {
   const sources = contribution.sources || {}
   const rules = contribution.rules || {}
@@ -323,7 +338,7 @@ function assertWorkspaceContribution(
     if (definition.sources?.[key]) {
       throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with an existing Workspace Source.`)
     }
-    const contributedSource = normalizedContributionSource(key, source)
+    const contributedSource = normalizedContributionSource(key, source, runtime)
     for (const existing of contributionSources) {
       if (sourcesConflict(existing, contributedSource)) {
         throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with contributed Workspace Source "${existing.key}" at mount "${contributedSource.mountPath || "."}".`)
@@ -331,7 +346,7 @@ function assertWorkspaceContribution(
     }
     contributionSources.push({ key, ...contributedSource })
     for (const [existingKey, existingSource] of Object.entries(definition.sources || {})) {
-      const existing = normalizedContributionSource(existingKey, existingSource)
+      const existing = normalizedContributionSource(existingKey, existingSource, runtime)
       if (sourcesConflict(existing, contributedSource)) {
         throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with Workspace Source "${existingKey}" at mount "${contributedSource.mountPath || "."}".`)
       }
@@ -370,6 +385,7 @@ async function assertResolvedWorkspaceContributionSources(
   definition: WorkspaceDefinition,
   selectedWorkspaceScope: WorkspaceSelectedScope | undefined,
   workspace: ReadonlyWorkspaceFacade,
+  runtime: WorkspaceContributionRuntime,
 ) {
   const contributed = new Map<string, string>()
   for (const contribution of registries) {
@@ -379,13 +395,13 @@ async function assertResolvedWorkspaceContributionSources(
   for (const [key, capabilityId] of contributed) {
     const source = definition.sources?.[key]
     if (!source) continue
-    const contributedSource = normalizedContributionSource(key, source)
-    if (!selectedScopeContainsSource(selectedWorkspaceScope, key, contributedSource)) {
+    const contributedSource = normalizedContributionSource(key, source, runtime)
+    if (!selectedScopeContainsSource(runtime, selectedWorkspaceScope, key, contributedSource)) {
       throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" is outside the selected Workspace Scope.`)
     }
     for (const [existingKey, existingSource] of Object.entries(definition.sources || {})) {
       if (existingKey === key) continue
-      const existing = normalizedContributionSource(existingKey, existingSource)
+      const existing = normalizedContributionSource(existingKey, existingSource, runtime)
       if (sourcesConflict(existing, contributedSource)) {
         const label = contributed.has(existingKey) ? "contributed Workspace Source" : "Workspace Source"
         throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with ${label} "${existingKey}" at mount "${contributedSource.mountPath || "."}".`)
@@ -417,17 +433,19 @@ function selectedScopeContainsMount(scope: WorkspaceSelectedScope | undefined, m
 }
 
 function selectedScopeContainsSource(
+  runtime: WorkspaceContributionRuntime,
   scope: WorkspaceSelectedScope | undefined,
   key: string,
   source: { mountPath: string, requestOnly: boolean },
 ): boolean {
-  return selectedScopeContainsMount(scope, sourceScopePath(key, source))
+  return selectedScopeContainsMount(scope, sourceScopePath(runtime, key, source))
 }
 
 function assertStaticWorkspaceContributionSourcesInScope(
   registries: AgentCapabilityRegistries["workspaceContributions"],
   definition: WorkspaceDefinition,
   selectedWorkspaceScope: WorkspaceSelectedScope | undefined,
+  runtime: WorkspaceContributionRuntime,
 ) {
   if (!selectedWorkspaceScope || selectedWorkspaceScope.all) return
   const contributed = new Map<string, string>()
@@ -441,9 +459,9 @@ function assertStaticWorkspaceContributionSourcesInScope(
     if (metadata.source?.resolve) continue
     const contributedSource = {
       mountPath: metadata.mountPath,
-      requestOnly: Boolean(metadata.source && isWorkspaceSourceRequestOnly(metadata.source)),
+      requestOnly: isRequestOnlyWorkspaceSource(runtime, metadata.source),
     }
-    if (!selectedScopeContainsSource(selectedWorkspaceScope, key, contributedSource)) {
+    if (!selectedScopeContainsSource(runtime, selectedWorkspaceScope, key, contributedSource)) {
       throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" is outside the selected Workspace Scope.`)
     }
   }
@@ -476,6 +494,7 @@ async function applyCapabilityWorkspaceContributions<
 ): Promise<{ definition: WorkspaceDefinition, registries: AgentCapabilityRegistries["workspaceContributions"], workspace: ReadonlyWorkspaceFacade<Name> } | undefined> {
   let definition = context.workspaceDefinition
   const registries: AgentCapabilityRegistries["workspaceContributions"] = []
+  const workspaceRuntime = await import("@vite-hub/workspace")
 
   for (const capability of capabilities) {
     if (!capability.workspace) continue
@@ -488,7 +507,7 @@ async function applyCapabilityWorkspaceContributions<
       : capability.workspace
     if (!resolved) continue
 
-    assertWorkspaceContribution(capability.id, resolved, definition)
+    assertWorkspaceContribution(capability.id, resolved, definition, workspaceRuntime)
     const sources = withInvocationReadableSources(resolved.sources || {})
     const rules = resolved.rules || {}
     definition = {
@@ -504,10 +523,9 @@ async function applyCapabilityWorkspaceContributions<
   }
 
   if (!registries.length) return
-  const { createWorkspaceSourceResolutionFacade } = await import("@vite-hub/workspace")
   const selectedWorkspaceScope = selectedWorkspaceScopeFromContext(context.context)
-  assertStaticWorkspaceContributionSourcesInScope(registries, definition, selectedWorkspaceScope)
-  const sourceResolution = await createWorkspaceSourceResolutionFacade(context.workspace, definition, {
+  assertStaticWorkspaceContributionSourcesInScope(registries, definition, selectedWorkspaceScope, workspaceRuntime)
+  const sourceResolution = await workspaceRuntime.createWorkspaceSourceResolutionFacade(context.workspace, definition, {
     invocation: {
       context: context.context,
       run: context.run,
@@ -520,6 +538,7 @@ async function applyCapabilityWorkspaceContributions<
     sourceResolution.definition,
     selectedWorkspaceScope,
     context.workspace,
+    workspaceRuntime,
   )
   return {
     definition: sourceResolution.definition,

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -276,12 +276,19 @@ function assertWorkspaceContribution(
   const rules = contribution.rules || {}
   const sourceEntries = Object.entries(sources)
   const rulePatterns = Object.keys(rules)
+  const contributionMounts: Array<{ key: string, mountPath: string }> = []
 
   for (const [key, source] of sourceEntries) {
     if (definition.sources?.[key]) {
       throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with an existing Workspace Source.`)
     }
     const mountPath = normalizeAgentWorkspaceSource(key, source).mountPath
+    for (const existing of contributionMounts) {
+      if (pathsConflict(existing.mountPath, mountPath)) {
+        throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with contributed Workspace Source "${existing.key}" at mount "${mountPath || "."}".`)
+      }
+    }
+    contributionMounts.push({ key, mountPath })
     for (const [existingKey, existingSource] of Object.entries(definition.sources || {})) {
       const existingMountPath = normalizeAgentWorkspaceSource(existingKey, existingSource).mountPath
       if (pathsConflict(existingMountPath, mountPath)) {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -45,7 +45,7 @@ import type {
 } from "./types.ts"
 import type { WorkspaceOverrideRuntime } from "./access-runtime.ts"
 import type { Message } from "./messages.ts"
-import type { ReadonlyWorkspaceFacade, WorkspaceDefinition, WorkspaceName } from "@vite-hub/workspace"
+import type { ReadonlyWorkspaceFacade, WorkspaceDefinition, WorkspaceName, WorkspaceSelectedScope } from "@vite-hub/workspace"
 
 type ResolvedAgentOutputRenderer = ((result: unknown, extensions?: AgentInvocationExtensions) => MaybePromise<unknown>) & {
   providerCount: number
@@ -267,6 +267,19 @@ function pathsConflict(left: string, right: string): boolean {
   return pathContains(left, right) || pathContains(right, left)
 }
 
+function ruleConflictBase(pattern: string): string {
+  const wildcard = pattern.search(/[*{[(?]/)
+  const base = wildcard === -1 ? pattern : pattern.slice(0, wildcard)
+  return base.replace(/\/+$/, "")
+}
+
+function rulesConflict(left: string, right: string): boolean {
+  if (left === right) return true
+  const leftBase = ruleConflictBase(left)
+  const rightBase = ruleConflictBase(right)
+  return !leftBase || !rightBase || pathsConflict(leftBase, rightBase)
+}
+
 function assertWorkspaceContribution(
   capabilityId: string,
   contribution: AgentCapabilityWorkspaceContribution,
@@ -298,9 +311,62 @@ function assertWorkspaceContribution(
   }
 
   for (const pattern of rulePatterns) {
-    if (definition.rules?.[pattern]) {
-      throw new Error(`[vitehub] ${capabilityId}() workspace contribution rule "${pattern}" conflicts with an existing Workspace Rule.`)
+    for (const existingPattern of Object.keys(definition.rules || {})) {
+      if (rulesConflict(existingPattern, pattern)) {
+        throw new Error(`[vitehub] ${capabilityId}() workspace contribution rule "${pattern}" conflicts with existing Workspace Rule "${existingPattern}".`)
+      }
     }
+  }
+}
+
+async function workspacePathExists(workspace: ReadonlyWorkspaceFacade, path: string): Promise<boolean> {
+  if (!path) return false
+  if (await workspace.fs.exists(path as never)) return true
+  try {
+    return Boolean((await workspace.fs.list(path as never)).length)
+  }
+  catch {
+    return false
+  }
+}
+
+async function assertResolvedWorkspaceContributionSources(
+  registries: AgentCapabilityRegistries["workspaceContributions"],
+  definition: WorkspaceDefinition,
+  workspace: ReadonlyWorkspaceFacade,
+) {
+  const contributed = new Map<string, string>()
+  for (const contribution of registries) {
+    for (const source of contribution.sources) contributed.set(source, contribution.capabilityId)
+  }
+
+  for (const [key, capabilityId] of contributed) {
+    const source = definition.sources?.[key]
+    if (!source) continue
+    const mountPath = normalizeAgentWorkspaceSource(key, source).mountPath
+    for (const [existingKey, existingSource] of Object.entries(definition.sources || {})) {
+      if (existingKey === key) continue
+      const existingMountPath = normalizeAgentWorkspaceSource(existingKey, existingSource).mountPath
+      if (pathsConflict(existingMountPath, mountPath)) {
+        const label = contributed.has(existingKey) ? "contributed Workspace Source" : "Workspace Source"
+        throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with ${label} "${existingKey}" at mount "${mountPath || "."}".`)
+      }
+    }
+    if (await workspacePathExists(workspace, mountPath)) {
+      throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with an existing Workspace path at mount "${mountPath}".`)
+    }
+  }
+}
+
+function selectedWorkspaceScopeFromContext(context: AgentInvocationContextStore): WorkspaceSelectedScope | undefined {
+  const access = context.get<{ workspaceScope?: { all?: boolean, paths?: readonly string[], role?: string, scope?: string } }>("access")
+  const scope = access?.workspaceScope
+  if (!scope?.scope) return
+  return {
+    all: scope.all === true,
+    name: scope.scope,
+    paths: scope.paths,
+    role: scope.role,
   }
 }
 
@@ -349,7 +415,9 @@ async function applyCapabilityWorkspaceContributions<
       run: context.run,
     },
     overlay: true,
+    selectedWorkspaceScope: selectedWorkspaceScopeFromContext(context.context),
   })
+  await assertResolvedWorkspaceContributionSources(registries, sourceResolution.definition, context.workspace)
   return {
     definition: sourceResolution.definition,
     registries,
@@ -427,26 +495,33 @@ export async function resolveAgentCapabilities<
     if (errors.length > 1) throw new AggregateError(errors, "[vitehub] Multiple capability close callbacks failed.")
   }
 
-  try {
-    if (currentWorkspace && currentWorkspaceDefinition) {
-      const workspaceContribution = await applyCapabilityWorkspaceContributions(capabilities, {
-        ...runtimeContext,
-        actor: invoker,
-        context: invocationContext,
-        fs: currentWorkspace.fs,
-        invoker,
-        runtimeContext: runtime,
-        workspace: currentWorkspace,
-        workspaceDefinition: currentWorkspaceDefinition,
-      })
-      if (workspaceContribution) {
-        currentWorkspace = workspaceContribution.workspace
-        currentWorkspaceDefinition = workspaceContribution.definition
-        registries.workspaceContributions = workspaceContribution.registries
-      }
+  let workspaceContributionsApplied = false
+  async function applyWorkspaceContributions() {
+    if (workspaceContributionsApplied) return
+    workspaceContributionsApplied = true
+    if (!currentWorkspace || !currentWorkspaceDefinition) return
+    const sourceResolvedDefinition = invocationContext.get<WorkspaceDefinition>("workspace.sourceResolution.definition")
+    if (sourceResolvedDefinition) currentWorkspaceDefinition = sourceResolvedDefinition
+    const workspaceContribution = await applyCapabilityWorkspaceContributions(capabilities, {
+      ...runtimeContext,
+      actor: invoker,
+      context: invocationContext,
+      fs: currentWorkspace.fs,
+      invoker,
+      runtimeContext: runtime,
+      workspace: currentWorkspace,
+      workspaceDefinition: currentWorkspaceDefinition,
+    })
+    if (workspaceContribution) {
+      currentWorkspace = workspaceContribution.workspace
+      currentWorkspaceDefinition = workspaceContribution.definition
+      registries.workspaceContributions = workspaceContribution.registries
     }
+  }
 
+  try {
     for (const capability of capabilities) {
+      if (capability.id !== "access") await applyWorkspaceContributions()
       await validateCapabilityRuntimeRequirement(capability as AgentCapabilityDefinition, currentWorkspace, workspaceMode)
       const phases = invocationOptions.phases || defaultCapabilityRuntimePhases
       const metadataContext = {
@@ -623,6 +698,7 @@ export async function resolveAgentCapabilities<
           }
         }
       }
+      if (capability.id === "access") await applyWorkspaceContributions()
 
       if (invocationOptions.resolveInstructions !== false && capability.instructions !== undefined) {
         const values = await resolveInstructionValue(capability, capabilityContext)
@@ -635,6 +711,7 @@ export async function resolveAgentCapabilities<
         if (isToolSet(resolved)) tools = { ...tools, ...resolved }
       }
     }
+    await applyWorkspaceContributions()
   }
   catch (error) {
     try {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1,6 +1,6 @@
 import { resolveRuntimeValue } from "@vite-hub/runtime"
 
-import { workspaceOverrideSymbol } from "./access-runtime.ts"
+import { hasTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "./access-runtime.ts"
 import { createMessage } from "./messages.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
 import { normalizeAgentWorkspaceSource } from "./workspace-source-metadata.ts"
@@ -345,6 +345,7 @@ async function assertResolvedWorkspaceContributionSources(
   definition: WorkspaceDefinition,
   selectedWorkspaceScope: WorkspaceSelectedScope | undefined,
   workspace: ReadonlyWorkspaceFacade,
+  isSourceRequestOnly: (key: string, source: WorkspaceSourceInput) => boolean,
 ) {
   const contributed = new Map<string, string>()
   for (const contribution of registries) {
@@ -366,7 +367,7 @@ async function assertResolvedWorkspaceContributionSources(
         throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with ${label} "${existingKey}" at mount "${mountPath || "."}".`)
       }
     }
-    if (await workspacePathExists(workspace, mountPath)) {
+    if (!isSourceRequestOnly(key, source) && await workspacePathExists(workspace, mountPath)) {
       throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with an existing Workspace path at mount "${mountPath}".`)
     }
   }
@@ -443,7 +444,7 @@ async function applyCapabilityWorkspaceContributions<
   }
 
   if (!registries.length) return
-  const { createWorkspaceSourceResolutionFacade } = await import("@vite-hub/workspace")
+  const { createWorkspaceSourceResolutionFacade, isWorkspaceSourceRequestOnly } = await import("@vite-hub/workspace")
   const selectedWorkspaceScope = selectedWorkspaceScopeFromContext(context.context)
   const sourceResolution = await createWorkspaceSourceResolutionFacade(context.workspace, definition, {
     invocation: {
@@ -453,7 +454,16 @@ async function applyCapabilityWorkspaceContributions<
     overlay: true,
     selectedWorkspaceScope,
   })
-  await assertResolvedWorkspaceContributionSources(registries, sourceResolution.definition, selectedWorkspaceScope, context.workspace)
+  await assertResolvedWorkspaceContributionSources(
+    registries,
+    sourceResolution.definition,
+    selectedWorkspaceScope,
+    context.workspace,
+    (key, source) => {
+      const metadata = normalizeAgentWorkspaceSource(key, source)
+      return Boolean(metadata.source && isWorkspaceSourceRequestOnly(metadata.source))
+    },
+  )
   return {
     definition: sourceResolution.definition,
     registries,
@@ -536,7 +546,9 @@ export async function resolveAgentCapabilities<
     if (workspaceContributionsApplied) return
     workspaceContributionsApplied = true
     if (!currentWorkspace || !currentWorkspaceDefinition) return
-    const sourceResolvedDefinition = invocationContext.get<WorkspaceDefinition>("workspace.sourceResolution.definition")
+    const sourceResolvedDefinition = hasTrustedWorkspaceSourceResolutionDefinition(invocationContext)
+      ? invocationContext.get<WorkspaceDefinition>("workspace.sourceResolution.definition")
+      : undefined
     if (sourceResolvedDefinition) currentWorkspaceDefinition = sourceResolvedDefinition
     const workspaceContribution = await applyCapabilityWorkspaceContributions(capabilities, {
       ...runtimeContext,

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1,6 +1,7 @@
 import { resolveRuntimeValue } from "@vite-hub/runtime"
+import { isWorkspaceSourceRequestOnly, workspaceSourceRequestDescriptorPath } from "@vite-hub/workspace"
 
-import { hasTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "./access-runtime.ts"
+import { hasTrustedWorkspaceAccessScope, hasTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "./access-runtime.ts"
 import { createMessage } from "./messages.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
 import { normalizeAgentWorkspaceSource } from "./workspace-source-metadata.ts"
@@ -283,6 +284,30 @@ function rulesConflict(left: string, right: string): boolean {
   return !leftBase || !rightBase || pathsConflict(leftBase, rightBase)
 }
 
+function workspaceRulePatterns(definition: WorkspaceDefinition): string[] {
+  return [
+    ...Object.keys(definition.rules || {}),
+    ...(definition.plugins || []).flatMap(plugin => Object.keys(plugin.rules || {})),
+  ]
+}
+
+function normalizedContributionSource(key: string, source: WorkspaceSourceInput): { mountPath: string, requestOnly: boolean } {
+  const metadata = normalizeAgentWorkspaceSource(key, source)
+  return {
+    mountPath: metadata.mountPath,
+    requestOnly: Boolean(metadata.source && isWorkspaceSourceRequestOnly(metadata.source)),
+  }
+}
+
+function sourceScopePath(key: string, source: { mountPath: string, requestOnly: boolean }): string {
+  return source.requestOnly ? workspaceSourceRequestDescriptorPath(key) : source.mountPath
+}
+
+function sourcesConflict(left: { mountPath: string, requestOnly: boolean }, right: { mountPath: string, requestOnly: boolean }): boolean {
+  if (left.requestOnly || right.requestOnly) return false
+  return pathsConflict(left.mountPath, right.mountPath)
+}
+
 function assertWorkspaceContribution(
   capabilityId: string,
   contribution: AgentCapabilityWorkspaceContribution,
@@ -292,29 +317,29 @@ function assertWorkspaceContribution(
   const rules = contribution.rules || {}
   const sourceEntries = Object.entries(sources)
   const rulePatterns = Object.keys(rules)
-  const contributionMounts: Array<{ key: string, mountPath: string }> = []
+  const contributionSources: Array<{ key: string, mountPath: string, requestOnly: boolean }> = []
 
   for (const [key, source] of sourceEntries) {
     if (definition.sources?.[key]) {
       throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with an existing Workspace Source.`)
     }
-    const mountPath = normalizeAgentWorkspaceSource(key, source).mountPath
-    for (const existing of contributionMounts) {
-      if (pathsConflict(existing.mountPath, mountPath)) {
-        throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with contributed Workspace Source "${existing.key}" at mount "${mountPath || "."}".`)
+    const contributedSource = normalizedContributionSource(key, source)
+    for (const existing of contributionSources) {
+      if (sourcesConflict(existing, contributedSource)) {
+        throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with contributed Workspace Source "${existing.key}" at mount "${contributedSource.mountPath || "."}".`)
       }
     }
-    contributionMounts.push({ key, mountPath })
+    contributionSources.push({ key, ...contributedSource })
     for (const [existingKey, existingSource] of Object.entries(definition.sources || {})) {
-      const existingMountPath = normalizeAgentWorkspaceSource(existingKey, existingSource).mountPath
-      if (pathsConflict(existingMountPath, mountPath)) {
-        throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with Workspace Source "${existingKey}" at mount "${mountPath || "."}".`)
+      const existing = normalizedContributionSource(existingKey, existingSource)
+      if (sourcesConflict(existing, contributedSource)) {
+        throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with Workspace Source "${existingKey}" at mount "${contributedSource.mountPath || "."}".`)
       }
     }
   }
 
   for (const pattern of rulePatterns) {
-    for (const existingPattern of Object.keys(definition.rules || {})) {
+    for (const existingPattern of workspaceRulePatterns(definition)) {
       if (rulesConflict(existingPattern, pattern)) {
         throw new Error(`[vitehub] ${capabilityId}() workspace contribution rule "${pattern}" conflicts with existing Workspace Rule "${existingPattern}".`)
       }
@@ -345,7 +370,6 @@ async function assertResolvedWorkspaceContributionSources(
   definition: WorkspaceDefinition,
   selectedWorkspaceScope: WorkspaceSelectedScope | undefined,
   workspace: ReadonlyWorkspaceFacade,
-  isSourceRequestOnly: (key: string, source: WorkspaceSourceInput) => boolean,
 ) {
   const contributed = new Map<string, string>()
   for (const contribution of registries) {
@@ -355,25 +379,26 @@ async function assertResolvedWorkspaceContributionSources(
   for (const [key, capabilityId] of contributed) {
     const source = definition.sources?.[key]
     if (!source) continue
-    const mountPath = normalizeAgentWorkspaceSource(key, source).mountPath
-    if (!selectedScopeContainsMount(selectedWorkspaceScope, mountPath)) {
+    const contributedSource = normalizedContributionSource(key, source)
+    if (!selectedScopeContainsSource(selectedWorkspaceScope, key, contributedSource)) {
       throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" is outside the selected Workspace Scope.`)
     }
     for (const [existingKey, existingSource] of Object.entries(definition.sources || {})) {
       if (existingKey === key) continue
-      const existingMountPath = normalizeAgentWorkspaceSource(existingKey, existingSource).mountPath
-      if (pathsConflict(existingMountPath, mountPath)) {
+      const existing = normalizedContributionSource(existingKey, existingSource)
+      if (sourcesConflict(existing, contributedSource)) {
         const label = contributed.has(existingKey) ? "contributed Workspace Source" : "Workspace Source"
-        throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with ${label} "${existingKey}" at mount "${mountPath || "."}".`)
+        throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with ${label} "${existingKey}" at mount "${contributedSource.mountPath || "."}".`)
       }
     }
-    if (!isSourceRequestOnly(key, source) && await workspacePathExists(workspace, mountPath)) {
-      throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with an existing Workspace path at mount "${mountPath}".`)
+    if (!contributedSource.requestOnly && await workspacePathExists(workspace, contributedSource.mountPath)) {
+      throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with an existing Workspace path at mount "${contributedSource.mountPath}".`)
     }
   }
 }
 
 function selectedWorkspaceScopeFromContext(context: AgentInvocationContextStore): WorkspaceSelectedScope | undefined {
+  if (!hasTrustedWorkspaceAccessScope(context)) return
   const access = context.get<{ workspaceScope?: { all?: boolean, paths?: readonly string[], role?: string, scope?: string } }>("access")
   const scope = access?.workspaceScope
   if (!scope?.scope) return
@@ -389,6 +414,39 @@ function selectedScopeContainsMount(scope: WorkspaceSelectedScope | undefined, m
   if (!scope || scope.all) return true
   if (!mountPath) return Boolean(scope.paths?.includes(""))
   return Boolean(scope.paths?.some(path => pathContains(path, mountPath)))
+}
+
+function selectedScopeContainsSource(
+  scope: WorkspaceSelectedScope | undefined,
+  key: string,
+  source: { mountPath: string, requestOnly: boolean },
+): boolean {
+  return selectedScopeContainsMount(scope, sourceScopePath(key, source))
+}
+
+function assertStaticWorkspaceContributionSourcesInScope(
+  registries: AgentCapabilityRegistries["workspaceContributions"],
+  definition: WorkspaceDefinition,
+  selectedWorkspaceScope: WorkspaceSelectedScope | undefined,
+) {
+  if (!selectedWorkspaceScope || selectedWorkspaceScope.all) return
+  const contributed = new Map<string, string>()
+  for (const contribution of registries) {
+    for (const source of contribution.sources) contributed.set(source, contribution.capabilityId)
+  }
+  for (const [key, capabilityId] of contributed) {
+    const source = definition.sources?.[key]
+    if (!source) continue
+    const metadata = normalizeAgentWorkspaceSource(key, source)
+    if (metadata.source?.resolve) continue
+    const contributedSource = {
+      mountPath: metadata.mountPath,
+      requestOnly: Boolean(metadata.source && isWorkspaceSourceRequestOnly(metadata.source)),
+    }
+    if (!selectedScopeContainsSource(selectedWorkspaceScope, key, contributedSource)) {
+      throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" is outside the selected Workspace Scope.`)
+    }
+  }
 }
 
 function withInvocationReadableSource(input: WorkspaceSourceInput): WorkspaceSourceInput {
@@ -414,12 +472,14 @@ async function applyCapabilityWorkspaceContributions<
     workspace: ReadonlyWorkspaceFacade<Name>
     workspaceDefinition: WorkspaceDefinition
   },
+  workspaceMode: AgentCapabilityMode,
 ): Promise<{ definition: WorkspaceDefinition, registries: AgentCapabilityRegistries["workspaceContributions"], workspace: ReadonlyWorkspaceFacade<Name> } | undefined> {
   let definition = context.workspaceDefinition
   const registries: AgentCapabilityRegistries["workspaceContributions"] = []
 
   for (const capability of capabilities) {
     if (!capability.workspace) continue
+    await validateCapabilityRuntimeRequirement(capability as AgentCapabilityDefinition, context.workspace, workspaceMode)
     const resolved = typeof capability.workspace === "function"
       ? await capability.workspace({
           ...context,
@@ -444,8 +504,9 @@ async function applyCapabilityWorkspaceContributions<
   }
 
   if (!registries.length) return
-  const { createWorkspaceSourceResolutionFacade, isWorkspaceSourceRequestOnly } = await import("@vite-hub/workspace")
+  const { createWorkspaceSourceResolutionFacade } = await import("@vite-hub/workspace")
   const selectedWorkspaceScope = selectedWorkspaceScopeFromContext(context.context)
+  assertStaticWorkspaceContributionSourcesInScope(registries, definition, selectedWorkspaceScope)
   const sourceResolution = await createWorkspaceSourceResolutionFacade(context.workspace, definition, {
     invocation: {
       context: context.context,
@@ -459,10 +520,6 @@ async function applyCapabilityWorkspaceContributions<
     sourceResolution.definition,
     selectedWorkspaceScope,
     context.workspace,
-    (key, source) => {
-      const metadata = normalizeAgentWorkspaceSource(key, source)
-      return Boolean(metadata.source && isWorkspaceSourceRequestOnly(metadata.source))
-    },
   )
   return {
     definition: sourceResolution.definition,
@@ -559,7 +616,7 @@ export async function resolveAgentCapabilities<
       runtimeContext: runtime,
       workspace: currentWorkspace,
       workspaceDefinition: currentWorkspaceDefinition,
-    })
+    }, workspaceMode)
     if (workspaceContribution) {
       currentWorkspace = workspaceContribution.workspace
       currentWorkspaceDefinition = workspaceContribution.definition

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1,5 +1,4 @@
 import { resolveRuntimeValue } from "@vite-hub/runtime"
-import { createWorkspaceSourceResolutionFacade } from "@vite-hub/workspace"
 
 import { workspaceOverrideSymbol } from "./access-runtime.ts"
 import { createMessage } from "./messages.ts"
@@ -409,6 +408,7 @@ async function applyCapabilityWorkspaceContributions<
   }
 
   if (!registries.length) return
+  const { createWorkspaceSourceResolutionFacade } = await import("@vite-hub/workspace")
   const sourceResolution = await createWorkspaceSourceResolutionFacade(context.workspace, definition, {
     invocation: {
       context: context.context,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1238,7 +1238,7 @@ async function createAgentInvocationContext<
       : undefined
     const activeWorkspace = capabilities.workspace || workspace
     const sourceResolvedWorkspaceDefinition = invocationContext.get<WorkspaceDefinition>("workspace.sourceResolution.definition")
-    const activeWorkspaceDefinition = sourceResolvedWorkspaceDefinition || capabilities.workspaceDefinition || resolvedWorkspaceDefinition
+    const activeWorkspaceDefinition = capabilities.workspaceDefinition || sourceResolvedWorkspaceDefinition || resolvedWorkspaceDefinition
     const workspaceScope = invocationContext.get("access")?.workspaceScope
     const sourceInstructions = activeWorkspaceDefinition && activeWorkspace
       ? await resolveWorkspaceSourceInstructionBlock(

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -697,7 +697,7 @@ function accessCapabilityRequiresWorkspace(capability: NormalizedCapability): bo
 function validateNonWorkspaceCapabilities(capabilities: NormalizedCapability[], hasWorkspace: boolean): void {
   if (hasWorkspace) return
   for (const capability of capabilities) {
-    if (capability.id === "workspace-shell" || capability.id === "sandbox" || accessCapabilityRequiresWorkspace(capability)) {
+    if (capability.workspace || capability.id === "workspace-shell" || capability.id === "sandbox" || accessCapabilityRequiresWorkspace(capability)) {
       const name = capability.id === "workspace-shell" ? "workspaceShell" : capability.id
       throw new Error(`[vitehub] ${name}() requires an explicit workspace.`)
     }
@@ -1238,7 +1238,7 @@ async function createAgentInvocationContext<
       : undefined
     const activeWorkspace = capabilities.workspace || workspace
     const sourceResolvedWorkspaceDefinition = invocationContext.get<WorkspaceDefinition>("workspace.sourceResolution.definition")
-    const activeWorkspaceDefinition = sourceResolvedWorkspaceDefinition || resolvedWorkspaceDefinition
+    const activeWorkspaceDefinition = sourceResolvedWorkspaceDefinition || capabilities.workspaceDefinition || resolvedWorkspaceDefinition
     const workspaceScope = invocationContext.get("access")?.workspaceScope
     const sourceInstructions = activeWorkspaceDefinition && activeWorkspace
       ? await resolveWorkspaceSourceInstructionBlock(

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -15,6 +15,8 @@ import type {
   WorkspaceDefinition,
   WorkspaceDefinitionInput,
   WorkspaceName,
+  WorkspaceRules,
+  WorkspaceSourceInput,
 } from "@vite-hub/workspace"
 
 export type {
@@ -444,6 +446,18 @@ export type AgentCapabilityToolResolver<
   | Record<string, unknown>
   | ((context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<Record<string, unknown> | undefined>)
 
+export interface AgentCapabilityWorkspaceContribution {
+  rules?: WorkspaceRules
+  sources?: Record<string, WorkspaceSourceInput>
+}
+
+export type AgentCapabilityWorkspaceContributionResolver<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> =
+  | AgentCapabilityWorkspaceContribution
+  | ((context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<AgentCapabilityWorkspaceContribution | false | null | undefined>)
+
 export type AgentCapabilityPhase = "configure" | "prepare" | "bind" | "input" | "resolve" | "output" | "close"
 export type AgentCapabilityHookName = `capability:${AgentCapabilityPhase}` | `capability:${AgentCapabilityPhase}:after`
 
@@ -547,6 +561,7 @@ export interface AgentCapabilityDefinition<
   tools?: AgentCapabilityToolResolver<TRuntimeConfig, Name>
   triggers?: Record<string, AgentTriggerDefinition<TRuntimeConfig, Name, any, any>>
   workspaceSources?: WorkspaceDefinition["sources"]
+  workspace?: AgentCapabilityWorkspaceContributionResolver<TRuntimeConfig, Name>
 }
 
 export type AgentCapabilityInput<

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1213,7 +1213,7 @@ async function resolveWorkspaceMetadataCapabilityContext<
 
   return {
     capabilityInstructions: capabilities.capabilityInstructions,
-    definition: sourceResolvedDefinition || capabilities.workspaceDefinition || workspaceDefinition,
+    definition: capabilities.workspaceDefinition || sourceResolvedDefinition || workspaceDefinition,
     metadataContext: {
       ...agentCallbackContext(runtime),
       actor: invoker,

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1213,7 +1213,7 @@ async function resolveWorkspaceMetadataCapabilityContext<
 
   return {
     capabilityInstructions: capabilities.capabilityInstructions,
-    definition: sourceResolvedDefinition || workspaceDefinition,
+    definition: sourceResolvedDefinition || capabilities.workspaceDefinition || workspaceDefinition,
     metadataContext: {
       ...agentCallbackContext(runtime),
       actor: invoker,

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -343,6 +343,173 @@ describe("agent capability runtime", () => {
     })).rejects.toThrow('workspace contribution source "review" conflicts with contributed Workspace Source "files"')
   })
 
+  it("rejects overlapping capability workspace rules", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            rules: {
+              "artifacts/review/**": { write: true },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        rules: {
+          "artifacts/**": { write: true },
+        },
+      },
+    })).rejects.toThrow('workspace contribution rule "artifacts/review/**" conflicts with existing Workspace Rule "artifacts/**"')
+  })
+
+  it("rechecks capability workspace source mounts after Source Resolution", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: {
+                mount: "pull-request",
+                async resolve() {
+                  return {
+                    mount: "docs",
+                    async getKeys() {
+                      return ["summary.md"]
+                    },
+                    async getItem(key: string) {
+                      return { content: "review", key }
+                    },
+                  }
+                },
+                async getKeys() {
+                  return []
+                },
+                async getItem(key: string) {
+                  return { content: "", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {
+          docs: {
+            mount: "docs",
+            async getKeys() {
+              return ["README.md"]
+            },
+            async getItem(key: string) {
+              return { content: "docs", key }
+            },
+          },
+        },
+      },
+    })).rejects.toThrow('workspace contribution source "pullRequest" conflicts with Workspace Source "docs"')
+  })
+
+  it("rejects capability workspace sources that shadow existing Workspace paths", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const workspace = writableWorkspace()
+    await workspace.fs.writeFile("pull-request", "existing")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: {
+                materialize: "lazy",
+                mount: "pull-request",
+                async getKeys() {
+                  return ["summary.md"]
+                },
+                async getItem(key: string) {
+                  return { content: "review", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, workspace as never, "write", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow('workspace contribution source "pullRequest" conflicts with an existing Workspace path at mount "pull-request"')
+  })
+
+  it("resolves capability workspace sources after access selects Workspace Scope", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+    const resolveSource = vi.fn(({ selectedWorkspaceScope }) => {
+      if (!selectedWorkspaceScope?.name) return false
+      return {
+        materialize: "lazy" as const,
+        mount: `ingestion/${selectedWorkspaceScope.name}`,
+        async getKeys() {
+          return ["orders.sql"]
+        },
+        async getItem(key: string) {
+          return { content: `select * from ${selectedWorkspaceScope.name}_orders\n`, key }
+        },
+      }
+    })
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "acme",
+            scopes: {
+              acme: { paths: ["ingestion/acme"] },
+            },
+          },
+        }),
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: {
+                async resolve(context) {
+                  return resolveSource(context)
+                },
+                async getKeys() {
+                  return []
+                },
+                async getItem(key: string) {
+                  return { content: "", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    expect(resolveSource).toHaveBeenCalledWith(expect.objectContaining({
+      selectedWorkspaceScope: expect.objectContaining({ name: "acme" }),
+    }))
+    await expect(resolved.workspace?.fs.readFile("ingestion/acme/orders.sql")).resolves.toBe("select * from acme_orders\n")
+  })
+
   it("preserves writable workspace methods when applying workspace contributions", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const workspace = writableWorkspace()

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -483,6 +483,33 @@ describe("agent capability runtime", () => {
     })).rejects.toThrow('workspace contribution source "repository" conflicts with an existing Workspace path at mount ""')
   })
 
+  it("allows request-only capability workspace sources in non-empty Workspaces", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { fetch } = await import("@vite-hub/workspace")
+    const workspace = emptyWorkspace()
+    workspace.fs.list.mockResolvedValue([{ path: "README.md", type: "file" }] as never)
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              inventory: fetch({ url: "https://portal.example.com/runtime/inventory-health" }),
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, workspace as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    expect(resolved.workspaceDefinition?.sources).toHaveProperty("inventory")
+  })
+
   it("resolves capability workspace sources after access selects Workspace Scope", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
@@ -639,6 +666,48 @@ describe("agent capability runtime", () => {
     await expect(runAgent(agent, runtime(), {
       context: { mode: "technical" },
     })).rejects.toThrow('Invocation context value "mode" is already set')
+  })
+
+  it("ignores caller-supplied source-resolution definitions while applying workspace contributions", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            rules: {
+              "artifacts/**": { write: true },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {
+      context: {
+        "workspace.sourceResolution.definition": {
+          name: "review",
+          sources: {
+            injected: {
+              mount: "injected",
+              async getKeys() {
+                return ["secret.md"]
+              },
+              async getItem(key: string) {
+                return { content: "secret", key }
+              },
+            },
+          },
+        },
+      },
+    }, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    expect(resolved.workspaceDefinition?.sources).toEqual({})
+    expect(resolved.workspaceDefinition?.rules).toHaveProperty("artifacts/**")
   })
 
   it("closes streamed and Response outputs after consumption", async () => {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -230,7 +230,6 @@ describe("agent capability runtime", () => {
             },
             sources: {
               pullRequest: {
-                materialize: "lazy",
                 mount: "pull-request",
                 async getKeys() {
                   return ["summary.md"]
@@ -255,6 +254,7 @@ describe("agent capability runtime", () => {
     })
 
     await expect(resolved.workspace?.fs.readFile("pull-request/summary.md")).resolves.toBe("review context")
+    expect(resolved.workspaceDefinition?.sources?.pullRequest).toMatchObject({ materialize: "lazy" })
     expect(resolved.workspaceDefinition?.sources).toHaveProperty("pullRequest")
     expect(resolved.workspaceDefinition?.rules).toHaveProperty("artifacts/review/**")
     expect(resolved.registries.workspaceContributions).toEqual([
@@ -451,6 +451,38 @@ describe("agent capability runtime", () => {
     })).rejects.toThrow('workspace contribution source "pullRequest" conflicts with an existing Workspace path at mount "pull-request"')
   })
 
+  it("rejects root-mounted capability workspace sources that shadow existing Workspace paths", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const workspace = emptyWorkspace()
+    workspace.fs.list.mockResolvedValue([{ path: "README.md", type: "file" }] as never)
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              repository: {
+                mount: "",
+                async getKeys() {
+                  return ["README.md"]
+                },
+                async getItem(key: string) {
+                  return { content: "review", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, workspace as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow('workspace contribution source "repository" conflicts with an existing Workspace path at mount ""')
+  })
+
   it("resolves capability workspace sources after access selects Workspace Scope", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
@@ -508,6 +540,47 @@ describe("agent capability runtime", () => {
       selectedWorkspaceScope: expect.objectContaining({ name: "acme" }),
     }))
     await expect(resolved.workspace?.fs.readFile("ingestion/acme/orders.sql")).resolves.toBe("select * from acme_orders\n")
+  })
+
+  it("rejects static capability workspace sources outside the selected Workspace Scope", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: {
+                mount: "pull-request",
+                async getKeys() {
+                  return ["summary.md"]
+                },
+                async getItem(key: string) {
+                  return { content: "review", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {
+      context: {
+        access: {
+          workspaceScope: {
+            all: false,
+            paths: ["customers/acme"],
+            role: "viewer",
+            scope: "acme",
+          },
+        },
+      },
+    }, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow('workspace contribution source "pullRequest" is outside the selected Workspace Scope')
   })
 
   it("preserves writable workspace methods when applying workspace contributions", async () => {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -9,6 +9,22 @@ const runtime = () => ({
   waitUntil: vi.fn(),
 })
 
+const emptyWorkspace = () => ({
+  fs: {
+    exists: vi.fn(async () => false),
+    glob: vi.fn(async () => []),
+    list: vi.fn(async () => []),
+    materializeSources: vi.fn(async () => ({ bytes: 0, directories: 0, durationMs: 0, files: 0, path: "", sources: [] })),
+    readFile: vi.fn(async () => { throw new Error("missing") }),
+    search: vi.fn(async () => []),
+    stat: vi.fn(async () => { throw new Error("missing") }),
+  },
+  tools: {
+    inspect: vi.fn(() => ({})),
+    none: vi.fn(() => ({})),
+  },
+})
+
 describe("agent capability runtime", () => {
   it("runs lifecycle phases in capability order and closes in reverse order", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
@@ -153,6 +169,93 @@ describe("agent capability runtime", () => {
 
     expect(resolved.registries.deliveryEffectIntents).toEqual([{ intent: "started", kind: "reaction" }])
     expect(resolved.input.context).toBeUndefined()
+  })
+
+  it("applies capability workspace contributions before runtime surfaces resolve", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            rules: {
+              "artifacts/review/**": { write: true },
+            },
+            sources: {
+              pullRequest: {
+                materialize: "lazy",
+                mount: "pull-request",
+                async getKeys() {
+                  return ["summary.md"]
+                },
+                async getItem(key: string) {
+                  return {
+                    content: "review context",
+                    key,
+                    mediaType: "text/markdown",
+                  }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    await expect(resolved.workspace?.fs.readFile("pull-request/summary.md")).resolves.toBe("review context")
+    expect(resolved.workspaceDefinition?.sources).toHaveProperty("pullRequest")
+    expect(resolved.workspaceDefinition?.rules).toHaveProperty("artifacts/review/**")
+    expect(resolved.registries.workspaceContributions).toEqual([
+      {
+        capabilityId: "review",
+        rules: ["artifacts/review/**"],
+        sources: ["pullRequest"],
+      },
+    ])
+  })
+
+  it("rejects capability workspace source conflicts", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              docs: {
+                async getKeys() {
+                  return ["duplicate.md"]
+                },
+                async getItem(key: string) {
+                  return { content: "duplicate", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {
+          docs: {
+            async getKeys() {
+              return ["docs.md"]
+            },
+            async getItem(key: string) {
+              return { content: "docs", key }
+            },
+          },
+        },
+      },
+    })).rejects.toThrow('workspace contribution source "docs" conflicts')
   })
 
   it("rejects duplicate invocation context values", async () => {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -367,6 +367,35 @@ describe("agent capability runtime", () => {
     })).rejects.toThrow('workspace contribution rule "artifacts/review/**" conflicts with existing Workspace Rule "artifacts/**"')
   })
 
+  it("rejects capability workspace rules that overlap plugin rules", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            rules: {
+              "artifacts/review/**": { write: true },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        plugins: [
+          {
+            id: "limits",
+            rules: {
+              "artifacts/**": { write: true },
+            },
+          },
+        ],
+      },
+    })).rejects.toThrow('workspace contribution rule "artifacts/review/**" conflicts with existing Workspace Rule "artifacts/**"')
+  })
+
   it("rechecks capability workspace source mounts after Source Resolution", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 
@@ -503,11 +532,56 @@ describe("agent capability runtime", () => {
     }, runtime(), {}, workspace as never, "read", {
       workspaceDefinition: {
         name: "review",
+        sources: {
+          docs: {
+            mount: "docs",
+            async getKeys() {
+              return ["README.md"]
+            },
+            async getItem(key: string) {
+              return { content: "docs", key }
+            },
+          },
+        },
+      },
+    })
+
+    expect(resolved.workspaceDefinition?.sources).toHaveProperty("inventory")
+  })
+
+  it("allows request-only capability workspace sources selected by descriptor path", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+    const { fetch } = await import("@vite-hub/workspace")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "api",
+            scopes: {
+              api: { paths: [".vitehub/sources/inventory.json"] },
+            },
+          },
+        }),
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              inventory: fetch({ url: "https://portal.example.com/runtime/inventory-health" }),
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
         sources: {},
       },
     })
 
     expect(resolved.workspaceDefinition?.sources).toHaveProperty("inventory")
+    await expect(resolved.workspace?.fs.exists(".vitehub/sources/inventory.json")).resolves.toBe(true)
   })
 
   it("resolves capability workspace sources after access selects Workspace Scope", async () => {
@@ -571,8 +645,47 @@ describe("agent capability runtime", () => {
 
   it("rejects static capability workspace sources outside the selected Workspace Scope", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
 
     await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "acme",
+            scopes: {
+              acme: { paths: ["customers/acme"] },
+            },
+          },
+        }),
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: {
+                mount: "pull-request",
+                async getKeys() {
+                  return ["summary.md"]
+                },
+                async getItem(key: string) {
+                  return { content: "review", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow('workspace contribution source "pullRequest" is outside the selected Workspace Scope')
+  })
+
+  it("ignores caller-supplied Workspace Scope context while applying workspace contributions", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
       capabilities: [
         defineCapability({
           id: "review",
@@ -607,7 +720,32 @@ describe("agent capability runtime", () => {
         name: "review",
         sources: {},
       },
-    })).rejects.toThrow('workspace contribution source "pullRequest" is outside the selected Workspace Scope')
+    })
+
+    expect(resolved.workspaceDefinition?.sources).toHaveProperty("pullRequest")
+  })
+
+  it("validates workspace requirements before running capability workspace resolvers", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const resolveWorkspace = vi.fn(() => {
+      throw new Error("resolver should not run")
+    })
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          requires: [{ workspace: { mode: "write", required: true } }],
+          workspace: resolveWorkspace,
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow('review() requires workspace.mode: "write"')
+    expect(resolveWorkspace).not.toHaveBeenCalled()
   })
 
   it("preserves writable workspace methods when applying workspace contributions", async () => {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -544,7 +544,7 @@ describe("agent capability runtime", () => {
     await expect(resolved.workspace?.fs.readFile("pull-request/summary.md")).resolves.toBe("review context")
     const resolvedWorkspace = resolved.workspace as unknown as ReturnType<typeof writableWorkspace>
     await resolvedWorkspace.fs.writeFile("artifacts/review.md", "ok")
-    expect(workspace.fs.writeFile).toHaveBeenCalledWith("artifacts/review.md", "ok")
+    expect(workspace.fs.writeFile).toHaveBeenCalledWith("artifacts/review.md", "ok", undefined)
     expect(resolvedWorkspace.tools.write).toEqual(expect.any(Function))
   })
 

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -25,6 +25,52 @@ const emptyWorkspace = () => ({
   },
 })
 
+const writableWorkspace = () => {
+  const files = new Map<string, string>()
+  const fs = {
+    appendFile: vi.fn(async (path: string, content: string) => {
+      files.set(path, `${files.get(path) || ""}${content}`)
+    }),
+    copyPath: vi.fn(async (from: string, to: string) => {
+      files.set(to, files.get(from) || "")
+    }),
+    exists: vi.fn(async (path: string) => files.has(path)),
+    glob: vi.fn(async () => []),
+    list: vi.fn(async () => []),
+    mkdir: vi.fn(async () => {}),
+    movePath: vi.fn(async (from: string, to: string) => {
+      files.set(to, files.get(from) || "")
+      files.delete(from)
+    }),
+    readFile: vi.fn(async (path: string) => {
+      const content = files.get(path)
+      if (content === undefined) throw new Error("missing")
+      return content
+    }),
+    rm: vi.fn(async (path: string) => {
+      files.delete(path)
+    }),
+    search: vi.fn(async () => []),
+    stat: vi.fn(async () => { throw new Error("missing") }),
+    writeFile: vi.fn(async (path: string, content: string) => {
+      files.set(path, content)
+    }),
+  }
+  return {
+    diff: vi.fn(async () => ({ changes: [] })),
+    fs,
+    materializeSources: vi.fn(async () => ({ bytes: 0, directories: 0, durationMs: 0, files: 0, path: "", sources: [] })),
+    snapshot: vi.fn(async () => ({ id: "snapshot" })),
+    startSession: vi.fn(async () => ({ close: vi.fn() })),
+    sync: vi.fn(async () => ({ bytes: 0, created: 0, deleted: 0, updated: 0 })),
+    tools: {
+      inspect: vi.fn(() => ({})),
+      none: vi.fn(() => ({})),
+      write: vi.fn(() => ({})),
+    },
+  }
+}
+
 describe("agent capability runtime", () => {
   it("runs lifecycle phases in capability order and closes in reverse order", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
@@ -256,6 +302,83 @@ describe("agent capability runtime", () => {
         },
       },
     })).rejects.toThrow('workspace contribution source "docs" conflicts')
+  })
+
+  it("rejects capability workspace source conflicts inside one contribution", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              files: {
+                mount: "review/files",
+                async getKeys() {
+                  return []
+                },
+                async getItem(key: string) {
+                  return { content: "", key }
+                },
+              },
+              review: {
+                mount: "review",
+                async getKeys() {
+                  return []
+                },
+                async getItem(key: string) {
+                  return { content: "", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow('workspace contribution source "review" conflicts with contributed Workspace Source "files"')
+  })
+
+  it("preserves writable workspace methods when applying workspace contributions", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const workspace = writableWorkspace()
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: {
+                materialize: "lazy",
+                mount: "pull-request",
+                async getKeys() {
+                  return ["summary.md"]
+                },
+                async getItem(key: string) {
+                  return { content: "review context", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, workspace as never, "write", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    await expect(resolved.workspace?.fs.readFile("pull-request/summary.md")).resolves.toBe("review context")
+    const resolvedWorkspace = resolved.workspace as unknown as ReturnType<typeof writableWorkspace>
+    await resolvedWorkspace.fs.writeFile("artifacts/review.md", "ok")
+    expect(workspace.fs.writeFile).toHaveBeenCalledWith("artifacts/review.md", "ok")
+    expect(resolvedWorkspace.tools.write).toEqual(expect.any(Function))
   })
 
   it("rejects duplicate invocation context values", async () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1197,7 +1197,7 @@ describe("agent chat capability discovery", () => {
     })
 
     expect(materializedState.title).toBe("support")
-    expect(materializedState.files).toEqual([
+    expect(materializedState.files).toEqual(expect.arrayContaining([
       expect.objectContaining({
         children: [
           expect.objectContaining({
@@ -1218,13 +1218,7 @@ describe("agent chat capability discovery", () => {
         source: "ingestion",
         status: "ready",
       }),
-      expect.objectContaining({
-        materialized: false,
-        path: "portal",
-        source: "portal",
-        status: "lazy",
-      }),
-    ])
+    ]))
 
     const nextState = await invokeState(handlers[0]!, {
       action: "materialize-source",

--- a/packages/agent/test/pull-request-context.test.ts
+++ b/packages/agent/test/pull-request-context.test.ts
@@ -129,4 +129,27 @@ describe("pullRequestContext", () => {
       },
     ])
   })
+
+  it("rejects duplicate pull request context values before resolving trusted context", async () => {
+    const { pullRequestContext } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        pullRequestContext({
+          context: {
+            number: 42,
+            repository: "trusted/repo",
+          },
+        }),
+      ],
+    }, runtime(), {
+      context: {
+        pullRequest: {
+          number: 1,
+          repository: "caller/repo",
+        },
+      } as never,
+    })).rejects.toThrow('Invocation context value "pullRequest" is already set')
+  })
 })

--- a/packages/agent/test/pull-request-context.test.ts
+++ b/packages/agent/test/pull-request-context.test.ts
@@ -47,6 +47,28 @@ describe("pullRequestContext", () => {
     })).toThrow("pull-request-context() requires an explicit workspace")
   })
 
+  it("supports context-only usage without a workspace", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { pullRequestContext } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [
+        pullRequestContext({
+          context: {
+            number: 42,
+            repository: "acme/app",
+          },
+        }),
+      ],
+      run: ({ context }) => context.get("pullRequest"),
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toEqual({
+      number: 42,
+      repository: "acme/app",
+    })
+  })
+
   it("records pull request metadata and contributes workspace inputs", async () => {
     const { pullRequestContext } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
@@ -64,21 +86,24 @@ describe("pullRequestContext", () => {
           rules: {
             "artifacts/review/**": { write: true },
           },
-          sources: {
-            pullRequest: {
-              materialize: "lazy",
-              mount: "pull-request",
-              async getKeys() {
-                return ["body.md"]
+          sources: ({ context }) => {
+            const pullRequest = context.get("pullRequest") as { number: number } | undefined
+            return {
+              pullRequest: {
+                materialize: "lazy",
+                mount: "pull-request",
+                async getKeys() {
+                  return ["body.md"]
+                },
+                async getItem(key: string) {
+                  return {
+                    content: `PR ${pullRequest?.number} body`,
+                    key,
+                    mediaType: "text/markdown",
+                  }
+                },
               },
-              async getItem(key: string) {
-                return {
-                  content: "PR body",
-                  key,
-                  mediaType: "text/markdown",
-                }
-              },
-            },
+            }
           },
         }),
       ],
@@ -95,7 +120,7 @@ describe("pullRequestContext", () => {
       number: 42,
       repository: "acme/app",
     })
-    await expect(resolved.workspace?.fs.readFile("pull-request/body.md")).resolves.toBe("PR body")
+    await expect(resolved.workspace?.fs.readFile("pull-request/body.md")).resolves.toBe("PR 42 body")
     expect(resolved.registries.workspaceContributions).toEqual([
       {
         capabilityId: "pull-request-context",

--- a/packages/agent/test/pull-request-context.test.ts
+++ b/packages/agent/test/pull-request-context.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest"
+
+const runtime = () => ({
+  memo: vi.fn(),
+  runtime: "unknown" as const,
+  runtimeConfig: {},
+  waitUntil: vi.fn(),
+})
+
+const emptyWorkspace = () => ({
+  fs: {
+    exists: vi.fn(async () => false),
+    glob: vi.fn(async () => []),
+    list: vi.fn(async () => []),
+    materializeSources: vi.fn(async () => ({ bytes: 0, directories: 0, durationMs: 0, files: 0, path: "", sources: [] })),
+    readFile: vi.fn(async () => { throw new Error("missing") }),
+    search: vi.fn(async () => []),
+    stat: vi.fn(async () => { throw new Error("missing") }),
+  },
+  tools: {
+    inspect: vi.fn(() => ({})),
+    none: vi.fn(() => ({})),
+  },
+})
+
+describe("pullRequestContext", () => {
+  it("requires an explicit workspace when contributing sources", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { pullRequestContext } = await import("../src/capabilities.ts")
+
+    expect(() => defineAgent({
+      capabilities: [
+        pullRequestContext({
+          sources: {
+            pullRequest: {
+              async getKeys() {
+                return []
+              },
+              async getItem(key: string) {
+                return { content: "", key }
+              },
+            },
+          },
+        }),
+      ],
+      run: () => "ok",
+    })).toThrow("pull-request-context() requires an explicit workspace")
+  })
+
+  it("records pull request metadata and contributes workspace inputs", async () => {
+    const { pullRequestContext } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { createAgentInvocationContextStore } = await import("../src/invocation-context.ts")
+    const context = createAgentInvocationContextStore()
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        pullRequestContext({
+          context: {
+            headRef: "feature",
+            number: 42,
+            repository: "acme/app",
+          },
+          rules: {
+            "artifacts/review/**": { write: true },
+          },
+          sources: {
+            pullRequest: {
+              materialize: "lazy",
+              mount: "pull-request",
+              async getKeys() {
+                return ["body.md"]
+              },
+              async getItem(key: string) {
+                return {
+                  content: "PR body",
+                  key,
+                  mediaType: "text/markdown",
+                }
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      context,
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    expect(context.get("pullRequest")).toEqual({
+      headRef: "feature",
+      number: 42,
+      repository: "acme/app",
+    })
+    await expect(resolved.workspace?.fs.readFile("pull-request/body.md")).resolves.toBe("PR body")
+    expect(resolved.registries.workspaceContributions).toEqual([
+      {
+        capabilityId: "pull-request-context",
+        rules: ["artifacts/review/**"],
+        sources: ["pullRequest"],
+      },
+    ])
+  })
+})

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -8,7 +8,7 @@ import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentUsageRecord } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
-import { file, github as githubSource, source } from "@vite-hub/workspace"
+import { file, github as githubSource } from "@vite-hub/workspace"
 import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatPlatformResolver, AgentChatRunContext, FetchCapabilityToolOptions, PullRequestContextValue, RepositoryHostClient, TranscriptionResult, UsageTelemetryOutputExtension, UsageTelemetrySummaryOptions } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
@@ -103,7 +103,7 @@ describe("agent public types", () => {
             "artifacts/review/**": { write: true },
           },
           sources: {
-            pullRequest: source.file({ mount: "pull-request", path: "README.md" }),
+            pullRequest: file({ mount: "pull-request", path: "README.md" }),
           },
         }),
         skills(),

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,15 +1,15 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, type AgentActor, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDefinition, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentUsageRecord } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
-import { file, github as githubSource } from "@vite-hub/workspace"
-import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatPlatformResolver, AgentChatRunContext, FetchCapabilityToolOptions, RepositoryHostClient, TranscriptionResult, UsageTelemetryOutputExtension, UsageTelemetrySummaryOptions } from "../src/capabilities.ts"
+import { file, github as githubSource, source } from "@vite-hub/workspace"
+import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatPlatformResolver, AgentChatRunContext, FetchCapabilityToolOptions, PullRequestContextValue, RepositoryHostClient, TranscriptionResult, UsageTelemetryOutputExtension, UsageTelemetrySummaryOptions } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
   it("accepts capabilities from the capabilities entry", () => {
@@ -93,6 +93,18 @@ describe("agent public types", () => {
           mode: "write",
           policy: "require-approval",
           provider: "github",
+        }),
+        pullRequestContext({
+          context: {
+            number: 12,
+            repository: "acme/app",
+          } satisfies PullRequestContextValue,
+          rules: {
+            "artifacts/review/**": { write: true },
+          },
+          sources: {
+            pullRequest: source.file({ mount: "pull-request", path: "README.md" }),
+          },
         }),
         skills(),
         skills({ path: "skills/agent-browser", source: githubSource({ repo: "vercel/vercel-plugin", root: "skills/agent-browser" }) }),

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2686,8 +2686,14 @@ describe("defineAgent workspace option", () => {
   it("renders Capability Workspace Contribution source instructions in resolved DevTools metadata", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const { pullRequestContext } = await import("../src/capabilities.ts")
-    exists.mockImplementation(async path => path === "pull-request")
+    exists.mockResolvedValue(false)
     list.mockResolvedValue([])
+    const metadataWorkspace = readonlyWorkspaceFacade()
+    metadataWorkspace.fs.exists = vi.fn(async path => path === "pull-request")
+    createWorkspaceSourceResolutionFacade.mockImplementationOnce(async (_workspace, definition) => ({
+      definition,
+      workspace: metadataWorkspace,
+    }))
     const agent = withAgentDefaults(defineAgent({
       workspace: {},
       capabilities: [

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2683,6 +2683,43 @@ describe("defineAgent workspace option", () => {
     expect(createWorkspaceSourceResolutionFacade).toHaveBeenCalledOnce()
   })
 
+  it("renders Capability Workspace Contribution source instructions in resolved DevTools metadata", async () => {
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
+    const { pullRequestContext } = await import("../src/capabilities.ts")
+    exists.mockImplementation(async path => path === "pull-request")
+    list.mockResolvedValue([])
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      capabilities: [
+        pullRequestContext({
+          sources: {
+            pullRequest: {
+              instructions: "Use this source for pull-request review material.",
+              materialize: "lazy",
+              mount: "pull-request",
+              async getKeys() {
+                return []
+              },
+              async getItem(key: string) {
+                return { content: "", key }
+              },
+            },
+          },
+        }),
+      ],
+      instructions: "Answer from the workspace.\n\n{{ workspace.sources }}",
+      model: {} as never,
+    }), { workspace: "support" })
+
+    await expect(resolveAgentDevtoolsMetadata(agent)).resolves.toMatchObject({
+      instructions: [[
+        "Answer from the workspace.",
+        "## Workspace Sources",
+        "### pullRequest\n\nUse this source for pull-request review material.",
+      ].join("\n\n")],
+    })
+  })
+
   it("flattens virtual workspace AGENTS.md while keeping sibling instruction files", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     list.mockResolvedValue([

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2685,11 +2685,16 @@ describe("defineAgent workspace option", () => {
 
   it("renders Capability Workspace Contribution source instructions in resolved DevTools metadata", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
-    const { pullRequestContext } = await import("../src/capabilities.ts")
+    const { access, pullRequestContext } = await import("../src/capabilities.ts")
     exists.mockResolvedValue(false)
     list.mockResolvedValue([])
+    useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
     const metadataWorkspace = readonlyWorkspaceFacade()
     metadataWorkspace.fs.exists = vi.fn(async path => path === "pull-request")
+    createWorkspaceSourceResolutionFacade.mockImplementationOnce(async (workspace, definition) => ({
+      definition: { ...(definition as object) },
+      workspace,
+    }))
     createWorkspaceSourceResolutionFacade.mockImplementationOnce(async (_workspace, definition) => ({
       definition,
       workspace: metadataWorkspace,
@@ -2697,11 +2702,18 @@ describe("defineAgent workspace option", () => {
     const agent = withAgentDefaults(defineAgent({
       workspace: {},
       capabilities: [
+        access({
+          workspace: {
+            resolve: { role: "admin", scope: "review" },
+            scopes: {
+              review: { all: true },
+            },
+          },
+        }),
         pullRequestContext({
           sources: {
             pullRequest: {
               instructions: "Use this source for pull-request review material.",
-              materialize: "lazy",
               mount: "pull-request",
               async getKeys() {
                 return []

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -627,6 +627,8 @@ export interface Workspace {
   name: string
   sync(options: WorkspaceSyncOptions): Promise<WorkspaceSourceSyncResult>
   materializeSources?(options?: WorkspaceMaterializeSourcesOptions): Promise<WorkspaceMaterializeSourcesResult>
+  getMeta?(key: string): Promise<unknown>
+  setMeta?(key: string, value: unknown): Promise<void>
   readFile<TOptions extends ReadFileOptions | undefined = undefined>(path: string, options?: TOptions): Promise<ReadFileResult<TOptions>>
   writeFile(path: string, content: WorkspaceContent, options?: WriteFileOptions): Promise<void>
   list(path?: string, options?: ListOptions): Promise<WorkspaceEntry[]>

--- a/packages/workspace/src/core/use.ts
+++ b/packages/workspace/src/core/use.ts
@@ -116,7 +116,9 @@ export interface ReadonlyWorkspaceFacade<Name extends WorkspaceName = WorkspaceN
 export interface WritableWorkspaceFacade<Name extends WorkspaceName = WorkspaceName> {
   diff(options?: DiffOptions): Promise<WorkspaceDiff>
   fs: WritableWorkspaceFs<Name>
+  getMeta?(key: string): Promise<unknown>
   materializeSources(options?: WorkspaceMaterializeSourcesOptions): Promise<WorkspaceMaterializeSourcesResult>
+  setMeta?(key: string, value: unknown): Promise<void>
   snapshot(options?: SnapshotOptions): Promise<WorkspaceSnapshot>
   startSession(options?: WorkspaceSessionOptions): Promise<WorkspaceSession>
   sync(options: WorkspaceSyncOptions): Promise<WorkspaceSourceSyncResult>
@@ -225,6 +227,12 @@ function createLazyWorkspace(name: WorkspaceName, definition?: WorkspaceDefiniti
     },
     async diff(options) {
       return await (await resolveSyncedWorkspace()).diff(options)
+    },
+    async getMeta(key) {
+      return await (await resolveWorkspace()).getMeta?.(key)
+    },
+    async setMeta(key, value) {
+      await (await resolveWorkspace()).setMeta?.(key, value)
     },
     async startSession(options) {
       return await (await resolveSyncedWorkspace()).startSession(options)
@@ -461,7 +469,9 @@ export function useWorkspace<Name extends WorkspaceName>(name: Name, options?: U
     return {
       diff: async options => await workspace.diff(options),
       fs: createWritableFs<Name>(workspace),
+      getMeta: async key => await workspace.getMeta?.(key),
       materializeSources: async options => await materializeWorkspaceSources(workspace, options),
+      setMeta: async (key, value) => await workspace.setMeta?.(key, value),
       snapshot: async options => await workspace.snapshot(options),
       startSession: async options => await workspace.startSession(options),
       sync: async options => await workspace.sync(options),

--- a/packages/workspace/src/core/workspace.ts
+++ b/packages/workspace/src/core/workspace.ts
@@ -37,6 +37,12 @@ export function createWorkspace(definition: WorkspaceDefinition): Workspace {
     async materializeSources(options) {
       return await files.materializeSources(options)
     },
+    async getMeta(key) {
+      return await store.getMeta?.(key)
+    },
+    async setMeta(key, value) {
+      await store.setMeta?.(key, value)
+    },
     async readFile(path, options) {
       return await files.readFile(path, options)
     },

--- a/packages/workspace/src/sources/request-execution.ts
+++ b/packages/workspace/src/sources/request-execution.ts
@@ -1,5 +1,5 @@
 import { createSourceContext, normalizeWorkspaceSources } from "./config.ts"
-import { getWorkspaceSourceRequestExecutor } from "./request-metadata.ts"
+import { getWorkspaceSourceRequestExecutor, workspaceSourceRequestDescriptorPath } from "./request-metadata.ts"
 
 import type {
   WorkspaceDefinition,
@@ -34,6 +34,7 @@ export function createWorkspaceSourceRequestExecution(
 ): WorkspaceSourceRequestExecutionTarget | undefined {
   const sources = normalizeWorkspaceSources(definition.sources)
     .filter(source => source.requestDescriptor && getWorkspaceSourceRequestExecutor(source.source))
+    .filter(source => sourceRequestVisible(source, options.selectedWorkspaceScope))
 
   if (!sources.length) return undefined
 
@@ -61,6 +62,24 @@ export function createWorkspaceSourceRequestExecution(
       }, undefined, { selectedWorkspaceScope: options.selectedWorkspaceScope }))
     },
   }
+}
+
+function sourceRequestVisible(
+  source: ReturnType<typeof normalizeWorkspaceSources>[number],
+  scope: WorkspaceSelectedScope | undefined,
+): boolean {
+  if (!scope || scope.all) return true
+  const descriptorPath = workspaceSourceRequestDescriptorPath(source.key)
+  return Boolean(scope.paths?.some(path => pathIntersects(path, descriptorPath) || !source.requestOnly && pathIntersects(path, source.mountPath)))
+}
+
+function pathContains(container: string, path: string): boolean {
+  if (!container || !path) return container === path
+  return path === container || path.startsWith(`${container}/`)
+}
+
+function pathIntersects(left: string, right: string): boolean {
+  return pathContains(left, right) || pathContains(right, left)
 }
 
 function sameRequestTarget(left: string, right: string): boolean {

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -24,6 +24,7 @@ import type {
 
 export interface WorkspaceSourceResolutionOptions {
   invocation: WorkspaceSourceResolutionInvocation<object>
+  overlay?: boolean
   selectedWorkspaceScope?: WorkspaceSelectedScope<string>
 }
 
@@ -63,7 +64,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
   const sourceRequestExecution = createWorkspaceSourceRequestExecution(resolvedDefinition, {
     selectedWorkspaceScope: options.selectedWorkspaceScope,
   })
-  if (resolvedDefinition === definition && !sourceRequestExecution) return { definition, workspace }
+  if (!options.overlay && resolvedDefinition === definition && !sourceRequestExecution) return { definition, workspace }
 
   const sourceView = createWorkspaceSourceView(resolvedDefinition, createMemoryWorkspaceStore())
   const fs: ReadonlyWorkspaceFacade<Name>["fs"] = attachWorkspaceSourceRequestExecution({

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -6,7 +6,14 @@ import { attachWorkspaceSourceRequestExecution, createWorkspaceSourceRequestExec
 import { resolveWorkspacePath } from "./resolver.ts"
 import { createWorkspaceSourceView } from "./view.ts"
 
-import type { WorkspaceFacadeToolOptions, ReadonlyWorkspaceFacade, WorkspaceReadToolSet } from "../core/use.ts"
+import type {
+  ReadonlyWorkspaceFacade,
+  WorkspaceFacadeToolOptions,
+  WorkspaceReadToolSet,
+  WorkspaceWriteToolSet,
+  WritableWorkspaceFacade,
+  WritableWorkspaceFacadeToolOptions,
+} from "../core/use.ts"
 import type {
   ListOptions,
   WorkspaceDefinition,
@@ -35,6 +42,21 @@ export interface WorkspaceSourceResolutionFacade<Name extends WorkspaceName = Wo
 
 export function hasWorkspaceSourceResolvers(definition: Pick<WorkspaceDefinition, "sources"> | undefined): boolean {
   return normalizeWorkspaceSources(definition?.sources).some(source => typeof source.source.resolve === "function")
+}
+
+function isWritableWorkspaceFacade<Name extends WorkspaceName>(workspace: ReadonlyWorkspaceFacade<Name>): workspace is WritableWorkspaceFacade<Name> {
+  return typeof (workspace as WritableWorkspaceFacade<Name>).fs.writeFile === "function"
+}
+
+function writeOperations(options: WritableWorkspaceFacadeToolOptions | undefined) {
+  return {
+    appendFile: options?.appendFile !== false,
+    copyPath: options?.copyPath !== false,
+    deletePath: options?.deletePath !== false,
+    makeDir: options?.makeDir !== false,
+    movePath: options?.movePath !== false,
+    writeFile: options?.writeFile !== false,
+  }
 }
 
 export async function resolveWorkspaceSources(
@@ -67,6 +89,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
   if (!options.overlay && resolvedDefinition === definition && !sourceRequestExecution) return { definition, workspace }
 
   const sourceView = createWorkspaceSourceView(resolvedDefinition, createMemoryWorkspaceStore())
+  const materializeSources = async (options = {}) => await sourceView.materializeSources(options)
   const fs: ReadonlyWorkspaceFacade<Name>["fs"] = attachWorkspaceSourceRequestExecution({
     async readFile(path, options) {
       if (isSourcePath(resolvedDefinition, path) || await sourceViewHasPath(resolvedDefinition, sourceView, path)) {
@@ -108,9 +131,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
       ])
       return mergeHits(filterBaseHits(resolvedDefinition, baseHits), sourceHits).slice(0, query.limit ?? 100)
     },
-    async materializeSources(options = {}) {
-      return await sourceView.materializeSources(options)
-    },
+    materializeSources,
   }, sourceRequestExecution)
 
   const createTools = (options?: WorkspaceFacadeToolOptions) => createWorkspaceTools(fs, {
@@ -129,6 +150,63 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
   const tools = createTools() as WorkspaceReadToolSet
   tools.inspect = createTools as unknown as WorkspaceReadToolSet["inspect"]
   tools.none = (() => ({})) as WorkspaceReadToolSet["none"]
+
+  if (isWritableWorkspaceFacade(workspace)) {
+    const writeFs: WritableWorkspaceFacade<Name>["fs"] = attachWorkspaceSourceRequestExecution({
+      ...workspace.fs,
+      exists: fs.exists,
+      glob: fs.glob,
+      list: fs.list,
+      readFile: fs.readFile,
+      search: fs.search,
+      stat: fs.stat,
+    }, sourceRequestExecution)
+    const writeWorkspace = attachWorkspaceSourceRequestExecution({
+      diff: workspace.diff,
+      exists: writeFs.exists,
+      glob: writeFs.glob,
+      list: writeFs.list,
+      materializeSources,
+      mkdir: writeFs.mkdir,
+      readFile: writeFs.readFile,
+      rm: writeFs.rm,
+      search: writeFs.search,
+      snapshot: workspace.snapshot,
+      startSession: workspace.startSession,
+      stat: writeFs.stat,
+      sync: workspace.sync,
+      writeFile: writeFs.writeFile,
+    }, sourceRequestExecution)
+    const createWriteTools = (options?: WritableWorkspaceFacadeToolOptions) => createWorkspaceTools(writeWorkspace as never, {
+      broadSearchPaths: options?.broadSearchPaths,
+      cwd: options?.cwd,
+      maxShellCalls: options?.maxShellCalls,
+      maxOutputLength: options?.maxOutputLength,
+      operations: {
+        list: options?.list,
+        materialize: options?.materialize ?? true,
+        read: options?.read,
+        search: options?.search,
+        write: writeOperations(options),
+      },
+      timeout: options?.timeout,
+    })
+    const writeTools = createWriteTools() as WorkspaceWriteToolSet
+    writeTools.inspect = createTools as unknown as WorkspaceWriteToolSet["inspect"]
+    writeTools.none = (() => ({})) as WorkspaceWriteToolSet["none"]
+    writeTools.write = createWriteTools as unknown as WorkspaceWriteToolSet["write"]
+    const writableWorkspace: WritableWorkspaceFacade<Name> = {
+      ...workspace,
+      fs: writeFs,
+      materializeSources,
+      tools: writeTools,
+    }
+
+    return {
+      definition: resolvedDefinition,
+      workspace: writableWorkspace,
+    }
+  }
 
   return {
     definition: resolvedDefinition,

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -1,5 +1,7 @@
 import { createWorkspaceTools } from "../ai.ts"
 import { normalizeWorkspacePath } from "../core/path.ts"
+import { createWorkspaceWritePolicy } from "../core/rules.ts"
+import { appendWorkspaceFile, copyWorkspacePath } from "../fs-ops.ts"
 import { createBasicWorkspaceSession } from "../session/basic.ts"
 import { createMemoryWorkspaceStore } from "../storage/memory.ts"
 import { copyWorkspaceSourceMetadata, normalizeWorkspaceSource, normalizeWorkspaceSources } from "./config.ts"
@@ -26,6 +28,7 @@ import type {
   WorkspaceSearchHit,
   WorkspaceSearchQuery,
   WorkspaceStore,
+  WorkspaceWriteInput,
   WorkspaceSelectedScope,
   WorkspaceSource,
   WorkspaceSourceInput,
@@ -66,10 +69,12 @@ function writeOperations(options: WritableWorkspaceFacadeToolOptions | undefined
 
 function createOverlaySourceStore<Name extends WorkspaceName>(
   workspace: ReadonlyWorkspaceFacade<Name>,
+  fallback: (path: string) => boolean,
 ): WorkspaceStore {
   const memory = createMemoryWorkspaceStore()
 
   async function readBaseFile(path: string): Promise<WorkspaceFile | undefined> {
+    if (!fallback(path)) return
     if (!await workspace.fs.exists(path as never)) return
     const stat = await workspace.fs.stat(path as never).catch(() => undefined)
     if (stat?.type === "directory") return
@@ -82,7 +87,7 @@ function createOverlaySourceStore<Name extends WorkspaceName>(
 
   async function baseEntries(path = "", options?: ListOptions) {
     try {
-      return await workspace.fs.list(path as never, options)
+      return (await workspace.fs.list(path as never, options)).filter(entry => fallback(entry.path))
     }
     catch {
       return []
@@ -91,7 +96,7 @@ function createOverlaySourceStore<Name extends WorkspaceName>(
 
   async function baseGlob(pattern: string | string[], options?: GlobOptions) {
     try {
-      return await workspace.fs.glob(pattern as never, options)
+      return (await workspace.fs.glob(pattern as never, options)).filter(entry => fallback(entry.path))
     }
     catch {
       return []
@@ -99,6 +104,7 @@ function createOverlaySourceStore<Name extends WorkspaceName>(
   }
 
   async function baseStat(path: string) {
+    if (!fallback(path)) return
     try {
       return await workspace.fs.stat(path as never)
     }
@@ -185,7 +191,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
   })
   if (!options.overlay && resolvedDefinition === definition && !sourceRequestExecution) return { definition, workspace }
 
-  const sourceView = createWorkspaceSourceView(resolvedDefinition, createOverlaySourceStore(workspace))
+  const sourceView = createWorkspaceSourceView(resolvedDefinition, createOverlaySourceStore(workspace, path => !isLazySourcePath(resolvedDefinition, path)))
   const materializeSources = async (options = {}) => await sourceView.materializeSources(options)
   const fs: ReadonlyWorkspaceFacade<Name>["fs"] = attachWorkspaceSourceRequestExecution({
     async readFile(path, options) {
@@ -249,40 +255,68 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
   tools.none = (() => ({})) as WorkspaceReadToolSet["none"]
 
   if (isWritableWorkspaceFacade(workspace)) {
+    const writePolicy = createWorkspaceWritePolicy(resolvedDefinition)
+    let writeWorkspace!: Workspace
+
+    async function previousStat(path: string) {
+      try {
+        return await workspace.fs.stat(path as never)
+      }
+      catch {
+        return undefined
+      }
+    }
+
+    async function writeWithPolicy(
+      input: Omit<WorkspaceWriteInput, "previous" | "rule" | "workspace">,
+      write: (input: WorkspaceWriteInput) => Promise<void>,
+    ) {
+      await sourceView.assertWritable(input.path)
+      const next = await writePolicy.before({
+        ...input,
+        path: normalizeWorkspacePath(input.path),
+        previous: await previousStat(input.path),
+        workspace: resolvedDefinition.name,
+      })
+      try {
+        await sourceView.assertWritable(next.path)
+        await write(next)
+        await writePolicy.after(next)
+      }
+      catch (error) {
+        await writePolicy.error(next, error)
+        throw error
+      }
+    }
+
     const writeFs: WritableWorkspaceFacade<Name>["fs"] = attachWorkspaceSourceRequestExecution({
-      appendFile: async (path, content) => {
-        await sourceView.assertWritable(path)
-        await workspace.fs.appendFile(path, content)
-      },
-      copyPath: async (from, to, options) => {
-        await sourceView.assertWritable(to)
-        await workspace.fs.copyPath(from, to, options)
-      },
+      appendFile: async (path, content) => await appendWorkspaceFile(writeWorkspace, path, content),
+      copyPath: async (from, to, options) => await copyWorkspacePath(writeWorkspace, from, to, options?.overwrite),
       exists: fs.exists,
       glob: fs.glob,
       list: fs.list,
-      mkdir: async (path, options) => {
-        await sourceView.assertWritable(path)
-        await workspace.fs.mkdir(path, options)
-      },
+      mkdir: async (path, options) => await writeWithPolicy({
+        operation: "mkdir",
+        path,
+      }, async input => await workspace.fs.mkdir(input.path as never, options)),
       movePath: async (from, to, options) => {
-        await sourceView.assertWritable(from)
-        await sourceView.assertWritable(to)
-        await workspace.fs.movePath(from, to, options)
+        await copyWorkspacePath(writeWorkspace, from, to, options?.overwrite)
+        await writeWorkspace.rm(from, { recursive: true, force: true })
       },
       readFile: fs.readFile,
-      rm: async (path, options) => {
-        await sourceView.assertWritable(path)
-        await workspace.fs.rm(path, options)
-      },
+      rm: async (path, options) => await writeWithPolicy({
+        operation: "rm",
+        path,
+      }, async input => await workspace.fs.rm(input.path as never, options)),
       search: fs.search,
       stat: fs.stat,
-      writeFile: async (path, content, options) => {
-        await sourceView.assertWritable(path)
-        await workspace.fs.writeFile(path, content, options)
-      },
+      writeFile: async (path, content, options) => await writeWithPolicy({
+        content,
+        mediaType: options?.mediaType,
+        operation: "writeFile",
+        path,
+      }, async input => await workspace.fs.writeFile(input.path as never, input.content ?? content, input.mediaType === undefined ? options : { ...options, mediaType: input.mediaType })),
     }, sourceRequestExecution)
-    let writeWorkspace!: Workspace
     writeWorkspace = attachWorkspaceSourceRequestExecution({
       name: resolvedDefinition.name,
       diff: workspace.diff,
@@ -462,6 +496,13 @@ function sourcePathIntersects(definition: WorkspaceDefinition, path: string): bo
   return normalizeWorkspaceSources(definition.sources)
     .filter(source => source.materialize !== "none")
     .some(source => pathIntersects(source.mountPath, path))
+}
+
+function isLazySourcePath(definition: WorkspaceDefinition, path: string): boolean {
+  const normalized = normalizeWorkspacePath(path)
+  return normalizeWorkspaceSources(definition.sources)
+    .filter(source => source.materialize === "lazy")
+    .some(source => pathIntersects(source.mountPath, normalized))
 }
 
 function searchQueryTargetsSource(definition: WorkspaceDefinition, query: WorkspaceSearchQuery): boolean {

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -48,6 +48,11 @@ export interface WorkspaceSourceResolutionFacade<Name extends WorkspaceName = Wo
   workspace: ReadonlyWorkspaceFacade<Name>
 }
 
+type WorkspaceMetadataTarget = {
+  getMeta?(key: string): Promise<unknown>
+  setMeta?(key: string, value: unknown): Promise<void>
+}
+
 export function hasWorkspaceSourceResolvers(definition: Pick<WorkspaceDefinition, "sources"> | undefined): boolean {
   return normalizeWorkspaceSources(definition?.sources).some(source => typeof source.source.resolve === "function")
 }
@@ -152,6 +157,7 @@ function createOverlaySourceStore<Name extends WorkspaceName>(
 
 function createWritableFacadeStore(workspace: WritableWorkspaceFacade): WorkspaceStore {
   const meta = new Map<string, unknown>()
+  const metadata = workspace as WritableWorkspaceFacade & WorkspaceMetadataTarget
   return {
     async readFile(path) {
       try {
@@ -197,9 +203,14 @@ function createWritableFacadeStore(workspace: WritableWorkspaceFacade): Workspac
       return await workspace.diff(options)
     },
     async getMeta(key) {
+      if (metadata.getMeta) return await metadata.getMeta(key)
       return meta.get(key)
     },
     async setMeta(key, value) {
+      if (metadata.setMeta) {
+        await metadata.setMeta(key, value)
+        return
+      }
       meta.set(key, value)
     },
   }
@@ -221,9 +232,9 @@ export async function resolveWorkspaceSources(
   definition: WorkspaceDefinition,
   options: WorkspaceSourceResolutionOptions,
 ): Promise<WorkspaceDefinition> {
-  if (!hasWorkspaceSourceResolvers(definition)) return definition
+  if (!hasWorkspaceSourceResolvers(definition) && !options.selectedWorkspaceScope) return definition
 
-  const sources: Record<string, WorkspaceSource> = {}
+  const sources: Record<string, WorkspaceSourceInput> = {}
   for (const [key, source] of Object.entries(definition.sources || {})) {
     const resolved = await resolveWorkspaceSource(definition, key, source, options)
     if (resolved) sources[key] = resolved
@@ -311,6 +322,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
 
   if (isWritableWorkspaceFacade(workspace)) {
     const writePolicy = createWorkspaceWritePolicy(resolvedDefinition)
+    const syncStore = createWritableFacadeStore(workspace)
     let writeWorkspace!: Workspace
 
     async function previousStat(path: string) {
@@ -390,7 +402,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
       stat: writeFs.stat,
       sync: async (options) => {
         const { syncWorkspaceSources } = await import("./sync.ts")
-        return await syncWorkspaceSources(resolvedDefinition, createWritableFacadeStore(workspace), options)
+        return await syncWorkspaceSources(resolvedDefinition, syncStore, options)
       },
       writeFile: writeFs.writeFile,
       mount(options) {
@@ -460,10 +472,10 @@ async function resolveWorkspaceSource(
   key: string,
   input: WorkspaceSourceInput,
   options: WorkspaceSourceResolutionOptions,
-): Promise<WorkspaceSource | undefined> {
+): Promise<WorkspaceSourceInput | undefined> {
   const declared = normalizeWorkspaceSource(key, input)
   const source = declared.source
-  if (!source.resolve) return source
+  if (!source.resolve) return selectedScopeIntersectsSource(options.selectedWorkspaceScope, declared) ? input : undefined
 
   const context: WorkspaceSourceResolutionContext<object, string> = {
     invocation: options.invocation,
@@ -484,7 +496,7 @@ async function resolveWorkspaceSource(
 
   const resolvedSource = withResolvedSourceRuntimeDefaults(applyResolvedWorkspaceSourceBinding(input, resolved))
   const normalized = normalizeWorkspaceSource(key, resolvedSource)
-  if (!selectedScopeIntersectsMount(options.selectedWorkspaceScope, normalized.mountPath)) return undefined
+  if (!selectedScopeIntersectsSource(options.selectedWorkspaceScope, normalized)) return undefined
 
   return copyWorkspaceSourceMetadata(resolvedSource, {
     ...resolvedSource,
@@ -608,9 +620,15 @@ function mergeHits(base: WorkspaceSearchHit[], source: WorkspaceSearchHit[]): Wo
   })
 }
 
-function selectedScopeIntersectsMount(scope: WorkspaceSelectedScope | undefined, mountPath: string): boolean {
+function selectedScopeIntersectsSource(
+  scope: WorkspaceSelectedScope | undefined,
+  source: ReturnType<typeof normalizeWorkspaceSources>[number],
+): boolean {
   if (!scope || scope.all) return true
-  return Boolean(scope.paths?.some(path => pathIntersects(path, mountPath)))
+  return Boolean(scope.paths?.some((path) => {
+    if (source.requestDescriptor && pathIntersects(path, workspaceSourceRequestDescriptorPath(source.key))) return true
+    return !source.requestOnly && pathIntersects(path, source.mountPath)
+  }))
 }
 
 function pathContains(container: string, path: string): boolean {

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -4,7 +4,7 @@ import { createWorkspaceWritePolicy } from "../core/rules.ts"
 import { appendWorkspaceFile, copyWorkspacePath } from "../fs-ops.ts"
 import { createBasicWorkspaceSession } from "../session/basic.ts"
 import { createMemoryWorkspaceStore } from "../storage/memory.ts"
-import { copyWorkspaceSourceMetadata, normalizeWorkspaceSource, normalizeWorkspaceSources } from "./config.ts"
+import { copyWorkspaceSourceMetadata, normalizeWorkspaceSource, normalizeWorkspaceSources, workspaceSourceRequestDescriptorPath } from "./config.ts"
 import { attachWorkspaceSourceRequestExecution, createWorkspaceSourceRequestExecution, getWorkspaceSourceRequestExecution } from "./request-execution.ts"
 import { resolveWorkspacePath } from "./resolver.ts"
 import { createWorkspaceSourceView } from "./view.ts"
@@ -539,6 +539,7 @@ function isPlainRecord(input: unknown): input is Record<string, unknown> {
 }
 
 function isSourcePath(definition: WorkspaceDefinition, path: string): boolean {
+  if (isWorkspaceMetadataPath(path)) return false
   return resolveWorkspacePath(definition, path).type === "source"
 }
 
@@ -553,9 +554,21 @@ async function sourceViewHasPath(definition: WorkspaceDefinition, sourceView: Re
 }
 
 function sourcePathIntersects(definition: WorkspaceDefinition, path: string): boolean {
+  if (isWorkspaceMetadataPath(path)) return sourceDescriptorPathIntersects(definition, path)
   return normalizeWorkspaceSources(definition.sources)
     .filter(source => source.materialize !== "none")
     .some(source => pathIntersects(source.mountPath, path))
+}
+
+function isWorkspaceMetadataPath(path: string): boolean {
+  const normalized = normalizeWorkspacePath(path)
+  return normalized === ".vitehub" || normalized.startsWith(".vitehub/")
+}
+
+function sourceDescriptorPathIntersects(definition: WorkspaceDefinition, path: string): boolean {
+  const normalized = normalizeWorkspacePath(path)
+  return normalizeWorkspaceSources(definition.sources)
+    .some(source => source.requestDescriptor && pathIntersects(workspaceSourceRequestDescriptorPath(source.key), normalized))
 }
 
 function isLazySourcePath(definition: WorkspaceDefinition, path: string): boolean {

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -1,5 +1,6 @@
 import { createWorkspaceTools } from "../ai.ts"
 import { normalizeWorkspacePath } from "../core/path.ts"
+import { createBasicWorkspaceSession } from "../session/basic.ts"
 import { createMemoryWorkspaceStore } from "../storage/memory.ts"
 import { copyWorkspaceSourceMetadata, normalizeWorkspaceSource, normalizeWorkspaceSources } from "./config.ts"
 import { attachWorkspaceSourceRequestExecution, createWorkspaceSourceRequestExecution } from "./request-execution.ts"
@@ -15,12 +16,16 @@ import type {
   WritableWorkspaceFacadeToolOptions,
 } from "../core/use.ts"
 import type {
+  GlobOptions,
   ListOptions,
+  Workspace,
   WorkspaceDefinition,
   WorkspaceEntry,
+  WorkspaceFile,
   WorkspaceName,
   WorkspaceSearchHit,
   WorkspaceSearchQuery,
+  WorkspaceStore,
   WorkspaceSelectedScope,
   WorkspaceSource,
   WorkspaceSourceInput,
@@ -59,6 +64,98 @@ function writeOperations(options: WritableWorkspaceFacadeToolOptions | undefined
   }
 }
 
+function createOverlaySourceStore<Name extends WorkspaceName>(
+  workspace: ReadonlyWorkspaceFacade<Name>,
+): WorkspaceStore {
+  const memory = createMemoryWorkspaceStore()
+
+  async function readBaseFile(path: string): Promise<WorkspaceFile | undefined> {
+    if (!await workspace.fs.exists(path as never)) return
+    const stat = await workspace.fs.stat(path as never).catch(() => undefined)
+    if (stat?.type === "directory") return
+    return {
+      content: await workspace.fs.readFile(path as never, { encoding: "binary" } as never) as Uint8Array,
+      mediaType: stat?.mediaType,
+      path,
+    }
+  }
+
+  async function baseEntries(path = "", options?: ListOptions) {
+    try {
+      return await workspace.fs.list(path as never, options)
+    }
+    catch {
+      return []
+    }
+  }
+
+  async function baseGlob(pattern: string | string[], options?: GlobOptions) {
+    try {
+      return await workspace.fs.glob(pattern as never, options)
+    }
+    catch {
+      return []
+    }
+  }
+
+  async function baseStat(path: string) {
+    try {
+      return await workspace.fs.stat(path as never)
+    }
+    catch {
+      return undefined
+    }
+  }
+
+  return {
+    async readFile(path) {
+      return await memory.readFile(path) || await readBaseFile(path)
+    },
+    async writeFile(path, file) {
+      await memory.writeFile(path, file)
+    },
+    async list(path, options) {
+      return mergeEntries(await baseEntries(path, options), await memory.list(path, options))
+    },
+    async glob(pattern, options) {
+      return mergeEntries(await baseGlob(pattern, options), await memory.glob(pattern, options))
+    },
+    async stat(path) {
+      return await memory.stat(path) || await baseStat(path)
+    },
+    async mkdir(path, options) {
+      await memory.mkdir(path, options)
+    },
+    async rm(path, options) {
+      await memory.rm(path, options)
+    },
+    async snapshot(options) {
+      return await memory.snapshot(options)
+    },
+    async diff(options) {
+      return await memory.diff(options)
+    },
+    async getMeta(key) {
+      return await memory.getMeta?.(key)
+    },
+    async setMeta(key, value) {
+      await memory.setMeta?.(key, value)
+    },
+  }
+}
+
+async function startOverlayWorkspaceSession(definition: WorkspaceDefinition, workspace: Workspace) {
+  if (definition.runtime === "sandbox") {
+    const { createSandboxWorkspaceSession } = await import("../session/sandbox.ts")
+    return await createSandboxWorkspaceSession(definition, workspace)
+  }
+  if (definition.runtime === "trusted-host") {
+    const { createTrustedHostWorkspaceSession } = await import("../session/trusted-host.ts")
+    return await createTrustedHostWorkspaceSession(definition, workspace)
+  }
+  return createBasicWorkspaceSession(workspace)
+}
+
 export async function resolveWorkspaceSources(
   definition: WorkspaceDefinition,
   options: WorkspaceSourceResolutionOptions,
@@ -88,7 +185,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
   })
   if (!options.overlay && resolvedDefinition === definition && !sourceRequestExecution) return { definition, workspace }
 
-  const sourceView = createWorkspaceSourceView(resolvedDefinition, createMemoryWorkspaceStore())
+  const sourceView = createWorkspaceSourceView(resolvedDefinition, createOverlaySourceStore(workspace))
   const materializeSources = async (options = {}) => await sourceView.materializeSources(options)
   const fs: ReadonlyWorkspaceFacade<Name>["fs"] = attachWorkspaceSourceRequestExecution({
     async readFile(path, options) {
@@ -153,15 +250,41 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
 
   if (isWritableWorkspaceFacade(workspace)) {
     const writeFs: WritableWorkspaceFacade<Name>["fs"] = attachWorkspaceSourceRequestExecution({
-      ...workspace.fs,
+      appendFile: async (path, content) => {
+        await sourceView.assertWritable(path)
+        await workspace.fs.appendFile(path, content)
+      },
+      copyPath: async (from, to, options) => {
+        await sourceView.assertWritable(to)
+        await workspace.fs.copyPath(from, to, options)
+      },
       exists: fs.exists,
       glob: fs.glob,
       list: fs.list,
+      mkdir: async (path, options) => {
+        await sourceView.assertWritable(path)
+        await workspace.fs.mkdir(path, options)
+      },
+      movePath: async (from, to, options) => {
+        await sourceView.assertWritable(from)
+        await sourceView.assertWritable(to)
+        await workspace.fs.movePath(from, to, options)
+      },
       readFile: fs.readFile,
+      rm: async (path, options) => {
+        await sourceView.assertWritable(path)
+        await workspace.fs.rm(path, options)
+      },
       search: fs.search,
       stat: fs.stat,
+      writeFile: async (path, content, options) => {
+        await sourceView.assertWritable(path)
+        await workspace.fs.writeFile(path, content, options)
+      },
     }, sourceRequestExecution)
-    const writeWorkspace = attachWorkspaceSourceRequestExecution({
+    let writeWorkspace!: Workspace
+    writeWorkspace = attachWorkspaceSourceRequestExecution({
+      name: resolvedDefinition.name,
       diff: workspace.diff,
       exists: writeFs.exists,
       glob: writeFs.glob,
@@ -172,10 +295,27 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
       rm: writeFs.rm,
       search: writeFs.search,
       snapshot: workspace.snapshot,
-      startSession: workspace.startSession,
+      startSession: async () => await startOverlayWorkspaceSession(resolvedDefinition, writeWorkspace),
       stat: writeFs.stat,
       sync: workspace.sync,
       writeFile: writeFs.writeFile,
+      mount(options) {
+        const mode = options?.mode || "read-only"
+        return {
+          workspace: writeWorkspace,
+          mode,
+          target: options?.target || "/workspace",
+          async diff() {
+            return await writeWorkspace.diff()
+          },
+          async commit() {
+            await writeWorkspace.snapshot({ name: "mount-commit" })
+          },
+          async export() {
+            return await writeWorkspace.snapshot({ name: "mount-export" })
+          },
+        }
+      },
     }, sourceRequestExecution)
     const createWriteTools = (options?: WritableWorkspaceFacadeToolOptions) => createWorkspaceTools(writeWorkspace as never, {
       broadSearchPaths: options?.broadSearchPaths,
@@ -197,8 +337,12 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
     writeTools.write = createWriteTools as unknown as WorkspaceWriteToolSet["write"]
     const writableWorkspace: WritableWorkspaceFacade<Name> = {
       ...workspace,
+      diff: writeWorkspace.diff,
       fs: writeFs,
       materializeSources,
+      snapshot: writeWorkspace.snapshot,
+      startSession: writeWorkspace.startSession,
+      sync: writeWorkspace.sync,
       tools: writeTools,
     }
 

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -5,7 +5,7 @@ import { appendWorkspaceFile, copyWorkspacePath } from "../fs-ops.ts"
 import { createBasicWorkspaceSession } from "../session/basic.ts"
 import { createMemoryWorkspaceStore } from "../storage/memory.ts"
 import { copyWorkspaceSourceMetadata, normalizeWorkspaceSource, normalizeWorkspaceSources } from "./config.ts"
-import { attachWorkspaceSourceRequestExecution, createWorkspaceSourceRequestExecution } from "./request-execution.ts"
+import { attachWorkspaceSourceRequestExecution, createWorkspaceSourceRequestExecution, getWorkspaceSourceRequestExecution } from "./request-execution.ts"
 import { resolveWorkspacePath } from "./resolver.ts"
 import { createWorkspaceSourceView } from "./view.ts"
 
@@ -150,6 +150,61 @@ function createOverlaySourceStore<Name extends WorkspaceName>(
   }
 }
 
+function createWritableFacadeStore(workspace: WritableWorkspaceFacade): WorkspaceStore {
+  const meta = new Map<string, unknown>()
+  return {
+    async readFile(path) {
+      try {
+        const stat = await workspace.fs.stat(path as never)
+        if (stat.type === "directory") return
+        return {
+          content: await workspace.fs.readFile(path as never, { encoding: "binary" } as never) as Uint8Array,
+          mediaType: stat.mediaType,
+          path,
+        }
+      }
+      catch {
+        return undefined
+      }
+    },
+    async writeFile(path, file) {
+      await workspace.fs.writeFile(path as never, file.content, { mediaType: file.mediaType })
+    },
+    async list(path, options) {
+      return await workspace.fs.list(path as never, options)
+    },
+    async glob(pattern, options) {
+      return await workspace.fs.glob(pattern as never, options)
+    },
+    async stat(path) {
+      try {
+        return await workspace.fs.stat(path as never)
+      }
+      catch {
+        return undefined
+      }
+    },
+    async mkdir(path, options) {
+      await workspace.fs.mkdir(path as never, options)
+    },
+    async rm(path, options) {
+      await workspace.fs.rm(path as never, options)
+    },
+    async snapshot(options) {
+      return await workspace.snapshot(options)
+    },
+    async diff(options) {
+      return await workspace.diff(options)
+    },
+    async getMeta(key) {
+      return meta.get(key)
+    },
+    async setMeta(key, value) {
+      meta.set(key, value)
+    },
+  }
+}
+
 async function startOverlayWorkspaceSession(definition: WorkspaceDefinition, workspace: Workspace) {
   if (definition.runtime === "sandbox") {
     const { createSandboxWorkspaceSession } = await import("../session/sandbox.ts")
@@ -188,7 +243,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
   const resolvedDefinition = await resolveWorkspaceSources(definition, options)
   const sourceRequestExecution = createWorkspaceSourceRequestExecution(resolvedDefinition, {
     selectedWorkspaceScope: options.selectedWorkspaceScope,
-  })
+  }) ?? getWorkspaceSourceRequestExecution(workspace.fs)
   if (!options.overlay && resolvedDefinition === definition && !sourceRequestExecution) return { definition, workspace }
 
   const sourceView = createWorkspaceSourceView(resolvedDefinition, createOverlaySourceStore(workspace, path => !isLazySourcePath(resolvedDefinition, path)))
@@ -300,6 +355,8 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
         path,
       }, async input => await workspace.fs.mkdir(input.path as never, options)),
       movePath: async (from, to, options) => {
+        await sourceView.assertWritable(from)
+        await sourceView.assertWritable(to)
         await copyWorkspacePath(writeWorkspace, from, to, options?.overwrite)
         await writeWorkspace.rm(from, { recursive: true, force: true })
       },
@@ -331,7 +388,10 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
       snapshot: workspace.snapshot,
       startSession: async () => await startOverlayWorkspaceSession(resolvedDefinition, writeWorkspace),
       stat: writeFs.stat,
-      sync: workspace.sync,
+      sync: async (options) => {
+        const { syncWorkspaceSources } = await import("./sync.ts")
+        return await syncWorkspaceSources(resolvedDefinition, createWritableFacadeStore(workspace), options)
+      },
       writeFile: writeFs.writeFile,
       mount(options) {
         const mode = options?.mode || "read-only"

--- a/packages/workspace/src/sources/view.ts
+++ b/packages/workspace/src/sources/view.ts
@@ -34,6 +34,7 @@ import type {
 export interface WorkspaceSourceView {
   readFile<TOptions extends ReadFileOptions | undefined = undefined>(path: string, options?: TOptions): Promise<ReadFileResult<TOptions>>
   writeFile(path: string, content: WorkspaceContent, options?: WriteFileOptions): Promise<void>
+  assertWritable(path: string): Promise<void>
   list(path?: string, options?: ListOptions): Promise<WorkspaceEntry[]>
   glob(pattern: string | string[], options?: GlobOptions): Promise<WorkspaceEntry[]>
   search(query: WorkspaceSearchQuery): Promise<WorkspaceSearchHit[]>
@@ -311,7 +312,22 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
     }
   }
 
+  async function assertWritablePath(path: string) {
+    if (isDescriptorPath(normalizeWorkspacePath(path))) {
+      throw new WorkspaceError(`[vitehub] Source-backed workspace paths are read-only: ${path}.`)
+    }
+    const resolution = resolveWorkspacePath(definition, path)
+    if (isDescriptorPath(resolution.workspacePath)) {
+      throw new WorkspaceError(`[vitehub] Source-backed workspace paths are read-only: ${path}.`)
+    }
+    await assertWritableResolvedStorePath(path, resolution.workspacePath, resolution.type)
+    return resolution
+  }
+
   return {
+    async assertWritable(path) {
+      await assertWritablePath(path)
+    },
     async readFile(path, options) {
       const descriptorSource = descriptorSourceForPath(normalizeWorkspacePath(path))
       if (descriptorSource) return decodeFile(descriptorContent(descriptorSource), options)
@@ -331,14 +347,7 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
       return decodeFile(file.content, options)
     },
     async writeFile(path, content, options) {
-      if (isDescriptorPath(normalizeWorkspacePath(path))) {
-        throw new WorkspaceError(`[vitehub] Source-backed workspace paths are read-only: ${path}.`)
-      }
-      const resolution = resolveWorkspacePath(definition, path)
-      if (isDescriptorPath(resolution.workspacePath)) {
-        throw new WorkspaceError(`[vitehub] Source-backed workspace paths are read-only: ${path}.`)
-      }
-      await assertWritableResolvedStorePath(path, resolution.workspacePath, resolution.type)
+      const resolution = await assertWritablePath(path)
       const input = await writePolicy.before({
         content,
         mediaType: options?.mediaType,
@@ -432,14 +441,7 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
       return Boolean(await store.stat(resolution.workspacePath))
     },
     async mkdir(path, options) {
-      if (isDescriptorPath(normalizeWorkspacePath(path))) {
-        throw new WorkspaceError(`[vitehub] Source-backed workspace paths are read-only: ${path}.`)
-      }
-      const resolution = resolveWorkspacePath(definition, path)
-      if (isDescriptorPath(resolution.workspacePath)) {
-        throw new WorkspaceError(`[vitehub] Source-backed workspace paths are read-only: ${path}.`)
-      }
-      await assertWritableResolvedStorePath(path, resolution.workspacePath, resolution.type)
+      const resolution = await assertWritablePath(path)
       const input = await writePolicy.before({
         operation: "mkdir",
         path: resolution.workspacePath,
@@ -456,14 +458,7 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
       }
     },
     async rm(path, options) {
-      if (isDescriptorPath(normalizeWorkspacePath(path))) {
-        throw new WorkspaceError(`[vitehub] Source-backed workspace paths are read-only: ${path}.`)
-      }
-      const resolution = resolveWorkspacePath(definition, path)
-      if (isDescriptorPath(resolution.workspacePath)) {
-        throw new WorkspaceError(`[vitehub] Source-backed workspace paths are read-only: ${path}.`)
-      }
-      await assertWritableResolvedStorePath(path, resolution.workspacePath, resolution.type)
+      const resolution = await assertWritablePath(path)
       const input = await writePolicy.before({
         operation: "rm",
         path: resolution.workspacePath,

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -118,6 +118,7 @@ function writableFacade(workspace: ReturnType<typeof createWorkspace>): Writable
       stat: async path => await workspace.stat(path),
       writeFile: async (path, content, options) => await workspace.writeFile(path, content, options),
     },
+    getMeta: async key => await workspace.getMeta?.(key),
     materializeSources: async options => await workspace.materializeSources?.(options) ?? {
       bytes: 0,
       directories: 0,
@@ -126,6 +127,7 @@ function writableFacade(workspace: ReturnType<typeof createWorkspace>): Writable
       path: options?.path || "",
       sources: [],
     },
+    setMeta: async (key, value) => await workspace.setMeta?.(key, value),
     snapshot: async options => await workspace.snapshot(options),
     startSession: async options => await workspace.startSession(options),
     sync: async options => await workspace.sync(options),
@@ -426,6 +428,46 @@ describe("Workspace Source Resolution", () => {
     expect(resolved.sources).toEqual({})
   })
 
+  it("keeps scoped-out static sources hidden in overlays", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        privateDocs: custom({
+          materialize: "lazy",
+          mount: "private",
+          async getKeys() {
+            return ["secret.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "secret\n" }
+          },
+        }),
+        publicDocs: custom({
+          materialize: "lazy",
+          mount: "public",
+          async getKeys() {
+            return ["README.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "public\n" }
+          },
+        }),
+      },
+    }
+
+    const { definition: resolvedDefinition, workspace } = await createWorkspaceSourceResolutionFacade(
+      facade(base),
+      definition,
+      { ...scope("public", ["public"]), overlay: true },
+    )
+
+    expect(resolvedDefinition.sources).toHaveProperty("publicDocs")
+    expect(resolvedDefinition.sources).not.toHaveProperty("privateDocs")
+    await expect(workspace.fs.readFile("public/README.md")).resolves.toBe("public\n")
+    await expect(workspace.fs.exists("private/secret.md")).resolves.toBe(false)
+  })
+
   it("layers resolved source-backed paths over the base Workspace without persistent cross-scope materialization", async () => {
     const base = createWorkspace({ name: "support", store: { provider: "memory" } })
     await base.writeFile("notes.md", "base workspace\n")
@@ -573,6 +615,48 @@ describe("Workspace Source Resolution", () => {
       sources: [expect.objectContaining({ source: "docs", status: "ready" })],
     })
     await expect(base.readFile("docs/README.md")).resolves.toBe("# Docs\n")
+  })
+
+  it("persists Source Sync state across writable overlay facades", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    let keys = ["README.md", "old.md"]
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        docs: custom({
+          mount: "docs",
+          sync: { stale: "remove" },
+          async getKeys() {
+            return keys
+          },
+          async getItem(key) {
+            return { key, path: key, content: `# ${key}\n` }
+          },
+        }),
+      },
+    }
+
+    const first = await createWorkspaceSourceResolutionFacade(writableFacade(base), definition, {
+      invocation,
+      overlay: true,
+    })
+    await expect((first.workspace as WritableWorkspaceFacade).sync({ sources: ["docs"] })).resolves.toMatchObject({
+      status: "ready",
+    })
+    await expect(base.readFile("docs/old.md")).resolves.toBe("# old.md\n")
+
+    keys = ["README.md"]
+    const second = await createWorkspaceSourceResolutionFacade(writableFacade(base), definition, {
+      invocation,
+      overlay: true,
+    })
+    await expect((second.workspace as WritableWorkspaceFacade).sync({ sources: ["docs"] })).resolves.toMatchObject({
+      status: "ready",
+      sources: [expect.objectContaining({
+        counts: expect.objectContaining({ removed: 1 }),
+      })],
+    })
+    await expect(base.exists("docs/old.md")).resolves.toBe(false)
   })
 
   it("starts writable overlay sessions from contributed sources and rules", async () => {

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -9,6 +9,7 @@ import {
   type WorkspaceShellResult,
   workspaceSourceRequestDescriptorPath,
   type ReadonlyWorkspaceFacade,
+  type WritableWorkspaceFacade,
   type WorkspaceDefinition,
   type WorkspaceSourceResolutionOptions,
 } from "../src/index.ts"
@@ -88,6 +89,50 @@ function facade(workspace: ReturnType<typeof createWorkspace>): ReadonlyWorkspac
     tools: {
       inspect: () => ({}),
       none: () => ({}),
+    } as never,
+  }
+}
+
+function writableFacade(workspace: ReturnType<typeof createWorkspace>): WritableWorkspaceFacade {
+  return {
+    diff: async options => await workspace.diff(options),
+    fs: {
+      appendFile: async (path, content) => {
+        const current = await workspace.readFile(path).catch(() => "")
+        await workspace.writeFile(path, `${current}${content}`)
+      },
+      copyPath: async (from, to) => {
+        await workspace.writeFile(to, await workspace.readFile(from, { encoding: "binary" }))
+      },
+      exists: async path => await workspace.exists(path),
+      glob: async (pattern, options) => await workspace.glob(pattern as never, options),
+      list: async (path, options) => await workspace.list(path || "", options),
+      mkdir: async (path, options) => await workspace.mkdir(path, options),
+      movePath: async (from, to) => {
+        await workspace.writeFile(to, await workspace.readFile(from, { encoding: "binary" }))
+        await workspace.rm(from, { force: true, recursive: true })
+      },
+      readFile: async (path, options) => await workspace.readFile(path, options as never),
+      rm: async (path, options) => await workspace.rm(path, options),
+      search: async query => await workspace.search(query),
+      stat: async path => await workspace.stat(path),
+      writeFile: async (path, content, options) => await workspace.writeFile(path, content, options),
+    },
+    materializeSources: async options => await workspace.materializeSources?.(options) ?? {
+      bytes: 0,
+      directories: 0,
+      durationMs: 0,
+      files: 0,
+      path: options?.path || "",
+      sources: [],
+    },
+    snapshot: async options => await workspace.snapshot(options),
+    startSession: async options => await workspace.startSession(options),
+    sync: async options => await workspace.sync(options),
+    tools: {
+      inspect: () => ({}),
+      none: () => ({}),
+      write: () => ({}),
     } as never,
   }
 }
@@ -388,5 +433,102 @@ describe("Workspace Source Resolution", () => {
     await expect(workspace.fs.readFile("ingestion/acme/models/orders.sql")).resolves.toBe("select * from acme_orders\n")
     await expect(workspace.fs.exists("ingestion/globex/models/orders.sql")).resolves.toBe(false)
     await expect(base.exists("ingestion/acme/models/orders.sql")).resolves.toBe(false)
+  })
+
+  it("preserves base Workspace files for non-lazy sources in overlays", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    await base.writeFile("docs/README.md", "# Docs\n")
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        docs: custom({
+          mount: "docs",
+          async getKeys() {
+            return ["README.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "# Source docs\n" }
+          },
+        }),
+      },
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(facade(base), definition, {
+      invocation,
+      overlay: true,
+    })
+
+    await expect(workspace.fs.readFile("docs/README.md")).resolves.toBe("# Docs\n")
+  })
+
+  it("keeps source-backed paths read-only in writable overlays", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      rules: {
+        "artifacts/**": { write: true },
+      },
+      sources: {
+        pullRequest: custom({
+          materialize: "lazy",
+          mount: "pull-request",
+          async getKeys() {
+            return ["body.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "# Pull request\n" }
+          },
+        }),
+      },
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(writableFacade(base), definition, {
+      invocation,
+      overlay: true,
+    })
+    const writable = workspace as WritableWorkspaceFacade
+
+    await expect(writable.fs.readFile("pull-request/body.md")).resolves.toBe("# Pull request\n")
+    await expect(writable.fs.writeFile("pull-request/body.md", "nope")).rejects.toThrow("read-only")
+    await expect(writable.fs.mkdir("pull-request/new")).rejects.toThrow("read-only")
+    await expect(writable.fs.rm("pull-request/body.md")).rejects.toThrow("read-only")
+    await expect(writable.fs.copyPath("artifacts/missing.md", "pull-request/copy.md")).rejects.toThrow("read-only")
+
+    await writable.fs.writeFile("artifacts/review.md", "ok")
+    await expect(base.readFile("artifacts/review.md")).resolves.toBe("ok")
+  })
+
+  it("starts writable overlay sessions from contributed sources and rules", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      rules: {
+        "artifacts/**": { write: true },
+      },
+      sources: {
+        pullRequest: custom({
+          materialize: "lazy",
+          mount: "pull-request",
+          async getKeys() {
+            return ["body.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "# Pull request\n" }
+          },
+        }),
+      },
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(writableFacade(base), definition, {
+      invocation,
+      overlay: true,
+    })
+    const session = await (workspace as WritableWorkspaceFacade).startSession()
+
+    await expect(session.readFile("pull-request/body.md")).resolves.toBe("# Pull request\n")
+    await expect(session.writeFile("pull-request/body.md", "nope")).rejects.toThrow("read-only")
+    await session.writeFile("artifacts/session.md", "ok")
+    await session.commit({ message: "session" })
+    await expect(base.readFile("artifacts/session.md")).resolves.toBe("ok")
   })
 })

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -294,6 +294,9 @@ describe("Workspace Source Resolution", () => {
     const definition: WorkspaceDefinition = {
       name: "support",
       sources: {
+        hiddenInventory: fetch({
+          url: "https://portal.example.com/runtime/hidden-inventory",
+        }),
         inventoryHealthSummary: custom({
           async resolve() {
             return fetch({
@@ -374,9 +377,19 @@ describe("Workspace Source Resolution", () => {
     ) as WorkspaceShellResult
 
     expect(result).toMatchObject({ exitCode: 0, stdout: JSON.stringify({ status: "ok" }, null, 2) })
+    const hiddenResult = await workspace.tools.shell.execute!(
+      { command: "curl 'https://portal.example.com/runtime/hidden-inventory'" },
+      { toolCallId: "test", messages: [] } as never,
+    ) as WorkspaceShellResult
+
+    expect(hiddenResult).toMatchObject({
+      exitCode: 126,
+      stderr: expect.stringContaining("not visible in the selected workspace scope"),
+    })
     const init = request.mock.calls[0]?.[1] as RequestInit
     expect((init.headers as Headers).get("cookie")).toBe("auth_token=secret")
     expect((init.headers as Headers).get("x-scope")).toBe("support")
+    expect(request).toHaveBeenCalledOnce()
     expect(requestFactory).toHaveBeenCalledWith(expect.objectContaining({
       selectedWorkspaceScope: expect.objectContaining({ name: "support" }),
     }))
@@ -526,8 +539,40 @@ describe("Workspace Source Resolution", () => {
     await expect(writable.fs.writeFile("artifacts/review.md", "nope")).rejects.toThrow("limits writes")
     await writable.fs.writeFile("artifacts/review.md", "ok")
     await writable.fs.copyPath("pull-request/body.md", "artifacts/body.md")
+    await expect(writable.fs.movePath("pull-request/body.md", "artifacts/moved.md")).rejects.toThrow("read-only")
     await expect(base.readFile("artifacts/review.md")).resolves.toBe("ok")
     await expect(base.readFile("artifacts/body.md")).resolves.toBe("# Pull request\n")
+    await expect(base.exists("artifacts/moved.md")).resolves.toBe(false)
+  })
+
+  it("syncs contributed sources through writable overlays", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        docs: custom({
+          mount: "docs",
+          sync: true,
+          async getKeys() {
+            return ["README.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "# Docs\n" }
+          },
+        }),
+      },
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(writableFacade(base), definition, {
+      invocation,
+      overlay: true,
+    })
+
+    await expect((workspace as WritableWorkspaceFacade).sync({ sources: ["docs"] })).resolves.toMatchObject({
+      status: "ready",
+      sources: [expect.objectContaining({ source: "docs", status: "ready" })],
+    })
+    await expect(base.readFile("docs/README.md")).resolves.toBe("# Docs\n")
   })
 
   it("starts writable overlay sessions from contributed sources and rules", async () => {

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -461,12 +461,41 @@ describe("Workspace Source Resolution", () => {
     await expect(workspace.fs.readFile("docs/README.md")).resolves.toBe("# Docs\n")
   })
 
+  it("does not serve stale base files as lazy source output in overlays", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    await base.writeFile("ingestion/acme/old.sql", "stale\n")
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        ingestion: custom({
+          materialize: "lazy",
+          mount: "ingestion/acme",
+          async getKeys() {
+            return ["models/orders.sql"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "select 1\n" }
+          },
+        }),
+      },
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(facade(base), definition, {
+      invocation,
+      overlay: true,
+    })
+
+    await expect(workspace.fs.readFile("ingestion/acme/models/orders.sql")).resolves.toBe("select 1\n")
+    await expect(workspace.fs.readFile("ingestion/acme/old.sql")).rejects.toThrow("does not exist")
+  })
+
   it("keeps source-backed paths read-only in writable overlays", async () => {
     const base = createWorkspace({ name: "support", store: { provider: "memory" } })
     const definition: WorkspaceDefinition = {
       name: "support",
       rules: {
         "artifacts/**": { write: true },
+        "artifacts/review.md": { write: true, maxBytes: 2 },
       },
       sources: {
         pullRequest: custom({
@@ -492,10 +521,13 @@ describe("Workspace Source Resolution", () => {
     await expect(writable.fs.writeFile("pull-request/body.md", "nope")).rejects.toThrow("read-only")
     await expect(writable.fs.mkdir("pull-request/new")).rejects.toThrow("read-only")
     await expect(writable.fs.rm("pull-request/body.md")).rejects.toThrow("read-only")
-    await expect(writable.fs.copyPath("artifacts/missing.md", "pull-request/copy.md")).rejects.toThrow("read-only")
+    await expect(writable.fs.copyPath("pull-request/body.md", "pull-request/copy.md")).rejects.toThrow("read-only")
 
+    await expect(writable.fs.writeFile("artifacts/review.md", "nope")).rejects.toThrow("limits writes")
     await writable.fs.writeFile("artifacts/review.md", "ok")
+    await writable.fs.copyPath("pull-request/body.md", "artifacts/body.md")
     await expect(base.readFile("artifacts/review.md")).resolves.toBe("ok")
+    await expect(base.readFile("artifacts/body.md")).resolves.toBe("# Pull request\n")
   })
 
   it("starts writable overlay sessions from contributed sources and rules", async () => {


### PR DESCRIPTION
Adds Capability Workspace Contributions to `defineCapability()` so capabilities can contribute invocation-scoped Workspace Sources and Workspace Rules before agent driver surfaces are built. Contributions are add-only and fail on source, rule, and mount conflicts.

Adds `pullRequestContext()` as the reusable review intake capability. It records trusted pull-request metadata as invocation context, accepts lazy workspace sources/rules for review material, and stays out of markdown rendering or publication sinks.

Updates ADR 0069 and the Agent/Capability/Workspace glossaries to match the implemented direction.