### PR TITLE
feat(agent): let observability include usage telemetry

### DIFF
--- a/docs/content/docs/capabilities/observability.md
+++ b/docs/content/docs/capabilities/observability.md
@@ -42,8 +42,9 @@ When enabled usage telemetry records usage from the Agent Driver or custom resul
 Use `observability({ usageTelemetry: false })` to opt out.
 With that opt-out, a custom `result.usageRecord` can still stay on the result, but `observability.usage` is not populated.
 
-If an Agent also lists `usageTelemetry(...)` in `capabilities`, that explicit configuration wins for the Agent Usage Record itself.
-`observability({ usageTelemetry: false })` still suppresses the `observability.usage` alias; omit the opt-out when observability should carry the same usage record in its metadata.
+If an Agent also lists `usageTelemetry(...)` in `capabilities`, that explicit Capability keeps its top-level order and wins for the Agent Usage Record itself.
+Place `usageTelemetry(...)` before `observability()` when `observability.usage` should reference the explicit record.
+`observability({ usageTelemetry: false })` still suppresses the `observability.usage` alias.
 
 ## Eval assertions
 

--- a/docs/content/docs/capabilities/observability.md
+++ b/docs/content/docs/capabilities/observability.md
@@ -42,8 +42,8 @@ When enabled usage telemetry records usage from the Agent Driver or custom resul
 Use `observability({ usageTelemetry: false })` to opt out.
 With that opt-out, a custom `result.usageRecord` can still stay on the result, but `observability.usage` is not populated.
 
-If an Agent also lists `usageTelemetry(...)` in `capabilities`, that explicit configuration wins.
-This keeps usage telemetry independent while letting observability carry the same usage record in its metadata.
+If an Agent also lists `usageTelemetry(...)` in `capabilities`, that explicit configuration wins for the Agent Usage Record itself.
+`observability({ usageTelemetry: false })` still suppresses the `observability.usage` alias; omit the opt-out when observability should carry the same usage record in its metadata.
 
 ## Eval assertions
 

--- a/docs/content/docs/capabilities/observability.md
+++ b/docs/content/docs/capabilities/observability.md
@@ -8,7 +8,7 @@ icon: i-lucide-radar
 ---
 
 `observability()` gives an Agent Definition one place to attach runtime telemetry.
-It can instrument model execution, emit lifecycle events, and provide a finish extension with invocation status, duration, and result kind.
+It can instrument model execution, emit lifecycle events, provide a finish extension with invocation status, duration, and result kind, and enable usage telemetry for the same invocation.
 
 ## Installation
 
@@ -34,8 +34,15 @@ The Capability emits a `start` event before driver execution.
 When `onEvent` is configured, it also emits a `finish` or `error` event after the invocation completes.
 `onEvent` is a telemetry sink; sink failures are swallowed so observability cannot change Agent output or hide the original driver failure.
 
-It provides an `observability` finish extension with `{ status, durationMs, resultKind }` for completed invocations and `{ status, durationMs }` for failed invocations.
+It provides an `observability` finish extension with `{ status, durationMs, resultKind, usage }` for completed invocations and `{ status, durationMs, usage }` for failed invocations.
 Agent Evals and the Agent test runner capture this finish extension automatically.
+
+`observability()` enables `usageTelemetry()` by default.
+When usage is reported by the Agent Driver or custom result, `observability.usage` points at the same Agent Usage Record exposed through the `usage-telemetry` finish extension and final `result.usageRecord`.
+Use `observability({ usageTelemetry: false })` to opt out.
+
+If an Agent also lists `usageTelemetry(...)` in `capabilities`, that explicit configuration wins.
+This keeps usage telemetry independent while letting observability carry the same usage record in its metadata.
 
 ## Eval assertions
 
