### PR TITLE
feat(agent): preserve eval follow-up history

### DIFF
--- a/docs/content/docs/agents/evals.md
+++ b/docs/content/docs/agents/evals.md
@@ -29,8 +29,9 @@ export default defineEval({
 })
 ```
 
-`test(t)` is a single Agent Invocation helper.
-Call `t.send(...)` exactly once; use `messages` or `context` in that input when the Agent needs prior chat state, and split independent follow-up checks into separate scenarios.
+`test(t)` is an Agent Invocation helper.
+Call `t.send(...)` with the first user message, then call it again for follow-ups that should keep the same Chat History.
+Use `messages` or `context` in the input when the eval needs a precise starting state, and split independent checks into separate scenarios.
 
 Use `scenarios` when one eval file should run several cases or reuse the same scorers.
 

--- a/docs/content/docs/development/agent-evals.md
+++ b/docs/content/docs/development/agent-evals.md
@@ -27,8 +27,9 @@ export default defineEval({
 })
 ```
 
-`test(t)` runs one Agent Invocation.
-It must call `t.send(...)` exactly once; pass `messages`, `context`, or trigger input to model a specific conversation state, and use separate scenarios for independent follow-up cases.
+`test(t)` runs Agent Invocations.
+Call `t.send(...)` with the first user message, then call it again for follow-ups that should keep the same Chat History.
+Pass `messages`, `context`, or trigger input to model a specific starting state, and use separate scenarios for independent cases.
 
 Use `scenarios` when one eval file should run several cases or share scorers across cases.
 

--- a/packages/agent/src/eval.ts
+++ b/packages/agent/src/eval.ts
@@ -22,6 +22,10 @@ import {
   createAgentTestRunner,
   type AgentTestRunResult,
 } from "./test.ts"
+import {
+  createMessage,
+  type Message,
+} from "./messages.ts"
 import type { WorkspaceName } from "@vite-hub/workspace"
 
 export interface AgentScore {
@@ -400,12 +404,52 @@ function normalizeTestSendInput<CALL_OPTIONS>(input: string | AgentRunInput<CALL
   return typeof input === "string" ? { prompt: input } : input
 }
 
+function messagesFromTestInput<CALL_OPTIONS>(input: AgentRunInput<CALL_OPTIONS>): Message[] {
+  const messages = [...(input.messages || [])]
+  if (typeof input.message === "string") {
+    messages.push(createMessage({ role: "user", text: input.message }))
+  }
+  else if (input.message) {
+    messages.push(input.message)
+  }
+  if (typeof input.prompt === "string") {
+    messages.push(createMessage({ role: "user", text: input.prompt }))
+  }
+  else if (Array.isArray(input.prompt)) {
+    messages.push(...input.prompt)
+  }
+  return messages
+}
+
+function withTestHistory<CALL_OPTIONS>(
+  input: AgentRunInput<CALL_OPTIONS>,
+  history: Message[],
+): AgentRunInput<CALL_OPTIONS> {
+  if (!history.length) return input
+  const messages = messagesFromTestInput(input)
+  if (!messages.length) return input
+  const rest = { ...input }
+  delete rest.message
+  delete rest.messages
+  delete rest.prompt
+  return {
+    ...rest,
+    messages: [...history, ...messages],
+  }
+}
+
+function appendAssistantMessage(history: Message[], text: string): Message[] {
+  if (!text) return history
+  return [...history, createMessage({ role: "assistant", text })]
+}
+
 async function runEvalTest<CALL_OPTIONS>(
   runner: ReturnType<typeof createAgentTestRunner<AgentRuntimeConfig, CALL_OPTIONS>>,
   testCase: NormalizedEvalTest<CALL_OPTIONS>,
   variant: AgentEvalVariant,
 ): Promise<AgentObservationWithScores> {
   let observation: AgentObservation | undefined
+  let history: Message[] = []
   const assertions: AgentScorer[] = []
   const context: AgentEvalTestContext<CALL_OPTIONS> = {
     get observation() {
@@ -435,11 +479,11 @@ async function runEvalTest<CALL_OPTIONS>(
       assertions.push(scorer)
     },
     async send(input) {
-      if (observation) {
-        throw new Error("[vitehub] Agent Eval test.send() supports one Agent Invocation per test.")
-      }
-      const result = await runner.run(normalizeTestSendInput(input))
+      const normalizedInput = normalizeTestSendInput(input)
+      const runInput = withTestHistory(normalizedInput, history)
+      const result = await runner.run(runInput)
       observation = toObservation(result, testCase, variant)
+      history = appendAssistantMessage(messagesFromTestInput(runInput), result.text)
       return observation
     },
     textContains(expected) {

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -266,23 +266,35 @@ describe("agent eval", () => {
       .toThrow("Agent Eval test() must call t.send(...)")
   })
 
-  it("rejects follow-up sends inside one test callback", async () => {
+  it("preserves chat history for follow-up sends inside one test callback", async () => {
     const { defineEval } = await import("../src/eval.ts")
-    const generate = vi.fn(async () => ({ text: "ok" }))
+    const generate = vi.fn()
+      .mockResolvedValueOnce({ text: "first reply" })
+      .mockResolvedValueOnce({ text: "second reply" })
 
     defineEval({
       agent: { generate, stream: vi.fn(), tools: {}, version: "agent-v1" } as never,
       name: "support",
       async test(t) {
         await t.send("hello")
-        await expect(t.send("again")).rejects.toThrow("Agent Eval test.send() supports one Agent Invocation per test.")
+        await t.send("again")
       },
     })
 
     await expect(evaliteCalls[0]!.opts.task(evaliteCalls[0]!.opts.data[0].input))
       .resolves
-      .toMatchObject({ text: "ok" })
-    expect(generate).toHaveBeenCalledTimes(1)
+      .toMatchObject({ text: "second reply" })
+    expect(generate).toHaveBeenCalledTimes(2)
+    expect(generate.mock.calls[0]?.[0]).toMatchObject({
+      prompt: "hello",
+    })
+    expect(generate.mock.calls[1]?.[0]).toMatchObject({
+      messages: [
+        { content: "hello", role: "user" },
+        { content: "first reply", role: "assistant" },
+        { content: "again", role: "user" },
+      ],
+    })
   })
 
   it("adds scenario scorers to global scorers and captures observations", async () => {


### PR DESCRIPTION
Adds session-preserving follow-up behavior for defineEval({ test }) by replaying prior user and assistant messages into subsequent t.send(...) calls. Scenario evals keep their explicit single input shape, while follow-up chat proof can move out of ad hoc downstream scripts.

Updates the Agent Eval docs and replaces the old rejection test with regression coverage for a second send receiving the first turn as Chat History.

Local package verification is currently blocked by pnpm minimum-release-age policy on the main lockfile AI SDK v7 packages; git diff --check passes.