### PR TITLE
feat(agent): compose instruction documents

### DIFF
--- a/.agents/adr/0072-instruction-documents-compose-model-instructions.md
+++ b/.agents/adr/0072-instruction-documents-compose-model-instructions.md
@@ -1,0 +1,25 @@
+# Instruction Documents Compose Model Instructions
+
+ViteHub treats an Agent instruction document as Markdown plus ViteHub Instruction Composition. The document is authored for humans and agents, then rendered by the Agent Package into model-facing instructions for model-backed Agent Drivers.
+
+Instruction Composition supports local Markdown imports, safe conditional blocks, explicit `context.*` bindings, Capability instruction slots, and visible Source Instructions. It must not become a general prompt configuration language or an arbitrary JavaScript runtime. Runtime data enters composition only through explicit Agent Invocation Context Values exposed at `context.*`.
+
+Capabilities may contribute model-facing instruction blocks and may write Agent Invocation Context Values that instruction documents read later. Duplicate Capability instruction block ids fail loudly because silent merge or last-write-wins behavior would make composed instructions hard to inspect.
+
+`WorkspaceSource.instructions` remains the low-level Source Instruction field. The Agent Package may render those Source Instructions through Instruction Composition when it builds final model instructions, but Source Instructions still guide Source use only. Markdown never grants access; Access, Workspace Scope, Workspace Rules, and Capability requirements remain the runtime enforcement boundaries.
+
+## Considered Options
+
+- A prompt configuration subsystem was rejected because the durable abstraction is an instruction document, not provider-specific prompt config.
+- A broad MDC or MDX runtime was rejected for V1 because ViteHub only needs imports, conditionals, and explicit bindings now.
+- Arbitrary JavaScript conditions were rejected because instructions need diagnostics and inspectability without executing author-controlled code during rendering.
+- A custom insert directive was rejected because scalar `{{ context.value }}` bindings and trusted Markdown `{{{ context.value }}}` bindings cover the V1 use case.
+- Treating Source Instructions as access grants was rejected because access is trusted runtime enforcement, not Markdown policy.
+
+## Consequences
+
+Instruction documents stay readable Markdown. Advanced behavior must earn its place as a small composition rule rather than growing a new template framework.
+
+Capabilities that need reusable composition should write named Agent Invocation Context Values or instruction blocks through `defineCapability`. They should not hide runtime data behind ambient globals or mutate Agent Definition instructions.
+
+Generated Agent Package metadata may include composed instruction text for inspection, but the source of truth remains the authored instruction document plus visible Capability and Source contributions.

--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -20,6 +20,14 @@ _Avoid_: Adapter, runtime, top-level model selector, top-level harness selector,
 Model-facing instruction text or callbacks configured on a model-backed Agent Driver and composed before the model call.
 _Avoid_: Root Agent Definition instructions, harness instructions, workspace `AGENTS.md`
 
+**Instruction Document**:
+Markdown authored for an Agent and rendered through ViteHub Instruction Composition into model-facing instructions.
+_Avoid_: Prompt config, raw system prompt, model adapter prompt
+
+**Instruction Composition**:
+The ViteHub-owned render pass that expands local Markdown imports, evaluates safe `context.*` conditions, resolves `context.*` bindings, inserts Capability instruction slots, and inserts visible Source Instructions.
+_Avoid_: Prompt templating engine, arbitrary JavaScript, access policy
+
 **Agent Model Execution**:
 The model-backed Agent Driver boundary for `execution` settings such as model call settings, step limits, workspace fallback behavior, and model execution instrumentation.
 _Avoid_: Adapter options, provider options, passthrough
@@ -218,6 +226,10 @@ _Avoid_: Fake agent, dummy model, test bot
 - An **Agent Driver** may be model-backed, harness-backed, or custom-run-backed.
 - A model-backed **Agent Driver** uses the AI SDK model execution path when it uses a model.
 - A model-backed **Agent Driver** may configure **Model Driver Instructions**.
+- **Model Driver Instructions** may be authored as an **Instruction Document**.
+- **Instruction Composition** reads only explicit **Agent Invocation Context Values** through `context.*` paths.
+- **Instruction Composition** does not execute arbitrary JavaScript and does not grant **Capabilities**, **Workspace Scope**, Source visibility, or runtime access.
+- **Instruction Composition** can insert visible **Source Instructions** through the `{{ workspace.sources }}` slot while keeping `WorkspaceSource.instructions` as the low-level Source guidance field.
 - A model-backed **Agent Driver** uses `execution` for **Agent Model Execution** settings.
 - A harness-backed **Agent Driver** does not receive **Model Driver Instructions** as a system prompt by default.
 - Harness-backed instruction behavior should rely on explicit harness or Workspace instruction surfaces, such as workspace `AGENTS.md`, unless a future harness-specific option is introduced.

--- a/.agents/contexts/capabilities/CONTEXT.md
+++ b/.agents/contexts/capabilities/CONTEXT.md
@@ -253,6 +253,8 @@ _Avoid_: KV Store, hubKv, model-facing storage
 - A **Capability Definition** may provide **Capability Driver Contributions** when the ability needs to feed the active Agent Driver.
 - **Capability Driver Contributions** are conditional on the selected **Agent Driver**.
 - A model-backed **Agent Driver** may receive model-facing tools and model-facing instructions from **Capability Driver Contributions**.
+- A model-backed **Agent Driver** may receive Instruction Composition context from **Capability Driver Contributions** by writing explicit **Agent Invocation Context Values** before instructions are rendered.
+- Duplicate Capability instruction block ids fail instead of merging, overriding, or silently ordering competing composition keys.
 - A harness-backed **Agent Driver** receives only explicitly supported harness-compatible **Capability Driver Contributions**; model-facing prompt and tool assumptions must not be silently passed into the harness.
 - A **Harness Workspace Path Contribution** is an explicitly supported harness-compatible **Capability Driver Contribution**.
 - A **Harness Workspace Path Contribution** is runtime support for the Capability, not a **Workspace Scope Grant** and not model-facing prompt text.

--- a/.agents/contexts/packages/agent/CONTEXT.md
+++ b/.agents/contexts/packages/agent/CONTEXT.md
@@ -32,6 +32,10 @@ _Avoid_: `defineAgent({ name })`, display name
 The Agent Package-owned boundary where model-backed Agent Drivers configure `execution` settings and instrumentation.
 _Avoid_: Adapter options, provider package, model package
 
