### PR TITLE
feat(agent): render instructions with comark

### DIFF
--- a/.agents/adr/0072-instruction-documents-compose-model-instructions.md
+++ b/.agents/adr/0072-instruction-documents-compose-model-instructions.md
@@ -1,8 +1,8 @@
 # Instruction Documents Compose Model Instructions
 
-ViteHub treats an Agent instruction document as Markdown plus ViteHub Instruction Composition. The document is authored for humans and agents, then rendered by the Agent Package into model-facing instructions for model-backed Agent Drivers.
+ViteHub treats an Agent instruction document as Comark-parsed Markdown plus ViteHub Instruction Composition. The document is authored for humans and agents, then rendered by the Agent Package into model-facing instructions for model-backed Agent Drivers.
 
-Instruction Composition supports local Markdown imports, safe conditional blocks, explicit `context.*` bindings, Capability instruction slots, and visible Source Instructions. It must not become a general prompt configuration language or an arbitrary JavaScript runtime. Runtime data enters composition only through explicit Agent Invocation Context Values exposed at `context.*`.
+Instruction Composition supports local Markdown imports, safe conditional blocks, explicit `context.*` bindings, Capability instruction slots, and visible Source Instructions through a Comark-backed Markdown render pass. It must not become a general prompt configuration language or an arbitrary JavaScript runtime. Runtime data enters composition only through explicit Agent Invocation Context Values exposed at `context.*`.
 
 Capabilities may contribute model-facing instruction blocks and may write Agent Invocation Context Values that instruction documents read later. Duplicate Capability instruction block ids fail loudly because silent merge or last-write-wins behavior would make composed instructions hard to inspect.
 
@@ -11,14 +11,14 @@ Capabilities may contribute model-facing instruction blocks and may write Agent 
 ## Considered Options
 
 - A prompt configuration subsystem was rejected because the durable abstraction is an instruction document, not provider-specific prompt config.
-- A broad MDC or MDX runtime was rejected for V1 because ViteHub only needs imports, conditionals, and explicit bindings now.
+- A broad MDX runtime or prompt configuration runtime was rejected for V1 because ViteHub only needs Comark-backed Markdown parsing, imports, conditionals, and explicit bindings now.
 - Arbitrary JavaScript conditions were rejected because instructions need diagnostics and inspectability without executing author-controlled code during rendering.
 - A custom insert directive was rejected because scalar `{{ context.value }}` bindings and trusted Markdown `{{{ context.value }}}` bindings cover the V1 use case.
 - Treating Source Instructions as access grants was rejected because access is trusted runtime enforcement, not Markdown policy.
 
 ## Consequences
 
-Instruction documents stay readable Markdown. Advanced behavior must earn its place as a small composition rule rather than growing a new template framework.
+Instruction documents stay readable Markdown. Comark owns Markdown-aware parsing and rendering, while Access, Workspace Scope, Workspace Rules, Capability registration, Source visibility, workspace sessions, and write-back remain TypeScript-owned runtime boundaries. Advanced behavior must earn its place as a small composition rule rather than growing a new template framework.
 
 Capabilities that need reusable composition should write named Agent Invocation Context Values or instruction blocks through `defineCapability`. They should not hide runtime data behind ambient globals or mutate Agent Definition instructions.
 

--- a/docs/content/docs/agents/instructions.md
+++ b/docs/content/docs/agents/instructions.md
@@ -5,7 +5,7 @@ navigation.order: 24
 icon: i-lucide-scroll-text
 ---
 
-An instruction document is Markdown that ViteHub composes into model-facing instructions. Use it for durable behavior, trust boundaries, source-use policy, and uncertainty handling. Capabilities and Sources contribute their own instruction blocks when they own the guidance.
+An instruction document is Markdown parsed through Comark that ViteHub composes into model-facing instructions. Use it for durable behavior, trust boundaries, source-use policy, and uncertainty handling. Capabilities and Sources contribute their own instruction blocks when they own the guidance.
 
 Model Driver Instructions are the model-backed Agent Driver field that receives the composed document. ViteHub keeps that model-facing surface separate from harness and custom-run execution.
 
@@ -100,6 +100,8 @@ Keep the answer concise.
 ```
 
 Conditions use a small safe expression subset: `context.*` paths, string, number, boolean, and `null` literals, equality checks, `&&`, `||`, `!`, and parentheses. ViteHub rejects function calls, property access outside `context.*`, and other JavaScript.
+
+Use Comark attribute syntax such as `::if{condition="context.audience === 'technical'"}` when authoring new condition blocks. The shorter `::if{context.audience === 'technical'}` form remains supported.
 
 ## Place Capability slots
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -131,6 +131,7 @@
     "@vite-hub/workspace": "workspace:*",
     "@vitejs/devtools-kit": "catalog:vite",
     "chat": "catalog:chat",
+    "comark": "catalog:ui",
     "esbuild": "catalog:esbuild-v27",
     "evalite": "catalog:ai",
     "hookable": "catalog:unjs",

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -565,8 +565,8 @@ async function resolveInstructions(options: AiSdkAdapterOptions, context: AgentA
   return joinInstructions(...instructions)
 }
 
-function composeInstructions(instructions: string, context: AgentAdapterMetadataContext) {
-  return composeInstructionDocument(instructions, { context: context.context.toJSON() })
+async function composeInstructions(instructions: string, context: AgentAdapterMetadataContext) {
+  return await composeInstructionDocument(instructions, { context: context.context.toJSON() })
 }
 
 async function resolveTools(options: AiSdkAdapterOptions, context: AgentAdapterMetadataContext, reportToolStep?: AgentAdapterRunContext["devtools"] extends infer T ? T extends { reportToolStep?: infer R } ? R : never : never) {
@@ -826,8 +826,8 @@ async function createAgent(
   const instrumentedModel = instrumentations.length
     ? await instrumentModel(model, instrumentations, { ...runtime, actor: context.actor, context: context.context, invoker: context.invoker, model, run: context.runtime.run })
     : model
-  const baseInstructions = composeInstructions(context.instructions ?? await resolveInstructions(options, metadataContext), metadataContext)
-  const instructions = composeInstructions(applyWorkspaceSourceInstructionSlot(
+  const baseInstructions = await composeInstructions(context.instructions ?? await resolveInstructions(options, metadataContext), metadataContext)
+  const instructions = await composeInstructions(applyWorkspaceSourceInstructionSlot(
     applyCapabilityInstructionSlots(baseInstructions, context.capabilityInstructions),
     context.sourceInstructions,
   ), metadataContext)

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -161,10 +161,10 @@ function selectedWorkspaceScopePaths(context: AgentAdapterRunContext): string[] 
   return paths.length ? paths : []
 }
 
-function toHarnessCallInput(context: AgentAdapterRunContext) {
+async function toHarnessCallInput(context: AgentAdapterRunContext) {
   const compositionContext = { context: context.context.toJSON() }
-  const baseInstructions = composeInstructionDocument(context.instructions || "", compositionContext)
-  const instructions = composeInstructionDocument(applyWorkspaceSourceInstructionSlot(
+  const baseInstructions = await composeInstructionDocument(context.instructions || "", compositionContext)
+  const instructions = await composeInstructionDocument(applyWorkspaceSourceInstructionSlot(
     applyCapabilityInstructionSlots(baseInstructions, context.capabilityInstructions),
     context.sourceInstructions,
   ), compositionContext)
@@ -506,7 +506,7 @@ export function createHarnessAgentAdapter<
       const { agent, cleanup, session } = await createAgentAndSession(context)
       try {
         const result = defineAgentUsageMetadata(await agent.generate({
-          ...toHarnessCallInput(context),
+          ...await toHarnessCallInput(context),
           session,
         }), usageMetadata)
         await cleanup()
@@ -522,7 +522,7 @@ export function createHarnessAgentAdapter<
       const { agent, cleanup, session } = await createAgentAndSession(context)
       try {
         const result = defineAgentUsageMetadata(await agent.stream({
-          ...toHarnessCallInput(context),
+          ...await toHarnessCallInput(context),
           session,
         }), usageMetadata)
         return await withSessionCleanup(result, cleanup, context.input.abortSignal)

--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -1,3 +1,7 @@
+import { parse } from "comark"
+import binding, { Binding } from "comark/plugins/binding"
+import { renderMarkdown } from "comark/render"
+
 export interface InstructionImportResolution {
   content: string
   file: string
@@ -18,88 +22,107 @@ type ConditionToken =
   | { type: "literal", value: unknown }
   | { type: "op", value: ConditionOperator }
   | { path: string, type: "path" }
+type ComarkElementAttributes = Record<string, unknown>
+type ComarkElement = [string, ComarkElementAttributes, ...ComarkNode[]]
+type ComarkComment = [null, ComarkElementAttributes, string]
+type ComarkNode = ComarkComment | ComarkElement | string
 
 const defaultImportDepth = 4
 const contextPathPattern = /context(?:\.[A-Za-z_$][\w$-]*)+/
 const tripleBindingPattern = /\{\{\{\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}\}/g
-const scalarBindingPattern = /\{\{(?!\{)\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}/g
+const comarkComponents = { Binding }
+const noLinkify = {
+  markdownItPlugins: [(md: { disable: (rule: string) => unknown, set: (options: Record<string, unknown>) => unknown }) => {
+    md.disable("linkify")
+    md.set({ linkify: false })
+  }],
+  name: "vitehub-no-linkify",
+}
 
-export function resolveInstructionImports(content: string, options: ResolveInstructionImportsOptions): string {
-  return expandInstructionImports(content, {
+export async function resolveInstructionImports(content: string, options: ResolveInstructionImportsOptions): Promise<string> {
+  return await expandInstructionImports(normalizeConditionShorthand(content), {
     ...options,
     maxDepth: options.maxDepth ?? defaultImportDepth,
     seen: new Set([options.file]),
   })
 }
 
-export function composeInstructionDocument(content: string, options: ComposeInstructionDocumentOptions = {}): string {
+export async function composeInstructionDocument(content: string, options: ComposeInstructionDocumentOptions = {}): Promise<string> {
   const context = options.context || {}
-  return renderContextBindings(renderConditionals(content, context), context).trim().replace(/\n{3,}/g, "\n\n")
+  const normalized = await normalizeTripleBindings(normalizeConditionShorthand(content))
+  const tree = await parseInstructionMarkdown(normalized, true)
+  const nodes = await composeNodes(tree.nodes, context)
+  return cleanMarkdown(await renderMarkdown({ ...tree, nodes }, { components: comarkComponents }))
 }
 
-function expandInstructionImports(
+async function parseInstructionMarkdown(content: string, bindings = false) {
+  return await parse(content, {
+    autoClose: false,
+    autoUnwrap: false,
+    plugins: bindings ? [noLinkify, binding()] : [noLinkify],
+  })
+}
+
+function cleanMarkdown(content: string): string {
+  return content.trim().replace(/\n{3,}/g, "\n\n")
+}
+
+async function expandInstructionImports(
   content: string,
   options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
   depth = 0,
-): string {
-  let fenced = false
-  return content.split(/\r?\n/).map((line) => {
-    if (/^\s*(```|~~~)/.test(line)) {
-      fenced = !fenced
-      return line
-    }
-    return fenced ? line : replaceImportsInLine(line, options, depth)
-  }).join("\n")
+): Promise<string> {
+  const tree = await parseInstructionMarkdown(content)
+  const nodes = await expandImportNodes(tree.nodes, options, depth)
+  const rendered = cleanMarkdown(await renderMarkdown({ ...tree, nodes }, { components: comarkComponents }))
+  return content.endsWith("\n") ? `${rendered}\n` : rendered
 }
 
