### PR TITLE
fix(workspace): prefer executable shell providers

### DIFF
--- a/docs/content/docs/server-primitives/shell.md
+++ b/docs/content/docs/server-primitives/shell.md
@@ -52,7 +52,7 @@ await shell.exec('rg auth docs', { cwd: workspaceMountPoint })
 | `createShellRuntime` from `@vite-hub/shell` | Create a Shell Runtime from an Execution Provider. |
 | `analyzeShellCommand` from `@vite-hub/shell` | Parse a command and return static command facts. |
 | `createJustBashProvider` from `@vite-hub/shell/providers/just-bash` | Run Bash-compatible commands in the `just-bash` browser runtime. |
-| `createCloudflareShellProvider` from `@vite-hub/shell/providers/cloudflare` | Adapt a Cloudflare sandbox-like client to Shell. |
+| `createCloudflareShellProvider` from `@vite-hub/shell/providers/cloudflare` | Adapt a Cloudflare execution client to Shell. |
 | `createReadonlyWorkspaceFs`, `createWritableWorkspaceFs`, `workspaceMountPoint` from `@vite-hub/shell/workspace` | Mount Workspace file access into Shell providers. |
 | `runWorkspaceInspectionCommand` from `@vite-hub/shell/workspace` | Run a preflighted read-only Workspace inspection command. |
 | `cleanWorkspaceShellPath`, `cleanWorkspaceMutationPath` from `@vite-hub/shell/workspace` | Normalize Workspace paths for shell-facing behavior. |
@@ -66,8 +66,16 @@ Shell providers implement `ShellExecutionProvider`. Shell has provider adapters,
 | Provider | Configure with | Boundary nuance |
 | --- | --- | --- |
 | Just Bash | `createJustBashProvider({ fs, commands?, cwd? })` | Runs `just-bash` against an explicit filesystem adapter. Network is disabled; background and interactive processes are unsupported. |
-| Cloudflare | `createCloudflareShellProvider({ sandbox })` | Delegates execution to a Cloudflare sandbox-like client. CWD and env support come from `sandbox.supports`; network is reported as `unknown`. |
+| Cloudflare | `createCloudflareShellProvider({ sandbox })` | Delegates command execution to a Cloudflare client that exposes `exec(command, args, options)`. CWD and env support come from `sandbox.supports`; network is reported as `unknown`. |
 | Custom | A `ShellExecutionProvider` object | Implement `boundary`, `exec`, optional `analyze`, and optional process methods directly. |
+
+For Cloudflare Workers agents that use Cloudflare's structured shell runtime, install the Cloudflare packages beside ViteHub Shell:
+
+```bash [Terminal]
+pnpm add @cloudflare/shell @cloudflare/codemode
+```
+
+`@cloudflare/shell` exposes structured `state.*` and git tools through `@cloudflare/codemode`; it is not a Bash interpreter. Use `createCloudflareShellProvider()` when the Cloudflare runtime boundary also exposes a command-execution client, and use a custom `ShellExecutionProvider` when the app wants to translate ViteHub Shell calls into `@cloudflare/shell` state operations.
 
 ## Create a Shell Runtime
 

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -368,12 +368,12 @@ async function resolveWorkspaceScope<
 ): Promise<ResolvedWorkspaceScope> {
   const selection = normalizeSelection(await resolveSelection(options, context))
   if (!selection) {
-    throw new Error("[vitehub] access({ workspace }) could not resolve a Workspace Scope. Configure defaultScope or resolve().")
+    throw new Error("[vitehub] access({ workspace }) could not resolve a Workspace Scope. defaultScope or resolve() must produce a Workspace Scope.")
   }
 
   const definition = selection.definition || options.scopes?.[selection.scope]
   if (!definition) {
-    throw new Error(`[vitehub] access({ workspace }) resolved unknown Workspace Scope "${selection.scope}". Configure scopes.${selection.scope} or return an inline scope definition.`)
+    throw new Error(`[vitehub] access({ workspace }) resolved unknown Workspace Scope "${selection.scope}". scopes.${selection.scope} or an inline scope definition must define it.`)
   }
 
   const role = selection.role || "viewer"

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -28,6 +28,8 @@ import type {
   WorkspaceName,
   WorkspaceSearchHit,
   WorkspaceSearchQuery,
+  WorkspaceSession,
+  WorkspaceSessionOptions,
   WorkspaceSourceRequestDescriptor,
   WorkspaceSourceRequestExecutionInput,
   WorkspaceSourceInput,
@@ -46,6 +48,7 @@ type WorkspaceAccessRuntime = Pick<
 >
 
 type WorkspaceSourceRequestExecution = ReturnType<WorkspaceAccessRuntime["getWorkspaceSourceRequestExecution"]>
+type WorkspaceSessionStarter = { startSession(options?: WorkspaceSessionOptions): Promise<WorkspaceSession> }
 
 export type AccessRoleName = "viewer" | "admin" | (string & {})
 
@@ -702,6 +705,28 @@ function scopedSearchQuery(scope: ResolvedWorkspaceScope, query: WorkspaceSearch
   }
 }
 
+function workspaceSessionStarter(input: object): WorkspaceSessionStarter | undefined {
+  return typeof (input as Partial<WorkspaceSessionStarter>).startSession === "function"
+    ? input as WorkspaceSessionStarter
+    : undefined
+}
+
+function scopedSessionPaths(scope: ResolvedWorkspaceScope, paths: readonly string[] | undefined): string[] | undefined {
+  if (scope.all) return paths ? [...paths] : undefined
+  const requestedPaths = paths?.length ? paths : [""]
+  const scopedPaths = new Set<string>()
+  for (const rawPath of requestedPaths) {
+    const requested = normalizeScopePath(rawPath)
+    for (const grant of scope.materializeGrants) {
+      const grantPath = normalizeScopePath(grant.path)
+      if (pathContains(grantPath, requested)) scopedPaths.add(requested)
+      else if (!requested || pathContains(requested, grantPath)) scopedPaths.add(grantPath)
+    }
+  }
+  if (!scopedPaths.size) throw notFound(requestedPaths[0] || "")
+  return [...scopedPaths].sort()
+}
+
 function createScopedWorkspaceFacade<Name extends WorkspaceName>(
   workspace: ReadonlyWorkspaceFacade<Name>,
   scope: ResolvedWorkspaceScope,
@@ -709,6 +734,7 @@ function createScopedWorkspaceFacade<Name extends WorkspaceName>(
 ): ReadonlyWorkspaceFacade<Name> {
   let fs: ReadonlyWorkspaceFacade<Name>["fs"]
   const sourceRequestExecution = workspaceRuntime.getWorkspaceSourceRequestExecution(workspace.fs)
+  const starter = workspaceSessionStarter(workspace.fs)
   fs = workspaceRuntime.attachWorkspaceSourceRequestExecution({
     async readFile(path, options) {
       const normalized = normalizeScopePath(path)
@@ -749,7 +775,17 @@ function createScopedWorkspaceFacade<Name extends WorkspaceName>(
       }))
       return mergeMaterializedSources(options.path || "", results)
     },
-  } satisfies ReadonlyWorkspaceFacade<Name>["fs"], scopedSourceRequestExecution(() => fs, sourceRequestExecution))
+    ...(starter
+      ? {
+          async startSession(options?: WorkspaceSessionOptions) {
+            return await starter.startSession({
+              ...options,
+              paths: scopedSessionPaths(scope, options?.paths),
+            })
+          },
+        }
+      : {}),
+  } satisfies ReadonlyWorkspaceFacade<Name>["fs"] & Partial<WorkspaceSessionStarter>, scopedSourceRequestExecution(() => fs, sourceRequestExecution))
 
   const createTools = (options?: WorkspaceFacadeToolOptions) => workspaceRuntime.createWorkspaceTools(fs, {
     broadSearchPaths: options?.broadSearchPaths,

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -86,7 +86,7 @@ function parseGitCommand(command: string): string[] {
   const words = shellWords(command)
   if (words[0] !== "git") throw new Error("[vitehub] git commands must start with `git`.")
   if (!words[1]) throw new Error("[vitehub] git command requires a subcommand.")
-  if (words[1].startsWith("-")) throw new Error("[vitehub] git() does not accept global git flags. Use the tool cwd option instead of `git -C`.")
+  if (words[1].startsWith("-")) throw new Error("[vitehub] git() does not accept global git flags. The tool cwd option provides repository scoping without `git -C`.")
   return words.slice(1)
 }
 

--- a/packages/agent/src/capabilities/subagents.ts
+++ b/packages/agent/src/capabilities/subagents.ts
@@ -94,7 +94,7 @@ function normalizeAgents<TRuntimeConfig extends AgentRuntimeConfig>(
     if (!definition?.agent) throw new TypeError(`[vitehub] subagents() "${name}" requires an agent.`)
     if (!definition.description?.trim()) throw new TypeError(`[vitehub] subagents() "${name}" requires a description.`)
     const toolName = toolNameFor(name, definition)
-    if (toolNames.has(toolName)) throw new TypeError(`[vitehub] Duplicate subagent tool name "${toolName}". Use explicit toolName values to disambiguate.`)
+    if (toolNames.has(toolName)) throw new TypeError(`[vitehub] Duplicate subagent tool name "${toolName}". Explicit toolName values disambiguate duplicate subagent tools.`)
     toolNames.add(toolName)
     return { definition, name, toolName }
   })

--- a/packages/agent/src/capabilities/workspace-exec.ts
+++ b/packages/agent/src/capabilities/workspace-exec.ts
@@ -105,7 +105,7 @@ function normalizeCwd(cwd: unknown): string {
 
 function assertWorkspace(workspace: unknown): asserts workspace is WorkspaceExecWorkspace {
   if (!workspace || typeof workspace !== "object" || typeof (workspace as { startSession?: unknown }).startSession !== "function") {
-    throw new Error("[vitehub] workspaceExec() requires an executable Workspace Session. Configure the agent with a writable workspace for trusted workspace/session execution.")
+    throw new Error("[vitehub] workspaceExec() requires an executable Workspace Session. Trusted workspace/session execution requires a writable workspace.")
   }
 }
 

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -530,7 +530,7 @@ async function githubAppPrivateKey<TRuntimeConfig extends AgentRuntimeConfig>(
 ) {
   const inline = cleanSecret(await githubAppSetting(options, env, "privateKey", "appPrivateKey", context))
   if (inline) return inline.replace(/\\n/g, "\n")
-  throw new Error("[vitehub] Missing GitHub App privateKey. Set github.appPrivateKey or GITHUB_APP_PRIVATE_KEY.")
+  throw new Error("[vitehub] Missing GitHub App privateKey. github.appPrivateKey or GITHUB_APP_PRIVATE_KEY is required.")
 }
 
 function base64url(value: string | Buffer) {
@@ -857,7 +857,7 @@ export function http<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCon
   options: AgentChannelOptions<TRuntimeConfig> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {
   if ("path" in options) {
-    throw new TypeError("[vitehub] http({ path }) is not wired yet. Use webhooks.path for webhook routes.")
+    throw new TypeError("[vitehub] http({ path }) is not wired yet. Webhook routes are configured with webhooks.path.")
   }
   return defineChannel("http", options)
 }

--- a/packages/agent/src/eval.ts
+++ b/packages/agent/src/eval.ts
@@ -136,7 +136,7 @@ async function resolveSiblingAgent<TRuntimeConfig extends AgentRuntimeConfig>(
   caller: string | undefined,
 ): Promise<AgentEvalAgent<TRuntimeConfig>> {
   if (!caller) {
-    throw new Error("[vitehub] defineEval() could not infer the sibling Agent Definition. Pass agent explicitly.")
+    throw new Error("[vitehub] defineEval() could not infer the sibling Agent Definition. The sibling Agent Definition must be passed explicitly.")
   }
 
   const extension = extname(caller)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -463,7 +463,7 @@ function resolveAgentWorkflowRuntimeBinding<
 
 function resolveAgentWorkflowName(binding: AgentWorkflowRuntimeBinding): string {
   if (binding.name) return binding.name
-  throw new Error("[vitehub] Agent runtime workflow() requires a name when invoked directly. Use workflow(\"name\") so the Agent Invocation can target a stable Workflow Definition.")
+  throw new Error("[vitehub] Agent runtime workflow() requires a name when invoked directly. A stable Workflow Definition target requires workflow(\"name\").")
 }
 
 async function getAgentWorkflowHandle<

--- a/packages/agent/src/internal/agent-driver.ts
+++ b/packages/agent/src/internal/agent-driver.ts
@@ -63,7 +63,7 @@ function normalizeHarnessCredentialSource(value: unknown): AgentHarnessCredentia
     throw new TypeError("[vitehub] defineAgent({ driver.credentials }) must be a credential source object.")
   }
   if (hasOwnDefined(value, "value")) {
-    throw new Error("[vitehub] defineAgent({ driver.credentials.value }) is not supported by the generic harness adapter yet. Pass provider credentials to the harness adapter constructor or omit credentials for ambient adapter auth.")
+    throw new Error("[vitehub] defineAgent({ driver.credentials.value }) is not supported by the generic harness adapter yet. Provider credentials belong on the harness adapter constructor, or credentials must be omitted for ambient adapter auth.")
   }
 
   const label = value.label
@@ -168,5 +168,5 @@ export function normalizeAgentDriver<
     }
   }
 
-  throw new Error("[vitehub] Agent Driver is required. Use defineAgent({ driver: { model } }) or defineAgent({ driver: { run } }).")
+  throw new Error("[vitehub] Agent Driver is required. Expected defineAgent({ driver: { model } }) or defineAgent({ driver: { run } }).")
 }

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -294,7 +294,7 @@ async function verifyRequiredWebhookHeaders<TRuntimeConfig extends AgentRuntimeC
     if (!registration.secretHeader) {
       if (secretToken === false) return { registration, verified: true }
       if (secretToken) {
-        throw webhookVerificationError(`[vitehub] Webhook registration "${registration.id || registration.provider}" declares secretToken but no secretHeader is configured. Set secretHeader or secretToken: false to explicitly disable verification.`)
+        throw webhookVerificationError(`[vitehub] Webhook registration "${registration.id || registration.provider}" declares secretToken but no secretHeader is configured. Verification requires secretHeader; secretToken: false explicitly disables verification.`)
       }
       continue
     }
