### PR TITLE
docs: clarify agent setup prerequisites

### DIFF
--- a/docs/content/blog/3.build-ai-chatbot.md
+++ b/docs/content/blog/3.build-ai-chatbot.md
@@ -28,7 +28,7 @@ Workspace.
 
 That gives you a better shape than a model call hidden in a route. The [Agent Definition](/docs/agents/agent-definitions)
 grows from a tiny chat actor into a reviewable server-side declaration that
-names the model, instructions, Capabilities, and Workspace Sources.
+names the Agent Driver, Capabilities, and Workspace Sources.
 
 This post builds a support Agent in layers: first chat, then `AGENTS.md`, then a
 GitHub Source, then DevTools inspection, and finally an Agent Eval.
@@ -40,8 +40,10 @@ import { defineAgent } from '@vite-hub/agent'
 import { chat } from '@vite-hub/agent/capabilities'
 
 export default defineAgent({
-  model: gateway('openai/gpt-5.1-mini'),
-  instructions: 'Answer support questions in a short, concrete style.',
+  driver: {
+    model: gateway('openai/gpt-5.1-mini'),
+    instructions: 'Answer support questions in a short, concrete style.',
+  },
   capabilities: [
     chat(),
   ],
@@ -51,8 +53,8 @@ export default defineAgent({
 
 The first code sample is intentionally small:
 
-- `model` chooses the model execution path.
-- `instructions` gives the Agent durable behavior.
+- `driver.model` chooses the model execution path.
+- `driver.instructions` gives the Agent durable behavior.
 - `chat()` adds a chat-oriented Capability.
 
 No Workspace, no `AGENTS.md`, no files yet. The next sections add those only
@@ -111,8 +113,10 @@ import { defineAgent } from '@vite-hub/agent'
 import { chat } from '@vite-hub/agent/capabilities'
 
 export default defineAgent({
-  model: gateway('openai/gpt-5.1-mini'),
-  instructions: 'Answer support questions in a short, concrete style.',
+  driver: {
+    model: gateway('openai/gpt-5.1-mini'),
+    instructions: 'Answer support questions in a short, concrete style.',
+  },
   capabilities: [
     chat(),
   ],
@@ -155,13 +159,15 @@ import { chat, workspaceShell } from '@vite-hub/agent/capabilities'
 import { file } from '@vite-hub/workspace'
 
 export default defineAgent({
-  model: gateway('openai/gpt-5.1-mini'),
+  driver: {
+    model: gateway('openai/gpt-5.1-mini'),
+    instructions: async ({ fs }) => await fs.readFile('AGENTS.md'),
+  },
   workspace: {
     sources: {
       instructions: file('AGENTS.md'),
     },
   },
-  instructions: async ({ fs }) => await fs.readFile('AGENTS.md'),
   capabilities: [
     chat(),
     workspaceShell({ mode: 'read' }),
@@ -208,7 +214,10 @@ import { chat, workspaceShell } from '@vite-hub/agent/capabilities'
 import { file, github } from '@vite-hub/workspace'
 
 export default defineAgent({
-  model: gateway('openai/gpt-5.1-mini'),
+  driver: {
+    model: gateway('openai/gpt-5.1-mini'),
+    instructions: async ({ fs }) => await fs.readFile('AGENTS.md'),
+  },
   workspace: {
     sources: {
       instructions: file('AGENTS.md'),
@@ -222,7 +231,6 @@ export default defineAgent({
       }),
     },
   },
-  instructions: async ({ fs }) => await fs.readFile('AGENTS.md'),
   capabilities: [
     chat(),
     workspaceShell({ mode: 'read' }),

--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -18,7 +18,6 @@ import { gateway } from '@ai-sdk/gateway'
 import { defineAgent } from '@vite-hub/agent'
 
 export default defineAgent({
-  title: 'Support Agent',
   driver: {
     model: gateway('openai/gpt-5.1-mini'),
     instructions: 'Answer support requests with short, concrete replies.',

--- a/docs/content/docs/agents/agent-drivers.md
+++ b/docs/content/docs/agents/agent-drivers.md
@@ -48,6 +48,12 @@ Capability Driver Contributions such as model-facing tools and instructions are 
 
 Use a harness-backed driver when the Agent should delegate execution to a harness adapter. ViteHub adapts the harness behind the Agent Harness Driver Contract and keeps permission policy under ViteHub runtime boundaries.
 
+Install the Agent Package with the harness adapter package you use.
+
+```bash [Terminal]
+pnpm add @vite-hub/agent @ai-sdk/harness-codex
+```
+
 ```ts [server/agents/codex/config.ts]
 import { createCodex } from '@ai-sdk/harness-codex'
 import { defineAgent } from '@vite-hub/agent'
@@ -87,6 +93,27 @@ Harness-backed drivers do not receive `driver.instructions` as a model prompt. U
 
 Harness-backed drivers also do not receive model-facing Capability tools, provider tools, or Capability instructions.
 When a Capability should support harness execution, give the harness files it can inspect through Workspace Sources, `harnessWorkspacePaths`, or a harness-native configuration surface.
+
+For a fresh TypeScript app, use ESM and NodeNext resolution so the ESM-only ViteHub and harness subpath imports load correctly.
+
+```json [package.json]
+{
+  "type": "module"
+}
+```
+
+```json [tsconfig.json]
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022"
+  },
+  "include": ["server/**/*.ts"]
+}
+```
+
+`tsc --noEmit` only checks the Agent Definition imports and driver shape. It does not start a real harness invocation.
 
 ## Custom run driver
 

--- a/docs/content/docs/agents/agent-drivers.md
+++ b/docs/content/docs/agents/agent-drivers.md
@@ -51,7 +51,7 @@ Use a harness-backed driver when the Agent should delegate execution to a harnes
 Install the Agent Package with the harness adapter package you use.
 
 ```bash [Terminal]
-pnpm add @vite-hub/agent @ai-sdk/harness-codex
+pnpm add @vite-hub/agent @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel
 ```
 
 ```ts [server/agents/codex/config.ts]

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -23,6 +23,25 @@ ViteHub materializes `server/agents/<name>/instructions.md` into the Agent Works
 
 Declare a colocated Workspace when the Agent primarily owns the file-tree context. Add Source Instructions when the model-backed driver needs guidance about a Source.
 
+Install the Workspace Package and register its Vite integration before the Agent integration when the Agent declares Workspace Sources.
+
+```bash [Terminal]
+pnpm add @vite-hub/workspace
+```
+
+```ts [vite.config.ts]
+import { hubAgent } from '@vite-hub/agent/vite'
+import { hubWorkspace } from '@vite-hub/workspace/vite'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    hubWorkspace(),
+    hubAgent(),
+  ],
+})
+```
+
 ```ts [server/agents/docs/config.ts]
 import { gateway } from '@ai-sdk/gateway'
 import { defineAgent } from '@vite-hub/agent'

--- a/docs/content/docs/capabilities/blob.md
+++ b/docs/content/docs/capabilities/blob.md
@@ -12,7 +12,7 @@ It exposes object read, metadata, and list operations by default, then adds edit
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/chat-summary.md
+++ b/docs/content/docs/capabilities/chat-summary.md
@@ -12,7 +12,7 @@ It looks for an explicit command in the latest user input, generates a summary, 
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/chat-title.md
+++ b/docs/content/docs/capabilities/chat-title.md
@@ -12,7 +12,7 @@ It can use a model, a custom executor, or a local heuristic, then streams or ret
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/chat.md
+++ b/docs/content/docs/capabilities/chat.md
@@ -12,7 +12,7 @@ It contributes a `chat.message` Agent Trigger, optional Chat Platform Adapter we
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/db.md
+++ b/docs/content/docs/capabilities/db.md
@@ -12,7 +12,7 @@ It exposes read-only query and schema inspection by default, then adds SQL mutat
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/entry.md
+++ b/docs/content/docs/capabilities/entry.md
@@ -12,7 +12,7 @@ Use it when a product event needs an Agent Trigger but the behavior has not earn
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/fetch.md
+++ b/docs/content/docs/capabilities/fetch.md
@@ -12,7 +12,7 @@ Use it for specific endpoints, not for unrestricted web browsing.
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/input-commands.md
+++ b/docs/content/docs/capabilities/input-commands.md
@@ -12,7 +12,7 @@ Use it for commands that transform or enrich the user's prompt, not for host UI 
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/kv.md
+++ b/docs/content/docs/capabilities/kv.md
@@ -12,7 +12,7 @@ It exposes read tools by default and edit tools only in write mode.
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/llm-gate.md
+++ b/docs/content/docs/capabilities/llm-gate.md
@@ -12,7 +12,7 @@ It can stop the Agent Invocation before the main Agent Driver runs.
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/llm-route.md
+++ b/docs/content/docs/capabilities/llm-route.md
@@ -12,7 +12,7 @@ It records the chosen route as an Agent Invocation Context Value and does not ap
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/mcp.md
+++ b/docs/content/docs/capabilities/mcp.md
@@ -12,7 +12,7 @@ It resolves each configured MCP Server and exposes its tools as model-facing Age
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/memory.md
+++ b/docs/content/docs/capabilities/memory.md
@@ -12,7 +12,7 @@ Memory is explicit Agent behavior and is not the same as Chat History.
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/rate-limit.md
+++ b/docs/content/docs/capabilities/rate-limit.md
@@ -12,7 +12,7 @@ It uses trusted invocation identity, records a typed decision, and can reject be
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/sandbox.md
+++ b/docs/content/docs/capabilities/sandbox.md
@@ -12,7 +12,7 @@ Use it only when the Agent needs to run a small allowlist of executable names.
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/schedule.md
+++ b/docs/content/docs/capabilities/schedule.md
@@ -12,7 +12,7 @@ It can declare fixed Agent Schedules as Capability metadata, or it can expose Ru
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/transcribe.md
+++ b/docs/content/docs/capabilities/transcribe.md
@@ -12,7 +12,7 @@ It turns audio message parts into transcript text before the Agent Driver receiv
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/web-search.md
+++ b/docs/content/docs/capabilities/web-search.md
@@ -12,7 +12,7 @@ Use model mode for provider-native web search, or tool mode for normalized `web_
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/capabilities/workspace-shell.md
+++ b/docs/content/docs/capabilities/workspace-shell.md
@@ -12,7 +12,7 @@ It exposes shell-shaped inspection by default and write tools only when the Agen
 
 ## Installation
 
-Import the Capability factory from `-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 Use the configuration example below as the starting point, then tighten modes, policies, stores, and providers for the Agent boundary.
 
 ## What it adds

--- a/docs/content/docs/concepts/workspace-and-sources.md
+++ b/docs/content/docs/concepts/workspace-and-sources.md
@@ -19,15 +19,36 @@ Workspace is also useful outside agents. Server code can read, write, snapshot, 
 
 Declare Sources inside the Workspace that owns their placement and policy.
 
+Register the Workspace Vite Integration from `@vite-hub/workspace/vite` so ViteHub discovers Workspace Definitions.
+
+```ts [vite.config.ts]
+import { hubWorkspace } from '@vite-hub/workspace/vite'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    hubWorkspace(),
+  ],
+})
+```
+
 ```ts [server/workspaces/docs.ts]
-import { defineWorkspace, glob } from '@vite-hub/workspace'
+import { defineWorkspace, file, glob, markdown } from '@vite-hub/workspace'
 
 export default defineWorkspace({
   sources: {
+    readme: file({
+      path: 'README.md',
+      instructions: 'Use this file for the project overview.',
+    }),
     docs: glob({
       cwd: '.',
-      include: ['README.md', 'docs/**/*.md'],
+      include: ['docs/**/*.md'],
       instructions: 'Use these docs for public product behavior.',
+    }),
+    supportPolicy: markdown({
+      path: 'docs/support-policy.md',
+      instructions: 'Use this source for support policy answers.',
     }),
   },
   rules: {

--- a/docs/content/docs/development/agent-evals.md
+++ b/docs/content/docs/development/agent-evals.md
@@ -53,6 +53,12 @@ export default defineEval({
 
 ## Run the evals
 
+Install the CLI and Evalite peer in the app that owns the Agent Definitions. ViteHub contributes the `agent eval` command through `hubAgent()`, so the app also needs an ESM Vite config, such as `"type": "module"` in `package.json`.
+
+```bash [Terminal]
+pnpm add -D @vite-hub/cli evalite@1.0.0-beta.16
+```
+
 Run all discovered Agent Evals with no target.
 Pass a path when you want one Agent Eval Target.
 

--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -118,6 +118,7 @@ pnpm vitehub provision run --provider vercel --dry-run
 | Provision fails before applying actions | Required provider credentials are missing. | Set `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`, or set `VERCEL_TOKEN`. |
 | Agent eval CLI is disabled | `agent.eval` or `agent.cli` disables the Agent Eval Runner. | Re-enable the Agent integration option for local development. |
 | Agent eval times out | The eval case, model call, or harness run exceeds `agent.eval.testTimeout`. | Increase `agent.eval.testTimeout` in `vite.config.ts` or narrow the eval case. |
+| Vite config fails while loading a ViteHub plugin import | A fresh npm project is loading `vite.config.ts` as CommonJS, but ViteHub packages are ESM-only. | Set `"type": "module"` in `package.json` or rename the config to `vite.config.mts`. |
 | `No Compatible Vite Development Server found` | The app dev server is not running or `--url` points at the wrong port. | Start Vite separately, then pass the dev server URL. |
 | Agent Dev Loop request times out | The invocation exceeded the CLI request timeout. | Pass `--timeout <ms>` for the dev-loop command or shorten the Agent work. |
 | `Agent Dev Loop context file must contain a JSON object` | The `--context` file is not a JSON object. | Replace the file contents with one object whose keys are Agent Invocation Context Value ids. |

--- a/docs/content/docs/frameworks-hosts/cloudflare.md
+++ b/docs/content/docs/frameworks-hosts/cloudflare.md
@@ -65,6 +65,17 @@ pnpm build
 find dist -maxdepth 4 -type f | sort
 ```
 
+Agent-only Vite apps are different in 0.0.2. `VITEHUB_HOSTING=cloudflare pnpm build` writes generated Agent route source under `.vitehub/agent`, but it does not emit a Worker bundle or `wrangler.json`. For a Cloudflare Worker entry, use the public Agent Package handler.
+
+```ts [worker.ts]
+import { defineCloudflareAgentHandler } from '@vite-hub/agent/cloudflare'
+import echo from './server/agents/echo/config'
+
+export default {
+  fetch: defineCloudflareAgentHandler(echo),
+}
+```
+
 ## Production notes
 
 Cloudflare local development and deployed Workers do not always expose the same runtime behavior.

--- a/docs/content/docs/frameworks-hosts/deno.md
+++ b/docs/content/docs/frameworks-hosts/deno.md
@@ -72,6 +72,7 @@ deno run --unstable-kv --allow-net=127.0.0.1:8787 .vitehub/agent/deno-server.ts 
 ```
 
 For a single discovered `support` Agent with the default chat route enabled, send a chat request to the generated route.
+The target Agent must expose the `chat.message` trigger, usually by attaching `chat()` from `@vite-hub/agent/capabilities`; a custom `driver.run` Agent without that Capability can mount the route but will reject chat requests.
 
 ```bash [Terminal]
 curl -X POST http://127.0.0.1:8787/api/_vitehub/agents/support/chat \

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ ViteHub starts with the `@vite-hub/vite` preset. Add direct primitive, Agent Pac
 
 - Node 24 or newer.
 - Vite 8 or newer.
-- A server app with a `vite.config.ts` file.
+- A server app with an ESM Vite config, such as `vite.config.ts` in a `"type": "module"` package or `vite.config.mts`.
 - A package manager such as `pnpm`, `npm`, `yarn`, or `bun`.
 - A local `.env` file or provider environment variable system for host credentials.
 
@@ -47,7 +47,7 @@ Install only the packages you use. Add Env, Database, Blob, Queue, Workflow, Sch
 
 ## Register the Vite Integration
 
-Register the preset Vite Integration with `vitehub()` in `vite.config.ts`.
+Register the preset Vite Integration with `vitehub()` in `vite.config.ts`. ViteHub packages are ESM-only, so fresh npm projects should either set `"type": "module"` in `package.json` or name the config `vite.config.mts`.
 
 ```ts [vite.config.ts]
 import { vitehub } from "@vite-hub/vite";

--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -18,6 +18,7 @@ They may resolve to Runtime Registries, generated files, virtual modules, or pac
 | `@vite-hub/agent/eval` | Agent Package | Agent Eval authoring helpers. |
 | `@vite-hub/agent/test` | Agent Package | Agent test runner helpers for local and CI Agent Invocation checks. |
 | `@vite-hub/agent/harness/local-sandbox` | Agent Package | Trusted local harness sandbox helper for development and Agent Evals. |
+| `@vite-hub/agent/cloudflare` | Agent Package | Cloudflare Worker handler helpers and Agent state helpers. |
 | `@vite-hub/vite/agent` | Vite Preset | Agent Definition helpers forwarded by the preset package. |
 | `@vite-hub/vite/agent/capabilities` | Vite Preset | Official Capability factories forwarded by the preset package. |
 | `@vite-hub/vite/agent/channels` | Vite Preset | Official Channel Kind helpers forwarded by the preset package. |

--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -59,11 +59,12 @@ They may resolve to Runtime Registries, generated files, virtual modules, or pac
 | --- | --- | --- |
 | `.vitehub/**` | Generated | Inspect during development; do not author imports against these files. |
 | `.vercel/output/**` | Generated Provider Output | Deploy or inspect as Vercel Build Output. |
+| `.netlify/v1/**` | Generated Provider Output | Deploy or inspect as Netlify function output. |
 | `dist/**/wrangler.json` | Generated Provider Output | Deploy or inspect as Cloudflare output. |
 | Vite virtual module ids with `\0` prefixes | Internal | Never import directly. |
 | `@vite-hub/internal/*` | Internal | Package implementation only. |
 
-The 0.0.2 preview does not expose a stable `@vite-hub/agent/netlify` app import. Treat Netlify Agent output as undocumented until a provider page names the public contract.
+The 0.0.2 preview does not expose a stable `@vite-hub/agent/netlify` app import. Netlify Agent output is generated Provider Output under `.netlify/v1` plus the `.vitehub/agent/netlify-function.mjs` source wrapper.
 
 ## Related
 

--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -62,6 +62,8 @@ They may resolve to Runtime Registries, generated files, virtual modules, or pac
 | Vite virtual module ids with `\0` prefixes | Internal | Never import directly. |
 | `@vite-hub/internal/*` | Internal | Package implementation only. |
 
+The 0.0.2 preview does not expose a stable `@vite-hub/agent/netlify` app import. Treat Netlify Agent output as undocumented until a provider page names the public contract.
+
 ## Related
 
 - [Generated files](/docs/development/generated-files)

--- a/docs/content/docs/reference/provider-output.md
+++ b/docs/content/docs/reference/provider-output.md
@@ -15,6 +15,7 @@ It belongs to the package that owns the primitive and should not become applicat
 | Worker bundle | Cloudflare | Package integration using Cloudflare output | Runs server or primitive runtime code in Workers. |
 | `wrangler.json` entries | Cloudflare | Blob, Database, Queue, Schedule, Workflow, Sandbox, Agent state as applicable | Declares bindings, crons, durable objects, queues, and other worker config. |
 | Vercel Build Output | Vercel | Package integration using Vercel output | Writes functions, static files, routes, and function config under `.vercel/output`. |
+| Netlify function output | Netlify | Agent and Schedule Packages | Writes generated functions and static config under `.netlify/v1`. |
 | Deno Agent server output | Deno | Agent Package | Writes `.vitehub/agent/deno-server.ts` for `Deno.serve` chat and webhook routes. |
 | Deno cron output | Deno | Schedule Package | Writes `.vitehub/schedule/deno-cron.mjs` for `Deno.cron` static schedule wake output. |
 | Generated Runtime Registry | Local and hosted | Package that discovers Definitions | Maps Discovery Identity to lazy-loaded Definitions. |
@@ -48,7 +49,7 @@ pnpm --filter @vite-hub/workflow test
 Application code should import Runtime Helpers and stable handlers.
 Generated Provider Output may import generated files, virtual modules, or provider runtime packages internally.
 
-Netlify Agent output is not a public 0.0.2 contract yet: there is no documented stable `@vite-hub/agent/netlify` import or Netlify output family. Use the documented Cloudflare, Vercel, Deno, or Node-shaped host paths until Netlify support is documented.
+Netlify Agent output is Provider Output, not an app import: there is no stable `@vite-hub/agent/netlify` import. Inspect `.netlify/v1/functions/vitehub-agent.mjs` and `.vitehub/agent/netlify-function.mjs` during deployment debugging instead of importing them from application code.
 
 | Do | Avoid |
 | --- | --- |

--- a/docs/content/docs/reference/provider-output.md
+++ b/docs/content/docs/reference/provider-output.md
@@ -48,6 +48,8 @@ pnpm --filter @vite-hub/workflow test
 Application code should import Runtime Helpers and stable handlers.
 Generated Provider Output may import generated files, virtual modules, or provider runtime packages internally.
 
+Netlify Agent output is not a public 0.0.2 contract yet: there is no documented stable `@vite-hub/agent/netlify` import or Netlify output family. Use the documented Cloudflare, Vercel, Deno, or Node-shaped host paths until Netlify support is documented.
+
 | Do | Avoid |
 | --- | --- |
 | Call `runQueue('welcome-email', payload)`. | Import a generated queue consumer from `.vitehub`. |


### PR DESCRIPTION
Clarifies the setup prerequisites that showed up in the 0.0.2 workflow scenario evidence. Workspace Source docs now show `@vite-hub/workspace` plus `hubWorkspace()`, Agent Eval docs call out the Evalite peer and ESM Vite config, and harness driver docs make the package and NodeNext setup concrete without documenting current package-install workarounds.

This follow-up also aligns public examples on the current `driver` API, removes unsupported `defineAgent({ title })` usage, calls out the `chat()` requirement for generated Deno chat routes, fixes the broken Capability import text, adds a narrow Netlify support-status note for 0.0.2, and adds a compact Source composition example for `file`, `glob`, and `markdown`.

S14 clarifies the Cloudflare Agent boundary: Agent-only Vite builds write generated Agent source under `.vitehub/agent`, but do not emit a Worker bundle or `wrangler.json`; Cloudflare Worker entries should use the public `@vite-hub/agent/cloudflare` handler path until generated Agent Worker output exists.

Refs S2, S4, S6, S7, S8, S10, and S14 scenario reports.