### PR TITLE
fix(agent): observe harness shell tool calls in evals

### DIFF
--- a/packages/agent/src/eval.ts
+++ b/packages/agent/src/eval.ts
@@ -402,9 +402,15 @@ export function doesNotLeakSource(): AgentScorer {
 }
 
 function stepIncludesTool(step: AgentToolStep, name: string): boolean {
-  return Boolean(step.toolCalls?.some(call => call.toolName === name)
-    || step.toolErrors?.some(error => error.toolName === name)
-    || step.toolResults?.some(result => result.toolName === name))
+  const expected = normalizeObservedToolName(name)
+  return Boolean(step.toolCalls?.some(call => normalizeObservedToolName(call.toolName) === expected)
+    || step.toolErrors?.some(error => normalizeObservedToolName(error.toolName) === expected)
+    || step.toolResults?.some(result => normalizeObservedToolName(result.toolName) === expected))
+}
+
+function normalizeObservedToolName(name: unknown): string | undefined {
+  if (typeof name !== "string") return
+  return name === "bash" ? "shell" : name
 }
 
 export function callsTool(name: string): AgentScorer {

--- a/packages/agent/src/test.ts
+++ b/packages/agent/src/test.ts
@@ -49,6 +49,8 @@ export interface AgentTestRunner<CALL_OPTIONS = never> {
   run: (input: AgentRunInput<CALL_OPTIONS>) => Promise<AgentTestRunResult>
 }
 
+type AgentToolStepItem = NonNullable<AgentToolStep["toolCalls"]>[number]
+
 let runIdCounter = 0
 
 function isWorkspaceAgentDefinition(value: unknown): value is WorkspaceAgentDefinition {
@@ -165,6 +167,104 @@ function stringifyToolOutput(output: unknown): string {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function readString(record: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === "string" && value) return value
+  }
+}
+
+function readValue(record: Record<string, unknown>, ...keys: string[]): unknown {
+  for (const key of keys) {
+    if (key in record) return record[key]
+  }
+}
+
+function readToolName(record: Record<string, unknown>, toolNames: Map<string, string>): string | undefined {
+  const id = readString(record, "toolCallId", "id")
+  const name = readString(record, "toolName", "name") ?? (id ? toolNames.get(id) : undefined)
+  if (!name) return
+  const normalized = name === "bash" ? "shell" : name
+  if (id) toolNames.set(id, normalized)
+  return normalized
+}
+
+function appendToolStepItem(items: AgentToolStepItem[], value: unknown, toolNames: Map<string, string>) {
+  if (!isRecord(value)) return
+  const toolName = readToolName(value, toolNames)
+  if (!toolName) return
+  const input = readValue(value, "input", "args")
+  const output = readValue(value, "output", "result")
+  const toolCallId = readString(value, "toolCallId", "id")
+  items.push({
+    ...(toolCallId ? { toolCallId } : {}),
+    ...(input !== undefined ? { input } : {}),
+    ...(output !== undefined ? { output } : {}),
+    toolName,
+  })
+}
+
+function appendToolStepItems(items: AgentToolStepItem[], value: unknown, toolNames: Map<string, string>) {
+  if (!Array.isArray(value)) return
+  for (const item of value) appendToolStepItem(items, item, toolNames)
+}
+
+function toolStepFromRawStep(value: unknown, toolNames: Map<string, string>): AgentToolStep | undefined {
+  if (!isRecord(value)) return
+  const toolCalls: AgentToolStepItem[] = []
+  const toolErrors: AgentToolStepItem[] = []
+  const toolResults: AgentToolStepItem[] = []
+  appendToolStepItems(toolCalls, value.toolCalls, toolNames)
+  appendToolStepItems(toolErrors, value.toolErrors, toolNames)
+  appendToolStepItems(toolResults, value.toolResults, toolNames)
+
+  const parts = Array.isArray(value.content) ? value.content : [value]
+  for (const part of parts) {
+    if (!isRecord(part)) continue
+    const type = String(part.type || "")
+    if (type === "tool-call" || type === "tool-input-available" || type === "tool-input-start") {
+      appendToolStepItem(toolCalls, part, toolNames)
+    }
+    else if (type === "tool-error" || type === "tool-output-error") {
+      appendToolStepItem(toolErrors, part, toolNames)
+    }
+    else if (type === "tool-result" || type === "tool-output-available") {
+      appendToolStepItem(toolResults, part, toolNames)
+    }
+  }
+
+  return toolCalls.length || toolErrors.length || toolResults.length
+    ? {
+        ...(toolCalls.length ? { toolCalls } : {}),
+        ...(toolErrors.length ? { toolErrors } : {}),
+        ...(toolResults.length ? { toolResults } : {}),
+      }
+    : undefined
+}
+
+function toolStepsFromRaw(value: unknown): AgentToolStep[] {
+  const toolSteps: AgentToolStep[] = []
+  const toolNames = new Map<string, string>()
+  const seen = new Set<unknown>()
+  const collect = (source: unknown) => {
+    if (!isRecord(source) || seen.has(source)) return
+    seen.add(source)
+    if (Array.isArray(source.steps)) {
+      for (const step of source.steps) {
+        const toolStep = toolStepFromRawStep(step, toolNames)
+        if (toolStep) toolSteps.push(toolStep)
+      }
+    }
+    collect(source.raw)
+  }
+  collect(value)
+  return toolSteps
+}
+
 function textFromRaw(value: unknown): string {
   if (typeof value === "string") {
     return value
@@ -194,7 +294,7 @@ async function normalizeAgentTestResult(value: unknown, toolSteps: AgentToolStep
     finishReason: result?.finishReason,
     raw: value,
     text: textFromRaw(value),
-    toolSteps,
+    toolSteps: [...toolSteps, ...toolStepsFromRaw(value)],
     usage: result?.usage,
     warnings: result?.warnings,
   }

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -382,6 +382,10 @@ describe("agent eval", () => {
       ...observation,
       toolSteps: [{ toolErrors: [{ output: "network failed", toolName: "refund" }] }],
     }
+    const codexShellObservation = {
+      ...observation,
+      toolSteps: [{ toolCalls: [{ input: { command: "pwd" }, toolName: "bash" }] }],
+    }
 
     expect(await textContains("billing").score(observation)).toMatchObject({ score: 1, passed: true })
     const globalPattern = /billing/g
@@ -391,7 +395,9 @@ describe("agent eval", () => {
     expect(globalPattern.lastIndex).toBe(0)
     expect(await doesNotLeakSource().score({ ...observation, text: "export const token = 'x'" })).toMatchObject({ score: 0, passed: false })
     expect(await callsTool("classifyTicket").score(observation)).toMatchObject({ score: 1, passed: true })
+    expect(await callsTool("shell").score(codexShellObservation)).toMatchObject({ score: 1, passed: true })
     expect(await callsTool("refund").score(erroredToolObservation)).toMatchObject({ score: 1, passed: true })
+    expect(await doesNotCallTool("shell").score(codexShellObservation)).toMatchObject({ score: 0, passed: false })
     expect(await doesNotCallTool("refund").score(erroredToolObservation)).toMatchObject({ score: 0, passed: false })
     expect(await doesNotCallTool("refund").score(observation)).toMatchObject({ score: 1, passed: true })
     expect(await staysUnderTokenBudget(10).score(observation)).toMatchObject({ score: 1, passed: true })

--- a/packages/agent/test/test-runner.test.ts
+++ b/packages/agent/test/test-runner.test.ts
@@ -81,6 +81,36 @@ describe("agent test runner", () => {
     })
   })
 
+  it("collects harness-native raw tool steps for eval scorers", async () => {
+    const { createAgentTestRunner } = await import("../src/test.ts")
+    const agent = {
+      generate: vi.fn(async () => ({
+        finishReason: "stop",
+        raw: {
+          steps: [{
+            content: [
+              { input: { command: "pwd" }, toolCallId: "call-1", toolName: "bash", type: "tool-call" },
+              { output: { stdout: "/workspace" }, toolCallId: "call-1", type: "tool-result" },
+            ],
+          }],
+        },
+        text: "done",
+      })),
+      stream: vi.fn(),
+      tools: {},
+      version: "agent-v1",
+    }
+
+    const result = await createAgentTestRunner(agent as never, {
+      runtimeConfig: {},
+    }).run({ prompt: "Use the shell" })
+
+    expect(result.toolSteps).toEqual([{
+      toolCalls: [{ input: { command: "pwd" }, toolCallId: "call-1", toolName: "shell" }],
+      toolResults: [{ output: { stdout: "/workspace" }, toolCallId: "call-1", toolName: "shell" }],
+    }])
+  })
+
   it("applies workspace defaults and collects workspace tool steps", async () => {
     const { registerWorkspace } = await import("@vite-hub/workspace/test")
     const execute = vi.fn(async () => "workspace result")


### PR DESCRIPTION
Normalizes raw harness tool-call steps into Agent Eval observations so Codex-native bash calls are scored as the ViteHub shell tool. This lets downstream evals use callsTool('shell') instead of reading raw harness output.\n\nAlso keeps callsTool/doesNotCallTool alias-aware for raw bash observations and covers both the observation mapping and scorer behavior in agent tests.