### PR TITLE
feat(agent): add input command delivery hooks

### DIFF
--- a/docs/content/docs/capabilities/input-commands.md
+++ b/docs/content/docs/capabilities/input-commands.md
@@ -36,7 +36,7 @@ export default defineAgent({
       commands: {
         docs: {
           description: 'Add documentation context to the request.',
-          run: ({ args }) => `Use documentation context for: ${args}`,
+          call: ({ args }) => `Use documentation context for: ${args}`,
         },
       },
     }),
@@ -48,6 +48,8 @@ export default defineAgent({
 
 `inputCommands()` runs during the input phase.
 It finds command invocations in the latest user text, calls the matching command handler, and updates the Agent Run Input before other model-facing behavior consumes it.
+Command `agent:input` hooks run after the command updates the input and before the Agent Driver runs.
+Command `agent:finish` hooks run for completed and failed Agent Invocations.
 
 The Capability records command names and descriptions in metadata.
 It stops command expansion when no configured command remains.
@@ -80,10 +82,12 @@ Check DevTools metadata for the `inputCommands` Capability and its command descr
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `commands` | `Record<string, InputCommand>` | required | Command map keyed by lowercase stable command names. |
-| `id` | `string` | `"input-commands"` | Capability id. |
+| `id` | `string` | `"inputCommands"` | Capability id. |
 | `trigger` | `string` | `"/"` | Non-whitespace command prefix. |
 | `commands.*.description` | `string` | required | Command description for metadata and inspection. |
-| `commands.*.run` | `(input) => AgentRunInput \| Response \| string \| void` | required | Handler that accepts, rejects, transforms, or enriches invocation input. |
+| `commands.*.call` | `(input) => AgentRunInput \| Response \| string \| void` | required | Handler that accepts, rejects, transforms, or enriches invocation input. |
+| `commands.*.channels` | `string[]` | all channels | Optional configured Channel ID allowlist. |
+| `commands.*.hooks` | `{ 'agent:input'?, 'agent:finish'? }` | none | Command-scoped lifecycle hooks with `ctx.message.reply/update/react` delivery primitives. |
 
 ## Reference
 

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -183,6 +183,11 @@ export type {
   GitCapabilityToolPolicy,
 } from "./git.ts"
 export type {
+  InputCommandAgentFinishHookContext,
+  InputCommandAgentInputHookContext,
+  InputCommandCall,
+  InputCommandDeliveryMessage,
+  InputCommandHooks,
   InputCommand,
   InputCommandResult,
   InputCommandRunInput,

--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -437,9 +437,9 @@ export function inputCommands(options: InputCommandsOptions): AgentCapabilityDef
           name: invocation.name,
           text: invocation.text,
         })
+        scheduleInputCommandFinishHook(command, context as AgentCapabilityRuntimeContext, invocation)
         if (result instanceof Response) return result
 
-        scheduleInputCommandFinishHook(command, context as AgentCapabilityRuntimeContext, invocation)
         const previousText = text
         input = context.input.get()
         target = getInputCommandTarget(input)

--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -5,16 +5,51 @@ import {
 } from "../messages.ts"
 
 import type {
+  AgentChannelDeliveryEffectIntent,
   AgentCapabilityDefinition,
   AgentCapabilityRuntimeContext,
+  AgentFinishEvent,
+  AgentRunCallbackContext,
   AgentRunInput,
   MaybePromise,
 } from "../types.ts"
 import type { Message } from "../messages.ts"
 
+export interface InputCommandDeliveryMessage {
+  react: (content: string, options?: { transient?: boolean }) => Promise<void>
+  reply: (body: string) => Promise<void>
+  update: (body: string) => Promise<void>
+}
+
+export interface InputCommandAgentInputHookContext extends AgentRunCallbackContext {
+  args: string
+  command: InputCommand
+  message: InputCommandDeliveryMessage
+  name: string
+  text: string
+}
+
+export interface InputCommandAgentFinishHookContext extends AgentFinishEvent {
+  args: string
+  command: InputCommand
+  message: InputCommandDeliveryMessage
+  name: string
+  text: string
+}
+
+export interface InputCommandHooks {
+  "agent:finish"?: (context: InputCommandAgentFinishHookContext) => MaybePromise<void>
+  "agent:input"?: (context: InputCommandAgentInputHookContext) => MaybePromise<void>
+}
+
+export type InputCommandCall = (input: InputCommandRunInput) => MaybePromise<InputCommandResult>
+
 export interface InputCommand {
+  call?: InputCommandCall
+  channels?: readonly string[]
   description: string
-  run: (input: InputCommandRunInput) => MaybePromise<InputCommandResult>
+  hooks?: InputCommandHooks
+  run?: InputCommandCall
 }
 
 export type InputCommandResult = Partial<AgentRunInput> | Response | string | void
@@ -57,6 +92,8 @@ export interface InputCommandTextReplacement {
   start: number
 }
 
+let transientReactionId = 0
+
 export function assertInputCommandName(name: string): void {
   if (!/^[a-z][a-z0-9_-]*$/.test(name)) {
     throw new TypeError(`[vitehub] Input command "${name}" must be a lowercase stable identifier.`)
@@ -75,8 +112,11 @@ function normalizeInputCommands(options: InputCommandsOptions): Record<string, I
     if (typeof command.description !== "string" || !command.description.trim()) {
       throw new TypeError(`[vitehub] Input command "${name}" requires a description.`)
     }
-    if (typeof command.run !== "function") {
-      throw new TypeError(`[vitehub] Input command "${name}" requires a run() handler.`)
+    if (typeof command.call !== "function" && typeof command.run !== "function") {
+      throw new TypeError(`[vitehub] Input command "${name}" requires a call() handler.`)
+    }
+    if (command.channels !== undefined && (!Array.isArray(command.channels) || command.channels.some(channel => typeof channel !== "string" || !channel.trim()))) {
+      throw new TypeError(`[vitehub] Input command "${name}" channels must be non-empty Channel IDs.`)
     }
   }
   return options.commands
@@ -261,13 +301,112 @@ function mergeInputCommandResult(input: AgentRunInput, result: Partial<AgentRunI
   return next
 }
 
+function inputCommandCall(command: InputCommand): InputCommandCall {
+  return command.call || command.run!
+}
+
+function activeChannelId(context: AgentCapabilityRuntimeContext): string | undefined {
+  return context.run?.channelId || context.context.get<{ channelId?: string }>("agent.trigger")?.channelId
+}
+
+function commandAllowsCurrentChannel(command: InputCommand, context: AgentCapabilityRuntimeContext): boolean {
+  return !command.channels?.length || command.channels.includes(activeChannelId(context) || "")
+}
+
+function createInputCommandMessage(
+  emit: (intent: AgentChannelDeliveryEffectIntent, options?: { transient?: boolean }) => void,
+): InputCommandDeliveryMessage {
+  return {
+    async react(content, options) {
+      const key = options?.transient === false ? undefined : `input-command:${++transientReactionId}`
+      emit({
+        kind: "reaction",
+        metadata: key ? { transient: true, transientKey: key } : undefined,
+        payload: { content },
+      }, { transient: Boolean(key) })
+    },
+    async reply(body) {
+      emit({ kind: "reply", payload: body })
+    },
+    async update(body) {
+      emit({ kind: "update", payload: body })
+    },
+  }
+}
+
+function inputPhaseMessage(context: AgentCapabilityRuntimeContext): InputCommandDeliveryMessage {
+  return createInputCommandMessage((intent, options) => {
+    context.delivery.effect(intent)
+    if (options?.transient && typeof intent.metadata?.transientKey === "string") {
+      context.delivery.finishEffect(() => ({
+        kind: intent.kind,
+        metadata: {
+          transient: true,
+          transientKey: intent.metadata!.transientKey,
+        },
+        payload: {
+          action: "remove",
+          content: typeof intent.payload === "string" ? intent.payload : (intent.payload as { content?: unknown } | undefined)?.content,
+        },
+      }))
+    }
+  })
+}
+
+function finishPhaseMessage(effects: AgentChannelDeliveryEffectIntent[]): InputCommandDeliveryMessage {
+  return createInputCommandMessage(intent => effects.push(intent))
+}
+
+async function runInputCommandInputHook(
+  command: InputCommand,
+  context: AgentCapabilityRuntimeContext,
+  invocation: InputCommandInvocation,
+): Promise<void> {
+  const hook = command.hooks?.["agent:input"]
+  if (!hook) return
+  const input = context.input.get()
+  await hook({
+    ...context,
+    args: invocation.args,
+    command,
+    input,
+    message: inputPhaseMessage(context),
+    name: invocation.name,
+    text: invocation.text,
+  } as InputCommandAgentInputHookContext)
+}
+
+function scheduleInputCommandFinishHook(
+  command: InputCommand,
+  context: AgentCapabilityRuntimeContext,
+  invocation: InputCommandInvocation,
+): void {
+  const hook = command.hooks?.["agent:finish"]
+  if (!hook) return
+  context.delivery.finishEffect(async (event) => {
+    const effects: AgentChannelDeliveryEffectIntent[] = []
+    await hook({
+      ...event,
+      args: invocation.args,
+      command,
+      message: finishPhaseMessage(effects),
+      name: invocation.name,
+      text: invocation.text,
+    } as InputCommandAgentFinishHookContext)
+    return effects.length ? effects : false
+  })
+}
+
 export function inputCommands(options: InputCommandsOptions): AgentCapabilityDefinition {
   const commands = normalizeInputCommands(options)
   const trigger = normalizeInputCommandTrigger(options.trigger)
   return defineCapability({
     id: options.id || "inputCommands",
     metadata: {
-      commands: Object.fromEntries(Object.entries(commands).map(([name, command]) => [name, { description: command.description }])),
+      commands: Object.fromEntries(Object.entries(commands).map(([name, command]) => [name, {
+        ...(command.channels?.length ? { channels: [...command.channels] } : {}),
+        description: command.description,
+      }])),
       trigger,
     },
     input: async (context) => {
@@ -285,7 +424,11 @@ export function inputCommands(options: InputCommandsOptions): AgentCapabilityDef
         if (++runs > maxRuns) throw new Error("[vitehub] inputCommands exceeded the maximum command expansion depth.")
 
         const command = commands[invocation.name]!
-        const result = await command.run({
+        if (!commandAllowsCurrentChannel(command, context as AgentCapabilityRuntimeContext)) {
+          cursor = invocation.end
+          continue
+        }
+        const result = await inputCommandCall(command)({
           args: invocation.args,
           command,
           context: context as AgentCapabilityRuntimeContext,
@@ -296,6 +439,7 @@ export function inputCommands(options: InputCommandsOptions): AgentCapabilityDef
         })
         if (result instanceof Response) return result
 
+        scheduleInputCommandFinishHook(command, context as AgentCapabilityRuntimeContext, invocation)
         const previousText = text
         input = context.input.get()
         target = getInputCommandTarget(input)
@@ -319,6 +463,7 @@ export function inputCommands(options: InputCommandsOptions): AgentCapabilityDef
           target = getInputCommandTarget(input)
           if (!target) return
           maxRuns = Math.max(maxRuns, text.length + 1)
+          await runInputCommandInputHook(command, context as AgentCapabilityRuntimeContext, invocation)
           cursor = replacement === invocation.text ? invocation.end : invocation.start
           continue
         }
@@ -332,10 +477,12 @@ export function inputCommands(options: InputCommandsOptions): AgentCapabilityDef
           text = target.text
           maxRuns = Math.max(maxRuns, text.length + 1)
           if (text !== previousText) {
+            await runInputCommandInputHook(command, context as AgentCapabilityRuntimeContext, invocation)
             cursor = 0
             continue
           }
           if (changesText) {
+            await runInputCommandInputHook(command, context as AgentCapabilityRuntimeContext, invocation)
             cursor = invocation.end
             continue
           }
@@ -348,14 +495,17 @@ export function inputCommands(options: InputCommandsOptions): AgentCapabilityDef
           if (!target) return
           text = target.text
           maxRuns = Math.max(maxRuns, text.length + 1)
+          await runInputCommandInputHook(command, context as AgentCapabilityRuntimeContext, invocation)
           cursor = 0
           continue
         }
 
         if (text !== previousText) {
+          await runInputCommandInputHook(command, context as AgentCapabilityRuntimeContext, invocation)
           cursor = 0
           continue
         }
+        await runInputCommandInputHook(command, context as AgentCapabilityRuntimeContext, invocation)
         cursor = invocation.end
       }
     },

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -841,7 +841,8 @@ export async function resolveAgentCapabilities<
             invocationContext.set(channelDeliveryEffectsContextKey, next, { overwrite: true })
           },
           finishEffect(effect) {
-            if (typeof effect !== "function" && (!effect || typeof effect !== "object" || typeof effect.kind !== "string" || !effect.kind.trim())) {
+            const effects = Array.isArray(effect) ? effect : [effect]
+            if (typeof effect !== "function" && effects.some(effect => !effect || typeof effect !== "object" || typeof effect.kind !== "string" || !effect.kind.trim())) {
               throw new TypeError("[vitehub] delivery.finishEffect() requires an effect intent or resolver.")
             }
             const next = [...registries.finishDeliveryEffectProviders, effect]

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -325,10 +325,13 @@ function parseSlashCommand(body: string): { args: string, command: `/${string}` 
 }
 
 type AgentChannelTriggerContextWithCapabilities<TRuntimeConfig extends AgentRuntimeConfig> =
-  AgentCallbackContext<TRuntimeConfig> & { capabilities?: readonly AgentCapabilityDefinition<TRuntimeConfig>[] }
+  AgentCallbackContext<TRuntimeConfig> & {
+    capabilities?: readonly AgentCapabilityDefinition<TRuntimeConfig>[]
+    trigger?: { channelId?: string }
+  }
 
 type InputCommandsMetadata = {
-  commands: Record<string, unknown>
+  commands: Record<string, { channels?: readonly string[] } | unknown>
   trigger: string
 }
 
@@ -342,13 +345,17 @@ function declaredInputCommand<TRuntimeConfig extends AgentRuntimeConfig>(
   command: string,
 ): boolean | undefined {
   let sawMatchingTrigger = false
+  const channelId = (context as AgentChannelTriggerContextWithCapabilities<TRuntimeConfig>).trigger?.channelId
   for (const capability of (context as AgentChannelTriggerContextWithCapabilities<TRuntimeConfig>).capabilities || []) {
     const metadata = inputCommandsMetadata(capability.metadata)
     if (!metadata || !command.startsWith(metadata.trigger)) continue
     const name = command.slice(metadata.trigger.length)
     if (!name) continue
     sawMatchingTrigger = true
-    if (Object.hasOwn(metadata.commands, name)) return true
+    const configured = metadata.commands[name]
+    if (!configured) continue
+    const channels = isRecord(configured) && Array.isArray(configured.channels) ? configured.channels : undefined
+    if (!channels?.length || channels.includes(channelId || "")) return true
   }
   return sawMatchingTrigger ? false : undefined
 }
@@ -756,6 +763,30 @@ function reactionContent<TRuntimeConfig extends AgentRuntimeConfig>(
   return "eyes"
 }
 
+function reactionAction<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
+): string | undefined {
+  return isRecord(context.effect.payload) ? maybeString(context.effect.payload.action) : undefined
+}
+
+function transientReactionKey<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
+): string | undefined {
+  return maybeString(context.effect.metadata?.transientKey)
+}
+
+type GitHubTransientReaction = {
+  id: number
+}
+
+function transientReactionStore(input: AgentRunInput): Record<string, GitHubTransientReaction> {
+  const context = input.context as Record<string, unknown> | undefined
+  if (!context) return {}
+  const key = "github.delivery.transientReactions"
+  if (!isRecord(context[key])) context[key] = {}
+  return context[key] as Record<string, GitHubTransientReaction>
+}
+
 function replyBody<TRuntimeConfig extends AgentRuntimeConfig>(
   context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
 ): string | undefined {
@@ -883,11 +914,25 @@ function githubPullRequestEffects<TRuntimeConfig extends AgentRuntimeConfig = Ag
       const fetcher = options.fetch || fetch
       const token = await resolveEffectOption(options.token, context)
       const url = `${options.apiBaseUrl || "https://api.github.com"}/repos/${command.owner}/${command.repo}/issues/comments/${command.commentId}/reactions`
-      await githubApi(fetcher, url, {
+      const key = transientReactionKey(context)
+      if (reactionAction(context) === "remove") {
+        const id = key ? transientReactionStore(context.input)[key]?.id : undefined
+        if (!id) return
+        await githubApi(fetcher, `${url}/${id}`, {
+          headers: githubApiHeaders(token, options.userAgent),
+          method: "DELETE",
+        })
+        delete transientReactionStore(context.input)[key!]
+        return
+      }
+      const response = await githubApi(fetcher, url, {
         body: JSON.stringify({ content: reactionContent(context) }),
         headers: githubApiHeaders(token, options.userAgent),
         method: "POST",
       })
+      const body = await response.json().catch(() => undefined)
+      const id = isRecord(body) ? maybeNumber(body.id) : undefined
+      if (key && id) transientReactionStore(context.input)[key] = { id }
     },
     async reply(context) {
       const command = githubCommandFromEffect(context)
@@ -900,6 +945,19 @@ function githubPullRequestEffects<TRuntimeConfig extends AgentRuntimeConfig = Ag
         body: JSON.stringify({ body }),
         headers: githubApiHeaders(token, options.userAgent),
         method: "POST",
+      })
+    },
+    async update(context) {
+      const command = githubCommandFromEffect(context)
+      const body = githubBodyWithArtifacts(context, replyBody(context))
+      if (!command || !body) return
+      const fetcher = options.fetch || fetch
+      const token = await resolveEffectOption(options.token, context)
+      const url = `${options.apiBaseUrl || "https://api.github.com"}/repos/${command.owner}/${command.repo}/issues/comments/${command.commentId}`
+      await githubApi(fetcher, url, {
+        body: JSON.stringify({ body }),
+        headers: githubApiHeaders(token, options.userAgent),
+        method: "PATCH",
       })
     },
     async review(context) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1577,6 +1577,15 @@ function assertDeliveryEffectIntent(value: unknown): asserts value is AgentChann
   }
 }
 
+function appendDeliveryEffectIntent(intents: AgentChannelDeliveryEffectIntent[], value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) appendDeliveryEffectIntent(intents, item)
+    return
+  }
+  assertDeliveryEffectIntent(value)
+  intents.push(value)
+}
+
 async function resolveFinishDeliveryEffectIntents<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -1595,8 +1604,7 @@ async function resolveFinishDeliveryEffectIntents<
   for (const provider of providers) {
     const intent = typeof provider === "function" ? await provider(event, finishContext) : provider
     if (!intent) continue
-    assertDeliveryEffectIntent(intent)
-    intents.push(intent)
+    appendDeliveryEffectIntent(intents, intent)
   }
   return intents
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -222,7 +222,8 @@ export type AgentChannelDeliveryEffects<
 > = Partial<Record<AgentChannelDeliveryEffectKind, AgentChannelDeliveryEffectHandler<TRuntimeConfig> | readonly AgentChannelDeliveryEffectHandler<TRuntimeConfig>[]>>
 export type AgentChannelDeliveryFinishEffect =
   | AgentChannelDeliveryEffectIntent
