### PR TITLE
feat(agent)!: remove run metadata from chat context

### DIFF
--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -149,8 +149,8 @@ Runtime state created while an Agent Invocation is being processed.
 _Avoid_: Chat state, workflow state
 
 **Agent Run Origin**:
-Host-provided metadata naming where an Agent Invocation came from, such as `http`, `devtools`, or a Chat Platform name.
-_Avoid_: Platform, Agent Trigger, runtime
+Host-provided Agent Run metadata naming where an Agent Invocation came from, such as `http`, `devtools`, or a Chat Platform name. It is first-class invocation provenance, not Chat context.
+_Avoid_: Platform, Agent Trigger, runtime, Chat state
 
 **Agent Run Channel**:
 Agent Run metadata that records the configured Channel ID and Channel Kind that triggered an Agent Invocation.
@@ -337,7 +337,7 @@ _Avoid_: Fake agent, dummy model, test bot
 - Model-facing tools and instructions are **Capability Driver Contributions** consumed only by compatible Agent Drivers.
 - Workspace Tools are derived from an Agent's Colocated Workspace Definition.
 - An **Agent Invocation** can create or update **Agent Run State**.
-- An **Agent Run Origin** is observability metadata for an **Agent Invocation**; it is not the **Agent Trigger** that prepared the invocation.
+- An **Agent Run Origin** is observability metadata for an **Agent Invocation**; it is not the **Agent Trigger** that prepared the invocation and is not mirrored into Chat context.
 - **Chat History** is conversation-scoped and is not **Agent Memory**.
 - A **Chat Session** is part of Chat History behavior and is not **Agent Memory**.
 - Message-shaped **Channels** resolve the active **Chat Session** before applying the **Chat History Window**.

--- a/.agents/contexts/packages/agent/CONTEXT.md
+++ b/.agents/contexts/packages/agent/CONTEXT.md
@@ -139,6 +139,7 @@ _Avoid_: Root Agent Package export, Capability factory export, Chat Adapter Faca
 - The **Agent Package** owns **Agent Error Normalization** for Agent Invocation lifecycle events and public response boundaries.
 - An **Agent Trigger Consumer** uses the **Agent Trigger API** and does not create a parallel chat-specific behavior surface.
 - An **Agent Trigger Consumer** may pass a trusted Agent Actor through trigger input when it has already authenticated or resolved caller identity; trigger metadata should not become a parallel identity or command-admission boundary.
+- Message-shaped Agent Trigger input may pass Agent Run metadata for invocation provenance, but the Agent Package should not copy that metadata into public Chat context.
 - The Agent Invocation Stream Endpoint consumes **Agent Dev Loop Payload Loading** by passing payload files to the selected Agent Trigger before any Agent Invocation is streamed.
 - The Agent Package should not put development-only sample payloads on the public Agent Definition shape.
 - A **Channel** may be implemented by an **Agent Trigger Consumer**, but Channel is the framework term for Agent reachability.

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -66,7 +66,7 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
-The `run` fields are Agent Run State and observability metadata. They help DevTools, traces, and finish hooks explain where the invocation came from.
+The `run` fields are first-class Agent Run metadata, not Chat context. They help DevTools, traces, and finish hooks explain where the invocation came from.
 
 ## Add identity separately
 

--- a/docs/content/docs/agents/chat-history-sessions.md
+++ b/docs/content/docs/agents/chat-history-sessions.md
@@ -51,7 +51,7 @@ With this configuration, a follow-up in the same thread can keep the same Chat H
 
 This is not Agent Memory. Thread-scoped Chat History keeps recent conversation input together; it does not remember user preferences or facts across unrelated threads.
 
-For Chat Platform Adapters, ViteHub receives normalized channel, message, and thread facts from the message-shaped Channel. For app-owned chat routes, pass the current thread's messages to `chat.message` and include a stable `run.threadId` so DevTools, traces, sessions, and finish hooks can describe the same boundary.
+For Chat Platform Adapters, ViteHub receives normalized channel, message, and thread facts from the message-shaped Channel. For app-owned chat routes, pass the current thread's messages to `chat.message` and include a stable first-class `run.threadId` so DevTools, traces, sessions, and finish hooks can describe the same boundary without making run metadata part of Chat context.
 
 Use `sessions` only when one platform thread can contain more than one host-visible conversation. For example, add sessions when a support UI has a "new conversation" button inside the same customer chat, or when inactivity should start a fresh conversation without creating a new platform thread.
 

