### PR TITLE
feat(agent): finalize output delivery shaping

### DIFF
--- a/docs/content/docs/capabilities/usage-telemetry.md
+++ b/docs/content/docs/capabilities/usage-telemetry.md
@@ -12,7 +12,7 @@ It normalizes usage fields, can estimate cost through a pricing function, and at
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds
@@ -20,6 +20,7 @@ Use the configuration example below as the starting point, then tighten modes, p
 The Capability wraps compatible streams and output results.
 It emits `usage` stream events when a finish chunk contains usage, attaches `usage` and `usageRecord` to final results, and calls an optional `onUsage` callback.
 Later output renderers can read `context.output.extensions.get('usage-telemetry')` for `{ usageRecord, summary }`.
+Use `context.output.final()` when a renderer needs the completed final text from either a model result or a stream before finish hooks and delivery effects run.
 
 ## Configuration
 
@@ -47,6 +48,37 @@ It reads usage from result objects or finish stream chunks, normalizes token and
 
 Pricing functions enrich telemetry only.
 Pricing errors do not fail the Agent Invocation.
+
+Final output shaping can stay Capability-owned:
+
+```ts [server/agents/review.ts]
+import { defineAgent, defineCapability } from '@vite-hub/agent'
+import { usageTelemetry } from '@vite-hub/agent/capabilities'
+
+export default defineAgent({
+  capabilities: [
+    usageTelemetry({ summary: { subject: 'Review run' } }),
+    defineCapability({
+      id: 'review-output',
+      output(context) {
+        context.output.final((result, renderContext) => {
+          const usage = renderContext.output.extensions.get<{ summary?: string }>('usage-telemetry')
+          const text = typeof result === 'object' && result && 'text' in result
+            ? String(result.text || '')
+            : String(result || '')
+
+          return {
+            raw: result,
+            text: [text, usage?.summary].filter(Boolean).join('\n\n'),
+          }
+        })
+      },
+    }),
+  ],
+})
+```
+
+For lower-level stream handling, import `streamAgentOutputToEvents()`, `toAgentRunResult()`, and `toAgentStreamEvent()` from `@vite-hub/agent/output`.
 
 ## Requirements
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -81,6 +81,10 @@
       "types": "./dist/messages.d.ts",
       "import": "./dist/messages.js"
     },
