### PR TITLE
fix: enforce scoped workspace source access

### DIFF
--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -307,11 +307,14 @@ function normalizedContributionSource(
   key: string,
   source: WorkspaceSourceInput,
   runtime: WorkspaceContributionRuntime,
-): { mountPath: string, requestOnly: boolean } {
+): { key: string, mountPath: string, probePaths?: string[], requestOnly: boolean, source?: WorkspaceSource } {
   const metadata = normalizeAgentWorkspaceSource(key, source)
   return {
+    key,
     mountPath: metadata.mountPath,
+    ...(metadata.probeKeys?.length ? { probePaths: metadata.probeKeys.map(sourcePath => joinSourcePath(metadata.mountPath, sourcePath)) } : {}),
     requestOnly: isRequestOnlyWorkspaceSource(runtime, metadata.source),
+    ...(metadata.source ? { source: metadata.source } : {}),
   }
 }
 
@@ -346,7 +349,7 @@ function assertWorkspaceContribution(
         throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with contributed Workspace Source "${existing.key}" at mount "${contributedSource.mountPath || "."}".`)
       }
     }
-    contributionSources.push({ key, ...contributedSource })
+    contributionSources.push(contributedSource)
     for (const [existingKey, existingSource] of Object.entries(definition.sources || {})) {
       const existing = normalizedContributionSource(existingKey, existingSource, runtime)
       if (sourcesConflict(existing, contributedSource)) {
@@ -382,6 +385,38 @@ async function workspacePathExists(workspace: ReadonlyWorkspaceFacade, path: str
   }
 }
 
+function joinSourcePath(mountPath: string, sourcePath: string): string {
+  return [mountPath, sourcePath].filter(Boolean).join("/")
+}
+
+async function sourceConflictPaths(source: { key: string, mountPath: string, probePaths?: string[], source?: WorkspaceSource }): Promise<string[]> {
+  if (source.mountPath) return [source.mountPath]
+  if (source.probePaths?.length) return source.probePaths
+  if (source.source?.getKeys.length === 0) {
+    try {
+      const keys = await source.source.getKeys({
+        mountPath: source.mountPath,
+        rootDir: process.cwd(),
+        source: source.key,
+        workspace: "workspace",
+      })
+      if (keys.length) return keys.map(key => joinSourcePath(source.mountPath, key))
+    }
+    catch {}
+  }
+  return [source.mountPath]
+}
+
+async function workspaceSourcePathExists(
+  workspace: ReadonlyWorkspaceFacade,
+  source: { key: string, mountPath: string, probePaths?: string[], source?: WorkspaceSource },
+): Promise<boolean> {
+  for (const path of await sourceConflictPaths(source)) {
+    if (await workspacePathExists(workspace, path)) return true
+  }
+  return false
+}
+
 async function assertResolvedWorkspaceContributionSources(
   registries: AgentCapabilityRegistries["workspaceContributions"],
   definition: WorkspaceDefinition,
@@ -409,7 +444,7 @@ async function assertResolvedWorkspaceContributionSources(
         throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with ${label} "${existingKey}" at mount "${contributedSource.mountPath || "."}".`)
       }
     }
-    if (!contributedSource.requestOnly && await workspacePathExists(workspace, contributedSource.mountPath)) {
+    if (!contributedSource.requestOnly && await workspaceSourcePathExists(workspace, contributedSource)) {
       throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" conflicts with an existing Workspace path at mount "${contributedSource.mountPath}".`)
     }
   }
@@ -648,7 +683,6 @@ export async function resolveAgentCapabilities<
 
   try {
     for (const capability of capabilities) {
-      if (capability.id !== "access") await applyWorkspaceContributions()
       await validateCapabilityRuntimeRequirement(capability as AgentCapabilityDefinition, currentWorkspace, workspaceMode)
       const phases = invocationOptions.phases || defaultCapabilityRuntimePhases
       const metadataContext = {
@@ -830,8 +864,6 @@ export async function resolveAgentCapabilities<
           }
         }
       }
