### PR TITLE
fix(agent): surface stalled invocation streams

### DIFF
--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -10,6 +10,7 @@ import {
   resolveInputAgentInvoker,
 } from "./invoker.ts"
 import { runObservedAgentHook } from "./hooks.ts"
+import { nextWithAbort } from "./internal/abortable-stream.ts"
 import type {
   AgentAdapterInstructionsValue,
   AgentCallbackContext,
@@ -1174,12 +1175,18 @@ export async function createAgentInvocationExtensions(
 export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(
   stream: T,
   close: (error?: unknown) => Promise<void>,
+  options: { abortSignal?: AbortSignal } = {},
 ): AsyncIterable<unknown> {
   return (async function* () {
+    const iterator = stream[Symbol.asyncIterator]()
     let error: unknown
     let failed = false
     try {
-      yield* stream
+      for (;;) {
+        const result = await nextWithAbort(iterator.next(), options.abortSignal, "[vitehub] Agent Invocation stream aborted.")
+        if (result.done) break
+        yield result.value
+      }
     }
     catch (caught) {
       failed = true
@@ -1187,6 +1194,7 @@ export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(
       throw caught
     }
     finally {
+      if (failed) void iterator.return?.().catch(() => {})
       await close(failed ? error : undefined)
     }
   })()

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -3,6 +3,7 @@ import {
   defineAgentUsageMetadata,
 } from "./internal/agent-usage-metadata.ts"
 import { hasTrustedWorkspaceAccessScope } from "./access-runtime.ts"
+import { nextWithAbort } from "./internal/abortable-stream.ts"
 import { toAiSdkModelMessages } from "./ai-sdk.ts"
 import { isAsyncIterable } from "./internal/stream-result.ts"
 
@@ -220,14 +221,20 @@ async function destroySession(session: HarnessAgentSessionLike) {
   await session.destroy()
 }
 
-function withCleanup<T>(iterable: AsyncIterable<T>, cleanup: (error?: unknown) => Promise<void>): AsyncIterable<T> {
+function withCleanup<T>(iterable: AsyncIterable<T>, cleanup: (error?: unknown) => Promise<void>, abortSignal?: AbortSignal): AsyncIterable<T> {
   return (async function* () {
+    const iterator = iterable[Symbol.asyncIterator]()
     let caught: unknown
     try {
-      yield* iterable
+      for (;;) {
+        const result = await nextWithAbort(iterator.next(), abortSignal, "[vitehub] Harness Agent Driver stream aborted.")
+        if (result.done) break
+        yield result.value
+      }
     }
     catch (error) {
       caught = error
+      void iterator.return?.().catch(() => {})
       throw error
     }
     finally {
@@ -236,7 +243,7 @@ function withCleanup<T>(iterable: AsyncIterable<T>, cleanup: (error?: unknown) =
   })()
 }
 
-async function withSessionCleanup(result: unknown, cleanup: (error?: unknown) => Promise<void>): Promise<unknown> {
+async function withSessionCleanup(result: unknown, cleanup: (error?: unknown) => Promise<void>, abortSignal?: AbortSignal): Promise<unknown> {
   let cleanupCalled = false
   const cleanupOnce = async (error?: unknown) => {
     if (cleanupCalled) return
@@ -245,7 +252,7 @@ async function withSessionCleanup(result: unknown, cleanup: (error?: unknown) =>
   }
 
   if (isAsyncIterable(result)) {
-    return withCleanup(result, cleanupOnce)
+    return withCleanup(result, cleanupOnce, abortSignal)
   }
   if (!result || typeof result !== "object") {
     await cleanupOnce()
@@ -268,7 +275,7 @@ async function withSessionCleanup(result: unknown, cleanup: (error?: unknown) =>
     Object.defineProperty(clone, key, {
       configurable: true,
       enumerable: true,
-      value: withCleanup(iterable, cleanupOnce),
+      value: withCleanup(iterable, cleanupOnce, abortSignal),
     })
   }
   return clone
@@ -298,12 +305,13 @@ export function createHarnessAgentAdapter<
   ) {
     const sessionId = await resolveHarnessSessionKey(options.sessionKey, context)
     const resumeFrom = sessionId ? resumeStates.get(sessionId) : undefined
-    const session = await agent.createSession(sessionId
-      ? {
-          sessionId,
-          ...(resumeFrom !== undefined ? { resumeFrom } : {}),
-        }
-      : undefined)
+    const sessionOptions = {
+      ...(context.input.abortSignal ? { abortSignal: context.input.abortSignal } : {}),
+      ...(sessionId ? { sessionId } : {}),
+      ...(resumeFrom !== undefined ? { resumeFrom } : {}),
+      ...(typeof context.input.timeout === "number" ? { timeout: context.input.timeout } : {}),
+    }
+    const session = await agent.createSession(Object.keys(sessionOptions).length ? sessionOptions : undefined)
     const cleanup = async (error?: unknown) => {
       let closeError = error
       try {
@@ -373,7 +381,7 @@ export function createHarnessAgentAdapter<
           ...toHarnessCallInput(context),
           session,
         }), usageMetadata)
-        return await withSessionCleanup(result, cleanup)
+        return await withSessionCleanup(result, cleanup, context.input.abortSignal)
       }
       catch (error) {
         await cleanup(error)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1373,6 +1373,30 @@ function withStreamResultProperties<T extends AsyncIterable<StreamEvent>>(stream
   return stream
 }
 
+function withStreamedText(
+  stream: AsyncIterable<unknown>,
+  append: (text: string) => void,
+): AsyncIterable<unknown> {
+  return (async function* () {
+    for await (const event of stream) {
+      if (event && typeof event === "object" && (event as { type?: unknown }).type === "text-delta") {
+        const text = (event as { text?: unknown }).text
+        if (typeof text === "string") append(text)
+      }
+      yield event
+    }
+  })()
+}
+
+function resultWithStreamedText(result: unknown, text: string): unknown {
+  if (!text || typeof result === "string") return result
+  if (result && typeof result === "object" && !(result instanceof Response)) {
+    const current = (result as { text?: unknown }).text
+    return typeof current === "string" && current ? result : { ...result, text }
+  }
+  return { raw: result, text }
+}
+
 function traceUiMessageStream<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -1518,7 +1542,6 @@ async function finishAgentInvocation<
   const durationMs = Date.now() - context.startedAt
   try {
     await context.close()
-    if (error === undefined) await commitWorkspaceChanges(context)
     if (hasFinishWork(context)) {
       const eventBase = {
         ...(error !== undefined ? { error } : {}),
@@ -1544,6 +1567,7 @@ async function finishAgentInvocation<
         await context.finishHook?.(finishEvent)
       })
     }
+    if (error === undefined) await commitWorkspaceChanges(context)
     if (error === undefined) {
       await traceAgentInvocationFinish(toTraceContext(context), {
         "invocation.durationMs": durationMs,
@@ -1602,7 +1626,7 @@ async function finalizeAgentInvocationResult<
     if (isAsyncIterable(result) && !hasTraceableStreamResult(result) && !options.finalizeRawStreams) {
       finishLifecycleStarted = shouldWrapOutput
       const stream = options.wrapStream?.(result) || result
-      return shouldWrapOutput ? withCapabilityCleanup(stream, error => finishAgentInvocation(context, error === undefined ? result : undefined, error)) : stream
+      return shouldWrapOutput ? withCapabilityCleanup(stream, error => finishAgentInvocation(context, error === undefined ? result : undefined, error), { abortSignal: context.input.abortSignal }) : stream
     }
     const finalized = await finalizeObject(result)
     finishLifecycleStarted = true
@@ -1761,13 +1785,14 @@ export async function streamAgentInline<
         ? streamAgentOutputToEvents(rendered)
         : rendered as AsyncIterable<StreamEvent>
       const shouldWrapOutput = shouldWrapInvocationOutput(runContext)
-      const tracedStream = maybeTraceAgentStream(stream, runContext)
+      let streamedText = ""
+      const tracedStream = maybeTraceAgentStream(withStreamedText(stream, text => { streamedText += text }) as AsyncIterable<StreamEvent>, runContext)
       return {
         deferFinish: isStream && shouldWrapOutput,
         finishResult: rendered,
         value: isStream
           ? withStreamResultProperties(shouldWrapOutput
-              ? withCapabilityCleanup(tracedStream, error => finishAgentInvocation(runContext, error === undefined ? rendered : undefined, error)) as AsyncIterable<StreamEvent>
+              ? withCapabilityCleanup(tracedStream, error => finishAgentInvocation(runContext, error === undefined ? resultWithStreamedText(rendered, streamedText) : undefined, error), { abortSignal: runContext.input.abortSignal }) as AsyncIterable<StreamEvent>
               : tracedStream, rendered)
           : rendered,
       }
@@ -1807,12 +1832,13 @@ export async function streamAgentInline<
       return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, adapterContext), shouldWrapInvocationOutput(adapterContext), error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error))
     }
     const events = streamAgentOutputToEvents(rendered)
-    const tracedEvents = maybeTraceAgentStream(events, adapterContext)
+    let streamedText = ""
+    const tracedEvents = maybeTraceAgentStream(withStreamedText(events, text => { streamedText += text }) as AsyncIterable<StreamEvent>, adapterContext)
     const shouldWrapOutput = shouldWrapInvocationOutput(adapterContext)
     return {
       deferFinish: shouldWrapOutput,
       finishResult: rendered,
-      value: shouldWrapOutput ? withCapabilityCleanup(tracedEvents, error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error)) : tracedEvents,
+      value: shouldWrapOutput ? withCapabilityCleanup(tracedEvents, error => finishAgentInvocation(adapterContext, error === undefined ? resultWithStreamedText(rendered, streamedText) : undefined, error), { abortSignal: adapterContext.input.abortSignal }) : tracedEvents,
     }
   }, "[vitehub] Agent stream failed and finish lifecycle also failed.", { finalizeRawStreams: output === "ui-message-stream" })
 }

--- a/packages/agent/src/internal/abortable-stream.ts
+++ b/packages/agent/src/internal/abortable-stream.ts
@@ -1,0 +1,30 @@
+export function abortSignalError(signal: AbortSignal, fallbackMessage: string): unknown {
+  return signal.reason ?? new Error(fallbackMessage)
+}
+
+export async function nextWithAbort<T>(
+  next: Promise<IteratorResult<T>>,
+  signal: AbortSignal | undefined,
+  fallbackMessage: string,
+): Promise<IteratorResult<T>> {
+  if (!signal) return await next
+  if (signal.aborted) throw abortSignalError(signal, fallbackMessage)
+
+  return await new Promise<IteratorResult<T>>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort)
+      reject(abortSignalError(signal, fallbackMessage))
+    }
+    signal.addEventListener("abort", onAbort, { once: true })
+    next.then(
+      (result) => {
+        signal.removeEventListener("abort", onAbort)
+        resolve(result)
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort)
+        reject(error)
+      },
+    )
+  })
+}

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -8,6 +8,7 @@ export const agentInvocationStreamHeaderValue = "1"
 export type AgentInvocationStreamEvent =
   | StreamEvent
   | { channelId?: string, effect: AgentChannelDeliveryEffectIntent, run?: AgentRunMetadata, type: "delivery-preview" }
