### PR TITLE
feat(agent)!: trust channel route metadata after admission

### DIFF
--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -305,6 +305,8 @@ _Avoid_: Fake agent, dummy model, test bot
 - Channel webhook delivery can use generated Agent Package **Agent Webhook Routes** without making non-chat Channels message-shaped or Chat Platform Adapters.
 - A **Channel** can resolve an **Agent Actor**, but it does not own identity; Auth, trusted app routing, subagents, schedules, or fallback runtime behavior may also seed the Agent Actor.
 - **Channel Delivery Admission** belongs to the **Channel** because protocol-level delivery acceptance, rejection, and retry semantics are owned by the external surface that triggered the Agent Invocation.
+- A generated message-shaped **Channel** route may copy request body `meta`, `user`, or `session` into `chat.message` input only when **Channel Delivery Admission** authenticates the request and explicitly trusts those fields.
+- Server-derived **Channel Delivery Admission** context runs after trusted request input so it can enrich or override client-provided message context before the **Agent Trigger** starts.
 - **Channel Delivery Effects** belong to the **Channel** because they communicate delivery progress or state back on the same external surface that triggered the Agent Invocation.
 - **Channel Delivery Effects** may use generic effect kinds such as reactions, replies, or statuses; platform-prefixed names belong to Channel implementation details or examples, not the shared effect vocabulary.
 - A Capability may contribute a **Channel Delivery Effect Intent** for the current delivery, but the active **Channel** owns whether and how that intent becomes a **Channel Delivery Effect**.

--- a/.agents/contexts/packages/agent/CONTEXT.md
+++ b/.agents/contexts/packages/agent/CONTEXT.md
@@ -140,6 +140,8 @@ _Avoid_: Root Agent Package export, Capability factory export, Chat Adapter Faca
 - An **Agent Trigger Consumer** uses the **Agent Trigger API** and does not create a parallel chat-specific behavior surface.
 - An **Agent Trigger Consumer** may pass a trusted Agent Actor through trigger input when it has already authenticated or resolved caller identity; trigger metadata should not become a parallel identity or command-admission boundary.
 - Message-shaped Agent Trigger input may pass Agent Run metadata for invocation provenance, but the Agent Package should not copy that metadata into public Chat context.
+- Generated Channel route handlers are internal Agent Package infrastructure; public code configures them through Channel definitions rather than importing handler factories.
+- Generated message-shaped Channel routes should reject client-supplied identity, Agent Run metadata, and Chat Session fields unless Channel route admission authenticates the request and explicitly trusts that field.
 - The Agent Invocation Stream Endpoint consumes **Agent Dev Loop Payload Loading** by passing payload files to the selected Agent Trigger before any Agent Invocation is streamed.
 - The Agent Package should not put development-only sample payloads on the public Agent Definition shape.
 - A **Channel** may be implemented by an **Agent Trigger Consumer**, but Channel is the framework term for Agent reachability.

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -1,6 +1,6 @@
 ---
 title: Channels
-description: Keep message origins, delivery facts, Agent Actors, and input commands separate.
+description: Keep invocation origins, delivery facts, Agent Actors, and input commands separate.
 navigation.order: 25
 icon: i-lucide-radio
 ---
@@ -39,7 +39,7 @@ This split keeps shared channels from becoming implicit access roles. A Teams ch
 
 ## Message-shaped input
 
-Chat and channel surfaces usually start Agents with `messages`. The Chat Capability registers the `chat.message` Agent Trigger and translates UI-message-like input into Agent messages.
+Message-shaped Channels usually start Agents with `messages`. The `chat.message` Agent Trigger maps UI-message-like input into Agent messages; chat history and sessions stay in message Channel settings rather than route admission.
 
 ```ts [server/api/support-chat.post.ts]
 import { streamAgentTrigger } from '@vite-hub/agent'

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -70,7 +70,7 @@ The `run` fields are first-class Agent Run metadata, not Chat context. They help
 
 ## Admit web chat requests
 
-Use `webChat({ route: { admission } })` when an app-owned web chat route needs the common AI SDK UI-message request shape but still owns authentication and product context.
+Use `webChat({ route })` when an app-owned web chat route needs the common AI SDK UI-message request shape but still owns authentication and product context.
 
 ```ts [server/agents/support.ts]
 import { defineAgent } from '@vite-hub/agent'
@@ -85,13 +85,9 @@ export default defineAgent({
             verifyPortalSignature(rawBody, request.headers.get('x-portal-signature'))
             return { customer: request.headers.get('x-customer') }
           },
-          context({ auth, body }) {
-            return {
-              meta: { ...body.meta, customer: auth.customer },
-              run: { origin: 'portal' },
-              user: body.user,
-            }
-          },
+        },
+        input: {
+          trust: ['meta', 'user', 'session'],
         },
       },
     }),
@@ -100,7 +96,7 @@ export default defineAgent({
 })
 ```
 
-ViteHub reads the raw request body once, parses the JSON object, runs `authenticate` with `rawBody`, then validates `admission.body` when a Standard Schema is provided. The `context` callback receives the validated body and returns trusted `chat.message` input fields such as `user`, `meta`, `run`, `session`, or `invoker`.
+ViteHub reads the raw request body once, parses the JSON object, runs `authenticate` with `rawBody`, then validates `admission.body` when a Standard Schema is provided. `input.trust` lists request body fields that may be copied after authentication. Use `admission.context` only when the route needs to derive or validate different `chat.message` input.
 
 ## Add identity separately
 

--- a/docs/content/docs/agents/triggers.md
+++ b/docs/content/docs/agents/triggers.md
@@ -51,7 +51,7 @@ export default defineAgent({
 })
 ```
 
