### PR TITLE
docs(agent): record agent dx proof decisions

### DIFF
--- a/.agents/adr/0070-agent-dx-proof-stays-cli-first.md
+++ b/.agents/adr/0070-agent-dx-proof-stays-cli-first.md
@@ -1,0 +1,24 @@
+# ADR 0070: Agent DX Proof Stays CLI-First
+
+## Status
+
+Accepted.
+
+## Context
+
+Recent Agent Package work added harness-backed evals, capability finish metadata, invocation traces, and local dev-loop proof surfaces.
+The Eve comparison made the next attractive direction clear: agent workflows need inspectable command-line entry points before they need dashboards or implicit project conventions.
+
+## Decision
+
+Keep near-term Agent DX proof CLI-first and JSON-friendly.
+Prefer explicit surfaces such as Agent Eval Runner output, Agent Dev Loop target attachment, future Agent Surface Inspection, and URL-backed agent proof over hosted dashboards or hidden discovery.
+
+Public docs should describe only implemented contracts.
+Unimplemented ideas belong in `.agents` language and ADRs until the CLI/runtime supports them.
+
+## Consequences
+
+- Eval and dev-loop docs must explain the current timeout, target, driver, capability, and observability boundaries.
+- Capability docs should show eval-visible finish metadata and Workspace contributions because those are supported today.
+- Future work should add `agent info --json`, URL-backed Agent Eval targets, and remote Agent Dev targets as explicit CLI features instead of special-purpose downstream scripts.

--- a/.agents/contexts/cli/CONTEXT.md
+++ b/.agents/contexts/cli/CONTEXT.md
@@ -33,6 +33,10 @@ _Avoid_: Server-side Chat Session, Agent Memory, persisted transcript
 The discovered Agent selected for one Agent Dev Loop terminal session.
 _Avoid_: Eval target, DevTools selected chat, default bot
 
+**Remote Agent Dev Target**:
+A future Agent Dev Loop Target reached through an explicit URL for preview or deployed Agent proof, using the same Agent Invocation Stream shape as local development.
+_Avoid_: production shell, dashboard chat, remote model runner
+
 **Agent Dev Loop Control**:
 A terminal control handled by the Agent Dev Loop client without becoming Agent input.
 _Avoid_: Input Command, slash command, model tool
@@ -49,9 +53,17 @@ _Avoid_: Frequency-owned command, flat command, shortcut-first command
 An optional eval file path filter that narrows the Agent Evals run by the Agent Eval Runner.
 _Avoid_: Required suite name, eval display name
 
+**URL-Backed Agent Eval Target**:
+A future Agent Eval Target that runs eval cases against a reachable Agent Invocation Stream Endpoint instead of an in-process Agent Definition.
+_Avoid_: remote eval product, deployed-only benchmark, curl smoke
+
 **Agent Eval Output Mode**:
 The selected output contract for Agent Eval Runner results.
 _Avoid_: Logger mode, reporter implementation
+
+**Agent Surface Inspection**:
+A future CLI Feature that prints discovered Agent Definitions, triggers, channels, drivers, Capabilities, evals, and invocation endpoints in a script-friendly format.
+_Avoid_: dashboard inventory, generated-file spelunking, hidden discovery
 
 **Integration-Owned CLI Option**:
 A command-exposure or command-plumbing option configured through the package's Vite Integration or an internal Server Host Adapter.
@@ -118,7 +130,10 @@ _Avoid_: Secrets file, env file, GitHub output
 - DevTools and OpenTelemetry are explicit follow-on surfaces for Agent telemetry, not the default **Agent Dev Loop** experience.
 - The **Agent Eval Runner** runs all discovered Agent Evals when no **Agent Eval Target** is provided.
 - An **Agent Eval Target** identifies Agent Eval files by path filter.
+- A **URL-Backed Agent Eval Target** should reuse Agent Eval cases while moving only the invocation transport out of process.
 - **Agent Eval Output Mode** defaults to concise human output and can be changed to script-friendly structured output.
