### PR TITLE
fix(agent): preserve harness ui message streams

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -8,7 +8,7 @@ import { applyWorkspaceSourceInstructionSlot } from "./workspace-agent.ts"
 import { normalizeAgentWorkspaceSources } from "./workspace-source-metadata.ts"
 import { nextWithAbort } from "./internal/abortable-stream.ts"
 import { toAiSdkModelMessages } from "./ai-sdk.ts"
-import { isAsyncIterable } from "./internal/stream-result.ts"
+import { isAsyncIterable, toReadableAsyncIterableStream } from "./internal/stream-result.ts"
 import {
   applyAgentToolPolicies,
   withAgentToolStepReporting,
@@ -326,6 +326,45 @@ function withCleanup<T>(iterable: AsyncIterable<T>, cleanup: (error?: unknown) =
   })()
 }
 
+function withCleanupStream<T>(stream: ReadableStream<T>, cleanup: (error?: unknown) => Promise<void>): ReadableStream<T> {
+  const reader = stream.getReader()
+  let cleaned = false
+  const cleanupOnce = async (error?: unknown) => {
+    if (cleaned) return
+    cleaned = true
+    await cleanup(error)
+  }
+  return new ReadableStream<T>({
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason)
+      }
+      finally {
+        await cleanupOnce(reason)
+      }
+    },
+    async pull(controller) {
+      try {
+        const result = await reader.read()
+        if (result.done) {
+          await cleanupOnce()
+          controller.close()
+          return
+        }
+        controller.enqueue(result.value)
+      }
+      catch (error) {
+        await cleanupOnce(error)
+        controller.error(error)
+      }
+    },
+  })
+}
+
+function wrapCleanupIterable<T>(iterable: AsyncIterable<T>, cleanup: (error?: unknown) => Promise<void>, abortSignal?: AbortSignal) {
+  return toReadableAsyncIterableStream(withCleanup(iterable, cleanup, abortSignal))
+}
+
 async function withSessionCleanup(result: unknown, cleanup: (error?: unknown) => Promise<void>, abortSignal?: AbortSignal): Promise<unknown> {
   let cleanupCalled = false
   const cleanupOnce = async (error?: unknown) => {
@@ -358,7 +397,26 @@ async function withSessionCleanup(result: unknown, cleanup: (error?: unknown) =>
     Object.defineProperty(clone, key, {
       configurable: true,
       enumerable: true,
-      value: withCleanup(iterable, cleanupOnce, abortSignal),
+      value: wrapCleanupIterable(iterable, cleanupOnce, abortSignal),
+    })
+  }
+  const toUIMessageStream = (result as { toUIMessageStream?: unknown }).toUIMessageStream
+  if (typeof toUIMessageStream === "function") {
+    Object.defineProperty(clone, "toUIMessageStream", {
+      configurable: true,
+      enumerable: false,
+      value: (...args: unknown[]) => {
+        try {
+          const stream = toUIMessageStream.apply(clone, args) as unknown
+          return typeof stream === "object" && stream !== null && typeof (stream as ReadableStream<unknown>).getReader === "function"
+            ? withCleanupStream(stream as ReadableStream<unknown>, cleanupOnce)
+            : stream
+        }
+        catch (error) {
+          void cleanupOnce(error)
+          throw error
+        }
+      },
     })
   }
   return clone

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1059,6 +1059,52 @@ describe("agent message protocol", () => {
     })
   })
 
+  it("keeps harness UI message streams readable after session cleanup wrapping", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessStream.mockResolvedValueOnce({
+      fullStream: new ReadableStream<unknown>({
+        start(controller) {
+          controller.enqueue({ messageId: "msg-1", type: "start" })
+          controller.enqueue({ id: "msg-1", type: "text-start" })
+          controller.enqueue({ delta: "ok", id: "msg-1", type: "text-delta" })
+          controller.enqueue({ id: "msg-1", type: "text-end" })
+          controller.enqueue({ finishReason: "stop", type: "finish" })
+          controller.close()
+        },
+      }),
+      toUIMessageStream(this: { fullStream: ReadableStream<unknown> }) {
+        return this.fullStream.pipeThrough(new TransformStream<unknown, unknown>({
+          transform(chunk, controller) {
+            controller.enqueue(chunk)
+          },
+        }))
+      },
+    })
+
+    const agent = defineAgent({
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: { provider: "sandbox" },
+      },
+    })
+
+    const stream = await streamAgent(
+      agent,
+      { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() },
+      { prompt: "hello" },
+      { output: "ui-message-stream" },
+    ) as ReadableStream<unknown>
+    const chunks: unknown[] = []
+    for await (const chunk of stream) {
+      chunks.push(chunk)
+    }
+
+    expect(chunks).toContainEqual({ delta: "ok", id: "msg-1", type: "text-delta" })
+    expect(session.destroy).toHaveBeenCalledOnce()
+  })
+
   it("passes model-facing Capability tools into harness Agent Drivers", async () => {
     const { defineCapability } = await import("../src/capability-runtime.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")


### PR DESCRIPTION
Preserves harness stream results as Web ReadableStreams when ViteHub adds session cleanup wrappers, so AI SDK harness results that call `fullStream.pipeThrough(...)` from `toUIMessageStream()` keep working.

This fixes downstream chat routes that request UI-message stream output, including Quiver Portal Ask AI, where the previous cleanup wrapper converted `fullStream` into a plain async generator and crashed before the response could stream. The UI stream wrapper also keeps session cleanup attached when the stream drains or is cancelled.