### PR TITLE
fix(storage): compose blob and database provider output

### DIFF
--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -347,10 +347,22 @@ function hasExplicitFsStore(blob: BlobModuleOptions | ResolvedBlobModuleOptions 
   return "driver" in blob && blob.driver === "fs"
 }
 
+function shouldCreateProviderOutput(blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined) {
+  return !hasExplicitFsStore(blob)
+}
+
+function registerSupportedProviderRuntimeModules(
+  providerOutput: ComposedProviderOutput | undefined,
+  artifacts: GeneratedBlobArtifacts,
+  blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined,
+): void {
+  registerProviderRuntimeModules(providerOutput, productName, shouldCreateProviderOutput(blob) ? artifacts.runtimeModuleFiles : {})
+}
+
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedBlobArtifacts> {
   const artifacts = options.artifacts ?? await prepareProviderOutputs(options)
-  registerProviderRuntimeModules(options.providerOutput, productName, artifacts.runtimeModuleFiles)
-  const localOnly = hasExplicitFsStore(options.blob)
+  registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob)
+  const localOnly = !shouldCreateProviderOutput(options.blob)
   await writeProviderDeploymentOutputs({
     clientOutDir: options.clientOutDir,
     cloudflare: localOnly ? undefined : createCloudflareOutput(options.blob, artifacts, options.providerOutput),
@@ -362,6 +374,6 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
 
 export async function prepareProviderOutputs(options: Pick<GenerateProviderOutputsOptions, "blob" | "providerOutput" | "rootDir">): Promise<GeneratedBlobArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.blob)
-  registerProviderRuntimeModules(options.providerOutput, productName, artifacts.runtimeModuleFiles)
+  registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob)
   return artifacts
 }

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs"
 import { mkdir, writeFile } from "node:fs/promises"
 import { resolve } from "pathe"
 
@@ -40,6 +41,7 @@ const providerEntrySpecs: ProviderEntrySpec[] = [
 ]
 
 interface GenerateProviderOutputsOptions {
+  artifacts?: GeneratedBlobArtifacts
   blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined
   clientOutDir: string
   rootDir: string
@@ -268,8 +270,14 @@ async function writeProviderEntries(rootDir: string, blob: BlobModuleOptions | R
   } satisfies GeneratedBlobArtifacts
 }
 
