### PR TITLE
fix(kv): emit cloudflare provider output

### DIFF
--- a/packages/internal/src/build/cloudflare.ts
+++ b/packages/internal/src/build/cloudflare.ts
@@ -5,7 +5,7 @@ import { toSafeAppName } from "./user-entry.ts"
 
 export const defaultCloudflareCompatibilityDate = "2026-04-20"
 
-export interface CloudflareWranglerConfigOptions {
+interface CloudflareWranglerConfigOptions {
   outputRoot?: string
   rootDir: string
   wranglerConfig?: object

--- a/packages/internal/src/build/cloudflare.ts
+++ b/packages/internal/src/build/cloudflare.ts
@@ -1,1 +1,85 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { resolve } from "node:path"
+
+import { toSafeAppName } from "./user-entry.ts"
+
 export const defaultCloudflareCompatibilityDate = "2026-04-20"
+
+export interface CloudflareWranglerConfigOptions {
+  outputRoot?: string
+  rootDir: string
+  wranglerConfig?: object
+  wranglerConfigKeys?: string[]
+}
+
+export function createDefaultCloudflareOutputRoot(rootDir: string): string {
+  return resolve(rootDir, "dist", toSafeAppName(rootDir))
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+async function readJsonObject(file: string): Promise<Record<string, unknown>> {
+  try {
+    const parsed = JSON.parse(await readFile(file, "utf8"))
+    return isJsonObject(parsed) ? parsed : {}
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {}
+    throw error
+  }
+}
+
+function deleteJsonObjectKeys(value: Record<string, unknown>, keys: string[] | undefined): Record<string, unknown> {
+  if (!keys?.length) return value
+  const next = { ...value }
+  for (const key of keys) {
+    delete next[key]
+  }
+  return next
+}
+
+async function writeMergedJsonObject(file: string, value: object, ownedKeys?: string[]): Promise<void> {
+  const existing = await readJsonObject(file)
+  await writeFile(file, `${JSON.stringify({ ...deleteJsonObjectKeys(existing, ownedKeys), ...value }, null, 2)}\n`, "utf8")
+}
+
+async function deleteJsonObjectKeysFromFile(file: string, keys: string[] | undefined): Promise<void> {
+  if (!keys?.length) return
+  let existing: Record<string, unknown>
+  try {
+    const parsed = JSON.parse(await readFile(file, "utf8"))
+    existing = isJsonObject(parsed) ? parsed : {}
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    throw error
+  }
+  const next = { ...existing }
+  let changed = false
+  for (const key of keys) {
+    if (key in next) {
+      delete next[key]
+      changed = true
+    }
+  }
+  if (!changed) return
+  if (!Object.keys(next).length) {
+    await rm(file, { force: true })
+    return
+  }
+  await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
+}
+
+export async function writeCloudflareWranglerConfig(options: CloudflareWranglerConfigOptions): Promise<void> {
+  const outputRoot = options.outputRoot ?? createDefaultCloudflareOutputRoot(options.rootDir)
+  const configFile = resolve(outputRoot, "wrangler.json")
+  if (!options.wranglerConfig) {
+    await deleteJsonObjectKeysFromFile(configFile, options.wranglerConfigKeys)
+    return
+  }
+
+  await mkdir(outputRoot, { recursive: true })
+  await writeMergedJsonObject(configFile, options.wranglerConfig, options.wranglerConfigKeys)
+}

--- a/packages/internal/src/build/cloudflare.ts
+++ b/packages/internal/src/build/cloudflare.ts
@@ -6,6 +6,7 @@ import { toSafeAppName } from "./user-entry.ts"
 export const defaultCloudflareCompatibilityDate = "2026-04-20"
 
 interface CloudflareWranglerConfigOptions {
+  wranglerArrayOwnedValues?: Record<string, unknown[]>
   outputRoot?: string
   rootDir: string
   wranglerArrayMergeKeys?: Record<string, string>
@@ -45,22 +46,32 @@ function mergeJsonObjectArrays(
   existing: Record<string, unknown>,
   value: Record<string, unknown>,
   arrayMergeKeys: Record<string, string> | undefined,
+  arrayOwnedValues: Record<string, unknown[]> | undefined,
 ): Record<string, unknown> {
   if (!arrayMergeKeys) return value
   const next = { ...value }
   for (const [field, key] of Object.entries(arrayMergeKeys)) {
-    const incoming = value[field]
-    if (!Array.isArray(incoming)) continue
     const current = existing[field]
-    if (!Array.isArray(current)) continue
+    const incoming = value[field]
+    const currentArray = Array.isArray(current) ? current : []
+    const incomingArray = Array.isArray(incoming) ? incoming : []
+    const ownedValues = new Set(arrayOwnedValues?.[field] ?? [])
+    if (!currentArray.length && !incomingArray.length) continue
+
     const incomingKeys = new Set<unknown>()
-    for (const item of incoming) {
+    for (const item of incomingArray) {
       if (isJsonObject(item) && item[key] !== undefined) incomingKeys.add(item[key])
     }
-    next[field] = [
-      ...current.filter(item => !isJsonObject(item) || !incomingKeys.has(item[key])),
-      ...incoming,
+    const removedKeys = new Set([...ownedValues, ...incomingKeys])
+    const merged = [
+      ...currentArray.filter(item => !isJsonObject(item) || !removedKeys.has(item[key])),
+      ...incomingArray,
     ]
+    if (!merged.length) {
+      delete next[field]
+      continue
+    }
+    next[field] = merged
   }
   return next
 }
@@ -70,9 +81,18 @@ async function writeMergedJsonObject(
   value: object,
   ownedKeys?: string[],
   arrayMergeKeys?: Record<string, string>,
+  arrayOwnedValues?: Record<string, unknown[]>,
 ): Promise<void> {
   const existing = await readJsonObject(file)
-  const next = { ...deleteJsonObjectKeys(existing, ownedKeys), ...mergeJsonObjectArrays(existing, value as Record<string, unknown>, arrayMergeKeys) }
+  const ownedTopLevelKeys = [...(ownedKeys ?? []), ...Object.keys(arrayMergeKeys ?? {})]
+  const next = {
+    ...deleteJsonObjectKeys(existing, ownedTopLevelKeys),
+    ...mergeJsonObjectArrays(existing, value as Record<string, unknown>, arrayMergeKeys, arrayOwnedValues),
+  }
+  if (!Object.keys(next).length) {
+    await rm(file, { force: true })
+    return
+  }
   await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
 }
 
@@ -107,10 +127,21 @@ export async function writeCloudflareWranglerConfig(options: CloudflareWranglerC
   const outputRoot = options.outputRoot ?? createDefaultCloudflareOutputRoot(options.rootDir)
   const configFile = resolve(outputRoot, "wrangler.json")
   if (!options.wranglerConfig) {
+    if (options.wranglerArrayOwnedValues && options.wranglerArrayMergeKeys) {
+      await mkdir(outputRoot, { recursive: true })
+      await writeMergedJsonObject(configFile, {}, options.wranglerConfigKeys, options.wranglerArrayMergeKeys, options.wranglerArrayOwnedValues)
+      return
+    }
     await deleteJsonObjectKeysFromFile(configFile, options.wranglerConfigKeys)
     return
   }
 
   await mkdir(outputRoot, { recursive: true })
-  await writeMergedJsonObject(configFile, options.wranglerConfig, options.wranglerConfigKeys, options.wranglerArrayMergeKeys)
+  await writeMergedJsonObject(
+    configFile,
+    options.wranglerConfig,
+    options.wranglerConfigKeys,
+    options.wranglerArrayMergeKeys,
+    options.wranglerArrayOwnedValues,
+  )
 }

--- a/packages/internal/src/build/cloudflare.ts
+++ b/packages/internal/src/build/cloudflare.ts
@@ -8,6 +8,7 @@ export const defaultCloudflareCompatibilityDate = "2026-04-20"
 interface CloudflareWranglerConfigOptions {
   outputRoot?: string
   rootDir: string
+  wranglerArrayMergeKeys?: Record<string, string>
   wranglerConfig?: object
   wranglerConfigKeys?: string[]
 }
@@ -40,9 +41,39 @@ function deleteJsonObjectKeys(value: Record<string, unknown>, keys: string[] | u
   return next
 }
 
-async function writeMergedJsonObject(file: string, value: object, ownedKeys?: string[]): Promise<void> {
+function mergeJsonObjectArrays(
+  existing: Record<string, unknown>,
+  value: Record<string, unknown>,
+  arrayMergeKeys: Record<string, string> | undefined,
+): Record<string, unknown> {
+  if (!arrayMergeKeys) return value
+  const next = { ...value }
+  for (const [field, key] of Object.entries(arrayMergeKeys)) {
+    const incoming = value[field]
+    if (!Array.isArray(incoming)) continue
+    const current = existing[field]
+    if (!Array.isArray(current)) continue
+    const incomingKeys = new Set<unknown>()
+    for (const item of incoming) {
+      if (isJsonObject(item) && item[key] !== undefined) incomingKeys.add(item[key])
+    }
+    next[field] = [
+      ...current.filter(item => !isJsonObject(item) || !incomingKeys.has(item[key])),
+      ...incoming,
+    ]
+  }
+  return next
+}
+
+async function writeMergedJsonObject(
+  file: string,
+  value: object,
+  ownedKeys?: string[],
+  arrayMergeKeys?: Record<string, string>,
+): Promise<void> {
   const existing = await readJsonObject(file)
-  await writeFile(file, `${JSON.stringify({ ...deleteJsonObjectKeys(existing, ownedKeys), ...value }, null, 2)}\n`, "utf8")
+  const next = { ...deleteJsonObjectKeys(existing, ownedKeys), ...mergeJsonObjectArrays(existing, value as Record<string, unknown>, arrayMergeKeys) }
+  await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
 }
 
 async function deleteJsonObjectKeysFromFile(file: string, keys: string[] | undefined): Promise<void> {
@@ -81,5 +112,5 @@ export async function writeCloudflareWranglerConfig(options: CloudflareWranglerC
   }
 
   await mkdir(outputRoot, { recursive: true })
-  await writeMergedJsonObject(configFile, options.wranglerConfig, options.wranglerConfigKeys)
+  await writeMergedJsonObject(configFile, options.wranglerConfig, options.wranglerConfigKeys, options.wranglerArrayMergeKeys)
 }

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -195,7 +195,7 @@ async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutp
 
   const writes = [
     writeMergedJsonObject(resolve(outputRoot, "wrangler.json"), options.wranglerConfig, options.wranglerConfigKeys),
-    staticIndex
+    options.bundleEntry && staticIndex
       ? copyClientOutput(clientDir, options.staticOutputDir ?? createDefaultCloudflareStaticOutputDir(options.rootDir))
       : Promise.resolve(),
   ]

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -14,8 +14,8 @@ interface SharedDeploymentOptions {
 }
 
 interface CloudflareDeploymentOutputOptions extends SharedDeploymentOptions {
-  bundleEntry: string
-  bundleOptions: BundleOptions
+  bundleEntry?: string
+  bundleOptions?: BundleOptions
   bundleOutfileName?: string
   outputRoot?: string
   staticOutputDir?: string
@@ -190,18 +190,23 @@ async function appendNetlifyFunctionConfig(outfile: string, config: object | und
 async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutputOptions): Promise<void> {
   const { clientDir, staticIndex } = resolveClientOutput(options.rootDir, options.clientOutDir)
   const outputRoot = options.outputRoot ?? createDefaultCloudflareOutputRoot(options.rootDir)
-  const workerOutfile = resolve(outputRoot, options.bundleOutfileName ?? "index.js")
 
   await mkdir(outputRoot, { recursive: true })
-  await rm(workerOutfile, { force: true, recursive: true })
 
-  await Promise.all([
-    bundleEsmEntry(options.bundleEntry, workerOutfile, options.bundleOptions),
+  const writes = [
     writeMergedJsonObject(resolve(outputRoot, "wrangler.json"), options.wranglerConfig, options.wranglerConfigKeys),
     staticIndex
       ? copyClientOutput(clientDir, options.staticOutputDir ?? createDefaultCloudflareStaticOutputDir(options.rootDir))
       : Promise.resolve(),
-  ])
+  ]
+
+  if (options.bundleEntry) {
+    const workerOutfile = resolve(outputRoot, options.bundleOutfileName ?? "index.js")
+    await rm(workerOutfile, { force: true, recursive: true })
+    writes.push(bundleEsmEntry(options.bundleEntry, workerOutfile, options.bundleOptions))
+  }
+
+  await Promise.all(writes)
 }
 
 async function writeVercelDeploymentOutput(options: VercelDeploymentOutputOptions): Promise<void> {

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -2,9 +2,12 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { dirname, resolve } from "node:path"
 
 import { copyClientOutput, hasStaticIndex } from "./client-output.ts"
+import { createDefaultCloudflareOutputRoot, writeCloudflareWranglerConfig } from "./cloudflare.ts"
 import { bundleEsmEntry } from "./esbuild.ts"
-import { toSafeAppName } from "./user-entry.ts"
 import { createNodeFunctionConfig, createVercelConfigJson } from "./vercel-config.ts"
+
+export { createDefaultCloudflareOutputRoot } from "./cloudflare.ts"
+export { shouldSkipViteProviderBuild } from "./vite.ts"
 
 type BundleOptions = NonNullable<Parameters<typeof bundleEsmEntry>[2]>
 
@@ -150,14 +153,6 @@ async function deleteJsonObjectKeysFromFile(file: string, keys: string[] | undef
   await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
 }
 
-export function shouldSkipViteProviderBuild(command: "build" | "serve" | undefined, mode?: string): boolean {
-  return command === "serve" || mode === "e2e"
-}
-
-export function createDefaultCloudflareOutputRoot(rootDir: string): string {
-  return resolve(rootDir, "dist", toSafeAppName(rootDir))
-}
-
 function createDefaultCloudflareStaticOutputDir(rootDir: string): string {
   return resolve(rootDir, "dist", "client")
 }
@@ -194,7 +189,12 @@ async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutp
   await mkdir(outputRoot, { recursive: true })
 
   const writes = [
-    writeMergedJsonObject(resolve(outputRoot, "wrangler.json"), options.wranglerConfig, options.wranglerConfigKeys),
+    writeCloudflareWranglerConfig({
+      outputRoot,
+      rootDir: options.rootDir,
+      wranglerConfig: options.wranglerConfig,
+      wranglerConfigKeys: options.wranglerConfigKeys,
+    }),
     options.bundleEntry && staticIndex
       ? copyClientOutput(clientDir, options.staticOutputDir ?? createDefaultCloudflareStaticOutputDir(options.rootDir))
       : Promise.resolve(),
@@ -256,7 +256,11 @@ async function cleanupCloudflareDeploymentOutput(rootDir: string, cleanup: Cloud
   if (cleanup.bundleOutfileName) {
     writes.push(rm(resolve(outputRoot, cleanup.bundleOutfileName), { force: true, recursive: true }))
   }
-  writes.push(deleteJsonObjectKeysFromFile(resolve(outputRoot, "wrangler.json"), cleanup.wranglerConfigKeys))
+  writes.push(writeCloudflareWranglerConfig({
+    outputRoot,
+    rootDir,
+    wranglerConfigKeys: cleanup.wranglerConfigKeys,
+  }))
   await Promise.all(writes)
 }
 

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -35,6 +35,10 @@ export function isServerEnvironment(name: string, config: { consumer?: string })
   return name === "ssr" || config.consumer === "server"
 }
 
+export function shouldSkipViteProviderBuild(command: "build" | "serve" | undefined, mode?: string): boolean {
+  return command === "serve" || mode === "e2e"
+}
+
 export function mergeGeneratedViteHubWatchIgnored(ignored: WatchIgnoredValue): WatchIgnoredValue {
   if (!ignored) return [generatedViteHubFilesPattern]
   if (Array.isArray(ignored)) {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -109,6 +109,33 @@ describe("provider deployment outputs", () => {
     })
   })
 
+  it("does not copy client output for config-only Cloudflare output", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultCloudflareOutputRoot,
+      writeProviderDeploymentOutputs,
+    } = await import("../src/build/deployment-output.ts")
+    const cloudflareDir = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(join(rootDir, "dist"), { recursive: true })
+    await writeFile(join(rootDir, "dist", "index.html"), "<!doctype html>\n")
+
+    await writeProviderDeploymentOutputs({
+      clientOutDir: "dist",
+      cloudflare: {
+        wranglerConfig: {
+          kv_namespaces: [{ binding: "SETTINGS", id: "namespace-id" }],
+        },
+        wranglerConfigKeys: ["kv_namespaces"],
+      },
+      rootDir,
+    })
+
+    expect(existsSync(join(rootDir, "dist", "client"))).toBe(false)
+    await expect(readFile(join(cloudflareDir, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      kv_namespaces: [{ binding: "SETTINGS", id: "namespace-id" }],
+    })
+  })
+
   it("preserves sibling Vercel functions and config keys", async () => {
     const rootDir = await createTempProject()
     const {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -167,6 +167,17 @@ describe("provider deployment outputs", () => {
       ],
       triggers: { crons: ["0 0 * * *"] },
     })
+
+    await writeCloudflareWranglerConfig({
+      rootDir,
+      wranglerArrayMergeKeys: { kv_namespaces: "binding" },
+      wranglerArrayOwnedValues: { kv_namespaces: ["SETTINGS"] },
+    })
+
+    await expect(readFile(join(cloudflareDir, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      kv_namespaces: [{ binding: "MANUAL", id: "manual-namespace" }],
+      triggers: { crons: ["0 0 * * *"] },
+    })
   })
 
   it("preserves sibling Vercel functions and config keys", async () => {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -136,6 +136,39 @@ describe("provider deployment outputs", () => {
     })
   })
 
+  it("merges keyed Cloudflare config arrays without dropping unrelated entries", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultCloudflareOutputRoot,
+      writeCloudflareWranglerConfig,
+    } = await import("../src/build/cloudflare.ts")
+    const cloudflareDir = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(cloudflareDir, { recursive: true })
+    await writeFile(join(cloudflareDir, "wrangler.json"), `${JSON.stringify({
+      kv_namespaces: [
+        { binding: "MANUAL", id: "manual-namespace" },
+        { binding: "SETTINGS", id: "old-namespace" },
+      ],
+      triggers: { crons: ["0 0 * * *"] },
+    }, null, 2)}\n`)
+
+    await writeCloudflareWranglerConfig({
+      rootDir,
+      wranglerArrayMergeKeys: { kv_namespaces: "binding" },
+      wranglerConfig: {
+        kv_namespaces: [{ binding: "SETTINGS", id: "new-namespace" }],
+      },
+    })
+
+    await expect(readFile(join(cloudflareDir, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      kv_namespaces: [
+        { binding: "MANUAL", id: "manual-namespace" },
+        { binding: "SETTINGS", id: "new-namespace" },
+      ],
+      triggers: { crons: ["0 0 * * *"] },
+    })
+  })
+
   it("preserves sibling Vercel functions and config keys", async () => {
     const rootDir = await createTempProject()
     const {

--- a/packages/kv/src/vite.ts
+++ b/packages/kv/src/vite.ts
@@ -125,9 +125,12 @@ export function hubKv(options?: KVModuleOptions): KVVitePlugin {
       async handler() {
         if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
 
+        const wranglerConfig = createCloudflareKVWranglerConfig(getConfig().kv)
+        if (!wranglerConfig) return
+
         await writeCloudflareWranglerConfig({
           rootDir: resolved.root,
-          wranglerConfig: createCloudflareKVWranglerConfig(getConfig().kv),
+          wranglerConfig,
           wranglerConfigKeys: ["kv_namespaces"],
         })
       },

--- a/packages/kv/src/vite.ts
+++ b/packages/kv/src/vite.ts
@@ -4,11 +4,15 @@ import {
   resolveKVViteConfig,
 } from "./vite-config.ts"
 
+import { getViteMode } from "@vite-hub/internal/build/mode"
+import { shouldSkipViteProviderBuild, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { createNoExternalMerger, isServerEnvironment } from "@vite-hub/internal/build/vite"
+
+import { configureCloudflareKV } from "./integrations/cloudflare.ts"
 
 import type { KVViteRuntimeConfig } from "./vite-config.ts"
 import type { KVModuleOptions, ResolvedKVModuleOptions } from "./types.ts"
-import type { Plugin } from "vite"
+import type { Plugin, ResolvedConfig } from "vite"
 
 const RESOLVED_KV_VIRTUAL_CONFIG_ID = `\0${KV_VIRTUAL_CONFIG_ID}`
 const KV_RUNTIME_ID = "#vitehub/kv/runtime"
@@ -37,6 +41,13 @@ function serializeVirtualConfig(config: KVViteRuntimeConfig): string {
 function isCloudflareKVConfig(kv: KVViteRuntimeConfig["kv"]): kv is ResolvedKVModuleOptions {
   return Boolean(kv) && Object.values((kv as ResolvedKVModuleOptions).stores || { default: (kv as ResolvedKVModuleOptions).store })
     .every(store => store.driver === "cloudflare-kv-binding")
+}
+
+function createCloudflareKVWranglerConfig(kv: KVViteRuntimeConfig["kv"]) {
+  if (!kv) return
+  const target: { cloudflare?: { wrangler?: { kv_namespaces?: Array<{ binding: string, id?: string }> } } } = {}
+  configureCloudflareKV(target, kv)
+  return target.cloudflare?.wrangler?.kv_namespaces?.length ? target.cloudflare.wrangler : undefined
 }
 
 function serializeCloudflareRuntime(config: ResolvedKVModuleOptions): string {
@@ -76,6 +87,7 @@ function serializeCloudflareRuntime(config: ResolvedKVModuleOptions): string {
 }
 
 export function hubKv(options?: KVModuleOptions): KVVitePlugin {
+  let resolved: ResolvedConfig | undefined
   let runtimeConfig: KVViteRuntimeConfig | undefined
   const getConfig = () => runtimeConfig ??= resolveKVViteConfig(options)
 
@@ -84,6 +96,7 @@ export function hubKv(options?: KVModuleOptions): KVVitePlugin {
     enforce: "pre",
     api: { getConfig },
     configResolved(config) {
+      resolved = config
       runtimeConfig = resolveKVViteConfig(config.kv ?? options)
     },
     configEnvironment(name, config) {
@@ -105,6 +118,19 @@ export function hubKv(options?: KVModuleOptions): KVVitePlugin {
         if (isCloudflareKVConfig(kv)) return serializeCloudflareRuntime(kv)
       }
       if (id === RESOLVED_KV_VIRTUAL_CONFIG_ID) return serializeVirtualConfig(getConfig())
+    },
+    async closeBundle() {
+      if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
+
+      const wranglerConfig = createCloudflareKVWranglerConfig(getConfig().kv)
+      await writeProviderDeploymentOutputs({
+        clientOutDir: resolved.build.outDir,
+        cloudflare: wranglerConfig
+          ? { wranglerConfig, wranglerConfigKeys: ["kv_namespaces"] }
+          : undefined,
+        cleanup: { cloudflare: { wranglerConfigKeys: ["kv_namespaces"] } },
+        rootDir: resolved.root,
+      })
     },
   }
 }

--- a/packages/kv/src/vite.ts
+++ b/packages/kv/src/vite.ts
@@ -130,8 +130,8 @@ export function hubKv(options?: KVModuleOptions): KVVitePlugin {
 
         await writeCloudflareWranglerConfig({
           rootDir: resolved.root,
+          wranglerArrayMergeKeys: { kv_namespaces: "binding" },
           wranglerConfig,
-          wranglerConfigKeys: ["kv_namespaces"],
         })
       },
     },

--- a/packages/kv/src/vite.ts
+++ b/packages/kv/src/vite.ts
@@ -1,10 +1,13 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
 import {
   KV_VIRTUAL_CONFIG_ID,
   KV_VITE_PLUGIN_NAME,
   resolveKVViteConfig,
 } from "./vite-config.ts"
 
-import { writeCloudflareWranglerConfig } from "@vite-hub/internal/build/cloudflare"
+import { createDefaultCloudflareOutputRoot, writeCloudflareWranglerConfig } from "@vite-hub/internal/build/cloudflare"
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { createNoExternalMerger, isServerEnvironment, shouldSkipViteProviderBuild } from "@vite-hub/internal/build/vite"
 
@@ -20,6 +23,7 @@ const RESOLVED_KV_RUNTIME_ID = `\0${KV_RUNTIME_ID}`
 const UNSTORAGE_IMPORT_ID = import.meta.resolve("unstorage")
 const CLOUDFLARE_KV_DRIVER_IMPORT_ID = import.meta.resolve("unstorage/drivers/cloudflare-kv-binding")
 const mergeNoExternal = createNoExternalMerger("@vite-hub/kv")
+const KV_CLOUDFLARE_BINDINGS_FILE = ".vitehub-kv-bindings.json"
 
 export { KV_VIRTUAL_CONFIG_ID, KV_VITE_PLUGIN_NAME, resolveKVViteConfig }
 export type { KVViteRuntimeConfig } from "./vite-config.ts"
@@ -48,6 +52,31 @@ function createCloudflareKVWranglerConfig(kv: KVViteRuntimeConfig["kv"]) {
   const target: { cloudflare?: { wrangler?: { kv_namespaces?: Array<{ binding: string, id?: string }> } } } = {}
   configureCloudflareKV(target, kv)
   return target.cloudflare?.wrangler?.kv_namespaces?.length ? target.cloudflare.wrangler : undefined
+}
+
+function cloudflareBindingsFile(rootDir: string) {
+  return join(createDefaultCloudflareOutputRoot(rootDir), KV_CLOUDFLARE_BINDINGS_FILE)
+}
+
+async function readOwnedCloudflareKVBindings(rootDir: string): Promise<string[]> {
+  try {
+    const parsed = JSON.parse(await readFile(cloudflareBindingsFile(rootDir), "utf8"))
+    return Array.isArray(parsed) ? parsed.filter(value => typeof value === "string") : []
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
+    throw error
+  }
+}
+
+async function writeOwnedCloudflareKVBindings(rootDir: string, bindings: string[]): Promise<void> {
+  const file = cloudflareBindingsFile(rootDir)
+  if (!bindings.length) {
+    await rm(file, { force: true })
+    return
+  }
+  await mkdir(createDefaultCloudflareOutputRoot(rootDir), { recursive: true })
+  await writeFile(file, `${JSON.stringify([...new Set(bindings)], null, 2)}\n`, "utf8")
 }
 
 function serializeCloudflareRuntime(config: ResolvedKVModuleOptions): string {
@@ -126,13 +155,17 @@ export function hubKv(options?: KVModuleOptions): KVVitePlugin {
         if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
 
         const wranglerConfig = createCloudflareKVWranglerConfig(getConfig().kv)
-        if (!wranglerConfig) return
+        const nextBindings = wranglerConfig?.kv_namespaces?.map(binding => binding.binding) ?? []
+        const previousBindings = await readOwnedCloudflareKVBindings(resolved.root)
+        if (!wranglerConfig && !previousBindings.length) return
 
         await writeCloudflareWranglerConfig({
           rootDir: resolved.root,
+          wranglerArrayOwnedValues: { kv_namespaces: [...previousBindings, ...nextBindings] },
           wranglerArrayMergeKeys: { kv_namespaces: "binding" },
-          wranglerConfig,
+          ...(wranglerConfig ? { wranglerConfig } : {}),
         })
+        await writeOwnedCloudflareKVBindings(resolved.root, nextBindings)
       },
     },
   }

--- a/packages/kv/src/vite.ts
+++ b/packages/kv/src/vite.ts
@@ -4,9 +4,9 @@ import {
   resolveKVViteConfig,
 } from "./vite-config.ts"
 
+import { writeCloudflareWranglerConfig } from "@vite-hub/internal/build/cloudflare"
 import { getViteMode } from "@vite-hub/internal/build/mode"
-import { shouldSkipViteProviderBuild, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, shouldSkipViteProviderBuild } from "@vite-hub/internal/build/vite"
 
 import { configureCloudflareKV } from "./integrations/cloudflare.ts"
 
@@ -119,18 +119,18 @@ export function hubKv(options?: KVModuleOptions): KVVitePlugin {
       }
       if (id === RESOLVED_KV_VIRTUAL_CONFIG_ID) return serializeVirtualConfig(getConfig())
     },
-    async closeBundle() {
-      if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
+    closeBundle: {
+      order: "post",
+      sequential: true,
+      async handler() {
+        if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
 
-      const wranglerConfig = createCloudflareKVWranglerConfig(getConfig().kv)
-      await writeProviderDeploymentOutputs({
-        clientOutDir: resolved.build.outDir,
-        cloudflare: wranglerConfig
-          ? { wranglerConfig, wranglerConfigKeys: ["kv_namespaces"] }
-          : undefined,
-        cleanup: { cloudflare: { wranglerConfigKeys: ["kv_namespaces"] } },
-        rootDir: resolved.root,
-      })
+        await writeCloudflareWranglerConfig({
+          rootDir: resolved.root,
+          wranglerConfig: createCloudflareKVWranglerConfig(getConfig().kv),
+          wranglerConfigKeys: ["kv_namespaces"],
+        })
+      },
     },
   }
 }

--- a/packages/kv/test/vite-output.test.ts
+++ b/packages/kv/test/vite-output.test.ts
@@ -186,6 +186,46 @@ describe("KV Vite output", () => {
       kv_namespaces: [{ binding: "SETTINGS", id: "22222222222222222222222222222222" }],
     })
   })
+
+  it("leaves existing Cloudflare KV namespaces alone without a Cloudflare KV contribution", async () => {
+    const rootDir = await createConsumerRoot()
+    const entry = join(rootDir, "src", "worker.ts")
+    const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(cloudflareOutputRoot, { recursive: true })
+    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+      kv_namespaces: [{ binding: "MANUAL", id: "manual-namespace" }],
+      triggers: { crons: ["0 0 * * *"] },
+    }, null, 2)}\n`, "utf8")
+    const [{ build }, { hubKv }] = await Promise.all([
+      import("vite"),
+      import("../src/vite.ts"),
+    ])
+
+    await build({
+      appType: "custom",
+      build: {
+        emptyOutDir: false,
+        outDir: "dist",
+        rollupOptions: {
+          input: entry,
+          output: { entryFileNames: "worker.js" },
+        },
+        ssr: entry,
+      },
+      configFile: false,
+      kv: { driver: "fs-lite" },
+      logLevel: "silent",
+      plugins: [hubKv()],
+      root: rootDir,
+    })
+
+    const wrangler = JSON.parse(await readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8"))
+
+    expect(wrangler).toEqual({
+      kv_namespaces: [{ binding: "MANUAL", id: "manual-namespace" }],
+      triggers: { crons: ["0 0 * * *"] },
+    })
+  })
 })
 
 describe("KV source type visibility", () => {

--- a/packages/kv/test/vite-output.test.ts
+++ b/packages/kv/test/vite-output.test.ts
@@ -10,6 +10,7 @@ import { createDefaultCloudflareOutputRoot } from "@vite-hub/internal/build/clou
 
 const tempDirs: string[] = []
 const execFileAsync = promisify(execFile)
+const kvBindingsFile = ".vitehub-kv-bindings.json"
 
 async function createConsumerRoot() {
   const rootDir = await mkdtemp(join(tmpdir(), "vitehub-kv-vite-"))
@@ -232,6 +233,95 @@ describe("KV Vite output", () => {
       kv_namespaces: [{ binding: "MANUAL", id: "manual-namespace" }],
       triggers: { crons: ["0 0 * * *"] },
     })
+  })
+
+  it("replaces stale generated Cloudflare KV namespaces without deleting manual bindings", async () => {
+    const rootDir = await createConsumerRoot()
+    const entry = join(rootDir, "src", "worker.ts")
+    const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(cloudflareOutputRoot, { recursive: true })
+    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+      kv_namespaces: [
+        { binding: "MANUAL", id: "manual-namespace" },
+        { binding: "OLD", id: "old-namespace" },
+      ],
+    }, null, 2)}\n`, "utf8")
+    await writeFile(join(cloudflareOutputRoot, kvBindingsFile), `${JSON.stringify(["OLD"], null, 2)}\n`, "utf8")
+    const [{ build }, { hubKv }] = await Promise.all([
+      import("vite"),
+      import("../src/vite.ts"),
+    ])
+
+    await build({
+      appType: "custom",
+      build: {
+        emptyOutDir: false,
+        outDir: "dist",
+        rollupOptions: {
+          input: entry,
+          output: { entryFileNames: "worker.js" },
+        },
+        ssr: entry,
+      },
+      configFile: false,
+      kv: {
+        binding: "NEW",
+        driver: "cloudflare-kv-binding",
+        namespaceId: "new-namespace",
+      },
+      logLevel: "silent",
+      plugins: [hubKv()],
+      root: rootDir,
+    })
+
+    const wrangler = JSON.parse(await readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8"))
+
+    expect(wrangler.kv_namespaces).toEqual([
+      { binding: "MANUAL", id: "manual-namespace" },
+      { binding: "NEW", id: "new-namespace" },
+    ])
+    await expect(readFile(join(cloudflareOutputRoot, kvBindingsFile), "utf8").then(JSON.parse)).resolves.toEqual(["NEW"])
+  })
+
+  it("removes stale generated Cloudflare KV namespaces when KV stops contributing", async () => {
+    const rootDir = await createConsumerRoot()
+    const entry = join(rootDir, "src", "worker.ts")
+    const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(cloudflareOutputRoot, { recursive: true })
+    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+      kv_namespaces: [
+        { binding: "MANUAL", id: "manual-namespace" },
+        { binding: "OLD", id: "old-namespace" },
+      ],
+    }, null, 2)}\n`, "utf8")
+    await writeFile(join(cloudflareOutputRoot, kvBindingsFile), `${JSON.stringify(["OLD"], null, 2)}\n`, "utf8")
+    const [{ build }, { hubKv }] = await Promise.all([
+      import("vite"),
+      import("../src/vite.ts"),
+    ])
+
+    await build({
+      appType: "custom",
+      build: {
+        emptyOutDir: false,
+        outDir: "dist",
+        rollupOptions: {
+          input: entry,
+          output: { entryFileNames: "worker.js" },
+        },
+        ssr: entry,
+      },
+      configFile: false,
+      kv: { driver: "fs-lite" },
+      logLevel: "silent",
+      plugins: [hubKv()],
+      root: rootDir,
+    })
+
+    const wrangler = JSON.parse(await readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8"))
+
+    expect(wrangler.kv_namespaces).toEqual([{ binding: "MANUAL", id: "manual-namespace" }])
+    expect(existsSync(join(cloudflareOutputRoot, kvBindingsFile))).toBe(false)
   })
 })
 

--- a/packages/kv/test/vite-output.test.ts
+++ b/packages/kv/test/vite-output.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs"
 import { execFile } from "node:child_process"
 import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
@@ -5,6 +6,7 @@ import { join, resolve } from "node:path"
 import { promisify } from "node:util"
 
 import { afterEach, describe, expect, it } from "vitest"
+import { createDefaultCloudflareOutputRoot } from "@vite-hub/internal/build/deployment-output"
 
 const tempDirs: string[] = []
 const execFileAsync = promisify(execFile)
@@ -86,6 +88,53 @@ describe("KV Vite output", () => {
     expect(output).not.toContain("@upstash/redis")
     expect(output).toContain("cloudflare-kv-binding")
     expect(output).toContain("KV_CUSTOM")
+  })
+
+  it("merges configured Cloudflare KV namespaces into provider output", async () => {
+    const rootDir = await createConsumerRoot()
+    const entry = join(rootDir, "src", "worker.ts")
+    const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(cloudflareOutputRoot, { recursive: true })
+    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+      d1_databases: [{ binding: "DB", database_id: "database-id", database_name: "app" }],
+      kv_namespaces: [{ binding: "OLD", id: "old-namespace" }],
+      triggers: { crons: ["0 0 * * *"] },
+    }, null, 2)}\n`, "utf8")
+    const [{ build }, { hubKv }] = await Promise.all([
+      import("vite"),
+      import("../src/vite.ts"),
+    ])
+
+    await build({
+      appType: "custom",
+      build: {
+        emptyOutDir: false,
+        outDir: "dist",
+        rollupOptions: {
+          input: entry,
+          output: { entryFileNames: "worker.js" },
+        },
+        ssr: entry,
+      },
+      configFile: false,
+      kv: {
+        binding: "SETTINGS",
+        driver: "cloudflare-kv-binding",
+        namespaceId: "11111111111111111111111111111111",
+      },
+      logLevel: "silent",
+      plugins: [hubKv()],
+      root: rootDir,
+    })
+
+    const wrangler = JSON.parse(await readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8"))
+
+    expect(existsSync(join(cloudflareOutputRoot, "index.js"))).toBe(false)
+    expect(wrangler).toEqual({
+      d1_databases: [{ binding: "DB", database_id: "database-id", database_name: "app" }],
+      kv_namespaces: [{ binding: "SETTINGS", id: "11111111111111111111111111111111" }],
+      triggers: { crons: ["0 0 * * *"] },
+    })
   })
 })
 

--- a/packages/kv/test/vite-output.test.ts
+++ b/packages/kv/test/vite-output.test.ts
@@ -132,7 +132,10 @@ describe("KV Vite output", () => {
     expect(existsSync(join(cloudflareOutputRoot, "index.js"))).toBe(false)
     expect(wrangler).toEqual({
       d1_databases: [{ binding: "DB", database_id: "database-id", database_name: "app" }],
-      kv_namespaces: [{ binding: "SETTINGS", id: "11111111111111111111111111111111" }],
+      kv_namespaces: [
+        { binding: "OLD", id: "old-namespace" },
+        { binding: "SETTINGS", id: "11111111111111111111111111111111" },
+      ],
       triggers: { crons: ["0 0 * * *"] },
     })
   })
@@ -172,6 +175,7 @@ describe("KV Vite output", () => {
             await mkdir(cloudflareOutputRoot, { recursive: true })
             await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
               d1_databases: [{ binding: "DB", database_id: "database-id", database_name: "app" }],
+              kv_namespaces: [{ binding: "MANUAL", id: "manual-namespace" }],
             }, null, 2)}\n`, "utf8")
           },
         },
@@ -183,7 +187,10 @@ describe("KV Vite output", () => {
 
     expect(wrangler).toEqual({
       d1_databases: [{ binding: "DB", database_id: "database-id", database_name: "app" }],
-      kv_namespaces: [{ binding: "SETTINGS", id: "22222222222222222222222222222222" }],
+      kv_namespaces: [
+        { binding: "MANUAL", id: "manual-namespace" },
+        { binding: "SETTINGS", id: "22222222222222222222222222222222" },
+      ],
     })
   })
 

--- a/packages/kv/test/vite-output.test.ts
+++ b/packages/kv/test/vite-output.test.ts
@@ -6,7 +6,7 @@ import { join, resolve } from "node:path"
 import { promisify } from "node:util"
 
 import { afterEach, describe, expect, it } from "vitest"
-import { createDefaultCloudflareOutputRoot } from "@vite-hub/internal/build/deployment-output"
+import { createDefaultCloudflareOutputRoot } from "@vite-hub/internal/build/cloudflare"
 
 const tempDirs: string[] = []
 const execFileAsync = promisify(execFile)
@@ -134,6 +134,56 @@ describe("KV Vite output", () => {
       d1_databases: [{ binding: "DB", database_id: "database-id", database_name: "app" }],
       kv_namespaces: [{ binding: "SETTINGS", id: "11111111111111111111111111111111" }],
       triggers: { crons: ["0 0 * * *"] },
+    })
+  })
+
+  it("preserves sibling Cloudflare provider output from closeBundle hooks", async () => {
+    const rootDir = await createConsumerRoot()
+    const entry = join(rootDir, "src", "worker.ts")
+    const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    const [{ build }, { hubKv }] = await Promise.all([
+      import("vite"),
+      import("../src/vite.ts"),
+    ])
+
+    await build({
+      appType: "custom",
+      build: {
+        outDir: "dist",
+        rollupOptions: {
+          input: entry,
+          output: { entryFileNames: "worker.js" },
+        },
+        ssr: entry,
+      },
+      configFile: false,
+      kv: {
+        binding: "SETTINGS",
+        driver: "cloudflare-kv-binding",
+        namespaceId: "22222222222222222222222222222222",
+      },
+      logLevel: "silent",
+      plugins: [
+        hubKv(),
+        {
+          name: "late-cloudflare-provider-output",
+          async closeBundle() {
+            await new Promise(resolve => setTimeout(resolve, 10))
+            await mkdir(cloudflareOutputRoot, { recursive: true })
+            await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+              d1_databases: [{ binding: "DB", database_id: "database-id", database_name: "app" }],
+            }, null, 2)}\n`, "utf8")
+          },
+        },
+      ],
+      root: rootDir,
+    })
+
+    const wrangler = JSON.parse(await readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8"))
+
+    expect(wrangler).toEqual({
+      d1_databases: [{ binding: "DB", database_id: "database-id", database_name: "app" }],
+      kv_namespaces: [{ binding: "SETTINGS", id: "22222222222222222222222222222222" }],
     })
   })
 })


### PR DESCRIPTION
Makes direct `hubKv()` production builds write Cloudflare Provider Output for configured KV namespaces by reusing the KV package's Cloudflare config helper and the shared deployment-output merge path.

Cloudflare output may be config-only when there is no worker bundle, so KV can contribute `kv_namespaces` without generating a KV-owned worker or clobbering sibling `wrangler.json` keys.