### PR TITLE
fix(agent): scope harness workspace sessions

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -127,7 +127,8 @@
     "@vitejs/devtools-kit": "catalog:vite",
     "chat": "catalog:chat",
     "esbuild": "catalog:esbuild-v27",
-    "hookable": "catalog:unjs"
+    "hookable": "catalog:unjs",
+    "vitest": "catalog:tooling"
   },
   "devDependencies": {
     "@ai-sdk/harness": "catalog:ai",
@@ -142,8 +143,7 @@
     "publint": "catalog:tooling",
     "typescript": "catalog:tooling",
     "vite": "catalog:vite",
-    "vite-plus": "catalog:tooling",
-    "vitest": "catalog:tooling"
+    "vite-plus": "catalog:tooling"
   },
   "peerDependencies": {
     "@ai-sdk/harness": "catalog:ai",

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -271,6 +271,11 @@ function pathContains(container: string, path: string): boolean {
   return !container || path === container || path.startsWith(`${container}/`)
 }
 
+function compactWorkspacePaths(paths: readonly string[]): string[] {
+  const sorted = [...new Set(paths)].sort((left, right) => left.length - right.length || left.localeCompare(right))
+  return sorted.filter((path, index) => !sorted.some((candidate, candidateIndex) => candidateIndex < index && pathContains(candidate, path)))
+}
+
 function pathsConflict(left: string, right: string): boolean {
   return pathContains(left, right) || pathContains(right, left)
 }
@@ -659,7 +664,10 @@ export async function resolveAgentCapabilities<
   const capabilities = normalizeCapabilities(options?.capabilities as AgentCapabilityDefinition[] | undefined) as AgentCapabilityDefinition<TRuntimeConfig, Name>[]
   validateAccessCapabilityOrder(capabilities)
   const harnessWorkspacePaths = driverKind === "harness"
-    ? [...new Set(capabilities.flatMap(capability => [...capability.harnessWorkspacePaths || []]))]
+    ? compactWorkspacePaths(capabilities.flatMap(capability => [
+        ...(capability.harnessWorkspacePaths || []),
+        ...(capability.requires || []).flatMap(requirement => requirement.workspace?.paths || []),
+      ]))
     : []
   let currentInput = normalizeRunInput(input)
   let currentWorkspace = workspace as ReadonlyWorkspaceFacade<Name> | undefined

--- a/packages/agent/src/eval.ts
+++ b/packages/agent/src/eval.ts
@@ -102,6 +102,37 @@ function isVariantOverride(variant: AgentEvalVariant): boolean {
   return variant.instructions !== undefined || variant.model !== undefined
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function variantModelDriver(variant: AgentEvalVariant): Record<string, unknown> {
+  return {
+    ...(variant.instructions !== undefined ? { instructions: variant.instructions } : {}),
+    model: variant.model,
+  }
+}
+
+function applyVariantToExplicitDriver(
+  driver: unknown,
+  variant: AgentEvalVariant,
+): Record<string, unknown> {
+  if (!isRecord(driver)) {
+    throw new Error("[vitehub] Agent Evaluation variants with model or instructions require a model-backed Agent Driver.")
+  }
+  if ("model" in driver) {
+    return {
+      ...driver,
+      ...(variant.instructions !== undefined ? { instructions: variant.instructions } : {}),
+      ...(variant.model !== undefined ? { model: variant.model as never } : {}),
+    }
+  }
+  if ("harness" in driver && variant.model !== undefined) {
+    return variantModelDriver(variant)
+  }
+  throw new Error("[vitehub] Agent Evaluation variants with model or instructions require a model-backed Agent Driver.")
+}
+
 function resolveEvalNameFromFile(caller: string): string {
   const base = basename(caller, extname(caller))
   if (base === "eval") return basename(dirname(caller))
@@ -200,16 +231,9 @@ function applyVariant<TRuntimeConfig extends AgentRuntimeConfig>(
   if (settings) {
     const driver = (settings as { driver?: unknown }).driver
     if (driver) {
-      if (typeof driver !== "object" || !("model" in driver)) {
-        throw new Error("[vitehub] Agent Evaluation variants with model or instructions require a model-backed Agent Driver.")
-      }
       return defineAgent({
         ...settings,
-        driver: {
-          ...driver,
-          ...(variant.instructions !== undefined ? { instructions: variant.instructions } : {}),
-          ...(variant.model !== undefined ? { model: variant.model as never } : {}),
-        },
+        driver: applyVariantToExplicitDriver(driver, variant) as never,
       } as never)
     }
     return defineAgent({
@@ -225,16 +249,9 @@ function applyVariant<TRuntimeConfig extends AgentRuntimeConfig>(
   const options = agent.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<TRuntimeConfig>
   const driver = (options as { driver?: unknown }).driver
   if (driver) {
-    if (typeof driver !== "object" || !("model" in driver)) {
-      throw new Error("[vitehub] Agent Evaluation variants with model or instructions require a model-backed Agent Driver.")
-    }
     return defineAgent({
       ...options,
-      driver: {
-        ...driver,
-        ...(variant.instructions !== undefined ? { instructions: variant.instructions } : {}),
-        ...(variant.model !== undefined ? { model: variant.model as never } : {}),
-      },
+      driver: applyVariantToExplicitDriver(driver, variant) as never,
     } as never)
   }
   return defineAgent({

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -148,9 +148,9 @@ function explicitHarnessWorkspacePaths(context: AgentAdapterRunContext): string[
 
 function selectedWorkspaceScopePaths(context: AgentAdapterRunContext): string[] | undefined {
   const harnessPaths = explicitHarnessWorkspacePaths(context)
-  if (!hasTrustedWorkspaceAccessScope(context.context)) return harnessPaths
+  if (!hasTrustedWorkspaceAccessScope(context.context)) return harnessPaths.length ? harnessPaths : undefined
   const scope = context.context.get("access")?.workspaceScope
-  if (!scope) return harnessPaths
+  if (!scope) return harnessPaths.length ? harnessPaths : undefined
   if (scope.all) return [""]
   const paths = [...new Set([...scope.paths, ...harnessPaths])]
   return paths.length ? paths : []

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -3,6 +3,9 @@ import {
   defineAgentUsageMetadata,
 } from "./internal/agent-usage-metadata.ts"
 import { hasTrustedWorkspaceAccessScope } from "./access-runtime.ts"
+import { applyCapabilityInstructionSlots } from "./capability-runtime.ts"
+import { applyWorkspaceSourceInstructionSlot } from "./workspace-agent.ts"
+import { normalizeAgentWorkspaceSources } from "./workspace-source-metadata.ts"
 import { nextWithAbort } from "./internal/abortable-stream.ts"
 import { toAiSdkModelMessages } from "./ai-sdk.ts"
 import { isAsyncIterable } from "./internal/stream-result.ts"
@@ -53,7 +56,6 @@ function unsupportedHarnessContributionKinds(context: AgentAdapterRunContext): S
   const kinds = new Set<AgentDriverContributionKind>()
   if (hasEntries(context.tools)) kinds.add("Capability tools")
   if (context.providerTools?.length) kinds.add("provider tools")
-  if (context.capabilityInstructions?.length) kinds.add("Capability instructions")
   return kinds
 }
 
@@ -88,7 +90,6 @@ function formatUnsupportedHarnessContributions(context: AgentAdapterRunContext):
   return [
     unsupportedKinds.has("Capability tools") ? "Capability tools" : undefined,
     unsupportedKinds.has("provider tools") ? "provider tools" : undefined,
-    unsupportedKinds.has("Capability instructions") ? "Capability instructions" : undefined,
   ].filter((value): value is string => Boolean(value))
 }
 
@@ -96,21 +97,73 @@ function assertSupportedHarnessDriverContributions(context: AgentAdapterRunConte
   const unsupported = formatUnsupportedHarnessContributions(context)
 
   if (unsupported.length) {
-    throw new Error(`[vitehub] Harness Agent Drivers do not support these Capability Driver Contributions yet: ${unsupported.join("; ")}. Move model-facing tools and instructions to harness-native workspace files or remove those capabilities for harness.`)
+    throw new Error(`[vitehub] Harness Agent Drivers do not support these Capability Driver Contributions yet: ${unsupported.join("; ")}. Move model-facing tools to harness-native workspace files or remove those capabilities for harness.`)
   }
 }
 
+function staticWorkspaceRulePath(pattern: string): string | undefined {
+  const wildcard = pattern.search(/[*{[(?]/)
+  const base = wildcard === -1 ? pattern : pattern.slice(0, wildcard)
+  const normalized = base.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "").replace(/\/+/g, "/")
+  const parts = normalized.split("/").filter(Boolean)
+  if (!normalized || parts.some(part => part === "." || part === "..")) return
+  return normalized
+}
+
+function workspaceRuleHarnessPaths(context: AgentAdapterRunContext): string[] {
+  const definition = context.workspaceDefinition
+  if (!definition) return []
+  const rules = [
+    ...Object.entries(definition.rules || {}),
+    ...(definition.plugins || []).flatMap(plugin => Object.entries(plugin.rules || {})),
+  ]
+  return rules.flatMap(([pattern, rule]) => rule.write ? [staticWorkspaceRulePath(pattern)].filter((path): path is string => Boolean(path)) : [])
+}
+
+function workspaceSourceHarnessPaths(context: AgentAdapterRunContext): string[] {
+  const sources = context.workspaceDefinition?.sources
+  if (!sources) return []
+  return normalizeAgentWorkspaceSources(sources).flatMap((source) => {
+    if (source.materialize !== "build" || !source.probeKeys?.length) return []
+    return source.probeKeys.map(key => [source.mountPath, key].filter(Boolean).join("/"))
+  })
+}
+
+function pathContains(container: string, path: string): boolean {
+  return !container || path === container || path.startsWith(`${container}/`)
+}
+
+function compactWorkspacePaths(paths: readonly string[]): string[] {
+  const sorted = [...new Set(paths)].sort((left, right) => left.length - right.length || left.localeCompare(right))
+  return sorted.filter((path, index) => !sorted.some((candidate, candidateIndex) => candidateIndex < index && pathContains(candidate, path)))
+}
+
+function explicitHarnessWorkspacePaths(context: AgentAdapterRunContext): string[] {
+  return compactWorkspacePaths([
+    ...(context.harnessWorkspacePaths || []),
+    ...workspaceRuleHarnessPaths(context),
+    ...workspaceSourceHarnessPaths(context),
+  ])
+}
+
 function selectedWorkspaceScopePaths(context: AgentAdapterRunContext): string[] | undefined {
-  if (!hasTrustedWorkspaceAccessScope(context.context)) return
+  const harnessPaths = explicitHarnessWorkspacePaths(context)
+  if (!hasTrustedWorkspaceAccessScope(context.context)) return harnessPaths
   const scope = context.context.get("access")?.workspaceScope
-  if (!scope || scope.all) return
-  const paths = [...new Set([...scope.paths, ...(context.harnessWorkspacePaths || [])])]
-  return paths.length ? paths : undefined
+  if (!scope) return harnessPaths
+  if (scope.all) return [""]
+  const paths = [...new Set([...scope.paths, ...harnessPaths])]
+  return paths.length ? paths : []
 }
 
 function toHarnessCallInput(context: AgentAdapterRunContext) {
+  const instructions = applyWorkspaceSourceInstructionSlot(
+    applyCapabilityInstructionSlots(context.instructions || "", context.capabilityInstructions),
+    context.sourceInstructions,
+  )
   const base = {
     abortSignal: context.input.abortSignal,
+    ...(instructions ? { instructions } : {}),
     timeout: context.input.timeout,
     ...("options" in context.input ? { options: context.input.options } : {}),
   }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1272,6 +1272,7 @@ export interface AgentAdapterRunContext<
   sourceInstructions?: string
   tools?: AgentToolSet
   workspace?: ReadonlyWorkspaceFacade<Name>
+  workspaceDefinition?: WorkspaceDefinition
 }
 
 export interface AgentAdapter<

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -285,6 +285,32 @@ describe("agent eval", () => {
     })
   })
 
+  it("applies model variants by replacing harness drivers for workspace agents", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineEval } = await import("../src/eval.ts")
+    const variantModel = { id: "variant" }
+
+    defineEval({
+      agent: defineAgent({
+        driver: {
+          harness: { provider: "codex" },
+          sandbox: { provider: "sandbox" },
+        },
+        workspace: {},
+      }),
+      name: "support",
+      scenarios: [{ input: { prompt: "hello" }, name: "hello" }],
+      variants: [{ model: variantModel, name: "variant" }],
+      workspace: "support",
+    })
+
+    await evaliteCalls[0]!.opts.task(evaliteCalls[0]!.opts.data[0].input, evaliteCalls[0]!.variants![0]!.input)
+
+    expect(agentSettings.at(-1)).toMatchObject({
+      model: variantModel,
+    })
+  })
+
   it("applies replacement instruction variants for base agents", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineEval } = await import("../src/eval.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -943,9 +943,12 @@ describe("agent message protocol", () => {
     expect(harnessGenerate).not.toHaveBeenCalled()
   })
 
-  it("rejects model-facing Capability instructions before harness execution", async () => {
+  it("passes model-facing Capability instructions into harness execution", async () => {
     const { defineCapability } = await import("../src/capability-runtime.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
     const agent = defineAgent({
       capabilities: [
@@ -961,10 +964,13 @@ describe("agent message protocol", () => {
     })
 
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "hello" }))
-      .rejects.toThrow("model-instructions: Capability instructions")
-    expect(harnessAgentSettings).toHaveLength(0)
-    expect(harnessCreateSession).not.toHaveBeenCalled()
-    expect(harnessGenerate).not.toHaveBeenCalled()
+      .resolves.toMatchObject({ text: "ok" })
+    expect(harnessAgentSettings).toHaveLength(1)
+    expect(harnessGenerate).toHaveBeenCalledWith(expect.objectContaining({
+      instructions: "Use model-only context.",
+      prompt: "hello",
+      session,
+    }))
   })
 
   it("resumes harness Agent Drivers with an explicit session key", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -806,7 +806,7 @@ describe("defineAgent workspace option", () => {
     expect(harnessSession.destroy).toHaveBeenCalledOnce()
   })
 
-  it("uses an empty harness Workspace Session scope when no explicit paths are available", async () => {
+  it("uses an unrestricted harness Workspace Session scope when no explicit paths are available", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const harnessWorkspaceSession = { close: vi.fn() }
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
@@ -827,7 +827,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      paths: [],
+      paths: undefined,
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -314,7 +314,12 @@ describe("defineAgent workspace option", () => {
     expect(readFile).not.toHaveBeenCalledWith("skills/agent-browser/SKILL.md")
     expect(inspectTools).not.toHaveBeenCalled()
     expect(writeTools).not.toHaveBeenCalled()
-    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledOnce()
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
+      abortSignal: undefined,
+      paths: ["skills/agent-browser"],
+      session: harnessSandboxSession,
+      sessionWorkDir: "/workspace/codex-session",
+    })
     expect(harnessAgentSettings.at(-1)).not.toHaveProperty("tools")
     expect(harnessGenerate).toHaveBeenCalledWith(expect.objectContaining({
       prompt: "hello",
@@ -783,6 +788,7 @@ describe("defineAgent workspace option", () => {
     expect(useWorkspace).toHaveBeenCalledWith("docs")
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
+      paths: ["AGENTS.md"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -792,11 +798,114 @@ describe("defineAgent workspace option", () => {
       sandbox: { provider: "sandbox" },
     })
     expect(harnessGenerate).toHaveBeenCalledWith(expect.objectContaining({
+      instructions: "## Workspace Sources\n\n### guide\n\nUse this guide for operating rules.",
       prompt: "hello",
       session: harnessSession,
     }))
     expect(harnessWorkspaceSession.close).toHaveBeenCalledWith(undefined)
     expect(harnessSession.destroy).toHaveBeenCalledOnce()
+  })
+
+  it("uses an empty harness Workspace Session scope when no explicit paths are available", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+
+    const agent = withAgentDefaults(defineAgent({
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: { provider: "sandbox" },
+      },
+      workspace: {},
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
+      abortSignal: undefined,
+      paths: [],
+      session: harnessSandboxSession,
+      sessionWorkDir: "/workspace/codex-session",
+    })
+  })
+
+  it("passes source instructions and scopes workspace instruction files into harness Agent calls", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))
+    tempRoots.push(sourceRootDir)
+    await writeLocalFile(join(sourceRootDir, "instructions.md"), "Use colocated workspace instructions.\n")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+
+    const agent = withAgentDefaults(defineAgent({
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: { provider: "sandbox" },
+      },
+      workspace: {
+        sourceRootDir,
+        sources: {
+          docs: { instructions: "Use docs for product behavior.", name: "docs" } as never,
+        },
+      },
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
+      abortSignal: undefined,
+      paths: ["AGENTS.md"],
+      session: harnessSandboxSession,
+      sessionWorkDir: "/workspace/codex-session",
+    })
+    expect(harnessGenerate).toHaveBeenCalledWith(expect.objectContaining({
+      instructions: "## Workspace Sources\n\n### docs\n\nUse docs for product behavior.",
+      prompt: "hello",
+    }))
+  })
+
+  it("uses concrete write rules as harness Workspace Session paths", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+
+    const agent = withAgentDefaults(defineAgent({
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: { provider: "sandbox" },
+      },
+      workspace: {
+        mode: "write",
+        rules: {
+          "pr-diff-summary.md": { write: true },
+          "summary.md": { write: true },
+          "artifacts/browser/**": { write: true },
+          "artifacts/usage/**": { write: true },
+          "**": { write: false },
+        },
+      },
+    }), { workspace: "review" })
+
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
+      abortSignal: undefined,
+      paths: ["summary.md", "artifacts/usage", "artifacts/browser", "pr-diff-summary.md"],
+      session: harnessSandboxSession,
+      sessionWorkDir: "/workspace/codex-session",
+    })
   })
 
   it("passes selected Workspace Scope paths into Harness Workspace Sessions", async () => {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -26,6 +26,10 @@
   "type": "module",
   "sideEffects": false,
   "types": "./dist/index.d.ts",
+  "imports": {
+    "#vitehub/database/databases": "./dist/runtime/virtual-databases.js",
+    "#vitehub/database/schema": "./dist/runtime/virtual-schema.js"
+  },
   "exports": {
     ".": "./dist/index.js",
     "./cli": "./dist/cli.js",
@@ -35,6 +39,8 @@
     "./runtime/cloudflare-vite": "./dist/runtime/cloudflare-vite.js",
     "./runtime/hosted": "./dist/runtime/hosted.js",
     "./runtime/vercel-vite": "./dist/runtime/vercel-vite.js",
+    "./runtime/virtual-databases": "./dist/runtime/virtual-databases.js",
+    "./runtime/virtual-schema": "./dist/runtime/virtual-schema.js",
     "./virtual": "./dist/virtual.js",
     "./vite": "./dist/vite.js",
     "./package.json": "./package.json"

--- a/packages/database/src/runtime/virtual-databases.ts
+++ b/packages/database/src/runtime/virtual-databases.ts
@@ -1,0 +1,4 @@
+const databases = {}
+
+export { databases }
+export default databases

--- a/packages/database/src/runtime/virtual-schema.ts
+++ b/packages/database/src/runtime/virtual-schema.ts
@@ -1,0 +1,4 @@
+const schema = {}
+
+export { schema }
+export default schema

--- a/packages/database/test/runtime.test.ts
+++ b/packages/database/test/runtime.test.ts
@@ -1,6 +1,8 @@
+import { execFile } from "node:child_process"
 import { mkdtemp, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
+import { promisify } from "node:util"
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { sql } from "drizzle-orm"
@@ -25,6 +27,8 @@ const runtimeState = {
   analyticsDbPath: "",
   dbPath: "",
 }
+
+const execFileAsync = promisify(execFile)
 
 function createFakeD1Binding() {
   return {
@@ -113,6 +117,24 @@ afterEach(async () => {
 })
 
 describe("drizzle runtime", () => {
+  it("loads the published drizzle subpath without a Vite virtual module", async () => {
+    const script = [
+      'const { databases, db, schema } = await import("@vite-hub/database/drizzle")',
+      'if (JSON.stringify(schema) !== "{}") throw new Error("expected empty schema fallback")',
+      'if (JSON.stringify(databases.default.schema) !== "{}") throw new Error("expected empty default database schema")',
+      'try {',
+      "  db.run",
+      '}',
+      'catch (error) {',
+      '  if (String(error.message).includes("requires `hubDb()`")) process.exit(0)',
+      "  throw error",
+      '}',
+      'throw new Error("expected missing database proxy to throw")',
+    ].join("\n")
+
+    await expect(execFileAsync(process.execPath, ["--input-type=module", "-e", script], { cwd: process.cwd() })).resolves.toBeDefined()
+  })
+
   it("provides a default fallback entry when the virtual database registry is empty", async () => {
     runtimeDatabaseEntriesFactory = () => ({})
     vi.resetModules()

--- a/packages/database/vite.config.ts
+++ b/packages/database/vite.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
       "src/vite.ts",
       "src/runtime/cloudflare-vite.ts",
       "src/runtime/hosted.ts",
+      "src/runtime/virtual-databases.ts",
+      "src/runtime/virtual-schema.ts",
       "src/runtime/vercel-vite.ts",
     ],
     exports: {

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -1,11 +1,11 @@
 import { createReadStream } from "node:fs"
 import { readFile, stat } from "node:fs/promises"
+import type { IncomingMessage, ServerResponse } from "node:http"
 import { fileURLToPath } from "node:url"
 import { extname, join, relative, resolve } from "node:path"
 import { defineDockEntry, defineRpcFunction } from "@vitejs/devtools-kit"
 
-import type { DevToolsDockEntry, DevToolsViewIframe, ViteDevToolsNodeContext } from "@vitejs/devtools-kit"
-import type { Plugin, ViteDevServer } from "vite"
+import type { DevToolsDockEntry, DevToolsViewIframe, PluginWithDevTools, ViteDevToolsNodeContext } from "@vitejs/devtools-kit"
 
 export interface ViteHubDevtoolsFeature {
   bridge: string
@@ -58,6 +58,12 @@ interface ViteHubDevtoolsRegistry {
   registeredShellPanel: boolean
   registeredShellRpc: boolean
   registeredShell: boolean
+}
+
+interface DevtoolsMiddlewareHost {
+  middlewares: {
+    use(handler: (request: IncomingMessage, response: ServerResponse, next: (error?: unknown) => void) => void): void
+  }
 }
 
 const registryKey = Symbol.for("@vite-hub/devtools:registry")
@@ -114,7 +120,7 @@ function resolveDevtoolsShellFile(pathname: string): string | undefined {
   return filePath
 }
 
-function registerDevtoolsShellMiddleware(server: ViteDevServer): void {
+function registerDevtoolsShellMiddleware(server: DevtoolsMiddlewareHost): void {
   server.middlewares.use(async (request, response, next) => {
     if (!request.url) {
       next()
@@ -231,7 +237,7 @@ export function listViteHubDevtoolsFeatures(ctx: ViteDevToolsNodeContext): ViteH
   return [...getRegistry(ctx).registeredFeatures.values()]
 }
 
-export function hubDevtools(options: HubDevtoolsOptions = {}): Plugin {
+export function hubDevtools(options: HubDevtoolsOptions = {}): PluginWithDevTools {
   return {
     name: "@vite-hub/devtools/vite",
     configureServer(server) {
@@ -242,7 +248,7 @@ export function hubDevtools(options: HubDevtoolsOptions = {}): Plugin {
       registerDevtoolsShellMiddleware(server)
     },
     devtools: {
-      setup(ctx) {
+      setup(ctx: ViteDevToolsNodeContext) {
         if (options.enabled === false) {
           return
         }

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -6,6 +6,7 @@ import type {
   ReadonlyWorkspaceFacade,
   WritableWorkspaceFacade,
 } from "../core/use.ts"
+import { isMissingWorkspacePathError } from "./scope.ts"
 import type {
   MkdirOptions,
   WorkspaceEntry,
@@ -143,7 +144,12 @@ async function materializeWorkspaceSourcesForSession(workspace: WorkspaceFacade,
   if (!materialize) return
 
   if (paths && !paths.length) return
-  await Promise.all((paths || [""]).map(async path => await materialize({ path })))
+  await Promise.all((paths || [""]).map(async (path) => {
+    await materialize({ path }).catch((error) => {
+      if (path && isMissingWorkspacePathError(error)) return
+      throw error
+    })
+  }))
 }
 
 function bytesEqual(left: Uint8Array | undefined, right: Uint8Array) {

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -1,7 +1,8 @@
 import { posix } from "node:path"
+import { gzipSync } from "node:zlib"
 import { lookup } from "mrmime"
 
-import { normalizeSafeWorkspacePath } from "../core/path.ts"
+import { contentToBytes, normalizeSafeWorkspacePath } from "../core/path.ts"
 import type {
   ReadonlyWorkspaceFacade,
   WritableWorkspaceFacade,
@@ -39,7 +40,9 @@ type InitialTree = {
 }
 type SourceMaterializer = (options?: { path?: string }) => Promise<unknown>
 type WorkspaceFsWithSources = { materializeSources?: SourceMaterializer }
-const sandboxWriteConcurrency = 4
+const archivePath = ".vitehub-workspace.tar.gz"
+const tarBlockSize = 512
+const workspaceReadConcurrency = 16
 
 function isWritableWorkspaceFacade(workspace: WorkspaceFacade): workspace is WritableWorkspaceFacade {
   return "startSession" in workspace && typeof workspace.startSession === "function"
@@ -181,16 +184,91 @@ async function resetSandboxWorkDir(
   })
 }
 
-async function mkdirSandboxDirectories(
+function paddedTarContent(content: Uint8Array) {
+  const padding = content.byteLength % tarBlockSize
+    ? tarBlockSize - (content.byteLength % tarBlockSize)
+    : 0
+  if (!padding) return Buffer.from(content)
+  return Buffer.concat([Buffer.from(content), Buffer.alloc(padding)])
+}
+
+function splitTarPath(path: string): { name: string, prefix?: string } {
+  if (Buffer.byteLength(path) <= 100) return { name: path }
+  const parts = path.split("/")
+  for (let index = 1; index < parts.length; index++) {
+    const prefix = parts.slice(0, index).join("/")
+    const name = parts.slice(index).join("/")
+    if (Buffer.byteLength(prefix) <= 155 && Buffer.byteLength(name) <= 100)
+      return { name, prefix }
+  }
+  throw new Error(`[vitehub] Harness Workspace Session path is too long for tar transfer: ${path}`)
+}
+
+function writeTarString(header: Buffer, offset: number, length: number, value: string) {
+  const bytes = Buffer.from(value)
+  bytes.copy(header, offset, 0, Math.min(bytes.byteLength, length))
+}
+
+function writeTarOctal(header: Buffer, offset: number, length: number, value: number) {
+  const text = value.toString(8).padStart(length - 1, "0").slice(-(length - 1))
+  header.write(text, offset, length - 1, "ascii")
+  header[offset + length - 1] = 0
+}
+
+function tarHeader(path: string, options: { mode: number, size: number, type: "directory" | "file" }) {
+  const header = Buffer.alloc(tarBlockSize)
+  const { name, prefix } = splitTarPath(path)
+  writeTarString(header, 0, 100, name)
+  writeTarOctal(header, 100, 8, options.mode)
+  writeTarOctal(header, 108, 8, 0)
+  writeTarOctal(header, 116, 8, 0)
+  writeTarOctal(header, 124, 12, options.size)
+  writeTarOctal(header, 136, 12, 0)
+  header.fill(0x20, 148, 156)
+  header[156] = options.type === "directory" ? 0x35 : 0x30
+  writeTarString(header, 257, 6, "ustar")
+  writeTarString(header, 263, 2, "00")
+  if (prefix) writeTarString(header, 345, 155, prefix)
+  let checksum = 0
+  for (const byte of header) checksum += byte
+  header.write(checksum.toString(8).padStart(6, "0"), 148, 6, "ascii")
+  header[154] = 0
+  header[155] = 0x20
+  return header
+}
+
+function createWorkspaceTarGz(directories: Iterable<string>, files: Map<string, InitialFile>) {
+  const blocks: Buffer[] = []
+  for (const directory of [...directories].sort((left, right) => left.localeCompare(right))) {
+    const path = directory.endsWith("/") ? directory : `${directory}/`
+    blocks.push(tarHeader(path, { mode: 0o755, size: 0, type: "directory" }))
+  }
+  for (const [path, file] of [...files.entries()].sort(([left], [right]) => left.localeCompare(right))) {
+    blocks.push(tarHeader(path, { mode: 0o644, size: file.content.byteLength, type: "file" }))
+    blocks.push(paddedTarContent(file.content))
+  }
+  blocks.push(Buffer.alloc(tarBlockSize * 2))
+  return gzipSync(Buffer.concat(blocks))
+}
+
+async function extractWorkspaceArchive(
   sandbox: HarnessSandboxSession,
-  directories: string[],
   sessionWorkDir: string,
+  initialTree: InitialTree,
+  directories: Set<string>,
   abortSignal: AbortSignal | undefined,
 ) {
-  if (!directories.length) return
+  if (!initialTree.files.size && !directories.size) return
+  const path = sandboxPath(sessionWorkDir, archivePath)
+  await sandbox.writeBinaryFile({
+    abortSignal,
+    content: createWorkspaceTarGz(directories, initialTree.files),
+    path,
+  })
   await runSandbox(sandbox, {
     abortSignal,
-    command: `mkdir -p ${directories.map(path => shellQuote(sandboxPath(sessionWorkDir, path))).join(" ")}`,
+    command: `tar -xzf ${shellQuote(archivePath)} && rm ${shellQuote(archivePath)}`,
+    workingDirectory: sessionWorkDir,
   })
 }
 
@@ -224,17 +302,12 @@ async function copyWorkspaceToSandbox(
   }
   const files = workspaceFiles(entries)
   for (const entry of files) addParentDirectories(directoriesToCreate, entry.path)
-  await resetSandboxWorkDir(sandbox, sessionWorkDir, abortSignal)
-  await mkdirSandboxDirectories(sandbox, [...directoriesToCreate], sessionWorkDir, abortSignal)
-  await forEachConcurrent(files, sandboxWriteConcurrency, async (entry) => {
+  await forEachConcurrent(files, workspaceReadConcurrency, async (entry) => {
     const content = await workspace.fs.readFile(entry.path, { encoding: "binary" })
-    initialTree.files.set(entry.path, { content, mediaType: entry.mediaType })
-    await sandbox.writeBinaryFile({
-      abortSignal,
-      content,
-      path: sandboxPath(sessionWorkDir, entry.path),
-    })
+    initialTree.files.set(entry.path, { content: contentToBytes(content), mediaType: entry.mediaType })
   })
+  await resetSandboxWorkDir(sandbox, sessionWorkDir, abortSignal)
+  await extractWorkspaceArchive(sandbox, sessionWorkDir, initialTree, directoriesToCreate, abortSignal)
   return initialTree
 }
 

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -74,8 +74,9 @@ function normalizeHarnessWorkspacePath(path = "") {
 }
 
 function normalizeSessionPaths(paths?: readonly string[]): string[] | undefined {
+  if (paths === undefined) return undefined
   const normalized = [...new Set((paths || []).map(normalizeHarnessWorkspacePath))]
-  if (!normalized.length || normalized.includes("")) return undefined
+  if (normalized.includes("")) return undefined
   return normalized.sort((left, right) => left.length - right.length || left.localeCompare(right))
 }
 
@@ -122,6 +123,7 @@ async function forEachConcurrent<T>(items: readonly T[], limit: number, fn: (ite
 }
 
 async function workspaceEntries(workspace: WorkspaceFacade, paths: string[] | undefined) {
+  if (paths && !paths.length) return []
   if (!paths) return await workspace.fs.list("", { recursive: true })
 
   const entries = new Map<string, WorkspaceEntry>()
@@ -140,7 +142,8 @@ async function materializeWorkspaceSourcesForSession(workspace: WorkspaceFacade,
   const materialize = workspaceSourceMaterializer(workspace)
   if (!materialize) return
 
-  await Promise.all((paths?.length ? paths : [""]).map(async path => await materialize({ path })))
+  if (paths && !paths.length) return
+  await Promise.all((paths || [""]).map(async path => await materialize({ path })))
 }
 
 function bytesEqual(left: Uint8Array | undefined, right: Uint8Array) {
@@ -274,7 +277,7 @@ export async function prepareHarnessWorkspaceSession(
   const paths = normalizeSessionPaths(options.paths)
   const initialTree = await copyWorkspaceToSandbox(workspace, options.session, options.sessionWorkDir, options.abortSignal, paths)
   const sessionOptions: WorkspaceSessionOptions | undefined = paths ? { paths } : undefined
-  const workspaceSession = isWritableWorkspaceFacade(workspace)
+  const workspaceSession = isWritableWorkspaceFacade(workspace) && (paths === undefined || paths.length)
     ? await workspace.startSession(sessionOptions)
     : undefined
 

--- a/packages/workspace/src/session/sandbox.ts
+++ b/packages/workspace/src/session/sandbox.ts
@@ -3,7 +3,7 @@ import { posix } from "node:path"
 import { WorkspaceError } from "../core/errors.ts"
 import { contentToBytes, decodeFile, normalizeSafeWorkspacePath, normalizeWorkspacePath, sha256 } from "../core/path.ts"
 import { createSnapshotFromEntries, diffSnapshots } from "../storage/utils.ts"
-import { assertDiffInsideSessionPaths, assertPathInSessionScope, filterSessionDiff, filterSessionEntries, scopedSearchQuery } from "./scope.ts"
+import { assertDiffInsideSessionPaths, assertPathInSessionScope, filterSessionDiff, filterSessionEntries, isMissingWorkspacePathError, scopedSearchQuery } from "./scope.ts"
 
 import type {
   ReadFileOptions,
@@ -113,7 +113,11 @@ async function sessionEntries(workspace: Workspace, options?: WorkspaceSessionOp
 
   const entries = new Map<string, WorkspaceEntry>()
   for (const path of paths) {
-    const stat = await workspace.stat(path)
+    const stat = await workspace.stat(path).catch((error) => {
+      if (isMissingWorkspacePathError(error)) return undefined
+      throw error
+    })
+    if (!stat) continue
     entries.set(stat.path, stat)
     if (stat.type === "directory") {
       for (const entry of await workspace.list(path, { recursive: true })) entries.set(entry.path, entry)

--- a/packages/workspace/src/session/scope.ts
+++ b/packages/workspace/src/session/scope.ts
@@ -2,6 +2,10 @@ import { WorkspaceError } from "../core/errors.ts"
 
 import type { WorkspaceDiff, WorkspaceEntry, WorkspaceSearchQuery } from "../core/types.ts"
 
+export function isMissingWorkspacePathError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("Workspace path does not exist:")
+}
+
 export function pathInSessionScope(path: string, paths: string[] | undefined): boolean {
   return !paths || paths.some(scope => path === scope || path.startsWith(`${scope}/`))
 }

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -6,7 +6,7 @@ import { dirname, join, posix, relative, sep } from "node:path"
 import { WorkspaceError } from "../core/errors.ts"
 import { contentToBytes, decodeFile, matchesAny, normalizeSafeWorkspacePath, normalizeWorkspacePath, resolveInside, sha256 } from "../core/path.ts"
 import { createSnapshotFromEntries, diffSnapshots } from "../storage/utils.ts"
-import { assertDiffInsideSessionPaths, assertPathInSessionScope, filterSessionDiff, filterSessionEntries, scopedSearchQuery } from "./scope.ts"
+import { assertDiffInsideSessionPaths, assertPathInSessionScope, filterSessionDiff, filterSessionEntries, isMissingWorkspacePathError, scopedSearchQuery } from "./scope.ts"
 
 import type {
   ExecOptions,
@@ -132,7 +132,11 @@ async function sessionEntries(workspace: Workspace, options?: WorkspaceSessionOp
 
   const entries = new Map<string, WorkspaceEntry>()
   for (const path of paths) {
-    const stat = await workspace.stat(path)
+    const stat = await workspace.stat(path).catch((error) => {
+      if (isMissingWorkspacePathError(error)) return undefined
+      throw error
+    })
+    if (!stat) continue
     entries.set(stat.path, stat)
     if (stat.type === "directory") {
       for (const entry of await workspace.list(path, { recursive: true })) entries.set(entry.path, entry)

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -20,6 +20,22 @@ function sandboxRun(files: string[] = [], directories: string[] = []) {
   })
 }
 
+function expectArchiveWrite(writeBinaryFile: ReturnType<typeof vi.fn>, root = "/work/agent") {
+  expect(writeBinaryFile).toHaveBeenCalledWith({
+    abortSignal: undefined,
+    content: expect.any(Uint8Array),
+    path: `${root}/.vitehub-workspace.tar.gz`,
+  })
+}
+
+function expectArchiveExtract(run: ReturnType<typeof vi.fn>, root = "/work/agent") {
+  expect(run).toHaveBeenCalledWith({
+    abortSignal: undefined,
+    command: "tar -xzf '.vitehub-workspace.tar.gz' && rm '.vitehub-workspace.tar.gz'",
+    workingDirectory: root,
+  })
+}
+
 describe("Harness Workspace Session", () => {
   it("resets and materializes selected Workspace files into the harness sandbox", async () => {
     const readme = bytes("# Docs\n")
@@ -44,16 +60,9 @@ describe("Harness Workspace Session", () => {
       abortSignal: undefined,
       command: "rm -rf '/work/agent' && mkdir -p '/work/agent'",
     })
-    expect(run).toHaveBeenCalledWith({
-      abortSignal: undefined,
-      command: "mkdir -p '/work/agent/notes'",
-    })
     expect(readFile).toHaveBeenCalledWith("README.md", { encoding: "binary" })
-    expect(writeBinaryFile).toHaveBeenCalledWith({
-      abortSignal: undefined,
-      content: readme,
-      path: "/work/agent/README.md",
-    })
+    expectArchiveWrite(writeBinaryFile)
+    expectArchiveExtract(run)
 
     await session.close()
   })
@@ -105,11 +114,7 @@ describe("Harness Workspace Session", () => {
     expect(list).toHaveBeenCalledWith("public", { recursive: true })
     expect(list).not.toHaveBeenCalledWith("", { recursive: true })
     expect(readFile).toHaveBeenCalledWith("public/README.md", { encoding: "binary" })
-    expect(writeBinaryFile).toHaveBeenCalledWith({
-      abortSignal: undefined,
-      content: publicReadme,
-      path: "/work/agent/public/README.md",
-    })
+    expectArchiveWrite(writeBinaryFile)
     expect(startSession).toHaveBeenCalledWith({ paths: ["public"] })
 
     await session.close()
@@ -205,11 +210,7 @@ describe("Harness Workspace Session", () => {
 
     expect(materializeSources).toHaveBeenCalledWith({ path: "" })
     expect(list).toHaveBeenCalledWith("", { recursive: true })
-    expect(writeBinaryFile).toHaveBeenCalledWith({
-      abortSignal: undefined,
-      content: sourceFile,
-      path: "/work/agent/portal/app/OrderSuggestion.vue",
-    })
+    expectArchiveWrite(writeBinaryFile)
 
     await session.close()
   })
@@ -244,9 +245,7 @@ describe("Harness Workspace Session", () => {
     expect(stat).toHaveBeenCalledWith("public")
     expect(stat).toHaveBeenCalledWith(".vitehub/sources/public.json")
     expect(list).toHaveBeenCalledWith("public", { recursive: true })
-    expect(writeBinaryFile).toHaveBeenCalledWith(expect.objectContaining({
-      path: "/work/agent/public/README.md",
-    }))
+    expectArchiveWrite(writeBinaryFile)
 
     await session.close()
   })
@@ -271,15 +270,8 @@ describe("Harness Workspace Session", () => {
       sessionWorkDir: "/work/agent",
     })
 
-    expect(run).toHaveBeenCalledWith({
-      abortSignal: undefined,
-      command: "mkdir -p '/work/agent/docs'",
-    })
-    expect(writeBinaryFile).toHaveBeenCalledWith({
-      abortSignal: undefined,
-      content: readme,
-      path: "/work/agent/docs/README.md",
-    })
+    expectArchiveWrite(writeBinaryFile)
+    expectArchiveExtract(run)
 
     await session.close()
   })
@@ -385,10 +377,10 @@ describe("Harness Workspace Session", () => {
 
     const session = await prepareHarnessWorkspaceSession({
       fs: {
-        list: workspace.list,
+        list: workspace.list.bind(workspace),
         materializeSources: workspace.materializeSources,
-        readFile: workspace.readFile,
-        stat: workspace.stat,
+        readFile: workspace.readFile.bind(workspace),
+        stat: workspace.stat.bind(workspace),
       },
       startSession: workspace.startSession,
       tools: {},
@@ -417,9 +409,9 @@ describe("Harness Workspace Session", () => {
 
     const session = await prepareHarnessWorkspaceSession({
       fs: {
-        list: workspace.list,
-        readFile: workspace.readFile,
-        stat: workspace.stat,
+        list: workspace.list.bind(workspace),
+        readFile: workspace.readFile.bind(workspace),
+        stat: workspace.stat.bind(workspace),
       },
       startSession: workspace.startSession,
       tools: {},

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -115,6 +115,54 @@ describe("Harness Workspace Session", () => {
     await session.close()
   })
 
+  it("keeps an empty selected Workspace Session scope empty", async () => {
+    const list = vi.fn(async () => [
+      { path: "README.md", type: "file" },
+    ])
+    const materializeSources = vi.fn(async () => ({
+      bytes: 0,
+      directories: 0,
+      durationMs: 0,
+      files: 0,
+      path: "",
+      sources: [],
+    }))
+    const startSession = vi.fn(async () => ({
+      close: vi.fn(async () => {}),
+      commit: vi.fn(async () => {}),
+      diff: vi.fn(async () => ({ entries: [], to: "next" })),
+      mkdir: vi.fn(async () => {}),
+      rm: vi.fn(async () => {}),
+      writeFile: vi.fn(async () => {}),
+    }))
+    const writeBinaryFile = vi.fn(async () => {})
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: {
+        list,
+        materializeSources,
+        readFile: vi.fn(async () => bytes("root")),
+      },
+      startSession,
+      tools: {},
+    } as never, {
+      paths: [],
+      session: {
+        readBinaryFile: vi.fn(async () => null),
+        run: sandboxRun(),
+        writeBinaryFile,
+      },
+      sessionWorkDir: "/work/agent",
+    })
+
+    expect(materializeSources).not.toHaveBeenCalled()
+    expect(list).not.toHaveBeenCalled()
+    expect(writeBinaryFile).not.toHaveBeenCalled()
+    expect(startSession).not.toHaveBeenCalled()
+
+    await session.close()
+  })
+
   it("materializes lazy source files before copying them into the harness sandbox", async () => {
     const sourceFile = bytes("Months of Stock\n")
     let materialized = false

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -373,6 +373,40 @@ describe("Harness Workspace Session", () => {
     expect(workspaceSession.close).toHaveBeenCalledOnce()
   })
 
+  it("commits generated files selected by missing Workspace Session paths", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    await workspace.snapshot({ name: "baseline" })
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: {
+        list: workspace.list,
+        materializeSources: workspace.materializeSources,
+        readFile: workspace.readFile,
+        stat: workspace.stat,
+      },
+      startSession: workspace.startSession,
+      tools: {},
+    } as never, {
+      paths: ["summary.md"],
+      session: {
+        readBinaryFile: vi.fn(async () => bytes("summary")),
+        run: sandboxRun(["summary.md"]),
+        writeBinaryFile: vi.fn(async () => {}),
+      },
+      sessionWorkDir: "/work/agent",
+    })
+
+    await session.close()
+
+    await expect(workspace.readFile("summary.md")).resolves.toBe("summary")
+  })
+
   it("rejects out-of-scope harness sandbox changes in the basic Workspace Session", async () => {
     const workspace = createWorkspace({
       ...defineWorkspace({ store: { provider: "memory" } }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,7 +448,10 @@ importers:
         version: 6.1.1
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
-        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
     devDependencies:
       '@ai-sdk/harness':
         specifier: catalog:ai
@@ -482,10 +485,7 @@ importers:
         version: 6.0.2
       vite-plus:
         specifier: catalog:tooling
-        version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
-      vitest:
-        specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+        version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
 
   packages/auth:
     dependencies:
@@ -516,7 +516,7 @@ importers:
         version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
 
   packages/blob:
     dependencies:
@@ -562,7 +562,7 @@ importers:
         version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
 
   packages/ci:
     dependencies:
@@ -612,7 +612,7 @@ importers:
         version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
 
   packages/database:
     dependencies:
@@ -840,7 +840,7 @@ importers:
         version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
 
   packages/runtime:
     devDependencies:
@@ -956,7 +956,7 @@ importers:
         version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
 
   packages/shell:
     dependencies:
@@ -1076,7 +1076,7 @@ importers:
         version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
 
   packages/workflow:
     dependencies:
@@ -1128,7 +1128,7 @@ importers:
         version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
 
   packages/workspace:
     dependencies:
@@ -1201,7 +1201,7 @@ importers:
         version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
 
 packages:
 
@@ -17320,7 +17320,7 @@ snapshots:
       rolldown: 1.0.3
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
 
   '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16)':
     dependencies:
@@ -18668,7 +18668,7 @@ snapshots:
       devframe: 0.1.19(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@nuxt/kit@4.4.6(magicast@0.5.3))(launch-editor@2.13.2)(typescript@6.0.2)
       ohash: 2.0.11
       sirv: 3.0.2
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - '@nuxt/kit'
@@ -18703,7 +18703,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       tinyexec: 1.1.2
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -19088,7 +19088,7 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       tinyexec: 1.1.2
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
       vue: 3.5.34(typescript@6.0.2)
       ws: 8.20.1
     transitivePeerDependencies:
@@ -19186,7 +19186,7 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       tinyexec: 1.1.2
-      vite: 8.0.16(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
       vue: 3.5.34(typescript@6.0.2)
       ws: 8.20.1
     transitivePeerDependencies:
@@ -19440,88 +19440,6 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.17
       vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.6(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.4.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.0)))(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
-      ws: 8.20.1
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 24.13.2
-    transitivePeerDependencies:
-      - '@arethetypeswrong/core'
-      - '@tsdown/css'
-      - '@tsdown/exe'
-      - '@vitejs/devtools'
-      - bufferutil
-      - esbuild
-      - jiti
-      - less
-      - publint
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - typescript
-      - unplugin-unused
-      - unrun
-      - utf-8-validate
-      - yaml
-
-  '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
-      es-module-lexer: 1.7.0
-      obug: 2.1.1
-      pixelmatch: 7.2.0
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.17
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
-      ws: 8.20.1
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 24.13.2
-    transitivePeerDependencies:
-      - '@arethetypeswrong/core'
-      - '@tsdown/css'
-      - '@tsdown/exe'
-      - '@vitejs/devtools'
-      - bufferutil
-      - esbuild
-      - jiti
-      - less
-      - publint
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - typescript
-      - unplugin-unused
-      - unrun
-      - utf-8-validate
-      - yaml
-
-  '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
-      es-module-lexer: 1.7.0
-      obug: 2.1.1
-      pixelmatch: 7.2.0
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.17
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
       ws: 8.20.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -20330,7 +20248,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/ai': 0.16.0(@opentelemetry/api@1.9.0)
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/plugin-transform-runtime'
@@ -20613,7 +20531,7 @@ snapshots:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)
       react: 19.2.6
-      vitest: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
       vue: 3.5.34(typescript@6.0.2)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -27670,7 +27588,7 @@ snapshots:
       '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
       '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
-      '@voidzero-dev/vite-plus-test': 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)
       oxfmt: 0.52.0(vite-plus@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0))
       oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0
@@ -27720,7 +27638,7 @@ snapshots:
       '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
       '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
-      '@voidzero-dev/vite-plus-test': 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)
       oxfmt: 0.52.0(vite-plus@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0))
       oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0


### PR DESCRIPTION
Fixes harness-backed agent workspace setup so an absent selected scope no longer expands to root materialization and copy. Harness calls now pass normal agent, source, and capability instructions, derive explicit sandbox paths from harness capabilities, concrete write rules, and build-time instruction files, and preserve an empty scope as an empty Workspace Session.

This keeps lazy workspace sources out of Codex harness startup unless they are selected explicitly, while retaining root behavior for explicit `access.workspaceScope.all`.