+function getSiblingRuntimeAlias(artifacts: GeneratedBlobArtifacts, product: string, provider: BlobProvider) {
+  const runtimeFile = resolve(artifacts.generatedDir, "..", product, `${provider}-runtime.mjs`)
+  return existsSync(runtimeFile) ? runtimeFile : undefined
+}
+
 function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined, artifacts: GeneratedBlobArtifacts): CloudflareProviderDeploymentOutput {
   const resolved = resolveBlobConfig(blob, "cloudflare")
+  const databaseRuntime = getSiblingRuntimeAlias(artifacts, "database", "cloudflare")
 
   const wranglerConfig: CloudflareBlobConfig = {
     compatibility_date: defaultCloudflareCompatibilityDate,
@@ -284,6 +292,7 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
     bundleOptions: {
       alias: {
         "@vite-hub/blob": artifacts.runtimeModuleFiles.cloudflare,
+        ...(databaseRuntime ? { "@vite-hub/database/drizzle": databaseRuntime } : {}),
       },
       conditions: ["workerd", "worker", "browser", "default"],
       external: [
@@ -299,11 +308,14 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
 }
 
 function createVercelOutput(artifacts: GeneratedBlobArtifacts): VercelProviderDeploymentOutput {
+  const databaseRuntime = getSiblingRuntimeAlias(artifacts, "database", "vercel")
+
   return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
       alias: {
         "@vite-hub/blob": artifacts.runtimeModuleFiles.vercel,
+        ...(databaseRuntime ? { "@vite-hub/database/drizzle": databaseRuntime } : {}),
       },
       external: [
         "files-sdk",
@@ -341,7 +353,7 @@ function hasExplicitFsStore(blob: BlobModuleOptions | ResolvedBlobModuleOptions 
 }
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedBlobArtifacts> {
-  const artifacts = await writeProviderEntries(options.rootDir, options.blob)
+  const artifacts = options.artifacts ?? await prepareProviderOutputs(options)
   const localOnly = hasExplicitFsStore(options.blob)
   await writeProviderDeploymentOutputs({
     clientOutDir: options.clientOutDir,
@@ -350,4 +362,8 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     vercel: localOnly ? undefined : createVercelOutput(artifacts),
   })
   return artifacts
+}
+
+export async function prepareProviderOutputs(options: Pick<GenerateProviderOutputsOptions, "blob" | "rootDir">): Promise<GeneratedBlobArtifacts> {
+  return await writeProviderEntries(options.rootDir, options.blob)
 }

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -1,16 +1,15 @@
-import { existsSync } from "node:fs"
 import { mkdir, writeFile } from "node:fs/promises"
 import { resolve } from "pathe"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
-import { writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
+import { getProviderRuntimeModule, registerProviderRuntimeModules, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
 
 import { normalizeBlobOptions } from "../config.ts"
 
 import type { BlobModuleOptions, ResolvedBlobModuleOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
-import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
+import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const blobPackageName = "@vite-hub/blob"
 const productName = "blob"
@@ -44,6 +43,7 @@ interface GenerateProviderOutputsOptions {
   artifacts?: GeneratedBlobArtifacts
   blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined
   clientOutDir: string
+  providerOutput?: ComposedProviderOutput
   rootDir: string
 }
 
@@ -270,14 +270,9 @@ async function writeProviderEntries(rootDir: string, blob: BlobModuleOptions | R
   } satisfies GeneratedBlobArtifacts
 }
 
-function getSiblingRuntimeAlias(artifacts: GeneratedBlobArtifacts, product: string, provider: BlobProvider) {
-  const runtimeFile = resolve(artifacts.generatedDir, "..", product, `${provider}-runtime.mjs`)
-  return existsSync(runtimeFile) ? runtimeFile : undefined
-}
-
-function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined, artifacts: GeneratedBlobArtifacts): CloudflareProviderDeploymentOutput {
+function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined, artifacts: GeneratedBlobArtifacts, providerOutput: ComposedProviderOutput | undefined): CloudflareProviderDeploymentOutput {
   const resolved = resolveBlobConfig(blob, "cloudflare")
-  const databaseRuntime = getSiblingRuntimeAlias(artifacts, "database", "cloudflare")
+  const databaseRuntime = getProviderRuntimeModule(providerOutput, "database", "cloudflare")
 
   const wranglerConfig: CloudflareBlobConfig = {
     compatibility_date: defaultCloudflareCompatibilityDate,
@@ -307,8 +302,8 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
   }
 }
 
-function createVercelOutput(artifacts: GeneratedBlobArtifacts): VercelProviderDeploymentOutput {
-  const databaseRuntime = getSiblingRuntimeAlias(artifacts, "database", "vercel")
+function createVercelOutput(artifacts: GeneratedBlobArtifacts, providerOutput: ComposedProviderOutput | undefined): VercelProviderDeploymentOutput {
+  const databaseRuntime = getProviderRuntimeModule(providerOutput, "database", "vercel")
 
   return {
     bundleEntry: artifacts.vercelServerFile,
@@ -354,16 +349,19 @@ function hasExplicitFsStore(blob: BlobModuleOptions | ResolvedBlobModuleOptions 
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedBlobArtifacts> {
   const artifacts = options.artifacts ?? await prepareProviderOutputs(options)
+  registerProviderRuntimeModules(options.providerOutput, productName, artifacts.runtimeModuleFiles)
   const localOnly = hasExplicitFsStore(options.blob)
   await writeProviderDeploymentOutputs({
     clientOutDir: options.clientOutDir,
-    cloudflare: localOnly ? undefined : createCloudflareOutput(options.blob, artifacts),
+    cloudflare: localOnly ? undefined : createCloudflareOutput(options.blob, artifacts, options.providerOutput),
     rootDir: options.rootDir,
-    vercel: localOnly ? undefined : createVercelOutput(artifacts),
+    vercel: localOnly ? undefined : createVercelOutput(artifacts, options.providerOutput),
   })
   return artifacts
 }
 
-export async function prepareProviderOutputs(options: Pick<GenerateProviderOutputsOptions, "blob" | "rootDir">): Promise<GeneratedBlobArtifacts> {
-  return await writeProviderEntries(options.rootDir, options.blob)
+export async function prepareProviderOutputs(options: Pick<GenerateProviderOutputsOptions, "blob" | "providerOutput" | "rootDir">): Promise<GeneratedBlobArtifacts> {
+  const artifacts = await writeProviderEntries(options.rootDir, options.blob)
+  registerProviderRuntimeModules(options.providerOutput, productName, artifacts.runtimeModuleFiles)
+  return artifacts
 }

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -2,7 +2,7 @@ import { getViteMode } from "@vite-hub/internal/build/mode"
 import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
 import { createNoExternalMerger, isServerEnvironment } from "@vite-hub/internal/build/vite"
 
-import { generateProviderOutputs, blobPackageName } from "./internal/vite-build.ts"
+import { generateProviderOutputs, prepareProviderOutputs, blobPackageName } from "./internal/vite-build.ts"
 import { createBlobCloudflareProvisionStep, createBlobVercelProvisionStep } from "./provision.ts"
 import {
   BLOB_VIRTUAL_CONFIG_ID,
@@ -44,6 +44,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
   let blob: BlobModuleOptions | undefined = options
   let clientOutDir = "dist"
   let command: "build" | "serve" = "serve"
+  let providerArtifacts: Awaited<ReturnType<typeof prepareProviderOutputs>> | undefined
   let rootDir = process.cwd()
   let runtimeConfig: BlobViteRuntimeConfig | undefined
   const getConfig = () => runtimeConfig ??= resolveBlobViteConfig(options)
@@ -80,6 +81,16 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
         },
       }
     },
+    async buildEnd() {
+      if (shouldSkipViteProviderBuild(command, getViteMode())) {
+        return
+      }
+
+      providerArtifacts = await prepareProviderOutputs({
+        blob,
+        rootDir,
+      })
+    },
     async closeBundle() {
       if (shouldSkipViteProviderBuild(command, getViteMode())) {
         return
@@ -88,6 +99,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       await generateProviderOutputs({
         blob,
         clientOutDir,
+        artifacts: providerArtifacts,
         rootDir,
       })
     },

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -1,5 +1,5 @@
 import { getViteMode } from "@vite-hub/internal/build/mode"
-import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
+import { resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import { createNoExternalMerger, isServerEnvironment } from "@vite-hub/internal/build/vite"
 
 import { generateProviderOutputs, prepareProviderOutputs, blobPackageName } from "./internal/vite-build.ts"
@@ -13,6 +13,7 @@ import {
 import type { BlobViteRuntimeConfig } from "./vite-config.ts"
 import type { BlobModuleOptions } from "./types.ts"
 import type { ViteHubCliContributor } from "@vite-hub/internal/cli"
+import type { ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import type { Plugin } from "vite"
 
 const RESOLVED_BLOB_VIRTUAL_CONFIG_ID = `\0${BLOB_VIRTUAL_CONFIG_ID}`
@@ -45,6 +46,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
   let clientOutDir = "dist"
   let command: "build" | "serve" = "serve"
   let providerArtifacts: Awaited<ReturnType<typeof prepareProviderOutputs>> | undefined
+  let providerOutput: ComposedProviderOutput | undefined
   let rootDir = process.cwd()
   let runtimeConfig: BlobViteRuntimeConfig | undefined
   const getConfig = () => runtimeConfig ??= resolveBlobViteConfig(options)
@@ -68,6 +70,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       clientOutDir = config.build.outDir
       rootDir = config.root
       blob = config.blob ?? blob
+      providerOutput = useComposedProviderOutput(config)
       runtimeConfig = resolveBlobViteConfig(blob)
     },
     configEnvironment(name, config) {
@@ -81,6 +84,9 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
         },
       }
     },
+    buildStart() {
+      resetComposedProviderOutput(providerOutput)
+    },
     async buildEnd() {
       if (shouldSkipViteProviderBuild(command, getViteMode())) {
         return
@@ -88,6 +94,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
 
       providerArtifacts = await prepareProviderOutputs({
         blob,
+        providerOutput,
         rootDir,
       })
     },
@@ -100,6 +107,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
         blob,
         clientOutDir,
         artifacts: providerArtifacts,
+        providerOutput,
         rootDir,
       })
     },

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -7,10 +7,11 @@ import { promisify } from "node:util"
 
 import { build as bundle } from "esbuild"
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { getProviderRuntimeModule, type ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import { toSafeAppName } from "@vite-hub/internal/build/user-entry"
 
 import { normalizeBlobOptions } from "../src/config.ts"
-import { generateProviderOutputs } from "../src/internal/vite-build.ts"
+import { generateProviderOutputs, prepareProviderOutputs } from "../src/internal/vite-build.ts"
 
 const execFileAsync = promisify(execFile)
 const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
@@ -240,6 +241,20 @@ describe("Vite provider outputs", () => {
 
     await expect(readFile(join(rootDir, "dist", toSafeAppName(rootDir), "index.js"), "utf8")).resolves.toBe("existing cloudflare output\n")
     await expect(readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")).resolves.toBe("existing vercel output\n")
+  })
+
+  it("does not register local fs provider runtimes for composed sibling output", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-local-fs-registry-")
+    const providerOutput = { runtimeModuleFilesByProduct: {} } satisfies ComposedProviderOutput
+    const blob = { driver: "fs" as const, base: ".data/blob" }
+
+    await prepareProviderOutputs({ blob, providerOutput, rootDir })
+    expect(getProviderRuntimeModule(providerOutput, "blob", "cloudflare")).toBeUndefined()
+    expect(getProviderRuntimeModule(providerOutput, "blob", "vercel")).toBeUndefined()
+
+    await generateProviderOutputs({ blob, clientOutDir: "dist", providerOutput, rootDir })
+    expect(getProviderRuntimeModule(providerOutput, "blob", "cloudflare")).toBeUndefined()
+    expect(getProviderRuntimeModule(providerOutput, "blob", "vercel")).toBeUndefined()
   })
 
   it("loads the fs driver from bundled SSR output", async () => {

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -1,7 +1,6 @@
-import { existsSync } from "node:fs"
 import { mkdir, writeFile } from "node:fs/promises"
 
-import { writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
+import { getProviderRuntimeModule, registerProviderRuntimeModules, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
@@ -13,7 +12,7 @@ import { resolveCloudflareD1Bindings } from "./cloudflare.ts"
 
 import type { ProvisionState } from "@vite-hub/internal/provision"
 import type { ResolvedDBViteConfig, ResolvedDrizzleDatabaseConfig } from "../types.ts"
-import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
+import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const dbPackageName = "@vite-hub/database"
 const productName = "database"
@@ -37,6 +36,7 @@ const providerEntrySpecs: ProviderEntrySpec[] = [
 interface GenerateProviderOutputsOptions {
   artifacts?: GeneratedDBArtifacts
   clientOutDir: string
+  providerOutput?: ComposedProviderOutput
   rootDir: string
   runtimeConfig: ResolvedDBViteConfig
 }
@@ -201,17 +201,13 @@ function getVercelUnsupportedDatabases(runtimeConfig: ResolvedDBViteConfig) {
 interface ProviderWriteOptions {
   artifacts: GeneratedDBArtifacts
   clientOutDir: string
+  providerOutput?: ComposedProviderOutput
   provisionState: ProvisionState
   rootDir: string
   runtimeConfig: ResolvedDBViteConfig
 }
 
-function getSiblingRuntimeAlias(artifacts: GeneratedDBArtifacts, product: string, provider: DBProvider) {
-  const runtimeFile = resolve(artifacts.generatedDir, "..", product, `${provider}-runtime.mjs`)
-  return existsSync(runtimeFile) ? runtimeFile : undefined
-}
-
-function createCloudflareOutput({ artifacts, provisionState, runtimeConfig }: ProviderWriteOptions): CloudflareProviderDeploymentOutput {
+function createCloudflareOutput({ artifacts, providerOutput, provisionState, runtimeConfig }: ProviderWriteOptions): CloudflareProviderDeploymentOutput {
   const databasesMissingNames = getCloudflareDatabasesMissingNames(runtimeConfig, provisionState)
   if (databasesMissingNames.length) {
     throw new Error(`[vitehub] Cloudflare output requires \`db.cloudflare.databaseName\` when \`db.cloudflare.databaseId\` is set for databases: ${databasesMissingNames.join(", ")}.`)
@@ -223,7 +219,7 @@ function createCloudflareOutput({ artifacts, provisionState, runtimeConfig }: Pr
   }
 
   const d1Databases = resolveCloudflareD1Bindings(runtimeConfig, { provisionState }).d1Databases
-  const blobRuntime = getSiblingRuntimeAlias(artifacts, "blob", "cloudflare")
+  const blobRuntime = getProviderRuntimeModule(providerOutput, "blob", "cloudflare")
 
   const wranglerConfig: CloudflareDBConfig = {
     compatibility_date: defaultCloudflareCompatibilityDate,
@@ -250,12 +246,12 @@ function createCloudflareOutput({ artifacts, provisionState, runtimeConfig }: Pr
   }
 }
 
-function createVercelOutput({ artifacts, runtimeConfig }: ProviderWriteOptions): VercelProviderDeploymentOutput {
+function createVercelOutput({ artifacts, providerOutput, runtimeConfig }: ProviderWriteOptions): VercelProviderDeploymentOutput {
   const unsupportedDatabases = getVercelUnsupportedDatabases(runtimeConfig)
   if (unsupportedDatabases.length) {
     throw new Error(`[vitehub] Vercel output requires a remote libSQL \`db.connection.url\` for databases: ${unsupportedDatabases.join(", ")}.`)
   }
-  const blobRuntime = getSiblingRuntimeAlias(artifacts, "blob", "vercel")
+  const blobRuntime = getProviderRuntimeModule(providerOutput, "blob", "vercel")
 
   return {
     bundleEntry: artifacts.vercelServerFile,
@@ -280,6 +276,7 @@ function shouldCreateCloudflareOutput(runtimeConfig: ResolvedDBViteConfig, provi
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedDBArtifacts> {
   const artifacts = options.artifacts ?? await prepareProviderOutputs(options)
+  registerProviderRuntimeModules(options.providerOutput, productName, artifacts.runtimeModuleFiles)
   const provisionState = readProvisionStateSync(options.rootDir)
   const writeOptions: ProviderWriteOptions = { artifacts, provisionState, ...options }
   await writeProviderDeploymentOutputs({
@@ -294,6 +291,8 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   return artifacts
 }
 
-export async function prepareProviderOutputs(options: Pick<GenerateProviderOutputsOptions, "rootDir" | "runtimeConfig">): Promise<GeneratedDBArtifacts> {
-  return await writeProviderEntries(options.rootDir, options.runtimeConfig)
+export async function prepareProviderOutputs(options: Pick<GenerateProviderOutputsOptions, "providerOutput" | "rootDir" | "runtimeConfig">): Promise<GeneratedDBArtifacts> {
+  const artifacts = await writeProviderEntries(options.rootDir, options.runtimeConfig)
+  registerProviderRuntimeModules(options.providerOutput, productName, artifacts.runtimeModuleFiles)
+  return artifacts
 }

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs"
 import { mkdir, writeFile } from "node:fs/promises"
 
 import { writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
@@ -34,6 +35,7 @@ const providerEntrySpecs: ProviderEntrySpec[] = [
 ]
 
 interface GenerateProviderOutputsOptions {
+  artifacts?: GeneratedDBArtifacts
   clientOutDir: string
   rootDir: string
   runtimeConfig: ResolvedDBViteConfig
@@ -204,6 +206,11 @@ interface ProviderWriteOptions {
   runtimeConfig: ResolvedDBViteConfig
 }
 
+function getSiblingRuntimeAlias(artifacts: GeneratedDBArtifacts, product: string, provider: DBProvider) {
+  const runtimeFile = resolve(artifacts.generatedDir, "..", product, `${provider}-runtime.mjs`)
+  return existsSync(runtimeFile) ? runtimeFile : undefined
+}
+
 function createCloudflareOutput({ artifacts, provisionState, runtimeConfig }: ProviderWriteOptions): CloudflareProviderDeploymentOutput {
   const databasesMissingNames = getCloudflareDatabasesMissingNames(runtimeConfig, provisionState)
   if (databasesMissingNames.length) {
@@ -216,6 +223,7 @@ function createCloudflareOutput({ artifacts, provisionState, runtimeConfig }: Pr
   }
 
   const d1Databases = resolveCloudflareD1Bindings(runtimeConfig, { provisionState }).d1Databases
+  const blobRuntime = getSiblingRuntimeAlias(artifacts, "blob", "cloudflare")
 
   const wranglerConfig: CloudflareDBConfig = {
     compatibility_date: defaultCloudflareCompatibilityDate,
@@ -228,7 +236,10 @@ function createCloudflareOutput({ artifacts, provisionState, runtimeConfig }: Pr
   return {
     bundleEntry: artifacts.cloudflareWorkerFile,
     bundleOptions: {
-      alias: { "@vite-hub/database/drizzle": artifacts.runtimeModuleFiles.cloudflare },
+      alias: {
+        "@vite-hub/database/drizzle": artifacts.runtimeModuleFiles.cloudflare,
+        ...(blobRuntime ? { "@vite-hub/blob": blobRuntime } : {}),
+      },
       conditions: ["workerd", "worker", "browser", "default"],
       external: ["node:async_hooks"],
       format: "esm",
@@ -244,11 +255,15 @@ function createVercelOutput({ artifacts, runtimeConfig }: ProviderWriteOptions):
   if (unsupportedDatabases.length) {
     throw new Error(`[vitehub] Vercel output requires a remote libSQL \`db.connection.url\` for databases: ${unsupportedDatabases.join(", ")}.`)
   }
+  const blobRuntime = getSiblingRuntimeAlias(artifacts, "blob", "vercel")
 
   return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
-      alias: { "@vite-hub/database/drizzle": artifacts.runtimeModuleFiles.vercel },
+      alias: {
+        "@vite-hub/database/drizzle": artifacts.runtimeModuleFiles.vercel,
+        ...(blobRuntime ? { "@vite-hub/blob": blobRuntime } : {}),
+      },
       format: "esm",
       platform: "node",
     },
@@ -264,7 +279,7 @@ function shouldCreateCloudflareOutput(runtimeConfig: ResolvedDBViteConfig, provi
 }
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedDBArtifacts> {
-  const artifacts = await writeProviderEntries(options.rootDir, options.runtimeConfig)
+  const artifacts = options.artifacts ?? await prepareProviderOutputs(options)
   const provisionState = readProvisionStateSync(options.rootDir)
   const writeOptions: ProviderWriteOptions = { artifacts, provisionState, ...options }
   await writeProviderDeploymentOutputs({
@@ -277,4 +292,8 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     vercel: shouldCreateVercelOutput(options.runtimeConfig) ? createVercelOutput(writeOptions) : undefined,
   })
   return artifacts
+}
+
+export async function prepareProviderOutputs(options: Pick<GenerateProviderOutputsOptions, "rootDir" | "runtimeConfig">): Promise<GeneratedDBArtifacts> {
+  return await writeProviderEntries(options.rootDir, options.runtimeConfig)
 }

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -274,10 +274,30 @@ function shouldCreateCloudflareOutput(runtimeConfig: ResolvedDBViteConfig, provi
   return getCloudflareUnsupportedDatabases(runtimeConfig, provisionState).length === 0
 }
 
+function getSupportedProviderRuntimeModules(
+  artifacts: GeneratedDBArtifacts,
+  runtimeConfig: ResolvedDBViteConfig,
+  provisionState: ProvisionState,
+): Record<string, string> {
+  return {
+    ...(shouldCreateCloudflareOutput(runtimeConfig, provisionState) ? { cloudflare: artifacts.runtimeModuleFiles.cloudflare } : {}),
+    ...(shouldCreateVercelOutput(runtimeConfig) ? { vercel: artifacts.runtimeModuleFiles.vercel } : {}),
+  }
+}
+
+function registerSupportedProviderRuntimeModules(
+  providerOutput: ComposedProviderOutput | undefined,
+  artifacts: GeneratedDBArtifacts,
+  runtimeConfig: ResolvedDBViteConfig,
+  provisionState: ProvisionState,
+): void {
+  registerProviderRuntimeModules(providerOutput, productName, getSupportedProviderRuntimeModules(artifacts, runtimeConfig, provisionState))
+}
+
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedDBArtifacts> {
   const artifacts = options.artifacts ?? await prepareProviderOutputs(options)
-  registerProviderRuntimeModules(options.providerOutput, productName, artifacts.runtimeModuleFiles)
   const provisionState = readProvisionStateSync(options.rootDir)
+  registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.runtimeConfig, provisionState)
   const writeOptions: ProviderWriteOptions = { artifacts, provisionState, ...options }
   await writeProviderDeploymentOutputs({
     clientOutDir: options.clientOutDir,
@@ -293,6 +313,6 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
 
 export async function prepareProviderOutputs(options: Pick<GenerateProviderOutputsOptions, "providerOutput" | "rootDir" | "runtimeConfig">): Promise<GeneratedDBArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.runtimeConfig)
-  registerProviderRuntimeModules(options.providerOutput, productName, artifacts.runtimeModuleFiles)
+  registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.runtimeConfig, readProvisionStateSync(options.rootDir))
   return artifacts
 }

--- a/packages/database/src/vite.ts
+++ b/packages/database/src/vite.ts
@@ -1,5 +1,5 @@
 import { getViteMode } from "@vite-hub/internal/build/mode"
-import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
+import { resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import { createNoExternalMerger, isServerEnvironment } from "@vite-hub/internal/build/vite"
 import { normalize } from "pathe"
 
@@ -10,6 +10,7 @@ import { dbPackageName, generateProviderOutputs, prepareProviderOutputs } from "
 import { createDatabaseProvisionStep } from "./provision.ts"
 
 import type { ViteHubCliContributor } from "@vite-hub/internal/cli"
+import type { ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import type { Plugin, ResolvedConfig } from "vite"
 import type { DBModulePublicOptions, ResolvedDBViteConfig, ResolvedDrizzleDatabaseConfig } from "./types.ts"
 
@@ -120,6 +121,7 @@ function renderDatabasesModule(config: ResolvedDBViteConfig | undefined) {
 
 export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
   let providerArtifacts: Awaited<ReturnType<typeof prepareProviderOutputs>> | undefined
+  let providerOutput: ComposedProviderOutput | undefined
   let resolved: ResolvedConfig | undefined
   let runtimeConfig: ResolvedDBViteConfig | undefined
 
@@ -153,6 +155,7 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
     },
     async configResolved(config) {
       resolved = config
+      providerOutput = useComposedProviderOutput(config)
       await refreshRuntimeConfig()
     },
     configEnvironment(name, config) {
@@ -163,6 +166,9 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
       return {
         resolve: { noExternal: mergeNoExternal(config.resolve?.noExternal) },
       }
+    },
+    buildStart() {
+      resetComposedProviderOutput(providerOutput)
     },
     async handleHotUpdate(context) {
       if (!runtimeConfig) return
@@ -185,6 +191,7 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
 
       await writeGeneratedDatabaseArtifacts(runtimeConfig)
       providerArtifacts = await prepareProviderOutputs({
+        providerOutput,
         rootDir: resolved.root,
         runtimeConfig,
       })
@@ -208,6 +215,7 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
       await generateProviderOutputs({
         artifacts: providerArtifacts,
         clientOutDir: resolved.build.outDir,
+        providerOutput,
         rootDir: resolved.root,
         runtimeConfig,
       })

--- a/packages/database/src/vite.ts
+++ b/packages/database/src/vite.ts
@@ -6,7 +6,7 @@ import { normalize } from "pathe"
 import { createDbCliContributor } from "./cli.ts"
 import { resolveDBViteConfig } from "./config.ts"
 import { writeGeneratedDatabaseArtifacts } from "./internal/generated.ts"
-import { dbPackageName, generateProviderOutputs } from "./internal/vite-build.ts"
+import { dbPackageName, generateProviderOutputs, prepareProviderOutputs } from "./internal/vite-build.ts"
 import { createDatabaseProvisionStep } from "./provision.ts"
 
 import type { ViteHubCliContributor } from "@vite-hub/internal/cli"
@@ -119,6 +119,7 @@ function renderDatabasesModule(config: ResolvedDBViteConfig | undefined) {
 }
 
 export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
+  let providerArtifacts: Awaited<ReturnType<typeof prepareProviderOutputs>> | undefined
   let resolved: ResolvedConfig | undefined
   let runtimeConfig: ResolvedDBViteConfig | undefined
 
@@ -177,6 +178,17 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
       if (schemaModule) context.server.moduleGraph.invalidateModule(schemaModule)
       if (databasesModule) context.server.moduleGraph.invalidateModule(databasesModule)
     },
+    async buildEnd() {
+      if (!resolved || !runtimeConfig || shouldSkipViteProviderBuild(resolved.command, getViteMode())) {
+        return
+      }
+
+      await writeGeneratedDatabaseArtifacts(runtimeConfig)
+      providerArtifacts = await prepareProviderOutputs({
+        rootDir: resolved.root,
+        runtimeConfig,
+      })
+    },
     resolveId(id) {
       return resolveDatabaseVirtualId(id)
     },
@@ -194,6 +206,7 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
 
       await writeGeneratedDatabaseArtifacts(runtimeConfig)
       await generateProviderOutputs({
+        artifacts: providerArtifacts,
         clientOutDir: resolved.build.outDir,
         rootDir: resolved.root,
         runtimeConfig,

--- a/packages/database/test/vite-output.test.ts
+++ b/packages/database/test/vite-output.test.ts
@@ -5,6 +5,11 @@ import { dirname, join, resolve } from "node:path"
 import { promisify } from "node:util"
 
 import { afterAll, describe, expect, it } from "vitest"
+import { getProviderRuntimeModule, type ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
+
+import { prepareProviderOutputs as prepareDatabaseProviderOutputs } from "../src/internal/vite-build.ts"
+
+import type { ResolvedDBViteConfig } from "../src/types.ts"
 
 const execFileAsync = promisify(execFile)
 const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
@@ -101,6 +106,31 @@ async function createDbBuildProject(prefix: string) {
     ].join("\n"),
   })
   return rootDir
+}
+
+function createRuntimeConfig(rootDir: string, database: Record<string, unknown>): ResolvedDBViteConfig {
+  return {
+    databaseNames: ["primary"],
+    databases: {
+      primary: {
+        connection: {},
+        drizzle: {},
+        migrationsDir: "server/databases/primary/migrations",
+        ...database,
+      },
+    },
+    definitions: [{
+      handler: join(rootDir, "server", "databases", "primary", "config.ts"),
+      name: "primary",
+    }],
+    generatedConfigFile: join(rootDir, ".vitehub", "database", "drizzle.config.ts"),
+    generatedConfigFiles: [],
+    generatedConfigFilesByDatabase: {},
+    generatedSchemaFile: join(rootDir, ".vitehub", "database", "schema.ts"),
+    generatedSchemaFilesByDatabase: {
+      primary: join(rootDir, ".vitehub", "database", "primary-schema.ts"),
+    },
+  } as unknown as ResolvedDBViteConfig
 }
 
 async function createDbBlobBuildProject(prefix: string, plugins: string) {
@@ -225,6 +255,26 @@ afterAll(async () => {
 })
 
 describe("Vite db provider outputs", () => {
+  it("does not register unsupported Vercel database runtimes for composed sibling output", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-db-vite-vercel-registry-")
+    const providerOutput = { runtimeModuleFilesByProduct: {} } satisfies ComposedProviderOutput
+
+    await prepareDatabaseProviderOutputs({
+      providerOutput,
+      rootDir,
+      runtimeConfig: createRuntimeConfig(rootDir, {
+        cloudflare: {
+          binding: "DB_PRIMARY",
+          databaseId: "primary-d1-id",
+          databaseName: "primary",
+        },
+      }),
+    })
+
+    expect(getProviderRuntimeModule(providerOutput, "database", "cloudflare")).toContain("cloudflare-runtime.mjs")
+    expect(getProviderRuntimeModule(providerOutput, "database", "vercel")).toBeUndefined()
+  })
+
   it("composes direct Blob and Database provider output in either plugin order", async () => {
     for (const [label, plugins] of [
       ["blob-db", "hubBlob({ driver: 'cloudflare-r2', bucketName: 'assets' }), hubDb()"],

--- a/packages/database/test/vite-output.test.ts
+++ b/packages/database/test/vite-output.test.ts
@@ -103,6 +103,38 @@ async function createDbBuildProject(prefix: string) {
   return rootDir
 }
 
+async function createDbBlobBuildProject(prefix: string, plugins: string) {
+  const rootDir = await createDbBuildProject(prefix)
+  await writeFile(join(rootDir, "src/server.ts"), [
+    "import { blob } from '@vite-hub/blob'",
+    "import { databases } from '@vite-hub/database/drizzle'",
+    "export default {",
+    "  async fetch() {",
+    "    await blob.put('proof.txt', Object.keys(databases).join(','))",
+    "    return new Response(await (await blob.get('proof.txt'))?.text())",
+    "  },",
+    "}",
+    "",
+  ].join("\n"))
+  await writeFile(join(rootDir, "vite.config.ts"), [
+    "import { resolve } from 'node:path'",
+    "import { defineConfig } from 'vite'",
+    "import { hubBlob } from '@vite-hub/blob/vite'",
+    "import { hubDb } from '@vite-hub/database/vite'",
+    "export default defineConfig({",
+    "  appType: 'custom',",
+    "  build: {",
+    "    outDir: 'dist/client',",
+    "    rollupOptions: { input: resolve(import.meta.dirname, 'src/server.ts') },",
+    "    ssr: true,",
+    "  },",
+    `  plugins: [${plugins}],`,
+    "})",
+    "",
+  ].join("\n"))
+  return rootDir
+}
+
 async function runDbBuild(rootDir: string, env: NodeJS.ProcessEnv = {}) {
   return execFileAsync("vp", ["build"], {
     cwd: rootDir,
@@ -122,6 +154,14 @@ async function readCloudflareConfig(rootDir: string) {
   return JSON.parse(await readFile(join(distDir, outputDir, "wrangler.json"), "utf8"))
 }
 
+async function readCloudflareWorker(rootDir: string) {
+  const distDir = join(rootDir, "dist")
+  const entries = await readdir(distDir)
+  const outputDir = entries.find(entry => entry !== "client")
+  if (!outputDir) throw new Error("Cloudflare output directory was not generated.")
+  return await readFile(join(distDir, outputDir, "index.js"), "utf8")
+}
+
 function errorText(error: unknown) {
   return (error as { stderr?: string; message?: string } | undefined)?.stderr
     || (error as { message?: string } | undefined)?.message
@@ -132,11 +172,45 @@ function outputText(output: Awaited<ReturnType<typeof runDbBuild>>) {
   return `${output.stdout}\n${output.stderr}`
 }
 
+function expectNoRuntimeImport(code: string, specifier: string) {
+  const escaped = specifier.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  expect(code).not.toMatch(new RegExp(`\\b(?:from\\s+|import\\(|require\\()["']${escaped}["']`))
+}
+
 afterAll(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
 })
 
 describe("Vite db provider outputs", () => {
+  it("composes direct Blob and Database provider output in either plugin order", async () => {
+    for (const [label, plugins] of [
+      ["blob-db", "hubBlob({ driver: 'cloudflare-r2', bucketName: 'assets' }), hubDb()"],
+      ["db-blob", "hubDb(), hubBlob({ driver: 'cloudflare-r2', bucketName: 'assets' })"],
+    ]) {
+      const rootDir = await createDbBlobBuildProject(`vitehub-db-blob-${label}-`, plugins)
+
+      await runDbBuild(rootDir, {
+        TURSO_ANALYTICS_DATABASE_URL: "libsql://analytics.example.turso.io",
+        TURSO_AUTH_TOKEN: "token",
+        TURSO_DATABASE_URL: "libsql://database.example.turso.io",
+        VITEHUB_D1_ANALYTICS_DATABASE_ID: "analytics-d1-id",
+        VITEHUB_D1_DATABASE_ID: "primary-d1-id",
+      })
+
+      const cloudflareConfig = await readCloudflareConfig(rootDir)
+      const cloudflareWorker = await readCloudflareWorker(rootDir)
+      const vercelServer = join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs")
+      const vercelServerCode = await readFile(vercelServer, "utf8")
+
+      expect(cloudflareConfig.r2_buckets).toContainEqual({ binding: "BLOB", bucket_name: "assets" })
+      expect(cloudflareConfig.d1_databases).toHaveLength(2)
+      expectNoRuntimeImport(cloudflareWorker, "@vite-hub/blob")
+      expectNoRuntimeImport(cloudflareWorker, "@vite-hub/database/drizzle")
+      expectNoRuntimeImport(vercelServerCode, "@vite-hub/blob")
+      expectNoRuntimeImport(vercelServerCode, "@vite-hub/database/drizzle")
+    }
+  }, 60_000)
+
   it("builds and emits named database Cloudflare and Vercel outputs", async () => {
     const rootDir = await createDbBuildProject("vitehub-db-vite-output-")
 

--- a/packages/database/test/vite-output.test.ts
+++ b/packages/database/test/vite-output.test.ts
@@ -135,6 +135,49 @@ async function createDbBlobBuildProject(prefix: string, plugins: string) {
   return rootDir
 }
 
+async function createBlobBuildProject(prefix: string) {
+  const rootDir = await createWorkspaceTempDir(prefix)
+  const nodeModules = resolvePlaygroundNodeModules()
+  await mkdir(join(rootDir, "src"), { recursive: true })
+  await symlink(nodeModules, join(rootDir, "node_modules"), "dir")
+  await writeFile(join(rootDir, "package.json"), "{\"type\":\"module\"}\n")
+  await writeFile(join(rootDir, "src/server.ts"), [
+    "import { blob } from '@vite-hub/blob'",
+    "import { databases } from '@vite-hub/database/drizzle'",
+    "export default {",
+    "  async fetch() {",
+    "    await blob.put('proof.txt', Object.keys(databases).join(','))",
+    "    return new Response(await (await blob.get('proof.txt'))?.text())",
+    "  },",
+    "}",
+    "",
+  ].join("\n"))
+  await writeFile(join(rootDir, "vite.config.ts"), [
+    "import { resolve } from 'node:path'",
+    "import { defineConfig } from 'vite'",
+    "import { hubBlob } from '@vite-hub/blob/vite'",
+    "export default defineConfig({",
+    "  appType: 'custom',",
+    "  build: {",
+    "    outDir: 'dist/client',",
+    "    rollupOptions: { input: resolve(import.meta.dirname, 'src/server.ts') },",
+    "    ssr: true,",
+    "  },",
+    "  plugins: [hubBlob({ driver: 'cloudflare-r2', bucketName: 'assets' })],",
+    "})",
+    "",
+  ].join("\n"))
+  return rootDir
+}
+
+async function writeStaleRuntimeFiles(rootDir: string, product: string, code: string) {
+  for (const provider of ["cloudflare", "vercel"]) {
+    const file = join(rootDir, ".vitehub", product, `${provider}-runtime.mjs`)
+    await mkdir(dirname(file), { recursive: true })
+    await writeFile(file, code, "utf8")
+  }
+}
+
 async function runDbBuild(rootDir: string, env: NodeJS.ProcessEnv = {}) {
   return execFileAsync("vp", ["build"], {
     cwd: rootDir,
@@ -209,6 +252,57 @@ describe("Vite db provider outputs", () => {
       expectNoRuntimeImport(vercelServerCode, "@vite-hub/blob")
       expectNoRuntimeImport(vercelServerCode, "@vite-hub/database/drizzle")
     }
+  }, 60_000)
+
+  it("ignores stale sibling runtime files that were not prepared in the current build", async () => {
+    const staleDatabaseMarker = "stale_database_runtime_marker"
+    const blobRootDir = await createBlobBuildProject("vitehub-blob-stale-db-runtime-")
+    await writeStaleRuntimeFiles(blobRootDir, "database", [
+      `export const databases = { ${staleDatabaseMarker}: true }`,
+      "export const db = {}",
+      "export const schema = {}",
+      "",
+    ].join("\n"))
+
+    let blobError: Error | undefined
+    try {
+      await runDbBuild(blobRootDir)
+    }
+    catch (caught) {
+      blobError = caught as Error
+    }
+
+    expect(errorText(blobError)).toContain('Could not resolve "node:path"')
+    expect(errorText(blobError)).not.toContain(staleDatabaseMarker)
+
+    const staleBlobMarker = "stale_blob_runtime_marker"
+    const dbRootDir = await createDbBuildProject("vitehub-db-stale-blob-runtime-")
+    await writeFile(join(dbRootDir, "src/server.ts"), [
+      "import { blob } from '@vite-hub/blob'",
+      "import { databases } from '@vite-hub/database/drizzle'",
+      "export default {",
+      "  fetch: () => new Response(`${Object.keys(databases).join(',')}:${String((blob as any).runtimeFlag)}`),",
+      "}",
+      "",
+    ].join("\n"))
+    await writeStaleRuntimeFiles(dbRootDir, "blob", [
+      `export const blob = { runtimeFlag: ${JSON.stringify(staleBlobMarker)} }`,
+      "export const ensureBlob = () => blob",
+      "",
+    ].join("\n"))
+
+    await runDbBuild(dbRootDir, {
+      TURSO_ANALYTICS_DATABASE_URL: "libsql://analytics.example.turso.io",
+      TURSO_AUTH_TOKEN: "token",
+      TURSO_DATABASE_URL: "libsql://database.example.turso.io",
+      VITEHUB_D1_ANALYTICS_DATABASE_ID: "analytics-d1-id",
+      VITEHUB_D1_DATABASE_ID: "primary-d1-id",
+    })
+
+    const dbCloudflareWorker = await readCloudflareWorker(dbRootDir)
+    const dbVercelServer = await readFile(join(dbRootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
+    expect(dbCloudflareWorker).not.toContain(staleBlobMarker)
+    expect(dbVercelServer).not.toContain(staleBlobMarker)
   }, 60_000)
 
   it("builds and emits named database Cloudflare and Vercel outputs", async () => {

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -81,6 +81,29 @@ interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
   vercel?: VercelProviderDeploymentOutput
 }
 
+const composedProviderOutputKey = Symbol.for("vitehub.composedProviderOutput")
+
+export interface ComposedProviderOutput {
+  runtimeModuleFilesByProduct: Record<string, Record<string, string> | undefined>
+}
+
+export function useComposedProviderOutput(config: object): ComposedProviderOutput {
+  const owner = config as Record<symbol, ComposedProviderOutput | undefined>
+  return owner[composedProviderOutputKey] ??= { runtimeModuleFilesByProduct: {} }
+}
+
+export function resetComposedProviderOutput(composed: ComposedProviderOutput | undefined): void {
+  if (composed) composed.runtimeModuleFilesByProduct = {}
+}
+
+export function registerProviderRuntimeModules(composed: ComposedProviderOutput | undefined, product: string, runtimeModuleFiles: Record<string, string>): void {
+  if (composed) composed.runtimeModuleFilesByProduct[product] = runtimeModuleFiles
+}
+
+export function getProviderRuntimeModule(composed: ComposedProviderOutput | undefined, product: string, provider: string): string | undefined {
+  return composed?.runtimeModuleFilesByProduct[product]?.[provider]
+}
+
 interface ResolvedClientOutput {
   clientDir: string
   staticIndex: boolean

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -82,6 +82,7 @@ interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
 }
 
 const composedProviderOutputKey = Symbol.for("vitehub.composedProviderOutput")
+const providerDeploymentOutputWrites = new Map<string, Promise<void>>()
 
 export interface ComposedProviderOutput {
   runtimeModuleFilesByProduct: Record<string, Record<string, string> | undefined>
@@ -297,7 +298,7 @@ async function cleanupNetlifyDeploymentOutput(rootDir: string, cleanup: NetlifyP
   await Promise.all(writes)
 }
 
-export async function writeProviderDeploymentOutputs(options: ProviderDeploymentOutputOptions): Promise<void> {
+async function writeProviderDeploymentOutputsNow(options: ProviderDeploymentOutputOptions): Promise<void> {
   const writes: Array<Promise<void>> = []
   if (options.cloudflare) {
     writes.push(writeCloudflareDeploymentOutput({
@@ -327,4 +328,17 @@ export async function writeProviderDeploymentOutputs(options: ProviderDeployment
     writes.push(cleanupVercelDeploymentOutput(options.rootDir, options.cleanup.vercel))
   }
   await Promise.all(writes)
+}
+
+export async function writeProviderDeploymentOutputs(options: ProviderDeploymentOutputOptions): Promise<void> {
+  const key = resolve(options.rootDir)
+  const previous = providerDeploymentOutputWrites.get(key) ?? Promise.resolve()
+  const write = previous.catch(() => undefined).then(() => writeProviderDeploymentOutputsNow(options))
+  providerDeploymentOutputWrites.set(key, write)
+  try {
+    await write
+  }
+  finally {
+    if (providerDeploymentOutputWrites.get(key) === write) providerDeploymentOutputWrites.delete(key)
+  }
 }

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -142,6 +142,75 @@ describe("provider deployment outputs", () => {
     })
   })
 
+  it("serializes concurrent writes to shared provider config files", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultCloudflareOutputRoot,
+      createDefaultVercelOutputRoot,
+      writeProviderDeploymentOutputs,
+    } = await import("../src/build/deployment-output.ts")
+
+    await Promise.all([
+      writeProviderDeploymentOutputs({
+        clientOutDir: "dist/client",
+        cloudflare: {
+          bundleEntry: join(rootDir, "blob.mjs"),
+          bundleOptions: {},
+          bundleOutfileName: "blob.js",
+          wranglerConfig: {
+            main: "blob.js",
+            r2_buckets: [{ binding: "BLOB", bucket_name: "assets" }],
+          },
+          wranglerConfigKeys: ["r2_buckets"],
+        },
+        rootDir,
+        vercel: {
+          bundleEntry: join(rootDir, "blob.mjs"),
+          bundleOptions: {},
+          config: {
+            routes: [{ dest: "/blob", src: "/blob" }],
+            version: 3,
+          },
+          configKeys: ["routes"],
+          serverFunctionName: "blob.func",
+        },
+      }),
+      writeProviderDeploymentOutputs({
+        clientOutDir: "dist/client",
+        cloudflare: {
+          bundleEntry: join(rootDir, "database.mjs"),
+          bundleOptions: {},
+          bundleOutfileName: "database.js",
+          wranglerConfig: {
+            d1_databases: [{ binding: "DB", database_id: "database-id", database_name: "database" }],
+            main: "database.js",
+          },
+          wranglerConfigKeys: ["d1_databases"],
+        },
+        rootDir,
+        vercel: {
+          bundleEntry: join(rootDir, "database.mjs"),
+          bundleOptions: {},
+          config: {
+            crons: [{ path: "/database", schedule: "0 0 * * *" }],
+            version: 3,
+          },
+          configKeys: ["crons"],
+          serverFunctionName: "database.func",
+        },
+      }),
+    ])
+
+    await expect(readFile(join(createDefaultCloudflareOutputRoot(rootDir), "wrangler.json"), "utf8").then(JSON.parse)).resolves.toMatchObject({
+      d1_databases: [{ binding: "DB", database_id: "database-id", database_name: "database" }],
+      r2_buckets: [{ binding: "BLOB", bucket_name: "assets" }],
+    })
+    await expect(readFile(join(createDefaultVercelOutputRoot(rootDir), "config.json"), "utf8").then(JSON.parse)).resolves.toMatchObject({
+      crons: [{ path: "/database", schedule: "0 0 * * *" }],
+      routes: [{ dest: "/blob", src: "/blob" }],
+    })
+  })
+
   it("writes Netlify functions with static config and preserves shared config keys", async () => {
     const rootDir = await createTempProject()
     const {


### PR DESCRIPTION
Fixes direct Blob + Database Vite plugin composition so each Provider Output bundler can see the sibling primitive runtime generated during build, regardless of plugin order.

The direct regression covers both `plugins: [hubBlob(), hubDb()]` and `plugins: [hubDb(), hubBlob()]` against one shared public `src/server.ts` entry.