+    "./output": {
+      "types": "./dist/output.d.ts",
+      "import": "./dist/output.js"
+    },
     "./runtime/empty-registry": {
       "types": "./dist/runtime/empty-registry.d.ts",
       "import": "./dist/runtime/empty-registry.js"

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -139,7 +139,10 @@ function usageRecordFromUsage(rawUsage: unknown, metadataSource?: unknown, fallb
     ...(inputTokenDetails ? { inputTokenDetails } : {}),
     ...(outputTokenDetails ? { outputTokenDetails } : {}),
   }
-  if (!Object.keys(usage).length) return
+  if (!Object.keys(usage).length) {
+    if (!Object.keys(rawUsage).length) return
+    usage.details = rawUsage
+  }
   const model = modelFromResult(metadataSource) ?? modelFromResult(fallbackMetadataSource)
   const response = responseFromResult(metadataSource) ?? responseFromResult(fallbackMetadataSource)
   return {

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -396,7 +396,11 @@ async function* withUsageTelemetryStream(
   let fallbackResult: UnknownRecord | undefined
   let recorded = false
   for await (const chunk of stream) {
-    if (isRecord(chunk) && chunk.type === "finish") {
+    if (isRecord(chunk) && chunk.type === "usage" && isRecord(chunk.usageRecord)) {
+      recorded = true
+      onRecord?.(chunk.usageRecord as AgentUsageRecord)
+    }
+    if (!recorded && isRecord(chunk) && chunk.type === "finish") {
       const usageRecord = await recordUsage(chunk, options, run, chunk.usage !== undefined || chunk.totalUsage !== undefined ? metadataSource : undefined)
       if (usageRecord) {
         recorded = true

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -288,6 +288,16 @@ function formatUsageCost(cost: AgentUsageRecord["cost"]): string | undefined {
   return cost.currency === "USD" ? `$${amount}` : `${amount} ${cost.currency}`
 }
 
+function formatUsageDetails(details: AgentUsage["details"]): string | undefined {
+  const entries = Object.entries(details || {})
+    .filter((entry): entry is [string, number | string] =>
+      typeof entry[1] === "string" && entry[1].trim().length > 0
+      || typeof entry[1] === "number" && Number.isFinite(entry[1]))
+    .slice(0, 4)
+  if (!entries.length) return details && Object.keys(details).length ? "reported usage" : undefined
+  return `reported ${entries.map(([key, value]) => `${key}: ${typeof value === "number" ? formatUsageNumber(value) : value}`).join(", ")}`
+}
+
 function formatUsageDuration(durationMs: unknown): string | undefined {
   const finite = finiteUsageNumber(durationMs)
   if (finite === undefined) return
@@ -318,12 +328,14 @@ async function formatUsageSummary(record: AgentUsageRecord, options: UsageTeleme
   }
   const cost = formatUsageCost(record.cost)
   const tokens = formatUsageTokens(record.usage)
+  const details = formatUsageDetails(record.usage?.details)
   const model = record.model?.id
   const duration = formatUsageDuration(record.latency?.durationMs)
   const speed = formatUsageSpeed(record)
   const run = [model ? `using ${model}` : undefined, duration ? `in ${duration}` : undefined, speed ? `at ${speed}` : undefined].filter(Boolean).join(" ")
   if (cost) return `${subject} cost ${record.cost?.estimated ? "about " : ""}${cost}${run ? ` ${run}` : ""}${tokens ? ` (${tokens})` : ""}.`
   if (tokens) return `${subject} used ${tokens}${run ? ` ${run}` : ""}.`
+  if (details) return `${subject} ${details}${run ? ` ${run}` : ""}.`
   if (run) return `${subject} ran ${run}.`
 }
 
@@ -474,7 +486,8 @@ export function usageTelemetry(options: UsageTelemetryOptions = {}): AgentCapabi
         ? event.result.usageRecord
         : undefined, event, options))
       context.output.provide(async (event: AgentOutputExtensionEvent) => {
-        if (!isRecord(event.result) || hasUsageTelemetryStream(event.result)) return
+        if (!isRecord(event.result)) return
+        if (hasUsageTelemetryStream(event.result) && !isRecord(event.result.usageRecord)) return
         const usageRecord = isRecord(event.result.usageRecord)
           ? event.result.usageRecord as AgentUsageRecord
           : await recordUsage(event.result, options, context.run)

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -397,6 +397,7 @@ async function* withUsageTelemetryStream(
   let recorded = false
   for await (const chunk of stream) {
     if (isRecord(chunk) && chunk.type === "usage" && isRecord(chunk.usageRecord)) {
+      await options.onUsage?.(chunk.usageRecord as AgentUsageRecord, run ? { run } : {})
       recorded = true
       onRecord?.(chunk.usageRecord as AgentUsageRecord)
     }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1137,14 +1137,15 @@ export async function applyOutputRenderers(
   result: unknown,
   renderers: ResolvedAgentOutputRenderer[] = [],
   providers: ResolvedAgentOutputExtensionProvider[] = [],
+  values: Map<string, unknown> = new Map<string, unknown>(),
 ): Promise<unknown> {
   let current = result
   let providerIndex = 0
-  const values = new Map<string, unknown>()
   const extensions = createAgentExtensionReader(values)
   for (const renderer of renderers) {
     while (providerIndex < renderer.providerCount) {
       const provider = providers[providerIndex++]
+      if (values.has(provider.id)) continue
       const value = await provider.resolve({ extensions, result: current })
       if (value !== undefined) values.set(provider.id, value)
     }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -73,6 +73,7 @@ export interface AgentCapabilityRegistries {
   deliveryEffectIntents: AgentChannelDeliveryEffectIntent[]
   finishDeliveryEffectProviders: AgentChannelDeliveryFinishEffect[]
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
+  finalOutputRenderers: ResolvedAgentOutputRenderer[]
   modelExecutionInstrumentation: AgentModelExecutionInstrumentation[]
   outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
   outputRenderers: ResolvedAgentOutputRenderer[]
@@ -685,6 +686,7 @@ export async function resolveAgentCapabilities<
     deliveryEffectIntents: [...initialDeliveryEffectIntents],
     finishDeliveryEffectProviders: [...initialFinishDeliveryEffectProviders],
     finishExtensionProviders: [],
+    finalOutputRenderers: [],
     modelExecutionInstrumentation: [],
     outputExtensionProviders: [],
     outputRenderers: [],
@@ -860,6 +862,17 @@ export async function resolveAgentCapabilities<
         },
         output: {
           extensions: createAgentExtensionReader(new Map()),
+          final(renderer: AgentOutputRenderer) {
+            const resolved = ((result: unknown, extensions = createAgentExtensionReader(new Map())) => renderer(result, {
+              ...capabilityContext,
+              output: {
+                ...capabilityContext.output,
+                extensions,
+              },
+            })) as ResolvedAgentOutputRenderer
+            resolved.providerCount = registries.outputExtensionProviders.length
+            registries.finalOutputRenderers.push(resolved)
+          },
           provide(value) {
             registries.outputExtensionProviders.push({
               id: capability.id,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -240,6 +240,7 @@ export type {
   AgentModuleOptions,
   AgentOutputExtensionEvent,
   AgentOutputExtensionProvider,
+  AgentOutputRenderer,
   AgentProvidersOptions,
   AgentRegistryHandlerOptions,
   AgentRegistry,
@@ -1072,6 +1073,7 @@ type AgentInvocationContext<
   deliveryEffectIntents: AgentChannelDeliveryEffectIntent[]
   devtools?: AgentRuntimeContext<TRuntimeConfig>["devtools"]
   driverContributions: AgentDriverContribution[]
+  finalOutputRenderers: AgentCapabilityRegistries["finalOutputRenderers"]
   finishDeliveryEffectProviders: AgentChannelDeliveryFinishEffect[]
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
   finishHook?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS> extends infer TEvent ? (event: TEvent) => MaybePromise<void> : never
@@ -1282,6 +1284,7 @@ async function createAgentInvocationContext<
       deliveryEffectIntents: capabilities.registries.deliveryEffectIntents,
       devtools: context.devtools,
       driverContributions: capabilities.driverContributions,
+      finalOutputRenderers: capabilities.registries.finalOutputRenderers,
       finishDeliveryEffectProviders: capabilities.registries.finishDeliveryEffectProviders,
       finishExtensionProviders: capabilities.registries.finishExtensionProviders,
       finishHook: definition?.hooks?.["agent:finish"] as never,
@@ -1333,9 +1336,11 @@ type InvocationRunContext<
   deliveryEffectIntents?: readonly AgentChannelDeliveryEffectIntent[]
   finishDeliveryEffectProviders: AgentChannelDeliveryFinishEffect[]
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
+  finalOutputRenderers: AgentCapabilityRegistries["finalOutputRenderers"]
   finishHook?: (event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void>
   hooks?: AgentHookObserverHooks
   input: AgentRunInput<CALL_OPTIONS>
+  outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
   actor: AgentInvoker
   invoker: AgentInvoker
   runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
@@ -1497,7 +1502,7 @@ function shouldDeferFinish<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS> & { hasCapabilityCleanup: boolean }): boolean {
-  return context.hasCapabilityCleanup || hasFinishWork(context) || hasWorkspaceAutoCommit(context)
+  return context.hasCapabilityCleanup || hasFinishWork(context) || Boolean(context.finalOutputRenderers.length) || hasWorkspaceAutoCommit(context)
 }
 
 function shouldWrapInvocationOutput<
@@ -1518,6 +1523,16 @@ async function commitWorkspaceChanges<
   const commit = resolveWorkspaceAutoCommit(context.workspaceDefinition, diff)
   if (!commit) return
   await context.workspace.snapshot({ name: commit.message })
+}
+
+async function applyFinalOutputRenderers<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  result: unknown,
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+): Promise<unknown> {
+  return await applyOutputRenderers(result, context.finalOutputRenderers, context.outputExtensionProviders)
 }
 
 function assertDeliveryEffectIntent(value: unknown): asserts value is AgentChannelDeliveryEffectIntent {
@@ -1691,7 +1706,8 @@ export async function runAgentInline<
     }
     return await finalizeAgentInvocationResult(runContext, result, async (result) => {
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
-      return { finishResult: rendered, value: rendered }
+      const final = await applyFinalOutputRenderers(rendered, runContext)
+      return { finishResult: final, value: final }
     }, "[vitehub] Agent run failed and finish lifecycle also failed.", {
       wrapStream: stream => maybeTraceAgentStream(stream as AsyncIterable<StreamEvent>, runContext),
     })
@@ -1713,8 +1729,9 @@ export async function runAgentInline<
   }
   return await finalizeAgentInvocationResult(adapterContext, result, async (result) => {
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders)
-    const runResult = toAgentRunResult(rendered)
-    return { finishResult: rendered, value: runResult }
+    const final = await applyFinalOutputRenderers(rendered, adapterContext)
+    const runResult = toAgentRunResult(final)
+    return { finishResult: final, value: runResult }
   }, "[vitehub] Agent run failed and finish lifecycle also failed.")
 }
 
@@ -1796,10 +1813,19 @@ export async function streamAgentInline<
     return await finalizeAgentInvocationResult(runContext, result, async (result) => {
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
       if (output === "ui-message-stream") {
-        return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, runContext), shouldWrapInvocationOutput(runContext), error => finishAgentInvocation(runContext, error === undefined ? rendered : undefined, error))
+        return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, runContext), shouldWrapInvocationOutput(runContext), async (error, streamedText) => {
+          const finishResult = error === undefined
+            ? await applyFinalOutputRenderers(resultWithStreamedText(rendered, streamedText || ""), runContext)
+            : undefined
+          await finishAgentInvocation(runContext, finishResult, error)
+        })
       }
       const isStreamResult = hasTraceableStreamResult(rendered)
       const isStream = isAsyncIterable(rendered) || isStreamResult
+      if (!isStream) {
+        const final = await applyFinalOutputRenderers(rendered, runContext)
+        return { finishResult: final, value: final }
+      }
       const stream = isStreamResult
         ? streamAgentOutputToEvents(rendered)
         : rendered as AsyncIterable<StreamEvent>
@@ -1811,7 +1837,12 @@ export async function streamAgentInline<
         finishResult: rendered,
         value: isStream
           ? withStreamResultProperties(shouldWrapOutput
-              ? withCapabilityCleanup(tracedStream, error => finishAgentInvocation(runContext, error === undefined ? resultWithStreamedText(rendered, streamedText) : undefined, error), { abortSignal: runContext.input.abortSignal }) as AsyncIterable<StreamEvent>
+              ? withCapabilityCleanup(tracedStream, async (error) => {
+                  const finishResult = error === undefined
+                    ? await applyFinalOutputRenderers(resultWithStreamedText(rendered, streamedText), runContext)
+                    : undefined
+                  await finishAgentInvocation(runContext, finishResult, error)
+                }, { abortSignal: runContext.input.abortSignal }) as AsyncIterable<StreamEvent>
               : tracedStream, rendered)
           : rendered,
       }
@@ -1848,7 +1879,12 @@ export async function streamAgentInline<
   return await finalizeAgentInvocationResult(adapterContext, result, async (result) => {
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders)
     if (output === "ui-message-stream") {
-      return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, adapterContext), shouldWrapInvocationOutput(adapterContext), error => finishAgentInvocation(adapterContext, error === undefined ? rendered : undefined, error))
+      return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, adapterContext), shouldWrapInvocationOutput(adapterContext), async (error, streamedText) => {
+        const finishResult = error === undefined
+          ? await applyFinalOutputRenderers(resultWithStreamedText(rendered, streamedText || ""), adapterContext)
+          : undefined
+        await finishAgentInvocation(adapterContext, finishResult, error)
+      })
     }
     const events = streamAgentOutputToEvents(rendered)
     let streamedText = ""
@@ -1857,7 +1893,12 @@ export async function streamAgentInline<
     return {
       deferFinish: shouldWrapOutput,
       finishResult: rendered,
-      value: shouldWrapOutput ? withCapabilityCleanup(tracedEvents, error => finishAgentInvocation(adapterContext, error === undefined ? resultWithStreamedText(rendered, streamedText) : undefined, error), { abortSignal: adapterContext.input.abortSignal }) : tracedEvents,
+      value: shouldWrapOutput ? withCapabilityCleanup(tracedEvents, async (error) => {
+        const finishResult = error === undefined
+          ? await applyFinalOutputRenderers(resultWithStreamedText(rendered, streamedText), adapterContext)
+          : undefined
+        await finishAgentInvocation(adapterContext, finishResult, error)
+      }, { abortSignal: adapterContext.input.abortSignal }) : tracedEvents,
     }
   }, "[vitehub] Agent stream failed and finish lifecycle also failed.", { finalizeRawStreams: output === "ui-message-stream" })
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1411,6 +1411,30 @@ function resultWithStreamedText(result: unknown, text: string): unknown {
   return { raw: result, text }
 }
 
+async function finishStreamAgentInvocation<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+  result: unknown,
+  streamedText: string,
+  error: unknown,
+  failureMessage: string,
+): Promise<void> {
+  if (error !== undefined) {
+    await finishAgentInvocation(context, undefined, error)
+    return
+  }
+  let finishResult: unknown
+  try {
+    finishResult = await applyFinalOutputRenderers(resultWithStreamedText(result, streamedText), context)
+  }
+  catch (finishError) {
+    await finishFailedAgentInvocation(context, finishError, failureMessage)
+  }
+  await finishAgentInvocation(context, finishResult)
+}
+
 function traceUiMessageStream<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -1657,7 +1681,7 @@ async function finalizeAgentInvocationResult<
       finishLifecycleStarted = shouldWrapOutput
       return response
     }
-    if (isAsyncIterable(result) && !hasTraceableStreamResult(result) && !options.finalizeRawStreams) {
+    if (isAsyncIterable(result) && !hasTraceableStreamResult(result) && !options.finalizeRawStreams && !context.finalOutputRenderers.length) {
       finishLifecycleStarted = shouldWrapOutput
       const stream = options.wrapStream?.(result) || result
       return shouldWrapOutput ? withCapabilityCleanup(stream, error => finishAgentInvocation(context, error === undefined ? result : undefined, error), { abortSignal: context.input.abortSignal }) : stream
@@ -1697,7 +1721,7 @@ export async function runAgentInline<
       return await finishFailedAgentInvocation(runContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
     }
     try {
-      if (isAsyncIterable(result)) {
+      if (isAsyncIterable(result) && !runContext.finalOutputRenderers.length) {
         result = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
       }
     }
@@ -1803,7 +1827,7 @@ export async function streamAgentInline<
       return await finishFailedAgentInvocation(runContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
     }
     try {
-      if (isAsyncIterable(result) && output !== "ui-message-stream") {
+      if (isAsyncIterable(result) && output !== "ui-message-stream" && !runContext.finalOutputRenderers.length) {
         result = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
       }
     }
@@ -1814,10 +1838,7 @@ export async function streamAgentInline<
       const rendered = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
       if (output === "ui-message-stream") {
         return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, runContext), shouldWrapInvocationOutput(runContext), async (error, streamedText) => {
-          const finishResult = error === undefined
-            ? await applyFinalOutputRenderers(resultWithStreamedText(rendered, streamedText || ""), runContext)
-            : undefined
-          await finishAgentInvocation(runContext, finishResult, error)
+          await finishStreamAgentInvocation(runContext, rendered, streamedText || "", error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
         })
       }
       const isStreamResult = hasTraceableStreamResult(rendered)
@@ -1837,12 +1858,9 @@ export async function streamAgentInline<
         finishResult: rendered,
         value: isStream
           ? withStreamResultProperties(shouldWrapOutput
-              ? withCapabilityCleanup(tracedStream, async (error) => {
-                  const finishResult = error === undefined
-                    ? await applyFinalOutputRenderers(resultWithStreamedText(rendered, streamedText), runContext)
-                    : undefined
-                  await finishAgentInvocation(runContext, finishResult, error)
-                }, { abortSignal: runContext.input.abortSignal }) as AsyncIterable<StreamEvent>
+            ? withCapabilityCleanup(tracedStream, async (error) => {
+                await finishStreamAgentInvocation(runContext, rendered, streamedText, error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
+              }, { abortSignal: runContext.input.abortSignal }) as AsyncIterable<StreamEvent>
               : tracedStream, rendered)
           : rendered,
       }
@@ -1869,7 +1887,7 @@ export async function streamAgentInline<
     return await finishFailedAgentInvocation(adapterContext, error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
   }
   try {
-    if (isAsyncIterable(result) && output !== "ui-message-stream") {
+    if (isAsyncIterable(result) && output !== "ui-message-stream" && !adapterContext.finalOutputRenderers.length) {
       result = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders)
     }
   }
@@ -1880,10 +1898,7 @@ export async function streamAgentInline<
     const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders)
     if (output === "ui-message-stream") {
       return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, adapterContext), shouldWrapInvocationOutput(adapterContext), async (error, streamedText) => {
-        const finishResult = error === undefined
-          ? await applyFinalOutputRenderers(resultWithStreamedText(rendered, streamedText || ""), adapterContext)
-          : undefined
-        await finishAgentInvocation(adapterContext, finishResult, error)
+        await finishStreamAgentInvocation(adapterContext, rendered, streamedText || "", error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
       })
     }
     const events = streamAgentOutputToEvents(rendered)
@@ -1894,10 +1909,7 @@ export async function streamAgentInline<
       deferFinish: shouldWrapOutput,
       finishResult: rendered,
       value: shouldWrapOutput ? withCapabilityCleanup(tracedEvents, async (error) => {
-        const finishResult = error === undefined
-          ? await applyFinalOutputRenderers(resultWithStreamedText(rendered, streamedText), adapterContext)
-          : undefined
-        await finishAgentInvocation(adapterContext, finishResult, error)
+        await finishStreamAgentInvocation(adapterContext, rendered, streamedText, error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
       }, { abortSignal: adapterContext.input.abortSignal }) : tracedEvents,
     }
   }, "[vitehub] Agent stream failed and finish lifecycle also failed.", { finalizeRawStreams: output === "ui-message-stream" })

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1387,21 +1387,6 @@ function withStreamResultProperties<T extends AsyncIterable<StreamEvent>>(stream
   return stream
 }
 