-      if (capability.id === "access") await applyWorkspaceContributions()
-
       if (invocationOptions.resolveInstructions !== false && capability.instructions !== undefined) {
         const values = await resolveInstructionValue(capability, capabilityContext)
         for (const value of values) {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -412,9 +412,22 @@ async function workspaceSourcePathExists(
   source: { key: string, mountPath: string, probePaths?: string[], source?: WorkspaceSource },
 ): Promise<boolean> {
   for (const path of await sourceConflictPaths(source)) {
+    for (const parent of parentPaths(path)) {
+      try {
+        const stat = await workspace.fs.stat(parent as never)
+        if (stat?.type !== "directory") return true
+      }
+      catch {}
+    }
     if (await workspacePathExists(workspace, path)) return true
   }
   return false
+}
+
+function parentPaths(path: string): string[] {
+  const parts = path.split("/").filter(Boolean)
+  parts.pop()
+  return parts.map((_, index) => parts.slice(0, index + 1).join("/"))
 }
 
 async function assertResolvedWorkspaceContributionSources(
@@ -433,7 +446,7 @@ async function assertResolvedWorkspaceContributionSources(
     const source = definition.sources?.[key]
     if (!source) continue
     const contributedSource = normalizedContributionSource(key, source, runtime)
-    if (!selectedScopeContainsSource(runtime, selectedWorkspaceScope, key, contributedSource)) {
+    if (!await selectedScopeContainsResolvedSource(runtime, selectedWorkspaceScope, key, contributedSource)) {
       throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" is outside the selected Workspace Scope.`)
     }
     for (const [existingKey, existingSource] of Object.entries(definition.sources || {})) {
@@ -473,9 +486,23 @@ function selectedScopeContainsSource(
   runtime: WorkspaceContributionRuntime,
   scope: WorkspaceSelectedScope | undefined,
   key: string,
-  source: { mountPath: string, requestOnly: boolean },
+  source: { mountPath: string, probePaths?: string[], requestOnly: boolean },
 ): boolean {
+  if (source.probePaths?.length) {
+    return source.probePaths.some(path => selectedScopeContainsMount(scope, path))
+  }
   return selectedScopeContainsMount(scope, sourceScopePath(runtime, key, source))
+}
+
+async function selectedScopeContainsResolvedSource(
+  runtime: WorkspaceContributionRuntime,
+  scope: WorkspaceSelectedScope | undefined,
+  key: string,
+  source: { key: string, mountPath: string, probePaths?: string[], requestOnly: boolean, source?: WorkspaceSource },
+): Promise<boolean> {
+  if (selectedScopeContainsSource(runtime, scope, key, source)) return true
+  if (source.mountPath || source.requestOnly || !source.source) return false
+  return (await sourceConflictPaths(source)).some(path => selectedScopeContainsMount(scope, path))
 }
 
 function assertStaticWorkspaceContributionSourcesInScope(
@@ -492,12 +519,9 @@ function assertStaticWorkspaceContributionSourcesInScope(
   for (const [key, capabilityId] of contributed) {
     const source = definition.sources?.[key]
     if (!source) continue
-    const metadata = normalizeAgentWorkspaceSource(key, source)
-    if (metadata.source?.resolve) continue
-    const contributedSource = {
-      mountPath: metadata.mountPath,
-      requestOnly: isRequestOnlyWorkspaceSource(runtime, metadata.source),
-    }
+    const contributedSource = normalizedContributionSource(key, source, runtime)
+    if (contributedSource.source?.resolve) continue
+    if (!contributedSource.mountPath && !contributedSource.probePaths?.length && contributedSource.source) continue
     if (!selectedScopeContainsSource(runtime, selectedWorkspaceScope, key, contributedSource)) {
       throw new Error(`[vitehub] ${capabilityId}() workspace contribution source "${key}" is outside the selected Workspace Scope.`)
     }
@@ -640,6 +664,10 @@ export async function resolveAgentCapabilities<
     triggers: [],
     workspaceContributions: [],
   }
+  const capabilityContexts: Array<{
+    capability: AgentCapabilityDefinition<TRuntimeConfig, Name>
+    context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name> & WorkspaceOverrideRuntime<Name>
+  }> = []
 
   async function closeRegisteredCallbacks() {
     const errors: unknown[] = []
@@ -653,6 +681,14 @@ export async function resolveAgentCapabilities<
     }
     if (errors.length === 1) throw errors[0]
     if (errors.length > 1) throw new AggregateError(errors, "[vitehub] Multiple capability close callbacks failed.")
+  }
+
+  function syncCapabilityWorkspaceContext(context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) {
+    if (currentWorkspace) {
+      context.fs = currentWorkspace.fs
+      context.workspace = currentWorkspace
+    }
+    if (currentWorkspaceDefinition) context.workspaceDefinition = currentWorkspaceDefinition
   }
 
   let workspaceContributionsApplied = false
@@ -679,6 +715,7 @@ export async function resolveAgentCapabilities<
       currentWorkspaceDefinition = workspaceContribution.definition
       registries.workspaceContributions = workspaceContribution.registries
     }
+    for (const item of capabilityContexts) syncCapabilityWorkspaceContext(item.context)
   }
 
   try {
@@ -700,8 +737,7 @@ export async function resolveAgentCapabilities<
         ...metadataContext,
         [workspaceOverrideSymbol](nextWorkspace: ReadonlyWorkspaceFacade<Name>) {
           currentWorkspace = nextWorkspace
-          capabilityContext.fs = nextWorkspace.fs
-          capabilityContext.workspace = nextWorkspace
+          syncCapabilityWorkspaceContext(capabilityContext)
         },
         capability,
         mode: capability.mode,
@@ -746,7 +782,12 @@ export async function resolveAgentCapabilities<
             if (resolver === undefined) {
               throw new Error(`[vitehub] ${capability.id}() requires a model option or an agent model.`)
             }
-            return await resolveRuntimeValue(resolver as never, metadataContext as never) as unknown
+            return await resolveRuntimeValue(resolver as never, {
+              ...metadataContext,
+              fs: currentWorkspace?.fs,
+              workspace: currentWorkspace,
+              workspaceDefinition: currentWorkspaceDefinition,
+            } as never) as unknown
           },
         },
         modelExecution: {
@@ -809,6 +850,7 @@ export async function resolveAgentCapabilities<
         },
         workspace: currentWorkspace,
       } as AgentCapabilityRuntimeContext<TRuntimeConfig, Name> & WorkspaceOverrideRuntime<Name>
+      capabilityContexts.push({ capability, context: capabilityContext })
 
       for (const [name, trigger] of Object.entries(capability.triggers || {})) {
         assertTriggerName(name, capability.id)
@@ -864,18 +906,20 @@ export async function resolveAgentCapabilities<
           }
         }
       }
+    }
+    await applyWorkspaceContributions()
+    for (const { capability, context } of capabilityContexts) {
       if (invocationOptions.resolveInstructions !== false && capability.instructions !== undefined) {
-        const values = await resolveInstructionValue(capability, capabilityContext)
+        const values = await resolveInstructionValue(capability, context)
         for (const value of values) {
           addInstructionBlock(capabilityInstructions, capability.id, value)
         }
       }
       if (invocationOptions.resolveTools !== false && capability.tools) {
-        const resolved = await resolveRuntimeValue(capability.tools as never, capabilityContext) as unknown
+        const resolved = await resolveRuntimeValue(capability.tools as never, context) as unknown
         if (isToolSet(resolved)) tools = { ...tools, ...resolved }
       }
     }
