### PR TITLE
feat(agent): derive access scopes from workspace sources

### DIFF
--- a/.agents/adr/0074-source-scoped-access-derives-source-grants.md
+++ b/.agents/adr/0074-source-scoped-access-derives-source-grants.md
@@ -1,0 +1,9 @@
+# Source-Scoped Access Derives Source Grants
+
+ViteHub will let Workspace Source Bindings declare static Workspace Source Scope Membership with `scopes`, and the Access Capability will derive additive Workspace Scope Grants from that metadata. Workspace Scope selection, Access Roles, All-Scopes Workspace Scope, explicit path grants, and Workspace Scope Instructions stay in `access({ workspace })`; allowing `defineCapability()` to mutate `defineChannel()` was rejected for this slice because Channels declare reachability, while source visibility is Workspace and Access behavior.
+
+## Considered Options
+
+- Keeping every Source key only in `access.workspace.scopes[scope].sources` was rejected because it duplicates Source Map keys across normal static audience configurations.
+- A new Access builder or policy DSL was rejected because static Source membership needs only one Workspace Source Binding field.
+- Capability-to-Channel mutation was deferred because this change does not need Channel reachability changes, and cross-owner mutation would cut across the accepted Channels boundary.

--- a/.agents/contexts/workspace/CONTEXT.md
+++ b/.agents/contexts/workspace/CONTEXT.md
@@ -175,6 +175,10 @@ _Avoid_: Default admin view, merged workspace, unrestricted context
 A declared visibility grant inside a Workspace Scope, expressed through Source keys, Workspace path prefixes, or both.
 _Avoid_: Prompt filter, role, Workspace Rule
 
+**Workspace Source Scope Membership**:
+Static Workspace Source Binding metadata that names the Workspace Scopes a Source should be granted to when the Access Capability applies Workspace Scope.
+_Avoid_: Source-owned authorization, dynamic resolver, Access Role
+
 **Workspace Scope Instructions**:
 Developer-authored model-facing guidance attached to a selected Workspace Scope, describing how the agent should talk about or handle that explicit scope.
 _Avoid_: Generated scope prompt, Access Role, Source Instructions
@@ -372,6 +376,8 @@ _Avoid_: Chat Session, thread id, implicit conversation state
 - A **Workspace Scope** is enforced by Workspace reads, lists, searches, shell-shaped commands, and Workspace Tools; the model sees only the scoped Workspace File Tree.
 - A **Workspace Scope** contains **Workspace Scope Grants**.
 - A **Workspace Scope Grant** can target a Source key, a Workspace path prefix, or a path prefix within a Source.