-function withStreamedText(
-  stream: AsyncIterable<unknown>,
-  append: (text: string) => void,
-): AsyncIterable<unknown> {
-  return (async function* () {
-    for await (const event of stream) {
-      if (event && typeof event === "object" && (event as { type?: unknown }).type === "text-delta") {
-        const text = (event as { text?: unknown }).text
-        if (typeof text === "string") append(text)
-      }
-      yield event
-    }
-  })()
-}
-
 function resultWithStreamedText(result: unknown, text: string): unknown {
   if (!text || typeof result === "string") return result
   if (result && typeof result === "object" && !(result instanceof Response)) {
@@ -1411,15 +1396,40 @@ function resultWithStreamedText(result: unknown, text: string): unknown {
   return { raw: result, text }
 }
 
+function withStreamedResult(stream: AsyncIterable<unknown>, result: unknown) {
+  const toolNames = new Map<string, string>()
+  let streamedText = ""
+  let usageRecord: Extract<StreamEvent, { type: "usage" }>["usageRecord"] | undefined
+  return {
+    finishResult() {
+      const output = resultWithStreamedText(result, streamedText)
+      if (usageRecord && output && typeof output === "object" && !(output instanceof Response)) {
+        const record = output as { usage?: unknown, usageRecord?: unknown }
+        record.usageRecord ??= usageRecord
+        record.usage ??= usageRecord.usage
+      }
+      return output
+    },
+    stream: (async function* () {
+      for await (const chunk of stream) {
+        const event = toAgentStreamEvent(chunk, toolNames)
+        if (event?.type === "text-delta" && event.text) streamedText += event.text
+        if (event?.type === "usage") usageRecord = event.usageRecord
+        yield chunk
+      }
+    })(),
+  }
+}
+
 async function finishStreamAgentInvocation<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
   result: unknown,
-  streamedText: string,
   error: unknown,
   failureMessage: string,
+  outputExtensions = new Map<string, unknown>(),
 ): Promise<void> {
   if (error !== undefined) {
     await finishAgentInvocation(context, undefined, error)
@@ -1427,7 +1437,7 @@ async function finishStreamAgentInvocation<
   }
   let finishResult: unknown
   try {
-    finishResult = await applyFinalOutputRenderers(resultWithStreamedText(result, streamedText), context)
+    finishResult = await applyFinalOutputRenderers(result, context, outputExtensions)
   }
   catch (finishError) {
     await finishFailedAgentInvocation(context, finishError, failureMessage)
@@ -1555,8 +1565,9 @@ async function applyFinalOutputRenderers<
 >(
   result: unknown,
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+  outputExtensions = new Map<string, unknown>(),
 ): Promise<unknown> {
-  return await applyOutputRenderers(result, context.finalOutputRenderers, context.outputExtensionProviders)
+  return await applyOutputRenderers(result, context.finalOutputRenderers, context.outputExtensionProviders, outputExtensions)
 }
 
 function assertDeliveryEffectIntent(value: unknown): asserts value is AgentChannelDeliveryEffectIntent {
@@ -1670,6 +1681,7 @@ async function finalizeAgentInvocationResult<
   failureMessage: string,
   options: {
     finalizeRawStreams?: boolean
+    outputExtensions?: Map<string, unknown>
     wrapStream?: (stream: AsyncIterable<unknown>) => AsyncIterable<unknown>
   } = {},
 ): Promise<Response | AsyncIterable<unknown> | TResult> {
@@ -1681,9 +1693,13 @@ async function finalizeAgentInvocationResult<
       finishLifecycleStarted = shouldWrapOutput
       return response
     }
-    if (isAsyncIterable(result) && !hasTraceableStreamResult(result) && !options.finalizeRawStreams && !context.finalOutputRenderers.length) {
+    if (isAsyncIterable(result) && !hasTraceableStreamResult(result) && !options.finalizeRawStreams) {
       finishLifecycleStarted = shouldWrapOutput
       const stream = options.wrapStream?.(result) || result
+      if (shouldWrapOutput && context.finalOutputRenderers.length) {
+        const streamed = withStreamedResult(stream, result)
+        return withCapabilityCleanup(streamed.stream, error => finishStreamAgentInvocation(context, streamed.finishResult(), error, failureMessage, options.outputExtensions), { abortSignal: context.input.abortSignal })
+      }
       return shouldWrapOutput ? withCapabilityCleanup(stream, error => finishAgentInvocation(context, error === undefined ? result : undefined, error), { abortSignal: context.input.abortSignal }) : stream
     }
     const finalized = await finalizeObject(result)
@@ -1720,19 +1736,23 @@ export async function runAgentInline<
     catch (error) {
       return await finishFailedAgentInvocation(runContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
     }
+    const outputExtensions = new Map<string, unknown>()
+    let renderedResult = false
     try {
-      if (isAsyncIterable(result) && !runContext.finalOutputRenderers.length) {
-        result = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
+      if (isAsyncIterable(result)) {
+        result = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders, outputExtensions)
+        renderedResult = true
       }
     }
     catch (error) {
       return await finishFailedAgentInvocation(runContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
     }
     return await finalizeAgentInvocationResult(runContext, result, async (result) => {
-      const rendered = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
-      const final = await applyFinalOutputRenderers(rendered, runContext)
+      const rendered = renderedResult ? result : await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders, outputExtensions)
+      const final = await applyFinalOutputRenderers(rendered, runContext, outputExtensions)
       return { finishResult: final, value: final }
     }, "[vitehub] Agent run failed and finish lifecycle also failed.", {
+      outputExtensions,
       wrapStream: stream => maybeTraceAgentStream(stream as AsyncIterable<StreamEvent>, runContext),
     })
   }
@@ -1752,8 +1772,9 @@ export async function runAgentInline<
     return await finishFailedAgentInvocation(adapterContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
   }
   return await finalizeAgentInvocationResult(adapterContext, result, async (result) => {
-    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders)
-    const final = await applyFinalOutputRenderers(rendered, adapterContext)
+    const outputExtensions = new Map<string, unknown>()
+    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders, outputExtensions)
+    const final = await applyFinalOutputRenderers(rendered, adapterContext, outputExtensions)
     const runResult = toAgentRunResult(final)
     return { finishResult: final, value: runResult }
   }, "[vitehub] Agent run failed and finish lifecycle also failed.")
@@ -1826,46 +1847,50 @@ export async function streamAgentInline<
     catch (error) {
       return await finishFailedAgentInvocation(runContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
     }
+    const outputExtensions = new Map<string, unknown>()
+    let renderedResult = false
     try {
       if (isAsyncIterable(result) && output !== "ui-message-stream" && !runContext.finalOutputRenderers.length) {
-        result = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
+        result = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders, outputExtensions)
+        renderedResult = true
       }
     }
     catch (error) {
       return await finishFailedAgentInvocation(runContext, error, "[vitehub] Agent run failed and finish lifecycle also failed.")
     }
     return await finalizeAgentInvocationResult(runContext, result, async (result) => {
-      const rendered = await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders)
+      const rendered = renderedResult ? result : await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders, outputExtensions)
       if (output === "ui-message-stream") {
         return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, runContext), shouldWrapInvocationOutput(runContext), async (error, streamedText) => {
-          await finishStreamAgentInvocation(runContext, rendered, streamedText || "", error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
+          await finishStreamAgentInvocation(runContext, resultWithStreamedText(rendered, streamedText || ""), error, "[vitehub] Agent stream failed and finish lifecycle also failed.", outputExtensions)
         })
       }
       const isStreamResult = hasTraceableStreamResult(rendered)
       const isStream = isAsyncIterable(rendered) || isStreamResult
       if (!isStream) {
-        const final = await applyFinalOutputRenderers(rendered, runContext)
+        const final = await applyFinalOutputRenderers(rendered, runContext, outputExtensions)
         return { finishResult: final, value: final }
       }
       const stream = isStreamResult
         ? streamAgentOutputToEvents(rendered)
         : rendered as AsyncIterable<StreamEvent>
       const shouldWrapOutput = shouldWrapInvocationOutput(runContext)
-      let streamedText = ""
-      const tracedStream = maybeTraceAgentStream(withStreamedText(stream, text => { streamedText += text }) as AsyncIterable<StreamEvent>, runContext)
+      const streamed = withStreamedResult(stream, rendered)
+      const tracedStream = maybeTraceAgentStream(streamed.stream as AsyncIterable<StreamEvent>, runContext)
       return {
         deferFinish: isStream && shouldWrapOutput,
         finishResult: rendered,
         value: isStream
           ? withStreamResultProperties(shouldWrapOutput
             ? withCapabilityCleanup(tracedStream, async (error) => {
-                await finishStreamAgentInvocation(runContext, rendered, streamedText, error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
+                await finishStreamAgentInvocation(runContext, streamed.finishResult(), error, "[vitehub] Agent stream failed and finish lifecycle also failed.", outputExtensions)
               }, { abortSignal: runContext.input.abortSignal }) as AsyncIterable<StreamEvent>
               : tracedStream, rendered)
           : rendered,
       }
     }, "[vitehub] Agent run failed and finish lifecycle also failed.", {
-      finalizeRawStreams: output === "ui-message-stream",
+      finalizeRawStreams: output === "ui-message-stream" || Boolean(runContext.finalOutputRenderers.length),
+      outputExtensions,
       wrapStream: stream => maybeTraceAgentStream(stream as AsyncIterable<StreamEvent>, runContext),
     })
   }
