### PR TITLE
feat(agent): randomize chat fallback placeholders

### DIFF
--- a/docs/content/docs/capabilities/chat.md
+++ b/docs/content/docs/capabilities/chat.md
@@ -76,7 +76,7 @@ When adapters are configured, inspect generated webhook registrations for the ex
 | `stream` | `boolean` | inherited | Whether the chat trigger should stream output. |
 | `concurrency` | `"drop" \| "parallel" \| "queue" \| "reject" \| string` | inherited | Message concurrency behavior. |
 | `lockScope` | `"agent" \| "channel" \| "thread" \| string` | inherited | Scope used for message locks. |
-| `fallbackStreamingPlaceholderText` | `string \| null \| function` | inherited | Placeholder text while streaming starts. |
+| `fallbackStreamingPlaceholderText` | `string \| string[] \| null \| function` | inherited | Placeholder text while streaming starts. Arrays pick one entry per Agent Invocation; empty arrays skip the placeholder. |
 | `errorFallbackText` | `string \| null \| function` | inherited | Fallback message when chat handling fails. |
 
 ## Reference

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -111,6 +111,10 @@ async function resolveChatThinkingFallback<TRuntimeConfig extends AgentRuntimeCo
     if (resolved === null) return null
     return typeof resolved === "string" ? resolved : undefined
   }
+  if (Array.isArray(fallback)) {
+    if (fallback.length === 0) return null
+    return fallback[Math.floor(Math.random() * fallback.length)]
+  }
   if (typeof fallback === "string") return fallback
   return undefined
 }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -557,6 +557,28 @@ function chatStreamPostable(thread: Thread, response: ChatTextStream): ChatTextS
     : response
 }
 
+async function postChatStream(
+  thread: Thread,
+  response: ChatTextStream,
+  fallback: string | null | undefined,
+): Promise<void> {
+  if (fallback === undefined) {
+    await thread.post(chatStreamPostable(thread, response) as never)
+    return
+  }
+
+  // ponytail: Chat SDK has no per-stream fallback option; replace this when it exposes one.
+  const chatThread = thread as Thread & { _fallbackStreamingPlaceholderText?: string | null }
+  const previous = chatThread._fallbackStreamingPlaceholderText
+  chatThread._fallbackStreamingPlaceholderText = fallback
+  try {
+    await thread.post(chatStreamPostable(thread, response) as never)
+  }
+  finally {
+    chatThread._fallbackStreamingPlaceholderText = previous
+  }
+}
+
 function randomToken(): string {
   return globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
@@ -1088,8 +1110,13 @@ async function handleChatSdkMessage(
         output: "events",
       })
       const response = streamAgentOutputToChatText(result)
+      const thinkingFallback = invocation.metadata?.thinkingFallback
       try {
-        await thread.post(chatStreamPostable(thread, response) as never)
+        await postChatStream(
+          thread,
+          response,
+          typeof thinkingFallback === "string" || thinkingFallback === null ? thinkingFallback : undefined,
+        )
       }
       finally {
         typing?.stop()

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1142,7 +1142,7 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
   concurrency?: AgentMessageConcurrency
   dedupeTtlMs?: number
   errorFallbackText?: string | null | ((context: AgentChatErrorHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
-  fallbackStreamingPlaceholderText?: string | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
+  fallbackStreamingPlaceholderText?: string | readonly string[] | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   history?: AgentChatAgentBindingOptions["history"]
   identity?: IdentityResolver
   lockScope?: AgentMessageLockScope

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2149,12 +2149,12 @@ describe("server helpers", () => {
 
       const responsePromise = handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
         body: JSON.stringify({
-          update_id: 1046,
+          update_id: 1048,
           message: {
             chat: { id: 456, type: "private" },
             date: 1781092800,
             from: { first_name: "Maxi", id: 123, username: "maxi" },
-            message_id: 1046,
+            message_id: 1048,
             text: "hello",
           },
         }),

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2112,6 +2112,72 @@ describe("server helpers", () => {
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "done" })
   })
 
+  it("posts a random chat fallback option while streamed webhook work is still running", async () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.75)
+    try {
+      const { defineAgent } = await import("../src/index.ts")
+      const { chat } = await import("../src/capabilities.ts")
+      const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+      const adapter = createTestChatAdapter()
+      let runStarted!: () => void
+      let finishRun!: () => void
+      const runStartedPromise = new Promise<void>(resolve => {
+        runStarted = resolve
+      })
+      const finishRunPromise = new Promise<void>(resolve => {
+        finishRun = resolve
+      })
+      const agent = defineAgent({
+        capabilities: [
+          chat({
+            platforms: {
+              telegram: () => adapter as never,
+            },
+            fallbackStreamingPlaceholderText: ["Working on it...", "Checking context..."],
+            webhooks: {
+              telegram: {},
+            },
+          }),
+        ],
+        run: async () => {
+          runStarted()
+          await finishRunPromise
+          return "done"
+        },
+      })
+      const handler = createChannelWebhookRouteHandler(agent as never)
+
+      const responsePromise = handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+        body: JSON.stringify({
+          update_id: 1046,
+          message: {
+            chat: { id: 456, type: "private" },
+            date: 1781092800,
+            from: { first_name: "Maxi", id: 123, username: "maxi" },
+            message_id: 1046,
+            text: "hello",
+          },
+        }),
+        method: "POST",
+      }), "telegram")
+
+      await runStartedPromise
+      await Promise.resolve()
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Checking context...")
+      expect(adapter.editMessage).not.toHaveBeenCalled()
+
+      finishRun()
+      const response = await responsePromise
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ ok: true })
+      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "done" })
+    }
+    finally {
+      random.mockRestore()
+    }
+  })
+
   it("activates Cloudflare env while webhook work runs", async () => {
     const { getActiveCloudflareEnv } = await import("@vite-hub/internal/runtime/cloudflare-env")
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5066,6 +5066,25 @@ describe("agent message protocol", () => {
     expect(invocation.metadata).toEqual({ thinkingFallback: null })
   })
 
+  it("disables chat thinking fallback metadata for empty placeholder arrays", async () => {
+    const { defineAgent, resolveAgentTriggerInvocation } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [chat({ fallbackStreamingPlaceholderText: [] })],
+      run: () => "ok",
+    })
+
+    const invocation = await resolveAgentTriggerInvocation(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, "chat.message", {
+      messages: [createMessage({ role: "user", text: "hello" })],
+    })
+
+    if ("response" in invocation) throw new Error("Expected chat trigger invocation input.")
+    expect(invocation.metadata).toEqual({ thinkingFallback: null })
+  })
+
   it("converts async stream events to AI SDK UI message streams", async () => {
     const { readUIMessageStream } = await import("ai")
     const { defineAgent, streamAgent } = await import("../src/index.ts")

--- a/playground/vite/server/agents/devtools-demo.ts
+++ b/playground/vite/server/agents/devtools-demo.ts
@@ -110,7 +110,7 @@ export default defineAgent({
   capabilities: [
     chat({
       concurrency: "queue",
-      fallbackStreamingPlaceholderText: "Thinking...",
+      fallbackStreamingPlaceholderText: ["Thinking...", "Reading the workspace...", "Checking the run context..."],
       history: { maxMessages: 8, source: "thread" },
     }),
     transcribe({


### PR DESCRIPTION
Allows `fallbackStreamingPlaceholderText` to take an array and resolves one entry per Agent Invocation, so chat adapters can reuse ViteHub's fallback behavior without app-local randomizer callbacks.

Empty arrays disable the placeholder, while existing string, function, and `null` behavior stays intact. The demo and chat capability docs now show the array form.