-function replaceImportsInLine(
-  line: string,
+async function expandImportNodes(
+  nodes: ComarkNode[],
   options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
   depth: number,
-): string {
-  let rendered = ""
-  let inlineCode: string | undefined
-  for (let index = 0; index < line.length;) {
-    const char = line[index]
-    if (char === "`") {
-      const fence = line.slice(index).match(/^`+/)![0]
-      if (!inlineCode) inlineCode = fence
-      else if (fence === inlineCode) inlineCode = undefined
-      rendered += fence
-      index += fence.length
-      continue
-    }
-    if (char !== "@" || inlineCode) {
-      rendered += char
-      index += 1
-      continue
-    }
+): Promise<ComarkNode[]> {
+  return (await Promise.all(nodes.map(node => expandImportNode(node, options, depth)))).flat()
+}
 
-    const end = importTokenEnd(line, index)
-    const token = line.slice(index, end)
-    const replacement = importReplacement(token, options, depth)
-    if (replacement === undefined) {
-      rendered += token
-    }
-    else {
-      rendered += replacement
-    }
-    index = end
+async function expandImportNode(
+  node: ComarkNode,
+  options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
+  depth: number,
+): Promise<ComarkNode[]> {
+  if (typeof node === "string") {
+    return [await replaceImportsInText(node, options, depth)]
   }
-  return rendered
+  if (!isElement(node)) return [node]
+
+  const [tag, attrs, ...children] = node
+  if (tag === "code") return [node]
+  return [[tag, attrs, ...(await expandImportNodes(children, options, depth))] as ComarkElement]
 }
 
-function importTokenEnd(line: string, start: number): number {
-  let index = start
-  while (index < line.length && !/\s|[<>{}\[\]]/.test(line[index]!)) index += 1
-  return index
+async function replaceImportsInText(
+  text: string,
+  options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
+  depth: number,
+): Promise<string> {
+  let rendered = ""
+  let index = 0
+  for (const match of text.matchAll(/@[^\s<>{}\[\]]+/g)) {
+    rendered += text.slice(index, match.index)
+    const token = match[0]
+    const replacement = await importReplacement(token, options, depth)
+    rendered += replacement ?? token
+    index = match.index + token.length
+  }
+  return rendered + text.slice(index)
 }
 
-function importReplacement(
+async function importReplacement(
   token: string,
   options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
   depth: number,
-): string | undefined {
+): Promise<string | undefined> {
   if (/^@(?:https?:)?\/\//.test(token) || token.startsWith("@/")) {
     throw new Error(`[vitehub] Instruction import "${token}" must be a relative file path.`)
   }
@@ -120,105 +143,137 @@ function importReplacement(
   }
   options.seen.add(resolved.file)
   try {
-    return `${expandInstructionImports(resolved.content, { ...options, file: resolved.file }, depth + 1)}${trailing}`
+    return `${await expandInstructionImports(resolved.content, { ...options, file: resolved.file }, depth + 1)}${trailing}`
   }
   finally {
     options.seen.delete(resolved.file)
   }
 }
 
-function renderConditionals(content: string, context: Record<string, unknown>): string {
-  const lines = content.split(/\r?\n/)
-  const rendered: string[] = []
-  for (let index = 0; index < lines.length;) {
-    const line = lines[index]!
-    const directive = directiveLine(line)
-    if (directive?.kind === "if") {
-      const result = renderIfChain(lines, index, directive.expression, context)
-      rendered.push(result.content)
-      index = result.next
-      continue
+function normalizeConditionShorthand(content: string): string {
+  let fenced: string | undefined
+  return content.split(/\r?\n/).map((line) => {
+    const fence = line.match(/^\s*(```|~~~)/)?.[1]
+    if (fence) {
+      fenced = fenced ? undefined : fence
+      return line
     }
-    if (directive?.kind === "else" || directive?.kind === "else-if") {
-      throw new Error(`[vitehub] Instruction ${directive.kind} block must follow an if block.`)
-    }
-    rendered.push(line)
-    index += 1
-  }
-  return rendered.join("\n")
+    if (fenced) return line
+    return line.replace(/^(\s*::(?:if|else-if))\{([\s\S]+)\}(\s*)$/, (match, start: string, expression: string, end: string) =>
+      /^(?:if|condition)\s*=/.test(expression.trim())
+        ? match
+        : `${start}{condition=${JSON.stringify(expression.trim())}}${end}`)
+  }).join("\n")
 }
 