@@ -1886,33 +1911,39 @@ export async function streamAgentInline<
   catch (error) {
     return await finishFailedAgentInvocation(adapterContext, error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
   }
+  const outputExtensions = new Map<string, unknown>()
+  let renderedResult = false
   try {
     if (isAsyncIterable(result) && output !== "ui-message-stream" && !adapterContext.finalOutputRenderers.length) {
-      result = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders)
+      result = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders, outputExtensions)
+      renderedResult = true
     }
   }
   catch (error) {
     return await finishFailedAgentInvocation(adapterContext, error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
   }
   return await finalizeAgentInvocationResult(adapterContext, result, async (result) => {
-    const rendered = await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders)
+    const rendered = renderedResult ? result : await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders, outputExtensions)
     if (output === "ui-message-stream") {
       return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, adapterContext), shouldWrapInvocationOutput(adapterContext), async (error, streamedText) => {
-        await finishStreamAgentInvocation(adapterContext, rendered, streamedText || "", error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
+        await finishStreamAgentInvocation(adapterContext, resultWithStreamedText(rendered, streamedText || ""), error, "[vitehub] Agent stream failed and finish lifecycle also failed.", outputExtensions)
       })
     }
     const events = streamAgentOutputToEvents(rendered)
-    let streamedText = ""
-    const tracedEvents = maybeTraceAgentStream(withStreamedText(events, text => { streamedText += text }) as AsyncIterable<StreamEvent>, adapterContext)
+    const streamed = withStreamedResult(events, rendered)
+    const tracedEvents = maybeTraceAgentStream(streamed.stream as AsyncIterable<StreamEvent>, adapterContext)
     const shouldWrapOutput = shouldWrapInvocationOutput(adapterContext)
     return {
       deferFinish: shouldWrapOutput,
       finishResult: rendered,
       value: shouldWrapOutput ? withCapabilityCleanup(tracedEvents, async (error) => {
-        await finishStreamAgentInvocation(adapterContext, rendered, streamedText, error, "[vitehub] Agent stream failed and finish lifecycle also failed.")
+        await finishStreamAgentInvocation(adapterContext, streamed.finishResult(), error, "[vitehub] Agent stream failed and finish lifecycle also failed.", outputExtensions)
       }, { abortSignal: adapterContext.input.abortSignal }) : tracedEvents,
     }
