### PR TITLE
fix(agent): upstream bitacora harness patches

### DIFF
--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -262,9 +262,9 @@ _Avoid_: Fake agent, dummy model, test bot
 - Harness-backed instruction behavior should rely on explicit harness or Workspace instruction surfaces, such as workspace `AGENTS.md`, unless a future harness-specific option is introduced.
 - A harness-backed **Agent Driver** implements the **Agent Harness Driver Contract**.
 - V1 harness-backed **Agent Drivers** use a single active permission layer: ViteHub-owned Workspace and runtime boundaries.
-- V1 **Harness Permission Policy** bypasses adapter-level approval prompts by configuring the harness adapter to its most permissive no-approval mode when the adapter supports one.
-- V1 does not expose a public permission option; bypass is implicit for supported harness-backed **Agent Drivers** until a second policy is intentionally designed.
-- For the current AI SDK Codex adapter, V1 should use `permissionMode: "allow-all"` behind the ViteHub harness adapter boundary.
+- V1 **Harness Permission Policy** defaults to bypassing adapter-level approval prompts by configuring the harness adapter to its most permissive no-approval mode when the adapter supports one.
+- V1 exposes `driver.permissionMode` as a narrow harness-backed **Agent Driver** override when a harness adapter needs a less permissive no-approval mode.
+- For the current AI SDK harness adapter, V1 should default to `permissionMode: "allow-all"` behind the ViteHub harness adapter boundary.
 - A harness adapter that cannot bypass its own approval layer should be unsupported for V1 rather than introducing a second hidden permission layer.
 - V1 should not enable host-executed HarnessAgent approval flows for harness-backed Agent Drivers; approval-based policy is a future design.
 - A harness-backed **Agent Driver** receives Workspace state through a scoped **Workspace Session** or equivalent materialized filesystem, not model-facing Workspace Tools by default.
@@ -428,8 +428,8 @@ _Avoid_: Fake agent, dummy model, test bot
 - Root Agent Definition `instructions` were considered shared by model-backed and harness-backed execution - resolved: use **Model Driver Instructions** for model-backed drivers, and do not pass them to harness-backed drivers by default.
 - Ambient Source, Capability, and Skill prose was considered convenient default model guidance - resolved: use **Explicit Instruction Coverage** and **Instruction Coverage Diagnostics** so model-facing guidance has an authored owner.
 - AI SDK `HarnessAgent` was considered as the public harness boundary - resolved: use the ViteHub-owned **Agent Harness Driver Contract** and adapt AI SDK harnesses behind it.
-- Adapter-level harness approvals were considered for V1 - resolved: use **Harness Permission Policy** to bypass adapter approvals and rely on ViteHub-owned Workspace and runtime boundaries, avoiding two active permission layers.
-- A public permission option was considered for V1 - resolved: avoid it because bypass is the only supported **Harness Permission Policy** for now.
+- Adapter-level harness approvals were considered for V1 - resolved: use **Harness Permission Policy** to bypass adapter approvals by default and rely on ViteHub-owned Workspace and runtime boundaries, avoiding two active permission layers.
+- A public permission option was considered for V1 - resolved: expose only `driver.permissionMode` for harness adapter no-approval modes, while keeping raw harness permissions unsupported.
 - A full approval policy matrix was considered for V1 - resolved: defer it; if a harness adapter cannot bypass its own approval layer, mark it unsupported for V1.
 - Model-facing Workspace Tools were considered the default Workspace surface for harness-backed drivers - resolved: harness-backed drivers use a scoped **Workspace Session** or equivalent materialized filesystem by default.
 - Capability-owned support files were considered harness instructions - resolved: pass them only as **Harness Workspace Path Contributions** when a harness-backed **Agent Driver** needs filesystem-visible support files.

--- a/.agents/contexts/packages/agent/CONTEXT.md
+++ b/.agents/contexts/packages/agent/CONTEXT.md
@@ -111,9 +111,9 @@ _Avoid_: Root Agent Package export, Capability factory export, Chat Adapter Faca
 - The **Agent Package** owns the **Agent Driver Boundary**.
 - The **Agent Package** owns the **Agent Harness Driver Contract** for harness-backed Agent Drivers.
 - The **Agent Package** owns **Harness Permission Policy** for harness-backed Agent Drivers.
