### PR TITLE
fix(blob): statically reach Cloudflare R2 driver

### DIFF
--- a/packages/blob/src/runtime/storage.ts
+++ b/packages/blob/src/runtime/storage.ts
@@ -1,5 +1,6 @@
 import { createBlobStorage } from "../storage.ts"
 import { resolveRuntimeMinioBlobStore, resolveRuntimeVercelBlobStore } from "../config.ts"
+import { createDriver as createCloudflareR2Driver } from "../drivers/cloudflare.ts"
 
 import { getBlobRuntimeConfig, getNamedBlobRuntimeStorage, setNamedBlobRuntimeStorage } from "./state.ts"
 
@@ -27,6 +28,10 @@ const driverModules = {
 } satisfies Record<ResolvedBlobStoreConfig["driver"], string>
 
 async function importRuntimeDriver(config: ResolvedBlobStoreConfig) {
+  if (config.driver === "cloudflare-r2") {
+    return createCloudflareR2Driver(config)
+  }
+
   const isSourceRuntime = typeof import.meta !== "undefined"
     && typeof import.meta.url === "string"
     && import.meta.url.endsWith(".ts")

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -268,6 +268,36 @@ describe("Vite provider outputs", () => {
     expect(stdout.trim()).toBe("ok")
   })
 
+  it("statically reaches the Cloudflare R2 driver from bundled SSR output", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-bundled-r2-")
+    const entryFile = join(rootDir, "entry.ts")
+    const bundleFile = join(rootDir, "worker.mjs")
+
+    await writeFile(entryFile, [
+      `import { blob } from ${JSON.stringify(resolve(import.meta.dirname, "../src/index.ts"))}`,
+      `import { setBlobRuntimeConfig } from ${JSON.stringify(resolve(import.meta.dirname, "../src/runtime/state.ts"))}`,
+      "setBlobRuntimeConfig({ store: { binding: 'BLOB', driver: 'cloudflare-r2' } })",
+      "await blob.put('proof.txt', 'ok')",
+      "",
+    ].join("\n"), "utf8")
+
+    await bundle({
+      bundle: true,
+      entryPoints: [entryFile],
+      external: ["node:async_hooks"],
+      format: "esm",
+      logLevel: "silent",
+      outfile: bundleFile,
+      platform: "neutral",
+      target: "es2022",
+    })
+
+    const bundled = await readFile(bundleFile, "utf8")
+    expect(bundled).not.toContain("@vite-hub/blob/drivers/cloudflare")
+    expect(bundled).toContain("config.driver === \"cloudflare-r2\"")
+    expect(bundled).toContain("R2 binding")
+  })
+
   it("rehydrates masked Vercel tokens from generated runtime output", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-vercel-runtime-")
     await mkdir(join(rootDir, "src"), { recursive: true })


### PR DESCRIPTION
Makes the Cloudflare R2 Blob Driver Module statically reachable from the shared `@vite-hub/blob` runtime path used by Vite-built Workers. The runtime now short-circuits `cloudflare-r2` to the local driver before the fallback dynamic driver import, so Workerd does not have to resolve `@vite-hub/blob/drivers/cloudflare` at request time.

Adds a bundled SSR output regression that checks the R2 driver code and branch are present in the output.