@@ -63,9 +70,17 @@ For custom checks, read `observation.extensions.get('observability')` or `t.capa
 
 | Agent Driver | Support |
 | --- | --- |
-| Model-backed | Supports model instrumentation, lifecycle events, and finish extensions. |
-| Harness-backed | Supports lifecycle events and finish extensions; instrumentation applies only to model-backed execution. |
-| Custom-run-backed | Supports lifecycle events and finish extensions around the custom result. |
+| Model-backed | Supports model instrumentation, lifecycle events, finish extensions, and usage records when the model result reports usage. |
+| Harness-backed | Supports lifecycle events, finish extensions, and usage records when the harness reports usage; instrumentation applies only to model-backed execution. |
+| Custom-run-backed | Supports lifecycle events, finish extensions, and usage records around the custom result. |
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `instrumentation` | `AgentModelExecutionInstrumentation` | none | Model and call-settings instrumentation for model-backed drivers. |
+| `onEvent` | `(event) => void` | none | Lifecycle event sink for start, finish, and error events. |
+| `usageTelemetry` | `boolean \| UsageTelemetryOptions` | `true` | Enables usage telemetry by default, accepts inline usage telemetry options, or opts out when set to `false`. |
 
 ## Reference
 

--- a/docs/content/docs/capabilities/observability.md
+++ b/docs/content/docs/capabilities/observability.md
@@ -38,8 +38,9 @@ It provides an `observability` finish extension with `{ status, durationMs, resu
 Agent Evals and the Agent test runner capture this finish extension automatically.
 
 `observability()` enables `usageTelemetry()` by default.
-When usage is reported by the Agent Driver or custom result, `observability.usage` points at the same Agent Usage Record exposed through the `usage-telemetry` finish extension and final `result.usageRecord`.
+When enabled usage telemetry records usage from the Agent Driver or custom result, `observability.usage` points at the same Agent Usage Record exposed through the `usage-telemetry` finish extension and final `result.usageRecord`.
 Use `observability({ usageTelemetry: false })` to opt out.
+With that opt-out, a custom `result.usageRecord` can still stay on the result, but `observability.usage` is not populated.
 
 If an Agent also lists `usageTelemetry(...)` in `capabilities`, that explicit configuration wins.
 This keeps usage telemetry independent while letting observability carry the same usage record in its metadata.
@@ -72,7 +73,7 @@ For custom checks, read `observation.extensions.get('observability')` or `t.capa
 | --- | --- |
 | Model-backed | Supports model instrumentation, lifecycle events, finish extensions, and usage records when the model result reports usage. |
 | Harness-backed | Supports lifecycle events, finish extensions, and usage records when the harness reports usage; instrumentation applies only to model-backed execution. |
-| Custom-run-backed | Supports lifecycle events, finish extensions, and usage records around the custom result. |
+| Custom-run-backed | Supports lifecycle events, finish extensions, and usage records when usage telemetry is enabled and the custom result reports usage. |
 
 ## Options
 

--- a/docs/content/docs/capabilities/usage-telemetry.md
+++ b/docs/content/docs/capabilities/usage-telemetry.md
@@ -26,6 +26,8 @@ Use `context.output.final()` when a renderer needs the completed final text from
 
 Attach `usageTelemetry()` when an Agent should report usage to application telemetry.
 The callback receives a normalized Agent Usage Record.
+Agents that use `observability()` get usage telemetry by default.
+Add `usageTelemetry(...)` explicitly when the Agent needs custom pricing, summaries, raw payload retention, or an `onUsage` sink.
 
 ```ts [server/agents/support.ts]
 import { defineAgent } from '@vite-hub/agent'
@@ -48,6 +50,9 @@ It reads usage from result objects or finish stream chunks, normalizes token and
 
 Pricing functions enrich telemetry only.
 Pricing errors do not fail the Agent Invocation.
+
+When `observability()` is also enabled, the `observability` finish extension references the same Agent Usage Record.
+Do not treat it as a second usage record to persist.
 
 Final output shaping can stay Capability-owned:
 

--- a/docs/content/docs/concepts/capabilities-api.md
+++ b/docs/content/docs/concepts/capabilities-api.md
@@ -60,6 +60,8 @@ The Agent Package root stays focused on Agent Definition, invocation, message, a
 
 Capabilities are attached before the Agent Invocation runs. Pre-Invocation Decisions can record context values, reject, or influence conditional contributions, but they do not dynamically attach new Capabilities.
 
+Capabilities run in array order. A Capability can include nested default Capabilities, but an explicitly listed Capability keeps its top-level position.
+
 ## Next steps
 
 - Read the [Capabilities](/docs/capabilities) section.

--- a/packages/agent/src/capabilities/observability.ts
+++ b/packages/agent/src/capabilities/observability.ts
@@ -177,7 +177,7 @@ export function observability<
       }
     },
     async finish(event: AgentFinishEvent<TRuntimeConfig>) {
-      const usage = usageRecordFromFinishEvent(event)
+      const usage = options.usageTelemetry === false ? undefined : usageRecordFromFinishEvent(event)
       if (event.error !== undefined) {
         return {
           durationMs: event.invocation.durationMs,

--- a/packages/agent/src/capabilities/observability.ts
+++ b/packages/agent/src/capabilities/observability.ts
@@ -1,4 +1,5 @@
 import { defineCapability } from "../capability-runtime.ts"
+import { usageTelemetry } from "./usage-telemetry.ts"
 
 import type {
   AgentActor,
@@ -10,9 +11,11 @@ import type {
   AgentRunInput,
   AgentRunMetadata,
   AgentRuntimeConfig,
+  AgentUsageRecord,
   MaybePromise,
   ResolvedAgentRuntimeContext,
 } from "../types.ts"
+import type { UsageTelemetryOptions } from "./usage-telemetry.ts"
 
 export type AgentObservabilityStatus = "completed" | "failed"
 
@@ -56,12 +59,14 @@ export interface AgentObservabilityOptions<
 > {
   instrumentation?: AgentModelExecutionInstrumentation<TRuntimeConfig, CALL_OPTIONS>
   onEvent?: AgentObservabilityEventHandler<TRuntimeConfig>
+  usageTelemetry?: boolean | UsageTelemetryOptions
 }
 
 export interface AgentObservabilityFinishExtension {
   durationMs: number
   resultKind?: string
   status: AgentObservabilityStatus
+  usage?: AgentUsageRecord
 }
 
 interface AgentObservabilityCapabilityMetadata<
@@ -81,6 +86,16 @@ function resultKind(result: unknown): string {
   if (isAsyncIterable(result)) return "stream"
   if (Array.isArray(result)) return "array"
   return typeof result
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function usageRecordFromFinishEvent(event: AgentFinishEvent): AgentUsageRecord | undefined {
+  const usageExtension = event.extensions.get<AgentUsageRecord>("usage-telemetry")
+  if (isRecord(usageExtension?.usage)) return usageExtension
+  if (isRecord(event.result) && isRecord(event.result.usageRecord)) return event.result.usageRecord as AgentUsageRecord
 }
 
 function capabilityEventBase<TRuntimeConfig extends AgentRuntimeConfig>(
@@ -123,7 +138,13 @@ export function observability<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
 >(options: AgentObservabilityOptions<TRuntimeConfig, CALL_OPTIONS> = {}): AgentCapabilityDefinition<TRuntimeConfig> {
-  return defineCapability({
+  const usage = options.usageTelemetry === undefined || options.usageTelemetry === true
+    ? usageTelemetry() as AgentCapabilityDefinition<TRuntimeConfig>
+    : typeof options.usageTelemetry === "object" && options.usageTelemetry !== null
+      ? usageTelemetry(options.usageTelemetry) as AgentCapabilityDefinition<TRuntimeConfig>
+      : undefined
+  return defineCapability<TRuntimeConfig>({
+    ...(usage ? { capabilities: [usage] } : {}),
     id: "observability",
     metadata: {
       kind: "observability",
@@ -157,10 +178,12 @@ export function observability<
       }
     },
     async finish(event: AgentFinishEvent<TRuntimeConfig>) {
+      const usage = usageRecordFromFinishEvent(event)
       if (event.error !== undefined) {
         return {
           durationMs: event.invocation.durationMs,
           status: "failed",
+          ...(usage ? { usage } : {}),
         } satisfies AgentObservabilityFinishExtension
       }
 
@@ -168,6 +191,7 @@ export function observability<
         durationMs: event.invocation.durationMs,
         resultKind: resultKind(event.result),
         status: "completed",
+        ...(usage ? { usage } : {}),
       } satisfies AgentObservabilityFinishExtension
     },
     input(context) {

--- a/packages/agent/src/capabilities/observability.ts
+++ b/packages/agent/src/capabilities/observability.ts
@@ -94,8 +94,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function usageRecordFromFinishEvent(event: AgentFinishEvent): AgentUsageRecord | undefined {
   const usageExtension = event.extensions.get<AgentUsageRecord>("usage-telemetry")
-  if (isRecord(usageExtension?.usage)) return usageExtension
-  if (isRecord(event.result) && isRecord(event.result.usageRecord)) return event.result.usageRecord as AgentUsageRecord
+  return isRecord(usageExtension?.usage) ? usageExtension : undefined
 }
 
 function capabilityEventBase<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -166,15 +166,27 @@ export function normalizeCapabilities(
   if (!Array.isArray(capabilities)) {
     throw new TypeError("[vitehub] defineAgent({ capabilities }) must be an ordered array.")
   }
-  const seen = new Set<string>()
-  return capabilities.map((capability) => {
-    const normalized = defineCapability(capability)
-    if (seen.has(normalized.id)) {
-      throw new Error(`[vitehub] Duplicate capability id "${normalized.id}" in one agent.`)
+  const explicit = capabilities.map(capability => defineCapability(capability))
+  const explicitById = new Map<string, AgentCapabilityDefinition>()
+  for (const capability of explicit) {
+    if (explicitById.has(capability.id)) {
+      throw new Error(`[vitehub] Duplicate capability id "${capability.id}" in one agent.`)
     }
-    seen.add(normalized.id)
-    return normalized
-  })
+    explicitById.set(capability.id, capability)
+  }
+
+  const normalized: AgentCapabilityDefinition[] = []
+  const seen = new Set<string>()
+  const add = (capability: AgentCapabilityDefinition) => {
+    const resolved = explicitById.get(capability.id) || defineCapability(capability)
+    if (seen.has(resolved.id)) return
+    seen.add(resolved.id)
+    for (const nested of resolved.capabilities || []) add(nested as AgentCapabilityDefinition)
+    normalized.push(resolved)
+  }
+
+  for (const capability of explicit) add(capability)
+  return normalized
 }
 
 export function capabilityWorkspaceSources(

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -178,10 +178,13 @@ export function normalizeCapabilities(
   const normalized: AgentCapabilityDefinition[] = []
   const seen = new Set<string>()
   const add = (capability: AgentCapabilityDefinition) => {
-    const resolved = explicitById.get(capability.id) || defineCapability(capability)
+    const resolved = defineCapability(capability)
     if (seen.has(resolved.id)) return
     seen.add(resolved.id)
-    for (const nested of resolved.capabilities || []) add(nested as AgentCapabilityDefinition)
+    for (const nested of resolved.capabilities || []) {
+      const normalizedNested = defineCapability(nested as AgentCapabilityDefinition)
+      if (!explicitById.has(normalizedNested.id)) add(normalizedNested)
+    }
     normalized.push(resolved)
   }
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -588,6 +588,7 @@ export interface AgentCapabilityDefinition<
 > {
   readonly __vitehubTypeContract?: TTypeContract
   bind?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
+  capabilities?: readonly AgentCapabilityDefinition<TRuntimeConfig, Name>[]
   close?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   configure?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   finish?: AgentFinishExtensionProvider<TRuntimeConfig>

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -263,8 +263,8 @@ describe("agent message protocol", () => {
     const onUsage = vi.fn()
     const agent = defineAgent({
       capabilities: [
-        observability(),
         usageTelemetry({ onUsage }),
+        observability(),
       ],
       hooks: {
         "agent:finish": finish,
@@ -288,6 +288,43 @@ describe("agent message protocol", () => {
     const extensions = finish.mock.calls[0]![0].extensions
     const usage = extensions.get("usage-telemetry")
     expect(extensions.get("observability", "usage")).toBe(usage)
+  })
+
+  it("preserves explicit capability order over nested defaults", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const agent = defineAgent({
+      capabilities: [
+        observability(),
+        defineCapability({
+          id: "usage-renderer",
+          output(context) {
+            context.output.render(result => ({
+              ...(result as Record<string, unknown>),
+              totalUsage: {
+                inputTokens: 4,
+                outputTokens: 6,
+              },
+            }))
+          },
+        }),
+        usageTelemetry(),
+      ],
+      run: () => ({ text: "ok" }),
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })).resolves.toMatchObject({
+      text: "ok",
+      usageRecord: {
+        usage: {
+          totalTokens: 10,
+        },
+      },
+    })
   })
 
   it("does not let observability sink failures change Agent output", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -215,6 +215,47 @@ describe("agent message protocol", () => {
     expect(extensions.get("observability", "usage")).toBeUndefined()
   })
 
+  it("keeps observability usage opt-out order-independent with explicit usage telemetry", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const orders = [
+      () => [usageTelemetry(), observability({ usageTelemetry: false })],
+      () => [observability({ usageTelemetry: false }), usageTelemetry()],
+    ]
+
+    for (const capabilities of orders) {
+      const finish = vi.fn()
+      const agent = defineAgent({
+        capabilities: capabilities(),
+        hooks: {
+          "agent:finish": finish,
+        },
+        run: () => ({
+          text: "ok",
+          totalUsage: {
+            inputTokens: 4,
+            outputTokens: 6,
+          },
+        }),
+      })
+
+      const result = await runAgent(agent, {
+        memo: vi.fn(),
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, { prompt: "hello" })
+
+      expect((result as { usageRecord?: unknown }).usageRecord).toEqual(expect.objectContaining({
+        usage: expect.objectContaining({
+          totalTokens: 10,
+        }),
+      }))
+      const extensions = finish.mock.calls[0]![0].extensions
+      expect(extensions.get("usage-telemetry")).toBe((result as { usageRecord?: unknown }).usageRecord)
+      expect(extensions.get("observability", "usage")).toBeUndefined()
+    }
+  })
+
   it("uses explicit usage telemetry configuration for observability", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -185,6 +185,13 @@ describe("agent message protocol", () => {
   it("lets observability opt out of default usage telemetry", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finish = vi.fn()
+    const usageRecord = {
+      usage: {
+        inputTokens: 4,
+        outputTokens: 6,
+        totalTokens: 10,
+      },
+    }
     const agent = defineAgent({
       capabilities: [observability({ usageTelemetry: false })],
       hooks: {
@@ -192,10 +199,7 @@ describe("agent message protocol", () => {
       },
       run: () => ({
         text: "ok",
-        totalUsage: {
-          inputTokens: 4,
-          outputTokens: 6,
-        },
+        usageRecord,
       }),
     })
 
@@ -205,7 +209,7 @@ describe("agent message protocol", () => {
       waitUntil: vi.fn(),
     }, { prompt: "hello" })
 
-    expect((result as { usageRecord?: unknown }).usageRecord).toBeUndefined()
+    expect((result as { usageRecord?: unknown }).usageRecord).toBe(usageRecord)
     const extensions = finish.mock.calls[0]![0].extensions
     expect(extensions.get("usage-telemetry")).toBeUndefined()
     expect(extensions.get("observability", "usage")).toBeUndefined()

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -142,6 +142,109 @@ describe("agent message protocol", () => {
     })
   })
 
+  it("enables usage telemetry from observability by default", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [observability()],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({
+        text: "ok",
+        totalUsage: {
+          inputTokens: 4,
+          outputTokens: 6,
+        },
+      }),
+    })
+
+    const result = await runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-1" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })
+
+    expect(result).toMatchObject({
+      text: "ok",
+      usageRecord: {
+        usage: {
+          inputTokens: 4,
+          outputTokens: 6,
+          totalTokens: 10,
+        },
+      },
+    })
+    const extensions = finish.mock.calls[0]![0].extensions
+    const usage = extensions.get("usage-telemetry")
+    expect(usage).toBe((result as { usageRecord?: unknown }).usageRecord)
+    expect(extensions.get("observability", "usage")).toBe(usage)
+  })
+
+  it("lets observability opt out of default usage telemetry", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [observability({ usageTelemetry: false })],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({
+        text: "ok",
+        totalUsage: {
+          inputTokens: 4,
+          outputTokens: 6,
+        },
+      }),
+    })
+
+    const result = await runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })
+
+    expect((result as { usageRecord?: unknown }).usageRecord).toBeUndefined()
+    const extensions = finish.mock.calls[0]![0].extensions
+    expect(extensions.get("usage-telemetry")).toBeUndefined()
+    expect(extensions.get("observability", "usage")).toBeUndefined()
+  })
+
+  it("uses explicit usage telemetry configuration for observability", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { usageTelemetry } = await import("../src/capabilities.ts")
+    const finish = vi.fn()
+    const onUsage = vi.fn()
+    const agent = defineAgent({
+      capabilities: [
+        observability(),
+        usageTelemetry({ onUsage }),
+      ],
+      hooks: {
+        "agent:finish": finish,
+      },
+      run: () => ({
+        text: "ok",
+        totalUsage: {
+          inputTokens: 8,
+          outputTokens: 2,
+        },
+      }),
+    })
+
+    await runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })
+
+    expect(onUsage).toHaveBeenCalledTimes(1)
+    const extensions = finish.mock.calls[0]![0].extensions
+    const usage = extensions.get("usage-telemetry")
+    expect(extensions.get("observability", "usage")).toBe(usage)
+  })
+
   it("does not let observability sink failures change Agent output", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const onEvent = vi.fn(() => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -153,7 +153,9 @@ describe("agent public types", () => {
               expectTypeOf(event.status).toEqualTypeOf<"failed">()
             }
           },
+          usageTelemetry: { summary: true },
         }),
+        observability({ usageTelemetry: false }),
         chatTitle({
           model: () => ({}),
           template({ fallback, maxLength, text, trigger }) {


### PR DESCRIPTION
Adds nested capability support so capabilities can declare default dependencies, then uses it to make `observability()` include `usageTelemetry()` unless the user opts out.

This lets observability carry the same Agent Usage Record exposed by usage telemetry, while explicit `usageTelemetry(...)` configuration still wins when present. The docs now call out the default, the opt-out path, and that `observability.usage` is an alias for the same usage record rather than a second record to persist.