-    await applyWorkspaceContributions()
   }
   catch (error) {
     try {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { createMessage } from "@vite-hub/agent"
+import { createMessage, type AgentCapabilityContext, type AgentCapabilityRuntimeContext } from "@vite-hub/agent"
 
 const runtime = () => ({
   memo: vi.fn(),
@@ -17,7 +17,7 @@ const emptyWorkspace = () => ({
     materializeSources: vi.fn(async () => ({ bytes: 0, directories: 0, durationMs: 0, files: 0, path: "", sources: [] })),
     readFile: vi.fn(async () => { throw new Error("missing") }),
     search: vi.fn(async () => []),
-    stat: vi.fn(async () => { throw new Error("missing") }),
+    stat: vi.fn(async (_path?: string) => { throw new Error("missing") }),
   },
   tools: {
     inspect: vi.fn(() => ({})),
@@ -244,6 +244,12 @@ describe("agent capability runtime", () => {
               },
             },
           },
+          instructions: async (context: AgentCapabilityRuntimeContext) => await context.workspace!.fs.readFile("pull-request/summary.md"),
+          tools: async (context: AgentCapabilityContext) => ({
+            reviewContext: {
+              name: await context.workspace!.fs.readFile("pull-request/summary.md"),
+            },
+          }),
         }),
       ],
     }, runtime(), {}, emptyWorkspace() as never, "read", {
@@ -254,6 +260,12 @@ describe("agent capability runtime", () => {
     })
 
     await expect(resolved.workspace?.fs.readFile("pull-request/summary.md")).resolves.toBe("review context")
+    expect(resolved.capabilityInstructions).toEqual([
+      { id: "capabilities.review", instructions: "review context" },
+    ])
+    expect(resolved.tools).toEqual({
+      reviewContext: { name: "review context" },
+    })
     expect(resolved.workspaceDefinition?.sources?.pullRequest).toMatchObject({ materialize: "lazy" })
     expect(resolved.workspaceDefinition?.sources).toHaveProperty("pullRequest")
     expect(resolved.workspaceDefinition?.rules).toHaveProperty("artifacts/review/**")
@@ -512,6 +524,41 @@ describe("agent capability runtime", () => {
     })).rejects.toThrow('workspace contribution source "repository" conflicts with an existing Workspace path at mount ""')
   })
 
+  it("rejects root-mounted capability workspace sources whose parent is an existing Workspace file", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const workspace = emptyWorkspace()
+    workspace.fs.stat.mockImplementation(async (path?: string) => {
+      if (path === "docs") return { path, type: "file" } as never
+      throw new Error("missing")
+    })
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              repository: {
+                mount: "",
+                async getKeys() {
+                  return ["docs/README.md"]
+                },
+                async getItem(key: string) {
+                  return { content: "review", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, workspace as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow('workspace contribution source "repository" conflicts with an existing Workspace path at mount ""')
+  })
+
   it("allows request-only capability workspace sources in non-empty Workspaces", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { fetch } = await import("@vite-hub/workspace")
@@ -579,6 +626,44 @@ describe("agent capability runtime", () => {
     })
 
     expect(resolved.workspaceDefinition?.sources).toHaveProperty("pullRequest")
+  })
+
+  it("allows root-mounted finite capability sources selected by concrete path", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+    const { fetch } = await import("@vite-hub/workspace")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "review",
+            scopes: {
+              review: { paths: ["pull-request.json"] },
+            },
+          },
+        }),
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: fetch({
+                url: "https://api.github.com/repos/vite-hub/vitehub/pulls/366",
+                workspacePath: "pull-request.json",
+              }),
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    expect(resolved.workspaceDefinition?.sources).toHaveProperty("pullRequest")
+    await expect(resolved.workspace?.fs.exists("pull-request.json")).resolves.toBe(true)
   })
 
   it("allows request-only capability workspace sources selected by descriptor path", async () => {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -549,6 +549,38 @@ describe("agent capability runtime", () => {
     expect(resolved.workspaceDefinition?.sources).toHaveProperty("inventory")
   })
 
+  it("allows root-mounted finite capability sources beside unrelated root entries", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { fetch } = await import("@vite-hub/workspace")
+    const workspace = emptyWorkspace()
+    workspace.fs.list.mockImplementation(async (path = "") => path
+      ? []
+      : [{ path: "README.md", type: "file" }] as never)
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: fetch({
+                url: "https://api.github.com/repos/vite-hub/vitehub/pulls/366",
+                workspacePath: "pull-request.json",
+              }),
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, workspace as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    expect(resolved.workspaceDefinition?.sources).toHaveProperty("pullRequest")
+  })
+
   it("allows request-only capability workspace sources selected by descriptor path", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
@@ -746,6 +778,63 @@ describe("agent capability runtime", () => {
       },
     })).rejects.toThrow('review() requires workspace.mode: "write"')
     expect(resolveWorkspace).not.toHaveBeenCalled()
