### PR TITLE
fix(agent): render pull request context workspace item

### DIFF
--- a/docs/content/docs/capabilities/official-capabilities.md
+++ b/docs/content/docs/capabilities/official-capabilities.md
@@ -28,6 +28,7 @@ import {
   mcp,
   memory,
   observability,
+  pullRequestContext,
   rateLimit,
   repositoryHost,
   sandbox,
@@ -52,6 +53,7 @@ import {
 | Subagents | [`subagents()`](/docs/capabilities/subagents) | A model-backed Agent should delegate bounded work to named Agent Definitions through model-facing tools. |
 | Workspace files | [`workspaceShell()`](/docs/capabilities/workspace-shell) | The Agent should inspect or edit Workspace files through constrained Workspace tools. |
 | Git source history | [`git()`](/docs/capabilities/git) | The Agent needs bounded Git source-history inspection or local Workspace Session git state selection. |
+| Pull Request context | [`pullRequestContext()`](/docs/capabilities/pull-request-context) | A trigger or host already knows the current Change Request and the Agent should inspect that normalized context in the Workspace. |
 | Repository host | [`repositoryHost()`](/docs/capabilities/repository-host) | The Agent needs provider-hosted repository, Change Request, issue, comment, check, or status data through a configured Repository Host client. |
 | Skills file | [`skills()`](/docs/capabilities/skills) | The Agent requires a Workspace skill file at invocation time. |
 | KV storage | [`kv()`](/docs/capabilities/kv) | The Agent needs scoped key-value read or edit tools. |

--- a/docs/content/docs/capabilities/pull-request-context.md
+++ b/docs/content/docs/capabilities/pull-request-context.md
@@ -1,0 +1,86 @@
+---
+title: Pull Request context
+description: Record normalized Change Request invocation context and expose it as a Workspace file.
+navigation.title: Pull Request context
+navigation.order: 120
+navigation.group: External context
+icon: i-lucide-git-pull-request
+---
+
+`pullRequestContext()` records a normalized Pull Request or Change Request value for the Agent Invocation.
+Use it when a trigger, webhook, or host already knows which Change Request started the Agent run.
+
+## Installation
+
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Add a Workspace when Workspace-aware tools or runner code should read the generated context file.
+
+## What it adds
+
+The Capability stores the value in Agent Invocation Context under `pullRequest` by default.
+When the Agent has a Workspace, it also adds a lazy Live Source at `pull-request-context/context.md`.
+
+The file is markdown with frontmatter for common fields such as `repository`, `number`, `provider`, `baseRef`, `headRef`, `actor`, and `deliveryId`.
+
+## Configuration
+
+```ts [server/agents/reviewer.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { pullRequestContext } from '@vite-hub/agent/capabilities'
+
+export default defineAgent({
+  driver: { model },
+  workspace,
+  capabilities: [
+    pullRequestContext({
+      context: {
+        number: 42,
+        provider: 'github',
+        repository: 'acme/app',
+      },
+    }),
+  ],
+})
+```
+
+## Runtime behavior
+
+`pullRequestContext()` does not fetch provider data.
+It only records the normalized context value supplied by the caller and exposes it as Workspace context for the Agent.
+
+Apps can render their own review summary, Markham file, or report from `pull-request-context/context.md`.
+Use `repositoryHost()` separately when the Agent needs to read comments, files, checks, statuses, or other provider-hosted repository data.
+
+## Requirements
+
+Context-only usage does not require a Workspace.
+Explicit custom `sources` or `rules` require a Workspace because they contribute Workspace inputs.
+
+## Driver support
+
+| Agent Driver | Support |
+| --- | --- |
+| Model-backed | Can inspect the Workspace file through Workspace-aware tools. |
+| Harness-backed | Can inspect the generated file through normal Workspace paths. |
+| Custom-run-backed | Can read the invocation context value directly through `context.get('pullRequest')`. |
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `context` | `PullRequestContextValue \| function` | none | Normalized Change Request context supplied by the trigger or caller. |
+| `contextKey` | `string` | `"pullRequest"` | Agent Invocation Context key used to store the value. |
+| `sources` | `Record<string, WorkspaceSourceInput> \| function` | none | Extra Workspace Sources to merge with the default context Source. |
+| `rules` | `WorkspaceRules \| function` | none | Workspace rules contributed with the context Source. |
+| `triggers` | `Record<string, AgentTriggerDefinition>` | none | Trigger contributions tied to this context. |
+
+## Inspect and verify
+
+Read `pull-request-context/context.md` from the Workspace.
+Confirm the frontmatter matches the trigger payload and that provider data is only available when a separate Capability supplies it.
+
+## Reference
+
+- [Repository host](/docs/capabilities/repository-host)
+- [Workspace and Sources](/docs/concepts/workspace-and-sources)
+- Source: `packages/agent/src/capabilities/pull-request-context.ts`

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -162,12 +162,10 @@ function pullRequestContextSource(
   contextKey: string,
   mount: string,
 ): WorkspaceSource {
-  const scopeName = selectedWorkspaceScopeName(context)
   return {
     materialize: "lazy",
     mount,
     probeKeys: [defaultSourcePath],
-    ...(scopeName ? { scopes: [scopeName] } : {}),
     async getKeys() {
       return [defaultSourcePath]
     },
@@ -184,11 +182,20 @@ function pullRequestContextSource(
   }
 }
 
-function selectedWorkspaceScopeName(context: AgentInvocationContextStore): string | undefined {
+function grantSelectedWorkspaceScopePath(context: AgentInvocationContextStore, path: string): void {
   if (!hasTrustedWorkspaceAccessScope(context)) return
-  const access = context.get<{ workspaceScope?: { all?: boolean, scope?: string } }>("access")
-  if (access?.workspaceScope?.all) return
-  return access?.workspaceScope?.scope
+  const access = context.get<{ workspaceScope?: { all?: boolean, paths?: readonly string[], role?: string, scope?: string } }>("access")
+  const scope = access?.workspaceScope
+  if (!scope || scope.all) return
+  const paths = scope.paths || []
+  if (paths.includes(path)) return
+  context.set("access", {
+    ...access,
+    workspaceScope: {
+      ...scope,
+      paths: [...paths, path],
+    },
+  }, { overwrite: true })
 }
 
 function defaultSourceIdentity(capabilityId: string) {
@@ -233,6 +240,10 @@ export function pullRequestContext<
       await recordContext(context)
       const sources = await resolveMaybeFunction(options.sources, context)
       const rules = await resolveMaybeFunction(options.rules, context)
+      if (sources && Object.hasOwn(sources, source.key)) {
+        throw new Error(`[vitehub] ${capabilityId}() sources cannot use reserved Workspace Source key "${source.key}".`)
+      }
+      grantSelectedWorkspaceScopePath(context.context, [source.mount, defaultSourcePath].join("/"))
       return {
         ...(rules ? { rules } : {}),
         sources: {

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -1,4 +1,5 @@
-import { defineCapability } from "../capability-runtime.ts"
+import { hasTrustedWorkspaceAccessScope } from "../access-runtime.ts"
+import { defineCapability, optionalWorkspaceCapabilitySymbol } from "../capability-runtime.ts"
 
 import type {
   AgentInvocationContextStore,
@@ -66,7 +67,9 @@ type PullRequestContextCapabilityTypeContract<
 }
 
 const defaultSourceKey = "pullRequestContext"
+const defaultSourceMount = "pull-request-context"
 const defaultSourcePath = "context.md"
+const defaultCapabilityId = "pull-request-context"
 
 async function resolveMaybeFunction<TValue, TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
   value: TValue | ((context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<TValue | false | null | undefined>) | undefined,
@@ -82,7 +85,60 @@ function frontmatterValue(value: number | string): string {
   return typeof value === "number" ? String(value) : JSON.stringify(value)
 }
 
-function renderPullRequestContextMarkdown(value: PullRequestContextValue | undefined): string {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+function maybeString(value: unknown): string | undefined {
+  return typeof value === "string" && value ? value : undefined
+}
+
+function maybeContextValue(value: unknown): number | string | undefined {
+  return typeof value === "number" || typeof value === "string" ? value : undefined
+}
+
+function normalizePullRequestContext(value: unknown): PullRequestContextValue | undefined {
+  if (!isRecord(value)) return
+
+  const flatNumber = maybeContextValue(value.number)
+  const flatRepository = maybeString(value.repository)
+  if (flatNumber !== undefined && flatRepository) {
+    return {
+      ...(maybeString(value.actor) ? { actor: maybeString(value.actor) } : {}),
+      ...(maybeString(value.baseRef) ? { baseRef: maybeString(value.baseRef) } : {}),
+      ...(maybeString(value.deliveryId) ? { deliveryId: maybeString(value.deliveryId) } : {}),
+      ...(maybeString(value.headRef) ? { headRef: maybeString(value.headRef) } : {}),
+      ...(maybeContextValue(value.id) !== undefined ? { id: maybeContextValue(value.id) } : {}),
+      number: flatNumber,
+      ...(maybeString(value.provider) ? { provider: maybeString(value.provider) } : {}),
+      repository: flatRepository,
+    }
+  }
+
+  const pullRequest = isRecord(value.pullRequest) ? value.pullRequest : undefined
+  const repository = isRecord(value.repository) ? value.repository : undefined
+  const trigger = isRecord(value.trigger) ? value.trigger : undefined
+  const actor = isRecord(trigger?.actor) ? trigger.actor : undefined
+  const source = isRecord(pullRequest?.source) ? pullRequest.source : undefined
+  const number = maybeContextValue(pullRequest?.number)
+  const repositoryName = maybeString(repository?.fullName)
+  if (number === undefined || !repositoryName) return
+  const actorLogin = actor ? maybeString(actor.login) : undefined
+  const deliveryId = trigger ? maybeString(trigger.deliveryId) : undefined
+  const headRef = source ? maybeString(source.ref) : undefined
+
+  return {
+    ...(actorLogin ? { actor: actorLogin } : {}),
+    ...(deliveryId ? { deliveryId } : {}),
+    ...(headRef ? { headRef } : {}),
+    number,
+    provider: "github",
+    repository: repositoryName,
+  }
+}
+
+function renderPullRequestContextMarkdown(input: unknown): string {
+  const value = normalizePullRequestContext(input)
   const frontmatter = ([
     ["repository", value?.repository],
     ["number", value?.number],
@@ -104,22 +160,41 @@ function renderPullRequestContextMarkdown(value: PullRequestContextValue | undef
 function pullRequestContextSource(
   context: AgentInvocationContextStore,
   contextKey: string,
+  mount: string,
 ): WorkspaceSource {
+  const scopeName = selectedWorkspaceScopeName(context)
   return {
     materialize: "lazy",
-    mount: "pull-request-context",
+    mount,
     probeKeys: [defaultSourcePath],
+    ...(scopeName ? { scopes: [scopeName] } : {}),
     async getKeys() {
       return [defaultSourcePath]
     },
     async getItem(key) {
+      if (key !== defaultSourcePath) {
+        throw new Error(`[vitehub] Workspace file does not exist: ${mount}/${key}.`)
+      }
       return {
-        content: renderPullRequestContextMarkdown(context.get<PullRequestContextValue>(contextKey)),
+        content: renderPullRequestContextMarkdown(context.get(contextKey)),
         key,
         mediaType: "text/markdown",
       }
     },
   }
+}
+
+function selectedWorkspaceScopeName(context: AgentInvocationContextStore): string | undefined {
+  if (!hasTrustedWorkspaceAccessScope(context)) return
+  const access = context.get<{ workspaceScope?: { all?: boolean, scope?: string } }>("access")
+  if (access?.workspaceScope?.all) return
+  return access?.workspaceScope?.scope
+}
+
+function defaultSourceIdentity(capabilityId: string) {
+  return capabilityId === defaultCapabilityId
+    ? { key: defaultSourceKey, mount: defaultSourceMount }
+    : { key: `${capabilityId}-context`, mount: capabilityId }
 }
 
 export function pullRequestContext<
@@ -130,7 +205,9 @@ export function pullRequestContext<
 >(
   options: PullRequestContextOptions<TRuntimeConfig, Name> & { contextKey?: TContextKey, sources?: TSourceMap | PullRequestContextSources<TRuntimeConfig, Name> } = {},
 ): AgentCapabilityDefinition<TRuntimeConfig, Name, PullRequestContextCapabilityTypeContract<TContextKey>> {
+  const capabilityId = options.id || defaultCapabilityId
   const contextKey = options.contextKey || "pullRequest"
+  const source = defaultSourceIdentity(capabilityId)
   const hasCustomWorkspaceContribution = options.sources !== undefined || options.rules !== undefined
   const recordedContexts = new WeakSet<AgentCapabilityContext<TRuntimeConfig, Name>["context"]>()
 
@@ -144,11 +221,11 @@ export function pullRequestContext<
   }
 
   return defineCapability({
-    id: options.id || "pull-request-context",
+    id: capabilityId,
     metadata: {
       contextKey,
       kind: "pull-request-context",
-      workspaceOptional: !hasCustomWorkspaceContribution,
+      [optionalWorkspaceCapabilitySymbol]: !hasCustomWorkspaceContribution,
     },
     prepare: recordContext,
     triggers: options.triggers,
@@ -159,7 +236,7 @@ export function pullRequestContext<
       return {
         ...(rules ? { rules } : {}),
         sources: {
-          [defaultSourceKey]: pullRequestContextSource(context.context, contextKey),
+          [source.key]: pullRequestContextSource(context.context, contextKey, source.mount),
           ...(sources || {}),
         },
       }

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -1,6 +1,7 @@
 import { defineCapability } from "../capability-runtime.ts"
 
 import type {
+  AgentInvocationContextStore,
   AgentCapabilityContext,
   AgentCapabilityDefinition,
   AgentCapabilityTypeContract,
@@ -9,7 +10,9 @@ import type {
   AgentTriggerDefinition,
   MaybePromise,
 } from "../types.ts"
+import { markLiveWorkspaceSource } from "@vite-hub/workspace"
 import type {
+  WorkspaceSource,
   WorkspaceName,
   WorkspaceRules,
   WorkspaceSourceInput,
@@ -63,6 +66,10 @@ type PullRequestContextCapabilityTypeContract<
   invocationContext: Record<TContextKey, PullRequestContextValue>
 }
 
+const defaultSourceKey = "pullRequestContext"
+const defaultSourcePath = "context.md"
+const defaultWorkspacePath = "pull-request-context/context.md"
+
 async function resolveMaybeFunction<TValue, TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
   value: TValue | ((context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<TValue | false | null | undefined>) | undefined,
   context: AgentCapabilityContext<TRuntimeConfig, Name>,
@@ -71,6 +78,50 @@ async function resolveMaybeFunction<TValue, TRuntimeConfig extends AgentRuntimeC
     ? await (value as (context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<TValue | false | null | undefined>)(context)
     : value
   return resolved || undefined
+}
+
+function frontmatterValue(value: number | string): string {
+  return typeof value === "number" ? String(value) : JSON.stringify(value)
+}
+
+function renderPullRequestContextMarkdown(value: PullRequestContextValue | undefined): string {
+  const frontmatter = ([
+    ["repository", value?.repository],
+    ["number", value?.number],
+    ["id", value?.id],
+    ["provider", value?.provider],
+    ["baseRef", value?.baseRef],
+    ["headRef", value?.headRef],
+    ["actor", value?.actor],
+    ["deliveryId", value?.deliveryId],
+  ] as const)
+    .flatMap(([key, item]) => item === undefined ? [] : `${key}: ${frontmatterValue(item)}`)
+    .join("\n")
+  const body = value
+    ? `# Pull Request Context\n\nChange Request ${value.number} in ${value.repository}.`
+    : "# Pull Request Context\n\nNo pull request context was recorded for this Agent Invocation."
+  return `---\n${frontmatter}\n---\n\n${body}\n`
+}
+
+function pullRequestContextSource(
+  context: AgentInvocationContextStore,
+  contextKey: string,
+): WorkspaceSource {
+  return markLiveWorkspaceSource({
+    materialize: "lazy",
+    mount: "pull-request-context",
+    probeKeys: [defaultSourcePath],
+    async getKeys() {
+      return [defaultSourcePath]
+    },
+    async getItem(key) {
+      return {
+        content: renderPullRequestContextMarkdown(context.get<PullRequestContextValue>(contextKey)),
+        key,
+        mediaType: "text/markdown",
+      }
+    },
+  }, { [defaultWorkspacePath]: defaultSourcePath })
 }
 
 export function pullRequestContext<
@@ -82,7 +133,7 @@ export function pullRequestContext<
   options: PullRequestContextOptions<TRuntimeConfig, Name> & { contextKey?: TContextKey, sources?: TSourceMap | PullRequestContextSources<TRuntimeConfig, Name> } = {},
 ): AgentCapabilityDefinition<TRuntimeConfig, Name, PullRequestContextCapabilityTypeContract<TContextKey>> {
   const contextKey = options.contextKey || "pullRequest"
-  const hasWorkspaceContribution = options.sources !== undefined || options.rules !== undefined
+  const hasCustomWorkspaceContribution = options.sources !== undefined || options.rules !== undefined
   const recordedContexts = new WeakSet<AgentCapabilityContext<TRuntimeConfig, Name>["context"]>()
 
   async function recordContext(context: AgentCapabilityContext<TRuntimeConfig, Name>) {
@@ -99,22 +150,21 @@ export function pullRequestContext<
     metadata: {
       contextKey,
       kind: "pull-request-context",
+      workspaceOptional: !hasCustomWorkspaceContribution,
     },
     prepare: recordContext,
     triggers: options.triggers,
-    ...(hasWorkspaceContribution
-      ? {
-          workspace: async (context): Promise<AgentCapabilityWorkspaceContribution | undefined> => {
-            await recordContext(context)
-            const sources = await resolveMaybeFunction(options.sources, context)
-            const rules = await resolveMaybeFunction(options.rules, context)
-            if (!sources && !rules) return
-            return {
-              ...(rules ? { rules } : {}),
-              ...(sources ? { sources } : {}),
-            }
-          },
-        }
-      : {}),
+    workspace: async (context): Promise<AgentCapabilityWorkspaceContribution | undefined> => {
+      await recordContext(context)
+      const sources = await resolveMaybeFunction(options.sources, context)
+      const rules = await resolveMaybeFunction(options.rules, context)
+      return {
+        ...(rules ? { rules } : {}),
+        sources: {
+          [defaultSourceKey]: pullRequestContextSource(context.context, contextKey),
+          ...(sources || {}),
+        },
+      }
+    },
   })
 }

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -10,7 +10,6 @@ import type {
   AgentTriggerDefinition,
   MaybePromise,
 } from "../types.ts"
-import { markLiveWorkspaceSource } from "@vite-hub/workspace"
 import type {
   WorkspaceSource,
   WorkspaceName,
@@ -68,7 +67,6 @@ type PullRequestContextCapabilityTypeContract<
 
 const defaultSourceKey = "pullRequestContext"
 const defaultSourcePath = "context.md"
-const defaultWorkspacePath = "pull-request-context/context.md"
 
 async function resolveMaybeFunction<TValue, TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
   value: TValue | ((context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<TValue | false | null | undefined>) | undefined,
@@ -107,7 +105,7 @@ function pullRequestContextSource(
   context: AgentInvocationContextStore,
   contextKey: string,
 ): WorkspaceSource {
-  return markLiveWorkspaceSource({
+  return {
     materialize: "lazy",
     mount: "pull-request-context",
     probeKeys: [defaultSourcePath],
@@ -121,7 +119,7 @@ function pullRequestContextSource(
         mediaType: "text/markdown",
       }
     },
-  }, { [defaultWorkspacePath]: defaultSourcePath })
+  }
 }
 
 export function pullRequestContext<

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -59,6 +59,7 @@ const defaultCapabilityRuntimePhases = ["configure", "prepare", "bind", "input",
 export const channelDeliveryEffectsContextKey = "channel.delivery.effects"
 export const channelDeliveryFinishEffectsContextKey = "channel.delivery.finishEffects"
 type AgentCapabilityRuntimePhase = typeof defaultCapabilityRuntimePhases[number]
+export const optionalWorkspaceCapabilitySymbol = Symbol("vitehub.agent.optionalWorkspaceCapability")
 
 export interface ResolvedAgentFinishExtensionProvider {
   id: string

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -59,7 +59,7 @@ const defaultCapabilityRuntimePhases = ["configure", "prepare", "bind", "input",
 export const channelDeliveryEffectsContextKey = "channel.delivery.effects"
 export const channelDeliveryFinishEffectsContextKey = "channel.delivery.finishEffects"
 type AgentCapabilityRuntimePhase = typeof defaultCapabilityRuntimePhases[number]
-export const optionalWorkspaceCapabilitySymbol = Symbol("vitehub.agent.optionalWorkspaceCapability")
+export const optionalWorkspaceCapabilitySymbol: unique symbol = Symbol("vitehub.agent.optionalWorkspaceCapability")
 
 export interface ResolvedAgentFinishExtensionProvider {
   id: string

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -763,10 +763,17 @@ function accessCapabilityRequiresWorkspace(capability: NormalizedCapability): bo
     && (metadata as { workspace?: unknown }).workspace === true
 }
 
+function capabilityWorkspaceIsOptional(capability: NormalizedCapability): boolean {
+  const metadata = capability.metadata
+  return typeof metadata === "object"
+    && metadata !== null
+    && (metadata as { workspaceOptional?: unknown }).workspaceOptional === true
+}
+
 function validateNonWorkspaceCapabilities(capabilities: NormalizedCapability[], hasWorkspace: boolean): void {
   if (hasWorkspace) return
   for (const capability of capabilities) {
-    if (capability.workspace || capability.id === "workspace-shell" || capability.id === "sandbox" || accessCapabilityRequiresWorkspace(capability)) {
+    if (capability.workspace && !capabilityWorkspaceIsOptional(capability) || capability.id === "workspace-shell" || capability.id === "sandbox" || accessCapabilityRequiresWorkspace(capability)) {
       const name = capability.id === "workspace-shell" ? "workspaceShell" : capability.id
       throw new Error(`[vitehub] ${name}() requires an explicit workspace.`)
     }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -20,6 +20,7 @@ import {
   defineCapability,
   normalizeCapabilities,
   normalizeMode,
+  optionalWorkspaceCapabilitySymbol,
   resolveAgentCapabilities,
   resolveStaticCapabilityTools,
   withCapabilityCleanup,
@@ -767,7 +768,7 @@ function capabilityWorkspaceIsOptional(capability: NormalizedCapability): boolea
   const metadata = capability.metadata
   return typeof metadata === "object"
     && metadata !== null
-    && (metadata as { workspaceOptional?: unknown }).workspaceOptional === true
+    && (metadata as { [optionalWorkspaceCapabilitySymbol]?: unknown })[optionalWorkspaceCapabilitySymbol] === true
 }
 
 function validateNonWorkspaceCapabilities(capabilities: NormalizedCapability[], hasWorkspace: boolean): void {

--- a/packages/agent/test/config.test.ts
+++ b/packages/agent/test/config.test.ts
@@ -179,6 +179,32 @@ describe("agent config", () => {
     }
   })
 
+  it("does not let custom capabilities bypass explicit workspace with public metadata", async () => {
+    const { defineAgent, defineCapability } = await import("../src/index.ts")
+
+    expect(() => defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "custom",
+          metadata: { workspaceOptional: true },
+          workspace: {
+            sources: {
+              notes: {
+                async getKeys() {
+                  return []
+                },
+                async getItem(key: string) {
+                  return { content: "", key }
+                },
+              },
+            },
+          },
+        }),
+      ],
+      run: () => "ok",
+    })).toThrow("custom() requires an explicit workspace")
+  })
+
   it("uses the default routes when routes are true", () => {
     expect(normalizeAgentOptions({ routes: { chat: true, webhooks: true } })).toMatchObject({
       routes: {

--- a/packages/agent/test/pull-request-context.test.ts
+++ b/packages/agent/test/pull-request-context.test.ts
@@ -263,6 +263,68 @@ describe("pullRequestContext", () => {
     await expect(resolved.workspace?.fs.readFile("pull-request-context/context.md")).resolves.toContain("Change Request 42 in acme/app.")
   })
 
+  it("grants the default source to an inline Workspace Scope selection", async () => {
+    const { access, pullRequestContext } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            resolve: {
+              paths: ["src"],
+              scope: "review",
+            },
+          },
+        }),
+        pullRequestContext({
+          context: {
+            number: 42,
+            repository: "acme/app",
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    await expect(resolved.workspace?.fs.readFile("pull-request-context/context.md")).resolves.toContain("Change Request 42 in acme/app.")
+  })
+
+  it("rejects custom sources that reuse the default source key", async () => {
+    const { pullRequestContext } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        pullRequestContext({
+          context: {
+            number: 42,
+            repository: "acme/app",
+          },
+          sources: {
+            pullRequestContext: {
+              async getKeys() {
+                return ["context.md"]
+              },
+              async getItem(key: string) {
+                return { content: "replacement", key }
+              },
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow('sources cannot use reserved Workspace Source key "pullRequestContext"')
+  })
+
   it("uses custom capability ids for default source identity", async () => {
     const { pullRequestContext } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")

--- a/packages/agent/test/pull-request-context.test.ts
+++ b/packages/agent/test/pull-request-context.test.ts
@@ -24,7 +24,7 @@ const emptyWorkspace = () => ({
 })
 
 describe("pullRequestContext", () => {
-  it("requires an explicit workspace when contributing sources", async () => {
+  it("requires an explicit workspace when contributing custom sources", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { pullRequestContext } = await import("../src/capabilities.ts")
 
@@ -125,9 +125,47 @@ describe("pullRequestContext", () => {
       {
         capabilityId: "pull-request-context",
         rules: ["artifacts/review/**"],
-        sources: ["pullRequest"],
+        sources: ["pullRequestContext", "pullRequest"],
       },
     ])
+  })
+
+  it("renders pull request context as markdown frontmatter in the workspace", async () => {
+    const { pullRequestContext } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        pullRequestContext({
+          context: {
+            actor: "mona",
+            baseRef: "main",
+            headRef: "feature",
+            number: 42,
+            provider: "github",
+            repository: "acme/app",
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    await expect(resolved.workspace?.fs.readFile("pull-request-context/context.md")).resolves.toContain([
+      "---",
+      'repository: "acme/app"',
+      "number: 42",
+      'provider: "github"',
+      'baseRef: "main"',
+      'headRef: "feature"',
+      'actor: "mona"',
+      "---",
+      "",
+      "# Pull Request Context",
+    ].join("\n"))
   })
 
   it("rejects duplicate pull request context values before resolving trusted context", async () => {

--- a/packages/agent/test/pull-request-context.test.ts
+++ b/packages/agent/test/pull-request-context.test.ts
@@ -166,6 +166,147 @@ describe("pullRequestContext", () => {
       "",
       "# Pull Request Context",
     ].join("\n"))
+    await expect(resolved.workspace?.fs.readFile("pull-request-context/diff.md")).rejects.toThrow("Workspace file does not exist")
+  })
+
+  it("renders built-in GitHub pull request context values", async () => {
+    const { pullRequestContext } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [pullRequestContext()],
+    }, runtime(), {
+      context: {
+        pullRequest: {
+          pullRequest: {
+            apiUrl: "https://api.github.test/repos/acme/app/pulls/42",
+            number: 42,
+            source: {
+              mount: "vitehub",
+              ref: "refs/pull/42/head",
+              repo: "acme/app",
+            },
+          },
+          repository: {
+            fullName: "acme/app",
+            name: "app",
+            owner: "acme",
+          },
+          run: {
+            messageId: "100",
+            origin: "github-pull-request-comment",
+            runId: "delivery-1",
+            threadId: "thread",
+          },
+          trigger: {
+            action: "created",
+            actor: { login: "mona" },
+            args: "",
+            command: "/review",
+            comment: { id: 100 },
+            deliveryId: "delivery-1",
+            event: "issue_comment",
+          },
+        },
+      },
+    }, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    await expect(resolved.workspace?.fs.readFile("pull-request-context/context.md")).resolves.toContain([
+      "---",
+      'repository: "acme/app"',
+      "number: 42",
+      'provider: "github"',
+      'headRef: "refs/pull/42/head"',
+      'actor: "mona"',
+      'deliveryId: "delivery-1"',
+      "---",
+      "",
+      "# Pull Request Context",
+      "",
+      "Change Request 42 in acme/app.",
+    ].join("\n"))
+  })
+
+  it("grants the default source to the selected Workspace Scope", async () => {
+    const { access, pullRequestContext } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "review",
+            scopes: {
+              review: { paths: ["src"] },
+            },
+          },
+        }),
+        pullRequestContext({
+          context: {
+            number: 42,
+            repository: "acme/app",
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    await expect(resolved.workspace?.fs.readFile("pull-request-context/context.md")).resolves.toContain("Change Request 42 in acme/app.")
+  })
+
+  it("uses custom capability ids for default source identity", async () => {
+    const { pullRequestContext } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        pullRequestContext({
+          context: {
+            number: 1,
+            repository: "acme/first",
+          },
+          contextKey: "firstPullRequest",
+          id: "first-pull-request",
+        }),
+        pullRequestContext({
+          context: {
+            number: 2,
+            repository: "acme/second",
+          },
+          contextKey: "secondPullRequest",
+          id: "second-pull-request",
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    await expect(resolved.workspace?.fs.readFile("first-pull-request/context.md")).resolves.toContain("Change Request 1 in acme/first.")
+    await expect(resolved.workspace?.fs.readFile("second-pull-request/context.md")).resolves.toContain("Change Request 2 in acme/second.")
+    expect(resolved.registries.workspaceContributions).toEqual([
+      {
+        capabilityId: "first-pull-request",
+        rules: [],
+        sources: ["first-pull-request-context"],
+      },
+      {
+        capabilityId: "second-pull-request",
+        rules: [],
+        sources: ["second-pull-request-context"],
+      },
+    ])
   })
 
   it("rejects duplicate pull request context values before resolving trusted context", async () => {

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -38,6 +38,7 @@ export {
   isWorkspaceSourceRequestOnly,
   workspaceSourceRequestDescriptorPath,
 } from "./sources/config.ts"
+export { markLiveWorkspaceSource } from "./sources/live.ts"
 export {
   attachWorkspaceSourceRequestExecution,
   getWorkspaceSourceRequestExecution,


### PR DESCRIPTION
Adds a default Pull Request Context Capability Workspace Source that renders the normalized Agent Invocation Context Value as `pull-request-context/context.md` with markdown frontmatter. The source stays provider-free and custom sources/rules continue to merge as Capability Workspace Contributions.

Also keeps context-only usage working without a Workspace, while explicit custom workspace inputs still require one.