@@ -302,7 +302,7 @@ async function verifyRequiredWebhookHeaders<TRuntimeConfig extends AgentRuntimeC
       return { registration, verified: true }
     }
     if (!secretToken) {
-      throw webhookVerificationError(`[vitehub] Webhook registration "${registration.id || registration.provider}" declares secretHeader "${registration.secretHeader}" but no secretToken is configured. Set secretToken (from Server Env) or secretToken: false to explicitly disable verification.`)
+      throw webhookVerificationError(`[vitehub] Webhook registration "${registration.id || registration.provider}" declares secretHeader "${registration.secretHeader}" but no secretToken is configured. Verification requires secretToken from Server Env; secretToken: false explicitly disables verification.`)
     }
     throw webhookVerificationError(`[vitehub] Webhook secret header "${registration.secretHeader}" is required.`)
   }
@@ -335,7 +335,7 @@ export async function verifyAgentWebhookRequest<TRuntimeConfig extends AgentRunt
       return { registration, verified: true }
     }
     if (!secretToken) {
-      throw webhookVerificationError(`[vitehub] Webhook registration "${registration.id || registration.provider}" declares secretHeader "${registration.secretHeader}" but no secretToken is configured. Set secretToken (from Server Env) or secretToken: false to explicitly disable verification.`)
+      throw webhookVerificationError(`[vitehub] Webhook registration "${registration.id || registration.provider}" declares secretHeader "${registration.secretHeader}" but no secretToken is configured. Verification requires secretToken from Server Env; secretToken: false explicitly disables verification.`)
     }
     if (registration.signature === "github-sha256") {
       const expected = `sha256=${await hmacSha256(secretToken, await request.clone().text())}`

--- a/packages/agent/src/workspace-source-metadata.ts
+++ b/packages/agent/src/workspace-source-metadata.ts
@@ -116,7 +116,7 @@ function inferWorkspaceSourceFamily(input: Record<string, unknown>): WorkspaceSo
 }
 
 function ambiguousSourceConfiguration(families: WorkspaceSourceFamily[]): TypeError {
-  return new TypeError(`[vitehub] Workspace source configuration is ambiguous. Matched ${families.join(", ")}. Use { source: ... } or custom(...) to make the source kind explicit.`)
+  return new TypeError(`[vitehub] Workspace source configuration is ambiguous. Matched ${families.join(", ")}. A { source: ... } wrapper or custom(...) call makes the source kind explicit.`)
 }
 
 function fileSourceDefaults(input: Record<string, unknown>): WorkspaceSourceMetadataDescriptor {

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -491,6 +491,52 @@ describe("access capability", () => {
     expect(result.stdout).not.toContain("globex")
   })
 
+  it("keeps scoped workspace shell searches on executable sessions", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access, workspaceShell } = await import("../src/capabilities.ts")
+    const exec = vi.fn(async (command: string, args: string[] = [], options?: { cwd?: string }) => ({
+      args,
+      command,
+      exitCode: 0,
+      stderr: "",
+      stdout: "native rg\n",
+      cwd: options?.cwd,
+    }))
+    const close = vi.fn()
+    const startSession = vi.fn(async () => ({ close, exec }))
+    const base = createWorkspace()
+    const workspace: ReadonlyWorkspaceFacade = {
+      ...base,
+      fs: {
+        ...base.fs,
+        async exists(path: string) {
+          return path === "portal/app" || await base.fs.exists(path)
+        },
+        startSession,
+      } as never,
+    }
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "portal",
+            scopes: {
+              portal: { paths: ["portal"] },
+            },
+          },
+        }),
+        workspaceShell(),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, workspace)
+    const result = await resolved.tools!.shell.execute!({ command: `rg -i "months.*stock" portal/app --max-depth 3` }) as { stdout: string }
+
+    expect(result.stdout).toBe("native rg\n")
+    expect(startSession).toHaveBeenCalledWith({ paths: ["portal/app"] })
+    expect(exec).toHaveBeenCalledWith("sh", ["-lc", `rg -i "months.*stock" portal/app --max-depth 3`], expect.objectContaining({ cwd: "/workspace" }))
+    expect(close).toHaveBeenCalled()
+  })
+
   it("preserves source request execution on scoped workspace shell commands", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access, workspaceShell } = await import("../src/capabilities.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1275,7 +1275,7 @@ describe("server helpers", () => {
     }), "custom-support")
 
     expect(response.status).toBe(401)
-    await expect(response.json()).resolves.toEqual({ error: "[vitehub] Webhook registration \"custom-support\" declares secretHeader \"x-test-secret\" but no secretToken is configured. Set secretToken (from Server Env) or secretToken: false to explicitly disable verification." })
+    await expect(response.json()).resolves.toEqual({ error: "[vitehub] Webhook registration \"custom-support\" declares secretHeader \"x-test-secret\" but no secretToken is configured. Verification requires secretToken from Server Env; secretToken: false explicitly disables verification." })
     expect(adapter.handleWebhook).not.toHaveBeenCalled()
     expect(run).not.toHaveBeenCalled()
   })
@@ -1329,7 +1329,7 @@ describe("server helpers", () => {
     }), "github")
 
     expect(response.status).toBe(401)
-    await expect(response.json()).resolves.toEqual({ error: "[vitehub] Webhook registration \"github\" declares secretHeader \"x-hub-signature-256\" but no secretToken is configured. Set secretToken (from Server Env) or secretToken: false to explicitly disable verification." })
+    await expect(response.json()).resolves.toEqual({ error: "[vitehub] Webhook registration \"github\" declares secretHeader \"x-hub-signature-256\" but no secretToken is configured. Verification requires secretToken from Server Env; secretToken: false explicitly disables verification." })
     expect(run).not.toHaveBeenCalled()
   })
 

