### PR TITLE
feat(agent): use hooks for openapi requests

### DIFF
--- a/docs/content/docs/capabilities/openapi.md
+++ b/docs/content/docs/capabilities/openapi.md
@@ -69,19 +69,15 @@ ViteHub derives the request server from the OpenAPI document by default:
 1. `servers[0].url`
 2. the OpenAPI spec URL origin
 
-Use `request.onRequest` for runtime auth, cookies, tenant values, body additions, query additions, and timeout changes.
+Use `hooks.request` for runtime auth, cookies, tenant values, body additions, query additions, and timeout changes.
 The hook receives the selected operation, Agent Capability context, visible model input, and a mutable draft request.
 
 ```ts [server/agents/support.ts]
 openapi({
   spec: 'https://portal.example.com/_openapi.json',
   operations: ['portalProductSearch', 'portalPurchaseOrders'],
-  request: {
-    hidden: {
-      body: ['cubeToken'],
-      path: ['tenantId'],
-    },
-    async onRequest({ context, operation, request }) {
+  hooks: {
+    async request({ context, operation, request }) {
       const session = context.get<{
         cubeToken: string
         tenantId: string
@@ -94,8 +90,8 @@ openapi({
 
       if (operation.id === 'portalPurchaseOrders') {
         request.body = {
-          cubeToken: session.cubeToken,
           ...(request.body as Record<string, unknown> | undefined),
+          cubeToken: session.cubeToken,
         }
       }
     },
@@ -103,8 +99,7 @@ openapi({
 })
 ```
 
-`request.hidden` removes host-supplied fields from the model-facing tool schema and generated Capability CLI input schema.
-Use it only for fields the host supplies inside `onRequest`.
+ViteHub validates the final prepared request after `hooks.request` runs, so the hook can fill spec-required runtime values before HTTP execution.
 
 For a broken, missing, or environment-neutral `servers` entry, use `server` as an override escape hatch.
 `server` can also be a callback when the override comes from the current Agent Invocation context.
