### PR TITLE
feat(agent): add openapi capability tools

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -131,6 +131,10 @@ openapi({
     body: { cubeToken: context.get<{ cubeToken: string }>("portal")?.cubeToken },
   }),
   input: { omit: { body: ["cubeToken"] } },
+  transformResponse: (response, { operation }) => ({
+    operationId: operation.id,
+    response,
+  }),
 })
 ```
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -110,11 +110,29 @@ export default defineConfig({
 - `chat()` exposes the agent as a chat surface; see the [AI agent tutorial](https://vitehub.dev/docs/tutorials/build-ai-chatbot).
 - `workspaceShell()` runs scoped shell/file work through [`@vite-hub/shell`](../shell/README.md).
 - `webSearch()` searches and reads the web with [Brave](https://brave.com/search/api/), [Exa](https://docs.exa.ai/), [Jina](https://jina.ai/en-US/reader/), [SearXNG](https://docs.searxng.org/dev/search_api.html), [SerpApi](https://serpapi.com/search-api), [SerpBase](https://serpbase.dev/docs), or [Tavily](https://docs.tavily.com/).
+- `openapi()` turns an allowed OpenAPI `operationId` subset into bounded HTTP tools.
 - `transcribe()` uses the [AI SDK transcription API](https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/transcribe).
 - `mcp()` connects tools from [Model Context Protocol](https://modelcontextprotocol.io/) servers through `@ai-sdk/mcp`.
 - `kv()`, `blob()`, and `db()` expose [`@vite-hub/kv`](../kv/README.md), [`@vite-hub/blob`](../blob/README.md), and [`@vite-hub/database`](../database/README.md).
 - `sandbox()` and `schedule()` expose [`@vite-hub/sandbox`](../sandbox/README.md) and [`@vite-hub/schedule`](../schedule/README.md).
 - `skills()`, `access()`, `memory()`, `fetch()`, `llmRoute()`, `llmGate()`, and `usageTelemetry()` cover prompt skills, workspace scope, durable notes, HTTP reads, pre-run decisions, and usage reporting.
+
+```ts
+import { openapi } from "@vite-hub/agent/capabilities"
+
+openapi({
+  spec: "https://api.example.com/openapi.json",
+  operations: { allow: ["listCustomers", "getInvoice", "createTicket"] },
+  enabled: ({ actor }) => actor.kind === "portal",
+  headers: async ({ context }) => ({
+    authorization: `Bearer ${context.get<{ token: string }>("portal")?.token}`,
+  }),
+  defaults: async ({ context }) => ({
+    body: { cubeToken: context.get<{ cubeToken: string }>("portal")?.cubeToken },
+  }),
+  input: { omit: { body: ["cubeToken"] } },
+})
+```
 
 ## Chat state
 

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -37,6 +37,9 @@ export {
   observability,
 } from "./observability.ts"
 export {
+  openapi,
+} from "./openapi.ts"
+export {
   repositoryHost,
 } from "./repository-host.ts"
 export {
@@ -220,6 +223,12 @@ export type {
   AgentObservabilityStartEvent,
   AgentObservabilityStatus,
 } from "./observability.ts"
+export type {
+  OpenAPICapabilityOptions,
+  OpenAPIInputOptions,
+  OpenAPIRequestContext,
+  OpenAPIRequestDefaults,
+} from "./openapi.ts"
 export type {
   RepositoryHostClient,
   RepositoryHostOptions,

--- a/packages/agent/src/capabilities/openapi.ts
+++ b/packages/agent/src/capabilities/openapi.ts
@@ -1,0 +1,525 @@
+import { executeHttpRequest } from "@vite-hub/internal/http-request"
+import { defineCapability } from "../capability-runtime.ts"
+import { defineInternalTool } from "./internal.ts"
+
+import type {
+  AgentCapabilityContext,
+  AgentCapabilityDefinition,
+  AgentRuntimeConfig,
+  AgentToolDefinition,
+  AgentToolSet,
+  MaybePromise,
+} from "../types.ts"
+import type { WorkspaceName } from "@vite-hub/workspace"
+
+type JsonSchema = Record<string, unknown>
+type OpenAPIMethod = "GET" | "HEAD" | "POST"
+type OpenAPIPathMethod = "get" | "head" | "post" | "put" | "patch" | "delete" | "options" | "trace"
+type OpenAPIHeaders = Record<string, string>
+
+interface OpenAPIDocument {
+  components?: Record<string, unknown>
+  paths?: Record<string, OpenAPIPathItem>
+  servers?: Array<{ url?: string }>
+}
+
+interface OpenAPIPathItem extends Record<string, unknown> {
+  parameters?: OpenAPIParameter[]
+}
+
+interface OpenAPIOperation {
+  description?: string
+  operationId?: string
+  parameters?: OpenAPIParameter[]
+  requestBody?: OpenAPIRequestBody | OpenAPIReference
+  summary?: string
+}
+
+interface OpenAPIParameter {
+  description?: string
+  in?: string
+  name?: string
+  required?: boolean
+  schema?: JsonSchema | OpenAPIReference
+}
+
+interface OpenAPIRequestBody {
+  content?: Record<string, { schema?: JsonSchema | OpenAPIReference }>
+}
+
+interface OpenAPIReference {
+  $ref: string
+}
+
+interface OpenAPIOperationTool {
+  bodySchema?: JsonSchema
+  description: string
+  method: OpenAPIMethod
+  operationId: string
+  path: string
+  pathParameters: OpenAPIParameter[]
+  queryParameters: OpenAPIParameter[]
+}
+
+interface OpenAPIToolInput {
+  body?: unknown
+  path?: Record<string, unknown>
+  query?: Record<string, unknown>
+}
+
+export interface OpenAPIRequestContext<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> extends AgentCapabilityContext<TRuntimeConfig, Name> {
+  input: OpenAPIToolInput
+  operation: {
+    id: string
+    method: OpenAPIMethod
+    path: string
+  }
+}
+
+export interface OpenAPIRequestDefaults {
+  body?: unknown
+  path?: Record<string, unknown>
+  query?: Record<string, unknown>
+}
+
+export interface OpenAPIInputOptions {
+  omit?: {
+    body?: readonly string[]
+    path?: readonly string[]
+    query?: readonly string[]
+  }
+}
+
+export interface OpenAPICapabilityOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> {
+  baseUrl?: string | URL
+  defaults?: OpenAPIRequestDefaults | ((context: OpenAPIRequestContext<TRuntimeConfig, Name>) => MaybePromise<OpenAPIRequestDefaults | undefined>)
+  description?: string
+  enabled?: boolean | ((context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<boolean>)
+  headers?: OpenAPIHeaders | ((context: OpenAPIRequestContext<TRuntimeConfig, Name>) => MaybePromise<OpenAPIHeaders | undefined>)
+  input?: OpenAPIInputOptions
+  operations: {
+    allow: readonly string[]
+    exclude?: readonly string[]
+  }
+  responseType?: "json" | "text"
+  spec: string | URL | OpenAPIDocument
+  specHeaders?: OpenAPIHeaders
+  timeout?: number
+}
+
+const pathMethods = new Set<OpenAPIPathMethod>(["get", "head", "post", "put", "patch", "delete", "options", "trace"])
+const supportedMethods = new Set(["GET", "HEAD", "POST"])
+
+export function openapi<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+>(options: OpenAPICapabilityOptions<TRuntimeConfig, Name>): AgentCapabilityDefinition<TRuntimeConfig, Name> {
+  assertOpenAPIOptions(options)
+  let operations: Promise<{ baseUrl: URL, tools: OpenAPIOperationTool[] }> | undefined
+
+  return defineCapability({
+    id: "openapi",
+    metadata: {
+      operations: [...options.operations.allow],
+      spec: typeof options.spec === "object" && !(options.spec instanceof URL) ? "inline" : String(options.spec),
+    },
+    async tools(context) {
+      if (!await isOpenAPIEnabled(options, context)) return undefined
+      operations ||= loadOpenAPIOperations(options)
+      const resolved = await operations
+      return Object.fromEntries(resolved.tools.map(operation => [
+        operation.operationId,
+        createOpenAPITool(operation, resolved.baseUrl, options, context),
+      ])) as AgentToolSet
+    },
+  })
+}
+
+async function isOpenAPIEnabled<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: OpenAPICapabilityOptions<TRuntimeConfig, Name>,
+  context: AgentCapabilityContext<TRuntimeConfig, Name>,
+): Promise<boolean> {
+  if (options.enabled === undefined) return true
+  return typeof options.enabled === "function" ? await options.enabled(context) : options.enabled
+}
+
+function assertOpenAPIOptions(options: OpenAPICapabilityOptions): void {
+  if (!options || typeof options !== "object") throw new TypeError("[vitehub] openapi() requires options.")
+  if (!options.spec) throw new TypeError("[vitehub] openapi({ spec }) requires an OpenAPI document URL or object.")
+  if (!Array.isArray(options.operations?.allow) || !options.operations.allow.length) {
+    throw new TypeError("[vitehub] openapi({ operations: { allow } }) requires at least one allowed operationId.")
+  }
+}
+
+async function loadOpenAPIOperations(options: OpenAPICapabilityOptions): Promise<{ baseUrl: URL, tools: OpenAPIOperationTool[] }> {
+  const { document, specUrl } = await loadOpenAPIDocument(options)
+  const baseUrl = resolveBaseUrl(options.baseUrl, document, specUrl)
+  const allowed = new Set(options.operations.allow)
+  const allOperations = collectOperations(document, allowed)
+  const excluded = new Set(options.operations.exclude || [])
+  const selected = options.operations.allow
+    .filter(operationId => !excluded.has(operationId))
+    .map((operationId) => {
+      const operation = allOperations.get(operationId)
+      if (!operation) throw new Error(`[vitehub] openapi() operationId "${operationId}" was not found in the OpenAPI spec.`)
+      return operation
+    })
+  if (!selected.length) throw new Error("[vitehub] openapi() operation filters removed every operation.")
+  return { baseUrl, tools: selected }
+}
+
+async function loadOpenAPIDocument(options: OpenAPICapabilityOptions): Promise<{ document: OpenAPIDocument, specUrl?: URL }> {
+  if (typeof options.spec === "object" && !(options.spec instanceof URL)) {
+    return { document: options.spec }
+  }
+  const specUrl = options.spec instanceof URL ? options.spec : new URL(options.spec)
+  const result = await executeHttpRequest({
+    headers: options.specHeaders,
+    timeout: options.timeout,
+    url: specUrl,
+  })
+  if (!result.data || typeof result.data !== "object") {
+    throw new Error("[vitehub] openapi() spec must be a JSON OpenAPI document.")
+  }
+  return { document: result.data as OpenAPIDocument, specUrl }
+}
+
+function resolveBaseUrl(baseUrl: string | URL | undefined, document: OpenAPIDocument, specUrl: URL | undefined): URL {
+  const value = baseUrl ?? document.servers?.[0]?.url ?? (specUrl ? specUrl.origin : undefined)
+  if (!value) throw new Error("[vitehub] openapi() requires baseUrl when the spec does not declare servers[0].url.")
+  return value instanceof URL ? new URL(value) : new URL(value, specUrl)
+}
+
+function collectOperations(document: OpenAPIDocument, allowed: Set<string>): Map<string, OpenAPIOperationTool> {
+  const result = new Map<string, OpenAPIOperationTool>()
+  for (const [path, pathItem] of Object.entries(document.paths || {})) {
+    for (const [methodName, value] of Object.entries(pathItem)) {
+      if (!pathMethods.has(methodName as OpenAPIPathMethod)) continue
+      const operation = dereference(document, value) as OpenAPIOperation
+      if (!operation?.operationId) continue
+      assertToolName(operation.operationId)
+      const method = methodName.toUpperCase()
+      if (!supportedMethods.has(method) && allowed.has(operation.operationId)) {
+        throw new Error(`[vitehub] openapi() operation "${operation.operationId}" uses ${method}; v1 supports GET, HEAD, and POST.`)
+      }
+      if (!supportedMethods.has(method)) continue
+      if (result.has(operation.operationId)) {
+        throw new Error(`[vitehub] Duplicate OpenAPI operationId "${operation.operationId}".`)
+      }
+      result.set(operation.operationId, {
+        bodySchema: requestBodySchema(document, operation),
+        description: operationDescription(operation),
+        method: method as OpenAPIMethod,
+        operationId: operation.operationId,
+        path,
+        pathParameters: operationParameters(document, pathItem, operation, "path"),
+        queryParameters: operationParameters(document, pathItem, operation, "query"),
+      })
+    }
+  }
+  return result
+}
+
+function assertToolName(operationId: string): void {
+  if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(operationId)) {
+    throw new TypeError(`[vitehub] OpenAPI operationId "${operationId}" must be usable as a tool name: letters, numbers, and underscores only.`)
+  }
+}
+
+function operationDescription(operation: OpenAPIOperation): string {
+  return [operation.summary, operation.description].filter(Boolean).join(" ") || `Call ${operation.operationId}.`
+}
+
+function operationParameters(document: OpenAPIDocument, pathItem: OpenAPIPathItem, operation: OpenAPIOperation, location: "path" | "query"): OpenAPIParameter[] {
+  const params = new Map<string, OpenAPIParameter>()
+  for (const raw of [...(pathItem.parameters || []), ...(operation.parameters || [])]) {
+    const parameter = dereference(document, raw) as OpenAPIParameter
+    if (parameter.in === location && parameter.name) params.set(parameter.name, {
+      ...parameter,
+      schema: dereference(document, parameter.schema || { type: "string" }) as JsonSchema,
+    })
+  }
+  return [...params.values()]
+}
+
+function requestBodySchema(document: OpenAPIDocument, operation: OpenAPIOperation): JsonSchema | undefined {
+  const body = dereference(document, operation.requestBody) as OpenAPIRequestBody | undefined
+  const content = body?.content
+  if (!content) return undefined
+  const entry = content["application/json"] || Object.entries(content).find(([type]) => type.endsWith("+json"))?.[1]
+  return entry?.schema ? dereference(document, entry.schema) as JsonSchema : undefined
+}
+
+function createOpenAPITool<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  operation: OpenAPIOperationTool,
+  baseUrl: URL,
+  options: OpenAPICapabilityOptions<TRuntimeConfig, Name>,
+  context: AgentCapabilityContext<TRuntimeConfig, Name>,
+): AgentToolDefinition {
+  return defineInternalTool({
+    description: [options.description, operation.description].filter(Boolean).join(" "),
+    async execute(input) {
+      const rawInput = normalizeRawToolInput(operation, input)
+      const rawUrl = operationTemplateUrl(baseUrl, operation.path)
+      const requestInput = normalizeToolInput(operation, mergeToolInput(
+        await resolveDefaults(options, context, operation, rawInput, rawUrl),
+        rawInput,
+      ))
+      const url = operationUrl(baseUrl, operation, requestInput.path)
+      const headers = await resolveHeaders(options, context, operation, requestInput, url)
+      const result = await executeHttpRequest({
+        body: requestInput.body,
+        headers,
+        method: operation.method,
+        query: requestInput.query,
+        timeout: options.timeout,
+        url,
+      }, {
+        responseType: options.responseType || "json",
+      })
+      return result.data
+    },
+    inputSchema: operationInputSchema(operation, options.input),
+    metadata: {
+      openapi: {
+        method: operation.method,
+        operationId: operation.operationId,
+        path: operation.path,
+      },
+    },
+    name: operation.operationId,
+  })
+}
+
+function normalizeRawToolInput(operation: OpenAPIOperationTool, input: unknown): OpenAPIToolInput {
+  const value = input == null ? {} : input
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`[vitehub] ${operation.operationId} input must be an object.`)
+  }
+  const record = value as Record<string, unknown>
+  const allowedTopLevel = new Set(["path", "query", "body"])
+  const extra = Object.keys(record).filter(key => !allowedTopLevel.has(key))
+  if (extra.length) throw new Error(`[vitehub] ${operation.operationId} does not support input option${extra.length === 1 ? "" : "s"}: ${extra.join(", ")}.`)
+  if (record.path !== undefined && !isPlainRecord(record.path)) {
+    throw new TypeError(`[vitehub] ${operation.operationId} path input must be an object.`)
+  }
+  if (record.query !== undefined && !isPlainRecord(record.query)) {
+    throw new TypeError(`[vitehub] ${operation.operationId} query input must be an object.`)
+  }
+  if (!operation.bodySchema && record.body !== undefined) {
+    throw new Error(`[vitehub] ${operation.operationId} does not declare a request body.`)
+  }
+  return {
+    ...(record.body !== undefined ? { body: record.body } : {}),
+    ...(record.path ? { path: record.path as Record<string, unknown> } : {}),
+    ...(record.query ? { query: record.query as Record<string, unknown> } : {}),
+  }
+}
+
+function normalizeToolInput(operation: OpenAPIOperationTool, input: OpenAPIToolInput): OpenAPIToolInput {
+  const path = normalizeParameterInput(operation.operationId, "path", operation.pathParameters, input.path)
+  const query = normalizeParameterInput(operation.operationId, "query", operation.queryParameters, input.query)
+  if (!operation.bodySchema && input.body !== undefined) {
+    throw new Error(`[vitehub] ${operation.operationId} does not declare a request body.`)
+  }
+  return {
+    ...(input.body !== undefined ? { body: input.body } : {}),
+    ...(path ? { path } : {}),
+    ...(query ? { query } : {}),
+  }
+}
+
+async function resolveDefaults<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: OpenAPICapabilityOptions<TRuntimeConfig, Name>,
+  context: AgentCapabilityContext<TRuntimeConfig, Name>,
+  operation: OpenAPIOperationTool,
+  input: OpenAPIToolInput,
+  url: URL,
+): Promise<OpenAPIRequestDefaults | undefined> {
+  if (typeof options.defaults === "function") {
+    return await options.defaults({
+      ...context,
+      input,
+      operation: {
+        id: operation.operationId,
+        method: operation.method,
+        path: `${url.origin}${url.pathname}`,
+      },
+    })
+  }
+  return options.defaults
+}
+
+function mergeToolInput(defaults: OpenAPIRequestDefaults | undefined, input: OpenAPIToolInput): OpenAPIToolInput {
+  if (!defaults) return input
+  return {
+    body: mergeBody(defaults.body, input.body),
+    path: { ...defaults.path, ...input.path },
+    query: { ...defaults.query, ...input.query },
+  }
+}
+
+function mergeBody(defaultBody: unknown, inputBody: unknown): unknown {
+  if (inputBody === undefined) return defaultBody
+  if (isPlainRecord(defaultBody) && isPlainRecord(inputBody)) return { ...defaultBody, ...inputBody }
+  return inputBody
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+function normalizeParameterInput(operationId: string, location: "path" | "query", parameters: OpenAPIParameter[], input: unknown): Record<string, unknown> | undefined {
+  const required = parameters.filter(parameter => location === "path" || parameter.required).map(parameter => parameter.name as string)
+  if (input === undefined) {
+    if (required.length) throw new Error(`[vitehub] ${operationId} requires ${location} parameter${required.length === 1 ? "" : "s"}: ${required.join(", ")}.`)
+    return undefined
+  }
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError(`[vitehub] ${operationId} ${location} input must be an object.`)
+  }
+  const allowed = new Set(parameters.map(parameter => parameter.name as string))
+  const value = input as Record<string, unknown>
+  const extra = Object.keys(value).filter(key => !allowed.has(key))
+  if (extra.length) throw new Error(`[vitehub] ${operationId} does not support ${location} parameter${extra.length === 1 ? "" : "s"}: ${extra.join(", ")}.`)
+  for (const name of required) {
+    if (value[name] === undefined) throw new Error(`[vitehub] ${operationId} requires ${location} parameter "${name}".`)
+  }
+  return value
+}
+
+function operationUrl(baseUrl: URL, operation: OpenAPIOperationTool, pathInput: Record<string, unknown> | undefined): URL {
+  return operationTemplateUrl(baseUrl, operation.path.replace(/\{([^}]+)\}/g, (_match, name: string) => {
+    const value = pathInput?.[name]
+    if (value === undefined) throw new Error(`[vitehub] ${operation.operationId} requires path parameter "${name}".`)
+    return encodeURIComponent(String(value))
+  }))
+}
+
+function operationTemplateUrl(baseUrl: URL, path: string): URL {
+  const url = new URL(baseUrl)
+  const prefix = url.pathname.endsWith("/") ? url.pathname.slice(0, -1) : url.pathname
+  url.pathname = `${prefix}${path.startsWith("/") ? path : `/${path}`}`
+  url.search = ""
+  url.hash = ""
+  return url
+}
+
+async function resolveHeaders<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: OpenAPICapabilityOptions<TRuntimeConfig, Name>,
+  context: AgentCapabilityContext<TRuntimeConfig, Name>,
+  operation: OpenAPIOperationTool,
+  input: OpenAPIToolInput,
+  url: URL,
+): Promise<OpenAPIHeaders | undefined> {
+  if (typeof options.headers === "function") {
+    return await options.headers({
+      ...context,
+      input,
+      operation: {
+        id: operation.operationId,
+        method: operation.method,
+        path: `${url.origin}${url.pathname}`,
+      },
+    })
+  }
+  return options.headers
+}
+
+function operationInputSchema(operation: OpenAPIOperationTool, input?: OpenAPIInputOptions): JsonSchema {
+  const properties: Record<string, JsonSchema> = {}
+  const required: string[] = []
+  const pathParameters = visibleParameters(operation.pathParameters, input?.omit?.path)
+  const queryParameters = visibleParameters(operation.queryParameters, input?.omit?.query)
+  const bodySchema = visibleObjectSchema(operation.bodySchema, input?.omit?.body)
+  if (pathParameters.length) {
+    properties.path = parameterObjectSchema(pathParameters)
+    if (pathParameters.some(parameter => parameter.required || parameter.in === "path")) required.push("path")
+  }
+  if (queryParameters.length) {
+    properties.query = parameterObjectSchema(queryParameters)
+  }
+  if (bodySchema) {
+    properties.body = bodySchema
+    if (hasRequiredProperties(bodySchema)) required.push("body")
+  }
+  return {
+    additionalProperties: false,
+    properties,
+    ...(required.length ? { required } : {}),
+    type: "object",
+  }
+}
+
+function visibleParameters(parameters: OpenAPIParameter[], omit: readonly string[] | undefined): OpenAPIParameter[] {
+  if (!omit?.length) return parameters
+  const omitted = new Set(omit)
+  return parameters.filter(parameter => !parameter.name || !omitted.has(parameter.name))
+}
+
+function visibleObjectSchema(schema: JsonSchema | undefined, omit: readonly string[] | undefined): JsonSchema | undefined {
+  if (!schema || !omit?.length) return schema
+  if (!isPlainRecord(schema.properties)) return schema
+  const omitted = new Set(omit)
+  const properties = Object.fromEntries(Object.entries(schema.properties).filter(([key]) => !omitted.has(key)))
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter(value => typeof value === "string" && !omitted.has(value))
+    : []
+  const { required: _required, ...rest } = schema
+  return {
+    ...rest,
+    properties,
+    ...(required.length ? { required } : {}),
+  }
+}
+
+function hasRequiredProperties(schema: JsonSchema): boolean {
+  return Array.isArray(schema.required) && schema.required.some(value => typeof value === "string")
+}
+
+function parameterObjectSchema(parameters: OpenAPIParameter[]): JsonSchema {
+  return {
+    additionalProperties: false,
+    properties: Object.fromEntries(parameters.map(parameter => [parameter.name, {
+      ...(parameter.schema as JsonSchema),
+      ...(parameter.description ? { description: parameter.description } : {}),
+    }])),
+    required: parameters.filter(parameter => parameter.in === "path" || parameter.required).map(parameter => parameter.name),
+    type: "object",
+  }
+}
+
+function dereference(document: OpenAPIDocument, value: unknown, seen = new Set<string>()): unknown {
+  if (!value || typeof value !== "object") return value
+  if ("$ref" in value && typeof (value as OpenAPIReference).$ref === "string") {
+    const ref = (value as OpenAPIReference).$ref
+    if (!ref.startsWith("#/") || seen.has(ref)) return {}
+    seen.add(ref)
+    return dereference(document, ref.slice(2).split("/").reduce<unknown>((current, part) => {
+      return current && typeof current === "object" ? (current as Record<string, unknown>)[part.replaceAll("~1", "/").replaceAll("~0", "~")] : undefined
+    }, document), seen)
+  }
+  if (Array.isArray(value)) return value.map(item => dereference(document, item, new Set(seen)))
+  return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+    key,
+    dereference(document, item, new Set(seen)),
+  ]))
+}

--- a/packages/agent/src/capabilities/openapi.ts
+++ b/packages/agent/src/capabilities/openapi.ts
@@ -79,6 +79,17 @@ export interface OpenAPIRequestContext<
   }
 }
 
+export interface OpenAPIResponseContext<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> extends OpenAPIRequestContext<TRuntimeConfig, Name> {
+  response: {
+    data: unknown
+    mediaType?: string
+    status: number
+  }
+}
+
 export interface OpenAPIRequestDefaults {
   body?: unknown
   path?: Record<string, unknown>
@@ -111,6 +122,7 @@ export interface OpenAPICapabilityOptions<
   spec: string | URL | OpenAPIDocument
   specHeaders?: OpenAPIHeaders
   timeout?: number
+  transformResponse?: (response: unknown, context: OpenAPIResponseContext<TRuntimeConfig, Name>) => MaybePromise<unknown>
 }
 
 const pathMethods = new Set<OpenAPIPathMethod>(["get", "head", "post", "put", "patch", "delete", "options", "trace"])
@@ -289,7 +301,7 @@ function createOpenAPITool<
       }, {
         responseType: options.responseType || "json",
       })
-      return result.data
+      return transformOpenAPIResponse(options, context, operation, requestInput, url, result)
     },
     inputSchema: operationInputSchema(operation, options.input),
     metadata: {
@@ -300,6 +312,34 @@ function createOpenAPITool<
       },
     },
     name: operation.operationId,
+  })
+}
+
+async function transformOpenAPIResponse<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: OpenAPICapabilityOptions<TRuntimeConfig, Name>,
+  context: AgentCapabilityContext<TRuntimeConfig, Name>,
+  operation: OpenAPIOperationTool,
+  input: OpenAPIToolInput,
+  url: URL,
+  result: { data: unknown, mediaType?: string, status: number },
+): Promise<unknown> {
+  if (!options.transformResponse) return result.data
+  return await options.transformResponse(result.data, {
+    ...context,
+    input,
+    operation: {
+      id: operation.operationId,
+      method: operation.method,
+      path: `${url.origin}${url.pathname}`,
+    },
+    response: {
+      data: result.data,
+      mediaType: result.mediaType,
+      status: result.status,
+    },
   })
 }
 

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -9,6 +9,11 @@ import { normalizeAgentWorkspaceSources } from "./workspace-source-metadata.ts"
 import { nextWithAbort } from "./internal/abortable-stream.ts"
 import { toAiSdkModelMessages } from "./ai-sdk.ts"
 import { isAsyncIterable } from "./internal/stream-result.ts"
+import {
+  applyAgentToolPolicies,
+  withAgentToolStepReporting,
+  withJsonCompatibleToolOutputs,
+} from "./tool-runtime.ts"
 
 import type {
   AgentAdapter,
@@ -20,6 +25,7 @@ import type {
   AgentHarnessSessionKey,
   AgentRunCallbackContext,
   AgentRuntimeConfig,
+  AgentToolSet,
   MaybePromise,
 } from "./types.ts"
 
@@ -54,7 +60,6 @@ function hasEntries(value: unknown): value is Record<string, unknown> {
 
 function unsupportedHarnessContributionKinds(context: AgentAdapterRunContext): Set<AgentDriverContributionKind> {
   const kinds = new Set<AgentDriverContributionKind>()
-  if (hasEntries(context.tools)) kinds.add("Capability tools")
   if (context.providerTools?.length) kinds.add("provider tools")
   return kinds
 }
@@ -88,7 +93,6 @@ function formatUnsupportedHarnessContributions(context: AgentAdapterRunContext):
   }
 
   return [
-    unsupportedKinds.has("Capability tools") ? "Capability tools" : undefined,
     unsupportedKinds.has("provider tools") ? "provider tools" : undefined,
   ].filter((value): value is string => Boolean(value))
 }
@@ -186,6 +190,14 @@ function toHarnessCallInput(context: AgentAdapterRunContext) {
   }
 }
 
+function toHarnessTools(context: AgentAdapterRunContext): AgentToolSet | undefined {
+  if (!hasEntries(context.tools)) return
+  return withAgentToolStepReporting(
+    withJsonCompatibleToolOutputs(applyAgentToolPolicies(context.tools as AgentToolSet) || {}),
+    context.devtools?.reportToolStep,
+  )
+}
+
 function toRunCallbackContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -270,6 +282,7 @@ async function createHarnessAgent<
   const { HarnessAgent } = await import("@ai-sdk/harness/agent") as unknown as { HarnessAgent: HarnessAgentConstructor }
   const sandbox = await resolveHarnessSandbox(options.sandbox, context)
   const harness = await resolveHarness(options.harness, context)
+  const tools = toHarnessTools(context)
   return new HarnessAgent({
     harness,
     onSandboxSession: async ({ abortSignal, session, sessionWorkDir }: { abortSignal?: AbortSignal, session: unknown, sessionWorkDir: string }) => {
@@ -277,6 +290,7 @@ async function createHarnessAgent<
     },
     permissionMode: "allow-all",
     sandbox,
+    ...(tools ? { tools } : {}),
   })
 }
 

--- a/packages/agent/test/openapi-capability.test.ts
+++ b/packages/agent/test/openapi-capability.test.ts
@@ -178,4 +178,45 @@ describe("openapi capability", () => {
     expect((init.headers as Headers).get("cookie")).toBe("preview=preview-cookie")
     expect((init.headers as Headers).get("x-cube-token")).toBe("cube-token")
   })
+
+  it("can transform raw operation responses with request context", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({
+      data: [{ "Product.sku": "sku-1", "PurchaseOrder.quantity": 12 }],
+    }))
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        openapi({
+          defaults: {
+            body: { cubeToken: "cube-token" },
+            path: { tenantId: "acme" },
+          },
+          input: { omit: { body: ["cubeToken"], path: ["tenantId"] } },
+          operations: { allow: ["createOrder"] },
+          spec: portalSpec(),
+          transformResponse(response, context) {
+            return {
+              operationId: context.operation.id,
+              status: context.response.status,
+              rows: (response as { data: Array<Record<string, unknown>> }).data.map(row => ({
+                quantity: row["PurchaseOrder.quantity"],
+                sku: row["Product.sku"],
+              })),
+            }
+          },
+        }),
+      ],
+    }, runtime(), { prompt: "create" })
+    const tools = resolved.tools as AgentToolSet
+
+    await expect(tools.createOrder.execute?.({
+      body: { sku: "sku-1" },
+    })).resolves.toEqual({
+      operationId: "createOrder",
+      rows: [{ quantity: 12, sku: "sku-1" }],
+      status: 200,
+    })
+  })
 })

--- a/packages/agent/test/openapi-capability.test.ts
+++ b/packages/agent/test/openapi-capability.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { AgentToolSet } from "../src/types.ts"
+
+const runtime = () => ({
+  capabilities: {},
+  memo: vi.fn(),
+  runtime: "unknown" as const,
+  runtimeConfig: {},
+  waitUntil: vi.fn(),
+})
+
+function jsonResponse(value: unknown) {
+  return new Response(JSON.stringify(value), {
+    headers: { "content-type": "application/json" },
+    status: 200,
+  })
+}
+
+function portalSpec() {
+  return {
+    openapi: "3.1.0",
+    servers: [{ url: "https://portal.example.com/runtime" }],
+    paths: {
+      "/customers": {
+        get: {
+          operationId: "listCustomers",
+          parameters: [
+            { in: "query", name: "region", schema: { type: "string" } },
+          ],
+          summary: "List customers.",
+        },
+      },
+      "/customers/{id}": {
+        delete: {
+          operationId: "deleteCustomer",
+          summary: "Delete customer.",
+        },
+      },
+      "/tenants/{tenantId}/orders": {
+        post: {
+          operationId: "createOrder",
+          parameters: [
+            { in: "path", name: "tenantId", required: true, schema: { type: "string" } },
+            { in: "query", name: "currency", schema: { type: "string" } },
+          ],
+          requestBody: {
+            content: {
+              "application/json": {
+                schema: {
+                  additionalProperties: false,
+                  properties: {
+                    cubeToken: { type: "string" },
+                    quantity: { type: "number" },
+                    sku: { type: "string" },
+                  },
+                  required: ["cubeToken", "sku"],
+                  type: "object",
+                },
+              },
+            },
+          },
+          summary: "Create order.",
+        },
+      },
+    },
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("openapi capability", () => {
+  it("ignores unsupported methods outside the operation allowlist", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        openapi({
+          operations: { allow: ["listCustomers"] },
+          spec: portalSpec(),
+        }),
+      ],
+    }, runtime(), { prompt: "list" })
+
+    expect(Object.keys(resolved.tools || {})).toEqual(["listCustomers"])
+  })
+
+  it("fails only when an allowed operation uses an unsupported method", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        openapi({
+          operations: { allow: ["deleteCustomer"] },
+          spec: portalSpec(),
+        }),
+      ],
+    }, runtime(), { prompt: "delete" })).rejects.toThrow("v1 supports GET, HEAD, and POST")
+  })
+
+  it("can hide tools by invocation context", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+    const capability = openapi({
+      enabled: ({ actor }) => actor.kind === "portal",
+      operations: { allow: ["listCustomers"] },
+      spec: portalSpec(),
+    })
+
+    const hidden = await resolveAgentCapabilities({
+      capabilities: [capability],
+    }, runtime(), { context: { actor: { id: "support", kind: "support" } }, prompt: "list" })
+    const visible = await resolveAgentCapabilities({
+      capabilities: [capability],
+    }, runtime(), { context: { actor: { id: "portal", kind: "portal" } }, prompt: "list" })
+
+    expect(hidden.tools).toBeUndefined()
+    expect(Object.keys(visible.tools || {})).toEqual(["listCustomers"])
+  })
+
+  it("uses defaults and headers while omitting host-supplied fields from tool schema", async () => {
+    const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ ok: true }))
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        openapi({
+          defaults: ({ context }) => ({
+            body: { cubeToken: context.get<{ cubeToken: string }>("portal")?.cubeToken },
+            path: { tenantId: "acme" },
+            query: { currency: "EUR" },
+          }),
+          headers: ({ context }) => ({
+            cookie: `preview=${context.get<{ previewCookie: string }>("portal")?.previewCookie}`,
+            "x-cube-token": context.get<{ cubeToken: string }>("portal")?.cubeToken || "",
+          }),
+          input: {
+            omit: {
+              body: ["cubeToken"],
+              path: ["tenantId"],
+              query: ["currency"],
+            },
+          },
+          operations: { allow: ["createOrder"] },
+          spec: portalSpec(),
+        }),
+      ],
+    }, runtime(), {
+      context: {
+        actor: { id: "portal", kind: "portal" },
+        portal: { cubeToken: "cube-token", previewCookie: "preview-cookie" },
+      },
+      prompt: "create",
+    })
+    const tools = resolved.tools as AgentToolSet
+    const schema = tools.createOrder.inputSchema as {
+      properties: Record<string, { properties?: Record<string, unknown>, required?: string[] } | undefined>
+    }
+
+    expect(schema.properties.path).toBeUndefined()
+    expect(schema.properties.query).toBeUndefined()
+    const bodySchema = schema.properties.body!
+    expect(bodySchema.required).toEqual(["sku"])
+    expect(bodySchema.properties?.cubeToken).toBeUndefined()
+
+    await expect(tools.createOrder.execute?.({
+      body: { quantity: 2, sku: "sku-1" },
+    })).resolves.toEqual({ ok: true })
+
+    const init = request.mock.calls[0]?.[1] as RequestInit
+    expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/tenants/acme/orders?currency=EUR")
+    expect(init.body).toBe(JSON.stringify({ cubeToken: "cube-token", quantity: 2, sku: "sku-1" }))
+    expect((init.headers as Headers).get("cookie")).toBe("preview=preview-cookie")
+    expect((init.headers as Headers).get("x-cube-token")).toBe("cube-token")
+  })
+})

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -935,9 +935,12 @@ describe("agent message protocol", () => {
     expect(session.destroy).toHaveBeenCalledOnce()
   })
 
-  it("rejects model-facing Capability tools before harness execution", async () => {
+  it("passes model-facing Capability tools into harness Agent Drivers", async () => {
     const { defineCapability } = await import("../src/capability-runtime.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
     const agent = defineAgent({
       capabilities: [
@@ -957,11 +960,14 @@ describe("agent message protocol", () => {
       },
     })
 
-    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "hello" }))
-      .rejects.toThrow("model-tools: Capability tools (lookup)")
-    expect(harnessAgentSettings).toHaveLength(0)
-    expect(harnessCreateSession).not.toHaveBeenCalled()
-    expect(harnessGenerate).not.toHaveBeenCalled()
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "hello" })).resolves.toMatchObject({ text: "ok" })
+    expect(harnessAgentSettings).toHaveLength(1)
+    expect(harnessAgentSettings.at(-1)?.tools).toHaveProperty("lookup")
+    expect(harnessCreateSession).toHaveBeenCalledWith(undefined)
+    expect(harnessGenerate).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: "hello",
+      session,
+    }))
   })
 
   it("does not resolve static Capability tools for harness Agent Drivers", async () => {


### PR DESCRIPTION
Adds an @vite-hub/agent openapi() capability that fetches JSON OpenAPI specs or accepts inline docs, exposes only explicit operationId allow-lists as per-operation tools, and keeps generated input schemas scoped to path/query/body for the selected operation. It supports context gating, per-invocation headers/defaults, and input.omit so hosts can inject auth/default fields without asking the model for them.

Includes focused tests for unsupported unallowed methods, supported allow-list failure boundaries, context-gated tools, async headers/defaults, schema omission, and defaults-supplied path params.