-  }, "[vitehub] Agent stream failed and finish lifecycle also failed.", { finalizeRawStreams: output === "ui-message-stream" })
+  }, "[vitehub] Agent stream failed and finish lifecycle also failed.", {
+    finalizeRawStreams: output === "ui-message-stream" || Boolean(adapterContext.finalOutputRenderers.length),
+    outputExtensions,
+  })
 }
 
 export async function streamAgent<

--- a/packages/agent/src/output.ts
+++ b/packages/agent/src/output.ts
@@ -1,0 +1,7 @@
+export {
+  isAsyncIterable,
+  streamAgentOutputToEvents,
+  toAgentRunResult,
+  toAgentStreamEvent,
+} from "./agent-output.ts"
+

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -87,7 +87,11 @@ export function createAgentUIMessageStreamResponse(options: {
   })
 }
 
-export function withReadableStreamCleanup<T>(stream: ReadableStream<T>, cleanup: (error?: unknown) => Promise<void>): ReadableStream<T> {
+export function withReadableStreamCleanup<T>(
+  stream: ReadableStream<T>,
+  cleanup: (error?: unknown) => Promise<void>,
+  options: { onChunk?: (chunk: T) => void } = {},
+): ReadableStream<T> {
   const reader = stream.getReader()
   let cleaned = false
   const runCleanup = async (error?: unknown) => {
@@ -104,6 +108,7 @@ export function withReadableStreamCleanup<T>(stream: ReadableStream<T>, cleanup:
           controller.close()
           return
         }
+        options.onChunk?.(result.value)
         controller.enqueue(result.value)
       }
       catch (error) {
@@ -129,6 +134,15 @@ function streamEventType(event: unknown): string | undefined {
   return typeof event === "object" && event !== null && typeof (event as { type?: unknown }).type === "string"
     ? (event as { type: string }).type
     : undefined
+}
+
+function uiMessageTextDelta(event: unknown): string | undefined {
+  const type = streamEventType(event)
+  if (type !== "text" && type !== "text-delta") return
+  const text = (event as { delta?: unknown, text?: unknown, textDelta?: unknown }).text
+    ?? (event as { delta?: unknown, textDelta?: unknown }).textDelta
+    ?? (event as { delta?: unknown }).delta
+  return typeof text === "string" ? text : undefined
 }
 
 function uiDataType(data: unknown): `data-${string}` {
@@ -191,7 +205,7 @@ async function writeEventsToUiMessageStream(writer: AgentUIMessageStreamWriter, 
 export async function finalizeUiMessageStreamOutput(
   rendered: unknown,
   shouldWrapOutput: boolean,
-  finish: (error?: unknown) => MaybePromise<void>,
+  finish: (error?: unknown, streamedText?: string) => MaybePromise<void>,
 ): Promise<FinalizedStreamOutput<unknown>> {
   const hasUiMessageStream = isUIMessageStreamResult(rendered)
   const hasAsyncIterable = isAsyncIterable(rendered)
@@ -215,11 +229,16 @@ export async function finalizeUiMessageStreamOutput(
           writer.write({ type: "finish", finishReason: "stop" })
         },
       })
+  let streamedText = ""
   return {
     deferFinish: shouldWrapOutput,
     finishResult: rendered,
     value: shouldWrapOutput
-      ? withReadableStreamCleanup(stream, error => Promise.resolve(finish(error)))
+      ? withReadableStreamCleanup(stream, error => Promise.resolve(finish(error, streamedText)), {
+          onChunk(chunk) {
+            streamedText += uiMessageTextDelta(chunk) || ""
+          },
+        })
       : stream,
   }
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -556,6 +556,7 @@ export interface AgentCapabilityRuntimeContext<
   }
   output: {
     extensions: AgentInvocationExtensions
+    final: (renderer: AgentOutputRenderer) => void
     provide: (value: unknown | AgentOutputExtensionProvider) => void
     render: (renderer: AgentOutputRenderer) => void
   }

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -428,6 +428,44 @@ describe("agent output helpers", () => {
     ])
   })
 
+  it("preserves non-token stream usage details", async () => {
+    const output = {
+      fullStream: (async function* () {
+        yield { text: "ok", type: "text-delta" }
+        yield {
+          type: "finish",
+          usage: {
+            actions: 2,
+            sessions: 1,
+            wallTimeMs: 800,
+          },
+        }
+      })(),
+    }
+
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents(output)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: {
+          usage: {
+            details: {
+              actions: 2,
+              sessions: 1,
+              wallTimeMs: 800,
+            },
+          },
+        },
+      },
+      { type: "finish" },
+    ])
+  })
+
   it("adds a terminal finish event to textStream output", async () => {
     const output = {
       textStream: (async function* () {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -609,6 +609,17 @@ describe("agent Vite plugin", () => {
       import: "./dist/server/routes.js",
     })
   })
+
+  it("publishes the Agent output helper subpath", async () => {
+    const pkg = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8")) as {
+      exports?: Record<string, unknown>
+    }
+
+    expect(pkg.exports?.["./output"]).toEqual({
+      types: "./dist/output.d.ts",
+      import: "./dist/output.js",
+    })
+  })
 })
 
 describe("server helpers", () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3055,6 +3055,191 @@ describe("agent message protocol", () => {
     expect(delivered).toHaveBeenCalledWith("raw review\nReview run used 15 tokens: 10 in / 5 out.")
   })
 
+  it("runs final output renderers for bare event streams before finish delivery effects", async () => {
+    const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const delivered = vi.fn()
+
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "bare-stream-output",
+          output(context) {
+            context.output.final(result => ({
+              ...result as Record<string, unknown>,
+              text: `${(result as { text?: string }).text}:final`,
+            }))
+            context.delivery.finishEffect(event => ({
+              kind: "reply",
+              payload: (event.result as { text?: string }).text,
+            }))
+          },
+        }),
+      ],
+      channels: {
+        review: defineChannel("review", {
+          effects: {
+            reply({ effect }) {
+              delivered(effect.payload)
+            },
+          },
+          messages: false,
+        }),
+      },
+      run: () => (async function* () {
+        yield { text: "bare ", type: "text-delta" }
+        yield { text: "stream", type: "text-delta" }
+        yield { type: "finish" }
+      })(),
+    })
+
+    const stream = await streamAgent(agent, {
+      memo: vi.fn(),
+      run: {
+        channelId: "review",
+        runId: "run-1",
+      },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})
+
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "bare ", type: "text-delta" },
+      { text: "stream", type: "text-delta" },
+      { type: "finish" },
+    ])
+    expect(delivered).toHaveBeenCalledWith("bare stream:final")
+  })
+
+  it("exposes explicit stream usage events to final output renderers", async () => {
+    const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const delivered = vi.fn()
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({ summary: { subject: "Review run" } }),
+        defineCapability({
+          id: "explicit-usage-output",
+          output(context) {
+            context.output.final((result, renderContext) => {
+              const usage = renderContext.output.extensions.get<{ summary?: string }>("usage-telemetry")
+              return {
+                ...result as Record<string, unknown>,
+                text: `${(result as { text?: string }).text}\n${usage?.summary}`,
+              }
+            })
+            context.delivery.finishEffect(event => ({
+              kind: "reply",
+              payload: (event.result as { text?: string }).text,
+            }))
+          },
+        }),
+      ],
+      channels: {
+        review: defineChannel("review", {
+          effects: {
+            reply({ effect }) {
+              delivered(effect.payload)
+            },
+          },
+          messages: false,
+        }),
+      },
+      run: () => ({
+        fullStream: (async function* () {
+          yield { text: "raw ", type: "text-delta" }
+          yield { text: "review", type: "text-delta" }
+          yield {
+            type: "usage",
+            usageRecord: {
+              usage: {
+                inputTokens: 10,
+                outputTokens: 5,
+                totalTokens: 15,
+              },
+            },
+          }
+          yield { type: "finish" }
+        })(),
+      }),
+    })
+
+    const stream = await streamAgent(agent, {
+      memo: vi.fn(),
+      run: {
+        channelId: "review",
+        runId: "run-1",
+      },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})
+
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "raw ", type: "text-delta" },
+      { text: "review", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: {
+          usage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            totalTokens: 15,
+          },
+        },
+      },
+      { type: "finish" },
+    ])
+    expect(delivered).toHaveBeenCalledWith("raw review\nReview run used 15 tokens: 10 in / 5 out.")
+  })
+
+  it("routes stream final output renderer failures through finish lifecycle", async () => {
+    const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
+    const finalError = new Error("final failed")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "broken-final-output",
+          output(context) {
+            context.output.final(() => {
+              throw finalError
+            })
+          },
+        }),
+      ],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({
+        fullStream: (async function* () {
+          yield { text: "ok", type: "text-delta" }
+          yield { type: "finish" }
+        })(),
+      }),
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})
+
+    await expect((async () => {
+      for await (const _event of stream as AsyncIterable<unknown>) {}
+    })()).rejects.toThrow("final failed")
+    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+      error: finalError,
+    }))
+  })
+
   it("runs final output renderers before ui-message-stream finish delivery effects", async () => {
     const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -938,6 +938,127 @@ describe("agent message protocol", () => {
     expect(session.destroy).toHaveBeenCalledOnce()
   })
 
+  it("finalizes harness result output before finish hooks", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const finish = vi.fn()
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessGenerate.mockResolvedValueOnce({
+      text: "ok",
+      usage: {
+        actions: 2,
+      },
+    })
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({ summary: { subject: "Harness run" } }),
+        defineCapability({
+          id: "harness-output",
+          output(context) {
+            context.output.final((result, renderContext) => {
+              const usage = renderContext.output.extensions.get<{ summary?: string }>("usage-telemetry")
+              return {
+                ...result as Record<string, unknown>,
+                text: `${(result as { text?: string }).text}\n${usage?.summary}`,
+              }
+            })
+          },
+        }),
+      ],
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: { provider: "sandbox" },
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "hello" })).resolves.toMatchObject({
+      text: "ok\nHarness run reported actions: 2.",
+      usageRecord: {
+        usage: {
+          details: {
+            actions: 2,
+          },
+        },
+      },
+    })
+    expect(finish.mock.calls[0]![0].result).toMatchObject({
+      text: "ok\nHarness run reported actions: 2.",
+    })
+  })
+
+  it("finalizes harness stream output before finish hooks", async () => {
+    const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const finish = vi.fn()
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessStream.mockResolvedValueOnce({
+      fullStream: (async function* () {
+        yield { text: "ok", type: "text-delta" }
+        yield {
+          type: "finish",
+          usage: {
+            actions: 3,
+          },
+        }
+      })(),
+    })
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({ summary: { subject: "Harness stream" } }),
+        defineCapability({
+          id: "harness-stream-output",
+          output(context) {
+            context.output.final((result, renderContext) => {
+              const usage = renderContext.output.extensions.get<{ summary?: string }>("usage-telemetry")
+              return {
+                ...result as Record<string, unknown>,
+                text: `${(result as { text?: string }).text}\n${usage?.summary}`,
+              }
+            })
+          },
+        }),
+      ],
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: { provider: "sandbox" },
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "hello" })
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "ok", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: expect.objectContaining({
+          usage: {
+            details: {
+              actions: 3,
+            },
+          },
+        }),
+      },
+      { type: "finish" },
+    ])
+    expect(finish.mock.calls[0]![0].result).toMatchObject({
+      text: "ok\nHarness stream reported actions: 3.",
+    })
+  })
+
   it("passes model-facing Capability tools into harness Agent Drivers", async () => {
     const { defineCapability } = await import("../src/capability-runtime.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")
@@ -2782,6 +2903,228 @@ describe("agent message protocol", () => {
     finally {
       vi.doUnmock("ai")
     }
+  })
+
+  it("finalizes model-backed results before finish hooks", async () => {
+    vi.doMock("ai", () => ({
+      jsonSchema: vi.fn(schema => schema),
+      ToolLoopAgent: class {
+        async generate() {
+          return {
+            text: "ok",
+            usage: {
+              inputTokens: 4,
+              outputTokens: 2,
+            },
+          }
+        }
+      },
+      isStepCount: () => () => false,
+    }))
+
+    try {
+      const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+      const { usageTelemetry } = await import("../src/capabilities.ts")
+      const finish = vi.fn()
+      const agent = defineAgent({
+        capabilities: [
+          usageTelemetry({ summary: { subject: "Model run" } }),
+          defineCapability({
+            id: "model-output",
+            output(context) {
+              context.output.final((result, renderContext) => {
+                const usage = renderContext.output.extensions.get<{ summary?: string }>("usage-telemetry")
+                return {
+                  ...result as Record<string, unknown>,
+                  text: `${(result as { text?: string }).text}\n${usage?.summary}`,
+                }
+              })
+            },
+          }),
+        ],
+        hooks: {
+          "agent:finish": finish,
+        },
+        model: {} as never,
+      })
+
+      await expect(runAgent(agent, {
+        memo: vi.fn(),
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, {})).resolves.toMatchObject({
+        text: "ok\nModel run used 6 tokens: 4 in / 2 out.",
+        usageRecord: {
+          usage: {
+            inputTokens: 4,
+            outputTokens: 2,
+            totalTokens: 6,
+          },
+        },
+      })
+      expect(finish.mock.calls[0]![0].result).toMatchObject({
+        text: "ok\nModel run used 6 tokens: 4 in / 2 out.",
+      })
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
+  it("runs final output renderers before finish delivery effects", async () => {
+    const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const delivered = vi.fn()
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({ summary: { subject: "Review run" } }),
+        defineCapability({
+          id: "delivery-output",
+          output(context) {
+            context.output.final((result, renderContext) => {
+              const usage = renderContext.output.extensions.get<{ summary?: string }>("usage-telemetry")
+              return {
+                ...result as Record<string, unknown>,
+                text: `${(result as { text?: string }).text}\n${usage?.summary}`,
+              }
+            })
+            context.delivery.finishEffect(event => ({
+              kind: "reply",
+              payload: (event.result as { text?: string }).text,
+            }))
+          },
+        }),
+      ],
+      channels: {
+        review: defineChannel("review", {
+          effects: {
+            reply({ effect }) {
+              delivered(effect.payload)
+            },
+          },
+          messages: false,
+        }),
+      },
+      run: () => ({
+        fullStream: (async function* () {
+          yield { text: "raw ", type: "text-delta" }
+          yield { text: "review", type: "text-delta" }
+          yield {
+            totalUsage: {
+              inputTokens: 10,
+              outputTokens: 5,
+            },
+            type: "finish",
+          }
+        })(),
+      }),
+    })
+
+    const stream = await streamAgent(agent, {
+      memo: vi.fn(),
+      run: {
+        channelId: "review",
+        runId: "run-1",
+      },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})
+
+    const events: unknown[] = []
+    for await (const event of stream as AsyncIterable<unknown>) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { text: "raw ", type: "text-delta" },
+      { text: "review", type: "text-delta" },
+      {
+        type: "usage",
+        usageRecord: expect.objectContaining({
+          usage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            totalTokens: 15,
+          },
+        }),
+      },
+      { type: "finish" },
+    ])
+    expect(delivered).toHaveBeenCalledWith("raw review\nReview run used 15 tokens: 10 in / 5 out.")
+  })
+
+  it("runs final output renderers before ui-message-stream finish delivery effects", async () => {
+    const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const delivered = vi.fn()
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({ summary: { subject: "Review ui" } }),
+        defineCapability({
+          id: "delivery-ui-output",
+          output(context) {
+            context.output.final((result, renderContext) => {
+              const usage = renderContext.output.extensions.get<{ summary?: string }>("usage-telemetry")
+              return {
+                ...result as Record<string, unknown>,
+                text: `${(result as { text?: string }).text}\n${usage?.summary}`,
+              }
+            })
+            context.delivery.finishEffect(event => ({
+              kind: "reply",
+              payload: (event.result as { text?: string }).text,
+            }))
+          },
+        }),
+      ],
+      channels: {
+        review: defineChannel("review", {
+          effects: {
+            reply({ effect }) {
+              delivered(effect.payload)
+            },
+          },
+          messages: false,
+        }),
+      },
+      run: () => ({
+        toUIMessageStream() {
+          return new ReadableStream({
+            start(controller) {
+              controller.enqueue({ delta: "ui ", type: "text-delta" })
+              controller.enqueue({ delta: "review", type: "text-delta" })
+              controller.enqueue({ type: "finish" })
+              controller.close()
+            },
+          })
+        },
+        usage: {
+          inputTokens: 1,
+          outputTokens: 2,
+        },
+      }),
+    })
+
+    const stream = await streamAgent(agent, {
+      memo: vi.fn(),
+      run: {
+        channelId: "review",
+        runId: "run-1",
+      },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {}, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    const reader = stream.getReader()
+    while (true) {
+      const { done } = await reader.read()
+      if (done) break
+    }
+
+    expect(delivered).toHaveBeenCalledWith("ui review\nReview ui used 3 tokens: 1 in / 2 out.")
   })
 
   it("runs agent finish hooks after generated streams are consumed", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2794,6 +2794,33 @@ describe("agent message protocol", () => {
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok:12 tokens:12 tokens:undefined")
   })
 
+  it("keeps normal output extensions visible to final renderers", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "usage-note",
+          output(context) {
+            context.output.provide({ summary: "12 tokens" })
+            context.output.render(() => "plain")
+          },
+        }),
+        defineCapability({
+          id: "summary-output",
+          output(context) {
+            context.output.final((result, renderContext) => {
+              const summary = renderContext.output.extensions.get<string>("usage-note", "summary")
+              return `${result}:${summary}`
+            })
+          },
+        }),
+      ],
+      run: () => ({ text: "ok" }),
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("plain:12 tokens")
+  })
+
   it("keeps one-argument output render callbacks working", async () => {
     const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
     const agent = defineAgent({
@@ -3116,7 +3143,7 @@ describe("agent message protocol", () => {
     expect(delivered).toHaveBeenCalledWith("bare stream:final")
   })
 
-  it("exposes explicit stream usage events to final output renderers", async () => {
+  it("carries bare stream usage events into final output renderers", async () => {
     const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")
@@ -3125,6 +3152,111 @@ describe("agent message protocol", () => {
     const agent = defineAgent({
       capabilities: [
         usageTelemetry({ summary: { subject: "Review run" } }),
+        defineCapability({
+          id: "bare-usage-output",
+          output(context) {
+            context.output.final((result, renderContext) => {
+              const usage = renderContext.output.extensions.get<{ summary?: string }>("usage-telemetry")
+              return {
+                ...result as Record<string, unknown>,
+                text: `${(result as { text?: string }).text}\n${usage?.summary}`,
+              }
+            })
+            context.delivery.finishEffect(event => ({
+              kind: "reply",
+              payload: (event.result as { text?: string }).text,
+            }))
+          },
+        }),
+      ],
+      channels: {
+        review: defineChannel("review", {
+          effects: {
+            reply({ effect }) {
+              delivered(effect.payload)
+            },
+          },
+          messages: false,
+        }),
+      },
+      run: () => (async function* () {
+        yield { text: "bare ", type: "text-delta" }
+        yield { text: "review", type: "text-delta" }
+        yield {
+          type: "usage",
+          usageRecord: {
+            usage: {
+              inputTokens: 3,
+              outputTokens: 4,
+              totalTokens: 7,
+            },
+          },
+        }
+        yield { type: "finish" }
+      })(),
+    })
+
+    const stream = await streamAgent(agent, {
+      memo: vi.fn(),
+      run: {
+        channelId: "review",
+        runId: "run-1",
+      },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})
+
+    for await (const _event of stream as AsyncIterable<unknown>) {}
+
+    expect(delivered).toHaveBeenCalledWith("bare review\nReview run used 7 tokens: 3 in / 4 out.")
+  })
+
+  it("defers runAgent final renderers for bare streams until consumption", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "run-stream-output",
+          output(context) {
+            context.output.final(result => ({
+              ...result as Record<string, unknown>,
+              text: `${(result as { text?: string }).text}:final`,
+            }))
+          },
+        }),
+      ],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => (async function* () {
+        yield { text: "run ", type: "text-delta" }
+        yield { text: "stream", type: "text-delta" }
+        yield { type: "finish" }
+      })(),
+    })
+
+    const stream = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})
+    expect(finish).not.toHaveBeenCalled()
+    for await (const _event of stream as AsyncIterable<unknown>) {}
+
+    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+      result: expect.objectContaining({
+        text: "run stream:final",
+      }),
+    }))
+  })
+
+  it("exposes explicit stream usage events to final output renderers", async () => {
+    const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const delivered = vi.fn()
+    const onUsage = vi.fn()
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({ onUsage, summary: { subject: "Review run" } }),
         defineCapability({
           id: "explicit-usage-output",
           output(context) {
@@ -3201,6 +3333,15 @@ describe("agent message protocol", () => {
       },
       { type: "finish" },
     ])
+    expect(onUsage).toHaveBeenCalledWith(expect.objectContaining({
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      },
+    }), expect.objectContaining({
+      run: expect.objectContaining({ runId: "run-1" }),
+    }))
     expect(delivered).toHaveBeenCalledWith("raw review\nReview run used 15 tokens: 10 in / 5 out.")
   })
 

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -6,7 +6,8 @@ import { defineChannel, github, http, stream, teams, telegram, webChat, type Git
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
-import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentUsageRecord } from "../src/index.ts"
+import { streamAgentOutputToEvents, toAgentRunResult } from "../src/output.ts"
+import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentUsageRecord, StreamEvent } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
 import { file, github as githubSource } from "@vite-hub/workspace"
 import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatPlatformResolver, AgentChatRunContext, FetchCapabilityToolOptions, PullRequestContextValue, RepositoryHostClient, TranscriptionResult, UsageTelemetryOutputExtension, UsageTelemetrySummaryOptions } from "../src/capabilities.ts"
