### PR TITLE
docs: clarify chat thread context defaults

### DIFF
--- a/docs/content/docs/agents/chat-history-sessions.md
+++ b/docs/content/docs/agents/chat-history-sessions.md
@@ -5,13 +5,13 @@ navigation.order: 29
 icon: i-lucide-messages-square
 ---
 
-Chat History is ordered conversational messages for one chat interaction with an Agent. A Chat Session is the host-visible boundary that decides which messages are eligible for the Chat History Window.
+Chat History is ordered conversational messages for one chat interaction with an Agent. A Chat Session is the host-visible boundary that decides which supplied messages are eligible for the Chat History Window.
 
 Chat History is not Agent Memory. Chat History is conversation-scoped message state, while Agent Memory is durable knowledge or preferences across Agent Invocations.
 
 ## Enable Chat History
 
-The Chat Capability owns Chat History behavior. Configure it on the Agent Definition when message history should be included in future `chat.message` invocations.
+The Chat Capability owns Chat History selection. Configure it on the Agent Definition when prior messages should be included in future `chat.message` invocations.
 
 ```ts [server/agents/support.ts]
 import { gateway } from '@ai-sdk/gateway'
@@ -32,6 +32,28 @@ export default defineAgent({
 ```
 
 The Chat History Window limits how many prior messages enter the Agent Invocation. It does not delete the host's preserved history.
+
+## Use threads as conversation boundaries
+
+Use thread-scoped Chat History when the platform or application already has a visible conversation thread. Discord threads, Slack channel threads, Teams conversations, GitHub comment threads, and app-owned support chats should usually keep follow-up context inside that thread.
+
+```ts [server/agents/support.ts]
+import { chat } from '@vite-hub/agent/capabilities'
+
+export const supportChat = chat({
+  history: { maxMessages: 20, source: 'thread' },
+  concurrency: 'queue',
+  lockScope: 'thread',
+})
+```
+
+With this configuration, a follow-up in the same thread can keep the same Chat History Window. A new Discord or Slack thread starts a separate conversation boundary, so it should not inherit the previous thread's context.
+
+This is not Agent Memory. Thread-scoped Chat History keeps recent conversation input together; it does not remember user preferences or facts across unrelated threads.
+
+For Chat Platform Adapters, ViteHub receives normalized channel, message, and thread facts from the message-shaped Channel. For app-owned chat routes, pass the current thread's messages to `chat.message` and include a stable `run.threadId` so DevTools, traces, sessions, and finish hooks can describe the same boundary.
+
+Use `sessions` only when one platform thread can contain more than one host-visible conversation. For example, add sessions when a support UI has a "new conversation" button inside the same customer chat, or when inactivity should start a fresh conversation without creating a new platform thread.
 
 ## Add sessions
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
         command: "node packages/database/test/e2e.mjs",
         dependsOn: ["@vite-hub/database#build"],
       },
-      "docs:build": "vp run --filter vitehub-docs build",
+      "docs:build": {
+        cache: false,
+        command: "vp run --filter vitehub-docs build",
+      },
       "docs:dev": {
         cache: false,
         command: "vp run --filter vitehub-docs dev",
@@ -41,13 +44,19 @@ export default defineConfig({
         command: "node test/local/deno-real-project.mjs --live",
         dependsOn: ["build"],
       },
-      "fallow:dead-code": "vp exec fallow dead-code --summary --format markdown --fail-on-issues",
+      "fallow:dead-code": {
+        cache: false,
+        command: "vp exec fallow dead-code --summary --format markdown --fail-on-issues",
+      },
       "kv:e2e": {
         cache: false,
         command: "node packages/kv/test/e2e.mjs",
         dependsOn: ["@vite-hub/kv#build"],
       },
-      lint: "vp exec oxlint . --ignore-path .gitignore",
+      lint: {
+        cache: false,
+        command: "vp exec oxlint . --ignore-path .gitignore",
+      },
       "playground:vite:build": {
         cache: false,
         command: "cd playground/vite && vp build",
@@ -72,8 +81,10 @@ export default defineConfig({
         command: "node packages/queue/test/e2e-live.mjs",
         dependsOn: ["@vite-hub/queue#build"],
       },
-      release:
-        'vp dlx bumpp@11.1.0 package.json packages/*/package.json --commit "chore(release): v%s" --tag "v%s" --push --no-push-all --git-check',
+      release: {
+        cache: false,
+        command: 'vp dlx bumpp@11.1.0 package.json packages/*/package.json --commit "chore(release): v%s" --tag "v%s" --push --no-push-all --git-check',
+      },
       "sandbox:e2e": {
         cache: false,
         command: "node packages/sandbox/test/e2e.mjs",
@@ -88,7 +99,10 @@ export default defineConfig({
         cache: false,
         command: "node test/run-package-task.mjs test",
       },
-      "test:contracts": "vp test",
+      "test:contracts": {
+        cache: false,
+        command: "vp test",
+      },
       "test:output": {
         cache: false,
         command: "vp test --config test/output/vitest.config.ts",
@@ -103,22 +117,11 @@ export default defineConfig({
       },
       typecheck: {
         cache: false,
-        command: [
-          "vp run build",
-          "vp run --filter vitehub-docs --ignore-depends-on typecheck",
-          "node test/run-package-task.mjs typecheck",
-        ],
+        command: "vp run build && vp run --filter vitehub-docs --ignore-depends-on typecheck && node test/run-package-task.mjs typecheck",
       },
       verify: {
         cache: false,
-        command: [
-          "vp run fallow:dead-code",
-          "vp run lint",
-          "vp run typecheck",
-          "vp run test:contracts",
-          "vp run test",
-          "vp run build",
-        ],
+        command: "vp run fallow:dead-code && vp run lint && vp run typecheck && vp run test:contracts && vp run test && vp run build",
       },
       "workflow:e2e": {
         cache: false,


### PR DESCRIPTION
Documents the recommended thread-scoped Chat History shape for Discord, Slack, Teams, GitHub, and app-owned support chats, clarifying that `history: { source: 'thread' }` keeps follow-up context inside the current thread while sessions are for splitting a thread further, not Agent Memory.

Also normalizes root Vite+ task entries to the structured task config shape so the docs test and build tasks can load under the current runner.