### PR TITLE
fix(workspace): materialize requested build sources

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -8,7 +8,7 @@ import { applyWorkspaceSourceInstructionSlot } from "./workspace-agent.ts"
 import { normalizeAgentWorkspaceSources } from "./workspace-source-metadata.ts"
 import { nextWithAbort } from "./internal/abortable-stream.ts"
 import { toAiSdkModelMessages } from "./ai-sdk.ts"
-import { isAsyncIterable } from "./internal/stream-result.ts"
+import { isAsyncIterable, toReadableAsyncIterableStream } from "./internal/stream-result.ts"
 import {
   applyAgentToolPolicies,
   withAgentToolStepReporting,
@@ -326,6 +326,45 @@ function withCleanup<T>(iterable: AsyncIterable<T>, cleanup: (error?: unknown) =
   })()
 }
 
+function withCleanupStream<T>(stream: ReadableStream<T>, cleanup: (error?: unknown) => Promise<void>): ReadableStream<T> {
+  const reader = stream.getReader()
+  let cleaned = false
+  const cleanupOnce = async (error?: unknown) => {
+    if (cleaned) return
+    cleaned = true
+    await cleanup(error)
+  }
+  return new ReadableStream<T>({
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason)
+      }
+      finally {
+        await cleanupOnce(reason)
+      }
+    },
+    async pull(controller) {
+      try {
+        const result = await reader.read()
+        if (result.done) {
+          await cleanupOnce()
+          controller.close()
+          return
+        }
+        controller.enqueue(result.value)
+      }
+      catch (error) {
+        await cleanupOnce(error)
+        controller.error(error)
+      }
+    },
+  })
+}
+
+function wrapCleanupIterable<T>(iterable: AsyncIterable<T>, cleanup: (error?: unknown) => Promise<void>, abortSignal?: AbortSignal) {
+  return toReadableAsyncIterableStream(withCleanup(iterable, cleanup, abortSignal))
+}
+
 async function withSessionCleanup(result: unknown, cleanup: (error?: unknown) => Promise<void>, abortSignal?: AbortSignal): Promise<unknown> {
   let cleanupCalled = false
   const cleanupOnce = async (error?: unknown) => {
@@ -358,7 +397,26 @@ async function withSessionCleanup(result: unknown, cleanup: (error?: unknown) =>
     Object.defineProperty(clone, key, {
       configurable: true,
       enumerable: true,
-      value: withCleanup(iterable, cleanupOnce, abortSignal),
+      value: wrapCleanupIterable(iterable, cleanupOnce, abortSignal),
+    })
+  }
+  const toUIMessageStream = (result as { toUIMessageStream?: unknown }).toUIMessageStream
+  if (typeof toUIMessageStream === "function") {
+    Object.defineProperty(clone, "toUIMessageStream", {
+      configurable: true,
+      enumerable: false,
+      value: (...args: unknown[]) => {
+        try {
+          const stream = toUIMessageStream.apply(clone, args) as unknown
+          return typeof stream === "object" && stream !== null && typeof (stream as ReadableStream<unknown>).getReader === "function"
+            ? withCleanupStream(stream as ReadableStream<unknown>, cleanupOnce)
+            : stream
+        }
+        catch (error) {
+          void cleanupOnce(error)
+          throw error
+        }
+      },
     })
   }
   return clone

--- a/packages/agent/src/workspace-source-metadata.ts
+++ b/packages/agent/src/workspace-source-metadata.ts
@@ -163,6 +163,7 @@ function copySourceRuntimeOptions(
     instructions: input.instructions as WorkspaceSourceInstructions | undefined ?? defaults.instructions,
     materialize: input.materialize as WorkspaceMaterializeMode | undefined ?? defaults.materialize,
     mount: input.mount as WorkspaceSourceMount | undefined ?? defaults.mount,
+    probeKeys: input.probeKeys as string[] | undefined ?? defaults.probeKeys,
     sync: input.sync as WorkspaceSourceSyncConfig | undefined ?? defaults.sync,
   }
 }
@@ -177,6 +178,7 @@ function applyWorkspaceSourceBinding(
     instructions: hasOwn(input, "instructions") ? input.instructions as WorkspaceSourceInstructions | undefined : descriptor.instructions,
     materialize: hasOwn(input, "materialize") ? input.materialize as WorkspaceMaterializeMode | undefined : descriptor.materialize,
     mount: hasOwn(input, "mount") ? input.mount as WorkspaceSourceMount | undefined : descriptor.mount,
+    probeKeys: hasOwn(input, "probeKeys") ? input.probeKeys as string[] | undefined : descriptor.probeKeys,
     sync: hasOwn(input, "sync") ? input.sync as WorkspaceSourceSyncConfig | undefined : descriptor.sync,
   }
 }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1059,6 +1059,52 @@ describe("agent message protocol", () => {
     })
   })
 
