### PR TITLE
fix(agent): support context-backed channel dev triggers

### DIFF
--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -504,6 +504,61 @@ function githubCommandFromUnknown(value: unknown): GitHubPullRequestCommand | un
   }
 }
 
+function commandWithSlash(value: unknown): `/${string}` | (string & {}) | undefined {
+  const command = maybeString(value)
+  if (!command) return
+  return command.startsWith("/") ? command : `/${command}`
+}
+
+function githubCommandFromInvocationContext(input: unknown): GitHubPullRequestCommand | undefined {
+  if (!isRecord(input) || !isRecord(input.context)) return
+  const pullRequestContext = isRecord(input.context.pullRequest) ? input.context.pullRequest : undefined
+  const pullRequest = isRecord(pullRequestContext?.pullRequest) ? pullRequestContext.pullRequest : undefined
+  const repositoryContext = isRecord(pullRequestContext?.repository) ? pullRequestContext.repository : undefined
+  const trigger = isRecord(pullRequestContext?.trigger) ? pullRequestContext.trigger : undefined
+  const triggerComment = isRecord(trigger?.comment) ? trigger.comment : undefined
+  const repository = maybeString(repositoryContext?.fullName) || maybeString(isRecord(pullRequest?.source) ? pullRequest.source.repo : undefined)
+  const [owner, repo] = repository?.split("/") || []
+  const issueNumber = maybeNumber(pullRequest?.number)
+  const pullRequestUrl = maybeString(pullRequest?.apiUrl)
+    || (repository && issueNumber ? `https://api.github.com/repos/${repository}/pulls/${issueNumber}` : undefined)
+  const commentId = maybeNumber(triggerComment?.id) || 1
+  const command = commandWithSlash(trigger?.command) || commandWithSlash(triggerComment?.body) || "/review"
+  const prompt = maybeString(input.prompt)
+  const body = prompt?.trim()
+    ? prompt.trim().startsWith("/") ? prompt.trim() : `${command} ${prompt.trim()}`
+    : maybeString(triggerComment?.body) || command
+  const parsed = parseSlashCommand(body)
+  if (!repository || !owner || !repo || !issueNumber || !pullRequestUrl || !parsed) return
+  const commentNodeId = maybeString(triggerComment?.nodeId)
+  const deliveryId = maybeString(trigger?.deliveryId)
+  const installationId = maybeNumber(trigger?.installationId)
+  const actor = isRecord(trigger?.actor) && maybeString(trigger.actor.login)
+    ? {
+        ...(maybeString(trigger.actor.association) ? { association: maybeString(trigger.actor.association) } : {}),
+        ...(maybeNumber(trigger.actor.id) ? { id: maybeNumber(trigger.actor.id) } : {}),
+        login: maybeString(trigger.actor.login)!,
+        ...(maybeString(trigger.actor.type) ? { type: maybeString(trigger.actor.type) } : {}),
+      }
+    : { login: "dev" }
+  return {
+    action: "created",
+    actor,
+    args: parsed.args,
+    body,
+    command: parsed.command,
+    commentId,
+    ...(commentNodeId ? { commentNodeId } : {}),
+    ...(deliveryId ? { deliveryId } : {}),
+    ...(installationId ? { installationId } : {}),
+    issueNumber,
+    owner,
+    pullRequestUrl,
+    repo,
+    repository,
+  }
+}
+
 function githubCommandFromEffect<TRuntimeConfig extends AgentRuntimeConfig>(
   context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
 ): GitHubPullRequestCommand | undefined {
@@ -923,12 +978,13 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
       async invoke(context, input): Promise<AgentTriggerInvokeResult> {
         const payload = inputPayloadOrBody(input)
         const command = githubPullRequestCommandFromInput(isRecord(input) ? { ...input, payload } : { payload })
-        if (!payload) return options.ignored?.("missing_payload") || ignored("missing_payload")
+          || githubCommandFromInvocationContext(input)
+        if (!payload && !command) return options.ignored?.("missing_payload") || ignored("missing_payload")
         if (!command) return options.ignored?.("not_command") || ignored("not_command")
         if (declaredInputCommand(context, command.command) === false) return options.ignored?.("not_command") || ignored("not_command")
         const pullRequest = githubPullRequestRunContext(command, {
           ...options,
-          threadId: options.threadId || maybeString(payload.issue?.pull_request?.html_url) || maybeString(payload.issue?.html_url),
+          threadId: options.threadId || maybeString(payload?.issue?.pull_request?.html_url) || maybeString(payload?.issue?.html_url) || command.pullRequestUrl,
         }, payload)
         const finishEffects = githubPullRequestCommentFinishEffects(options)
         return {

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -150,6 +150,31 @@ function writeDevText(context: AgentCliContext, value: unknown): boolean {
   return true
 }
 
+function compactPreviewText(text: string): string {
+  const withoutDetails = text.replace(/<details\b[\s\S]*?<\/details>/gi, "").trim()
+  const firstLine = withoutDetails.split(/\r?\n/).map(line => line.trim()).find(Boolean) || text.trim()
+  return firstLine
+    .replace(/^#+\s*/, "")
+    .replace(/^\*\*(.+?):\*\*\s*/, "$1: ")
+    .replace(/^\*\*(.+?)\*\*:\s*/, "$1: ")
+}
+
+function deliveryPreviewPayload(value: unknown): { label: string, value: unknown } | undefined {
+  if (typeof value === "string") return { label: "payload", value: compactPreviewText(value) }
+  if (!isRecord(value)) return value === undefined ? undefined : { label: "payload", value }
+  for (const label of ["body", "text", "markdown"]) {
+    const text = value[label]
+    if (typeof text === "string") return { label, value: compactPreviewText(text) }
+  }
+  return { label: "payload", value }
+}
+
+function writeDeliveryPreviewPayload(context: AgentCliContext, value: unknown): void {
+  const preview = deliveryPreviewPayload(value)
+  if (!preview) return
+  writeDevPayload(context, preview.label, preview.value)
+}
+
 function toolTextOutput(value: unknown, seen = new Set<unknown>()): string | undefined {
   if (!isRecord(value) || seen.has(value)) return
   seen.add(value)
@@ -257,8 +282,16 @@ async function enrichUsageCost(record: AgentUsageRecord): Promise<AgentUsageReco
 }
 
 function shellCommand(value: unknown): string | undefined {
-  if (!isRecord(value) || typeof value.command !== "string") return
-  const command = value.command.trim()
+  if (!isRecord(value)) return
+  const raw = typeof value.command === "string"
+    ? value.command
+    : typeof value.cmd === "string"
+      ? value.cmd
+      : isRecord(value.args) && typeof value.args.command === "string"
+        ? value.args.command
+        : undefined
+  if (typeof raw !== "string") return
+  const command = raw.trim()
   return command && !command.includes("\n") ? command : undefined
 }
 
@@ -675,8 +708,13 @@ async function sendDevMessage(
   let lastUsageRecord: AgentUsageRecord | undefined
   let wroteUsageNote = false
   let finishSeen = false
+  let previewSeen = false
+  const delayTextForPreview = Boolean(parsed.trigger && parsed.trigger !== "chat.message")
+  let canWriteDelayedUsage = false
   const visibleTools = new Set<string>()
   const writeUsageNote = () => {
+    if (delayTextForPreview && !canWriteDelayedUsage) return
+    if (previewSeen) return
     if (!lastUsageRecord || wroteUsageNote) return
     const usage = formatUsageRecord(lastUsageRecord, Date.now() - startedAt)
     if (!usage) return
@@ -716,8 +754,8 @@ async function sendDevMessage(
       }
       if (event.type === "text-delta") {
         clearPendingFallback()
-        context.stdout.write(event.text)
         output += event.text
+        if (!delayTextForPreview) context.stdout.write(event.text)
         continue
       }
       if (event.type === "tool-call" || event.type === "tool-input-start") {
@@ -756,9 +794,10 @@ async function sendDevMessage(
       }
       if (event.type === "delivery-preview") {
         clearPendingFallback()
+        previewSeen = true
         context.stderr.write(`\n[delivery preview] would ${event.effect.kind}${event.channelId ? ` on ${event.channelId}` : ""}\n`)
         writeDevPayload(context, "intent", event.effect.intent)
-        writeDevPayload(context, "payload", event.effect.payload)
+        writeDeliveryPreviewPayload(context, event.effect.payload)
         writeDevPayload(context, "metadata", event.effect.metadata)
         continue
       }
@@ -789,7 +828,12 @@ async function sendDevMessage(
     throw error
   }
   clearPendingFallback()
-  context.stdout.write("\n")
+  if (delayTextForPreview && !previewSeen && output) {
+    context.stdout.write(output)
+    canWriteDelayedUsage = true
+    writeUsageNote()
+  }
+  if (!delayTextForPreview || output && !previewSeen) context.stdout.write("\n")
   if (!output && needsApproval) return
   return messages.length || output ? [...messages, assistantMessage(output, messages.length)] : []
 }

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -277,6 +277,26 @@ function messagesFromBody(body: AgentInvocationStreamBody): AgentChatMessageTrig
   throw new Response("Missing Agent Dev Loop message text.", { status: 400 })
 }
 
+function textFromUiMessage(message: AgentChatMessageTriggerInput["messages"][number]): string {
+  return (Array.isArray(message.parts) ? message.parts : [])
+    .filter((part): part is { text: string } => isRecord(part) && part.type === "text" && typeof part.text === "string")
+    .map(part => part.text)
+    .join("")
+}
+
+function promptFromBody(body: AgentInvocationStreamBody): string | undefined {
+  if (typeof body.text === "string" && body.text.trim()) return body.text
+  const messages = Array.isArray(body.messages) ? body.messages : []
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]!
+    if (message.role !== "user") continue
+    const text = textFromUiMessage(message)
+    if (text.trim()) return text
+  }
+  const text = messages.length ? textFromUiMessage(messages.at(-1)!) : undefined
+  return text?.trim() ? text : undefined
+}
+
 function selectedTrigger(entry: AgentInvocationStreamEntry, body: AgentInvocationStreamBody): ResolvedAgentTriggerDefinition | undefined {
   if (typeof body.trigger === "string" && body.trigger.trim()) {
     const trigger = entry.triggers[body.trigger]
@@ -289,7 +309,18 @@ function selectedTrigger(entry: AgentInvocationStreamEntry, body: AgentInvocatio
 function triggerInput(trigger: ResolvedAgentTriggerDefinition, body: AgentInvocationStreamBody, signal: AbortSignal, run: AgentRunMetadata, timeout: number): unknown {
   if ("input" in body) return body.input
   if (trigger.id !== "chat.message") {
-    throw new Response("Missing Agent Trigger input. Pass input.", { status: 400 })
+    const prompt = promptFromBody(body)
+    if (!prompt) throw new Response("Missing Agent Trigger input. Pass input or prompt.", { status: 400 })
+    const context = contextFromBody(body)
+    return {
+      abortSignal: signal,
+      ...(context ? { context } : {}),
+      prompt,
+      run,
+      timeout,
+      ...(typeof body.invokerProfileId === "string" ? { invokerProfileId: body.invokerProfileId } : {}),
+      ...(isRecord(body.meta) ? { meta: body.meta } : {}),
+    }
   }
   return {
     abortSignal: signal,
@@ -355,7 +386,8 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
     let output: Awaited<ReturnType<typeof streamAgent>>
     const trigger = selectedTrigger(entry, body)
     if (trigger) {
-      const invocation = await resolveAgentTriggerInvocation(entry.agent as never, context as never, trigger.id, triggerInput(trigger, body, signal, run, timeout))
+      const triggerContext = trigger.id === "chat.message" ? context : { ...context, request: undefined }
+      const invocation = await resolveAgentTriggerInvocation(entry.agent as never, triggerContext as never, trigger.id, triggerInput(trigger, body, signal, run, timeout))
       if (isResolvedAgentTriggerHandledInvocation(invocation)) {
         output = invocation.response
       }

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -348,6 +348,7 @@ describe("agent CLI", () => {
           { id: "tool-1", name: "shell", type: "tool-input-start" },
           { id: "tool-1", input: { command: "cat file.md" }, name: "shell", type: "tool-call" },
           { id: "tool-1", name: "shell", output: { command: "cat file.md", exitCode: 0, stderr: "", stdout: longOutput }, type: "tool-result" },
+          { id: "tool-4", input: { cmd: "pnpm test" }, name: "bash", type: "tool-call" },
           { id: "tool-2", name: "workspace_list", output: { path: "." }, type: "tool-result" },
           { id: "tool-3", name: "run_summary", output: { raw: { raw: { steps: longOutput } }, text: "summary body" }, type: "tool-result" },
           { text: "done", type: "text-delta" },
@@ -374,6 +375,9 @@ describe("agent CLI", () => {
 
     expect(exitCode).toBe(0)
     expect(stderr.output()).toContain("[tool] cat file.md")
+    expect(stderr.output()).toContain("[tool] pnpm test")
+    expect(stderr.output()).not.toContain("[tool] bash")
+    expect(stderr.output()).not.toContain("[tool done]")
     expect(stderr.output()).not.toContain(`input: {"command":"cat file.md"}`)
     expect(stderr.output()).toContain("[truncated ")
     expect(stderr.output()).not.toContain(longOutput)
@@ -437,12 +441,13 @@ describe("agent CLI", () => {
 
   it("renders Agent Dev Loop delivery previews", async () => {
     const stderr = stream()
+    const stdout = stream()
     const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       if (init?.method === "POST") {
         return ndjson([
           { agent: "review", trigger: "github.webhook", type: "start" },
-          { text: "summary", type: "text-delta" },
-          { channelId: "github", effect: { kind: "reply", payload: "summary" }, type: "delivery-preview" },
+          { text: "verbose review prose", type: "text-delta" },
+          { channelId: "github", effect: { kind: "reply", payload: { body: "**Summary:** Short review.\n\n<details>\n<summary>Usage telemetry</summary>\n\nlarge table\n</details>" } }, type: "delivery-preview" },
           { type: "finish" },
           { type: "done" },
         ])
@@ -459,12 +464,16 @@ describe("agent CLI", () => {
       rootDir: "/repo",
       spawn: vi.fn(),
       stderr,
-      stdout: stream(),
+      stdout,
     }, { fetch: fetchAgentStream as never })
 
     expect(exitCode).toBe(0)
+    expect(stdout.output()).toBe("")
     expect(stderr.output()).toContain("[delivery preview] would reply on github")
-    expect(stderr.output()).toContain("payload: summary")
+    expect(stderr.output()).toContain("body: Summary: Short review.")
+    expect(stderr.output()).not.toContain("Usage telemetry")
+    expect(stderr.output()).not.toContain("large table")
+    expect(stderr.output()).not.toContain("verbose review prose")
   })
 
   it("runs Evalite through the Node runner with ViteHub defaults", async () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -656,6 +656,140 @@ describe("agent chat capability discovery", () => {
     ])
   })
 
+  it("passes Agent Dev Loop context and prompt into explicit channel trigger invocations", async () => {
+    const root = await createTempRoot("vitehub-agent-invocation-stream-channel-context-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "review.ts"), "export default {}", "utf8")
+
+    const { defineChannel } = await import("../src/channels.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const triggerInputs: unknown[] = []
+    const agent = defineAgent({
+      channels: {
+        github: defineChannel("github", {
+          messages: false,
+          triggers: {
+            webhook: {
+              invoke: (_context, input) => {
+                triggerInputs.push(input)
+                return {
+                  input: { prompt: (input as { prompt?: string }).prompt },
+                  run: { channelId: "github", origin: "github-pull-request-comment", runId: "github-run" },
+                }
+              },
+            },
+          },
+          webhooks: { secretHeader: "x-test-secret", secretToken: "secret-token" },
+        }),
+      },
+      run: ({ context, input }) => `context ${context.get<{ number: number }>("pullRequest")?.number} ${input.prompt}`,
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
+
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      agent: "review",
+      context: {
+        pullRequest: { number: 42 },
+      },
+      messages: [{
+        id: "user-1",
+        parts: [{ text: "/review", type: "text" }],
+        role: "user",
+      }],
+      trigger: "github.webhook",
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    })
+    const events = response.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+
+    expect(triggerInputs).toEqual([expect.objectContaining({
+      context: { pullRequest: { number: 42 } },
+      prompt: "/review",
+    })])
+    expect(events).toEqual([
+      expect.objectContaining({ agent: "review", trigger: "github.webhook", type: "start" }),
+      { text: "context 42 /review", type: "text-delta" },
+      { type: "finish" },
+      { type: "done" },
+    ])
+  })
+
+  it("derives built-in GitHub webhook dev input from pull request context", async () => {
+    const root = await createTempRoot("vitehub-agent-invocation-stream-github-context-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "review.ts"), "export default {}", "utf8")
+
+    const { github } = await import("../src/channels.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const agent = defineAgent({
+      channels: {
+        github: github({ events: { pullRequestComments: { reply: false } }, webhooks: { secretToken: "secret-token" } }),
+      },
+      run: ({ context, input }) => {
+        const github = context.get<{ command: string, repository: string }>("github")
+        const pullRequest = context.get<{ pullRequest: { number: number } }>("pullRequest")
+        return `context ${github?.repository}#${pullRequest?.pullRequest.number} ${github?.command} ${input.prompt}`
+      },
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
+
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      agent: "review",
+      context: {
+        pullRequest: {
+          pullRequest: {
+            htmlUrl: "https://github.com/quiverdk/portal/pull/709",
+            number: 709,
+            source: {
+              mount: "portal",
+              ref: "refs/pull/709/head",
+              repo: "quiverdk/portal",
+            },
+          },
+          repository: { fullName: "quiverdk/portal" },
+          trigger: {
+            actor: { login: "maxi" },
+            args: "",
+            command: "review",
+            comment: { body: "/review", id: 123 },
+          },
+        },
+      },
+      messages: [{
+        id: "user-1",
+        parts: [{ text: "/review", type: "text" }],
+        role: "user",
+      }],
+      trigger: "github.webhook",
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    })
+    const events = response.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+
+    expect(events).toEqual([
+      expect.objectContaining({ agent: "review", trigger: "github.webhook", type: "start" }),
+      { text: "context quiverdk/portal#709 /review /review", type: "text-delta" },
+      { type: "finish" },
+      { type: "done" },
+    ])
+  })
+
   it("accepts declared workspace agent names as dev loop aliases", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-alias-")
     await mkdir(join(root, "server", "agents", "review"), { recursive: true })


### PR DESCRIPTION
Updates the Agent Dev Loop so explicit channel trigger runs can derive prompt-shaped input from `-p` / message text while carrying JSON context into the invocation. This lets downstream review-style agents run `vitehub agent dev --trigger github.webhook --context ... -p "/review"` without wrapper scripts.

Also tightens dev-loop output so shell tool starts show the actual command, delivery-preview runs do not dump verbose streamed prose first, and `[tool done]` remains absent from the terminal transcript.