### PR TITLE
feat(agent): improve agent eval DX

### DIFF
--- a/docs/content/docs/agents/agent-drivers.md
+++ b/docs/content/docs/agents/agent-drivers.md
@@ -63,6 +63,26 @@ export default defineAgent({
 })
 ```
 
+Use `driver.sandbox` when the harness needs a specific execution runtime. For local development and Agent Evals, `@vite-hub/agent/harness/local-sandbox` provides a trusted-host sandbox that runs commands on the local machine.
+
+```ts [server/agents/codex/config.ts]
+import { createCodex } from '@ai-sdk/harness-codex'
+import { defineAgent } from '@vite-hub/agent'
+import { createLocalHarnessSandbox } from '@vite-hub/agent/harness/local-sandbox'
+
+export default defineAgent({
+  driver: {
+    harness: createCodex({ model: 'gpt-5.5' }),
+    sandbox: createLocalHarnessSandbox(),
+    credentials: { label: 'local Codex', source: 'ambient' },
+  },
+})
+```
+
+`createLocalHarnessSandbox()` is for trusted local development and tests. It is not a production isolation boundary.
+
+`driver.harness`, `driver.sandbox`, and `driver.sessionKey` can also be callbacks. Use callbacks when one Agent Definition needs invocation-scoped harness auth, sandbox selection, or session reuse.
+
 Harness-backed drivers do not receive `driver.instructions` as a model prompt. Use explicit harness configuration or Workspace instruction surfaces when the harness needs guidance.
 
 ## Custom run driver

--- a/docs/content/docs/agents/evals.md
+++ b/docs/content/docs/agents/evals.md
@@ -51,7 +51,8 @@ export default defineEval({
 })
 ```
 
-Scenarios pass normal Agent Invocation input. Scorers receive the Agent output text, raw result, tool steps, usage, warnings, scenario name, and variant name.
+Scenarios pass normal Agent Invocation input.
+Scorers receive the Agent output text, raw result, tool steps, usage, warnings, capability finish extensions, scenario name, and variant name.
 
 ## Compare variants
 
@@ -90,6 +91,22 @@ Use `--watch` while editing prompts or scenarios. Use `--threshold` and `--outpu
 ## Score useful behavior
 
 Good evals score source-grounded answers, refusal behavior, expected tool use, no source leakage, and regressions in usage or latency when telemetry is attached.
+When the behavior belongs to a Capability, assert its finish extension instead of duplicating host-specific hooks.
+
+```ts [server/agents/support.eval.ts]
+import { defineEval, hasCapabilityExtension } from '@vite-hub/agent/eval'
+import support from './support'
+
+export default defineEval({
+  agent: support,
+  async test(t) {
+    await t.send('What changed in the order forecast?')
+    t.hasCapabilityExtension('observability')
+    t.expect(hasCapabilityExtension('observability', 'status'))
+    t.expect(hasCapabilityExtension('usage-telemetry'))
+  },
+})
+```
 
 Keep evals close to the Agent Definition they protect. A small eval with clear scenarios is more useful than a broad suite that hides which boundary changed.
 

--- a/docs/content/docs/agents/evals.md
+++ b/docs/content/docs/agents/evals.md
@@ -9,6 +9,8 @@ Agent Evals are repeatable development checks that run an Agent Definition again
 
 ViteHub Agent Evals use `defineEval` and run through the Agent test runner. They preserve Agent Driver, Capability, Workspace, and runtime boundaries unless a variant explicitly overrides model-backed driver fields.
 
+Keep harness, credentials, sandbox, and runtime selection on the Agent Definition. An eval should declare scenarios and scorers; it should not duplicate the Agent Driver setup. For harness-backed Agents, configure local or hosted sandbox behavior with `driver.sandbox` on the Agent Definition, then import that Agent into the eval.
+
 ## Define an eval
 
 Create eval files beside the Agent they protect. A sibling `support.eval.ts` can import `./support`, and a folder-level `eval.ts` can infer `./config`.

--- a/docs/content/docs/agents/evals.md
+++ b/docs/content/docs/agents/evals.md
@@ -16,6 +16,22 @@ Keep harness, credentials, sandbox, and runtime selection on the Agent Definitio
 Create eval files beside the Agent they protect. A sibling `support.eval.ts` can import `./support`, and a folder-level `eval.ts` can infer `./config`.
 
 ```ts [server/agents/support.eval.ts]
+import { defineEval } from '@vite-hub/agent/eval'
+import support from './support'
+
+export default defineEval({
+  agent: support,
+  async test(t) {
+    await t.send('How do I configure billing retries?')
+    t.completed()
+    t.textContains('billing')
+  },
+})
+```
+
+Use `scenarios` when one eval file should run several cases or reuse the same scorers.
+
+```ts [server/agents/support.eval.ts]
 import { defineEval, textContains } from '@vite-hub/agent/eval'
 import support from './support'
 

--- a/docs/content/docs/capabilities/custom-capabilities.md
+++ b/docs/content/docs/capabilities/custom-capabilities.md
@@ -87,6 +87,44 @@ Check that the custom Capability id appears once, its requirements pass, its too
 Add an Agent Eval when the Capability changes product behavior.
 Use a focused fixture that proves the Capability exposes the intended ability and does not expose adjacent authority.
 
+## Expose eval-visible metadata
+
+Use a `finish` provider when the Capability should publish invocation metadata for finish hooks, channel delivery code, or eval assertions.
+The value is keyed by Capability id and is available through `observation.extensions.get(id)` in Agent Evals.
+
+```ts [server/agents/capabilities/tickets.ts]
+import { defineCapability } from '@vite-hub/agent'
+
+export function tickets() {
+  return defineCapability({
+    id: 'tickets',
+    instructions: 'Use ticket tools only for support ticket lookup and triage.',
+    finish(event) {
+      return {
+        resultKind: typeof event.result,
+        status: event.error ? 'failed' : 'completed',
+      }
+    },
+  })
+}
+```
+
+```ts [server/agents/support.eval.ts]
+import { defineEval, hasCapabilityExtension } from '@vite-hub/agent/eval'
+import support from './support'
+
+export default defineEval({
+  agent: support,
+  scenarios: [{
+    name: 'uses ticket boundary',
+    input: { prompt: 'Find the open billing ticket' },
+    scorers: [
+      hasCapabilityExtension('tickets', 'status'),
+    ],
+  }],
+})
+```
+
 ## Reference
 
 - [Capabilities overview](/docs/capabilities)