--- a/packages/agent/test/webhook-verification.test.ts
+++ b/packages/agent/test/webhook-verification.test.ts
@@ -133,7 +133,7 @@ describe("agent webhook verification", () => {
     })), "chat.message", chatInput()))
       .rejects
       .toMatchObject({
-        message: "[vitehub] Webhook registration \"telegram\" declares secretHeader \"x-telegram-bot-api-secret-token\" but no secretToken is configured. Set secretToken (from Server Env) or secretToken: false to explicitly disable verification.",
+        message: "[vitehub] Webhook registration \"telegram\" declares secretHeader \"x-telegram-bot-api-secret-token\" but no secretToken is configured. Verification requires secretToken from Server Env; secretToken: false explicitly disables verification.",
         statusCode: 401,
       })
     expect(invoked).not.toHaveBeenCalled()
@@ -147,7 +147,7 @@ describe("agent webhook verification", () => {
     }], new Request("https://example.com", { method: "POST" }), runtime(), { requireSecretHeader: true }))
       .rejects
       .toMatchObject({
-        message: "[vitehub] Webhook registration \"custom\" declares secretToken but no secretHeader is configured. Set secretHeader or secretToken: false to explicitly disable verification.",
+        message: "[vitehub] Webhook registration \"custom\" declares secretToken but no secretHeader is configured. Verification requires secretHeader; secretToken: false explicitly disables verification.",
         statusCode: 401,
       })
   })

--- a/packages/cli/src/provision.ts
+++ b/packages/cli/src/provision.ts
@@ -75,7 +75,7 @@ export async function runProvision(args: string[], context: ProvisionFeatureCont
       : resolveVercelProvisionConfig(context.env)
     if (!config) {
       const required = provider === "cloudflare" ? "CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN" : "VERCEL_TOKEN"
-      context.stderr.write(`Provision requires ${required} to be set. Use --dry-run to preview without credentials.\n`)
+      context.stderr.write(`Provision requires ${required} to be set. Dry-run preview does not require credentials (--dry-run).\n`)
       return 1
     }
   }

--- a/packages/database/src/runtime/hosted.ts
+++ b/packages/database/src/runtime/hosted.ts
@@ -16,7 +16,7 @@ export function createHostedDrizzleDb<TSchema extends Record<string, unknown>>(
 ) {
   return createDrizzleSqliteAdapter(dbConfig, schema, {
     libsql: { createClient, drizzle: drizzleLibsql as never },
-    missingConnectionMessage: config => `[vitehub] Hosted DB "${config.name}" requires a Cloudflare D1 binding or a remote libSQL URL. Set \`db.connection.url\` to a hosted libSQL endpoint before deploying this database to Cloudflare or Vercel.`,
+    missingConnectionMessage: config => `[vitehub] Hosted DB "${config.name}" requires a Cloudflare D1 binding or a remote libSQL URL. Hosted deployment requires \`db.connection.url\` to be a hosted libSQL endpoint before deploying this database to Cloudflare or Vercel.`,
     requireRemoteUrl: true,
   })
 }

