### PR TITLE
fix(sandbox): wire generated runtime registry

### DIFF
--- a/packages/sandbox/src/bundle.ts
+++ b/packages/sandbox/src/bundle.ts
@@ -3,8 +3,13 @@ import type { SandboxDefinitionBundle } from './module-types'
 
 const SHIM_NAMESPACE = 'vitehub-sandbox-runtime-shim'
 
-export async function bundleSandboxDefinition(source: string, file: string): Promise<SandboxDefinitionBundle> {
+export async function bundleSandboxDefinition(
+  source: string,
+  file: string,
+  options: { alias?: Record<string, string> } = {},
+): Promise<SandboxDefinitionBundle> {
   return await bundleDiscoveredDefinitionModuleGraph({
+    alias: options.alias,
     filename: file,
     source,
     plugins: [

--- a/packages/sandbox/src/discovery.ts
+++ b/packages/sandbox/src/discovery.ts
@@ -1,27 +1,72 @@
 import {
   createDirectoryDefinitionSource,
+  createSuffixDefinitionSource,
   discoverDefinitions,
+  mergeDefinitions,
+  normalizePathDefinitionName,
+  normalizeSuffixDefinitionName,
+  resolveDefinitionScanRoots,
 } from '@vite-hub/internal/definition-catalog'
+import { resolve } from 'pathe'
 import type { ScannedDefinition } from './internal/shared/feature-definitions'
 
 export interface DiscoveredSandboxDefinition extends ScannedDefinition {
-  source: 'server-sandboxes'
+  source: 'server-sandboxes' | 'vite-suffix'
+}
+
+const sandboxSuffixPattern = /\.sandbox\.(?:c|m)?[jt]s$/i
+
+function createDiscoveredSandboxDefinition(source: DiscoveredSandboxDefinition['source']) {
+  return (context: { file: string, name: string }): DiscoveredSandboxDefinition => ({
+    handler: context.file,
+    name: context.name,
+    source,
+    _meta: {
+      filename: context.name,
+      sourcePath: context.file,
+    },
+  })
+}
+
+function normalizeSuffixSandboxName(rootDir: string, file: string) {
+  return normalizeSuffixDefinitionName(rootDir, file, sandboxSuffixPattern, { stripPrefix: 'src/' })
+}
+
+function normalizeDirectorySandboxName(directory: string, file: string) {
+  return normalizePathDefinitionName(directory, file)
 }
 
 export function discoverServerSandboxDefinitions(scanDirs: string[]): DiscoveredSandboxDefinition[] {
   return discoverDefinitions("sandbox", [
     createDirectoryDefinitionSource<DiscoveredSandboxDefinition>("server-sandboxes", scanDirs, "sandboxes", {
-      createDefinition({ file, name }) {
-        return {
-          handler: file,
-          name,
-          source: "server-sandboxes",
-          _meta: {
-            filename: name,
-            sourcePath: file,
-          },
-        }
-      },
+      createDefinition: createDiscoveredSandboxDefinition('server-sandboxes'),
+      normalizeName: normalizeDirectorySandboxName,
     }),
   ])
+}
+
+export function discoverSandboxDefinitions(options:
+  | { mode?: 'vite-suffix', rootDir: string, scanDirs?: string[] }
+  | { mode: 'server-sandboxes', scanDirs: string[] }
+): DiscoveredSandboxDefinition[] {
+  if (options.mode === 'server-sandboxes')
+    return discoverServerSandboxDefinitions(options.scanDirs)
+
+  const roots = resolveDefinitionScanRoots(options.rootDir, options.scanDirs)
+  const serverScanDirs = roots.map(root => resolve(root, 'server'))
+
+  return mergeDefinitions(
+    'sandbox',
+    discoverDefinitions('sandbox', [
+      createSuffixDefinitionSource('vite-suffix', roots, sandboxSuffixPattern, normalizeSuffixSandboxName, {
+        createDefinition: createDiscoveredSandboxDefinition('vite-suffix'),
+      }),
+    ]),
+    discoverDefinitions('sandbox', [
+      createDirectoryDefinitionSource('server-sandboxes', serverScanDirs, 'sandboxes', {
+        createDefinition: createDiscoveredSandboxDefinition('server-sandboxes'),
+        normalizeName: normalizeDirectorySandboxName,
+      }),
+    ]),
+  )
 }

--- a/packages/sandbox/src/discovery.ts
+++ b/packages/sandbox/src/discovery.ts
@@ -7,7 +7,7 @@ import {
   normalizeSuffixDefinitionName,
   resolveDefinitionScanRoots,
 } from '@vite-hub/internal/definition-catalog'
-import { resolve } from 'pathe'
+import { relative, resolve } from 'pathe'
 import type { ScannedDefinition } from './internal/shared/feature-definitions'
 
 export interface DiscoveredSandboxDefinition extends ScannedDefinition {
@@ -28,12 +28,19 @@ function createDiscoveredSandboxDefinition(source: DiscoveredSandboxDefinition['
   })
 }
 
+function isServerSandboxFile(rootDir: string, file: string) {
+  const path = relative(rootDir, file).replace(/\\/g, '/')
+  return path.startsWith('server/sandboxes/') || path.startsWith('src/server/sandboxes/')
+}
+
 function normalizeSuffixSandboxName(rootDir: string, file: string) {
+  if (isServerSandboxFile(rootDir, file))
+    return undefined
   return normalizeSuffixDefinitionName(rootDir, file, sandboxSuffixPattern, { stripPrefix: 'src/' })
 }
 
 function normalizeDirectorySandboxName(directory: string, file: string) {
-  return normalizePathDefinitionName(directory, file)
+  return normalizePathDefinitionName(directory, file).replace(/\.sandbox$/, '')
 }
 
 export function discoverServerSandboxDefinitions(scanDirs: string[]): DiscoveredSandboxDefinition[] {

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -187,14 +187,22 @@ export async function createSandboxFeaturePlan(
 ): Promise<FeatureRuntimePlan> {
   const resolvedConfig = resolveSandboxFeatureConfig(sandboxConfig, hosting)
   const manifest = createSandboxManifest(paths.aliasPath, createSandboxTypeTemplateContents(definitions))
-  const definitionCompiler = await createDiscoveredDefinitionCompiler(discoveredDefinitionOptions)
-  const definitionMetadata = await loadSandboxDefinitionMetadata(definitions)
-  const metadataByName = new Map(definitionMetadata.map(definition => [definition.name, definition] as const))
   const sandboxDefinitions = definitions.map(definition => ({
     ...definition,
     definitionArtifactKey: `sandbox-definition:${definition.name}`,
     definitionFilename: `runtime/sandbox-definitions/${toTemplateSafeName(definition.name)}.mjs`,
   }))
+  const definitionFileByName = new Map<string, string>()
+  for (const definition of sandboxDefinitions) {
+    const existing = definitionFileByName.get(definition.definitionFilename)
+    if (existing) {
+      throw new Error(`[vitehub] Sandbox definitions "${existing}" and "${definition.name}" generate the same artifact path "${definition.definitionFilename}".`)
+    }
+    definitionFileByName.set(definition.definitionFilename, definition.name)
+  }
+  const definitionCompiler = await createDiscoveredDefinitionCompiler(discoveredDefinitionOptions)
+  const definitionMetadata = await loadSandboxDefinitionMetadata(definitions)
+  const metadataByName = new Map(definitionMetadata.map(definition => [definition.name, definition] as const))
   const sandboxArtifacts: GeneratedArtifact[] = sandboxDefinitions.map(definition => ({
     key: definition.definitionArtifactKey,
     filename: definition.definitionFilename,

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -86,6 +86,10 @@ type SandboxDefinitionMetadata = {
   options?: SandboxDefinitionOptions
 }
 
+type SandboxDefinitionCompilerOptions = Partial<DiscoveredDefinitionCompilerOptions> & {
+  bundleAlias?: Record<string, string>
+}
+
 function normalizeSandboxDefinitionOptions(name: string, options: SandboxDefinitionOptions | undefined) {
   if (!options)
     return undefined
@@ -183,10 +187,15 @@ export async function createSandboxFeaturePlan(
   },
   deps: Record<string, string>,
   hosting?: string,
-  discoveredDefinitionOptions: Partial<DiscoveredDefinitionCompilerOptions> = {},
+  discoveredDefinitionOptions: SandboxDefinitionCompilerOptions = {},
 ): Promise<FeatureRuntimePlan> {
   const resolvedConfig = resolveSandboxFeatureConfig(sandboxConfig, hosting)
   const manifest = createSandboxManifest(paths.aliasPath, createSandboxTypeTemplateContents(definitions))
+  const {
+    bundleAlias,
+    featureImports = manifest.imports,
+    ...definitionCompilerOptions
+  } = discoveredDefinitionOptions
   const sandboxDefinitions = definitions.map(definition => ({
     ...definition,
     definitionArtifactKey: `sandbox-definition:${definition.name}`,
@@ -200,7 +209,10 @@ export async function createSandboxFeaturePlan(
     }
     definitionFileByName.set(definition.definitionFilename, definition.name)
   }
-  const definitionCompiler = await createDiscoveredDefinitionCompiler(discoveredDefinitionOptions)
+  const definitionCompiler = await createDiscoveredDefinitionCompiler({
+    ...definitionCompilerOptions,
+    featureImports,
+  })
   const definitionMetadata = await loadSandboxDefinitionMetadata(definitions)
   const metadataByName = new Map(definitionMetadata.map(definition => [definition.name, definition] as const))
   const sandboxArtifacts: GeneratedArtifact[] = sandboxDefinitions.map(definition => ({
@@ -208,7 +220,9 @@ export async function createSandboxFeaturePlan(
     filename: definition.definitionFilename,
     async getContents() {
       const source = await definitionCompiler.readSource(definition._meta.sourcePath)
-      const bundle = await bundleSandboxDefinition(source, definition._meta.sourcePath)
+      const bundle = await bundleSandboxDefinition(source, definition._meta.sourcePath, {
+        alias: bundleAlias,
+      })
       const metadata = metadataByName.get(definition.name)
       return `export default ${JSON.stringify({
         bundle,

--- a/packages/sandbox/src/internal/shared/discovered-definition/bundler.ts
+++ b/packages/sandbox/src/internal/shared/discovered-definition/bundler.ts
@@ -3,6 +3,7 @@ import { dirname, relative, resolve as resolvePath } from 'pathe'
 import { build, type Loader, type Plugin } from 'esbuild'
 
 export interface DiscoveredDefinitionBundleOptions {
+  alias?: Record<string, string>
   filename: string
   source: string
   external?: string[]
@@ -40,6 +41,7 @@ function isJsxDefinitionLoader(options: DiscoveredDefinitionBundleOptions) {
 
 export async function bundleDiscoveredDefinitionModule(options: DiscoveredDefinitionBundleOptions) {
   const result = await build({
+    alias: options.alias,
     stdin: {
       contents: options.source,
       loader: resolveDefinitionLoader(options),
@@ -71,6 +73,7 @@ export async function bundleDiscoveredDefinitionModuleGraph(
 ): Promise<DiscoveredDefinitionModuleGraph> {
   const outdir = resolvePath(dirname(options.filename), '.vitehub-discovered-definition')
   const result = await build({
+    alias: options.alias,
     stdin: {
       contents: options.source,
       loader: resolveDefinitionLoader(options),

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -151,6 +151,7 @@ async function prepareSandboxRuntimeAliases(
   rawConfig: Record<string, unknown>,
   rawEnv: ConfigEnv,
   resolved: ResolvedConfig | undefined,
+  options: { writeArtifacts?: boolean } = {},
 ): Promise<PreparedSandboxRuntime> {
   const rootDir = resolved?.root || resolve(process.cwd(), typeof rawConfig.root === 'string' ? rawConfig.root : '.')
   const context = await buildFeatureViteContext(engine, { ...rawConfig, root: rootDir }, rawEnv)
@@ -174,6 +175,13 @@ async function prepareSandboxRuntimeAliases(
     },
   )
   const aliases = createGeneratedAliasMap(rootDir, plan)
+  if (options.writeArtifacts === false) {
+    return {
+      aliases,
+      definitions,
+      files: [],
+    }
+  }
   const emitted = await writeSandboxArtifacts(rootDir, plan)
   await writeFileIfChanged(
     facadeFile,
@@ -271,7 +279,10 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
       const result = typeof configHook === 'function'
         ? await configHook.call(this, config, env)
         : undefined
-      await refreshSandboxRuntime()
+      const prepared = await prepareSandboxRuntimeAliases(engine, rawConfig, rawEnv, resolvedConfig, { writeArtifacts: false })
+      generatedAliases = prepared.aliases
+      generatedFiles = prepared.files
+      definitions = prepared.definitions
       return {
         ...(result && typeof result === 'object' ? result : {}),
         resolve: {

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -2,7 +2,7 @@ import { buildFeatureViteContext } from '@vite-hub/internal/feature-bridge'
 import { createImportPath, ensureGeneratedDir } from '@vite-hub/internal/build/paths'
 import { createNoExternalMerger, isServerEnvironment } from '@vite-hub/internal/build/vite'
 import { writeFileIfChanged } from '@vite-hub/internal/definition-catalog'
-import { resolve } from 'pathe'
+import { normalize, resolve } from 'pathe'
 
 import { createFeatureVitePlugin } from './internal/shared/vite'
 import { resolveFeatureRuntimePath } from './internal/shared/feature-runtime-path'
@@ -12,6 +12,7 @@ import { sandboxFeatureEngine, type SandboxPublicOptions } from './integration'
 import type { AgentSandboxConfig } from './module-types'
 import type { EmittedArtifact, FeatureRuntimePlan } from './internal/shared/runtime-artifacts'
 import type { Alias, AliasOptions, ConfigEnv, Plugin, ResolvedConfig } from 'vite'
+import type { DiscoveredSandboxDefinition } from './discovery'
 
 export { createViteHubDefinitionAutoImportsPlugin } from './internal/shared/vitehub-auto-imports'
 export type { SandboxPublicOptions } from './integration'
@@ -24,6 +25,17 @@ const SANDBOX_REGISTRY_ID = '#vitehub-sandbox-registry'
 
 type AliasMap = Record<string, string>
 type SandboxAlias = Alias & { replacement: string }
+type PreparedSandboxRuntime = {
+  aliases: AliasMap
+  definitions: DiscoveredSandboxDefinition[]
+  files: string[]
+}
+
+const emptyPreparedSandboxRuntime: PreparedSandboxRuntime = {
+  aliases: {},
+  definitions: [],
+  files: [],
+}
 
 function sandboxProviderLoaderFallback() {
   return resolveFeatureRuntimePath(import.meta.url, '@vite-hub/sandbox', './runtime/provider-loader', 'runtime/provider-loader.js')
@@ -52,6 +64,11 @@ function readAliasEntries(alias: unknown): Alias[] {
 function mergeAliases(alias: unknown, aliases: AliasMap): AliasOptions | undefined {
   const entries = [...toSandboxAliasEntries(aliases), ...readAliasEntries(alias)]
   return entries.length ? entries : undefined
+}
+
+function withoutSandboxPackageAlias(aliases: AliasMap): AliasMap {
+  const { [SANDBOX_PACKAGE_ID]: _sandboxAlias, ...rest } = aliases
+  return rest
 }
 
 function readResolveOptions(config: unknown): { alias?: unknown } {
@@ -102,6 +119,10 @@ function createGeneratedAliasMap(rootDir: string, plan: FeatureRuntimePlan): Ali
 async function writeSandboxArtifacts(rootDir: string, plan: FeatureRuntimePlan) {
   const generatedDir = ensureGeneratedDir(rootDir, 'sandbox')
   const emitted = new Map<string, EmittedArtifact>()
+  const typeTemplate = plan.manifest.typeTemplate
+
+  if (typeTemplate)
+    await writeFileIfChanged(resolve(generatedDir, typeTemplate.filename), typeTemplate.contents)
 
   for (const artifact of plan.artifacts || []) {
     const dst = resolve(generatedDir, artifact.filename)
@@ -121,12 +142,12 @@ async function prepareSandboxRuntimeAliases(
   rawConfig: Record<string, unknown>,
   rawEnv: ConfigEnv,
   resolved: ResolvedConfig | undefined,
-): Promise<AliasMap> {
+): Promise<PreparedSandboxRuntime> {
   const rootDir = resolved?.root || resolve(process.cwd(), typeof rawConfig.root === 'string' ? rawConfig.root : '.')
   const context = await buildFeatureViteContext(engine, { ...rawConfig, root: rootDir }, rawEnv)
   const sandboxConfig = context?.config as AgentSandboxConfig | false | undefined
   if (!context || !sandboxConfig)
-    return {}
+    return emptyPreparedSandboxRuntime
 
   const facadeFile = resolve(ensureGeneratedDir(rootDir, 'sandbox'), 'runtime/sandbox.mjs')
   const definitions = discoverSandboxDefinitions({ rootDir })
@@ -138,7 +159,7 @@ async function prepareSandboxRuntimeAliases(
     context.hosting,
   )
   const aliases = createGeneratedAliasMap(rootDir, plan)
-  await writeSandboxArtifacts(rootDir, plan)
+  const emitted = await writeSandboxArtifacts(rootDir, plan)
   await writeFileIfChanged(
     facadeFile,
     createSandboxRuntimeFacadeContents(
@@ -147,7 +168,32 @@ async function prepareSandboxRuntimeAliases(
       aliases[SANDBOX_REGISTRY_ID]!,
     ),
   )
-  return aliases
+  return {
+    aliases,
+    definitions,
+    files: [facadeFile, ...Array.from(emitted.values(), artifact => artifact.dst)],
+  }
+}
+
+function isSandboxSourceFile(file: string) {
+  return /\.(?:c|m)?[jt]s$/i.test(file) && !/\.d\.(?:c|m)?[jt]s$/i.test(file)
+}
+
+function isSandboxDefinitionUpdate(file: string, definitions: DiscoveredSandboxDefinition[]) {
+  const changedFile = normalize(file)
+  if (definitions.some(definition => normalize(definition.handler) === changedFile))
+    return true
+  if (!isSandboxSourceFile(changedFile))
+    return false
+  return /\.sandbox\.(?:c|m)?[jt]s$/i.test(changedFile) || /(?:^|\/)(?:src\/)?server\/sandboxes\//.test(changedFile)
+}
+
+function invalidateGeneratedSandboxModules(files: string[], moduleGraph: { getModuleById: (id: string) => unknown, invalidateModule: (module: never) => void }) {
+  for (const file of [...new Set(files.map(file => normalize(file)))]) {
+    const module = moduleGraph.getModuleById(file)
+    if (module)
+      moduleGraph.invalidateModule(module as never)
+  }
 }
 
 export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
@@ -167,9 +213,20 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
   const configEnvironment = plugin.configEnvironment
   const mergeNoExternal = createNoExternalMerger('@vite-hub/sandbox')
   let generatedAliases: AliasMap = {}
+  let generatedFiles: string[] = []
+  let definitions: DiscoveredSandboxDefinition[] = []
   let rawConfig: Record<string, unknown> = {}
   let rawEnv: ConfigEnv = { command: 'serve', mode: 'development' }
   let resolvedConfig: ResolvedConfig | undefined
+
+  async function refreshSandboxRuntime() {
+    const prepared = await prepareSandboxRuntimeAliases(engine, rawConfig, rawEnv, resolvedConfig)
+    generatedAliases = prepared.aliases
+    generatedFiles = prepared.files
+    definitions = prepared.definitions
+    return prepared
+  }
+
   return {
     ...plugin,
     async config(config, env) {
@@ -178,21 +235,29 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
       const result = typeof configHook === 'function'
         ? await configHook.call(this, config, env)
         : undefined
-      generatedAliases = await prepareSandboxRuntimeAliases(engine, rawConfig, rawEnv, resolvedConfig)
+      await refreshSandboxRuntime()
       return {
         ...(result && typeof result === 'object' ? result : {}),
         resolve: {
           ...readResolveOptions(result),
           alias: mergeAliases(readResolveOptions(result).alias, {
             [SANDBOX_PROVIDER_LOADER_ID]: sandboxProviderLoaderFallback(),
-            ...generatedAliases,
+            ...withoutSandboxPackageAlias(generatedAliases),
           }),
         },
       }
     },
     async configResolved(config) {
       resolvedConfig = config
-      generatedAliases = await prepareSandboxRuntimeAliases(engine, rawConfig, rawEnv, resolvedConfig)
+      await refreshSandboxRuntime()
+    },
+    async handleHotUpdate(context) {
+      if (!isSandboxDefinitionUpdate(context.file, definitions))
+        return
+
+      const previousFiles = [...generatedFiles, ...Object.values(generatedAliases)]
+      await refreshSandboxRuntime()
+      invalidateGeneratedSandboxModules([...previousFiles, ...generatedFiles, ...Object.values(generatedAliases)], context.server.moduleGraph)
     },
     configEnvironment(name, config) {
       const result = typeof configEnvironment === 'function'

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -2,7 +2,7 @@ import { buildFeatureViteContext } from '@vite-hub/internal/feature-bridge'
 import { createImportPath, ensureGeneratedDir } from '@vite-hub/internal/build/paths'
 import { createNoExternalMerger, isServerEnvironment } from '@vite-hub/internal/build/vite'
 import { writeFileIfChanged } from '@vite-hub/internal/definition-catalog'
-import { normalize, resolve } from 'pathe'
+import { normalize, relative, resolve } from 'pathe'
 
 import { createFeatureVitePlugin } from './internal/shared/vite'
 import { resolveFeatureRuntimePath } from './internal/shared/feature-runtime-path'
@@ -64,6 +64,15 @@ function readAliasEntries(alias: unknown): Alias[] {
 function mergeAliases(alias: unknown, aliases: AliasMap): AliasOptions | undefined {
   const entries = [...toSandboxAliasEntries(aliases), ...readAliasEntries(alias)]
   return entries.length ? entries : undefined
+}
+
+function resolveStringAliases(alias: unknown): AliasMap {
+  const aliases: AliasMap = {}
+  for (const entry of readAliasEntries(alias)) {
+    if (typeof entry.find === 'string' && typeof entry.replacement === 'string')
+      aliases[entry.find] = entry.replacement
+  }
+  return aliases
 }
 
 function withoutSandboxPackageAlias(aliases: AliasMap): AliasMap {
@@ -157,6 +166,12 @@ async function prepareSandboxRuntimeAliases(
     { aliasPath: facadeFile },
     context.deps,
     context.hosting,
+    {
+      bundleAlias: resolveStringAliases(resolved?.resolve.alias ?? readResolveOptions(rawConfig).alias),
+      rootDir,
+      scanRoots: [rootDir],
+      serverImports: { presets: [] },
+    },
   )
   const aliases = createGeneratedAliasMap(rootDir, plan)
   const emitted = await writeSandboxArtifacts(rootDir, plan)
@@ -179,13 +194,34 @@ function isSandboxSourceFile(file: string) {
   return /\.(?:c|m)?[jt]s$/i.test(file) && !/\.d\.(?:c|m)?[jt]s$/i.test(file)
 }
 
-function isSandboxDefinitionUpdate(file: string, definitions: DiscoveredSandboxDefinition[]) {
+function isLocalSourceFile(file: string, rootDir: string | undefined) {
+  if (!rootDir)
+    return false
+
+  const path = normalize(relative(rootDir, file))
+  return path !== ''
+    && !path.startsWith('../')
+    && !path.startsWith('/')
+    && !path.startsWith('node_modules/')
+    && !path.startsWith('.vitehub/')
+}
+
+function isSandboxDefinitionUpdate(
+  file: string,
+  definitions: DiscoveredSandboxDefinition[],
+  generatedFiles: string[],
+  rootDir: string | undefined,
+) {
   const changedFile = normalize(file)
   if (definitions.some(definition => normalize(definition.handler) === changedFile))
     return true
+  if (generatedFiles.some(file => normalize(file) === changedFile))
+    return false
   if (!isSandboxSourceFile(changedFile))
     return false
-  return /\.sandbox\.(?:c|m)?[jt]s$/i.test(changedFile) || /(?:^|\/)(?:src\/)?server\/sandboxes\//.test(changedFile)
+  return /\.sandbox\.(?:c|m)?[jt]s$/i.test(changedFile)
+    || /(?:^|\/)(?:src\/)?server\/sandboxes\//.test(changedFile)
+    || isLocalSourceFile(changedFile, rootDir)
 }
 
 function invalidateGeneratedSandboxModules(files: string[], moduleGraph: { getModuleById: (id: string) => unknown, invalidateModule: (module: never) => void }) {
@@ -252,7 +288,7 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
       await refreshSandboxRuntime()
     },
     async handleHotUpdate(context) {
-      if (!isSandboxDefinitionUpdate(context.file, definitions))
+      if (!isSandboxDefinitionUpdate(context.file, definitions, generatedFiles, resolvedConfig?.root))
         return
 
       const previousFiles = [...generatedFiles, ...Object.values(generatedAliases)]

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -1,34 +1,57 @@
-import type { Plugin } from 'vite'
+import { buildFeatureViteContext } from '@vite-hub/internal/feature-bridge'
+import { createImportPath, ensureGeneratedDir } from '@vite-hub/internal/build/paths'
 import { createNoExternalMerger, isServerEnvironment } from '@vite-hub/internal/build/vite'
+import { writeFileIfChanged } from '@vite-hub/internal/definition-catalog'
+import { resolve } from 'pathe'
 
 import { createFeatureVitePlugin } from './internal/shared/vite'
 import { resolveFeatureRuntimePath } from './internal/shared/feature-runtime-path'
+import { discoverSandboxDefinitions } from './discovery'
+import { createSandboxFeaturePlan } from './feature'
 import { sandboxFeatureEngine, type SandboxPublicOptions } from './integration'
+import type { AgentSandboxConfig } from './module-types'
+import type { EmittedArtifact, FeatureRuntimePlan } from './internal/shared/runtime-artifacts'
+import type { Alias, AliasOptions, ConfigEnv, Plugin, ResolvedConfig } from 'vite'
 
 export { createViteHubDefinitionAutoImportsPlugin } from './internal/shared/vitehub-auto-imports'
 export type { SandboxPublicOptions } from './integration'
 
 export type SandboxVitePlugin = Plugin
 
+const SANDBOX_PACKAGE_ID = '@vite-hub/sandbox'
 const SANDBOX_PROVIDER_LOADER_ID = 'vitehub-sandbox-provider-loader'
+const SANDBOX_REGISTRY_ID = '#vitehub-sandbox-registry'
+
+type AliasMap = Record<string, string>
+type SandboxAlias = Alias & { replacement: string }
 
 function sandboxProviderLoaderFallback() {
   return resolveFeatureRuntimePath(import.meta.url, '@vite-hub/sandbox', './runtime/provider-loader', 'runtime/provider-loader.js')
 }
 
-function mergeProviderLoaderAlias(alias: unknown) {
-  const replacement = sandboxProviderLoaderFallback()
+function toSandboxAliasEntries(aliases: AliasMap): SandboxAlias[] {
+  return Object.entries(aliases).map(([find, replacement]) => ({
+    find: find === SANDBOX_PACKAGE_ID ? /^@vite-hub\/sandbox$/ : find,
+    replacement,
+  }))
+}
+
+function readAliasEntries(alias: unknown): Alias[] {
   if (Array.isArray(alias)) {
-    return [
-      { find: SANDBOX_PROVIDER_LOADER_ID, replacement },
-      ...alias,
-    ]
+    return alias as Alias[]
   }
 
-  return {
-    ...(alias && typeof alias === 'object' ? alias : {}),
-    [SANDBOX_PROVIDER_LOADER_ID]: replacement,
-  }
+  if (!alias || typeof alias !== 'object')
+    return []
+
+  return Object.entries(alias as Record<string, unknown>)
+    .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+    .map(([find, replacement]) => ({ find, replacement }))
+}
+
+function mergeAliases(alias: unknown, aliases: AliasMap): AliasOptions | undefined {
+  const entries = [...toSandboxAliasEntries(aliases), ...readAliasEntries(alias)]
+  return entries.length ? entries : undefined
 }
 
 function readResolveOptions(config: unknown): { alias?: unknown } {
@@ -41,8 +64,94 @@ function readResolveOptions(config: unknown): { alias?: unknown } {
     : {}
 }
 
+function createSandboxRuntimeFacadeContents(file: string, runtimeConfig: unknown, registryFile: string) {
+  const stateFile = resolveFeatureRuntimePath(import.meta.url, SANDBOX_PACKAGE_ID, './runtime/state', 'runtime/state.js')
+  const packageIndexFile = resolveFeatureRuntimePath(import.meta.url, SANDBOX_PACKAGE_ID, './index', 'index.js')
+
+  return [
+    `import sandboxRegistry from ${JSON.stringify(createImportPath(file, registryFile))}`,
+    `import { setSandboxRuntimeConfig, setSandboxRuntimeRegistry } from ${JSON.stringify(createImportPath(file, stateFile))}`,
+    '',
+    `setSandboxRuntimeConfig(${JSON.stringify(runtimeConfig, null, 2)})`,
+    'setSandboxRuntimeRegistry(sandboxRegistry)',
+    '',
+    `export * from ${JSON.stringify(createImportPath(file, packageIndexFile))}`,
+    '',
+  ].join('\n')
+}
+
+function createGeneratedAliasMap(rootDir: string, plan: FeatureRuntimePlan): AliasMap {
+  const generatedDir = ensureGeneratedDir(rootDir, 'sandbox')
+  const artifactPaths = new Map((plan.artifacts || []).map(artifact => [artifact.key, resolve(generatedDir, artifact.filename)]))
+  const aliases: AliasMap = {
+    [SANDBOX_PACKAGE_ID]: plan.manifest.aliasPath,
+  }
+
+  for (const alias of plan.aliases || []) {
+    if (alias.value) {
+      aliases[alias.key] = alias.value
+      continue
+    }
+    if (alias.artifactKey && artifactPaths.has(alias.artifactKey))
+      aliases[alias.key] = artifactPaths.get(alias.artifactKey)!
+  }
+
+  return aliases
+}
+
+async function writeSandboxArtifacts(rootDir: string, plan: FeatureRuntimePlan) {
+  const generatedDir = ensureGeneratedDir(rootDir, 'sandbox')
+  const emitted = new Map<string, EmittedArtifact>()
+
+  for (const artifact of plan.artifacts || []) {
+    const dst = resolve(generatedDir, artifact.filename)
+    const contents = artifact.contents ?? await artifact.getContents?.(emitted)
+    if (typeof contents !== 'string')
+      throw new Error(`[vitehub] Sandbox generated artifact "${artifact.key}" did not return contents.`)
+
+    emitted.set(artifact.key, { ...artifact, contents, dst })
+    await writeFileIfChanged(dst, contents)
+  }
+
+  return emitted
+}
+
+async function prepareSandboxRuntimeAliases(
+  engine: typeof sandboxFeatureEngine,
+  rawConfig: Record<string, unknown>,
+  rawEnv: ConfigEnv,
+  resolved: ResolvedConfig | undefined,
+): Promise<AliasMap> {
+  const rootDir = resolved?.root || resolve(process.cwd(), typeof rawConfig.root === 'string' ? rawConfig.root : '.')
+  const context = await buildFeatureViteContext(engine, { ...rawConfig, root: rootDir }, rawEnv)
+  const sandboxConfig = context?.config as AgentSandboxConfig | false | undefined
+  if (!context || !sandboxConfig)
+    return {}
+
+  const facadeFile = resolve(ensureGeneratedDir(rootDir, 'sandbox'), 'runtime/sandbox.mjs')
+  const definitions = discoverSandboxDefinitions({ rootDir })
+  const plan = await createSandboxFeaturePlan(
+    sandboxConfig,
+    definitions,
+    { aliasPath: facadeFile },
+    context.deps,
+    context.hosting,
+  )
+  const aliases = createGeneratedAliasMap(rootDir, plan)
+  await writeSandboxArtifacts(rootDir, plan)
+  await writeFileIfChanged(
+    facadeFile,
+    createSandboxRuntimeFacadeContents(
+      facadeFile,
+      (context.runtimeConfig as { sandbox?: unknown }).sandbox ?? context.config,
+      aliases[SANDBOX_REGISTRY_ID]!,
+    ),
+  )
+  return aliases
+}
+
 export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
-  const plugin = createFeatureVitePlugin({
+  const engine = {
     ...sandboxFeatureEngine,
     readPublicOptions(source) {
       const configOptions = sandboxFeatureEngine.readPublicOptions(source)
@@ -50,23 +159,40 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
         ? options
         : configOptions
     },
+  } satisfies typeof sandboxFeatureEngine
+  const plugin = createFeatureVitePlugin({
+    ...engine,
   }) as SandboxVitePlugin
   const configHook = plugin.config
   const configEnvironment = plugin.configEnvironment
   const mergeNoExternal = createNoExternalMerger('@vite-hub/sandbox')
+  let generatedAliases: AliasMap = {}
+  let rawConfig: Record<string, unknown> = {}
+  let rawEnv: ConfigEnv = { command: 'serve', mode: 'development' }
+  let resolvedConfig: ResolvedConfig | undefined
   return {
     ...plugin,
     async config(config, env) {
+      rawConfig = config as Record<string, unknown>
+      rawEnv = env
       const result = typeof configHook === 'function'
         ? await configHook.call(this, config, env)
         : undefined
+      generatedAliases = await prepareSandboxRuntimeAliases(engine, rawConfig, rawEnv, resolvedConfig)
       return {
         ...(result && typeof result === 'object' ? result : {}),
         resolve: {
           ...readResolveOptions(result),
-          alias: mergeProviderLoaderAlias(readResolveOptions(result).alias),
+          alias: mergeAliases(readResolveOptions(result).alias, {
+            [SANDBOX_PROVIDER_LOADER_ID]: sandboxProviderLoaderFallback(),
+            ...generatedAliases,
+          }),
         },
       }
+    },
+    async configResolved(config) {
+      resolvedConfig = config
+      generatedAliases = await prepareSandboxRuntimeAliases(engine, rawConfig, rawEnv, resolvedConfig)
     },
     configEnvironment(name, config) {
       const result = typeof configEnvironment === 'function'
@@ -79,7 +205,10 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
         ...result,
         resolve: {
           ...readResolveOptions(result),
-          alias: mergeProviderLoaderAlias(readResolveOptions(result).alias),
+          alias: mergeAliases(readResolveOptions(result).alias, {
+            [SANDBOX_PROVIDER_LOADER_ID]: sandboxProviderLoaderFallback(),
+            ...generatedAliases,
+          }),
           noExternal: mergeNoExternal(config.resolve?.noExternal),
         },
       }

--- a/packages/sandbox/test/discovery.test.ts
+++ b/packages/sandbox/test/discovery.test.ts
@@ -38,6 +38,21 @@ describe("discoverServerSandboxDefinitions", () => {
     ])
   })
 
+  it("does not discover server sandbox files through suffix scanning", async () => {
+    const rootDir = await createTempDir("vitehub-sandbox-vite-server-suffix-")
+    await mkdir(join(rootDir, "server", "sandboxes"), { recursive: true })
+    await mkdir(join(rootDir, "src", "server", "sandboxes"), { recursive: true })
+    await writeFile(join(rootDir, "server", "sandboxes", "release-notes.sandbox.ts"), "export default null\n", "utf8")
+    await writeFile(join(rootDir, "src", "server", "sandboxes", "ignored.sandbox.ts"), "export default null\n", "utf8")
+
+    expect(discoverSandboxDefinitions({ rootDir }).map(definition => ({
+      name: definition.name,
+      source: definition.source,
+    }))).toEqual([
+      { name: "release-notes", source: "server-sandboxes" },
+    ])
+  })
+
   it("discovers sandbox names from server/sandboxes directories", async () => {
     const scanDir = await createTempDir("vitehub-sandbox-server-discovery-")
     await mkdir(join(scanDir, "sandboxes", "content"), { recursive: true })

--- a/packages/sandbox/test/discovery.test.ts
+++ b/packages/sandbox/test/discovery.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
 
 import { createRuntimeRegistryContents } from "@vite-hub/internal/definition-discovery"
-import { discoverServerSandboxDefinitions } from "../src/discovery.ts"
+import { discoverSandboxDefinitions, discoverServerSandboxDefinitions } from "../src/discovery.ts"
 
 const tempDirs: string[] = []
 
@@ -20,6 +20,24 @@ afterEach(async () => {
 })
 
 describe("discoverServerSandboxDefinitions", () => {
+  it("discovers sandbox names for Vite suffix and server entrypoints", async () => {
+    const rootDir = await createTempDir("vitehub-sandbox-vite-discovery-")
+    await mkdir(join(rootDir, "src", "content"), { recursive: true })
+    await mkdir(join(rootDir, "server", "sandboxes", "billing"), { recursive: true })
+    await writeFile(join(rootDir, "src", "release-notes.sandbox.ts"), "export default null\n", "utf8")
+    await writeFile(join(rootDir, "src", "content", "summary.sandbox.ts"), "export default null\n", "utf8")
+    await writeFile(join(rootDir, "server", "sandboxes", "billing", "index.ts"), "export default null\n", "utf8")
+
+    expect(discoverSandboxDefinitions({ rootDir }).map(definition => ({
+      name: definition.name,
+      source: definition.source,
+    }))).toEqual([
+      { name: "billing", source: "server-sandboxes" },
+      { name: "content/summary", source: "vite-suffix" },
+      { name: "release-notes", source: "vite-suffix" },
+    ])
+  })
+
   it("discovers sandbox names from server/sandboxes directories", async () => {
     const scanDir = await createTempDir("vitehub-sandbox-server-discovery-")
     await mkdir(join(scanDir, "sandboxes", "content"), { recursive: true })

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -46,6 +46,7 @@ describe("hubSandbox", () => {
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox()
     const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: { root: string, resolve: { alias: [] } }) => unknown | Promise<unknown>
     const resolveId = plugin.resolveId as (id: string) => string | undefined | Promise<string | undefined>
     const load = plugin.load as (id: string) => string | undefined | Promise<string | undefined>
 
@@ -58,6 +59,7 @@ describe("hubSandbox", () => {
       command: "serve",
       mode: "development",
     })
+    await configResolved({ root: rootDir, resolve: { alias: [] } })
 
     const resolvedId = await resolveId("#vitehub/sandbox")
     const code = await load(resolvedId as string)
@@ -126,6 +128,7 @@ describe("hubSandbox", () => {
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox({ provider: "vercel" })
     const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: { root: string, resolve: { alias: AliasOptions } }) => unknown | Promise<unknown>
 
     await configHook({
       root: rootDir,
@@ -138,8 +141,55 @@ describe("hubSandbox", () => {
       command: "serve",
       mode: "development",
     })
+    await configResolved({
+      root: rootDir,
+      resolve: {
+        alias: [
+          {
+            find: "@",
+            replacement: join(rootDir, "src"),
+          },
+        ],
+      },
+    })
 
     await expect(readFile(join(rootDir, ".vitehub/sandbox/runtime/sandbox-definitions/tools__release-notes.mjs"), "utf8")).resolves.toContain("from alias")
+  })
+
+  it("defers generated definition bundling until Vite aliases are resolved", async () => {
+    const rootDir = await createViteRoot()
+    await mkdir(join(rootDir, "src/lib"), { recursive: true })
+    await writeFile(join(rootDir, "src/lib/message.ts"), `export const message = "from late alias"\n`)
+    await writeFile(join(rootDir, "src/tools/release-notes.sandbox.ts"), [
+      `import { message } from "#late/message"`,
+      ``,
+      `export default defineSandbox(async () => ({ message }))`,
+      ``,
+    ].join("\n"))
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "vercel" })
+    const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: { root: string, resolve: { alias: AliasOptions } }) => unknown | Promise<unknown>
+
+    await configHook({
+      root: rootDir,
+    }, {
+      command: "serve",
+      mode: "development",
+    })
+    await configResolved({
+      root: rootDir,
+      resolve: {
+        alias: [
+          {
+            find: "#late",
+            replacement: join(rootDir, "src/lib"),
+          },
+        ],
+      },
+    })
+
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/runtime/sandbox-definitions/tools__release-notes.mjs"), "utf8")).resolves.toContain("from late alias")
   })
 
   it("lets Vite config override direct integration options", async () => {
@@ -287,12 +337,14 @@ describe("hubSandbox", () => {
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox({ provider: "vercel" })
     const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: { root: string, resolve: { alias: [] } }) => unknown | Promise<unknown>
     await configHook({
       root: rootDir,
     }, {
       command: "serve",
       mode: "development",
     })
+    await configResolved({ root: rootDir, resolve: { alias: [] } })
 
     const configEnvironment = plugin.configEnvironment as (name: string, environment: { consumer: "client" | "server" }) => unknown
     const sandboxAlias = readAlias((configEnvironment("ssr", { consumer: "server" }) as { resolve: { alias: AliasOptions } }).resolve.alias, "@vite-hub/sandbox")!

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -65,10 +65,13 @@ describe("hubSandbox", () => {
     expect(code).toContain('"feature": "sandbox"')
     expect(code).toContain('"provider": "vercel"')
     const alias = (configResult as { resolve: { alias: AliasOptions } }).resolve.alias
-    const sandboxAlias = readAlias(alias, "@vite-hub/sandbox")!
     const registryAlias = readAlias(alias, "#vitehub-sandbox-registry")!
     const providerLoaderAlias = readAlias(alias, "vitehub-sandbox-provider-loader")!
+    const configEnvironment = plugin.configEnvironment as (name: string, environment: { consumer: "client" | "server" }) => unknown
+    const serverConfig = configEnvironment("ssr", { consumer: "server" }) as { resolve: { alias: AliasOptions } }
+    const sandboxAlias = readAlias(serverConfig.resolve.alias, "@vite-hub/sandbox")!
 
+    expect(readAlias(alias, "@vite-hub/sandbox")).toBeUndefined()
     expect(sandboxAlias).toContain(".vitehub/sandbox/runtime/sandbox.mjs")
     expect(registryAlias).toContain(".vitehub/sandbox/runtime/sandbox-registry.mjs")
     expect(providerLoaderAlias).toContain(".vitehub/sandbox/runtime/sandbox-provider-loader.mjs")
@@ -86,6 +89,7 @@ describe("hubSandbox", () => {
     expect(registry).toContain('"tools/release-notes"')
     expect(providerLoader).toContain("createVercelSandboxClient")
     expect(providerLoader).not.toContain("import('./providers/vercel.js')")
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/runtime/sandbox.d.ts"), "utf8")).resolves.toContain('"tools/release-notes"')
   })
 
   it("accepts direct integration options", async () => {
@@ -224,6 +228,17 @@ describe("hubSandbox", () => {
     }))
   })
 
+  it("rejects generated sandbox artifact path collisions", async () => {
+    const { createSandboxFeaturePlan } = await import("../src/feature.ts")
+
+    await expect(createSandboxFeaturePlan({}, [
+      { handler: "/tmp/tools/release-notes.ts", name: "tools/release-notes", _meta: { filename: "tools/release-notes", sourcePath: "/tmp/tools/release-notes.ts" } },
+      { handler: "/tmp/tools__release-notes.ts", name: "tools__release-notes", _meta: { filename: "tools__release-notes", sourcePath: "/tmp/tools__release-notes.ts" } },
+    ], {
+      aliasPath: "/tmp/vitehub-sandbox/index.js",
+    }, {})).rejects.toThrow("generate the same artifact path")
+  })
+
   it("passes explicit Cloudflare sandbox container names to Cloudflare targets", async () => {
     const { createSandboxFeaturePlan } = await import("../src/feature.ts")
     const plan = await createSandboxFeaturePlan({ provider: "cloudflare", name: "custom-sandbox" }, [], {
@@ -236,5 +251,58 @@ describe("hubSandbox", () => {
       migrationTag: "v1",
       name: "custom-sandbox",
     })
+  })
+
+  it("refreshes generated artifacts during sandbox definition hot updates", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "vercel" })
+    const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    await configHook({
+      root: rootDir,
+    }, {
+      command: "serve",
+      mode: "development",
+    })
+
+    const configEnvironment = plugin.configEnvironment as (name: string, environment: { consumer: "client" | "server" }) => unknown
+    const sandboxAlias = readAlias((configEnvironment("ssr", { consumer: "server" }) as { resolve: { alias: AliasOptions } }).resolve.alias, "@vite-hub/sandbox")!
+    const registryAlias = join(rootDir, ".vitehub/sandbox/runtime/sandbox-registry.mjs")
+    const definitionArtifact = join(rootDir, ".vitehub/sandbox/runtime/sandbox-definitions/tools__release-notes.mjs")
+    const definition = join(rootDir, "src/tools/release-notes.sandbox.ts")
+    const invalidated: string[] = []
+    const handleHotUpdate = plugin.handleHotUpdate as unknown as (context: {
+      file: string
+      server: {
+        moduleGraph: {
+          getModuleById: (id: string) => { id: string } | undefined
+          invalidateModule: (module: { id: string }) => void
+        }
+      }
+    }) => Promise<void>
+
+    await writeFile(definition, [
+      `import { defineSandbox } from "@vite-hub/sandbox"`,
+      ``,
+      `export default defineSandbox(async () => ({ message: "updated" }))`,
+      ``,
+    ].join("\n"))
+    await handleHotUpdate({
+      file: definition,
+      server: {
+        moduleGraph: {
+          getModuleById(id) {
+            if ([sandboxAlias, registryAlias, definitionArtifact].includes(id))
+              return { id }
+          },
+          invalidateModule(module) {
+            invalidated.push(module.id)
+          },
+        },
+      },
+    })
+
+    expect(invalidated).toEqual(expect.arrayContaining([sandboxAlias, registryAlias, definitionArtifact]))
+    await expect(readFile(definitionArtifact, "utf8")).resolves.toContain("updated")
   })
 })

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -1,10 +1,22 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
+import type { AliasOptions } from "vite"
 
 const tempDirs: string[] = []
+
+function readAlias(alias: AliasOptions | undefined, id: string) {
+  if (Array.isArray(alias)) {
+    return alias.find((entry) => {
+      if (typeof entry.find === "string") return entry.find === id
+      return entry.find.test(id)
+    })?.replacement
+  }
+
+  return (alias as Record<string, string> | undefined)?.[id]
+}
 
 async function createViteRoot() {
   const rootDir = await mkdtemp(join(tmpdir(), "vitehub-sandbox-vite-"))
@@ -52,13 +64,28 @@ describe("hubSandbox", () => {
 
     expect(code).toContain('"feature": "sandbox"')
     expect(code).toContain('"provider": "vercel"')
-    expect(configResult).toEqual({
-      resolve: {
-        alias: {
-          "vitehub-sandbox-provider-loader": expect.stringContaining("runtime/provider-loader"),
-        },
-      },
-    })
+    const alias = (configResult as { resolve: { alias: AliasOptions } }).resolve.alias
+    const sandboxAlias = readAlias(alias, "@vite-hub/sandbox")!
+    const registryAlias = readAlias(alias, "#vitehub-sandbox-registry")!
+    const providerLoaderAlias = readAlias(alias, "vitehub-sandbox-provider-loader")!
+
+    expect(sandboxAlias).toContain(".vitehub/sandbox/runtime/sandbox.mjs")
+    expect(registryAlias).toContain(".vitehub/sandbox/runtime/sandbox-registry.mjs")
+    expect(providerLoaderAlias).toContain(".vitehub/sandbox/runtime/sandbox-provider-loader.mjs")
+    expect(readAlias(alias, "@vite-hub/sandbox/runtime/state")).toBeUndefined()
+    expect(readAlias(alias, "@vite-hub/sandbox/runtime/provider-loader")).toContain(".vitehub/sandbox/runtime/sandbox-provider-loader.mjs")
+
+    const [facade, registry, providerLoader] = await Promise.all([
+      readFile(sandboxAlias, "utf8"),
+      readFile(registryAlias, "utf8"),
+      readFile(providerLoaderAlias, "utf8"),
+    ])
+    expect(facade).toContain("setSandboxRuntimeConfig")
+    expect(facade).toContain("setSandboxRuntimeRegistry(sandboxRegistry)")
+    expect(facade).toContain("export * from")
+    expect(registry).toContain('"tools/release-notes"')
+    expect(providerLoader).toContain("createVercelSandboxClient")
+    expect(providerLoader).not.toContain("import('./providers/vercel.js')")
   })
 
   it("accepts direct integration options", async () => {
@@ -139,9 +166,12 @@ describe("hubSandbox", () => {
         __VITEHUB_ENVIRONMENT_SANDBOX__: "\"rsc\"",
       },
       resolve: {
-        alias: {
-          "vitehub-sandbox-provider-loader": expect.stringContaining("runtime/provider-loader"),
-        },
+        alias: expect.arrayContaining([
+          expect.objectContaining({
+            find: "vitehub-sandbox-provider-loader",
+            replacement: expect.stringContaining("runtime/provider-loader"),
+          }),
+        ]),
         noExternal: ["@vite-hub/sandbox"],
       },
     })

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -113,6 +113,35 @@ describe("hubSandbox", () => {
     expect(code).toContain('"provider": "vercel"')
   })
 
+  it("bundles generated definitions with auto-imports and Vite aliases", async () => {
+    const rootDir = await createViteRoot()
+    await mkdir(join(rootDir, "src/lib"), { recursive: true })
+    await writeFile(join(rootDir, "src/lib/message.ts"), `export const message = "from alias"\n`)
+    await writeFile(join(rootDir, "src/tools/release-notes.sandbox.ts"), [
+      `import { message } from "@/lib/message"`,
+      ``,
+      `export default defineSandbox(async () => ({ message }))`,
+      ``,
+    ].join("\n"))
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "vercel" })
+    const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+
+    await configHook({
+      root: rootDir,
+      resolve: {
+        alias: {
+          "@": join(rootDir, "src"),
+        },
+      },
+    }, {
+      command: "serve",
+      mode: "development",
+    })
+
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/runtime/sandbox-definitions/tools__release-notes.mjs"), "utf8")).resolves.toContain("from alias")
+  })
+
   it("lets Vite config override direct integration options", async () => {
     const rootDir = await createViteRoot()
     const { hubSandbox } = await import("../src/vite.ts")
@@ -304,5 +333,65 @@ describe("hubSandbox", () => {
 
     expect(invalidated).toEqual(expect.arrayContaining([sandboxAlias, registryAlias, definitionArtifact]))
     await expect(readFile(definitionArtifact, "utf8")).resolves.toContain("updated")
+  })
+
+  it("refreshes generated artifacts when imported local modules change", async () => {
+    const rootDir = await createViteRoot()
+    const helper = join(rootDir, "src/tools/message.ts")
+    const definition = join(rootDir, "src/tools/release-notes.sandbox.ts")
+    await writeFile(helper, `export const message = "initial"\n`)
+    await writeFile(definition, [
+      `import { defineSandbox } from "@vite-hub/sandbox"`,
+      `import { message } from "./message"`,
+      ``,
+      `export default defineSandbox(async () => ({ message }))`,
+      ``,
+    ].join("\n"))
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "vercel" })
+    const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: { root: string, resolve: { alias: [] } }) => unknown | Promise<unknown>
+    await configHook({
+      root: rootDir,
+    }, {
+      command: "serve",
+      mode: "development",
+    })
+    await configResolved({ root: rootDir, resolve: { alias: [] } })
+
+    const configEnvironment = plugin.configEnvironment as (name: string, environment: { consumer: "client" | "server" }) => unknown
+    const sandboxAlias = readAlias((configEnvironment("ssr", { consumer: "server" }) as { resolve: { alias: AliasOptions } }).resolve.alias, "@vite-hub/sandbox")!
+    const registryAlias = join(rootDir, ".vitehub/sandbox/runtime/sandbox-registry.mjs")
+    const definitionArtifact = join(rootDir, ".vitehub/sandbox/runtime/sandbox-definitions/tools__release-notes.mjs")
+    const invalidated: string[] = []
+    const handleHotUpdate = plugin.handleHotUpdate as unknown as (context: {
+      file: string
+      server: {
+        moduleGraph: {
+          getModuleById: (id: string) => { id: string } | undefined
+          invalidateModule: (module: { id: string }) => void
+        }
+      }
+    }) => Promise<void>
+
+    await expect(readFile(definitionArtifact, "utf8")).resolves.toContain("initial")
+    await writeFile(helper, `export const message = "updated helper"\n`)
+    await handleHotUpdate({
+      file: helper,
+      server: {
+        moduleGraph: {
+          getModuleById(id) {
+            if ([sandboxAlias, registryAlias, definitionArtifact].includes(id))
+              return { id }
+          },
+          invalidateModule(module) {
+            invalidated.push(module.id)
+          },
+        },
+      },
+    })
+
+    expect(invalidated).toEqual(expect.arrayContaining([sandboxAlias, registryAlias, definitionArtifact]))
+    await expect(readFile(definitionArtifact, "utf8")).resolves.toContain("updated helper")
   })
 })


### PR DESCRIPTION
Wires the Sandbox Vite integration to generate and alias the runtime facade, registry, and provider loader for direct `hubSandbox()` usage. Public `@vite-hub/sandbox` SSR imports now preload the resolved Runtime Config and discovered Sandbox Runtime Registry while package subpath imports stay on their published paths.

This fixes fresh SSR builds where `runSandbox("release-notes")` needed app-owned `#vitehub/sandbox` state wiring or `ssr.external` special casing, and it ensures provider-loader output uses generated static provider modules instead of unresolved relative runtime imports.