### PR TITLE
fix(database): avoid duplicate generated config keys

### DIFF
--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -56,8 +56,12 @@ interface CloudflareDBConfig {
   observability: { enabled: true }
 }
 
-function serializeDatabaseConfig(database: ResolvedDrizzleDatabaseConfig) {
+function serializeDatabaseConfig({ cloudflare: _cloudflare, connection: _connection, drizzle: _drizzle, ...database }: ResolvedDrizzleDatabaseConfig) {
   return JSON.stringify(database, null, 4)
+}
+
+function renderConfigExpression(value: unknown) {
+  return typeof value === "undefined" ? "undefined" : JSON.stringify(value)
 }
 
 function getDefaultCloudflareBindingName(name: string) {
@@ -75,8 +79,8 @@ function renderDatabaseConfigExpression(name: string, runtimeConfig: ResolvedDBV
   return [
     "{",
     `      ...${serializeDatabaseConfig(base)},`,
-    `      cloudflare: ${definitionVariable}.cloudflare ? { ...${definitionVariable}.cloudflare, binding: ${definitionVariable}.cloudflare.binding ?? ${JSON.stringify(base.cloudflare?.binding ?? getDefaultCloudflareBindingName(name))}, migrationsDir: ${JSON.stringify(base.migrationsDir)} } : undefined,`,
-    `      connection: ${definitionVariable}.connection ? { ...${JSON.stringify(base.connection)}, ...${definitionVariable}.connection, authToken: ${definitionVariable}.connection.authToken ?? ${JSON.stringify(base.connection?.authToken)}, url: ${definitionVariable}.connection.url ?? ${JSON.stringify(base.connection?.url)} } : ${JSON.stringify(base.connection)},`,
+    `      cloudflare: ${definitionVariable}.cloudflare ? { binding: ${definitionVariable}.cloudflare.binding ?? ${JSON.stringify(base.cloudflare?.binding ?? getDefaultCloudflareBindingName(name))}, databaseId: ${definitionVariable}.cloudflare.databaseId, databaseName: ${definitionVariable}.cloudflare.databaseName, migrationsDir: ${JSON.stringify(base.migrationsDir)}, migrationsTable: ${definitionVariable}.cloudflare.migrationsTable, previewDatabaseId: ${definitionVariable}.cloudflare.previewDatabaseId } : undefined,`,
+    `      connection: ${definitionVariable}.connection ? { authToken: ${definitionVariable}.connection.authToken ?? ${renderConfigExpression(base.connection?.authToken)}, url: ${definitionVariable}.connection.url ?? ${renderConfigExpression(base.connection?.url)} } : ${renderConfigExpression(base.connection)},`,
     `      drizzle: ${definitionVariable}.drizzle ?? {},`,
     "    }",
   ].join("\n")

--- a/packages/database/src/vite.ts
+++ b/packages/database/src/vite.ts
@@ -11,7 +11,7 @@ import { createDatabaseProvisionStep } from "./provision.ts"
 
 import type { ViteHubCliContributor } from "@vite-hub/internal/cli"
 import type { Plugin, ResolvedConfig } from "vite"
-import type { DBModulePublicOptions, ResolvedDBViteConfig } from "./types.ts"
+import type { DBModulePublicOptions, ResolvedDBViteConfig, ResolvedDrizzleDatabaseConfig } from "./types.ts"
 
 export const DB_VIRTUAL_SCHEMA_ID = "#vitehub/database/schema"
 export const DB_VIRTUAL_DATABASES_ID = "#vitehub/database/databases"
@@ -61,13 +61,31 @@ function renderSchemaModule(config: ResolvedDBViteConfig | undefined) {
   ].join("\n")
 }
 
+function getDefaultCloudflareBindingName(name: string) {
+  if (name === "default") return "DB"
+  const suffix = name
+    .replace(/[^a-z0-9]+/gi, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_")
+    .toUpperCase()
+  return `DB_${suffix || "DATABASE"}`
+}
+
+function serializeDatabaseConfig({ cloudflare: _cloudflare, connection: _connection, drizzle: _drizzle, ...database }: ResolvedDrizzleDatabaseConfig) {
+  return JSON.stringify(database, null, 6)
+}
+
+function renderConfigExpression(value: unknown) {
+  return typeof value === "undefined" ? "undefined" : JSON.stringify(value)
+}
+
 function renderDatabaseConfigExpression(name: string, config: ResolvedDBViteConfig, definitionVariable: string) {
   const base = config.databases[name]!
   return [
     "{",
-    `      ...${JSON.stringify(base, null, 6)},`,
-    `      cloudflare: ${definitionVariable}.cloudflare ? { ...${definitionVariable}.cloudflare, binding: ${definitionVariable}.cloudflare.binding ?? ${JSON.stringify(base.cloudflare?.binding ?? (name === "default" ? "DB" : `DB_${name.replace(/[^a-z0-9]+/gi, "_").replace(/^_+|_+$/g, "").replace(/_+/g, "_").toUpperCase() || "DATABASE"}`))}, migrationsDir: ${JSON.stringify(base.migrationsDir)} } : undefined,`,
-    `      connection: ${definitionVariable}.connection ? { ...${JSON.stringify(base.connection)}, ...${definitionVariable}.connection, authToken: ${definitionVariable}.connection.authToken ?? ${JSON.stringify(base.connection?.authToken)}, url: ${definitionVariable}.connection.url ?? ${JSON.stringify(base.connection?.url)} } : ${JSON.stringify(base.connection)},`,
+    `      ...${serializeDatabaseConfig(base)},`,
+    `      cloudflare: ${definitionVariable}.cloudflare ? { binding: ${definitionVariable}.cloudflare.binding ?? ${JSON.stringify(base.cloudflare?.binding ?? getDefaultCloudflareBindingName(name))}, databaseId: ${definitionVariable}.cloudflare.databaseId, databaseName: ${definitionVariable}.cloudflare.databaseName, migrationsDir: ${JSON.stringify(base.migrationsDir)}, migrationsTable: ${definitionVariable}.cloudflare.migrationsTable, previewDatabaseId: ${definitionVariable}.cloudflare.previewDatabaseId } : undefined,`,
+    `      connection: ${definitionVariable}.connection ? { authToken: ${definitionVariable}.connection.authToken ?? ${renderConfigExpression(base.connection?.authToken)}, url: ${definitionVariable}.connection.url ?? ${renderConfigExpression(base.connection?.url)} } : ${renderConfigExpression(base.connection)},`,
     `      drizzle: ${definitionVariable}.drizzle ?? {},`,
     "    }",
   ].join("\n")

--- a/packages/database/test/vite-output.test.ts
+++ b/packages/database/test/vite-output.test.ts
@@ -128,6 +128,10 @@ function errorText(error: unknown) {
     || String(error)
 }
 
+function outputText(output: Awaited<ReturnType<typeof runDbBuild>>) {
+  return `${output.stdout}\n${output.stderr}`
+}
+
 afterAll(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
 })
@@ -136,13 +140,14 @@ describe("Vite db provider outputs", () => {
   it("builds and emits named database Cloudflare and Vercel outputs", async () => {
     const rootDir = await createDbBuildProject("vitehub-db-vite-output-")
 
-    await runDbBuild(rootDir, {
+    const output = await runDbBuild(rootDir, {
       TURSO_ANALYTICS_DATABASE_URL: "libsql://analytics.example.turso.io",
       TURSO_AUTH_TOKEN: "token",
       TURSO_DATABASE_URL: "libsql://database.example.turso.io",
       VITEHUB_D1_ANALYTICS_DATABASE_ID: "analytics-d1-id",
       VITEHUB_D1_DATABASE_ID: "primary-d1-id",
     })
+    expect(outputText(output)).not.toMatch(/Duplicate key "(?:cloudflare|connection|url|drizzle)"/)
 
     const cloudflareConfig = await readCloudflareConfig(rootDir)
     const vercelServer = join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs")


### PR DESCRIPTION
Removes duplicate config keys from generated Database Runtime Config by omitting the generated cloudflare, connection, and drizzle fields from the base object before writing definition-aware overrides.

The database Provider Output Contract now fails if a normal DB provider build emits duplicate-key warnings for the generated Cloudflare/Vercel output path.