### PR TITLE
fix(agent): render operation tools as dev commands

### DIFF
--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -97,6 +97,7 @@ pnpm vitehub agent dev --agent support --timeout 180000 -p "/summary"
 
 Use `--cli` when a Capability attached to the Agent declares a Capability CLI.
 Everything after `--` is parsed as the nested Capability CLI command.
+During Agent runs, ViteHub renders operation tool calls as command lines, such as `api listCustomers --query '{"status":"active"}'`, instead of dumping the raw input object.
 
 ```bash [Terminal]
 pnpm vitehub agent dev --url http://localhost:3000 --agent support --cli inventory -- items list --json

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -359,6 +359,11 @@ function quoteCliValue(value: unknown): string | undefined {
     : `'${text.replace(/'/g, "'\\''")}'`
 }
 
+function quoteCliPart(value: unknown): string | undefined {
+  const quoted = quoteCliValue(value)
+  return quoted && !quoted.includes("\n") ? quoted : undefined
+}
+
 function operationCommand(name: string, value: unknown): string | undefined {
   if (!isRecord(value)) return
   const operation = typeof value.operationId === "string" && value.operationId.trim()
@@ -366,27 +371,50 @@ function operationCommand(name: string, value: unknown): string | undefined {
     : typeof value.operation === "string" && value.operation.trim()
       ? value.operation.trim()
       : undefined
-  const quotedOperation = quoteCliValue(operation)
-  if (!quotedOperation || quotedOperation.includes("\n")) return
+  const quotedOperation = quoteCliPart(operation)
+  if (!quotedOperation) return
 
   const parts = [name, quotedOperation]
   for (const key of ["path", "query", "body"]) {
     if (value[key] === undefined) continue
-    const quoted = quoteCliValue(value[key])
+    const quoted = quoteCliPart(value[key])
     if (quoted) parts.push(`--${key}`, quoted)
   }
 
   const rest = Object.fromEntries(Object.entries(value).filter(([key, item]) =>
     item !== undefined && !["operation", "operationId", "path", "query", "body"].includes(key),
   ))
-  const quotedRest = Object.keys(rest).length ? quoteCliValue(rest) : undefined
+  const quotedRest = Object.keys(rest).length ? quoteCliPart(rest) : undefined
   if (quotedRest) parts.push("--input", quotedRest)
 
   return parts.join(" ")
 }
 
+function argvCommand(name: string, value: unknown): string | undefined {
+  if (!isRecord(value)) return
+  const argv = value.argv
+  if (!Array.isArray(argv) || argv.some(arg => typeof arg !== "string")) return
+  const parts = [name]
+  for (const arg of argv) {
+    const quoted = quoteCliPart(arg)
+    if (!quoted) return
+    parts.push(quoted)
+  }
+  if (value.json === true && !argv.includes("--json")) parts.push("--json")
+  if (value.input !== undefined && !argv.includes("--input") && !argv.some(arg => arg.startsWith("--input="))) {
+    const quoted = quoteCliPart(value.input)
+    if (quoted) parts.push("--input", quoted)
+  }
+  return parts.join(" ")
+}
+
 function toolCommand(name: string, input?: unknown, output?: unknown): string | undefined {
-  return shellCommand(input) ?? shellCommand(output) ?? operationCommand(name, input) ?? operationCommand(name, output)
+  return shellCommand(input)
+    ?? shellCommand(output)
+    ?? argvCommand(name, input)
+    ?? argvCommand(name, output)
+    ?? operationCommand(name, input)
+    ?? operationCommand(name, output)
 }
 
 function toolHeader(name: string, input?: unknown, output?: unknown): string {

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -406,7 +406,7 @@ function argvCommand(name: string, value: unknown): string | undefined {
   }
   if (value.json === true && !argv.includes("--json")) parts.push("--json")
   if (value.input !== undefined && !argv.includes("--input") && !argv.some(arg => arg.startsWith("--input="))) {
-    const quoted = quoteCliPart(value.input)
+    const quoted = quoteCliPart(JSON.stringify(value.input))
     if (!quoted) return
     parts.push("--input", quoted)
   }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -351,8 +351,46 @@ function shellCommand(value: unknown): string | undefined {
   return command && !command.includes("\n") ? command : undefined
 }
 
+function quoteCliValue(value: unknown): string | undefined {
+  const text = typeof value === "string" ? value : JSON.stringify(value)
+  if (!text) return
+  return /^[\w./:@=-]+$/.test(text)
+    ? text
+    : `'${text.replace(/'/g, "'\\''")}'`
+}
+
+function operationCommand(name: string, value: unknown): string | undefined {
+  if (!isRecord(value)) return
+  const operation = typeof value.operationId === "string" && value.operationId.trim()
+    ? value.operationId.trim()
+    : typeof value.operation === "string" && value.operation.trim()
+      ? value.operation.trim()
+      : undefined
+  const quotedOperation = quoteCliValue(operation)
+  if (!quotedOperation || quotedOperation.includes("\n")) return
+
+  const parts = [name, quotedOperation]
+  for (const key of ["path", "query", "body"]) {
+    if (value[key] === undefined) continue
+    const quoted = quoteCliValue(value[key])
+    if (quoted) parts.push(`--${key}`, quoted)
+  }
+
+  const rest = Object.fromEntries(Object.entries(value).filter(([key, item]) =>
+    item !== undefined && !["operation", "operationId", "path", "query", "body"].includes(key),
+  ))
+  const quotedRest = Object.keys(rest).length ? quoteCliValue(rest) : undefined
+  if (quotedRest) parts.push("--input", quotedRest)
+
+  return parts.join(" ")
+}
+
+function toolCommand(name: string, input?: unknown, output?: unknown): string | undefined {
+  return shellCommand(input) ?? shellCommand(output) ?? operationCommand(name, input) ?? operationCommand(name, output)
+}
+
 function toolHeader(name: string, input?: unknown, output?: unknown): string {
-  const command = shellCommand(input) ?? shellCommand(output)
+  const command = toolCommand(name, input, output)
   if (command) return `[tool] ${command}`
 
   const formattedInput = isRecord(input) && Object.keys(input).length === 0 ? undefined : formatDevPayload(input)
@@ -841,10 +879,18 @@ async function sendDevMessage(
         if (event.type === "tool-input-start" && event.input === undefined) continue
         if (!visibleTools.has(event.id)) {
           visibleTools.add(event.id)
-          visibleToolInputs.set(event.id, formatDevPayload(event.input))
+          visibleToolInputs.set(event.id, toolCommand(event.name, event.input) ?? formatDevPayload(event.input))
           context.stderr.write(`\n${toolHeader(event.name, event.input)}\n`)
         }
-        else if (event.input !== undefined && !shellCommand(event.input)) {
+        else if (event.input !== undefined) {
+          const command = toolCommand(event.name, event.input)
+          if (command) {
+            if (command !== visibleToolInputs.get(event.id)) {
+              visibleToolInputs.set(event.id, command)
+              context.stderr.write(`\n[tool] ${command}\n`)
+            }
+            continue
+          }
           const formattedInput = formatDevPayload(event.input)
           if (formattedInput !== visibleToolInputs.get(event.id)) {
             visibleToolInputs.set(event.id, formattedInput)

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -378,14 +378,18 @@ function operationCommand(name: string, value: unknown): string | undefined {
   for (const key of ["path", "query", "body"]) {
     if (value[key] === undefined) continue
     const quoted = quoteCliPart(value[key])
-    if (quoted) parts.push(`--${key}`, quoted)
+    if (!quoted) return
+    parts.push(`--${key}`, quoted)
   }
 
   const rest = Object.fromEntries(Object.entries(value).filter(([key, item]) =>
     item !== undefined && !["operation", "operationId", "path", "query", "body"].includes(key),
   ))
-  const quotedRest = Object.keys(rest).length ? quoteCliPart(rest) : undefined
-  if (quotedRest) parts.push("--input", quotedRest)
+  if (Object.keys(rest).length) {
+    const quotedRest = quoteCliPart(rest)
+    if (!quotedRest) return
+    parts.push("--input", quotedRest)
+  }
 
   return parts.join(" ")
 }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -407,7 +407,8 @@ function argvCommand(name: string, value: unknown): string | undefined {
   if (value.json === true && !argv.includes("--json")) parts.push("--json")
   if (value.input !== undefined && !argv.includes("--input") && !argv.some(arg => arg.startsWith("--input="))) {
     const quoted = quoteCliPart(value.input)
-    if (quoted) parts.push("--input", quoted)
+    if (!quoted) return
+    parts.push("--input", quoted)
   }
   return parts.join(" ")
 }

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -648,6 +648,8 @@ describe("agent CLI", () => {
           { id: "tool-7", input: {}, name: "lookup_doc", type: "tool-call" },
           { id: "tool-7", input: { slug: "final" }, name: "lookup_doc", type: "tool-call" },
           { id: "tool-7", name: "lookup_doc", output: { text: "lookup result" }, type: "tool-result" },
+          { id: "tool-12", input: { operationId: "portalPurchaseOrders" }, name: "portal", type: "tool-call" },
+          { id: "tool-12", input: { body: { limit: 100 }, operationId: "portalPurchaseOrders", query: { planningGroupId: "demo" } }, name: "portal", type: "tool-call" },
           { id: "tool-9", input: { query: "first" }, name: "first_tool", type: "tool-call" },
           { id: "tool-10", input: { query: "second" }, name: "second_tool", type: "tool-call" },
           { id: "tool-10", name: "second_tool", output: { text: "second done" }, type: "tool-result" },
@@ -689,6 +691,9 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain(`\n[tool] search_docs {"query":"Agent Dev Loop"}\nsearch result\n---\n`)
     expect(stderr.output()).toContain(`\n[tool] lookup_doc\n  input: {"slug":"final"}\nlookup result\n---\n`)
     expect(stderr.output()).not.toContain(`\n[tool] lookup_doc {}\n`)
+    expect(stderr.output()).toContain(`\n[tool] portal portalPurchaseOrders\n`)
+    expect(stderr.output()).toContain(`\n[tool] portal portalPurchaseOrders --query '{"planningGroupId":"demo"}' --body '{"limit":100}'\n`)
+    expect(stderr.output()).not.toContain(`[tool] portal {"operationId":"portalPurchaseOrders"}`)
     const firstToolIndex = stderr.output().indexOf(`[tool] first_tool {"query":"first"}`)
     const secondToolIndex = stderr.output().indexOf(`[tool] second_tool {"query":"second"}`)
     expect(firstToolIndex).toBeGreaterThanOrEqual(0)

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -650,6 +650,7 @@ describe("agent CLI", () => {
           { id: "tool-7", name: "lookup_doc", output: { text: "lookup result" }, type: "tool-result" },
           { id: "tool-12", input: { argv: ["purchase-orders"] }, name: "portal", type: "tool-call" },
           { id: "tool-12", input: { argv: ["purchase-orders"], input: { limit: 100, planningGroupId: "demo" }, json: true }, name: "portal", type: "tool-call" },
+          { id: "tool-14", input: { argv: ["post"], input: "line one\nline two" }, name: "portal", type: "tool-call" },
           { id: "tool-13", input: { operation: "comment", body: "line one\nline two", target: { id: "PR-1" } }, name: "repository_host_write", type: "tool-call" },
           { id: "tool-9", input: { query: "first" }, name: "first_tool", type: "tool-call" },
           { id: "tool-10", input: { query: "second" }, name: "second_tool", type: "tool-call" },
@@ -695,6 +696,7 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain(`\n[tool] portal purchase-orders\n`)
     expect(stderr.output()).toContain(`\n[tool] portal purchase-orders --json --input '{"limit":100,"planningGroupId":"demo"}'\n`)
     expect(stderr.output()).not.toContain(`[tool] portal {"argv":["purchase-orders"]`)
+    expect(stderr.output()).toContain(`\n[tool] portal {"argv":["post"],"input":"line one\\nline two"}\n`)
     expect(stderr.output()).toContain(`\n[tool] repository_host_write {"operation":"comment","body":"line one\\nline two","target":{"id":"PR-1"}}\n`)
     const firstToolIndex = stderr.output().indexOf(`[tool] first_tool {"query":"first"}`)
     const secondToolIndex = stderr.output().indexOf(`[tool] second_tool {"query":"second"}`)

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -650,6 +650,7 @@ describe("agent CLI", () => {
           { id: "tool-7", name: "lookup_doc", output: { text: "lookup result" }, type: "tool-result" },
           { id: "tool-12", input: { argv: ["purchase-orders"] }, name: "portal", type: "tool-call" },
           { id: "tool-12", input: { argv: ["purchase-orders"], input: { limit: 100, planningGroupId: "demo" }, json: true }, name: "portal", type: "tool-call" },
+          { id: "tool-13", input: { operation: "comment", body: "line one\nline two", target: { id: "PR-1" } }, name: "repository_host_write", type: "tool-call" },
           { id: "tool-9", input: { query: "first" }, name: "first_tool", type: "tool-call" },
           { id: "tool-10", input: { query: "second" }, name: "second_tool", type: "tool-call" },
           { id: "tool-10", name: "second_tool", output: { text: "second done" }, type: "tool-result" },
@@ -694,6 +695,7 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain(`\n[tool] portal purchase-orders\n`)
     expect(stderr.output()).toContain(`\n[tool] portal purchase-orders --json --input '{"limit":100,"planningGroupId":"demo"}'\n`)
     expect(stderr.output()).not.toContain(`[tool] portal {"argv":["purchase-orders"]`)
+    expect(stderr.output()).toContain(`\n[tool] repository_host_write {"operation":"comment","body":"line one\\nline two","target":{"id":"PR-1"}}\n`)
     const firstToolIndex = stderr.output().indexOf(`[tool] first_tool {"query":"first"}`)
     const secondToolIndex = stderr.output().indexOf(`[tool] second_tool {"query":"second"}`)
     expect(firstToolIndex).toBeGreaterThanOrEqual(0)

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -650,6 +650,7 @@ describe("agent CLI", () => {
           { id: "tool-7", name: "lookup_doc", output: { text: "lookup result" }, type: "tool-result" },
           { id: "tool-12", input: { argv: ["purchase-orders"] }, name: "portal", type: "tool-call" },
           { id: "tool-12", input: { argv: ["purchase-orders"], input: { limit: 100, planningGroupId: "demo" }, json: true }, name: "portal", type: "tool-call" },
+          { id: "tool-15", input: { argv: ["post"], input: "abc" }, name: "portal", type: "tool-call" },
           { id: "tool-14", input: { argv: ["post"], input: "line one\nline two" }, name: "portal", type: "tool-call" },
           { id: "tool-13", input: { operation: "comment", body: "line one\nline two", target: { id: "PR-1" } }, name: "repository_host_write", type: "tool-call" },
           { id: "tool-9", input: { query: "first" }, name: "first_tool", type: "tool-call" },
@@ -695,8 +696,9 @@ describe("agent CLI", () => {
     expect(stderr.output()).not.toContain(`\n[tool] lookup_doc {}\n`)
     expect(stderr.output()).toContain(`\n[tool] portal purchase-orders\n`)
     expect(stderr.output()).toContain(`\n[tool] portal purchase-orders --json --input '{"limit":100,"planningGroupId":"demo"}'\n`)
+    expect(stderr.output()).toContain(`\n[tool] portal post --input '"abc"'\n`)
     expect(stderr.output()).not.toContain(`[tool] portal {"argv":["purchase-orders"]`)
-    expect(stderr.output()).toContain(`\n[tool] portal {"argv":["post"],"input":"line one\\nline two"}\n`)
+    expect(stderr.output()).toContain(`\n[tool] portal post --input '"line one\\nline two"'\n`)
     expect(stderr.output()).toContain(`\n[tool] repository_host_write {"operation":"comment","body":"line one\\nline two","target":{"id":"PR-1"}}\n`)
     const firstToolIndex = stderr.output().indexOf(`[tool] first_tool {"query":"first"}`)
     const secondToolIndex = stderr.output().indexOf(`[tool] second_tool {"query":"second"}`)

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -648,8 +648,8 @@ describe("agent CLI", () => {
           { id: "tool-7", input: {}, name: "lookup_doc", type: "tool-call" },
           { id: "tool-7", input: { slug: "final" }, name: "lookup_doc", type: "tool-call" },
           { id: "tool-7", name: "lookup_doc", output: { text: "lookup result" }, type: "tool-result" },
-          { id: "tool-12", input: { operationId: "portalPurchaseOrders" }, name: "portal", type: "tool-call" },
-          { id: "tool-12", input: { body: { limit: 100 }, operationId: "portalPurchaseOrders", query: { planningGroupId: "demo" } }, name: "portal", type: "tool-call" },
+          { id: "tool-12", input: { argv: ["purchase-orders"] }, name: "portal", type: "tool-call" },
+          { id: "tool-12", input: { argv: ["purchase-orders"], input: { limit: 100, planningGroupId: "demo" }, json: true }, name: "portal", type: "tool-call" },
           { id: "tool-9", input: { query: "first" }, name: "first_tool", type: "tool-call" },
           { id: "tool-10", input: { query: "second" }, name: "second_tool", type: "tool-call" },
           { id: "tool-10", name: "second_tool", output: { text: "second done" }, type: "tool-result" },
@@ -691,9 +691,9 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain(`\n[tool] search_docs {"query":"Agent Dev Loop"}\nsearch result\n---\n`)
     expect(stderr.output()).toContain(`\n[tool] lookup_doc\n  input: {"slug":"final"}\nlookup result\n---\n`)
     expect(stderr.output()).not.toContain(`\n[tool] lookup_doc {}\n`)
-    expect(stderr.output()).toContain(`\n[tool] portal portalPurchaseOrders\n`)
-    expect(stderr.output()).toContain(`\n[tool] portal portalPurchaseOrders --query '{"planningGroupId":"demo"}' --body '{"limit":100}'\n`)
-    expect(stderr.output()).not.toContain(`[tool] portal {"operationId":"portalPurchaseOrders"}`)
+    expect(stderr.output()).toContain(`\n[tool] portal purchase-orders\n`)
+    expect(stderr.output()).toContain(`\n[tool] portal purchase-orders --json --input '{"limit":100,"planningGroupId":"demo"}'\n`)
+    expect(stderr.output()).not.toContain(`[tool] portal {"argv":["purchase-orders"]`)
     const firstToolIndex = stderr.output().indexOf(`[tool] first_tool {"query":"first"}`)
     const secondToolIndex = stderr.output().indexOf(`[tool] second_tool {"query":"second"}`)
     expect(firstToolIndex).toBeGreaterThanOrEqual(0)


### PR DESCRIPTION
Renders operation-shaped Agent Dev Loop tool calls as command-like lines instead of dumping the raw input object. This makes CLI-backed tools such as Portal/OpenAPI capabilities easier to scan in `vitehub agent dev` output while preserving generic JSON rendering for ordinary tools.

Also documents the dev CLI behavior and covers streamed operation input updates so later `--query` or `--body` values stay command-shaped instead of disappearing or becoming JSON noise.
