### PR TITLE
feat(agent): add web chat route admission

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -68,6 +68,40 @@ export default defineEventHandler(async (event) => {
 
 The `run` fields are first-class Agent Run metadata, not Chat context. They help DevTools, traces, and finish hooks explain where the invocation came from.
 
+## Admit web chat requests
+
+Use `webChat({ route: { admission } })` when an app-owned web chat route needs the common AI SDK UI-message request shape but still owns authentication and product context.
+
+```ts [server/agents/support.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { webChat } from '@vite-hub/agent/channels'
+
+export default defineAgent({
+  channels: {
+    portal: webChat({
+      route: {
+        admission: {
+          authenticate({ rawBody, request }) {
+            verifyPortalSignature(rawBody, request.headers.get('x-portal-signature'))
+            return { customer: request.headers.get('x-customer') }
+          },
+          context({ auth, body }) {
+            return {
+              meta: { ...body.meta, customer: auth.customer },
+              run: { origin: 'portal' },
+              user: body.user,
+            }
+          },
+        },
+      },
+    }),
+  },
+  run: () => 'ok',
+})
+```
+
+ViteHub reads the raw request body once, parses the JSON object, runs `authenticate` with `rawBody`, then validates `admission.body` when a Standard Schema is provided. The `context` callback receives the validated body and returns trusted `chat.message` input fields such as `user`, `meta`, `run`, `session`, or `invoker`.
+
 ## Add identity separately
 
 When the channel handler authenticates a user, pass that identity as the Agent Actor. The current runtime input field is still named `invoker`, so Agents and Capabilities read `context.invoker` until the compatibility API is replaced.

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -21,7 +21,7 @@ import type {
   MaybeResolvable,
   PublishedAgentDeliveryArtifact,
 } from "./types.ts"
-import type { AgentChannelChatRouteHandlerOptions } from "./server.ts"
+import type { AgentChannelChatRouteBody, AgentChannelChatRouteHandlerOptions } from "./server.ts"
 
 export type {
   AgentChannelDeliveryEffectContext,
@@ -50,10 +50,21 @@ export interface AgentChannelOptions<TRuntimeConfig extends AgentRuntimeConfig =
 type AgentChannelDefinitionOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> =
   Omit<AgentChannelDefinition<TRuntimeConfig>, "kind">
 
-export interface AgentStreamChannelOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
+export interface AgentStreamChannelOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody,
+  TAuth = unknown,
+>
   extends AgentChannelOptions<TRuntimeConfig> {
-  route?: true | AgentChannelChatRouteHandlerOptions
+  route?: true | AgentChannelChatRouteHandlerOptions<TBody, TAuth>
 }
+
+export interface AgentWebChatChannelOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody,
+  TAuth = unknown,
+>
+  extends AgentStreamChannelOptions<TRuntimeConfig, TBody, TAuth> {}
 
 export interface AgentDeliveryArtifactPublishInput {
   artifact: AgentDeliveryArtifact
@@ -1073,8 +1084,12 @@ export function teams<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCo
   return defineChannel("teams", options)
 }
 
-export function stream<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
-  options: AgentStreamChannelOptions<TRuntimeConfig> = {},
+export function stream<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody,
+  TAuth = unknown,
+>(
+  options: AgentStreamChannelOptions<TRuntimeConfig, TBody, TAuth> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {
   return defineChannel("stream", {
     ...options,
@@ -1091,8 +1106,12 @@ export function telegram<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntim
   })
 }
 
-export function webChat<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
-  options: AgentChannelOptions<TRuntimeConfig> = {},
+export function webChat<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody,
+  TAuth = unknown,
+>(
+  options: AgentWebChatChannelOptions<TRuntimeConfig, TBody, TAuth> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {
   return defineChannel("web-chat", options)
 }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1,3 +1,4 @@
+import { parseStandardSchema } from "@vite-hub/internal/http-request"
 import { runWithActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { createRuntimeWaitUntilController } from "@vite-hub/runtime"
 import { Chat, StreamingPlan } from "chat"
@@ -82,10 +83,25 @@ export interface AgentChannelChatRouteRequestOptions extends AgentRouteRuntimeOp
   agentName?: string
 }
 
-export interface AgentChannelChatRouteMapInputContext {
+export interface AgentChannelChatRouteStandardSchemaResultSuccess<T = unknown> {
+  issues?: undefined
+  value: T
+}
+
+export interface AgentChannelChatRouteStandardSchemaResultFailure {
+  issues: readonly unknown[]
+}
+
+export interface AgentChannelChatRouteStandardSchemaV1<T = unknown> {
+  "~standard": {
+    validate: (input: unknown) => AgentChannelChatRouteStandardSchemaResultSuccess<T> | AgentChannelChatRouteStandardSchemaResultFailure | Promise<AgentChannelChatRouteStandardSchemaResultSuccess<T> | AgentChannelChatRouteStandardSchemaResultFailure>
+  }
+}
+
+export interface AgentChannelChatRouteAdmissionContext<TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody> {
   agentName: string
-  body: AgentChannelChatRouteBody
-  input: AgentChatMessageTriggerInput
+  body: TBody
+  rawBody: string
   request: Request
 }
 
@@ -93,9 +109,25 @@ type AgentChannelChatRouteInputPatch = Omit<Partial<AgentChatMessageTriggerInput
   run?: Partial<AgentRunMetadata>
 }
 
-export interface AgentChannelChatRouteHandlerOptions {
+export interface AgentChannelChatRouteContext<TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody, TAuth = unknown>
+  extends AgentChannelChatRouteAdmissionContext<TBody> {
+  auth: Exclude<TAuth, false>
+  input: AgentChatMessageTriggerInput
+}
+
+export interface AgentChannelChatRouteMapInputContext<TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody, TAuth = unknown>
+  extends AgentChannelChatRouteContext<TBody, TAuth> {}
+
+export interface AgentChannelChatRouteAdmissionOptions<TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody, TAuth = unknown> {
+  authenticate?: (context: AgentChannelChatRouteAdmissionContext) => MaybePromise<TAuth | false>
+  body?: AgentChannelChatRouteStandardSchemaV1<TBody>
+  context?: (context: AgentChannelChatRouteContext<TBody, TAuth>) => MaybePromise<AgentChannelChatRouteInputPatch | undefined | void>
+}
+
+export interface AgentChannelChatRouteHandlerOptions<TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody, TAuth = unknown> {
+  admission?: AgentChannelChatRouteAdmissionOptions<TBody, TAuth>
   channelId?: string
-  mapInput?: (context: AgentChannelChatRouteMapInputContext) => MaybePromise<AgentChannelChatRouteInputPatch | undefined | void>
+  mapInput?: (context: AgentChannelChatRouteMapInputContext<TBody, TAuth>) => MaybePromise<AgentChannelChatRouteInputPatch | undefined | void>
   origin?: string
 }
 
@@ -121,8 +153,12 @@ interface ChatTypingRefresh {
   stop(): void
 }
 
+function createRouteError(statusCode: number, message: string): Error & { status?: number, statusCode?: number } {
+  return Object.assign(new Error(message), { status: statusCode, statusCode })
+}
+
 function createRouteBodyError(message: string): Error & { status?: number, statusCode?: number } {
-  return Object.assign(new Error(message), { status: 400, statusCode: 400 })
+  return createRouteError(400, message)
 }
 
 function firstString(...values: unknown[]): string | undefined {
@@ -1448,17 +1484,30 @@ function createHttpChatRunMetadata(
   }
 }
 
-async function parseAgentChannelChatRouteBody(request: Request): Promise<AgentChannelChatRouteBody> {
+async function parseAgentChannelChatRouteBody(request: Request): Promise<{ body: AgentChannelChatRouteBody, rawBody: string }> {
   const raw = await request.text()
   if (!raw.trim()) throw createRouteBodyError("Missing agent chat payload.")
   try {
     const body = JSON.parse(raw) as AgentChannelChatRouteBody
     if (!isRecord(body)) throw createRouteBodyError("Agent chat payload must be a JSON object.")
-    return body
+    return { body, rawBody: raw }
   }
   catch (error) {
     if (error instanceof Error && "statusCode" in error) throw error
     throw createRouteBodyError("Malformed agent chat payload.")
+  }
+}
+
+async function parseAgentChannelChatRouteAdmissionBody<TBody extends AgentChannelChatRouteBody>(
+  body: AgentChannelChatRouteBody,
+  schema: AgentChannelChatRouteStandardSchemaV1<TBody> | undefined,
+): Promise<TBody> {
+  if (!schema) return body as TBody
+  try {
+    return await parseStandardSchema(schema, body, "agent chat route body")
+  }
+  catch (error) {
+    throw createRouteBodyError(error instanceof Error ? error.message : "Invalid agent chat route body.")
   }
 }
 
@@ -1534,6 +1583,7 @@ function resolveAgentChannelChatRouteHandlerOptions(
   return {
     ...channelOptions,
     ...options,
+    admission: options.admission ?? channelOptions?.admission,
     mapInput: options.mapInput ?? channelOptions?.mapInput,
   }
 }
@@ -1936,18 +1986,26 @@ export function createChannelChatRouteHandler(
     }
 
     try {
-      const body = await parseAgentChannelChatRouteBody(request)
+      const parsed = await parseAgentChannelChatRouteBody(request)
       const agentName = handlerOptions.agentName || "agent"
+      const auth = await routeOptions.admission?.authenticate?.({ agentName, body: parsed.body, rawBody: parsed.rawBody, request })
+      if (auth === false) throw createRouteError(401, "Agent chat route request was not admitted.")
+      const body = await parseAgentChannelChatRouteAdmissionBody(parsed.body, routeOptions.admission?.body)
       const context = createRuntimeContext(
         request,
         undefined,
         await resolveRuntimeWaitUntil(handlerOptions.waitUntil),
         handlerOptions.cloudflare,
       )
-      const baseInput = agentChannelChatRouteInput(body, agentName, Boolean(routeOptions.mapInput), routeOptions)
-      const triggerInput = mergeAgentChannelChatRouteInput(
+      const baseInput = agentChannelChatRouteInput(body, agentName, Boolean(routeOptions.admission?.context || routeOptions.mapInput), routeOptions)
+      const inputContext = { agentName, auth: auth as never, body, input: baseInput, rawBody: parsed.rawBody, request }
+      const admittedInput = mergeAgentChannelChatRouteInput(
         baseInput,
-        await routeOptions.mapInput?.({ agentName, body, input: baseInput, request }),
+        await routeOptions.admission?.context?.(inputContext),
+      )
+      const triggerInput = mergeAgentChannelChatRouteInput(
+        admittedInput,
+        await routeOptions.mapInput?.({ ...inputContext, input: admittedInput }),
       )
       const result = await runWithRuntimeCloudflareEnv(context, async () => await streamAgentTrigger(agent as never, context as never, "chat.message", triggerInput, {
         output: "ui-message-stream",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path"
 import { Message } from "chat"
 import { describe, expect, it, vi } from "vitest"
 
+import type { AgentChannelChatRouteStandardSchemaV1 } from "../src/server.ts"
 import type { Adapter, ChatInstance, StreamChunk, WebhookOptions } from "chat"
 
 vi.mock("@vite-hub/internal/build/vercel-runtime-packages", () => ({
@@ -983,6 +984,131 @@ describe("server helpers", () => {
     expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
     await expect(response.text()).resolves.toContain("portal portal portal portal:portal-thread customer:acme user@example.com technical")
     expect(run).toHaveBeenCalled()
+  })
+
+  it("serves webChat routes with admission callbacks", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { webChat } = await import("../src/channels.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    type PortalBody = {
+      id?: string
+      messages: unknown[]
+      meta: Record<string, unknown>
+      user: Record<string, unknown>
+    }
+    const bodySchema: AgentChannelChatRouteStandardSchemaV1<PortalBody> = {
+      "~standard": {
+        validate(input: unknown) {
+          const body = input as PortalBody
+          if (!Array.isArray(body.messages)) return { issues: ["messages must be an array"] }
+          return { value: body }
+        },
+      },
+    }
+    const authenticate = vi.fn(({ rawBody, request }) => {
+      expect(rawBody.length).toBeGreaterThan(0)
+      return request.headers.get("x-quiver-chat-token") === "trusted"
+        ? { invokerProfileId: "customer:acme" }
+        : false
+    })
+    const run = vi.fn(({ context, invoker, run }) => {
+      const chatContext = context.get("chat") as { meta?: { audience?: string, customer?: string }, user?: { email?: string } } | undefined
+      return `web ${run.channelId} ${run.origin} ${run.threadId} ${invoker.id} ${chatContext?.user?.email} ${chatContext?.meta?.customer} ${chatContext?.meta?.audience}`
+    })
+    const handler = createChannelChatRouteHandler(defineAgent({
+      channels: {
+        portal: webChat({
+          route: {
+            admission: {
+              body: bodySchema,
+              authenticate,
+              context({ auth, body }) {
+                return {
+                  invokerProfileId: auth.invokerProfileId,
+                  meta: body.meta,
+                  run: { origin: "portal" },
+                  user: body.user,
+                }
+              },
+            },
+          },
+        }),
+      },
+      invoker: {
+        profiles: [{
+          id: "customer:acme",
+          kind: "customerPortal",
+          meta: { scope: "acme" },
+        }],
+      },
+      run,
+    }) as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        id: "portal-thread",
+        messages: [{
+          id: "user-1",
+          parts: [{ text: "hello", type: "text" }],
+          role: "user",
+        }],
+        meta: { audience: "technical", customer: "acme", source: "portal" },
+        user: { email: "user@example.com" },
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-quiver-chat-token": "trusted",
+      },
+      method: "POST",
+    }), { agentName: "support" })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
+    await expect(response.text()).resolves.toContain("web portal portal portal:portal-thread customer:acme user@example.com acme technical")
+    expect(run).toHaveBeenCalled()
+    authenticate.mockClear()
+
+    const malformedResponse = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        id: "portal-thread",
+        messages: "bad",
+        meta: {},
+        user: {},
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-quiver-chat-token": "trusted",
+      },
+      method: "POST",
+    }), { agentName: "support" })
+
+    expect(malformedResponse.status).toBe(400)
+    expect(authenticate).toHaveBeenCalledWith(expect.objectContaining({
+      rawBody: expect.stringContaining("portal-thread"),
+    }))
+    authenticate.mockClear()
+
+    const rejectedResponse = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        messages: [{
+          id: "user-1",
+          parts: [{ text: "hello", type: "text" }],
+          role: "user",
+        }],
+        meta: {},
+        user: {},
+      }),
+      headers: { "x-quiver-chat-token": "nope" },
+      method: "POST",
+    }), { agentName: "support" })
+
+    expect(rejectedResponse.status).toBe(401)
+    await expect(rejectedResponse.json()).resolves.toMatchObject({
+      error: "Agent chat route request was not admitted.",
+    })
+    expect(authenticate).toHaveBeenCalledWith(expect.objectContaining({
+      rawBody: expect.stringContaining("hello"),
+    }))
   })
 
   it("returns a validation error for malformed AI SDK chat requests", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -616,7 +616,36 @@ describe("agent public types", () => {
             },
           },
         }),
-        web: webChat(),
+        web: webChat({
+          route: {
+            admission: {
+              body: {
+                "~standard": {
+                  validate: (input: unknown) => ({
+                    value: input as { messages: unknown[], meta: { customer: string }, user: { email: string } },
+                  }),
+                },
+              },
+              authenticate({ body, rawBody, request }) {
+                expectTypeOf(body.messages).toEqualTypeOf<unknown>()
+                expectTypeOf(rawBody).toEqualTypeOf<string>()
+                expectTypeOf(request).toEqualTypeOf<Request>()
+                return { invokerProfileId: "customer:acme" }
+              },
+              context({ auth, body, rawBody }) {
+                expectTypeOf(auth.invokerProfileId).toEqualTypeOf<string>()
+                expectTypeOf(body.meta.customer).toEqualTypeOf<string>()
+                expectTypeOf(body.user.email).toEqualTypeOf<string>()
+                expectTypeOf(rawBody).toEqualTypeOf<string>()
+                return {
+                  invokerProfileId: auth.invokerProfileId,
+                  meta: body.meta,
+                  user: body.user,
+                }
+              },
+            },
+          },
+        }),
       },
       hooks: {
         "hook:observe"(event) {


### PR DESCRIPTION
Adds `webChat({ route: { admission } })` for app-owned web chat routes so ViteHub owns JSON parsing, optional Standard Schema body validation, trusted context placement, and `chat.message` streaming while apps keep authentication and domain context callbacks.

`authenticate` receives the parsed request object plus `rawBody` before schema validation, so header-token and signature-style admission can share the same small web-chat contract without turning this into a generic webhook framework. `mapInput` remains available as the lower-level escape hatch.