### PR TITLE
fix(database): preserve drizzle registry in server bundles

### DIFF
--- a/packages/database/src/vite.ts
+++ b/packages/database/src/vite.ts
@@ -17,8 +17,11 @@ export const DB_VIRTUAL_SCHEMA_ID = "#vitehub/database/schema"
 export const DB_VIRTUAL_DATABASES_ID = "#vitehub/database/databases"
 export const DB_VITE_PLUGIN_NAME = "@vite-hub/database/vite"
 
+const DB_INTERNAL_VIRTUAL_SCHEMA_ID = "virtual:vitehub/database/schema"
+const DB_INTERNAL_VIRTUAL_DATABASES_ID = "virtual:vitehub/database/databases"
 const RESOLVED_DB_VIRTUAL_SCHEMA_ID = `\0${DB_VIRTUAL_SCHEMA_ID}`
 const RESOLVED_DB_VIRTUAL_DATABASES_ID = `\0${DB_VIRTUAL_DATABASES_ID}`
+const DB_DRIZZLE_ENTRY_PATTERN = /(?:^|\/)(?:@vite-hub\/database|database)\/dist\/drizzle\.js$/
 
 export interface DBVitePluginAPI {
   getConfig: () => ResolvedDBViteConfig | undefined
@@ -34,6 +37,17 @@ interface DBCliContributingPlugin {
 export type DBVitePlugin = Plugin & DBCliContributingPlugin & { api: DBVitePluginAPI }
 
 const mergeNoExternal = createNoExternalMerger(dbPackageName)
+
+function resolveDatabaseVirtualId(id: string) {
+  if (id === DB_VIRTUAL_SCHEMA_ID || id === DB_INTERNAL_VIRTUAL_SCHEMA_ID) return RESOLVED_DB_VIRTUAL_SCHEMA_ID
+  if (id === DB_VIRTUAL_DATABASES_ID || id === DB_INTERNAL_VIRTUAL_DATABASES_ID) return RESOLVED_DB_VIRTUAL_DATABASES_ID
+}
+
+function rewriteDrizzleVirtualImports(code: string) {
+  return code
+    .replaceAll(DB_VIRTUAL_SCHEMA_ID, DB_INTERNAL_VIRTUAL_SCHEMA_ID)
+    .replaceAll(DB_VIRTUAL_DATABASES_ID, DB_INTERNAL_VIRTUAL_DATABASES_ID)
+}
 
 function renderSchemaModule(config: ResolvedDBViteConfig | undefined) {
   if (!config?.databaseNames.length) {
@@ -146,8 +160,10 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
       if (databasesModule) context.server.moduleGraph.invalidateModule(databasesModule)
     },
     resolveId(id) {
-      if (id === DB_VIRTUAL_SCHEMA_ID) return RESOLVED_DB_VIRTUAL_SCHEMA_ID
-      if (id === DB_VIRTUAL_DATABASES_ID) return RESOLVED_DB_VIRTUAL_DATABASES_ID
+      return resolveDatabaseVirtualId(id)
+    },
+    transform(code, id) {
+      if (DB_DRIZZLE_ENTRY_PATTERN.test(normalize(id))) return rewriteDrizzleVirtualImports(code)
     },
     load(id) {
       if (id === RESOLVED_DB_VIRTUAL_SCHEMA_ID) return renderSchemaModule(runtimeConfig)

--- a/packages/database/test/vite-output.test.ts
+++ b/packages/database/test/vite-output.test.ts
@@ -160,6 +160,12 @@ describe("Vite db provider outputs", () => {
       }),
     ])
     expect(existsSync(vercelServer)).toBe(true)
+    const bundledServerCode = await readFile(join(rootDir, "dist/client/server.js"), "utf8")
+    expect(bundledServerCode.includes("\"analytics\"")).toBe(true)
+    expect(bundledServerCode.includes("\"primary\"")).toBe(true)
+    expect(bundledServerCode.includes("runtime/virtual-databases.js")).toBe(false)
+    expect(bundledServerCode.includes("var databases$1 = {};")).toBe(false)
+
     const vercelServerCode = await readFile(vercelServer, "utf8")
     expect(vercelServerCode).toContain("process.env.TURSO_ANALYTICS_DATABASE_URL || process.env.TURSO_DATABASE_URL")
     expect(vercelServerCode).toContain("process.env.TURSO_DATABASE_URL")


### PR DESCRIPTION
Fixes the database Vite integration so server builds that bundle `@vite-hub/database/drizzle` keep the generated Drizzle Runtime Surface instead of falling through to package import fallbacks. The packed drizzle entry still contains `#vitehub/database/*` package imports; in dependency-bundled builds those can resolve to `dist/runtime/virtual-*.js` before normal `resolveId` sees them, so `hubDb()` now rewrites only the packed drizzle entry to internal virtual ids that the plugin resolves to generated modules.

Adds regression coverage to the database provider-output test by asserting the built SSR server bundle contains named database entries and not the empty `virtual-databases` fallback.