-  | ((event: AgentFinishEvent, context: AgentChannelDeliveryFinishEffectContext) => MaybePromise<AgentChannelDeliveryEffectIntent | false | null | undefined>)
+  | readonly AgentChannelDeliveryEffectIntent[]
+  | ((event: AgentFinishEvent, context: AgentChannelDeliveryFinishEffectContext) => MaybePromise<AgentChannelDeliveryEffectIntent | readonly AgentChannelDeliveryEffectIntent[] | false | null | undefined>)
 
 export interface AgentTriggerRunInvokeResult<CALL_OPTIONS = unknown> {
   delivery?: {

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -19,7 +19,7 @@ describe("inputCommands", () => {
         commands: {
           review: {
             description: "Review the request.",
-            run: ({ args }) => `Review this: ${args}`,
+            call: ({ args }) => `Review this: ${args}`,
           },
         },
       })],
@@ -368,7 +368,13 @@ describe("inputCommands", () => {
       commands: {
         review: { description: "Review." } as never,
       },
-    })).toThrow("requires a run() handler")
+    })).toThrow("requires a call() handler")
+
+    expect(() => inputCommands({
+      commands: {
+        review: { description: "Review.", call: () => undefined, channels: [""] },
+      },
+    })).toThrow("channels must be non-empty Channel IDs")
   })
 
   it("leaves unknown commands unchanged", async () => {

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -266,6 +266,34 @@ describe("inputCommands", () => {
     expect(resolved.input.prompt).toBe("")
   })
 
+  it("registers finish hooks when a command returns a handled response", async () => {
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [inputCommands({
+        commands: {
+          block: {
+            description: "Block the request.",
+            run: () => Response.json({ accepted: false }),
+            hooks: {
+              async "agent:finish"(context) {
+                await context.message.reply(`handled:${context.text}`)
+              },
+            },
+          },
+        },
+      })],
+    }, runtime(), { prompt: "/block now" })
+    const finishProvider = resolved.registries.finishDeliveryEffectProviders[0] as (event: unknown, context: unknown) => unknown
+
+    expect(resolved.response).toBeInstanceOf(Response)
+    expect(typeof finishProvider).toBe("function")
+    await expect(finishProvider({ result: resolved.response } as never, {} as never)).resolves.toEqual([
+      { kind: "reply", payload: "handled:/block now" },
+    ])
+  })
+
   it("treats returned messages as authoritative over a stale string prompt", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -189,6 +189,108 @@ describe("agent message protocol", () => {
     expect(run).not.toHaveBeenCalled()
   })
 
+  it("runs command input and finish hooks around agent execution", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const events: string[] = []
+    const agent = defineAgent({
+      capabilities: [inputCommands({
+        commands: {
+          review: {
+            description: "Review the request.",
+            call: ({ args }) => `review:${args}`,
+            hooks: {
+              "agent:input"(context) {
+                events.push(`command-input:${context.input.prompt}`)
+              },
+              "agent:finish"(context) {
+                events.push(context.error ? `command-finish:error:${(context.error as Error).message}` : `command-finish:${context.result}`)
+              },
+            },
+          },
+        },
+      })],
+      driver: {
+        run(context) {
+          events.push(`run:${context.prompt}`)
+          if (context.prompt === "review:fail") throw new Error("boom")
+          return `ok:${context.prompt}`
+        },
+      },
+      hooks: {
+        "agent:input"(context) {
+          events.push(`agent-input:${context.input.prompt}`)
+        },
+        "agent:finish"(context) {
+          events.push(context.error ? `agent-finish:error:${(context.error as Error).message}` : `agent-finish:${context.result}`)
+        },
+      },
+    })
+    const runtime = { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }
+
+    await expect(runAgent(agent, runtime, { prompt: "/review pass" })).resolves.toBe("ok:review:pass")
+    await expect(runAgent(agent, runtime, { prompt: "/review fail" })).rejects.toThrow("boom")
+
+    expect(events).toEqual([
+      "command-input:review:pass",
+      "agent-input:review:pass",
+      "run:review:pass",
+      "command-finish:ok:review:pass",
+      "agent-finish:ok:review:pass",
+      "command-input:review:fail",
+      "agent-input:review:fail",
+      "run:review:fail",
+      "command-finish:error:boom",
+      "agent-finish:error:boom",
+    ])
+  })
+
+  it("lets command finish hooks reply after agent errors", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const effects: unknown[] = []
+    const agent = defineAgent({
+      capabilities: [inputCommands({
+        commands: {
+          review: {
+            description: "Review the request.",
+            call: ({ args }) => args,
+            hooks: {
+              async "agent:finish"(context) {
+                if (context.error) await context.message.reply("I couldn't start the review.")
+              },
+            },
+          },
+        },
+      })],
+      channels: {
+        github: defineChannel("github", {
+          effects: {
+            reply(context) {
+              effects.push(context.effect)
+            },
+          },
+          messages: false,
+        }),
+      },
+      driver: {
+        run() {
+          throw new Error("failed")
+        },
+      },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { channelId: "github", runId: "run-1" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "/review please" })).rejects.toThrow("failed")
+
+    expect(effects).toEqual([{ kind: "reply", payload: "I couldn't start the review." }])
+  })
+
   it("emits invocation Trace Events without persisting prompt content", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const traceLog = createTraceEventLog()
@@ -2215,6 +2317,9 @@ describe("agent message protocol", () => {
       if (href.endsWith("/pulls/42")) {
         return Response.json({ head: { sha: "abc123" } })
       }
+      if (href.endsWith("/issues/comments/99/reactions") && init?.method === "POST") {
+        return Response.json({ id: 777 }, { status: 201 })
+      }
       return Response.json({ ok: true }, { status: init?.method === "POST" ? 201 : 200 })
     })
     const input = {
@@ -2253,15 +2358,13 @@ describe("agent message protocol", () => {
       capabilities: [defineCapability({
         id: "review-feedback",
         prepare(context) {
-          context.delivery.effect({ intent: "started", kind: "reaction" })
-          context.delivery.effect({ kind: "reply", payload: "Review queued." })
           context.delivery.effect({ intent: "completed", kind: "status", metadata: { description: "Review completed." } })
         },
       }), inputCommands({
         commands: {
           review: {
             description: "Review a pull request.",
-            run({ input }) {
+            call({ input }) {
               const command = input.context?.github as Record<string, unknown> | undefined
               const pullRequest = input.context?.pullRequest as Record<string, unknown> | undefined
               if (!command || !pullRequest) throw new Error("Missing GitHub pull request context.")
@@ -2293,6 +2396,12 @@ describe("agent message protocol", () => {
                   sender: { login: "onmax" },
                 },
               })
+            },
+            hooks: {
+              async "agent:input"(context) {
+                await context.message.react("eyes")
+                await context.message.reply("Review queued.")
+              },
             },
           },
         },
@@ -2340,6 +2449,13 @@ describe("agent message protocol", () => {
         body: JSON.stringify({ content: "eyes" }),
         headers: expect.objectContaining({ authorization: "Bearer installation-token" }),
         method: "POST",
+      }),
+    )
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.github.test/repos/vite-hub/vitehub/issues/comments/99/reactions/777",
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "Bearer installation-token" }),
+        method: "DELETE",
       }),
     )
     expect(fetcher).toHaveBeenCalledWith(
@@ -2478,6 +2594,74 @@ describe("agent message protocol", () => {
     await expect((response as Response).json()).resolves.toEqual({ accepted: false, ok: true, reason: "not_command" })
     expect(summaryRun).not.toHaveBeenCalled()
     expect(run).not.toHaveBeenCalled()
+  })
+
+  it("filters GitHub PR comment input commands by configured channel id", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { github } = await import("../src/channels.ts")
+    const calls: string[] = []
+    const agent = defineAgent({
+      capabilities: [inputCommands({
+        commands: {
+          review: {
+            channels: ["github"],
+            description: "Review a pull request.",
+            call: ({ args }) => {
+              calls.push(`review:${args}`)
+              return args
+            },
+          },
+          summary: {
+            description: "Summarize a pull request.",
+            call: ({ args }) => {
+              calls.push(`summary:${args}`)
+              return args
+            },
+          },
+        },
+      })],
+      channels: {
+        github: github({
+          app: { webhookSecret: false },
+          events: { pullRequestComments: true },
+        }),
+        triage: github({
+          app: { webhookSecret: false },
+          events: { pullRequestComments: true },
+        }),
+      },
+      run: context => `ran:${context.prompt}`,
+    })
+    const delivery = (body: string, id: number) => ({
+      github: { deliveryId: `delivery-${id}`, event: "issue_comment" },
+      payload: {
+        action: "created",
+        comment: {
+          body,
+          id,
+          user: { login: "contributor", type: "User" },
+        },
+        issue: {
+          number: 42,
+          pull_request: { url: "https://api.github.test/repos/vite-hub/vitehub/pulls/42" },
+        },
+        repository: {
+          full_name: "vite-hub/vitehub",
+          name: "vitehub",
+          owner: { login: "vite-hub" },
+        },
+      },
+    })
+    const runtime = { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }
+
+    const filtered = await runAgentTrigger(agent, runtime, "triage.webhook", delivery("/review please", 201))
+    expect(filtered).toBeInstanceOf(Response)
+    await expect((filtered as Response).json()).resolves.toEqual({ accepted: false, ok: true, reason: "not_command" })
+
+    await expect(runAgentTrigger(agent, runtime, "triage.webhook", delivery("/summary please", 202))).resolves.toBe("ran:please")
+    await expect(runAgentTrigger(agent, runtime, "github.webhook", delivery("/review please", 203))).resolves.toBe("ran:please")
+    expect(calls).toEqual(["summary:please", "review:please"])
   })
 
   it("keeps channel chat triggers discoverable for workspace agents", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -65,7 +65,7 @@ describe("agent public types", () => {
           commands: {
             review: {
               description: "Review the request.",
-              run: ({ args }) => `review:${args}`,
+              call: ({ args }) => `review:${args}`,
             },
           },
         }),
@@ -561,13 +561,22 @@ describe("agent public types", () => {
       }, inputCommands({
         commands: {
           review: {
+            channels: ["github"],
             description: "Review the pull request.",
-            run({ args, input }) {
+            call({ args, input }) {
               expectTypeOf(args).toEqualTypeOf<string>()
               expectTypeOf(input.context?.github).toEqualTypeOf<GitHubPullRequestCommand | undefined>()
               const pullRequest = input.context?.pullRequest
               expectTypeOf(pullRequest).toEqualTypeOf<GitHubPullRequestRunContext | undefined>()
               return { prompt: args }
+            },
+            hooks: {
+              async "agent:input"(context) {
+                await context.message.react("eyes")
+              },
+              async "agent:finish"(context) {
+                if (context.error) await context.message.reply("failed")
+              },
             },
           },
         },

--- a/packages/database/src/vite.ts
+++ b/packages/database/src/vite.ts
@@ -17,8 +17,11 @@ export const DB_VIRTUAL_SCHEMA_ID = "#vitehub/database/schema"
 export const DB_VIRTUAL_DATABASES_ID = "#vitehub/database/databases"
 export const DB_VITE_PLUGIN_NAME = "@vite-hub/database/vite"
 
+const DB_INTERNAL_VIRTUAL_SCHEMA_ID = "virtual:vitehub/database/schema"
+const DB_INTERNAL_VIRTUAL_DATABASES_ID = "virtual:vitehub/database/databases"
 const RESOLVED_DB_VIRTUAL_SCHEMA_ID = `\0${DB_VIRTUAL_SCHEMA_ID}`
 const RESOLVED_DB_VIRTUAL_DATABASES_ID = `\0${DB_VIRTUAL_DATABASES_ID}`
+const DB_DRIZZLE_ENTRY_PATTERN = /(?:^|\/)(?:@vite-hub\/database|database)\/dist\/drizzle\.js$/
 
 export interface DBVitePluginAPI {
   getConfig: () => ResolvedDBViteConfig | undefined
@@ -34,6 +37,17 @@ interface DBCliContributingPlugin {
 export type DBVitePlugin = Plugin & DBCliContributingPlugin & { api: DBVitePluginAPI }
 
 const mergeNoExternal = createNoExternalMerger(dbPackageName)
+
+function resolveDatabaseVirtualId(id: string) {
+  if (id === DB_VIRTUAL_SCHEMA_ID || id === DB_INTERNAL_VIRTUAL_SCHEMA_ID) return RESOLVED_DB_VIRTUAL_SCHEMA_ID
+  if (id === DB_VIRTUAL_DATABASES_ID || id === DB_INTERNAL_VIRTUAL_DATABASES_ID) return RESOLVED_DB_VIRTUAL_DATABASES_ID
+}
+
+function rewriteDrizzleVirtualImports(code: string) {
+  return code
+    .replaceAll(DB_VIRTUAL_SCHEMA_ID, DB_INTERNAL_VIRTUAL_SCHEMA_ID)
+    .replaceAll(DB_VIRTUAL_DATABASES_ID, DB_INTERNAL_VIRTUAL_DATABASES_ID)
+}
 
 function renderSchemaModule(config: ResolvedDBViteConfig | undefined) {
   if (!config?.databaseNames.length) {
@@ -146,8 +160,10 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
       if (databasesModule) context.server.moduleGraph.invalidateModule(databasesModule)
     },
     resolveId(id) {
-      if (id === DB_VIRTUAL_SCHEMA_ID) return RESOLVED_DB_VIRTUAL_SCHEMA_ID
-      if (id === DB_VIRTUAL_DATABASES_ID) return RESOLVED_DB_VIRTUAL_DATABASES_ID
+      return resolveDatabaseVirtualId(id)
+    },
+    transform(code, id) {
+      if (DB_DRIZZLE_ENTRY_PATTERN.test(normalize(id))) return rewriteDrizzleVirtualImports(code)
     },
     load(id) {
       if (id === RESOLVED_DB_VIRTUAL_SCHEMA_ID) return renderSchemaModule(runtimeConfig)

--- a/packages/database/test/vite-output.test.ts
+++ b/packages/database/test/vite-output.test.ts
@@ -160,6 +160,12 @@ describe("Vite db provider outputs", () => {
       }),
     ])
     expect(existsSync(vercelServer)).toBe(true)
+    const bundledServerCode = await readFile(join(rootDir, "dist/client/server.js"), "utf8")
+    expect(bundledServerCode.includes("\"analytics\"")).toBe(true)
+    expect(bundledServerCode.includes("\"primary\"")).toBe(true)
+    expect(bundledServerCode.includes("runtime/virtual-databases.js")).toBe(false)
+    expect(bundledServerCode.includes("var databases$1 = {};")).toBe(false)
+
     const vercelServerCode = await readFile(vercelServer, "utf8")
     expect(vercelServerCode).toContain("process.env.TURSO_ANALYTICS_DATABASE_URL || process.env.TURSO_DATABASE_URL")
     expect(vercelServerCode).toContain("process.env.TURSO_DATABASE_URL")


### PR DESCRIPTION
Adds `call` as the canonical Input Command handler while preserving `run` as a compatibility alias, plus command-scoped `agent:input` and `agent:finish` hooks with channel-neutral `ctx.message.reply/update/react` delivery primitives. Command `channels` now filter by configured Channel ID and default to all channels when unset.

Wires GitHub PR comment delivery to those primitives, including transient reaction cleanup on finish, and updates focused docs/tests for channel admission, lifecycle ordering, and failure replies.