### PR TITLE
docs: expand runtime showcase providers

### DIFF
--- a/docs/app/components/LandingHero.vue
+++ b/docs/app/components/LandingHero.vue
@@ -79,6 +79,7 @@ const platformSignalGroups = [
       { label: "Cloudflare", icon: "i-simple-icons-cloudflare", color: "" },
       { label: "Vercel", icon: "i-simple-icons-vercel", color: "" },
       { label: "Netlify", icon: "i-simple-icons-netlify", color: "" },
+      { label: "Docker", icon: "i-simple-icons-docker", color: "" },
       { label: "Deno", icon: "i-simple-icons-deno", color: "" },
       { label: "Node/self-hosted", icon: "i-simple-icons-nodedotjs", color: "" },
       { label: "Any host", icon: "i-lucide-server", color: "" },
@@ -152,12 +153,13 @@ const heroAgentCoreNodes = [
 ] as const;
 
 const heroProviderNodes = [
-  { label: "Cloudflare", icon: "i-simple-icons-cloudflare", angle: 20 },
-  { label: "Vercel", icon: "i-simple-icons-vercel", angle: 80 },
-  { label: "Netlify", icon: "i-simple-icons-netlify", angle: 140 },
-  { label: "Node", icon: "i-simple-icons-nodedotjs", angle: 200 },
-  { label: "Deno", icon: "i-simple-icons-deno", angle: 260 },
-  { label: "Fly.io", icon: "i-simple-icons-flydotio", angle: 320 },
+  { label: "Cloudflare", icon: "i-simple-icons-cloudflare", angle: 0 },
+  { label: "Vercel", icon: "i-simple-icons-vercel", angle: 51 },
+  { label: "Netlify", icon: "i-simple-icons-netlify", angle: 103 },
+  { label: "Docker", icon: "i-simple-icons-docker", angle: 154 },
+  { label: "Node", icon: "i-simple-icons-nodedotjs", angle: 206 },
+  { label: "Deno", icon: "i-simple-icons-deno", angle: 257 },
+  { label: "Fly.io", icon: "i-simple-icons-flydotio", angle: 309 },
 ] as const;
 
 const heroAgentRecipes = [
@@ -976,7 +978,7 @@ onBeforeUnmount(() => {
             </div>
           </div>
           <p class="sr-only">
-            ViteHub orbits an Agent Definition around Channels, Capabilities, Driver behavior, Workspace context, and provider targets such as Cloudflare, Vercel, Netlify, Node, Deno, and Fly.io. The center cycles recipes for Review, Support, Field, Onboarding, Ops, and Community Agents.
+            ViteHub orbits an Agent Definition around Channels, Capabilities, Driver behavior, Workspace context, and provider targets such as Cloudflare, Vercel, Netlify, Docker, Node, Deno, and Fly.io. The center cycles recipes for Review, Support, Field, Onboarding, Ops, and Community Agents.
           </p>
         </div>
       </div>
@@ -1012,7 +1014,7 @@ onBeforeUnmount(() => {
               <UIcon name="i-lucide-server" class="size-4 text-primary" aria-hidden="true" />
               Deploy clearly
             </dt>
-            <dd class="mt-1 text-sm/6 text-muted">Use the same project on Cloudflare, Vercel, Netlify, or Node.</dd>
+            <dd class="mt-1 text-sm/6 text-muted">Use the same project on Cloudflare, Vercel, Netlify, Docker, Deno, or Node.</dd>
           </div>
         </dl>
       </div>

--- a/docs/test/showcase.test.ts
+++ b/docs/test/showcase.test.ts
@@ -55,4 +55,17 @@ describe("showcase examples", () => {
     expect(config).toContain("plugins: [vitehub()]");
     expect(files.find(file => file.path === "env.example")?.code).toContain("KV_REST_API_URL=https://example.upstash.io");
   });
+
+  it("shows provider tabs for supported non-default runtimes", () => {
+    const providersByExample = Object.fromEntries(
+      getShowcaseExamples().map(example => [example.docsPath, example.providers.map(provider => provider.id)]),
+    );
+
+    expect(providersByExample.blob).toEqual(expect.arrayContaining(["netlify-blobs", "minio"]));
+    expect(providersByExample.kv).toEqual(expect.arrayContaining(["deno-kv", "fs-lite"]));
+    expect(providersByExample.schedule).toEqual(expect.arrayContaining(["netlify", "deno"]));
+    expect(providersByExample.workflow).toEqual(expect.arrayContaining(["openworkflow"]));
+    expect(providersByExample.queue).toEqual(["cloudflare", "vercel"]);
+    expect(providersByExample.sandbox).toEqual(["cloudflare", "vercel"]);
+  });
 });

--- a/packages/blob/examples/showcase.json
+++ b/packages/blob/examples/showcase.json
@@ -17,6 +17,19 @@
       "darkInvert": true,
       "configOverride": "  blob: {\n    driver: 'vercel-blob',\n  },",
       "envOverride": "BLOB_READ_WRITE_TOKEN=<blob-read-write-token>"
+    },
+    {
+      "id": "netlify-blobs",
+      "label": "Netlify",
+      "icon": "i-simple-icons-netlify",
+      "configOverride": "  blob: {\n    driver: 'netlify-blobs',\n    name: 'vitehub-blob',\n  },"
+    },
+    {
+      "id": "minio",
+      "label": "Docker/MinIO",
+      "icon": "i-simple-icons-docker",
+      "configOverride": "  blob: {\n    driver: 'minio',\n  },",
+      "envOverride": "MINIO_ENDPOINT=http://minio:9000\nMINIO_ROOT_USER=minio\nMINIO_ROOT_PASSWORD=password\nBLOB_BUCKET_NAME=vitehub-blob"
     }
   ],
   "frameworks": {

--- a/packages/kv/examples/showcase.json
+++ b/packages/kv/examples/showcase.json
@@ -15,6 +15,18 @@
       "icon": "i-simple-icons-vercel",
       "configOverride": "  kv: {\n    driver: 'upstash',\n  },",
       "envOverride": "KV_REST_API_URL=https://example.upstash.io\nKV_REST_API_TOKEN=<upstash-rest-token>"
+    },
+    {
+      "id": "deno-kv",
+      "label": "Deno",
+      "icon": "i-simple-icons-deno",
+      "configOverride": "  kv: {\n    driver: 'deno-kv',\n  },"
+    },
+    {
+      "id": "fs-lite",
+      "label": "Docker/Node",
+      "icon": "i-simple-icons-docker",
+      "configOverride": "  kv: {\n    driver: 'fs-lite',\n    base: '.data/kv',\n  },"
     }
   ],
   "frameworks": {

--- a/packages/schedule/examples/showcase.json
+++ b/packages/schedule/examples/showcase.json
@@ -15,6 +15,16 @@
       "label": "Vercel",
       "icon": "i-simple-icons-vercel",
       "darkInvert": true
+    },
+    {
+      "id": "netlify",
+      "label": "Netlify",
+      "icon": "i-simple-icons-netlify"
+    },
+    {
+      "id": "deno",
+      "label": "Deno",
+      "icon": "i-simple-icons-deno"
     }
   ],
   "frameworks": {

--- a/packages/workflow/examples/showcase.json
+++ b/packages/workflow/examples/showcase.json
@@ -17,6 +17,12 @@
       "icon": "i-simple-icons-vercel",
       "darkInvert": true,
       "configOverride": "  workflow: {\n    provider: 'vercel',\n  },"
+    },
+    {
+      "id": "openworkflow",
+      "label": "Docker/OpenWorkflow",
+      "icon": "i-simple-icons-docker",
+      "configOverride": "  workflow: {\n    provider: 'openworkflow',\n    sqlite: {\n      path: '.data/workflow.sqlite',\n    },\n  },"
     }
   ],
   "frameworks": {


### PR DESCRIPTION
Expands the landing-page provider signals and primitive showcase metadata so supported non-default runtimes show up where the examples can honestly render them. Blob now shows Netlify Blobs and Docker/MinIO, KV shows Deno KV and Docker/Node fs-lite, Schedule shows Netlify and Deno, and Workflow shows Docker/OpenWorkflow.

Queue and Sandbox stay Cloudflare/Vercel-only because their package config still only supports those providers. The focused docs tests, docs artifact tests, typecheck, whitespace check, and browser smoke all passed locally before this branch was pushed.