+**Instruction Composition Renderer**:
+The Agent Package-owned implementation that turns Instruction Documents, Capability instruction blocks, explicit `context.*` bindings, and visible Source Instructions into final model-facing instructions.
+_Avoid_: Prompt framework, host markdown engine, access layer
+
 **Agent Driver Boundary**:
 The Agent Package-owned Agent Definition boundary for selecting and configuring how Agent Invocations are driven, including model-backed and harness-backed drivers.
 _Avoid_: Public adapter selector, top-level model selector, top-level harness selector, driver factory wrapper, root run callback
@@ -119,6 +123,8 @@ _Avoid_: Root Agent Package export, Capability factory export, Chat Adapter Faca
 - **Agent Driver Boundary** variants are mutually exclusive; the Agent Package should reject a driver object that combines `model`, `harness`, or `run`.
 - The **Agent Package** owns filtering Capability Driver Contributions for the selected Agent Driver.
 - The **Agent Package** owns composing visible Workspace Source Instructions into final model instructions for model-backed Agent Drivers.
+- The **Agent Package** owns the **Instruction Composition Renderer** for model-backed Agent Drivers and generated Agent Package metadata.
+- The **Instruction Composition Renderer** accepts local Markdown imports and safe `context.*` expressions; it must not execute arbitrary JavaScript or widen runtime access.
 - The **Agent Package** does not pass model-facing instructions to harness-backed Agent Drivers by default.
 - The **Agent Package** treats **Harness Workspace Path Contributions** as harness filesystem support, not as model-facing instructions or public Agent Definition fields.
 - The **Agent Package** owns the **Agent Trigger API** that resolves trigger contributions from Agent Capabilities and declared Channel delivery paths.

--- a/.agents/contexts/workspace/CONTEXT.md
+++ b/.agents/contexts/workspace/CONTEXT.md
@@ -226,6 +226,7 @@ _Avoid_: Chat Session, thread id, implicit conversation state
 - **Source Instructions** may be declared statically or produced by **Source Resolution**.
 - **Source Instructions** are explicit developer-authored Source configuration, not inferred provider metadata.
 - **Source Instructions** guide model-backed Agent Driver behavior, but they do not grant access to hidden Sources or change Workspace Scope.
+- **Source Instructions** remain the low-level `WorkspaceSource.instructions` field even when the Agent Package renders them through **Instruction Composition**.
 - A **Source** may contribute a **Source Network Grant** separately from its **Source Instructions**.
 - **Source Network Grants** grant controlled shell network access; **Source Instructions** only guide model-backed Agent Driver behavior.
 - A visible API-backed **Source** may contribute a **Source Network Grant** automatically when a Workspace-backed Shell Runtime is enabled.

--- a/docs/content/docs/agents/instructions.md
+++ b/docs/content/docs/agents/instructions.md
@@ -11,7 +11,7 @@ Model Driver Instructions are the model-backed Agent Driver field that receives 
 
 ## Add an instruction document
 
-Place `instructions.md` beside an Agent module when the instructions are long enough to read better as Markdown. ViteHub loads that sibling file before model execution.
+Place `instructions.md` beside a workspace-backed Agent module when the instructions are long enough to read better as Markdown. ViteHub loads that sibling file before model execution.
 
 ```md [server/agents/support/instructions.md]
 # Support
@@ -30,6 +30,9 @@ import { defineAgent } from '@vite-hub/agent'
 export default defineAgent({
   driver: {
     model: gateway('openai/gpt-5.1-mini'),
+  },
+  workspace: {
+    sources: {},
   },
 })
 ```

--- a/docs/content/docs/agents/instructions.md
+++ b/docs/content/docs/agents/instructions.md
@@ -1,17 +1,40 @@
 ---
 title: Instructions
-description: Compose model-facing behavior with Model Driver Instructions, Source Instructions, and Capability instruction slots.
+description: Compose model-facing behavior with instruction documents, Source Instructions, and Capability instruction slots.
 navigation.order: 24
 icon: i-lucide-scroll-text
 ---
 
-Model Driver Instructions are model-facing instructions configured on a model-backed Agent Driver. Put them under `defineAgent({ driver: { model, instructions } })` so ViteHub can keep model execution separate from harness and custom-run execution.
+An instruction document is Markdown that ViteHub composes into model-facing instructions. Use it for durable behavior, trust boundaries, source-use policy, and uncertainty handling. Capabilities and Sources contribute their own instruction blocks when they own the guidance.
 
-Instructions should describe durable behavior, trust boundaries, and uncertainty handling. Capabilities and Sources contribute their own instruction blocks when they own the guidance.
+Model Driver Instructions are the model-backed Agent Driver field that receives the composed document. ViteHub keeps that model-facing surface separate from harness and custom-run execution.
 
-## Add Model Driver Instructions
+## Add an instruction document
 
-Use strings, string arrays, or instruction callbacks for model-backed drivers. Keep the text stable and aligned with the Agent's actual Capabilities.
+Place `instructions.md` beside an Agent module when the instructions are long enough to read better as Markdown. ViteHub loads that sibling file before model execution.
+
+```md [server/agents/support/instructions.md]
+# Support
+
+You are a support engineer.
+
+Answer from inspected workspace evidence before using outside knowledge.
+
+When sources do not answer the question, say that directly.
+```
+
+```ts [server/agents/support/config.ts]
+import { gateway } from '@ai-sdk/gateway'
+import { defineAgent } from '@vite-hub/agent'
+
+export default defineAgent({
+  driver: {
+    model: gateway('openai/gpt-5.1-mini'),
+  },
+})
+```
+
+Use strings, string arrays, or instruction callbacks when the instruction text is short or generated from trusted runtime data.
 
 ```ts [server/agents/support.ts]
 import { gateway } from '@ai-sdk/gateway'
@@ -31,9 +54,53 @@ export default defineAgent({
 
 Do not document tool syntax in instructions when a Capability can expose that syntax through tool metadata. Instructions should name policy and behavior, not repeat API reference.
 
+## Import Markdown
+
+Use static `@./path.md` imports to split a large instruction document into local Markdown files.
+
+```md [server/agents/support/instructions.md]
+# Support
+
+@./shared-style.md
+
+@./escalation-policy.md
+```
+
+Imports are relative to the file that declares them. ViteHub expands imported Markdown recursively, up to four levels, and processes imported Markdown like the parent document. Imports inside code spans and fenced code blocks stay literal.
+
+Instruction imports only read relative files. Remote URLs, absolute paths, and globs fail because an instruction document should not widen runtime reachability.
+
+## Read invocation context
+
+Instruction composition can read explicit `context.*` paths from trusted Agent Invocation Context Values. Use double braces for scalar values and triple braces for trusted Markdown content.
+
+```md [server/agents/support/instructions.md]
+Answer for {{ context.customerName }}.
+
+{{{ context.supportPolicy }}}
+```
+
+The value must already exist in invocation context. Composition does not read arbitrary runtime objects, environment variables, request fields, or JavaScript expressions.
+
+## Branch with conditions
+
+Use `if`, `else-if`, and `else` blocks for conditional instruction sections.
+
+```md [server/agents/support/instructions.md]
+::if{context.audience === 'technical'}
+Include implementation details and cite file paths.
+::else-if{context.audience === 'support'}
+Prefer customer-facing language and next actions.
+::else
+Keep the answer concise.
+::
+```
+
+Conditions use a small safe expression subset: `context.*` paths, string, number, boolean, and `null` literals, equality checks, `&&`, `||`, `!`, and parentheses. ViteHub rejects function calls, property access outside `context.*`, and other JavaScript.
+
 ## Place Capability slots
 
-Capabilities may contribute named instruction blocks. Place one Capability block with `{{ capabilities.<id> }}`, or place every remaining Capability block with `{{ capabilities }}`.
+Capabilities may contribute named instruction blocks. Place one Capability block with `{{ capabilities.<id> }}`, or place every remaining Capability block with `{{ capabilities }}`. ViteHub fails when two Capability contributions use the same instruction block id.
 
 ```ts [server/agents/support.ts]
 import { gateway } from '@ai-sdk/gateway'