--- a/packages/kv/src/runtime/deno-kv.ts
+++ b/packages/kv/src/runtime/deno-kv.ts
@@ -40,7 +40,7 @@ export default function createDenoKVDriver(options: ResolvedDenoKVStoreConfig = 
   const open = () => kvPromise ||= (async () => {
     const openKv = getDenoRuntime()?.openKv
     if (!openKv) {
-      throw new Error("[vitehub] Deno KV requires Deno.openKv(). Run in Deno with KV enabled or choose another KV Store driver.")
+      throw new Error("[vitehub] Deno KV requires Deno.openKv(). The runtime must be Deno with KV enabled, or the KV Store needs another driver.")
     }
     return openKv(options.path)
   })()

--- a/packages/queue/src/providers/vercel.ts
+++ b/packages/queue/src/providers/vercel.ts
@@ -69,7 +69,7 @@ async function loadVercelQueueClient(region: string | undefined): Promise<Vercel
     }
   }
   catch (error) {
-    throw new QueueError(`@vercel/queue load failed. Install it to use the Vercel provider. Original error: ${error instanceof Error ? error.message : error}`, {
+    throw new QueueError(`@vercel/queue load failed. The Vercel provider requires @vercel/queue to be installed. Original error: ${error instanceof Error ? error.message : error}`, {
       cause: error,
       code: "VERCEL_QUEUE_SDK_LOAD_FAILED",
       provider: "vercel",

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -169,7 +169,7 @@ export function resolveSandboxFeatureConfig(sandboxConfig: AgentSandboxConfig, h
 
   const unsupportedHostedProvider = getHostingProvider(hosting)
   if (unsupportedHostedProvider === 'netlify') {
-    throw new TypeError('[vitehub] Sandbox hosting inference does not support Netlify. Set `sandbox.provider` explicitly.')
+    throw new TypeError('[vitehub] Sandbox hosting inference does not support Netlify. An explicit `sandbox.provider` is required.')
   }
 
   return config

--- a/packages/sandbox/src/internal/shared/named-resource.ts
+++ b/packages/sandbox/src/internal/shared/named-resource.ts
@@ -2,7 +2,7 @@ import { upperFirst } from 'scule'
 
 export function resolveNamedResourceName(feature: string, name: string | undefined) {
   if (!name)
-    throw new Error(`[vitehub] ${upperFirst(feature)} name is required. Pass an explicit name.`)
+    throw new Error(`[vitehub] ${upperFirst(feature)} name is required. An explicit name is required.`)
   return name
 }
 

--- a/packages/sandbox/src/runtime/providers/cloudflare.ts
+++ b/packages/sandbox/src/runtime/providers/cloudflare.ts
@@ -19,7 +19,7 @@ async function loadCloudflareSandbox() {
     return (await import('@cloudflare/sandbox')).getSandbox
   }
   catch (error) {
-    throw new Error(`@cloudflare/sandbox load failed. Install it to use the Cloudflare provider. Original error: ${error instanceof Error ? error.message : error}`)
+    throw new Error(`@cloudflare/sandbox load failed. The Cloudflare provider requires @cloudflare/sandbox to be installed. Original error: ${error instanceof Error ? error.message : error}`)
   }
 }
 

--- a/packages/sandbox/src/sandbox/providers/cloudflare.ts
+++ b/packages/sandbox/src/sandbox/providers/cloudflare.ts
@@ -7,7 +7,7 @@ async function loadCloudflareSandbox() {
     return (await import('@cloudflare/sandbox')).getSandbox
   }
   catch (error) {
-    throw new SandboxError(`@cloudflare/sandbox load failed. Install it to use the Cloudflare provider. Original error: ${error instanceof Error ? error.message : error}`)
+    throw new SandboxError(`@cloudflare/sandbox load failed. The Cloudflare provider requires @cloudflare/sandbox to be installed. Original error: ${error instanceof Error ? error.message : error}`)
   }
 }
 

--- a/packages/sandbox/src/sandbox/providers/vercel.ts
+++ b/packages/sandbox/src/sandbox/providers/vercel.ts
@@ -87,7 +87,7 @@ async function loadVercelSandbox(): Promise<VercelSandboxSDK> {
     }
   }
   catch (error) {
-    throw new SandboxError(`@vercel/sandbox load failed. Install it to use the Vercel provider. Original error: ${error instanceof Error ? error.message : error}`)
+    throw new SandboxError(`@vercel/sandbox load failed. The Vercel provider requires @vercel/sandbox to be installed. Original error: ${error instanceof Error ? error.message : error}`)
   }
 }
 

--- a/packages/shell/src/providers/just-bash.ts
+++ b/packages/shell/src/providers/just-bash.ts
@@ -331,7 +331,7 @@ function policyDeniedCurl(command: string, cwd: string | undefined, message: str
     stderr: `[vitehub] ${message}\n`,
     stdout: [
       "[vitehub] Controlled curl request was not run.",
-      "Inspect `.vitehub/sources/<sourceKey>.json`, then retry with a single curl command that matches a visible Source request descriptor.",
+      "Expected a single curl command matching a visible Source Request Descriptor at `.vitehub/sources/<sourceKey>.json`.",
     ].join("\n") + "\n",
   }
 }

--- a/packages/shell/src/runtime/session.ts
+++ b/packages/shell/src/runtime/session.ts
@@ -66,7 +66,7 @@ class RuntimeShellSession implements ShellSession {
       return createPolicyObservation(
         command,
         options.cwd,
-        `[vitehub] Shell session command budget exhausted after ${this.policy.maxShellCalls} calls. Answer from the evidence already collected instead of running more shell commands.`,
+        `[vitehub] Shell session command budget exhausted after ${this.policy.maxShellCalls} calls. The Shell Session policy limits command calls for this run.`,
       )
     }
 

--- a/packages/shell/src/runtime/types.ts
+++ b/packages/shell/src/runtime/types.ts
@@ -11,6 +11,7 @@ export interface ShellRuntimeExecOptions {
   onStdout?: (data: string) => void
   stdin?: string
   timeout?: number
+  workspacePaths?: string[]
 }
 
 export interface ShellObservation {

--- a/packages/shell/src/workspace/inspection.ts
+++ b/packages/shell/src/workspace/inspection.ts
@@ -200,9 +200,8 @@ function missingWorkspacePathFeedback(command: string, resolvedPath: string): Sh
     stderr: "",
     stdout: [
       `[vitehub] Workspace path is not mounted: ${resolvedPath}`,
-      "The agent cannot inspect files outside the configured workspace sources.",
-      "If this path should exist, update the Agent workspace source configuration or materialize the correct mounted source.",
-      "Otherwise answer that the requested evidence is unavailable in the current workspace.",
+      "Configured Workspace Sources do not expose this path.",
+      "This usually means the Workspace Source configuration or materialized source selection does not include it.",
     ].join("\n") + "\n",
     workspaceGuardrail: { kind: "missing_path", path: resolvedPath },
   }
@@ -227,12 +226,12 @@ function isBroadWorkspaceSearch(segment: ReturnType<typeof analyzeWorkspaceInspe
 
 function broadWorkspaceSearchFeedback(broadSearchPaths: string[] = []): ShellObservation {
   const hint = broadSearchPaths.length
-    ? ` Try one of these paths: ${broadSearchPaths.map(path => `"${path}"`).join(", ")}.`
-    : " Use a narrow mounted source or subdirectory path instead."
+    ? ` Mounted search roots: ${broadSearchPaths.map(path => `"${path}"`).join(", ")}.`
+    : " Expected a mounted source or subdirectory path."
   const feedback = [
     "[vitehub] Workspace search is too broad for this agent tool.",
-    "Use one specific mounted subdirectory or file path.",
-    "If the requested evidence is not in the mounted workspace paths, answer that it is unavailable instead of trying broader searches.",
+    "The command targets the workspace root or too many paths.",
+    "Workspace searches are bounded to mounted source subdirectories.",
   ].join("\n") + "\n"
 
   return {
@@ -273,8 +272,7 @@ function searchNoMatchFeedback(command: string, result: ShellObservation, broadS
       }
       return [
         "[vitehub] Search returned no matches in the mounted workspace source.",
-        "If the expected file is outside this mounted source, tell the user the evidence is unavailable in the current workspace instead of continuing broad searches.",
-        "Use a more specific mounted subdirectory only if the user request can be answered from the listed workspace paths.",
+        "Expected content may be outside the mounted workspace paths or under a different mounted subdirectory.",
       ].join("\n") + "\n"
     }
   }
@@ -318,8 +316,8 @@ function unsupportedWorkspaceCommandFeedback(command: string, name: string, comm
     stderr: `[vitehub] Unsupported workspace shell command: ${name}. Available commands: ${available.join(", ") || "none"}.\n`,
     stdout: [
       `[vitehub] Workspace shell command is not available: ${name}`,
-      `Use only the available workspace commands: ${formatted}.`,
-      "Rewrite the command with supported workspace commands, or answer from the evidence already collected.",
+      `Available workspace commands: ${formatted}.`,
+      "This shell only supports configured Workspace inspection commands.",
     ].join("\n") + "\n",
   }
 }

--- a/packages/shell/src/workspace/inspection.ts
+++ b/packages/shell/src/workspace/inspection.ts
@@ -6,7 +6,7 @@ import { analyzeWorkspaceInspectionCommand } from "./command-analysis.ts"
 import { workspaceMountPoint } from "./filesystem.ts"
 import { cleanWorkspaceShellPath } from "./path.ts"
 
-import type { ShellObservation } from "../runtime/types.ts"
+import type { ShellExecutionProvider, ShellObservation } from "../runtime/types.ts"
 import type { ShellNetworkGrantExecutor } from "../providers/just-bash.ts"
 import type { WorkspaceShellFileSystem } from "./filesystem.ts"
 import type { SearchableShellWorkspace } from "./types.ts"
@@ -18,6 +18,7 @@ interface WorkspaceInspectionCommandOptions {
   fs: WorkspaceShellFileSystem
   maxOutputLength?: number
   networkGrants?: ShellNetworkGrantExecutor
+  provider?: ShellExecutionProvider
   timeout?: number
 }
 
@@ -39,7 +40,7 @@ export async function runWorkspaceInspectionCommand(
       maxOutputLength,
       timeout,
     },
-    provider: createJustBashProvider({
+    provider: options.provider ?? createJustBashProvider({
       commands: options.commands,
       cwd: options.cwd || workspaceMountPoint,
       fs: options.fs,

--- a/packages/shell/src/workspace/inspection.ts
+++ b/packages/shell/src/workspace/inspection.ts
@@ -29,28 +29,80 @@ export async function runWorkspaceInspectionCommand(
 ): Promise<ShellObservation> {
   const maxOutputLength = options.maxOutputLength || 30_000
   const timeout = options.timeout || 30_000
+  const provider = options.networkGrants && usesWorkspaceNetworkGrant(command) ? undefined : options.provider
+  const unsupportedSyntax = preflightUnsupportedWorkspaceSyntax(command, options.commands, Boolean(provider))
+  if (unsupportedSyntax) return unsupportedSyntax
   const preflight = await preflightWorkspaceInspectionCommand(command, options.fs, options.broadSearchPaths, options.cwd)
   if (preflight) return preflight
+  const pipedBroadSearch = preflightPipedSearchWithoutPath(command, options.broadSearchPaths)
+  if (pipedBroadSearch) return pipedBroadSearch
   const missingPath = await preflightMissingWorkspacePath(command, options.fs, options.cwd)
   if (missingPath) return missingPath
-  const unsupported = preflightUnsupportedWorkspaceCommand(command, options.commands)
+  const unsupported = preflightUnsupportedWorkspaceCommand(command, options.commands, Boolean(provider))
   if (unsupported) return unsupported
   const runtime = createShellRuntime({
     policy: {
       maxOutputLength,
       timeout,
     },
-    provider: options.provider ?? createJustBashProvider({
+    provider: provider ?? createJustBashProvider({
       commands: options.commands,
       cwd: options.cwd || workspaceMountPoint,
       fs: options.fs,
       networkGrants: options.networkGrants,
     }),
   })
-  const result = await runtime.exec(command, { cwd: options.cwd || workspaceMountPoint, timeout })
+  const cwd = options.cwd || workspaceMountPoint
+  const result = await runtime.exec(command, { cwd, timeout, workspacePaths: workspaceSessionPaths(command, cwd) })
   const noMatchFeedback = searchNoMatchFeedback(command, result, options.broadSearchPaths, options.cwd)
 
   return noMatchFeedback ? { ...result, stdout: noMatchFeedback, workspaceGuardrail: { kind: "no_match" } } : result
+}
+
+function workspaceSessionPaths(command: string, cwd = workspaceMountPoint): string[] | undefined {
+  try {
+    const paths = new Set<string>()
+    let currentCwd = cwd
+    for (const segment of analyzeWorkspaceInspectionCommand(command)) {
+      const words = segment.words
+      if (words[0] === "cd") {
+        const path = words[1] || workspaceMountPoint
+        if (isWorkspacePathCandidate(path)) currentCwd = resolvedWorkspaceCwd(currentCwd, path)
+        continue
+      }
+      for (const path of segment.paths) {
+        const resolvedPath = resolveConcreteWorkspacePath(currentCwd, path)
+        if (resolvedPath) paths.add(resolvedPath)
+      }
+    }
+    return paths.size ? [...paths].sort() : undefined
+  }
+  catch {
+    return undefined
+  }
+}
+
+function preflightPipedSearchWithoutPath(command: string, broadSearchPaths: string[] = []): ShellObservation | undefined {
+  try {
+    for (const segment of analyzeWorkspaceInspectionCommand(command)) {
+      if (segment.separatorAfter !== "|" || segment.paths.length) continue
+      const name = segment.words[0]
+      if (name === "rg" || name === "grep") return broadWorkspaceSearchFeedback(broadSearchPaths)
+    }
+  }
+  catch {
+    return undefined
+  }
+}
+
+function usesWorkspaceNetworkGrant(command: string) {
+  try {
+    return analyzeWorkspaceInspectionCommand(command)
+      .some(segment => workspaceExecutable(segment.words)?.name === "curl")
+  }
+  catch {
+    return false
+  }
 }
 
 async function preflightWorkspaceInspectionCommand(command: string, fs: WorkspaceShellFileSystem, broadSearchPaths: string[] = [], cwd = workspaceMountPoint): Promise<ShellObservation | undefined> {
@@ -232,9 +284,11 @@ function searchNoMatchFeedback(command: string, result: ShellObservation, broadS
   return ""
 }
 
-function preflightUnsupportedWorkspaceCommand(command: string, commands?: string[]): ShellObservation | undefined {
+function preflightUnsupportedWorkspaceCommand(command: string, commands?: string[], strictProvider = false): ShellObservation | undefined {
+  const syntax = preflightUnsupportedWorkspaceSyntax(command, commands, strictProvider)
+  if (syntax) return syntax
+  if (!strictProvider && usesCompoundShellSyntax(command)) return undefined
   if (!commands) return undefined
-  if (usesCompoundShellSyntax(command)) return undefined
   const allowed = new Set([...commands, "cd", "false", "true"])
   for (const segment of analyzeWorkspaceInspectionCommand(command)) {
     const executable = workspaceExecutable(segment.words)
@@ -243,7 +297,18 @@ function preflightUnsupportedWorkspaceCommand(command: string, commands?: string
   }
 }
 
-function unsupportedWorkspaceCommandFeedback(command: string, name: string, commands: string[]): ShellObservation {
+function preflightUnsupportedWorkspaceSyntax(command: string, commands?: string[], strictProvider = false): ShellObservation | undefined {
+  if (usesShellSubstitution(command)) {
+    if (strictProvider || commands) return unsupportedWorkspaceCommandFeedback(command, "shell substitution", commands)
+    return undefined
+  }
+  if (usesCompoundShellSyntax(command)) {
+    if (strictProvider) return unsupportedWorkspaceCommandFeedback(command, "compound shell syntax", commands)
+    return undefined
+  }
+}
+
+function unsupportedWorkspaceCommandFeedback(command: string, name: string, commands: string[] = []): ShellObservation {
   const available = [...new Set(commands)].sort()
   const formatted = available.length ? available.map(command => `\`${command}\``).join(", ") : "none"
   return {
@@ -257,6 +322,38 @@ function unsupportedWorkspaceCommandFeedback(command: string, name: string, comm
       "Rewrite the command with supported workspace commands, or answer from the evidence already collected.",
     ].join("\n") + "\n",
   }
+}
+
+function usesShellSubstitution(command: string) {
+  let quote: "'" | "\"" | undefined
+  let escaped = false
+  for (let index = 0; index < command.length; index++) {
+    const char = command[index]!
+    const next = command[index + 1]
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (char === "\\") {
+      escaped = true
+      continue
+    }
+    if (quote === "'") {
+      if (char === "'") quote = undefined
+      continue
+    }
+    if (quote === "\"") {
+      if (char === "\"") quote = undefined
+      else if (char === "`" || char === "$" && next === "(" || (char === "<" || char === ">") && next === "(") return true
+      continue
+    }
+    if (char === "'" || char === "\"") {
+      quote = char
+      continue
+    }
+    if (char === "`" || char === "$" && next === "(" || (char === "<" || char === ">") && next === "(") return true
+  }
+  return false
 }
 
 function workspaceExecutable(words: string[]) {
@@ -302,6 +399,17 @@ const shellSyntaxWords = new Set([
 
 function isConcreteWorkspacePath(path: string) {
   return isWorkspacePathCandidate(path) && cleanWorkspaceShellPath(path) !== ""
+}
+
+function resolveConcreteWorkspacePath(cwd: string, path: string) {
+  if (!isWorkspacePathCandidate(path)) return undefined
+  try {
+    const resolvedPath = resolveWorkspaceShellPath(cwd, path)
+    return resolvedPath === "" ? undefined : resolvedPath
+  }
+  catch {
+    return undefined
+  }
 }
 
 function isWorkspacePathCandidate(path: string) {

--- a/packages/shell/test/workspace-inspection.test.ts
+++ b/packages/shell/test/workspace-inspection.test.ts
@@ -644,7 +644,7 @@ describe("@vite-hub/shell workspace inspection", () => {
       event: "policy_denied",
       exitCode: 126,
       stderr: expect.stringContaining("Unsupported workspace shell command: xargs"),
-      stdout: expect.stringContaining("Use only the available workspace commands"),
+      stdout: expect.stringContaining("Available workspace commands"),
     })
   })
 

--- a/packages/workspace/src/ai.ts
+++ b/packages/workspace/src/ai.ts
@@ -502,7 +502,7 @@ export function createWorkspaceTools<Operations extends WorkspaceToolOperations 
   }
 
   if (writeEnabled && !isWorkspace(input)) {
-    throw new TypeError("[vitehub] Write operations require a mutable Workspace. Use useWorkspace(name, { mode: \"write\" }).tools.write().")
+    throw new TypeError("[vitehub] Write operations require a mutable Workspace. A useWorkspace(name, { mode: \"write\" }).tools.write() call provides one.")
   }
 
   const result: Record<string, Tool<any, any>> = {}
@@ -530,7 +530,7 @@ export function createWorkspaceTools<Operations extends WorkspaceToolOperations 
             cwd: resolved.cwd,
             event: "policy_denied",
             exitCode: 126,
-            stderr: `[vitehub] Workspace shell command budget exhausted after ${resolved.maxShellCalls} calls. Answer from the evidence already collected instead of running more shell commands.\n`,
+            stderr: `[vitehub] Workspace shell command budget exhausted after ${resolved.maxShellCalls} calls. The Workspace Tools shell call budget is exhausted for this run.\n`,
             stdout: "",
           } satisfies WorkspaceShellResult
         }

--- a/packages/workspace/src/ai.ts
+++ b/packages/workspace/src/ai.ts
@@ -149,7 +149,7 @@ function createWorkspaceSessionShellProvider(starter: WorkspaceSessionStarter): 
       },
     },
     async exec(command: string, execOptions: ShellRuntimeExecOptions = {}) {
-      const session = await starter.startSession()
+      const session = await starter.startSession({ paths: execOptions.workspacePaths })
       try {
         const result = await session.exec("sh", ["-lc", command], {
           cwd: execOptions.cwd || workspaceMountPoint,

--- a/packages/workspace/src/ai.ts
+++ b/packages/workspace/src/ai.ts
@@ -3,7 +3,7 @@ import { appendWorkspaceFile, copyWorkspacePath } from "./fs-ops.ts"
 import { getWorkspaceSourceRequestExecution } from "./sources/request-execution.ts"
 
 import type { Workspace, WorkspaceAssets, WorkspaceMaterializeSourcesResult, WriteFileOptions } from "./core/types.ts"
-import type { ShellObservation, ShellSessionPolicy } from "@vite-hub/shell"
+import type { ShellExecutionProvider, ShellObservation, ShellRuntimeExecOptions, ShellSessionPolicy } from "@vite-hub/shell"
 import type { JSONSchema7, Schema, Tool, ToolSet } from "ai"
 
 export type { WorkspaceMaterializeSourcesResult } from "./core/types.ts"
@@ -42,6 +42,7 @@ export type WorkspaceToolOperations = WorkspaceReadOperations & {
 export interface WorkspaceToolOptions<Operations extends WorkspaceToolOperations | undefined = undefined> extends Pick<ShellSessionPolicy, "maxOutputLength" | "maxShellCalls" | "timeout"> {
   broadSearchPaths?: string[]
   cwd?: string
+  executionProvider?: ShellExecutionProvider | (() => MaybePromise<ShellExecutionProvider | undefined>)
   operations?: Operations
 }
 
@@ -94,6 +95,8 @@ type ValidationResult<T> =
   | { error: Error, success: false }
 
 type JsonSchemaInput = JSONSchema7 | (() => JSONSchema7)
+type MaybePromise<T> = T | Promise<T>
+type WorkspaceSessionStarter = Pick<Workspace, "startSession">
 
 function jsonSchema<T = unknown>(
   schema: JsonSchemaInput,
@@ -117,6 +120,75 @@ function tool<T extends Tool<any, any>>(definition: T): T {
 
 function isWorkspace(input: Workspace | WorkspaceAssets): input is Workspace {
   return "sync" in input
+}
+
+function getWorkspaceSessionStarter(input: Workspace | WorkspaceAssets): WorkspaceSessionStarter | undefined {
+  return typeof (input as Partial<WorkspaceSessionStarter>).startSession === "function"
+    ? input as WorkspaceSessionStarter
+    : undefined
+}
+
+function createWorkspaceSessionShellProvider(starter: WorkspaceSessionStarter): ShellExecutionProvider {
+  return {
+    boundary: {
+      cwd: true,
+      env: true,
+      filesystem: {
+        mountPoint: workspaceMountPoint,
+        writable: true,
+      },
+      network: "unknown",
+      processes: {
+        background: false,
+        interactive: false,
+      },
+      streaming: false,
+      timeout: {
+        enforcedBy: "provider",
+        supported: true,
+      },
+    },
+    async exec(command: string, execOptions: ShellRuntimeExecOptions = {}) {
+      const session = await starter.startSession()
+      try {
+        const result = await session.exec("sh", ["-lc", command], {
+          cwd: execOptions.cwd || workspaceMountPoint,
+          env: execOptions.env,
+          timeout: execOptions.timeout,
+        })
+        execOptions.onStdout?.(result.stdout)
+        execOptions.onStderr?.(result.stderr)
+        const timedOut = result.exitCode === 124 && /timed out/i.test(result.stderr)
+        return {
+          command,
+          cwd: execOptions.cwd,
+          event: timedOut ? "command_timed_out" : "command_finished",
+          exitCode: result.exitCode,
+          stderr: result.stderr,
+          stdout: result.stdout,
+          timedOut,
+        } satisfies ShellObservation
+      }
+      finally {
+        await session.close()
+      }
+    },
+  }
+}
+
+async function resolveExecutionProvider(
+  provider: WorkspaceToolOptions["executionProvider"],
+): Promise<ShellExecutionProvider | undefined> {
+  return typeof provider === "function" ? await provider() : provider
+}
+
+function isUnavailableWorkspaceSession(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes("Workspace exec requires an executable runtime")
+    || (message.includes("Workspace") && message.includes("is not registered"))
+    || message.includes("Workspace runtime `trusted-host` is only available outside production")
+    || message.includes("Workspace runtime `sandbox` requires app-level `sandbox` config")
+    || message.includes("Sandbox workspace runtime requires @vite-hub/sandbox")
 }
 
 function cleanWorkspaceShellPath(path: string) {
@@ -203,11 +275,11 @@ function describeShellCommands(commands: string[], options: { sourceRequests?: b
 async function runShellCommand(
   input: Workspace | WorkspaceAssets,
   command: string,
-  options: { broadSearchPaths: string[], commands: string[], cwd: string, maxOutputLength: number, timeout?: number },
+  options: { broadSearchPaths: string[], commands: string[], cwd: string, executionProvider?: WorkspaceToolOptions["executionProvider"], maxOutputLength: number, timeout?: number },
 ): Promise<WorkspaceShellResult> {
   const networkGrants = getWorkspaceSourceRequestExecution(input)
   const { createReadonlyWorkspaceFs, runWorkspaceInspectionCommand } = await import("@vite-hub/shell/workspace")
-  return await runWorkspaceInspectionCommand(input, command, {
+  const inspectionOptions = {
     broadSearchPaths: options.broadSearchPaths,
     commands: networkGrants ? [...options.commands, "curl"] : options.commands,
     cwd: options.cwd,
@@ -215,6 +287,23 @@ async function runShellCommand(
     maxOutputLength: options.maxOutputLength,
     networkGrants,
     timeout: options.timeout,
+  }
+  const starter = getWorkspaceSessionStarter(input)
+  if (starter) {
+    try {
+      return await runWorkspaceInspectionCommand(input, command, {
+        ...inspectionOptions,
+        provider: createWorkspaceSessionShellProvider(starter),
+      })
+    }
+    catch (error) {
+      if (!isUnavailableWorkspaceSession(error)) throw error
+    }
+  }
+  const provider = await resolveExecutionProvider(options.executionProvider)
+  return await runWorkspaceInspectionCommand(input, command, {
+    ...inspectionOptions,
+    ...(provider ? { provider } : {}),
   })
 }
 
@@ -398,6 +487,7 @@ export function createWorkspaceTools<Operations extends WorkspaceToolOperations 
     broadSearchPaths: options.broadSearchPaths || [],
     commands: shellCommandsFor(resolveReadOperations(options.operations)),
     cwd: options.cwd || workspaceMountPoint,
+    executionProvider: options.executionProvider,
     materialize: resolveReadOperations(options.operations).materialize,
     maxShellCalls: options.maxShellCalls,
     maxOutputLength: options.maxOutputLength || defaultMaxOutputLength,

--- a/packages/workspace/src/core/use.ts
+++ b/packages/workspace/src/core/use.ts
@@ -406,6 +406,7 @@ function createReadonlyFs<Name extends WorkspaceName>(
       path: options?.path || "",
       sources: [],
     },
+    startSession: async (options?: WorkspaceSessionOptions) => await workspace.startSession(options),
   }, getWorkspaceSourceRequestExecution(workspace))
 }
 

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -219,7 +219,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
     });
     if (this.#baselineRefSha && remote.refSha !== this.#baselineRefSha) {
       throw new WorkspaceError(
-        `[vitehub] GitHub Workspace Store conflict for ${this.#repository}@${this.#branch}: the branch changed after this Workspace Store loaded. Retry with a fresh Workspace Store before snapshotting.`,
+        `[vitehub] GitHub Workspace Store conflict for ${this.#repository}@${this.#branch}: the branch changed after this Workspace Store loaded. Snapshotting requires a Workspace Store loaded from the current branch head.`,
       );
     }
     this.#remoteFiles = remote.files;

--- a/packages/workspace/src/providers/vercel/blob-store.ts
+++ b/packages/workspace/src/providers/vercel/blob-store.ts
@@ -58,7 +58,7 @@ async function createVercelFiles(options: VercelBlobWorkspaceStoreOptions) {
 
 function handleFilesSdkImportError(error: unknown): never {
   if (isMissingFilesSdkError(error)) {
-    throw new WorkspaceError(`[vitehub] Install files-sdk to use the Vercel Blob Workspace Store: pnpm add files-sdk`, { cause: error })
+    throw new WorkspaceError("[vitehub] files-sdk is required for the Vercel Blob Workspace Store. Package: files-sdk.", { cause: error })
   }
   throw error
 }

--- a/packages/workspace/src/session/basic.ts
+++ b/packages/workspace/src/session/basic.ts
@@ -3,7 +3,7 @@ import { WorkspaceError } from "../core/errors.ts"
 import type { ExecOptions, ExecResult, Workspace, WorkspaceSession } from "../core/types.ts"
 
 function unsupportedExec(): never {
-  throw new WorkspaceError("[vitehub] Workspace exec requires an executable runtime. Set `runtime: 'sandbox'` for hosted or untrusted execution, set `runtime: 'trusted-host'` for trusted local development and tests, or avoid session.exec().")
+  throw new WorkspaceError("[vitehub] Workspace exec requires an executable runtime. Hosted or untrusted execution needs `runtime: 'sandbox'`; trusted local development and tests need `runtime: 'trusted-host'`.")
 }
 
 export function createBasicWorkspaceSession(workspace: Workspace): WorkspaceSession {

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -36,7 +36,7 @@ function trustedHostRuntimeAllowsProduction(definition: WorkspaceDefinition) {
 function assertTrustedHostWorkspaceRuntimeAllowed(definition: WorkspaceDefinition) {
   const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
   if (env?.NODE_ENV === "production" && !trustedHostRuntimeAllowsProduction(definition)) {
-    throw new WorkspaceError("[vitehub] Workspace runtime `trusted-host` is only available outside production. Use `runtime: 'sandbox'` for hosted executable workspaces.")
+    throw new WorkspaceError("[vitehub] Workspace runtime `trusted-host` is only available outside production. Hosted executable workspaces need `runtime: 'sandbox'`.")
   }
 }
 

--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -209,7 +209,7 @@ function inferWorkspaceSource(input: WorkspaceSourceInput): WorkspaceSourceInput
 }
 
 function ambiguousSourceConfiguration(families: WorkspaceSourceFamily[]): TypeError {
-  return new TypeError(`[vitehub] Workspace source configuration is ambiguous. Matched ${families.join(", ")}. Use { source: ... } or custom(...) to make the source kind explicit.`)
+  return new TypeError(`[vitehub] Workspace source configuration is ambiguous. Matched ${families.join(", ")}. A { source: ... } wrapper or custom(...) call makes the source kind explicit.`)
 }
 
 function createInferredFetchSource(input: WorkspaceSourceInput): WorkspaceSource {

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -27,6 +27,7 @@ import type {
   WorkspaceEntry,
   WorkspaceFile,
   WorkspaceName,
+  WorkspaceRuntime,
   WorkspaceSearchHit,
   WorkspaceSearchQuery,
   WorkspaceStore,
@@ -219,12 +220,17 @@ function createWritableFacadeStore(workspace: WritableWorkspaceFacade): Workspac
   }
 }
 
+function workspaceRuntimeType(runtime: WorkspaceRuntime | undefined) {
+  return typeof runtime === "string" ? runtime : runtime?.type
+}
+
 async function startOverlayWorkspaceSession(definition: WorkspaceDefinition, workspace: Workspace, options?: WorkspaceSessionOptions) {
-  if (definition.runtime === "sandbox") {
+  const runtime = workspaceRuntimeType(definition.runtime)
+  if (runtime === "sandbox") {
     const { createSandboxWorkspaceSession } = await import("../session/sandbox.ts")
     return await createSandboxWorkspaceSession(definition, workspace, options)
   }
-  if (definition.runtime === "trusted-host") {
+  if (runtime === "trusted-host") {
     const { createTrustedHostWorkspaceSession } = await import("../session/trusted-host.ts")
     return await createTrustedHostWorkspaceSession(definition, workspace, options)
   }

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -259,7 +259,8 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
 
   const sourceView = createWorkspaceSourceView(resolvedDefinition, createOverlaySourceStore(workspace, path => !isLazySourcePath(resolvedDefinition, path)))
   const materializeSources = async (options = {}) => await sourceView.materializeSources(options)
-  const fs: ReadonlyWorkspaceFacade<Name>["fs"] = attachWorkspaceSourceRequestExecution({
+  let readWorkspace!: Workspace
+  const fs = attachWorkspaceSourceRequestExecution({
     async readFile(path, options) {
       if (isSourcePath(resolvedDefinition, path) || await sourceViewHasPath(resolvedDefinition, sourceView, path)) {
         return await sourceView.readFile(path, options as never)
@@ -301,7 +302,23 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
       return mergeHits(filterBaseHits(resolvedDefinition, baseHits), sourceHits).slice(0, query.limit ?? 100)
     },
     materializeSources,
-  }, sourceRequestExecution)
+    startSession: async (options) => {
+      const paths = options?.paths?.length ? options.paths : [""]
+      await Promise.all(paths.map(path => materializeSources({ path })))
+      return await startOverlayWorkspaceSession(resolvedDefinition, readWorkspace)
+    },
+  } as ReadonlyWorkspaceFacade<Name>["fs"] & Pick<Workspace, "startSession">, sourceRequestExecution)
+  readWorkspace = attachWorkspaceSourceRequestExecution({
+    name: resolvedDefinition.name,
+    exists: fs.exists,
+    glob: fs.glob,
+    list: fs.list,
+    materializeSources,
+    readFile: fs.readFile,
+    search: fs.search,
+    startSession: fs.startSession,
+    stat: fs.stat,
+  } as unknown as Workspace, sourceRequestExecution)
 
   const createTools = (options?: WorkspaceFacadeToolOptions) => createWorkspaceTools(fs, {
     broadSearchPaths: options?.broadSearchPaths,

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -28,6 +28,7 @@ import type {
   WorkspaceSearchHit,
   WorkspaceSearchQuery,
   WorkspaceStore,
+  WorkspaceSessionOptions,
   WorkspaceWriteInput,
   WorkspaceSelectedScope,
   WorkspaceSource,
@@ -216,14 +217,14 @@ function createWritableFacadeStore(workspace: WritableWorkspaceFacade): Workspac
   }
 }
 
-async function startOverlayWorkspaceSession(definition: WorkspaceDefinition, workspace: Workspace) {
+async function startOverlayWorkspaceSession(definition: WorkspaceDefinition, workspace: Workspace, options?: WorkspaceSessionOptions) {
   if (definition.runtime === "sandbox") {
     const { createSandboxWorkspaceSession } = await import("../session/sandbox.ts")
-    return await createSandboxWorkspaceSession(definition, workspace)
+    return await createSandboxWorkspaceSession(definition, workspace, options)
   }
   if (definition.runtime === "trusted-host") {
     const { createTrustedHostWorkspaceSession } = await import("../session/trusted-host.ts")
-    return await createTrustedHostWorkspaceSession(definition, workspace)
+    return await createTrustedHostWorkspaceSession(definition, workspace, options)
   }
   return createBasicWorkspaceSession(workspace)
 }
@@ -305,7 +306,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
     startSession: async (options) => {
       const paths = options?.paths?.length ? options.paths : [""]
       await Promise.all(paths.map(path => materializeSources({ path })))
-      return await startOverlayWorkspaceSession(resolvedDefinition, readWorkspace)
+      return await startOverlayWorkspaceSession(resolvedDefinition, readWorkspace, options)
     },
   } as ReadonlyWorkspaceFacade<Name>["fs"] & Pick<Workspace, "startSession">, sourceRequestExecution)
   readWorkspace = attachWorkspaceSourceRequestExecution({
@@ -415,7 +416,7 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
       rm: writeFs.rm,
       search: writeFs.search,
       snapshot: workspace.snapshot,
-      startSession: async () => await startOverlayWorkspaceSession(resolvedDefinition, writeWorkspace),
+      startSession: async options => await startOverlayWorkspaceSession(resolvedDefinition, writeWorkspace, options),
       stat: writeFs.stat,
       sync: async (options) => {
         const { syncWorkspaceSources } = await import("./sync.ts")

--- a/packages/workspace/test/ai.test.ts
+++ b/packages/workspace/test/ai.test.ts
@@ -185,13 +185,13 @@ describe("createWorkspaceTools", () => {
       event: "policy_denied",
       exitCode: 126,
       stderr: expect.stringContaining("Unsupported workspace shell command: cat"),
-      stdout: expect.stringContaining("Use only the available workspace commands"),
+      stdout: expect.stringContaining("Available workspace commands"),
     })
     await expect(runShell(tools, "rg orders models")).resolves.toMatchObject({
       event: "policy_denied",
       exitCode: 126,
       stderr: expect.stringContaining("Unsupported workspace shell command: rg"),
-      stdout: expect.stringContaining("Use only the available workspace commands"),
+      stdout: expect.stringContaining("Available workspace commands"),
     })
   })
 
@@ -204,7 +204,7 @@ describe("createWorkspaceTools", () => {
       event: "policy_denied",
       exitCode: 126,
       stderr: expect.stringContaining("Unsupported workspace shell command: rm"),
-      stdout: expect.stringContaining("Use only the available workspace commands"),
+      stdout: expect.stringContaining("Available workspace commands"),
     })
     await expect(runShell(tools, "cat README.md | wc -l")).resolves.toMatchObject({
       exitCode: 0,

--- a/packages/workspace/test/ai.test.ts
+++ b/packages/workspace/test/ai.test.ts
@@ -107,6 +107,8 @@ describe("createWorkspaceTools", () => {
 
   it("prefers executable Workspace Session shell execution", async () => {
     const workspace = createMutableWorkspace()
+    await workspace.mkdir("models")
+    await workspace.writeFile("models/orders.sql", "select * from orders\n")
     const close = vi.fn()
     const exec = vi.fn(async (command: string, args: string[] = [], options?: { cwd?: string }) => ({
       args,
@@ -121,11 +123,23 @@ describe("createWorkspaceTools", () => {
     } as unknown as WorkspaceSession))
     const tools = createWorkspaceTools(workspace)
 
-    await expect(runShell(tools, "pwd")).resolves.toMatchObject({
+    await expect(runShell(tools, "rg orders models")).resolves.toMatchObject({
       exitCode: 0,
-      stdout: "session:sh -lc pwd /workspace\n",
+      stdout: "session:sh -lc rg orders models /workspace\n",
     })
-    expect(exec).toHaveBeenCalledWith("sh", ["-lc", "pwd"], expect.objectContaining({ cwd: "/workspace" }))
+    expect(workspace.startSession).toHaveBeenCalledWith({ paths: ["models"] })
+    expect(exec).toHaveBeenCalledWith("sh", ["-lc", "rg orders models"], expect.objectContaining({ cwd: "/workspace" }))
+    await expect(runShell(tools, "cat $(python -c 'print(\"models/orders.sql\")')")).resolves.toMatchObject({
+      event: "policy_denied",
+      exitCode: 126,
+      stderr: expect.stringContaining("Unsupported workspace shell command: shell substitution"),
+    })
+    await expect(runShell(tools, "if true; then python -c 'print(1)'; fi")).resolves.toMatchObject({
+      event: "policy_denied",
+      exitCode: 126,
+      stderr: expect.stringContaining("Unsupported workspace shell command: compound shell syntax"),
+    })
+    expect(exec).toHaveBeenCalledTimes(1)
     expect(close).toHaveBeenCalled()
   })
 
@@ -276,6 +290,15 @@ describe("createWorkspaceTools", () => {
       },
       store: { provider: "memory" },
     })
+    await workspace.writeFile("README.md", "# Docs\n")
+    workspace.startSession = vi.fn(async () => ({
+      close: vi.fn(),
+      exec: vi.fn(async () => ({
+        exitCode: 0,
+        stderr: "",
+        stdout: "session\n",
+      })),
+    } as unknown as WorkspaceSession))
     const tools = createWorkspaceTools(workspace)
 
     expect(tools.shell.description).toContain("controlled `curl`")
@@ -289,6 +312,15 @@ describe("createWorkspaceTools", () => {
     })
     const init = request.mock.calls[0]?.[1] as RequestInit
     expect((init.headers as Headers).get("cookie")).toBe("auth_token=secret")
+    expect(workspace.startSession).not.toHaveBeenCalled()
+
+    await expect(runShell(tools, "cat README.md")).resolves.toMatchObject({
+      event: "command_finished",
+      exitCode: 0,
+      stdout: "session\n",
+    })
+    expect(workspace.startSession).toHaveBeenCalledWith({ paths: ["README.md"] })
+    expect(request).toHaveBeenCalledTimes(1)
 
     await expect(runShell(tools, "curl -d '{\"region\":\"eu\"}' https://portal.example.com/runtime/inventory-health")).resolves.toMatchObject({
       event: "policy_denied",

--- a/packages/workspace/test/ai.test.ts
+++ b/packages/workspace/test/ai.test.ts
@@ -6,6 +6,9 @@ import { createWorkspaceAssets } from "../src/runtime/assets.ts"
 import { setWorkspaceRuntimeAssetsRegistry } from "../src/runtime/state.ts"
 import { createWorkspace } from "../src/core/workspace.ts"
 
+import type { WorkspaceSession } from "../src/core/types.ts"
+import type { ShellExecutionProvider } from "@vite-hub/shell"
+
 function createAssets(files: Record<string, string | Uint8Array>) {
   return createWorkspaceAssets(Object.fromEntries(
     Object.entries(files).map(([path, content]) => [path, { load: async () => content }]),
@@ -21,6 +24,35 @@ function createMutableWorkspace() {
     name: "mutable",
     store: { provider: "memory" },
   })
+}
+
+function createProvider(stdout: string): ShellExecutionProvider {
+  return {
+    boundary: {
+      cwd: true,
+      env: true,
+      filesystem: { mountPoint: "/workspace", writable: true },
+      network: "unknown",
+      processes: {
+        background: false,
+        interactive: false,
+      },
+      streaming: false,
+      timeout: {
+        enforcedBy: "provider",
+        supported: true,
+      },
+    },
+    async exec(command) {
+      return {
+        command,
+        event: "command_finished",
+        exitCode: 0,
+        stderr: "",
+        stdout,
+      }
+    },
+  }
 }
 
 afterEach(() => {
@@ -71,6 +103,53 @@ describe("createWorkspaceTools", () => {
     expect(tools.shell.description).toContain("Use these commands")
     expect(tools.shell.description).toContain("Skip unsupported helpers such as `xargs`")
     expect(tools.shell.description).not.toContain("controlled `curl`")
+  })
+
+  it("prefers executable Workspace Session shell execution", async () => {
+    const workspace = createMutableWorkspace()
+    const close = vi.fn()
+    const exec = vi.fn(async (command: string, args: string[] = [], options?: { cwd?: string }) => ({
+      args,
+      command,
+      exitCode: 0,
+      stderr: "",
+      stdout: `session:${command} ${args.join(" ")} ${options?.cwd}\n`,
+    }))
+    workspace.startSession = vi.fn(async () => ({
+      close,
+      exec,
+    } as unknown as WorkspaceSession))
+    const tools = createWorkspaceTools(workspace)
+
+    await expect(runShell(tools, "pwd")).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "session:sh -lc pwd /workspace\n",
+    })
+    expect(exec).toHaveBeenCalledWith("sh", ["-lc", "pwd"], expect.objectContaining({ cwd: "/workspace" }))
+    expect(close).toHaveBeenCalled()
+  })
+
+  it("uses an explicit shell execution provider when no executable Workspace Session is available", async () => {
+    const tools = createWorkspaceTools(createAssets({
+      "README.md": "# Docs\n",
+    }), {
+      executionProvider: createProvider("provider\n"),
+    })
+
+    await expect(runShell(tools, "pwd")).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "provider\n",
+    })
+  })
+
+  it("falls back to Just Bash when a Workspace Session is not executable", async () => {
+    const workspace = createMutableWorkspace()
+    await workspace.writeFile("README.md", "# Docs\n")
+
+    await expect(runShell(createWorkspaceTools(workspace), "cat README.md")).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "# Docs\n",
+    })
   })
 
   it("limits shell commands to the enabled read capabilities", async () => {

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -659,6 +659,41 @@ describe("Workspace Source Resolution", () => {
     await expect(base.exists("docs/old.md")).resolves.toBe(false)
   })
 
+  it("preserves readonly overlay sessions for resolved sources", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      runtime: "trusted-host",
+      sources: {
+        docs: custom({
+          materialize: "lazy",
+          mount: "docs",
+          async getKeys() {
+            return ["guide.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "needle\n" }
+          },
+        }),
+      },
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(facade(base), definition, {
+      invocation,
+      overlay: true,
+    })
+    const session = await ((workspace.fs as unknown) as {
+      startSession(): Promise<{ close(): Promise<void>, readFile(path: string): Promise<string> }>
+    }).startSession()
+
+    try {
+      await expect(session.readFile("docs/guide.md")).resolves.toBe("needle\n")
+    }
+    finally {
+      await session.close()
+    }
+  })
+
   it("starts writable overlay sessions from contributed sources and rules", async () => {
     const base = createWorkspace({ name: "support", store: { provider: "memory" } })
     const definition: WorkspaceDefinition = {

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -414,7 +414,7 @@ describe("Workspace Source Resolution", () => {
     const base = createWorkspace({ name: "support", store: { provider: "memory" } })
     const definition: WorkspaceDefinition = {
       name: "support",
-      runtime: "trusted-host",
+      runtime: { allowProduction: true, type: "trusted-host" },
       sources: {
         inventoryHealthSummary: fetch({
           url: "https://portal.example.com/runtime/inventory-health",

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -910,6 +910,44 @@ describe("Workspace Source Resolution", () => {
     }
   })
 
+  it("routes source-backed shell searches through readonly overlay sessions", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      runtime: "trusted-host",
+      sources: {
+        portal: custom({
+          materialize: "lazy",
+          mount: "portal",
+          async getKeys() {
+            return ["app/components/OrderSuggestion.vue"]
+          },
+          async getItem(key) {
+            return {
+              key,
+              path: key,
+              content: "Months of Stock (Incl. Order Suggestion)\n",
+            }
+          },
+        }),
+      },
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(facade(base), definition, {
+      invocation,
+      overlay: true,
+    })
+    const startSession = vi.spyOn(workspace.fs as typeof workspace.fs & {
+      startSession(options?: { paths?: string[] }): Promise<unknown>
+    }, "startSession")
+
+    await expect(runShell(workspace, `rg -i "months.*stock" portal/app --max-depth 3`)).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "portal/app/components/OrderSuggestion.vue:Months of Stock (Incl. Order Suggestion)\n",
+    })
+    expect(startSession).toHaveBeenCalledWith({ paths: ["portal/app"] })
+  })
+
   it("starts writable overlay sessions from contributed sources and rules", async () => {
     const base = createWorkspace({ name: "support", store: { provider: "memory" } })
     const definition: WorkspaceDefinition = {

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -139,6 +139,13 @@ function writableFacade(workspace: ReturnType<typeof createWorkspace>): Writable
   }
 }
 
+async function runShell(workspace: ReadonlyWorkspaceFacade, command: string): Promise<WorkspaceShellResult> {
+  return await workspace.tools.shell.execute!(
+    { command },
+    { toolCallId: "test", messages: [] } as never,
+  ) as WorkspaceShellResult
+}
+
 afterEach(() => {
   vi.restoreAllMocks()
 })
@@ -395,6 +402,98 @@ describe("Workspace Source Resolution", () => {
     expect(requestFactory).toHaveBeenCalledWith(expect.objectContaining({
       selectedWorkspaceScope: expect.objectContaining({ name: "support" }),
     }))
+  })
+
+  it("replays agent shell command transcripts against source-backed workspace sessions", async () => {
+    const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ status: "ok" }), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    }))
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      runtime: "trusted-host",
+      sources: {
+        inventoryHealthSummary: fetch({
+          url: "https://portal.example.com/runtime/inventory-health",
+        }),
+        portal: custom({
+          materialize: "lazy",
+          mount: "portal",
+          async getKeys() {
+            return [
+              "app/pages/ordersuggestions.vue",
+              "app/components/ordersuggestions/MonthsOfStockCell.vue",
+              "other/unrelated.txt",
+            ]
+          },
+          async getItem(key) {
+            if (key === "other/unrelated.txt") throw new Error("unscoped source materialization")
+            return {
+              key,
+              path: key,
+              content: key.endsWith(".vue")
+                ? "label: Months of Stock (Incl. Order Suggestion)\nvalue: months_of_stock_incl_order_suggestion\n"
+                : "",
+            }
+          },
+        }),
+        forecastingEngine: custom({
+          materialize: "lazy",
+          mount: "forecasting-engine",
+          async getKeys() {
+            return ["services/purchase_orders/dtos.py"]
+          },
+          async getItem(key) {
+            return {
+              key,
+              path: key,
+              content: "months_of_stock_incl_order_suggestion = stock_after_order / monthly_forecast\n",
+            }
+          },
+        }),
+      },
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(facade(base), definition, {
+      invocation,
+      overlay: true,
+      selectedWorkspaceScope: {
+        all: false,
+        name: "support",
+        paths: [
+          "portal",
+          "forecasting-engine",
+          workspaceSourceRequestDescriptorPath("inventoryHealthSummary"),
+        ],
+        role: "viewer",
+      },
+    })
+
+    await expect(runShell(workspace, "grep -ri \"Months of Stock\" portal/app")).resolves.toMatchObject({
+      event: "command_finished",
+      exitCode: 0,
+      stderr: "",
+      stdout: expect.stringContaining("portal/app/pages/ordersuggestions.vue"),
+    })
+    await expect(runShell(workspace, "find portal/app -name 'MonthsOfStockCell.vue'")).resolves.toMatchObject({
+      event: "command_finished",
+      exitCode: 0,
+      stderr: "",
+      stdout: "portal/app/components/ordersuggestions/MonthsOfStockCell.vue\n",
+    })
+    await expect(runShell(workspace, "cat forecasting-engine/services/purchase_orders/dtos.py | grep -i \"months\"")).resolves.toMatchObject({
+      event: "command_finished",
+      exitCode: 0,
+      stderr: "",
+      stdout: "months_of_stock_incl_order_suggestion = stock_after_order / monthly_forecast\n",
+    })
+    await expect(runShell(workspace, "curl 'https://portal.example.com/runtime/inventory-health'")).resolves.toMatchObject({
+      event: "command_finished",
+      exitCode: 0,
+      stdout: JSON.stringify({ status: "ok" }, null, 2),
+    })
+    expect(request).toHaveBeenCalledOnce()
   })
 
   it("fails closed when a resolved source mount is outside the Selected Workspace Scope", async () => {
@@ -675,6 +774,16 @@ describe("Workspace Source Resolution", () => {
             return { key, path: key, content: "needle\n" }
           },
         }),
+        privateDocs: custom({
+          materialize: "lazy",
+          mount: "private",
+          async getKeys() {
+            return ["secret.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "secret\n" }
+          },
+        }),
       },
     }
 
@@ -682,12 +791,14 @@ describe("Workspace Source Resolution", () => {
       invocation,
       overlay: true,
     })
+    await expect(workspace.fs.readFile("private/secret.md")).resolves.toBe("secret\n")
     const session = await ((workspace.fs as unknown) as {
-      startSession(): Promise<{ close(): Promise<void>, readFile(path: string): Promise<string> }>
-    }).startSession()
+      startSession(options?: { paths?: string[] }): Promise<{ close(): Promise<void>, readFile(path: string): Promise<string> }>
+    }).startSession({ paths: ["docs"] })
 
     try {
       await expect(session.readFile("docs/guide.md")).resolves.toBe("needle\n")
+      await expect(session.readFile("private/secret.md")).rejects.toThrow("does not exist")
     }
     finally {
       await session.close()

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -1,3 +1,7 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { delimiter, join } from "node:path"
+
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
@@ -910,11 +914,11 @@ describe("Workspace Source Resolution", () => {
     }
   })
 
-  it("routes source-backed shell searches through readonly overlay sessions", async () => {
+  it("routes source-backed executable shell searches through readonly overlay sessions", async () => {
     const base = createWorkspace({ name: "support", store: { provider: "memory" } })
     const definition: WorkspaceDefinition = {
       name: "support",
-      runtime: "trusted-host",
+      runtime: { allowProduction: true, type: "trusted-host" },
       sources: {
         portal: custom({
           materialize: "lazy",
@@ -940,12 +944,34 @@ describe("Workspace Source Resolution", () => {
     const startSession = vi.spyOn(workspace.fs as typeof workspace.fs & {
       startSession(options?: { paths?: string[] }): Promise<unknown>
     }, "startSession")
+    const fakeBin = await mkdtemp(join(tmpdir(), "vitehub-fake-rg-"))
+    const originalPath = process.env.PATH
+    await writeFile(join(fakeBin, "rg"), [
+      "#!/bin/sh",
+      "if [ \"$1\" = \"-i\" ]; then shift; fi",
+      "pattern=\"$1\"",
+      "path=\"$2\"",
+      "file=\"$path/components/OrderSuggestion.vue\"",
+      "if grep -i \"$pattern\" \"$file\" >/dev/null; then",
+      "  printf '%s:%s\\n' \"$file\" \"$(cat \"$file\")\"",
+      "fi",
+      "",
+    ].join("\n"))
+    await chmod(join(fakeBin, "rg"), 0o755)
+    process.env.PATH = [fakeBin, originalPath].filter(Boolean).join(delimiter)
 
-    await expect(runShell(workspace, `rg -i "months.*stock" portal/app --max-depth 3`)).resolves.toMatchObject({
-      exitCode: 0,
-      stdout: "portal/app/components/OrderSuggestion.vue:Months of Stock (Incl. Order Suggestion)\n",
-    })
-    expect(startSession).toHaveBeenCalledWith({ paths: ["portal/app"] })
+    try {
+      await expect(runShell(workspace, `rg -i "months.*stock" portal/app --max-depth 3`)).resolves.toMatchObject({
+        exitCode: 0,
+        stdout: "portal/app/components/OrderSuggestion.vue:Months of Stock (Incl. Order Suggestion)\n",
+      })
+      expect(startSession).toHaveBeenCalledWith({ paths: ["portal/app"] })
+    }
+    finally {
+      if (originalPath === undefined) delete process.env.PATH
+      else process.env.PATH = originalPath
+      await rm(fakeBin, { force: true, recursive: true })
+    }
   })
 
   it("starts writable overlay sessions from contributed sources and rules", async () => {


### PR DESCRIPTION
Routes Workspace shell inspection through a WorkspaceSession-backed Shell Execution Provider when the input exposes `startSession()`, then through an explicit `executionProvider` hook, and finally through the existing Just Bash virtual filesystem fallback.

This keeps commands such as `rg` as ordinary shell behavior instead of adding command-specific handling, while preserving the current Just Bash path for non-executable Workspaces. Cloudflare shell support has an obvious provider slot now; automatic Cloudflare shell client discovery is still not wired into the Workspace runtime.

Adds source-backed command transcript coverage that replays realistic agent shell commands across lazy sources, controlled `curl`, and native trusted-host sessions. It also covers scoped session propagation so `startSession({ paths })` does not expose unrelated materialized source mounts.