-The Chat Capability owns Chat History behavior, optional Chat Platform Adapter webhooks, and the `chat.message` trigger. The Agent Definition still owns the active Agent Driver.
+The Chat Capability owns Chat History behavior and the `chat.message` trigger. Message-shaped Channels own delivery and webhook admission; the Agent Definition still owns the active Agent Driver.
 
 ## Consume a trigger from an app route
 

--- a/docs/content/docs/capabilities/chat.md
+++ b/docs/content/docs/capabilities/chat.md
@@ -8,7 +8,7 @@ icon: i-lucide-messages-square
 ---
 
 `chat()` adds chat-oriented runtime behavior to an Agent Definition.
-It contributes a `chat.message` Agent Trigger, optional Chat Platform Adapter webhooks, Chat History state requirements, and a chat finish extension.
+It contributes a `chat.message` Agent Trigger, Chat History state requirements, and a chat finish extension.
 
 ## Installation
 
@@ -18,7 +18,7 @@ Use the configuration example below as the starting point, then tighten modes, p
 ## What it adds
 
 The Chat Capability turns message-shaped input into Agent Invocations and exposes the trigger to DevTools.
-When adapters are configured, the Agent Package can infer Chat Webhook Routes for supported platform events.
+Message-shaped Channels own route admission and delivery into that trigger.
 
 ## Configuration
 

--- a/docs/content/docs/concepts/channels-api.md
+++ b/docs/content/docs/concepts/channels-api.md
@@ -1,19 +1,19 @@
 ---
 title: Channels API
-description: Understand message-shaped Agent Invocations, channel metadata, Chat Capability behavior, and host-owned commands.
+description: Understand message-shaped Agent Invocations, Channel metadata, chat state, and host-owned commands.
 navigation.order: 9
 icon: i-lucide-message-square
 ---
 
-The Channels API names message-shaped reachability without turning delivery metadata into trusted identity. It keeps channel facts, message input, Chat Capability behavior, and host-owned commands separate.
+The Channels API names message-shaped reachability without turning delivery metadata into trusted identity. It keeps Channel facts, message input, chat state, and host-owned commands separate.
 
 Message-shaped input is one way to start an Agent Invocation. ViteHub keeps it separate from the Agent itself: an Agent can receive plain prompts, structured input, or messages depending on the trigger and Capability behavior.
 
-The broader Channel language is still narrow in the current package surface. Today, `channelId` is Agent Run metadata supplied by a host or adapter, while the Chat Capability owns the `chat.message` trigger and Chat History behavior.
+Channel definitions own invocation reachability, route admission, and delivery facts. Chat state owns conversation history and session selection. The `chat.message` trigger is the shared message-shaped entry point that both generated Channel routes and app-owned trigger consumers can use.
 
-## Chat Capability
+## Message-shaped invocation
 
-The Chat Capability gives an Agent chat-oriented runtime behavior. It can contribute the `chat.message` Agent Trigger, Chat History handling, Chat Session selection, Chat Platform Adapter webhooks, and chat-derived Agent Invoker defaults.
+Generated routes should be configured on Channel definitions, such as `webChat({ route })` or `defineChannel(kind, { route })`. Application code should not import generated route handler factories.
 
 Application routes can consume the same trigger directly when the app owns the chat UI.
 
