### PR TITLE
feat(agent): adopt ai sdk v7 stable

### DIFF
--- a/.agents/adr/0071-ai-sdk-v7-stable-agent-runtime.md
+++ b/.agents/adr/0071-ai-sdk-v7-stable-agent-runtime.md
@@ -1,0 +1,11 @@
+# AI SDK v7 Stable Agent Runtime
+
+ViteHub Agent Package targets AI SDK v7 stable for model-backed and harness-backed Agent Drivers. The package catalog should pin stable AI SDK packages instead of canary builds, and the public peer range should require AI SDK v7.
+
+AI SDK remains an optional peer at the package boundary. Model-backed drivers and AI SDK-powered capabilities load it lazily; custom `run()` agents and host route bundles must not need `ai` installed.
+
+Model-backed execution should use AI SDK v7 names directly: `instructions`, `isStepCount`, `telemetry`, `onStepEnd`, `onToolExecutionStart`, `onToolExecutionEnd`, `runtimeContext`, and `stream`. Deprecated aliases may still be read as compatibility input where it costs almost nothing, but ViteHub-owned code should not emit deprecated AI SDK settings.
+
+The ViteHub-only `onRunStepFinish` and `onRunToolCall*` callback shims are removed from the model-backed runtime. AI SDK v7 `runtimeContext` is the native way to carry Agent Invocation data into steps, tools, telemetry, and `prepareStep`.
+
+`@ai-sdk/tui` and `runAgentTUI` are not part of this adoption slice. They are useful for an app-owned terminal chat around a local AI SDK Agent, but ViteHub's current Agent Dev Loop is a server/Vite endpoint debugger with trigger input, context JSON, delivery previews, and runtime traces. Adding a TUI command now would create a second workflow instead of deleting the existing one.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -3,7 +3,7 @@
 <p>
   <a href="https://vitehub.dev"><img alt="ViteHub" src="https://img.shields.io/badge/ViteHub-vitehub.dev-646cff?style=flat-square"></a>
   <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-ready-3178c6?style=flat-square">
-  <img alt="AI SDK" src="https://img.shields.io/badge/AI%20SDK-models-111827?style=flat-square">
+  <img alt="AI SDK" src="https://img.shields.io/badge/AI%20SDK-v7-111827?style=flat-square">
 </p>
 
 `@vite-hub/agent` defines model-backed agents from files such as `server/agents/support/config.ts`.
@@ -20,12 +20,14 @@ Keep the three pieces separate:
 pnpm add @vite-hub/agent @vite-hub/workspace ai
 ```
 
+`ai` is required for model-backed drivers and AI SDK-powered capabilities such as model-backed `chatTitle()`, `chatSummary()`, `llmGate()`, and `transcribe()`. Agents with a custom `run()` function can bundle without installing `ai`.
+
 Add the AI SDK model provider you pass to `model`.
 
-For AI SDK harness drivers, add the experimental harness packages:
+For AI SDK harness drivers, add the harness packages:
 
 ```sh