+- A **Workspace Source Binding** may declare **Workspace Source Scope Membership**.
+- The **Access Capability** derives **Workspace Scope Grants** from **Workspace Source Scope Membership** without moving Workspace Scope selection, Access Roles, All-Scopes Workspace Scope, explicit path grants, or Workspace Scope Instructions into Sources.
 - A **Workspace Scope** may have **Workspace Scope Instructions**.
 - **Workspace Scope Instructions** are explicit developer-authored guidance; ViteHub does not infer them from grants, role, Agent Actor metadata, or Source metadata.
 - **Workspace Scope Instructions** may be declared on a static Workspace Scope or returned by a Workspace Scope Resolver for the selected invocation.

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -405,9 +405,13 @@ function validateWorkspaceSourceScopeNames(
   options: { scopes?: Record<string, unknown> },
   workspaceDefinition: WorkspaceDefinition | undefined,
 ): void {
-  if (!options.scopes) return
+  const scopes = workspaceSourceScopeNames(workspaceDefinition?.sources)
+  if (!scopes.length) return
+  if (!options.scopes) {
+    throw new Error("[vitehub] Workspace Source scopes require access({ workspace }).scopes.")
+  }
   const allowed = new Set(Object.keys(options.scopes))
-  for (const scope of workspaceSourceScopeNames(workspaceDefinition?.sources)) {
+  for (const scope of scopes) {
     if (!allowed.has(scope)) {
       throw new Error(`[vitehub] Workspace Source scope "${scope}" is not defined in access({ workspace }).scopes.`)
     }

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -1,6 +1,6 @@
 import { markTrustedWorkspaceAccessScope, markTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "../access-runtime.ts"
 import { defineCapability } from "../capability-runtime.ts"
-import { normalizeAgentWorkspaceSource, workspaceSourceKeysForScope, workspaceSourceScopeNames } from "../workspace-source-metadata.ts"
+import { workspaceSourceKeysForScope, workspaceSourceScopeNames, workspaceSourceScopePaths } from "../workspace-source-metadata.ts"
 import type { AccessCapabilityMetadata } from "./access-metadata.ts"
 
 import type {
@@ -44,6 +44,7 @@ type WorkspaceAccessRuntime = Pick<
   | "getWorkspaceSourceRequestExecution"
   | "hasWorkspaceSourceResolvers"
   | "isWorkspaceSourceRequestOnly"
+  | "resolveWorkspaceSources"
   | "workspaceSourceRequestDescriptorPath"
 >
 
@@ -317,24 +318,26 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
       const workspaceRuntime = await loadWorkspaceAccessRuntime()
       const scope = await resolveWorkspaceScope(options.workspace, context, workspaceRuntime)
       const sourceResolutionScope = withHarnessWorkspacePaths(scope, context.harnessWorkspacePaths)
+      const sourceResolutionOptions = {
+        invocation: {
+          context: context.context,
+          run: context.run,
+        },
+        selectedWorkspaceScope: toWorkspaceSelectedScope(sourceResolutionScope),
+      }
+      const resolvedDefinition = context.workspaceDefinition
+        ? await workspaceRuntime.resolveWorkspaceSources(context.workspaceDefinition, sourceResolutionOptions)
+        : undefined
       const hasSourceResolvers = context.workspaceDefinition
         ? workspaceRuntime.hasWorkspaceSourceResolvers(context.workspaceDefinition)
         : false
-      const sourceResolution = context.workspaceDefinition
-        ? await workspaceRuntime.createWorkspaceSourceResolutionFacade(context.workspace, context.workspaceDefinition, {
-            invocation: {
-              context: context.context,
-              run: context.run,
-            },
-            selectedWorkspaceScope: {
-              all: sourceResolutionScope.all,
-              name: sourceResolutionScope.scope,
-              paths: sourceResolutionScope.paths,
-              role: sourceResolutionScope.role,
-            },
+      const finalScope = withHarnessWorkspacePaths(finalizeResolvedWorkspaceScope(scope, resolvedDefinition, workspaceRuntime), context.harnessWorkspacePaths)
+      const sourceResolution = resolvedDefinition
+        ? await workspaceRuntime.createWorkspaceSourceResolutionFacade(context.workspace, resolvedDefinition, {
+            ...sourceResolutionOptions,
+            selectedWorkspaceScope: toWorkspaceSelectedScope(finalScope),
           })
-        : { definition: context.workspaceDefinition, workspace: context.workspace }
-      const finalScope = withHarnessWorkspacePaths(finalizeResolvedWorkspaceScope(scope, sourceResolution.definition, workspaceRuntime), context.harnessWorkspacePaths)
+        : { definition: resolvedDefinition, workspace: context.workspace }
       const workspaceForScope = hasSourceResolvers ? sourceResolution.workspace : context.workspace
       const scopedWorkspace = finalScope.all
         ? workspaceForScope
@@ -360,6 +363,15 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function toWorkspaceSelectedScope(scope: ResolvedWorkspaceScope) {
+  return {
+    all: scope.all,
+    name: scope.scope,
+    paths: scope.paths,
+    role: scope.role,
+  }
 }
 
 async function resolveWorkspaceScope<
@@ -529,9 +541,6 @@ function scopePaths(
     paths.push(...sourcePaths(normalizeStringList(grant.source, grant.sources), workspaceDefinition, workspaceRuntime))
   }
   const normalized = [...new Set(paths.map(path => normalizeScopePath(path)))]
-  if (!normalized.length) {
-    throw new Error("[vitehub] Workspace Scope must grant at least one path or source.")
-  }
   return normalized.sort((left, right) => left.length - right.length || left.localeCompare(right))
 }
 
@@ -608,20 +617,7 @@ function sourceScopePaths(
   if (!definition) {
     throw new Error(`[vitehub] Workspace Scope source grant references unknown source "${source}".`)
   }
-  const metadata = normalizeAgentWorkspaceSource(source, definition)
-  const descriptorSource = metadata.source
-  const descriptorPath = workspaceRuntime.workspaceSourceRequestDescriptorPath(source)
-  if (descriptorSource && workspaceRuntime.isWorkspaceSourceRequestOnly(descriptorSource)) {
-    return [descriptorPath]
-  }
-  const mountPath = metadata.mountPath
-  if (normalizeScopePath(mountPath) === "") {
-    throw new Error(`[vitehub] Workspace Scope source grant "${source}" is root-mounted; grant explicit paths instead.`)
-  }
-  return [
-    mountPath,
-    descriptorPath,
-  ]
+  return workspaceSourceScopePaths(source, definition, workspaceRuntime)
 }
 
 function normalizeScopePath(path = ""): string {

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -557,8 +557,7 @@ function scopeMaterializeGrants(
     })
   }
   const addSource = (source: string) => {
-    const path = sourceMaterializePath(source, workspaceDefinition, workspaceRuntime)
-    if (path !== undefined) add(path, [source])
+    for (const path of sourceMaterializePaths(source, workspaceDefinition, workspaceRuntime)) add(path, [source])
   }
   for (const path of normalizeStringList(definition.path, definition.paths)) add(path)
   for (const source of normalizeStringList(definition.source, definition.sources)) addSource(source)
@@ -596,13 +595,12 @@ function sourcePaths(
   return sources.flatMap(source => sourceScopePaths(source, workspaceDefinition, workspaceRuntime))
 }
 
-function sourceMaterializePath(
+function sourceMaterializePaths(
   source: string,
   workspaceDefinition: WorkspaceDefinition | undefined,
   workspaceRuntime: WorkspaceAccessRuntime,
-): string | undefined {
-  const paths = sourceScopePaths(source, workspaceDefinition, workspaceRuntime).filter(path => !path.startsWith(".vitehub/sources/"))
-  return paths[0]
+): string[] {
+  return sourceScopePaths(source, workspaceDefinition, workspaceRuntime).filter(path => !path.startsWith(".vitehub/sources/"))
 }
 
 function sourceScopePaths(

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -1,6 +1,6 @@
 import { markTrustedWorkspaceAccessScope, markTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "../access-runtime.ts"
 import { defineCapability } from "../capability-runtime.ts"
-import { normalizeAgentWorkspaceSource } from "../workspace-source-metadata.ts"
+import { normalizeAgentWorkspaceSource, workspaceSourceKeysForScope, workspaceSourceScopeNames } from "../workspace-source-metadata.ts"
 import type { AccessCapabilityMetadata } from "./access-metadata.ts"
 
 import type {
@@ -56,11 +56,13 @@ export type AccessCapabilityTypeContract<
   TSourceName extends string = string,
   TInputContext extends object = Record<string, unknown>,
   TScopeName extends string = string,
+  TWorkspaceScopeName extends string = string,
 > = AgentCapabilityTypeContract & {
   inputContext: TInputContext
   invocationContext: {
     access: AccessInvocationContextValue<TScopeName>
   }
+  workspaceScopes: TWorkspaceScopeName
   workspaceSources: TSourceName
 }
 
@@ -281,7 +283,7 @@ export function access<
   Name extends WorkspaceName = WorkspaceName,
   TInputContext extends object = Record<string, unknown>,
   const TWorkspace extends AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext> = AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext>,
->(options: { chat?: AccessChatOptions<TRuntimeConfig>, input?: undefined, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext, AccessWorkspaceScopeNameOrString<TWorkspace>>>
+>(options: { chat?: AccessChatOptions<TRuntimeConfig>, input?: undefined, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext, AccessWorkspaceScopeNameOrString<TWorkspace>, AccessWorkspaceStaticScopeName<TWorkspace>>>
 export function access<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
@@ -375,25 +377,53 @@ async function resolveWorkspaceScope<
     throw new Error("[vitehub] access({ workspace }) could not resolve a Workspace Scope. defaultScope or resolve() must produce a Workspace Scope.")
   }
 
+  validateWorkspaceSourceScopeNames(options, context.workspaceDefinition)
   const definition = selection.definition || options.scopes?.[selection.scope]
   if (!definition) {
     throw new Error(`[vitehub] access({ workspace }) resolved unknown Workspace Scope "${selection.scope}". scopes.${selection.scope} or an inline scope definition must define it.`)
   }
+  const scopedDefinition = withWorkspaceSourceScopeGrants(definition, selection.scope, context.workspaceDefinition)
 
   const role = selection.role || "viewer"
-  const all = definition.all === true
+  const all = scopedDefinition.all === true
   if (all && role !== "admin") {
     throw new Error(`[vitehub] Workspace Scope "${selection.scope}" requires the admin role.`)
   }
 
   return {
     all,
-    definition,
-    instructions: selection.instructions ?? normalizeScopeInstructions(definition.instructions, `Workspace Scope "${selection.scope}" instructions`),
-    materializeGrants: all ? [{ path: "" }] : scopeMaterializeGrants(definition, context.workspaceDefinition, workspaceRuntime),
-    paths: all ? [""] : scopePaths(definition, context.workspaceDefinition, workspaceRuntime),
+    definition: scopedDefinition,
+    instructions: selection.instructions ?? normalizeScopeInstructions(scopedDefinition.instructions, `Workspace Scope "${selection.scope}" instructions`),
+    materializeGrants: all ? [{ path: "" }] : scopeMaterializeGrants(scopedDefinition, context.workspaceDefinition, workspaceRuntime),
+    paths: all ? [""] : scopePaths(scopedDefinition, context.workspaceDefinition, workspaceRuntime),
     role,
     scope: selection.scope,
+  }
+}
+
+function validateWorkspaceSourceScopeNames(
+  options: { scopes?: Record<string, unknown> },
+  workspaceDefinition: WorkspaceDefinition | undefined,
+): void {
+  if (!options.scopes) return
+  const allowed = new Set(Object.keys(options.scopes))
+  for (const scope of workspaceSourceScopeNames(workspaceDefinition?.sources)) {
+    if (!allowed.has(scope)) {
+      throw new Error(`[vitehub] Workspace Source scope "${scope}" is not defined in access({ workspace }).scopes.`)
+    }
+  }
+}
+
+function withWorkspaceSourceScopeGrants(
+  definition: AccessWorkspaceScopeDefinition,
+  scope: string,
+  workspaceDefinition: WorkspaceDefinition | undefined,
+): AccessWorkspaceScopeDefinition {
+  const sources = workspaceSourceKeysForScope(workspaceDefinition?.sources, scope)
+  if (!sources.length) return definition
+  return {
+    ...definition,
+    sources: [...new Set([...normalizeStringList(definition.source, definition.sources), ...sources])],
   }
 }
 

--- a/packages/agent/src/capabilities/workspace-shell.ts
+++ b/packages/agent/src/capabilities/workspace-shell.ts
@@ -7,8 +7,14 @@ import type {
   AgentCapabilityContext,
   AgentCapabilityDefinition,
   AgentCapabilityMode,
+  AgentRuntimeConfig,
   AgentToolSet,
 } from "../types.ts"
+import type { WorkspaceName } from "@vite-hub/workspace"
+
+type WorkspaceShellCapabilityTypeContract = {
+  workspaceScopes: never
+}
 
 async function sourceRequestHint(context: AgentCapabilityContext): Promise<string | false> {
   if (!context.workspace) return false
@@ -35,7 +41,7 @@ async function sourceRequestHint(context: AgentCapabilityContext): Promise<strin
   ].join("\n")
 }
 
-export function workspaceShell(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition {
+export function workspaceShell(options: { mode?: AgentCapabilityMode } = {}): AgentCapabilityDefinition<AgentRuntimeConfig, WorkspaceName, WorkspaceShellCapabilityTypeContract> {
   const mode = normalizeMode(options.mode, "Workspace Shell")
   return defineCapability({
     id: "workspace-shell",

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -150,9 +150,10 @@ export function defineCapability<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
   TTypeContract extends AgentCapabilityTypeContract = AgentCapabilityTypeContract,
+  const TCapability extends AgentCapabilityDefinition<TRuntimeConfig, Name, TTypeContract> = AgentCapabilityDefinition<TRuntimeConfig, Name, TTypeContract>,
 >(
-  capability: AgentCapabilityDefinition<TRuntimeConfig, Name, TTypeContract>,
-): AgentCapabilityDefinition<TRuntimeConfig, Name, TTypeContract> {
+  capability: TCapability,
+): TCapability {
   if (!capability || typeof capability !== "object") {
     throw new TypeError("[vitehub] defineCapability() requires a capability definition.")
   }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -660,6 +660,7 @@ async function applyCapabilityWorkspaceContributions<
     workspaceDefinition: WorkspaceDefinition
   },
   workspaceMode: AgentCapabilityMode,
+  baseWorkspace: ReadonlyWorkspaceFacade<Name>,
 ): Promise<{ definition: WorkspaceDefinition, registries: AgentCapabilityRegistries["workspaceContributions"], workspace: ReadonlyWorkspaceFacade<Name> } | undefined> {
   let definition = context.workspaceDefinition
   const registries: AgentCapabilityRegistries["workspaceContributions"] = []
@@ -716,7 +717,7 @@ async function applyCapabilityWorkspaceContributions<
     registries,
     sourceResolution.definition,
     selectedWorkspaceScope,
-    context.workspace,
+    baseWorkspace,
     workspaceRuntime,
   )
   return {
@@ -870,7 +871,7 @@ export async function resolveAgentCapabilities<
       runtimeContext: runtime,
       workspace: currentWorkspace,
       workspaceDefinition: currentWorkspaceDefinition,
-    }, workspaceMode)
+    }, workspaceMode, workspace || currentWorkspace)
     if (workspaceContribution) {
       currentWorkspace = workspaceContribution.workspace
       currentWorkspaceDefinition = workspaceContribution.definition

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -4,7 +4,7 @@ import { hasTrustedWorkspaceAccessScope, hasTrustedWorkspaceSourceResolutionDefi
 import { getAccessCapabilityOptions } from "./capabilities/access-metadata.ts"
 import { createMessage } from "./messages.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
-import { normalizeAgentWorkspaceSource, workspaceSourceScopeNames } from "./workspace-source-metadata.ts"
+import { normalizeAgentWorkspaceSource, workspaceSourceScopeNames, workspaceSourceScopePaths } from "./workspace-source-metadata.ts"
 import {
   createFallbackAgentInvoker,
   ensureAgentInvokerContext,
@@ -343,6 +343,7 @@ type WorkspaceContributionRuntime = Pick<
   typeof import("@vite-hub/workspace"),
   | "createWorkspaceSourceResolutionFacade"
   | "isWorkspaceSourceRequestOnly"
+  | "resolveWorkspaceSources"
   | "workspaceSourceRequestDescriptorPath"
 >
 
@@ -523,12 +524,41 @@ function selectedWorkspaceScopeFromContext(context: AgentInvocationContextStore)
   }
 }
 
+function setSelectedWorkspaceScopeContext(context: AgentInvocationContextStore, scope: WorkspaceSelectedScope | undefined) {
+  if (!scope || !hasTrustedWorkspaceAccessScope(context)) return
+  const access = context.get<{ workspaceScope?: { all?: boolean, paths?: readonly string[], role?: string, scope?: string } }>("access")
+  context.set("access", {
+    ...access,
+    workspaceScope: {
+      ...access?.workspaceScope,
+      all: scope.all,
+      paths: scope.paths,
+      role: scope.role,
+      scope: scope.name,
+    },
+  }, { overwrite: true })
+}
+
 function mergeSelectedWorkspaceScopePaths(scope: WorkspaceSelectedScope | undefined, paths: readonly string[]): WorkspaceSelectedScope | undefined {
   if (!scope || scope.all || !paths.length) return scope
   return {
     ...scope,
-    paths: [...new Set([...(scope.paths || []), ...paths])],
+    paths: compactWorkspacePaths([...(scope.paths || []), ...paths]),
   }
+}
+
+function mergeSelectedWorkspaceSourceScopePaths(
+  scope: WorkspaceSelectedScope | undefined,
+  definition: WorkspaceDefinition,
+  runtime: WorkspaceContributionRuntime,
+): WorkspaceSelectedScope | undefined {
+  if (!scope || scope.all || !scope.name) return scope
+  const paths = Object.entries(definition.sources || {}).flatMap(([key, source]) => {
+    const metadata = normalizeAgentWorkspaceSource(key, source)
+    if (!metadata.scopes?.includes(scope.name)) return []
+    return workspaceSourceScopePaths(key, source, runtime)
+  })
+  return mergeSelectedWorkspaceScopePaths(scope, paths)
 }
 
 function selectedScopeContainsMount(scope: WorkspaceSelectedScope | undefined, mountPath: string): boolean {
@@ -662,9 +692,19 @@ async function applyCapabilityWorkspaceContributions<
   }
 
   if (!registries.length) return
-  const selectedWorkspaceScope = mergeSelectedWorkspaceScopePaths(selectedWorkspaceScopeFromContext(context.context), context.harnessWorkspacePaths || [])
+  let selectedWorkspaceScope = mergeSelectedWorkspaceScopePaths(selectedWorkspaceScopeFromContext(context.context), context.harnessWorkspacePaths || [])
+  selectedWorkspaceScope = mergeSelectedWorkspaceSourceScopePaths(selectedWorkspaceScope, definition, workspaceRuntime)
   assertStaticWorkspaceContributionSourcesInScope(registries, definition, selectedWorkspaceScope, workspaceRuntime)
-  const sourceResolution = await workspaceRuntime.createWorkspaceSourceResolutionFacade(context.workspace, definition, {
+  const resolvedDefinition = await workspaceRuntime.resolveWorkspaceSources(definition, {
+    invocation: {
+      context: context.context,
+      run: context.run,
+    },
+    selectedWorkspaceScope,
+  })
+  selectedWorkspaceScope = mergeSelectedWorkspaceSourceScopePaths(selectedWorkspaceScope, resolvedDefinition, workspaceRuntime)
+  setSelectedWorkspaceScopeContext(context.context, selectedWorkspaceScope)
+  const sourceResolution = await workspaceRuntime.createWorkspaceSourceResolutionFacade(context.workspace, resolvedDefinition, {
     invocation: {
       context: context.context,
       run: context.run,

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -3,7 +3,7 @@ import { resolveRuntimeValue } from "@vite-hub/runtime"
 import { hasTrustedWorkspaceAccessScope, hasTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "./access-runtime.ts"
 import { createMessage } from "./messages.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
-import { normalizeAgentWorkspaceSource } from "./workspace-source-metadata.ts"
+import { normalizeAgentWorkspaceSource, workspaceSourceScopeNames } from "./workspace-source-metadata.ts"
 import {
   createFallbackAgentInvoker,
   ensureAgentInvokerContext,
@@ -137,6 +137,12 @@ function assertTriggerName(name: unknown, capabilityId: string): asserts name is
   if (!/^[a-z][a-z0-9-_]*$/i.test(name)) {
     throw new TypeError(`[vitehub] Capability "${capabilityId}" trigger "${name}" must be a stable local identifier.`)
   }
+}
+
+function capabilityUsesWorkspaceAccess(capability: AgentCapabilityDefinition): boolean {
+  return capability.id === "access"
+    && isPlainRecord(capability.metadata)
+    && capability.metadata.workspace === true
 }
 
 export function defineCapability<
@@ -690,6 +696,9 @@ export async function resolveAgentCapabilities<
   const driverKind = invocationOptions.driverKind || "model"
   ensureAgentInvokerContext(invocationContext, invoker)
   const capabilities = normalizeCapabilities(options?.capabilities as AgentCapabilityDefinition[] | undefined) as AgentCapabilityDefinition<TRuntimeConfig, Name>[]
+  if (workspaceSourceScopeNames(invocationOptions.workspaceDefinition?.sources).length && !capabilities.some(capabilityUsesWorkspaceAccess)) {
+    throw new Error("[vitehub] Workspace Source scopes require access({ workspace }).")
+  }
   validateAccessCapabilityOrder(capabilities)
   const harnessWorkspacePaths = driverKind === "harness"
     ? compactWorkspacePaths(capabilities.flatMap(capability => [

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -304,14 +304,6 @@ function compactWorkspacePaths(paths: readonly string[]): string[] {
   return sorted.filter((path, index) => !sorted.some((candidate, candidateIndex) => candidateIndex < index && pathContains(candidate, path)))
 }
 
-function workspaceDefinitionBuildSourcePaths(definition: WorkspaceDefinition | undefined): string[] {
-  return Object.entries(definition?.sources || {}).flatMap(([key, source]) => {
-    const metadata = normalizeAgentWorkspaceSource(key, source)
-    if (metadata.materialize !== "build" || !metadata.probeKeys?.length) return []
-    return metadata.probeKeys.map(sourcePath => joinSourcePath(metadata.mountPath, sourcePath))
-  })
-}
-
 function pathsConflict(left: string, right: string): boolean {
   return pathContains(left, right) || pathContains(right, left)
 }
@@ -767,7 +759,7 @@ export async function resolveAgentCapabilities<
     ? compactWorkspacePaths(capabilities.flatMap(capability => [
         ...(capability.harnessWorkspacePaths || []),
         ...(capability.requires || []).flatMap(requirement => requirement.workspace?.paths || []),
-      ]).concat(workspaceDefinitionBuildSourcePaths(invocationOptions.workspaceDefinition)))
+      ]))
     : []
   let currentInput = normalizeRunInput(input)
   let currentWorkspace = workspace as ReadonlyWorkspaceFacade<Name> | undefined

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1,6 +1,7 @@
 import { resolveRuntimeValue } from "@vite-hub/runtime"
 
 import { hasTrustedWorkspaceAccessScope, hasTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "./access-runtime.ts"
+import { getAccessCapabilityOptions } from "./capabilities/access-metadata.ts"
 import { createMessage } from "./messages.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
 import { normalizeAgentWorkspaceSource, workspaceSourceScopeNames } from "./workspace-source-metadata.ts"
@@ -596,6 +597,28 @@ function withInvocationReadableSources(sources: Record<string, WorkspaceSourceIn
   return Object.fromEntries(Object.entries(sources).map(([key, source]) => [key, withInvocationReadableSource(source)]))
 }
 
+function assertWorkspaceSourceScopesRequireAccess(
+  workspaceDefinition: WorkspaceDefinition | undefined,
+  capabilities: AgentCapabilityDefinition[],
+) {
+  const sourceScopes = workspaceSourceScopeNames(workspaceDefinition?.sources)
+  if (!sourceScopes.length) return
+  if (!capabilities.some(capabilityUsesWorkspaceAccess)) {
+    throw new Error("[vitehub] Workspace Source scopes require access({ workspace }).")
+  }
+  const accessScopeNames = new Set(getAccessCapabilityOptions<AgentRuntimeConfig>(capabilities).flatMap(options =>
+    options.workspace?.scopes ? Object.keys(options.workspace.scopes) : [],
+  ))
+  if (!accessScopeNames.size) {
+    throw new Error("[vitehub] Workspace Source scopes require access({ workspace }).scopes.")
+  }
+  for (const scope of sourceScopes) {
+    if (!accessScopeNames.has(scope)) {
+      throw new Error(`[vitehub] Workspace Source scope "${scope}" is not defined in access({ workspace }).scopes.`)
+    }
+  }
+}
+
 async function applyCapabilityWorkspaceContributions<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
@@ -696,9 +719,7 @@ export async function resolveAgentCapabilities<
   const driverKind = invocationOptions.driverKind || "model"
   ensureAgentInvokerContext(invocationContext, invoker)
   const capabilities = normalizeCapabilities(options?.capabilities as AgentCapabilityDefinition[] | undefined) as AgentCapabilityDefinition<TRuntimeConfig, Name>[]
-  if (workspaceSourceScopeNames(invocationOptions.workspaceDefinition?.sources).length && !capabilities.some(capabilityUsesWorkspaceAccess)) {
-    throw new Error("[vitehub] Workspace Source scopes require access({ workspace }).")
-  }
+  assertWorkspaceSourceScopesRequireAccess(invocationOptions.workspaceDefinition, capabilities)
   validateAccessCapabilityOrder(capabilities)
   const harnessWorkspacePaths = driverKind === "harness"
     ? compactWorkspacePaths(capabilities.flatMap(capability => [
@@ -797,6 +818,7 @@ export async function resolveAgentCapabilities<
       ? invocationContext.get<WorkspaceDefinition>("workspace.sourceResolution.definition")
       : undefined
     if (sourceResolvedDefinition) currentWorkspaceDefinition = sourceResolvedDefinition
+    assertWorkspaceSourceScopesRequireAccess(currentWorkspaceDefinition, capabilities)
     const workspaceContribution = await applyCapabilityWorkspaceContributions(capabilities, {
       ...runtimeContext,
       actor: invoker,
@@ -814,6 +836,7 @@ export async function resolveAgentCapabilities<
       currentWorkspaceDefinition = workspaceContribution.definition
       registries.workspaceContributions = workspaceContribution.registries
     }
+    assertWorkspaceSourceScopesRequireAccess(currentWorkspaceDefinition, capabilities)
     for (const item of capabilityContexts) syncCapabilityWorkspaceContext(item.context)
   }
 

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -128,8 +128,12 @@ function workspaceRuleHarnessPaths(context: AgentAdapterRunContext): string[] {
 function workspaceSourceHarnessPaths(context: AgentAdapterRunContext): string[] {
   const sources = context.workspaceDefinition?.sources
   if (!sources) return []
+  const scope = hasTrustedWorkspaceAccessScope(context.context)
+    ? context.context.get("access")?.workspaceScope
+    : undefined
   return normalizeAgentWorkspaceSources(sources).flatMap((source) => {
     if (source.materialize !== "build" || !source.probeKeys?.length) return []
+    if (source.scopes?.length && scope && !scope.all && !source.scopes.includes(scope.scope)) return []
     return source.probeKeys.map(key => [source.mountPath, key].filter(Boolean).join("/"))
   })
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -404,11 +404,7 @@ type CapabilityWorkspaceScopeNames<TCapability> =
   TCapability extends AgentCapabilityDefinition<any, any, infer TTypeContract>
     ? (TTypeContract extends { workspaceScopes: infer TScopeName }
           ? Extract<TScopeName, string>
-          : AgentCapabilityTypeContract extends TTypeContract
-            ? TCapability extends { id: infer TCapabilityId }
-              ? string extends TCapabilityId ? string : never
-              : never
-            : never)
+          : never)
         | (TCapability extends { capabilities: infer TNestedCapabilities }
             ? AgentCapabilitiesWorkspaceScopeNames<TNestedCapabilities>
             : never)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -57,6 +57,7 @@ import {
   workspaceModeFromOptions,
   workspaceNameFromOptions,
 } from "./workspace-agent.ts"
+import { workspaceSourceScopeNames } from "./workspace-source-metadata.ts"
 
 import type {
   AgentAdapter,
@@ -345,8 +346,21 @@ type WorkspaceSourceNames<TWorkspace> =
   TWorkspace extends { sources: infer TSources }
     ? Extract<keyof NonNullable<TSources>, string>
     : string
+type WorkspaceSourceInputScopeNames<TSource> =
+  TSource extends { scopes?: readonly (infer TScope)[] }
+    ? Extract<TScope, string>
+    : TSource extends { source: infer TInnerSource }
+      ? WorkspaceSourceInputScopeNames<TInnerSource>
+      : never
+type WorkspaceSourceScopeNames<TWorkspace> =
+  TWorkspace extends { sources: infer TSources }
+    ? { [Key in keyof NonNullable<TSources>]: WorkspaceSourceInputScopeNames<NonNullable<TSources>[Key]> }[keyof NonNullable<TSources>]
+    : never
 type InvalidWorkspaceSourceGrant<TSourceName> = {
   readonly __vitehubInvalidWorkspaceSourceGrant: TSourceName
+}
+type InvalidWorkspaceSourceScope<TScopeName> = {
+  readonly __vitehubInvalidWorkspaceSourceScope: TScopeName
 }
 type ValidateCapabilityWorkspaceSources<
   TSourceName,
@@ -364,8 +378,8 @@ type ValidateCapabilityWorkspaceSources<
     : TCapability
 type ValidateAgentCapability<TCapability, TWorkspace> =
   TCapability extends AgentCapabilityDefinition<any, any, infer TTypeContract>
-    ? TTypeContract extends AgentCapabilityTypeContract
-      ? ValidateCapabilityWorkspaceSources<TTypeContract["workspaceSources"], TWorkspace, TCapability>
+    ? TTypeContract extends { workspaceSources: infer TSourceName }
+      ? ValidateCapabilityWorkspaceSources<TSourceName, TWorkspace, TCapability>
       : TCapability
     : TCapability
 type ValidateAgentCapabilities<TCapabilities, TWorkspace> =
@@ -374,6 +388,26 @@ type ValidateAgentCapabilities<TCapabilities, TWorkspace> =
     : TCapabilities extends readonly (infer TCapability)[]
       ? ValidateAgentCapability<TCapability, TWorkspace>[]
       : TCapabilities
+type CapabilityWorkspaceScopeNames<TCapability> =
+  TCapability extends AgentCapabilityDefinition<any, any, infer TTypeContract>
+    ? TTypeContract extends { workspaceScopes: infer TScopeName }
+      ? Extract<TScopeName, string>
+      : never
+    : never
+type AgentCapabilitiesWorkspaceScopeNames<TCapabilities> =
+  TCapabilities extends readonly [unknown, ...unknown[]] | readonly []
+    ? CapabilityWorkspaceScopeNames<TCapabilities[number]>
+    : TCapabilities extends readonly (infer TCapability)[]
+      ? CapabilityWorkspaceScopeNames<TCapability>
+      : never
+type ValidateWorkspaceSourceScopes<TCapabilities, TWorkspace> =
+  [WorkspaceSourceScopeNames<TWorkspace>] extends [never]
+    ? unknown
+    : string extends WorkspaceSourceScopeNames<TWorkspace>
+      ? unknown
+      : Exclude<WorkspaceSourceScopeNames<TWorkspace>, AgentCapabilitiesWorkspaceScopeNames<TCapabilities>> extends never
+        ? unknown
+        : InvalidWorkspaceSourceScope<Exclude<WorkspaceSourceScopeNames<TWorkspace>, AgentCapabilitiesWorkspaceScopeNames<TCapabilities>>>
 
 type UnionToIntersection<T> =
   (T extends unknown ? (value: T) => void : never) extends (value: infer TIntersection) => void
@@ -397,7 +431,7 @@ type AgentCapabilitiesInvocationContextValues<TCapabilities> =
   >
 type ValidateWorkspaceAgentOptions<TOptions> =
   TOptions extends { capabilities?: infer TCapabilities, workspace: infer TWorkspace }
-    ? { capabilities?: ValidateAgentCapabilities<TCapabilities, TWorkspace> }
+    ? { capabilities?: ValidateAgentCapabilities<TCapabilities, TWorkspace> } & ValidateWorkspaceSourceScopes<TCapabilities, TWorkspace>
     : unknown
 type BaseAgentResolver<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig, CALL_OPTIONS = unknown> =
   (context: AgentRuntimeContext<TRuntimeConfig>) => Promise<AgentAdapter<CALL_OPTIONS>>
@@ -691,9 +725,12 @@ function validateSandboxCommands(commands: unknown): string[] {
   return commands
 }
 
-function validateWorkspaceCapabilities<Name extends WorkspaceName>(options: WorkspaceAgentOptions<AgentRuntimeConfig, Name>): void {
+function validateWorkspaceCapabilities<Name extends WorkspaceName>(options: WorkspaceAgentOptions<AgentRuntimeConfig, Name>, workspaceDefinition: Pick<WorkspaceDefinition, "sources">): void {
   const capabilities = normalizeCapabilities(options.capabilities)
   const workspaceMode = workspaceModeFromOptions(options)
+  if (workspaceSourceScopeNames(workspaceDefinition.sources).length && !capabilities.some(accessCapabilityRequiresWorkspace)) {
+    throw new Error("[vitehub] Workspace Source scopes require access({ workspace }).")
+  }
   for (const capability of capabilities) {
     if (capability.id === "workspace-shell" && normalizeMode(capability.mode, "Workspace Shell") === "write" && workspaceMode !== "write") {
       throw new Error("[vitehub] workspaceShell({ mode: \"write\" }) requires workspace.mode: \"write\".")
@@ -923,7 +960,7 @@ function createWorkspaceAgentDefinition<
   defaults: WorkspaceAgentDefaults<Name> = {},
 ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS> {
   const workspaceDefinition = workspaceDefinitionFromOptions(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>)
-  validateWorkspaceCapabilities(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>)
+  validateWorkspaceCapabilities(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>, workspaceDefinition)
   const definition = defineBaseAgent<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile>({
     ...options,
     description: options.description,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -347,7 +347,11 @@ type WorkspaceSourceNames<TWorkspace> =
     ? Extract<keyof NonNullable<TSources>, string>
     : string
 type WorkspaceSourceScopeOptionNames<TSource> =
-  "scopes" extends keyof TSource
+  TSource extends { __vitehubWorkspaceSourceScopeNames?: infer TScopes }
+    ? NonNullable<TScopes> extends readonly (infer TScope)[]
+      ? Extract<TScope, string>
+      : never
+    : "scopes" extends keyof TSource
     ? TSource extends { scopes?: infer TScopes }
       ? NonNullable<TScopes> extends readonly (infer TScope)[]
         ? string extends TScope ? never : Extract<TScope, string>
@@ -398,9 +402,14 @@ type ValidateAgentCapabilities<TCapabilities, TWorkspace> =
       : TCapabilities
 type CapabilityWorkspaceScopeNames<TCapability> =
   TCapability extends AgentCapabilityDefinition<any, any, infer TTypeContract>
-    ? TTypeContract extends { workspaceScopes: infer TScopeName }
-      ? Extract<TScopeName, string>
-      : never
+    ? (TTypeContract extends { workspaceScopes: infer TScopeName }
+          ? Extract<TScopeName, string>
+          : AgentCapabilityTypeContract extends TTypeContract
+            ? string
+            : never)
+        | (TCapability extends { capabilities: infer TNestedCapabilities }
+            ? AgentCapabilitiesWorkspaceScopeNames<TNestedCapabilities>
+            : never)
     : never
 type AgentCapabilitiesWorkspaceScopeNames<TCapabilities> =
   TCapabilities extends readonly [unknown, ...unknown[]] | readonly []
@@ -411,9 +420,7 @@ type AgentCapabilitiesWorkspaceScopeNames<TCapabilities> =
 type ValidateWorkspaceSourceScopes<TCapabilities, TWorkspace> =
   [WorkspaceSourceScopeNames<TWorkspace>] extends [never]
     ? unknown
-    : string extends WorkspaceSourceScopeNames<TWorkspace>
-      ? unknown
-      : Exclude<WorkspaceSourceScopeNames<TWorkspace>, AgentCapabilitiesWorkspaceScopeNames<TCapabilities>> extends never
+    : Exclude<WorkspaceSourceScopeNames<TWorkspace>, AgentCapabilitiesWorkspaceScopeNames<TCapabilities>> extends never
         ? unknown
         : InvalidWorkspaceSourceScope<Exclude<WorkspaceSourceScopeNames<TWorkspace>, AgentCapabilitiesWorkspaceScopeNames<TCapabilities>>>
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -349,7 +349,7 @@ type WorkspaceSourceNames<TWorkspace> =
 type WorkspaceSourceScopeOptionNames<TSource> =
   TSource extends { __vitehubWorkspaceSourceScopeNames?: infer TScopes }
     ? NonNullable<TScopes> extends readonly (infer TScope)[]
-      ? Extract<TScope, string>
+      ? string extends TScope ? never : Extract<TScope, string>
       : never
     : "scopes" extends keyof TSource
     ? TSource extends { scopes?: infer TScopes }
@@ -405,7 +405,9 @@ type CapabilityWorkspaceScopeNames<TCapability> =
     ? (TTypeContract extends { workspaceScopes: infer TScopeName }
           ? Extract<TScopeName, string>
           : AgentCapabilityTypeContract extends TTypeContract
-            ? string
+            ? TCapability extends { id: infer TCapabilityId }
+              ? string extends TCapabilityId ? string : never
+              : never
             : never)
         | (TCapability extends { capabilities: infer TNestedCapabilities }
             ? AgentCapabilitiesWorkspaceScopeNames<TNestedCapabilities>

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -405,9 +405,9 @@ type CapabilityWorkspaceScopeNames<TCapability> =
 type AgentCapabilitiesWorkspaceScopeNames<TCapabilities> =
   TCapabilities extends readonly [unknown, ...unknown[]] | readonly []
     ? CapabilityWorkspaceScopeNames<TCapabilities[number]>
-    : TCapabilities extends readonly (infer TCapability)[]
-      ? CapabilityWorkspaceScopeNames<TCapability>
-      : never
+  : TCapabilities extends readonly (infer TCapability)[]
+    ? AgentCapabilityDefinition extends TCapability ? string : CapabilityWorkspaceScopeNames<TCapability>
+    : never
 type ValidateWorkspaceSourceScopes<TCapabilities, TWorkspace> =
   [WorkspaceSourceScopeNames<TWorkspace>] extends [never]
     ? unknown

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -346,12 +346,20 @@ type WorkspaceSourceNames<TWorkspace> =
   TWorkspace extends { sources: infer TSources }
     ? Extract<keyof NonNullable<TSources>, string>
     : string
-type WorkspaceSourceInputScopeNames<TSource> =
-  TSource extends { scopes?: readonly (infer TScope)[] }
-    ? Extract<TScope, string>
-    : TSource extends { source: infer TInnerSource }
-      ? WorkspaceSourceInputScopeNames<TInnerSource>
+type WorkspaceSourceScopeOptionNames<TSource> =
+  "scopes" extends keyof TSource
+    ? TSource extends { scopes?: infer TScopes }
+      ? NonNullable<TScopes> extends readonly (infer TScope)[]
+        ? string extends TScope ? never : Extract<TScope, string>
+        : never
       : never
+    : never
+type WorkspaceSourceInputScopeNames<TSource> =
+  TSource extends { source: infer TInnerSource }
+    ? "scopes" extends keyof TSource
+      ? WorkspaceSourceScopeOptionNames<TSource>
+      : WorkspaceSourceInputScopeNames<TInnerSource>
+    : WorkspaceSourceScopeOptionNames<TSource>
 type WorkspaceSourceScopeNames<TWorkspace> =
   TWorkspace extends { sources: infer TSources }
     ? { [Key in keyof NonNullable<TSources>]: WorkspaceSourceInputScopeNames<NonNullable<TSources>[Key]> }[keyof NonNullable<TSources>]

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -580,6 +580,7 @@ export interface AgentCapabilityRuntimeContext<
 export interface AgentCapabilityTypeContract {
   inputContext?: object
   invocationContext?: object
+  workspaceScopes?: string
   workspaceSources?: string
 }
 

--- a/packages/agent/src/workspace-source-metadata.ts
+++ b/packages/agent/src/workspace-source-metadata.ts
@@ -84,9 +84,8 @@ export function workspaceSourceScopePaths(
   if (metadata.source && runtime.isWorkspaceSourceRequestOnly(metadata.source)) {
     return [descriptorPath]
   }
-  const paths = metadata.mountPath
-    ? [metadata.mountPath]
-    : metadata.probeKeys?.map(sourcePath => joinSourcePath(metadata.mountPath, sourcePath)).filter(Boolean) || []
+  const probePaths = metadata.probeKeys?.map(sourcePath => joinSourcePath(metadata.mountPath, sourcePath)).filter(Boolean) || []
+  const paths = probePaths.length ? probePaths : metadata.mountPath ? [metadata.mountPath] : []
   if (!paths.length) {
     throw new Error(`[vitehub] Workspace Scope source grant "${key}" is root-mounted; grant explicit paths instead.`)
   }

--- a/packages/agent/src/workspace-source-metadata.ts
+++ b/packages/agent/src/workspace-source-metadata.ts
@@ -80,8 +80,11 @@ export function workspaceSourceScopePaths(
   runtime: Pick<typeof import("@vite-hub/workspace"), "isWorkspaceSourceRequestOnly" | "workspaceSourceRequestDescriptorPath">,
 ): string[] {
   const metadata = normalizeAgentWorkspaceSource(key, input)
-  const descriptorPath = runtime.workspaceSourceRequestDescriptorPath(key)
+  const descriptorPath = safeWorkspaceSourceRequestDescriptorPath(runtime, key)
   if (metadata.source && runtime.isWorkspaceSourceRequestOnly(metadata.source)) {
+    if (!descriptorPath) {
+      throw new Error(`[vitehub] Workspace Scope source grant "${key}" is request-only without a Source Request descriptor.`)
+    }
     return [descriptorPath]
   }
   const probePaths = metadata.probeKeys?.map(sourcePath => joinSourcePath(metadata.mountPath, sourcePath)).filter(Boolean) || []
@@ -89,7 +92,19 @@ export function workspaceSourceScopePaths(
   if (!paths.length) {
     throw new Error(`[vitehub] Workspace Scope source grant "${key}" is root-mounted; grant explicit paths instead.`)
   }
-  return [...paths, descriptorPath]
+  return descriptorPath ? [...paths, descriptorPath] : paths
+}
+
+function safeWorkspaceSourceRequestDescriptorPath(
+  runtime: Pick<typeof import("@vite-hub/workspace"), "workspaceSourceRequestDescriptorPath">,
+  key: string,
+): string | undefined {
+  try {
+    return runtime.workspaceSourceRequestDescriptorPath(key)
+  }
+  catch {
+    return undefined
+  }
 }
 
 function describeWorkspaceSourceInput(input: WorkspaceSourceInput): WorkspaceSourceMetadataDescriptor {

--- a/packages/agent/src/workspace-source-metadata.ts
+++ b/packages/agent/src/workspace-source-metadata.ts
@@ -271,7 +271,11 @@ function fileSourceKey(input: Record<string, unknown>): string {
 
 function inferFetchWorkspacePath(input: Record<string, unknown>) {
   const responseType = input.responseType === "text" ? "text" : "json"
-  const explicitPath = typeof input.path === "string" ? input.path : undefined
+  const explicitPath = typeof input.workspacePath === "string"
+    ? input.workspacePath
+    : typeof input.path === "string"
+      ? input.path
+      : undefined
   if (explicitPath) return normalizeAgentWorkspacePath(explicitPath, { allowEmpty: false })
 
   const url = input.url instanceof URL ? input.url : new URL(String(input.url))

--- a/packages/agent/src/workspace-source-metadata.ts
+++ b/packages/agent/src/workspace-source-metadata.ts
@@ -74,6 +74,25 @@ export function workspaceSourceScopeNames(sources: WorkspaceDefinition["sources"
   return [...new Set(normalizeAgentWorkspaceSources(sources).flatMap(source => source.scopes || []))].sort()
 }
 
+export function workspaceSourceScopePaths(
+  key: string,
+  input: WorkspaceSourceInput,
+  runtime: Pick<typeof import("@vite-hub/workspace"), "isWorkspaceSourceRequestOnly" | "workspaceSourceRequestDescriptorPath">,
+): string[] {
+  const metadata = normalizeAgentWorkspaceSource(key, input)
+  const descriptorPath = runtime.workspaceSourceRequestDescriptorPath(key)
+  if (metadata.source && runtime.isWorkspaceSourceRequestOnly(metadata.source)) {
+    return [descriptorPath]
+  }
+  const paths = metadata.mountPath
+    ? [metadata.mountPath]
+    : metadata.probeKeys?.map(sourcePath => joinSourcePath(metadata.mountPath, sourcePath)).filter(Boolean) || []
+  if (!paths.length) {
+    throw new Error(`[vitehub] Workspace Scope source grant "${key}" is root-mounted; grant explicit paths instead.`)
+  }
+  return [...paths, descriptorPath]
+}
+
 function describeWorkspaceSourceInput(input: WorkspaceSourceInput): WorkspaceSourceMetadataDescriptor {
   if (typeof input === "string") {
     return {
@@ -255,6 +274,10 @@ function inferFetchWorkspacePath(input: Record<string, unknown>) {
 
 function inferRepositoryMount(repo: unknown) {
   return typeof repo === "string" ? repo.split("/").filter(Boolean).at(-1) : undefined
+}
+
+function joinSourcePath(mountPath: string, sourcePath: string): string {
+  return [mountPath, sourcePath].filter(Boolean).join("/")
 }
 
 function dirname(path: string) {

--- a/packages/agent/src/workspace-source-metadata.ts
+++ b/packages/agent/src/workspace-source-metadata.ts
@@ -18,6 +18,7 @@ interface WorkspaceSourceMetadataDescriptor {
   materialize?: WorkspaceMaterializeMode
   mount?: WorkspaceSourceMount
   probeKeys?: string[]
+  scopes?: readonly string[]
   source?: WorkspaceSource
   sync?: WorkspaceSourceSyncConfig
 }
@@ -29,6 +30,7 @@ export interface AgentWorkspaceSourceMetadata {
   materialize: WorkspaceMaterializeMode
   mountPath: string
   probeKeys?: string[]
+  scopes?: readonly string[]
   source?: WorkspaceSource
   sync: false | WorkspaceSourceSyncConfig
 }
@@ -47,6 +49,7 @@ export function normalizeAgentWorkspaceSource(key: string, input: WorkspaceSourc
   const cache = normalizeSourceCache(mount.cache ?? descriptor.cache) ?? false
   const sync = normalizeSourceSync(descriptor.sync)
   const mountPath = typeof mount.path === "string" ? mount.path : key
+  const scopes = normalizeWorkspaceSourceScopes(key, descriptor.scopes)
 
   return {
     cache,
@@ -55,9 +58,20 @@ export function normalizeAgentWorkspaceSource(key: string, input: WorkspaceSourc
     materialize: mount.materialize || descriptor.materialize || descriptor.defaultMaterialize || (cache ? "lazy" : sync ? "none" : "build"),
     mountPath: normalizeAgentWorkspacePath(mountPath, { allowEmpty: true }),
     ...(descriptor.probeKeys?.length ? { probeKeys: descriptor.probeKeys } : {}),
+    ...(scopes.length ? { scopes } : {}),
     ...(descriptor.source ? { source: descriptor.source } : {}),
     sync,
   }
+}
+
+export function workspaceSourceKeysForScope(sources: WorkspaceDefinition["sources"], scope: string): string[] {
+  return normalizeAgentWorkspaceSources(sources)
+    .filter(source => source.scopes?.includes(scope))
+    .map(source => source.key)
+}
+
+export function workspaceSourceScopeNames(sources: WorkspaceDefinition["sources"]): string[] {
+  return [...new Set(normalizeAgentWorkspaceSources(sources).flatMap(source => source.scopes || []))].sort()
 }
 
 function describeWorkspaceSourceInput(input: WorkspaceSourceInput): WorkspaceSourceMetadataDescriptor {
@@ -164,6 +178,7 @@ function copySourceRuntimeOptions(
     materialize: input.materialize as WorkspaceMaterializeMode | undefined ?? defaults.materialize,
     mount: input.mount as WorkspaceSourceMount | undefined ?? defaults.mount,
     probeKeys: input.probeKeys as string[] | undefined ?? defaults.probeKeys,
+    scopes: input.scopes as readonly string[] | undefined ?? defaults.scopes,
     sync: input.sync as WorkspaceSourceSyncConfig | undefined ?? defaults.sync,
   }
 }
@@ -179,6 +194,7 @@ function applyWorkspaceSourceBinding(
     materialize: hasOwn(input, "materialize") ? input.materialize as WorkspaceMaterializeMode | undefined : descriptor.materialize,
     mount: hasOwn(input, "mount") ? input.mount as WorkspaceSourceMount | undefined : descriptor.mount,
     probeKeys: hasOwn(input, "probeKeys") ? input.probeKeys as string[] | undefined : descriptor.probeKeys,
+    scopes: hasOwn(input, "scopes") ? input.scopes as readonly string[] | undefined : descriptor.scopes,
     sync: hasOwn(input, "sync") ? input.sync as WorkspaceSourceSyncConfig | undefined : descriptor.sync,
   }
 }
@@ -196,6 +212,14 @@ function normalizeSourceCache(cache: false | WorkspaceCacheOptions | undefined):
 function normalizeSourceSync(sync: WorkspaceSourceSyncConfig | undefined): false | WorkspaceSourceSyncConfig {
   if (!sync) return false
   return sync
+}
+
+function normalizeWorkspaceSourceScopes(key: string, scopes: unknown): readonly string[] {
+  if (scopes === undefined) return []
+  if (!Array.isArray(scopes) || scopes.some(scope => typeof scope !== "string")) {
+    throw new TypeError(`[vitehub] Workspace Source "${key}" scopes must be an array of strings.`)
+  }
+  return scopes.map(scope => scope.trim()).filter(Boolean)
 }
 
 function isExplicitSourceBinding(input: Record<string, unknown>): input is Record<string, unknown> & { source: WorkspaceSourceInput } {

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -1143,6 +1143,31 @@ describe("access capability", () => {
     })).rejects.toThrow("Workspace Source scope \"missing\"")
   })
 
+  it("fails closed when Workspace Source scopes use inline Access definitions", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            resolve: {
+              scope: "support",
+              paths: ["customers/acme"],
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace(), "read", {
+      workspaceDefinition: {
+        name: "support",
+        sources: {
+          customerDocs: { mount: "customers/acme", scopes: ["support"] } as never,
+        },
+      },
+    })).rejects.toThrow("Workspace Source scopes require access({ workspace }).scopes")
+  })
+
   it("fails closed when Workspace Source scopes are configured without Access", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -1138,6 +1138,16 @@ describe("access capability", () => {
     await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(false)
   })
 
+  it("derives probed source grant paths before broad mounts", async () => {
+    const { workspaceSourceScopePaths } = await import("../src/workspace-source-metadata.ts")
+    const workspaceRuntime = await import("@vite-hub/workspace")
+
+    expect(workspaceSourceScopePaths("docs", file({ path: "README.md", mount: "docs", scopes: ["support"] }), workspaceRuntime)).toEqual([
+      "docs/README.md",
+      ".vitehub/sources/docs.json",
+    ])
+  })
+
   it("resolves scoped resolver sources before applying final scope paths", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -1182,6 +1182,14 @@ describe("access capability", () => {
       "docs/README.md",
       ".vitehub/sources/docs.json",
     ])
+    expect(workspaceSourceScopePaths("status", {
+      scopes: ["support"],
+      url: "https://status.example.com/health",
+      workspacePath: "external/status/health.json",
+    } as never, workspaceRuntime)).toEqual([
+      "external/status/health.json",
+      ".vitehub/sources/status.json",
+    ])
   })
 
   it("does not derive descriptor paths for non-request path-keyed sources", async () => {

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import type { AgentRuntimeContext, AgentToolSet } from "../src/types.ts"
-import { attachWorkspaceSourceRequestExecution, custom, type ReadonlyWorkspaceFacade, type WorkspaceDefinition, type WorkspaceEntry, type WorkspaceSearchHit, type WorkspaceStat } from "@vite-hub/workspace"
+import { attachWorkspaceSourceRequestExecution, custom, file, type ReadonlyWorkspaceFacade, type WorkspaceDefinition, type WorkspaceEntry, type WorkspaceSearchHit, type WorkspaceStat } from "@vite-hub/workspace"
 
 function runtime(): AgentRuntimeContext {
   return {
@@ -91,6 +91,27 @@ function createWorkspace(executor?: Parameters<typeof attachWorkspaceSourceReque
       inspect: () => ({}),
       none: () => ({}),
     } as unknown as ReadonlyWorkspaceFacade["tools"],
+  }
+}
+
+function createWorkspaceWithRootFile(path: string, content: string): ReadonlyWorkspaceFacade {
+  const base = createWorkspace()
+  return {
+    ...base,
+    fs: {
+      ...base.fs,
+      async readFile(requested, options) {
+        if (requested === path) return (options?.encoding === "binary" ? new TextEncoder().encode(content) : content) as never
+        return await base.fs.readFile(requested, options as never)
+      },
+      async stat(requested) {
+        if (requested === path) return { path, size: content.length, type: "file" } as WorkspaceStat
+        return await base.fs.stat(requested)
+      },
+      async exists(requested) {
+        return requested === path || await base.fs.exists(requested)
+      },
+    },
   }
 }
 
@@ -1086,6 +1107,88 @@ describe("access capability", () => {
     })
 
     await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(true)
+    await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(false)
+  })
+
+  it("honors root file sources granted by Workspace Source scopes", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "support",
+            scopes: {
+              support: {},
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspaceWithRootFile("README.md", "root readme"), "read", {
+      workspaceDefinition: {
+        name: "support",
+        sources: {
+          readme: file({ path: "README.md", scopes: ["support"] }),
+        },
+      },
+    })
+
+    await expect(resolved.workspace!.fs.readFile("README.md")).resolves.toBe("root readme")
+    await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(false)
+  })
+
+  it("resolves scoped resolver sources before applying final scope paths", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+    const resolveSource = vi.fn(({ selectedWorkspaceScope }) => ({
+      materialize: "lazy" as const,
+      mount: `customers/${selectedWorkspaceScope?.name}`,
+      async getKeys() {
+        return ["resolved.md"]
+      },
+      async getItem(key: string) {
+        return { content: `resolved for ${selectedWorkspaceScope?.name}`, key }
+      },
+    }))
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "acme",
+            scopes: {
+              acme: {},
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace(), "read", {
+      workspaceDefinition: {
+        name: "support",
+        sources: {
+          customerDocs: {
+            source: custom({
+              async resolve(context) {
+                return resolveSource(context)
+              },
+              async getKeys() {
+                return []
+              },
+              async getItem(key: string) {
+                return { content: "", key }
+              },
+            }),
+            scopes: ["acme"],
+          } as never,
+        },
+      },
+    })
+
+    expect(resolveSource).toHaveBeenCalledWith(expect.objectContaining({
+      selectedWorkspaceScope: expect.objectContaining({ name: "acme" }),
+    }))
+    await expect(resolved.workspace!.fs.readFile("customers/acme/resolved.md")).resolves.toBe("resolved for acme")
     await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(false)
   })
 

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -906,6 +906,42 @@ describe("access capability", () => {
     })
     await sourceScoped.workspace!.fs.materializeSources?.()
     expect(calls).toEqual([{ path: "ingestion/acme", sources: ["acme"] }])
+
+    calls.length = 0
+    const multiProbeScoped = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            resolve: {
+              grants: [{ source: "reports" }],
+              scope: "support",
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, workspace, "read", {
+      workspaceDefinition: {
+        name: "support",
+        sources: {
+          reports: custom({
+            materialize: "lazy",
+            mount: "",
+            probeKeys: ["a.md", "b.md"],
+            async getKeys() {
+              return []
+            },
+            async getItem(key) {
+              return { key, content: "" }
+            },
+          }),
+        },
+      },
+    })
+    await multiProbeScoped.workspace!.fs.materializeSources?.()
+    expect(calls).toEqual([
+      { path: "a.md", sources: ["reports"] },
+      { path: "b.md", sources: ["reports"] },
+    ])
   })
 
   it("omits resolved Source Instructions when the resolved source is outside access scope", async () => {
@@ -1145,6 +1181,15 @@ describe("access capability", () => {
     expect(workspaceSourceScopePaths("docs", file({ path: "README.md", mount: "docs", scopes: ["support"] }), workspaceRuntime)).toEqual([
       "docs/README.md",
       ".vitehub/sources/docs.json",
+    ])
+  })
+
+  it("does not derive descriptor paths for non-request path-keyed sources", async () => {
+    const { workspaceSourceScopePaths } = await import("../src/workspace-source-metadata.ts")
+    const workspaceRuntime = await import("@vite-hub/workspace")
+
+    expect(workspaceSourceScopePaths("customers/acme", { scopes: ["support"] } as never, workspaceRuntime)).toEqual([
+      "customers/acme",
     ])
   })
 

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -1060,6 +1060,104 @@ describe("access capability", () => {
     await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(false)
   })
 
+  it("derives source grants from Workspace Source scopes", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "support",
+            scopes: {
+              support: {},
+              technical: { paths: ["customers/globex"] },
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace(), "read", {
+      workspaceDefinition: {
+        name: "support",
+        sources: {
+          customerDocs: { mount: "customers/acme", scopes: ["support"] } as never,
+        },
+      },
+    })
+
+    await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(true)
+    await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(false)
+  })
+
+  it("keeps explicit Workspace Scope grants additive with source scopes", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "support",
+            scopes: {
+              support: { paths: ["customers/globex"] },
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace(), "read", {
+      workspaceDefinition: {
+        name: "support",
+        sources: {
+          publicDocs: { mount: "public", scopes: ["support"] } as never,
+        },
+      },
+    })
+
+    await expect(resolved.workspace!.fs.exists("public/readme.md")).resolves.toBe(true)
+    await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(true)
+    await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(false)
+  })
+
+  it("fails closed when Workspace Source scopes are not declared in Access", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "support",
+            scopes: {
+              support: { paths: ["public"] },
+            },
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace(), "read", {
+      workspaceDefinition: {
+        name: "support",
+        sources: {
+          customerDocs: { mount: "customers/acme", scopes: ["missing"] } as never,
+        },
+      },
+    })).rejects.toThrow("Workspace Source scope \"missing\"")
+  })
+
+  it("fails closed when Workspace Source scopes are configured without Access", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace(), "read", {
+      workspaceDefinition: {
+        name: "support",
+        sources: {
+          customerDocs: { mount: "customers/acme", scopes: ["support"] } as never,
+        },
+      },
+    })).rejects.toThrow("Workspace Source scopes require access({ workspace })")
+  })
+
   it("fails closed for unknown source grants", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -25,6 +25,42 @@ const emptyWorkspace = () => ({
   },
 })
 
+const workspaceWithFiles = (files: Record<string, string>) => {
+  const paths = new Set(Object.keys(files))
+  for (const path of Object.keys(files)) {
+    const parts = path.split("/")
+    parts.pop()
+    while (parts.length) {
+      paths.add(parts.join("/"))
+      parts.pop()
+    }
+  }
+  return {
+    fs: {
+      exists: vi.fn(async (path: string) => paths.has(path)),
+      glob: vi.fn(async () => [...paths].map(path => ({ path, type: files[path] === undefined ? "directory" : "file" }))),
+      list: vi.fn(async (path = "") => [...paths]
+        .filter(candidate => candidate !== path && (!path || candidate.startsWith(`${path}/`)))
+        .map(path => ({ path, type: files[path] === undefined ? "directory" : "file" }))),
+      materializeSources: vi.fn(async () => ({ bytes: 0, directories: 0, durationMs: 0, files: 0, path: "", sources: [] })),
+      readFile: vi.fn(async (path: string) => {
+        const content = files[path]
+        if (content === undefined) throw new Error("missing")
+        return content
+      }),
+      search: vi.fn(async () => []),
+      stat: vi.fn(async (path: string) => {
+        if (!paths.has(path)) throw new Error("missing")
+        return { path, type: files[path] === undefined ? "directory" : "file" }
+      }),
+    },
+    tools: {
+      inspect: vi.fn(() => ({})),
+      none: vi.fn(() => ({})),
+    },
+  }
+}
+
 const writableWorkspace = () => {
   const files = new Map<string, string>()
   const fs = {
@@ -410,6 +446,46 @@ describe("agent capability runtime", () => {
     })
 
     await expect(resolved.workspace?.fs.readFile("pull-request/summary.md")).resolves.toBe("review context")
+  })
+
+  it("rejects scoped capability workspace sources that shadow unscoped base paths", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "review",
+            scopes: {
+              review: {},
+            },
+          },
+        }),
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: {
+                mount: "pull-request",
+                scopes: ["review"],
+                async getKeys() {
+                  return ["summary.md"]
+                },
+                async getItem(key: string) {
+                  return { content: "review context", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, workspaceWithFiles({ "pull-request/summary.md": "existing summary" }) as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow('workspace contribution source "pullRequest" conflicts with an existing Workspace path at mount "pull-request"')
   })
 
   it("rejects capability workspace source conflicts", async () => {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -299,6 +299,77 @@ describe("agent capability runtime", () => {
     ])
   })
 
+  it("requires Access when capability workspace contributions add scoped sources", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: {
+                mount: "pull-request",
+                scopes: ["review"],
+                async getKeys() {
+                  return ["summary.md"]
+                },
+                async getItem(key: string) {
+                  return { content: "review context", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow("Workspace Source scopes require access({ workspace })")
+  })
+
+  it("requires contributed source scopes to be declared in Access", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "review",
+            scopes: {
+              review: { paths: ["pull-request"] },
+            },
+          },
+        }),
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: {
+                mount: "pull-request",
+                scopes: ["missing"],
+                async getKeys() {
+                  return ["summary.md"]
+                },
+                async getItem(key: string) {
+                  return { content: "review context", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow('Workspace Source scope "missing"')
+  })
+
   it("rejects capability workspace source conflicts", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -370,6 +370,48 @@ describe("agent capability runtime", () => {
     })).rejects.toThrow('Workspace Source scope "missing"')
   })
 
+  it("derives grants for scoped capability workspace contribution sources", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "review",
+            scopes: {
+              review: {},
+            },
+          },
+        }),
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              pullRequest: {
+                mount: "pull-request",
+                scopes: ["review"],
+                async getKeys() {
+                  return ["summary.md"]
+                },
+                async getItem(key: string) {
+                  return { content: "review context", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    await expect(resolved.workspace?.fs.readFile("pull-request/summary.md")).resolves.toBe("review context")
+  })
+
   it("rejects capability workspace source conflicts", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, type AgentActor, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentDeliveryArtifact, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, type AgentActor, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentDeliveryArtifact, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, observability, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceExec, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -9,7 +9,7 @@ import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../src/output.ts"
 import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentUsageRecord, StreamEvent } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
-import { file, github as githubSource } from "@vite-hub/workspace"
+import { fetch as fetchSource, file, github as githubSource } from "@vite-hub/workspace"
 import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatPlatformResolver, AgentChatRunContext, FetchCapabilityToolOptions, PullRequestContextValue, RepositoryHostClient, TranscriptionResult, UsageTelemetryOutputExtension, UsageTelemetrySummaryOptions } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
@@ -979,6 +979,30 @@ describe("agent public types", () => {
       model: {} as never,
     })
 
+    // @ts-expect-error typed fetch response generics do not disable Workspace Source scope checks
+    defineAgent({
+      workspace: {
+        sources: {
+          status: fetchSource<{ status: string }>({
+            scopes: ["missing"] as const,
+            url: "https://status.example.com/api/summary",
+            workspacePath: "status/summary.json",
+          }),
+        },
+      },
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "customer",
+            scopes: {
+              customer: { source: "status" },
+            },
+          },
+        }),
+      ],
+      model: {} as never,
+    })
+
     // @ts-expect-error Workspace Source scopes require access({ workspace })
     defineAgent({
       workspace: {
@@ -1020,6 +1044,49 @@ describe("agent public types", () => {
         },
       },
       capabilities: broadCapabilities,
+      model: {} as never,
+    })
+
+    const widenedAccessCapability: AgentCapabilityDefinition = access({
+      workspace: {
+        defaultScope: "customer",
+        scopes: {
+          customer: { source: "docs" },
+        },
+      },
+    })
+
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: githubSource({ repo: "acme/docs", scopes: ["customer"] as const }),
+        },
+      },
+      capabilities: [widenedAccessCapability],
+      model: {} as never,
+    })
+
+    const bundledAccessCapability = defineCapability({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "customer",
+            scopes: {
+              customer: { source: "docs" },
+            },
+          },
+        }),
+      ],
+      id: "workspace-access-bundle",
+    })
+
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: githubSource({ repo: "acme/docs", scopes: ["customer"] as const }),
+        },
+      },
+      capabilities: [bundledAccessCapability],
       model: {} as never,
     })
   })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -982,8 +982,38 @@ describe("agent public types", () => {
     defineAgent({
       workspace: {
         sources: {
-          status: fetchSource<{ status: string }>({
+          status: fetchSource({
             scopes: ["customer"] as const,
+            transform(data: { status: string }) {
+              return data
+            },
+            url: "https://status.example.com/api/summary",
+            workspacePath: "status/summary.json",
+          }),
+        },
+      },
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "customer",
+            scopes: {
+              customer: { source: "status" },
+            },
+          },
+        }),
+      ],
+      model: {} as never,
+    })
+
+    // @ts-expect-error typed fetch source scopes must be backed by Access Workspace Scopes
+    defineAgent({
+      workspace: {
+        sources: {
+          status: fetchSource({
+            scopes: ["missing"] as const,
+            transform(data: { status: string }) {
+              return data
+            },
             url: "https://status.example.com/api/summary",
             workspacePath: "status/summary.json",
           }),

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -979,12 +979,11 @@ describe("agent public types", () => {
       model: {} as never,
     })
 
-    // @ts-expect-error typed fetch response generics do not disable Workspace Source scope checks
     defineAgent({
       workspace: {
         sources: {
           status: fetchSource<{ status: string }>({
-            scopes: ["missing"] as const,
+            scopes: ["customer"] as const,
             url: "https://status.example.com/api/summary",
             workspacePath: "status/summary.json",
           }),
@@ -999,6 +998,19 @@ describe("agent public types", () => {
             },
           },
         }),
+      ],
+      model: {} as never,
+    })
+
+    // @ts-expect-error concrete custom capabilities do not satisfy Workspace Source scopes
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: githubSource({ repo: "acme/docs", scopes: ["customer"] as const }),
+        },
+      },
+      capabilities: [
+        defineCapability({ id: "audit" }),
       ],
       model: {} as never,
     })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -896,6 +896,68 @@ describe("agent public types", () => {
         },
       },
     })
+
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: githubSource({ repo: "acme/docs", scopes: ["customer"] as const }),
+        },
+      },
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "customer",
+            scopes: {
+              customer: { source: "docs" },
+            },
+          },
+        }),
+      ],
+      model: {} as never,
+    })
+
+    // @ts-expect-error source-local scopes are checked against access workspace scope keys
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: githubSource({ repo: "acme/docs", scopes: ["missing"] as const }),
+        },
+      },
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "customer",
+            scopes: {
+              customer: { source: "docs" },
+            },
+          },
+        }),
+      ],
+      model: {} as never,
+    })
+
+    // @ts-expect-error Workspace Source scopes require access({ workspace })
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: githubSource({ repo: "acme/docs", scopes: ["customer"] as const }),
+        },
+      },
+      model: {} as never,
+    })
+
+    // @ts-expect-error non-Access capabilities do not satisfy Workspace Source scopes
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: githubSource({ repo: "acme/docs", scopes: ["customer"] as const }),
+        },
+      },
+      capabilities: [
+        workspaceShell(),
+      ],
+      model: {} as never,
+    })
   })
 
   it("types Agent Actor consumers in access and lifecycle callbacks", () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1098,6 +1098,7 @@ describe("agent public types", () => {
       },
     })
 
