### PR TITLE
docs(schedule): use handler in schedule example

### DIFF
--- a/docs/content/blog/2.server-primitives-any-host.md
+++ b/docs/content/blog/2.server-primitives-any-host.md
@@ -303,7 +303,7 @@ import { defineSchedule } from '@vite-hub/schedule'
 
 export default defineSchedule({
   cron: '0 9 * * *',
-  async run(context) {
+  async handler(context) {
     console.log(`Run daily report at ${context.scheduledAt.toISOString()}`)
   },
 })


### PR DESCRIPTION
Updates the stale Schedule example in the server primitives blog to use the `handler` option that `defineSchedule` actually accepts.