### PR TITLE
feat(workspace): support public github sources

### DIFF
--- a/packages/source/src/sources/github/types.ts
+++ b/packages/source/src/sources/github/types.ts
@@ -4,7 +4,7 @@ export interface GitHubSourceOptions {
   repo: string
   ref?: string
   root?: string
-  auth?: string | (() => string | undefined)
+  auth?: false | string | (() => string | undefined)
   include?: string | string[]
   exclude?: string | string[]
   cache?: false | SourceCacheOptions

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -113,6 +113,19 @@ describe("@vite-hub/source GitHub source", () => {
     expect((archiveCall?.[1]?.headers as Record<string, string> | undefined)?.authorization).toBe("Bearer github-token")
   })
 
+  it("omits GitHub auth when auth is explicitly false", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    }, { apiStatus: 403 })
+
+    registerSources({ docs: github({ auth: false, repo: "acme/app", root: "docs" }) })
+
+    await expect(useSource("docs").keys()).resolves.toEqual(["README.md"])
+
+    const headers = vi.mocked(fetch).mock.calls.map(([, init]) => init?.headers as Record<string, string> | undefined)
+    expect(headers.every(header => header?.authorization === undefined)).toBe(true)
+  })
+
   it("keys GitHub archive cache by the resolved auth token", async () => {
     let token = "first-token"
     vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -39,7 +39,7 @@ describe("@vite-hub/source types", () => {
     expectTypeOf(mcpResources({ server: { transport: { type: "http", url: "https://example.com/mcp" } } })).toMatchTypeOf<Source<string>>()
     const sources = defineSources({
       docs: staticSource,
-      dynamic: github({ repo: "acme/app" }),
+      dynamic: github({ auth: false, repo: "acme/app" }),
     })
 
     registerSources(sources)

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -118,6 +118,7 @@ function inferRepositoryMount(repo: string | undefined) {
 }
 
 function createGitHubAuthResolver(auth: GitHubAuth | undefined, envFileToken?: string) {
+  if (auth === false) return false
   return () => {
     return resolveGitHubAuth(auth)
       || getActiveCloudflareBinding<string>("GITHUB_TOKEN")
@@ -127,5 +128,7 @@ function createGitHubAuthResolver(auth: GitHubAuth | undefined, envFileToken?: s
 }
 
 function resolveGitHubAuth(auth: GitHubAuth | undefined): string | undefined {
-  return typeof auth === "function" ? auth() : auth
+  if (auth === false) return undefined
+  if (typeof auth === "function") return auth()
+  return typeof auth === "string" ? auth : undefined
 }

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -309,6 +309,22 @@ describe("sources, loaders, and publishers", () => {
     expect(archiveRequestAuthorization()).toBe("Bearer explicit-token")
   })
 
+  it("skips all GitHub auth fallbacks when auth is false", async () => {
+    const root = await createRoot()
+    await writeFile(join(root, ".env"), "GITHUB_TOKEN=env-file-token\n")
+    process.env.GITHUB_TOKEN = "runtime-token"
+    ;(globalThis as { __env__?: Record<string, unknown> }).__env__ = { GITHUB_TOKEN: "cloudflare-token" }
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+
+    const githubSource = github({ auth: false, repo: "acme/public" })
+
+    await githubSource.getKeys({ rootDir: root, workspace: "github-public-auth-false" })
+
+    expect(archiveRequestAuthorization()).toBeUndefined()
+  })
+
   it("keeps public GitHub source requests unauthenticated when no token exists", async () => {
     stubGitHubSource({
       "docs/README.md": "# Docs\n",

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -33,7 +33,7 @@ declare global {
 describe("workspace types", () => {
   it("exports source helper option types from the root", () => {
     const fetchOptions = { url: "https://status.example.com/api/summary" } satisfies FetchSourceOptions
-    const githubOptions = { repo: "acme/docs" } satisfies GitHubSourceOptions
+    const githubOptions = { auth: false, repo: "acme/docs" } satisfies GitHubSourceOptions
     const globOptions = { include: "**/*.md" } satisfies GlobSourceOptions
     const mcpResourcesOptions = { server: { transport: { type: "http", url: "https://example.com/mcp" } } } satisfies McpResourcesSourceOptions
 


### PR DESCRIPTION
Adds an explicit `auth: false` option for GitHub sources so public repositories can bypass configured or environment GitHub token fallback.

This keeps the existing auth fallback behavior when `auth` is omitted, while allowing callers to force unauthenticated requests for public source materialization.