+    // @ts-expect-error individual widened capabilities cannot prove Access Workspace Scope names
     defineAgent({
       workspace: {
         sources: {
@@ -1105,6 +1106,27 @@ describe("agent public types", () => {
         },
       },
       capabilities: [widenedAccessCapability],
+      model: {} as never,
+    })
+
+    // @ts-expect-error broad official capabilities do not satisfy missing Workspace Source scopes
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: githubSource({ repo: "acme/docs", scopes: ["missing"] as const }),
+        },
+      },
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "customer",
+            scopes: {
+              customer: { source: "docs" },
+            },
+          },
+        }),
+        blob(),
+      ],
       model: {} as never,
     })
 

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -936,6 +936,49 @@ describe("agent public types", () => {
       model: {} as never,
     })
 
+    // @ts-expect-error unscoped sources do not disable Workspace Source scope checks
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: githubSource({ repo: "acme/docs", scopes: ["missing"] as const }),
+          readme: file("README.md"),
+        },
+      },
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "customer",
+            scopes: {
+              customer: { source: "docs" },
+            },
+          },
+        }),
+      ],
+      model: {} as never,
+    })
+
+    const dynamicScopes: string[] = ["dynamic"]
+    // @ts-expect-error broad source scopes do not disable literal Workspace Source scope checks
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: githubSource({ repo: "acme/docs", scopes: ["missing"] as const }),
+          dynamic: githubSource({ repo: "acme/dynamic", scopes: dynamicScopes }),
+        },
+      },
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "customer",
+            scopes: {
+              customer: { source: "docs" },
+            },
+          },
+        }),
+      ],
+      model: {} as never,
+    })
+
     // @ts-expect-error Workspace Source scopes require access({ workspace })
     defineAgent({
       workspace: {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, type AgentActor, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentDeliveryArtifact, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, type AgentActor, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentDeliveryArtifact, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, observability, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceExec, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -999,6 +999,27 @@ describe("agent public types", () => {
       capabilities: [
         workspaceShell(),
       ],
+      model: {} as never,
+    })
+
+    const broadCapabilities: AgentCapabilityDefinition[] = [
+      access({
+        workspace: {
+          defaultScope: "customer",
+          scopes: {
+            customer: { source: "docs" },
+          },
+        },
+      }),
+    ]
+
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: githubSource({ repo: "acme/docs", scopes: ["customer"] as const }),
+        },
+      },
+      capabilities: broadCapabilities,
       model: {} as never,
     })
   })

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1009,6 +1009,53 @@ describe("defineAgent workspace option", () => {
     expect(harnessWorkspaceSession.close).toHaveBeenCalledWith(undefined)
   })
 