--- a/docs/content/docs/capabilities/index.md
+++ b/docs/content/docs/capabilities/index.md
@@ -53,6 +53,9 @@ export default defineAgent({
 | Output behavior | Stream renderers, finish extensions, usage records, titles, and summaries. |
 | Metadata | Inspectable configuration for runtime diagnostics and DevTools. |
 
+Use `defineCapability({ finish })` for metadata that evals, finish hooks, or channel delivery code should read after an invocation.
+Agent Evals expose those values through `observation.extensions.get(capabilityId)` and the `hasCapabilityExtension(capabilityId)` scorer.
+
 ## Driver boundary
 
 Capabilities attach above the Agent Driver.

--- a/docs/content/docs/capabilities/observability.md
+++ b/docs/content/docs/capabilities/observability.md
@@ -1,0 +1,73 @@
+---
+title: Observability
+description: Attach lifecycle events, model instrumentation, and eval-visible finish metadata.
+navigation.title: Observability
+navigation.order: 230
+navigation.group: Decisions and output
+icon: i-lucide-radar
+---
+
+`observability()` gives an Agent Definition one place to attach runtime telemetry.
+It can instrument model execution, emit lifecycle events, and provide a finish extension with invocation status, duration, and result kind.
+
+## Installation
+
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+
+```ts [server/agents/support.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { observability } from '@vite-hub/agent/capabilities'
+
+export default defineAgent({
+  driver: { model },
+  capabilities: [
+    observability({
+      onEvent: async event => writeAgentEvent(event),
+    }),
+  ],
+})
+```
+
+## What it adds
+
+The Capability emits a `start` event before driver execution.
+When `onEvent` is configured, it also emits a `finish` or `error` event after the invocation completes.
+
+It provides an `observability` finish extension with `{ status, durationMs, resultKind }` for completed invocations and `{ status, durationMs }` for failed invocations.
+Agent Evals and the Agent test runner capture this finish extension automatically.
+
+## Eval assertions
+
+Use the built-in scorer or the test callback helpers when an eval should prove the observability path is attached.
+
+```ts [server/agents/support.eval.ts]
+import { defineEval, hasCapabilityExtension } from '@vite-hub/agent/eval'
+import support from './support'
+
+export default defineEval({
+  agent: support,
+  scorers: [
+    hasCapabilityExtension('observability', 'status'),
+  ],
+  async test(t) {
+    await t.send('Check order status')
+    t.hasCapabilityExtension('observability')
+  },
+})
+```
+
+For custom checks, read `observation.extensions.get('observability')` or `t.capabilityExtension('observability')`.
+
+## Driver support
+
+| Agent Driver | Support |
+| --- | --- |
+| Model-backed | Supports model instrumentation, lifecycle events, and finish extensions. |
+| Harness-backed | Supports lifecycle events and finish extensions; instrumentation applies only to model-backed execution. |
+| Custom-run-backed | Supports lifecycle events and finish extensions around the custom result. |
+
+## Reference
+
+- [Agent Evals](/docs/agents/evals)
+- [Custom capabilities](/docs/capabilities/custom-capabilities)
+- Source: `packages/agent/src/capabilities/observability.ts`

--- a/docs/content/docs/capabilities/official-capabilities.md
+++ b/docs/content/docs/capabilities/official-capabilities.md
@@ -27,6 +27,7 @@ import {
   llmRoute,
   mcp,
   memory,
+  observability,
   rateLimit,
   repositoryHost,
   sandbox,
@@ -69,6 +70,7 @@ import {
 | Chat title | [`chatTitle()`](/docs/capabilities/chat-title) | Chat streams and finish extensions should include a generated conversation title. |
 | Chat summary | [`chatSummary()`](/docs/capabilities/chat-summary) | A summary command should replace explicit input with a conversation summary. |
 | Usage telemetry | [`usageTelemetry()`](/docs/capabilities/usage-telemetry) | Agent Usage Records should be normalized, emitted, or attached to output. |
+| Observability | [`observability()`](/docs/capabilities/observability) | Lifecycle events, model instrumentation, and finish metadata should be attached to Agent Invocations. |
 
 ## Read capability pages first
 

--- a/docs/content/docs/development/agent-evals.md
+++ b/docs/content/docs/development/agent-evals.md
@@ -14,6 +14,22 @@ Keep eval files close to the Agent Definition they protect.
 The Agent Eval Runner discovers evals and writes an Evalite config with ViteHub defaults.
 
 ```ts [server/agents/support.eval.ts]
+import { defineEval } from '@vite-hub/agent/eval'
+import support from './support'
+
+export default defineEval({
+  agent: support,
+  async test(t) {
+    await t.send('How do I run provisioning?')
+    t.completed()
+    t.textContains('vitehub provision')
+  },
+})
+```
+
+Use `scenarios` when one eval file should run several cases or share scorers across cases.
+
+```ts [server/agents/support.eval.ts]
 import { defineEval, textContains } from '@vite-hub/agent/eval'
 import support from './support'
 

--- a/docs/content/docs/development/agent-evals.md
+++ b/docs/content/docs/development/agent-evals.md
@@ -90,7 +90,7 @@ export default defineConfig({
 | Behavior | Useful assertion |
 | --- | --- |
 | Source-grounded answer | Expected citation, phrase, or refusal when the Source does not answer. |
-| Capability behavior | Tool was used, rejected, or omitted as expected. |
+| Capability behavior | Tool was used, rejected, omitted, or reported through `hasCapabilityExtension(id)` as expected. |
 | Access boundary | Scoped-out Workspace content does not appear in the answer. |
 | Cost or latency | Agent Usage Record stays within the expected budget when telemetry is attached. |
 

--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -16,6 +16,7 @@ They may resolve to Runtime Registries, generated files, virtual modules, or pac
 | `@vite-hub/agent/capabilities` | Agent Package | Official Capability factories such as `access()`, `workspaceShell()`, `inputCommands()`, and `subagents()`. |
 | `@vite-hub/agent/channels` | Agent Package | Official Channel Kind helpers such as `github()`, `stream()`, `teams()`, `telegram()`, `webChat()`, and `defineChannel()`. |
 | `@vite-hub/agent/eval` | Agent Package | Agent Eval authoring helpers. |
+| `@vite-hub/agent/harness/local-sandbox` | Agent Package | Trusted local harness sandbox helper for development and Agent Evals. |
 | `@vite-hub/vite/agent` | Vite Preset | Agent Definition helpers forwarded by the preset package. |
 | `@vite-hub/vite/agent/capabilities` | Vite Preset | Official Capability factories forwarded by the preset package. |
 | `@vite-hub/vite/agent/channels` | Vite Preset | Official Channel Kind helpers forwarded by the preset package. |

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -66,6 +66,7 @@ Harness-backed agents use AI SDK `HarnessAgent` behind the ViteHub Agent Driver 
 import { createCodex } from "@ai-sdk/harness-codex"
 import { defineAgent } from "@vite-hub/agent"
 import { skills } from "@vite-hub/agent/capabilities"
+import { createLocalHarnessSandbox } from "@vite-hub/agent/harness/local-sandbox"
 import { file } from "@vite-hub/workspace"
 
 export default defineAgent({
@@ -74,6 +75,7 @@ export default defineAgent({
       model: "gpt-5.5",
       reasoningEffort: "low",
     }),
+    sandbox: createLocalHarnessSandbox(),
     credentials: { label: "local Codex", source: "ambient" },
   },
   workspace: {
@@ -88,7 +90,7 @@ export default defineAgent({
 })
 ```
 
-`driver.harness` is the AI SDK harness adapter instance. `driver.sandbox` can provide an AI SDK sandbox provider; when omitted, ViteHub uses the AI SDK Vercel Sandbox default for bridge-backed harnesses. Workspace-backed harness drivers receive a Harness Workspace Session prepared from the selected Workspace. When `access()` narrows Workspace Scope, ViteHub materializes only that selected scope plus generated source descriptors. Read mode materializes files and discards sandbox changes; write mode syncs additions, updates, and deletions back through Workspace rules. V1 configures built-in harness permissions internally with the no-approval policy and does not expose a public permission option. Skills stay a Capability through `skills()` rather than becoming a root Agent Definition field. For harness drivers, `skills()` relies on mounted Workspace files and does not inject model instructions or Workspace Shell tools. Put harness guidance in Workspace files such as `AGENTS.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet. Unsupported model-facing Capability contributions are rejected before harness execution with the contributing Capability id in the error.
+`driver.harness` is the AI SDK harness adapter instance. `driver.sandbox` can provide an AI SDK sandbox provider; when omitted, ViteHub uses the AI SDK Vercel Sandbox default for bridge-backed harnesses. `createLocalHarnessSandbox()` is a trusted-host sandbox for local development and Agent Evals, not a production isolation boundary. `driver.harness`, `driver.sandbox`, and `driver.sessionKey` can also be callbacks when one Agent Definition needs invocation-scoped harness setup. Workspace-backed harness drivers receive a Harness Workspace Session prepared from the selected Workspace. When `access()` narrows Workspace Scope, ViteHub materializes only that selected scope plus generated source descriptors. Read mode materializes files and discards sandbox changes; write mode syncs additions, updates, and deletions back through Workspace rules. V1 configures built-in harness permissions internally with the no-approval policy and does not expose a public permission option. Skills stay a Capability through `skills()` rather than becoming a root Agent Definition field. For harness drivers, `skills()` relies on mounted Workspace files and does not inject model instructions or Workspace Shell tools. Put harness guidance in Workspace files such as `AGENTS.md`; model-facing Source Instructions are not forwarded to harness-backed Agent Drivers yet. Unsupported model-facing Capability contributions are rejected before harness execution with the contributing Capability id in the error.
 
 ```ts
 // vite.config.ts

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -65,6 +65,10 @@
       "types": "./dist/eval.d.ts",
       "import": "./dist/eval.js"
     },
+    "./harness/local-sandbox": {
+      "types": "./dist/harness/local-sandbox.d.ts",
+      "import": "./dist/harness/local-sandbox.js"
+    },
     "./mcp": {
       "types": "./dist/mcp.d.ts",
       "import": "./dist/mcp.js"

--- a/packages/agent/src/capabilities/observability.ts
+++ b/packages/agent/src/capabilities/observability.ts
@@ -131,20 +131,6 @@ export function observability<
     } satisfies AgentObservabilityCapabilityMetadata<TRuntimeConfig, CALL_OPTIONS>,
     configure(context) {
       if (options.instrumentation) context.modelExecution.instrument(options.instrumentation as never)
-      context.finish.provide(async (event: AgentFinishEvent<TRuntimeConfig>) => {
-        if (event.error !== undefined) {
-          return {
-            durationMs: event.invocation.durationMs,
-            status: "failed",
-          } satisfies AgentObservabilityFinishExtension
-        }
-
-        return {
-          durationMs: event.invocation.durationMs,
-          resultKind: resultKind(event.result),
-          status: "completed",
-        } satisfies AgentObservabilityFinishExtension
-      })
       if (options.onEvent) {
         // Returning false reuses finish-time lifecycle scheduling without creating a Channel Delivery Effect.
         context.delivery.finishEffect(async (event): Promise<false> => {
@@ -169,6 +155,20 @@ export function observability<
           return false
         })
       }
+    },
+    async finish(event: AgentFinishEvent<TRuntimeConfig>) {
+      if (event.error !== undefined) {
+        return {
+          durationMs: event.invocation.durationMs,
+          status: "failed",
+        } satisfies AgentObservabilityFinishExtension
+      }
+
+      return {
+        durationMs: event.invocation.durationMs,
+        resultKind: resultKind(event.result),
+        status: "completed",
+      } satisfies AgentObservabilityFinishExtension
     },
     input(context) {
       return notify(options.onEvent, {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -711,6 +711,15 @@ export async function resolveAgentCapabilities<
     }
   }
 
+  function addFinishExtensionProvider(capabilityId: string, value: unknown | AgentFinishExtensionProvider) {
+    registries.finishExtensionProviders.push({
+      id: capabilityId,
+      resolve: typeof value === "function"
+        ? value as AgentFinishExtensionProvider
+        : () => value,
+    })
+  }
+
   async function closeRegisteredCallbacks() {
     const errors: unknown[] = []
     for (const callback of [...closeCallbacks].reverse()) {
@@ -871,12 +880,7 @@ export async function resolveAgentCapabilities<
         },
         finish: {
           provide(value) {
-            registries.finishExtensionProviders.push({
-              id: capability.id,
-              resolve: typeof value === "function"
-                ? value as AgentFinishExtensionProvider
-                : () => value,
-            })
+            addFinishExtensionProvider(capability.id, value)
           },
         },
         state: {
@@ -899,6 +903,7 @@ export async function resolveAgentCapabilities<
         workspace: currentWorkspace,
       } as AgentCapabilityRuntimeContext<TRuntimeConfig, Name> & WorkspaceOverrideRuntime<Name>
       capabilityContexts.push({ capability, context: capabilityContext })
+      if (capability.finish) addFinishExtensionProvider(capability.id, capability.finish)
 
       for (const [name, trigger] of Object.entries(capability.triggers || {})) {
         assertTriggerName(name, capability.id)
@@ -1129,11 +1134,17 @@ export async function applyOutputRenderers(
 
 function createAgentExtensionReader(values: Map<string, unknown>): AgentInvocationExtensions {
   return {
+    entries() {
+      return Array.from(values.entries())
+    },
     get<T = unknown>(capabilityId: string, key?: string): T | undefined {
       const value = values.get(capabilityId)
       if (key === undefined) return value as T | undefined
       if (typeof value !== "object" || value === null) return undefined
       return (value as Record<string, unknown>)[key] as T | undefined
+    },
+    toJSON() {
+      return Object.fromEntries(values.entries())
     },
   }
 }

--- a/packages/agent/src/eval.ts
+++ b/packages/agent/src/eval.ts
@@ -61,27 +61,66 @@ export interface AgentEvalVariant {
   name: string
 }
 
-export interface AgentEvalDefinition<
+export interface AgentEvalTestContext<CALL_OPTIONS = never> {
+  readonly observation?: AgentObservation
+  readonly reply: string
+  calledTool: (name: string) => void
+  completed: () => void
+  doesNotCallTool: (name: string) => void
+  expect: (scorer: AgentScorer) => void
+  send: (input: string | AgentRunInput<CALL_OPTIONS>) => Promise<AgentObservation>
+  textContains: (expected: string | RegExp) => void
+}
+
+export type AgentEvalTest<CALL_OPTIONS = never> = (context: AgentEvalTestContext<CALL_OPTIONS>) => MaybePromise<void>
+
+interface AgentEvalBaseDefinition<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = never,
 > {
   agent?: AgentEvalAgent<TRuntimeConfig> | (() => MaybePromise<AgentEvalAgent<TRuntimeConfig>>)
   name?: string
   runtimeConfig?: TRuntimeConfig | (() => MaybePromise<TRuntimeConfig>)
-  scenarios: Array<AgentEvalScenario<CALL_OPTIONS>>
   scorers?: AgentScorer[]
   variants?: AgentEvalVariant[]
   workspace?: WorkspaceName
 }
 
+export type AgentEvalDefinition<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = never,
+> = AgentEvalBaseDefinition<TRuntimeConfig, CALL_OPTIONS> & (
+  | {
+    scenarios: Array<AgentEvalScenario<CALL_OPTIONS>>
+    test?: never
+  }
+  | {
+    scenarios?: never
+    test: AgentEvalTest<CALL_OPTIONS>
+  }
+)
+
 type AgentEvalAgent<TRuntimeConfig extends AgentRuntimeConfig> = AgentInput<AgentRuntimeContext<TRuntimeConfig>>
 
 interface NormalizedEvalScenario<CALL_OPTIONS> extends AgentEvalScenario<CALL_OPTIONS> {
+  kind: "scenario"
   scorers: AgentScorer[]
 }
 
+interface NormalizedEvalTest<CALL_OPTIONS> {
+  kind: "test"
+  metadata?: unknown
+  name: string
+  scorers: AgentScorer[]
+  test: AgentEvalTest<CALL_OPTIONS>
+}
+
+type NormalizedEvalCase<CALL_OPTIONS> =
+  | NormalizedEvalScenario<CALL_OPTIONS>
+  | NormalizedEvalTest<CALL_OPTIONS>
+
 interface AgentEvalInput<CALL_OPTIONS> {
-  scenario: NormalizedEvalScenario<CALL_OPTIONS>
+  scenario: NormalizedEvalCase<CALL_OPTIONS>
   variant: AgentEvalVariant
 }
 
@@ -254,8 +293,30 @@ function normalizeScenarios<CALL_OPTIONS>(
   const globalScorers = scorers || []
   return scenarios.map(scenario => ({
     ...scenario,
+    kind: "scenario",
     scorers: [...globalScorers, ...(scenario.scorers || [])],
   }))
+}
+
+function normalizeEvalCases<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  definition: AgentEvalDefinition<TRuntimeConfig, CALL_OPTIONS>,
+  name: string,
+): Array<NormalizedEvalCase<CALL_OPTIONS>> {
+  if (definition.scenarios !== undefined) {
+    return normalizeScenarios(definition.scenarios, definition.scorers)
+  }
+  if (definition.test) {
+    return [{
+      kind: "test",
+      name,
+      scorers: definition.scorers || [],
+      test: definition.test,
+    }]
+  }
+  throw new Error("[vitehub] defineEval() requires scenarios or test.")
 }
 
 function normalizeVariants(variants: AgentEvalVariant[] | undefined): AgentEvalVariant[] {
@@ -283,7 +344,7 @@ async function scoreObservation(observation: AgentObservation, scorers: AgentSco
   }))
 }
 
-function toObservation<CALL_OPTIONS>(result: AgentTestRunResult, scenario: AgentEvalScenario<CALL_OPTIONS>, variant: AgentEvalVariant): AgentObservation {
+function toObservation(result: AgentTestRunResult, scenario: { metadata?: unknown, name: string }, variant: AgentEvalVariant): AgentObservation {
   return {
     finishReason: result.finishReason,
     metadata: scenario.metadata,
@@ -294,6 +355,72 @@ function toObservation<CALL_OPTIONS>(result: AgentTestRunResult, scenario: Agent
     usage: result.usage,
     variant: variant.name,
     warnings: result.warnings,
+  }
+}
+
+function completedScorer(): AgentScorer {
+  return {
+    name: "completed",
+    score() {
+      return {
+        passed: true,
+        reason: "Agent invocation completed.",
+        score: 1,
+      }
+    },
+  }
+}
+
+function normalizeTestSendInput<CALL_OPTIONS>(input: string | AgentRunInput<CALL_OPTIONS>): AgentRunInput<CALL_OPTIONS> {
+  return typeof input === "string" ? { prompt: input } : input
+}
+
+async function runEvalTest<CALL_OPTIONS>(
+  runner: ReturnType<typeof createAgentTestRunner<AgentRuntimeConfig, CALL_OPTIONS>>,
+  testCase: NormalizedEvalTest<CALL_OPTIONS>,
+  variant: AgentEvalVariant,
+): Promise<AgentObservationWithScores> {
+  let observation: AgentObservation | undefined
+  const assertions: AgentScorer[] = []
+  const context: AgentEvalTestContext<CALL_OPTIONS> = {
+    get observation() {
+      return observation
+    },
+    get reply() {
+      return observation?.text || ""
+    },
+    calledTool(name) {
+      assertions.push(callsTool(name))
+    },
+    completed() {
+      assertions.push(completedScorer())
+    },
+    doesNotCallTool(name) {
+      assertions.push(doesNotCallTool(name))
+    },
+    expect(scorer) {
+      assertions.push(scorer)
+    },
+    async send(input) {
+      if (observation) {
+        throw new Error("[vitehub] Agent Eval test.send() supports one Agent Invocation per test.")
+      }
+      const result = await runner.run(normalizeTestSendInput(input))
+      observation = toObservation(result, testCase, variant)
+      return observation
+    },
+    textContains(expected) {
+      assertions.push(textContains(expected))
+    },
+  }
+
+  await testCase.test(context)
+  if (!observation) {
+    throw new Error("[vitehub] Agent Eval test() must call t.send(...).")
+  }
+  return {
+    ...observation,
+    scores: await scoreObservation(observation, [...testCase.scorers, ...assertions]),
   }
 }
 
@@ -311,6 +438,9 @@ async function runScenario<
     runtimeConfig: definition.runtimeConfig || ({} as TRuntimeConfig),
     workspace: definition.workspace,
   })
+  if (input.scenario.kind === "test") {
+    return await runEvalTest(runner, input.scenario, input.variant)
+  }
   const result = await runner.run(input.scenario.input)
   const observation = toObservation(result, input.scenario, input.variant)
   return {
@@ -342,13 +472,13 @@ export function defineEval<
   definition: AgentEvalDefinition<TRuntimeConfig, CALL_OPTIONS>,
 ): unknown {
   const caller = getCallerFile()
-  const scenarios = normalizeScenarios(definition.scenarios, definition.scorers)
-  const variants = normalizeVariants(definition.variants)
   const name = definition.name || (caller ? resolveEvalNameFromFile(caller) : "agent")
+  const scenarios = normalizeEvalCases(definition, name)
+  const variants = normalizeVariants(definition.variants)
   const data = scenarios.map(scenario => ({ input: { scenario } }))
   const opts = {
     data,
-    async task(input: { scenario: NormalizedEvalScenario<CALL_OPTIONS> }, variant: AgentEvalVariant = baselineVariant) {
+    async task(input: { scenario: NormalizedEvalCase<CALL_OPTIONS> }, variant: AgentEvalVariant = baselineVariant) {
       return await runScenario(definition, caller, { scenario: input.scenario, variant })
     },
     scorers: [{

--- a/packages/agent/src/eval.ts
+++ b/packages/agent/src/eval.ts
@@ -7,6 +7,7 @@ import { evalite } from "evalite"
 import {
   defineAgent,
   type AgentInput,
+  type AgentInvocationExtensions,
   type AgentModelInput,
   type AgentRunInput,
   type AgentRuntimeContext,
@@ -31,6 +32,7 @@ export interface AgentScore {
 }
 
 export interface AgentObservation {
+  extensions?: AgentInvocationExtensions
   finishReason?: unknown
   metadata?: unknown
   raw: unknown
@@ -65,8 +67,13 @@ export interface AgentEvalTestContext<CALL_OPTIONS = never> {
   readonly observation?: AgentObservation
   readonly reply: string
   calledTool: (name: string) => void
+  capabilityExtension: {
+    <T = unknown>(capabilityId: string): T | undefined
+    <T = unknown>(capabilityId: string, key: string): T | undefined
+  }
   completed: () => void
   doesNotCallTool: (name: string) => void
+  hasCapabilityExtension: (capabilityId: string, key?: string) => void
   expect: (scorer: AgentScorer) => void
   send: (input: string | AgentRunInput<CALL_OPTIONS>) => Promise<AgentObservation>
   textContains: (expected: string | RegExp) => void
@@ -346,6 +353,7 @@ async function scoreObservation(observation: AgentObservation, scorers: AgentSco
 
 function toObservation(result: AgentTestRunResult, scenario: { metadata?: unknown, name: string }, variant: AgentEvalVariant): AgentObservation {
   return {
+    ...(result.extensions ? { extensions: result.extensions } : {}),
     finishReason: result.finishReason,
     metadata: scenario.metadata,
     raw: result.raw,
@@ -392,11 +400,19 @@ async function runEvalTest<CALL_OPTIONS>(
     calledTool(name) {
       assertions.push(callsTool(name))
     },
+    capabilityExtension(capabilityId: string, key?: string) {
+      return key === undefined
+        ? observation?.extensions?.get(capabilityId)
+        : observation?.extensions?.get(capabilityId, key)
+    },
     completed() {
       assertions.push(completedScorer())
     },
     doesNotCallTool(name) {
       assertions.push(doesNotCallTool(name))
+    },
+    hasCapabilityExtension(capabilityId, key) {
+      assertions.push(hasCapabilityExtension(capabilityId, key))
     },
     expect(scorer) {
       assertions.push(scorer)
@@ -560,6 +576,29 @@ export function doesNotCallTool(name: string): AgentScorer {
         passed: !called,
         reason: called ? `Tool "${name}" was called.` : `Tool "${name}" was not called.`,
         score: called ? 0 : 1,
+      }
+    },
+  }
+}
+
+export function hasCapabilityExtension(capabilityId: string, key?: string): AgentScorer {
+  return {
+    name: key === undefined ? `hasCapabilityExtension:${capabilityId}` : `hasCapabilityExtension:${capabilityId}.${key}`,
+    score(observation) {
+      const value = key === undefined
+        ? observation.extensions?.get(capabilityId)
+        : observation.extensions?.get(capabilityId, key)
+      const found = value !== undefined
+      return {
+        metadata: {
+          capabilityId,
+          ...(key === undefined ? {} : { key }),
+        },
+        passed: found,
+        reason: found
+          ? `Capability "${capabilityId}" reported an extension.`
+          : `Capability "${capabilityId}" did not report an extension.`,
+        score: found ? 1 : 0,
       }
     },
   }

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -40,7 +40,7 @@ interface HarnessAgentAdapterOptions<
   CALL_OPTIONS = unknown,
 > {
   credentials?: AgentHarnessCredentialSource
-  harness: AgentHarnessDriverInput
+  harness: AgentHarnessDriverInput<TRuntimeConfig, CALL_OPTIONS>
   sandbox?: AgentHarnessSandboxInput<TRuntimeConfig, CALL_OPTIONS>
   sessionKey?: AgentHarnessSessionKey<TRuntimeConfig, CALL_OPTIONS>
 }
@@ -192,6 +192,19 @@ async function resolveHarnessSandbox<
   return sandbox ?? await createDefaultHarnessSandbox()
 }
 
+async function resolveHarness<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  harness: AgentHarnessDriverInput<TRuntimeConfig, CALL_OPTIONS>,
+  context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>,
+) {
+  if (typeof harness === "function") {
+    return await harness(toRunCallbackContext(context))
+  }
+  return harness
+}
+
 async function createHarnessAgent<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -203,8 +216,9 @@ async function createHarnessAgent<
   assertSupportedHarnessDriverContributions(context)
   const { HarnessAgent } = await import("@ai-sdk/harness/agent") as unknown as { HarnessAgent: HarnessAgentConstructor }
   const sandbox = await resolveHarnessSandbox(options.sandbox, context)
+  const harness = await resolveHarness(options.harness, context)
   return new HarnessAgent({
-    harness: options.harness,
+    harness,
     onSandboxSession: async ({ abortSignal, session, sessionWorkDir }: { abortSignal?: AbortSignal, session: unknown, sessionWorkDir: string }) => {
       await prepareWorkspaceSession(session, sessionWorkDir, abortSignal)
     },

--- a/packages/agent/src/harness/local-sandbox.ts
+++ b/packages/agent/src/harness/local-sandbox.ts
@@ -1,0 +1,201 @@
+import { spawn as spawnChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, isAbsolute, join } from "node:path"
+import { Readable } from "node:stream"
+import { randomUUID } from "node:crypto"
+
+import type { HarnessV1NetworkSandboxSession, HarnessV1SandboxProvider } from "@ai-sdk/harness"
+
+export interface LocalHarnessSandboxOptions {
+  cleanup?: boolean
+  env?: Record<string, string | undefined>
+  ports?: readonly number[]
+  rootDir?: string
+}
+
+interface LocalHarnessSandboxSession extends HarnessV1NetworkSandboxSession {
+  readonly cleanup: boolean
+  readonly env: Record<string, string>
+  readonly processes: Set<ChildProcessWithoutNullStreams>
+  readonly rootDir: string
+}
+
+function stringEnv(env: Record<string, string | undefined>): Record<string, string> {
+  return Object.fromEntries(Object.entries(env).filter((entry): entry is [string, string] => typeof entry[1] === "string"))
+}
+
+async function defaultRootDir(sessionId: string | undefined) {
+  if (sessionId) {
+    const root = join(tmpdir(), "vitehub-harness", sessionId)
+    await mkdir(root, { recursive: true })
+    return root
+  }
+  return await mkdtemp(join(tmpdir(), "vitehub-harness-"))
+}
+
+function resolvePath(session: LocalHarnessSandboxSession, path: string) {
+  return isAbsolute(path) ? path : join(session.defaultWorkingDirectory, path)
+}
+
+function readableStreamFromBytes(bytes: Uint8Array) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes)
+      controller.close()
+    },
+  })
+}
+
+async function bytesFromReadableStream(stream: ReadableStream<Uint8Array>) {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  const size = chunks.reduce((total, chunk) => total + chunk.byteLength, 0)
+  const bytes = new Uint8Array(size)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
+}
+
+function spawnProcess(session: LocalHarnessSandboxSession, options: {
+  abortSignal?: AbortSignal
+  command: string
+  env?: Record<string, string>
+  workingDirectory?: string
+}) {
+  const child = spawnChildProcess(options.command, {
+    cwd: options.workingDirectory || session.defaultWorkingDirectory,
+    env: { ...session.env, ...options.env },
+    shell: true,
+  })
+  session.processes.add(child)
+
+  let abortReason: unknown
+  const abort = () => {
+    abortReason = options.abortSignal?.reason || new Error("Sandbox command aborted.")
+    child.kill()
+  }
+  options.abortSignal?.addEventListener("abort", abort, { once: true })
+
+  const wait = new Promise<{ exitCode: number }>((resolve, reject) => {
+    child.once("error", reject)
+    child.once("close", (code) => {
+      session.processes.delete(child)
+      options.abortSignal?.removeEventListener("abort", abort)
+      if (abortReason) {
+        reject(abortReason)
+        return
+      }
+      resolve({ exitCode: code ?? 1 })
+    })
+  })
+
+  return {
+    pid: child.pid,
+    stdout: Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+    stderr: Readable.toWeb(child.stderr) as ReadableStream<Uint8Array>,
+    wait: () => wait,
+    kill: async () => {
+      child.kill()
+      await wait.catch(() => undefined)
+    },
+  }
+}
+
+async function collect(stream: ReadableStream<Uint8Array>) {
+  return new TextDecoder().decode(await bytesFromReadableStream(stream))
+}
+
+async function createSession(options: LocalHarnessSandboxOptions, sessionId: string | undefined): Promise<LocalHarnessSandboxSession> {
+  const rootDir = options.rootDir || await defaultRootDir(sessionId)
+  await mkdir(rootDir, { recursive: true })
+  const env = stringEnv(options.env || process.env)
+  const session = {
+    cleanup: options.cleanup ?? !options.rootDir,
+    defaultWorkingDirectory: rootDir,
+    description: `Local shell sandbox rooted at ${rootDir}.`,
+    env,
+    id: sessionId || randomUUID(),
+    ports: options.ports || [4000],
+    processes: new Set<ChildProcessWithoutNullStreams>(),
+    rootDir,
+    async destroy() {
+      await this.stop()
+      if (this.cleanup) await rm(this.rootDir, { force: true, recursive: true })
+    },
+    async getPortUrl({ port, protocol = "http" }: { port: number, protocol?: "http" | "https" | "ws" }) {
+      return `${protocol}://127.0.0.1:${port}`
+    },
+    async readBinaryFile({ path }: { path: string }) {
+      return await readFile(resolvePath(this, path)).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return null
+        throw error
+      })
+    },
+    async readFile({ path }: { path: string }) {
+      const bytes = await this.readBinaryFile({ path })
+      return bytes ? readableStreamFromBytes(bytes) : null
+    },
+    async readTextFile({ encoding = "utf8", endLine, path, startLine }: { encoding?: string, endLine?: number, path: string, startLine?: number }) {
+      const bytes = await this.readBinaryFile({ path })
+      if (!bytes) return null
+      const text = Buffer.from(bytes).toString(encoding as BufferEncoding)
+      if (startLine === undefined && endLine === undefined) return text
+      return text.split(/\r?\n/).slice((startLine || 1) - 1, endLine).join("\n")
+    },
+    restricted() {
+      return this
+    },
+    async run(runOptions: { abortSignal?: AbortSignal, command: string, env?: Record<string, string>, workingDirectory?: string }) {
+      const child = await this.spawn(runOptions)
+      const [stdout, stderr, { exitCode }] = await Promise.all([
+        collect(child.stdout),
+        collect(child.stderr),
+        child.wait(),
+      ])
+      return { exitCode, stderr, stdout }
+    },
+    async spawn(spawnOptions: { abortSignal?: AbortSignal, command: string, env?: Record<string, string>, workingDirectory?: string }) {
+      return spawnProcess(this, spawnOptions)
+    },
+    async stop() {
+      await Promise.all(Array.from(this.processes, child => new Promise<void>((resolve) => {
+        child.once("close", () => resolve())
+        child.kill()
+      })))
+    },
+    async writeBinaryFile({ content, path }: { content: Uint8Array, path: string }) {
+      const resolved = resolvePath(this, path)
+      await mkdir(dirname(resolved), { recursive: true })
+      await writeFile(resolved, content)
+    },
+    async writeFile({ content, path }: { content: ReadableStream<Uint8Array>, path: string }) {
+      await this.writeBinaryFile({ content: await bytesFromReadableStream(content), path })
+    },
+    async writeTextFile({ content, encoding = "utf8", path }: { content: string, encoding?: string, path: string }) {
+      await this.writeBinaryFile({ content: Buffer.from(content, encoding as BufferEncoding), path })
+    },
+  } satisfies LocalHarnessSandboxSession
+  return session
+}
+
+export function createLocalHarnessSandbox(options: LocalHarnessSandboxOptions = {}): HarnessV1SandboxProvider {
+  return {
+    bridgePorts: options.ports || [4000],
+    providerId: "local",
+    specificationVersion: "harness-sandbox-v1",
+    async createSession(createOptions) {
+      const session = await createSession(options, createOptions?.sessionId)
+      await createOptions?.onFirstCreate?.(session, { abortSignal: createOptions.abortSignal })
+      return session
+    },
+  }
+}

--- a/packages/agent/src/internal/agent-driver.ts
+++ b/packages/agent/src/internal/agent-driver.ts
@@ -26,7 +26,7 @@ type NormalizedAgentDriver<
   }
   | {
     credentials?: AgentHarnessCredentialSource
-    harness: AgentHarnessDriverInput
+    harness: AgentHarnessDriverInput<TRuntimeConfig, CALL_OPTIONS>
     kind: "harness"
     sandbox?: AgentHarnessSandboxInput<TRuntimeConfig, CALL_OPTIONS>
     sessionKey?: AgentHarnessSessionKey<TRuntimeConfig, CALL_OPTIONS>

--- a/packages/agent/src/test.ts
+++ b/packages/agent/src/test.ts
@@ -8,6 +8,8 @@ import { registerWorkspace } from "@vite-hub/workspace/test"
 
 import type {
   AgentInput,
+  AgentFinishEvent,
+  AgentInvocationExtensions,
   AgentModelExecutionOptions,
   AgentModelInstrumentation,
   AgentRunInput,
@@ -37,6 +39,7 @@ export interface AgentTestRunnerOptions<TRuntimeConfig extends AgentRuntimeConfi
 }
 
 export interface AgentTestRunResult {
+  extensions?: AgentInvocationExtensions
   finishReason?: unknown
   raw: unknown
   text: string
@@ -56,6 +59,13 @@ function isWorkspaceAgentDefinition(value: unknown): value is WorkspaceAgentDefi
     && value !== null
     && "__vitehubWorkspaceAgent" in value
     && (value as { __vitehubWorkspaceAgent?: unknown }).__vitehubWorkspaceAgent === true
+}
+
+function isAgentDefinition(value: unknown): value is AgentInput<AgentRuntimeContext<AgentRuntimeConfig>> & { hooks?: Record<string, unknown> } {
+  return typeof value === "object"
+    && value !== null
+    && "resolve" in value
+    && typeof (value as { resolve?: unknown }).resolve === "function"
 }
 
 function withTestModelInstrumentation<TRuntimeConfig extends AgentRuntimeConfig>(
@@ -117,6 +127,26 @@ function createDefaultRun(name: string | undefined): AgentRunMetadata {
   }
 }
 
+function withTestFinishCapture<TRuntimeConfig extends AgentRuntimeConfig>(
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  capture: (extensions: AgentInvocationExtensions) => void,
+): AgentInput<AgentRuntimeContext<TRuntimeConfig>> {
+  if (!isAgentDefinition(agent)) return agent
+
+  const clone = Object.create(Object.getPrototypeOf(agent)) as AgentInput<AgentRuntimeContext<TRuntimeConfig>> & { hooks?: Record<string, unknown> }
+  Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
+  const hooks = clone.hooks || {}
+  const finishHook = hooks["agent:finish"] as ((event: AgentFinishEvent<TRuntimeConfig>) => MaybePromise<void>) | undefined
+  clone.hooks = {
+    ...hooks,
+    async "agent:finish"(event: AgentFinishEvent<TRuntimeConfig>) {
+      capture(event.extensions)
+      await finishHook?.(event)
+    },
+  }
+  return clone
+}
+
 async function resolveRun(
   name: string | undefined,
   run: AgentTestRunnerOptions["run"],
@@ -176,10 +206,16 @@ function textFromRaw(value: unknown): string {
   return ""
 }
 
-async function normalizeAgentTestResult(value: unknown, toolSteps: AgentToolStep[]): Promise<AgentTestRunResult> {
+async function normalizeAgentTestResult(
+  value: unknown,
+  toolSteps: AgentToolStep[],
+  getExtensions: () => AgentInvocationExtensions | undefined,
+): Promise<AgentTestRunResult> {
   if (value instanceof Response) {
     const text = await value.clone().text()
+    const extensions = getExtensions()
     return {
+      ...(extensions ? { extensions } : {}),
       raw: value,
       text,
       toolSteps,
@@ -189,8 +225,10 @@ async function normalizeAgentTestResult(value: unknown, toolSteps: AgentToolStep
   const result = typeof value === "object" && value !== null
     ? value as AgentRunResult
     : undefined
+  const extensions = getExtensions()
 
   return {
+    ...(extensions ? { extensions } : {}),
     finishReason: result?.finishReason,
     raw: value,
     text: textFromRaw(value),
@@ -223,6 +261,7 @@ export function createAgentTestRunner<
     async run(input) {
       const toolSteps: AgentToolStep[] = []
       let workspaceInspectionGuardrails = 0
+      let extensions: AgentInvocationExtensions | undefined
       const context = createAgentRuntimeContext({
         devtools: {
           reportToolStep(step) {
@@ -246,11 +285,13 @@ export function createAgentTestRunner<
       })
 
       const raw = await runAgent<TRuntimeConfig, CALL_OPTIONS>(
-        preparedAgent,
+        withTestFinishCapture(preparedAgent, value => {
+          extensions = value
+        }),
         context,
         input,
       )
-      return await normalizeAgentTestResult(raw, toolSteps)
+      return await normalizeAgentTestResult(raw, toolSteps, () => extensions)
     },
   }
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -701,9 +701,12 @@ export type AgentHarnessSessionKey<
   | string
   | ((context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>) => MaybePromise<string | undefined>)
 
-export type AgentHarnessDriverInput =
+export type AgentHarnessDriverInput<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> =
   | object
-  | ((...args: never[]) => unknown)
+  | ((context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<object>)
 
 export type AgentHarnessSandboxInput<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -736,7 +739,7 @@ export interface AgentHarnessDriver<
 > {
   credentials?: AgentHarnessCredentialSource
   execution?: never
-  harness: AgentHarnessDriverInput
+  harness: AgentHarnessDriverInput<TRuntimeConfig, CALL_OPTIONS>
   instructions?: never
   model?: never
   permissionMode?: never

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -338,8 +338,10 @@ export interface AgentRunResult {
 }
 
 export interface AgentInvocationExtensions {
+  entries: () => Array<[string, unknown]>
   get<T = unknown>(capabilityId: string): T | undefined
   get<T = unknown>(capabilityId: string, key: string): T | undefined
+  toJSON: () => Record<string, unknown>
 }
 
 export interface AgentOutputExtensionEvent {
@@ -511,7 +513,12 @@ export type AgentOutputRenderer = (
   context: AgentCapabilityRuntimeContext,
 ) => MaybePromise<unknown>
 export type AgentOutputExtensionProvider = (event: AgentOutputExtensionEvent) => MaybePromise<unknown>
-export type AgentFinishExtensionProvider = (event: AgentFinishEvent) => MaybePromise<unknown>
+export type AgentFinishExtensionProvider<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> = {
+  bivarianceHack(event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>): MaybePromise<unknown>
+}["bivarianceHack"]
 
 export interface AgentCapabilityStateRequirement {
   name: string
@@ -582,6 +589,7 @@ export interface AgentCapabilityDefinition<
   bind?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   close?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   configure?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
+  finish?: AgentFinishExtensionProvider<TRuntimeConfig>
   hooks?: AgentCapabilityHooks<TRuntimeConfig, Name>
   id: string
   input?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<Response | void>

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -219,6 +219,37 @@ describe("agent eval", () => {
     expect(score.score).toBe(1)
   })
 
+  it("captures capability finish extensions in eval observations", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { observability } = await import("../src/capabilities.ts")
+    const { defineEval, hasCapabilityExtension } = await import("../src/eval.ts")
+
+    defineEval({
+      agent: defineAgent({
+        capabilities: [observability()],
+        run: () => "ok",
+      }),
+      name: "support",
+      scorers: [hasCapabilityExtension("observability", "status")],
+      async test(t) {
+        const observation = await t.send("hello")
+        expect(observation.extensions?.get("observability", "status")).toBe("completed")
+        expect(t.capabilityExtension("observability", "status")).toBe("completed")
+        t.hasCapabilityExtension("observability")
+      },
+    })
+
+    const output = await evaliteCalls[0]!.opts.task(evaliteCalls[0]!.opts.data[0].input)
+    const score = await evaliteCalls[0]!.opts.scorers[0].scorer({ output })
+
+    expect(output.extensions?.get("observability")).toMatchObject({
+      resultKind: "string",
+      status: "completed",
+    })
+    expect(output.scores).toHaveLength(2)
+    expect(score.score).toBe(1)
+  })
+
   it("requires test callbacks to send one message", async () => {
     const { defineEval } = await import("../src/eval.ts")
 
@@ -409,10 +440,21 @@ describe("agent eval", () => {
       callsTool,
       doesNotCallTool,
       doesNotLeakSource,
+      hasCapabilityExtension,
       staysUnderTokenBudget,
       textContains,
     } = await import("../src/eval.ts")
+    const extensions = {
+      entries: (): Array<[string, unknown]> => [["observability", { status: "completed" }]],
+      get<T = unknown>(capabilityId: string, key?: string): T | undefined {
+        if (capabilityId !== "observability") return undefined
+        const value = key === "status" ? "completed" : { status: "completed" }
+        return value as T
+      },
+      toJSON: () => ({ observability: { status: "completed" } }),
+    }
     const observation = {
+      extensions,
       raw: {},
       scenario: "tools",
       text: "Queued for billing.",
@@ -436,6 +478,9 @@ describe("agent eval", () => {
     expect(await callsTool("refund").score(erroredToolObservation)).toMatchObject({ score: 1, passed: true })
     expect(await doesNotCallTool("refund").score(erroredToolObservation)).toMatchObject({ score: 0, passed: false })
     expect(await doesNotCallTool("refund").score(observation)).toMatchObject({ score: 1, passed: true })
+    expect(await hasCapabilityExtension("observability").score(observation)).toMatchObject({ score: 1, passed: true })
+    expect(await hasCapabilityExtension("observability", "status").score(observation)).toMatchObject({ score: 1, passed: true })
+    expect(await hasCapabilityExtension("missing").score(observation)).toMatchObject({ score: 0, passed: false })
     expect(await staysUnderTokenBudget(10).score(observation)).toMatchObject({ score: 1, passed: true })
     expect(await staysUnderTokenBudget(4).score(observation)).toMatchObject({ score: 0.8, passed: false })
   })

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -193,6 +193,48 @@ describe("agent eval", () => {
     ])
   })
 
+  it("supports eve-style test callbacks", async () => {
+    const { defineEval } = await import("../src/eval.ts")
+
+    defineEval({
+      agent: { generate: vi.fn(async () => ({ text: "ok" })), stream: vi.fn(), tools: {}, version: "agent-v1" } as never,
+      name: "support",
+      async test(t) {
+        await t.send("hello")
+        t.completed()
+        t.textContains("ok")
+        t.doesNotCallTool("refund")
+      },
+    })
+
+    const output = await evaliteCalls[0]!.opts.task(evaliteCalls[0]!.opts.data[0].input)
+    const score = await evaliteCalls[0]!.opts.scorers[0].scorer({ output })
+
+    expect(output).toMatchObject({
+      scenario: "support",
+      text: "ok",
+      variant: "baseline",
+    })
+    expect(output.scores).toHaveLength(3)
+    expect(score.score).toBe(1)
+  })
+
+  it("requires test callbacks to send one message", async () => {
+    const { defineEval } = await import("../src/eval.ts")
+
+    defineEval({
+      agent: { generate: vi.fn(async () => ({ text: "ok" })), stream: vi.fn(), tools: {}, version: "agent-v1" } as never,
+      name: "support",
+      test(t) {
+        t.completed()
+      },
+    })
+
+    await expect(evaliteCalls[0]!.opts.task(evaliteCalls[0]!.opts.data[0].input))
+      .rejects
+      .toThrow("Agent Eval test() must call t.send(...)")
+  })
+
   it("adds scenario scorers to global scorers and captures observations", async () => {
     const { defineEval, textContains } = await import("../src/eval.ts")
     const globalScorer = textContains("ok")

--- a/packages/agent/test/local-sandbox.test.ts
+++ b/packages/agent/test/local-sandbox.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+
+import { createLocalHarnessSandbox } from "../src/harness/local-sandbox.ts"
+
+describe("local harness sandbox", () => {
+  it("runs commands and reads written files", async () => {
+    const provider = createLocalHarnessSandbox({ env: { PATH: process.env.PATH } })
+    const session = await provider.createSession()
+
+    try {
+      await session.writeTextFile({ content: "hello", path: "input.txt" })
+
+      const result = await session.run({ command: "cat input.txt" })
+
+      expect(result).toMatchObject({ exitCode: 0, stdout: "hello" })
+      await expect(session.getPortUrl({ port: 4000, protocol: "ws" })).resolves.toBe("ws://127.0.0.1:4000")
+    }
+    finally {
+      await session.destroy?.()
+    }
+  })
+})

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -774,6 +774,36 @@ describe("agent message protocol", () => {
     expect(session.destroy).toHaveBeenCalledTimes(1)
   })
 
+  it("resolves harness Agent Driver factories for each invocation", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    harnessAgentSettings.length = 0
+    const resolvedHarness = { provider: "codex", runId: "run-1" }
+    const harness = vi.fn(() => resolvedHarness)
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessGenerate.mockResolvedValueOnce({ text: "ok" })
+
+    const agent = defineAgent({
+      driver: {
+        harness,
+      },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-1" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })).resolves.toMatchObject({ text: "ok" })
+
+    expect(harness).toHaveBeenCalledWith(expect.objectContaining({
+      run: expect.objectContaining({ runId: "run-1" }),
+    }))
+    expect(harnessAgentSettings.at(-1)).toMatchObject({
+      harness: resolvedHarness,
+    })
+  })
+
   it("labels non-token harness usage with sanitized credentials", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")

--- a/packages/agent/test/test-runner.test.ts
+++ b/packages/agent/test/test-runner.test.ts
@@ -81,6 +81,42 @@ describe("agent test runner", () => {
     })
   })
 
+  it("captures capability finish extensions", async () => {
+    const { defineAgent, defineCapability } = await import("../src/index.ts")
+    const { runAgentForTest } = await import("../src/test.ts")
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "review-output",
+          finish(event) {
+            return {
+              resultKind: typeof event.result,
+              runId: event.invocation.run?.runId,
+            }
+          },
+        }),
+      ],
+      run: () => ({ text: "done" }),
+    })
+
+    const result = await runAgentForTest(agent, {
+      run: { runId: "run-extensions" },
+      runtimeConfig: {},
+    }, {
+      prompt: "hello",
+    })
+
+    expect(result.extensions?.get("review-output")).toEqual({
+      resultKind: "object",
+      runId: "run-extensions",
+    })
+    expect(result.extensions?.get("review-output", "runId")).toBe("run-extensions")
+    expect(result.extensions?.entries()).toEqual([
+      ["review-output", { resultKind: "object", runId: "run-extensions" }],
+    ])
+    expect(JSON.stringify(result.extensions)).toBe('{"review-output":{"resultKind":"object","runId":"run-extensions"}}')
+  })
+
   it("applies workspace defaults and collects workspace tool steps", async () => {
     const { registerWorkspace } = await import("@vite-hub/workspace/test")
     const execute = vi.fn(async () => "workspace result")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -3,7 +3,7 @@ import { describe, expectTypeOf, it } from "vitest"
 import { defineAgent, defineAgentInvoker, type AgentActor, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentDeliveryArtifact, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, observability, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceExec, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
-import { defineEval, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
+import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentUsageRecord } from "../src/index.ts"
@@ -312,6 +312,11 @@ describe("agent public types", () => {
     defineAgent({
       capabilities: [{
         id: "finish-extension",
+        finish(event) {
+          expectTypeOf(event.extensions.get("finish-extension")).toEqualTypeOf<unknown>()
+          expectTypeOf(event.result).toEqualTypeOf<unknown>()
+          return "ok"
+        },
         output(context) {
           context.finish.provide("ok")
           // @ts-expect-error finish extensions are registered through context.finish
@@ -925,6 +930,7 @@ describe("agent public types", () => {
 
   it("accepts agent eval definitions", () => {
     const scorer: AgentScorer = textContains("ok")
+    const capabilityScorer: AgentScorer = hasCapabilityExtension("observability")
     const definition: AgentEvalDefinition = {
       agent: defineAgent({
         model: {} as never,
@@ -948,11 +954,16 @@ describe("agent public types", () => {
       async test(t) {
         const observation = await t.send("hello")
         observation.text.toUpperCase()
+        expectTypeOf(observation.extensions?.get("observability")).toEqualTypeOf<unknown>()
+        expectTypeOf(t.capabilityExtension<{ status: string }>("observability")).toEqualTypeOf<{ status: string } | undefined>()
+        expectTypeOf(t.capabilityExtension<string>("observability", "status")).toEqualTypeOf<string | undefined>()
         t.completed()
         t.textContains("ok")
         t.calledTool("lookup")
         t.doesNotCallTool("refund")
+        t.hasCapabilityExtension("observability")
         t.expect(scorer)
+        t.expect(capabilityScorer)
       },
     })
 

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -941,6 +941,21 @@ describe("agent public types", () => {
 
     defineEval(definition)
 
+    defineEval({
+      agent: defineAgent({
+        model: {} as never,
+      }),
+      async test(t) {
+        const observation = await t.send("hello")
+        observation.text.toUpperCase()
+        t.completed()
+        t.textContains("ok")
+        t.calledTool("lookup")
+        t.doesNotCallTool("refund")
+        t.expect(scorer)
+      },
+    })
+
     const observation: AgentObservation = {
       raw: {},
       scenario: "hello",

--- a/packages/agent/vite.config.ts
+++ b/packages/agent/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       "src/cloudflare.ts",
       "src/cli.ts",
       "src/eval.ts",
+      "src/harness/local-sandbox.ts",
       "src/state/sqlite.ts",
       "src/cloudflare/state.ts",
       "src/runtime/empty-registry.ts",


### PR DESCRIPTION
Adds a local harness sandbox export and resolves function-valued harness driver config per invocation, so consumer Agent Definitions keep owning harness/auth/runtime selection while eval declarations stay thin.

Adds Eve-style eval test callbacks plus capability finish-extension assertions. Agent test/eval observations now expose capability extensions, defineCapability({ finish }) gives custom and official capabilities an eval-visible metadata surface, and observability() uses that shared path.

Updates eval and capability docs, including a new observability capability page.