+- **Agent Surface Inspection** should be the CLI proof surface before dashboards or implicit generated-file spelunking.
+- A **Remote Agent Dev Target** should be explicit about URL, Agent, trigger, and timeout; it must not silently switch local proof to deployed proof.
 - Durable Agent Eval Runner defaults should come from built-in defaults or `agent.eval` on the Agent Package integration surface.
 - `vitehub provision` is the canonical command for **Provision**; it aggregates package-contributed **Provision Steps**.
 - A **Provision Step** talks to provider APIs through shared provider clients, not by shelling out to provider CLIs.

--- a/.agents/contexts/verification/CONTEXT.md
+++ b/.agents/contexts/verification/CONTEXT.md
@@ -20,6 +20,10 @@ _Avoid_: Emulator test, mock deploy, dev server test
 A scheduled, intentionally thin execution of Primitive Suites against a real provider deployment.
 _Avoid_: Manual e2e, full regression, live test matrix
 
+**Agent Deployment Smoke**:
+A thin Agent proof that sends one or more explicit messages through a deployed Agent Invocation Stream Endpoint and checks the same observable contract used by local Agent Evals or the Agent Dev Loop.
+_Avoid_: remote agent run, manual chat test, full behavior suite
+
 **Downstream Escape**:
 A primitive defect first observed in a project outside this workspace.
 _Avoid_: User bug report, demo issue, flake
@@ -31,6 +35,7 @@ _Avoid_: User bug report, demo issue, flake
 - A **Local Provider Run** executes the same Provider Output that a **Live Smoke** deploys; fidelity gaps between them must be explicit, not silent.
 - **Provider Output Contracts** and **Local Provider Runs** gate pull requests; **Live Smoke** runs on a schedule.
 - Depth belongs to **Provider Output Contracts**, **Local Provider Runs**, and unit tests; **Live Smoke** stays thin by design.
+- **Agent Deployment Smoke** is the Agent Package equivalent of a **Live Smoke**: it proves reachability and observable behavior, while Agent Evals keep the deeper behavior matrix local or CI-owned.
 - A **Downstream Escape** is reproduced in a **Primitive Suite** or the playground together with its fix, so coverage grows exactly where reality proved it thin.
 
 ## Example Dialogue

