### PR TITLE
fix(blob): skip provider output for local fs stores

### DIFF
--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -333,13 +333,25 @@ function createVercelOutput(artifacts: GeneratedBlobArtifacts): VercelProviderDe
   }
 }
 
+function hasExplicitFsStore(blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined) {
+  if (!blob || typeof blob !== "object") return false
+  if ("stores" in blob && blob.stores) return Object.values(blob.stores).some(store => store.driver === "fs")
+  if ("store" in blob) return blob.store.driver === "fs"
+  return "driver" in blob && blob.driver === "fs"
+}
+
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedBlobArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.blob)
+  const localOnly = hasExplicitFsStore(options.blob)
   await writeProviderDeploymentOutputs({
     clientOutDir: options.clientOutDir,
-    cloudflare: createCloudflareOutput(options.blob, artifacts),
+    cloudflare: localOnly ? undefined : createCloudflareOutput(options.blob, artifacts),
+    cleanup: {
+      cloudflare: { bundleOutfileName: "index.js", wranglerConfigKeys: ["r2_buckets"] },
+      vercel: { serverFunctionName: "__server.func" },
+    },
     rootDir: options.rootDir,
-    vercel: createVercelOutput(artifacts),
+    vercel: localOnly ? undefined : createVercelOutput(artifacts),
   })
   return artifacts
 }

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -346,10 +346,6 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   await writeProviderDeploymentOutputs({
     clientOutDir: options.clientOutDir,
     cloudflare: localOnly ? undefined : createCloudflareOutput(options.blob, artifacts),
-    cleanup: {
-      cloudflare: { bundleOutfileName: "index.js", wranglerConfigKeys: ["r2_buckets"] },
-      vercel: { serverFunctionName: "__server.func" },
-    },
     rootDir: options.rootDir,
     vercel: localOnly ? undefined : createVercelOutput(artifacts),
   })

--- a/packages/blob/src/runtime/storage.ts
+++ b/packages/blob/src/runtime/storage.ts
@@ -32,7 +32,9 @@ async function importRuntimeDriver(config: ResolvedBlobStoreConfig) {
     && import.meta.url.endsWith(".ts")
 
   const moduleName = driverModules[config.driver]
-  const modulePath = new URL(isSourceRuntime ? `../drivers/${moduleName}.ts` : `../drivers/${moduleName}.js`, import.meta.url).href
+  const modulePath = isSourceRuntime
+    ? new URL(`../drivers/${moduleName}.ts`, import.meta.url).href
+    : `@vite-hub/blob/drivers/${moduleName}`
   const module = await import(modulePath) as { createDriver: (options: typeof config) => any }
   return module.createDriver(config)
 }

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 
+import { build as bundle } from "esbuild"
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
 import { toSafeAppName } from "@vite-hub/internal/build/user-entry"
 
@@ -239,6 +240,32 @@ describe("Vite provider outputs", () => {
 
     await expect(readFile(join(rootDir, "dist", toSafeAppName(rootDir), "index.js"), "utf8")).resolves.toBe("existing cloudflare output\n")
     await expect(readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")).resolves.toBe("existing vercel output\n")
+  })
+
+  it("loads the fs driver from bundled SSR output", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-bundled-fs-")
+    const entryFile = join(rootDir, "entry.ts")
+    const bundleFile = join(rootDir, "server.mjs")
+
+    await writeFile(entryFile, [
+      `import { blob } from ${JSON.stringify(resolve(import.meta.dirname, "../src/index.ts"))}`,
+      "await blob.put('proof.txt', 'ok')",
+      "console.log(await (await blob.get('proof.txt'))?.text())",
+      "",
+    ].join("\n"), "utf8")
+
+    await bundle({
+      bundle: true,
+      entryPoints: [entryFile],
+      format: "esm",
+      logLevel: "silent",
+      outfile: bundleFile,
+      platform: "node",
+      target: "es2022",
+    })
+
+    const { stdout } = await execFileAsync(process.execPath, [bundleFile], { cwd: rootDir })
+    expect(stdout.trim()).toBe("ok")
   })
 
   it("rehydrates masked Vercel tokens from generated runtime output", async () => {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -222,6 +222,22 @@ describe("Vite provider outputs", () => {
     ])
   })
 
+  it("skips provider output for local fs stores", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-local-fs-")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist"), { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+
+    await generateProviderOutputs({
+      blob: { driver: "fs", base: ".data/blob" },
+      clientOutDir: "dist",
+      rootDir,
+    })
+
+    expect(existsSync(join(rootDir, "dist", toSafeAppName(rootDir), "index.js"))).toBe(false)
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__server.func"))).toBe(false)
+  })
+
   it("rehydrates masked Vercel tokens from generated runtime output", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-vercel-runtime-")
     await mkdir(join(rootDir, "src"), { recursive: true })

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -225,7 +225,10 @@ describe("Vite provider outputs", () => {
   it("skips provider output for local fs stores", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-local-fs-")
     await mkdir(join(rootDir, "src"), { recursive: true })
-    await mkdir(join(rootDir, "dist"), { recursive: true })
+    await mkdir(join(rootDir, "dist", toSafeAppName(rootDir)), { recursive: true })
+    await mkdir(join(rootDir, ".vercel", "output", "functions", "__server.func"), { recursive: true })
+    await writeFile(join(rootDir, "dist", toSafeAppName(rootDir), "index.js"), "existing cloudflare output\n", "utf8")
+    await writeFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "existing vercel output\n", "utf8")
     await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
 
     await generateProviderOutputs({
@@ -234,8 +237,8 @@ describe("Vite provider outputs", () => {
       rootDir,
     })
 
-    expect(existsSync(join(rootDir, "dist", toSafeAppName(rootDir), "index.js"))).toBe(false)
-    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__server.func"))).toBe(false)
+    await expect(readFile(join(rootDir, "dist", toSafeAppName(rootDir), "index.js"), "utf8")).resolves.toBe("existing cloudflare output\n")
+    await expect(readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")).resolves.toBe("existing vercel output\n")
   })
 
   it("rehydrates masked Vercel tokens from generated runtime output", async () => {


### PR DESCRIPTION
S16 showed that a documented plain Vite app with `hubBlob()` and an explicit local `fs` Blob Store could finish the client build, then fail in the Blob Provider Output pass while esbuild tried to bundle `node:crypto`, `node:fs/promises`, and `node:path` from the fs driver.

This keeps explicit local fs stores out of Cloudflare and Vercel Provider Output generation while still writing the generated `.vitehub/blob/*` runtime sources for inspection. Hosted and implicit provider defaults keep their existing Provider Output path.

Refs S16 Blob Runtime Smoke.
