### PR TITLE
fix(agent): reject missing instruction bindings

### DIFF
--- a/docs/content/docs/agents/instructions.md
+++ b/docs/content/docs/agents/instructions.md
@@ -83,7 +83,7 @@ Answer for {{ context.customerName }}.
 {{{ context.supportPolicy }}}
 ```
 
-The value must already exist in invocation context. Composition does not read arbitrary runtime objects, environment variables, request fields, or JavaScript expressions.
+The value must already exist in invocation context. Missing `context.*` bindings fail during Instruction Composition instead of rendering empty output. Composition does not read arbitrary runtime objects, environment variables, request fields, or JavaScript expressions.
 
 ## Read Workspace bindings
 
@@ -112,6 +112,8 @@ export default defineAgent({
 ```
 
 `@workspace.<name>` inserts a Markdown binding and then runs the same Instruction Composition pass on that inserted Markdown. Use it for explicit instruction fragments that live in the Workspace. ViteHub reads only bindings declared under `workspace.bindings`; it does not scan or auto-load every Markdown file in the Workspace.
+
+Missing `workspace.*` bindings fail during Instruction Composition instead of rendering empty output.
 
 `workspace.sources` is reserved for Source Instructions. Keep using `{{ workspace.sources }}` to place visible Source Instructions in the final model instructions.
 

--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -356,10 +356,10 @@ function renderBinding(
   if (typeof path !== "string" || !compositionPathPattern.test(path)) return ["binding", attrs]
   if (path === "workspace.sources" && namespacePathValue(scopes.workspace, path) === undefined) return ["binding", attrs]
   const value = namespacePathValue(path.startsWith("workspace.") ? scopes.workspace : scopes.context, path)
-  if (value === undefined) {
+  if (value === null || value === undefined) {
     throw new Error(`[vitehub] Instruction binding "{{ ${path} }}" is not defined.`)
   }
-  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value)
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value)
   throw new TypeError(`[vitehub] Instruction binding "{{ ${path} }}" must resolve to a scalar value.`)
 }
 
@@ -379,7 +379,7 @@ async function renderTripleBindingPath(
   parent?: string,
 ): Promise<ComarkNode[]> {
   const value = namespacePathValue(context, path)
-  if (value === undefined) {
+  if (value === null || value === undefined) {
     throw new Error(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" is not defined.`)
   }
   if (typeof value !== "string") {

--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -356,8 +356,10 @@ function renderBinding(
   if (typeof path !== "string" || !compositionPathPattern.test(path)) return ["binding", attrs]
   if (path === "workspace.sources" && namespacePathValue(scopes.workspace, path) === undefined) return ["binding", attrs]
   const value = namespacePathValue(path.startsWith("workspace.") ? scopes.workspace : scopes.context, path)
-  if (value === null || value === undefined) return ""
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value)
+  if (value === undefined) {
+    throw new Error(`[vitehub] Instruction binding "{{ ${path} }}" is not defined.`)
+  }
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value)
   throw new TypeError(`[vitehub] Instruction binding "{{ ${path} }}" must resolve to a scalar value.`)
 }
 
@@ -377,7 +379,9 @@ async function renderTripleBindingPath(
   parent?: string,
 ): Promise<ComarkNode[]> {
   const value = namespacePathValue(context, path)
-  if (value === null || value === undefined) return []
+  if (value === undefined) {
+    throw new Error(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" is not defined.`)
+  }
   if (typeof value !== "string") {
     throw new TypeError(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" must resolve to a string.`)
   }

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -157,9 +157,15 @@ describe("instruction composition", () => {
   it("throws when instruction bindings are missing", async () => {
     await expect(composeInstructionDocument("Hello {{ context.doesNotExist }}."))
       .rejects.toThrow("Instruction binding \"{{ context.doesNotExist }}\" is not defined")
+    await expect(composeInstructionDocument("{{ context.customerName }}", { context: { customerName: null } }))
+      .rejects.toThrow("Instruction binding \"{{ context.customerName }}\" is not defined")
     await expect(composeInstructionDocument("{{ workspace.tone }}"))
       .rejects.toThrow("Instruction binding \"{{ workspace.tone }}\" is not defined")
+    await expect(composeInstructionDocument("{{ workspace.tone }}", { workspace: { tone: null } }))
+      .rejects.toThrow("Instruction binding \"{{ workspace.tone }}\" is not defined")
     await expect(composeInstructionDocument("{{{ context.policy }}}"))
+      .rejects.toThrow("Instruction markdown binding \"{{{ context.policy }}}\" is not defined")
+    await expect(composeInstructionDocument("{{{ context.policy }}}", { context: { policy: null } }))
       .rejects.toThrow("Instruction markdown binding \"{{{ context.policy }}}\" is not defined")
   })
 

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -154,6 +154,15 @@ describe("instruction composition", () => {
     })).toBe("Use short tone.\nPriority 2.")
   })
 
+  it("throws when instruction bindings are missing", async () => {
+    await expect(composeInstructionDocument("Hello {{ context.doesNotExist }}."))
+      .rejects.toThrow("Instruction binding \"{{ context.doesNotExist }}\" is not defined")
+    await expect(composeInstructionDocument("{{ workspace.tone }}"))
+      .rejects.toThrow("Instruction binding \"{{ workspace.tone }}\" is not defined")
+    await expect(composeInstructionDocument("{{{ context.policy }}}"))
+      .rejects.toThrow("Instruction markdown binding \"{{{ context.policy }}}\" is not defined")
+  })
+
   it("imports workspace markdown bindings through composition", async () => {
     expect(await composeInstructionDocument([
       "# Support",


### PR DESCRIPTION
Fails Instruction Composition when a raw Markdown binding references a missing value, so `{{ context.doesNotExist }}`, `{{ workspace.tone }}`, and `{{{ context.policy }}}` throw instead of silently rendering empty output. This keeps the nice Markdown API runtime-checked without adding a markdown type generator.

Updates the instruction docs and focused composition test so the workspace/context binding behavior is executable. Stacked on #416 (`codex/workspace-instruction-bindings`).