### PR TITLE
feat(agent): deliver assets through message channels

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -125,7 +125,43 @@ Link command docs and command examples to [Capabilities](/docs/capabilities), no
 
 ## Deliver Workspace artifacts
 
-Delivery effects can include artifacts that were written into the Agent Workspace. Use `publishWorkspaceArtifacts()` from `@vite-hub/agent/channels` inside a finish effect when a channel needs public URLs or channel-native attachment handles.
+Delivery effects can include artifacts that were written into the Agent Workspace. Use workspace-relative artifact paths so ViteHub can read the generated files through the Agent Workspace instead of exposing host filesystem paths.
+
+Adapter-backed message channels, such as Slack, Telegram, Teams, Discord, and custom `defineChannel()` integrations with an adapter, send delivery artifacts through Chat SDK message output. Artifacts with a `url` become Chat SDK attachments. Workspace artifacts without a `url` become uploaded files when the artifact is not marked with `placement: 'link'`.
+
+```ts [server/agents/support.ts]
+import { defineAgent, defineCapability } from '@vite-hub/agent'
+import { telegram } from '@vite-hub/agent/channels'
+
+const screenshotDelivery = defineCapability({
+  id: 'screenshot-delivery',
+  prepare(context) {
+    context.delivery.finishEffect(() => ({
+      artifacts: [{
+        mediaType: 'image/png',
+        path: 'screenshots/login.png',
+        placement: 'attachment',
+      }],
+      kind: 'reply',
+      payload: { body: 'See attached screenshot.' },
+    }))
+  },
+})
+
+export default defineAgent({
+  capabilities: [screenshotDelivery],
+  channels: {
+    support: telegram({ adapter: createTelegramAdapter }),
+  },
+  workspace: { mode: 'write' },
+  run: async ({ workspace }) => {
+    await renderScreenshot(workspace, 'screenshots/login.png')
+    return 'Captured the login state.'
+  },
+})
+```
+
+GitHub comments and reviews need hosted markdown URLs instead of channel-native file uploads. The GitHub channel publishes workspace image paths that appear in reply or review bodies, then rewrites those paths to hosted raw URLs. Use `publishWorkspaceArtifacts()` from `@vite-hub/agent/channels` inside a finish effect when explicit GitHub artifacts need public URLs before delivery.
 
 ```ts [server/agents/review.ts]
 import { defineAgent } from '@vite-hub/agent'
@@ -162,7 +198,7 @@ export default defineAgent({
 })
 ```
 
-The GitHub channel renders inline image artifacts as markdown in `reply` and `review` effects. It only renders artifacts that already have a `url`; it does not scan `screenshots/**` or upload files unless your finish effect explicitly asks it to.
+The GitHub channel renders inline image artifacts as markdown in `reply` and `review` effects. It does not attach local files directly to GitHub comments.
 
 ## Next steps
 

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -26,7 +26,7 @@ import type {
   PublishedAgentDeliveryArtifact,
 } from "./types.ts"
 import type { AgentChannelChatRouteBody, AgentChannelChatRouteHandlerOptions } from "./server.ts"