@@ -340,6 +341,10 @@ describe("agent public types", () => {
             expectTypeOf(renderContext.output.extensions.get<{ summary: string }>("output-extension")).toEqualTypeOf<{ summary: string } | undefined>()
             expectTypeOf(renderContext.output.extensions.get<string>("output-extension", "summary")).toEqualTypeOf<string | undefined>()
             expectTypeOf(renderContext.output.extensions.get<UsageTelemetryOutputExtension>("usage-telemetry")).toEqualTypeOf<UsageTelemetryOutputExtension | undefined>()
+            return result
+          })
+          context.output.final((result, renderContext) => {
+            expectTypeOf(renderContext.output.extensions.get<{ summary: string }>("output-extension")).toEqualTypeOf<{ summary: string } | undefined>()
             return result
           })
         },
@@ -1058,5 +1063,10 @@ describe("agent public types", () => {
       // @ts-expect-error eval definitions do not expose test runner waitUntil plumbing
       waitUntil: () => {},
     })
+  })
+
+  it("exposes output helpers from the output entry", () => {
+    expectTypeOf(toAgentRunResult("ok").text).toEqualTypeOf<string | undefined>()
+    expectTypeOf(streamAgentOutputToEvents("ok")).toEqualTypeOf<AsyncIterable<StreamEvent>>()
   })
 })

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -1161,6 +1161,50 @@ describe("usage telemetry", () => {
     expect((result as { usageRecord?: { cost?: unknown } }).usageRecord?.cost).toBeUndefined()
   })
 
