### PR TITLE
fix(agent): use current harness sandbox hook

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -285,8 +285,10 @@ async function createHarnessAgent<
   const tools = toHarnessTools(context)
   return new HarnessAgent({
     harness,
-    onSandboxSession: async ({ abortSignal, session, sessionWorkDir }: { abortSignal?: AbortSignal, session: unknown, sessionWorkDir: string }) => {
-      await prepareWorkspaceSession(session, sessionWorkDir, abortSignal)
+    sandboxConfig: {
+      onSession: async ({ abortSignal, session, sessionWorkDir }: { abortSignal?: AbortSignal, session: unknown, sessionWorkDir: string }) => {
+        await prepareWorkspaceSession(session, sessionWorkDir, abortSignal)
+      },
     },
     permissionMode: "allow-all",
     sandbox,

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -64,7 +64,8 @@ vi.mock("@ai-sdk/harness/agent", () => ({
 
     async createSession(options?: Record<string, unknown>) {
       harnessCreateSessionOptions.push(options)
-      await (this.settings.onSandboxSession as ((input: Record<string, unknown>) => Promise<void>) | undefined)?.({
+      const sandboxConfig = this.settings.sandboxConfig as { onSession?: (input: Record<string, unknown>) => Promise<void> } | undefined
+      await sandboxConfig?.onSession?.({
         abortSignal: options?.abortSignal,
         session: {},
         sessionWorkDir: "/workspace",

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -783,6 +783,9 @@ describe("agent message protocol", () => {
     expect(harnessAgentSettings.at(-1)).toMatchObject({
       harness,
       permissionMode: "allow-all",
+      sandboxConfig: {
+        onSession: expect.any(Function),
+      },
       sandbox,
     })
     expect(harnessCreateSession).toHaveBeenCalledWith(undefined)

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -86,7 +86,8 @@ vi.mock("@ai-sdk/harness/agent", () => ({
     async createSession(...args: unknown[]) {
       const session = await harnessCreateSession.apply(this, args)
       const options = args[0] as { abortSignal?: AbortSignal } | undefined
-      await (this.settings.onSandboxSession as ((input: Record<string, unknown>) => Promise<void>) | undefined)?.({
+      const sandboxConfig = this.settings.sandboxConfig as { onSession?: (input: Record<string, unknown>) => Promise<void> } | undefined
+      await sandboxConfig?.onSession?.({
         abortSignal: options?.abortSignal,
         session: harnessSandboxSession,
         sessionWorkDir: "/workspace/codex-session",


### PR DESCRIPTION
Uses the current HarnessAgent sandboxConfig.onSession hook when preparing harness workspace sessions. This removes the deprecation warning emitted by newer @ai-sdk/harness versions while preserving workspace preparation behavior for harness-backed agents.