-function renderIfChain(
-  lines: string[],
-  start: number,
-  expression: string | undefined,
+async function normalizeTripleBindings(content: string): Promise<string> {
+  const tree = await parseInstructionMarkdown(content)
+  const nodes = replaceTextOutsideCode(tree.nodes, value =>
+    value.replace(tripleBindingPattern, (_match, path: string) => `:vitehubTriple{path=${JSON.stringify(path)}}`))
+  return await renderMarkdown({ ...tree, nodes }, { components: comarkComponents })
+}
+
+function replaceTextOutsideCode(nodes: ComarkNode[], replace: (value: string) => string): ComarkNode[] {
+  return nodes.map((node) => {
+    if (typeof node === "string") return replace(node)
+    if (!isElement(node)) return node
+    const [tag, attrs, ...children] = node
+    if (tag === "code") return node
+    return [tag, attrs, ...replaceTextOutsideCode(children, replace)] as ComarkElement
+  })
+}
+
+async function composeNodes(
+  nodes: ComarkNode[],
   context: Record<string, unknown>,
-): { content: string, next: number } {
-  const branches: Array<{ expression?: string, lines: string[] }> = [{ expression, lines: [] }]
-  let depth = 0
-  let sawElse = false
+  parent?: string,
+): Promise<ComarkNode[]> {
+  return (await Promise.all(nodes.map(node => composeNode(node, context, parent)))).flat()
+}
 
-  for (let index = start + 1; index < lines.length; index += 1) {
-    const line = lines[index]!
-    const directive = directiveLine(line)
+async function composeNode(
+  node: ComarkNode,
+  context: Record<string, unknown>,
+  parent?: string,
+): Promise<ComarkNode[]> {
+  if (typeof node === "string" || !isElement(node)) return [node]
+  const [tag, attrs, ...children] = node
 
-    if (directive?.kind === "if") {
-      depth += 1
-      branches.at(-1)!.lines.push(line)
-      continue
-    }
-    if (isDirectiveClose(line)) {
-      if (depth > 0) {
-        depth -= 1
-        branches.at(-1)!.lines.push(line)
-        continue
-      }
-      const selected = branches.find(branch =>
-        branch.expression === undefined || evaluateCondition(branch.expression, context))
-      return {
-        content: selected ? renderConditionals(selected.lines.join("\n"), context) : "",
-        next: index + 1,
-      }
-    }
-    if (depth === 0 && directive?.kind === "else-if") {
-      if (sawElse) throw new Error("[vitehub] Instruction else-if block cannot follow else.")
-      branches.push({ expression: directive.expression, lines: [] })
-      continue
-    }
-    if (depth === 0 && directive?.kind === "else") {
-      if (sawElse) throw new Error("[vitehub] Instruction if chain cannot contain more than one else block.")
-      sawElse = true
-      branches.push({ lines: [] })
-      continue
-    }
-    branches.at(-1)!.lines.push(line)
+  if (tag === "if") return await composeIfNode(node, context)
+  if (tag === "else" || tag === "else-if") {
+    throw new Error(`[vitehub] Instruction ${tag} block must follow an if block.`)
   }
-
-  throw new Error("[vitehub] Instruction if block is missing a closing :: line.")
-}
-
-function directiveLine(line: string): { expression?: string, kind: "else" | "else-if" | "if" } | undefined {
-  const match = line.match(/^\s*::(if|else-if|else)(?:\{(.+)\})?\s*$/)
-  if (!match) return
-  const kind = match[1] as "else" | "else-if" | "if"
-  if (kind === "else") {
-    if (match[2]?.trim()) throw new Error("[vitehub] Instruction else block does not accept a condition.")
-    return { kind }
+  if (tag === "binding") return [renderBinding(attrs, context)]
+  if (tag === "vitehubTriple" || tag === "vitehub-triple") {
+    return await renderTripleBinding(attrs, context, parent)
   }
-  const expression = conditionExpression(match[2])
-  if (!expression) throw new Error(`[vitehub] Instruction ${kind} block requires a condition.`)
-  return { expression, kind }
+  if (tag === "code") return [node]
+  return [[tag, attrs, ...(await composeNodes(children, context, tag))] as ComarkElement]
 }
 
-function isDirectiveClose(line: string): boolean {
-  return /^\s*::\s*$/.test(line)
+function renderBinding(attrs: Record<string, unknown>, context: Record<string, unknown>): ComarkNode {
+  const path = attrs[":value"]
+  if (typeof path !== "string" || !path.startsWith("context.")) return ["binding", attrs]
+  const value = contextPathValue(context, path)
+  if (value === null || value === undefined) return ""
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value)
+  throw new TypeError(`[vitehub] Instruction binding "{{ ${path} }}" must resolve to a scalar value.`)
 }
 
-function conditionExpression(raw: string | undefined): string | undefined {
-  const value = raw?.trim()
-  if (!value) return
-  const attr = value.match(/^(?:if|condition)\s*=\s*(["'])([\s\S]*)\1$/)
-  return (attr ? attr[2] : value).trim()
+async function renderTripleBinding(
+  attrs: Record<string, unknown>,
+  context: Record<string, unknown>,
+  parent?: string,
+): Promise<ComarkNode[]> {
+  const path = attrs.path
+  if (typeof path !== "string" || !path.startsWith("context.")) return []
+  const value = contextPathValue(context, path)
+  if (value === null || value === undefined) return []
+  if (typeof value !== "string") {
+    throw new TypeError(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" must resolve to a string.`)
+  }
+  if (parent === "p") return [value]
+  return (await parseInstructionMarkdown(value)).nodes
+}
+
+async function composeIfNode(node: ComarkElement, context: Record<string, unknown>): Promise<ComarkNode[]> {
+  const { after, branches } = conditionalBranches(node)
+  const selected = branches.find(branch =>
+    branch.expression === undefined || evaluateCondition(branch.expression, context))
+  return [
+    ...(selected ? await composeNodes(selected.nodes, context) : []),
+    ...await composeNodes(after, context),
+  ]
+}
+
+function conditionalBranches(node: ComarkElement): { after: ComarkNode[], branches: Array<{ expression?: string, nodes: ComarkNode[] }> } {
+  const branches: Array<{ expression?: string, nodes: ComarkNode[] }> = []
+  let current: ComarkElement | undefined = node
+  const after: ComarkNode[] = []
+  while (current) {
+    const [tag, attrs, ...children] = current
+    const expression = tag === "else" ? undefined : conditionExpressionFromAttrs(attrs, tag)
+    const nextIndex = children.findIndex(child => isElement(child) && (child[0] === "else-if" || child[0] === "else"))
+    branches.push({
+      expression,
+      nodes: nextIndex === -1 ? children : children.slice(0, nextIndex),
+    })
+    if (nextIndex !== -1) after.push(...children.slice(nextIndex + 1))
+    current = nextIndex === -1 ? undefined : children[nextIndex] as ComarkElement
+  }
+  return { after, branches }
+}
+
+function isElement(node: ComarkNode): node is ComarkElement {
+  return Array.isArray(node) && typeof node[0] === "string"
+}
+
+function conditionExpressionFromAttrs(attrs: Record<string, unknown>, kind: string): string {
+  const expression = attrs.condition ?? attrs.if
+  if (typeof expression !== "string" || !expression.trim()) {
+    throw new Error(`[vitehub] Instruction ${kind} block requires a condition.`)
+  }
+  return expression.trim()
 }
 
 function evaluateCondition(expression: string, context: Record<string, unknown>): boolean {
@@ -361,22 +416,4 @@ function nestedPathValue(value: unknown, segments: string[]): unknown {
     current = (current as Record<string, unknown>)[segment]
   }
   return current
-}
-
-function renderContextBindings(content: string, context: Record<string, unknown>): string {
-  return content
-    .replace(tripleBindingPattern, (_match, path: string) => {
-      const value = contextPathValue(context, path)
-      if (value === null || value === undefined) return ""
-      if (typeof value !== "string") {
-        throw new TypeError(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" must resolve to a string.`)
-      }
-      return value
-    })
-    .replace(scalarBindingPattern, (_match, path: string) => {
-      const value = contextPathValue(context, path)
-      if (value === null || value === undefined) return ""
-      if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value)
-      throw new TypeError(`[vitehub] Instruction binding "{{ ${path} }}" must resolve to a scalar value.`)
-    })
 }

--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -83,7 +83,11 @@ async function expandImportNodes(
   options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
   depth: number,
 ): Promise<ComarkNode[]> {
-  return (await Promise.all(nodes.map(node => expandImportNode(node, options, depth)))).flat()
+  const expanded: ComarkNode[] = []
+  for (const node of nodes) {
+    expanded.push(...await expandImportNode(node, options, depth))
+  }
+  return expanded
 }
 
 async function expandImportNode(
@@ -143,7 +147,7 @@ async function importReplacement(
   }
   options.seen.add(resolved.file)
   try {
-    return `${await expandInstructionImports(resolved.content, { ...options, file: resolved.file }, depth + 1)}${trailing}`
+    return `${await expandInstructionImports(normalizeConditionShorthand(resolved.content), { ...options, file: resolved.file }, depth + 1)}${trailing}`
   }
   finally {
     options.seen.delete(resolved.file)
@@ -252,6 +256,9 @@ function conditionalBranches(node: ComarkElement): { after: ComarkNode[], branch
   const after: ComarkNode[] = []
   while (current) {
     const [tag, attrs, ...children] = current
+    if (tag === "else" && Object.keys(attrs).length) {
+      throw new Error("[vitehub] Instruction else block does not accept a condition.")
+    }
     const expression = tag === "else" ? undefined : conditionExpressionFromAttrs(attrs, tag)
     const nextIndex = children.findIndex(child => isElement(child) && (child[0] === "else-if" || child[0] === "else"))
     branches.push({

--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -26,10 +26,16 @@ type ComarkElementAttributes = Record<string, unknown>
 type ComarkElement = [string, ComarkElementAttributes, ...ComarkNode[]]
 type ComarkComment = [null, ComarkElementAttributes, string]
 type ComarkNode = ComarkComment | ComarkElement | string
+interface ComposeInstructionState {
+  context: Record<string, unknown>
+  tripleBindings: string[]
+}
 
 const defaultImportDepth = 4
 const contextPathPattern = /context(?:\.[A-Za-z_$][\w$-]*)+/
 const tripleBindingPattern = /\{\{\{\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}\}/g
+const tripleBindingPlaceholderPattern = /%%VITEHUB_TRIPLE_BINDING_(\d+)%%/g
+const scalarBindingPattern = /\{\{(?!\{)\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}/g
 const comarkComponents = { Binding }
 const noLinkify = {
   markdownItPlugins: [(md: { disable: (rule: string) => unknown, set: (options: Record<string, unknown>) => unknown }) => {
@@ -49,16 +55,26 @@ export async function resolveInstructionImports(content: string, options: Resolv
 
 export async function composeInstructionDocument(content: string, options: ComposeInstructionDocumentOptions = {}): Promise<string> {
   const context = options.context || {}
-  const normalized = await normalizeTripleBindings(normalizeConditionShorthand(content))
-  const tree = await parseInstructionMarkdown(normalized, true)
-  const nodes = await composeNodes(tree.nodes, context)
+  const shorthand = normalizeConditionShorthand(content)
+  validateConditionalDirectives(shorthand)
+  const normalized = await normalizeTripleBindings(shorthand)
+  const tree = await parseInstructionMarkdown(normalized.content, true)
+  const nodes = await composeNodes(tree.nodes, { context, tripleBindings: normalized.tripleBindings })
   return cleanMarkdown(await renderMarkdown({ ...tree, nodes }, { components: comarkComponents }))
+}
+
+export function composeStaticInstructionDocument(content: string, options: ComposeInstructionDocumentOptions = {}): string {
+  const context = options.context || {}
+  const normalized = normalizeConditionShorthand(content)
+  validateConditionalDirectives(normalized)
+  return renderStaticContextBindings(renderStaticConditionals(normalized, context), context).trim().replace(/\n{3,}/g, "\n\n")
 }
 
 async function parseInstructionMarkdown(content: string, bindings = false) {
   return await parse(content, {
     autoClose: false,
     autoUnwrap: false,
+    html: false,
     plugins: bindings ? [noLinkify, binding()] : [noLinkify],
   })
 }
@@ -170,11 +186,18 @@ function normalizeConditionShorthand(content: string): string {
   }).join("\n")
 }
 
-async function normalizeTripleBindings(content: string): Promise<string> {
+async function normalizeTripleBindings(content: string): Promise<{ content: string, tripleBindings: string[] }> {
+  const tripleBindings: string[] = []
   const tree = await parseInstructionMarkdown(content)
   const nodes = replaceTextOutsideCode(tree.nodes, value =>
-    value.replace(tripleBindingPattern, (_match, path: string) => `:vitehubTriple{path=${JSON.stringify(path)}}`))
-  return await renderMarkdown({ ...tree, nodes }, { components: comarkComponents })
+    value.replace(tripleBindingPattern, (_match, path: string) => {
+      const index = tripleBindings.push(path) - 1
+      return `%%VITEHUB_TRIPLE_BINDING_${index}%%`
+    }))
+  return {
+    content: await renderMarkdown({ ...tree, nodes }, { components: comarkComponents }),
+    tripleBindings,
+  }
 }
 
 function replaceTextOutsideCode(nodes: ComarkNode[], replace: (value: string) => string): ComarkNode[] {
@@ -189,30 +212,48 @@ function replaceTextOutsideCode(nodes: ComarkNode[], replace: (value: string) =>
 
 async function composeNodes(
   nodes: ComarkNode[],
-  context: Record<string, unknown>,
+  state: ComposeInstructionState,
   parent?: string,
 ): Promise<ComarkNode[]> {
-  return (await Promise.all(nodes.map(node => composeNode(node, context, parent)))).flat()
+  return (await Promise.all(nodes.map(node => composeNode(node, state, parent)))).flat()
 }
 
 async function composeNode(
   node: ComarkNode,
-  context: Record<string, unknown>,
+  state: ComposeInstructionState,
   parent?: string,
 ): Promise<ComarkNode[]> {
-  if (typeof node === "string" || !isElement(node)) return [node]
+  if (typeof node === "string") return await composeTextNode(node, state, parent)
+  if (!isElement(node)) return [node]
   const [tag, attrs, ...children] = node
 
-  if (tag === "if") return await composeIfNode(node, context)
+  if (tag === "if") return await composeIfNode(node, state)
   if (tag === "else" || tag === "else-if") {
     throw new Error(`[vitehub] Instruction ${tag} block must follow an if block.`)
   }
-  if (tag === "binding") return [renderBinding(attrs, context)]
+  if (tag === "binding") return [renderBinding(attrs, state.context)]
   if (tag === "vitehubTriple" || tag === "vitehub-triple") {
-    return await renderTripleBinding(attrs, context, parent)
+    return await renderTripleBinding(attrs, state.context, parent)
   }
   if (tag === "code") return [node]
-  return [[tag, attrs, ...(await composeNodes(children, context, tag))] as ComarkElement]
+  return [[tag, attrs, ...(await composeNodes(children, state, tag))] as ComarkElement]
+}
+
+async function composeTextNode(
+  value: string,
+  state: ComposeInstructionState,
+  parent?: string,
+): Promise<ComarkNode[]> {
+  const nodes: ComarkNode[] = []
+  let index = 0
+  for (const match of value.matchAll(tripleBindingPlaceholderPattern)) {
+    nodes.push(value.slice(index, match.index))
+    const path = state.tripleBindings[Number(match[1])]
+    nodes.push(...(path ? await renderTripleBindingPath(path, state.context, parent) : [match[0]]))
+    index = match.index + match[0].length
+  }
+  nodes.push(value.slice(index))
+  return nodes.filter(node => node !== "")
 }
 
 function renderBinding(attrs: Record<string, unknown>, context: Record<string, unknown>): ComarkNode {
@@ -231,6 +272,14 @@ async function renderTripleBinding(
 ): Promise<ComarkNode[]> {
   const path = attrs.path
   if (typeof path !== "string" || !path.startsWith("context.")) return []
+  return await renderTripleBindingPath(path, context, parent)
+}
+
+async function renderTripleBindingPath(
+  path: string,
+  context: Record<string, unknown>,
+  parent?: string,
+): Promise<ComarkNode[]> {
   const value = contextPathValue(context, path)
   if (value === null || value === undefined) return []
   if (typeof value !== "string") {
@@ -240,13 +289,13 @@ async function renderTripleBinding(
   return (await parseInstructionMarkdown(value)).nodes
 }
 
-async function composeIfNode(node: ComarkElement, context: Record<string, unknown>): Promise<ComarkNode[]> {
+async function composeIfNode(node: ComarkElement, state: ComposeInstructionState): Promise<ComarkNode[]> {
   const { after, branches } = conditionalBranches(node)
   const selected = branches.find(branch =>
-    branch.expression === undefined || evaluateCondition(branch.expression, context))
+    branch.expression === undefined || evaluateCondition(branch.expression, state.context))
   return [
-    ...(selected ? await composeNodes(selected.nodes, context) : []),
-    ...await composeNodes(after, context),
+    ...(selected ? await composeNodes(selected.nodes, state) : []),
+    ...await composeNodes(after, state),
   ]
 }
 
@@ -261,6 +310,9 @@ function conditionalBranches(node: ComarkElement): { after: ComarkNode[], branch
     }
     const expression = tag === "else" ? undefined : conditionExpressionFromAttrs(attrs, tag)
     const nextIndex = children.findIndex(child => isElement(child) && (child[0] === "else-if" || child[0] === "else"))
+    if (tag === "else" && nextIndex !== -1) {
+      throw new Error("[vitehub] Instruction else block cannot be followed by another branch.")
+    }
     branches.push({
       expression,
       nodes: nextIndex === -1 ? children : children.slice(0, nextIndex),
@@ -281,6 +333,141 @@ function conditionExpressionFromAttrs(attrs: Record<string, unknown>, kind: stri
     throw new Error(`[vitehub] Instruction ${kind} block requires a condition.`)
   }
   return expression.trim()
+}
+
+function validateConditionalDirectives(content: string): void {
+  const stack: Array<{ sawElse: boolean }> = []
+  let fenced: string | undefined
+
+  for (const line of content.split(/\r?\n/)) {
+    const fence = line.match(/^\s*(```|~~~)/)?.[1]
+    if (fence) {
+      fenced = fenced === fence ? undefined : fence
+      continue
+    }
+    if (fenced) continue
+    if (/^\s*::\s*$/.test(line)) {
+      stack.pop()
+      continue
+    }
+
+    const directive = directiveLine(line)
+    if (!directive) continue
+    if (directive.kind === "if") {
+      stack.push({ sawElse: false })
+      continue
+    }
+
+    const current = stack.at(-1)
+    if (!current) {
+      throw new Error(`[vitehub] Instruction ${directive.kind} block must follow an if block.`)
+    }
+    if (directive.kind === "else-if") {
+      if (current.sawElse) throw new Error("[vitehub] Instruction else-if block cannot follow else.")
+      continue
+    }
+    if (directive.raw?.trim()) {
+      throw new Error("[vitehub] Instruction else block does not accept a condition.")
+    }
+    if (current.sawElse) throw new Error("[vitehub] Instruction if chain cannot contain more than one else block.")
+    current.sawElse = true
+  }
+
+  if (stack.length) throw new Error("[vitehub] Instruction if block is missing a closing :: line.")
+}
+
+function renderStaticConditionals(content: string, context: Record<string, unknown>): string {
+  const lines = content.split(/\r?\n/)
+  const rendered: string[] = []
+  for (let index = 0; index < lines.length;) {
+    const line = lines[index]!
+    const directive = directiveLine(line)
+    if (directive?.kind === "if") {
+      const result = renderStaticIfChain(lines, index, directive.expression, context)
+      rendered.push(result.content)
+      index = result.next
+      continue
+    }
+    if (directive?.kind === "else" || directive?.kind === "else-if") {
+      throw new Error(`[vitehub] Instruction ${directive.kind} block must follow an if block.`)
+    }
+    rendered.push(line)
+    index += 1
+  }
+  return rendered.join("\n")
+}
+
+function renderStaticIfChain(
+  lines: string[],
+  start: number,
+  expression: string | undefined,
+  context: Record<string, unknown>,
+): { content: string, next: number } {
+  const branches: Array<{ expression?: string, lines: string[] }> = [{ expression, lines: [] }]
+  let depth = 0
+  let sawElse = false
+
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index]!
+    const directive = directiveLine(line)
+
+    if (directive?.kind === "if") {
+      depth += 1
+      branches.at(-1)!.lines.push(line)
+      continue
+    }
+    if (isDirectiveClose(line)) {
+      if (depth > 0) {
+        depth -= 1
+        branches.at(-1)!.lines.push(line)
+        continue
+      }
+      const selected = branches.find(branch =>
+        branch.expression === undefined || evaluateCondition(branch.expression, context))
+      return {
+        content: selected ? renderStaticConditionals(selected.lines.join("\n"), context) : "",
+        next: index + 1,
+      }
+    }
+    if (depth === 0 && directive?.kind === "else-if") {
+      if (sawElse) throw new Error("[vitehub] Instruction else-if block cannot follow else.")
+      branches.push({ expression: directive.expression, lines: [] })
+      continue
+    }
+    if (depth === 0 && directive?.kind === "else") {
+      if (sawElse) throw new Error("[vitehub] Instruction if chain cannot contain more than one else block.")
+      sawElse = true
+      branches.push({ lines: [] })
+      continue
+    }
+    branches.at(-1)!.lines.push(line)
+  }
+
+  throw new Error("[vitehub] Instruction if block is missing a closing :: line.")
+}
+
+function directiveLine(line: string): { expression?: string, kind: "else" | "else-if" | "if", raw?: string } | undefined {
+  const match = line.match(/^\s*::(if|else-if|else)(?:\{(.+)\})?\s*$/)
+  if (!match) return
+  const kind = match[1] as "else" | "else-if" | "if"
+  if (kind === "else") {
+    if (match[2]?.trim()) throw new Error("[vitehub] Instruction else block does not accept a condition.")
+    return { kind, raw: match[2] }
+  }
+  const expression = conditionExpression(match[2])
+  if (!expression) throw new Error(`[vitehub] Instruction ${kind} block requires a condition.`)
+  return { expression, kind, raw: match[2] }
+}
+
+function isDirectiveClose(line: string): boolean {
+  return /^\s*::\s*$/.test(line)
+}
+
+function conditionExpression(raw: string | undefined): string | undefined {
+  const value = raw?.trim()
+  if (!value) return
+  const attr = value.match(/^(?:if|condition)\s*=\s*(["'])([\s\S]*)\1$/)
+  return (attr ? attr[2] : value).trim()
 }
 
 function evaluateCondition(expression: string, context: Record<string, unknown>): boolean {
@@ -423,4 +610,22 @@ function nestedPathValue(value: unknown, segments: string[]): unknown {
     current = (current as Record<string, unknown>)[segment]
   }
   return current
+}
+
+function renderStaticContextBindings(content: string, context: Record<string, unknown>): string {
+  return content
+    .replace(tripleBindingPattern, (_match, path: string) => {
+      const value = contextPathValue(context, path)
+      if (value === null || value === undefined) return ""
+      if (typeof value !== "string") {
+        throw new TypeError(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" must resolve to a string.`)
+      }
+      return value
+    })
+    .replace(scalarBindingPattern, (_match, path: string) => {
+      const value = contextPathValue(context, path)
+      if (value === null || value === undefined) return ""
+      if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value)
+      throw new TypeError(`[vitehub] Instruction binding "{{ ${path} }}" must resolve to a scalar value.`)
+    })
 }

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -242,10 +242,10 @@ function resolveWorkspaceSourceRoot(file: string): string {
     : dirname(file)
 }
 
-function readColocatedAgentInstructions(handler: string): string | undefined {
+async function readColocatedAgentInstructions(handler: string): Promise<string | undefined> {
   const file = join(dirname(handler), "instructions.md")
   if (!existsSync(file) || !statSync(file).isFile()) return
-  return resolveInstructionImports(readFileSync(file, "utf8"), {
+  return await resolveInstructionImports(readFileSync(file, "utf8"), {
     file,
     read(specifier, importer) {
       const imported = resolve(dirname(importer), specifier)
@@ -313,31 +313,32 @@ function generatedNetlifyRuntimeHelpers(): string[] {
   ]
 }
 
-function generateAgentWebhookRouteHandler(
+async function generateAgentWebhookRouteHandler(
   definitions: DiscoveredAgentDefinition[],
   handlerPath: string,
   options: { chatRoute?: false | string, cloudflareState?: boolean, webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
-): string {
+): Promise<string> {
   const agentImportBase = options.agentImportBase ?? agentPackageName
   const workspaceImportBase = options.workspaceImportBase ?? workspacePackageName
   const imports = definitions
     .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
     .join("\n")
-  const workspaceEntries = definitions
-    .map((definition, index) => {
+  const workspaceEntries = (await Promise.all(definitions
+    .map(async (definition, index) => {
       const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
       return definition.workspace
-        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
+        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
         : undefined
-    })
+    })))
     .filter(Boolean)
     .join(",\n  ")
   const agentEntries = definitions
-    .map((definition, index) => {
+    .map(async (definition, index) => {
       const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      const agentExpression = `withAgentDefaults(withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(readColocatedAgentInstructions(definition.handler))}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
+      const agentExpression = `withAgentDefaults(withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
       return `${JSON.stringify(definition.name)}: ${agentExpression}`
     })
+  const resolvedAgentEntries = (await Promise.all(agentEntries))
     .join(",\n  ")
   const agentModuleEntries = definitions
     .map((definition, index) => `${JSON.stringify(definition.name)}: agent${index}`)
@@ -399,7 +400,7 @@ function generateAgentWebhookRouteHandler(
     "",
     `setWorkspaceRuntimeRegistry(Object.fromEntries([${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}].filter(Boolean)))`,
     "",
-    `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
+    `const agents = {${resolvedAgentEntries ? `\n  ${resolvedAgentEntries}\n` : ""}}`,
     `const agentModules = {${agentModuleEntries ? `\n  ${agentModuleEntries}\n` : ""}}`,
     "const chatHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, createChannelChatRouteHandler(agent, resolveChatRouteOptions(agentModules[name]))]))",
     "const webhookHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, createChannelWebhookRouteHandler(agent)]))",
@@ -425,30 +426,30 @@ function generateAgentWebhookRouteHandler(
   ].join("\n")
 }
 
-function generateAgentNetlifyFunctionRouteHandler(
+async function generateAgentNetlifyFunctionRouteHandler(
   definitions: DiscoveredAgentDefinition[],
   handlerPath: string,
   options: { chatRoute?: false | string, webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
-): string {
+): Promise<string> {
   const agentImportBase = options.agentImportBase ?? agentPackageName
   const imports = definitions
     .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
     .join("\n")
-  const workspaceEntries = definitions
-    .map((definition, index) => {
+  const workspaceEntries = (await Promise.all(definitions
+    .map(async (definition, index) => {
       const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
       return definition.workspace
-        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
+        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
         : undefined
-    })
+    })))
     .filter(Boolean)
     .join(",\n  ")
-  const agentEntries = definitions
-    .map((definition, index) => {
+  const agentEntries = (await Promise.all(definitions
+    .map(async (definition, index) => {
       const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      const agentExpression = `withAgentDefaults(withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(readColocatedAgentInstructions(definition.handler))}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
+      const agentExpression = `withAgentDefaults(withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
       return `${JSON.stringify(definition.name)}: ${agentExpression}`
-    })
+    })))
     .join(",\n  ")
   const agentModuleEntries = definitions
     .map((definition, index) => `${JSON.stringify(definition.name)}: agent${index}`)
@@ -528,34 +529,34 @@ async function writeAgentWebhookRouteHandler(
     scanDirs: [join(root, "server")],
   })
   await mkdir(dirname(handlerPath), { recursive: true })
-  await writeFile(handlerPath, generateAgentWebhookRouteHandler(definitions, handlerPath, options), "utf8")
+  await writeFile(handlerPath, await generateAgentWebhookRouteHandler(definitions, handlerPath, options), "utf8")
 }
 
-function generateAgentDenoServer(
+async function generateAgentDenoServer(
   definitions: DiscoveredAgentDefinition[],
   handlerPath: string,
   options: { chatRoute?: false | string, webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
-): string {
+): Promise<string> {
   const agentImportBase = options.agentImportBase ?? agentPackageName
   const workspaceImportBase = options.workspaceImportBase ?? workspacePackageName
   const imports = definitions
     .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
     .join("\n")
-  const workspaceEntries = definitions
-    .map((definition, index) => {
+  const workspaceEntries = (await Promise.all(definitions
+    .map(async (definition, index) => {
       const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
       return definition.workspace
-        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
+        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
         : undefined
-    })
+    })))
     .filter(Boolean)
     .join(",\n  ")
-  const agentEntries = definitions
-    .map((definition, index) => {
+  const agentEntries = (await Promise.all(definitions
+    .map(async (definition, index) => {
       const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      const agentExpression = `withAgentDefaults(withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(readColocatedAgentInstructions(definition.handler))}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
+      const agentExpression = `withAgentDefaults(withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}), ${JSON.stringify({ inferredName: definition.name, workspace: definition.workspace })})`
       return `${JSON.stringify(definition.name)}: ${agentExpression}`
-    })
+    })))
     .join(",\n  ")
   const agentModuleEntries = definitions
     .map((definition, index) => `${JSON.stringify(definition.name)}: agent${index}`)
@@ -682,7 +683,7 @@ async function writeAgentDenoServer(
     scanDirs: [join(root, "server")],
   })
   await mkdir(dirname(handlerPath), { recursive: true })
-  await writeFile(handlerPath, generateAgentDenoServer(definitions, handlerPath, options), "utf8")
+  await writeFile(handlerPath, await generateAgentDenoServer(definitions, handlerPath, options), "utf8")
 }
 
 async function writeAgentNetlifyFunctionRouteHandler(
@@ -695,7 +696,7 @@ async function writeAgentNetlifyFunctionRouteHandler(
     scanDirs: [join(root, "server")],
   })
   await mkdir(dirname(handlerPath), { recursive: true })
-  await writeFile(handlerPath, generateAgentNetlifyFunctionRouteHandler(definitions, handlerPath, options), "utf8")
+  await writeFile(handlerPath, await generateAgentNetlifyFunctionRouteHandler(definitions, handlerPath, options), "utf8")
   return handlerPath
 }
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -13,6 +13,7 @@ import {
 } from "./invoker.ts"
 import {
   composeInstructionDocument,
+  composeStaticInstructionDocument,
   resolveInstructionImports,
 } from "./instruction-composition.ts"
 import { normalizeAgentDriver } from "./internal/agent-driver.ts"
@@ -893,7 +894,7 @@ function workspaceMetadataInstructions<
     )],
     renderWorkspaceSourceInstructionBlock(workspaceDefinitionFromOptions(options).sources),
   )
-  const composed = cleanInstructions(renderedInstructions.join("\n\n"))
+  const composed = composeStaticInstructionDocument(renderedInstructions.join("\n\n"))
   return composed ? [composed] : []
 }
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -646,15 +646,19 @@ function resolveInstructionImportFromFile(specifier: string, importer: string): 
   }
 }
 
-function resolveInstructionDocumentImports(content: string, file: string): string {
-  return resolveInstructionImports(content, {
+async function resolveInstructionDocumentImports(content: string, file: string): Promise<string> {
+  return await resolveInstructionImports(content, {
     file,
     read: resolveInstructionImportFromFile,
   })
 }
 
-function composeInstructions(content: string, context?: AgentInvocationContextStore): string {
-  return composeInstructionDocument(content, { context: context?.toJSON() })
+async function composeInstructions(content: string, context?: AgentInvocationContextStore): Promise<string> {
+  return await composeInstructionDocument(content, { context: context?.toJSON() })
+}
+
+function cleanInstructions(content: string): string {
+  return content.trim().replace(/\n{3,}/g, "\n\n")
 }
 
 function localWorkspaceRoots<
@@ -869,7 +873,7 @@ function workspaceMetadataInstructions<
 ): string[] {
   const configuredInstructions = modelDriverInstructions(options)
   const defaultInstructions = shouldUseColocatedAgentInstructions(options)
-    ? readColocatedAgentInstructions(options)
+    ? readColocatedAgentInstructionsRaw(options)
     : undefined
   const parts = Array.isArray(configuredInstructions) ? configuredInstructions : [configuredInstructions]
   const instructions = parts.flatMap((part) => {
@@ -889,7 +893,7 @@ function workspaceMetadataInstructions<
     )],
     renderWorkspaceSourceInstructionBlock(workspaceDefinitionFromOptions(options).sources),
   )
-  const composed = composeInstructions(renderedInstructions.join("\n\n"))
+  const composed = cleanInstructions(renderedInstructions.join("\n\n"))
   return composed ? [composed] : []
 }
 
@@ -910,7 +914,7 @@ function readLocalWorkspaceInstructions<
   }
 }
 
-function readColocatedAgentInstructions<
+function readColocatedAgentInstructionsRaw<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
 >(options: WorkspaceAgentOptions<TRuntimeConfig, Name>): string | undefined {
@@ -919,7 +923,20 @@ function readColocatedAgentInstructions<
   const sourceRootDir = workspaceDefinitionFromOptions(options).sourceRootDir
   if (!fs || !path || !hasColocatedAgentInstructions(sourceRootDir)) return undefined
   const file = path.join(sourceRootDir!, colocatedAgentInstructionsPath)
-  const content = resolveInstructionDocumentImports(fs.readFileSync(file, "utf8"), file).trim()
+  const content = fs.readFileSync(file, "utf8").trim()
+  if (content) return content
+}
+
+async function readColocatedAgentInstructions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(options: WorkspaceAgentOptions<TRuntimeConfig, Name>): Promise<string | undefined> {
+  const fs = getNodeBuiltin<typeof import("node:fs")>("node:fs")
+  const path = getNodeBuiltin<typeof import("node:path")>("node:path")
+  const sourceRootDir = workspaceDefinitionFromOptions(options).sourceRootDir
+  if (!fs || !path || !hasColocatedAgentInstructions(sourceRootDir)) return undefined
+  const file = path.join(sourceRootDir!, colocatedAgentInstructionsPath)
+  const content = (await resolveInstructionDocumentImports(fs.readFileSync(file, "utf8"), file)).trim()
   if (content) return content
 }
 
@@ -944,7 +961,7 @@ export async function resolveWorkspaceAgentDefaultInstructions<
   const path = getNodeBuiltin<typeof import("node:path")>("node:path")
   const sourceRootDir = definition.sourceRootDir
   if (fs && path && sourceRootDir && hasColocatedAgentInstructions(sourceRootDir)) {
-    return resolveInstructionDocumentImports(content, path.join(sourceRootDir, colocatedAgentInstructionsPath))
+    return await resolveInstructionDocumentImports(content, path.join(sourceRootDir, colocatedAgentInstructionsPath))
   }
   return content
 }
@@ -981,7 +998,7 @@ async function resolveWorkspaceMetadataInstructions<
     [applyPassiveCapabilityInstructionSlots(baseInstructions.join("\n\n"), capabilityBlocks)],
     await resolveWorkspaceSourceInstructionBlock(sourceDefinition, workspace),
   )
-  const composed = composeInstructions(renderedInstructions.join("\n\n"), compositionContext)
+  const composed = await composeInstructions(renderedInstructions.join("\n\n"), compositionContext)
   return composed ? [composed] : []
 }
 

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -100,6 +100,18 @@ describe("instruction composition", () => {
     ].join("\n"))
   })
 
+  it("preserves trusted markdown bindings after punctuation", async () => {
+    expect(await composeInstructionDocument("Use ({{{ context.policy }}}).", {
+      context: { policy: "trusted policy" },
+    })).toBe("Use (trusted policy).")
+  })
+
+  it("preserves XML-style prompt tags as authored text", async () => {
+    expect(await composeInstructionDocument("<policy>Use {{ context.name }}.</policy>", {
+      context: { name: "Acme" },
+    })).toBe("<policy>Use Acme.</policy>")
+  })
+
   it("parses boolean chains without skipping the right side", async () => {
     expect(await composeInstructionDocument([
       "::if{context.enabled && context.customerName}",
@@ -184,6 +196,10 @@ describe("instruction composition", () => {
       .rejects.toThrow("must resolve to a scalar")
     await expect(composeInstructionDocument("::if{context.enabled}\nEnabled\n::else{condition=\"context.admin\"}\nFallback\n::"))
       .rejects.toThrow("else block does not accept a condition")
+    await expect(composeInstructionDocument("::if{context.enabled}\nEnabled"))
+      .rejects.toThrow("missing a closing")
+    await expect(composeInstructionDocument("::if{context.enabled}\nEnabled\n::else\nFallback\n::else-if{context.admin}\nAdmin\n::"))
+      .rejects.toThrow("else-if block cannot follow else")
     await expect(resolveInstructionImports("@https://example.com/policy.md", {
       file: "/agent/instructions.md",
       read: importReader(new Map()),

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -49,6 +49,29 @@ describe("instruction composition", () => {
     ].join("\n"))
   })
 
+  it("allows sibling imports to reuse the same file", async () => {
+    const files = new Map([["/agent/shared.md", "Shared"]])
+
+    expect(await resolveInstructionImports([
+      "@./shared.md",
+      "",
+      "@./shared.md",
+    ].join("\n"), {
+      file: "/agent/instructions.md",
+      read: importReader(files),
+    })).toBe("Shared\n\nShared")
+  })
+
+  it("normalizes shorthand conditions from imported documents", async () => {
+    const files = new Map([["/agent/policy.md", "::if{context.enabled}\nEnabled\n::"]])
+    const imported = await resolveInstructionImports("@./policy.md", {
+      file: "/agent/instructions.md",
+      read: importReader(files),
+    })
+
+    expect(await composeInstructionDocument(imported, { context: { enabled: true } })).toBe("Enabled")
+  })
+
   it("renders condition chains and context bindings without executing JavaScript", async () => {
     const document = [
       "Hello {{ context.customerName }}.",
@@ -159,6 +182,8 @@ describe("instruction composition", () => {
       .rejects.toThrow("Unsafe instruction condition")
     await expect(composeInstructionDocument("{{ context.customer }}", { context: { customer: { name: "Acme" } } }))
       .rejects.toThrow("must resolve to a scalar")
+    await expect(composeInstructionDocument("::if{context.enabled}\nEnabled\n::else{condition=\"context.admin\"}\nFallback\n::"))
+      .rejects.toThrow("else block does not accept a condition")
     await expect(resolveInstructionImports("@https://example.com/policy.md", {
       file: "/agent/instructions.md",
       read: importReader(new Map()),

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -19,13 +19,13 @@ function importReader(files: Map<string, string>) {
 }
 
 describe("instruction composition", () => {
-  it("expands relative markdown imports outside code spans and fences", () => {
+  it("expands relative markdown imports outside code spans and fences", async () => {
     const files = new Map([
       ["/agent/nested.md", "Nested\n@./policy.md"],
       ["/agent/policy.md", "Policy"],
     ])
 
-    expect(resolveInstructionImports([
+    expect(await resolveInstructionImports([
       "Base",
       "@./nested.md",
       "`@./ignored.md`",
@@ -41,14 +41,15 @@ describe("instruction composition", () => {
       "Nested",
       "Policy",
       "`@./ignored.md`",
-      "``@./ignored.md``",
+      "`@./ignored.md`",
+      "",
       "```",
       "@./ignored.md",
       "```",
     ].join("\n"))
   })
 
-  it("renders condition chains and context bindings without executing JavaScript", () => {
+  it("renders condition chains and context bindings without executing JavaScript", async () => {
     const document = [
       "Hello {{ context.customerName }}.",
       "{{{ context.supportPolicy }}}",
@@ -61,7 +62,7 @@ describe("instruction composition", () => {
       "::",
     ].join("\n")
 
-    expect(composeInstructionDocument(document, {
+    expect(await composeInstructionDocument(document, {
       context: {
         audience: "technical",
         customerName: "Acme",
@@ -71,12 +72,13 @@ describe("instruction composition", () => {
       "Hello Acme.",
       "## Policy",
       "Use trusted policy.",
+      "",
       "Use technical detail.",
     ].join("\n"))
   })
 
-  it("parses boolean chains without skipping the right side", () => {
-    expect(composeInstructionDocument([
+  it("parses boolean chains without skipping the right side", async () => {
+    expect(await composeInstructionDocument([
       "::if{context.enabled && context.customerName}",
       "Enabled.",
       "::else",
@@ -84,7 +86,7 @@ describe("instruction composition", () => {
       "::",
     ].join("\n"), { context: { customerName: "Acme", enabled: false } })).toBe("Disabled.")
 
-    expect(composeInstructionDocument([
+    expect(await composeInstructionDocument([
       "::if{context.enabled || context.customerName}",
       "Enabled.",
       "::else",
@@ -93,8 +95,8 @@ describe("instruction composition", () => {
     ].join("\n"), { context: { customerName: "Acme", enabled: true } })).toBe("Enabled.")
   })
 
-  it("reads stable context ids with hyphens and dotted names", () => {
-    expect(composeInstructionDocument([
+  it("reads stable context ids with hyphens and dotted names", async () => {
+    expect(await composeInstructionDocument([
       "{{ context.llm-route.choice }}",
       "{{ context.support.customer.name }}",
     ].join("\n"), {
@@ -105,7 +107,34 @@ describe("instruction composition", () => {
     })).toBe("fast\nAcme")
   })
 
-  it("renders conditionals before consuming capability and source instruction slots", () => {
+  it("does not render bindings or directives inside code spans and fences", async () => {
+    expect(await composeInstructionDocument([
+      "Hello {{ context.name }}.",
+      "`{{ context.name }}`",
+      "`::if{context.enabled}`",
+      "```md",
+      "{{ context.name }}",
+      "::if{context.enabled}",
+      "Hidden",
+      "::",
+      "```",
+    ].join("\n"), {
+      context: { enabled: false, name: "Acme" },
+    })).toBe([
+      "Hello Acme.",
+      "`{{ context.name }}`",
+      "`::if{context.enabled}`",
+      "",
+      "```md",
+      "{{ context.name }}",
+      "::if{context.enabled}",
+      "Hidden",
+      "::",
+      "```",
+    ].join("\n"))
+  })
+
+  it("renders conditionals before consuming capability and source instruction slots", async () => {
     const document = [
       "::if{context.showCapability}",
       "{{ capabilities.docs }}",
@@ -114,7 +143,7 @@ describe("instruction composition", () => {
       "No capability instructions.",
       "::",
     ].join("\n")
-    const baseInstructions = composeInstructionDocument(document, {
+    const baseInstructions = await composeInstructionDocument(document, {
       context: { showCapability: false },
     })
 
@@ -125,18 +154,18 @@ describe("instruction composition", () => {
       .toBe("No capability instructions.\n\nUse docs source.")
   })
 
-  it("rejects unsafe expressions and non-scalar double bindings", () => {
-    expect(() => composeInstructionDocument("::if{process.exit()}\nNo\n::"))
-      .toThrow("Unsafe instruction condition")
-    expect(() => composeInstructionDocument("{{ context.customer }}", { context: { customer: { name: "Acme" } } }))
-      .toThrow("must resolve to a scalar")
-    expect(() => resolveInstructionImports("@https://example.com/policy.md", {
+  it("rejects unsafe expressions and non-scalar double bindings", async () => {
+    await expect(composeInstructionDocument("::if{process.exit()}\nNo\n::"))
+      .rejects.toThrow("Unsafe instruction condition")
+    await expect(composeInstructionDocument("{{ context.customer }}", { context: { customer: { name: "Acme" } } }))
+      .rejects.toThrow("must resolve to a scalar")
+    await expect(resolveInstructionImports("@https://example.com/policy.md", {
       file: "/agent/instructions.md",
       read: importReader(new Map()),
-    })).toThrow("must be a relative file path")
-    expect(() => resolveInstructionImports("@./*.md", {
+    })).rejects.toThrow("must be a relative file path")
+    await expect(resolveInstructionImports("@./*.md", {
       file: "/agent/instructions.md",
       read: importReader(new Map()),
-    })).toThrow("cannot use globs")
+    })).rejects.toThrow("cannot use globs")
   })
 })

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1299,9 +1299,9 @@ describe("defineAgent workspace option", () => {
     await agent.run!(context())
 
     expect(agentSettings.at(-1)?.instructions).toBe([
-      "# Support\nImported policy.",
+      "# Support\n\nImported policy.",
       "Use technical detail for Acme.",
-      "## Runtime policy\nUse trusted runtime context.",
+      "## Runtime policy\n\nUse trusted runtime context.",
       "## Workspace Sources",
       "### docs\n\nUse docs for Acme.",
       "Capability note for Acme.",
@@ -1655,6 +1655,7 @@ describe("defineAgent workspace option", () => {
       "Answer from the workspace.",
       [
         "API-backed Sources you can inspect with curl:",
+        "",
         "- inventoryHealthSummary: read `.vitehub/sources/inventoryHealthSummary.json` before using curl.",
         "Use normal curl syntax that matches the descriptor.",
       ].join("\n"),

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2855,6 +2855,24 @@ describe("defineAgent workspace option", () => {
     })
   })
 
+  it("composes static DevTools instruction metadata", async () => {
+    const { createAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      instructions: [
+        "::if{context.enabled}",
+        "Hidden.",
+        "::else",
+        "Answer from the workspace.",
+        "::",
+        "{{ context.missing }}",
+      ].join("\n"),
+      model: {} as never,
+    }), { workspace: "support" })
+
+    expect(createAgentDevtoolsMetadata(agent).instructions).toEqual(["Answer from the workspace."])
+  })
+
   it("includes skill sources in DevTools file metadata", async () => {
     const { createAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")

--- a/packages/internal/src/build/esbuild.ts
+++ b/packages/internal/src/build/esbuild.ts
@@ -5,6 +5,7 @@ interface BundleEsmEntryOptions {
   conditions?: string[]
   external?: string[]
   format?: "esm" | "cjs"
+  mainFields?: string[]
   minifyIdentifiers?: boolean
   platform?: "browser" | "node" | "neutral"
   plugins?: Plugin[]
@@ -38,6 +39,7 @@ export async function bundleEsmEntry(
     external: options.external,
     format,
     logLevel: "silent",
+    mainFields: options.mainFields ?? (platform === "neutral" ? ["module", "main"] : undefined),
     minifyIdentifiers: options.minifyIdentifiers,
     outfile,
     platform,

--- a/packages/internal/test/esbuild.test.ts
+++ b/packages/internal/test/esbuild.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { pathToFileURL } from "node:url"
@@ -55,5 +55,22 @@ describe("bundleEsmEntry", () => {
       filename: "netlify-runtime",
       requireType: "function",
     })
+  })
+
+  it("resolves package entry fields in neutral bundles", async () => {
+    const rootDir = await createTempDir()
+    const packageDir = join(rootDir, "node_modules", "main-only-package")
+    const entry = join(rootDir, "entry.mjs")
+    const outfile = join(rootDir, "bundle.mjs")
+    await mkdir(packageDir, { recursive: true })
+    await writeFile(join(packageDir, "package.json"), JSON.stringify({ main: "index.js", name: "main-only-package", type: "module" }), "utf8")
+    await writeFile(join(packageDir, "index.js"), "export const value = 'neutral-main'\n", "utf8")
+    await writeFile(entry, "import { value } from 'main-only-package'\nexport default value\n", "utf8")
+
+    const { bundleEsmEntry } = await import("../src/build/esbuild.ts")
+    await bundleEsmEntry(entry, outfile, { format: "esm", platform: "neutral" })
+
+    const loaded = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: string }
+    expect(loaded.default).toBe("neutral-main")
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ catalogs:
     '@vueuse/core':
       specifier: ^14.3.0
       version: 14.3.0
+    comark:
+      specifier: ^0.3.2
+      version: 0.3.2
     motion-v:
       specifier: ^2.2.1
       version: 2.2.1
@@ -440,6 +443,9 @@ importers:
       chat:
         specifier: catalog:chat
         version: 4.29.0(ai@7.0.0(zod@4.4.3))(zod@4.4.3)
+      comark:
+        specifier: catalog:ui
+        version: 0.3.2(shiki@4.0.2)
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,6 +69,7 @@ catalogs:
     vue-tsc: ^3.2.6
   ui:
     "@comark/vue": ^0.3.1
+    comark: ^0.3.2
     "@iconify-json/lucide": ^1.2.111
     "@iconify-json/ph": ^1.2.2
     "@iconify-json/simple-icons": ^1.2.84


### PR DESCRIPTION
Moves Agent Instruction Composition onto Comark-backed Markdown parsing/rendering for authored `instructions.md` primitives. Imports, conditionals, scalar `{{ context.* }}` bindings, trusted `{{{ context.* }}}` Markdown bindings, Capability slots, and Source Instructions now run through the same Markdown-aware render pass instead of the previous hand-rolled line/code-span parser.

Runtime enforcement stays in TypeScript-owned Agent, Capability, Access, Workspace, and Source boundaries. This keeps Comark responsible for authored document syntax while leaving access, source visibility, session write-back, and capability registration outside Markdown policy.

Coordination: this can merge independently, but may need a small rebase if #411 lands first because both touch `packages/agent/src/harness-agent.ts`.