### PR TITLE
fix(cli): show workspace command feedback

### DIFF
--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -1052,6 +1052,7 @@ async function sendDevWorkspaceCommand(
     context.stderr.write("No private Agent Dev Loop command token found. Start the Compatible Vite Development Server first.\n")
     return 1
   }
+  context.stderr.write("[vitehub] Workspace command started; first run may materialize sources.\n")
   let response: Response
   try {
     response = await fetchImpl(url, {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -250,7 +250,7 @@ describe("agent CLI", () => {
 
       expect(exitCode).toBe(0)
       expect(stdout.output()).toBe("ok\n")
-      expect(stderr.output()).toBe(`Loaded payload: ${payloadPath}\n`)
+      expect(stderr.output()).toBe(`Loaded payload: ${payloadPath}\n[vitehub] Workspace command started; first run may materialize sources.\n`)
       const post = fetchAgentStream.mock.calls[1]
       expect(post?.[1]?.headers).toMatchObject({
         [workspaceDevTokenHeader]: token,

--- a/packages/workspace/src/cli.ts
+++ b/packages/workspace/src/cli.ts
@@ -187,6 +187,7 @@ async function sendWorkspaceCommand(
     context.stderr.write("No private Workspace Dev token found. Start the Compatible Vite Development Server first.\n")
     return 1
   }
+  context.stderr.write("[vitehub] Workspace command started; first run may materialize sources.\n")
   const response = await fetchImpl(target.url, {
     body: JSON.stringify({
       workspaceCommand: {

--- a/packages/workspace/test/cli.test.ts
+++ b/packages/workspace/test/cli.test.ts
@@ -64,6 +64,7 @@ describe("workspace CLI", () => {
 
   it("runs Workspace Dev commands through the Workspace dev endpoint", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vitehub-workspace-cli-"))
+    const stderr = stream()
     const stdout = stream()
     const tokenServerId = "pid-1:4321"
     const token = await refreshWorkspaceDevToken(rootDir, { serverId: tokenServerId })
@@ -100,11 +101,12 @@ describe("workspace CLI", () => {
         cwd: rootDir,
         env: {},
         rootDir,
-        stderr: stream(),
+        stderr,
         stdout,
       }, { fetch: fetchWorkspaceDev as never })
 
       expect(exitCode).toBe(0)
+      expect(stderr.output()).toBe("[vitehub] Workspace command started; first run may materialize sources.\n")
       expect(stdout.output()).toBe("ok\n")
       const [get, post] = fetchWorkspaceDev.mock.calls
       expect(String(get?.[0])).toBe("http://127.0.0.1:4321/__vitehub/workspace/dev")


### PR DESCRIPTION
Adds a stderr progress line before workspace command requests are sent from `vitehub workspace dev` and `vitehub agent dev !...`, so slow first-run materialization is visible instead of appearing hung.\n\nNo protocol change; command stdout remains clean.