-import type { FileUpload } from "chat"
+import type { Adapter, FileUpload } from "chat"
 
 export { deliveryArtifactAttachments } from "./delivery-artifacts.ts"
 export type {
@@ -279,6 +279,10 @@ function maybeStrings(value: unknown): string[] | undefined {
 
 function chatFinishExtension(input: AgentRunInput): AgentChatFinishExtension | undefined {
   const value = isRecord(input.context) ? input.context[CHAT_FINISH_EXTENSION_CONTEXT_KEY] : undefined
+  return chatFinishExtensionFromUnknown(value)
+}
+
+function chatFinishExtensionFromUnknown(value: unknown): AgentChatFinishExtension | undefined {
   return isRecord(value) && typeof value.sendMessage === "function"
     ? value as unknown as AgentChatFinishExtension
     : undefined
@@ -771,6 +775,17 @@ function replyBody<TRuntimeConfig extends AgentRuntimeConfig>(
   if (typeof context.effect.metadata?.body === "string") return context.effect.metadata.body
 }
 
+function replyBodyWithLinkArtifacts(body: string | undefined, artifacts: readonly PublishedAgentDeliveryArtifact[]): string | undefined {
+  const links = artifacts.flatMap((artifact) => {
+    if (artifact.placement !== "link" || !artifact.url) return []
+    const label = (artifact.alt || artifact.path.split("/").pop() || artifact.path).replace(/[\r\n\[\]]+/g, " ").trim() || "Artifact"
+    const url = artifact.url.replace(/[\r\n<>]+/g, "")
+    return url ? [`[${label}](<${url}>)`] : []
+  })
+  if (!links.length) return body
+  return body ? `${body}\n\n${links.join("\n")}` : links.join("\n")
+}
+
 function deliveryArtifactFromUnknown(value: unknown): PublishedAgentDeliveryArtifact | undefined {
   if (!isRecord(value) || typeof value.path !== "string") return
   return {
@@ -830,10 +845,8 @@ async function deliveryArtifactFiles<TRuntimeConfig extends AgentRuntimeConfig>(
 async function messageChannelReplyEffect<TRuntimeConfig extends AgentRuntimeConfig>(
   context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
 ): Promise<void> {
-  const chat = chatFinishExtension(context.input)
-  if (!chat) return
-  const body = replyBody(context)
   const artifacts = deliveryArtifacts(context)
+  const body = replyBodyWithLinkArtifacts(replyBody(context), artifacts)
   const attachments = deliveryArtifactAttachments(artifacts)
   const files = await deliveryArtifactFiles(context, artifacts)
   if (!body && !attachments.length && !files.length) return
@@ -842,7 +855,19 @@ async function messageChannelReplyEffect<TRuntimeConfig extends AgentRuntimeConf
     ...(attachments.length ? { attachments } : {}),
     ...(files.length ? { files } : {}),
   }
-  await chat.sendMessage(message)
+  const chat = context.finish
+    ? chatFinishExtensionFromUnknown(context.finish.extensions.get("chat")) || chatFinishExtension(context.input)
+    : undefined
+  if (chat) {
+    await chat.sendMessage(message)
+    return
+  }
+  const adapter = context.channel.adapter
+    ? await resolveEffectOption(context.channel.adapter as MaybeResolvable<Adapter, AgentChannelDeliveryEffectContext<TRuntimeConfig>>, context)
+    : undefined
+  if (adapter && context.run?.threadId) {
+    await adapter.postMessage(adapter.channelIdFromThreadId(context.run.threadId), message)
+  }
 }
 
 function messageChannelDeliveryEffects<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1,8 +1,12 @@
 import { createHash, createSign } from "node:crypto"
+import { CHAT_FINISH_EXTENSION_CONTEXT_KEY } from "./chat-trigger.ts"
+import { deliveryArtifactAttachments } from "./delivery-artifacts.ts"
 
 import type {
   AgentCallbackContext,
   AgentCapabilityDefinition,
+  AgentChatFinishExtension,
+  AgentChatMessage,
   AgentChannelDefinition,
   AgentChannelDeliveryEffectContext,
   AgentChannelDeliveryEffectIntent,
@@ -22,6 +26,7 @@ import type {
   PublishedAgentDeliveryArtifact,
 } from "./types.ts"
 import type { AgentChannelChatRouteBody, AgentChannelChatRouteHandlerOptions } from "./server.ts"
+import type { FileUpload } from "chat"
 
 export { deliveryArtifactAttachments } from "./delivery-artifacts.ts"
 export type {
@@ -270,6 +275,13 @@ function maybeStrings(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return
   const strings = value.filter((item): item is string => typeof item === "string" && Boolean(item))
   return strings.length ? strings : undefined
+}
+
+function chatFinishExtension(input: AgentRunInput): AgentChatFinishExtension | undefined {
+  const value = isRecord(input.context) ? input.context[CHAT_FINISH_EXTENSION_CONTEXT_KEY] : undefined
+  return isRecord(value) && typeof value.sendMessage === "function"
+    ? value as unknown as AgentChatFinishExtension
+    : undefined
 }
 
 function normalizeDeliveryArtifactPath(path: string, label: string): string {
@@ -781,6 +793,67 @@ function deliveryArtifacts<TRuntimeConfig extends AgentRuntimeConfig>(
   return artifacts.map(deliveryArtifactFromUnknown).filter((artifact): artifact is PublishedAgentDeliveryArtifact => Boolean(artifact))
 }
 
+function deliveryArtifactFilename(artifact: PublishedAgentDeliveryArtifact): string {
+  return artifact.path.split("/").filter(Boolean).at(-1) || "artifact"
+}
+
+function arrayBufferContent(value: ArrayBuffer | Uint8Array | string): ArrayBuffer {
+  if (value instanceof ArrayBuffer) return value
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value
+  const copy = new Uint8Array(bytes.byteLength)
+  copy.set(bytes)
+  return copy.buffer
+}
+
+async function deliveryArtifactFiles<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
+  artifacts: readonly PublishedAgentDeliveryArtifact[],
+): Promise<FileUpload[]> {
+  if (!context.workspace) return []
+  const files: FileUpload[] = []
+  for (const artifact of artifacts) {
+    if (artifact.url || artifact.placement === "link") continue
+    const path = normalizeDeliveryArtifactPath(artifact.path, "Delivery artifact path")
+    const stat = await context.workspace.fs.stat(path).catch(() => undefined)
+    if (stat && stat.type !== "file") continue
+    const mediaType = artifact.mediaType || stat?.mediaType
+    const content = await context.workspace.fs.readFile(path, { encoding: "binary" })
+    files.push({
+      data: arrayBufferContent(content as ArrayBuffer | Uint8Array | string),
+      filename: deliveryArtifactFilename(artifact),
+      ...(mediaType ? { mimeType: mediaType } : {}),
+    })
+  }
+  return files
+}
+
+async function messageChannelReplyEffect<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
+): Promise<void> {
+  const chat = chatFinishExtension(context.input)
+  if (!chat) return
+  const body = replyBody(context)
+  const artifacts = deliveryArtifacts(context)
+  const attachments = deliveryArtifactAttachments(artifacts)
+  const files = await deliveryArtifactFiles(context, artifacts)
+  if (!body && !attachments.length && !files.length) return
+  const message: AgentChatMessage = {
+    markdown: body || "",
+    ...(attachments.length ? { attachments } : {}),
+    ...(files.length ? { files } : {}),
+  }
+  await chat.sendMessage(message)
+}
+
+function messageChannelDeliveryEffects<TRuntimeConfig extends AgentRuntimeConfig>(
+  effects: AgentChannelDeliveryEffects<TRuntimeConfig> | undefined,
+): AgentChannelDeliveryEffects<TRuntimeConfig> {
+  return {
+    ...effects,
+    reply: effects?.reply ?? messageChannelReplyEffect,
+  }
+}
+
 function githubMarkdownText(value: string): string {
   return value.replace(/[\r\n\[\]]+/g, " ").trim() || "Artifact"
 }
@@ -1194,8 +1267,12 @@ export function defineChannel<TRuntimeConfig extends AgentRuntimeConfig = AgentR
   }
   const messages: false | AgentMessageChannelSettings<TRuntimeConfig> =
     options.messages === undefined ? {} as AgentMessageChannelSettings<TRuntimeConfig> : options.messages
+  const effects = messages !== false && options.adapter
+    ? messageChannelDeliveryEffects(options.effects)
+    : options.effects
   return {
     ...options,
+    ...(effects ? { effects } : {}),
     kind,
     messages,
   }

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2824,6 +2824,104 @@ describe("server helpers", () => {
     })
   })
 
+  it("posts prepare-time channel delivery replies before the final chat answer", async () => {
+    const { defineAgent, defineCapability } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "prepare-reply",
+          prepare(context) {
+            context.delivery.effect({ kind: "reply", payload: { body: "Preparing assets." } })
+          },
+        }),
+      ],
+      channels: {
+        support: telegram({
+          adapter: () => adapter as never,
+        }),
+      },
+      driver: { run: () => "agent answer" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/support", {
+      body: JSON.stringify({
+        update_id: 1888,
+        message: {
+          chat: { id: 988, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 1888,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "support")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:988", { markdown: "Preparing assets." })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:988", { markdown: "agent answer" })
+  })
+
+  it("posts finish channel delivery replies after input replacement and appends link artifacts", async () => {
+    const { defineAgent, defineCapability } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "finish-link-reply",
+          prepare(context) {
+            context.input.set({ prompt: "rewritten" })
+            context.delivery.finishEffect(() => ({
+              artifacts: [{
+                alt: "Result report",
+                path: "reports/result.md",
+                placement: "link",
+                url: "https://assets.example/reports/result.md",
+              }],
+              kind: "reply",
+              payload: { body: "See the report." },
+            }))
+          },
+        }),
+      ],
+      channels: {
+        support: telegram({
+          adapter: () => adapter as never,
+        }),
+      },
+      driver: { run: () => "agent answer" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/support", {
+      body: JSON.stringify({
+        update_id: 1887,
+        message: {
+          chat: { id: 987, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 1887,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "support")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:987", { markdown: "agent answer" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:987", {
+      markdown: "See the report.\n\n[Result report](<https://assets.example/reports/result.md>)",
+    })
+  })
+
   it("maps channel delivery reply artifacts to Chat SDK attachments and files", async () => {
     const { defineAgent, defineCapability } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2824,6 +2824,87 @@ describe("server helpers", () => {
     })
   })
 
+  it("maps channel delivery reply artifacts to Chat SDK attachments and files", async () => {
+    const { defineAgent, defineCapability } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const content = new Uint8Array([1, 2, 3])
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "delivery-assets",
+          prepare(context) {
+            context.delivery.finishEffect(() => ({
+              artifacts: [{
+                mediaType: "image/png",
+                path: "screenshots/login.png",
+                placement: "attachment",
+              }, {
+                mediaType: "image/png",
+                path: "screenshots/published.png",
+                placement: "inline",
+                url: "https://assets.example/screenshots/published.png",
+              }],
+              kind: "reply",
+              payload: { body: "See attached screenshots." },
+            }))
+          },
+        }),
+      ],
+      channels: {
+        support: telegram({
+          adapter: () => adapter as never,
+        }),
+      },
+      driver: {
+        run: async ({ workspace }) => {
+          await (workspace as { fs: { writeFile: (path: string, content: Uint8Array, options?: { mediaType?: string }) => Promise<void> } }).fs.writeFile("screenshots/login.png", content, { mediaType: "image/png" })
+          return "agent answer"
+        },
+      },
+      workspace: { mode: "write", store: { provider: "memory" } },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/support", {
+      body: JSON.stringify({
+        update_id: 1989,
+        message: {
+          chat: { id: 989, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 1989,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "support")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:989", { markdown: "agent answer" })
+    const deliveryMessage = adapter.postMessage.mock.calls[1]?.[1] as {
+      attachments?: Array<{ mimeType?: string, name?: string, type?: string, url?: string }>
+      files?: Array<{ data: ArrayBuffer, filename: string, mimeType?: string }>
+      markdown?: string
+    }
+    expect(deliveryMessage).toMatchObject({
+      attachments: [{
+        mimeType: "image/png",
+        name: "published.png",
+        type: "image",
+        url: "https://assets.example/screenshots/published.png",
+      }],
+      files: [{
+        filename: "login.png",
+        mimeType: "image/png",
+      }],
+      markdown: "See attached screenshots.",
+    })
+    expect(new Uint8Array(deliveryMessage.files![0]!.data)).toEqual(content)
+  })
+
   it("commits native streamed chat responses before flushing finish hook messages", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { chat } = await import("../src/capabilities.ts")


### PR DESCRIPTION
Extends the delivery artifact path from #444 to adapter-backed message channels. Default channel reply effects now send published artifact URLs as Chat SDK attachments and workspace-backed artifacts as Chat SDK files, so Telegram/Slack-style adapters can upload generated screenshots instead of rendering paths.

GitHub remains on its dedicated publish/rewrite delivery path because it needs repository asset hosting. The Channels docs now document both behaviors.