-- V1 **Harness Permission Policy** bypasses adapter-level approval prompts by configuring the harness adapter to its most permissive no-approval mode when available.
-- The **Agent Package** should not expose a public permission option in V1; bypass is implicit because it is the only supported **Harness Permission Policy**.
-- For the current AI SDK Codex adapter, the **Agent Package** should set `permissionMode: "allow-all"` behind the ViteHub harness adapter boundary.
+- V1 **Harness Permission Policy** defaults to bypassing adapter-level approval prompts by configuring the harness adapter to its most permissive no-approval mode when available.
+- The **Agent Package** exposes `driver.permissionMode` as a narrow harness-backed **Agent Driver** override when a harness adapter needs a less permissive no-approval mode.
+- For the current AI SDK harness adapter, the **Agent Package** should default to `permissionMode: "allow-all"` behind the ViteHub harness adapter boundary.
 - The **Agent Package** should reject or mark unsupported a V1 harness adapter that cannot bypass its own approval layer.
 - V1 harness-backed Agent Drivers should rely on ViteHub-owned Workspace and runtime boundaries instead of host-executed HarnessAgent approval flows.
 - The **Agent Package** allows harness-backed Agent Drivers to omit `credentials`.
@@ -205,8 +205,8 @@ _Avoid_: Root Agent Package export, Capability factory export, Chat Adapter Faca
 - Capability-owned support files were considered harness instructions or root Agent fields - resolved: keep them as **Harness Workspace Path Contributions** from Capabilities.
 - Capability tools and instructions were considered unconditional Agent inputs - resolved: treat them as Capability Driver Contributions filtered by the selected Agent Driver.
 - AI SDK `HarnessAgent` was considered as the public harness boundary - resolved: use the ViteHub-owned **Agent Harness Driver Contract** and adapt AI SDK harnesses behind it.
-- Adapter-level harness approvals were considered for V1 - resolved: use Agent Package-owned **Harness Permission Policy** to bypass adapter approvals and rely on ViteHub-owned Workspace and runtime boundaries.
-- A public permission option was considered for V1 - resolved: avoid it because bypass is the only supported **Harness Permission Policy** for now.
+- Adapter-level harness approvals were considered for V1 - resolved: use Agent Package-owned **Harness Permission Policy** to bypass adapter approvals by default and rely on ViteHub-owned Workspace and runtime boundaries.
+- A public permission option was considered for V1 - resolved: expose only `driver.permissionMode` for harness adapter no-approval modes, while keeping raw harness permissions unsupported.
 - A complete approval and permission matrix was considered for V1 - resolved: defer it; V1 rejects or marks unsupported harness adapters that cannot bypass their own approval layer.
 - Model-facing Workspace Tools were considered the default Workspace surface for harness-backed drivers - resolved: harness-backed drivers use a scoped Workspace Session or equivalent materialized filesystem by default.
 - Durable harness sessions were considered as an implicit chat or thread default - resolved: harness-backed Agent Drivers use invocation-scoped Harness Workspace Sessions by default and require an explicit Harness Session Key for reuse.

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -22,6 +22,7 @@ import type {
   AgentDriverContributionKind,
   AgentHarnessCredentialSource,
   AgentHarnessDriverInput,
+  AgentHarnessPermissionMode,
   AgentHarnessSandboxInput,
   AgentHarnessSessionKey,
   AgentRunCallbackContext,
@@ -56,6 +57,7 @@ interface HarnessAgentAdapterOptions<
 > {
   credentials?: AgentHarnessCredentialSource
   harness: AgentHarnessDriverInput<TRuntimeConfig, CALL_OPTIONS>
+  permissionMode?: AgentHarnessPermissionMode
   sandbox?: AgentHarnessSandboxInput<TRuntimeConfig, CALL_OPTIONS>
   sessionKey?: AgentHarnessSessionKey<TRuntimeConfig, CALL_OPTIONS>
 }
@@ -351,7 +353,7 @@ async function createHarnessAgent<
         await prepareWorkspaceSession(session, sessionWorkDir, abortSignal)
       },
     },
