### PR TITLE
fix(kv): bundle cloudflare runtime config

### DIFF
--- a/packages/kv/src/runtime/storage.ts
+++ b/packages/kv/src/runtime/storage.ts
@@ -1,3 +1,5 @@
+/// <reference path="../virtual-module.d.ts" />
+
 import { readEnv } from "@vite-hub/internal/env"
 import { getActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 

--- a/packages/kv/src/runtime/storage.ts
+++ b/packages/kv/src/runtime/storage.ts
@@ -33,13 +33,8 @@ function shouldFallbackHostedConfigImport(error: unknown) {
 }
 
 async function resolveHostedConfig(): Promise<false | ResolvedKVModuleOptions | undefined> {
-  const virtualConfigId = "#vitehub/kv/config"
-
   try {
-    const module = await import(
-      /* @vite-ignore */
-      virtualConfigId
-    ) as { kv: false | ResolvedKVModuleOptions }
+    const module = await import("#vitehub/kv/config") as { kv: false | ResolvedKVModuleOptions }
     return module.kv
   }
   catch (error) {

--- a/packages/kv/src/vite.ts
+++ b/packages/kv/src/vite.ts
@@ -13,6 +13,8 @@ import type { Plugin } from "vite"
 const RESOLVED_KV_VIRTUAL_CONFIG_ID = `\0${KV_VIRTUAL_CONFIG_ID}`
 const KV_RUNTIME_ID = "#vitehub/kv/runtime"
 const RESOLVED_KV_RUNTIME_ID = `\0${KV_RUNTIME_ID}`
+const UNSTORAGE_IMPORT_ID = import.meta.resolve("unstorage")
+const CLOUDFLARE_KV_DRIVER_IMPORT_ID = import.meta.resolve("unstorage/drivers/cloudflare-kv-binding")
 const mergeNoExternal = createNoExternalMerger("@vite-hub/kv")
 
 export { KV_VIRTUAL_CONFIG_ID, KV_VITE_PLUGIN_NAME, resolveKVViteConfig }
@@ -39,8 +41,8 @@ function isCloudflareKVConfig(kv: KVViteRuntimeConfig["kv"]): kv is ResolvedKVMo
 
 function serializeCloudflareRuntime(config: ResolvedKVModuleOptions): string {
   return [
-    `import { createStorage } from "unstorage";`,
-    `import createDriver from "unstorage/drivers/cloudflare-kv-binding";`,
+    `import { createStorage } from ${JSON.stringify(UNSTORAGE_IMPORT_ID)};`,
+    `import createDriver from ${JSON.stringify(CLOUDFLARE_KV_DRIVER_IMPORT_ID)};`,
     "",
     `const kvConfig = ${JSON.stringify(config, null, 2)}`,
     "const storages = new Map();",

--- a/packages/kv/src/vite.ts
+++ b/packages/kv/src/vite.ts
@@ -4,11 +4,16 @@ import {
   resolveKVViteConfig,
 } from "./vite-config.ts"
 
+import { createNoExternalMerger, isServerEnvironment } from "@vite-hub/internal/build/vite"
+
 import type { KVViteRuntimeConfig } from "./vite-config.ts"
-import type { KVModuleOptions } from "./types.ts"
+import type { KVModuleOptions, ResolvedKVModuleOptions } from "./types.ts"
 import type { Plugin } from "vite"
 
 const RESOLVED_KV_VIRTUAL_CONFIG_ID = `\0${KV_VIRTUAL_CONFIG_ID}`
+const KV_RUNTIME_ID = "#vitehub/kv/runtime"
+const RESOLVED_KV_RUNTIME_ID = `\0${KV_RUNTIME_ID}`
+const mergeNoExternal = createNoExternalMerger("@vite-hub/kv")
 
 export { KV_VIRTUAL_CONFIG_ID, KV_VITE_PLUGIN_NAME, resolveKVViteConfig }
 export type { KVViteRuntimeConfig } from "./vite-config.ts"
@@ -27,20 +32,76 @@ function serializeVirtualConfig(config: KVViteRuntimeConfig): string {
   ].join("\n")
 }
 
+function isCloudflareKVConfig(kv: KVViteRuntimeConfig["kv"]): kv is ResolvedKVModuleOptions {
+  return Boolean(kv) && Object.values((kv as ResolvedKVModuleOptions).stores || { default: (kv as ResolvedKVModuleOptions).store })
+    .every(store => store.driver === "cloudflare-kv-binding")
+}
+
+function serializeCloudflareRuntime(config: ResolvedKVModuleOptions): string {
+  return [
+    `import { createStorage } from "unstorage";`,
+    `import createDriver from "unstorage/drivers/cloudflare-kv-binding";`,
+    "",
+    `const kvConfig = ${JSON.stringify(config, null, 2)}`,
+    "const storages = new Map();",
+    "",
+    "function resolveStorage(name = \"default\") {",
+    "  const stores = kvConfig.stores || { default: kvConfig.store };",
+    "  const store = stores[name];",
+    "  if (!store) throw new Error(`[vitehub] Unknown KV store \"${name}\".`);",
+    "  const existing = storages.get(name);",
+    "  if (existing) return existing;",
+    "  const storage = createStorage({ driver: createDriver(store) });",
+    "  storages.set(name, storage);",
+    "  return storage;",
+    "}",
+    "",
+    "function createKVStorage(name = \"default\") {",
+    "  return {",
+    "    async clear(base, options) { await resolveStorage(name).clear(base, options); },",
+    "    async del(key, options) { await resolveStorage(name).removeItem(key, options); },",
+    "    async get(key, options) { return await resolveStorage(name).getItem(key, options); },",
+    "    async has(key, options) { return await resolveStorage(name).hasItem(key, options); },",
+    "    async keys(base, options) { return await resolveStorage(name).getKeys(base, options); },",
+    "    async set(key, value, options) { await resolveStorage(name).setItem(key, value, options); },",
+    "    store(storeName) { return createKVStorage(storeName); },",
+    "  };",
+    "}",
+    "",
+    "export const kv = createKVStorage();",
+    "",
+  ].join("\n")
+}
+
 export function hubKv(options?: KVModuleOptions): KVVitePlugin {
   let runtimeConfig: KVViteRuntimeConfig | undefined
   const getConfig = () => runtimeConfig ??= resolveKVViteConfig(options)
 
   return {
     name: KV_VITE_PLUGIN_NAME,
+    enforce: "pre",
     api: { getConfig },
     configResolved(config) {
       runtimeConfig = resolveKVViteConfig(config.kv ?? options)
     },
+    configEnvironment(name, config) {
+      if (!isServerEnvironment(name, config)) {
+        return
+      }
+
+      return {
+        resolve: { noExternal: mergeNoExternal(config.resolve?.noExternal) },
+      }
+    },
     resolveId(id) {
+      if (id === "@vite-hub/kv" && isCloudflareKVConfig(getConfig().kv)) return RESOLVED_KV_RUNTIME_ID
       if (id === KV_VIRTUAL_CONFIG_ID) return RESOLVED_KV_VIRTUAL_CONFIG_ID
     },
     load(id) {
+      if (id === RESOLVED_KV_RUNTIME_ID) {
+        const kv = getConfig().kv
+        if (isCloudflareKVConfig(kv)) return serializeCloudflareRuntime(kv)
+      }
       if (id === RESOLVED_KV_VIRTUAL_CONFIG_ID) return serializeVirtualConfig(getConfig())
     },
   }

--- a/packages/kv/test/frameworks.test.ts
+++ b/packages/kv/test/frameworks.test.ts
@@ -56,4 +56,17 @@ describe("hubKv", () => {
     expect(code).toContain("export const kv =")
     expect(code).toContain(".virtual/kv")
   })
+
+  it("anchors generated Cloudflare runtime imports to the KV package", async () => {
+    const { hubKv } = await import("../src/vite.ts")
+    const plugin = hubKv({ binding: "KV", driver: "cloudflare-kv-binding" })
+    const resolveId = plugin.resolveId as unknown as (id: string) => string | undefined | Promise<string | undefined>
+    const load = plugin.load as unknown as (id: string) => string | undefined | Promise<string | undefined>
+    const resolvedId = await resolveId("@vite-hub/kv")
+    const code = await load(resolvedId!)
+
+    expect(code).not.toContain(`from "unstorage"`)
+    expect(code).not.toContain(`from "unstorage/drivers/cloudflare-kv-binding"`)
+    expect(code).toContain("cloudflare-kv-binding")
+  })
 })

--- a/packages/kv/test/vite-output.test.ts
+++ b/packages/kv/test/vite-output.test.ts
@@ -1,10 +1,13 @@
+import { execFile } from "node:child_process"
 import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
+import { promisify } from "node:util"
 
 import { afterEach, describe, expect, it } from "vitest"
 
 const tempDirs: string[] = []
+const execFileAsync = promisify(execFile)
 
 async function createConsumerRoot() {
   const rootDir = await mkdtemp(join(tmpdir(), "vitehub-kv-vite-"))
@@ -83,5 +86,42 @@ describe("KV Vite output", () => {
     expect(output).not.toContain("@upstash/redis")
     expect(output).toContain("cloudflare-kv-binding")
     expect(output).toContain("KV_CUSTOM")
+  })
+})
+
+describe("KV source type visibility", () => {
+  it("typechecks source consumers that resolve @vite-hub/kv to package source", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-kv-source-types-"))
+    tempDirs.push(rootDir)
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await writeFile(join(rootDir, "package.json"), JSON.stringify({ type: "module" }))
+    await writeFile(join(rootDir, "src", "consumer.ts"), [
+      `import { kv } from "@vite-hub/kv"`,
+      ``,
+      `await kv.get("settings")`,
+      ``,
+    ].join("\n"))
+
+    const repoRoot = resolve(import.meta.dirname, "../../..")
+    await writeFile(join(rootDir, "tsconfig.json"), JSON.stringify({
+      extends: join(repoRoot, "tsconfig.json"),
+      compilerOptions: {
+        baseUrl: repoRoot,
+        paths: {
+          "@vite-hub/internal/*": ["packages/internal/src/*.ts"],
+          "@vite-hub/kv": ["packages/kv/src/index.ts"],
+        },
+        typeRoots: [join(repoRoot, "node_modules", "@types")],
+      },
+      files: ["src/consumer.ts"],
+    }, null, 2))
+
+    try {
+      await execFileAsync(resolve(repoRoot, "node_modules/.bin/tsc"), ["--noEmit", "-p", join(rootDir, "tsconfig.json")])
+    }
+    catch (error) {
+      const output = (error as { stderr?: string, stdout?: string }).stdout || (error as { stderr?: string, stdout?: string }).stderr
+      throw new Error(output)
+    }
   })
 })

--- a/packages/kv/test/vite-output.test.ts
+++ b/packages/kv/test/vite-output.test.ts
@@ -1,0 +1,87 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+const tempDirs: string[] = []
+
+async function createConsumerRoot() {
+  const rootDir = await mkdtemp(join(tmpdir(), "vitehub-kv-vite-"))
+  tempDirs.push(rootDir)
+
+  await mkdir(join(rootDir, "node_modules", "@vite-hub"), { recursive: true })
+  await symlink(resolve(import.meta.dirname, ".."), join(rootDir, "node_modules", "@vite-hub", "kv"), "dir")
+  await mkdir(join(rootDir, "src"), { recursive: true })
+  await writeFile(join(rootDir, "package.json"), JSON.stringify({
+    name: "vitehub-kv-vite-fixture",
+    private: true,
+    type: "module",
+  }, null, 2))
+  await writeFile(join(rootDir, "src", "worker.ts"), [
+    `import { kv } from "@vite-hub/kv"`,
+    ``,
+    `export default {`,
+    `  async fetch() {`,
+    `    await kv.set("settings", { ok: true })`,
+    `    return Response.json(await kv.get("settings"))`,
+    `  },`,
+    `}`,
+    ``,
+  ].join("\n"))
+
+  return rootDir
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(root => rm(root, { force: true, recursive: true })))
+})
+
+async function readOutput(root: string): Promise<string> {
+  const entries = await readdir(root, { recursive: true, withFileTypes: true })
+  const files = entries
+    .filter(entry => entry.isFile())
+    .map(entry => join(entry.parentPath, entry.name))
+    .sort()
+  return (await Promise.all(files.map(file => readFile(file, "utf8")))).join("\n")
+}
+
+describe("KV Vite output", () => {
+  it("bundles selected runtime config into server output", async () => {
+    const rootDir = await createConsumerRoot()
+    const entry = join(rootDir, "src", "worker.ts")
+    const [{ build }, { hubKv }] = await Promise.all([
+      import("vite"),
+      import("../src/vite.ts"),
+    ])
+
+    await build({
+      appType: "custom",
+      build: {
+        outDir: "dist",
+        rollupOptions: {
+          input: entry,
+          output: { entryFileNames: "worker.js" },
+        },
+        ssr: entry,
+      },
+      configFile: false,
+      kv: {
+        binding: "KV_CUSTOM",
+        driver: "cloudflare-kv-binding",
+        namespaceId: "namespace-id",
+      },
+      logLevel: "silent",
+      plugins: [hubKv()],
+      root: rootDir,
+    })
+
+    const output = await readOutput(join(rootDir, "dist"))
+
+    expect(output).not.toContain(`from "@vite-hub/kv"`)
+    expect(output).not.toContain("#vitehub/kv/config")
+    expect(output).not.toContain("@upstash/redis")
+    expect(output).toContain("cloudflare-kv-binding")
+    expect(output).toContain("KV_CUSTOM")
+  })
+})

--- a/packages/kv/vite.config.ts
+++ b/packages/kv/vite.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   pack: {
     tsconfig: "tsconfig.build.json",
     deps: {
-      neverBundle: ["vite"],
+      neverBundle: ["vite", "#vitehub/kv/config"],
       alwaysBundle: [/^@vite-hub\/internal/],
       onlyBundle: false,
     },


### PR DESCRIPTION
Fixes the `@vite-hub/kv` Vite server build path for Cloudflare KV by replacing the package runtime import with a Cloudflare-selected runtime module when every configured KV Store uses `cloudflare-kv-binding`.

That keeps selected KV Runtime Config reachable in the Worker bundle and avoids emitting Upstash runtime dependencies for Cloudflare KV builds.