### PR TITLE
feat(agent): publish delivery artifacts

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -93,6 +93,47 @@ Input Commands are Capability behavior. A channel can deliver `/summary`, but `i
 
 Link command docs and command examples to [Capabilities](/docs/capabilities), not to channel configuration.
 
+## Deliver Workspace artifacts
+
+Delivery effects can include artifacts that were written into the Agent Workspace. Use `publishWorkspaceArtifacts()` from `@vite-hub/agent/channels` inside a finish effect when a channel needs public URLs or channel-native attachment handles.
+
+```ts [server/agents/review.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { github, publishWorkspaceArtifacts } from '@vite-hub/agent/channels'
+import { blob } from '@vite-hub/blob'
+
+export default defineAgent({
+  channels: {
+    github: github({
+      app: true,
+      events: {
+        pullRequestComments: {
+          reply: async (event, context) => ({
+            artifacts: await publishWorkspaceArtifacts(context, [{
+              alt: 'Login footer version badge',
+              mediaType: 'image/png',
+              path: 'screenshots/login-version-badge-desktop.png',
+              placement: 'inline',
+            }], {
+              prefix: `reviews/${context.run?.runId || crypto.randomUUID()}`,
+              publish: async ({ content, mediaType, pathname }) => {
+                const object = await blob.put(pathname, content, { access: 'public', contentType: mediaType })
+                return { url: object.url }
+              },
+            }),
+            kind: 'review',
+            payload: { body: String(event.result || '').trim() || '_No review generated._' },
+          }),
+        },
+      },
+    }),
+  },
+  run: () => 'ok',
+})
+```
+
+The GitHub channel renders inline image artifacts as markdown in `reply` and `review` effects. It only renders artifacts that already have a `url`; it does not scan `screenshots/**` or upload files unless your finish effect explicitly asks it to.
+
 ## Next steps
 
 - Read [Triggers](/docs/agents/triggers) for `chat.message` and app-owned trigger consumers.

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -8,6 +8,7 @@ import type {
   AgentChannelDeliveryEffectIntent,
   AgentChannelDeliveryEffects,
   AgentChannelDeliveryFinishEffect,
+  AgentDeliveryArtifact,
   AgentChatWebhookRegistrationDefinition,
   AgentFinishEvent,
   AgentRunInput,
@@ -16,7 +17,9 @@ import type {
   AgentTriggerInvokeResult,
   AgentRuntimeConfig,
   AgentWebhookSecretToken,
+  MaybePromise,
   MaybeResolvable,
+  PublishedAgentDeliveryArtifact,
 } from "./types.ts"
 import type { AgentChatFetchHandlerOptions } from "./server.ts"
 
@@ -27,9 +30,13 @@ export type {
   AgentChannelDeliveryEffectKind,
   AgentChannelDeliveryEffects,
   AgentChannelDeliveryFinishEffect,
+  AgentChannelDeliveryFinishEffectContext,
   AgentChannelDefinition,
   AgentChannels,
+  AgentDeliveryArtifact,
+  AgentDeliveryArtifactPlacement,
   AgentMessageChannelSettings,
+  PublishedAgentDeliveryArtifact,
 } from "./types.ts"
 export interface AgentChannelOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   adapter?: AgentChannelDefinition<TRuntimeConfig>["adapter"]
@@ -44,6 +51,26 @@ export interface AgentChannelOptions<TRuntimeConfig extends AgentRuntimeConfig =
 export interface AgentStreamChannelOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
   extends AgentChannelOptions<TRuntimeConfig> {
   route?: true | AgentChatFetchHandlerOptions
+}
+
+export interface AgentDeliveryArtifactPublishInput {
+  artifact: AgentDeliveryArtifact
+  content: Uint8Array
+  mediaType?: string
+  pathname: string
+}
+
+export interface AgentDeliveryArtifactPublishResult {
+  channelAttachmentId?: string
+  url?: string
+}
+
+export type AgentDeliveryArtifactPublisher =
+  (input: AgentDeliveryArtifactPublishInput) => MaybePromise<AgentDeliveryArtifactPublishResult>
+
+export interface PublishWorkspaceArtifactsOptions {
+  prefix?: string
+  publish: AgentDeliveryArtifactPublisher
 }
 
 type GitHubAppValue<T, TRuntimeConfig extends AgentRuntimeConfig> =
@@ -224,6 +251,50 @@ function maybeStrings(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return
   const strings = value.filter((item): item is string => typeof item === "string" && Boolean(item))
   return strings.length ? strings : undefined
+}
+
+function normalizeDeliveryArtifactPath(path: string, label: string): string {
+  const normalized = path.trim().replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/\/+/g, "/")
+  if (!normalized || normalized === "." || normalized.startsWith("/") || normalized.split("/").includes("..")) {
+    throw new Error(`[vitehub] ${label} must stay inside the workspace: "${path}".`)
+  }
+  return normalized
+}
+
+function joinDeliveryArtifactPath(prefix: string | undefined, path: string): string {
+  const cleanPrefix = prefix ? normalizeDeliveryArtifactPath(prefix, "Delivery artifact prefix") : undefined
+  return cleanPrefix ? `${cleanPrefix}/${path}` : path
+}
+
+export async function publishWorkspaceArtifacts<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: Pick<AgentChannelDeliveryEffectContext<TRuntimeConfig>, "workspace">,
+  artifacts: readonly AgentDeliveryArtifact[],
+  options: PublishWorkspaceArtifactsOptions,
+): Promise<PublishedAgentDeliveryArtifact[]> {
+  if (!context.workspace) throw new Error("[vitehub] publishWorkspaceArtifacts() requires an Agent delivery context with a Workspace.")
+
+  const published: PublishedAgentDeliveryArtifact[] = []
+  for (const artifact of artifacts) {
+    const path = normalizeDeliveryArtifactPath(artifact.path, "Delivery artifact path")
+    const stat = await context.workspace.fs.stat(path).catch(() => undefined)
+    const mediaType = artifact.mediaType || (stat?.type === "file" ? stat.mediaType : undefined)
+    const content = await context.workspace.fs.readFile(path, { encoding: "binary" })
+    const normalized = {
+      ...artifact,
+      path,
+      ...(mediaType ? { mediaType } : {}),
+    }
+    published.push({
+      ...normalized,
+      ...await options.publish({
+        artifact: normalized,
+        content,
+        ...(mediaType ? { mediaType } : {}),
+        pathname: joinDeliveryArtifactPath(options.prefix, path),
+      }),
+    })
+  }
+  return published
 }
 
 function inputPayload(input: unknown): GitHubIssueCommentPayload | undefined {
@@ -638,6 +709,56 @@ function replyBody<TRuntimeConfig extends AgentRuntimeConfig>(
   if (typeof context.effect.metadata?.body === "string") return context.effect.metadata.body
 }
 
+function deliveryArtifactFromUnknown(value: unknown): PublishedAgentDeliveryArtifact | undefined {
+  if (!isRecord(value) || typeof value.path !== "string") return
+  return {
+    path: value.path,
+    ...(typeof value.alt === "string" ? { alt: value.alt } : {}),
+    ...(typeof value.channelAttachmentId === "string" ? { channelAttachmentId: value.channelAttachmentId } : {}),
+    ...(typeof value.mediaType === "string" ? { mediaType: value.mediaType } : {}),
+    ...(value.placement === "inline" || value.placement === "attachment" || value.placement === "link" ? { placement: value.placement } : {}),
+    ...(typeof value.url === "string" ? { url: value.url } : {}),
+  }
+}
+
+function deliveryArtifacts<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
+): PublishedAgentDeliveryArtifact[] {
+  const artifacts = [
+    ...(Array.isArray(context.effect.artifacts) ? context.effect.artifacts : []),
+    ...(isRecord(context.effect.payload) && Array.isArray(context.effect.payload.artifacts) ? context.effect.payload.artifacts : []),
+  ]
+  return artifacts.map(deliveryArtifactFromUnknown).filter((artifact): artifact is PublishedAgentDeliveryArtifact => Boolean(artifact))
+}
+
+function githubMarkdownText(value: string): string {
+  return value.replace(/[\r\n\[\]]+/g, " ").trim() || "Artifact"
+}
+
+function githubMarkdownUrl(value: string): string {
+  return value.replace(/[\r\n<>]+/g, "")
+}
+
+function githubArtifactMarkdown(artifact: PublishedAgentDeliveryArtifact): string | undefined {
+  if (!artifact.url) return
+  const label = githubMarkdownText(artifact.alt || artifact.path.split("/").pop() || artifact.path)
+  const url = githubMarkdownUrl(artifact.url)
+  if (!url || artifact.placement === "attachment") return
+  if ((artifact.placement || (artifact.mediaType?.startsWith("image/") ? "inline" : "link")) === "inline") {
+    return `![${label}](<${url}>)`
+  }
+  return `[${label}](<${url}>)`
+}
+
+function githubBodyWithArtifacts<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
+  body: string | undefined,
+): string | undefined {
+  const artifacts = deliveryArtifacts(context).map(githubArtifactMarkdown).filter((line): line is string => Boolean(line))
+  if (!artifacts.length) return body
+  return body ? `${body}\n\n${artifacts.join("\n")}` : artifacts.join("\n")
+}
+
 function finishResultText(result: unknown): string | undefined {
   if (typeof result === "string") return result
   if (result instanceof Response) return
@@ -715,13 +836,30 @@ function githubPullRequestEffects<TRuntimeConfig extends AgentRuntimeConfig = Ag
     },
     async reply(context) {
       const command = githubCommandFromEffect(context)
-      const body = replyBody(context)
+      const body = githubBodyWithArtifacts(context, replyBody(context))
       if (!command || !body) return
       const fetcher = options.fetch || fetch
       const token = await resolveEffectOption(options.token, context)
       const url = `${options.apiBaseUrl || "https://api.github.com"}/repos/${command.owner}/${command.repo}/issues/${command.issueNumber}/comments`
       await githubApi(fetcher, url, {
         body: JSON.stringify({ body }),
+        headers: githubApiHeaders(token, options.userAgent),
+        method: "POST",
+      })
+    },
+    async review(context) {
+      const command = githubCommandFromEffect(context)
+      const body = githubBodyWithArtifacts(context, replyBody(context))
+      if (!command || !body) return
+      const payload = isRecord(context.effect.payload) ? context.effect.payload : {}
+      const fetcher = options.fetch || fetch
+      const token = await resolveEffectOption(options.token, context)
+      const url = `${options.apiBaseUrl || "https://api.github.com"}/repos/${command.owner}/${command.repo}/pulls/${command.issueNumber}/reviews`
+      await githubApi(fetcher, url, {
+        body: JSON.stringify({
+          body,
+          event: maybeString(payload.event) || maybeString(context.effect.metadata?.event) || "COMMENT",
+        }),
         headers: githubApiHeaders(token, options.userAgent),
         method: "POST",
       })

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -76,6 +76,9 @@ import type {
   AgentChannelDeliveryEffectHandler,
   AgentChannelDeliveryEffectIntent,
   AgentChannelDeliveryFinishEffect,
+  AgentChannelDeliveryFinishEffectContext,
+  AgentDeliveryArtifact,
+  AgentDeliveryArtifactPlacement,
   AgentDefinition,
   AgentDriverContribution,
   AgentDriverKind,
@@ -112,6 +115,7 @@ import type {
   AgentWorkflowRuntimeBinding,
   AgentToolDefinition,
   MaybePromise,
+  PublishedAgentDeliveryArtifact,
   ResolvedAgentTriggerDefinition,
   ResolvedAgentRuntimeContext,
 } from "./types.ts"
@@ -162,6 +166,7 @@ export type {
   AgentChannelDeliveryEffectIntent,
   AgentChannelDeliveryEffectKind,
   AgentChannelDeliveryEffects,
+  AgentChannelDeliveryFinishEffectContext,
   AgentChatAgentHookArgs,
   AgentChatErrorHookArgs,
   AgentChatEventHookArgs,
@@ -178,6 +183,8 @@ export type {
   AgentChannelTriggerContext,
   AgentChannels,
   AgentRequestBody,
+  AgentDeliveryArtifact,
+  AgentDeliveryArtifactPlacement,
   AgentDefinition,
   AgentDevtoolsConfigMetadata,
   AgentDevtoolsConfigValue,
@@ -277,6 +284,7 @@ export type {
   DiscoveredAgentDefinition,
   MaybePromise,
   MaybeResolvable,
+  PublishedAgentDeliveryArtifact,
   Resolvable,
   ResolvedAgentModuleOptions,
   ResolvedAgentStateProviderOptions,
@@ -633,6 +641,7 @@ async function applyChannelDeliveryEffectIntents<
               ...(active.trigger?.id ? { id: active.trigger.id } : {}),
               ...(active.trigger?.name ? { name: active.trigger.name } : {}),
             },
+            workspace: context.workspace,
           })
           await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, metadata)
         })
@@ -1517,13 +1526,23 @@ function assertDeliveryEffectIntent(value: unknown): asserts value is AgentChann
   }
 }
 
-async function resolveFinishDeliveryEffectIntents(
+async function resolveFinishDeliveryEffectIntents<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
   providers: readonly AgentChannelDeliveryFinishEffect[],
   event: AgentFinishEvent,
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
 ): Promise<AgentChannelDeliveryEffectIntent[]> {
   const intents: AgentChannelDeliveryEffectIntent[] = []
+  const finishContext = {
+    ...context.runtimeContext,
+    input: context.input,
+    run: context.run,
+    workspace: context.workspace,
+  }
   for (const provider of providers) {
-    const intent = typeof provider === "function" ? await provider(event) : provider
+    const intent = typeof provider === "function" ? await provider(event, finishContext) : provider
     if (!intent) continue
     assertDeliveryEffectIntent(intent)
     intents.push(intent)
@@ -1557,7 +1576,7 @@ async function finishAgentInvocation<
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
       const finishEvent = { ...eventBase, extensions }
-      await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(context.finishDeliveryEffectProviders, finishEvent as never), finishEvent as never)
+      await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(context.finishDeliveryEffectProviders, finishEvent as never, context), finishEvent as never)
       await runObservedAgentHook(context.hooks, {
         ids: { runId: context.run?.runId },
         name: "agent:finish",

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -165,9 +165,24 @@ export interface AgentRunMetadata<TOrigin extends string = string> {
 
 export type AgentChannelDeliveryEffectKind = "reaction" | "reply" | "status" | (string & {})
 
+export type AgentDeliveryArtifactPlacement = "inline" | "attachment" | "link"
+
+export interface AgentDeliveryArtifact {
+  alt?: string
+  mediaType?: string
+  path: string
+  placement?: AgentDeliveryArtifactPlacement
+}
+
+export interface PublishedAgentDeliveryArtifact extends AgentDeliveryArtifact {
+  channelAttachmentId?: string
+  url?: string
+}
+
 export interface AgentChannelDeliveryEffectIntent<
   TKind extends AgentChannelDeliveryEffectKind = AgentChannelDeliveryEffectKind,
 > {
+  artifacts?: readonly PublishedAgentDeliveryArtifact[]
   intent?: string
   kind: TKind
   metadata?: Record<string, unknown>
@@ -187,6 +202,15 @@ export interface AgentChannelDeliveryEffectContext<
     id?: string
     name?: string
   }
+  workspace?: ReadonlyWorkspaceFacade | WritableWorkspaceFacade
+}
+
+export interface AgentChannelDeliveryFinishEffectContext<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+> extends AgentCallbackContext<TRuntimeConfig> {
+  input: AgentRunInput
+  run?: AgentRunMetadata
+  workspace?: ReadonlyWorkspaceFacade | WritableWorkspaceFacade
 }
 
 export type AgentChannelDeliveryEffectHandler<
@@ -198,7 +222,7 @@ export type AgentChannelDeliveryEffects<
 > = Partial<Record<AgentChannelDeliveryEffectKind, AgentChannelDeliveryEffectHandler<TRuntimeConfig> | readonly AgentChannelDeliveryEffectHandler<TRuntimeConfig>[]>>
 export type AgentChannelDeliveryFinishEffect =
   | AgentChannelDeliveryEffectIntent
-  | ((event: AgentFinishEvent) => MaybePromise<AgentChannelDeliveryEffectIntent | false | null | undefined>)
+  | ((event: AgentFinishEvent, context: AgentChannelDeliveryFinishEffectContext) => MaybePromise<AgentChannelDeliveryEffectIntent | false | null | undefined>)
 
 export interface AgentTriggerRunInvokeResult<CALL_OPTIONS = unknown> {
   delivery?: {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -1,0 +1,132 @@
+import { generateKeyPairSync } from "node:crypto"
+
+import { describe, expect, it, vi } from "vitest"
+
+describe("agent channels", () => {
+  it("publishes explicit Workspace artifacts", async () => {
+    const { publishWorkspaceArtifacts } = await import("../src/channels.ts")
+    const content = new Uint8Array([1, 2, 3])
+    const readFile = vi.fn(async () => content)
+    const stat = vi.fn(async () => ({ mediaType: "image/png", path: "screenshots/login.png", type: "file" as const }))
+    const publish = vi.fn(async () => ({ url: "https://assets.example/review/screenshots/login.png" }))
+
+    await expect(publishWorkspaceArtifacts({
+      workspace: {
+        fs: { readFile, stat },
+      } as never,
+    }, [{
+      alt: "Login badge",
+      path: "./screenshots/login.png",
+      placement: "inline",
+    }], {
+      prefix: "review",
+      publish,
+    })).resolves.toEqual([{
+      alt: "Login badge",
+      mediaType: "image/png",
+      path: "screenshots/login.png",
+      placement: "inline",
+      url: "https://assets.example/review/screenshots/login.png",
+    }])
+
+    expect(readFile).toHaveBeenCalledWith("screenshots/login.png", { encoding: "binary" })
+    expect(publish).toHaveBeenCalledWith({
+      artifact: {
+        alt: "Login badge",
+        mediaType: "image/png",
+        path: "screenshots/login.png",
+        placement: "inline",
+      },
+      content,
+      mediaType: "image/png",
+      pathname: "review/screenshots/login.png",
+    })
+  })
+
+  it("rejects unsafe Workspace artifact paths before publishing", async () => {
+    const { publishWorkspaceArtifacts } = await import("../src/channels.ts")
+    const publish = vi.fn()
+
+    await expect(publishWorkspaceArtifacts({
+      workspace: {
+        fs: {
+          readFile: vi.fn(),
+          stat: vi.fn(),
+        },
+      } as never,
+    }, [{ path: "../secret.png" }], { publish })).rejects.toThrow("Delivery artifact path must stay inside the workspace")
+    expect(publish).not.toHaveBeenCalled()
+  })
+
+  it("posts GitHub PR reviews with inline published image artifacts", async () => {
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
+    const fetcher = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
+      }
+      return Response.json({ ok: true }, { status: 201 })
+    })
+    const channel = github({
+      app: {
+        apiBaseUrl: "https://api.github.test",
+        appId: "1",
+        fetch: fetcher as typeof fetch,
+        installationId: 123,
+        privateKey: privateKeyPem,
+      },
+    })
+    const reviewEffect = channel.effects?.review
+    if (typeof reviewEffect !== "function") throw new Error("Missing GitHub review effect.")
+
+    await reviewEffect({
+      channel,
+      effect: {
+        artifacts: [{
+          alt: "Login badge",
+          mediaType: "image/png",
+          path: "screenshots/login.png",
+          placement: "inline",
+          url: "https://assets.example/review/screenshots/login.png",
+        }],
+        kind: "review",
+        payload: { body: "Review body" },
+      },
+      input: {
+        context: {
+          github: {
+            action: "created",
+            actor: { login: "onmax" },
+            args: "",
+            body: "/review",
+            command: "/review",
+            commentId: 99,
+            installationId: 123,
+            issueNumber: 42,
+            owner: "vite-hub",
+            pullRequestUrl: "https://api.github.test/repos/vite-hub/vitehub/pulls/42",
+            repo: "vitehub",
+            repository: "vite-hub/vitehub",
+          },
+        },
+        prompt: "/review",
+      },
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.github.test/repos/vite-hub/vitehub/pulls/42/reviews",
+      expect.objectContaining({
+        body: JSON.stringify({
+          body: "Review body\n\n![Login badge](<https://assets.example/review/screenshots/login.png>)",
+          event: "COMMENT",
+        }),
+        headers: expect.objectContaining({ authorization: "Bearer installation-token" }),
+        method: "POST",
+      }),
+    )
+  })
+})

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1486,6 +1486,66 @@ describe("agent message protocol", () => {
     expect(order).toEqual(["run", "effect:result:ok:done"])
   })
 
+  it("lets finish delivery effects publish Workspace artifacts", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel, publishWorkspaceArtifacts } = await import("../src/channels.ts")
+    const content = new Uint8Array([1, 2, 3])
+    const publish = vi.fn(async () => ({ url: "https://assets.example/review/screenshots/result.png" }))
+    const effect = vi.fn((context) => {
+      expect(context.effect).toMatchObject({
+        artifacts: [{
+          path: "screenshots/result.png",
+          url: "https://assets.example/review/screenshots/result.png",
+        }],
+        kind: "reply",
+        payload: "done",
+      })
+    })
+    const agent = defineAgent({
+      channels: {
+        portal: defineChannel("portal", {
+          effects: { reply: effect },
+          messages: false,
+          triggers: {
+            message: {
+              invoke: context => ({
+                delivery: {
+                  finishEffects: async (_event, finishContext) => ({
+                    artifacts: await publishWorkspaceArtifacts(finishContext, [{
+                      mediaType: "image/png",
+                      path: "screenshots/result.png",
+                      placement: "inline",
+                    }], {
+                      prefix: "review",
+                      publish,
+                    }),
+                    kind: "reply",
+                    payload: "done",
+                  }),
+                },
+                input: { prompt: "hello" },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run" },
+              }),
+            },
+          },
+        }),
+      },
+      run: async ({ workspace }) => {
+        await (workspace as WritableWorkspaceFacade).fs.writeFile("screenshots/result.png", content, { mediaType: "image/png" })
+        return "ok"
+      },
+      workspace: { mode: "write", store: { provider: "memory" } },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({
+      content,
+      mediaType: "image/png",
+      pathname: "review/screenshots/result.png",
+    }))
+    expect(effect).toHaveBeenCalledOnce()
+  })
+
   it("lets Capabilities expose finish delivery effects", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, type AgentActor, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDefinition, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, type AgentActor, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentDeliveryArtifact, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, observability, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceExec, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -510,6 +510,8 @@ describe("agent public types", () => {
         reaction(context) {
           expectTypeOf(context.effect.kind).toEqualTypeOf<AgentChannelDeliveryEffectKind>()
           expectTypeOf(context.effect).toEqualTypeOf<AgentChannelDeliveryEffectIntent>()
+          expectTypeOf(context.effect.artifacts?.[0]).toEqualTypeOf<PublishedAgentDeliveryArtifact | undefined>()
+          expectTypeOf(context.workspace).toEqualTypeOf<AgentChannelDeliveryEffectContext["workspace"]>()
         },
       },
       messages: false,
@@ -521,7 +523,14 @@ describe("agent public types", () => {
             expectTypeOf(input.text).toEqualTypeOf<string>()
             return {
               delivery: {
-                finishEffects: event => ({ kind: "reply", payload: event.result }),
+                finishEffects: (event, context) => {
+                  expectTypeOf(context.workspace).toEqualTypeOf<AgentChannelDeliveryFinishEffectContext["workspace"]>()
+                  return {
+                    artifacts: [{ path: "screenshots/result.png", url: "https://assets.example/result.png" }],
+                    kind: "reply",
+                    payload: event.result,
+                  }
+                },
               },
               input: { prompt: input.text },
             }
@@ -530,6 +539,7 @@ describe("agent public types", () => {
       },
     })
     expectTypeOf(custom.kind).toEqualTypeOf<string>()
+    expectTypeOf<AgentDeliveryArtifact>().toMatchTypeOf<{ path: string }>()
 
     defineAgent({
       capabilities: [{


### PR DESCRIPTION
Adds delivery artifact metadata to agent channel delivery intents and passes Workspace into finish and delivery contexts, so finish effects can publish explicit Workspace files before a channel posts output.

GitHub delivery now supports a built-in review effect and renders published inline image artifacts in replies and reviews. The channel docs cover Blob-backed publication through publishWorkspaceArtifacts().