### PR TITLE
docs(agent): update harness and eval guidance

### DIFF
--- a/docs/content/docs/agents/evals.md
+++ b/docs/content/docs/agents/evals.md
@@ -75,6 +75,30 @@ Good evals score source-grounded answers, refusal behavior, expected tool use, n
 
 Keep evals close to the Agent Definition they protect. A small eval with clear scenarios is more useful than a broad suite that hides which boundary changed.
 
+Use tool scorers when the important behavior is whether a Capability ran, not the exact text it returned.
+
+```ts [server/agents/support.eval.ts]
+import { callsTool, defineEval, doesNotCallTool, textContains } from '@vite-hub/agent/eval'
+import support from './support'
+
+export default defineEval({
+  agent: support,
+  scenarios: [
+    {
+      name: 'inspects workspace before answering',
+      input: { prompt: 'Where is the billing retry policy documented?' },
+      scorers: [
+        callsTool('shell'),
+        doesNotCallTool('refund'),
+        textContains('billing'),
+      ],
+    },
+  ],
+})
+```
+
+`callsTool(name)` and `doesNotCallTool(name)` score the normalized tool steps reported by the Agent test runner. Prefer these scorers over matching tool output text.
+
 ## Next steps
 
 - Read [Agent Drivers](/docs/agents/agent-drivers) before using model variants.

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -112,7 +112,7 @@ export default defineAgent({
 })
 ```
 
-Read mode materializes the selected Workspace into the harness sandbox and discards sandbox changes. Write mode syncs additions, updates, and deletions back through Workspace rules. Keep Skills behind the `skills()` Capability; ViteHub does not add root `skills`, `tools`, or `sandbox` Agent Definition fields for harness-backed Agents. Put harness guidance in colocated `instructions.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet.
+Read mode materializes the selected Workspace into the harness sandbox and discards sandbox changes. Write mode syncs additions, updates, and deletions back through Workspace rules. Capabilities can also contribute harness-only Workspace paths, such as skill directories, without broadening the product-data Workspace Scope. Keep Skills behind the `skills()` Capability; ViteHub does not add root `skills`, `tools`, or `sandbox` Agent Definition fields for harness-backed Agents. Put harness guidance in colocated `instructions.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet.
 
 ## Scope by Agent Invoker
 

--- a/docs/content/docs/capabilities/skills.md
+++ b/docs/content/docs/capabilities/skills.md
@@ -7,19 +7,19 @@ navigation.group: Workspace
 icon: i-lucide-scroll-text
 ---
 
-`skills()` adds a Workspace requirement and model-facing hint for a skill file.
-Use it when an Agent must have a `SKILL.md` file available before it runs.
+`skills()` makes a Workspace skill file available to an Agent Invocation.
+Use it when an Agent must have a `SKILL.md` file, and any files beside it, before it runs.
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds
 
-The Capability records the configured skill path in metadata, requires the Workspace path to exist, and tells model-backed Agents where to read the full skill.
-By default it does not expose model-facing tools beyond the instruction hint.
-When `shellExecution` is set, it also exposes `skill_shell`, which runs commands from the mounted skill instructions through the active Workspace Session.
+The Capability records the configured skill path in metadata and requires the Workspace path to exist.
+Model-backed Agents also receive a generated hint that tells them where to read the full skill.
+When `shellExecution` is set, model-backed Agents receive the normal Workspace Shell tools in the requested mode.
 When `source` is set, ViteHub adds that source to the Agent Workspace at definition time and mounts it at the skill path.
 
 ## Configuration
@@ -69,8 +69,9 @@ export default defineAgent({
 
 ViteHub validates the Workspace read requirement before the Agent Driver runs.
 The Capability metadata includes the directory path and the resolved `SKILL.md` path.
-Generated instructions include the skill path, the frontmatter `name` and `description` when available, and a reminder to read the full `SKILL.md`.
-With `shellExecution: 'write'`, successful `skill_shell` commands commit Workspace Session changes back into the Workspace.
+For model-backed drivers, generated instructions include the skill path, the frontmatter `name` and `description` when available, and a reminder to read the full `SKILL.md`.
+For harness-backed drivers, `skills()` contributes the skill directory to the Harness Workspace Session instead of adding model-facing instructions or tools.
+With `shellExecution: 'write'`, model-backed Workspace Shell writes commit Workspace Session changes back into the Workspace.
 With `source`, ViteHub still uses normal Workspace Source materialization, visibility, and DevTools metadata. `skills()` does not fetch source files at invocation time.
 
 ## Requirements
@@ -84,7 +85,7 @@ When `source` is configured, `path` is the canonical mount. ViteHub mounts the s
 | Agent Driver | Support |
 | --- | --- |
 | Model-backed | Validates the skill file requirement, receives the generated skill-read hint, and can read the mounted skill through Workspace tools. |
-| Harness-backed | Validates the skill file requirement before harness execution. |
+| Harness-backed | Validates the skill file requirement and mounts the skill directory into the Harness Workspace Session. It does not receive generated skill instructions or Workspace Shell tools from `skills()`. |
 | Custom-run-backed | Validates the skill file requirement before `driver.run`. |
 
 ## Inspect and verify
@@ -98,13 +99,11 @@ Inspect Capability metadata for the normalized `path` and `skillPath` values.
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `maxOutputLength` | `number` | `30000` | Maximum stdout/stderr characters returned from `skill_shell`. |
 | `instructions` | `string \| false` | generated | Override or disable the generated skill-read instructions. |
 | `path` | `string` | `"skills"` | Directory or `SKILL.md` path required in the Workspace. |
-| `shellExecution` | `"read" \| "write"` | none | Optional Workspace Session shell execution mode for commands described by the mounted skill. |
+| `shellExecution` | `"read" \| "write"` | none | Optional Workspace Shell mode for model-backed Agents. Harness-backed Agents still receive the skill files, not Workspace Shell tools. |
 | `source` | `WorkspaceSourceInput` | none | Workspace Source to mount at the skill directory. |
 | `sourceKey` | `string` | derived from `path` | Workspace source key used when `source` is configured. |
-| `timeout` | `number` | none | Default `skill_shell` timeout in milliseconds. |
 
 ## Reference
 

--- a/docs/content/docs/development/agent-evals.md
+++ b/docs/content/docs/development/agent-evals.md
@@ -78,6 +78,8 @@ export default defineConfig({
 | Access boundary | Scoped-out Workspace content does not appear in the answer. |
 | Cost or latency | Agent Usage Record stays within the expected budget when telemetry is attached. |
 
+Use `callsTool(name)` and `doesNotCallTool(name)` from `@vite-hub/agent/eval` for tool-use expectations. They read the Agent test runner's normalized tool steps, so the eval does not need to match rendered tool output text.
+
 ## Next steps
 
 - Use [CLI](/docs/development/cli) for command options.

--- a/docs/content/docs/development/troubleshooting.md
+++ b/docs/content/docs/development/troubleshooting.md
@@ -17,6 +17,7 @@ Identify whether the failure comes from discovery, generated files, provider res
 | Provider build fails | Provider Selection and required resource ids | [Provider output](/docs/reference/provider-output) |
 | DevTools feature is absent | `hubDevtools()` and package DevTools opt-out | [DevTools](/docs/development/devtools) |
 | Agent changed behavior | Agent Eval result and Agent Usage Record | [Agent Evals](/docs/development/agent-evals) |
+| Agent Invocation Stream timed out | Agent Dev Loop timeout, long-running driver work, or a stalled harness/session setup | `vitehub agent dev --timeout <ms>` and Agent package tests |
 | Runtime error lacks context | Package error family and diagnostics output | [Errors and diagnostics](/docs/reference/errors-diagnostics) |
 
 ## Discovery failures
@@ -56,6 +57,8 @@ Use DevTools to inspect one interactive Agent Invocation, then use Agent Evals w
 ```bash [Terminal]
 pnpm vitehub agent eval server/agents/support.eval.ts --output .vitehub/evals/support.json
 ```
+
+When the Agent Dev Loop reports `Agent Invocation Stream timed out after <ms>`, first decide whether the invocation is expected to run longer than the default timeout. If so, rerun with `vitehub agent dev --timeout <ms>`. If the timeout is surprising, inspect the Agent Driver boundary and any Workspace or harness session setup before changing prompts.
 
 ## When to escalate
 

--- a/docs/content/docs/reference/errors-diagnostics.md
+++ b/docs/content/docs/reference/errors-diagnostics.md
@@ -30,6 +30,7 @@ Use the error family to choose the next proof path before changing implementatio
 | `WorkflowError` | Workflow Package | Workflow run, step, or provider behavior failed. |
 | `RateLimitRejectedError` | Agent Package | Rate Limit Capability rejected an Agent Invocation. |
 | `LlmGateRejectedError` | Agent Package | LLM Gate Capability rejected before the main Agent Invocation. |
+| `Agent Invocation Stream timed out after <ms>.` | Agent Package | The dev-loop stream aborted a long or stalled Agent Invocation after its timeout. |
 
 ## Diagnostics sources
 


### PR DESCRIPTION
Updates the public docs after the recent agent harness/dev-loop work so Skills, Workspace context, Agent Evals, and troubleshooting match current main.

The docs now distinguish model-backed and harness-backed skills() behavior, explain harness-only workspace path contributions, show callsTool()/doesNotCallTool() for eval tool expectations, and add the Agent Invocation Stream timeout diagnostic path.

This PR intentionally does not document #377 or #378-specific behavior that has not landed on main yet.