+  it("keeps harness UI message streams readable after session cleanup wrapping", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessStream.mockResolvedValueOnce({
+      fullStream: new ReadableStream<unknown>({
+        start(controller) {
+          controller.enqueue({ messageId: "msg-1", type: "start" })
+          controller.enqueue({ id: "msg-1", type: "text-start" })
+          controller.enqueue({ delta: "ok", id: "msg-1", type: "text-delta" })
+          controller.enqueue({ id: "msg-1", type: "text-end" })
+          controller.enqueue({ finishReason: "stop", type: "finish" })
+          controller.close()
+        },
+      }),
+      toUIMessageStream(this: { fullStream: ReadableStream<unknown> }) {
+        return this.fullStream.pipeThrough(new TransformStream<unknown, unknown>({
+          transform(chunk, controller) {
+            controller.enqueue(chunk)
+          },
+        }))
+      },
+    })
+
+    const agent = defineAgent({
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: { provider: "sandbox" },
+      },
+    })
+
+    const stream = await streamAgent(
+      agent,
+      { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() },
+      { prompt: "hello" },
+      { output: "ui-message-stream" },
+    ) as ReadableStream<unknown>
+    const chunks: unknown[] = []
+    for await (const chunk of stream) {
+      chunks.push(chunk)
+    }
+
+    expect(chunks).toContainEqual({ delta: "ok", id: "msg-1", type: "text-delta" })
+    expect(session.destroy).toHaveBeenCalledOnce()
+  })
+
   it("passes model-facing Capability tools into harness Agent Drivers", async () => {
     const { defineCapability } = await import("../src/capability-runtime.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -817,6 +817,48 @@ describe("defineAgent workspace option", () => {
     expect(harnessSession.destroy).toHaveBeenCalledOnce()
   })
 
+  it("passes custom build source probe paths into Harness Workspace Sessions", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { custom } = await import("@vite-hub/workspace")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+
+    const agent = withAgentDefaults(defineAgent({
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: { provider: "sandbox" },
+      },
+      workspace: {
+        sources: {
+          reviewSkills: custom({
+            materialize: "build",
+            mount: "skills",
+            probeKeys: ["SKILL.md", "review-browser-evidence/SKILL.md"],
+            async getKeys() {
+              return ["SKILL.md", "review-browser-evidence/SKILL.md"]
+            },
+            async getItem(key) {
+              return { content: "skill", key, mediaType: "text/markdown", path: key }
+            },
+          }),
+        },
+      },
+    }), { workspace: "review" })
+
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
+      abortSignal: undefined,
+      paths: ["skills/SKILL.md", "skills/review-browser-evidence/SKILL.md"],
+      session: harnessSandboxSession,
+      sessionWorkDir: "/workspace/codex-session",
+    })
+  })
+
   it("uses an unrestricted harness Workspace Session scope when no explicit paths are available", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const harnessWorkspaceSession = { close: vi.fn() }

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -423,6 +423,7 @@ export interface WorkspaceSource {
   cache?: false | WorkspaceCacheOptions
   validate?: WorkspaceValidateMode
   sync?: WorkspaceSourceSyncConfig
+  probeKeys?: string[]
   fingerprint?: unknown
   instructions?: WorkspaceSourceInstructions
   resolve?: WorkspaceSourceResolver
@@ -446,7 +447,7 @@ export type WorkspaceSourceDefinition = WorkspaceSource | SourcePackageSource
 
 type WorkspaceSourceBindingOptions = Pick<
   WorkspaceSource,
-  "cache" | "instructions" | "materialize" | "mount" | "sync" | "validate"
+  "cache" | "instructions" | "materialize" | "mount" | "probeKeys" | "sync" | "validate"
 >
 
 export interface WorkspaceSourceBindingInput extends WorkspaceSourceBindingOptions {

--- a/packages/workspace/src/sources/materialization.ts
+++ b/packages/workspace/src/sources/materialization.ts
@@ -126,6 +126,12 @@ function materializesCompleteSource(source: ResolvedWorkspaceSource, options: Wo
   return !requested || Boolean(source.mountPath && pathContains(requested, source.mountPath))
 }
 
+function shouldMaterializeSource(source: ResolvedWorkspaceSource, options: WorkspaceMaterializeSourcesOptions | undefined) {
+  if (source.requestOnly || !sourcePathMatches("", source, options)) return false
+  if (source.materialize === "lazy") return true
+  return source.materialize === "build" && Boolean(options?.path)
+}
+
 function parentDirectoryPaths(path: string) {
   const parts = normalizeWorkspacePath(path).split("/").filter(Boolean)
   const paths: string[] = []
@@ -251,7 +257,7 @@ export async function materializeWorkspaceSources(
   options: WorkspaceMaterializeSourcesOptions = {},
 ): Promise<WorkspaceMaterializeSourcesResult> {
   const started = Date.now()
-  const sources = normalizeWorkspaceSources(definition.sources).filter(source => !source.requestOnly && source.materialize === "lazy" && sourcePathMatches("", source, options))
+  const sources = normalizeWorkspaceSources(definition.sources).filter(source => shouldMaterializeSource(source, options))
   const resultSources: WorkspaceSourceMaterializationStatus[] = []
   let files = 0
   let directories = 0

--- a/packages/workspace/test/lazy-sources.test.ts
+++ b/packages/workspace/test/lazy-sources.test.ts
@@ -94,6 +94,35 @@ describe("lazy sources", () => {
     ])
   })
 
+  it("materializes build sources when a path explicitly requests them", async () => {
+    const view = createWorkspaceSourceView({
+      name: "build-source-path",
+      sources: {
+        skills: custom({
+          materialize: "build",
+          mount: "skills",
+          async getKeys() {
+            return ["SKILL.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "# Skills\n", mediaType: "text/markdown" }
+          },
+        }),
+      },
+    }, createMemoryWorkspaceStore())
+
+    await expect(view.materializeSources()).resolves.toMatchObject({
+      files: 0,
+      sources: [],
+    })
+
+    await expect(view.materializeSources({ path: "skills" })).resolves.toMatchObject({
+      files: 1,
+      sources: [expect.objectContaining({ source: "skills", status: "ready" })],
+    })
+    await expect(view.readFile("skills/SKILL.md")).resolves.toBe("# Skills\n")
+  })
+
   it("defaults cached GitHub sources to lazy repo basename mounts", () => {
     const resolved = normalizeWorkspaceSources({
       forecastingEngine: githubSource({


### PR DESCRIPTION
Allows explicit source materialization requests for build sources when a caller passes a path or source key. Harness workspace setup already asks for selected paths before copying files into the sandbox, so build-mounted sources such as agent skills are now present in the sandbox instead of only appearing later in the host workspace.\n\nThis keeps broad materializeSources() calls focused on lazy sources while making path-scoped requests behave like the workspace view already suggests they should.