### PR TITLE
fix(queue): clarify local delivery boundary

### DIFF
--- a/docs/content/docs/server-primitives/queue.md
+++ b/docs/content/docs/server-primitives/queue.md
@@ -232,6 +232,25 @@ await runQueue('welcome-email', {
 
 Unsupported provider options throw `QueueError` instead of being ignored.
 
+## Develop locally
+
+Use the Vite Integration to check that ViteHub discovers your Queue Definitions and generates the right provider output. A standalone Node process, such as a `tsx` script, does not run Vite discovery or load the generated Queue Runtime Registry, so `runQueue()` cannot find queue files from there.
+
+```bash [Terminal]
+pnpm vite build
+```
+
+After the build, inspect `.vitehub/queue/registry.mjs` to confirm that ViteHub found the queue. Then inspect the provider output for the provider you configured.
+
+| Provider | Output to inspect |
+| --- | --- |
+| Cloudflare | `dist/**/wrangler.json` queue producers and consumers, plus the generated worker bundle. |
+| Vercel | `.vercel/output/functions/api/vitehub/queues/vercel/**` consumer functions and trigger config. |
+
+::note
+Queue does not include an in-memory Queue Provider for local Queue Delivery. Test the code your handler calls when you need fast unit coverage, and use generated provider runtime or deployed provider output when you need to prove Queue Enqueue and Queue Delivery together.
+::
+
 ## Runtime Helpers
 
 ### `runQueue(name, input)`

--- a/packages/queue/src/runtime/client.ts
+++ b/packages/queue/src/runtime/client.ts
@@ -10,6 +10,14 @@ import { getQueueClientCache, getQueueRuntimeConfig, getQueueRuntimeEvent, loadQ
 
 import type { CloudflareQueueClient, CloudflareQueueProviderOptions, QueueClient, QueueEnqueueInput, QueueProviderOptions, QueueSendResult, ResolvedQueueOptions, VercelQueueProviderOptions } from "../types.ts"
 
+function createQueueDefinitionNotFoundError(name: string): QueueError {
+  return new QueueError(`Unknown queue definition: ${name}. Queue Runtime Registry is installed by generated Provider Output; direct Node scripts cannot discover Queue Definitions by themselves.`, {
+    code: "QUEUE_DEFINITION_NOT_FOUND",
+    details: { name },
+    httpStatus: 404,
+  })
+}
+
 function resolveCloudflareBinding(binding: string | CloudflareQueueClient["binding"] | undefined, name: string) {
   if (binding && typeof binding !== "string") {
     return binding
@@ -80,11 +88,7 @@ async function createNamedQueueClient(name: string): Promise<QueueClient> {
 export async function getQueue(name: string): Promise<QueueClient> {
   const definition = await loadQueueDefinition(name)
   if (!definition) {
-    throw new QueueError(`Unknown queue definition: ${name}`, {
-      code: "QUEUE_DEFINITION_NOT_FOUND",
-      details: { name },
-      httpStatus: 404,
-    })
+    throw createQueueDefinitionNotFoundError(name)
   }
 
   const config = getActiveQueueConfig()
@@ -111,11 +115,7 @@ export async function getQueue(name: string): Promise<QueueClient> {
 export async function runQueue<TPayload = unknown>(name: string, input: QueueEnqueueInput<TPayload>): Promise<QueueSendResult> {
   const definition = await loadQueueDefinition(name)
   if (!definition) {
-    throw new QueueError(`Unknown queue definition: ${name}`, {
-      code: "QUEUE_DEFINITION_NOT_FOUND",
-      details: { name },
-      httpStatus: 404,
-    })
+    throw createQueueDefinitionNotFoundError(name)
   }
 
   const normalized = normalizeQueueEnqueueInput(input)

--- a/packages/queue/test/runtime.test.ts
+++ b/packages/queue/test/runtime.test.ts
@@ -53,6 +53,10 @@ afterEach(() => {
 })
 
 describe("cloudflare queue runtime", () => {
+  it("points direct Node scripts at generated provider output when no registry is loaded", async () => {
+    await expect(runQueue("welcome", { email: "ava@example.com" })).rejects.toThrow(/Queue Runtime Registry is installed by generated Provider Output/)
+  })
+
   it("acks successful messages and retries failed ones", async () => {
     const ack = vi.fn()
     const retry = vi.fn()


### PR DESCRIPTION
Clarifies the Queue 0.0.2 local runtime boundary after S20: direct Node scripts can import `runQueue()`, but they do not load the generated Queue Runtime Registry and are not a provider-account-free Queue Delivery path. The runtime error now points at generated Provider Output, and the Queue docs describe the local inspection proof users can run instead.

This keeps Queue Enqueue as provider acceptance and avoids making `runQueue()` pretend to return handler delivery results.