@@ -56,9 +123,23 @@ export default defineAgent({
 
 Use slots when the Agent should receive Capability-owned guidance without copying that guidance into every Agent Definition.
 
+Capabilities can also add invocation context values for instruction composition.
+
+```ts [server/agents/support.ts]
+import { defineCapability } from '@vite-hub/agent'
+
+const supportAudience = defineCapability({
+  id: 'support-audience',
+  configure(context) {
+    context.context.set('audience', 'technical')
+    context.context.set('customerName', 'Acme')
+  },
+})
+```
+
 ## Place Source Instructions
 
-Sources can contribute Source Instructions. Put `{{ workspace.sources }}` where those instructions belong in the final model prompt.
+Sources can contribute Source Instructions through the low-level `WorkspaceSource.instructions` field. Put `{{ workspace.sources }}` where those instructions belong in the final model instructions.
 
 ```ts [server/agents/docs.ts]
 import { gateway } from '@ai-sdk/gateway'
@@ -84,7 +165,7 @@ export default defineAgent({
 })
 ```
 
-Only visible Sources render Source Instructions. When Access selects a Workspace Scope, ViteHub omits hidden Source Instructions with the hidden files.
+Only visible Sources render Source Instructions. When Access selects a Workspace Scope, ViteHub omits hidden Source Instructions with the hidden files. Markdown never grants access; Access and Workspace Scope remain the runtime enforcement boundary.
 
 ## Harness and run drivers
 

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -9,6 +9,7 @@ import {
   applyCapabilityInstructionSlots,
   applyCapabilityToolTransforms,
 } from "./capability-runtime.ts"
+import { composeInstructionDocument } from "./instruction-composition.ts"
 import { applyWorkspaceSourceInstructionSlot } from "./workspace-agent.ts"
 import {
   applyAgentToolPolicies,
@@ -564,6 +565,10 @@ async function resolveInstructions(options: AiSdkAdapterOptions, context: AgentA
   return joinInstructions(...instructions)
 }
 
+function composeInstructions(instructions: string, context: AgentAdapterMetadataContext) {
+  return composeInstructionDocument(instructions, { context: context.context.toJSON() })
+}
+
 async function resolveTools(options: AiSdkAdapterOptions, context: AgentAdapterMetadataContext, reportToolStep?: AgentAdapterRunContext["devtools"] extends infer T ? T extends { reportToolStep?: infer R } ? R : never : never) {
   if (!options.tools) return undefined
   const resolved = await resolveValue(options.tools as never, context)
@@ -821,10 +826,10 @@ async function createAgent(
   const instrumentedModel = instrumentations.length
     ? await instrumentModel(model, instrumentations, { ...runtime, actor: context.actor, context: context.context, invoker: context.invoker, model, run: context.runtime.run })
     : model
-  const instructions = applyWorkspaceSourceInstructionSlot(
+  const instructions = composeInstructions(applyWorkspaceSourceInstructionSlot(
     applyCapabilityInstructionSlots(context.instructions ?? await resolveInstructions(options, metadataContext), context.capabilityInstructions),
     context.sourceInstructions,
-  )
+  ), metadataContext)
   const adapterTools = await resolveTools(options, metadataContext, context.devtools?.reportToolStep)
   const resolvedTools = withDefaultToolInputSchemas(withWorkspaceFallbackToolEvidence(await applyCapabilityToolTransforms({
     ...context.tools,

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -826,8 +826,9 @@ async function createAgent(
   const instrumentedModel = instrumentations.length
     ? await instrumentModel(model, instrumentations, { ...runtime, actor: context.actor, context: context.context, invoker: context.invoker, model, run: context.runtime.run })
     : model
+  const baseInstructions = composeInstructions(context.instructions ?? await resolveInstructions(options, metadataContext), metadataContext)
   const instructions = composeInstructions(applyWorkspaceSourceInstructionSlot(
-    applyCapabilityInstructionSlots(context.instructions ?? await resolveInstructions(options, metadataContext), context.capabilityInstructions),
+    applyCapabilityInstructionSlots(baseInstructions, context.capabilityInstructions),
     context.sourceInstructions,
   ), metadataContext)
   const adapterTools = await resolveTools(options, metadataContext, context.devtools?.reportToolStep)

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -265,8 +265,12 @@ function addInstructionBlock(
     .filter(Boolean)
     .join("\n\n")
   if (instructions) {
+    const id = capabilityInstructionBlockId(options?.id || capabilityId)
+    if (capabilityInstructions.some(block => block.id === id)) {
+      throw new Error(`[vitehub] Duplicate capability instruction block "${id}".`)
+    }
     capabilityInstructions.push({
-      id: capabilityInstructionBlockId(options?.id || capabilityId),
+      id,
       instructions,
     })
   }

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -4,6 +4,7 @@ import {
 } from "./internal/agent-usage-metadata.ts"
 import { hasTrustedWorkspaceAccessScope } from "./access-runtime.ts"
 import { applyCapabilityInstructionSlots } from "./capability-runtime.ts"
+import { composeInstructionDocument } from "./instruction-composition.ts"
 import { applyWorkspaceSourceInstructionSlot } from "./workspace-agent.ts"
 import { normalizeAgentWorkspaceSources } from "./workspace-source-metadata.ts"
 import { nextWithAbort } from "./internal/abortable-stream.ts"
@@ -161,10 +162,11 @@ function selectedWorkspaceScopePaths(context: AgentAdapterRunContext): string[] 
 }
 
 function toHarnessCallInput(context: AgentAdapterRunContext) {
-  const instructions = applyWorkspaceSourceInstructionSlot(
+  const compositionContext = { context: context.context.toJSON() }
+  const instructions = composeInstructionDocument(applyWorkspaceSourceInstructionSlot(
     applyCapabilityInstructionSlots(context.instructions || "", context.capabilityInstructions),
     context.sourceInstructions,
-  )
+  ), compositionContext)
   const base = {
     abortSignal: context.input.abortSignal,
     ...(instructions ? { instructions } : {}),

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -163,8 +163,9 @@ function selectedWorkspaceScopePaths(context: AgentAdapterRunContext): string[] 
 
 function toHarnessCallInput(context: AgentAdapterRunContext) {
   const compositionContext = { context: context.context.toJSON() }
+  const baseInstructions = composeInstructionDocument(context.instructions || "", compositionContext)
   const instructions = composeInstructionDocument(applyWorkspaceSourceInstructionSlot(
-    applyCapabilityInstructionSlots(context.instructions || "", context.capabilityInstructions),
+    applyCapabilityInstructionSlots(baseInstructions, context.capabilityInstructions),
     context.sourceInstructions,
   ), compositionContext)
   const base = {

--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -20,9 +20,9 @@ type ConditionToken =
   | { path: string, type: "path" }
 
 const defaultImportDepth = 4
-const contextPathPattern = /context(?:\.[A-Za-z_$][\w$]*)+/
-const tripleBindingPattern = /\{\{\{\s*(context(?:\.[A-Za-z_$][\w$]*)+)\s*\}\}\}/g
-const scalarBindingPattern = /\{\{(?!\{)\s*(context(?:\.[A-Za-z_$][\w$]*)+)\s*\}\}/g
+const contextPathPattern = /context(?:\.[A-Za-z_$][\w$-]*)+/
+const tripleBindingPattern = /\{\{\{\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}\}/g
+const scalarBindingPattern = /\{\{(?!\{)\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}/g
 
 export function resolveInstructionImports(content: string, options: ResolveInstructionImportsOptions): string {
   return expandInstructionImports(content, {
@@ -319,7 +319,8 @@ function createConditionParser(tokens: ConditionToken[], expression: string, con
     let value = parseEquality()
     while (peek()?.type === "op" && (peek() as { value: string }).value === "&&") {
       take("&&")
-      value = Boolean(value) && Boolean(parseEquality())
+      const right = parseEquality()
+      value = Boolean(value) && Boolean(right)
     }
     return value
   }
@@ -328,7 +329,8 @@ function createConditionParser(tokens: ConditionToken[], expression: string, con
     let value = parseAnd()
     while (peek()?.type === "op" && (peek() as { value: string }).value === "||") {
       take("||")
-      value = Boolean(value) || Boolean(parseAnd())
+      const right = parseAnd()
+      value = Boolean(value) || Boolean(right)
     }
     return value
   }
@@ -342,8 +344,19 @@ function createConditionParser(tokens: ConditionToken[], expression: string, con
 }
 
 function contextPathValue(context: Record<string, unknown>, path: string): unknown {
-  let current: unknown = context
-  for (const segment of path.split(".").slice(1)) {
+  const segments = path.split(".").slice(1)
+  for (let count = segments.length; count > 0; count -= 1) {
+    const key = segments.slice(0, count).join(".")
+    if (Object.hasOwn(context, key)) {
+      return nestedPathValue(context[key], segments.slice(count))
+    }
+  }
+  return nestedPathValue(context, segments)
+}
+
+function nestedPathValue(value: unknown, segments: string[]): unknown {
+  let current = value
+  for (const segment of segments) {
     if (!current || typeof current !== "object" || !Object.hasOwn(current, segment)) return undefined
     current = (current as Record<string, unknown>)[segment]
   }

--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -1,0 +1,369 @@
+export interface InstructionImportResolution {
+  content: string
+  file: string
+}
+
+export interface ResolveInstructionImportsOptions {
+  file: string
+  maxDepth?: number
+  read: (specifier: string, importer: string) => InstructionImportResolution
+}
+
+export interface ComposeInstructionDocumentOptions {
+  context?: Record<string, unknown>
+}
+
+type ConditionOperator = "!" | "!=" | "!==" | "&&" | "(" | ")" | "==" | "===" | "||"
+type ConditionToken =
+  | { type: "literal", value: unknown }
+  | { type: "op", value: ConditionOperator }
+  | { path: string, type: "path" }
+
+const defaultImportDepth = 4
+const contextPathPattern = /context(?:\.[A-Za-z_$][\w$]*)+/
+const tripleBindingPattern = /\{\{\{\s*(context(?:\.[A-Za-z_$][\w$]*)+)\s*\}\}\}/g
+const scalarBindingPattern = /\{\{(?!\{)\s*(context(?:\.[A-Za-z_$][\w$]*)+)\s*\}\}/g
+
+export function resolveInstructionImports(content: string, options: ResolveInstructionImportsOptions): string {
+  return expandInstructionImports(content, {
+    ...options,
+    maxDepth: options.maxDepth ?? defaultImportDepth,
+    seen: new Set([options.file]),
+  })
+}
+
+export function composeInstructionDocument(content: string, options: ComposeInstructionDocumentOptions = {}): string {
+  const context = options.context || {}
+  return renderContextBindings(renderConditionals(content, context), context).trim().replace(/\n{3,}/g, "\n\n")
+}
+
+function expandInstructionImports(
+  content: string,
+  options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
+  depth = 0,
+): string {
+  let fenced = false
+  return content.split(/\r?\n/).map((line) => {
+    if (/^\s*(```|~~~)/.test(line)) {
+      fenced = !fenced
+      return line
+    }
+    return fenced ? line : replaceImportsInLine(line, options, depth)
+  }).join("\n")
+}
+
+function replaceImportsInLine(
+  line: string,
+  options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
+  depth: number,
+): string {
+  let rendered = ""
+  let inlineCode: string | undefined
+  for (let index = 0; index < line.length;) {
+    const char = line[index]
+    if (char === "`") {
+      const fence = line.slice(index).match(/^`+/)![0]
+      if (!inlineCode) inlineCode = fence
+      else if (fence === inlineCode) inlineCode = undefined
+      rendered += fence
+      index += fence.length
+      continue
+    }
+    if (char !== "@" || inlineCode) {
+      rendered += char
+      index += 1
+      continue
+    }
+
+    const end = importTokenEnd(line, index)
+    const token = line.slice(index, end)
+    const replacement = importReplacement(token, options, depth)
+    if (replacement === undefined) {
+      rendered += token
+    }
+    else {
+      rendered += replacement
+    }
+    index = end
+  }
+  return rendered
+}
+
+function importTokenEnd(line: string, start: number): number {
+  let index = start
+  while (index < line.length && !/\s|[<>{}\[\]]/.test(line[index]!)) index += 1
+  return index
+}
+
+function importReplacement(
+  token: string,
+  options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
+  depth: number,
+): string | undefined {
+  if (/^@(?:https?:)?\/\//.test(token) || token.startsWith("@/")) {
+    throw new Error(`[vitehub] Instruction import "${token}" must be a relative file path.`)
+  }
+  if (!token.startsWith("@./") && !token.startsWith("@../")) return undefined
+
+  const trailing = token.match(/[.,;:!?)]*$/)?.[0] || ""
+  const specifier = token.slice(1, token.length - trailing.length)
+  if (/[*?]/.test(specifier)) {
+    throw new Error(`[vitehub] Instruction import "${specifier}" cannot use globs.`)
+  }
+  if (depth >= options.maxDepth) {
+    throw new Error(`[vitehub] Instruction import depth exceeded ${options.maxDepth}.`)
+  }
+
+  const resolved = options.read(specifier, options.file)
+  if (options.seen.has(resolved.file)) {
+    throw new Error(`[vitehub] Circular instruction import: ${specifier}.`)
+  }
+  options.seen.add(resolved.file)
+  try {
+    return `${expandInstructionImports(resolved.content, { ...options, file: resolved.file }, depth + 1)}${trailing}`
+  }
+  finally {
+    options.seen.delete(resolved.file)
+  }
+}
+
+function renderConditionals(content: string, context: Record<string, unknown>): string {
+  const lines = content.split(/\r?\n/)
+  const rendered: string[] = []
+  for (let index = 0; index < lines.length;) {
+    const line = lines[index]!
+    const directive = directiveLine(line)
+    if (directive?.kind === "if") {
+      const result = renderIfChain(lines, index, directive.expression, context)
+      rendered.push(result.content)
+      index = result.next
+      continue
+    }
+    if (directive?.kind === "else" || directive?.kind === "else-if") {
+      throw new Error(`[vitehub] Instruction ${directive.kind} block must follow an if block.`)
+    }
+    rendered.push(line)
+    index += 1
+  }
+  return rendered.join("\n")
+}
+
+function renderIfChain(
+  lines: string[],
+  start: number,
+  expression: string | undefined,
+  context: Record<string, unknown>,
+): { content: string, next: number } {
+  const branches: Array<{ expression?: string, lines: string[] }> = [{ expression, lines: [] }]
+  let depth = 0
+  let sawElse = false
+
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index]!
+    const directive = directiveLine(line)
+
+    if (directive?.kind === "if") {
+      depth += 1
+      branches.at(-1)!.lines.push(line)
+      continue
+    }
+    if (isDirectiveClose(line)) {
+      if (depth > 0) {
+        depth -= 1
+        branches.at(-1)!.lines.push(line)
+        continue
+      }
+      const selected = branches.find(branch =>
+        branch.expression === undefined || evaluateCondition(branch.expression, context))
+      return {
+        content: selected ? renderConditionals(selected.lines.join("\n"), context) : "",
+        next: index + 1,
+      }
+    }
+    if (depth === 0 && directive?.kind === "else-if") {
+      if (sawElse) throw new Error("[vitehub] Instruction else-if block cannot follow else.")
+      branches.push({ expression: directive.expression, lines: [] })
+      continue
+    }
+    if (depth === 0 && directive?.kind === "else") {
+      if (sawElse) throw new Error("[vitehub] Instruction if chain cannot contain more than one else block.")
+      sawElse = true
+      branches.push({ lines: [] })
+      continue
+    }
+    branches.at(-1)!.lines.push(line)
+  }
+
+  throw new Error("[vitehub] Instruction if block is missing a closing :: line.")
+}
+
+function directiveLine(line: string): { expression?: string, kind: "else" | "else-if" | "if" } | undefined {
+  const match = line.match(/^\s*::(if|else-if|else)(?:\{(.+)\})?\s*$/)
+  if (!match) return
+  const kind = match[1] as "else" | "else-if" | "if"
+  if (kind === "else") {
+    if (match[2]?.trim()) throw new Error("[vitehub] Instruction else block does not accept a condition.")
+    return { kind }
+  }
+  const expression = conditionExpression(match[2])
+  if (!expression) throw new Error(`[vitehub] Instruction ${kind} block requires a condition.`)
+  return { expression, kind }
+}
+
+function isDirectiveClose(line: string): boolean {
+  return /^\s*::\s*$/.test(line)
+}
+
+function conditionExpression(raw: string | undefined): string | undefined {
+  const value = raw?.trim()
+  if (!value) return
+  const attr = value.match(/^(?:if|condition)\s*=\s*(["'])([\s\S]*)\1$/)
+  return (attr ? attr[2] : value).trim()
+}
+
+function evaluateCondition(expression: string, context: Record<string, unknown>): boolean {
+  const parser = createConditionParser(tokenizeCondition(expression), expression, context)
+  const value = parser.parseOr()
+  parser.done()
+  return Boolean(value)
+}
+
+function tokenizeCondition(expression: string): ConditionToken[] {
+  const tokens: ConditionToken[] = []
+  for (let index = 0; index < expression.length;) {
+    const rest = expression.slice(index)
+    if (/^\s/.test(rest)) {
+      index += 1
+      continue
+    }
+    const op = rest.match(/^(===|!==|==|!=|&&|\|\||[!()])/)
+    if (op) {
+      tokens.push({ type: "op", value: op[1] as ConditionOperator })
+      index += op[1]!.length
+      continue
+    }
+    const path = rest.match(new RegExp(`^${contextPathPattern.source}`))
+    if (path) {
+      tokens.push({ path: path[0], type: "path" })
+      index += path[0].length
+      continue
+    }
+    const string = rest.match(/^(['"])((?:\\.|(?!\1)[^\\])*)\1/)
+    if (string) {
+      tokens.push({ type: "literal", value: string[2]!.replace(/\\(['"\\])/g, "$1") })
+      index += string[0].length
+      continue
+    }
+    const number = rest.match(/^-?\d+(?:\.\d+)?/)
+    if (number) {
+      tokens.push({ type: "literal", value: Number(number[0]) })
+      index += number[0].length
+      continue
+    }
+    const literal = rest.match(/^(true|false|null)\b/)
+    if (literal) {
+      tokens.push({ type: "literal", value: literal[1] === "true" ? true : literal[1] === "false" ? false : null })
+      index += literal[0].length
+      continue
+    }
+    throw new Error(`[vitehub] Unsafe instruction condition "${expression}". Conditions can only read context.* paths and use literals, ===, !==, &&, ||, !, and parentheses.`)
+  }
+  return tokens
+}
+
+function createConditionParser(tokens: ConditionToken[], expression: string, context: Record<string, unknown>) {
+  let index = 0
+  const error = () => new Error(`[vitehub] Invalid instruction condition "${expression}".`)
+  const peek = () => tokens[index]
+  const take = (value?: string) => {
+    const token = tokens[index]
+    if (value && (token?.type !== "op" || token.value !== value)) throw error()
+    index += 1
+    return token
+  }
+
+  function parsePrimary(): unknown {
+    const token = take()
+    if (!token) throw error()
+    if (token.type === "literal") return token.value
+    if (token.type === "path") return contextPathValue(context, token.path)
+    if (token.type === "op" && token.value === "(") {
+      const value = parseOr()
+      take(")")
+      return value
+    }
+    throw error()
+  }
+
+  function parseUnary(): unknown {
+    const token = peek()
+    if (token?.type === "op" && token.value === "!") {
+      take("!")
+      return !Boolean(parseUnary())
+    }
+    return parsePrimary()
+  }
+
+  function parseEquality(): unknown {
+    let value = parseUnary()
+    const token = peek()
+    if (token?.type === "op" && ["==", "===", "!=", "!=="].includes(token.value)) {
+      take()
+      const right = parseUnary()
+      value = token.value === "!=" || token.value === "!==" ? value !== right : value === right
+    }
+    return value
+  }
+
+  function parseAnd(): unknown {
+    let value = parseEquality()
+    while (peek()?.type === "op" && (peek() as { value: string }).value === "&&") {
+      take("&&")
+      value = Boolean(value) && Boolean(parseEquality())
+    }
+    return value
+  }
+
+  function parseOr(): unknown {
+    let value = parseAnd()
+    while (peek()?.type === "op" && (peek() as { value: string }).value === "||") {
+      take("||")
+      value = Boolean(value) || Boolean(parseAnd())
+    }
+    return value
+  }
+
+  return {
+    done() {
+      if (index !== tokens.length) throw error()
+    },
+    parseOr,
+  }
+}
+
+function contextPathValue(context: Record<string, unknown>, path: string): unknown {
+  let current: unknown = context
+  for (const segment of path.split(".").slice(1)) {
+    if (!current || typeof current !== "object" || !Object.hasOwn(current, segment)) return undefined
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+function renderContextBindings(content: string, context: Record<string, unknown>): string {
+  return content
+    .replace(tripleBindingPattern, (_match, path: string) => {
+      const value = contextPathValue(context, path)
+      if (value === null || value === undefined) return ""
+      if (typeof value !== "string") {
+        throw new TypeError(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" must resolve to a string.`)
+      }
+      return value
+    })
+    .replace(scalarBindingPattern, (_match, path: string) => {
+      const value = contextPathValue(context, path)
+      if (value === null || value === undefined) return ""
+      if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value)
+      throw new TypeError(`[vitehub] Instruction binding "{{ ${path} }}" must resolve to a scalar value.`)
+    })
+}

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, statSync } from "node:fs"
 import { mkdir, writeFile } from "node:fs/promises"
-import { dirname, join, relative } from "node:path"
+import { dirname, join, relative, resolve } from "node:path"
 
 import { writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
@@ -16,6 +16,7 @@ import {
 } from "./cloudflare.ts"
 import { normalizeAgentOptions } from "./config.ts"
 import { discoverAgentDefinitions } from "./discovery.ts"
+import { resolveInstructionImports } from "./instruction-composition.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig } from "./internal/evalite-config.ts"
 
 import type { Plugin, ResolvedConfig } from "vite"
@@ -216,7 +217,17 @@ function resolveWorkspaceSourceRoot(file: string): string {
 
 function readColocatedAgentInstructions(handler: string): string | undefined {
   const file = join(dirname(handler), "instructions.md")
-  if (existsSync(file) && statSync(file).isFile()) return readFileSync(file, "utf8")
+  if (!existsSync(file) || !statSync(file).isFile()) return
+  return resolveInstructionImports(readFileSync(file, "utf8"), {
+    file,
+    read(specifier, importer) {
+      const imported = resolve(dirname(importer), specifier)
+      return {
+        content: readFileSync(imported, "utf8"),
+        file: imported,
+      }
+    },
+  })
 }
 
 function moduleImportSpecifier(fromFile: string, targetFile: string): string {

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -11,6 +11,10 @@ import {
   normalizeAgentInvokerProfiles,
   resolveAgentInvoker,
 } from "./invoker.ts"
+import {
+  composeInstructionDocument,
+  resolveInstructionImports,
+} from "./instruction-composition.ts"
 import { normalizeAgentDriver } from "./internal/agent-driver.ts"
 import { normalizeAgentWorkspaceSources } from "./workspace-source-metadata.ts"
 
@@ -629,6 +633,30 @@ function getNodeBuiltin<T>(name: string): T | undefined {
   }
 }
 
+function resolveInstructionImportFromFile(specifier: string, importer: string): { content: string, file: string } {
+  const fs = getNodeBuiltin<typeof import("node:fs")>("node:fs")
+  const path = getNodeBuiltin<typeof import("node:path")>("node:path")
+  if (!fs || !path) {
+    throw new Error(`[vitehub] Instruction import "${specifier}" requires local filesystem access.`)
+  }
+  const file = path.resolve(path.dirname(importer), specifier)
+  return {
+    content: fs.readFileSync(file, "utf8"),
+    file,
+  }
+}
+
+function resolveInstructionDocumentImports(content: string, file: string): string {
+  return resolveInstructionImports(content, {
+    file,
+    read: resolveInstructionImportFromFile,
+  })
+}
+
+function composeInstructions(content: string, context?: AgentInvocationContextStore): string {
+  return composeInstructionDocument(content, { context: context?.toJSON() })
+}
+
 function localWorkspaceRoots<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
@@ -854,14 +882,15 @@ function workspaceMetadataInstructions<
     return []
   })
   if (defaultInstructions) instructions.unshift(defaultInstructions)
-  const renderedInstructions = applyPassiveCapabilityInstructionSlots(
-    instructions.join("\n\n"),
-    staticCapabilityInstructionBlocks(options),
-  )
-  return applyWorkspaceSourceInstructionsToParts(
-    renderedInstructions ? [renderedInstructions] : [],
+  const renderedInstructions = applyWorkspaceSourceInstructionsToParts(
+    [applyPassiveCapabilityInstructionSlots(
+      instructions.join("\n\n"),
+      staticCapabilityInstructionBlocks(options),
+    )],
     renderWorkspaceSourceInstructionBlock(workspaceDefinitionFromOptions(options).sources),
   )
+  const composed = composeInstructions(renderedInstructions.join("\n\n"))
+  return composed ? [composed] : []
 }
 
 function readLocalWorkspaceInstructions<
@@ -889,11 +918,9 @@ function readColocatedAgentInstructions<
   const path = getNodeBuiltin<typeof import("node:path")>("node:path")
   const sourceRootDir = workspaceDefinitionFromOptions(options).sourceRootDir
   if (!fs || !path || !hasColocatedAgentInstructions(sourceRootDir)) return undefined
-  try {
-    const content = fs.readFileSync(path.join(sourceRootDir!, colocatedAgentInstructionsPath), "utf8").trim()
-    if (content) return content
-  }
-  catch {}
+  const file = path.join(sourceRootDir!, colocatedAgentInstructionsPath)
+  const content = resolveInstructionDocumentImports(fs.readFileSync(file, "utf8"), file).trim()
+  if (content) return content
 }
 
 export async function resolveWorkspaceAgentDefaultInstructions<
@@ -906,11 +933,20 @@ export async function resolveWorkspaceAgentDefaultInstructions<
   if (!shouldUseColocatedAgentInstructions(options)) return undefined
   const definition = workspaceDefinitionFromOptions(options)
   if (!definition.sources || !(colocatedAgentInstructionsSourceKey in definition.sources)) return undefined
+  let content: string | undefined
   try {
-    const content = (await workspace.fs.readFile(colocatedAgentInstructionsWorkspacePath as never)).trim()
-    if (content) return content
+    content = (await workspace.fs.readFile(colocatedAgentInstructionsWorkspacePath as never)).trim()
   }
   catch {}
+  if (!content) return undefined
+
+  const fs = getNodeBuiltin<typeof import("node:fs")>("node:fs")
+  const path = getNodeBuiltin<typeof import("node:path")>("node:path")
+  const sourceRootDir = definition.sourceRootDir
+  if (fs && path && sourceRootDir && hasColocatedAgentInstructions(sourceRootDir)) {
+    return resolveInstructionDocumentImports(content, path.join(sourceRootDir, colocatedAgentInstructionsPath))
+  }
+  return content
 }
 
 async function resolveWorkspaceMetadataInstructions<
@@ -922,6 +958,7 @@ async function resolveWorkspaceMetadataInstructions<
   resolution: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name> = {},
   capabilityBlocks: AgentInstructionBlock[] = staticCapabilityInstructionBlocks(options),
   sourceDefinition: WorkspaceDefinition = workspaceDefinitionWithNameFromOptions(options, resolution),
+  compositionContext?: AgentInvocationContextStore,
 ) {
   const instructionContext = {
     fs: workspace.fs,
@@ -940,17 +977,12 @@ async function resolveWorkspaceMetadataInstructions<
     .map(part => part?.trim())
     .filter((part): part is string => Boolean(part))
   if (defaultInstructions) baseInstructions.unshift(defaultInstructions)
-  const renderedInstructions = applyPassiveCapabilityInstructionSlots(
-    baseInstructions.join("\n\n"),
-    capabilityBlocks,
+  const renderedInstructions = applyWorkspaceSourceInstructionsToParts(
+    [applyPassiveCapabilityInstructionSlots(baseInstructions.join("\n\n"), capabilityBlocks)],
+    await resolveWorkspaceSourceInstructionBlock(sourceDefinition, workspace),
   )
-  return applyWorkspaceSourceInstructionsToParts(
-    renderedInstructions ? [renderedInstructions] : [],
-    await resolveWorkspaceSourceInstructionBlock(
-      sourceDefinition,
-      workspace,
-    ),
-  )
+  const composed = composeInstructions(renderedInstructions.join("\n\n"), compositionContext)
+  return composed ? [composed] : []
 }
 
 function sourceInstructionsText(value: AgentWorkspaceSourceMetadata["instructions"]): string | undefined {
@@ -1322,6 +1354,7 @@ export async function resolveAgentDevtoolsMetadata<
       defaultsOverride,
       capabilityContext.capabilityInstructions,
       capabilityContext.definition,
+      capabilityContext.metadataContext.context,
     ),
     ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
     ...(config ? { config } : {}),
@@ -1387,6 +1420,7 @@ export async function materializeAgentDevtoolsSourceMetadata<
       options,
       capabilityContext.capabilityInstructions,
       capabilityContext.definition,
+      capabilityContext.metadataContext.context,
     ),
     ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
     ...(config ? { config } : {}),

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -171,6 +171,27 @@ describe("agent capability runtime", () => {
     await expect(applyOutputRenderers({ text: "base" }, resolved.registries.outputRenderers)).resolves.toEqual({ text: "base:rendered" })
   })
 
+  it("rejects duplicate capability instruction composition keys", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "first",
+          resolve(context) {
+            context.instructions.add("First.", { id: "audience" })
+          },
+        }),
+        defineCapability({
+          id: "second",
+          resolve(context) {
+            context.instructions.add("Second.", { id: "audience" })
+          },
+        }),
+      ],
+    }, runtime(), {})).rejects.toThrow('Duplicate capability instruction block "capabilities.audience"')
+  })
+
   it("passes named invocation context values through capabilities and custom runs", async () => {
     const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
 

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -1,0 +1,90 @@
+import { dirname, resolve } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import {
+  composeInstructionDocument,
+  resolveInstructionImports,
+} from "../src/instruction-composition.ts"
+
+function importReader(files: Map<string, string>) {
+  return (specifier: string, importer: string) => {
+    const file = resolve(dirname(importer), specifier)
+    const content = files.get(file)
+    if (content === undefined) throw new Error(`Missing test file: ${file}`)
+    return { content, file }
+  }
+}
+
+describe("instruction composition", () => {
+  it("expands relative markdown imports outside code spans and fences", () => {
+    const files = new Map([
+      ["/agent/nested.md", "Nested\n@./policy.md"],
+      ["/agent/policy.md", "Policy"],
+    ])
+
+    expect(resolveInstructionImports([
+      "Base",
+      "@./nested.md",
+      "`@./ignored.md`",
+      "``@./ignored.md``",
+      "```",
+      "@./ignored.md",
+      "```",
+    ].join("\n"), {
+      file: "/agent/instructions.md",
+      read: importReader(files),
+    })).toBe([
+      "Base",
+      "Nested",
+      "Policy",
+      "`@./ignored.md`",
+      "``@./ignored.md``",
+      "```",
+      "@./ignored.md",
+      "```",
+    ].join("\n"))
+  })
+
+  it("renders condition chains and context bindings without executing JavaScript", () => {
+    const document = [
+      "Hello {{ context.customerName }}.",
+      "{{{ context.supportPolicy }}}",
+      "::if{if=\"context.audience === 'technical' && !context.portal\"}",
+      "Use technical detail.",
+      "::else-if{context.audience === 'support'}",
+      "Use support detail.",
+      "::else",
+      "Use fallback detail.",
+      "::",
+    ].join("\n")
+
+    expect(composeInstructionDocument(document, {
+      context: {
+        audience: "technical",
+        customerName: "Acme",
+        supportPolicy: "## Policy\nUse trusted policy.",
+      },
+    })).toBe([
+      "Hello Acme.",
+      "## Policy",
+      "Use trusted policy.",
+      "Use technical detail.",
+    ].join("\n"))
+  })
+
+  it("rejects unsafe expressions and non-scalar double bindings", () => {
+    expect(() => composeInstructionDocument("::if{process.exit()}\nNo\n::"))
+      .toThrow("Unsafe instruction condition")
+    expect(() => composeInstructionDocument("{{ context.customer }}", { context: { customer: { name: "Acme" } } }))
+      .toThrow("must resolve to a scalar")
+    expect(() => resolveInstructionImports("@https://example.com/policy.md", {
+      file: "/agent/instructions.md",
+      read: importReader(new Map()),
+    })).toThrow("must be a relative file path")
+    expect(() => resolveInstructionImports("@./*.md", {
+      file: "/agent/instructions.md",
+      read: importReader(new Map()),
+    })).toThrow("cannot use globs")
+  })
+})

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -2,10 +2,12 @@ import { dirname, resolve } from "node:path"
 
 import { describe, expect, it } from "vitest"
 
+import { applyCapabilityInstructionSlots } from "../src/capability-runtime.ts"
 import {
   composeInstructionDocument,
   resolveInstructionImports,
 } from "../src/instruction-composition.ts"
+import { applyWorkspaceSourceInstructionSlot } from "../src/workspace-agent.ts"
 
 function importReader(files: Map<string, string>) {
   return (specifier: string, importer: string) => {
@@ -71,6 +73,56 @@ describe("instruction composition", () => {
       "Use trusted policy.",
       "Use technical detail.",
     ].join("\n"))
+  })
+
+  it("parses boolean chains without skipping the right side", () => {
+    expect(composeInstructionDocument([
+      "::if{context.enabled && context.customerName}",
+      "Enabled.",
+      "::else",
+      "Disabled.",
+      "::",
+    ].join("\n"), { context: { customerName: "Acme", enabled: false } })).toBe("Disabled.")
+
+    expect(composeInstructionDocument([
+      "::if{context.enabled || context.customerName}",
+      "Enabled.",
+      "::else",
+      "Disabled.",
+      "::",
+    ].join("\n"), { context: { customerName: "Acme", enabled: true } })).toBe("Enabled.")
+  })
+
+  it("reads stable context ids with hyphens and dotted names", () => {
+    expect(composeInstructionDocument([
+      "{{ context.llm-route.choice }}",
+      "{{ context.support.customer.name }}",
+    ].join("\n"), {
+      context: {
+        "llm-route": { choice: "fast" },
+        "support.customer": { name: "Acme" },
+      },
+    })).toBe("fast\nAcme")
+  })
+
+  it("renders conditionals before consuming capability and source instruction slots", () => {
+    const document = [
+      "::if{context.showCapability}",
+      "{{ capabilities.docs }}",
+      "{{ workspace.sources }}",
+      "::else",
+      "No capability instructions.",
+      "::",
+    ].join("\n")
+    const baseInstructions = composeInstructionDocument(document, {
+      context: { showCapability: false },
+    })
+
+    expect(applyCapabilityInstructionSlots(baseInstructions, [
+      { id: "capabilities.docs", instructions: "Use docs capability." },
+    ])).toBe("No capability instructions.\n\nUse docs capability.")
+    expect(applyWorkspaceSourceInstructionSlot(baseInstructions, "Use docs source."))
+      .toBe("No capability instructions.\n\nUse docs source.")
   })
 
   it("rejects unsafe expressions and non-scalar double bindings", () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1253,6 +1253,61 @@ describe("defineAgent workspace option", () => {
     ].join("\n\n"))
   })
 
+  it("composes colocated instruction documents from invocation context", async () => {
+    const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))
+    tempRoots.push(sourceRootDir)
+    const document = [
+      "# Support",
+      "@./policy.md",
+      "",
+      "::if{context.audience === 'technical'}",
+      "Use technical detail for {{ context.customerName }}.",
+      "::else",
+      "Use support detail.",
+      "::",
+      "",
+      "{{{ context.supportPolicy }}}",
+      "",
+      "{{ workspace.sources }}",
+    ].join("\n")
+    await writeLocalFile(join(sourceRootDir, "instructions.md"), document)
+    await writeLocalFile(join(sourceRootDir, "policy.md"), "Imported policy.\n")
+    readFile.mockResolvedValueOnce(document)
+    const { defineAgent, defineCapability } = await import("../src/index.ts")
+
+    const agent = withAgentDefaults(defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "support-context",
+          configure(context) {
+            context.context.set("audience", "technical")
+            context.context.set("customerName", "Acme")
+            context.context.set("supportPolicy", "## Runtime policy\nUse trusted runtime context.")
+            context.instructions.add("Capability note for {{ context.customerName }}.", { id: "support-note" })
+          },
+        }),
+      ],
+      workspace: {
+        sourceRootDir,
+        sources: {
+          docs: { instructions: "Use docs for {{ context.customerName }}.", name: "docs" } as never,
+        },
+      },
+      model: {} as never,
+    }), { workspace: "docs" })
+
+    await agent.run!(context())
+
+    expect(agentSettings.at(-1)?.instructions).toBe([
+      "# Support\nImported policy.",
+      "Use technical detail for Acme.",
+      "## Runtime policy\nUse trusted runtime context.",
+      "## Workspace Sources",
+      "### docs\n\nUse docs for Acme.",
+      "Capability note for Acme.",
+    ].join("\n\n"))
+  })
+
   it("reads materialized colocated instructions without host fs", async () => {
     const processWithBuiltins = globalThis.process as typeof process & {
       getBuiltinModule?: (name: string) => unknown


### PR DESCRIPTION
Adds ViteHub Instruction Composition for agent instruction documents: local Markdown imports, safe `context.*` conditionals, scalar and trusted Markdown bindings, Capability instruction slots, and visible Source Instructions in one final render pass.

This keeps `WorkspaceSource.instructions` as the low-level Source guidance field and preserves Access and Workspace Scope as runtime enforcement. The docs and `.agents` language now describe instruction documents as Markdown plus ViteHub composition rather than prompt config.