+  it("does not pass other scoped file sources into Harness Workspace Sessions", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { access } = await import("../src/capabilities.ts")
+    const { file } = await import("@vite-hub/workspace")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
+    exists.mockImplementation(async path => path === "public.md" || path === ".vitehub/sources/publicDocs.json")
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+
+    const agent = withAgentDefaults(defineAgent({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "public",
+            scopes: {
+              admin: {},
+              public: {},
+            },
+          },
+        }),
+      ],
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: { provider: "sandbox" },
+      },
+      workspace: {
+        sources: {
+          publicDocs: file({ path: "public.md", scopes: ["public"] }),
+          secretDocs: file({ path: "secret.md", scopes: ["admin"] }),
+        },
+      },
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+      abortSignal: undefined,
+      paths: ["public.md", ".vitehub/sources/publicDocs.json"],
+      session: harnessSandboxSession,
+      sessionWorkDir: "/workspace/codex-session",
+    }))
+  })
+
   it("keeps harness-native skill files visible when access() selects Workspace Scope", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { access, skills } = await import("../src/capabilities.ts")

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -423,6 +423,7 @@ export interface WorkspaceSource {
   cache?: false | WorkspaceCacheOptions
   validate?: WorkspaceValidateMode
   sync?: WorkspaceSourceSyncConfig
+  scopes?: readonly string[]
   probeKeys?: string[]
   fingerprint?: unknown
   instructions?: WorkspaceSourceInstructions
@@ -447,7 +448,7 @@ export type WorkspaceSourceDefinition = WorkspaceSource | SourcePackageSource
 
 type WorkspaceSourceBindingOptions = Pick<
   WorkspaceSource,
-  "cache" | "instructions" | "materialize" | "mount" | "probeKeys" | "sync" | "validate"
+  "cache" | "instructions" | "materialize" | "mount" | "probeKeys" | "scopes" | "sync" | "validate"
 >
 
 export interface WorkspaceSourceBindingInput extends WorkspaceSourceBindingOptions {

--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -388,12 +388,13 @@ function applyWorkspaceBinding(source: WorkspaceSource, input: WorkspaceSourceIn
   copyDefinedWorkspaceBindingOption(next, input, "instructions")
   copyDefinedWorkspaceBindingOption(next, input, "materialize")
   copyDefinedWorkspaceBindingOption(next, input, "mount")
+  copyDefinedWorkspaceBindingOption(next, input, "scopes")
   copyDefinedWorkspaceBindingOption(next, input, "sync")
   copyDefinedWorkspaceBindingOption(next, input, "validate")
   return next
 }
 
-function copyDefinedWorkspaceBindingOption<TKey extends "cache" | "instructions" | "materialize" | "mount" | "sync" | "validate">(
+function copyDefinedWorkspaceBindingOption<TKey extends "cache" | "instructions" | "materialize" | "mount" | "scopes" | "sync" | "validate">(
   target: WorkspaceSource,
   input: Record<string, unknown>,
   key: TKey,

--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -43,6 +43,7 @@ export interface ResolvedWorkspaceSource {
   readonly: true
   requestDescriptor?: WorkspaceSourceRequestDescriptor
   requestOnly?: boolean
+  scopes?: readonly string[]
 }
 
 export {
@@ -116,6 +117,7 @@ export function normalizeWorkspaceSource(key: string, input: WorkspaceSourceInpu
   const sync = normalizeSourceSync(source.sync)
   const mountPath = typeof mount.path === "string" ? mount.path : key
   const requestDescriptor = getWorkspaceSourceRequestDescriptor(source)
+  const scopes = normalizeSourceScopes(key, source.scopes)
   if (requestDescriptor) assertWorkspaceSourceRequestDescriptorKey(key)
   return {
     key,
@@ -130,6 +132,7 @@ export function normalizeWorkspaceSource(key: string, input: WorkspaceSourceInpu
     readonly: true,
     requestDescriptor,
     requestOnly: isWorkspaceSourceRequestOnly(source),
+    ...(scopes.length ? { scopes } : {}),
   }
 }
 
@@ -160,6 +163,14 @@ function normalizeSourceSync(sync: WorkspaceSource["sync"]): false | WorkspaceSo
     concurrency: sync.concurrency,
     stale: sync.stale || "keep",
   }
+}
+
+function normalizeSourceScopes(key: string, scopes: unknown): readonly string[] {
+  if (scopes === undefined) return []
+  if (!Array.isArray(scopes) || scopes.some(scope => typeof scope !== "string")) {
+    throw new TypeError(`[vitehub] Workspace source "${key}" scopes must be an array of strings.`)
+  }
+  return scopes.map(scope => scope.trim()).filter(Boolean)
 }
 
 function toWorkspaceSource(input: WorkspaceSourceInput): WorkspaceSource {
@@ -316,6 +327,7 @@ function copySourceRuntimeOptions(input: Record<string, unknown>, defaults: Part
     instructions: input.instructions as WorkspaceSource["instructions"] ?? defaults.instructions,
     materialize: input.materialize as WorkspaceSource["materialize"] ?? defaults.materialize,
     mount: input.mount as WorkspaceSource["mount"] ?? defaults.mount,
+    scopes: input.scopes as WorkspaceSource["scopes"] ?? defaults.scopes,
     sync: input.sync as WorkspaceSource["sync"] ?? defaults.sync,
     validate: input.validate as WorkspaceSource["validate"] ?? defaults.validate,
   }

--- a/packages/workspace/src/sources/custom.ts
+++ b/packages/workspace/src/sources/custom.ts
@@ -1,5 +1,8 @@
 import type { WorkspaceSource } from "../core/types.ts"
 
-export function custom(source: WorkspaceSource): WorkspaceSource {
-  return source
+type SourceScopes<T> = T extends { scopes?: infer TScopes } ? { scopes?: TScopes } : {}
+type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
+
+export function custom<const TSource extends WorkspaceSource>(source: TSource): TypedWorkspaceSource<TSource> {
+  return source as unknown as TypedWorkspaceSource<TSource>
 }

--- a/packages/workspace/src/sources/fetch.ts
+++ b/packages/workspace/src/sources/fetch.ts
@@ -48,7 +48,8 @@ export interface FetchSourceStandardJsonSchemaV1<T = unknown> extends FetchSourc
 
 type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "probeKeys" | "scopes" | "sync">
 type SourceScopes<T> = T extends { scopes?: infer TScopes } ? { scopes?: TScopes } : {}
-type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
+type SourceScopeNames<T> = T extends { scopes: infer TScopes } ? { readonly __vitehubWorkspaceSourceScopeNames?: TScopes } : {}
+type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T> & SourceScopeNames<T>
 type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
 
 export interface FetchSourceCredentialOptions {
@@ -105,12 +106,20 @@ export type FetchSourceInput<TResponse = unknown, TOutput = TResponse> =
   | FetchSourceOptions<TResponse, TOutput>
   | FetchSourceResolver<TResponse, TOutput>
 
-export function fetch<TResponse = unknown, TOutput = TResponse, const TOptions extends FetchSourceOptions<TResponse, TOutput> = FetchSourceOptions<TResponse, TOutput>>(options: ExactOptions<TOptions, FetchSourceOptions<TResponse, TOutput>>): TypedWorkspaceSource<TOptions>
+type FetchSourceOptionsWithScopes<TResponse, TOutput, TScopes extends readonly string[]> =
+  Omit<FetchSourceOptions<TResponse, TOutput>, "scopes"> & { scopes: TScopes }
+type FetchSourceOptionsWithoutScopes<TResponse, TOutput> =
+  Omit<FetchSourceOptions<TResponse, TOutput>, "scopes"> & { scopes?: undefined }
+
+export function fetch<TResponse = unknown, TOutput = TResponse, const TScopes extends readonly string[] = readonly string[]>(options: ExactOptions<FetchSourceOptionsWithScopes<TResponse, TOutput, TScopes>, FetchSourceOptions<TResponse, TOutput>>): TypedWorkspaceSource<FetchSourceOptionsWithScopes<TResponse, TOutput, TScopes>>
+export function fetch<TResponse = unknown, TOutput = TResponse, const TOptions extends FetchSourceOptionsWithoutScopes<TResponse, TOutput> = FetchSourceOptionsWithoutScopes<TResponse, TOutput>>(options: ExactOptions<TOptions, FetchSourceOptionsWithoutScopes<TResponse, TOutput>>): TypedWorkspaceSource<TOptions>
 export function fetch<TResponse = unknown, TOutput = TResponse>(resolve: FetchSourceResolver<TResponse, TOutput>): WorkspaceSource
 export function fetch<TResponse = unknown, TOutput = TResponse>(input: FetchSourceInput<TResponse, TOutput>): WorkspaceSource {
   if (typeof input === "function") return resolvableFetchSource(input)
+  return createFetchSource(input)
+}
 
-  const options = input
+function createFetchSource<TResponse = unknown, TOutput = TResponse>(options: FetchSourceOptions<TResponse, TOutput>): WorkspaceSource {
   const responseType = normalizePublicResponseType(options.responseType || "json")
   const method = normalizeMethod(options.method)
   assertRequestShape(options, method)
@@ -208,7 +217,7 @@ function resolvableFetchSource<TResponse, TOutput>(resolve: FetchSourceResolver<
     },
     async resolve(ctx) {
       const options = await resolve(ctx)
-      return options ? fetch<TResponse, TOutput>(options) : false
+      return options ? createFetchSource(options) : false
     },
   }
 }

--- a/packages/workspace/src/sources/fetch.ts
+++ b/packages/workspace/src/sources/fetch.ts
@@ -46,7 +46,7 @@ export interface FetchSourceStandardJsonSchemaV1<T = unknown> extends FetchSourc
   }
 }
 
-type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "scopes" | "sync">
+type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "probeKeys" | "scopes" | "sync">
 type SourceScopes<T> = T extends { scopes?: infer TScopes } ? { scopes?: TScopes } : {}
 type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
 type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
@@ -135,6 +135,7 @@ export function fetch<TResponse = unknown, TOutput = TResponse>(input: FetchSour
     instructions: options.instructions,
     materialize: options.materialize || (options.sync ? "none" : "lazy"),
     mount: mountPath,
+    probeKeys: options.probeKeys || (key ? [key] : undefined),
     scopes: options.scopes,
     sync: options.sync,
     async getKeys() {

--- a/packages/workspace/src/sources/fetch.ts
+++ b/packages/workspace/src/sources/fetch.ts
@@ -106,13 +106,11 @@ export type FetchSourceInput<TResponse = unknown, TOutput = TResponse> =
   | FetchSourceOptions<TResponse, TOutput>
   | FetchSourceResolver<TResponse, TOutput>
 
-type FetchSourceOptionsWithScopes<TResponse, TOutput, TScopes extends readonly string[]> =
-  Omit<FetchSourceOptions<TResponse, TOutput>, "scopes"> & { scopes: TScopes }
 type FetchSourceOptionsWithoutScopes<TResponse, TOutput> =
   Omit<FetchSourceOptions<TResponse, TOutput>, "scopes"> & { scopes?: undefined }
 
-export function fetch<TResponse = unknown, TOutput = TResponse, const TScopes extends readonly string[] = readonly string[]>(options: ExactOptions<FetchSourceOptionsWithScopes<TResponse, TOutput, TScopes>, FetchSourceOptions<TResponse, TOutput>>): TypedWorkspaceSource<FetchSourceOptionsWithScopes<TResponse, TOutput, TScopes>>
-export function fetch<TResponse = unknown, TOutput = TResponse, const TOptions extends FetchSourceOptionsWithoutScopes<TResponse, TOutput> = FetchSourceOptionsWithoutScopes<TResponse, TOutput>>(options: ExactOptions<TOptions, FetchSourceOptionsWithoutScopes<TResponse, TOutput>>): TypedWorkspaceSource<TOptions>
+export function fetch<TResponse = unknown, TOutput = TResponse>(options: ExactOptions<FetchSourceOptionsWithoutScopes<TResponse, TOutput>, FetchSourceOptions<TResponse, TOutput>>): TypedWorkspaceSource<FetchSourceOptionsWithoutScopes<TResponse, TOutput>>
+export function fetch<const TOptions extends FetchSourceOptions<any, any>>(options: ExactOptions<TOptions, FetchSourceOptions<any, any>>): TypedWorkspaceSource<TOptions>
 export function fetch<TResponse = unknown, TOutput = TResponse>(resolve: FetchSourceResolver<TResponse, TOutput>): WorkspaceSource
 export function fetch<TResponse = unknown, TOutput = TResponse>(input: FetchSourceInput<TResponse, TOutput>): WorkspaceSource {
   if (typeof input === "function") return resolvableFetchSource(input)

--- a/packages/workspace/src/sources/fetch.ts
+++ b/packages/workspace/src/sources/fetch.ts
@@ -46,7 +46,10 @@ export interface FetchSourceStandardJsonSchemaV1<T = unknown> extends FetchSourc
   }
 }
 
-type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "sync">
+type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "scopes" | "sync">
+type SourceScopes<T> = T extends { scopes?: infer TScopes } ? { scopes?: TScopes } : {}
+type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
+type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
 
 export interface FetchSourceCredentialOptions {
   cookies?: Record<string, string>
@@ -102,7 +105,7 @@ export type FetchSourceInput<TResponse = unknown, TOutput = TResponse> =
   | FetchSourceOptions<TResponse, TOutput>
   | FetchSourceResolver<TResponse, TOutput>
 
-export function fetch<TResponse = unknown, TOutput = TResponse>(options: FetchSourceOptions<TResponse, TOutput>): WorkspaceSource
+export function fetch<TResponse = unknown, TOutput = TResponse, const TOptions extends FetchSourceOptions<TResponse, TOutput> = FetchSourceOptions<TResponse, TOutput>>(options: ExactOptions<TOptions, FetchSourceOptions<TResponse, TOutput>>): TypedWorkspaceSource<TOptions>
 export function fetch<TResponse = unknown, TOutput = TResponse>(resolve: FetchSourceResolver<TResponse, TOutput>): WorkspaceSource
 export function fetch<TResponse = unknown, TOutput = TResponse>(input: FetchSourceInput<TResponse, TOutput>): WorkspaceSource {
   if (typeof input === "function") return resolvableFetchSource(input)
@@ -132,6 +135,7 @@ export function fetch<TResponse = unknown, TOutput = TResponse>(input: FetchSour
     instructions: options.instructions,
     materialize: options.materialize || (options.sync ? "none" : "lazy"),
     mount: mountPath,
+    scopes: options.scopes,
     sync: options.sync,
     async getKeys() {
       if (!workspacePath) return []
@@ -203,7 +207,7 @@ function resolvableFetchSource<TResponse, TOutput>(resolve: FetchSourceResolver<
     },
     async resolve(ctx) {
       const options = await resolve(ctx)
-      return options ? fetch(options) : false
+      return options ? fetch<TResponse, TOutput>(options) : false
     },
   }
 }

--- a/packages/workspace/src/sources/file.ts
+++ b/packages/workspace/src/sources/file.ts
@@ -2,13 +2,15 @@ import { file as createFileSource, type FileSourceOptions as SourcePackageFileSo
 
 import type { WorkspaceSource } from "../core/types.ts"
 
-type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "mount" | "sync" | "validate">
+type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "mount" | "scopes" | "sync" | "validate">
+type SourceScopes<T> = T extends { scopes?: infer TScopes } ? { scopes?: TScopes } : {}
+type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
 
 export type FileSourceOptions<TKey extends string = string> = SourcePackageFileSourceOptions<TKey> & SourceRuntimeOptions
 export type FileSourceInput<TKey extends string = string> = FileSourceOptions<TKey> | TKey
 
-export function file<const TKey extends string = string>(input: FileSourceInput<TKey>): WorkspaceSource {
-  const options = typeof input === "string" ? { path: input } as FileSourceOptions<TKey> : input
+export function file<const TKey extends string = string, const TInput extends FileSourceInput<TKey> = FileSourceInput<TKey>>(input: TInput): TypedWorkspaceSource<TInput> {
+  const options = (typeof input === "string" ? { path: input } : input) as FileSourceOptions<TKey>
   const mount = typeof options.mount === "object" && options.mount && !("path" in options.mount)
     ? { ...options.mount, path: "" }
     : options.mount ?? ""
@@ -19,7 +21,8 @@ export function file<const TKey extends string = string>(input: FileSourceInput<
     instructions: options.instructions,
     materialize: options.materialize,
     mount,
+    scopes: options.scopes,
     sync: options.sync,
     validate: options.validate,
-  }
+  } as unknown as TypedWorkspaceSource<TInput>
 }

--- a/packages/workspace/src/sources/file.ts
+++ b/packages/workspace/src/sources/file.ts
@@ -1,8 +1,10 @@
 import { file as createFileSource, type FileSourceOptions as SourcePackageFileSourceOptions } from "@vite-hub/source"
 
+import { normalizeSafeWorkspacePath } from "../core/path.ts"
+
 import type { WorkspaceSource } from "../core/types.ts"
 
-type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "mount" | "scopes" | "sync" | "validate">
+type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "mount" | "probeKeys" | "scopes" | "sync" | "validate">
 type SourceScopes<T> = T extends { scopes?: infer TScopes } ? { scopes?: TScopes } : {}
 type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
 
@@ -11,6 +13,7 @@ export type FileSourceInput<TKey extends string = string> = FileSourceOptions<TK
 
 export function file<const TKey extends string = string, const TInput extends FileSourceInput<TKey> = FileSourceInput<TKey>>(input: TInput): TypedWorkspaceSource<TInput> {
   const options = (typeof input === "string" ? { path: input } : input) as FileSourceOptions<TKey>
+  const key = normalizeSafeWorkspacePath(options.workspacePath || options.path || "")
   const mount = typeof options.mount === "object" && options.mount && !("path" in options.mount)
     ? { ...options.mount, path: "" }
     : options.mount ?? ""
@@ -21,6 +24,7 @@ export function file<const TKey extends string = string, const TInput extends Fi
     instructions: options.instructions,
     materialize: options.materialize,
     mount,
+    probeKeys: options.probeKeys || [key],
     scopes: options.scopes,
     sync: options.sync,
     validate: options.validate,

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -4,7 +4,9 @@ import { github as createGitHubSource, type GitHubSourceOptions as SourcePackage
 import { resolveWorkspaceEnv } from "../env.ts"
 import type { MaybePromise, WorkspaceSource, WorkspaceSourceResolutionContext } from "../core/types.ts"
 
-type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "mount" | "sync" | "validate">
+type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "mount" | "scopes" | "sync" | "validate">
+type SourceScopes<T> = T extends { scopes?: infer TScopes } ? { scopes?: TScopes } : {}
+type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
 type GitHubAuth = NonNullable<SourcePackageGitHubSourceOptions["auth"]>
 
 export interface GitHubSourceOptions extends Omit<SourcePackageGitHubSourceOptions, "auth">, SourceRuntimeOptions {
@@ -17,7 +19,7 @@ export type GitHubSourceResolver = (
 
 export type GitHubSourceInput = GitHubSourceOptions | GitHubSourceResolver
 
-export function github(options: GitHubSourceOptions): WorkspaceSource
+export function github<const TOptions extends GitHubSourceOptions>(options: TOptions): TypedWorkspaceSource<TOptions>
 export function github(resolve: GitHubSourceResolver): WorkspaceSource
 export function github(input: GitHubSourceInput): WorkspaceSource {
   if (typeof input === "function") return resolvableGitHubSource(input)
@@ -59,6 +61,7 @@ export function github(input: GitHubSourceInput): WorkspaceSource {
     instructions: resolvedOptions.instructions,
     materialize: resolvedOptions.materialize,
     mount: resolvedOptions.mount,
+    scopes: resolvedOptions.scopes,
     sync: resolvedOptions.sync,
     validate: resolvedOptions.validate,
     async prepare(ctx) {

--- a/packages/workspace/src/sources/glob.ts
+++ b/packages/workspace/src/sources/glob.ts
@@ -2,11 +2,13 @@ import { glob as createGlobSource, type GlobSourceOptions as SourcePackageGlobSo
 
 import type { WorkspaceSource } from "../core/types.ts"
 
-type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "mount" | "sync" | "validate">
+type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "mount" | "scopes" | "sync" | "validate">
+type SourceScopes<T> = T extends { scopes?: infer TScopes } ? { scopes?: TScopes } : {}
+type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
 
 export type GlobSourceOptions = SourcePackageGlobSourceOptions & SourceRuntimeOptions
 
-export function glob(options: GlobSourceOptions): WorkspaceSource {
+export function glob<const TOptions extends GlobSourceOptions>(options: TOptions): TypedWorkspaceSource<TOptions> {
   const source = createGlobSource({
     ...options,
     keyCache: options.keyCache ?? !isLazySource(options),
@@ -17,9 +19,10 @@ export function glob(options: GlobSourceOptions): WorkspaceSource {
     instructions: options.instructions,
     materialize: options.materialize,
     mount: options.mount,
+    scopes: options.scopes,
     sync: options.sync,
     validate: options.validate,
-  }
+  } as unknown as TypedWorkspaceSource<TOptions>
 }
 
 function isLazySource(options: GlobSourceOptions) {

--- a/packages/workspace/src/sources/mcp-resources.ts
+++ b/packages/workspace/src/sources/mcp-resources.ts
@@ -6,12 +6,14 @@ import { markLiveWorkspaceSource } from "./live.ts"
 import type { WorkspaceSource } from "../core/types.ts"
 import type { McpResourcesSourceOptions as SourcePackageMcpResourcesSourceOptions } from "@vite-hub/source"
 
-type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "mount" | "sync" | "validate">
+type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "instructions" | "materialize" | "mount" | "scopes" | "sync" | "validate">
+type SourceScopes<T> = T extends { scopes?: infer TScopes } ? { scopes?: TScopes } : {}
+type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
 
 export interface McpResourcesSourceOptions<TKey extends string = string>
   extends Omit<SourcePackageMcpResourcesSourceOptions<TKey>, "cache">, SourceRuntimeOptions {}
 
-export function mcpResources<const TKey extends string = string>(options: McpResourcesSourceOptions<TKey>): WorkspaceSource {
+export function mcpResources<const TKey extends string = string, const TOptions extends McpResourcesSourceOptions<TKey> = McpResourcesSourceOptions<TKey>>(options: TOptions): TypedWorkspaceSource<TOptions> {
   const livePaths: Record<string, string> = {}
   const baseSource = createMcpResourcesSource({
     ...options,
@@ -24,6 +26,7 @@ export function mcpResources<const TKey extends string = string>(options: McpRes
     instructions: options.instructions,
     materialize: options.materialize || (options.sync ? "none" : "lazy"),
     mount: options.mount,
+    scopes: options.scopes,
     async prepare(ctx) {
       await baseSource.prepare?.(ctx)
       const mountPath = resolveMountPath(options.mount, ctx)
@@ -32,7 +35,7 @@ export function mcpResources<const TKey extends string = string>(options: McpRes
     },
     sync: options.sync,
     validate: options.validate,
-  }, livePaths)
+  }, livePaths) as unknown as TypedWorkspaceSource<TOptions>
 }
 
 function resolveMountPath(mount: WorkspaceSource["mount"], ctx: { mountPath?: string, source?: string }) {

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -555,12 +555,13 @@ function applyResolvedWorkspaceSourceBinding(input: WorkspaceSourceInput, source
   copyDefinedWorkspaceBindingOption(next, input, "instructions")
   copyDefinedWorkspaceBindingOption(next, input, "materialize")
   copyDefinedWorkspaceBindingOption(next, input, "mount")
+  copyDefinedWorkspaceBindingOption(next, input, "scopes")
   copyDefinedWorkspaceBindingOption(next, input, "sync")
   copyDefinedWorkspaceBindingOption(next, input, "validate")
   return next
 }
 
-function copyDefinedWorkspaceBindingOption<TKey extends "cache" | "instructions" | "materialize" | "mount" | "sync" | "validate">(
+function copyDefinedWorkspaceBindingOption<TKey extends "cache" | "instructions" | "materialize" | "mount" | "scopes" | "sync" | "validate">(
   target: WorkspaceSource,
   input: Record<string, unknown>,
   key: TKey,

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -774,6 +774,7 @@ function selectedScopeIntersectsSource(
   source: ReturnType<typeof normalizeWorkspaceSources>[number],
 ): boolean {
   if (!scope || scope.all) return true
+  if (scope.name && source.scopes?.includes(scope.name)) return true
   return Boolean(scope.paths?.some((path) => {
     if (source.requestDescriptor && pathIntersects(path, workspaceSourceRequestDescriptorPath(source.key))) return true
     return !source.requestOnly && pathIntersects(path, source.mountPath)

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -549,8 +549,13 @@ async function resolveWorkspaceSource(
 }
 
 function applyResolvedWorkspaceSourceBinding(input: WorkspaceSourceInput, source: WorkspaceSource): WorkspaceSource {
-  if (!isPlainRecord(input) || !("source" in input)) return source
+  if (!isPlainRecord(input)) return source
   const next: WorkspaceSource = { ...source }
+  copyWorkspaceSourceMetadata(source, next)
+  if (!("source" in input)) {
+    copyDefinedWorkspaceBindingOption(next, input, "scopes")
+    return next
+  }
   copyDefinedWorkspaceBindingOption(next, input, "cache")
   copyDefinedWorkspaceBindingOption(next, input, "instructions")
   copyDefinedWorkspaceBindingOption(next, input, "materialize")

--- a/packages/workspace/test/fetch-source.test.ts
+++ b/packages/workspace/test/fetch-source.test.ts
@@ -34,9 +34,9 @@ describe("fetch sources", () => {
     registerWorkspace("fetch-json", defineWorkspace({
       store: { provider: "memory" },
       sources: {
-        status: fetch<{ ignored: boolean, status: string }, { status: string }>({
+        status: fetch({
           workspacePath: "api/summary.json",
-          transform: data => ({ status: data.status }),
+          transform: (data: { ignored: boolean, status: string }) => ({ status: data.status }),
           url: "https://status.example.com/api/summary",
         }),
       },

--- a/packages/workspace/test/lazy-sources.test.ts
+++ b/packages/workspace/test/lazy-sources.test.ts
@@ -96,6 +96,29 @@ describe("lazy sources", () => {
     ])
   })
 
+  it("normalizes source binding scopes", () => {
+    const resolved = normalizeWorkspaceSources({
+      docs: {
+        source: custom({
+          async getKeys() {
+            return []
+          },
+          async getItem(key) {
+            return { key, path: key, content: "" }
+          },
+        }),
+        scopes: ["support"],
+      },
+    })
+
+    expect(resolved).toEqual([
+      expect.objectContaining({
+        key: "docs",
+        scopes: ["support"],
+      }),
+    ])
+  })
+
   it("materializes build sources when a path explicitly requests them", async () => {
     const view = createWorkspaceSourceView({
       name: "build-source-path",

--- a/packages/workspace/test/lazy-sources.test.ts
+++ b/packages/workspace/test/lazy-sources.test.ts
@@ -62,6 +62,7 @@ describe("lazy sources", () => {
       docs: custom({
         materialize: "lazy",
         cache: { maxAge: 3600 },
+        scopes: ["support", "technical"],
         async getKeys() {
           return []
         },
@@ -90,6 +91,7 @@ describe("lazy sources", () => {
         mountPath: "docs",
         materialize: "lazy",
         cache: { maxAge: 3600 },
+        scopes: ["support", "technical"],
       }),
     ])
   })

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -205,6 +205,46 @@ describe("Workspace Source Resolution", () => {
     })
   })
 
+  it("resolves scoped resolver sources before filtering by final mount", async () => {
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        ingestion: {
+          source: custom({
+            async resolve({ selectedWorkspaceScope }) {
+              return custom({
+                materialize: "lazy",
+                mount: `customers/${selectedWorkspaceScope?.name}`,
+                async getKeys() {
+                  return ["summary.md"]
+                },
+                async getItem(key) {
+                  return { key, path: key, content: "summary\n" }
+                },
+              })
+            },
+            async getKeys() {
+              return []
+            },
+            async getItem(key) {
+              throw new Error(`unresolved source read: ${key}`)
+            },
+          }),
+          scopes: ["support"],
+        },
+      },
+    }
+
+    const resolved = await resolveWorkspaceSources(definition, scope("support", ["ingestion"]))
+    const [ingestion] = normalizeWorkspaceSources(resolved.sources)
+
+    expect(ingestion).toMatchObject({
+      key: "ingestion",
+      mountPath: "customers/support",
+      scopes: ["support"],
+    })
+  })
+
   it("defaults resolved GitHub sources to lazy materialization", async () => {
     const definition: WorkspaceDefinition = {
       name: "support",

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -205,6 +205,44 @@ describe("Workspace Source Resolution", () => {
     })
   })
 
+  it("preserves direct resolver source scopes when resolving sources", async () => {
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        ingestion: custom({
+          scopes: ["support"],
+          async resolve({ selectedWorkspaceScope }) {
+            return custom({
+              materialize: "lazy",
+              mount: `customers/${selectedWorkspaceScope?.name}`,
+              async getKeys() {
+                return ["summary.md"]
+              },
+              async getItem(key) {
+                return { key, path: key, content: "summary\n" }
+              },
+            })
+          },
+          async getKeys() {
+            return []
+          },
+          async getItem(key) {
+            throw new Error(`unresolved source read: ${key}`)
+          },
+        }),
+      },
+    }
+
+    const resolved = await resolveWorkspaceSources(definition, scope("support", ["ingestion"]))
+    const [ingestion] = normalizeWorkspaceSources(resolved.sources)
+
+    expect(ingestion).toMatchObject({
+      key: "ingestion",
+      mountPath: "customers/support",
+      scopes: ["support"],
+    })
+  })
+
   it("resolves scoped resolver sources before filtering by final mount", async () => {
     const definition: WorkspaceDefinition = {
       name: "support",

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -185,6 +185,26 @@ describe("Workspace Source Resolution", () => {
     })
   })
 
+  it("preserves source binding scopes when resolving sources", async () => {
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        ingestion: {
+          source: customerSource(),
+          scopes: ["support"],
+        },
+      },
+    }
+
+    const resolved = await resolveWorkspaceSources(definition, scope("support", ["ingestion/support"]))
+    const [ingestion] = normalizeWorkspaceSources(resolved.sources)
+
+    expect(ingestion).toMatchObject({
+      key: "ingestion",
+      scopes: ["support"],
+    })
+  })
+
   it("defaults resolved GitHub sources to lazy materialization", async () => {
     const definition: WorkspaceDefinition = {
       name: "support",

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -146,6 +146,15 @@ describe("workspace types", () => {
       url: "https://status.example.com/api/summary",
       workspacePath: "status/summary.json",
     })
+    fetch<{ status: string }>({
+      // @ts-expect-error scoped fetch source options must stay inferred so Workspace Scope literals are preserved
+      scopes: ["support"] as const,
+      transform(data) {
+        return data
+      },
+      url: "https://status.example.com/api/summary",
+      workspacePath: "status/summary.json",
+    })
     fetch({
       body: { scope: "all" },
       cookies: { auth_token: "secret" },


### PR DESCRIPTION
## Summary

- add `scopes` metadata to Workspace Source Bindings and preserve literal scope names through source helpers
- derive additive Access Workspace Scope source grants from source-local scope memberships
- validate source-local scope names against static Access scope keys in TypeScript and at runtime, and reject scoped sources without `access({ workspace })`
- document the Workspace Source Scope Membership boundary in `.agents` docs and ADR 0074

## Verification

- `git diff --check`
- `node_modules/.bin/tsc --noEmit --pretty false -p packages/workspace/tsconfig.json`
- `node_modules/.bin/tsc --noEmit --pretty false -p packages/agent/tsconfig.json`
- `(cd packages/workspace && ../../node_modules/.bin/vp test test/lazy-sources.test.ts)`
- `(cd packages/agent && ../../node_modules/.bin/vp test --typecheck test/access-capability.test.ts test/types.test-d.ts)`
- `node_modules/.bin/vp run -t @vite-hub/workspace#build`
- `(cd packages/agent && ../../node_modules/.bin/vp pack)`
- `node_modules/.bin/tsc --noEmit -p /tmp/vitehub-source-scope-valid/tsconfig.json`
- `node /tmp/vitehub-source-scope-valid/runtime.mjs`
- `node /tmp/vitehub-source-scope-invalid/runtime-missing-access.mjs`
- `node_modules/.bin/tsc --noEmit -p /tmp/vitehub-source-scope-invalid/tsconfig.json` fails as expected with `__vitehubInvalidWorkspaceSourceScope<"suport">`
