### PR TITLE
fix(agent): confine harness sessions to sandbox root

### DIFF
--- a/packages/agent/src/harness/local-sandbox.ts
+++ b/packages/agent/src/harness/local-sandbox.ts
@@ -39,12 +39,23 @@ function isInside(root: string, path: string) {
   return !next || (!next.startsWith("..") && !isAbsolute(next))
 }
 
+function isRootedPath(path: string) {
+  return isAbsolute(path) || /^[A-Za-z]:/.test(path) || /^[\\/]{2}/.test(path)
+}
+
+function rootRelativeFragment(path: string) {
+  return path
+    .replace(/^[A-Za-z]:[\\/]*/, "")
+    .replace(/^[\\/]+/, "")
+    .replace(/\\/g, "/")
+}
+
 function resolvePath(session: LocalHarnessSandboxSession, path = "") {
   const root = resolve(session.rootDir)
-  const candidate = isAbsolute(path)
-    ? isInside(root, resolve(path))
+  const candidate = isRootedPath(path)
+    ? isAbsolute(path) && isInside(root, resolve(path))
       ? resolve(path)
-      : resolve(root, path.replace(/^[/\\]+/, ""))
+      : resolve(root, rootRelativeFragment(path))
     : resolve(session.defaultWorkingDirectory, path)
 
   if (!isInside(root, candidate)) {

--- a/packages/agent/src/harness/local-sandbox.ts
+++ b/packages/agent/src/harness/local-sandbox.ts
@@ -1,7 +1,7 @@
 import { spawn as spawnChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { dirname, isAbsolute, join } from "node:path"
+import { dirname, isAbsolute, join, relative, resolve } from "node:path"
 import { Readable } from "node:stream"
 import { randomUUID } from "node:crypto"
 
@@ -34,8 +34,23 @@ async function defaultRootDir(sessionId: string | undefined) {
   return await mkdtemp(join(tmpdir(), "vitehub-harness-"))
 }
 
-function resolvePath(session: LocalHarnessSandboxSession, path: string) {
-  return isAbsolute(path) ? path : join(session.defaultWorkingDirectory, path)
+function isInside(root: string, path: string) {
+  const next = relative(root, path)
+  return !next || (!next.startsWith("..") && !isAbsolute(next))
+}
+
+function resolvePath(session: LocalHarnessSandboxSession, path = "") {
+  const root = resolve(session.rootDir)
+  const candidate = isAbsolute(path)
+    ? isInside(root, resolve(path))
+      ? resolve(path)
+      : resolve(root, path.replace(/^[/\\]+/, ""))
+    : resolve(session.defaultWorkingDirectory, path)
+
+  if (!isInside(root, candidate)) {
+    throw new Error(`[vitehub] Local harness sandbox path escapes the session root: ${path}`)
+  }
+  return candidate
 }
 
 function readableStreamFromBytes(bytes: Uint8Array) {
@@ -71,9 +86,10 @@ function spawnProcess(session: LocalHarnessSandboxSession, options: {
   env?: Record<string, string>
   workingDirectory?: string
 }) {
+  const cwd = resolvePath(session, options.workingDirectory)
   const child = spawnChildProcess(options.command, {
-    cwd: options.workingDirectory || session.defaultWorkingDirectory,
-    env: { ...session.env, ...options.env },
+    cwd,
+    env: { ...session.env, ...options.env, INIT_CWD: cwd, OLDPWD: cwd, PWD: cwd },
     shell: true,
   })
   session.processes.add(child)
@@ -117,7 +133,7 @@ async function collect(stream: ReadableStream<Uint8Array>) {
 async function createSession(options: LocalHarnessSandboxOptions, sessionId: string | undefined): Promise<LocalHarnessSandboxSession> {
   const rootDir = options.rootDir || await defaultRootDir(sessionId)
   await mkdir(rootDir, { recursive: true })
-  const env = stringEnv(options.env || process.env)
+  const env = { ...stringEnv(options.env || process.env), INIT_CWD: rootDir, OLDPWD: rootDir, PWD: rootDir }
   const session = {
     cleanup: options.cleanup ?? !options.rootDir,
     defaultWorkingDirectory: rootDir,

--- a/packages/agent/test/local-sandbox.test.ts
+++ b/packages/agent/test/local-sandbox.test.ts
@@ -43,6 +43,24 @@ describe("local harness sandbox", () => {
     }
   })
 
+  it("keeps Windows absolute file paths inside the local sandbox root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-local-sandbox-"))
+    const provider = createLocalHarnessSandbox({ env: { PATH: process.env.PATH }, rootDir: root })
+    const session = await provider.createSession()
+
+    try {
+      await session.writeTextFile({ content: "sandbox", path: "C:\\repo\\package.json" })
+      await session.writeTextFile({ content: "drive-relative", path: "D:repo\\nested.txt" })
+
+      await expect(readFile(join(root, "repo", "package.json"), "utf8")).resolves.toBe("sandbox")
+      await expect(readFile(join(root, "repo", "nested.txt"), "utf8")).resolves.toBe("drive-relative")
+    }
+    finally {
+      await session.destroy?.()
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("rejects relative file paths outside the local sandbox root", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-local-sandbox-"))
     const host = await mkdtemp(join(tmpdir(), "vitehub-host-"))
@@ -67,6 +85,28 @@ describe("local harness sandbox", () => {
       await session.destroy?.()
       await rm(root, { force: true, recursive: true })
       await rm(host, { force: true, recursive: true })
+    }
+  })
+
+  it("runs Windows absolute working directories inside the local sandbox root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-local-sandbox-"))
+    const provider = createLocalHarnessSandbox({ env: { PATH: process.env.PATH }, rootDir: root })
+    const session = await provider.createSession()
+
+    try {
+      await session.writeTextFile({ content: "ok", path: "C:\\repo\\input.txt" })
+      const result = await session.run({
+        command: "node -e \"console.log(process.cwd())\" && cat input.txt",
+        workingDirectory: "C:\\repo",
+      })
+
+      expect(result.exitCode).toBe(0)
+      const expectedCwd = join(root, "repo")
+      expect(result.stdout.trim().split("\n")).toEqual([await realpath(expectedCwd), "ok"])
+    }
+    finally {
+      await session.destroy?.()
+      await rm(root, { force: true, recursive: true })
     }
   })
 

--- a/packages/agent/test/local-sandbox.test.ts
+++ b/packages/agent/test/local-sandbox.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, relative } from "node:path"
+
 import { describe, expect, it } from "vitest"
 
 import { createLocalHarnessSandbox } from "../src/harness/local-sandbox.ts"
@@ -17,6 +21,91 @@ describe("local harness sandbox", () => {
     }
     finally {
       await session.destroy?.()
+    }
+  })
+
+  it("keeps absolute file paths inside the local sandbox root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-local-sandbox-"))
+    const host = await mkdtemp(join(tmpdir(), "vitehub-host-"))
+    const provider = createLocalHarnessSandbox({ env: { PATH: process.env.PATH }, rootDir: root })
+    const session = await provider.createSession()
+
+    try {
+      await session.writeTextFile({ content: "sandbox", path: `${host}/package.json` })
+
+      await expect(stat(join(host, "package.json"))).rejects.toMatchObject({ code: "ENOENT" })
+      await expect(readFile(join(root, host.replace(/^\/+/, ""), "package.json"), "utf8")).resolves.toBe("sandbox")
+    }
+    finally {
+      await session.destroy?.()
+      await rm(root, { force: true, recursive: true })
+      await rm(host, { force: true, recursive: true })
+    }
+  })
+
+  it("rejects relative file paths outside the local sandbox root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-local-sandbox-"))
+    const host = await mkdtemp(join(tmpdir(), "vitehub-host-"))
+    const provider = createLocalHarnessSandbox({ env: { PATH: process.env.PATH }, rootDir: root })
+    const session = await provider.createSession()
+    const hostFile = join(host, "package.json")
+
+    try {
+      await writeFile(hostFile, "host")
+
+      await expect(session.writeTextFile({
+        content: "sandbox",
+        path: relative(root, hostFile),
+      })).rejects.toThrow("escapes the session root")
+      await expect(session.run({
+        command: "pwd",
+        workingDirectory: relative(root, host),
+      })).rejects.toThrow("escapes the session root")
+      await expect(readFile(hostFile, "utf8")).resolves.toBe("host")
+    }
+    finally {
+      await session.destroy?.()
+      await rm(root, { force: true, recursive: true })
+      await rm(host, { force: true, recursive: true })
+    }
+  })
+
+  it("runs absolute working directories inside the local sandbox root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-local-sandbox-"))
+    const host = await mkdtemp(join(tmpdir(), "vitehub-host-"))
+    const provider = createLocalHarnessSandbox({
+      env: {
+        INIT_CWD: host,
+        OLDPWD: host,
+        PATH: process.env.PATH,
+        PWD: host,
+      },
+      rootDir: root,
+    })
+    const session = await provider.createSession()
+    const hostFile = join(host, "keep.txt")
+
+    try {
+      await writeFile(hostFile, "host")
+      await session.writeTextFile({ content: "ok", path: `${host}/input.txt` })
+      await session.writeTextFile({ content: "sandbox", path: `${host}/keep.txt` })
+      const result = await session.run({
+        command: "rm -f keep.txt; node -e \"console.log([process.cwd(), process.env.PWD, process.env.INIT_CWD].join('\\n'))\" && cat input.txt",
+        workingDirectory: host,
+      })
+
+      expect(result.exitCode).toBe(0)
+      const lines = result.stdout.trim().split("\n")
+      const expectedCwd = join(root, host.replace(/^\/+/, ""))
+      expect(lines.slice(0, 3)).toEqual([await realpath(expectedCwd), expectedCwd, expectedCwd])
+      expect(lines).not.toContain(host)
+      expect(lines).toContain("ok")
+      await expect(readFile(hostFile, "utf8")).resolves.toBe("host")
+    }
+    finally {
+      await session.destroy?.()
+      await rm(root, { force: true, recursive: true })
+      await rm(host, { force: true, recursive: true })
     }
   })
 })

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -179,15 +179,18 @@ async function resetSandboxWorkDir(
   sessionWorkDir: string,
   abortSignal: AbortSignal | undefined,
 ) {
+  const workDir = posix.normalize(sessionWorkDir)
+  const parent = posix.dirname(workDir)
+  const name = posix.basename(workDir)
   await sandbox.writeBinaryFile({
     abortSignal,
     content: new Uint8Array(),
-    path: sandboxPath(sessionWorkDir, ".vitehub-reset"),
+    path: sandboxPath(parent, ".vitehub-reset"),
   })
   await runSandbox(sandbox, {
     abortSignal,
-    command: "find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +",
-    workingDirectory: sessionWorkDir,
+    command: `rm -rf -- ${shellQuote(name)} && mkdir -p -- ${shellQuote(name)} && rm -f -- ${shellQuote(".vitehub-reset")}`,
+    workingDirectory: parent,
   })
 }
 

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -179,9 +179,15 @@ async function resetSandboxWorkDir(
   sessionWorkDir: string,
   abortSignal: AbortSignal | undefined,
 ) {
+  await sandbox.writeBinaryFile({
+    abortSignal,
+    content: new Uint8Array(),
+    path: sandboxPath(sessionWorkDir, ".vitehub-reset"),
+  })
   await runSandbox(sandbox, {
     abortSignal,
-    command: `rm -rf ${shellQuote(sessionWorkDir)} && mkdir -p ${shellQuote(sessionWorkDir)}`,
+    command: "find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +",
+    workingDirectory: sessionWorkDir,
   })
 }
 

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -37,15 +37,17 @@ function expectArchiveExtract(run: ReturnType<typeof vi.fn>, root = "/work/agent
 }
 
 function expectWorkDirReset(run: ReturnType<typeof vi.fn>, writeBinaryFile: ReturnType<typeof vi.fn>, root = "/work/agent") {
+  const parent = root.replace(/\/[^/]+$/, "") || "/"
+  const name = root.split("/").filter(Boolean).at(-1) || root
   expect(writeBinaryFile).toHaveBeenCalledWith({
     abortSignal: undefined,
     content: new Uint8Array(),
-    path: `${root}/.vitehub-reset`,
+    path: `${parent}/.vitehub-reset`,
   })
   expect(run).toHaveBeenCalledWith({
     abortSignal: undefined,
-    command: "find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +",
-    workingDirectory: root,
+    command: `rm -rf -- '${name}' && mkdir -p -- '${name}' && rm -f -- '.vitehub-reset'`,
+    workingDirectory: parent,
   })
 }
 

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -36,6 +36,19 @@ function expectArchiveExtract(run: ReturnType<typeof vi.fn>, root = "/work/agent
   })
 }
 