-pnpm add @ai-sdk/harness@canary @ai-sdk/harness-codex@canary @ai-sdk/sandbox-vercel@canary
+pnpm add @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel
 ```
 
 ## Minimal API
@@ -108,7 +110,7 @@ export default defineConfig({
 - `chat()` exposes the agent as a chat surface; see the [AI agent tutorial](https://vitehub.dev/docs/tutorials/build-ai-chatbot).
 - `workspaceShell()` runs scoped shell/file work through [`@vite-hub/shell`](../shell/README.md).
 - `webSearch()` searches and reads the web with [Brave](https://brave.com/search/api/), [Exa](https://docs.exa.ai/), [Jina](https://jina.ai/en-US/reader/), [SearXNG](https://docs.searxng.org/dev/search_api.html), [SerpApi](https://serpapi.com/search-api), [SerpBase](https://serpbase.dev/docs), or [Tavily](https://docs.tavily.com/).
-- `transcribe()` uses the [AI SDK transcription API](https://ai-sdk.dev/docs/reference/ai-sdk-core/transcribe).
+- `transcribe()` uses the [AI SDK transcription API](https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/transcribe).
 - `mcp()` connects tools from [Model Context Protocol](https://modelcontextprotocol.io/) servers through `@ai-sdk/mcp`.
 - `kv()`, `blob()`, and `db()` expose [`@vite-hub/kv`](../kv/README.md), [`@vite-hub/blob`](../blob/README.md), and [`@vite-hub/database`](../database/README.md).
 - `sandbox()` and `schedule()` expose [`@vite-hub/sandbox`](../sandbox/README.md) and [`@vite-hub/schedule`](../schedule/README.md).

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -167,13 +167,13 @@ function usageFromStreamChunk(chunk: unknown, fallbackMetadataSource?: unknown):
   return usageRecordFromUsage(type === "finish-step"
     ? chunk.usage
     : type === "finish"
-      ? chunk.totalUsage ?? chunk.usage
+      ? chunk.usage ?? chunk.totalUsage
       : undefined, chunk, fallbackMetadataSource)
 }
 
 async function usageFromResult(result: unknown): Promise<AgentUsageRecord | undefined> {
   if (!isRecord(result)) return
-  return usageRecordFromUsage(await resolveUsageValue(result.totalUsage ?? result.usage), result)
+  return usageRecordFromUsage(await resolveUsageValue(result.usage ?? result.totalUsage), result)
 }
 
 function optionalMessageId(messageId: string | undefined): { messageId?: string } {
@@ -285,13 +285,13 @@ export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<
   const result = value && typeof value === "object"
     ? value as { fullStream?: unknown, stream?: unknown, textStream?: unknown }
     : undefined
+  if (isAsyncIterable(result?.stream)) {
+    yield* streamChunksToEvents(result.stream, result)
+    return
+  }
   const fullStream = result?.fullStream
   if (isAsyncIterable(fullStream)) {
     yield* streamChunksToEvents(fullStream, result)
-    return
-  }
-  if (isAsyncIterable(result?.stream)) {
-    yield* streamChunksToEvents(result.stream, result)
     return
   }
   if (isAsyncIterable<string>(result?.textStream)) {

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1,10 +1,10 @@
 import { getMessageText } from "./messages.ts"
-import { jsonSchema } from "ai"
 import {
   cloneWithPropertyDescriptors,
   isAsyncIterable,
   teeingAsyncIterableStreamDescriptor,
 } from "./internal/stream-result.ts"
+import { loadAiSdk } from "./internal/ai-sdk-runtime.ts"
 import {
   applyCapabilityInstructionSlots,
   applyCapabilityToolTransforms,
@@ -315,13 +315,13 @@ async function synthesizeWorkspaceFallbackFromEvidence(
 ) {
   if (evidence.length === 0) return undefined
 
-  const { generateText } = await import("ai")
+  const { generateText } = await loadAiSdk()
   const summary = await generateText({
-    model,
-    system: [
+    instructions: [
       "Answer the user's last message using only the workspace tool results.",
       "If the tool results are insufficient, say what is missing.",
     ].join("\n"),
+    model,
     prompt: [
       `User message:\n${getPromptText(context)}`,
       `Workspace tool results:\n${evidence.join("\n\n---\n\n")}`,
@@ -521,14 +521,20 @@ function withWorkspaceFallbackStreamResult<T extends { fullStream?: AsyncIterabl
   capturedEvidence?: () => string[],
 ): T {
   if (!fallback.enabled) return result
-  if (result.fullStream) {
+  const stream = result.stream
+  const fullStream = result.fullStream
+  if (stream || fullStream) {
+    const wrappedStream = stream
+      ? withWorkspaceFallbackFullStream(stream, model, context, fallback.maxToolResults, capturedEvidence)
+      : undefined
+    const wrappedFullStream = fullStream
+      ? fullStream === stream && wrappedStream
+        ? wrappedStream
+        : withWorkspaceFallbackFullStream(fullStream, model, context, fallback.maxToolResults, capturedEvidence)
+      : undefined
     return cloneStreamTextResult(result as object, {
-      fullStream: withWorkspaceFallbackFullStream(result.fullStream, model, context, fallback.maxToolResults, capturedEvidence),
-    }) as T
-  }
-  if (result.stream) {
-    return cloneStreamTextResult(result as object, {
-      stream: withWorkspaceFallbackFullStream(result.stream, model, context, fallback.maxToolResults, capturedEvidence),
+      ...(wrappedStream ? { stream: wrappedStream } : {}),
+      ...(wrappedFullStream ? { fullStream: wrappedFullStream } : {}),
     }) as T
   }
   if (isAsyncIterable(result)) {
@@ -569,11 +575,13 @@ async function resolveTools(options: AiSdkAdapterOptions, context: AgentAdapterM
   }
 }
 
-const defaultToolInputSchema = jsonSchema({
-  additionalProperties: false,
-  properties: {},
-  type: "object",
-})
+const defaultToolInputSchema = {
+  jsonSchema: {
+    additionalProperties: false,
+    properties: {},
+    type: "object",
+  },
+}
 
 function withDefaultToolInputSchemas<TTools extends Record<string, unknown> | undefined>(tools: TTools): TTools {
   if (!tools) return tools
@@ -589,58 +597,32 @@ function withDefaultToolInputSchemas<TTools extends Record<string, unknown> | un
   })) as TTools
 }
 
-function withRunCallbacks(settings: Record<string, unknown>, context: AgentAdapterRunContext) {
-  const {
-    onRunStepFinish,
-    onRunToolCallFinish,
-    onRunToolCallStart,
-    onStepFinish,
-    experimental_onToolCallFinish,
-    experimental_onToolCallStart,
-    ...rest
-  } = settings as {
-    experimental_onToolCallFinish?: (event: unknown) => MaybePromise<void>
-    experimental_onToolCallStart?: (event: unknown) => MaybePromise<void>
-    onRunStepFinish?: (step: unknown, context: unknown) => MaybePromise<void>
-    onRunToolCallFinish?: (event: unknown, context: unknown) => MaybePromise<void>
-    onRunToolCallStart?: (event: unknown, context: unknown) => MaybePromise<void>
-    onStepFinish?: (step: unknown) => MaybePromise<void>
-  } & Record<string, unknown>
-  const callbackContext = {
-    ...context.runtime,
+function createAiSdkRuntimeContext(context: AgentAdapterRunContext) {
+  const { runtimeConfig: _runtimeConfig, ...runtime } = context.runtime
+  return {
+    ...runtime,
     actor: context.actor,
     context: context.context,
     input: context.input,
     invoker: context.invoker,
     run: context.runtime.run,
   }
+}
 
+function withRuntimeContext(settings: Record<string, unknown>, context: AgentAdapterRunContext): Record<string, unknown> {
+  const runtimeContext = createAiSdkRuntimeContext(context)
+  const existing = settings.runtimeContext
+  const {
+    onRunStepFinish: _onRunStepFinish,
+    onRunToolCallFinish: _onRunToolCallFinish,
+    onRunToolCallStart: _onRunToolCallStart,
+    ...rest
+  } = settings
   return {
     ...rest,
-    ...(onRunStepFinish
-      ? {
-          async onStepFinish(step: unknown) {
-            await onStepFinish?.(step)
-            await onRunStepFinish(step, callbackContext)
-          },
-        }
-      : onStepFinish ? { onStepFinish } : {}),
-    ...(onRunToolCallStart
-      ? {
-          async experimental_onToolCallStart(event: unknown) {
-            await experimental_onToolCallStart?.(event)
-            await onRunToolCallStart(event, callbackContext)
-          },
-        }
-      : experimental_onToolCallStart ? { experimental_onToolCallStart } : {}),
-    ...(onRunToolCallFinish
-      ? {
-          async experimental_onToolCallFinish(event: unknown) {
-            await experimental_onToolCallFinish?.(event)
-            await onRunToolCallFinish(event, callbackContext)
-          },
-        }
-      : experimental_onToolCallFinish ? { experimental_onToolCallFinish } : {}),
+    runtimeContext: existing && typeof existing === "object"
+      ? { ...runtimeContext, ...(existing as Record<string, unknown>) }
+      : runtimeContext,
   }
 }
 
@@ -650,7 +632,7 @@ function createUsageCapture() {
 
   const capture = (event: unknown) => {
     const record = typeof event === "object" && event !== null ? event as { totalUsage?: unknown, usage?: unknown } : undefined
-    const usage = record?.totalUsage ?? record?.usage
+    const usage = record?.usage ?? record?.totalUsage
     if (usage === undefined) return
     capturedUsage = usage
     captured = true
@@ -776,7 +758,6 @@ function withViteHubTelemetry(settings: Record<string, unknown>, context: AgentA
   return {
     ...settings,
     telemetry,
-    experimental_telemetry: telemetry,
   }
 }
 
@@ -824,7 +805,7 @@ async function createAgent(
   context: AgentAdapterRunContext,
   fallbackCapture?: ReturnType<typeof createWorkspaceFallbackEvidenceCapture>,
 ) {
-  const { ToolLoopAgent, stepCountIs } = await import("ai")
+  const { ToolLoopAgent, isStepCount } = await loadAiSdk()
   const execution = options.execution ?? options.modelExecution
   const { runtimeConfig: _runtimeConfig, ...runtime } = context.runtime
   const metadataContext = {
@@ -879,10 +860,10 @@ async function createAgent(
 
   return {
     agent: new ToolLoopAgent({
-      ...withRunCallbacks(withViteHubTelemetry(settings, context), context),
+      ...withRuntimeContext(withViteHubTelemetry(settings, context), context),
       instructions,
       model: instrumentedModel as never,
-      stopWhen: ((settings as Record<string, unknown>).stopWhen ?? stepCountIs(stepLimit ?? 20)) as never,
+      stopWhen: ((settings as Record<string, unknown>).stopWhen ?? isStepCount(stepLimit ?? 20)) as never,
       ...(Object.keys(toolSet).length ? { tools: toolSet as never } : {}),
     }),
     model: instrumentedModel,
@@ -959,7 +940,6 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         onEnd: usageCapture.onEnd,
         onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
         onStepEnd: captureStep,
-        onStepFinish: captureStep,
       } as never) as StreamTextResult<ToolSet, never, never>, usageCapture), model) as StreamTextResult<ToolSet, never, never>
       return withWorkspaceFallbackStreamResult(result, model as never, context, fallback, fallbackCapture?.evidence)
     },

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -575,21 +575,21 @@ async function resolveTools(options: AiSdkAdapterOptions, context: AgentAdapterM
   }
 }
 
-const defaultToolInputSchema = {
-  jsonSchema: {
-    additionalProperties: false,
-    properties: {},
-    type: "object",
-  },
-}
+const defaultToolInputSchemaJson = {
+  additionalProperties: false,
+  properties: {},
+  type: "object",
+} as const
 
-function withDefaultToolInputSchemas<TTools extends Record<string, unknown> | undefined>(tools: TTools): TTools {
+function withDefaultToolInputSchemas<TTools extends Record<string, unknown> | undefined>(tools: TTools, createDefaultToolInputSchema: () => unknown): TTools {
   if (!tools) return tools
+  let defaultToolInputSchema: unknown
   return Object.fromEntries(Object.entries(tools).map(([name, tool]) => {
     const record = tool as { inputSchema?: unknown, type?: unknown } | undefined
     if (!record || typeof record !== "object" || record.type === "provider" || record.type === "provider-defined" || record.inputSchema != null) {
       return [name, tool]
     }
+    defaultToolInputSchema ??= createDefaultToolInputSchema()
     return [name, {
       ...record,
       inputSchema: defaultToolInputSchema,
@@ -805,7 +805,7 @@ async function createAgent(
   context: AgentAdapterRunContext,
   fallbackCapture?: ReturnType<typeof createWorkspaceFallbackEvidenceCapture>,
 ) {
-  const { ToolLoopAgent, isStepCount } = await loadAiSdk()
+  const { ToolLoopAgent, isStepCount, jsonSchema } = await loadAiSdk()
   const execution = options.execution ?? options.modelExecution
   const { runtimeConfig: _runtimeConfig, ...runtime } = context.runtime
   const metadataContext = {
@@ -829,7 +829,7 @@ async function createAgent(
   const resolvedTools = withDefaultToolInputSchemas(withWorkspaceFallbackToolEvidence(await applyCapabilityToolTransforms({
     ...context.tools,
     ...adapterTools,
-  }, []), fallbackCapture))
+  }, []), fallbackCapture), () => jsonSchema(defaultToolInputSchemaJson))
   const providerTools = Object.fromEntries((context.providerTools || []).map(tool => [tool.name, {
     args: tool.args || {},
     id: tool.id,

--- a/packages/agent/src/capabilities/chat-summary.ts
+++ b/packages/agent/src/capabilities/chat-summary.ts
@@ -11,6 +11,7 @@ import {
   replaceMessageTextParts,
   replaceTargetText,
 } from "./input-commands.ts"
+import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 
 import type {
   AgentCapabilityDefinition,
@@ -80,14 +81,14 @@ async function generateChatSummary(options: ChatSummaryOptions, input: ChatSumma
   }
 
   if (options.model) {
-    const { generateText } = await import("ai")
+    const { generateText } = await loadAiSdk()
     const result = await generateText({
-      model: options.model as never,
-      system: options.instructions ?? [
+      instructions: options.instructions ?? [
         "Summarize this chat conversation for future context.",
         "Keep important user goals, decisions, constraints, and unresolved follow-ups.",
         "Return only the summary.",
       ].join("\n"),
+      model: options.model as never,
       prompt: input.args
         ? `${input.text}\n\nFocus: ${input.args}`
         : input.text,

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -1,5 +1,6 @@
 import { defineCapability } from "../capability-runtime.ts"
 import { getMessageText } from "../messages.ts"
+import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 
 import type {
   AgentCapabilityDefinition,
@@ -180,10 +181,10 @@ async function generateChatTitle(context: AgentCapabilityRuntimeContext, options
 
   const model = await resolveChatTitleModel(context, options)
   if (model) {
-    const { generateText } = await import("ai")
+    const { generateText } = await loadAiSdk()
     const prompt = await renderChatTitleTemplate(options, templateInput)
     const result = await generateText(options.instructions
-      ? { model: model as never, prompt, system: options.instructions }
+      ? { instructions: options.instructions, model: model as never, prompt }
       : { model: model as never, prompt })
     return cleanGeneratedTitle(result.text, maxLength, fallback)
   }
@@ -327,18 +328,19 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<StreamEvent> {
     && typeof (value as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] === "function"
 }
 
-function isStreamTextResult(value: unknown): value is { fullStream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string>, toUIMessageStream?: ToUIMessageStream } {
+function isStreamTextResult(value: unknown): value is { fullStream?: AsyncIterable<unknown>, stream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string>, toUIMessageStream?: ToUIMessageStream } {
   return !!value && typeof value === "object"
     && (
-      isAsyncIterable((value as { fullStream?: unknown }).fullStream)
+      isAsyncIterable((value as { stream?: unknown }).stream)
+      || isAsyncIterable((value as { fullStream?: unknown }).fullStream)
       || isAsyncIterable((value as { textStream?: unknown }).textStream)
       || typeof (value as { toUIMessageStream?: unknown }).toUIMessageStream === "function"
     )
 }
 
-function cloneStreamTextResult<T extends { fullStream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string>, toUIMessageStream?: ToUIMessageStream }>(
+function cloneStreamTextResult<T extends { fullStream?: AsyncIterable<unknown>, stream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string>, toUIMessageStream?: ToUIMessageStream }>(
   result: T,
-  streams: { fullStream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string>, toUIMessageStream?: ToUIMessageStream },
+  streams: { fullStream?: AsyncIterable<unknown>, stream?: AsyncIterable<unknown>, textStream?: AsyncIterable<string>, toUIMessageStream?: ToUIMessageStream },
 ): T {
   const clone = Object.create(Object.getPrototypeOf(result))
   Object.defineProperties(clone, Object.getOwnPropertyDescriptors(result))
@@ -347,6 +349,14 @@ function cloneStreamTextResult<T extends { fullStream?: AsyncIterable<unknown>, 
       configurable: true,
       enumerable: true,
       value: streams.fullStream,
+      writable: true,
+    })
+  }
+  if (streams.stream) {
+    Object.defineProperty(clone, "stream", {
+      configurable: true,
+      enumerable: true,
+      value: streams.stream,
       writable: true,
     })
   }
@@ -407,16 +417,24 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
         if (hasChatTitleApplied(result)) return result
         if (isStreamTextResult(result)) {
           const toUIMessageStream = result.toUIMessageStream?.bind(result)
-          if (result.fullStream) {
+          if (result.stream || result.fullStream) {
+            const stream = result.stream
+            const fullStream = result.fullStream
+            const title = getTitle()
+            const titleStream = stream ? withChatTitleFullStream(stream, title) : undefined
             return cloneStreamTextResult(result, {
-              fullStream: withChatTitleFullStream(result.fullStream, getTitle()),
-              ...chatTitleUiMessageStreamOverride(toUIMessageStream, getTitle()),
+              ...(titleStream ? { stream: titleStream } : {}),
+              ...(fullStream
+                ? { fullStream: fullStream === stream && titleStream ? titleStream : withChatTitleFullStream(fullStream, title) }
+                : {}),
+              ...chatTitleUiMessageStreamOverride(toUIMessageStream, title),
             })
           }
           if (result.textStream) {
+            const title = getTitle()
             return cloneStreamTextResult(result, {
-              fullStream: withChatTitleTextStream(result.textStream, getTitle()),
-              ...chatTitleUiMessageStreamOverride(toUIMessageStream, getTitle()),
+              stream: withChatTitleTextStream(result.textStream, title),
+              ...chatTitleUiMessageStreamOverride(toUIMessageStream, title),
             })
           }
           if (toUIMessageStream) {

--- a/packages/agent/src/capabilities/llm-decision-shared.ts
+++ b/packages/agent/src/capabilities/llm-decision-shared.ts
@@ -1,4 +1,5 @@
 import { getMessageText } from "../messages.ts"
+import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 
 import type { Message } from "../messages.ts"
 
@@ -117,8 +118,13 @@ export async function generateDecision<T>(input: {
   prompt: string
   schema: DecisionObjectSchema<T>
 }): Promise<T> {
-  const { Output, generateText, jsonSchema } = await import("ai")
+  const { Output, generateText, jsonSchema } = await loadAiSdk()
   const result = await generateText({
+    instructions: [
+      "You are a pre-invocation classifier for an AI agent.",
+      "Choose the best option from the allowed schema.",
+      "Do not answer the user request.",
+    ].join("\n"),
     model: input.model as never,
     output: Output.object({
       description: `Decision result for ${input.id}.`,
@@ -126,11 +132,6 @@ export async function generateDecision<T>(input: {
       schema: jsonSchema<T>(input.schema.schema as never, { validate: input.schema.validate }),
     }),
     prompt: input.prompt,
-    system: [
-      "You are a pre-invocation classifier for an AI agent.",
-      "Choose the best option from the allowed schema.",
-      "Do not answer the user request.",
-    ].join("\n"),
   })
   return (result as { output: T }).output
 }

--- a/packages/agent/src/capabilities/transcribe.ts
+++ b/packages/agent/src/capabilities/transcribe.ts
@@ -1,5 +1,6 @@
 import { defineCapability } from "../capability-runtime.ts"
 import { appendMessageText } from "../messages.ts"
+import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 
 import type {
   AgentCapabilityRuntimeContext,
@@ -11,7 +12,7 @@ import type {
 import type { AudioData, AudioPart, Message } from "../messages.ts"
 import type { WritableWorkspaceFacade, WorkspaceContent, WorkspaceName } from "@vite-hub/workspace"
 
-type AiSdkTranscribe = typeof import("ai")["experimental_transcribe"]
+type AiSdkTranscribe = typeof import("ai")["transcribe"]
 type AiSdkTranscribeOptions = Omit<Parameters<AiSdkTranscribe>[0], "abortSignal" | "audio">
 type AiSdkTranscriptionResult = Awaited<ReturnType<AiSdkTranscribe>>
 type TranscribeArtifactValue<T, TInput> = T | ((input: TInput) => MaybePromise<T>)
@@ -231,8 +232,8 @@ async function runTranscription(options: StaticTranscribeOptions, audio: AudioPa
     ...transcribeOptions
   } = options
   const maxBytes = normalizeMaxBytes(maxBytesOption)
-  const { createDownload, experimental_transcribe } = await import("ai")
-  const result = await experimental_transcribe({
+  const { createDownload, transcribe } = await loadAiSdk()
+  const result = await transcribe({
     ...transcribeOptions,
     abortSignal,
     audio: await toAiSdkAudio(audio, maxBytes),

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -156,10 +156,10 @@ export function normalizeAgentUsage(value: unknown): AgentUsage | undefined {
 }
 
 async function usageFromResult(result: UnknownRecord, fallback?: unknown): Promise<AgentUsage | undefined> {
-  const usage = normalizeAgentUsage(await resolveUsageValue(result.totalUsage ?? result.usage))
+  const usage = normalizeAgentUsage(await resolveUsageValue(result.usage ?? result.totalUsage))
   if (usage) return usage
   if (!isRecord(fallback)) return
-  return normalizeAgentUsage(await resolveUsageValue(fallback.totalUsage ?? fallback.usage))
+  return normalizeAgentUsage(await resolveUsageValue(fallback.usage ?? fallback.totalUsage))
 }
 
 function credentialSourceFromMetadata(metadata: unknown): AgentUsageRecord["credentialSource"] | undefined {
@@ -385,7 +385,7 @@ async function* withUsageTelemetryStream(
   let recorded = false
   for await (const chunk of stream) {
     if (isRecord(chunk) && chunk.type === "finish") {
-      const usageRecord = await recordUsage(chunk, options, run, chunk.totalUsage !== undefined || chunk.usage !== undefined ? metadataSource : undefined)
+      const usageRecord = await recordUsage(chunk, options, run, chunk.usage !== undefined || chunk.totalUsage !== undefined ? metadataSource : undefined)
       if (usageRecord) {
         recorded = true
         onRecord?.(usageRecord)

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -27,6 +27,7 @@ import { createChatDevtoolsStreamResponse } from "../devtools-stream.ts"
 import { createAgentRuntimeContext } from "../../runtime/context.ts"
 import { discoverAgentDefinitions } from "../../discovery.ts"
 import { workspaceAgentOwnsWorkspaceDefinition } from "../../workspace-agent.ts"
+import { loadAiSdk } from "../../internal/ai-sdk-runtime.ts"
 
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http"
 import type { UIMessage } from "ai"
@@ -684,7 +685,7 @@ async function sendDevtoolsUIMessage(
       await onChange?.(await serializeState(state, selected))
     },
   }))
-  const { readUIMessageStream } = await import("ai") as { readUIMessageStream: ReadUIMessageStream }
+  const { readUIMessageStream } = await loadAiSdk() as { readUIMessageStream: ReadUIMessageStream }
   let latestAssistant: UIMessage | undefined
   const refreshedMaterializationToolIds = new Set<string>()
   async function refreshCompletedMaterializations(message: UIMessage): Promise<void> {

--- a/packages/agent/src/internal/ai-sdk-runtime.ts
+++ b/packages/agent/src/internal/ai-sdk-runtime.ts
@@ -1,0 +1,5 @@
+const aiSdkPackageName = "ai"
+
+export async function loadAiSdk(): Promise<typeof import("ai")> {
+  return await import(/* @vite-ignore */ aiSdkPackageName) as typeof import("ai")
+}

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -15,6 +15,7 @@ import { isResolvedAgentTriggerHandledInvocation, verifyAgentWebhookRequest } fr
 import { toHttpErrorResponse } from "../http-error.ts"
 import { toAgentFetchResponse } from "../http-response.ts"
 import { createChatDevtoolsStreamResponse } from "../chat/devtools-stream.ts"
+import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 
 import type { AgentChatMessageTriggerInput } from "../chat-trigger.ts"
 import type {
@@ -1773,7 +1774,7 @@ async function sendDevtoolsUIMessage(
       await onChange?.(serializeAgentChatDevtoolsState(name, state, requestedSelection))
     },
   })))
-  const { readUIMessageStream } = await import("ai") as { readUIMessageStream: ReadUIMessageStream }
+  const { readUIMessageStream } = await loadAiSdk() as { readUIMessageStream: ReadUIMessageStream }
   let latestAssistant: UIMessage | undefined
   const refreshedMaterializationToolIds = new Set<string>()
   async function refreshCompletedMaterializations(message: UIMessage): Promise<void> {

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -296,11 +296,15 @@ describe("agent output helpers", () => {
     ])
   })
 
-  it("prefers fullStream over async iterable stream result surfaces", async () => {
+  it("prefers stream over deprecated fullStream and async iterable result surfaces", async () => {
     class StreamResult {
-      fullStream = (async function* () {
+      stream = (async function* () {
         yield { text: "ok", type: "text-delta" }
         yield { finishReason: "stop", type: "finish" }
+      })()
+
+      fullStream = (async function* () {
+        yield { text: "wrong-full-stream", type: "text-delta" }
       })()
 
       usage = Promise.resolve({

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -1108,7 +1108,7 @@ describe("agent capability runtime", () => {
           return { text: "ok" }
         }
       },
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
     }))
 
     try {
@@ -1139,7 +1139,7 @@ describe("agent capability runtime", () => {
           return { text: "ok" }
         }
       },
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
     }))
 
     try {
@@ -1171,7 +1171,7 @@ describe("agent capability runtime", () => {
           return { text: "ok" }
         }
       },
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
     }))
 
     try {

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -40,7 +40,7 @@ vi.mock("@vite-hub/workspace/test", () => ({
 
 vi.mock("ai", () => ({
   jsonSchema: vi.fn(schema => schema),
-  stepCountIs: vi.fn(count => ({ count })),
+  isStepCount: vi.fn(count => ({ count })),
   ToolLoopAgent: class {
     constructor(public settings: Record<string, unknown>) {
       agentSettings.push(settings)

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -531,7 +531,7 @@ describe("agent message protocol", () => {
           return await this.generate()
         }
       },
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
     }))
 
     try {
@@ -547,7 +547,6 @@ describe("agent message protocol", () => {
       }, {})).resolves.toMatchObject({ finishReason: "stop", text: "ok" })
 
       const telemetry = agentSettings[0]!.telemetry as { integrations: unknown[], recordInputs: boolean, recordOutputs: boolean }
-      expect(agentSettings[0]!.experimental_telemetry).toBe(telemetry)
       expect(telemetry.integrations[0]).toBe(globalIntegration)
       expect(telemetry.recordInputs).toBe(false)
       expect(telemetry.recordOutputs).toBe(false)
@@ -2594,7 +2593,7 @@ describe("agent message protocol", () => {
           return await this.generate()
         }
       },
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
     }))
 
     try {
@@ -2693,7 +2692,7 @@ describe("agent message protocol", () => {
           return await this.generate()
         }
       },
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
     }))
 
     try {
@@ -2746,7 +2745,7 @@ describe("agent message protocol", () => {
           }
         }
       },
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
     }))
 
     try {
@@ -3058,7 +3057,7 @@ describe("agent message protocol", () => {
           }
         }
       },
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
     }))
 
     try {
@@ -3145,9 +3144,9 @@ describe("agent message protocol", () => {
 
     const result = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
       messages: [createMessage({ role: "user", text: "First user request" })],
-    }) as TextStreamResult & { fullStream?: AsyncIterable<unknown> }
+    }) as TextStreamResult & { stream?: AsyncIterable<unknown> }
     const events = []
-    for await (const event of result.fullStream as AsyncIterable<unknown>) {
+    for await (const event of result.stream as AsyncIterable<unknown>) {
       events.push(event)
     }
 
@@ -3156,7 +3155,7 @@ describe("agent message protocol", () => {
     expect(result).toBeInstanceOf(TextStreamResult)
     expect(result.metadata).toEqual({ usage: "kept" })
     expect(result.textStream).toBeDefined()
-    expect(result.fullStream).toBeDefined()
+    expect(result.stream).toBeDefined()
     await expect(result.toTextStreamResponse().text()).resolves.toBe("native text")
     expect(finish.mock.calls[0]![0].result).toBe(result)
   })

--- a/packages/agent/test/test-runner.test.ts
+++ b/packages/agent/test/test-runner.test.ts
@@ -8,7 +8,7 @@ const agentGenerate = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ f
 
 vi.mock("ai", () => ({
   jsonSchema: vi.fn(schema => schema),
-  stepCountIs: vi.fn(count => ({ count })),
+  isStepCount: vi.fn(count => ({ count })),
   ToolLoopAgent: class {
     constructor(public settings: Record<string, unknown>) {
       agentSettings.push(settings)

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -544,7 +544,7 @@ describe("usage telemetry", () => {
   it("emits ToolLoopAgent stream result usage when chunks only contain finish", async () => {
     vi.doMock("ai", () => ({
       jsonSchema: vi.fn(schema => schema),
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
       ToolLoopAgent: class {
         async stream() {
           return {
@@ -599,7 +599,7 @@ describe("usage telemetry", () => {
   it("emits ToolLoopAgent onEnd usage when the stream result omits usage", async () => {
     vi.doMock("ai", () => ({
       jsonSchema: vi.fn(schema => schema),
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
       ToolLoopAgent: class {
         async stream(options: { onEnd?: (event: unknown) => unknown }) {
           return {
@@ -656,7 +656,7 @@ describe("usage telemetry", () => {
   it("emits ToolLoopAgent onStepEnd usage when the stream result omits usage", async () => {
     vi.doMock("ai", () => ({
       jsonSchema: vi.fn(schema => schema),
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
       ToolLoopAgent: class {
         async stream(options: { onStepEnd?: (event: unknown) => unknown }) {
           return {
@@ -713,7 +713,7 @@ describe("usage telemetry", () => {
   it("emits ToolLoopAgent model call end usage over empty stream result usage", async () => {
     vi.doMock("ai", () => ({
       jsonSchema: vi.fn(schema => schema),
-      stepCountIs: () => () => false,
+      isStepCount: () => () => false,
       ToolLoopAgent: class {
         async stream(options: { onLanguageModelCallEnd?: (event: unknown) => unknown }) {
           return {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -60,7 +60,7 @@ const prepareHarnessWorkspaceSession = vi.fn()
 vi.mock("ai", () => ({
   generateText,
   jsonSchema: vi.fn(schema => schema),
-  stepCountIs: vi.fn(count => ({ count })),
+  isStepCount: vi.fn(count => ({ count })),
   ToolLoopAgent: class {
     constructor(public settings: Record<string, unknown>) {
       agentSettings.push(settings)
@@ -1850,8 +1850,8 @@ describe("defineAgent workspace option", () => {
   it("synthesizes streamed answers from step finish callback tool results", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     agentStream.mockImplementationOnce(async (input: unknown) => {
-      const callInput = input as { onStepFinish?: (event: unknown) => Promise<void> }
-      await callInput.onStepFinish?.({
+      const callInput = input as { onStepEnd?: (event: unknown) => Promise<void> }
+      await callInput.onStepEnd?.({
         toolResults: [
           {
             output: { text: "Browser evidence from callback: screenshots/login-version-badge-desktop.png" },
@@ -1889,8 +1889,8 @@ describe("defineAgent workspace option", () => {
   it("keeps final stream text when callback evidence is only supporting evidence", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     agentStream.mockImplementationOnce(async (input: unknown) => {
-      const callInput = input as { onStepFinish?: (event: unknown) => Promise<void> }
-      await callInput.onStepFinish?.({
+      const callInput = input as { onStepEnd?: (event: unknown) => Promise<void> }
+      await callInput.onStepEnd?.({
         toolResults: [
           {
             output: { text: "Browser evidence from callback: screenshots/login-version-badge-desktop.png" },
@@ -2131,18 +2131,18 @@ describe("defineAgent workspace option", () => {
   it("passes AI SDK tool loop settings through workspace agents", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const stopWhen = { custom: true }
-    const onStepFinish = vi.fn()
-    const experimental_telemetry = { integrations: [], isEnabled: true }
+    const onStepEnd = vi.fn()
+    const telemetry = { integrations: [], isEnabled: true }
 
     const agent = withAgentDefaults(defineAgent({
       workspace: {},
       modelExecution: {
         callSettings: {
-          experimental_telemetry: experimental_telemetry as never,
           maxOutputTokens: 100,
-          onStepFinish,
+          onStepEnd,
           stopWhen: stopWhen as never,
           temperature: 0.2,
+          telemetry: telemetry as never,
           toolChoice: "auto",
         },
       },
@@ -2152,11 +2152,11 @@ describe("defineAgent workspace option", () => {
     await agent.run!(context())
 
     expect(agentSettings.at(-1)).toMatchObject({
-      experimental_telemetry,
       maxOutputTokens: 100,
-      onStepFinish,
+      onStepEnd,
       stopWhen,
       temperature: 0.2,
+      telemetry,
       toolChoice: "auto",
     })
   })
@@ -2208,7 +2208,7 @@ describe("defineAgent workspace option", () => {
       workspace: {},
       modelExecution: {
         callSettings: {
-          onStepFinish: vi.fn(),
+          onStepEnd: vi.fn(),
         },
         instrumentation: {
           model: instrumentModel,
@@ -2232,7 +2232,7 @@ describe("defineAgent workspace option", () => {
     }))
     expect(agentSettings.at(-1)).toMatchObject({
       model: wrappedModel,
-      onStepFinish: expect.any(Function),
+      onStepEnd: expect.any(Function),
     })
     expect(agentSettings.at(-1)).not.toHaveProperty("modelExecution")
   })
@@ -2306,7 +2306,7 @@ describe("defineAgent workspace option", () => {
   it("lets workspace agents instrument AI SDK call settings per run", async () => {
     const execute = vi.fn(async () => "workspace result")
     const instrumentCallSettings = vi.fn(({ callSettings }) => ({
-      experimental_telemetry: { isEnabled: true, runScoped: true },
+      telemetry: { isEnabled: true, runScoped: true },
       temperature: callSettings.temperature,
     }))
     inspectTools.mockReturnValueOnce({
@@ -2349,9 +2349,9 @@ describe("defineAgent workspace option", () => {
     }))
     expect(instrumentCallSettings.mock.calls[0]?.[0].callSettings).not.toHaveProperty("stepLimit")
     expect(agentSettings.at(-1)).toMatchObject({
-      experimental_telemetry: { isEnabled: true, runScoped: true },
       stopWhen: { count: 7 },
       temperature: 0.2,
+      telemetry: { isEnabled: true, runScoped: true },
     })
     expect(agentSettings.at(-1)).not.toHaveProperty("modelExecution")
   })
@@ -2388,25 +2388,25 @@ describe("defineAgent workspace option", () => {
     ])
   })
 
-  it("passes runtime context to run-aware step and tool callbacks", async () => {
-    const onStepFinish = vi.fn()
+  it("passes runtime context to native AI SDK step and tool callbacks", async () => {
+    const onStepEnd = vi.fn()
+    const onToolExecutionStart = vi.fn()
+    const onToolExecutionEnd = vi.fn()
     const onRunStepFinish = vi.fn()
-    const experimental_onToolCallStart = vi.fn()
-    const experimental_onToolCallFinish = vi.fn()
-    const onRunToolCallStart = vi.fn()
     const onRunToolCallFinish = vi.fn()
+    const onRunToolCallStart = vi.fn()
     const { defineAgent } = await import("../src/index.ts")
 
     const agent = withAgentDefaults(defineAgent({
       workspace: {},
       modelExecution: {
         callSettings: {
-          experimental_onToolCallFinish: experimental_onToolCallFinish as never,
-          experimental_onToolCallStart: experimental_onToolCallStart as never,
-          onRunStepFinish,
-          onRunToolCallFinish,
-          onRunToolCallStart,
-          onStepFinish,
+          onStepEnd,
+          onRunStepFinish: onRunStepFinish as never,
+          onRunToolCallFinish: onRunToolCallFinish as never,
+          onRunToolCallStart: onRunToolCallStart as never,
+          onToolExecutionEnd,
+          onToolExecutionStart,
         },
       },
       model: {} as never,
@@ -2419,22 +2419,26 @@ describe("defineAgent workspace option", () => {
     } as never)
 
     const settings = agentSettings.at(-1)!
-    await (settings.onStepFinish as (step: unknown) => Promise<void>)({ stepNumber: 1 })
-    await (settings.experimental_onToolCallStart as (event: unknown) => Promise<void>)({ toolName: "shell" })
-    await (settings.experimental_onToolCallFinish as (event: unknown) => Promise<void>)({ durationMs: 12, toolName: "shell" })
+    expect(settings).toMatchObject({
+      onStepEnd,
+      onToolExecutionEnd,
+      onToolExecutionStart,
+      runtimeContext: expect.objectContaining({
+        input: expect.objectContaining({ messages: [] }),
+        run: { runId: "run_123" },
+      }),
+    })
+    expect(settings).not.toHaveProperty("onRunStepFinish")
+    expect(settings).not.toHaveProperty("onRunToolCallFinish")
+    expect(settings).not.toHaveProperty("onRunToolCallStart")
+    await (settings.onStepEnd as (step: unknown) => Promise<void>)({ stepNumber: 1 })
+    await (settings.onToolExecutionStart as (event: unknown) => Promise<void>)({ toolName: "shell" })
+    await (settings.onToolExecutionEnd as (event: unknown) => Promise<void>)({ durationMs: 12, toolName: "shell" })
 
-    expect(onStepFinish).toHaveBeenCalledWith({ stepNumber: 1 })
-    expect(onRunStepFinish).toHaveBeenCalledWith({ stepNumber: 1 }, expect.objectContaining({
-      run: { runId: "run_123" },
-    }))
-    expect(experimental_onToolCallStart).toHaveBeenCalledWith({ toolName: "shell" })
-    expect(onRunToolCallStart).toHaveBeenCalledWith({ toolName: "shell" }, expect.objectContaining({
-      run: { runId: "run_123" },
-    }))
-    expect(experimental_onToolCallFinish).toHaveBeenCalledWith({ durationMs: 12, toolName: "shell" })
-    expect(onRunToolCallFinish).toHaveBeenCalledWith({ durationMs: 12, toolName: "shell" }, expect.objectContaining({
-      run: { runId: "run_123" },
-    }))
+    expect(onStepEnd).toHaveBeenCalledWith({ stepNumber: 1 })
+    expect(onToolExecutionStart).toHaveBeenCalledWith({ toolName: "shell" })
+    expect(onToolExecutionEnd).toHaveBeenCalledWith({ durationMs: 12, toolName: "shell" })
+    expect((settings.runtimeContext as { run?: unknown }).run).toEqual({ runId: "run_123" })
   })
 
   it("passes workspace to callback instructions", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -36,6 +36,7 @@ const useWorkspace = vi.fn<() => ReadonlyWorkspaceFacade | WritableWorkspaceFaca
 } as unknown as WritableWorkspaceFacade))
 const agentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
 const generateText = vi.hoisted(() => vi.fn())
+const jsonSchema = vi.hoisted(() => vi.fn(schema => ({ schema, type: "json-schema" })))
 const agentGenerate = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ finishReason: string, steps?: unknown[], text: string }>>(async () => ({ finishReason: "stop", text: "ok" })))
 const agentStream = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ fullStream: AsyncIterable<unknown> }>>(async () => ({
   fullStream: (async function* () {
@@ -59,7 +60,7 @@ const prepareHarnessWorkspaceSession = vi.fn()
 
 vi.mock("ai", () => ({
   generateText,
-  jsonSchema: vi.fn(schema => schema),
+  jsonSchema,
   isStepCount: vi.fn(count => ({ count })),
   ToolLoopAgent: class {
     constructor(public settings: Record<string, unknown>) {
@@ -174,6 +175,7 @@ describe("defineAgent workspace option", () => {
     })
     generateText.mockReset()
     generateText.mockResolvedValue({ text: "fallback answer" })
+    jsonSchema.mockClear()
     exists.mockReset()
     exists.mockResolvedValue(false)
     stat.mockReset()
@@ -2522,6 +2524,30 @@ describe("defineAgent workspace option", () => {
     expect(resolvedShell).toEqual(expect.objectContaining({ inputSchema: {} }))
     await resolvedShell?.execute({ command: "rg defineAgent" })
     expect(shell.execute).toHaveBeenCalledWith({ command: "rg defineAgent" })
+  })
+
+  it("wraps default tool input schemas with the AI SDK schema helper", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const search = { execute: vi.fn() }
+
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      model: {} as never,
+      capabilities: [{ id: "workspace-tools", tools: () => ({ search }) }],
+    }), { workspace: "docs" })
+
+    await agent.run!(context({ vertex: { model: "gemini" } }))
+
+    const schemaJson = {
+      additionalProperties: false,
+      properties: {},
+      type: "object",
+    }
+    expect(jsonSchema).toHaveBeenCalledWith(schemaJson)
+    expect((agentSettings.at(-1)?.tools as { search?: { inputSchema?: unknown } } | undefined)?.search?.inputSchema).toEqual({
+      schema: schemaJson,
+      type: "json-schema",
+    })
   })
 
   it("reports explicitly attached workspace tool usage when execution starts and finishes", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   ai:
     '@ai-sdk/harness':
-      specifier: 1.0.0-canary.9
-      version: 1.0.0-canary.9
+      specifier: 1.0.0
+      version: 1.0.0
     '@ai-sdk/harness-codex':
-      specifier: 1.0.0-canary.5
-      version: 1.0.0-canary.5
+      specifier: 1.0.0
+      version: 1.0.0
     '@ai-sdk/mcp':
-      specifier: 2.0.0-canary.65
-      version: 2.0.0-canary.65
+      specifier: 2.0.0
+      version: 2.0.0
     '@ai-sdk/sandbox-vercel':
-      specifier: 1.0.0-canary.9
-      version: 1.0.0-canary.9
+      specifier: 1.0.0
+      version: 1.0.0
     '@modelcontextprotocol/sdk':
       specifier: ^1.29.0
       version: 1.29.0
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^0.12.3
       version: 0.12.3
     ai:
-      specifier: 7.0.0-canary.173
-      version: 7.0.0-canary.173
+      specifier: 7.0.0
+      version: 7.0.0
     evalite:
       specifier: 1.0.0-beta.16
       version: 1.0.0-beta.16
@@ -321,7 +321,7 @@ importers:
         version: 0.2.0(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.4.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(crossws@0.4.5(srvx@0.11.15))(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))
       chat:
         specifier: catalog:chat
-        version: 4.29.0(ai@7.0.0-canary.173(zod@4.4.3))(zod@4.4.3)
+        version: 4.29.0(ai@7.0.0(zod@4.4.3))(zod@4.4.3)
       chat-state-cloudflare-do:
         specifier: catalog:chat
         version: 0.2.0(chat@4.29.0(zod@4.4.3))
@@ -372,7 +372,7 @@ importers:
         version: 14.3.0(vue@3.5.34(typescript@6.0.2))
       docus:
         specifier: catalog:nuxt
-        version: 5.11.0(84a95b12a3423511a81d057aa6db64d8)
+        version: 5.11.0(66e7467c0f946c8443dadc40c25a85ba)
       h3:
         specifier: catalog:h3-v1-compat
         version: 1.15.11
@@ -412,7 +412,7 @@ importers:
     dependencies:
       '@ai-sdk/harness-codex':
         specifier: catalog:ai
-        version: 1.0.0-canary.5
+        version: 1.0.0
       '@libsql/client':
         specifier: catalog:database
         version: 0.15.15
@@ -436,10 +436,10 @@ importers:
         version: 0.2.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@voidzero-dev/vite-plus-core@0.1.24)(crossws@0.4.5(srvx@0.11.15))(typescript@6.0.2)
       agents:
         specifier: catalog:ai
-        version: 0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(@voidzero-dev/vite-plus-core@0.1.24)(ai@7.0.0-canary.173(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(zod@4.4.3)
+        version: 0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(@voidzero-dev/vite-plus-core@0.1.24)(ai@7.0.0(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(zod@4.4.3)
       chat:
         specifier: catalog:chat
-        version: 4.29.0(ai@7.0.0-canary.173(zod@4.4.3))(zod@4.4.3)
+        version: 4.29.0(ai@7.0.0(zod@4.4.3))(zod@4.4.3)
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7
@@ -455,13 +455,13 @@ importers:
     devDependencies:
       '@ai-sdk/harness':
         specifier: catalog:ai
-        version: 1.0.0-canary.9(ws@8.20.1)(zod@4.4.3)
+        version: 1.0.0(ws@8.21.0)(zod@4.4.3)
       '@ai-sdk/mcp':
         specifier: catalog:ai
-        version: 2.0.0-canary.65(zod@4.4.3)
+        version: 2.0.0(zod@4.4.3)
       '@ai-sdk/sandbox-vercel':
         specifier: catalog:ai
-        version: 1.0.0-canary.9(ws@8.20.1)(zod@4.4.3)
+        version: 1.0.0(ws@8.21.0)(zod@4.4.3)
       '@types/node':
         specifier: catalog:tooling
         version: 24.13.2
@@ -473,10 +473,10 @@ importers:
         version: link:../workflow
       ai:
         specifier: catalog:ai
-        version: 7.0.0-canary.173(zod@4.4.3)
+        version: 7.0.0(zod@4.4.3)
       evalite:
         specifier: catalog:ai
-        version: 1.0.0-beta.16(ai@7.0.0-canary.173(zod@4.4.3))(better-sqlite3@12.9.0)
+        version: 1.0.0-beta.16(ai@7.0.0(zod@4.4.3))(better-sqlite3@12.9.0)
       publint:
         specifier: catalog:tooling
         version: 0.3.21
@@ -677,7 +677,7 @@ importers:
         version: 0.2.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@voidzero-dev/vite-plus-core@0.1.24)(crossws@0.4.5(srvx@0.11.15))(typescript@6.0.2)
       ai:
         specifier: catalog:ai
-        version: 7.0.0-canary.173(zod@4.4.3)
+        version: 7.0.0(zod@4.4.3)
       nuxt:
         specifier: catalog:nuxt
         version: 4.4.6(d09cb1cf5e2d8c177e0f3be952a262b3)
@@ -1177,10 +1177,10 @@ importers:
         version: link:../shell
       ai:
         specifier: catalog:ai
-        version: 7.0.0-canary.173(zod@4.4.3)
+        version: 7.0.0(zod@4.4.3)
       files-sdk:
         specifier: catalog:storage
-        version: 1.9.0(@aws-sdk/client-s3@3.1045.0)(@aws-sdk/s3-presigned-post@3.1045.0)(@aws-sdk/s3-request-presigner@3.1045.0)(@azure/core-auth@1.10.1)(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@cfworker/json-schema@4.1.1)(@google-cloud/storage@7.19.0)(@microsoft/microsoft-graph-client@3.0.7(@azure/identity@4.13.1))(@netlify/blobs@10.7.5)(@opentelemetry/api@1.9.0)(@supabase/storage-js@2.105.4)(@vercel/blob@2.4.0)(ai@7.0.0-canary.173(zod@4.4.3))(box-typescript-sdk-gen@1.19.1)(dropbox@10.34.0(@types/node-fetch@2.6.13))(google-auth-library@10.6.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(zod@4.4.3)
+        version: 1.9.0(@aws-sdk/client-s3@3.1045.0)(@aws-sdk/s3-presigned-post@3.1045.0)(@aws-sdk/s3-request-presigner@3.1045.0)(@azure/core-auth@1.10.1)(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@cfworker/json-schema@4.1.1)(@google-cloud/storage@7.19.0)(@microsoft/microsoft-graph-client@3.0.7(@azure/identity@4.13.1))(@netlify/blobs@10.7.5)(@opentelemetry/api@1.9.0)(@supabase/storage-js@2.105.4)(@vercel/blob@2.4.0)(ai@7.0.0(zod@4.4.3))(box-typescript-sdk-gen@1.19.1)(dropbox@10.34.0(@types/node-fetch@2.6.13))(google-auth-library@10.6.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(zod@4.4.3)
       h3:
         specifier: catalog:unjs
         version: 2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15))
@@ -1220,21 +1220,21 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@4.0.0-canary.105':
-    resolution: {integrity: sha512-RlN/+B+9+Fl+H0MPhJif37dWMjwa3spncFd8y/vWYSStVESBidtbLKyW44Zdfu6aFSaqUHHAmD7UCjP58C5qug==}
+  '@ai-sdk/gateway@4.0.0':
+    resolution: {integrity: sha512-rcKukspbM4h511ot2E8TsPl7rXjRK1zHKrMCP7w4+XF55UKqQHaDzo2kKbGv5rp8Bjb1yQatIHJZE1E2yrOOMw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/harness-codex@1.0.0-canary.5':
-    resolution: {integrity: sha512-402JkrZQxlS8JP9k2pETtcazRLW+55HL0sAxT3iTcA5ENC5ed7Y2crsBbdgB1fsanI9lFwBe5DPk5Yzd1YfRDQ==}
+  '@ai-sdk/harness-codex@1.0.0':
+    resolution: {integrity: sha512-nQ1LbFVq8FKiRTqecimmYobFPW9fEY3qcwCuduavBRZ60jtaPaICjJ3Abemf3X7hJgXR02beTs3CAeomBv/Avw==}
     engines: {node: '>=22'}
 
-  '@ai-sdk/harness@1.0.0-canary.9':
-    resolution: {integrity: sha512-4AJBN9KIdyv0TdT2q/ezuBwfo2/ZiJjgUvTXhHBWvJ+NDe1j0jqpxleUxBUOvHP7SYq299NgTkokTZNWMJCcUQ==}
+  '@ai-sdk/harness@1.0.0':
+    resolution: {integrity: sha512-XNAnCdw0nFt2qCzzdpDCDCMJStbTbQWUrpv1iy0MCrvZVBCRg7xrXNXEurakVaKuykac8JyxBzUS/s3QDIJP+g==}
     engines: {node: '>=22'}
     peerDependencies:
-      ws: ^8.20.1
+      ws: ^8.21.0
     peerDependenciesMeta:
       ws:
         optional: true
@@ -1245,8 +1245,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/mcp@2.0.0-canary.65':
-    resolution: {integrity: sha512-giyTeWVykKbgE/VDOlzoq6igW0MbIp60KfFTaxW/NYdmK1sb221Ozb1PaSYEn362tmDv1cnvyBSsXhXahrYzkA==}
+  '@ai-sdk/mcp@2.0.0':
+    resolution: {integrity: sha512-+N6gJ1AbcDk3+6asoEsdIojVmgEReKNcvWIT716pDL3AepGI6j7RJVdaRyhQLltwzTj0arwpwU4BBzvhOiCd/g==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1263,8 +1263,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@5.0.0-canary.48':
-    resolution: {integrity: sha512-340rMqAnqHDZOKS9ayrRbNr0/Om+orcopAnqJ7ftfEskxDUCTcudmhAhctFMSQeMzDnKaBPgz+4iff/hn7PkqQ==}
+  '@ai-sdk/provider-utils@5.0.0':
+    resolution: {integrity: sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1277,12 +1277,12 @@ packages:
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@4.0.0-canary.18':
-    resolution: {integrity: sha512-+XBwXEPkN+l/90bb7TaSK15jAq9ScsGrauJ/NLSGip0KX5Mf1pfEfqBWDuJMIYVRYHNdV1dDBy7JCoKUCQe/tA==}
+  '@ai-sdk/provider@4.0.0':
+    resolution: {integrity: sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==}
     engines: {node: '>=22'}
 
-  '@ai-sdk/sandbox-vercel@1.0.0-canary.9':
-    resolution: {integrity: sha512-WKhor+RTsvhK7zPOlrGA/mLf8ogMYKdvdpVz79zkbWvocF95XqBwAsNlZjG3v7dUS9/BoCbu/TSjbpZqLO+lqw==}
+  '@ai-sdk/sandbox-vercel@1.0.0':
+    resolution: {integrity: sha512-H/8IFbvjZzIu50CHkG3Jo6nG08mc+3cbkjlDp03xI3iYRvZJc5gAmC2PCOuTrLhIX5EUoQRZnLFpxJPg8lAn5g==}
     engines: {node: '>=22'}
 
   '@ai-sdk/vue@3.0.168':
@@ -7127,8 +7127,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  ai@7.0.0-canary.173:
-    resolution: {integrity: sha512-ehK+jSMvXx0sHNDDqIaK/vWAxo7DkQnZ/lEmnj+Q7WlC3NioRfC1L9jxvElRUQgDNU376Q275r7vjOV1EIejtw==}
+  ai@7.0.0:
+    resolution: {integrity: sha512-hncs+jamJh8r36K6G8xky7oF4Ai/RLU5TF85FMzI2vElyMJGGnLoHihpdmuDiuY2BsktDWHevKaJM1l0VcRLGw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -12720,6 +12720,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
@@ -12853,47 +12865,47 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/gateway@4.0.0-canary.105(zod@3.25.76)':
+  '@ai-sdk/gateway@4.0.0(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@3.25.76)
       '@vercel/oidc': 3.2.0
       zod: 3.25.76
 
-  '@ai-sdk/gateway@4.0.0-canary.105(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/harness-codex@1.0.0-canary.5':
+  '@ai-sdk/harness-codex@1.0.0':
     dependencies:
-      '@ai-sdk/harness': 1.0.0-canary.9(ws@8.20.1)(zod@3.25.76)
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@3.25.76)
-      ws: 8.20.1
+      '@ai-sdk/harness': 1.0.0(ws@8.21.0)(zod@3.25.76)
+      '@ai-sdk/provider-utils': 5.0.0(zod@3.25.76)
+      ws: 8.21.0
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@ai-sdk/harness@1.0.0-canary.9(ws@8.20.1)(zod@3.25.76)':
+  '@ai-sdk/harness@1.0.0(ws@8.21.0)(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@3.25.76)
-      ai: 7.0.0-canary.173(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@3.25.76)
+      ai: 7.0.0(zod@3.25.76)
     optionalDependencies:
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/harness@1.0.0-canary.9(ws@8.20.1)(zod@4.4.3)':
+  '@ai-sdk/harness@1.0.0(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@4.4.3)
-      ai: 7.0.0-canary.173(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
+      ai: 7.0.0(zod@4.4.3)
     optionalDependencies:
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - zod
 
@@ -12904,10 +12916,10 @@ snapshots:
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
-  '@ai-sdk/mcp@2.0.0-canary.65(zod@4.4.3)':
+  '@ai-sdk/mcp@2.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
@@ -12925,17 +12937,17 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@5.0.0-canary.48(zod@3.25.76)':
+  '@ai-sdk/provider-utils@5.0.0(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-canary.18
+      '@ai-sdk/provider': 4.0.0
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.0.8
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@5.0.0-canary.48(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-canary.18
+      '@ai-sdk/provider': 4.0.0
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.0.8
@@ -12949,14 +12961,14 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@4.0.0-canary.18':
+  '@ai-sdk/provider@4.0.0':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/sandbox-vercel@1.0.0-canary.9(ws@8.20.1)(zod@4.4.3)':
+  '@ai-sdk/sandbox-vercel@1.0.0(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/harness': 1.0.0-canary.9(ws@8.20.1)(zod@4.4.3)
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@4.4.3)
+      '@ai-sdk/harness': 1.0.0(ws@8.21.0)(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       '@vercel/sandbox': 2.2.1
     transitivePeerDependencies:
       - bare-abort-controller
@@ -16192,7 +16204,7 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/mcp-toolkit@0.13.4(@cfworker/json-schema@4.1.1)(agents@0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(ai@7.0.0-canary.173(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(vite@8.0.16)(zod@4.4.3))(h3@1.15.11)(magicast@0.5.3)(zod@4.4.3)':
+  '@nuxtjs/mcp-toolkit@0.13.4(@cfworker/json-schema@4.1.1)(agents@0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(ai@7.0.0(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(vite@8.0.16)(zod@4.4.3))(h3@1.15.11)(magicast@0.5.3)(zod@4.4.3)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
@@ -16200,7 +16212,7 @@ snapshots:
       tinyglobby: 0.2.16
       zod: 4.4.3
     optionalDependencies:
-      agents: 0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(ai@7.0.0-canary.173(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(vite@8.0.16)(zod@4.4.3)
+      agents: 0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(ai@7.0.0(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(vite@8.0.16)(zod@4.4.3)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - magicast
@@ -20231,13 +20243,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agents@0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(@voidzero-dev/vite-plus-core@0.1.24)(ai@7.0.0-canary.173(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(zod@4.4.3):
+  agents@0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(@voidzero-dev/vite-plus-core@0.1.24)(ai@7.0.0(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(zod@4.4.3):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@voidzero-dev/vite-plus-core@0.1.24)(rolldown@1.0.3)
-      ai: 7.0.0-canary.173(zod@4.4.3)
+      ai: 7.0.0(zod@4.4.3)
       cron-schedule: 6.0.0
       mimetext: 3.0.28
       nanoid: 5.1.11
@@ -20257,13 +20269,13 @@ snapshots:
       - rolldown
       - supports-color
 
-  agents@0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(ai@7.0.0-canary.173(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(vite@8.0.16)(zod@4.4.3):
+  agents@0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(ai@7.0.0(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(vite@8.0.16)(zod@4.4.3):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16)
-      ai: 7.0.0-canary.173(zod@4.4.3)
+      ai: 7.0.0(zod@4.4.3)
       cron-schedule: 6.0.0
       mimetext: 3.0.28
       nanoid: 5.1.11
@@ -20301,18 +20313,18 @@ snapshots:
       zod: 4.4.3
     optional: true
 
-  ai@7.0.0-canary.173(zod@3.25.76):
+  ai@7.0.0(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 4.0.0-canary.105(zod@3.25.76)
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@3.25.76)
+      '@ai-sdk/gateway': 4.0.0(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@3.25.76)
       zod: 3.25.76
 
-  ai@7.0.0-canary.173(zod@4.4.3):
+  ai@7.0.0(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 4.0.0-canary.105(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@4.4.3)
+      '@ai-sdk/gateway': 4.0.0(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.18.0):
@@ -20790,9 +20802,9 @@ snapshots:
 
   chat-state-cloudflare-do@0.2.0(chat@4.29.0(zod@4.4.3)):
     dependencies:
-      chat: 4.29.0(ai@7.0.0-canary.173(zod@4.4.3))(zod@4.4.3)
+      chat: 4.29.0(ai@7.0.0(zod@4.4.3))(zod@4.4.3)
 
-  chat@4.29.0(ai@7.0.0-canary.173(zod@4.4.3))(zod@4.4.3):
+  chat@4.29.0(ai@7.0.0(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -20802,7 +20814,7 @@ snapshots:
       remend: 1.3.0
       unified: 11.0.5
     optionalDependencies:
-      ai: 7.0.0-canary.173(zod@4.4.3)
+      ai: 7.0.0(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -21214,7 +21226,7 @@ snapshots:
 
   diff@9.0.0: {}
 
-  docus@5.11.0(84a95b12a3423511a81d057aa6db64d8):
+  docus@5.11.0(66e7467c0f946c8443dadc40c25a85ba):
     dependencies:
       '@ai-sdk/gateway': 3.0.109(zod@4.4.3)
       '@ai-sdk/mcp': 1.0.36(zod@4.4.3)
@@ -21227,7 +21239,7 @@ snapshots:
       '@nuxt/kit': 4.4.6(magicast@0.5.3)
       '@nuxt/ui': 4.8.1(462f46c54bfb4b176091c6797dfb7d5e)
       '@nuxtjs/i18n': 10.2.4(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@netlify/blobs@10.7.5)(@upstash/redis@1.37.0)(@vercel/blob@2.4.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@vue/compiler-dom@3.5.34)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(eslint@10.2.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(rollup@4.60.4)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.0))(vite@8.0.16)(vue@3.5.34(typescript@6.0.2))
-      '@nuxtjs/mcp-toolkit': 0.13.4(@cfworker/json-schema@4.1.1)(agents@0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(ai@7.0.0-canary.173(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(vite@8.0.16)(zod@4.4.3))(h3@1.15.11)(magicast@0.5.3)(zod@4.4.3)
+      '@nuxtjs/mcp-toolkit': 0.13.4(@cfworker/json-schema@4.1.1)(agents@0.12.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260509.1)(@tanstack/ai@0.16.0(@opentelemetry/api@1.9.0))(ai@7.0.0(zod@4.4.3))(react@19.2.6)(rolldown@1.0.3)(vite@8.0.16)(zod@4.4.3))(h3@1.15.11)(magicast@0.5.3)(zod@4.4.3)
       '@nuxtjs/mdc': 0.21.1(magicast@0.5.3)
       '@nuxtjs/robots': 6.0.7(@nuxt/schema@4.4.6)(magicast@0.5.3)(nuxt@4.4.6(b4c61b027feba81b91144b342001e71c))(vite@8.0.16)(vue@3.5.34(typescript@6.0.2))(zod@4.4.3)
       '@shikijs/core': 4.0.2
@@ -21789,7 +21801,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  evalite@1.0.0-beta.16(ai@7.0.0-canary.173(zod@4.4.3))(better-sqlite3@12.9.0):
+  evalite@1.0.0-beta.16(ai@7.0.0(zod@4.4.3))(better-sqlite3@12.9.0):
     dependencies:
       '@fastify/static': 8.3.0
       '@fastify/websocket': 11.2.0
@@ -21806,7 +21818,7 @@ snapshots:
       table: 6.9.0
       tinyrainbow: 3.1.0
     optionalDependencies:
-      ai: 7.0.0-canary.173(zod@4.4.3)
+      ai: 7.0.0(zod@4.4.3)
       better-sqlite3: 12.9.0
     transitivePeerDependencies:
       - bufferutil
@@ -22124,7 +22136,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  files-sdk@1.9.0(@aws-sdk/client-s3@3.1045.0)(@aws-sdk/s3-presigned-post@3.1045.0)(@aws-sdk/s3-request-presigner@3.1045.0)(@azure/core-auth@1.10.1)(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@cfworker/json-schema@4.1.1)(@google-cloud/storage@7.19.0)(@microsoft/microsoft-graph-client@3.0.7(@azure/identity@4.13.1))(@netlify/blobs@10.7.5)(@opentelemetry/api@1.9.0)(@supabase/storage-js@2.105.4)(@vercel/blob@2.4.0)(ai@7.0.0-canary.173(zod@4.4.3))(box-typescript-sdk-gen@1.19.1)(dropbox@10.34.0(@types/node-fetch@2.6.13))(google-auth-library@10.6.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(zod@4.4.3):
+  files-sdk@1.9.0(@aws-sdk/client-s3@3.1045.0)(@aws-sdk/s3-presigned-post@3.1045.0)(@aws-sdk/s3-request-presigner@3.1045.0)(@azure/core-auth@1.10.1)(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@cfworker/json-schema@4.1.1)(@google-cloud/storage@7.19.0)(@microsoft/microsoft-graph-client@3.0.7(@azure/identity@4.13.1))(@netlify/blobs@10.7.5)(@opentelemetry/api@1.9.0)(@supabase/storage-js@2.105.4)(@vercel/blob@2.4.0)(ai@7.0.0(zod@4.4.3))(box-typescript-sdk-gen@1.19.1)(dropbox@10.34.0(@types/node-fetch@2.6.13))(google-auth-library@10.6.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.20(patch_hash=7812192e785dc10115ae824c439aaf9af8f974543b7024005fcdb03470f81600)(crossws@0.4.5(srvx@0.11.15)))(tailwindcss@4.3.0))(zod@4.4.3):
     dependencies:
       commander: 15.0.0
       picomatch: 4.0.4
@@ -22142,7 +22154,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@supabase/storage-js': 2.105.4
       '@vercel/blob': 2.4.0
-      ai: 7.0.0-canary.173(zod@4.4.3)
+      ai: 7.0.0(zod@4.4.3)
       box-typescript-sdk-gen: 1.19.1
       dropbox: 10.34.0(@types/node-fetch@2.6.13)
       google-auth-library: 10.6.2
@@ -28203,6 +28215,8 @@ snapshots:
   ws@8.18.3: {}
 
   ws@8.20.1: {}
+
+  ws@8.21.0: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,16 +6,16 @@ catalogMode: prefer
 
 catalogs:
   ai:
-    "@ai-sdk/harness": 1.0.0-canary.9
-    "@ai-sdk/harness-codex": 1.0.0-canary.5
-    "@ai-sdk/mcp": 2.0.0-canary.65
-    "@ai-sdk/sandbox-vercel": 1.0.0-canary.9
+    "@ai-sdk/harness": 1.0.0
+    "@ai-sdk/harness-codex": 1.0.0
+    "@ai-sdk/mcp": 2.0.0
+    "@ai-sdk/sandbox-vercel": 1.0.0
     "@modelcontextprotocol/sdk": ^1.29.0
     agents: ^0.12.3
-    ai: 7.0.0-canary.173
+    ai: 7.0.0
     evalite: 1.0.0-beta.16
   ai-compat:
-    ai: ^6.0.0 || ^7.0.0-0
+    ai: ^7.0.0
   auth:
     better-auth: ^1.6.18
   chat:

--- a/test/run-package-task.mjs
+++ b/test/run-package-task.mjs
@@ -64,7 +64,18 @@ for (const pkg of orderedPackages) {
   }
 
   console.log(`\n[${task}] ${pkg.name}`);
-  const result = spawnSync("vp", ["run", "--filter", pkg.name, "--ignore-depends-on", task], {
+  if (task === "test" && pkg.manifest.scripts?.build) {
+    run("vp", ["run", "--filter", pkg.name, "--ignore-depends-on", "build"]);
+    run("vp", ["test"], { cwd: pkg.dir });
+  }
+  else {
+    run("vp", ["run", "--filter", pkg.name, "--ignore-depends-on", task]);
+  }
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
     env: process.env,
     stdio: "inherit",
   });

--- a/test/run-package-task.mjs
+++ b/test/run-package-task.mjs
@@ -64,7 +64,8 @@ for (const pkg of orderedPackages) {
   }
 
   console.log(`\n[${task}] ${pkg.name}`);
-  if (task === "test" && pkg.manifest.scripts?.build) {
+  const standardTestScript = `vp run -t ${pkg.name}#build && vp test`;
+  if (task === "test" && pkg.manifest.scripts?.build && pkg.manifest.scripts.test === standardTestScript) {
     run("vp", ["run", "--filter", pkg.name, "--ignore-depends-on", "build"]);
     run("vp", ["test"], { cwd: pkg.dir });
   }


### PR DESCRIPTION
Pins the AI SDK catalog to stable v7 packages and narrows the agent peer range to AI SDK v7.

Updates the model-backed Agent runtime to the stable v7 surface: native runtimeContext, telemetry, isStepCount, onStepEnd, onToolExecutionStart/End, stream-first output handling, and stable transcribe. The ViteHub-only run-aware callback shim is removed in favor of AI SDK runtimeContext.

Keeps AI SDK optional at the package boundary. Model-backed drivers and AI SDK-powered capabilities lazy-load `ai`, so custom `run()` agents and generated host route bundles can still build without installing AI SDK.

Hardens the root package test runner so the full workspace `vp run test` path builds each package once in topological order, then runs package tests directly. This avoids nested dependency-pack fanout and the intermittent CI pack cleanup failure seen while refining this PR.

Adds an ADR documenting the v7 adoption and why runAgentTUI is useful reference material but not adopted for the current server-backed Agent Dev Loop.
