### PR TITLE
feat(agent): add workspace exec capability

### DIFF
--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -67,6 +67,12 @@ export {
   workspaceShell,
 } from "./workspace-shell.ts"
 export {
+  workspaceExec,
+} from "./workspace-exec.ts"
+export type {
+  WorkspaceExecOptions,
+} from "./workspace-exec.ts"
+export {
   kv,
 } from "./storage/kv.ts"
 export {

--- a/packages/agent/src/capabilities/workspace-exec.ts
+++ b/packages/agent/src/capabilities/workspace-exec.ts
@@ -30,6 +30,11 @@ type WorkspaceExecWorkspace = {
 }
 
 const unsafeCommand = /[\s\x00-\x1F\x7F]/
+const blockedEnvKeys = new Set([
+  "NODE_OPTIONS",
+  "NODE_PATH",
+  "PATH",
+])
 
 function validateCommands(commands: unknown): string[] {
   if (!Array.isArray(commands) || !commands.length) {
@@ -71,8 +76,17 @@ function envRecord(value: unknown): Record<string, string> | undefined {
     throw new TypeError("[vitehub] workspace_exec env must be an object with string values.")
   }
   const env = value as Record<string, unknown>
-  if (Object.values(env).some(item => typeof item !== "string")) {
-    throw new TypeError("[vitehub] workspace_exec env must be an object with string values.")
+  for (const [key, item] of Object.entries(env)) {
+    if (!key || key.includes("=") || key.includes("\0")) {
+      throw new TypeError("[vitehub] workspace_exec env keys must be valid environment variable names.")
+    }
+    const normalizedKey = key.toUpperCase()
+    if (blockedEnvKeys.has(normalizedKey) || normalizedKey.startsWith("LD_") || normalizedKey.startsWith("DYLD_")) {
+      throw new TypeError("[vitehub] workspace_exec env cannot override PATH or loader-related variables.")
+    }
+    if (typeof item !== "string") {
+      throw new TypeError("[vitehub] workspace_exec env must be an object with string values.")
+    }
   }
   return env as Record<string, string>
 }

--- a/packages/agent/src/capabilities/workspace-exec.ts
+++ b/packages/agent/src/capabilities/workspace-exec.ts
@@ -1,0 +1,160 @@
+import {
+  defineCapability,
+  normalizeMode,
+} from "../capability-runtime.ts"
+import { defineInternalTool } from "./internal.ts"
+
+import type {
+  AgentCapabilityDefinition,
+  AgentCapabilityMode,
+  AgentToolSet,
+} from "../types.ts"
+import type { WorkspaceSession } from "@vite-hub/workspace"
+
+export interface WorkspaceExecOptions {
+  commands: string[]
+  mode?: AgentCapabilityMode
+  timeout?: number
+}
+
+interface WorkspaceExecInput {
+  args?: string[]
+  command: string
+  cwd?: string
+  env?: Record<string, string>
+  timeout?: number
+}
+
+type WorkspaceExecWorkspace = {
+  startSession: () => Promise<WorkspaceSession>
+}
+
+const unsafeCommand = /[\s\x00-\x1F\x7F]/
+
+function validateCommands(commands: unknown): string[] {
+  if (!Array.isArray(commands) || !commands.length) {
+    throw new TypeError("[vitehub] workspaceExec({ commands }) requires at least one command.")
+  }
+  for (const command of commands) {
+    if (typeof command !== "string" || !isValidCommand(command)) {
+      throw new TypeError("[vitehub] workspaceExec({ commands }) accepts simple executable names or absolute paths without whitespace/control characters.")
+    }
+  }
+  return commands
+}
+
+function isValidCommand(command: string): boolean {
+  if (!command || unsafeCommand.test(command)) return false
+  if (command.startsWith("/")) return command.length > 1 && !command.endsWith("/")
+  return command !== "." && command !== ".." && !command.includes("/")
+}
+
+function normalizeTimeout(value: unknown, label: string): number | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new TypeError(`[vitehub] ${label} must be a positive number.`)
+  }
+  return value
+}
+
+function stringArray(value: unknown, label: string): string[] {
+  if (value === undefined) return []
+  if (!Array.isArray(value) || value.some(item => typeof item !== "string")) {
+    throw new TypeError(`[vitehub] workspace_exec ${label} must be an array of strings.`)
+  }
+  return value
+}
+
+function envRecord(value: unknown): Record<string, string> | undefined {
+  if (value === undefined) return undefined
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("[vitehub] workspace_exec env must be an object with string values.")
+  }
+  const env = value as Record<string, unknown>
+  if (Object.values(env).some(item => typeof item !== "string")) {
+    throw new TypeError("[vitehub] workspace_exec env must be an object with string values.")
+  }
+  return env as Record<string, string>
+}
+
+function normalizeCwd(cwd: unknown): string {
+  if (cwd !== undefined && typeof cwd !== "string") {
+    throw new TypeError("[vitehub] workspace_exec cwd must be a string.")
+  }
+  const stripped = (cwd || "").replace(/\\/g, "/").replace(/^\/workspace(?:\/|$)/, "")
+  const parts = stripped.split("/").filter(Boolean)
+  if (parts.some(part => part === "." || part === "..")) {
+    throw new Error("[vitehub] workspace_exec cwd must stay inside the workspace.")
+  }
+  return parts.length ? `/workspace/${parts.join("/")}` : "/workspace"
+}
+
+function assertWorkspace(workspace: unknown): asserts workspace is WorkspaceExecWorkspace {
+  if (!workspace || typeof workspace !== "object" || typeof (workspace as { startSession?: unknown }).startSession !== "function") {
+    throw new Error("[vitehub] workspaceExec() requires an executable Workspace Session. Configure the agent with a writable workspace for trusted workspace/session execution.")
+  }
+}
+
+function workspaceExecTools(
+  commands: string[],
+  mode: AgentCapabilityMode,
+  timeout: number | undefined,
+  workspace: unknown,
+): AgentToolSet {
+  return {
+    workspace_exec: defineInternalTool({
+      description: `Run one configured command in a trusted Workspace Session at the workspace root. Allowed commands: ${commands.join(", ")}.`,
+      inputSchema: {
+        additionalProperties: false,
+        properties: {
+          args: { items: { type: "string" }, type: "array" },
+          command: { enum: commands, type: "string" },
+          cwd: { description: "Workspace-relative directory. Defaults to the workspace root.", type: "string" },
+          env: { additionalProperties: { type: "string" }, type: "object" },
+          timeout: { type: "number" },
+        },
+        required: ["command"],
+        type: "object",
+      },
+      name: "workspace_exec",
+      async execute(input: unknown) {
+        const value = input as WorkspaceExecInput
+        if (!value || typeof value.command !== "string") throw new TypeError("[vitehub] workspace_exec requires a command.")
+        if (!commands.includes(value.command)) throw new Error(`[vitehub] Workspace command "${value.command}" is not allowed.`)
+        const args = stringArray(value.args, "args")
+        const cwd = normalizeCwd(value.cwd)
+        const env = envRecord(value.env)
+        const commandTimeout = normalizeTimeout(value.timeout, "workspace_exec timeout") ?? timeout
+        assertWorkspace(workspace)
+        const session = await workspace.startSession()
+        try {
+          const result = await session.exec(value.command, args, { cwd, env, timeout: commandTimeout })
+          if (mode === "write" && result.exitCode === 0) await session.commit({ message: "workspace exec" })
+          return result
+        }
+        finally {
+          await session.close()
+        }
+      },
+    }),
+  }
+}
+
+export function workspaceExec(options: WorkspaceExecOptions): AgentCapabilityDefinition {
+  const commands = validateCommands(options?.commands)
+  const mode = normalizeMode(options?.mode, "Workspace Exec")
+  const timeout = normalizeTimeout(options?.timeout, "workspaceExec({ timeout })")
+  return defineCapability({
+    id: "workspace-exec",
+    instructions: [
+      `workspace_exec runs only configured commands in a trusted Workspace Session at the workspace root: ${commands.join(", ")}.`,
+      mode === "write"
+        ? "Successful commands are committed back to the Workspace Store. This is trusted workspace/session execution, not the read-only Workspace Shell."
+        : "Read mode requires a writable Workspace Session for trusted execution, but does not commit command changes. This is not the read-only Workspace Shell.",
+    ],
+    metadata: { commands, mode, ...(timeout ? { timeout } : {}) },
+    mode,
+    requires: [{ primitive: "workspace", workspace: { mode: "write", required: true } }],
+    tools: context => workspaceExecTools(commands, mode, timeout, context.workspace),
+  })
+}

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, type AgentActor, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDefinition, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceExec, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -57,6 +57,9 @@ describe("agent public types", () => {
         git(),
         git({ mode: "read" }),
         git({ mode: "write", policy: "require-approval" }),
+        workspaceExec({ commands: ["agent-browser", "/Users/maxi/quiver/agents/node_modules/.bin/agent-browser"] }),
+        workspaceExec({ commands: ["agent-browser"], mode: "read", timeout: 1_000 }),
+        workspaceExec({ commands: ["agent-browser"], mode: "write" }),
         inputCommands({
           commands: {
             review: {
@@ -182,6 +185,18 @@ describe("agent public types", () => {
 
     // @ts-expect-error git mode must be read or write
     git({ mode: "remote-write" })
+
+    // @ts-expect-error workspaceExec requires configured commands
+    workspaceExec()
+
+    // @ts-expect-error workspaceExec requires configured commands
+    workspaceExec({})
+
+    // @ts-expect-error workspaceExec mode must be read or write
+    workspaceExec({ commands: ["agent-browser"], mode: "execute" })
+
+    // @ts-expect-error workspaceExec timeout must be a number
+    workspaceExec({ commands: ["agent-browser"], timeout: "1000" })
 
     const invocationContext: AgentInvocationContextStore = {
       entries: () => new Map<string, unknown>().entries(),

--- a/packages/agent/test/workspace-exec-capability.test.ts
+++ b/packages/agent/test/workspace-exec-capability.test.ts
@@ -80,6 +80,17 @@ describe("workspaceExec capability", () => {
     expect(session.close).toHaveBeenCalledOnce()
   })
 
+  it("rejects env overrides that affect command resolution or loading", async () => {
+    const { startSession, tools } = await capabilityTools()
+
+    await expect(tools.workspace_exec!.execute?.({
+      command: "agent-browser",
+      env: { PATH: "/workspace/bin", NODE_OPTIONS: "--require ./loader.js" },
+    })).rejects.toThrow("cannot override PATH or loader-related variables")
+
+    expect(startSession).not.toHaveBeenCalled()
+  })
+
   it("commits successful write-mode commands", async () => {
     const { session, tools } = await capabilityTools(workspaceExec({ commands: ["agent-browser"], mode: "write" }))
 

--- a/packages/agent/test/workspace-exec-capability.test.ts
+++ b/packages/agent/test/workspace-exec-capability.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { workspaceExec } from "../src/capabilities.ts"
+
+import type { AgentCapabilityDefinition, AgentToolSet } from "../src/types.ts"
+import type { WorkspaceSession } from "@vite-hub/workspace"
+
+function workspaceSession(options: { exitCode?: number } = {}) {
+  return {
+    close: vi.fn(),
+    commit: vi.fn(),
+    exec: vi.fn(async (command: string, args: string[] = []) => ({
+      args,
+      command,
+      exitCode: options.exitCode ?? 0,
+      stderr: "",
+      stdout: "ok\n",
+    })),
+  } as unknown as WorkspaceSession & {
+    close: ReturnType<typeof vi.fn>
+    commit: ReturnType<typeof vi.fn>
+    exec: ReturnType<typeof vi.fn>
+  }
+}
+
+async function capabilityTools(
+  capability: AgentCapabilityDefinition = workspaceExec({ commands: ["agent-browser"] }),
+  session = workspaceSession(),
+): Promise<{ session: ReturnType<typeof workspaceSession>, startSession: ReturnType<typeof vi.fn>, tools: AgentToolSet }> {
+  if (typeof capability.tools !== "function") throw new Error("workspaceExec capability must expose tool resolver")
+  const startSession = vi.fn(async () => session)
+  const tools = await capability.tools({ workspace: { startSession } } as never) as AgentToolSet
+  return { session, startSession, tools }
+}
+
+describe("workspaceExec capability", () => {
+  it("validates configured commands and records workspace requirements", () => {
+    expect(workspaceExec({ commands: ["agent-browser", "/Users/maxi/quiver/agents/node_modules/.bin/agent-browser"] })).toMatchObject({
+      id: "workspace-exec",
+      metadata: {
+        commands: ["agent-browser", "/Users/maxi/quiver/agents/node_modules/.bin/agent-browser"],
+        mode: "read",
+      },
+      mode: "read",
+      requires: [{ workspace: { mode: "write", required: true } }],
+    })
+    expect(workspaceExec({ commands: ["agent-browser"], mode: "write" })).toMatchObject({
+      metadata: { mode: "write" },
+      requires: [{ workspace: { mode: "write", required: true } }],
+    })
+    expect(() => workspaceExec({ commands: [] })).toThrow("requires at least one command")
+    expect(() => workspaceExec({ commands: ["pnpm test"] })).toThrow("without whitespace")
+    expect(() => workspaceExec({ commands: ["./agent-browser"] })).toThrow("simple executable names or absolute paths")
+    expect(() => workspaceExec({ commands: ["agent-browser\n"] })).toThrow("without whitespace")
+  })
+
+  it("runs only allow-listed commands with structured exec options", async () => {
+    const command = "/Users/maxi/quiver/agents/node_modules/.bin/agent-browser"
+    const { session, startSession, tools } = await capabilityTools(workspaceExec({
+      commands: [command],
+      timeout: 5_000,
+    }))
+
+    await expect(tools.workspace_exec!.execute?.({
+      args: ["screenshot", "--output", "artifacts/browser.png"],
+      command,
+      cwd: "artifacts",
+      env: { NO_COLOR: "1" },
+      timeout: 1_000,
+    })).resolves.toMatchObject({ exitCode: 0, stdout: "ok\n" })
+    await expect(tools.workspace_exec!.execute?.({ command: "bash" })).rejects.toThrow("not allowed")
+
+    expect(startSession).toHaveBeenCalledOnce()
+    expect(session.exec).toHaveBeenCalledWith(command, ["screenshot", "--output", "artifacts/browser.png"], {
+      cwd: "/workspace/artifacts",
+      env: { NO_COLOR: "1" },
+      timeout: 1_000,
+    })
+    expect(session.commit).not.toHaveBeenCalled()
+    expect(session.close).toHaveBeenCalledOnce()
+  })
+
+  it("commits successful write-mode commands", async () => {
+    const { session, tools } = await capabilityTools(workspaceExec({ commands: ["agent-browser"], mode: "write" }))
+
+    await expect(tools.workspace_exec!.execute?.({ command: "agent-browser" })).resolves.toMatchObject({ exitCode: 0 })
+
+    expect(session.exec).toHaveBeenCalledWith("agent-browser", [], { cwd: "/workspace", env: undefined, timeout: undefined })
+    expect(session.commit).toHaveBeenCalledWith({ message: "workspace exec" })
+    expect(session.close).toHaveBeenCalledOnce()
+  })
+
+  it("does not commit read-mode or failed commands", async () => {
+    const read = await capabilityTools(workspaceExec({ commands: ["agent-browser"] }))
+    await expect(read.tools.workspace_exec!.execute?.({ command: "agent-browser" })).resolves.toMatchObject({ exitCode: 0 })
+    expect(read.session.commit).not.toHaveBeenCalled()
+    expect(read.session.close).toHaveBeenCalledOnce()
+
+    const failed = await capabilityTools(workspaceExec({ commands: ["agent-browser"], mode: "write" }), workspaceSession({ exitCode: 2 }))
+    await expect(failed.tools.workspace_exec!.execute?.({ command: "agent-browser" })).resolves.toMatchObject({ exitCode: 2 })
+    expect(failed.session.commit).not.toHaveBeenCalled()
+    expect(failed.session.close).toHaveBeenCalledOnce()
+  })
+
+  it("closes the workspace session when execution fails", async () => {
+    const session = workspaceSession()
+    session.exec.mockRejectedValueOnce(new Error("agent-browser failed"))
+    const { tools } = await capabilityTools(workspaceExec({ commands: ["agent-browser"], mode: "write" }), session)
+
+    await expect(tools.workspace_exec!.execute?.({ command: "agent-browser" })).rejects.toThrow("agent-browser failed")
+
+    expect(session.commit).not.toHaveBeenCalled()
+    expect(session.close).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
Adds a generic `workspaceExec()` Agent capability backed by Workspace Session command execution. The capability exposes a structured `workspace_exec` tool with configured command allow-listing, optional cwd/env/timeout fields, write-mode commits on successful commands, and no commits in read mode.

Checks run:
- `pnpm --filter @vite-hub/agent test -- --run test/workspace-exec-capability.test.ts`
- `pnpm --filter @vite-hub/agent typecheck`