-    permissionMode: "allow-all",
+    permissionMode: options.permissionMode ?? "allow-all",
     sandbox,
     ...(tools ? { tools } : {}),
   })

--- a/packages/agent/src/internal/agent-driver.ts
+++ b/packages/agent/src/internal/agent-driver.ts
@@ -4,6 +4,7 @@ import type {
   AgentAdapterInstructions,
   AgentHarnessCredentialSource,
   AgentHarnessDriverInput,
+  AgentHarnessPermissionMode,
   AgentHarnessSandboxInput,
   AgentHarnessSessionKey,
   AgentInvokerProfile,
@@ -28,6 +29,7 @@ type NormalizedAgentDriver<
     credentials?: AgentHarnessCredentialSource
     harness: AgentHarnessDriverInput<TRuntimeConfig, CALL_OPTIONS>
     kind: "harness"
+    permissionMode?: AgentHarnessPermissionMode
     sandbox?: AgentHarnessSandboxInput<TRuntimeConfig, CALL_OPTIONS>
     sessionKey?: AgentHarnessSessionKey<TRuntimeConfig, CALL_OPTIONS>
   }
@@ -52,9 +54,19 @@ function assertNoUnsupportedOptions(
 }
 
 function validateNoHarnessPermissionOption(driver: Record<string, unknown>): void {
-  if (hasOwnDefined(driver, "permissions") || hasOwnDefined(driver, "permissionMode")) {
-    throw new Error("[vitehub] defineAgent({ driver }) does not expose harness permission options in V1.")
+  if (hasOwnDefined(driver, "permissions")) {
+    throw new Error("[vitehub] defineAgent({ driver }) does not expose harness permissions in V1.")
   }
+}
+
+const harnessPermissionModes = new Set(["allow-reads", "allow-edits", "allow-all"])
+
+function normalizeHarnessPermissionMode(value: unknown): AgentHarnessPermissionMode | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== "string" || !harnessPermissionModes.has(value)) {
+    throw new TypeError("[vitehub] defineAgent({ driver.permissionMode }) must be allow-reads, allow-edits, or allow-all.")
+  }
+  return value as AgentHarnessPermissionMode
 }
 
 function normalizeHarnessCredentialSource(value: unknown): AgentHarnessCredentialSource | undefined {
@@ -82,7 +94,7 @@ function normalizeHarnessCredentialSource(value: unknown): AgentHarnessCredentia
 }
 
 const modelDriverKeys = new Set(["execution", "instructions", "model"])
-const harnessDriverKeys = new Set(["credentials", "harness", "sandbox", "sessionKey"])
+const harnessDriverKeys = new Set(["credentials", "harness", "permissionMode", "sandbox", "sessionKey"])
 const runDriverKeys = new Set(["run"])
 
 function normalizeExplicitAgentDriver<
@@ -122,6 +134,7 @@ function normalizeExplicitAgentDriver<
       credentials: normalizeHarnessCredentialSource(driver.credentials),
       harness: driver.harness as AgentHarnessDriverInput,
       kind: "harness",