--- a/docs/content/docs/agents/agent-drivers.md
+++ b/docs/content/docs/agents/agent-drivers.md
@@ -85,6 +85,9 @@ export default defineAgent({
 
 Harness-backed drivers do not receive `driver.instructions` as a model prompt. Use explicit harness configuration or Workspace instruction surfaces when the harness needs guidance.
 
+Harness-backed drivers also do not receive model-facing Capability tools, provider tools, or Capability instructions.
+When a Capability should support harness execution, give the harness files it can inspect through Workspace Sources, `harnessWorkspacePaths`, or a harness-native configuration surface.
+
 ## Custom run driver
 
 Use `driver.run` when developer code owns the Agent behavior. The run callback receives prepared input, messages, tools, Workspace access when configured, Agent Invocation Context Values, and `context.invoker`.

--- a/docs/content/docs/agents/evals.md
+++ b/docs/content/docs/agents/evals.md
@@ -29,6 +29,9 @@ export default defineEval({
 })
 ```
 
+`test(t)` is a single Agent Invocation helper.
+Call `t.send(...)` exactly once; use `messages` or `context` in that input when the Agent needs prior chat state, and split independent follow-up checks into separate scenarios.
+
 Use `scenarios` when one eval file should run several cases or reuse the same scorers.
 
 ```ts [server/agents/support.eval.ts]

--- a/docs/content/docs/capabilities/access.md
+++ b/docs/content/docs/capabilities/access.md
@@ -12,7 +12,7 @@ Attach it first when later Capabilities should see a narrowed Workspace or when 
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/custom-capabilities.md
+++ b/docs/content/docs/capabilities/custom-capabilities.md
@@ -71,6 +71,48 @@ Use it to require approval for writes, limit shell or sandbox commands, restrict
 Custom policy should be narrow and visible.
 A reviewer should be able to understand the Capability's authority by reading the Capability Definition.
 
+## Contribute Workspace inputs
+
+Use `workspace` when a Capability should add invocation-scoped Workspace Sources or rules.
+The contribution is add-only and inspectable; it does not mutate the Agent's authored Workspace Definition.
+
+```ts [server/agents/capabilities/tickets.ts]
+import { defineCapability } from '@vite-hub/agent'
+
+export function ticketContext() {
+  return defineCapability({
+    id: 'ticket-context',
+    workspace: ({ context }) => {
+      const ticketId = context.get<{ id?: string }>('ticket')?.id
+      if (!ticketId) return
+
+      return {
+        rules: {
+          'support/tickets/**': { read: true },
+        },
+        sources: {
+          ticket: {
+            mount: 'support/tickets',
+            async getKeys() {
+              return [`${ticketId}.md`]
+            },
+            async getItem(key) {
+              return {
+                content: await loadTicketMarkdown(key),
+                key,
+                mediaType: 'text/markdown',
+              }
+            },
+          },
+        },
+      }
+    },
+  })
+}
+```
+
+Use `harnessWorkspacePaths` when a harness-backed Agent needs specific contributed paths materialized into the harness Workspace Session.
+
 ## Driver support
 
 | Agent Driver | Custom Capability behavior |

--- a/docs/content/docs/capabilities/observability.md
+++ b/docs/content/docs/capabilities/observability.md
@@ -32,6 +32,7 @@ export default defineAgent({
 
 The Capability emits a `start` event before driver execution.
 When `onEvent` is configured, it also emits a `finish` or `error` event after the invocation completes.
+`onEvent` is a telemetry sink; sink failures are swallowed so observability cannot change Agent output or hide the original driver failure.
 
 It provides an `observability` finish extension with `{ status, durationMs, resultKind }` for completed invocations and `{ status, durationMs }` for failed invocations.
 Agent Evals and the Agent test runner capture this finish extension automatically.

--- a/docs/content/docs/development/agent-evals.md
+++ b/docs/content/docs/development/agent-evals.md
@@ -27,6 +27,9 @@ export default defineEval({
 })
 ```
 
+`test(t)` runs one Agent Invocation.
+It must call `t.send(...)` exactly once; pass `messages`, `context`, or trigger input to model a specific conversation state, and use separate scenarios for independent follow-up cases.
+
 Use `scenarios` when one eval file should run several cases or share scorers across cases.
 
 ```ts [server/agents/support.eval.ts]
@@ -62,6 +65,8 @@ Use output and threshold options in CI-shaped checks.
 ```bash [Terminal]
 pnpm vitehub agent eval --threshold 0.9 --output .vitehub/evals/support.json --hide-table
 ```
+
+Long-running model or harness evals should set `agent.eval.testTimeout` in `vite.config.ts` instead of adding ad hoc timeouts inside eval files.
 
 ## Configure defaults
 

--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -48,6 +48,8 @@ pnpm vitehub agent eval server/agents/support.eval.ts --threshold 0.9
 pnpm vitehub agent eval --output .vitehub/evals/support.json --hide-table
 ```
 
+Set `agent.eval.testTimeout` in `vite.config.ts` for long-running model or harness evals.
+
 ## Talk to an Agent during development
 
 Start the app's Vite dev server in one terminal.
@@ -85,6 +87,7 @@ It must contain one JSON object.
 ```bash [Terminal]
 pnpm vitehub agent dev --agent support --context server/agents/support/dev.context.json
 pnpm vitehub agent dev --agent support --context server/agents/support/dev.context.json -p "/summary"
+pnpm vitehub agent dev --agent support --timeout 180000 -p "/summary"
 ```
 
 Expected output includes the resolved context file path before the Agent Invocation starts.
@@ -114,7 +117,9 @@ pnpm vitehub provision run --provider vercel --dry-run
 | `Provision requires --provider cloudflare\|vercel` | The provider flag is missing or misspelled. | Pass a supported provider explicitly. |
 | Provision fails before applying actions | Required provider credentials are missing. | Set `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`, or set `VERCEL_TOKEN`. |
 | Agent eval CLI is disabled | `agent.eval` or `agent.cli` disables the Agent Eval Runner. | Re-enable the Agent integration option for local development. |
+| Agent eval times out | The eval case, model call, or harness run exceeds `agent.eval.testTimeout`. | Increase `agent.eval.testTimeout` in `vite.config.ts` or narrow the eval case. |
 | `No Compatible Vite Development Server found` | The app dev server is not running or `--url` points at the wrong port. | Start Vite separately, then pass the dev server URL. |
+| Agent Dev Loop request times out | The invocation exceeded the CLI request timeout. | Pass `--timeout <ms>` for the dev-loop command or shorten the Agent work. |
 | `Agent Dev Loop context file must contain a JSON object` | The `--context` file is not a JSON object. | Replace the file contents with one object whose keys are Agent Invocation Context Value ids. |
 
 ## Next steps

--- a/docs/content/docs/development/troubleshooting.md
+++ b/docs/content/docs/development/troubleshooting.md
@@ -17,6 +17,7 @@ Identify whether the failure comes from discovery, generated files, provider res
 | Provider build fails | Provider Selection and required resource ids | [Provider output](/docs/reference/provider-output) |
 | DevTools feature is absent | `hubDevtools()` and package DevTools opt-out | [DevTools](/docs/development/devtools) |
 | Agent changed behavior | Agent Eval result and Agent Usage Record | [Agent Evals](/docs/development/agent-evals) |
+| Agent proof times out | Dev-loop `--timeout` or `agent.eval.testTimeout` | [CLI](/docs/development/cli) and [Agent Evals](/docs/development/agent-evals) |
 | Runtime error lacks context | Package error family and diagnostics output | [Errors and diagnostics](/docs/reference/errors-diagnostics) |
 
 ## Discovery failures
@@ -52,6 +53,7 @@ find dist -maxdepth 4 -type f | sort
 
 Separate Agent runtime failures from model behavior.
 Use DevTools to inspect one interactive Agent Invocation, then use Agent Evals when the failure is repeatable behavior.
+If the proof is timing out before it reaches the interesting failure, increase the dev-loop `--timeout` or the Agent Eval Runner `agent.eval.testTimeout` in `vite.config.ts`.
 
 ```bash [Terminal]
 pnpm vitehub agent eval server/agents/support.eval.ts --output .vitehub/evals/support.json

--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -16,6 +16,7 @@ They may resolve to Runtime Registries, generated files, virtual modules, or pac
 | `@vite-hub/agent/capabilities` | Agent Package | Official Capability factories such as `access()`, `workspaceShell()`, `inputCommands()`, and `subagents()`. |
 | `@vite-hub/agent/channels` | Agent Package | Official Channel Kind helpers such as `github()`, `stream()`, `teams()`, `telegram()`, `webChat()`, and `defineChannel()`. |
 | `@vite-hub/agent/eval` | Agent Package | Agent Eval authoring helpers. |
+| `@vite-hub/agent/test` | Agent Package | Agent test runner helpers for local and CI Agent Invocation checks. |
 | `@vite-hub/agent/harness/local-sandbox` | Agent Package | Trusted local harness sandbox helper for development and Agent Evals. |
 | `@vite-hub/vite/agent` | Vite Preset | Agent Definition helpers forwarded by the preset package. |
 | `@vite-hub/vite/agent/capabilities` | Vite Preset | Official Capability factories forwarded by the preset package. |

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -266,6 +266,25 @@ describe("agent eval", () => {
       .toThrow("Agent Eval test() must call t.send(...)")
   })
 
+  it("rejects follow-up sends inside one test callback", async () => {
+    const { defineEval } = await import("../src/eval.ts")
+    const generate = vi.fn(async () => ({ text: "ok" }))
+
+    defineEval({
+      agent: { generate, stream: vi.fn(), tools: {}, version: "agent-v1" } as never,
+      name: "support",
+      async test(t) {
+        await t.send("hello")
+        await expect(t.send("again")).rejects.toThrow("Agent Eval test.send() supports one Agent Invocation per test.")
+      },
+    })
+
+    await expect(evaliteCalls[0]!.opts.task(evaliteCalls[0]!.opts.data[0].input))
+      .resolves
+      .toMatchObject({ text: "ok" })
+    expect(generate).toHaveBeenCalledTimes(1)
+  })
+
   it("adds scenario scorers to global scorers and captures observations", async () => {
     const { defineEval, textContains } = await import("../src/eval.ts")
     const globalScorer = textContains("ok")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -142,6 +142,26 @@ describe("agent message protocol", () => {
     })
   })
 
+  it("does not let observability sink failures change Agent output", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const onEvent = vi.fn(() => {
+      throw new Error("sink failed")
+    })
+    const agent = defineAgent({
+      capabilities: [
+        observability({ onEvent }),
+      ],
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })).resolves.toBe("ok")
+    expect(onEvent).toHaveBeenCalledTimes(2)
+  })
+
   it("skips agent input hooks after a capability handles the input", async () => {
     const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
     const handled = new Response("handled")
@@ -774,11 +794,17 @@ describe("agent message protocol", () => {
     expect(session.destroy).toHaveBeenCalledTimes(1)
   })
 
-  it("resolves harness Agent Driver factories for each invocation", async () => {
+  it("resolves function-valued harness Agent Driver config for each invocation", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     harnessAgentSettings.length = 0
     const resolvedHarness = { provider: "codex", runId: "run-1" }
+    const resolvedSandbox = { provider: "sandbox", tenant: "acme" }
     const harness = vi.fn(() => resolvedHarness)
+    const sandbox = vi.fn(() => resolvedSandbox)
+    const sessionKey = vi.fn(({ context, run }) => {
+      const tenant = context.get("tenant") as { id?: string } | undefined
+      return `${tenant?.id}:${run?.runId}`
+    })
     const session = { destroy: vi.fn() }
     harnessCreateSession.mockResolvedValueOnce(session)
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
@@ -786,6 +812,8 @@ describe("agent message protocol", () => {
     const agent = defineAgent({
       driver: {
         harness,
+        sandbox,
+        sessionKey,
       },
     })
 
@@ -794,14 +822,26 @@ describe("agent message protocol", () => {
       run: { runId: "run-1" },
       runtime: "unknown",
       waitUntil: vi.fn(),
-    }, { prompt: "hello" })).resolves.toMatchObject({ text: "ok" })
+    }, {
+      context: { tenant: { id: "acme" } },
+      prompt: "hello",
+    })).resolves.toMatchObject({ text: "ok" })
 
     expect(harness).toHaveBeenCalledWith(expect.objectContaining({
       run: expect.objectContaining({ runId: "run-1" }),
+      input: expect.objectContaining({ prompt: "hello" }),
+    }))
+    expect(sandbox).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({ prompt: "hello" }),
+    }))
+    expect(sessionKey).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.any(Object),
     }))
     expect(harnessAgentSettings.at(-1)).toMatchObject({
       harness: resolvedHarness,
+      sandbox: resolvedSandbox,
     })
+    expect(harnessCreateSession).toHaveBeenCalledWith({ sessionId: "acme:run-1" })
   })
 
   it("labels non-token harness usage with sanitized credentials", async () => {


### PR DESCRIPTION
Records the inferred Agent DX decisions from the Eve comparison and recent harness/eval work: proof stays CLI-first and JSON-friendly, while future remote info/eval/dev surfaces remain internal language until implemented.

Updates public docs for the supported eval, harness, capability, timeout, import-path, and observability contracts, and adds regression coverage for single-send eval tests, function-valued harness config, and observability sink isolation.