--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -100,7 +100,7 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
-Agent Trigger Consumers call the trigger surface. They do not own the Capability behavior that registered the trigger.
+Agent Trigger Consumers call the trigger surface. They do not own the Capability behavior that registered the trigger. The `run` field remains Agent Run metadata for the invocation rather than Chat context.
 
 ## Input lifecycle
 

--- a/docs/content/docs/agents/triggers.md
+++ b/docs/content/docs/agents/triggers.md
@@ -84,7 +84,7 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
-The route is an Agent Trigger Consumer. It does not declare Chat Capability behavior itself.
+The route is an Agent Trigger Consumer. It does not declare Chat Capability behavior itself. The `run` field is invocation provenance; Chat context stays focused on message, session, user, and chat-scoped metadata.
 
 ## Add app-owned event triggers
 

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -298,7 +298,6 @@ export function createChatMessageTriggerInput<TRuntimeConfig extends AgentRuntim
         ...(triggerInput?.invokerProfileId ? { invokerProfileId: triggerInput.invokerProfileId } : {}),
         chat: {
           message: hookArgs.message,
-          run: triggerInput?.run,
           session: triggerInput?.session,
           meta: triggerInput?.meta,
           user: triggerInput?.user,

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -10,7 +10,6 @@ import type {
   AgentChatPlatformResolver,
   AgentChannelWebhookRegistrationDefinition,
   AgentInvocationContextStore,
-  AgentRunMetadata,
   AgentRuntimeConfig,
   AgentTriggerDefinition,
   AgentWebhookRegistrationDefinition,
@@ -74,13 +73,11 @@ type KnownChatWebhookPlatform = keyof typeof CHAT_WEBHOOK_DEFAULTS
 export interface AgentChatRunContext<
   TMessageMetadata extends object = Record<string, unknown>,
   TUser extends object = Record<string, unknown>,
-  TOrigin extends string = string,
   TMeta extends object = Record<string, unknown>,
 > {
   chat?: {
     message?: Omit<AgentChatAgentHookArgs["message"], "metadata"> & { metadata?: TMessageMetadata }
     meta?: TMeta
-    run?: AgentRunMetadata<TOrigin>
     session?: AgentChatMessageTriggerInput["session"]
     user?: TUser
   }
@@ -89,20 +86,18 @@ export interface AgentChatRunContext<
 export type AgentChatContext<
   TMeta extends object = Record<string, unknown>,
   TUser extends object = Record<string, unknown>,
-  TOrigin extends string = string,
   TMessageMetadata extends object = Record<string, unknown>,
-> = NonNullable<AgentChatRunContext<TMessageMetadata, TUser, TOrigin, TMeta>["chat"]>
+> = NonNullable<AgentChatRunContext<TMessageMetadata, TUser, TMeta>["chat"]>
 
 export function getAgentChatContext<
   TMeta extends object = Record<string, unknown>,
   TUser extends object = Record<string, unknown>,
-  TOrigin extends string = string,
   TMessageMetadata extends object = Record<string, unknown>,
 >(
   input: AgentInvocationContextStore | { context: AgentInvocationContextStore },
-): AgentChatContext<TMeta, TUser, TOrigin, TMessageMetadata> | undefined {
+): AgentChatContext<TMeta, TUser, TMessageMetadata> | undefined {
   const store = "get" in input ? input : input.context
-  return store.get<AgentChatContext<TMeta, TUser, TOrigin, TMessageMetadata>>(agentChatContextKey)
+  return store.get<AgentChatContext<TMeta, TUser, TMessageMetadata>>(agentChatContextKey)
 }
 
 async function resolveChatThinkingFallback<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -221,7 +221,6 @@ function createDevtoolsMetadataInput(selection: ChatDevtoolsInvokerSelection = {
       chat: {
         message: { metadata: {} },
         ...(meta ? { meta } : {}),
-        run: { origin: "devtools" },
         user: chatDevtoolsUser,
       },
     },

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -209,6 +209,15 @@ function createRuntimeContext(server: ViteDevServer, req: IncomingMessage, run: 
   }) as ViteAgentDevtoolsRuntimeContext
 }
 
+function createDevtoolsMetadataRunMetadata(name: string): AgentRunMetadata<"devtools"> {
+  return {
+    channelId: `devtools:${name}`,
+    origin: "devtools",
+    runId: `devtools:${name}:metadata`,
+    threadId: `devtools:${name}:thread`,
+  }
+}
+
 function createDevtoolsMetadataInput(selection: ChatDevtoolsInvokerSelection = {}): AgentRunInput {
   const meta = optionalRecord(selection.meta)
   return {
@@ -345,6 +354,7 @@ async function startMetadataResolution(
   const task = resolveAgentDevtoolsMetadata(entry.agent as never, {
     ...entry.defaults,
     input: createDevtoolsMetadataInput(metadataSelection),
+    runtime: { run: createDevtoolsMetadataRunMetadata(entry.name) },
   } as never)
     .then((metadata) => {
       if (entry.metadataTask !== task || entry.metadataSelectionKey !== selectionKey) return
@@ -761,6 +771,7 @@ async function materializeDevtoolsSource(
       input: createDevtoolsMetadataInput(metadataSelection),
       ...(input.path ? { path: input.path } : {}),
       ...(input.source ? { source: input.source } : {}),
+      runtime: { run: createDevtoolsMetadataRunMetadata(entry.name) },
       sources: materializedSourceKeys(entry.metadata),
     } as never)
     entry.metadata = metadataWithAgentName(metadata, entry.name)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1317,7 +1317,7 @@ async function startAgentDevtoolsMetadataResolution(
   const task = resolveAgentDevtoolsMetadata(agent as never, {
     ...options.defaults,
     input: createDevtoolsMetadataInput(metadataSelection),
-    runtime,
+    runtime: { ...runtime, run: createDevtoolsMetadataRunMetadata(name) },
   } as never)
     .then((metadata) => {
       if (state.metadataTask !== task || state.metadataSelectionKey !== selectionKey) return
@@ -1407,6 +1407,15 @@ function createDevtoolsRunMetadata(name: string, userMessageId: string): AgentRu
     messageId: userMessageId,
     origin: "devtools",
     runId: globalThis.crypto?.randomUUID?.() || `devtools-run-${randomToken()}`,
+    threadId: `devtools:${name}:thread`,
+  }
+}
+
+function createDevtoolsMetadataRunMetadata(name: string): AgentRunMetadata<"devtools"> {
+  return {
+    channelId: `devtools:${name}`,
+    origin: "devtools",
+    runId: `devtools:${name}:metadata`,
     threadId: `devtools:${name}:thread`,
   }
 }
@@ -1683,15 +1692,16 @@ async function materializeDevtoolsSource(
 
   try {
     const { materializeAgentDevtoolsSourceMetadata } = await import("../workspace-agent.ts")
+    const name = agentChannelDevtoolsName(agent, options)
     const metadata = await materializeAgentDevtoolsSourceMetadata(agent as never, {
       ...options.defaults,
       input: createDevtoolsMetadataInput(metadataSelection),
       ...(input.path ? { path: input.path } : {}),
       ...(input.source ? { source: input.source } : {}),
-      runtime,
+      runtime: { ...runtime, run: createDevtoolsMetadataRunMetadata(name) },
       sources: materializedSourceKeys(state.metadata),
     } as never)
-    state.metadata = metadataWithAgentName(metadata, agentChannelDevtoolsName(agent, options))
+    state.metadata = metadataWithAgentName(metadata, name)
     state.metadataSelectionKey = metadataSelectionKey(metadataSelection)
     state.metadataStatus = "ready"
     state.metadataTask = undefined

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1226,7 +1226,6 @@ function createDevtoolsMetadataInput(selection: AgentChatDevtoolsInvokerSelectio
       chat: {
         message: { metadata: {} },
         ...(meta ? { meta } : {}),
-        run: { origin: "devtools" },
         user: chatDevtoolsUser(meta),
       },
     },

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -77,9 +77,9 @@ describe("chat message trigger input", () => {
 
     expect(result.input.context?.chat).toMatchObject({
       meta: { portal: { activePage: "/orders" } },
-      run: { origin: "portal", runId: "portal-run" },
       user: { email: "support@example.com" },
     })
+    expect(result.input.context?.chat).not.toHaveProperty("run")
     expect(result.input.context?.invoker).toEqual({
       id: "portal:acme:user_1",
       kind: "customerPortal",
@@ -116,6 +116,7 @@ describe("chat message trigger input", () => {
       kind: "devtools",
       meta: { email: "maximo@quiver.dk" },
     })
+    expect(result.input.context?.chat).not.toHaveProperty("run")
   })
 
   it("preserves completed UI tool calls", () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -390,9 +390,9 @@ describe("agent chat capability discovery", () => {
       capabilities: [
         access({
           workspace: {
-            resolve({ invoker }) {
+            resolve({ invoker, run }) {
               const email = typeof invoker.meta?.email === "string" ? invoker.meta.email.toLowerCase() : undefined
-              return invoker.meta?.scope === "support" || (email && technicalEmails.has(email))
+              return run?.origin === "devtools" && (invoker.meta?.scope === "support" || (email && technicalEmails.has(email)))
                 ? { role: "admin", scope: "support" }
                 : { role: "viewer", scope: "customer" }
             },

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -674,17 +674,16 @@ describe("agent public types", () => {
     type ChatContext = AgentChatRunContext<
       { quiver?: { customer?: string } },
       { email?: string },
-      "portal" | "teams",
       { customer?: string, email?: string }
     >
     const workspaceAccess: AccessWorkspaceOptionsFor<typeof workspace, ChatContext> = {
       defaultScope: "customer",
-      resolve({ input }) {
+      resolve({ input, run }) {
         const chat = input.get().context?.chat
         expectTypeOf(chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<string | undefined>()
         expectTypeOf(chat?.meta?.customer).toEqualTypeOf<string | undefined>()
         expectTypeOf(chat?.meta?.email).toEqualTypeOf<string | undefined>()
-        expectTypeOf(chat?.run?.origin).toEqualTypeOf<"portal" | "teams" | undefined>()
+        expectTypeOf(run?.origin).toEqualTypeOf<string | undefined>()
         expectTypeOf(chat?.user?.email).toEqualTypeOf<string | undefined>()
         return chat?.user?.email?.endsWith("@quiver.dk")
           ? { instructions: "Use the internal support tone.", role: "admin", scope: "quiver" }
@@ -772,7 +771,7 @@ describe("agent public types", () => {
       },
     }
     type SupportInvoker = AgentInvoker<{ audience?: "support" | "technical", customer?: "acme" }>
-    type SupportInputContext = AgentChatRunContext<SupportMessageMetadata, SupportChatUser, "teams"> & {
+    type SupportInputContext = AgentChatRunContext<SupportMessageMetadata, SupportChatUser> & {
       invoker?: SupportInvoker
     }
     const supportProfiles: readonly AgentInvokerProfile<{ audience?: "technical", customer?: "acme" }>[] = [
@@ -805,10 +804,10 @@ describe("agent public types", () => {
       },
     })
     const supportAccess: AccessWorkspaceOptionsFor<typeof workspace, SupportInputContext> = {
-      resolve({ actor, input, invoker }) {
+      resolve({ actor, input, invoker, run }) {
         const chat = input.get().context?.chat
         expectTypeOf(chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<string | undefined>()
-        expectTypeOf(chat?.run?.origin).toEqualTypeOf<"teams" | undefined>()
+        expectTypeOf(run?.origin).toEqualTypeOf<string | undefined>()
         expectTypeOf(chat?.user?.email).toEqualTypeOf<string | undefined>()
         expectTypeOf(actor.id).toEqualTypeOf<string>()
         expectTypeOf(invoker.id).toEqualTypeOf<string>()


### PR DESCRIPTION
Removes the Chat-context mirror of Agent Run metadata so `context.chat` stays scoped to chat state: message metadata, session, raw chat user, and chat-scoped meta. The `chat.message` trigger still accepts first-class `run` metadata, and invocation/runtime callbacks continue to expose run provenance outside Chat.

Also updates the Agent Package domain docs and public agent docs to steer identity policy toward `context.actor` / `context.invoker` and run provenance toward first-class Agent Run metadata.