+      permissionMode: normalizeHarnessPermissionMode(driver.permissionMode),
       sandbox: driver.sandbox as AgentHarnessSandboxInput<TRuntimeConfig, CALL_OPTIONS> | undefined,
       sessionKey: driver.sessionKey as AgentHarnessSessionKey<TRuntimeConfig, CALL_OPTIONS> | undefined,
     }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -788,6 +788,8 @@ export type AgentHarnessDriverInput<
   | object
   | ((context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<object>)
 
+export type AgentHarnessPermissionMode = "allow-reads" | "allow-edits" | "allow-all"
+
 export type AgentHarnessSandboxInput<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -822,7 +824,7 @@ export interface AgentHarnessDriver<
   harness: AgentHarnessDriverInput<TRuntimeConfig, CALL_OPTIONS>
   instructions?: never
   model?: never
-  permissionMode?: never
+  permissionMode?: AgentHarnessPermissionMode
   permissions?: never
   run?: never
   sandbox?: AgentHarnessSandboxInput<TRuntimeConfig, CALL_OPTIONS, TContextValues>

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1151,6 +1151,7 @@ describe("agent message protocol", () => {
     const agent = defineAgent({
       driver: {
         harness,
+        permissionMode: "allow-edits",
         sandbox,
       },
     })
@@ -1158,7 +1159,7 @@ describe("agent message protocol", () => {
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "hello" })).resolves.toMatchObject({ text: "ok" })
     expect(harnessAgentSettings.at(-1)).toMatchObject({
       harness,
-      permissionMode: "allow-all",
+      permissionMode: "allow-edits",
       sandboxConfig: {
         onSession: expect.any(Function),
       },
@@ -1671,7 +1672,11 @@ describe("agent message protocol", () => {
 
     expect(() => defineAgent({
       driver: { harness: { provider: "codex" }, permissions: "bypass" },
-    } as never)).toThrow("does not expose harness permission options")
+    } as never)).toThrow("does not expose harness permissions")
+
+    expect(() => defineAgent({
+      driver: { harness: { provider: "codex" }, permissionMode: "ask" },
+    } as never)).toThrow("driver.permissionMode")
 
     expect(() => defineAgent({
       driver: { credentials: { value: "secret" }, harness: { provider: "codex" } },

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -518,6 +518,7 @@ describe("agent public types", () => {
       driver: {
         credentials: { label: "local Codex", source: "ambient" },
         harness: { provider: "codex" },
+        permissionMode: "allow-edits",
         sandbox({ input }) {
           expectTypeOf(input.prompt).toEqualTypeOf<AgentRunInput["prompt"]>()
           return {}
@@ -528,7 +529,7 @@ describe("agent public types", () => {
     // @ts-expect-error Agent Driver variants are mutually exclusive
     const _mixedDriver: AgentDriver = { model: "model", run: () => "ok" }
 
-    // @ts-expect-error harness permissions are intentionally not public in V1
+    // @ts-expect-error raw harness permissions are intentionally not public in V1
     const _permissionDriver: AgentDriver = { harness: { provider: "codex" }, permissions: "bypass" }
 
     // @ts-expect-error raw harness credential material is not accepted by the generic driver boundary

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -266,8 +266,9 @@ class GitHubWorkspaceStore implements WorkspaceStore {
   }
 
   async diff(options: DiffOptions = {}): Promise<WorkspaceDiff> {
+    await this.#ensure({ refresh: true });
     const from = options.from || this.#baseline;
-    const to = await createSnapshotFromEntries(await this.list("", { recursive: true }));
+    const to = await createSnapshotFromEntries(await this.#listEntries("", { recursive: true }));
     return diffSnapshots(from, to);
   }
 
@@ -320,6 +321,10 @@ class GitHubWorkspaceStore implements WorkspaceStore {
             size: entry.size,
           },
         ]),
+      );
+      this.#baseline = await createSnapshotFromEntries(
+        await this.#listEntries("", { recursive: true }),
+        "github-workspace-store-load",
       );
     }
   }

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -252,6 +252,22 @@ describe("GitHub workspace store", () => {
     expect(requests.filter((request) => request.method !== "GET")).toEqual([]);
   });
 
+  it("diffs a fresh loaded store from the remote baseline", async () => {
+    seedRemote(".vitehub/workspaces/docs/README.md", "# Docs\n");
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await expect(store.diff()).resolves.toMatchObject({ entries: [] });
+  });
+
   it("uploads changed blobs during writes and snapshots by sha", async () => {
     const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
     const store = createGitHubWorkspaceStore(


### PR DESCRIPTION
Moves the downstream Bitácora pnpm patches into ViteHub source. Harness-backed Agent Drivers can now set `driver.permissionMode` (`allow-reads`, `allow-edits`, `allow-all`) while raw harness `permissions` stay unsupported; the default remains `allow-all`.

Also initializes the GitHub Workspace Store baseline during load and makes `diff()` load before reading that baseline, so fresh GitHub-backed harness workspace sessions do not see the whole remote tree as added.