### PR TITLE
feat(agent): expose workspace shell through skills

### DIFF
--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -8,29 +8,16 @@ import type {
   AgentRuntimeConfig,
   AgentToolSet,
 } from "../types.ts"
-import type { WorkspaceName, WorkspaceSession, WorkspaceSessionOptions, WorkspaceSourceInput } from "@vite-hub/workspace"
+import type { WorkspaceName, WorkspaceSourceInput } from "@vite-hub/workspace"
 
 export interface SkillsCapabilityOptions {
   instructions?: string | false
-  maxOutputLength?: number
   path?: string
   shellExecution?: AgentCapabilityMode
   source?: WorkspaceSourceInput
   sourceKey?: string
-  timeout?: number
 }
 
-interface SkillShellInput {
-  command?: string
-  cwd?: string
-  timeout?: number
-}
-
-type SkillShellWorkspace = {
-  startSession: (options?: WorkspaceSessionOptions) => Promise<WorkspaceSession>
-}
-
-const defaultMaxOutputLength = 30_000
 const skillFilename = "SKILL.md"
 
 function normalizeShellExecution(value: unknown): AgentCapabilityMode | undefined {
@@ -134,91 +121,26 @@ function renderSkillInstructions(options: {
     options.metadata.description ? `Description: ${options.metadata.description}` : "",
     `Read \`${options.skillPath}\` before using this skill.`,
     options.shellExecution
-      ? `Use the \`skill_shell\` tool for shell commands described by this skill. It runs inside \`${options.directoryPath || "."}\`${options.shellExecution === "write" ? " and commits successful changes back to the workspace" : ""}.`
+      ? `Use the Workspace Shell tools for shell commands described by this skill. They can inspect the workspace${options.shellExecution === "write" ? " and write changes back to it" : ""}.`
       : "",
   ].filter(Boolean).join("\n")
 }
 
-function isSkillShellWorkspace(workspace: unknown): workspace is SkillShellWorkspace {
-  return typeof workspace === "object"
-    && workspace !== null
-    && typeof (workspace as { startSession?: unknown }).startSession === "function"
-}
-
-function limitOutput(value: string, maxLength: number) {
-  if (value.length <= maxLength) return { output: value, truncated: false }
-  return {
-    output: `${value.slice(0, maxLength)}\n[vitehub] Output truncated after ${maxLength} characters.`,
-    truncated: true,
-  }
-}
-
-function skillShellInputSchema() {
-  return {
-    additionalProperties: false,
-    properties: {
-      command: { description: "Shell command from the mounted skill instructions.", type: "string" },
-      cwd: { description: "Workspace-relative directory. Defaults to the workspace root.", type: "string" },
-      timeout: { description: "Optional timeout in milliseconds for this command.", type: "number" },
-    },
-    required: ["command"],
-    type: "object",
-  }
-}
-
-function skillShellTools(
+function workspaceShellTools(
   mode: AgentCapabilityMode,
-  options: Required<Pick<SkillsCapabilityOptions, "maxOutputLength">> & Pick<SkillsCapabilityOptions, "timeout">,
-  directoryPath: string,
-  getSession: () => Promise<WorkspaceSession>,
+  workspace: { tools: { inspect: () => AgentToolSet, write?: () => AgentToolSet } } | undefined,
 ): AgentToolSet {
-  return {
-    skill_shell: {
-      description: [
-        "Run one shell command from the mounted skill instructions in the active Workspace Session.",
-        mode === "write"
-          ? "Successful commands are committed back to the workspace."
-          : "Workspace changes are discarded in read mode.",
-      ].join(" "),
-      async execute(input: unknown) {
-        const value = input as SkillShellInput
-        const command = value?.command?.trim()
-        if (!command) throw new Error("[vitehub] skill_shell requires a non-empty command.")
-        const session = await getSession()
-        try {
-          const result = await session.exec("bash", ["-lc", command], {
-            cwd: value.cwd ?? directoryPath,
-            timeout: value.timeout ?? options.timeout,
-          })
-          if (mode === "write" && result.exitCode === 0) await session.commit({ message: "skill shell" })
-          const stdout = limitOutput(result.stdout, options.maxOutputLength)
-          const stderr = limitOutput(result.stderr, options.maxOutputLength)
-          return {
-            args: result.args,
-            command,
-            cwd: value.cwd ?? directoryPath,
-            exitCode: result.exitCode,
-            outputTruncated: stdout.truncated || stderr.truncated,
-            stderr: stderr.output,
-            stdout: stdout.output,
-          }
-        }
-        finally {
-          await session.close()
-        }
-      },
-      inputSchema: skillShellInputSchema(),
-      name: "skill_shell",
-    },
-  }
+  if (!workspace) throw new Error("[vitehub] skills({ shellExecution }) requires an explicit workspace.")
+  return (mode === "write" && workspace.tools.write
+    ? workspace.tools.write()
+    : workspace.tools.inspect()) as AgentToolSet
 }
 
 export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDefinition {
   const path = options.path || "skills"
   const normalizedPath = normalizeSkillPath(path)
   const shellExecution = normalizeShellExecution(options.shellExecution)
-  const maxOutputLength = options.maxOutputLength ?? defaultMaxOutputLength
-  const workspaceRequirementMode = shellExecution ? "write" : "read"
+  const workspaceRequirementMode = shellExecution ?? "read"
   const skillPath = normalizedPath === skillFilename || normalizedPath.endsWith("/SKILL.md")
     ? normalizedPath
     : `${normalizedPath}/SKILL.md`
@@ -228,16 +150,6 @@ export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDe
         [options.sourceKey || skillSourceKey(directoryPath)]: sourceBinding(options.source, directoryPath),
       }
     : undefined
-
-  function getSessionResolver(context: { workspace?: unknown }): () => Promise<WorkspaceSession> {
-    return async () => {
-      const workspace = context.workspace
-      if (!isSkillShellWorkspace(workspace)) {
-        throw new Error("[vitehub] skills({ shellExecution }) requires an executable workspace session.")
-      }
-      return await workspace.startSession({ paths: [directoryPath] })
-    }
-  }
 
   return defineCapability({
     id: "skills",
@@ -255,19 +167,11 @@ export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDe
       ...(shellExecution ? { shellExecution } : {}),
       ...(workspaceSources ? { sourceKey: Object.keys(workspaceSources)[0] } : {}),
     },
-    prepare(context) {
-      if (shellExecution && !isSkillShellWorkspace(context.workspace)) {
-        throw new Error("[vitehub] skills({ shellExecution }) requires an executable workspace session.")
-      }
-    },
     requires: [{ primitive: "workspace", workspace: { mode: workspaceRequirementMode, paths: [skillPath], required: true } }],
     ...(workspaceSources ? { workspaceSources } : {}),
     ...(shellExecution
       ? {
-          tools: context => skillShellTools(shellExecution, {
-            maxOutputLength,
-            timeout: options.timeout,
-          }, directoryPath, getSessionResolver(context)),
+          tools: context => workspaceShellTools(shellExecution, context.workspace as never),
         }
       : {}),
   })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -108,6 +108,7 @@ describe("agent public types", () => {
         }),
         skills(),
         skills({ path: "skills/agent-browser", source: githubSource({ repo: "vercel/vercel-plugin", root: "skills/agent-browser" }) }),
+        skills({ path: "skills/agent-browser", shellExecution: "write", source: githubSource({ repo: "vercel/vercel-plugin", root: "skills/agent-browser" }) }),
         skills({ shellExecution: "read" }),
         skills({ shellExecution: "write" }),
         sandbox({ commands: ["node"] }),
@@ -175,6 +176,9 @@ describe("agent public types", () => {
 
     // @ts-expect-error skills shell execution mode must be read or write
     skills({ shellExecution: "allow" })
+
+    // @ts-expect-error skills delegates shell options to Workspace Shell tools
+    skills({ shellExecution: "read", timeout: 1000 })
 
     // @ts-expect-error git mode must be read or write
     git({ mode: "remote-write" })

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -14,6 +14,7 @@ const diff = vi.fn()
 const snapshot = vi.fn()
 const tools = vi.fn(() => ({}))
 const inspectTools = vi.fn(() => ({}))
+const writeTools = vi.fn(() => ({}))
 const createWorkspaceTools = vi.fn(() => ({}))
 const createWorkspaceSourceResolutionFacade = vi.fn(async (workspace: ReadonlyWorkspaceFacade | WritableWorkspaceFacade, definition: unknown) => ({ definition, workspace }))
 const getWorkspaceSourceRequestDescriptor = vi.fn((_: unknown): { method: string, url: string } | undefined => undefined)
@@ -188,6 +189,8 @@ describe("defineAgent workspace option", () => {
     tools.mockClear()
     inspectTools.mockReset()
     inspectTools.mockReturnValue({})
+    writeTools.mockReset()
+    writeTools.mockReturnValue({})
     createWorkspaceTools.mockReset()
     createWorkspaceTools.mockReturnValue({})
     createWorkspaceSourceResolutionFacade.mockClear()
@@ -280,7 +283,7 @@ describe("defineAgent workspace option", () => {
     expect(agentSettings.at(-1)?.instructions).toContain("Skill \"agent-browser\" is mounted at `skills/agent-browser`.")
     expect(agentSettings.at(-1)?.instructions).toContain("Description: Browser automation CLI for AI agents.")
     expect(agentSettings.at(-1)?.instructions).toContain("Read `skills/agent-browser/SKILL.md` before using this skill.")
-    expect(agentSettings.at(-1)?.instructions).toContain("Use the `skill_shell` tool")
+    expect(agentSettings.at(-1)?.instructions).toContain("Use the Workspace Shell tools")
   })
 
   it("records opt-in skill shell execution mode", async () => {
@@ -482,6 +485,50 @@ describe("defineAgent workspace option", () => {
     })
   })
 
+  it("attaches skill sources before validating the required skill path", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    const workspaceName = `review-${Math.random().toString(36).slice(2)}`
+    const skillSource = {
+      include: ["SKILL.md", "references/**", "templates/**"],
+      materialize: "lazy",
+      ref: "d9884256545389d67cfaba12cac9f8c60b5630e9",
+      repo: "vercel/vercel-plugin",
+      root: "skills/agent-browser",
+    }
+    let validated = false
+    exists.mockImplementationOnce(async (path) => {
+      expect(path).toBe("skills/agent-browser/SKILL.md")
+      expect(useWorkspace).toHaveBeenCalledWith(workspaceName, {
+        definition: expect.objectContaining({
+          sources: {
+            "skill.agent-browser": {
+              mount: "skills/agent-browser",
+              source: skillSource,
+            },
+          },
+        }),
+        mode: "read",
+      })
+      validated = true
+      return true
+    })
+
+    const agent = defineAgent({
+      capabilities: [
+        skills({
+          path: "skills/agent-browser",
+          source: skillSource as never,
+        }),
+      ],
+      model: {} as never,
+      workspace: { name: workspaceName },
+    })
+
+    await expect(agent.run!(context())).resolves.toBe("ok")
+    expect(validated).toBe(true)
+  })
+
   it("rejects duplicate capability source keys on shared named workspace references", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
@@ -512,33 +559,45 @@ describe("defineAgent workspace option", () => {
     await expect(agent.run!(context())).rejects.toThrow('Workspace source "instructions" is already defined.')
   })
 
-  it("exposes opt-in skill shell execution through a workspace session", async () => {
-    const session = {
-      close: vi.fn(),
-      commit: vi.fn(),
-      exec: vi.fn(async () => ({
-        args: ["-lc", "agent-browser snapshot -i"],
-        command: "bash",
-        exitCode: 0,
-        stderr: "",
-        stdout: "snapshot",
-      })),
-    }
-    const startSession = vi.fn(async () => session)
+  it("exposes read-mode skill shell execution through Workspace Shell inspect tools", async () => {
+    inspectTools.mockReturnValueOnce({
+      workspace_shell: { name: "workspace_shell" },
+    })
+    agentGenerate.mockImplementationOnce(async function (this: { settings: { tools: Record<string, unknown> } }) {
+      return { finishReason: "stop", text: Object.keys(this.settings.tools).sort().join(",") }
+    })
+    exists.mockResolvedValue(true)
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [skills({ path: "skills/agent-browser", shellExecution: "read" })],
+      model: {} as never,
+      workspace: {},
+    })
+
+    await expect(agent.run!(context())).resolves.toBe("workspace_shell")
+    expect(inspectTools).toHaveBeenCalledTimes(1)
+    expect(writeTools).not.toHaveBeenCalled()
+  })
+
+  it("exposes write-mode skill shell execution through Workspace Shell write tools", async () => {
+    writeTools.mockReturnValueOnce({
+      workspace_write: { name: "workspace_write" },
+    })
     useWorkspace.mockReturnValueOnce({
       diff,
       fs: { exists, list, readFile, writeFile },
       snapshot,
-      startSession,
       tools: Object.assign(tools, {
         inspect: inspectTools,
         none: vi.fn(() => ({})),
         readonly: inspectTools,
+        write: writeTools,
       }),
     } as unknown as WritableWorkspaceFacade)
-    agentGenerate.mockImplementationOnce(async function (this: { settings: { tools: Record<string, { execute: (input: unknown) => Promise<unknown> }> } }) {
-      const output = await this.settings.tools.skill_shell.execute({ command: "agent-browser snapshot -i" })
-      return { finishReason: "stop", text: JSON.stringify(output) }
+    agentGenerate.mockImplementationOnce(async function (this: { settings: { tools: Record<string, unknown> } }) {
+      return { finishReason: "stop", text: Object.keys(this.settings.tools).sort().join(",") }
     })
     exists.mockResolvedValue(true)
     const { defineAgent } = await import("../src/index.ts")
@@ -550,65 +609,15 @@ describe("defineAgent workspace option", () => {
       workspace: { mode: "write" },
     })
 
-    await expect(agent.run!(context())).resolves.toContain("snapshot")
-    expect(startSession).toHaveBeenCalledWith({ paths: ["skills/agent-browser"] })
-    expect(session.exec).toHaveBeenCalledWith("bash", ["-lc", "agent-browser snapshot -i"], {
-      cwd: "skills/agent-browser",
-      timeout: undefined,
-    })
-    expect(session.commit).toHaveBeenCalledWith({ message: "skill shell" })
-    expect(session.close).toHaveBeenCalledTimes(1)
+    await expect(agent.run!(context())).resolves.toBe("workspace_write")
+    expect(writeTools).toHaveBeenCalledTimes(1)
+    expect(inspectTools).not.toHaveBeenCalled()
   })
 
-  it("scopes root skill shell sessions to the workspace root", async () => {
-    const session = {
-      close: vi.fn(),
-      commit: vi.fn(),
-      exec: vi.fn(async () => ({
-        args: ["-lc", "echo root"],
-        command: "bash",
-        exitCode: 0,
-        stderr: "",
-        stdout: "root",
-      })),
-    }
-    const startSession = vi.fn(async () => session)
-    useWorkspace.mockReturnValueOnce({
-      diff,
-      fs: { exists, list, readFile, writeFile },
-      snapshot,
-      startSession,
-      tools: Object.assign(tools, {
-        inspect: inspectTools,
-        none: vi.fn(() => ({})),
-        readonly: inspectTools,
-      }),
-    } as unknown as WritableWorkspaceFacade)
-    agentGenerate.mockImplementationOnce(async function (this: { settings: { tools: Record<string, { execute: (input: unknown) => Promise<unknown> }> } }) {
-      const output = await this.settings.tools.skill_shell.execute({ command: "echo root" })
-      return { finishReason: "stop", text: JSON.stringify(output) }
-    })
+  it("allows read-mode skill shell execution on read workspaces", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
     exists.mockResolvedValue(true)
-    const { defineAgent } = await import("../src/index.ts")
-    const { skills } = await import("../src/capabilities.ts")
-
-    const agent = defineAgent({
-      capabilities: [skills({ path: "SKILL.md", shellExecution: "write" })],
-      model: {} as never,
-      workspace: { mode: "write" },
-    })
-
-    await expect(agent.run!(context())).resolves.toContain("root")
-    expect(startSession).toHaveBeenCalledWith({ paths: [""] })
-    expect(session.exec).toHaveBeenCalledWith("bash", ["-lc", "echo root"], {
-      cwd: "",
-      timeout: undefined,
-    })
-  })
-
-  it("requires writable workspace mode for read-mode skill shell execution", async () => {
-    const { defineAgent } = await import("../src/index.ts")
-    const { skills } = await import("../src/capabilities.ts")
 
     const agent = defineAgent({
       capabilities: [skills({ path: "skills/agent-browser", shellExecution: "read" })],
@@ -616,8 +625,7 @@ describe("defineAgent workspace option", () => {
       workspace: {},
     })
 
-    await expect(agent.run!(context())).rejects.toThrow('skills() requires workspace.mode: "write"')
-    expect(agentGenerate).not.toHaveBeenCalled()
+    await expect(agent.run!(context())).resolves.toBe("ok")
   })
 
   it("uses full file source paths as probe keys", async () => {
@@ -2370,6 +2378,36 @@ describe("defineAgent workspace option", () => {
           status: "available",
         }),
       ]),
+    })
+  })
+
+  it("includes skill sources in DevTools file metadata", async () => {
+    const { createAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      model: {} as never,
+      capabilities: [
+        skills({
+          path: "skills/agent-browser",
+          source: {
+            include: ["SKILL.md", "references/**", "templates/**"],
+            materialize: "lazy",
+            repo: "vercel/vercel-plugin",
+            root: "skills/agent-browser",
+          } as never,
+        }),
+      ],
+    }), { workspace: "support" })
+
+    expect(createAgentDevtoolsMetadata(agent).files).toContainEqual({
+      kind: "directory",
+      label: "agent-browser",
+      materialize: "lazy",
+      materialized: false,
+      path: "skills/agent-browser",
+      source: "skill.agent-browser",
+      status: "lazy",
     })
   })
 


### PR DESCRIPTION
Adds the upstream skills affordance Quiver needs: source-backed skills remain mounted through Workspace sources, and opt-in `skills({ shellExecution })` now exposes the normal Workspace Shell tool surface instead of a bespoke `skill_shell` tool.\n\nThe default `skills()` behavior stays read-only with no shell tools unless shell execution is explicitly requested.