+  it("summarizes non-token usage without cost or token counts", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [
+        usageTelemetry({
+          summary: { subject: "Harness run" },
+        }),
+        defineCapability({
+          id: "usage-note",
+          output(context) {
+            context.output.render((result, renderContext) => {
+              const usage = renderContext.output.extensions.get<{ summary?: string }>("usage-telemetry")
+              return {
+                ...result as Record<string, unknown>,
+                text: `${(result as { text?: string }).text}\n${usage?.summary}`,
+              }
+            })
+          },
+        }),
+      ],
+      run: () => ({
+        text: "ok",
+        usage: {
+          actions: 2,
+          sessions: 1,
+        },
+      }),
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+      text: "ok\nHarness run reported actions: 2, sessions: 1.",
+      usageRecord: {
+        usage: {
+          details: {
+            actions: 2,
+            sessions: 1,
+          },
+        },
+      },
+    })
+  })
+
   it("loads Vercel AI Gateway pricing from the models endpoint", async () => {
     const { vercelAiGatewayPricing } = await import("../src/capabilities.ts")
     const fetch = vi.fn(async () => Response.json({

--- a/packages/agent/vite.config.ts
+++ b/packages/agent/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       "src/messages.ts",
       "src/mcp.ts",
       "src/mcp/stdio.ts",
+      "src/output.ts",
       "src/cloudflare.ts",
       "src/cli.ts",
       "src/eval.ts",


### PR DESCRIPTION
Adds a public `@vite-hub/agent/output` subpath for the existing output normalization helpers and introduces `context.output.final()` as a narrow final renderer that runs after normal output rendering but before finish hooks and delivery finish effects. The final renderer path is wired through custom runs, model adapters, harness result/stream output, event streams, and UI-message streams so delivery code receives the shaped final result instead of raw progress text.

Usage telemetry now preserves non-token usage details, can summarize them honestly without inventing token or cost data, and exposes those summaries to final output shaping once stream telemetry has attached a usage record. The tests cover model and harness parity, non-token usage, finish delivery shaping, and the new output helper subpath.
