### PR TITLE
fix(agent): compact dev tool logs

### DIFF
--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -716,6 +716,7 @@ async function sendDevMessage(
   const delayTextForPreview = Boolean(parsed.trigger && parsed.trigger !== "chat.message")
   let canWriteDelayedUsage = false
   const visibleTools = new Set<string>()
+  const pendingToolInputs = new Map<string, unknown>()
   const writeUsageNote = () => {
     if (delayTextForPreview && !canWriteDelayedUsage) return
     if (previewSeen) return
@@ -764,19 +765,26 @@ async function sendDevMessage(
       }
       if (event.type === "tool-call" || event.type === "tool-input-start") {
         clearPendingFallback()
-        if (event.type === "tool-input-start") continue
+        if (event.type === "tool-input-start") {
+          if (event.input !== undefined) pendingToolInputs.set(event.id, event.input)
+          continue
+        }
         if (!visibleTools.has(event.id)) {
           visibleTools.add(event.id)
-          context.stderr.write(`\n${toolHeader(event.name, event.input)}\n`)
+          const input = event.input !== undefined ? event.input : pendingToolInputs.get(event.id)
+          context.stderr.write(`\n${toolHeader(event.name, input)}\n`)
         }
+        pendingToolInputs.delete(event.id)
         continue
       }
       if (event.type === "tool-result") {
         clearPendingFallback()
         if (!visibleTools.has(event.id)) {
           visibleTools.add(event.id)
-          context.stderr.write(`\n${toolHeader(event.name, undefined, event.output)}\n`)
+          const pendingInput = pendingToolInputs.get(event.id)
+          context.stderr.write(`\n${toolHeader(event.name, pendingToolInputs.has(event.id) ? pendingInput : undefined, event.output)}\n`)
         }
+        pendingToolInputs.delete(event.id)
         if (!writeShellOutput(context, event.output, event.error) && !writeToolTextOutput(context, event.output)) {
           writeDevPayload(context, "output", event.output)
           writeDevPayload(context, "error", event.error)

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -296,7 +296,11 @@ function shellCommand(value: unknown): string | undefined {
 }
 
 function toolHeader(name: string, input?: unknown, output?: unknown): string {
-  return `[tool] ${shellCommand(input) ?? shellCommand(output) ?? name}`
+  const command = shellCommand(input) ?? shellCommand(output)
+  if (command) return `[tool] ${command}`
+
+  const formattedInput = formatDevPayload(input)
+  return `[tool] ${name}${formattedInput ? ` ${formattedInput}` : ""}`
 }
 
 function writeShellOutput(context: AgentCliContext, output: unknown, error: unknown): boolean {
@@ -760,12 +764,11 @@ async function sendDevMessage(
       }
       if (event.type === "tool-call" || event.type === "tool-input-start") {
         clearPendingFallback()
-        if (event.type === "tool-input-start" && event.input === undefined) continue
+        if (event.type === "tool-input-start") continue
         if (!visibleTools.has(event.id)) {
           visibleTools.add(event.id)
           context.stderr.write(`\n${toolHeader(event.name, event.input)}\n`)
         }
-        if (!shellCommand(event.input)) writeDevPayload(context, "input", event.input)
         continue
       }
       if (event.type === "tool-result") {

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -769,12 +769,15 @@ async function sendDevMessage(
           if (event.input !== undefined) pendingToolInputs.set(event.id, event.input)
           continue
         }
+        if (event.input !== undefined) pendingToolInputs.set(event.id, event.input)
         if (!visibleTools.has(event.id)) {
-          visibleTools.add(event.id)
           const input = event.input !== undefined ? event.input : pendingToolInputs.get(event.id)
-          context.stderr.write(`\n${toolHeader(event.name, input)}\n`)
+          if (shellCommand(input)) {
+            visibleTools.add(event.id)
+            pendingToolInputs.delete(event.id)
+            context.stderr.write(`\n${toolHeader(event.name, input)}\n`)
+          }
         }
-        pendingToolInputs.delete(event.id)
         continue
       }
       if (event.type === "tool-result") {

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -299,7 +299,7 @@ function toolHeader(name: string, input?: unknown, output?: unknown): string {
   const command = shellCommand(input) ?? shellCommand(output)
   if (command) return `[tool] ${command}`
 
-  const formattedInput = formatDevPayload(input)
+  const formattedInput = isRecord(input) && Object.keys(input).length === 0 ? undefined : formatDevPayload(input)
   return `[tool] ${name}${formattedInput ? ` ${formattedInput}` : ""}`
 }
 
@@ -716,7 +716,7 @@ async function sendDevMessage(
   const delayTextForPreview = Boolean(parsed.trigger && parsed.trigger !== "chat.message")
   let canWriteDelayedUsage = false
   const visibleTools = new Set<string>()
-  const pendingToolInputs = new Map<string, unknown>()
+  const visibleToolInputs = new Map<string, string | undefined>()
   const writeUsageNote = () => {
     if (delayTextForPreview && !canWriteDelayedUsage) return
     if (previewSeen) return
@@ -765,17 +765,17 @@ async function sendDevMessage(
       }
       if (event.type === "tool-call" || event.type === "tool-input-start") {
         clearPendingFallback()
-        if (event.type === "tool-input-start") {
-          if (event.input !== undefined) pendingToolInputs.set(event.id, event.input)
-          continue
-        }
-        if (event.input !== undefined) pendingToolInputs.set(event.id, event.input)
+        if (event.type === "tool-input-start" && event.input === undefined) continue
         if (!visibleTools.has(event.id)) {
-          const input = event.input !== undefined ? event.input : pendingToolInputs.get(event.id)
-          if (shellCommand(input)) {
-            visibleTools.add(event.id)
-            pendingToolInputs.delete(event.id)
-            context.stderr.write(`\n${toolHeader(event.name, input)}\n`)
+          visibleTools.add(event.id)
+          visibleToolInputs.set(event.id, formatDevPayload(event.input))
+          context.stderr.write(`\n${toolHeader(event.name, event.input)}\n`)
+        }
+        else if (event.input !== undefined && !shellCommand(event.input)) {
+          const formattedInput = formatDevPayload(event.input)
+          if (formattedInput !== visibleToolInputs.get(event.id)) {
+            visibleToolInputs.set(event.id, formattedInput)
+            writeDevPayload(context, "input", event.input)
           }
         }
         continue
@@ -784,10 +784,9 @@ async function sendDevMessage(
         clearPendingFallback()
         if (!visibleTools.has(event.id)) {
           visibleTools.add(event.id)
-          const pendingInput = pendingToolInputs.get(event.id)
-          context.stderr.write(`\n${toolHeader(event.name, pendingToolInputs.has(event.id) ? pendingInput : undefined, event.output)}\n`)
+          context.stderr.write(`\n${toolHeader(event.name, undefined, event.output)}\n`)
         }
-        pendingToolInputs.delete(event.id)
+        visibleToolInputs.delete(event.id)
         if (!writeShellOutput(context, event.output, event.error) && !writeToolTextOutput(context, event.output)) {
           writeDevPayload(context, "output", event.output)
           writeDevPayload(context, "error", event.error)

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -352,11 +352,17 @@ describe("agent CLI", () => {
           { id: "tool-5", input: {}, name: "mcp_nuxt_get_documentation_page", type: "tool-input-start" },
           { id: "tool-5", input: { path: "/docs/4.x/api/composables/use-lazy-fetch" }, name: "mcp_nuxt_get_documentation_page", type: "tool-call" },
           { id: "tool-5", name: "mcp_nuxt_get_documentation_page", output: { content: "useLazyFetch docs" }, type: "tool-result" },
+          { id: "tool-8", input: { command: "sleep 10" }, name: "shell", type: "tool-input-start" },
           { id: "tool-6", input: { query: "Agent Dev Loop" }, name: "search_docs", type: "tool-input-start" },
           { id: "tool-6", name: "search_docs", output: { text: "search result" }, type: "tool-result" },
           { id: "tool-7", input: {}, name: "lookup_doc", type: "tool-call" },
           { id: "tool-7", input: { slug: "final" }, name: "lookup_doc", type: "tool-call" },
           { id: "tool-7", name: "lookup_doc", output: { text: "lookup result" }, type: "tool-result" },
+          { id: "tool-9", input: { query: "first" }, name: "first_tool", type: "tool-call" },
+          { id: "tool-10", input: { query: "second" }, name: "second_tool", type: "tool-call" },
+          { id: "tool-10", name: "second_tool", output: { text: "second done" }, type: "tool-result" },
+          { id: "tool-9", name: "first_tool", output: { text: "first done" }, type: "tool-result" },
+          { id: "tool-11", input: { query: "still running" }, name: "unfinished_tool", type: "tool-call" },
           { id: "tool-2", name: "workspace_list", output: { path: "." }, type: "tool-result" },
           { id: "tool-3", name: "run_summary", output: { raw: { raw: { steps: longOutput } }, text: "summary body" }, type: "tool-result" },
           { text: "done", type: "text-delta" },
@@ -387,12 +393,17 @@ describe("agent CLI", () => {
     expect(stderr.output()).not.toContain("[tool] bash")
     expect(stderr.output()).not.toContain("[tool done]")
     expect(stderr.output()).not.toContain(`input: {"command":"cat file.md"}`)
-    expect(stderr.output()).toContain(`\n[tool] mcp_nuxt_get_documentation_page {"path":"/docs/4.x/api/composables/use-lazy-fetch"}\n`)
+    expect(stderr.output()).toContain(`\n[tool] mcp_nuxt_get_documentation_page\n  input: {"path":"/docs/4.x/api/composables/use-lazy-fetch"}\n`)
     expect(stderr.output()).toContain(`output: {"content":"useLazyFetch docs"}`)
-    expect(stderr.output()).not.toContain(`input: {"path":"/docs/4.x/api/composables/use-lazy-fetch"}`)
+    expect(stderr.output()).toContain(`\n[tool] sleep 10\n`)
     expect(stderr.output()).toContain(`\n[tool] search_docs {"query":"Agent Dev Loop"}\nsearch result\n---\n`)
-    expect(stderr.output()).toContain(`\n[tool] lookup_doc {"slug":"final"}\nlookup result\n---\n`)
+    expect(stderr.output()).toContain(`\n[tool] lookup_doc\n  input: {"slug":"final"}\nlookup result\n---\n`)
     expect(stderr.output()).not.toContain(`\n[tool] lookup_doc {}\n`)
+    const firstToolIndex = stderr.output().indexOf(`[tool] first_tool {"query":"first"}`)
+    const secondToolIndex = stderr.output().indexOf(`[tool] second_tool {"query":"second"}`)
+    expect(firstToolIndex).toBeGreaterThanOrEqual(0)
+    expect(secondToolIndex).toBeGreaterThan(firstToolIndex)
+    expect(stderr.output()).toContain(`\n[tool] unfinished_tool {"query":"still running"}\n`)
     expect(stderr.output()).toContain("[truncated ")
     expect(stderr.output()).not.toContain(longOutput)
     expect(stderr.output()).toContain("---")

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -349,6 +349,9 @@ describe("agent CLI", () => {
           { id: "tool-1", input: { command: "cat file.md" }, name: "shell", type: "tool-call" },
           { id: "tool-1", name: "shell", output: { command: "cat file.md", exitCode: 0, stderr: "", stdout: longOutput }, type: "tool-result" },
           { id: "tool-4", input: { cmd: "pnpm test" }, name: "bash", type: "tool-call" },
+          { id: "tool-5", input: {}, name: "mcp_nuxt_get_documentation_page", type: "tool-input-start" },
+          { id: "tool-5", input: { path: "/docs/4.x/api/composables/use-lazy-fetch" }, name: "mcp_nuxt_get_documentation_page", type: "tool-call" },
+          { id: "tool-5", name: "mcp_nuxt_get_documentation_page", output: { content: "useLazyFetch docs" }, type: "tool-result" },
           { id: "tool-2", name: "workspace_list", output: { path: "." }, type: "tool-result" },
           { id: "tool-3", name: "run_summary", output: { raw: { raw: { steps: longOutput } }, text: "summary body" }, type: "tool-result" },
           { text: "done", type: "text-delta" },
@@ -379,6 +382,9 @@ describe("agent CLI", () => {
     expect(stderr.output()).not.toContain("[tool] bash")
     expect(stderr.output()).not.toContain("[tool done]")
     expect(stderr.output()).not.toContain(`input: {"command":"cat file.md"}`)
+    expect(stderr.output()).toContain(`\n[tool] mcp_nuxt_get_documentation_page {"path":"/docs/4.x/api/composables/use-lazy-fetch"}\n`)
+    expect(stderr.output()).toContain(`output: {"content":"useLazyFetch docs"}`)
+    expect(stderr.output()).not.toContain(`input: {"path":"/docs/4.x/api/composables/use-lazy-fetch"}`)
     expect(stderr.output()).toContain("[truncated ")
     expect(stderr.output()).not.toContain(longOutput)
     expect(stderr.output()).toContain("---")

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -352,6 +352,8 @@ describe("agent CLI", () => {
           { id: "tool-5", input: {}, name: "mcp_nuxt_get_documentation_page", type: "tool-input-start" },
           { id: "tool-5", input: { path: "/docs/4.x/api/composables/use-lazy-fetch" }, name: "mcp_nuxt_get_documentation_page", type: "tool-call" },
           { id: "tool-5", name: "mcp_nuxt_get_documentation_page", output: { content: "useLazyFetch docs" }, type: "tool-result" },
+          { id: "tool-6", input: { query: "Agent Dev Loop" }, name: "search_docs", type: "tool-input-start" },
+          { id: "tool-6", name: "search_docs", output: { text: "search result" }, type: "tool-result" },
           { id: "tool-2", name: "workspace_list", output: { path: "." }, type: "tool-result" },
           { id: "tool-3", name: "run_summary", output: { raw: { raw: { steps: longOutput } }, text: "summary body" }, type: "tool-result" },
           { text: "done", type: "text-delta" },
@@ -385,6 +387,7 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain(`\n[tool] mcp_nuxt_get_documentation_page {"path":"/docs/4.x/api/composables/use-lazy-fetch"}\n`)
     expect(stderr.output()).toContain(`output: {"content":"useLazyFetch docs"}`)
     expect(stderr.output()).not.toContain(`input: {"path":"/docs/4.x/api/composables/use-lazy-fetch"}`)
+    expect(stderr.output()).toContain(`\n[tool] search_docs {"query":"Agent Dev Loop"}\nsearch result\n---\n`)
     expect(stderr.output()).toContain("[truncated ")
     expect(stderr.output()).not.toContain(longOutput)
     expect(stderr.output()).toContain("---")

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -354,6 +354,9 @@ describe("agent CLI", () => {
           { id: "tool-5", name: "mcp_nuxt_get_documentation_page", output: { content: "useLazyFetch docs" }, type: "tool-result" },
           { id: "tool-6", input: { query: "Agent Dev Loop" }, name: "search_docs", type: "tool-input-start" },
           { id: "tool-6", name: "search_docs", output: { text: "search result" }, type: "tool-result" },
+          { id: "tool-7", input: {}, name: "lookup_doc", type: "tool-call" },
+          { id: "tool-7", input: { slug: "final" }, name: "lookup_doc", type: "tool-call" },
+          { id: "tool-7", name: "lookup_doc", output: { text: "lookup result" }, type: "tool-result" },
           { id: "tool-2", name: "workspace_list", output: { path: "." }, type: "tool-result" },
           { id: "tool-3", name: "run_summary", output: { raw: { raw: { steps: longOutput } }, text: "summary body" }, type: "tool-result" },
           { text: "done", type: "text-delta" },
@@ -388,6 +391,8 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain(`output: {"content":"useLazyFetch docs"}`)
     expect(stderr.output()).not.toContain(`input: {"path":"/docs/4.x/api/composables/use-lazy-fetch"}`)
     expect(stderr.output()).toContain(`\n[tool] search_docs {"query":"Agent Dev Loop"}\nsearch result\n---\n`)
+    expect(stderr.output()).toContain(`\n[tool] lookup_doc {"slug":"final"}\nlookup result\n---\n`)
+    expect(stderr.output()).not.toContain(`\n[tool] lookup_doc {}\n`)
     expect(stderr.output()).toContain("[truncated ")
     expect(stderr.output()).not.toContain(longOutput)
     expect(stderr.output()).toContain("---")


### PR DESCRIPTION
Moves structured Agent Dev Loop tool input onto the `[tool]` header line so MCP-style calls print as a compact one-line tool invocation followed by output on the next line.

Shell commands keep their existing compact `[tool] <command>` output.