+  | { error: string, type: "error" }
   | { agent: string, metadata?: Record<string, unknown>, run?: unknown, trigger?: string, type: "start" }
   | { type: "done" }
 
@@ -34,19 +35,29 @@ export async function* readAgentInvocationStream(body: ReadableStream<Uint8Array
 
 export function createAgentInvocationStreamResponse(
   run: (emit: (event: AgentInvocationStreamEvent) => void, signal: AbortSignal) => Promise<void>,
+  options: { timeout?: number } = {},
 ): Response {
   const encoder = new TextEncoder()
   const abortController = new AbortController()
   let closed = false
+  let timeout: ReturnType<typeof setTimeout> | undefined
+
+  function clearTimeoutSignal(): void {
+    if (!timeout) return
+    clearTimeout(timeout)
+    timeout = undefined
+  }
 
   function close(controller: ReadableStreamDefaultController<Uint8Array>): void {
+    clearTimeoutSignal()
     closed = true
     controller.close()
   }
 
   function fail(controller: ReadableStreamDefaultController<Uint8Array>, cause: unknown): void {
     if (closed) return
-    abortController.abort()
+    clearTimeoutSignal()
+    abortController.abort(cause)
     try {
       controller.enqueue(encoder.encode(`${JSON.stringify({
         error: cause instanceof Error ? cause.message : "Agent Invocation Stream event could not be serialized.",
@@ -74,6 +85,11 @@ export function createAgentInvocationStreamResponse(
 
   return new Response(new ReadableStream({
     start(controller) {
+      if (options.timeout && options.timeout > 0) {
+        timeout = setTimeout(() => {
+          fail(controller, new Error(`Agent Invocation Stream timed out after ${options.timeout}ms.`))
+        }, options.timeout)
+      }
       run(event => emit(controller, event), abortController.signal)
         .then(() => {
           if (closed || abortController.signal.aborted) return
@@ -81,6 +97,7 @@ export function createAgentInvocationStreamResponse(
         })
         .catch((cause) => {
           if (closed || abortController.signal.aborted) return
+          clearTimeoutSignal()
           emit(controller, {
             error: cause instanceof Error ? cause.message : "Agent Invocation Stream failed.",
             type: "error",
@@ -89,6 +106,7 @@ export function createAgentInvocationStreamResponse(
         })
     },
     cancel() {
+      clearTimeoutSignal()
       closed = true
       abortController.abort()
     },

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -86,9 +86,9 @@ function withDevLoopControls<CALL_OPTIONS>(
   timeout: number,
 ): AgentRunInput<CALL_OPTIONS> {
   return {
+    ...input,
     abortSignal: signal,
     timeout,
-    ...input,
   }
 }
 
@@ -388,7 +388,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
       if (signal.aborted) return
       emit(event)
     }
-  })
+  }, { timeout })
 }
 
 function routeMatches(req: IncomingMessage): boolean {

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -1,0 +1,364 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Readable } from "node:stream"
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { IncomingMessage, ServerResponse } from "node:http"
+import type { Connect } from "vite"
+
+const order = vi.hoisted(() => [] as string[])
+const diff = vi.hoisted(() => vi.fn(async () => {
+  order.push("workspace-diff")
+  return [{ path: "review.md", type: "modified" }]
+}))
+const snapshot = vi.hoisted(() => vi.fn(async () => {
+  order.push("workspace-snapshot")
+}))
+const workspaceCloseErrors = vi.hoisted(() => [] as unknown[])
+const workspaceClose = vi.hoisted(() => vi.fn(async (error?: unknown) => {
+  order.push("workspace-session-close")
+  workspaceCloseErrors.push(error)
+}))
+const prepareHarnessWorkspaceSession = vi.hoisted(() => vi.fn(async () => {
+  order.push("prepare-harness-workspace")
+  return { close: workspaceClose }
+}))
+const resolveWorkspaceAutoCommit = vi.hoisted(() => vi.fn(() => ({ message: "commit review output" })))
+const harnessCreateSessionOptions = vi.hoisted(() => [] as Array<Record<string, unknown> | undefined>)
+const harnessSessionDestroy = vi.hoisted(() => vi.fn(async () => {
+  order.push("harness-session-destroy")
+}))
+const harnessStreamInputs = vi.hoisted(() => [] as Record<string, unknown>[])
+const useWorkspace = vi.hoisted(() => vi.fn(() => ({
+  diff,
+  fs: {
+    exists: vi.fn(),
+    list: vi.fn(),
+    readFile: vi.fn(),
+    stat: vi.fn(),
+    writeFile: vi.fn(),
+  },
+  snapshot,
+  tools: Object.assign(vi.fn(() => ({})), {
+    inspect: vi.fn(() => ({})),
+    none: vi.fn(() => ({})),
+    readonly: vi.fn(() => ({})),
+  }),
+})))
+
+vi.mock("@vite-hub/workspace", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vite-hub/workspace")>()
+  return {
+    ...actual,
+    prepareHarnessWorkspaceSession,
+    resolveWorkspaceAutoCommit,
+    useWorkspace,
+  }
+})
+
+vi.mock("@ai-sdk/harness/agent", () => ({
+  HarnessAgent: class {
+    constructor(private settings: Record<string, unknown>) {}
+
+    async createSession(options?: Record<string, unknown>) {
+      harnessCreateSessionOptions.push(options)
+      await (this.settings.onSandboxSession as ((input: Record<string, unknown>) => Promise<void>) | undefined)?.({
+        abortSignal: options?.abortSignal,
+        session: {},
+        sessionWorkDir: "/workspace",
+      })
+      return { destroy: harnessSessionDestroy }
+    }
+
+    async generate() {
+      return { text: "unused" }
+    }
+
+    async stream(input: Record<string, unknown>) {
+      harnessStreamInputs.push(input)
+      return {
+        fullStream: {
+          [Symbol.asyncIterator]: () => ({
+            next: () => new Promise<IteratorResult<unknown>>(() => {}),
+            return: async () => {
+              order.push("harness-stream-return")
+              return { done: true, value: undefined }
+            },
+          }),
+        },
+      }
+    }
+  },
+}))
+
+function responseChunkText(chunk: unknown) {
+  if (typeof chunk === "string") return chunk
+  if (Buffer.isBuffer(chunk)) return chunk.toString("utf8")
+  if (chunk instanceof Uint8Array) return Buffer.from(chunk).toString("utf8")
+  return String(chunk)
+}
+
+function createFakeServer(root: string, module: unknown) {
+  const handlers: Connect.NextHandleFunction[] = []
+  const server = {
+    config: {
+      root,
+      server: { port: 3000 },
+    },
+    middlewares: {
+      use: vi.fn((handler: Connect.NextHandleFunction) => {
+        handlers.push(handler)
+      }),
+    },
+    resolvedUrls: {
+      local: ["http://localhost:3000/"],
+    },
+    ssrLoadModule: vi.fn(async () => module),
+  }
+  return { handlers, server }
+}
+
+async function configurePluginServer(plugin: { configureServer?: unknown }, server: unknown) {
+  const hook = plugin.configureServer
+  if (typeof hook === "function") {
+    await hook(server)
+  }
+  else if (hook && typeof hook === "object" && "handler" in hook && typeof hook.handler === "function") {
+    await hook.handler(server)
+  }
+}
+
+async function invokeMiddleware(
+  handler: Connect.NextHandleFunction,
+  body: Record<string, unknown>,
+  url: string,
+  headers: IncomingMessage["headers"],
+) {
+  let output = ""
+  const req = Readable.from([JSON.stringify(body)]) as IncomingMessage
+  req.headers = headers
+  req.method = "POST"
+  req.url = url
+
+  return await new Promise<{ body: string, statusCode: number }>((resolve, reject) => {
+    let statusCode = 200
+    const res = {
+      destroy(error?: Error) {
+        reject(error || new Error("response destroyed"))
+      },
+      end(chunk?: unknown) {
+        if (chunk) output += responseChunkText(chunk)
+        resolve({ body: output, statusCode })
+      },
+      get statusCode() {
+        return statusCode
+      },
+      off: vi.fn(),
+      once: vi.fn(),
+      set statusCode(value: number) {
+        statusCode = value
+      },
+      setHeader: vi.fn(),
+      write(chunk: unknown) {
+        output += responseChunkText(chunk)
+        return true
+      },
+    } as unknown as ServerResponse
+
+    handler(req, res, () => reject(new Error("middleware passed through")))
+  })
+}
+
+async function waitFor(assertion: () => void | Promise<void>) {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      await assertion()
+      return
+    }
+    catch (error) {
+      lastError = error
+      await new Promise(resolve => setTimeout(resolve, 10))
+    }
+  }
+  throw lastError
+}
+
+describe("Agent Invocation Stream write workspace finish lifecycle", () => {
+  beforeEach(() => {
+    order.length = 0
+    diff.mockClear()
+    snapshot.mockClear()
+    workspaceClose.mockClear()
+    workspaceCloseErrors.length = 0
+    prepareHarnessWorkspaceSession.mockClear()
+    resolveWorkspaceAutoCommit.mockClear()
+    resolveWorkspaceAutoCommit.mockReturnValue({ message: "commit review output" })
+    harnessCreateSessionOptions.length = 0
+    harnessSessionDestroy.mockClear()
+    harnessStreamInputs.length = 0
+    useWorkspace.mockClear()
+  })
+
+  it("previews trigger finish effects before write workspace auto-commit completes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-invocation-stream-workspace-"))
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "review.ts"), "export default {}", "utf8")
+
+    const { defineChannel } = await import("../src/channels.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const replyEffect = vi.fn()
+    const finishHook = vi.fn(() => {
+      order.push("agent-finish")
+    })
+    const agent = defineAgent({
+      channels: {
+        github: defineChannel("github", {
+          effects: { reply: replyEffect },
+          messages: false,
+          triggers: {
+            webhook: {
+              invoke: (context, input) => ({
+                delivery: {
+                  finishEffects: () => {
+                    order.push("finish-effect")
+                    return { kind: "reply", payload: "finished" }
+                  },
+                },
+                input,
+                run: { channelId: context.trigger.channelId, origin: "github-pull-request-comment", runId: "github-run" },
+              }),
+            },
+          },
+        }),
+      },
+      hooks: { "agent:finish": finishHook },
+      run: () => (async function* () {
+        yield { text: "Review completed.", type: "text-delta" }
+        order.push("run-stream-consumed")
+        yield { type: "finish" }
+      })(),
+      workspace: { mode: "write" },
+    })
+
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      agent: "review",
+      input: { prompt: "review" },
+      trigger: "github.webhook",
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    })
+    const events = response.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ agent: "review", trigger: "github.webhook", type: "start" }),
+      { text: "Review completed.", type: "text-delta" },
+      { type: "finish" },
+      expect.objectContaining({ channelId: "github", effect: { kind: "reply", payload: "finished" }, type: "delivery-preview" }),
+      { type: "done" },
+    ]))
+    expect(order).toEqual([
+      "run-stream-consumed",
+      "finish-effect",
+      "agent-finish",
+      "workspace-diff",
+      "workspace-snapshot",
+    ])
+    expect(useWorkspace).toHaveBeenCalledWith("review", { mode: "write" })
+    expect(replyEffect).not.toHaveBeenCalled()
+  })
+
+  it("times out hung harness streams and runs failure cleanup", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-invocation-stream-harness-timeout-"))
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "review.ts"), "export default {}", "utf8")
+
+    const { defineChannel } = await import("../src/channels.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const finishEvents: unknown[] = []
+    const finishHook = vi.fn((event: unknown) => {
+      finishEvents.push(event)
+      order.push("agent-finish")
+    })
+    const agent = defineAgent({
+      channels: {
+        github: defineChannel("github", {
+          effects: {},
+          messages: false,
+          triggers: {
+            webhook: {
+              invoke: (context, input) => ({
+                input,
+                run: { channelId: context.trigger.channelId, origin: "github-pull-request-comment", runId: "github-run" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: {},
+      },
+      hooks: { "agent:finish": finishHook },
+      workspace: { mode: "write" },
+    })
+
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      agent: "review",
+      input: { prompt: "review" },
+      timeout: 100,
+      trigger: "github.webhook",
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    })
+    const events = response.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+
+    expect(events).toEqual([
+      expect.objectContaining({ agent: "review", trigger: "github.webhook", type: "start" }),
+      { error: "Agent Invocation Stream timed out after 100ms.", type: "error" },
+      { type: "done" },
+    ])
+    expect(harnessCreateSessionOptions[0]?.abortSignal).toBeInstanceOf(AbortSignal)
+    expect(harnessCreateSessionOptions[0]?.timeout).toBe(100)
+    expect(harnessStreamInputs[0]?.abortSignal).toBeInstanceOf(AbortSignal)
+    expect(harnessStreamInputs[0]?.timeout).toBe(100)
+    await waitFor(() => {
+      expect(workspaceClose).toHaveBeenCalledOnce()
+      expect(harnessSessionDestroy).toHaveBeenCalledOnce()
+      expect(finishHook).toHaveBeenCalledOnce()
+    })
+    expect(workspaceCloseErrors[0]).toBeInstanceOf(Error)
+    expect(finishEvents[0]).toEqual(expect.objectContaining({
+      error: expect.any(Error),
+      invocation: expect.objectContaining({
+        run: { channelId: "github", origin: "github-pull-request-comment", runId: "github-run" },
+      }),
+    }))
+    expect(order).toEqual(expect.arrayContaining([
+      "prepare-harness-workspace",
+      "workspace-session-close",
+      "harness-session-destroy",
+      "agent-finish",
+    ]))
+  })
+})

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2593,6 +2593,53 @@ describe("agent message protocol", () => {
     }
   })
 
+  it("runs stream finish hooks with accumulated model-backed text", async () => {
+    vi.doMock("ai", () => ({
+      jsonSchema: vi.fn(schema => schema),
+      ToolLoopAgent: class {
+        async generate() {
+          return { text: "unused" }
+        }
+        async stream() {
+          return {
+            fullStream: (async function* () {
+              yield { text: "streamed ", type: "text-delta" }
+              yield { text: "review", type: "text-delta" }
+              yield { type: "finish" }
+            })(),
+          }
+        }
+      },
+      stepCountIs: () => () => false,
+    }))
+
+    try {
+      const { defineAgent, streamAgent } = await import("../src/index.ts")
+      const finish = vi.fn()
+      const agent = defineAgent({
+        hooks: {
+          "agent:finish": finish,
+        },
+        model: {} as never,
+      })
+
+      const stream = await streamAgent(agent, {
+        memo: vi.fn(),
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, {})
+
+      for await (const _event of stream as AsyncIterable<unknown>) {}
+
+      expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+        result: expect.objectContaining({ text: "streamed review" }),
+      }))
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
   it("runs agent finish hooks after generated streams are consumed", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const order: string[] = []


### PR DESCRIPTION
Surfaces stalled Agent Invocation streams instead of letting dev-loop clients wait until their own local abort. The invocation stream endpoint now emits a timeout error/done event, dev-loop trigger input receives timeout and abort controls, and harness-backed streams/session setup are wired through abort-aware cleanup.

Also keeps streamed text available to finish hooks and runs delivery preview effects before write-workspace auto-commit, so stream-backed channel finish effects can observe emitted output before slower workspace cleanup.