### PR TITLE
fix(agent): default workspace harnesses to local sandbox

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -27,8 +27,10 @@ Add the AI SDK model provider you pass to `model`.
 For AI SDK harness drivers, add the harness packages:
 
 ```sh
-pnpm add @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel
+pnpm add @ai-sdk/harness @ai-sdk/harness-codex
 ```
+
+For non-local omitted sandbox fallback, also add `@ai-sdk/sandbox-vercel`.
 
 ## Minimal API
 
@@ -67,7 +69,6 @@ Harness-backed agents use AI SDK `HarnessAgent` behind the ViteHub Agent Driver 
 import { createCodex } from "@ai-sdk/harness-codex"
 import { defineAgent } from "@vite-hub/agent"
 import { skills } from "@vite-hub/agent/capabilities"
-import { createLocalHarnessSandbox } from "@vite-hub/agent/harness/local-sandbox"
 import { file } from "@vite-hub/workspace"
 
 export default defineAgent({
@@ -76,8 +77,6 @@ export default defineAgent({
       model: "gpt-5.5",
       reasoningEffort: "low",
     }),
-    sandbox: createLocalHarnessSandbox(),
-    credentials: { label: "local Codex", source: "ambient" },
   },
   workspace: {
     mode: "write",
@@ -91,7 +90,7 @@ export default defineAgent({
 })
 ```
 
-`driver.harness` is the AI SDK harness adapter instance. `driver.sandbox` can provide an AI SDK sandbox provider; when omitted, ViteHub uses the AI SDK Vercel Sandbox default for bridge-backed harnesses. `createLocalHarnessSandbox()` is a trusted-host sandbox for local development and Agent Evals, not a production isolation boundary. `driver.harness`, `driver.sandbox`, and `driver.sessionKey` can also be callbacks when one Agent Definition needs invocation-scoped harness setup. Workspace-backed harness drivers receive a Harness Workspace Session prepared from the selected Workspace. When `access()` narrows Workspace Scope, ViteHub materializes only that selected scope plus generated source descriptors. Read mode materializes files and discards sandbox changes; write mode syncs additions, updates, and deletions back through Workspace rules. V1 configures built-in harness permissions internally with the no-approval policy and does not expose a public permission option. Skills stay a Capability through `skills()` rather than becoming a root Agent Definition field. For harness drivers, `skills()` relies on mounted Workspace files and does not inject model instructions or Workspace Shell tools. Put harness guidance in Workspace files such as `AGENTS.md`; Sources, Capabilities, and Skills do not inject extra model instructions by default.
+`driver.harness` is the AI SDK harness adapter instance. Workspace-backed harness drivers in Vite dev use ViteHub's local harness sandbox by default and receive a Harness Workspace Session prepared from the selected Workspace. `driver.sandbox` can provide an AI SDK sandbox provider as an advanced escape hatch; outside the local workspace path, omitted sandboxes use the AI SDK Vercel Sandbox default when `@ai-sdk/sandbox-vercel` is installed. `driver.harness`, `driver.sandbox`, and `driver.sessionKey` can also be callbacks when one Agent Definition needs invocation-scoped harness setup. When `access()` narrows Workspace Scope, ViteHub materializes only that selected scope plus generated source descriptors. Read mode materializes files and discards sandbox changes; write mode syncs additions, updates, and deletions back through Workspace rules. V1 configures built-in harness permissions internally with the no-approval policy and does not expose a public permission option. Skills stay a Capability through `skills()` rather than becoming a root Agent Definition field. For harness drivers, `skills()` relies on mounted Workspace files and does not inject model instructions or Workspace Shell tools. Put harness guidance in Workspace files such as `AGENTS.md`; Sources, Capabilities, and Skills do not inject extra model instructions by default.
 
 For model-backed drivers, put free-form guidance for configured Sources, Capabilities, and Skills in `driver.instructions` or a deterministic imported instruction file. Tool descriptions and schemas stay with the tools as structured contracts.
 

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -240,7 +240,12 @@ async function resolveHarnessSessionKey<
   return sessionKey || undefined
 }
 
-async function createDefaultHarnessSandbox() {
+async function createDefaultHarnessSandbox(context: AgentAdapterRunContext) {
+  if (context.workspace && context.runtime.runtime === "vite") {
+    const { createLocalHarnessSandbox } = await import("./harness/local-sandbox.ts")
+    return createLocalHarnessSandbox()
+  }
+
   let sandboxModule: { createVercelSandbox: (settings: Record<string, unknown>) => unknown }
   try {
     sandboxModule = await import("@ai-sdk/sandbox-vercel") as typeof sandboxModule
@@ -263,9 +268,9 @@ async function resolveHarnessSandbox<
   context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>,
 ) {
   if (typeof sandbox === "function") {
-    return await sandbox(toRunCallbackContext(context)) ?? await createDefaultHarnessSandbox()
+    return await sandbox(toRunCallbackContext(context)) ?? await createDefaultHarnessSandbox(context)
   }
-  return sandbox ?? await createDefaultHarnessSandbox()
+  return sandbox ?? await createDefaultHarnessSandbox(context)
 }
 
 function hasHarnessInstructionDocument(context: AgentAdapterRunContext): boolean {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -790,7 +790,6 @@ describe("defineAgent workspace option", () => {
     const agent = withAgentDefaults(defineAgent({
       driver: {
         harness: { provider: "codex" },
-        sandbox: { provider: "sandbox" },
       },
       workspace: {
         sources: {
@@ -817,7 +816,10 @@ describe("defineAgent workspace option", () => {
     expect(harnessAgentSettings.at(-1)).toMatchObject({
       harness: { provider: "codex" },
       permissionMode: "allow-all",
-      sandbox: { provider: "sandbox" },
+      sandbox: {
+        providerId: "local",
+        specificationVersion: "harness-sandbox-v1",
+      },
     })
     expect(harnessGenerate).toHaveBeenCalledWith(expect.objectContaining({
       prompt: "hello",


### PR DESCRIPTION
Defaults workspace-backed harness agents in local Vite dev to ViteHub's local harness sandbox, so app code can use `driver: { harness: createCodex(...) }` without local sandbox wrapper plumbing. Keeps `driver.sandbox` as the advanced escape hatch and clarifies that `@ai-sdk/sandbox-vercel` is only needed for non-local omitted sandbox fallback.