@@ -163,9 +158,9 @@ openapi({
 | `enabled` | Attach `openapi()` only to Agents that should have the ability. Use `access()`, Agent Trigger routing, or separate Agent Definitions for channel or customer gating. |
 | `operations: { allow: [...] }` | `operations: [...]` |
 | `baseUrl` | Use the OpenAPI `servers` entry. Use `server` only when the spec has no usable server. |
-| `headers` | Set headers in `request.onRequest`. |
-| `defaults` | Mutate `request.body`, `request.path`, or `request.query` in `request.onRequest`. |
-| `input.omit` | Use `request.hidden` for host-supplied fields that `request.onRequest` fills. |
+| `headers` | Set headers in `hooks.request`. |
+| `defaults` | Mutate `request.body`, `request.path`, or `request.query` in `hooks.request`. |
+| `input.omit` | Remove it. Fill runtime-owned fields in `hooks.request` before the final prepared request is validated. |
 
 ## Driver support
 
@@ -181,8 +176,7 @@ openapi({
 | --- | --- | --- | --- |
 | `spec` | `string \| URL \| object \| function` | required | OpenAPI document URL, inline document, or invocation-scoped document resolver. |
 | `operations` | `readonly string[]` | required | Selected OpenAPI `operationId`s exposed by this Capability. |
-| `request` | `function \| { hidden, onRequest }` | none | Fetch-style request preparation hook for runtime headers, cookies, path, query, body, and timeout values. |
-| `request.hidden` | `{ body?, path?, query? }` | none | Fields removed from model and generated CLI input because the host supplies them in `onRequest`. |
+| `hooks.request` | `(context) => patch \| void` | none | Fetch-style request preparation hook for runtime headers, cookies, path, query, body, and timeout values. |
 | `server` | `string \| URL \| function` | OpenAPI server | Override escape hatch for specs without a usable `servers[0].url` or spec URL origin. |
 | `cli` | `false \| { name, description? }` | `false` | Generates a Capability CLI instead of one model-facing tool per operation. |
 | `responseType` | `"json" \| "text"` | `"json"` | Response parser for operation results. |

--- a/docs/content/docs/capabilities/openapi.md
+++ b/docs/content/docs/capabilities/openapi.md
@@ -71,35 +71,42 @@ ViteHub derives the request server from the OpenAPI document by default:
 
 Use `hooks.request` for runtime auth, cookies, tenant values, body additions, query additions, and timeout changes.
 The hook receives the selected operation, Agent Capability context, visible model input, and a mutable draft request.
+When the hook owns OpenAPI fields such as tenant path params or runtime body tokens, declare them in `provides`; ViteHub removes those fields from the model and generated CLI schemas, strips them from caller input, then validates the final prepared request after the hook runs.
 
 ```ts [server/agents/support.ts]
 openapi({
   spec: 'https://portal.example.com/_openapi.json',
   operations: ['portalProductSearch', 'portalPurchaseOrders'],
   hooks: {
-    async request({ context, operation, request }) {
-      const session = context.get<{
-        cubeToken: string
-        tenantId: string
-        token: string
-      }>('portalSession')
-      if (!session) throw new Error('Portal session missing.')
+    request: {
+      provides: {
+        body: ['cubeToken'],
+        path: ['tenantId'],
+      },
+      async handler({ context, operation, request }) {
+        const session = context.get<{
+          cubeToken: string
+          tenantId: string
+          token: string
+        }>('portalSession')
+        if (!session) throw new Error('Portal session missing.')
 
-      request.headers.set('authorization', `Bearer ${session.token}`)
-      request.path.tenantId = session.tenantId
+        request.headers.set('authorization', `Bearer ${session.token}`)
+        request.path.tenantId = session.tenantId
 
-      if (operation.id === 'portalPurchaseOrders') {
-        request.body = {
-          ...(request.body as Record<string, unknown> | undefined),
-          cubeToken: session.cubeToken,
+        if (operation.id === 'portalPurchaseOrders') {
+          request.body = {
+            ...(request.body as Record<string, unknown> | undefined),
+            cubeToken: session.cubeToken,
+          }
         }
-      }
+      },
     },
   },
 })
 ```
 
-ViteHub validates the final prepared request after `hooks.request` runs, so the hook can fill spec-required runtime values before HTTP execution.
+ViteHub still keeps caller-owned required fields in the model and generated CLI schemas. If the hook only provides `tenantId`, another required path param such as `orderId` remains required from the caller.
 
 For a broken, missing, or environment-neutral `servers` entry, use `server` as an override escape hatch.
 `server` can also be a callback when the override comes from the current Agent Invocation context.
@@ -160,7 +167,7 @@ openapi({
 | `baseUrl` | Use the OpenAPI `servers` entry. Use `server` only when the spec has no usable server. |
 | `headers` | Set headers in `hooks.request`. |
 | `defaults` | Mutate `request.body`, `request.path`, or `request.query` in `hooks.request`. |
-| `input.omit` | Remove it. Fill runtime-owned fields in `hooks.request` before the final prepared request is validated. |
+| `input.omit` | Use `hooks.request.provides` for fields owned by the runtime hook. |
 
 ## Driver support
 
@@ -176,7 +183,8 @@ openapi({
 | --- | --- | --- | --- |
 | `spec` | `string \| URL \| object \| function` | required | OpenAPI document URL, inline document, or invocation-scoped document resolver. |
 | `operations` | `readonly string[]` | required | Selected OpenAPI `operationId`s exposed by this Capability. |
-| `hooks.request` | `(context) => patch \| void` | none | Fetch-style request preparation hook for runtime headers, cookies, path, query, body, and timeout values. |
+| `hooks.request` | `(context) => patch \| void` or `{ provides?, handler }` | none | Fetch-style request preparation hook for runtime headers, cookies, path, query, body, and timeout values. |
+| `hooks.request.provides` | `{ body?, path?, query? }` | none | Runtime-owned OpenAPI input fields to remove from model and generated CLI schemas before caller validation. |
 | `server` | `string \| URL \| function` | OpenAPI server | Override escape hatch for specs without a usable `servers[0].url` or spec URL origin. |
 | `cli` | `false \| { name, description? }` | `false` | Generates a Capability CLI instead of one model-facing tool per operation. |
 | `responseType` | `"json" \| "text"` | `"json"` | Response parser for operation results. |

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -127,12 +127,11 @@ openapi({
     description: "Inspect live billing API data.",
   },
   operations: ["billingListCustomers", "billingGetInvoice", "billingCreateTicket"],
-  request: {
-    hidden: { body: ["tenantId"] },
-    onRequest({ context, request }) {
+  hooks: {
+    request({ context, request }) {
       request.body = {
-        tenantId: context.get<{ tenantId: string }>("billing")?.tenantId,
         ...(request.body as Record<string, unknown> | undefined),
+        tenantId: context.get<{ tenantId: string }>("billing")?.tenantId,
       }
       request.headers.set("authorization", `Bearer ${context.get<{ token: string }>("billing")?.token}`)
     },

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -128,12 +128,17 @@ openapi({
   },
   operations: ["billingListCustomers", "billingGetInvoice", "billingCreateTicket"],
   hooks: {
-    request({ context, request }) {
-      request.body = {
-        ...(request.body as Record<string, unknown> | undefined),
-        tenantId: context.get<{ tenantId: string }>("billing")?.tenantId,
-      }
-      request.headers.set("authorization", `Bearer ${context.get<{ token: string }>("billing")?.token}`)
+    request: {
+      provides: {
+        body: ["tenantId"],
+      },
+      handler({ context, request }) {
+        request.body = {
+          ...(request.body as Record<string, unknown> | undefined),
+          tenantId: context.get<{ tenantId: string }>("billing")?.tenantId,
+        }
+        request.headers.set("authorization", `Bearer ${context.get<{ token: string }>("billing")?.token}`)
+      },
     },
   },
   transformResponse: (response, { operation }) => ({

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -221,11 +221,10 @@ export type {
 export type {
   OpenAPICapabilityOptions,
   OpenAPICliOptions,
-  OpenAPIHiddenRequestInput,
+  OpenAPIHooks,
   OpenAPIRequestContext,
   OpenAPIRequestDraft,
   OpenAPIRequestHook,
-  OpenAPIRequestOptions,
   OpenAPIRequestPatch,
   OpenAPIResponseContext,
 } from "./openapi.ts"

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -221,10 +221,12 @@ export type {
 export type {
   OpenAPICapabilityOptions,
   OpenAPICliOptions,
+  OpenAPIHookProvidedInput,
   OpenAPIHooks,
   OpenAPIRequestContext,
   OpenAPIRequestDraft,
   OpenAPIRequestHook,
+  OpenAPIRequestHookOptions,
   OpenAPIRequestPatch,
   OpenAPIResponseContext,
 } from "./openapi.ts"

--- a/packages/agent/src/capabilities/openapi.ts
+++ b/packages/agent/src/capabilities/openapi.ts
@@ -633,7 +633,7 @@ function operationInputSchema(operation: OpenAPIOperationTool, prepared = false,
   const properties: Record<string, JsonSchema> = {}
   const required: string[] = []
   if (operation.pathParameters.length) {
-    properties.path = parameterObjectSchema(operation.pathParameters)
+    properties.path = parameterObjectSchema(operation.pathParameters, requirePath)
     if (requirePath && operation.pathParameters.some(parameter => parameter.required || parameter.in === "path")) required.push("path")
   }
   if (operation.queryParameters.length) {
@@ -732,13 +732,16 @@ function jsonSchemaTypeMatches(type: string, value: unknown): boolean {
 }
 
 function parameterObjectSchema(parameters: OpenAPIParameter[], includeRequired = true): JsonSchema {
+  const required = includeRequired
+    ? parameters.filter(parameter => parameter.in === "path" || parameter.required).map(parameter => parameter.name)
+    : []
   return {
     additionalProperties: false,
     properties: Object.fromEntries(parameters.map(parameter => [parameter.name, {
       ...(parameter.schema as JsonSchema),
       ...(parameter.description ? { description: parameter.description } : {}),
     }])),
-    required: parameters.filter(parameter => parameter.in === "path" || includeRequired && parameter.required).map(parameter => parameter.name),
+    ...(required.length ? { required } : {}),
     type: "object",
   }
 }

--- a/packages/agent/src/capabilities/openapi.ts
+++ b/packages/agent/src/capabilities/openapi.ts
@@ -336,7 +336,7 @@ function createOpenAPITool<
     async execute(input) {
       return executeOpenAPIOperation(operation, baseUrl, options, context, input)
     },
-    inputSchema: operationInputSchema(operation),
+    inputSchema: operationInputSchema(operation, false, !options.hooks?.request),
     metadata: {
       openapi: {
         method: operation.method,

--- a/packages/agent/src/capabilities/openapi.ts
+++ b/packages/agent/src/capabilities/openapi.ts
@@ -116,23 +116,16 @@ export interface OpenAPIRequestPatch {
   timeout?: number
 }
 
-export interface OpenAPIHiddenRequestInput {
-  body?: readonly string[]
-  path?: readonly string[]
-  query?: readonly string[]
-}
-
 export type OpenAPIRequestHook<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > = (context: OpenAPIRequestContext<TRuntimeConfig, Name>) => MaybePromise<OpenAPIRequestPatch | void>
 
-export interface OpenAPIRequestOptions<
+export interface OpenAPIHooks<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > {
-  hidden?: OpenAPIHiddenRequestInput
-  onRequest: OpenAPIRequestHook<TRuntimeConfig, Name>
+  request?: OpenAPIRequestHook<TRuntimeConfig, Name>
 }
 
 export interface OpenAPICliOptions {
@@ -153,8 +146,8 @@ export interface OpenAPICapabilityOptions<
 > {
   cli?: false | OpenAPICliOptions
   description?: string
+  hooks?: OpenAPIHooks<TRuntimeConfig, Name>
   operations: readonly string[]
-  request?: OpenAPIRequestHook<TRuntimeConfig, Name> | OpenAPIRequestOptions<TRuntimeConfig, Name>
   responseType?: "json" | "text"
   server?: OpenAPIContextValue<string | URL, TRuntimeConfig, Name>
   spec: OpenAPIContextValue<string | URL | OpenAPIDocument, TRuntimeConfig, Name>
@@ -343,7 +336,7 @@ function createOpenAPITool<
     async execute(input) {
       return executeOpenAPIOperation(operation, baseUrl, options, context, input)
     },
-    inputSchema: operationInputSchema(operation, openAPIRequestHiddenInput(options)),
+    inputSchema: operationInputSchema(operation),
     metadata: {
       openapi: {
         method: operation.method,
@@ -376,7 +369,7 @@ function createOpenAPICli<
       description: operation.description,
       effects: [`http:${operation.method.toLowerCase()}`],
       examples: [`${cli.name} ${name}${outputFormat === "json" ? " --json" : ""}`],
-      input: openAPICliInputSchema(operation, openAPIRequestHiddenInput(options)),
+      input: openAPICliInputSchema(operation),
       output: { format: outputFormat },
       run: ({ input }) => executeOpenAPIOperation(operation, baseUrl, options, context, input),
     }
@@ -388,13 +381,13 @@ function createOpenAPICli<
   }
 }
 
-function openAPICliInputSchema(operation: OpenAPIOperationTool, hidden?: OpenAPIHiddenRequestInput): AgentCapabilityCliStandardSchemaV1<OpenAPIToolInput> {
-  const schema = operationInputSchema(operation, hidden)
+function openAPICliInputSchema(operation: OpenAPIOperationTool): AgentCapabilityCliStandardSchemaV1<OpenAPIToolInput> {
+  const schema = operationInputSchema(operation)
   return {
     "~standard": {
       validate(value) {
         try {
-          const normalized = compactOpenAPIInput(applyOpenAPIHiddenInput(normalizeRawToolInput(operation, value), hidden))
+          const normalized = compactOpenAPIInput(normalizeRawToolInput(operation, value))
           const issues = validateJsonSchema(schema, normalized, "input")
           return issues.length ? { issues } : { value: normalized }
         }
@@ -409,8 +402,8 @@ function openAPICliInputSchema(operation: OpenAPIOperationTool, hidden?: OpenAPI
 function compactOpenAPIInput(input: OpenAPIToolInput): OpenAPIToolInput {
   return {
     ...(input.body !== undefined ? { body: input.body } : {}),
-    ...(input.path !== undefined ? { path: input.path } : {}),
-    ...(input.query !== undefined ? { query: input.query } : {}),
+    ...(input.path !== undefined && Object.keys(input.path).length ? { path: input.path } : {}),
+    ...(input.query !== undefined && Object.keys(input.query).length ? { query: input.query } : {}),
   }
 }
 
@@ -424,7 +417,7 @@ async function executeOpenAPIOperation<
   context: AgentCapabilityContext<TRuntimeConfig, Name>,
   input: unknown,
 ): Promise<unknown> {
-  const rawInput = applyOpenAPIHiddenInput(normalizeRawToolInput(operation, input), openAPIRequestHiddenInput(options))
+  const rawInput = normalizeRawToolInput(operation, input)
   const rawUrl = operationTemplateUrl(baseUrl, operation.path)
   const draft = createOpenAPIRequestDraft(rawInput, options.timeout)
   await applyOpenAPIRequestHook(options, {
@@ -438,6 +431,7 @@ async function executeOpenAPIOperation<
     request: draft,
     runtimeRequest: context.request,
   })
+  assertValidOpenAPIRequest(operation, draft)
   const requestInput = normalizeToolInput(operation, draft)
   const url = operationUrl(baseUrl, operation, requestInput.path)
   const result = await executeHttpRequest({
@@ -452,25 +446,6 @@ async function executeOpenAPIOperation<
     responseType: options.responseType || "json",
   })
   return transformOpenAPIResponse(options, context, operation, requestInput, draft, url, result)
-}
-
-function openAPIRequestOptions<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  Name extends WorkspaceName,
->(
-  options: OpenAPICapabilityOptions<TRuntimeConfig, Name>,
-): OpenAPIRequestOptions<TRuntimeConfig, Name> | undefined {
-  if (!options.request) return undefined
-  return typeof options.request === "function" ? { onRequest: options.request } : options.request
-}
-
-function openAPIRequestHiddenInput<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  Name extends WorkspaceName,
->(
-  options: OpenAPICapabilityOptions<TRuntimeConfig, Name>,
-): OpenAPIHiddenRequestInput | undefined {
-  return openAPIRequestOptions(options)?.hidden
 }
 
 function createOpenAPIRequestDraft(input: OpenAPIToolInput, timeout: number | undefined): OpenAPIRequestDraft {
@@ -491,7 +466,7 @@ async function applyOpenAPIRequestHook<
   options: OpenAPICapabilityOptions<TRuntimeConfig, Name>,
   context: OpenAPIRequestContext<TRuntimeConfig, Name>,
 ): Promise<void> {
-  const hook = openAPIRequestOptions(options)?.onRequest
+  const hook = options.hooks?.request
   if (!hook) return
   const patch = await hook(context)
   if (patch) applyOpenAPIRequestPatch(context.request, patch)
@@ -515,24 +490,6 @@ function headersToRecord(headers: Headers): OpenAPIHeaders | undefined {
     result[key] = value
   })
   return Object.keys(result).length ? result : undefined
-}
-
-function applyOpenAPIHiddenInput(input: OpenAPIToolInput, hidden: OpenAPIHiddenRequestInput | undefined): OpenAPIToolInput {
-  if (!hidden) return input
-  return {
-    ...input,
-    body: omitInputFields(input.body, hidden.body),
-    path: omitInputFields(input.path, hidden.path),
-    query: omitInputFields(input.query, hidden.query),
-  }
-}
-
-function omitInputFields<T>(input: T, omitted: readonly string[] | undefined): T | undefined {
-  if (!omitted?.length || input === undefined) return input
-  if (!isPlainRecord(input)) return input
-  const hidden = new Set(omitted)
-  const visible = Object.fromEntries(Object.entries(input).filter(([key]) => !hidden.has(key)))
-  return Object.keys(visible).length ? visible as T : undefined
 }
 
 function operationCommandName(cliName: string, operationId: string): string {
@@ -570,6 +527,11 @@ async function transformOpenAPIResponse<
       status: result.status,
     },
   })
+}
+
+function assertValidOpenAPIRequest(operation: OpenAPIOperationTool, input: OpenAPIToolInput): void {
+  const issues = validateJsonSchema(operationInputSchema(operation, true), compactOpenAPIInput(input), "request")
+  if (issues.length) throw new Error(`[vitehub] ${operation.operationId} request is invalid: ${issues.join(", ")}`)
 }
 
 function normalizeRawToolInput(operation: OpenAPIOperationTool, input: unknown): OpenAPIToolInput {
@@ -667,22 +629,20 @@ function operationTemplateUrl(baseUrl: URL, path: string): URL {
   return url
 }
 
-function operationInputSchema(operation: OpenAPIOperationTool, hidden?: OpenAPIHiddenRequestInput): JsonSchema {
+function operationInputSchema(operation: OpenAPIOperationTool, prepared = false): JsonSchema {
   const properties: Record<string, JsonSchema> = {}
   const required: string[] = []
-  const pathParameters = visibleParameters(operation.pathParameters, hidden?.path)
-  const queryParameters = visibleParameters(operation.queryParameters, hidden?.query)
-  const bodySchema = visibleObjectSchema(operation.bodySchema, hidden?.body)
-  if (pathParameters.length) {
-    properties.path = parameterObjectSchema(pathParameters)
-    if (pathParameters.some(parameter => parameter.required || parameter.in === "path")) required.push("path")
+  if (operation.pathParameters.length) {
+    properties.path = parameterObjectSchema(operation.pathParameters)
+    if (operation.pathParameters.some(parameter => parameter.required || parameter.in === "path")) required.push("path")
   }
-  if (queryParameters.length) {
-    properties.query = parameterObjectSchema(queryParameters)
+  if (operation.queryParameters.length) {
+    properties.query = parameterObjectSchema(operation.queryParameters, prepared)
   }
+  const bodySchema = prepared ? operation.bodySchema : openAPIInputBodySchema(operation.bodySchema)
   if (bodySchema) {
     properties.body = bodySchema
-    if (hasRequiredProperties(bodySchema)) required.push("body")
+    if (prepared && hasRequiredProperties(bodySchema)) required.push("body")
   }
   return {
     additionalProperties: false,
@@ -692,26 +652,11 @@ function operationInputSchema(operation: OpenAPIOperationTool, hidden?: OpenAPIH
   }
 }
 
-function visibleParameters(parameters: OpenAPIParameter[], omit: readonly string[] | undefined): OpenAPIParameter[] {
-  if (!omit?.length) return parameters
-  const omitted = new Set(omit)
-  return parameters.filter(parameter => !parameter.name || !omitted.has(parameter.name))
-}
-
-function visibleObjectSchema(schema: JsonSchema | undefined, omit: readonly string[] | undefined): JsonSchema | undefined {
-  if (!schema || !omit?.length) return schema
-  if (!isPlainRecord(schema.properties)) return schema
-  const omitted = new Set(omit)
-  const properties = Object.fromEntries(Object.entries(schema.properties).filter(([key]) => !omitted.has(key)))
-  const required = Array.isArray(schema.required)
-    ? schema.required.filter(value => typeof value === "string" && !omitted.has(value))
-    : []
+function openAPIInputBodySchema(schema: JsonSchema | undefined): JsonSchema | undefined {
+  if (!schema) return undefined
+  if (!isPlainRecord(schema.properties) && !Array.isArray(schema.required)) return schema
   const { required: _required, ...rest } = schema
-  return {
-    ...rest,
-    properties,
-    ...(required.length ? { required } : {}),
-  }
+  return rest
 }
 
 function hasRequiredProperties(schema: JsonSchema): boolean {
@@ -786,14 +731,14 @@ function jsonSchemaTypeMatches(type: string, value: unknown): boolean {
   }
 }
 
-function parameterObjectSchema(parameters: OpenAPIParameter[]): JsonSchema {
+function parameterObjectSchema(parameters: OpenAPIParameter[], includeRequired = true): JsonSchema {
   return {
     additionalProperties: false,
     properties: Object.fromEntries(parameters.map(parameter => [parameter.name, {
       ...(parameter.schema as JsonSchema),
       ...(parameter.description ? { description: parameter.description } : {}),
     }])),
-    required: parameters.filter(parameter => parameter.in === "path" || parameter.required).map(parameter => parameter.name),
+    required: parameters.filter(parameter => parameter.in === "path" || includeRequired && parameter.required).map(parameter => parameter.name),
     type: "object",
   }
 }

--- a/packages/agent/src/capabilities/openapi.ts
+++ b/packages/agent/src/capabilities/openapi.ts
@@ -116,16 +116,30 @@ export interface OpenAPIRequestPatch {
   timeout?: number
 }
 
+export interface OpenAPIHookProvidedInput {
+  body?: readonly string[]
+  path?: readonly string[]
+  query?: readonly string[]
+}
+
 export type OpenAPIRequestHook<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > = (context: OpenAPIRequestContext<TRuntimeConfig, Name>) => MaybePromise<OpenAPIRequestPatch | void>
 
+export interface OpenAPIRequestHookOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> {
+  handler: OpenAPIRequestHook<TRuntimeConfig, Name>
+  provides?: OpenAPIHookProvidedInput
+}
+
 export interface OpenAPIHooks<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > {
-  request?: OpenAPIRequestHook<TRuntimeConfig, Name>
+  request?: OpenAPIRequestHook<TRuntimeConfig, Name> | OpenAPIRequestHookOptions<TRuntimeConfig, Name>
 }
 
 export interface OpenAPICliOptions {
@@ -336,7 +350,7 @@ function createOpenAPITool<
     async execute(input) {
       return executeOpenAPIOperation(operation, baseUrl, options, context, input)
     },
-    inputSchema: operationInputSchema(operation, false, !options.hooks?.request),
+    inputSchema: operationInputSchema(operation, openAPIRequestProvidedInput(options)),
     metadata: {
       openapi: {
         method: operation.method,
@@ -369,7 +383,7 @@ function createOpenAPICli<
       description: operation.description,
       effects: [`http:${operation.method.toLowerCase()}`],
       examples: [`${cli.name} ${name}${outputFormat === "json" ? " --json" : ""}`],
-      input: openAPICliInputSchema(operation),
+      input: openAPICliInputSchema(operation, openAPIRequestProvidedInput(options)),
       output: { format: outputFormat },
       run: ({ input }) => executeOpenAPIOperation(operation, baseUrl, options, context, input),
     }
@@ -381,13 +395,13 @@ function createOpenAPICli<
   }
 }
 
-function openAPICliInputSchema(operation: OpenAPIOperationTool): AgentCapabilityCliStandardSchemaV1<OpenAPIToolInput> {
-  const schema = operationInputSchema(operation, false, false)
+function openAPICliInputSchema(operation: OpenAPIOperationTool, provided?: OpenAPIHookProvidedInput): AgentCapabilityCliStandardSchemaV1<OpenAPIToolInput> {
+  const schema = operationInputSchema(operation, provided)
   return {
     "~standard": {
       validate(value) {
         try {
-          const normalized = compactOpenAPIInput(normalizeRawToolInput(operation, value))
+          const normalized = compactOpenAPIInput(applyOpenAPIProvidedInput(normalizeRawToolInput(operation, value), provided))
           const issues = validateJsonSchema(schema, normalized, "input")
           return issues.length ? { issues } : { value: normalized }
         }
@@ -417,7 +431,7 @@ async function executeOpenAPIOperation<
   context: AgentCapabilityContext<TRuntimeConfig, Name>,
   input: unknown,
 ): Promise<unknown> {
-  const rawInput = normalizeRawToolInput(operation, input)
+  const rawInput = applyOpenAPIProvidedInput(normalizeRawToolInput(operation, input), openAPIRequestProvidedInput(options))
   const rawUrl = operationTemplateUrl(baseUrl, operation.path)
   const draft = createOpenAPIRequestDraft(rawInput, options.timeout)
   await applyOpenAPIRequestHook(options, {
@@ -448,6 +462,25 @@ async function executeOpenAPIOperation<
   return transformOpenAPIResponse(options, context, operation, requestInput, draft, url, result)
 }
 
+function openAPIRequestOptions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: OpenAPICapabilityOptions<TRuntimeConfig, Name>,
+): OpenAPIRequestHookOptions<TRuntimeConfig, Name> | undefined {
+  if (!options.hooks?.request) return undefined
+  return typeof options.hooks.request === "function" ? { handler: options.hooks.request } : options.hooks.request
+}
+
+function openAPIRequestProvidedInput<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: OpenAPICapabilityOptions<TRuntimeConfig, Name>,
+): OpenAPIHookProvidedInput | undefined {
+  return openAPIRequestOptions(options)?.provides
+}
+
 function createOpenAPIRequestDraft(input: OpenAPIToolInput, timeout: number | undefined): OpenAPIRequestDraft {
   return {
     ...(input.body !== undefined ? { body: input.body } : {}),
@@ -466,7 +499,7 @@ async function applyOpenAPIRequestHook<
   options: OpenAPICapabilityOptions<TRuntimeConfig, Name>,
   context: OpenAPIRequestContext<TRuntimeConfig, Name>,
 ): Promise<void> {
-  const hook = options.hooks?.request
+  const hook = openAPIRequestOptions(options)?.handler
   if (!hook) return
   const patch = await hook(context)
   if (patch) applyOpenAPIRequestPatch(context.request, patch)
@@ -490,6 +523,24 @@ function headersToRecord(headers: Headers): OpenAPIHeaders | undefined {
     result[key] = value
   })
   return Object.keys(result).length ? result : undefined
+}
+
+function applyOpenAPIProvidedInput(input: OpenAPIToolInput, provided: OpenAPIHookProvidedInput | undefined): OpenAPIToolInput {
+  if (!provided) return input
+  return {
+    ...input,
+    body: omitInputFields(input.body, provided.body),
+    path: omitInputFields(input.path, provided.path),
+    query: omitInputFields(input.query, provided.query),
+  }
+}
+
+function omitInputFields<T>(input: T, omitted: readonly string[] | undefined): T | undefined {
+  if (!omitted?.length || input === undefined) return input
+  if (!isPlainRecord(input)) return input
+  const omittedFields = new Set(omitted)
+  const visible = Object.fromEntries(Object.entries(input).filter(([key]) => !omittedFields.has(key)))
+  return Object.keys(visible).length ? visible as T : undefined
 }
 
 function operationCommandName(cliName: string, operationId: string): string {
@@ -530,7 +581,7 @@ async function transformOpenAPIResponse<
 }
 
 function assertValidOpenAPIRequest(operation: OpenAPIOperationTool, input: OpenAPIToolInput): void {
-  const issues = validateJsonSchema(operationInputSchema(operation, true), compactOpenAPIInput(input), "request")
+  const issues = validateJsonSchema(operationInputSchema(operation), compactOpenAPIInput(input), "request")
   if (issues.length) throw new Error(`[vitehub] ${operation.operationId} request is invalid: ${issues.join(", ")}`)
 }
 
@@ -629,20 +680,23 @@ function operationTemplateUrl(baseUrl: URL, path: string): URL {
   return url
 }
 
-function operationInputSchema(operation: OpenAPIOperationTool, prepared = false, requirePath = true): JsonSchema {
+function operationInputSchema(operation: OpenAPIOperationTool, provided?: OpenAPIHookProvidedInput): JsonSchema {
   const properties: Record<string, JsonSchema> = {}
   const required: string[] = []
-  if (operation.pathParameters.length) {
-    properties.path = parameterObjectSchema(operation.pathParameters, requirePath)
-    if (requirePath && operation.pathParameters.some(parameter => parameter.required || parameter.in === "path")) required.push("path")
+  const pathParameters = visibleParameters(operation.pathParameters, provided?.path)
+  const queryParameters = visibleParameters(operation.queryParameters, provided?.query)
+  const bodySchema = visibleObjectSchema(operation.bodySchema, provided?.body)
+  if (pathParameters.length) {
+    properties.path = parameterObjectSchema(pathParameters)
+    if (pathParameters.some(parameter => parameter.required || parameter.in === "path")) required.push("path")
   }
-  if (operation.queryParameters.length) {
-    properties.query = parameterObjectSchema(operation.queryParameters, prepared)
+  if (queryParameters.length) {
+    properties.query = parameterObjectSchema(queryParameters)
+    if (queryParameters.some(parameter => parameter.required)) required.push("query")
   }
-  const bodySchema = prepared ? operation.bodySchema : openAPIInputBodySchema(operation.bodySchema)
   if (bodySchema) {
     properties.body = bodySchema
-    if (prepared && hasRequiredProperties(bodySchema)) required.push("body")
+    if (hasRequiredProperties(bodySchema)) required.push("body")
   }
   return {
     additionalProperties: false,
@@ -652,11 +706,26 @@ function operationInputSchema(operation: OpenAPIOperationTool, prepared = false,
   }
 }
 
-function openAPIInputBodySchema(schema: JsonSchema | undefined): JsonSchema | undefined {
-  if (!schema) return undefined
-  if (!isPlainRecord(schema.properties) && !Array.isArray(schema.required)) return schema
+function visibleParameters(parameters: OpenAPIParameter[], omit: readonly string[] | undefined): OpenAPIParameter[] {
+  if (!omit?.length) return parameters
+  const omitted = new Set(omit)
+  return parameters.filter(parameter => !parameter.name || !omitted.has(parameter.name))
+}
+
+function visibleObjectSchema(schema: JsonSchema | undefined, omit: readonly string[] | undefined): JsonSchema | undefined {
+  if (!schema || !omit?.length) return schema
+  if (!isPlainRecord(schema.properties)) return schema
+  const omitted = new Set(omit)
+  const properties = Object.fromEntries(Object.entries(schema.properties).filter(([key]) => !omitted.has(key)))
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter(value => typeof value === "string" && !omitted.has(value))
+    : []
   const { required: _required, ...rest } = schema
-  return rest
+  return {
+    ...rest,
+    properties,
+    ...(required.length ? { required } : {}),
+  }
 }
 
 function hasRequiredProperties(schema: JsonSchema): boolean {

--- a/packages/agent/src/capabilities/openapi.ts
+++ b/packages/agent/src/capabilities/openapi.ts
@@ -382,7 +382,7 @@ function createOpenAPICli<
 }
 
 function openAPICliInputSchema(operation: OpenAPIOperationTool): AgentCapabilityCliStandardSchemaV1<OpenAPIToolInput> {
-  const schema = operationInputSchema(operation)
+  const schema = operationInputSchema(operation, false, false)
   return {
     "~standard": {
       validate(value) {
@@ -629,12 +629,12 @@ function operationTemplateUrl(baseUrl: URL, path: string): URL {
   return url
 }
 
-function operationInputSchema(operation: OpenAPIOperationTool, prepared = false): JsonSchema {
+function operationInputSchema(operation: OpenAPIOperationTool, prepared = false, requirePath = true): JsonSchema {
   const properties: Record<string, JsonSchema> = {}
   const required: string[] = []
   if (operation.pathParameters.length) {
     properties.path = parameterObjectSchema(operation.pathParameters)
-    if (operation.pathParameters.some(parameter => parameter.required || parameter.in === "path")) required.push("path")
+    if (requirePath && operation.pathParameters.some(parameter => parameter.required || parameter.in === "path")) required.push("path")
   }
   if (operation.queryParameters.length) {
     properties.query = parameterObjectSchema(operation.queryParameters, prepared)

--- a/packages/agent/test/openapi-capability.test.ts
+++ b/packages/agent/test/openapi-capability.test.ts
@@ -273,7 +273,7 @@ describe("openapi capability", () => {
     expect(request.mock.calls[0]?.[0]).toBe("https://cli.example.com/runtime/customers?region=eu")
   })
 
-  it("prepares requests while hiding host-supplied fields from tool schema", async () => {
+  it("prepares requests with runtime hook values before HTTP execution", async () => {
     const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ ok: true }))
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { openapi } = await import("../src/capabilities.ts")
@@ -282,16 +282,11 @@ describe("openapi capability", () => {
       capabilities: [
         openapi({
           operations: ["createOrder"],
-          request: {
-            hidden: {
-              body: ["cubeToken"],
-              path: ["tenantId"],
-              query: ["currency"],
-            },
-            onRequest({ context, request }) {
+          hooks: {
+            request({ context, request }) {
               const cubeToken = context.get<{ cubeToken: string }>("portal")?.cubeToken
               const previewCookie = context.get<{ previewCookie: string }>("portal")?.previewCookie
-              request.body = { cubeToken, ...(request.body as Record<string, unknown> | undefined) }
+              request.body = { ...(request.body as Record<string, unknown> | undefined), cubeToken }
               request.path.tenantId = "acme"
               request.query.currency = "EUR"
               if (cubeToken) request.headers.set("x-cube-token", cubeToken)
@@ -309,28 +304,21 @@ describe("openapi capability", () => {
       prompt: "create",
     })
     const tools = resolved.tools as AgentToolSet
-    const schema = tools.createOrder.inputSchema as {
-      properties: Record<string, { properties?: Record<string, unknown>, required?: string[] } | undefined>
-    }
-
-    expect(schema.properties.path).toBeUndefined()
-    expect(schema.properties.query).toBeUndefined()
-    const bodySchema = schema.properties.body!
-    expect(bodySchema.required).toEqual(["sku"])
-    expect(bodySchema.properties?.cubeToken).toBeUndefined()
 
     await expect(tools.createOrder.execute?.({
-      body: { quantity: 2, sku: "sku-1" },
+      body: { cubeToken: "model-token", quantity: 2, sku: "sku-1" },
+      path: { tenantId: "model-tenant" },
+      query: { currency: "USD" },
     })).resolves.toEqual({ ok: true })
 
     const init = request.mock.calls[0]?.[1] as RequestInit
     expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/tenants/acme/orders?currency=EUR")
-    expect(init.body).toBe(JSON.stringify({ cubeToken: "cube-token", quantity: 2, sku: "sku-1" }))
+    expect(JSON.parse(init.body as string)).toEqual({ cubeToken: "cube-token", quantity: 2, sku: "sku-1" })
     expect((init.headers as Headers).get("cookie")).toBe("preview=preview-cookie")
     expect((init.headers as Headers).get("x-cube-token")).toBe("cube-token")
   })
 
-  it("hides host-supplied fields from generated OpenAPI CLI inputs", async () => {
+  it("prepares generated OpenAPI CLI requests with runtime hook values", async () => {
     const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ ok: true }))
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { openapi } = await import("../src/capabilities.ts")
@@ -340,16 +328,11 @@ describe("openapi capability", () => {
         openapi({
           cli: { name: "portal" },
           operations: ["createOrder"],
-          request: {
-            hidden: {
-              body: ["cubeToken"],
-              path: ["tenantId"],
-              query: ["currency"],
-            },
-            onRequest({ context, request }) {
+          hooks: {
+            request({ context, request }) {
               request.body = {
-                cubeToken: context.get<{ cubeToken: string }>("portal")?.cubeToken,
                 ...(request.body as Record<string, unknown> | undefined),
+                cubeToken: context.get<{ cubeToken: string }>("portal")?.cubeToken,
               }
               request.path.tenantId = "acme"
               request.query.currency = "EUR"
@@ -366,11 +349,9 @@ describe("openapi capability", () => {
     await expect(resolved.tools?.portal?.execute?.({
       argv: ["create-order", "--json"],
       input: {
-        cubeToken: "override-token",
+        body: { quantity: 2, sku: "sku-1" },
         path: { tenantId: "evil" },
-        quantity: 2,
         query: { currency: "USD" },
-        sku: "sku-1",
       },
     })).resolves.toMatchObject({
       cli: "portal",
@@ -380,7 +361,7 @@ describe("openapi capability", () => {
 
     const init = request.mock.calls[0]?.[1] as RequestInit
     expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/tenants/acme/orders?currency=EUR")
-    expect(init.body).toBe(JSON.stringify({ cubeToken: "cube-token", quantity: 2, sku: "sku-1" }))
+    expect(JSON.parse(init.body as string)).toEqual({ cubeToken: "cube-token", quantity: 2, sku: "sku-1" })
   })
 
   it("validates generated OpenAPI CLI inputs before requests", async () => {
@@ -400,8 +381,8 @@ describe("openapi capability", () => {
 
     await expect(resolved.tools?.portal?.execute?.({
       argv: ["create-order", "--json"],
-      input: { body: {} },
-    })).rejects.toThrow("Invalid portal create-order input")
+      input: { body: {}, path: { tenantId: "acme" } },
+    })).rejects.toThrow("createOrder request is invalid")
     await expect(resolved.tools?.portal?.execute?.({
       argv: ["create-order", "--json"],
       input: {
@@ -531,13 +512,9 @@ describe("openapi capability", () => {
       capabilities: [
         openapi({
           operations: ["createOrder"],
-          request: {
-            hidden: {
-              body: ["cubeToken"],
-              path: ["tenantId"],
-            },
-            onRequest({ request }) {
-              request.body = { cubeToken: "cube-token", ...(request.body as Record<string, unknown> | undefined) }
+          hooks: {
+            request({ request }) {
+              request.body = { ...(request.body as Record<string, unknown> | undefined), cubeToken: "cube-token" }
               request.path.tenantId = "acme"
             },
           },
@@ -553,7 +530,7 @@ describe("openapi capability", () => {
     })).resolves.toEqual({ ok: true })
 
     const init = request.mock.calls[0]?.[1] as RequestInit
-    expect(init.body).toBe(JSON.stringify({ cubeToken: "cube-token", quantity: 2, sku: "sku-1" }))
+    expect(JSON.parse(init.body as string)).toEqual({ cubeToken: "cube-token", quantity: 2, sku: "sku-1" })
   })
 
   it("can transform raw operation responses with request context", async () => {
@@ -567,10 +544,9 @@ describe("openapi capability", () => {
       capabilities: [
         openapi({
           operations: ["createOrder"],
-          request: {
-            hidden: { body: ["cubeToken"], path: ["tenantId"] },
-            onRequest({ request }) {
-              request.body = { cubeToken: "cube-token", ...(request.body as Record<string, unknown> | undefined) }
+          hooks: {
+            request({ request }) {
+              request.body = { ...(request.body as Record<string, unknown> | undefined), cubeToken: "cube-token" }
               request.path.tenantId = "acme"
             },
           },

--- a/packages/agent/test/openapi-capability.test.ts
+++ b/packages/agent/test/openapi-capability.test.ts
@@ -42,6 +42,7 @@ function portalSpec() {
           operationId: "getReport",
           parameters: [
             { in: "query", name: "period", required: true, schema: { type: "string" } },
+            { in: "query", name: "tenantId", required: true, schema: { type: "string" } },
           ],
           summary: "Get report.",
         },
@@ -385,6 +386,43 @@ describe("openapi capability", () => {
     expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/tenants/acme/orders/order-1")
   })
 
+  it("keeps caller-owned required query fields when hooks provide other query fields", async () => {
+    const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ ok: true }))
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        openapi({
+          operations: ["getReport"],
+          hooks: {
+            request: {
+              provides: { query: ["tenantId"] },
+              handler({ request }) {
+                request.query.tenantId = "acme"
+              },
+            },
+          },
+          spec: portalSpec(),
+        }),
+      ],
+    }, runtime(), { prompt: "report" })
+    const tools = resolved.tools as AgentToolSet
+    const schema = tools.getReport.inputSchema as {
+      properties: { query?: { properties?: Record<string, unknown>, required?: string[] } }
+      required?: string[]
+    }
+    expect(schema.properties.query?.required).toEqual(["period"])
+    expect(schema.properties.query?.properties?.tenantId).toBeUndefined()
+    expect(schema.required).toEqual(["query"])
+
+    await expect(tools.getReport.execute?.({
+      query: { period: "2026-Q2", tenantId: "evil" },
+    })).resolves.toEqual({ ok: true })
+
+    expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/reports?period=2026-Q2&tenantId=acme")
+  })
+
   it("keeps caller-owned required path query and body fields in tool schemas", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { openapi } = await import("../src/capabilities.ts")
@@ -411,7 +449,7 @@ describe("openapi capability", () => {
     expect(createOrder.properties.path?.required).toEqual(["tenantId"])
     expect(createOrder.properties.body?.required).toEqual(["cubeToken", "sku"])
     expect(getReport.required).toEqual(["query"])
-    expect(getReport.properties.query?.required).toEqual(["period"])
+    expect(getReport.properties.query?.required).toEqual(["period", "tenantId"])
   })
 
   it("prepares generated OpenAPI CLI requests with runtime hook values", async () => {
@@ -452,7 +490,7 @@ describe("openapi capability", () => {
     await expect(resolved.tools?.portal?.execute?.({
       argv: ["create-order", "--json"],
       input: {
-        body: { quantity: 2, sku: "sku-1" },
+        body: { cubeToken: "model-token", quantity: 2, sku: "sku-1" },
         query: { currency: "USD" },
       },
     })).resolves.toMatchObject({
@@ -464,6 +502,11 @@ describe("openapi capability", () => {
     const init = request.mock.calls[0]?.[1] as RequestInit
     expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/tenants/acme/orders?currency=EUR")
     expect(JSON.parse(init.body as string)).toEqual({ cubeToken: "cube-token", quantity: 2, sku: "sku-1" })
+
+    await expect(resolved.tools?.portal?.execute?.({
+      argv: ["create-order", "--json"],
+      input: { body: { quantity: 2 } },
+    })).rejects.toThrow("input.body.sku is required")
   })
 
   it("allows generated OpenAPI CLI requests to pass partial path input before hooks", async () => {
@@ -499,6 +542,55 @@ describe("openapi capability", () => {
     })
 
     expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/tenants/acme/orders/order-1")
+
+    await expect(resolved.tools?.portal?.execute?.({
+      argv: ["get-order", "--json"],
+      input: {},
+    })).rejects.toThrow("input.path is required")
+  })
+
+  it("keeps generated OpenAPI CLI caller-owned query fields required when hooks provide other query fields", async () => {
+    const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ ok: true }))
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        openapi({
+          cli: { name: "portal" },
+          operations: ["getReport"],
+          hooks: {
+            request: {
+              provides: { query: ["tenantId"] },
+              handler({ request }) {
+                request.query.tenantId = "acme"
+              },
+            },
+          },
+          spec: portalSpec(),
+        }),
+      ],
+    }, runtime(), { prompt: "report" })
+
+    await expect(resolved.tools?.portal?.execute?.({
+      argv: ["get-report", "--json"],
+      input: { query: { period: "2026-Q2", tenantId: "evil" } },
+    })).resolves.toMatchObject({
+      cli: "portal",
+      exitCode: 0,
+      json: { ok: true },
+    })
+
+    expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/reports?period=2026-Q2&tenantId=acme")
+
+    await expect(resolved.tools?.portal?.execute?.({
+      argv: ["get-report", "--json"],
+      input: {},
+    })).rejects.toThrow("input.query is required")
+    await expect(resolved.tools?.portal?.execute?.({
+      argv: ["get-report", "--json"],
+      input: { query: {} },
+    })).rejects.toThrow("input.query is required")
   })
 
   it("validates generated OpenAPI CLI inputs before requests", async () => {
@@ -654,9 +746,15 @@ describe("openapi capability", () => {
         openapi({
           operations: ["createOrder"],
           hooks: {
-            request({ request }) {
-              request.body = { ...(request.body as Record<string, unknown> | undefined), cubeToken: "cube-token" }
-              request.path.tenantId = "acme"
+            request: {
+              provides: {
+                body: ["cubeToken"],
+                path: ["tenantId"],
+              },
+              handler({ request }) {
+                request.body = { ...(request.body as Record<string, unknown> | undefined), cubeToken: "cube-token" }
+                request.path.tenantId = "acme"
+              },
             },
           },
           spec: portalSpec(),
@@ -686,9 +784,15 @@ describe("openapi capability", () => {
         openapi({
           operations: ["createOrder"],
           hooks: {
-            request({ request }) {
-              request.body = { ...(request.body as Record<string, unknown> | undefined), cubeToken: "cube-token" }
-              request.path.tenantId = "acme"
+            request: {
+              provides: {
+                body: ["cubeToken"],
+                path: ["tenantId"],
+              },
+              handler({ request }) {
+                request.body = { ...(request.body as Record<string, unknown> | undefined), cubeToken: "cube-token" }
+                request.path.tenantId = "acme"
+              },
             },
           },
           spec: portalSpec(),

--- a/packages/agent/test/openapi-capability.test.ts
+++ b/packages/agent/test/openapi-capability.test.ts
@@ -64,6 +64,16 @@ function portalSpec() {
           summary: "Create order.",
         },
       },
+      "/tenants/{tenantId}/orders/{orderId}": {
+        get: {
+          operationId: "getOrder",
+          parameters: [
+            { in: "path", name: "tenantId", required: true, schema: { type: "string" } },
+            { in: "path", name: "orderId", required: true, schema: { type: "string" } },
+          ],
+          summary: "Get order.",
+        },
+      },
     },
   }
 }
@@ -318,6 +328,35 @@ describe("openapi capability", () => {
     expect((init.headers as Headers).get("x-cube-token")).toBe("cube-token")
   })
 
+  it("allows hooks to fill path params without requiring them in tool input", async () => {
+    const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ ok: true }))
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        openapi({
+          operations: ["getOrder"],
+          hooks: {
+            request({ request }) {
+              request.path.tenantId = "acme"
+            },
+          },
+          spec: portalSpec(),
+        }),
+      ],
+    }, runtime(), { prompt: "get" })
+    const tools = resolved.tools as AgentToolSet
+    const schema = tools.getOrder.inputSchema as { properties: { path?: { required?: string[] } } }
+    expect(schema.properties.path?.required || []).toEqual([])
+
+    await expect(tools.getOrder.execute?.({
+      path: { orderId: "order-1" },
+    })).resolves.toEqual({ ok: true })
+
+    expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/tenants/acme/orders/order-1")
+  })
+
   it("prepares generated OpenAPI CLI requests with runtime hook values", async () => {
     const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ ok: true }))
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
@@ -361,6 +400,38 @@ describe("openapi capability", () => {
     const init = request.mock.calls[0]?.[1] as RequestInit
     expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/tenants/acme/orders?currency=EUR")
     expect(JSON.parse(init.body as string)).toEqual({ cubeToken: "cube-token", quantity: 2, sku: "sku-1" })
+  })
+
+  it("allows generated OpenAPI CLI requests to pass partial path input before hooks", async () => {
+    const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ ok: true }))
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        openapi({
+          cli: { name: "portal" },
+          operations: ["getOrder"],
+          hooks: {
+            request({ request }) {
+              request.path.tenantId = "acme"
+            },
+          },
+          spec: portalSpec(),
+        }),
+      ],
+    }, runtime(), { prompt: "get" })
+
+    await expect(resolved.tools?.portal?.execute?.({
+      argv: ["get-order", "--json"],
+      input: { path: { orderId: "order-1" } },
+    })).resolves.toMatchObject({
+      cli: "portal",
+      exitCode: 0,
+      json: { ok: true },
+    })
+
+    expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/tenants/acme/orders/order-1")
   })
 
   it("validates generated OpenAPI CLI inputs before requests", async () => {

--- a/packages/agent/test/openapi-capability.test.ts
+++ b/packages/agent/test/openapi-capability.test.ts
@@ -350,7 +350,6 @@ describe("openapi capability", () => {
       argv: ["create-order", "--json"],
       input: {
         body: { quantity: 2, sku: "sku-1" },
-        path: { tenantId: "evil" },
         query: { currency: "USD" },
       },
     })).resolves.toMatchObject({

--- a/packages/agent/test/openapi-capability.test.ts
+++ b/packages/agent/test/openapi-capability.test.ts
@@ -37,6 +37,15 @@ function portalSpec() {
           summary: "Delete customer.",
         },
       },
+      "/reports": {
+        get: {
+          operationId: "getReport",
+          parameters: [
+            { in: "query", name: "period", required: true, schema: { type: "string" } },
+          ],
+          summary: "Get report.",
+        },
+      },
       "/tenants/{tenantId}/orders": {
         post: {
           operationId: "createOrder",
@@ -293,14 +302,21 @@ describe("openapi capability", () => {
         openapi({
           operations: ["createOrder"],
           hooks: {
-            request({ context, request }) {
-              const cubeToken = context.get<{ cubeToken: string }>("portal")?.cubeToken
-              const previewCookie = context.get<{ previewCookie: string }>("portal")?.previewCookie
-              request.body = { ...(request.body as Record<string, unknown> | undefined), cubeToken }
-              request.path.tenantId = "acme"
-              request.query.currency = "EUR"
-              if (cubeToken) request.headers.set("x-cube-token", cubeToken)
-              if (previewCookie) request.cookies.preview = previewCookie
+            request: {
+              provides: {
+                body: ["cubeToken"],
+                path: ["tenantId"],
+                query: ["currency"],
+              },
+              handler({ context, request }) {
+                const cubeToken = context.get<{ cubeToken: string }>("portal")?.cubeToken
+                const previewCookie = context.get<{ previewCookie: string }>("portal")?.previewCookie
+                request.body = { ...(request.body as Record<string, unknown> | undefined), cubeToken }
+                request.path.tenantId = "acme"
+                request.query.currency = "EUR"
+                if (cubeToken) request.headers.set("x-cube-token", cubeToken)
+                if (previewCookie) request.cookies.preview = previewCookie
+              },
             },
           },
           spec: portalSpec(),
@@ -314,7 +330,15 @@ describe("openapi capability", () => {
       prompt: "create",
     })
     const tools = resolved.tools as AgentToolSet
-    expect(((tools.createOrder.inputSchema as { required?: string[] }).required || [])).not.toContain("path")
+    const schema = tools.createOrder.inputSchema as {
+      properties: Record<string, { properties?: Record<string, unknown>, required?: string[] } | undefined>
+      required?: string[]
+    }
+    expect(schema.properties.path).toBeUndefined()
+    expect(schema.properties.query).toBeUndefined()
+    expect(schema.properties.body?.required).toEqual(["sku"])
+    expect(schema.properties.body?.properties?.cubeToken).toBeUndefined()
+    expect(schema.required).toEqual(["body"])
 
     await expect(tools.createOrder.execute?.({
       body: { cubeToken: "model-token", quantity: 2, sku: "sku-1" },
@@ -338,8 +362,11 @@ describe("openapi capability", () => {
         openapi({
           operations: ["getOrder"],
           hooks: {
-            request({ request }) {
-              request.path.tenantId = "acme"
+            request: {
+              provides: { path: ["tenantId"] },
+              handler({ request }) {
+                request.path.tenantId = "acme"
+              },
             },
           },
           spec: portalSpec(),
@@ -347,14 +374,44 @@ describe("openapi capability", () => {
       ],
     }, runtime(), { prompt: "get" })
     const tools = resolved.tools as AgentToolSet
-    const schema = tools.getOrder.inputSchema as { properties: { path?: { required?: string[] } } }
-    expect(schema.properties.path?.required || []).toEqual([])
+    const schema = tools.getOrder.inputSchema as { properties: { path?: { required?: string[] } }, required?: string[] }
+    expect(schema.properties.path?.required).toEqual(["orderId"])
+    expect(schema.required).toEqual(["path"])
 
     await expect(tools.getOrder.execute?.({
       path: { orderId: "order-1" },
     })).resolves.toEqual({ ok: true })
 
     expect(request.mock.calls[0]?.[0]).toBe("https://portal.example.com/runtime/tenants/acme/orders/order-1")
+  })
+
+  it("keeps caller-owned required path query and body fields in tool schemas", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        openapi({
+          operations: ["createOrder", "getReport"],
+          spec: portalSpec(),
+        }),
+      ],
+    }, runtime(), { prompt: "inspect" })
+    const tools = resolved.tools as AgentToolSet
+    const createOrder = tools.createOrder.inputSchema as {
+      properties: { body?: { required?: string[] }, path?: { required?: string[] } }
+      required?: string[]
+    }
+    const getReport = tools.getReport.inputSchema as {
+      properties: { query?: { required?: string[] } }
+      required?: string[]
+    }
+
+    expect(createOrder.required).toEqual(["path", "body"])
+    expect(createOrder.properties.path?.required).toEqual(["tenantId"])
+    expect(createOrder.properties.body?.required).toEqual(["cubeToken", "sku"])
+    expect(getReport.required).toEqual(["query"])
+    expect(getReport.properties.query?.required).toEqual(["period"])
   })
 
   it("prepares generated OpenAPI CLI requests with runtime hook values", async () => {
@@ -368,13 +425,20 @@ describe("openapi capability", () => {
           cli: { name: "portal" },
           operations: ["createOrder"],
           hooks: {
-            request({ context, request }) {
-              request.body = {
-                ...(request.body as Record<string, unknown> | undefined),
-                cubeToken: context.get<{ cubeToken: string }>("portal")?.cubeToken,
-              }
-              request.path.tenantId = "acme"
-              request.query.currency = "EUR"
+            request: {
+              provides: {
+                body: ["cubeToken"],
+                path: ["tenantId"],
+                query: ["currency"],
+              },
+              handler({ context, request }) {
+                request.body = {
+                  ...(request.body as Record<string, unknown> | undefined),
+                  cubeToken: context.get<{ cubeToken: string }>("portal")?.cubeToken,
+                }
+                request.path.tenantId = "acme"
+                request.query.currency = "EUR"
+              },
             },
           },
           spec: portalSpec(),
@@ -413,8 +477,11 @@ describe("openapi capability", () => {
           cli: { name: "portal" },
           operations: ["getOrder"],
           hooks: {
-            request({ request }) {
-              request.path.tenantId = "acme"
+            request: {
+              provides: { path: ["tenantId"] },
+              handler({ request }) {
+                request.path.tenantId = "acme"
+              },
             },
           },
           spec: portalSpec(),
@@ -452,7 +519,11 @@ describe("openapi capability", () => {
     await expect(resolved.tools?.portal?.execute?.({
       argv: ["create-order", "--json"],
       input: { body: {}, path: { tenantId: "acme" } },
-    })).rejects.toThrow("createOrder request is invalid")
+    })).rejects.toThrow("input.body.cubeToken is required")
+    await expect(resolved.tools?.portal?.execute?.({
+      argv: ["create-order", "--json"],
+      input: { body: { cubeToken: "cube-token", sku: "sku-1" } },
+    })).rejects.toThrow("input.path is required")
     await expect(resolved.tools?.portal?.execute?.({
       argv: ["create-order", "--json"],
       input: {

--- a/packages/agent/test/openapi-capability.test.ts
+++ b/packages/agent/test/openapi-capability.test.ts
@@ -304,10 +304,10 @@ describe("openapi capability", () => {
       prompt: "create",
     })
     const tools = resolved.tools as AgentToolSet
+    expect(((tools.createOrder.inputSchema as { required?: string[] }).required || [])).not.toContain("path")
 
     await expect(tools.createOrder.execute?.({
       body: { cubeToken: "model-token", quantity: 2, sku: "sku-1" },
-      path: { tenantId: "model-tenant" },
       query: { currency: "USD" },
     })).resolves.toEqual({ ok: true })
 

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -84,6 +84,21 @@ describe("agent public types", () => {
             return response
           },
         }),
+        openapi({
+          operations: ["listCustomers"],
+          hooks: {
+            request: {
+              provides: {
+                query: ["region"],
+              },
+              handler({ request }) {
+                request.query.region = "eu"
+                return { headers: { authorization: "Bearer token" } }
+              },
+            },
+          },
+          spec: openAPISpec,
+        }),
         git(),
         git({ mode: "read" }),
         git({ mode: "write", policy: "require-approval" }),

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -68,12 +68,14 @@ describe("agent public types", () => {
         }),
         openapi({
           operations: ["listCustomers"],
-          request({ context, operation, request }) {
-            expectTypeOf(context.get<{ token: string }>("billing")?.token).toEqualTypeOf<string | undefined>()
-            expectTypeOf(operation.id).toEqualTypeOf<string>()
-            expectTypeOf(request.headers).toEqualTypeOf<Headers>()
-            request.headers.set("authorization", "Bearer token")
-            return { query: { region: "eu" } }
+          hooks: {
+            request({ context, operation, request }) {
+              expectTypeOf(context.get<{ token: string }>("billing")?.token).toEqualTypeOf<string | undefined>()
+              expectTypeOf(operation.id).toEqualTypeOf<string>()
+              expectTypeOf(request.headers).toEqualTypeOf<Headers>()
+              request.headers.set("authorization", "Bearer token")
+              return { query: { region: "eu" } }
+            },
           },
           spec: openAPISpec,
           transformResponse(response, { request }) {
@@ -238,8 +240,11 @@ describe("agent public types", () => {
     // @ts-expect-error use operations as the direct operationId allowlist
     openapi({ operations: { allow: ["listCustomers"] }, spec: openAPISpec })
 
-    // @ts-expect-error use request.onRequest for host-supplied request values
+    // @ts-expect-error use hooks.request for host-supplied request values
     openapi({ defaults: { body: { token: "secret" } }, operations: ["listCustomers"], spec: openAPISpec })
+
+    // @ts-expect-error OpenAPI request preparation uses hooks.request
+    openapi({ operations: ["listCustomers"], request: () => undefined, spec: openAPISpec })
 
     // @ts-expect-error use server only as the explicit server override
     openapi({ baseUrl: "https://api.example.com", operations: ["listCustomers"], spec: openAPISpec })


### PR DESCRIPTION
Replaces the OpenAPI capability request-preparation API with a Nuxt/UnJS-style `hooks.request` hook so runtime auth, tenant, body, header, and cookie values are injected on the request draft before final validation.

This removes the public `request.hidden` / `onRequest` shape left in #426 while keeping operation selection, spec-derived servers, the `server` escape hatch, generated CLI support, and `transformResponse`.