### PR TITLE
fix(queue): avoid vercel provider output pollution

### DIFF
--- a/docs/content/docs/server-primitives/queue.md
+++ b/docs/content/docs/server-primitives/queue.md
@@ -19,6 +19,13 @@ Queue is not Workflow. Queue Enqueue means the Queue Provider accepted the job; 
 pnpm add @vite-hub/queue
 ```
 
+For Vercel Queues, also install the provider package and ambient TypeScript types:
+
+```bash [Terminal]
+pnpm add @vercel/queue
+pnpm add -D @types/node @types/ws
+```
+
 ### Configure
 
 ```ts [vite.config.ts]
@@ -240,12 +247,14 @@ Use the Vite Integration to check that ViteHub discovers your Queue Definitions 
 pnpm vite build
 ```
 
-After the build, inspect `.vitehub/queue/registry.mjs` to confirm that ViteHub found the queue. Then inspect the provider output for the provider you configured.
+After the build, inspect `.vitehub/queue/registry.mjs` to confirm that ViteHub found the queue. Then inspect the Queue Provider Output for the Queue Provider you configured.
 
 | Provider | Output to inspect |
 | --- | --- |
 | Cloudflare | `dist/**/wrangler.json` queue producers and consumers, plus the generated worker bundle. |
 | Vercel | `.vercel/output/functions/api/vitehub/queues/vercel/**` consumer functions and trigger config. |
+
+Vercel projects that typecheck generated Queue Provider Output should include `lib: ['DOM', 'ESNext']` and `types: ['node']` in `tsconfig.json`.
 
 ::note
 Queue does not include an in-memory Queue Provider for local Queue Delivery. Test the code your handler calls when you need fast unit coverage, and use generated provider runtime or deployed provider output when you need to prove Queue Enqueue and Queue Delivery together.

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -143,6 +143,10 @@ async function deleteJsonObjectKeysFromFile(file: string, keys: string[] | undef
     }
   }
   if (!changed) return
+  if (!Object.keys(next).length) {
+    await rm(file, { force: true })
+    return
+  }
   await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
 }
 

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -17,6 +17,12 @@ pnpm add @vite-hub/queue
 
 Add `@vercel/queue` when you use the Vercel provider.
 
+Vercel Queue projects that typecheck the generated path need Node and ws ambient types:
+
+```sh
+pnpm add -D @types/node @types/ws
+```
+
 ## Minimal API
 
 ```ts
@@ -52,5 +58,7 @@ export default defineConfig({
 ## Vite Integration
 
 Use `hubQueue()` in Vite to discover `server/queues/<name>.ts` and `src/<name>.queue.ts`. The handler name comes from the file path, while provider output maps it to [Cloudflare Queues](https://developers.cloudflare.com/queues/) or [Vercel Queues](https://vercel.com/docs/queues).
+
+Run `vite build` to emit Queue Provider Output. Cloudflare output is written under `dist/**/wrangler.json`; Vercel output is written under `.vercel/output/functions/api/vitehub/queues/vercel/**`.
 
 Learn more at [vitehub.dev](https://vitehub.dev).

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -2,7 +2,7 @@ import { mkdir, rm, writeFile } from "node:fs/promises"
 import { relative, resolve } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
-import { createDefaultVercelOutputRoot, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
+import { createDefaultCloudflareOutputRoot, createDefaultVercelOutputRoot, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { bundleEsmEntry } from "@vite-hub/internal/build/esbuild"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg, toGeneratedPath } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
@@ -47,6 +47,21 @@ function isVercelQueueEnabled(queueConfig: NormalizedQueueOptions) {
 function resolveOutputQueueConfig(queue: QueueModuleOptions | undefined, hosting: string): NormalizedQueueOptions {
   if (typeof queue === "undefined") return false
   return normalizeQueueOptions(queue, { hosting }) || false
+}
+
+function shouldWriteProviderEntry(spec: ProviderEntrySpec, queue: QueueModuleOptions | undefined) {
+  const queueConfig = resolveOutputQueueConfig(queue, spec.hosting)
+  return queueConfig === false ? spec.name === "vercel" : queueConfig.provider === spec.name
+}
+
+function shouldCreateCloudflareOutput(queue: QueueModuleOptions | undefined) {
+  const queueConfig = resolveOutputQueueConfig(queue, "cloudflare")
+  return queueConfig !== false && queueConfig.provider === "cloudflare"
+}
+
+function shouldCreateVercelOutput(queue: QueueModuleOptions | undefined) {
+  const queueConfig = resolveOutputQueueConfig(queue, "vercel")
+  return queueConfig === false || queueConfig.provider === "vercel"
 }
 
 interface GeneratedQueueArtifacts {
@@ -120,6 +135,9 @@ async function writeProviderEntries(rootDir: string, queue: QueueModuleOptions |
 
   const entryFiles: Record<QueueProvider, string> = { cloudflare: "", vercel: "" }
   for (const spec of providerEntrySpecs) {
+    if (!shouldWriteProviderEntry(spec, queue)) {
+      continue
+    }
     const entryFile = resolve(generatedDir, spec.entryFile)
     const queueConfig = resolveOutputQueueConfig(queue, spec.hosting)
     const preloadVercelQueue = spec.name === "vercel" && definitions.length > 0 && isVercelQueueEnabled(queueConfig)
@@ -247,6 +265,14 @@ function createVercelOutput(artifacts: GeneratedQueueArtifacts): VercelProviderD
   }
 }
 
+async function cleanupCloudflareOutput(rootDir: string) {
+  const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+  await Promise.all([
+    rm(resolve(outputRoot, "index.js"), { force: true, recursive: true }),
+    rm(resolve(outputRoot, "wrangler.json"), { force: true, recursive: true }),
+  ])
+}
+
 async function writeVercelQueueFunctions(rootDir: string, queue: QueueModuleOptions | undefined, artifacts: GeneratedQueueArtifacts) {
   const outputRoot = createDefaultVercelOutputRoot(rootDir)
   const queueRoot = resolve(outputRoot, "functions", "api", "vitehub", "queues", "vercel")
@@ -291,11 +317,16 @@ async function writeVercelQueueFunctions(rootDir: string, queue: QueueModuleOpti
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedQueueArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.queue)
+  const createCloudflare = shouldCreateCloudflareOutput(options.queue)
+  const createVercel = shouldCreateVercelOutput(options.queue)
+  if (!createCloudflare && createVercel) {
+    await cleanupCloudflareOutput(options.rootDir)
+  }
   await writeProviderDeploymentOutputs({
     clientOutDir: options.clientOutDir,
-    cloudflare: createCloudflareOutput(artifacts),
+    cloudflare: createCloudflare ? createCloudflareOutput(artifacts) : undefined,
     rootDir: options.rootDir,
-    vercel: createVercelOutput(artifacts),
+    vercel: createVercel ? createVercelOutput(artifacts) : undefined,
   })
   await writeVercelQueueFunctions(options.rootDir, options.queue, artifacts)
   return artifacts

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -2,7 +2,7 @@ import { mkdir, rm, writeFile } from "node:fs/promises"
 import { relative, resolve } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
-import { createDefaultCloudflareOutputRoot, createDefaultVercelOutputRoot, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
+import { createDefaultVercelOutputRoot, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { bundleEsmEntry } from "@vite-hub/internal/build/esbuild"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg, toGeneratedPath } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
@@ -265,14 +265,6 @@ function createVercelOutput(artifacts: GeneratedQueueArtifacts): VercelProviderD
   }
 }
 
-async function cleanupCloudflareOutput(rootDir: string) {
-  const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
-  await Promise.all([
-    rm(resolve(outputRoot, "index.js"), { force: true, recursive: true }),
-    rm(resolve(outputRoot, "wrangler.json"), { force: true, recursive: true }),
-  ])
-}
-
 async function writeVercelQueueFunctions(rootDir: string, queue: QueueModuleOptions | undefined, artifacts: GeneratedQueueArtifacts) {
   const outputRoot = createDefaultVercelOutputRoot(rootDir)
   const queueRoot = resolve(outputRoot, "functions", "api", "vitehub", "queues", "vercel")
@@ -320,11 +312,20 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const createCloudflare = shouldCreateCloudflareOutput(options.queue)
   const createVercel = shouldCreateVercelOutput(options.queue)
   if (!createCloudflare && createVercel) {
-    await cleanupCloudflareOutput(options.rootDir)
+    await writeProviderDeploymentOutputs({
+      cleanup: {
+        cloudflare: { wranglerConfigKeys: ["queues"] },
+      },
+      clientOutDir: options.clientOutDir,
+      rootDir: options.rootDir,
+    })
   }
   await writeProviderDeploymentOutputs({
     clientOutDir: options.clientOutDir,
     cloudflare: createCloudflare ? createCloudflareOutput(artifacts) : undefined,
+    cleanup: {
+      vercel: { serverFunctionName: "__server.func" },
+    },
     rootDir: options.rootDir,
     vercel: createVercel ? createVercelOutput(artifacts) : undefined,
   })

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs"
 import { cp, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
-import { join, resolve } from "node:path"
+import { basename, join, relative, resolve } from "node:path"
 import { execFile } from "node:child_process"
 import { promisify } from "node:util"
 
@@ -15,6 +15,11 @@ const tempDirs: string[] = []
 function resolvePlaygroundNodeModules() {
   const nodeModules = join(playgroundDir, "node_modules")
   return existsSync(nodeModules) ? nodeModules : resolve(playgroundDir, "../../node_modules")
+}
+
+function createDefaultCloudflareOutputRoot(rootDir: string) {
+  const appName = basename(rootDir).replace(/[^a-z0-9-]+/gi, "-").replace(/-+/g, "-").replace(/^-|-$/g, "").toLowerCase()
+  return join(rootDir, "dist", appName)
 }
 
 async function createWorkspaceTempDir(prefix: string) {
@@ -113,10 +118,14 @@ describe("Vite provider outputs", () => {
 
   it("copies Vercel static output from Vite's default dist directory", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-default-dist-")
+    const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    const staleWranglerStaticPath = join(rootDir, ".vercel", "output", "static", relative(join(rootDir, "dist"), cloudflareOutputRoot), "wrangler.json")
     await mkdir(join(rootDir, "src"), { recursive: true })
     await mkdir(join(rootDir, "dist"), { recursive: true })
+    await mkdir(cloudflareOutputRoot, { recursive: true })
     await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
     await writeFile(join(rootDir, "dist", "index.html"), "<!doctype html><title>vitehub</title>\n", "utf8")
+    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), "{}\n", "utf8")
 
     await generateProviderOutputs({
       clientOutDir: "dist",
@@ -125,6 +134,8 @@ describe("Vite provider outputs", () => {
     })
 
     expect(await readFile(join(rootDir, ".vercel", "output", "static", "index.html"), "utf8")).toContain("<title>vitehub</title>")
+    expect(existsSync(join(rootDir, ".vitehub", "queue", "cloudflare-worker.mjs"))).toBe(false)
+    expect(existsSync(staleWranglerStaticPath)).toBe(false)
     const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
     expect(vercelServerContents).toContain("globalThis.__vitehubVercelQueue =")
   })
@@ -163,7 +174,7 @@ describe("Vite provider outputs", () => {
     expect(existsSync(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "queues", "vercel"))).toBe(false)
   })
 
-  it("does not preload or emit Vercel queue functions for a non-Vercel queue provider", async () => {
+  it("does not preload or emit Vercel output for a non-Vercel queue provider", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-cloudflare-provider-")
     await mkdir(join(rootDir, "src"), { recursive: true })
     await mkdir(join(rootDir, "dist"), { recursive: true })
@@ -176,8 +187,7 @@ describe("Vite provider outputs", () => {
       rootDir,
     })
 
-    const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
-    expect(vercelServerContents).not.toContain("@vercel/queue")
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"))).toBe(false)
     expect(existsSync(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "queues", "vercel"))).toBe(false)
   })
 

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -125,7 +125,12 @@ describe("Vite provider outputs", () => {
     await mkdir(cloudflareOutputRoot, { recursive: true })
     await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
     await writeFile(join(rootDir, "dist", "index.html"), "<!doctype html><title>vitehub</title>\n", "utf8")
-    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), "{}\n", "utf8")
+    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+      queues: {
+        consumers: [{ queue: "stale" }],
+        producers: [{ binding: "STALE_QUEUE", queue: "stale" }],
+      },
+    }, null, 2)}\n`, "utf8")
 
     await generateProviderOutputs({
       clientOutDir: "dist",
@@ -135,9 +140,37 @@ describe("Vite provider outputs", () => {
 
     expect(await readFile(join(rootDir, ".vercel", "output", "static", "index.html"), "utf8")).toContain("<title>vitehub</title>")
     expect(existsSync(join(rootDir, ".vitehub", "queue", "cloudflare-worker.mjs"))).toBe(false)
+    expect(existsSync(join(cloudflareOutputRoot, "wrangler.json"))).toBe(false)
     expect(existsSync(staleWranglerStaticPath)).toBe(false)
     const vercelServerContents = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
     expect(vercelServerContents).toContain("globalThis.__vitehubVercelQueue =")
+  })
+
+  it("preserves shared Cloudflare output during Vercel queue cleanup", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-shared-cloudflare-")
+    const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist"), { recursive: true })
+    await mkdir(cloudflareOutputRoot, { recursive: true })
+    await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
+    await writeFile(join(rootDir, "dist", "index.html"), "<!doctype html><title>vitehub</title>\n", "utf8")
+    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+      queues: {
+        consumers: [{ queue: "stale" }],
+        producers: [{ binding: "STALE_QUEUE", queue: "stale" }],
+      },
+      triggers: { crons: ["0 0 * * *"] },
+    }, null, 2)}\n`, "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist",
+      queue: { provider: "vercel" },
+      rootDir,
+    })
+
+    await expect(readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      triggers: { crons: ["0 0 * * *"] },
+    })
   })
 
   it("does not preload Vercel queue without queue definitions", async () => {
@@ -176,10 +209,16 @@ describe("Vite provider outputs", () => {
 
   it("does not preload or emit Vercel output for a non-Vercel queue provider", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-cloudflare-provider-")
+    const staleVercelServer = join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs")
+    const staleVercelConsumer = join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "queues", "vercel", "stale", "stale.func", "index.mjs")
     await mkdir(join(rootDir, "src"), { recursive: true })
     await mkdir(join(rootDir, "dist"), { recursive: true })
+    await mkdir(join(rootDir, ".vercel", "output", "functions", "__server.func"), { recursive: true })
+    await mkdir(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "queues", "vercel", "stale", "stale.func"), { recursive: true })
     await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
     await writeFile(join(rootDir, "dist", "index.html"), "<!doctype html><title>vitehub</title>\n", "utf8")
+    await writeFile(staleVercelServer, "import '@vercel/queue'\n", "utf8")
+    await writeFile(staleVercelConsumer, "import '@vercel/queue'\n", "utf8")
 
     await generateProviderOutputs({
       clientOutDir: "dist",


### PR DESCRIPTION
Stops Queue Vercel builds from generating Cloudflare Queue Provider Output or copying stale `wrangler.json` output into `.vercel/output/static`.

Also documents that `vite build` emits Queue Provider Output and that Vercel Queue projects need `@vercel/queue` plus Node/ws ambient types when typechecking generated output.