### PR TITLE
feat(agent): add observability capability

### DIFF
--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -40,7 +40,10 @@ import type {
   AgentAdapterMetadataContext,
   AgentAdapterRunContext,
   AgentAdapterResult,
+  AgentCallSettingsInstrumentationContext,
+  AgentModelExecutionInstrumentation,
   AgentModelExecutionOptions,
+  AgentModelInstrumentationContext,
   AgentRuntimeConfig,
   AgentToolSet,
   AgentToolResolverWithWorkspace,
@@ -777,6 +780,45 @@ function withViteHubTelemetry(settings: Record<string, unknown>, context: AgentA
   }
 }
 
+function modelExecutionInstrumentation(
+  options: AiSdkAdapterOptions,
+  context: AgentAdapterRunContext,
+): AgentModelExecutionInstrumentation[] {
+  const instrumentation = options.execution?.instrumentation ?? options.modelExecution?.instrumentation
+  return [
+    ...(instrumentation ? [instrumentation as AgentModelExecutionInstrumentation] : []),
+    ...(context.modelExecutionInstrumentation || []),
+  ]
+}
+
+async function instrumentModel(
+  model: unknown,
+  instrumentations: AgentModelExecutionInstrumentation[],
+  context: AgentModelInstrumentationContext,
+) {
+  let current = model
+  for (const instrumentation of instrumentations) {
+    current = await instrumentation.model?.({ ...context, model: current }) ?? current
+  }
+  return current
+}
+
+async function instrumentCallSettings(
+  callSettings: Record<string, unknown>,
+  instrumentations: AgentModelExecutionInstrumentation[],
+  context: Omit<AgentCallSettingsInstrumentationContext, "callSettings">,
+) {
+  let current = callSettings
+  let patch: Record<string, unknown> | undefined
+  for (const instrumentation of instrumentations) {
+    const next = await instrumentation.callSettings?.({ ...context, callSettings: { ...current } })
+    if (!next) continue
+    patch = { ...patch, ...next }
+    current = { ...current, ...next }
+  }
+  return patch
+}
+
 async function createAgent(
   options: AiSdkAdapterOptions,
   context: AgentAdapterRunContext,
@@ -794,9 +836,9 @@ async function createAgent(
     workspace: context.workspace,
   } as AgentAdapterMetadataContext
   const model = await resolveValue(options.model as never, metadataContext)
-  const modelInstrumentation = execution?.instrumentation?.model
-  const instrumentedModel = modelInstrumentation
-    ? await modelInstrumentation({ ...runtime, actor: context.actor, context: context.context, invoker: context.invoker, model, run: context.runtime.run })
+  const instrumentations = modelExecutionInstrumentation(options, context)
+  const instrumentedModel = instrumentations.length
+    ? await instrumentModel(model, instrumentations, { ...runtime, actor: context.actor, context: context.context, invoker: context.invoker, model, run: context.runtime.run })
     : model
   const instructions = applyWorkspaceSourceInstructionSlot(
     applyCapabilityInstructionSlots(context.instructions ?? await resolveInstructions(options, metadataContext), context.capabilityInstructions),
@@ -823,10 +865,9 @@ async function createAgent(
   } = options
   const stepLimit = execution?.stepLimit
   const baseCallSettings = { ...(execution?.callSettings || {}) }
-  const instrumentedCallSettings = await execution?.instrumentation?.callSettings?.({
+  const instrumentedCallSettings = await instrumentCallSettings(baseCallSettings, instrumentations, {
     ...runtime,
     actor: context.actor,
-    callSettings: { ...baseCallSettings },
     context: context.context,
     input: context.input,
     invoker: context.invoker,

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -34,6 +34,9 @@ export {
   rateLimit,
 } from "./rate-limit.ts"
 export {
+  observability,
+} from "./observability.ts"
+export {
   repositoryHost,
 } from "./repository-host.ts"
 export {
@@ -206,6 +209,17 @@ export type {
   RateLimitStoreResult,
   RateLimitWindow,
 } from "./rate-limit.ts"
+export type {
+  AgentObservabilityErrorEvent,
+  AgentObservabilityEvent,
+  AgentObservabilityEventBase,
+  AgentObservabilityEventHandler,
+  AgentObservabilityFinishEvent,
+  AgentObservabilityFinishExtension,
+  AgentObservabilityOptions,
+  AgentObservabilityStartEvent,
+  AgentObservabilityStatus,
+} from "./observability.ts"
 export type {
   RepositoryHostClient,
   RepositoryHostOptions,

--- a/packages/agent/src/capabilities/observability.ts
+++ b/packages/agent/src/capabilities/observability.ts
@@ -1,0 +1,178 @@
+import { defineCapability } from "../capability-runtime.ts"
+
+import type {
+  AgentActor,
+  AgentCapabilityDefinition,
+  AgentCapabilityRuntimeContext,
+  AgentFinishEvent,
+  AgentInvoker,
+  AgentModelExecutionInstrumentation,
+  AgentRunInput,
+  AgentRunMetadata,
+  AgentRuntimeConfig,
+  MaybePromise,
+  ResolvedAgentRuntimeContext,
+} from "../types.ts"
+
+export type AgentObservabilityStatus = "completed" | "failed"
+
+export interface AgentObservabilityEventBase<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  actor: AgentActor
+  input: AgentRunInput
+  invoker: AgentInvoker
+  run?: AgentRunMetadata
+  runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>
+}
+
+export interface AgentObservabilityStartEvent<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> extends AgentObservabilityEventBase<TRuntimeConfig> {
+  type: "start"
+}
+
+export interface AgentObservabilityFinishEvent<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> extends AgentObservabilityEventBase<TRuntimeConfig> {
+  durationMs: number
+  result: unknown
+  status: "completed"
+  type: "finish"
+}
+
+export interface AgentObservabilityErrorEvent<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> extends AgentObservabilityEventBase<TRuntimeConfig> {
+  durationMs: number
+  error: unknown
+  status: "failed"
+  type: "error"
+}
+
+export type AgentObservabilityEvent<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> =
+  | AgentObservabilityStartEvent<TRuntimeConfig>
+  | AgentObservabilityFinishEvent<TRuntimeConfig>
+  | AgentObservabilityErrorEvent<TRuntimeConfig>
+
+export type AgentObservabilityEventHandler<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> =
+  (event: AgentObservabilityEvent<TRuntimeConfig>) => MaybePromise<void>
+
+export interface AgentObservabilityOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> {
+  instrumentation?: AgentModelExecutionInstrumentation<TRuntimeConfig, CALL_OPTIONS>
+  onEvent?: AgentObservabilityEventHandler<TRuntimeConfig>
+}
+
+export interface AgentObservabilityFinishExtension {
+  durationMs: number
+  resultKind?: string
+  status: AgentObservabilityStatus
+}
+
+interface AgentObservabilityCapabilityMetadata<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> {
+  kind: "observability"
+  observability: AgentObservabilityOptions<TRuntimeConfig, CALL_OPTIONS>
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return Boolean(value && typeof value === "object" && Symbol.asyncIterator in value)
+}
+
+function resultKind(result: unknown): string {
+  if (result === null) return "null"
+  if (isAsyncIterable(result)) return "stream"
+  if (Array.isArray(result)) return "array"
+  return typeof result
+}
+
+function capabilityEventBase<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentCapabilityRuntimeContext<TRuntimeConfig>,
+): AgentObservabilityEventBase<TRuntimeConfig> {
+  return {
+    actor: context.actor,
+    input: context.input.get(),
+    invoker: context.invoker,
+    run: context.run,
+    runtime: context.runtimeContext as ResolvedAgentRuntimeContext<TRuntimeConfig>,
+  }
+}
+
+function finishEventBase<TRuntimeConfig extends AgentRuntimeConfig>(
+  event: AgentFinishEvent<TRuntimeConfig>,
+): AgentObservabilityEventBase<TRuntimeConfig> {
+  return {
+    actor: event.actor,
+    input: event.input,
+    invoker: event.invoker,
+    run: event.invocation.run,
+    runtime: event.runtime,
+  }
+}
+
+async function notify<TRuntimeConfig extends AgentRuntimeConfig>(
+  onEvent: AgentObservabilityEventHandler<TRuntimeConfig> | undefined,
+  event: AgentObservabilityEvent<TRuntimeConfig>,
+): Promise<void> {
+  try {
+    await onEvent?.(event)
+  }
+  catch {
+    // Observability sinks must not change Agent Invocation behavior.
+  }
+}
+
+export function observability<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+>(options: AgentObservabilityOptions<TRuntimeConfig, CALL_OPTIONS> = {}): AgentCapabilityDefinition<TRuntimeConfig> {
+  return defineCapability({
+    id: "observability",
+    metadata: {
+      kind: "observability",
+      observability: options,
+    } satisfies AgentObservabilityCapabilityMetadata<TRuntimeConfig, CALL_OPTIONS>,
+    configure(context) {
+      if (options.instrumentation) context.modelExecution.instrument(options.instrumentation as never)
+      context.finish.provide(async (event: AgentFinishEvent<TRuntimeConfig>) => {
+        if (event.error !== undefined) {
+          return {
+            durationMs: event.invocation.durationMs,
+            status: "failed",
+          } satisfies AgentObservabilityFinishExtension
+        }
+
+        return {
+          durationMs: event.invocation.durationMs,
+          resultKind: resultKind(event.result),
+          status: "completed",
+        } satisfies AgentObservabilityFinishExtension
+      })
+      // Returning false reuses finish-time lifecycle scheduling without creating a Channel Delivery Effect.
+      context.delivery.finishEffect(async (event): Promise<false> => {
+        if (event.error !== undefined) {
+          await notify(options.onEvent, {
+            ...finishEventBase(event as AgentFinishEvent<TRuntimeConfig>),
+            durationMs: event.invocation.durationMs,
+            error: event.error,
+            status: "failed",
+            type: "error",
+          })
+          return false
+        }
+
+        await notify(options.onEvent, {
+          ...finishEventBase(event as AgentFinishEvent<TRuntimeConfig>),
+          durationMs: event.invocation.durationMs,
+          result: event.result,
+          status: "completed",
+          type: "finish",
+        })
+        return false
+      })
+    },
+    input(context) {
+      return notify(options.onEvent, {
+        ...capabilityEventBase(context),
+        type: "start",
+      })
+    },
+  })
+}

--- a/packages/agent/src/capabilities/observability.ts
+++ b/packages/agent/src/capabilities/observability.ts
@@ -145,28 +145,30 @@ export function observability<
           status: "completed",
         } satisfies AgentObservabilityFinishExtension
       })
-      // Returning false reuses finish-time lifecycle scheduling without creating a Channel Delivery Effect.
-      context.delivery.finishEffect(async (event): Promise<false> => {
-        if (event.error !== undefined) {
+      if (options.onEvent) {
+        // Returning false reuses finish-time lifecycle scheduling without creating a Channel Delivery Effect.
+        context.delivery.finishEffect(async (event): Promise<false> => {
+          if (event.error !== undefined) {
+            await notify(options.onEvent, {
+              ...finishEventBase(event as AgentFinishEvent<TRuntimeConfig>),
+              durationMs: event.invocation.durationMs,
+              error: event.error,
+              status: "failed",
+              type: "error",
+            })
+            return false
+          }
+
           await notify(options.onEvent, {
             ...finishEventBase(event as AgentFinishEvent<TRuntimeConfig>),
             durationMs: event.invocation.durationMs,
-            error: event.error,
-            status: "failed",
-            type: "error",
+            result: event.result,
+            status: "completed",
+            type: "finish",
           })
           return false
-        }
-
-        await notify(options.onEvent, {
-          ...finishEventBase(event as AgentFinishEvent<TRuntimeConfig>),
-          durationMs: event.invocation.durationMs,
-          result: event.result,
-          status: "completed",
-          type: "finish",
         })
-        return false
-      })
+      }
     },
     input(context) {
       return notify(options.onEvent, {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -31,6 +31,7 @@ import type {
   AgentOutputExtensionProvider,
   AgentInvocationContextStore,
   AgentInvoker,
+  AgentModelExecutionInstrumentation,
   AgentModelResolver,
   AgentOutputRenderer,
   AgentProviderToolContribution,
@@ -68,6 +69,7 @@ export interface AgentCapabilityRegistries {
   deliveryEffectIntents: AgentChannelDeliveryEffectIntent[]
   finishDeliveryEffectProviders: AgentChannelDeliveryFinishEffect[]
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
+  modelExecutionInstrumentation: AgentModelExecutionInstrumentation[]
   outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
   outputRenderers: ResolvedAgentOutputRenderer[]
   providerTools: AgentProviderToolContribution[]
@@ -595,6 +597,7 @@ export async function resolveAgentCapabilities<
     deliveryEffectIntents: [...initialDeliveryEffectIntents],
     finishDeliveryEffectProviders: [...initialFinishDeliveryEffectProviders],
     finishExtensionProviders: [],
+    modelExecutionInstrumentation: [],
     outputExtensionProviders: [],
     outputRenderers: [],
     providerTools: [],
@@ -710,6 +713,11 @@ export async function resolveAgentCapabilities<
               throw new Error(`[vitehub] ${capability.id}() requires a model option or an agent model.`)
             }
             return await resolveRuntimeValue(resolver as never, metadataContext as never) as unknown
+          },
+        },
+        modelExecution: {
+          instrument(instrumentation) {
+            registries.modelExecutionInstrumentation.push(instrumentation)
           },
         },
         output: {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1059,6 +1059,7 @@ type AgentInvocationContext<
   finishHook?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS> extends infer TEvent ? (event: TEvent) => MaybePromise<void> : never
   hasCapabilityCleanup: boolean
   hooks?: AgentHookObserverHooks
+  modelExecutionInstrumentation: AgentCapabilityRegistries["modelExecutionInstrumentation"]
   outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
   outputRenderers: AgentCapabilityRegistries["outputRenderers"]
   runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
@@ -1082,6 +1083,7 @@ function toAgentAdapterRunContext<
   return {
     ...context,
     instructions: context.instructions,
+    modelExecutionInstrumentation: context.modelExecutionInstrumentation as never,
     runtime: context.runtimeContext,
     workspace: context.workspace as ReadonlyWorkspaceFacade<WorkspaceName> | undefined,
   }
@@ -1269,6 +1271,7 @@ async function createAgentInvocationContext<
       instructions,
       invoker,
       messages: capabilities.messages,
+      modelExecutionInstrumentation: capabilities.registries.modelExecutionInstrumentation,
       outputExtensionProviders: capabilities.registries.outputExtensionProviders,
       outputRenderers: capabilities.registries.outputRenderers,
       prompt: typeof capabilities.input.prompt === "string" ? capabilities.input.prompt : undefined,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -510,6 +510,9 @@ export interface AgentCapabilityRuntimeContext<
   model: {
     resolve: (model?: AgentModelResolver<TRuntimeConfig, Name>) => Promise<AgentModelInput>
   }
+  modelExecution: {
+    instrument: (instrumentation: AgentModelExecutionInstrumentation<TRuntimeConfig>) => void
+  }
   output: {
     extensions: AgentInvocationExtensions
     provide: (value: unknown | AgentOutputExtensionProvider) => void
@@ -1245,6 +1248,7 @@ export interface AgentAdapterRunContext<
   instructions?: string
   invoker: AgentInvoker
   messages: Message[]
+  modelExecutionInstrumentation?: AgentModelExecutionInstrumentation[]
   outputRenderers?: Array<(result: unknown) => MaybePromise<unknown>>
   prompt?: string
   providerTools?: AgentProviderToolContribution[]

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createMessage, getMessageText } from "@vite-hub/agent"
 import { createTraceEventLog, deriveTraceRuns, emitTraceEvent } from "@vite-hub/runtime"
-import { chat, chatTitle, schedule, subagents } from "../src/capabilities.ts"
+import { chat, chatTitle, observability, schedule, subagents } from "../src/capabilities.ts"
 import { toJsonCompatibleValue } from "../src/tool-runtime.ts"
 
 import type { WritableWorkspaceFacade } from "@vite-hub/workspace"
@@ -87,6 +87,59 @@ describe("agent message protocol", () => {
     })).rejects.toThrow("Missing GitHub field: context.pullRequest")
     expect(inputHook).toHaveBeenCalledTimes(2)
     expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it("emits observability events and finish extensions", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const standaloneEvents: string[] = []
+    const standaloneAgent = defineAgent({
+      capabilities: [
+        observability({
+          onEvent(event) {
+            standaloneEvents.push(event.type)
+          },
+        }),
+      ],
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgent(standaloneAgent, {
+      memo: vi.fn(),
+      run: { origin: "http", runId: "run-1" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })).resolves.toBe("ok")
+
+    expect(standaloneEvents).toEqual(["start", "finish"])
+
+    const events: string[] = []
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [
+        observability({
+          onEvent(event) {
+            events.push(event.type)
+          },
+        }),
+      ],
+      hooks: {
+        "agent:finish": finish,
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { origin: "http", runId: "run-1" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })).resolves.toBe("ok")
+
+    expect(events).toEqual(["start", "finish"])
+    expect(finish.mock.calls[0]?.[0].extensions.get("observability")).toMatchObject({
+      resultKind: "string",
+      status: "completed",
+    })
   })
 
   it("skips agent input hooks after a capability handles the input", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, type AgentActor, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDefinition, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceExec, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, observability, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceExec, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -132,6 +132,25 @@ describe("agent public types", () => {
               expectTypeOf(subject).toEqualTypeOf<string>()
               return "usage"
             },
+          },
+        }),
+        observability({
+          instrumentation: {
+            callSettings({ callSettings, run }) {
+              expectTypeOf(callSettings).toEqualTypeOf<Readonly<Record<string, unknown>>>()
+              expectTypeOf(run?.runId).toEqualTypeOf<string | undefined>()
+            },
+            model({ model }) {
+              expectTypeOf(model).toEqualTypeOf<unknown>()
+              return model
+            },
+          },
+          onEvent(event) {
+            expectTypeOf(event.type).toEqualTypeOf<"error" | "finish" | "start">()
+            if (event.type === "error") {
+              expectTypeOf(event.error).toEqualTypeOf<unknown>()
+              expectTypeOf(event.status).toEqualTypeOf<"failed">()
+            }
           },
         }),
         chatTitle({

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1992,7 +1992,7 @@ describe("defineAgent workspace option", () => {
 
   it("lets capabilities instrument workspace agent model execution", async () => {
     const { observability } = await import("../src/capabilities.ts")
-    const { defineAgent } = await import("../src/index.ts")
+    const { defineAgent, defineCapability } = await import("../src/index.ts")
     const baseModel = { id: "base" }
     const driverModel = { id: "driver" }
     const capabilityModel = { id: "capability" }
@@ -2013,6 +2013,14 @@ describe("defineAgent workspace option", () => {
           instrumentation: {
             callSettings: capabilityInstrumentCallSettings,
             model: capabilityInstrumentModel,
+          },
+        }),
+        defineCapability({
+          id: "finish-extension-trap",
+          configure(context) {
+            context.finish.provide(() => {
+              throw new Error("finish extension should not run")
+            })
           },
         }),
       ],

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1990,6 +1990,64 @@ describe("defineAgent workspace option", () => {
     expect(agentSettings.at(-1)).not.toHaveProperty("modelExecution")
   })
 
+  it("lets capabilities instrument workspace agent model execution", async () => {
+    const { observability } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const baseModel = { id: "base" }
+    const driverModel = { id: "driver" }
+    const capabilityModel = { id: "capability" }
+    const driverInstrumentModel = vi.fn(() => driverModel as never)
+    const capabilityInstrumentModel = vi.fn(() => capabilityModel as never)
+    const driverInstrumentCallSettings = vi.fn(({ callSettings }) => ({
+      temperature: callSettings.temperature,
+      topK: 1,
+    }))
+    const capabilityInstrumentCallSettings = vi.fn(({ callSettings }) => ({
+      metadata: { topK: callSettings.topK },
+    }))
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      capabilities: [
+        observability({
+          instrumentation: {
+            callSettings: capabilityInstrumentCallSettings,
+            model: capabilityInstrumentModel,
+          },
+        }),
+      ],
+      modelExecution: {
+        callSettings: {
+          temperature: 0.2,
+        },
+        instrumentation: {
+          callSettings: driverInstrumentCallSettings,
+          model: driverInstrumentModel,
+        },
+      },
+      model: baseModel as never,
+    }), { workspace: "docs" })
+
+    await agent.run!(context())
+
+    expect(driverInstrumentModel).toHaveBeenCalledWith(expect.objectContaining({ model: baseModel }))
+    expect(capabilityInstrumentModel).toHaveBeenCalledWith(expect.objectContaining({ model: driverModel }))
+    expect(driverInstrumentCallSettings).toHaveBeenCalledWith(expect.objectContaining({
+      callSettings: expect.objectContaining({ temperature: 0.2 }),
+      model: capabilityModel,
+    }))
+    expect(capabilityInstrumentCallSettings).toHaveBeenCalledWith(expect.objectContaining({
+      callSettings: expect.objectContaining({ temperature: 0.2, topK: 1 }),
+      model: capabilityModel,
+    }))
+    expect(agentSettings.at(-1)).toMatchObject({
+      metadata: { topK: 1 },
+      model: capabilityModel,
+      temperature: 0.2,
+      topK: 1,
+    })
+  })
+
   it("lets workspace agents instrument AI SDK call settings per run", async () => {
     const execute = vi.fn(async () => "workspace result")
     const instrumentCallSettings = vi.fn(({ callSettings }) => ({


### PR DESCRIPTION
Adds an official `observability()` capability on `@vite-hub/agent/capabilities`. It lets agents attach invocation event sinks and model execution instrumentation from one capability, so downstream projects can replace separate model wrapping plus finish-hook wiring.

The capability records start/finish/error events, exposes a finish extension for hooks that need structured completion data, and composes capability-provided model/call-settings instrumentation with existing driver instrumentation. Tests cover hook-free finish events, extension visibility, public types, and workspace-agent instrumentation composition.