@@ -38,7 +38,7 @@ export default defineEventHandler(async (event) => {
 
 | Concept | Meaning |
 | --- | --- |
-| Channel | Host-provided origin and delivery context, such as an app chat, GitHub thread, or external platform conversation. |
+| Channel | Host or integration entry surface with origin, admission, and delivery facts, such as an app chat, GitHub thread, or external platform conversation. |
 | Agent Invocation | One runtime request to an Agent. It may or may not be message-shaped. |
 | Message | A normalized chat-style record with a role and parts such as text, tool calls, approvals, data, audio, sources, or errors. |
 | Chat History | Ordered conversational messages for one chat interaction. |
@@ -54,7 +54,7 @@ For example, a summary command can be an Input Command when it produces Agent ru
 
 ## Inspect it
 
-Inspect the trigger id, normalized messages, and Agent Run metadata. DevTools can show message-shaped runs for chat-capable Agents, while server routes can log the exact trigger input they pass to `runAgentTrigger()`.
+Inspect the trigger id, normalized messages, and Agent Run metadata. DevTools can show message-shaped runs for Agents with message-shaped Channels, while server routes can log the exact trigger input they pass to `runAgentTrigger()`.
 
 ## Next steps
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -97,6 +97,10 @@
       "types": "./dist/server.d.ts",
       "import": "./dist/server.js"
     },
+    "./server/internal": {
+      "types": "./dist/server/internal.d.ts",
+      "import": "./dist/server/internal.js"
+    },
     "./server/workspace": {
       "types": "./dist/server/workspace.d.ts",
       "import": "./dist/server/workspace.js"

--- a/packages/agent/src/server/internal.ts
+++ b/packages/agent/src/server/internal.ts
@@ -1,3 +1,9 @@
+export {
+  createChannelChatRouteHandler,
+  createChannelDevtoolsRouteHandler,
+  createChannelWebhookRouteHandler,
+} from "./routes.ts"
+
 export type {
   AgentChannelChatRouteAdmissionContext,
   AgentChannelChatRouteAdmissionOptions,
@@ -14,4 +20,4 @@ export type {
   AgentChannelDevtoolsRouteHandlerOptions,
   AgentChannelDevtoolsRouteRequestOptions,
   AgentChannelWebhookRouteOptions,
-} from "./server/routes.ts"
+} from "./routes.ts"

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2022,18 +2022,18 @@ export function createChannelChatRouteHandler(
       )
       const trustInput = Boolean(routeOptions.admission?.authenticate && routeOptions.input?.trust?.length)
       const baseInput = agentChannelChatRouteInput(body, agentName, Boolean(trustInput || routeOptions.admission?.context || routeOptions.mapInput), routeOptions)
-      const inputContext = { agentName, auth: auth as never, body, input: baseInput, rawBody: parsed.rawBody, request }
-      const admittedInput = mergeAgentChannelChatRouteInput(
-        baseInput,
-        await routeOptions.admission?.context?.(inputContext),
-      )
       const trustedInput = mergeAgentChannelChatRouteInput(
-        admittedInput,
+        baseInput,
         trustInput ? trustAgentChannelChatRouteInput(body, routeOptions.input) : undefined,
       )
-      const triggerInput = mergeAgentChannelChatRouteInput(
+      const inputContext = { agentName, auth: auth as never, body, input: trustedInput, rawBody: parsed.rawBody, request }
+      const admittedInput = mergeAgentChannelChatRouteInput(
         trustedInput,
-        await routeOptions.mapInput?.({ ...inputContext, input: trustedInput }),
+        await routeOptions.admission?.context?.(inputContext),
+      )
+      const triggerInput = mergeAgentChannelChatRouteInput(
+        admittedInput,
+        await routeOptions.mapInput?.({ ...inputContext, input: admittedInput }),
       )
       const result = await runWithRuntimeCloudflareEnv(context, async () => await streamAgentTrigger(agent as never, context as never, "chat.message", triggerInput, {
         output: "ui-message-stream",

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -109,6 +109,11 @@ type AgentChannelChatRouteInputPatch = Omit<Partial<AgentChatMessageTriggerInput
   run?: Partial<AgentRunMetadata>
 }
 
+export type AgentChannelChatRouteTrustedInputField =
+  | "meta"
+  | "session"
+  | "user"
+
 export interface AgentChannelChatRouteContext<TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody, TAuth = unknown>
   extends AgentChannelChatRouteAdmissionContext<TBody> {
   auth: Exclude<TAuth, false>
@@ -124,9 +129,14 @@ export interface AgentChannelChatRouteAdmissionOptions<TBody extends AgentChanne
   context?: (context: AgentChannelChatRouteContext<TBody, TAuth>) => MaybePromise<AgentChannelChatRouteInputPatch | undefined | void>
 }
 
+export interface AgentChannelChatRouteInputOptions {
+  trust?: readonly AgentChannelChatRouteTrustedInputField[]
+}
+
 export interface AgentChannelChatRouteHandlerOptions<TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody, TAuth = unknown> {
   admission?: AgentChannelChatRouteAdmissionOptions<TBody, TAuth>
   channelId?: string
+  input?: AgentChannelChatRouteInputOptions
   mapInput?: (context: AgentChannelChatRouteMapInputContext<TBody, TAuth>) => MaybePromise<AgentChannelChatRouteInputPatch | undefined | void>
   origin?: string
 }
@@ -1533,7 +1543,7 @@ function agentChannelChatRouteInput(
   if (!Array.isArray(body.messages)) {
     throw createRouteBodyError("Agent chat payload requires a messages array.")
   }
-  if (!allowTrustedInput && ("invoker" in body || "invokerProfileId" in body || "meta" in body || "run" in body || "user" in body)) {
+  if (!allowTrustedInput && ("invoker" in body || "invokerProfileId" in body || "meta" in body || "run" in body || "session" in body || "user" in body)) {
     throw createRouteBodyError("Agent chat route identity must be derived server-side with defineAgent({ invoker }).")
   }
   const messages = body.messages as UIMessage[]
@@ -1584,8 +1594,23 @@ function resolveAgentChannelChatRouteHandlerOptions(
     ...channelOptions,
     ...options,
     admission: options.admission ?? channelOptions?.admission,
+    input: options.input ?? channelOptions?.input,
     mapInput: options.mapInput ?? channelOptions?.mapInput,
   }
+}
+
+function trustAgentChannelChatRouteInput(
+  body: AgentChannelChatRouteBody,
+  options: AgentChannelChatRouteInputOptions | undefined,
+): AgentChannelChatRouteInputPatch | undefined {
+  if (!options?.trust?.length) return undefined
+  const patch: AgentChannelChatRouteInputPatch = {}
+  for (const field of options.trust) {
+    if (field === "meta" && body.meta !== undefined) patch.meta = optionalBodyRecord(body.meta, "meta")
+    else if (field === "session" && body.session !== undefined) patch.session = optionalBodyRecord(body.session, "session") as AgentChatMessageTriggerInput["session"]
+    else if (field === "user" && body.user !== undefined) patch.user = optionalBodyRecord(body.user, "user")
+  }
+  return Object.keys(patch).length ? patch : undefined
 }
 
 function mergeAgentChannelChatRouteInput(
@@ -1997,15 +2022,20 @@ export function createChannelChatRouteHandler(
         await resolveRuntimeWaitUntil(handlerOptions.waitUntil),
         handlerOptions.cloudflare,
       )
-      const baseInput = agentChannelChatRouteInput(body, agentName, Boolean(routeOptions.admission?.context || routeOptions.mapInput), routeOptions)
+      const trustInput = Boolean(routeOptions.admission?.authenticate && routeOptions.input?.trust?.length)
+      const baseInput = agentChannelChatRouteInput(body, agentName, Boolean(trustInput || routeOptions.admission?.context || routeOptions.mapInput), routeOptions)
       const inputContext = { agentName, auth: auth as never, body, input: baseInput, rawBody: parsed.rawBody, request }
       const admittedInput = mergeAgentChannelChatRouteInput(
         baseInput,
         await routeOptions.admission?.context?.(inputContext),
       )
-      const triggerInput = mergeAgentChannelChatRouteInput(
+      const trustedInput = mergeAgentChannelChatRouteInput(
         admittedInput,
-        await routeOptions.mapInput?.({ ...inputContext, input: admittedInput }),
+        trustInput ? trustAgentChannelChatRouteInput(body, routeOptions.input) : undefined,
+      )
+      const triggerInput = mergeAgentChannelChatRouteInput(
+        trustedInput,
+        await routeOptions.mapInput?.({ ...inputContext, input: trustedInput }),
       )
       const result = await runWithRuntimeCloudflareEnv(context, async () => await streamAgentTrigger(agent as never, context as never, "chat.message", triggerInput, {
         output: "ui-message-stream",

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1547,12 +1547,10 @@ function agentChannelChatRouteInput(
     throw createRouteBodyError("Agent chat route identity must be derived server-side with defineAgent({ invoker }).")
   }
   const messages = body.messages as UIMessage[]
-  const session = optionalBodyRecord(body.session, "session") as AgentChatMessageTriggerInput["session"] | undefined
   return {
     ...(body.history !== undefined ? { history: body.history } : {}),
     messages,
     run: createHttpChatRunMetadata(agentName, body, messages, options),
-    ...(session ? { session } : {}),
   }
 }
 

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -342,7 +342,7 @@ async function generateAgentWebhookRouteHandler(
   return [
     `import { withAgentDefaults, workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
     ...(options.cloudflareState ? [`import { createCloudflareAgentState } from ${JSON.stringify(subpath(agentImportBase, "cloudflare"))}`] : []),
-    `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server"))}`,
+    `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
     `import { setWorkspaceRuntimeRegistry } from ${JSON.stringify(subpath(workspaceImportBase, "runtime"))}`,
     "import { createError, defineEventHandler, getRequestHeaders, getRequestURL, getRouterParam, readRawBody } from 'h3'",
     imports,
@@ -451,7 +451,7 @@ async function generateAgentNetlifyFunctionRouteHandler(
 
   return [
     `import { withAgentDefaults, workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
-    `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server"))}`,
+    `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
     `import { setWorkspaceRuntimeRegistry } from ${JSON.stringify(subpath(agentImportBase, "server/workspace"))}`,
     imports,
     "",
@@ -566,7 +566,7 @@ async function generateAgentDenoServer(
 
   return [
     `import { withAgentDefaults, workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
-    `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server"))}`,
+    `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
     ...workspaceRuntimeLines.slice(0, 1),
     imports,
     "",

--- a/packages/agent/test/config.test.ts
+++ b/packages/agent/test/config.test.ts
@@ -77,7 +77,7 @@ describe("agent config", () => {
     }
   })
 
-  it("keeps workspace runtime loading out of the Agent server route import", async () => {
+  it("keeps workspace runtime loading out of the internal Agent server route import", async () => {
     vi.resetModules()
     vi.doMock("@vite-hub/workspace", () => {
       throw new Error("workspace should only load when a workspace-backed path is used")
@@ -86,7 +86,10 @@ describe("agent config", () => {
       throw new Error("workspace runtime should only load when workspace registration is used")
     })
     try {
-      const server = await import("../src/server.ts")
+      const publicServer = await import("../src/server.ts")
+      expect(publicServer).not.toHaveProperty("createChannelChatRouteHandler")
+      expect(publicServer).not.toHaveProperty("createChannelWebhookRouteHandler")
+      const server = await import("../src/server/internal.ts")
       expect(server.createChannelChatRouteHandler).toBeTypeOf("function")
       expect(server.createChannelWebhookRouteHandler).toBeTypeOf("function")
     }
@@ -126,7 +129,7 @@ describe("agent config", () => {
     try {
       const { defineAgent } = await import("../src/index.ts")
       const { chat } = await import("../src/capabilities.ts")
-      const { createChannelChatRouteHandler } = await import("../src/server.ts")
+      const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
       const handler = createChannelChatRouteHandler(defineAgent({
         capabilities: [chat()],
         run({ messages }) {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17,6 +17,8 @@ vi.mock("@vite-hub/internal/build/deployment-output", () => ({
   writeProviderDeploymentOutputs: vi.fn(async () => undefined),
 }))
 
+vi.mock("#vitehub/agent/registry", () => ({ default: {} }))
+
 function githubSignature(secret: string, body: string) {
   return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`
 }
@@ -1140,6 +1142,97 @@ describe("server helpers", () => {
       run: () => "unused",
     }) as never)
 
+    const protectedFields = {
+      invoker: { id: "spoofed" },
+      invokerProfileId: "customer:acme",
+      meta: { customer: "acme" },
+      run: { origin: "portal" },
+      session: { id: "portal-session" },
+      user: { id: "spoofed" },
+    }
+
+    for (const [field, value] of Object.entries(protectedFields)) {
+      const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+        body: JSON.stringify({
+          messages: [{
+            id: "user-1",
+            parts: [{ text: "hello", type: "text" }],
+            role: "user",
+          }],
+          [field]: value,
+        }),
+        method: "POST",
+      }))
+
+      expect(response.status).toBe(400)
+      await expect(response.json()).resolves.toMatchObject({
+        error: "Agent chat route identity must be derived server-side with defineAgent({ invoker }).",
+      })
+    }
+  })
+
+  it("copies trusted webChat route input after admission", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { webChat } = await import("../src/channels.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const authenticate = vi.fn(({ request }) => request.headers.get("x-quiver-chat-token") === "trusted" ? true : false)
+    const run = vi.fn(({ context, invoker, run }) => {
+      const chatContext = context.get("chat") as { meta?: { audience?: string }, session?: { id?: string }, user?: { email?: string } } | undefined
+      return `trusted ${run.channelId} ${run.origin} ${run.threadId} ${invoker.id} ${chatContext?.user?.email} ${chatContext?.meta?.audience} ${chatContext?.session?.id}`
+    })
+    const handler = createChannelChatRouteHandler(defineAgent({
+      channels: {
+        portal: webChat({
+          route: {
+            admission: { authenticate },
+            input: { trust: ["meta", "user", "session"] },
+          },
+        }),
+      },
+      run,
+    }) as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        id: "portal-thread",
+        messages: [{
+          id: "user-1",
+          parts: [{ text: "hello", type: "text" }],
+          role: "user",
+        }],
+        meta: { audience: "technical", customer: "acme" },
+        run: { origin: "spoofed" },
+        session: { id: "portal-session" },
+        user: { email: "user@example.com" },
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-quiver-chat-token": "trusted",
+      },
+      method: "POST",
+    }), { agentName: "support" })
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toContain("trusted portal web-chat portal:portal-thread web-chat:user@example.com user@example.com technical portal-session")
+    expect(authenticate).toHaveBeenCalled()
+    expect(run).toHaveBeenCalled()
+  })
+
+  it("does not trust route input without admission authentication", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { webChat } = await import("../src/channels.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const handler = createChannelChatRouteHandler(defineAgent({
+      channels: {
+        portal: webChat({
+          route: {
+            input: { trust: ["meta"] },
+          },
+        }),
+      },
+      run: () => "unused",
+    }) as never)
+
     const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
       body: JSON.stringify({
         messages: [{
@@ -1147,10 +1240,10 @@ describe("server helpers", () => {
           parts: [{ text: "hello", type: "text" }],
           role: "user",
         }],
-        user: { id: "spoofed" },
+        meta: { customer: "acme" },
       }),
       method: "POST",
-    }))
+    }), { agentName: "support" })
 
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toMatchObject({

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -180,7 +180,7 @@ describe("agent Vite plugin", () => {
 
       const wrapper = await readFile(join(root, ".vitehub/agent/netlify-function.mjs"), "utf8")
       expect(wrapper).toContain("export default async function viteHubAgentNetlifyFunction(request, context)")
-      expect(wrapper).toContain("import { createChannelChatRouteHandler, createChannelWebhookRouteHandler } from \"@vite-hub/agent/server\"")
+      expect(wrapper).toContain("import { createChannelChatRouteHandler, createChannelWebhookRouteHandler } from \"@vite-hub/agent/server/internal\"")
       expect(wrapper).toContain("import { setWorkspaceRuntimeRegistry } from \"@vite-hub/agent/server/workspace\"")
       expect(wrapper).not.toContain("@vite-hub/workspace/internal/runtime/state")
       expect(wrapper).toContain("process.env.VITEHUB_HOSTING = 'netlify'")
@@ -512,7 +512,7 @@ describe("agent Vite plugin", () => {
 
       const denoServer = await readFile(join(root, ".vitehub/agent/deno-server.ts"), "utf8")
 
-      expect(denoServer).toContain("import { createChannelChatRouteHandler, createChannelWebhookRouteHandler } from \"@vite-hub/agent/server\"")
+      expect(denoServer).toContain("import { createChannelChatRouteHandler, createChannelWebhookRouteHandler } from \"@vite-hub/agent/server/internal\"")
       expect(denoServer).not.toContain("import { setWorkspaceRuntimeRegistry } from \"@vite-hub/workspace/runtime\"")
       expect(denoServer).toContain("await import('../schedule/deno-cron.mjs').catch")
       expect(denoServer).toContain("const chatRoutePattern = new RegExp(\"^/api/_vitehub/agents/(?<agent>[^/]+)/chat$\")")
@@ -612,6 +612,17 @@ describe("agent Vite plugin", () => {
     expect(pkg.exports?.["./cloudflare/state"]).toEqual({
       types: "./dist/cloudflare/state.d.ts",
       import: "./dist/cloudflare/state.js",
+    })
+  })
+
+  it("publishes the internal generated Agent route handler subpath", async () => {
+    const pkg = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8")) as {
+      exports?: Record<string, unknown>
+    }
+
+    expect(pkg.exports?.["./server/internal"]).toEqual({
+      types: "./dist/server/internal.d.ts",
+      import: "./dist/server/internal.js",
     })
   })
 
@@ -784,7 +795,7 @@ describe("server helpers", () => {
 
   it("serves hosted Chat DevTools state for an explicit agent handler", async () => {
     const { defineAgent, defineAgentInvoker } = await import("../src/index.ts")
-    const { createChannelDevtoolsRouteHandler } = await import("../src/server.ts")
+    const { createChannelDevtoolsRouteHandler } = await import("../src/server/internal.ts")
     const { custom, defineWorkspace } = await import("@vite-hub/workspace")
     const profiles: Array<{ id: string, kind?: string, meta?: Record<string, unknown> }> = [{
       id: "customer:demo:support",
@@ -874,7 +885,7 @@ describe("server helpers", () => {
   it("serves AI SDK UI message chat requests through the chat trigger", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const resolveInvoker = vi.fn(({ defaultInvoker, request }) => ({
       id: `customer:${request.headers.get("x-customer")}`,
       kind: "customer",
@@ -931,7 +942,7 @@ describe("server helpers", () => {
   it("serves stream Channel chat routes with channel-owned trusted input mapping", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { stream } = await import("../src/channels.ts")
-    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const run = vi.fn(({ context, invoker, run }) => {
       const chatContext = context.get("chat") as { meta?: { audience?: string }, user?: { email?: string } } | undefined
       return `portal ${run.channelId} ${run.origin} ${run.threadId} ${invoker.id} ${chatContext?.user?.email} ${chatContext?.meta?.audience}`
@@ -991,7 +1002,7 @@ describe("server helpers", () => {
   it("serves webChat routes with admission callbacks", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { webChat } = await import("../src/channels.ts")
-    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     type PortalBody = {
       id?: string
       messages: unknown[]
@@ -1116,7 +1127,7 @@ describe("server helpers", () => {
   it("returns a validation error for malformed AI SDK chat requests", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const handler = createChannelChatRouteHandler(defineAgent({
       capabilities: [chat()],
       run: () => "unused",
@@ -1136,7 +1147,7 @@ describe("server helpers", () => {
   it("rejects client-provided identity on generated AI SDK chat routes", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const handler = createChannelChatRouteHandler(defineAgent({
       capabilities: [chat()],
       run: () => "unused",
@@ -1174,7 +1185,7 @@ describe("server helpers", () => {
   it("copies trusted webChat route input after admission", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { webChat } = await import("../src/channels.ts")
-    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const authenticate = vi.fn(({ request }) => request.headers.get("x-quiver-chat-token") === "trusted" ? true : false)
     const run = vi.fn(({ context, invoker, run }) => {
       const chatContext = context.get("chat") as { meta?: { audience?: string }, session?: { id?: string }, user?: { email?: string } } | undefined
@@ -1221,7 +1232,7 @@ describe("server helpers", () => {
   it("does not copy untrusted session input after admission", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { webChat } = await import("../src/channels.ts")
-    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const run = vi.fn(({ context }) => {
       const chatContext = context.get("chat") as { meta?: { audience?: string }, session?: { id?: string }, user?: { email?: string } } | undefined
       return `trusted ${chatContext?.user?.email} ${chatContext?.meta?.audience} ${chatContext?.session?.id ?? "no-session"}`
@@ -1259,7 +1270,7 @@ describe("server helpers", () => {
   it("keeps admission context authoritative over trusted route input", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { webChat } = await import("../src/channels.ts")
-    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const run = vi.fn(({ context }) => {
       const chatContext = context.get("chat") as { meta?: { audience?: string, customer?: string } } | undefined
       return `trusted ${chatContext?.meta?.customer} ${chatContext?.meta?.audience}`
@@ -1305,7 +1316,7 @@ describe("server helpers", () => {
   it("does not trust route input without admission authentication", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { webChat } = await import("../src/channels.ts")
-    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const handler = createChannelChatRouteHandler(defineAgent({
       channels: {
         portal: webChat({
@@ -1338,7 +1349,7 @@ describe("server helpers", () => {
   it("maps trusted AI SDK chat route input before invoking the chat trigger", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const run = vi.fn(({ context, invoker, run }) => {
       const chatContext = context.get("chat") as { meta?: { audience?: string }, user?: { email?: string } } | undefined
       return `portal ${run.origin} ${invoker.id} ${invoker.meta.scope} ${chatContext?.user?.email} ${chatContext?.meta?.audience}`
@@ -1394,7 +1405,7 @@ describe("server helpers", () => {
   it("handles Chat SDK webhooks through the chat capability", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { access, chat, staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const admitChat = vi.fn(({ invoker }) => invoker?.id === "customer:acme")
     const invokerResolve = vi.fn(({ defaultInvoker }) => {
@@ -1536,7 +1547,7 @@ describe("server helpers", () => {
   it("routes channel webhook custom ids through the channel adapter", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { http } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const run = vi.fn(({ messages }) => {
       const text = messages[0]?.parts.find((part: { type?: string }) => part.type === "text") as { text?: string } | undefined
@@ -1581,7 +1592,7 @@ describe("server helpers", () => {
   it("rejects unsigned chat channel webhooks before adapter dispatch", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { http } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const run = vi.fn(() => "unexpected")
     const agent = defineAgent({
@@ -1609,7 +1620,7 @@ describe("server helpers", () => {
   it("fails closed when generated chat webhook secrets resolve empty", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { http } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const run = vi.fn(() => "unexpected")
     const agent = defineAgent({
@@ -1637,7 +1648,7 @@ describe("server helpers", () => {
   it("uses Telegram secret header defaults for generated chat webhooks", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const run = vi.fn(() => "unexpected")
     const agent = defineAgent({
@@ -1665,7 +1676,7 @@ describe("server helpers", () => {
   it("rejects generated GitHub webhooks without configured secrets", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { github } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const run = vi.fn(() => "unexpected")
     const agent = defineAgent({
       channels: {
@@ -1690,7 +1701,7 @@ describe("server helpers", () => {
   it("handles signed GitHub channel webhooks without a chat adapter", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { github } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const triggerInputs: unknown[] = []
     const run = vi.fn(({ input, run }) => ({
       raw: { context: input.context, run },
@@ -1799,7 +1810,7 @@ describe("server helpers", () => {
   it("handles direct single-agent GitHub channel webhook routes", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { github } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const run = vi.fn(() => "accepted")
     const agent = defineAgent({
       channels: {
@@ -1835,7 +1846,7 @@ describe("server helpers", () => {
   it("lets signed GitHub channel webhooks return a handled response without running the agent", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { github } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const triggerInputs: unknown[] = []
     const run = vi.fn(() => "unexpected")
     const agent = defineAgent({
@@ -1895,7 +1906,7 @@ describe("server helpers", () => {
   it("does not route channel webhook arrays by unsuffixed channel id", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { http } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const agent = defineAgent({
       channels: {
         support: http({
@@ -1922,7 +1933,7 @@ describe("server helpers", () => {
   it("does not route ambiguous provider webhook selectors", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { http } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const run = vi.fn(() => "ok")
     const agent = defineAgent({
       channels: {
@@ -1946,7 +1957,7 @@ describe("server helpers", () => {
   it("does not route ambiguous webhook paths", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { github } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const run = vi.fn(() => "unexpected")
     const agent = defineAgent({
       channels: {
@@ -1976,7 +1987,7 @@ describe("server helpers", () => {
   it("uses channel ids for same-kind channel webhook state", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { http } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const prefixes: string[] = []
     const agent = defineAgent({
       channels: {
@@ -2012,7 +2023,7 @@ describe("server helpers", () => {
   it("does not block chat webhook handling on typing status", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     adapter.startTyping.mockImplementation(() => new Promise(() => {}))
     const agent = defineAgent({
@@ -2058,7 +2069,7 @@ describe("server helpers", () => {
     vi.useFakeTimers()
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     let runStarted!: () => void
     let finishRun: () => void = () => {}
@@ -2127,7 +2138,7 @@ describe("server helpers", () => {
     vi.useFakeTimers()
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     let runStarted!: () => void
     let finishRun: () => void = () => {}
@@ -2228,7 +2239,7 @@ describe("server helpers", () => {
   it("posts configured chat fallback while streamed webhook work is still running", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     let runStarted!: () => void
     let finishRun!: () => void
@@ -2293,7 +2304,7 @@ describe("server helpers", () => {
     const { getActiveCloudflareEnv } = await import("@vite-hub/internal/runtime/cloudflare-env")
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const agent = defineAgent({
       capabilities: [
@@ -2340,7 +2351,7 @@ describe("server helpers", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter({ deferMessageProcessing: true })
     const waitUntilTasks: Promise<unknown>[] = []
     const agent = defineAgent({
@@ -2395,7 +2406,7 @@ describe("server helpers", () => {
 
   it("lets chat webhooks opt out of streaming model execution", async () => {
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const model = {
       generate: vi.fn(async () => ({ finishReason: "stop", text: "generated ok" })),
@@ -2445,7 +2456,7 @@ describe("server helpers", () => {
   it("runs non-streaming chat webhooks inline for workflow-backed agents", async () => {
     const { workflow } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const { resetWorkflowRuntime, setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
     const adapter = createTestChatAdapter()
     const model = {
@@ -2499,7 +2510,7 @@ describe("server helpers", () => {
 
   it("lets agent finish hooks post usage telemetry for non-streaming model chat webhooks", async () => {
     const { chat, staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const finish = vi.fn(async (event) => {
       const chat = event.extensions.get("chat") as { provider?: string, sendMessage?: (message: { markdown: string }) => Promise<void> } | undefined
@@ -2603,7 +2614,7 @@ describe("server helpers", () => {
   it("exposes chat sendMessage to agent finish hooks for chat webhooks", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const finish = vi.fn(async (event) => {
       const chat = event.extensions.get("chat") as { provider?: string, sendMessage?: (message: { markdown: string }) => Promise<void> } | undefined
@@ -2652,7 +2663,7 @@ describe("server helpers", () => {
   it("commits native streamed chat responses before flushing finish hook messages", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const order: string[] = []
     let streamConsumed!: () => void
@@ -2756,7 +2767,7 @@ describe("server helpers", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     adapter.stream = vi.fn(async (threadId: string, textStream: AsyncIterable<string | StreamChunk>) => {
       let text = ""
@@ -2822,7 +2833,7 @@ describe("server helpers", () => {
   it("flushes deferred non-streaming chat webhook work before returning", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat, usageTelemetry } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter({ deferMessageProcessing: true })
     adapter.startTyping.mockImplementation(() => new Promise(() => {}))
     let runStarted!: () => void
@@ -2906,7 +2917,7 @@ describe("server helpers", () => {
   it("lets agent finish hooks compose usage telemetry and chat follow-up messages", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { access, chat, staticModelPricing, usageTelemetry } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const finish = vi.fn(async (event) => {
       const chat = event.extensions.get("chat") as { provider?: string, sendMessage?: (message: { markdown: string }) => Promise<void> } | undefined
@@ -2993,7 +3004,7 @@ describe("server helpers", () => {
   it("lets access() reject app-specific chat invokers", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { access, chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const run = vi.fn(() => "unused")
     const agent = defineAgent({
@@ -3036,7 +3047,7 @@ describe("server helpers", () => {
   it("returns Chat SDK adapter webhook responses", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter({ secret: "secret" })
     const run = vi.fn(() => "unused")
     const agent = defineAgent({

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1218,6 +1218,44 @@ describe("server helpers", () => {
     expect(run).toHaveBeenCalled()
   })
 
+  it("does not copy untrusted session input after admission", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { webChat } = await import("../src/channels.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const run = vi.fn(({ context }) => {
+      const chatContext = context.get("chat") as { meta?: { audience?: string }, session?: { id?: string }, user?: { email?: string } } | undefined
+      return `trusted ${chatContext?.user?.email} ${chatContext?.meta?.audience} ${chatContext?.session?.id ?? "no-session"}`
+    })
+    const handler = createChannelChatRouteHandler(defineAgent({
+      channels: {
+        portal: webChat({
+          route: {
+            admission: { authenticate: () => true },
+            input: { trust: ["meta", "user"] },
+          },
+        }),
+      },
+      run,
+    }) as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        messages: [{
+          id: "user-1",
+          parts: [{ text: "hello", type: "text" }],
+          role: "user",
+        }],
+        meta: { audience: "technical" },
+        session: { id: "portal-session" },
+        user: { email: "user@example.com" },
+      }),
+      method: "POST",
+    }), { agentName: "support" })
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toContain("trusted user@example.com technical no-session")
+  })
+
   it("does not trust route input without admission authentication", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { webChat } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1256,6 +1256,52 @@ describe("server helpers", () => {
     await expect(response.text()).resolves.toContain("trusted user@example.com technical no-session")
   })
 
+  it("keeps admission context authoritative over trusted route input", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { webChat } = await import("../src/channels.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server.ts")
+    const run = vi.fn(({ context }) => {
+      const chatContext = context.get("chat") as { meta?: { audience?: string, customer?: string } } | undefined
+      return `trusted ${chatContext?.meta?.customer} ${chatContext?.meta?.audience}`
+    })
+    const handler = createChannelChatRouteHandler(defineAgent({
+      channels: {
+        portal: webChat({
+          route: {
+            admission: {
+              authenticate: () => ({ customer: "server-customer" }),
+              context({ auth, input }) {
+                return {
+                  meta: {
+                    ...input.meta,
+                    customer: auth.customer,
+                  },
+                }
+              },
+            },
+            input: { trust: ["meta"] },
+          },
+        }),
+      },
+      run,
+    }) as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        messages: [{
+          id: "user-1",
+          parts: [{ text: "hello", type: "text" }],
+          role: "user",
+        }],
+        meta: { audience: "technical", customer: "body-customer" },
+      }),
+      method: "POST",
+    }), { agentName: "support" })
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toContain("trusted server-customer technical")
+  })
+
   it("does not trust route input without admission authentication", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { webChat } = await import("../src/channels.ts")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -743,6 +743,9 @@ describe("agent public types", () => {
                 }
               },
             },
+            input: {
+              trust: ["meta", "user", "session"],
+            },
           },
         }),
       },

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -783,6 +783,17 @@ describe("agent public types", () => {
     type _PublicStream = ChannelExports["stream"]
     type _PublicTelegram = ChannelExports["telegram"]
     type _PublicTeams = ChannelExports["teams"]
+
+    type ServerExports = typeof import("../src/server.ts")
+    // @ts-expect-error generated route handler factories are internal Provider Output plumbing.
+    type _PublicChannelChatRouteHandler = ServerExports["createChannelChatRouteHandler"]
+    // @ts-expect-error generated route handler factories are internal Provider Output plumbing.
+    type _PublicChannelWebhookRouteHandler = ServerExports["createChannelWebhookRouteHandler"]
+    // @ts-expect-error generated route handler factories are internal Provider Output plumbing.
+    type _PublicChannelDevtoolsRouteHandler = ServerExports["createChannelDevtoolsRouteHandler"]
+
+    type InternalServerExports = typeof import("../src/server/internal.ts")
+    type _InternalChannelChatRouteHandler = InternalServerExports["createChannelChatRouteHandler"]
   })
 
   it("types access workspace source grants and chat run context", () => {

--- a/packages/agent/vite.config.ts
+++ b/packages/agent/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
       "src/runtime/empty-registry.ts",
       "src/runtime/workflow.ts",
       "src/server.ts",
+      "src/server/internal.ts",
       "src/server/workspace.ts",
       "src/test.ts",
       "src/vite.ts",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -35,6 +35,7 @@
     "./agent/mcp/stdio": "./dist/agent/mcp/stdio.js",
     "./agent/runtime/workflow": "./dist/agent/runtime/workflow.js",
     "./agent/server": "./dist/agent/server.js",
+    "./agent/server/internal": "./dist/agent/server/internal.js",
     "./agent/server/workspace": "./dist/agent/server/workspace.js",
     "./agent/state/sqlite": "./dist/agent/state/sqlite.js",
     "./blob": "./dist/blob.js",

--- a/packages/vite/src/agent/server/internal.ts
+++ b/packages/vite/src/agent/server/internal.ts
@@ -1,0 +1,1 @@
+export * from "@vite-hub/agent/server/internal"

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -43,6 +43,7 @@ const facadeAliases: Record<string, string> = {
   "@vite-hub/agent/mcp/stdio": "@vite-hub/vite/agent/mcp/stdio",
   "@vite-hub/agent/runtime/workflow": "@vite-hub/vite/agent/runtime/workflow",
   "@vite-hub/agent/server": "@vite-hub/vite/agent/server",
+  "@vite-hub/agent/server/internal": "@vite-hub/vite/agent/server/internal",
   "@vite-hub/agent/server/workspace": "@vite-hub/vite/agent/server/workspace",
   "@vite-hub/agent/state/sqlite": "@vite-hub/vite/agent/state/sqlite",
   "@vite-hub/blob": "@vite-hub/vite/blob",

--- a/packages/vite/test/vite.test.ts
+++ b/packages/vite/test/vite.test.ts
@@ -73,6 +73,7 @@ describe("vitehub", () => {
     }
 
     await expect(resolveId.call(context, "@vite-hub/agent/eval", "/app/server/agents/support.eval.ts")).resolves.toBe("resolved:@vite-hub/vite/agent/eval")
+    await expect(resolveId.call(context, "@vite-hub/agent/server/internal", "/app/.vitehub/agent/route.mjs")).resolves.toBe("resolved:@vite-hub/vite/agent/server/internal")
     await expect(resolveId.call(context, "@vite-hub/blob/drivers/s3", "/app/src/blob.ts")).resolves.toBe("resolved:@vite-hub/vite/blob/drivers/s3")
     await expect(resolveId.call(context, "@vite-hub/database", "/app/src/db.ts")).resolves.toBe("resolved:@vite-hub/vite/database")
     await expect(resolveId.call(context, "@vite-hub/database/drizzle", "/app/src/db.ts")).resolves.toBe("resolved:@vite-hub/vite/database/drizzle")

--- a/packages/vite/vite.config.ts
+++ b/packages/vite/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       "src/agent/mcp/stdio.ts",
       "src/agent/runtime/workflow.ts",
       "src/agent/server.ts",
+      "src/agent/server/internal.ts",
       "src/agent/server/workspace.ts",
       "src/agent/state/sqlite.ts",
       "src/blob.ts",


### PR DESCRIPTION
Adds `route.input.trust` for authenticated Channel routes so `webChat({ route })` and custom Channel definitions can copy already-authenticated `meta`, `user`, and `session` request fields into `chat.message` input without a custom mapper. The trust list is only honored after `admission.authenticate`, and `run`, `invoker`, and `invokerProfileId` stay server-owned.

Also moves generated `createChannel*RouteHandler` factories behind `@vite-hub/agent/server/internal` and the matching Vite facade so `defineChannel()` and Channel helpers remain the public source of truth for invocation route admission. The docs now separate Channel delivery/admission from Chat state and history.