+  })
+
+  it("runs workspace contribution resolvers after earlier lifecycle phases", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const seen = vi.fn()
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "setup",
+          configure(context) {
+            context.context.set("configured", true)
+          },
+          prepare(context) {
+            context.context.set("prepared", true)
+          },
+          input(context) {
+            context.context.set("input-ready", true)
+          },
+        }),
+        defineCapability({
+          id: "review",
+          workspace(context) {
+            seen({
+              configured: context.context.get("configured"),
+              inputReady: context.context.get("input-ready"),
+              prepared: context.context.get("prepared"),
+            })
+            return {
+              sources: {
+                pullRequest: {
+                  mount: "pull-request",
+                  async getKeys() {
+                    return ["summary.md"]
+                  },
+                  async getItem(key: string) {
+                    return { content: "review", key }
+                  },
+                },
+              },
+            }
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    expect(seen).toHaveBeenCalledWith({
+      configured: true,
+      inputReady: true,
+      prepared: true,
+    })
+    expect(resolved.workspaceDefinition?.sources).toHaveProperty("pullRequest")
   })
 
   it("preserves writable workspace methods when applying workspace contributions", async () => {

--- a/packages/workspace/src/sources/request-execution.ts
+++ b/packages/workspace/src/sources/request-execution.ts
@@ -70,7 +70,7 @@ function sourceRequestVisible(
 ): boolean {
   if (!scope || scope.all) return true
   const descriptorPath = workspaceSourceRequestDescriptorPath(source.key)
-  return Boolean(scope.paths?.some(path => pathIntersects(path, descriptorPath) || !source.requestOnly && pathIntersects(path, source.mountPath)))
+  return Boolean(scope.paths?.some(path => pathIntersects(path, descriptorPath)))
 }
 
 function pathContains(container: string, path: string): boolean {

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -266,24 +266,26 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
   const materializeSources = async (options = {}) => await sourceView.materializeSources(options)
   const fs: ReadonlyWorkspaceFacade<Name>["fs"] = attachWorkspaceSourceRequestExecution({
     async readFile(path, options) {
-      if (selectedScopeCanRead(selectedWorkspaceScope, path) && (isSourcePath(resolvedDefinition, path) || await sourceViewHasPath(resolvedDefinition, sourceView, path))) {
+      if (isSourcePath(resolvedDefinition, path)) {
         return await sourceView.readFile(path, options as never)
       }
+      if (selectedScopeCanRead(selectedWorkspaceScope, path) && await sourceViewHasPath(resolvedDefinition, sourceView, path)) return await sourceView.readFile(path, options as never)
       return await workspace.fs.readFile(path, options as never)
     },
     async stat(path) {
-      if (selectedScopeCanSee(selectedWorkspaceScope, path) && (isSourcePath(resolvedDefinition, path) || await sourceViewHasPath(resolvedDefinition, sourceView, path))) {
+      if (isSourcePath(resolvedDefinition, path)) {
         return await sourceView.stat(path)
       }
+      if (selectedScopeCanSee(selectedWorkspaceScope, path) && await sourceViewHasPath(resolvedDefinition, sourceView, path)) return await sourceView.stat(path)
       return await workspace.fs.stat(path)
     },
     async exists(path) {
-      if (selectedScopeCanSee(selectedWorkspaceScope, path) && isSourcePath(resolvedDefinition, path)) return await sourceView.exists(path)
+      if (isSourcePath(resolvedDefinition, path)) return await sourceView.exists(path)
       return selectedScopeCanSee(selectedWorkspaceScope, path) && await sourceViewHasPath(resolvedDefinition, sourceView, path) || await workspace.fs.exists(path)
     },
     async list(path = "", options = {}) {
       const normalized = normalizeWorkspacePath(path)
-      if (normalized && selectedScopeCanSee(selectedWorkspaceScope, normalized) && isSourcePath(resolvedDefinition, normalized)) {
+      if (normalized && isSourcePath(resolvedDefinition, normalized)) {
         return filterScopedEntries(selectedWorkspaceScope, await sourceView.list(normalized, options))
       }
       const [baseEntries, sourceEntries] = await Promise.all([
@@ -626,8 +628,18 @@ function scopedWorkspaceSource(
   source: ReturnType<typeof normalizeWorkspaceSources>[number],
   scope: WorkspaceSelectedScope,
 ): WorkspaceSource {
+  const scopedLivePaths: Record<string, string> | undefined = source.livePaths ? {} : undefined
+  syncScopedLivePaths(scopedLivePaths, source.livePaths, scope)
   const scoped: WorkspaceSource = {
     ...source.source,
+    ...(scopedLivePaths
+      ? {
+          async prepare(ctx) {
+            await source.source.prepare?.(ctx)
+            syncScopedLivePaths(scopedLivePaths, source.livePaths, scope)
+          },
+        }
+      : {}),
     ...(source.source.getItems
       ? {
           getItems: async ctx => (await source.source.getItems!(ctx))
@@ -663,13 +675,16 @@ function scopedWorkspaceSource(
       : {}),
   }
   copyWorkspaceSourceMetadata(source.source, scoped)
-  if (source.livePaths) {
-    markLiveWorkspaceSource(scoped, Object.fromEntries(
-      Object.entries(source.livePaths)
-        .filter(([path]) => selectedScopeCanRead(scope, path)),
-    ))
-  }
+  if (scopedLivePaths) markLiveWorkspaceSource(scoped, scopedLivePaths)
   return scoped
+}
+
+function syncScopedLivePaths(target: Record<string, string> | undefined, source: Record<string, string> | undefined, scope: WorkspaceSelectedScope) {
+  if (!target || !source) return
+  for (const path of Object.keys(target)) delete target[path]
+  for (const [path, value] of Object.entries(source)) {
+    if (selectedScopeCanRead(scope, path)) target[path] = value
+  }
 }
 
 function sourceItemWorkspacePath(

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -1,10 +1,12 @@
 import { createWorkspaceTools } from "../ai.ts"
+import { WorkspaceError } from "../core/errors.ts"
 import { normalizeWorkspacePath } from "../core/path.ts"
 import { createWorkspaceWritePolicy } from "../core/rules.ts"
 import { appendWorkspaceFile, copyWorkspacePath } from "../fs-ops.ts"
 import { createBasicWorkspaceSession } from "../session/basic.ts"
 import { createMemoryWorkspaceStore } from "../storage/memory.ts"
 import { copyWorkspaceSourceMetadata, normalizeWorkspaceSource, normalizeWorkspaceSources, workspaceSourceRequestDescriptorPath } from "./config.ts"
+import { markLiveWorkspaceSource } from "./live.ts"
 import { attachWorkspaceSourceRequestExecution, createWorkspaceSourceRequestExecution, getWorkspaceSourceRequestExecution } from "./request-execution.ts"
 import { resolveWorkspacePath } from "./resolver.ts"
 import { createWorkspaceSourceView } from "./view.ts"
@@ -30,6 +32,7 @@ import type {
   WorkspaceStore,
   WorkspaceWriteInput,
   WorkspaceSelectedScope,
+  WorkspaceSessionOptions,
   WorkspaceSource,
   WorkspaceSourceInput,
   WorkspaceSourceResolutionContext,
@@ -216,14 +219,14 @@ function createWritableFacadeStore(workspace: WritableWorkspaceFacade): Workspac
   }
 }
 
-async function startOverlayWorkspaceSession(definition: WorkspaceDefinition, workspace: Workspace) {
+async function startOverlayWorkspaceSession(definition: WorkspaceDefinition, workspace: Workspace, options?: WorkspaceSessionOptions) {
   if (definition.runtime === "sandbox") {
     const { createSandboxWorkspaceSession } = await import("../session/sandbox.ts")
-    return await createSandboxWorkspaceSession(definition, workspace)
+    return await createSandboxWorkspaceSession(definition, workspace, options)
   }
   if (definition.runtime === "trusted-host") {
     const { createTrustedHostWorkspaceSession } = await import("../session/trusted-host.ts")
-    return await createTrustedHostWorkspaceSession(definition, workspace)
+    return await createTrustedHostWorkspaceSession(definition, workspace, options)
   }
   return createBasicWorkspaceSession(workspace)
 }
@@ -257,40 +260,44 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
   }) ?? getWorkspaceSourceRequestExecution(workspace.fs)
   if (!options.overlay && resolvedDefinition === definition && !sourceRequestExecution) return { definition, workspace }
 
-  const sourceView = createWorkspaceSourceView(resolvedDefinition, createOverlaySourceStore(workspace, path => !isLazySourcePath(resolvedDefinition, path)))
+  const selectedWorkspaceScope = options.selectedWorkspaceScope
+  const sourceViewDefinition = createScopedSourceViewDefinition(resolvedDefinition, selectedWorkspaceScope)
+  const sourceView = createWorkspaceSourceView(sourceViewDefinition, createOverlaySourceStore(workspace, path => !isLazySourcePath(resolvedDefinition, path)))
   const materializeSources = async (options = {}) => await sourceView.materializeSources(options)
   const fs: ReadonlyWorkspaceFacade<Name>["fs"] = attachWorkspaceSourceRequestExecution({
     async readFile(path, options) {
-      if (isSourcePath(resolvedDefinition, path) || await sourceViewHasPath(resolvedDefinition, sourceView, path)) {
+      if (selectedScopeCanRead(selectedWorkspaceScope, path) && (isSourcePath(resolvedDefinition, path) || await sourceViewHasPath(resolvedDefinition, sourceView, path))) {
         return await sourceView.readFile(path, options as never)
       }
       return await workspace.fs.readFile(path, options as never)
     },
     async stat(path) {
-      if (isSourcePath(resolvedDefinition, path) || await sourceViewHasPath(resolvedDefinition, sourceView, path)) {
+      if (selectedScopeCanSee(selectedWorkspaceScope, path) && (isSourcePath(resolvedDefinition, path) || await sourceViewHasPath(resolvedDefinition, sourceView, path))) {
         return await sourceView.stat(path)
       }
       return await workspace.fs.stat(path)
     },
     async exists(path) {
-      if (isSourcePath(resolvedDefinition, path)) return await sourceView.exists(path)
-      return await sourceViewHasPath(resolvedDefinition, sourceView, path) || await workspace.fs.exists(path)
+      if (selectedScopeCanSee(selectedWorkspaceScope, path) && isSourcePath(resolvedDefinition, path)) return await sourceView.exists(path)
+      return selectedScopeCanSee(selectedWorkspaceScope, path) && await sourceViewHasPath(resolvedDefinition, sourceView, path) || await workspace.fs.exists(path)
     },
     async list(path = "", options = {}) {
       const normalized = normalizeWorkspacePath(path)
-      if (normalized && isSourcePath(resolvedDefinition, normalized)) return await sourceView.list(normalized, options)
+      if (normalized && selectedScopeCanSee(selectedWorkspaceScope, normalized) && isSourcePath(resolvedDefinition, normalized)) {
+        return filterScopedEntries(selectedWorkspaceScope, await sourceView.list(normalized, options))
+      }
       const [baseEntries, sourceEntries] = await Promise.all([
         workspace.fs.list(path as never, options as ListOptions),
-        sourcePathIntersects(resolvedDefinition, normalized) ? sourceView.list(normalized, options) : Promise.resolve([]),
+        selectedScopeCanSee(selectedWorkspaceScope, normalized) && sourcePathIntersects(resolvedDefinition, normalized) ? sourceView.list(normalized, options) : Promise.resolve([]),
       ])
-      return mergeEntries(filterBaseEntries(resolvedDefinition, baseEntries), sourceEntries)
+      return mergeEntries(filterBaseEntries(resolvedDefinition, baseEntries), filterScopedEntries(selectedWorkspaceScope, sourceEntries))
     },
     async glob(pattern, options) {
       const [baseEntries, sourceEntries] = await Promise.all([
         workspace.fs.glob(pattern as never, options),
         sourceView.glob(pattern as never, options),
       ])
-      return mergeEntries(filterBaseEntries(resolvedDefinition, baseEntries), sourceEntries)
+      return mergeEntries(filterBaseEntries(resolvedDefinition, baseEntries), filterScopedEntries(selectedWorkspaceScope, sourceEntries))
     },
     async search(query) {
       const scopedToSource = searchQueryTargetsSource(resolvedDefinition, query)
@@ -298,7 +305,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
         scopedToSource ? Promise.resolve([]) : workspace.fs.search(query),
         sourceView.search(query),
       ])
-      return mergeHits(filterBaseHits(resolvedDefinition, baseHits), sourceHits).slice(0, query.limit ?? 100)
+      return mergeHits(filterBaseHits(resolvedDefinition, baseHits), filterScopedHits(selectedWorkspaceScope, sourceHits)).slice(0, query.limit ?? 100)
     },
     materializeSources,
   }, sourceRequestExecution)
@@ -398,7 +405,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
       rm: writeFs.rm,
       search: writeFs.search,
       snapshot: workspace.snapshot,
-      startSession: async () => await startOverlayWorkspaceSession(resolvedDefinition, writeWorkspace),
+      startSession: async options => await startOverlayWorkspaceSession(resolvedDefinition, writeWorkspace, options),
       stat: writeFs.stat,
       sync: async (options) => {
         const { syncWorkspaceSources } = await import("./sync.ts")
@@ -601,6 +608,109 @@ function filterBaseEntries(definition: WorkspaceDefinition, entries: WorkspaceEn
 
 function filterBaseHits(definition: WorkspaceDefinition, hits: WorkspaceSearchHit[]): WorkspaceSearchHit[] {
   return hits.filter(hit => !isSourcePath(definition, hit.path))
+}
+
+function createScopedSourceViewDefinition(
+  definition: WorkspaceDefinition,
+  scope: WorkspaceSelectedScope | undefined,
+): WorkspaceDefinition {
+  if (!scope || scope.all) return definition
+  const sources: Record<string, WorkspaceSourceInput> = {}
+  for (const source of normalizeWorkspaceSources(definition.sources)) {
+    sources[source.key] = scopedWorkspaceSource(source, scope)
+  }
+  return { ...definition, sources }
+}
+
+function scopedWorkspaceSource(
+  source: ReturnType<typeof normalizeWorkspaceSources>[number],
+  scope: WorkspaceSelectedScope,
+): WorkspaceSource {
+  const scoped: WorkspaceSource = {
+    ...source.source,
+    ...(source.source.getItems
+      ? {
+          getItems: async ctx => (await source.source.getItems!(ctx))
+            .filter(item => selectedScopeCanRead(scope, sourceItemWorkspacePath(source, item.path || item.key))),
+        }
+      : {}),
+    getKeys: async ctx => (await source.source.getKeys(ctx))
+      .filter(key => selectedScopeCanRead(scope, sourceItemWorkspacePath(source, key))),
+    getItem: async (key, ctx) => {
+      const path = sourceItemWorkspacePath(source, key)
+      if (!selectedScopeCanRead(scope, path)) {
+        throw new WorkspaceError(`[vitehub] Workspace file does not exist: ${path}.`)
+      }
+      return await source.source.getItem(key, ctx)
+    },
+    ...(source.source.getMeta
+      ? {
+          getMeta: async (key, ctx) => {
+            if (!selectedScopeCanRead(scope, sourceItemWorkspacePath(source, key))) return undefined
+            return await source.source.getMeta!(key, ctx)
+          },
+        }
+      : {}),
+    ...(source.source.search
+      ? {
+          search: async (query, ctx) => {
+            const paths = selectedScopeQueryPaths(scope, query)
+              .filter(path => pathIntersects(source.mountPath, path))
+            if (!paths.length) return []
+            return filterScopedHits(scope, await source.source.search!({ ...query, paths }, ctx))
+          },
+        }
+      : {}),
+  }
+  copyWorkspaceSourceMetadata(source.source, scoped)
+  if (source.livePaths) {
+    markLiveWorkspaceSource(scoped, Object.fromEntries(
+      Object.entries(source.livePaths)
+        .filter(([path]) => selectedScopeCanRead(scope, path)),
+    ))
+  }
+  return scoped
+}
+
+function sourceItemWorkspacePath(
+  source: ReturnType<typeof normalizeWorkspaceSources>[number],
+  sourcePath: string,
+): string {
+  const normalized = normalizeWorkspacePath(sourcePath)
+  return normalizeWorkspacePath(source.mountPath ? `${source.mountPath}/${normalized}` : normalized)
+}
+
+function selectedScopeQueryPaths(scope: WorkspaceSelectedScope, query: WorkspaceSearchQuery): string[] {
+  const requestedPaths = (query.paths?.length ? query.paths : [query.cwd || ""]).map(path => normalizeWorkspacePath(path))
+  const scopedPaths = (scope.paths || []).map(path => normalizeWorkspacePath(path))
+  const paths = new Set<string>()
+  for (const scopedPath of scopedPaths) {
+    for (const requestedPath of requestedPaths) {
+      if (pathContains(scopedPath, requestedPath)) paths.add(requestedPath)
+      else if (pathContains(requestedPath, scopedPath)) paths.add(scopedPath)
+    }
+  }
+  return [...paths]
+}
+
+function selectedScopeCanRead(scope: WorkspaceSelectedScope | undefined, path: string): boolean {
+  if (!scope || scope.all) return true
+  const normalized = normalizeWorkspacePath(path)
+  return Boolean(scope.paths?.some(prefix => pathContains(normalizeWorkspacePath(prefix), normalized)))
+}
+
+function selectedScopeCanSee(scope: WorkspaceSelectedScope | undefined, path: string): boolean {
+  if (!scope || scope.all) return true
+  const normalized = normalizeWorkspacePath(path)
+  return Boolean(scope.paths?.some(prefix => pathIntersects(normalizeWorkspacePath(prefix), normalized)))
+}
+
+function filterScopedEntries(scope: WorkspaceSelectedScope | undefined, entries: WorkspaceEntry[]): WorkspaceEntry[] {
+  return entries.filter(entry => selectedScopeCanSee(scope, entry.path))
+}
+
+function filterScopedHits(scope: WorkspaceSelectedScope | undefined, hits: WorkspaceSearchHit[]): WorkspaceSearchHit[] {
+  return hits.filter(hit => selectedScopeCanRead(scope, hit.path))
 }
 
 function mergeEntries(base: WorkspaceEntry[], source: WorkspaceEntry[]): WorkspaceEntry[] {

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -6,6 +6,7 @@ import {
   fetch,
   getWorkspaceSourceRequestExecution,
   github,
+  mcpResources,
   resolveWorkspaceSources,
   type WorkspaceShellResult,
   workspaceSourceRequestDescriptorPath,
@@ -492,6 +493,7 @@ describe("Workspace Source Resolution", () => {
 
   it("keeps scoped-out source subpaths hidden in overlays", async () => {
     const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    await base.writeFile("docs/private.md", "stale secret\n")
     const getItem = vi.fn(async (key: string) => ({
       content: key === "public.md" ? "public\n" : "secret\n",
       key,
@@ -526,6 +528,49 @@ describe("Workspace Source Resolution", () => {
     ])
     await expect(workspace.fs.search({ pattern: "secret", paths: ["docs"] })).resolves.toEqual([])
     expect(getItem).not.toHaveBeenCalledWith("private.md", expect.anything())
+  })
+
+  it("preserves scoped live source paths populated during prepare", async () => {
+    const content = JSON.stringify([{ path: "/docs/getting-started/introduction" }], null, 2)
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        nuxt: mcpResources({
+          mount: "resources",
+          server: {
+            async listResources() {
+              return {
+                resources: [{
+                  name: "documentation-pages",
+                  uri: "resource://nuxt-com/documentation-pages",
+                }],
+              }
+            },
+            async readResource({ uri }) {
+              return {
+                contents: [{
+                  mimeType: "application/json",
+                  text: content,
+                  uri,
+                }],
+              }
+            },
+          },
+        }),
+      },
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(
+      facade(createWorkspace({ name: "support", store: { provider: "memory" } })),
+      definition,
+      { ...scope("docs", ["resources/nuxt-com/documentation-pages.json"]), overlay: true },
+    )
+
+    await expect(workspace.fs.exists("resources/nuxt-com/documentation-pages.json")).resolves.toBe(true)
+    await expect(workspace.fs.list("resources/nuxt-com")).resolves.toEqual([
+      { path: "resources/nuxt-com/documentation-pages.json", type: "file" },
+    ])
+    await expect(workspace.fs.readFile("resources/nuxt-com/documentation-pages.json")).resolves.toBe(content)
   })
 
   it("layers resolved source-backed paths over the base Workspace without persistent cross-scope materialization", async () => {

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -4,6 +4,7 @@ import {
   createWorkspaceSourceResolutionFacade,
   custom,
   fetch,
+  getWorkspaceSourceRequestExecution,
   github,
   resolveWorkspaceSources,
   type WorkspaceShellResult,
@@ -397,6 +398,27 @@ describe("Workspace Source Resolution", () => {
     }))
   })
 
+  it("requires descriptor visibility for scoped controlled curl", async () => {
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        inventory: fetch({
+          url: "https://portal.example.com/runtime/inventory-health",
+          workspacePath: "status/summary.json",
+        }),
+      },
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(
+      facade(createWorkspace({ name: "support", store: { provider: "memory" } })),
+      definition,
+      scope("status", ["status/summary.json"]),
+    )
+
+    expect(getWorkspaceSourceRequestExecution(workspace.fs)).toBeUndefined()
+    await expect(workspace.fs.list(".vitehub/sources")).resolves.toEqual([])
+  })
+
   it("fails closed when a resolved source mount is outside the Selected Workspace Scope", async () => {
     const definition: WorkspaceDefinition = {
       name: "support",
@@ -466,6 +488,44 @@ describe("Workspace Source Resolution", () => {
     expect(resolvedDefinition.sources).not.toHaveProperty("privateDocs")
     await expect(workspace.fs.readFile("public/README.md")).resolves.toBe("public\n")
     await expect(workspace.fs.exists("private/secret.md")).resolves.toBe(false)
+  })
+
+  it("keeps scoped-out source subpaths hidden in overlays", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    const getItem = vi.fn(async (key: string) => ({
+      content: key === "public.md" ? "public\n" : "secret\n",
+      key,
+      path: key,
+    }))
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        docs: custom({
+          materialize: "lazy",
+          mount: "docs",
+          async getKeys() {
+            return ["public.md", "private.md"]
+          },
+          getItem,
+        }),
+      },
+    }
+
+    const { definition: resolvedDefinition, workspace } = await createWorkspaceSourceResolutionFacade(
+      facade(base),
+      definition,
+      { ...scope("public", ["docs/public.md"]), overlay: true },
+    )
+
+    expect(resolvedDefinition.sources).toHaveProperty("docs")
+    await expect(workspace.fs.readFile("docs/public.md")).resolves.toBe("public\n")
+    await expect(workspace.fs.readFile("docs/private.md")).rejects.toThrow("does not exist")
+    await expect(workspace.fs.exists("docs/private.md")).resolves.toBe(false)
+    await expect(workspace.fs.list("docs")).resolves.toEqual([
+      expect.objectContaining({ path: "docs/public.md", type: "file" }),
+    ])
+    await expect(workspace.fs.search({ pattern: "secret", paths: ["docs"] })).resolves.toEqual([])
+    expect(getItem).not.toHaveBeenCalledWith("private.md", expect.anything())
   })
 
   it("layers resolved source-backed paths over the base Workspace without persistent cross-scope materialization", async () => {
@@ -691,5 +751,30 @@ describe("Workspace Source Resolution", () => {
     await session.writeFile("artifacts/session.md", "ok")
     await session.commit({ message: "session" })
     await expect(base.readFile("artifacts/session.md")).resolves.toBe("ok")
+  })
+
+  it("forwards Workspace Session path options in writable overlays", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    await base.writeFile("artifacts/allowed.md", "ok")
+    await base.writeFile("secrets/private.md", "secret")
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      runtime: "trusted-host",
+      sources: {},
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(writableFacade(base), definition, {
+      invocation,
+      overlay: true,
+    })
+    const session = await (workspace as WritableWorkspaceFacade).startSession({ paths: ["artifacts"] })
+
+    try {
+      await expect(session.readFile("artifacts/allowed.md")).resolves.toBe("ok")
+      await expect(session.readFile("secrets/private.md")).rejects.toThrow("does not exist")
+    }
+    finally {
+      await session.close()
+    }
   })
 })


### PR DESCRIPTION
Enforces Selected Workspace Scope before source overlay views read source-backed paths, including controlled source request descriptors and scoped session overlays.

Also narrows Capability Workspace Contribution validation so root-mounted finite sources only conflict with their concrete source-backed paths, and defers workspace contribution resolvers until after earlier lifecycle phases can seed context.

Refs #366.