+function expectWorkDirReset(run: ReturnType<typeof vi.fn>, writeBinaryFile: ReturnType<typeof vi.fn>, root = "/work/agent") {
+  expect(writeBinaryFile).toHaveBeenCalledWith({
+    abortSignal: undefined,
+    content: new Uint8Array(),
+    path: `${root}/.vitehub-reset`,
+  })
+  expect(run).toHaveBeenCalledWith({
+    abortSignal: undefined,
+    command: "find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +",
+    workingDirectory: root,
+  })
+}
+
 describe("Harness Workspace Session", () => {
   it("resets and materializes selected Workspace files into the harness sandbox", async () => {
     const readme = bytes("# Docs\n")
@@ -56,10 +69,7 @@ describe("Harness Workspace Session", () => {
     })
 
     expect(list).toHaveBeenCalledWith("", { recursive: true })
-    expect(run).toHaveBeenCalledWith({
-      abortSignal: undefined,
-      command: "rm -rf '/work/agent' && mkdir -p '/work/agent'",
-    })
+    expectWorkDirReset(run, writeBinaryFile)
     expect(readFile).toHaveBeenCalledWith("README.md", { encoding: "binary" })
     expectArchiveWrite(writeBinaryFile)
     expectArchiveExtract(run)
@@ -141,6 +151,7 @@ describe("Harness Workspace Session", () => {
       writeFile: vi.fn(async () => {}),
     }))
     const writeBinaryFile = vi.fn(async () => {})
+    const run = sandboxRun()
 
     const session = await prepareHarnessWorkspaceSession({
       fs: {
@@ -154,7 +165,7 @@ describe("Harness Workspace Session", () => {
       paths: [],
       session: {
         readBinaryFile: vi.fn(async () => null),
-        run: sandboxRun(),
+        run,
         writeBinaryFile,
       },
       sessionWorkDir: "/work/agent",
@@ -162,7 +173,7 @@ describe("Harness Workspace Session", () => {
 
     expect(materializeSources).not.toHaveBeenCalled()
     expect(list).not.toHaveBeenCalled()
-    expect(writeBinaryFile).not.toHaveBeenCalled()
+    expectWorkDirReset(run, writeBinaryFile)
     expect(startSession).not.toHaveBeenCalled()
 
     await session.close()


### PR DESCRIPTION
Confines local harness session file access and shell cwd resolution to the sandbox root so absolute host paths are mirrored inside the session and relative escapes fail before touching the host checkout.

Also resets Harness Workspace Sessions from inside the session working directory instead of deleting an absolute path from the parent shell context.