### PR TITLE
fix(agent): render dev delivery reactions

### DIFF
--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -193,6 +193,20 @@ function writeDeliveryPreviewPayload(context: AgentCliContext, value: unknown): 
   writeDevPayload(context, preview.label, preview.value)
 }
 
+function deliveryReactionContent(payload: unknown): string | undefined {
+  if (typeof payload === "string") return payload
+  return isRecord(payload) && typeof payload.content === "string" ? payload.content : undefined
+}
+
+function deliveryPreviewHeader(event: { channelId?: string, effect: { kind: string, payload?: unknown } }): string {
+  const channel = event.channelId ? ` on ${event.channelId}` : ""
+  if (event.effect.kind === "reaction") {
+    const content = deliveryReactionContent(event.effect.payload)
+    return `[delivery] reaction${content ? ` ${content}` : ""}${channel}`
+  }
+  return `[delivery preview] would ${event.effect.kind}${channel}`
+}
+
 function toolTextOutput(value: unknown, seen = new Set<unknown>()): string | undefined {
   if (!isRecord(value) || seen.has(value)) return
   seen.add(value)
@@ -843,9 +857,9 @@ async function sendDevMessage(
       if (event.type === "delivery-preview") {
         clearPendingFallback()
         previewSeen = true
-        context.stderr.write(`\n[delivery preview] would ${event.effect.kind}${event.channelId ? ` on ${event.channelId}` : ""}\n`)
+        context.stderr.write(`\n${deliveryPreviewHeader(event)}\n`)
         writeDevPayload(context, "intent", event.effect.intent)
-        writeDeliveryPreviewPayload(context, event.effect.payload)
+        if (event.effect.kind !== "reaction") writeDeliveryPreviewPayload(context, event.effect.payload)
         writeDevPayload(context, "metadata", event.effect.metadata)
         continue
       }

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -507,6 +507,10 @@ export function createHarnessAgentAdapter<
       ...(typeof context.input.timeout === "number" ? { timeout: context.input.timeout } : {}),
     }
     const session = await agent.createSession(Object.keys(sessionOptions).length ? sessionOptions : undefined)
+    if (context.input.abortSignal?.aborted) {
+      await destroySession(session)
+      throw context.input.abortSignal.reason || new Error("[vitehub] Harness Agent Driver session aborted.")
+    }
     const cleanup = async (error?: unknown) => {
       let closeError = error
       try {

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -507,10 +507,6 @@ export function createHarnessAgentAdapter<
       ...(typeof context.input.timeout === "number" ? { timeout: context.input.timeout } : {}),
     }
     const session = await agent.createSession(Object.keys(sessionOptions).length ? sessionOptions : undefined)
-    if (context.input.abortSignal?.aborted) {
-      await destroySession(session)
-      throw context.input.abortSignal.reason || new Error("[vitehub] Harness Agent Driver session aborted.")
-    }
     const cleanup = async (error?: unknown) => {
       let closeError = error
       try {
@@ -531,6 +527,11 @@ export function createHarnessAgentAdapter<
         return
       }
       resumeStates.set(sessionId, await session.detach())
+    }
+    if (context.input.abortSignal?.aborted) {
+      const error = context.input.abortSignal.reason || new Error("[vitehub] Harness Agent Driver session aborted.")
+      await cleanup(error)
+      throw error
     }
     return {
       cleanup,

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -762,6 +762,7 @@ describe("agent CLI", () => {
       if (init?.method === "POST") {
         return ndjson([
           { agent: "review", trigger: "github.webhook", type: "start" },
+          { channelId: "github", effect: { kind: "reaction", payload: { content: "eyes" } }, type: "delivery-preview" },
           { text: "verbose review prose", type: "text-delta" },
           { channelId: "github", effect: { kind: "reply", payload: { body: "**Summary:** Short review.\n\n<details>\n<summary>Usage telemetry</summary>\n\nlarge table\n</details>" } }, type: "delivery-preview" },
           { type: "finish" },
@@ -793,8 +794,10 @@ describe("agent CLI", () => {
     }
 
     expect(stdout.output()).toBe(`Loaded payload: ${join(rootDir, "payload.json")}\n`)
+    expect(stderr.output()).toContain("[delivery] reaction eyes on github")
     expect(stderr.output()).toContain("[delivery preview] would reply on github")
     expect(stderr.output()).toContain("body: Summary: Short review.")
+    expect(stderr.output().indexOf("[delivery] reaction eyes on github")).toBeLessThan(stderr.output().indexOf("body: Summary: Short review."))
     expect(stderr.output()).not.toContain("Usage telemetry")
     expect(stderr.output()).not.toContain("large table")
     expect(stderr.output()).not.toContain("verbose review prose")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1314,6 +1314,30 @@ describe("agent message protocol", () => {
     expect(session.destroy).toHaveBeenCalledOnce()
   })
 
+  it("destroys harness sessions created after abort before running the harness", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const controller = new AbortController()
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockImplementationOnce(async () => {
+      controller.abort(new Error("timed out"))
+      return session
+    })
+
+    const agent = defineAgent({
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: { provider: "sandbox" },
+      },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      abortSignal: controller.signal,
+      prompt: "hello",
+    })).rejects.toThrow("timed out")
+    expect(session.destroy).toHaveBeenCalledOnce()
+    expect(harnessGenerate).not.toHaveBeenCalled()
+  })
+
   it("finalizes harness result output before finish hooks", async () => {
     const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -829,6 +829,41 @@ describe("defineAgent workspace option", () => {
     expect(harnessSession.destroy).toHaveBeenCalledOnce()
   })
 
+  it("closes Harness Workspace Sessions when session creation aborts after workspace preparation", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const controller = new AbortController()
+    const harnessSession = { destroy: vi.fn() }
+    const harnessWorkspaceSession = { close: vi.fn() }
+    const abortError = new Error("timed out")
+    harnessCreateSession.mockResolvedValueOnce(harnessSession)
+    prepareHarnessWorkspaceSession.mockImplementationOnce(async () => {
+      controller.abort(abortError)
+      return harnessWorkspaceSession
+    })
+    exists.mockResolvedValue(true)
+
+    const agent = withAgentDefaults(defineAgent({
+      driver: {
+        harness: { provider: "codex" },
+      },
+      workspace: {
+        sources: {
+          guide: {
+            path: "AGENTS.md",
+          },
+        },
+      },
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), {
+      abortSignal: controller.signal,
+      prompt: "hello",
+    })).rejects.toThrow("timed out")
+    expect(harnessWorkspaceSession.close).toHaveBeenCalledWith(abortError)
+    expect(harnessSession.destroy).toHaveBeenCalledOnce()
+    expect(harnessGenerate).not.toHaveBeenCalled()
+  })
+
   it("writes composed Instruction Documents into harness instruction files", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))


### PR DESCRIPTION
## Summary
- render `delivery-preview` reaction intents in `vitehub agent dev` as compact `[delivery] reaction ...` lines before final reply previews
- destroy harness sessions that are created after an abort/timeout before running the harness, so bridge leases are released
- keep Review reactions on the existing `inputCommands()` / `message.react()` delivery-effect path; no GitHub channel reaction policy added

## Validation
- `corepack pnpm exec vp test run test/cli.test.ts test/runtime.test.ts --reporter=dot` from `packages/agent`
- `corepack pnpm --filter @vite-hub/agent run typecheck`
- `corepack pnpm --filter @vite-hub/agent run test`
- `git diff --check`