### PR TITLE
fix(workspace): stabilize github workspace dev sessions

### DIFF
--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -78,6 +78,17 @@ interface WorkspaceCommandInput {
   command: string
 }
 
+const workspaceCommandFeedbackIntervalMs = 15_000
+const workspaceCommandStartedMessage = "[vitehub] Workspace command started; first run may materialize sources.\n"
+const workspaceCommandWaitingMessage = "[vitehub] Workspace command still running; sources may still be materializing.\n"
+
+function startWorkspaceCommandFeedback(context: AgentCliContext): () => void {
+  context.stderr.write(workspaceCommandStartedMessage)
+  const timer = setInterval(() => context.stderr.write(workspaceCommandWaitingMessage), workspaceCommandFeedbackIntervalMs)
+  timer.unref?.()
+  return () => clearInterval(timer)
+}
+
 interface AgentDevCliOptions {
   fetch?: typeof fetch
 }
@@ -1052,10 +1063,9 @@ async function sendDevWorkspaceCommand(
     context.stderr.write("No private Agent Dev Loop command token found. Start the Compatible Vite Development Server first.\n")
     return 1
   }
-  context.stderr.write("[vitehub] Workspace command started; first run may materialize sources.\n")
-  let response: Response
+  const stopFeedback = startWorkspaceCommandFeedback(context)
   try {
-    response = await fetchImpl(url, {
+    const response = await fetchImpl(url, {
       body: JSON.stringify({
         agent,
         ...(parsed.payload ? { payload: parsed.payload } : {}),
@@ -1074,6 +1084,14 @@ async function sendDevWorkspaceCommand(
       method: "POST",
       signal,
     })
+    if (!response.ok) {
+      context.stderr.write(`${await response.text()}\n`)
+      return 1
+    }
+    const result = await response.json().catch(() => ({})) as { exitCode?: unknown, stderr?: unknown, stdout?: unknown }
+    if (typeof result.stdout === "string") context.stdout.write(result.stdout)
+    if (typeof result.stderr === "string" && result.stderr) context.stderr.write(result.stderr)
+    return typeof result.exitCode === "number" ? result.exitCode : 0
   }
   catch (error) {
     if (signal?.aborted || error instanceof DOMException && error.name === "AbortError") {
@@ -1082,14 +1100,9 @@ async function sendDevWorkspaceCommand(
     }
     throw error
   }
-  if (!response.ok) {
-    context.stderr.write(`${await response.text()}\n`)
-    return 1
+  finally {
+    stopFeedback()
   }
-  const result = await response.json().catch(() => ({})) as { exitCode?: unknown, stderr?: unknown, stdout?: unknown }
-  if (typeof result.stdout === "string") context.stdout.write(result.stdout)
-  if (typeof result.stderr === "string" && result.stderr) context.stderr.write(result.stderr)
-  return typeof result.exitCode === "number" ? result.exitCode : 0
 }
 
 function directWorkspaceCommand(text: string): string | undefined {

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -163,8 +163,12 @@ function harnessSupportWorkspacePaths(context: AgentAdapterRunContext): string[]
   ])
 }
 
+function withHarnessInstructionPaths(paths: readonly string[]): string[] {
+  return paths.length ? compactWorkspacePaths([...harnessInstructionFiles, ...paths]) : []
+}
+
 function explicitHarnessWorkspacePaths(context: AgentAdapterRunContext): string[] {
-  return compactWorkspacePaths([
+  return withHarnessInstructionPaths([
     ...harnessSupportWorkspacePaths(context),
     ...workspaceSourceHarnessPaths(context),
   ])
@@ -177,7 +181,7 @@ function selectedWorkspaceScopePaths(context: AgentAdapterRunContext): string[] 
   if (!scope) return harnessPaths.length ? harnessPaths : undefined
   if (scope.all) return [""]
   const paths = [...new Set([...(scope.paths || []), ...harnessSupportWorkspacePaths(context)])]
-  return paths.length ? paths : []
+  return paths.length ? withHarnessInstructionPaths(paths) : []
 }
 
 async function composeHarnessInstructions(content: string, context: AgentAdapterRunContext) {

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -65,6 +65,18 @@ function hasEntries(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && Object.keys(value).length > 0
 }
 
+function defaultHarnessPermissionMode(harness: unknown): "allow-all" | "allow-edits" {
+  if (
+    hasEntries(harness)
+    && harness.harnessId === "claude-code"
+    && typeof process.getuid === "function"
+    && process.getuid() === 0
+  ) {
+    return "allow-edits"
+  }
+  return "allow-all"
+}
+
 function unsupportedHarnessContributionKinds(context: AgentAdapterRunContext): Set<AgentDriverContributionKind> {
   const kinds = new Set<AgentDriverContributionKind>()
   if (context.providerTools?.length) kinds.add("provider tools")
@@ -393,7 +405,7 @@ async function createHarnessAgent<
         await prepareWorkspaceSession(session, sessionWorkDir, abortSignal)
       },
     },
-    permissionMode: "allow-all",
+    permissionMode: defaultHarnessPermissionMode(harness),
     sandbox,
     ...(tools ? { tools } : {}),
   })

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -50,11 +50,13 @@ const workspaceSessionExec = vi.hoisted(() => vi.fn(async (command: string, args
   stderr: "",
   stdout: "ok\n",
 })))
+const workspaceSessionDiff = vi.hoisted(() => vi.fn(async () => ({ entries: [{ path: "review.md", type: "modified" }] })))
 const workspaceSessionCommit = vi.hoisted(() => vi.fn(async () => {}))
 const workspaceSessionClose = vi.hoisted(() => vi.fn(async () => {}))
 const workspaceStartSession = vi.hoisted(() => vi.fn(async () => ({
   close: workspaceSessionClose,
   commit: workspaceSessionCommit,
+  diff: workspaceSessionDiff,
   exec: workspaceSessionExec,
 })))
 const useWorkspace = vi.hoisted(() => vi.fn(() => ({
@@ -232,6 +234,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
       },
     })
     workspaceSessionExec.mockClear()
+    workspaceSessionDiff.mockClear()
     workspaceSessionCommit.mockClear()
     workspaceSessionClose.mockClear()
     workspaceStartSession.mockClear()
@@ -435,6 +438,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
       abortSignal: expect.any(AbortSignal),
       timeout: 1234,
     })
+    expect(workspaceSessionDiff).toHaveBeenCalled()
     expect(workspaceSessionCommit).toHaveBeenCalledWith({ message: "workspace dev command" })
     expect(workspaceSessionClose).toHaveBeenCalled()
   })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1214,6 +1214,32 @@ describe("agent message protocol", () => {
     expect(session.destroy).toHaveBeenCalledTimes(1)
   })
 
+  it("avoids Claude Code bypass permissions when the host process runs as root", async () => {
+    const getuid = vi.spyOn(process, "getuid").mockReturnValue(0)
+    try {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const session = { destroy: vi.fn() }
+      const harness = { harnessId: "claude-code" }
+      harnessCreateSession.mockResolvedValueOnce(session)
+      harnessGenerate.mockResolvedValueOnce({ text: "ok" })
+
+      const agent = defineAgent({
+        driver: {
+          harness,
+        },
+      })
+
+      await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "hello" })).resolves.toMatchObject({ text: "ok" })
+      expect(harnessAgentSettings.at(-1)).toMatchObject({
+        harness,
+        permissionMode: "allow-edits",
+      })
+    }
+    finally {
+      getuid.mockRestore()
+    }
+  })
+
   it("uses harnessSandbox for harness runtime setup", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const session = { destroy: vi.fn() }

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -326,7 +326,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["AGENTS.md", "skills/agent-browser"],
+      paths: ["AGENTS.md", "CLAUDE.md", "skills/agent-browser"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -808,7 +808,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["AGENTS.md"],
+      paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -892,7 +892,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: ["AGENTS.md", "CLAUDE.md"],
-      paths: ["AGENTS.md"],
+      paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -964,7 +964,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["skills/SKILL.md", "skills/review-browser-evidence/SKILL.md"],
+      paths: ["AGENTS.md", "CLAUDE.md", "skills/SKILL.md", "skills/review-browser-evidence/SKILL.md"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -1015,7 +1015,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["docs", "portal"],
+      paths: ["docs", "portal", "AGENTS.md", "CLAUDE.md"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -1075,7 +1075,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["AGENTS.md"],
+      paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -1117,7 +1117,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["summary.md", "artifacts/usage", "artifacts/browser", "pr-diff-summary.md"],
+      paths: ["AGENTS.md", "CLAUDE.md", "summary.md", "artifacts/usage", "artifacts/browser", "pr-diff-summary.md"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -1162,7 +1162,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["public", ".vitehub/sources/public.json"],
+      paths: ["public", "AGENTS.md", "CLAUDE.md", ".vitehub/sources/public.json"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -1211,7 +1211,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
-      paths: ["public.md", ".vitehub/sources/publicDocs.json"],
+      paths: ["AGENTS.md", "CLAUDE.md", "public.md", ".vitehub/sources/publicDocs.json"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     }))
@@ -1264,7 +1264,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["public", ".vitehub/sources/public.json", "skills/agent-browser"],
+      paths: ["public", "AGENTS.md", "CLAUDE.md", "skills/agent-browser", ".vitehub/sources/public.json"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -1309,7 +1309,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["public", "pull-request-context/context.md"],
+      paths: ["public", "AGENTS.md", "CLAUDE.md", "pull-request-context/context.md"],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })

--- a/packages/sandbox/src/sandbox/adapters/cloudflare.ts
+++ b/packages/sandbox/src/sandbox/adapters/cloudflare.ts
@@ -277,7 +277,7 @@ export class CloudflareSandboxAdapter extends BaseSandboxAdapter<'cloudflare'> {
     if (this.native.listFiles) {
       const result = await this.native.listFiles(path, opts)
       return result.files
-        .filter((file): file is typeof file & { type: 'file' | 'directory' } => file.type === 'file' || file.type === 'directory')
+        .filter((file): file is typeof file & { type: 'directory' | 'file' | 'symlink' } => file.type === 'file' || file.type === 'directory' || file.type === 'symlink')
         .map(file => ({ name: file.name, path: file.absolutePath, type: file.type, size: file.size, mtime: file.modifiedAt }))
     }
     const result = await this.exec('ls', [opts?.recursive ? '-laR' : '-la', path])
@@ -292,7 +292,7 @@ export class CloudflareSandboxAdapter extends BaseSandboxAdapter<'cloudflare'> {
         return {
           name,
           path: `${path}/${name}`,
-          type: (line.startsWith('d') ? 'directory' : 'file') as 'file' | 'directory',
+          type: (line.startsWith('d') ? 'directory' : line.startsWith('l') ? 'symlink' : 'file') as 'directory' | 'file' | 'symlink',
         }
       })
       .filter(file => file.name && file.name !== '.' && file.name !== '..')

--- a/packages/sandbox/src/sandbox/adapters/cloudflare.ts
+++ b/packages/sandbox/src/sandbox/adapters/cloudflare.ts
@@ -287,7 +287,7 @@ export class CloudflareSandboxAdapter extends BaseSandboxAdapter<'cloudflare'> {
       .filter(Boolean)
       .slice(1)
       .map((line) => {
-        const parts = line.split(/\s+/)
+        const parts = line.replace(/\s+->\s+.*$/, '').split(/\s+/)
         const name = parts[parts.length - 1] || ''
         return {
           name,

--- a/packages/sandbox/src/sandbox/adapters/vercel.ts
+++ b/packages/sandbox/src/sandbox/adapters/vercel.ts
@@ -232,14 +232,14 @@ export class VercelSandboxAdapter extends BaseSandboxAdapter<'vercel'> {
         .filter(Boolean)
         .map((line): SandboxFileEntry | undefined => {
           const [kind, size, mtime, filePath] = line.split('\t')
-          if (!filePath || (kind !== 'f' && kind !== 'd')) return undefined
+          if (!filePath || (kind !== 'f' && kind !== 'd' && kind !== 'l')) return undefined
           const mtimeSeconds = Number(mtime)
           return {
             mtime: Number.isFinite(mtimeSeconds) ? new Date(mtimeSeconds * 1000).toISOString() : undefined,
             name: posix.basename(filePath),
             path: filePath,
             size: kind === 'f' ? Number(size) : undefined,
-            type: kind === 'd' ? 'directory' : 'file',
+            type: kind === 'd' ? 'directory' : kind === 'l' ? 'symlink' : 'file',
           }
         })
         .filter((entry): entry is SandboxFileEntry => Boolean(entry))
@@ -259,7 +259,7 @@ export class VercelSandboxAdapter extends BaseSandboxAdapter<'vercel'> {
           name,
           path: child,
           size: stat.isFile() ? stat.size : undefined,
-          type: stat.isDirectory() ? 'directory' : 'file',
+          type: stat.isDirectory() ? 'directory' : stat.isSymbolicLink() ? 'symlink' : 'file',
         }
         entries.push(entry)
         if (opts?.recursive && stat.isDirectory())

--- a/packages/sandbox/src/sandbox/adapters/vercel.ts
+++ b/packages/sandbox/src/sandbox/adapters/vercel.ts
@@ -219,7 +219,7 @@ export class VercelSandboxAdapter extends BaseSandboxAdapter<'vercel'> {
 
   override async listFiles(path: string, opts?: SandboxListFilesOptions): Promise<SandboxFileEntry[]> {
     const fs = this.native.fs
-    if (!fs?.readdir || !fs.stat) {
+    if (!fs?.readdir || !(fs.lstat || fs.stat)) {
       const root = path.replace(/\/+$/, '') || '/'
       const args = [root, '-mindepth', '1']
       if (!opts?.recursive)
@@ -253,7 +253,7 @@ export class VercelSandboxAdapter extends BaseSandboxAdapter<'vercel'> {
       const names = await fs.readdir(dir)
       await Promise.all(names.map(async (name) => {
         const child = posix.join(dir, name)
-        const stat = await fs.stat(child)
+        const stat = fs.lstat ? await fs.lstat(child) : await fs.stat(child)
         const entry: SandboxFileEntry = {
           mtime: stat.mtime?.toISOString?.() || (typeof stat.mtimeMs === 'number' ? new Date(stat.mtimeMs).toISOString() : undefined),
           name,

--- a/packages/sandbox/src/sandbox/types/common.ts
+++ b/packages/sandbox/src/sandbox/types/common.ts
@@ -45,7 +45,7 @@ export interface SandboxCapabilities {
 export interface SandboxFileEntry {
   name: string
   path: string
-  type: 'file' | 'directory'
+  type: 'directory' | 'file' | 'symlink'
   size?: number
   mtime?: string
 }

--- a/packages/sandbox/src/sandbox/types/vercel.ts
+++ b/packages/sandbox/src/sandbox/types/vercel.ts
@@ -22,6 +22,7 @@ export interface VercelSandboxInstance {
     mkdir: (path: string, options?: { recursive?: boolean, signal?: AbortSignal } | number) => Promise<string | undefined>
     readdir: (path: string, options?: { signal?: AbortSignal, withFileTypes?: false }) => Promise<string[]>
     stat: (path: string, options?: { signal?: AbortSignal }) => Promise<{ isFile(): boolean, isDirectory(): boolean, isSymbolicLink(): boolean, size: number, mtime?: Date, mtimeMs?: number }>
+    lstat?: (path: string, options?: { signal?: AbortSignal }) => Promise<{ isFile(): boolean, isDirectory(): boolean, isSymbolicLink(): boolean, size: number, mtime?: Date, mtimeMs?: number }>
     rm: (path: string, options?: { recursive?: boolean, force?: boolean, signal?: AbortSignal }) => Promise<void>
     rename: (oldPath: string, newPath: string, options?: { signal?: AbortSignal }) => Promise<void>
     exists?: (path: string, options?: { signal?: AbortSignal }) => Promise<boolean>

--- a/packages/sandbox/test/cloudflare-adapter.test.ts
+++ b/packages/sandbox/test/cloudflare-adapter.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { CloudflareSandboxAdapter } from "../src/sandbox/adapters/cloudflare.ts"
+import type { CloudflareSandboxStub } from "../src/sandbox/types/common.ts"
+
+describe("CloudflareSandboxAdapter", () => {
+  it("parses symlink names from ls fallback listings", async () => {
+    const exec = vi.fn(async () => ({
+      exitCode: 0,
+      stderr: "",
+      stdout: [
+        "total 0",
+        "lrwxrwxrwx 1 root root 9 Jun 29 00:00 CLAUDE.md -> AGENTS.md",
+      ].join("\n"),
+      success: true,
+    }))
+    const adapter = new CloudflareSandboxAdapter("sandbox-id", {
+      deleteFile: vi.fn(),
+      destroy: vi.fn(),
+      exec,
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+    } as unknown as CloudflareSandboxStub)
+
+    await expect(adapter.listFiles("/workspace")).resolves.toEqual([
+      {
+        name: "CLAUDE.md",
+        path: "/workspace/CLAUDE.md",
+        type: "symlink",
+      },
+    ])
+  })
+})

--- a/packages/sandbox/test/vercel-adapter.test.ts
+++ b/packages/sandbox/test/vercel-adapter.test.ts
@@ -14,6 +14,16 @@ function commandResult(stdout: string, exitCode = 0) {
   }
 }
 
+function fileStat(options: { directory?: boolean, file?: boolean, symlink?: boolean, size?: number }) {
+  return {
+    isDirectory: () => Boolean(options.directory),
+    isFile: () => Boolean(options.file),
+    isSymbolicLink: () => Boolean(options.symlink),
+    mtimeMs: 1710000000000,
+    size: options.size ?? 0,
+  }
+}
+
 describe("VercelSandboxAdapter", () => {
   it("falls back to find when native fs listing APIs are unavailable", async () => {
     const runCommandMock = vi.fn(async () => commandResult([
@@ -55,5 +65,65 @@ describe("VercelSandboxAdapter", () => {
       env: undefined,
       sudo: undefined,
     })
+  })
+
+  it("uses native lstat when listing Vercel symlinks", async () => {
+    const fs = {
+      lstat: vi.fn(async (path: string) => {
+        if (path === "/workspace/docs") return fileStat({ directory: true })
+        if (path === "/workspace/docs/readme.md") return fileStat({ file: true, size: 12 })
+        if (path === "/workspace/link") return fileStat({ symlink: true })
+        throw new Error(`unexpected lstat: ${path}`)
+      }),
+      mkdir: vi.fn(),
+      readFile: vi.fn(),
+      readdir: vi.fn(async (path: string) => {
+        if (path === "/workspace") return ["docs", "link"]
+        if (path === "/workspace/docs") return ["readme.md"]
+        throw new Error(`unexpected readdir: ${path}`)
+      }),
+      rename: vi.fn(),
+      rm: vi.fn(),
+      stat: vi.fn(async (path: string) => {
+        if (path === "/workspace/link") return fileStat({ directory: true })
+        throw new Error(`unexpected stat: ${path}`)
+      }),
+      writeFile: vi.fn(),
+    }
+    const adapter = new VercelSandboxAdapter("sandbox-id", {
+      domain: port => `https://sandbox-${port}.example.com`,
+      fs,
+      mkDir: vi.fn(),
+      readFile: vi.fn(),
+      readFileToBuffer: vi.fn(),
+      runCommand: vi.fn(),
+      writeFiles: vi.fn(),
+    }, { createdAt: "now", runtime: "node24" })
+
+    await expect(adapter.listFiles("/workspace", { recursive: true })).resolves.toEqual([
+      {
+        mtime: "2024-03-09T16:00:00.000Z",
+        name: "docs",
+        path: "/workspace/docs",
+        size: undefined,
+        type: "directory",
+      },
+      {
+        mtime: "2024-03-09T16:00:00.000Z",
+        name: "readme.md",
+        path: "/workspace/docs/readme.md",
+        size: 12,
+        type: "file",
+      },
+      {
+        mtime: "2024-03-09T16:00:00.000Z",
+        name: "link",
+        path: "/workspace/link",
+        size: undefined,
+        type: "symlink",
+      },
+    ])
+    expect(fs.stat).not.toHaveBeenCalled()
+    expect(fs.readdir).not.toHaveBeenCalledWith("/workspace/link")
   })
 })

--- a/packages/workspace/src/cli.ts
+++ b/packages/workspace/src/cli.ts
@@ -33,6 +33,7 @@ interface ParsedWorkspaceDevArgs {
   args?: string[]
   command?: string
   help: boolean
+  paths?: string[]
   timeout?: number
   url: string
   workspace?: string
@@ -73,6 +74,7 @@ function writeWorkspaceDevUsage(context: WorkspaceCliContext): void {
     "Options:",
     "  --url <url>       Compatible Vite Development Server URL. Defaults to http://localhost:5173.",
     "  --timeout <ms>    Workspace command timeout.",
+    "  --path <path>     Workspace path to materialize for command sessions. Repeatable.",
     "  -h, --help        Show this help.",
     "",
   ].join("\n"))
@@ -116,6 +118,17 @@ function parseWorkspaceDevArgs(args: string[], env: NodeJS.ProcessEnv): ParsedWo
       const timeout = Number.parseInt(arg.slice("--timeout=".length), 10)
       if (!Number.isFinite(timeout) || timeout <= 0) throw new Error("--timeout must be a positive number.")
       parsed.timeout = timeout
+      continue
+    }
+    if (arg === "--path") {
+      parsed.paths ??= []
+      parsed.paths.push(readOptionValue(args, index, arg))
+      index += 1
+      continue
+    }
+    if (arg.startsWith("--path=")) {
+      parsed.paths ??= []
+      parsed.paths.push(arg.slice("--path=".length))
       continue
     }
     if (arg.startsWith("-") && !parsed.workspace) throw new Error(`Unknown option: ${arg}.`)
@@ -205,6 +218,7 @@ async function sendWorkspaceCommand(
         workspaceCommand: {
           ...(parsed.args ? { args: parsed.args } : {}),
           command: parsed.command,
+          ...(parsed.paths?.length ? { paths: parsed.paths } : {}),
           ...(parsed.timeout ? { timeout: parsed.timeout } : {}),
           workspace: parsed.workspace,
         },

--- a/packages/workspace/src/cli.ts
+++ b/packages/workspace/src/cli.ts
@@ -53,6 +53,17 @@ interface WorkspaceDevTarget {
   url: string
 }
 
+const workspaceCommandFeedbackIntervalMs = 15_000
+const workspaceCommandStartedMessage = "[vitehub] Workspace command started; first run may materialize sources.\n"
+const workspaceCommandWaitingMessage = "[vitehub] Workspace command still running; sources may still be materializing.\n"
+
+function startWorkspaceCommandFeedback(context: WorkspaceCliContext): () => void {
+  context.stderr.write(workspaceCommandStartedMessage)
+  const timer = setInterval(() => context.stderr.write(workspaceCommandWaitingMessage), workspaceCommandFeedbackIntervalMs)
+  timer.unref?.()
+  return () => clearInterval(timer)
+}
+
 function writeWorkspaceDevUsage(context: WorkspaceCliContext): void {
   context.stdout.write([
     "Usage: vitehub workspace dev <workspace> [command...] [--url <url>] [--timeout <ms>]",
@@ -187,31 +198,36 @@ async function sendWorkspaceCommand(
     context.stderr.write("No private Workspace Dev token found. Start the Compatible Vite Development Server first.\n")
     return 1
   }
-  context.stderr.write("[vitehub] Workspace command started; first run may materialize sources.\n")
-  const response = await fetchImpl(target.url, {
-    body: JSON.stringify({
-      workspaceCommand: {
-        ...(parsed.args ? { args: parsed.args } : {}),
-        command: parsed.command,
-        ...(parsed.timeout ? { timeout: parsed.timeout } : {}),
-        workspace: parsed.workspace,
+  const stopFeedback = startWorkspaceCommandFeedback(context)
+  try {
+    const response = await fetchImpl(target.url, {
+      body: JSON.stringify({
+        workspaceCommand: {
+          ...(parsed.args ? { args: parsed.args } : {}),
+          command: parsed.command,
+          ...(parsed.timeout ? { timeout: parsed.timeout } : {}),
+          workspace: parsed.workspace,
+        },
+      }),
+      headers: {
+        "content-type": "application/json",
+        [workspaceDevHeader]: workspaceDevHeaderValue,
+        [workspaceDevTokenHeader]: token,
       },
-    }),
-    headers: {
-      "content-type": "application/json",
-      [workspaceDevHeader]: workspaceDevHeaderValue,
-      [workspaceDevTokenHeader]: token,
-    },
-    method: "POST",
-  })
-  if (!response.ok) {
-    context.stderr.write(`${await response.text()}\n`)
-    return 1
+      method: "POST",
+    })
+    if (!response.ok) {
+      context.stderr.write(`${await response.text()}\n`)
+      return 1
+    }
+    const result = await response.json().catch(() => ({})) as { exitCode?: unknown, stderr?: unknown, stdout?: unknown }
+    if (typeof result.stdout === "string") context.stdout.write(result.stdout)
+    if (typeof result.stderr === "string" && result.stderr) context.stderr.write(result.stderr)
+    return typeof result.exitCode === "number" ? result.exitCode : 0
   }
-  const result = await response.json().catch(() => ({})) as { exitCode?: unknown, stderr?: unknown, stdout?: unknown }
-  if (typeof result.stdout === "string") context.stdout.write(result.stdout)
-  if (typeof result.stderr === "string" && result.stderr) context.stderr.write(result.stderr)
-  return typeof result.exitCode === "number" ? result.exitCode : 0
+  finally {
+    stopFeedback()
+  }
 }
 
 async function runInteractiveWorkspaceDev(

--- a/packages/workspace/src/cloudflare.ts
+++ b/packages/workspace/src/cloudflare.ts
@@ -27,7 +27,7 @@ export interface CloudflareWorkspaceRuntimeOptions {
 export function configureCloudflareWorkspaceRuntime(options: CloudflareWorkspaceRuntimeOptions = {}): ResolvedWorkspaceModuleOptions {
   const root = resolve(process.cwd(), options.root || ".vitehub/workspaces")
   const store = options.store?.provider === "github"
-    ? resolveGitHubWorkspaceStore(options.store, options.env)
+    ? resolveGitHubWorkspaceStore(options.store, options.env, { runtime: true })
     : resolveCloudflareArtifactsStore(options.store, options.env)
   const config: ResolvedWorkspaceModuleOptions = {
     assets: options.assets,

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -64,6 +64,7 @@ export interface WorkspaceWriteInput {
   path: string
   content?: WorkspaceContent
   mediaType?: string
+  metadata?: Record<string, unknown>
   previous?: WorkspaceStat
   rule?: ResolvedWorkspaceRule
 }

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -235,6 +235,7 @@ export interface WorkspaceEntry {
   size?: number
   mtime?: number
   mediaType?: string
+  metadata?: Record<string, unknown>
   digest?: string
 }
 

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -251,6 +251,7 @@ export interface WorkspaceSnapshot {
   entries: Record<string, {
     type: "file" | "directory"
     digest?: string
+    metadata?: Record<string, unknown>
     size?: number
   }>
 }

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -18,6 +18,7 @@ export type ReadFileResult<TOptions extends ReadFileOptions | undefined = undefi
 
 export interface WriteFileOptions {
   mediaType?: string
+  metadata?: Record<string, unknown>
 }
 
 export interface ListOptions {

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -170,7 +170,7 @@ async function handleWorkspaceDevRequest(server: ViteDevServer, req: IncomingMes
   }
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 })
 
-  let body: { workspaceCommand?: { args?: unknown, command?: unknown, timeout?: unknown, workspace?: unknown } }
+  let body: { workspaceCommand?: { args?: unknown, command?: unknown, paths?: unknown, timeout?: unknown, workspace?: unknown } }
   try {
     body = JSON.parse(await readRequestBody(req)) as typeof body
   }
@@ -192,13 +192,18 @@ async function handleWorkspaceDevRequest(server: ViteDevServer, req: IncomingMes
   if (command.args !== undefined && (!Array.isArray(command.args) || command.args.some(arg => typeof arg !== "string"))) {
     return new Response("Workspace Dev command args must be strings.", { status: 400 })
   }
+  if (command.paths !== undefined && (!Array.isArray(command.paths) || command.paths.some(path => typeof path !== "string"))) {
+    return new Response("Workspace Dev command paths must be strings.", { status: 400 })
+  }
   const args = command.args as string[] | undefined
+  const paths = command.paths as string[] | undefined
   const timeout = typeof command.timeout === "number" && Number.isFinite(command.timeout) ? command.timeout : undefined
   return Response.json(await runWorkspaceDevCommand({
     abortSignal,
     ...(args ? { args } : {}),
     command: command.command,
     ...(isRecord(definition) ? { definition: normalizeWorkspaceDefinition(command.workspace, definition as never) } : {}),
+    ...(paths?.length ? { paths } : {}),
     ...(timeout ? { timeout } : {}),
     workspace: command.workspace,
   }))

--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -38,6 +38,7 @@ export interface GitHubFileUpdate {
   bytes?: Uint8Array;
   fullPath: string;
   gitSha: string;
+  mode?: string;
 }
 
 export interface GitHubCommitResult {
@@ -318,7 +319,7 @@ export async function commitGitHubChanges(input: {
         base_tree: input.baseTreeSha,
         tree: [
           ...input.files.map((file, index) => ({
-            mode: "100644",
+            mode: file.mode || "100644",
             path: file.fullPath,
             sha: blobs[index]!.sha,
             type: "blob",

--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -187,8 +187,9 @@ export function resolveGitHubTokenOption(
 ): string | undefined {
   const token = resolveGitHubOption(options.token);
   if (token && !isMaskedGitHubTokenOption(token)) return token;
+  const bindingToken = getActiveCloudflareBinding<string>("GITHUB_TOKEN");
+  if (bindingToken && !isMaskedGitHubTokenOption(bindingToken)) return bindingToken;
   return (
-    getActiveCloudflareBinding<string>("GITHUB_TOKEN") ||
     processEnv(env, "WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN")
   );
 }

--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -57,6 +57,10 @@ export function resolveGitHubOption(value: GitHubWorkspaceOption | undefined): s
   return typeof value === "function" ? value() : value;
 }
 
+function isMaskedGitHubTokenOption(value: string): boolean {
+  return value === "********" || value === "<redacted>" || value === "[redacted]";
+}
+
 export function requireGitHubOption(
   kind: "publisher" | "store",
   label: string,
@@ -182,7 +186,7 @@ export function resolveGitHubTokenOption(
   env: Record<string, string | undefined> = typeof process !== "undefined" ? process.env : {},
 ): string | undefined {
   const token = resolveGitHubOption(options.token);
-  if (token && token !== "********") return token;
+  if (token && !isMaskedGitHubTokenOption(token)) return token;
   return (
     getActiveCloudflareBinding<string>("GITHUB_TOKEN") ||
     processEnv(env, "WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN")

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -60,6 +60,10 @@ function contentLength(content: string | Uint8Array): number {
     : content.byteLength;
 }
 
+function gitHubFileMetadata(entry: GitHubTreeEntry): Record<string, unknown> | undefined {
+  return entry.mode === "120000" ? { gitMode: entry.mode } : undefined;
+}
+
 function parentDirectories(path: string): string[] {
   const parts = normalizeWorkspacePath(path).split("/").filter(Boolean);
   const directories: string[] = [];
@@ -317,6 +321,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
           path,
           {
             gitSha: entry.sha!,
+            metadata: gitHubFileMetadata(entry),
             path,
             size: entry.size,
           },
@@ -377,6 +382,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
     return {
       digest: file.gitSha,
       mediaType: file.mediaType,
+      metadata: file.metadata,
       path: file.path,
       size: file.size,
       type: "file",

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -64,6 +64,10 @@ function gitHubFileMetadata(entry: GitHubTreeEntry): Record<string, unknown> | u
   return entry.mode === "120000" ? { gitMode: entry.mode } : undefined;
 }
 
+function gitHubFileMode(metadata: Record<string, unknown> | undefined): string {
+  return metadata?.gitMode === "120000" ? "120000" : "100644";
+}
+
 function parentDirectories(path: string): string[] {
   const parts = normalizeWorkspacePath(path).split("/").filter(Boolean);
   const directories: string[] = [];
@@ -111,6 +115,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
     const update = await createGitHubFileUpdate(normalized, this.#root, file.content);
     const current = this.#files.get(normalized);
     if (current?.gitSha === update.gitSha) {
+      if (gitHubFileMode(current.metadata) !== gitHubFileMode(file.metadata)) this.#dirty = true;
       this.#files.set(normalized, {
         ...current,
         mediaType: file.mediaType,
@@ -231,7 +236,10 @@ class GitHubWorkspaceStore implements WorkspaceStore {
     this.#baselineTreeSha = remote.treeSha;
 
     const changedFiles = [...this.#files.values()].filter(
-      (file) => this.#remoteFiles.get(file.path)?.sha !== file.gitSha,
+      (file) => {
+        const remote = this.#remoteFiles.get(file.path);
+        return remote?.sha !== file.gitSha || (remote.mode || "100644") !== gitHubFileMode(file.metadata);
+      },
     );
     const deletePaths = [...this.#remoteFiles]
       .filter(([path]) => !this.#files.has(path))
@@ -248,6 +256,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
         bytes: file.bytes,
         fullPath: joinGitPath(this.#root, file.path),
         gitSha: file.gitSha,
+        mode: gitHubFileMode(file.metadata),
       };
     });
     const commit = await commitGitHubChanges({
@@ -415,6 +424,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
           sha: file.gitSha,
           size: file.size,
           type: "blob",
+          mode: gitHubFileMode(file.metadata),
         },
       ]),
     );

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -61,11 +61,21 @@ function contentLength(content: string | Uint8Array): number {
 }
 
 function gitHubFileMetadata(entry: GitHubTreeEntry): Record<string, unknown> | undefined {
-  return entry.mode === "120000" ? { gitMode: entry.mode } : undefined;
+  return entry.mode === "120000" || entry.mode === "100755" ? { gitMode: entry.mode } : undefined;
 }
 
 function gitHubFileMode(metadata: Record<string, unknown> | undefined): string {
-  return metadata?.gitMode === "120000" ? "120000" : "100644";
+  return metadata?.gitMode === "120000" || metadata?.gitMode === "100755"
+    ? metadata.gitMode
+    : "100644";
+}
+
+function inheritedGitHubFileMetadata(
+  file: WorkspaceFile,
+  current: GitHubWorkspaceStoreFile | undefined,
+): Record<string, unknown> | undefined {
+  if (file.metadata) return file.metadata;
+  return current?.metadata?.gitMode === "100755" ? current.metadata : undefined;
 }
 
 function parentDirectories(path: string): string[] {
@@ -114,12 +124,13 @@ class GitHubWorkspaceStore implements WorkspaceStore {
     await this.#ensure({ refresh: false });
     const update = await createGitHubFileUpdate(normalized, this.#root, file.content);
     const current = this.#files.get(normalized);
+    const metadata = inheritedGitHubFileMetadata(file, current);
     if (current?.gitSha === update.gitSha) {
-      if (gitHubFileMode(current.metadata) !== gitHubFileMode(file.metadata)) this.#dirty = true;
+      if (gitHubFileMode(current.metadata) !== gitHubFileMode(metadata)) this.#dirty = true;
       this.#files.set(normalized, {
         ...current,
         mediaType: file.mediaType,
-        metadata: file.metadata,
+        metadata,
         size: contentLength(file.content),
       });
       return;
@@ -133,7 +144,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
     this.#files.set(normalized, {
       gitSha: update.gitSha,
       mediaType: file.mediaType,
-      metadata: file.metadata,
+      metadata,
       path: normalized,
       size: contentLength(file.content),
     });

--- a/packages/workspace/src/server.ts
+++ b/packages/workspace/src/server.ts
@@ -228,7 +228,9 @@ export async function runWorkspaceDevCommand<Name extends WorkspaceName>(
     const result = input.args
       ? await session.exec(command, input.args, execOptions)
       : await session.exec("sh", ["-lc", command], execOptions)
-    if (result.exitCode === 0) await session.commit({ message: "workspace dev command" })
+    if (result.exitCode === 0 && (await session.diff()).entries.length) {
+      await session.commit({ message: "workspace dev command" })
+    }
     return result
   }
   finally {

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -308,6 +308,20 @@ async function listSandboxPaths(
   return new Set(pathsFromFindOutput(result.stdout))
 }
 
+async function readSandboxSymlinkTarget(
+  sandbox: HarnessSandboxSession,
+  sessionWorkDir: string,
+  path: string,
+  abortSignal: AbortSignal | undefined,
+) {
+  const result = await runSandbox(sandbox, {
+    abortSignal,
+    command: `readlink -- ${shellQuote(path)}`,
+    workingDirectory: sessionWorkDir,
+  })
+  return result.stdout.replace(/\n$/, "")
+}
+
 async function copyWorkspaceToSandbox(
   workspace: WorkspaceFacade,
   sandbox: HarnessSandboxSession,
@@ -372,6 +386,15 @@ async function copySandboxChangesToWorkspace(
     if (!content || (!initial?.symlinkTarget && bytesEqual(initial?.content, content))) continue
     await session.writeFile(path, content, {
       mediaType: initial?.mediaType || lookup(path) || undefined,
+    })
+  }
+  for (const path of sandboxSymlinks) {
+    if (ignoreWriteBackPaths.has(path)) continue
+    const initial = initialTree.files.get(path)
+    const target = await readSandboxSymlinkTarget(sandbox, sessionWorkDir, path, abortSignal)
+    if (initial?.symlinkTarget === target) continue
+    await session.writeFile(path, contentToBytes(target), {
+      metadata: { gitMode: "120000" },
     })
   }
 

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -365,12 +365,11 @@ async function copySandboxChangesToWorkspace(
   for (const path of sandboxFiles) {
     if (ignoreWriteBackPaths.has(path)) continue
     const initial = initialTree.files.get(path)
-    if (initial?.symlinkTarget) continue
     const content = await sandbox.readBinaryFile({
       abortSignal,
       path: sandboxPath(sessionWorkDir, path),
     })
-    if (!content || bytesEqual(initial?.content, content)) continue
+    if (!content || (!initial?.symlinkTarget && bytesEqual(initial?.content, content))) continue
     await session.writeFile(path, content, {
       mediaType: initial?.mediaType || lookup(path) || undefined,
     })

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -297,13 +297,12 @@ async function extractWorkspaceArchive(
 async function listSandboxPaths(
   sandbox: HarnessSandboxSession,
   sessionWorkDir: string,
-  type: "d" | "f",
+  type: "d" | "f" | "l",
   abortSignal: AbortSignal | undefined,
 ) {
-  const predicate = type === "f" ? "\\( -type f -o -type l \\)" : `-type ${type}`
   const result = await runSandbox(sandbox, {
     abortSignal,
-    command: `find . ${predicate} -print`,
+    command: `find . -type ${type} -print`,
     workingDirectory: sessionWorkDir,
   })
   return new Set(pathsFromFindOutput(result.stdout))
@@ -350,9 +349,11 @@ async function copySandboxChangesToWorkspace(
 
   const sandboxDirectories = await listSandboxPaths(sandbox, sessionWorkDir, "d", abortSignal)
   const sandboxFiles = await listSandboxPaths(sandbox, sessionWorkDir, "f", abortSignal)
+  const sandboxSymlinks = await listSandboxPaths(sandbox, sessionWorkDir, "l", abortSignal)
+  const sandboxFileEntries = new Set([...sandboxFiles, ...sandboxSymlinks])
   for (const path of initialTree.files.keys()) {
     if (ignoreWriteBackPaths.has(path)) continue
-    if (!sandboxFiles.has(path)) await session.rm(path, { force: true })
+    if (!sandboxFileEntries.has(path)) await session.rm(path, { force: true })
   }
   for (const path of [...initialTree.directories].sort((left, right) => right.length - left.length)) {
     if (!sandboxDirectories.has(path)) await session.rm(path, { force: true, recursive: true })
@@ -363,12 +364,12 @@ async function copySandboxChangesToWorkspace(
   }
   for (const path of sandboxFiles) {
     if (ignoreWriteBackPaths.has(path)) continue
+    const initial = initialTree.files.get(path)
+    if (initial?.symlinkTarget) continue
     const content = await sandbox.readBinaryFile({
       abortSignal,
       path: sandboxPath(sessionWorkDir, path),
     })
-    const initial = initialTree.files.get(path)
-    if (initial?.symlinkTarget) continue
     if (!content || bytesEqual(initial?.content, content)) continue
     await session.writeFile(path, content, {
       mediaType: initial?.mediaType || lookup(path) || undefined,

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -34,7 +34,7 @@ export interface PrepareHarnessWorkspaceSessionOptions {
 }
 
 type WorkspaceFacade = ReadonlyWorkspaceFacade | WritableWorkspaceFacade
-type InitialFile = { content: Uint8Array, mediaType?: string }
+type InitialFile = { content: Uint8Array, mediaType?: string, symlinkTarget?: string }
 type InitialTree = {
   archiveDirectories: Set<string>
   directories: Set<string>
@@ -226,9 +226,11 @@ function writeTarOctal(header: Buffer, offset: number, length: number, value: nu
   header[offset + length - 1] = 0
 }
 
-function tarHeader(path: string, options: { mode: number, size: number, type: "directory" | "file" }) {
+function tarHeader(path: string, options: { linkName?: string, mode: number, size: number, type: "directory" | "file" | "symlink" }) {
   const header = Buffer.alloc(tarBlockSize)
   const { name, prefix } = splitTarPath(path)
+  if (options.linkName && Buffer.byteLength(options.linkName) > 100)
+    throw new Error(`[vitehub] Harness Workspace Session symlink target is too long for tar transfer: ${path}`)
   writeTarString(header, 0, 100, name)
   writeTarOctal(header, 100, 8, options.mode)
   writeTarOctal(header, 108, 8, 0)
@@ -236,7 +238,8 @@ function tarHeader(path: string, options: { mode: number, size: number, type: "d
   writeTarOctal(header, 124, 12, options.size)
   writeTarOctal(header, 136, 12, 0)
   header.fill(0x20, 148, 156)
-  header[156] = options.type === "directory" ? 0x35 : 0x30
+  header[156] = options.type === "directory" ? 0x35 : options.type === "symlink" ? 0x32 : 0x30
+  if (options.linkName) writeTarString(header, 157, 100, options.linkName)
   writeTarString(header, 257, 6, "ustar")
   writeTarString(header, 263, 2, "00")
   if (prefix) writeTarString(header, 345, 155, prefix)
@@ -255,11 +258,19 @@ function createWorkspaceTarGz(directories: Iterable<string>, files: Map<string, 
     blocks.push(tarHeader(path, { mode: 0o755, size: 0, type: "directory" }))
   }
   for (const [path, file] of [...files.entries()].sort(([left], [right]) => left.localeCompare(right))) {
+    if (file.symlinkTarget) {
+      blocks.push(tarHeader(path, { linkName: file.symlinkTarget, mode: 0o777, size: 0, type: "symlink" }))
+      continue
+    }
     blocks.push(tarHeader(path, { mode: 0o644, size: file.content.byteLength, type: "file" }))
     blocks.push(paddedTarContent(file.content))
   }
   blocks.push(Buffer.alloc(tarBlockSize * 2))
   return gzipSync(Buffer.concat(blocks))
+}
+
+function gitSymlinkTarget(entry: WorkspaceEntry, content: Uint8Array): string | undefined {
+  return entry.metadata?.gitMode === "120000" ? new TextDecoder().decode(content) : undefined
 }
 
 async function extractWorkspaceArchive(
@@ -289,9 +300,10 @@ async function listSandboxPaths(
   type: "d" | "f",
   abortSignal: AbortSignal | undefined,
 ) {
+  const predicate = type === "f" ? "\\( -type f -o -type l \\)" : `-type ${type}`
   const result = await runSandbox(sandbox, {
     abortSignal,
-    command: `find . -type ${type} -print`,
+    command: `find . ${predicate} -print`,
     workingDirectory: sessionWorkDir,
   })
   return new Set(pathsFromFindOutput(result.stdout))
@@ -316,7 +328,8 @@ async function copyWorkspaceToSandbox(
   for (const entry of files) addParentDirectories(directoriesToCreate, entry.path)
   await forEachConcurrent(files, workspaceReadConcurrency, async (entry) => {
     const content = await workspace.fs.readFile(entry.path, { encoding: "binary" })
-    initialTree.files.set(entry.path, { content: contentToBytes(content), mediaType: entry.mediaType })
+    const bytes = contentToBytes(content)
+    initialTree.files.set(entry.path, { content: bytes, mediaType: entry.mediaType, symlinkTarget: gitSymlinkTarget(entry, bytes) })
   })
   await resetSandboxWorkDir(sandbox, sessionWorkDir, abortSignal)
   await extractWorkspaceArchive(sandbox, sessionWorkDir, initialTree, directoriesToCreate, abortSignal)
@@ -355,6 +368,7 @@ async function copySandboxChangesToWorkspace(
       path: sandboxPath(sessionWorkDir, path),
     })
     const initial = initialTree.files.get(path)
+    if (initial?.symlinkTarget) continue
     if (!content || bytesEqual(initial?.content, content)) continue
     await session.writeFile(path, content, {
       mediaType: initial?.mediaType || lookup(path) || undefined,

--- a/packages/workspace/src/session/sandbox.ts
+++ b/packages/workspace/src/session/sandbox.ts
@@ -22,7 +22,7 @@ import type {
 } from "../core/types.ts"
 
 type SandboxClient = Awaited<ReturnType<typeof import("@vite-hub/sandbox").createSandboxWithConfig>>
-type SandboxFileEntry = { path: string, size?: number, type: "file" | "directory" }
+type SandboxFileEntry = { path: string, size?: number, type: "directory" | "file" | "symlink" }
 type SandboxPackage = typeof import("@vite-hub/sandbox")
 type SandboxRuntimeStateModule = typeof import("@vite-hub/sandbox/runtime/state")
 
@@ -48,11 +48,16 @@ function fromSandboxPath(path: string) {
   return normalizeWorkspacePath(normalizedPath.slice(normalizedRoot.length + 1))
 }
 
-function toWorkspaceEntry(entry: { path: string, size?: number, type: "file" | "directory" }): WorkspaceEntry {
+function isGitSymlinkEntry(entry: WorkspaceEntry): boolean {
+  return entry.metadata?.gitMode === "120000"
+}
+
+function toWorkspaceEntry(entry: SandboxFileEntry): WorkspaceEntry {
   return {
+    metadata: entry.type === "symlink" ? { gitMode: "120000" } : undefined,
     path: fromSandboxPath(entry.path),
     size: entry.size,
-    type: entry.type,
+    type: entry.type === "directory" ? "directory" : "file",
   }
 }
 
@@ -60,6 +65,20 @@ async function ensureSandboxParent(sandbox: SandboxClient, path: string) {
   const parent = posix.dirname(path)
   if (parent && parent !== "." && parent !== "/")
     await sandbox.mkdir(parent, { recursive: true })
+}
+
+async function readSandboxSymlinkTarget(sandbox: SandboxClient, path: string): Promise<string> {
+  const result = await sandbox.exec("readlink", [path])
+  if (!result.ok)
+    throw new WorkspaceError(`[vitehub] Failed to read sandbox symlink: ${path}. ${result.stderr || "readlink failed"}`)
+  return result.stdout.replace(/\n$/, "")
+}
+
+async function writeSandboxSymlink(sandbox: SandboxClient, path: string, target: string) {
+  await sandbox.deleteFile(path).catch(() => undefined)
+  const result = await sandbox.exec("ln", ["-s", target, path])
+  if (!result.ok)
+    throw new WorkspaceError(`[vitehub] Failed to create sandbox symlink: ${path}. ${result.stderr || "ln failed"}`)
 }
 
 async function readSandboxFile(sandbox: SandboxClient, path: string): Promise<WorkspaceFile | undefined> {
@@ -84,7 +103,9 @@ async function snapshotSandbox(sandbox: SandboxClient, name?: string) {
   const entries = await listSandboxEntries(sandbox, "", true)
   const files = await Promise.all(entries.map(async (entry) => {
     if (entry.type !== "file") return entry
-    const content = await sandbox.readFile(toSandboxPath(entry.path), { encoding: "binary" })
+    const content = isGitSymlinkEntry(entry)
+      ? await readSandboxSymlinkTarget(sandbox, toSandboxPath(entry.path))
+      : await sandbox.readFile(toSandboxPath(entry.path), { encoding: "binary" })
     return {
       ...entry,
       digest: await sha256(content),
@@ -136,7 +157,10 @@ async function materializeWorkspace(workspace: Workspace, sandbox: SandboxClient
     const content = await workspace.readFile(entry.path, { encoding: "binary" })
     const target = toSandboxPath(entry.path)
     await ensureSandboxParent(sandbox, target)
-    await sandbox.writeFile(target, content)
+    if (isGitSymlinkEntry(entry))
+      await writeSandboxSymlink(sandbox, target, new TextDecoder().decode(contentToBytes(content)))
+    else
+      await sandbox.writeFile(target, content)
   }
   return await snapshotSandbox(sandbox, "sandbox-open")
 }
@@ -164,9 +188,12 @@ async function commitSandboxChanges(
       const before = entry.before?.type === "file"
         ? await workspace.stat(entry.path).catch(() => undefined)
         : undefined
-      const file = await readSandboxFile(sandbox, toSandboxPath(entry.path))
+      const target = toSandboxPath(entry.path)
+      const file = entry.after.metadata?.gitMode === "120000"
+        ? { content: await readSandboxSymlinkTarget(sandbox, target), metadata: entry.after.metadata, path: entry.path }
+        : await readSandboxFile(sandbox, target)
       if (file)
-        await workspace.writeFile(entry.path, file.content, { mediaType: file.mediaType || mediaTypes.get(entry.path) || before?.mediaType })
+        await workspace.writeFile(entry.path, file.content, { mediaType: file.mediaType || mediaTypes.get(entry.path) || before?.mediaType, metadata: file.metadata })
     }
   }
   await workspace.snapshot({ name: "sandbox-commit" })
@@ -213,7 +240,11 @@ export async function createSandboxWorkspaceSession(
       assertOpen()
       const target = toSandboxPath(assertPathInSessionScope(normalizeSafeWorkspacePath(path), sessionPaths))
       await ensureSandboxParent(sandbox, target)
-      await sandbox.writeFile(target, content)
+      await sandbox.deleteFile(target).catch(() => undefined)
+      if (options?.metadata?.gitMode === "120000")
+        await writeSandboxSymlink(sandbox, target, new TextDecoder().decode(contentToBytes(content)))
+      else
+        await sandbox.writeFile(target, content)
       const workspacePath = fromSandboxPath(target)
       if (options?.mediaType)
         mediaTypes.set(workspacePath, options.mediaType)

--- a/packages/workspace/src/session/sandbox.ts
+++ b/packages/workspace/src/session/sandbox.ts
@@ -263,6 +263,7 @@ export async function createSandboxWorkspaceSession(
     },
     async commit(options) {
       const diff = await currentDiff()
+      if (!diff.entries.length) return
       assertDiffInsideSessionPaths(diff, sessionPaths)
       await commitSandboxChanges(sandbox, workspace, diff, mediaTypes)
       baseline = await snapshotSandbox(sandbox, options?.message || "sandbox-commit")

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process"
-import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises"
+import { lstat, mkdir, mkdtemp, readFile, readdir, readlink, rm, symlink, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, posix, relative, sep } from "node:path"
 
@@ -88,11 +88,20 @@ async function listLocalEntries(root: string, path = "", recursive = false, opti
       if (recursive) entries.push(...await listLocalEntries(root, workspacePath, true, options))
       continue
     }
+    if (dirent.isSymbolicLink()) {
+      const item = await lstat(entryPath)
+      entries.push({ metadata: { gitMode: "120000" }, path: workspacePath, size: item.size, type: "file" })
+      continue
+    }
     if (!dirent.isFile()) continue
     const item = await stat(entryPath)
     entries.push({ path: workspacePath, size: item.size, type: "file" })
   }
   return entries.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+function isGitSymlinkEntry(entry: WorkspaceEntry): boolean {
+  return entry.metadata?.gitMode === "120000"
 }
 
 async function readLocalFile(root: string, path: string, options: { allowGenerated?: boolean } = {}): Promise<WorkspaceFile | undefined> {
@@ -110,7 +119,9 @@ async function snapshotLocal(root: string, name?: string) {
   const entries = await listLocalEntries(root, "", true, { allowGenerated: true, skipUncommitted: true })
   const files = await Promise.all(entries.map(async (entry) => {
     if (entry.type !== "file") return entry
-    const content = await readFile(toLocalPath(root, entry.path))
+    const content = isGitSymlinkEntry(entry)
+      ? await readlink(toLocalPath(root, entry.path))
+      : await readFile(toLocalPath(root, entry.path))
     return {
       ...entry,
       digest: await sha256(content),
@@ -153,6 +164,10 @@ async function materializeWorkspace(workspace: Workspace, root: string, options?
     if (entry.type !== "file") continue
     const target = toLocalPath(root, entry.path, { allowGenerated: true })
     await mkdir(dirname(target), { recursive: true })
+    if (isGitSymlinkEntry(entry)) {
+      await symlink(await workspace.readFile(entry.path), target)
+      continue
+    }
     await writeFile(target, await workspace.readFile(entry.path, { encoding: "binary" }))
   }
   return await snapshotLocal(root, "local-open")

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -104,9 +104,12 @@ function isGitSymlinkEntry(entry: WorkspaceEntry): boolean {
   return entry.metadata?.gitMode === "120000"
 }
 
-async function readLocalFile(root: string, path: string, options: { allowGenerated?: boolean } = {}): Promise<WorkspaceFile | undefined> {
+async function readLocalFile(root: string, path: string, options: { allowGenerated?: boolean, preserveSymlink?: boolean } = {}): Promise<WorkspaceFile | undefined> {
   const target = toLocalPath(root, path, options)
   try {
+    if (options.preserveSymlink && (await lstat(target)).isSymbolicLink()) {
+      return { content: await readlink(target), metadata: { gitMode: "120000" }, path: normalizeWorkspacePath(path) }
+    }
     return { content: await readFile(target), path: normalizeWorkspacePath(path) }
   }
   catch (error) {
@@ -197,9 +200,9 @@ async function commitLocalChanges(
       const before = entry.before?.type === "file"
         ? await workspace.stat(entry.path).catch(() => undefined)
         : undefined
-      const file = await readLocalFile(root, entry.path)
+      const file = await readLocalFile(root, entry.path, { preserveSymlink: true })
       if (file)
-        await workspace.writeFile(entry.path, file.content, { mediaType: file.mediaType || mediaTypes.get(entry.path) || before?.mediaType })
+        await workspace.writeFile(entry.path, file.content, { mediaType: file.mediaType || mediaTypes.get(entry.path) || before?.mediaType, metadata: file.metadata })
     }
   }
   await workspace.snapshot({ name: "local-commit" })

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -312,7 +312,11 @@ export async function createTrustedHostWorkspaceSession(
       const workspacePath = assertPathInSessionScope(normalizeLocalWorkspacePath(path), sessionPaths)
       const target = toLocalPath(root, workspacePath)
       await mkdir(dirname(target), { recursive: true })
-      await writeFile(target, content)
+      await rm(target, { force: true, recursive: true })
+      if (options?.metadata?.gitMode === "120000")
+        await symlink(new TextDecoder().decode(contentToBytes(content)), target)
+      else
+        await writeFile(target, content)
       if (options?.mediaType)
         mediaTypes.set(workspacePath, options.mediaType)
       else

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process"
 import { lstat, mkdir, mkdtemp, readFile, readdir, readlink, rm, symlink, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { dirname, join, posix, relative, sep } from "node:path"
+import { dirname, isAbsolute, join, posix, relative, resolve, sep } from "node:path"
 
 import { WorkspaceError } from "../core/errors.ts"
 import { contentToBytes, decodeFile, matchesAny, normalizeSafeWorkspacePath, normalizeWorkspacePath, resolveInside, sha256 } from "../core/path.ts"
@@ -104,6 +104,11 @@ function isGitSymlinkEntry(entry: WorkspaceEntry): boolean {
   return entry.metadata?.gitMode === "120000"
 }
 
+function isLocalSymlinkTargetInside(root: string, linkPath: string, target: string): boolean {
+  const rel = relative(resolve(root), resolve(dirname(linkPath), target))
+  return rel === "" || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`))
+}
+
 async function readLocalFile(root: string, path: string, options: { allowGenerated?: boolean, preserveSymlink?: boolean } = {}): Promise<WorkspaceFile | undefined> {
   const target = toLocalPath(root, path, options)
   try {
@@ -168,7 +173,9 @@ async function materializeWorkspace(workspace: Workspace, root: string, options?
     const target = toLocalPath(root, entry.path, { allowGenerated: true })
     await mkdir(dirname(target), { recursive: true })
     if (isGitSymlinkEntry(entry)) {
-      await symlink(await workspace.readFile(entry.path), target)
+      const linkTarget = await workspace.readFile(entry.path)
+      if (isLocalSymlinkTargetInside(root, target, linkTarget)) await symlink(linkTarget, target)
+      else await writeFile(target, linkTarget)
       continue
     }
     await writeFile(target, await workspace.readFile(entry.path, { encoding: "binary" }))
@@ -313,10 +320,14 @@ export async function createTrustedHostWorkspaceSession(
       const target = toLocalPath(root, workspacePath)
       await mkdir(dirname(target), { recursive: true })
       await rm(target, { force: true, recursive: true })
-      if (options?.metadata?.gitMode === "120000")
-        await symlink(new TextDecoder().decode(contentToBytes(content)), target)
-      else
+      if (options?.metadata?.gitMode === "120000") {
+        const linkTarget = new TextDecoder().decode(contentToBytes(content))
+        if (isLocalSymlinkTargetInside(root, target, linkTarget)) await symlink(linkTarget, target)
+        else await writeFile(target, content)
+      }
+      else {
         await writeFile(target, content)
+      }
       if (options?.mediaType)
         mediaTypes.set(workspacePath, options.mediaType)
       else

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process"
-import { lstat, mkdir, mkdtemp, readFile, readdir, readlink, rm, symlink, stat, writeFile } from "node:fs/promises"
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, readlink, rm, symlink, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, isAbsolute, join, posix, relative, resolve, sep } from "node:path"
 
@@ -53,6 +53,10 @@ function isUncommittedSessionPath(path: string): boolean {
   return isGeneratedSourceDescriptorPath(path) || path.split("/").includes(".git")
 }
 
+function executableGitMetadata(mode: number): Record<string, unknown> | undefined {
+  return (mode & 0o111) !== 0 ? { gitMode: "100755" } : undefined
+}
+
 function normalizeLocalWorkspacePath(path = "", options: { allowEmpty?: boolean, allowGenerated?: boolean } = {}) {
   const normalized = posix.normalize(path.replace(/\\/g, "/"))
   const workspacePath = normalized === "." ? "" : normalized
@@ -95,7 +99,8 @@ async function listLocalEntries(root: string, path = "", recursive = false, opti
     }
     if (!dirent.isFile()) continue
     const item = await stat(entryPath)
-    entries.push({ path: workspacePath, size: item.size, type: "file" })
+    const metadata = executableGitMetadata(item.mode)
+    entries.push(metadata ? { metadata, path: workspacePath, size: item.size, type: "file" } : { path: workspacePath, size: item.size, type: "file" })
   }
   return entries.sort((left, right) => left.path.localeCompare(right.path))
 }
@@ -104,18 +109,23 @@ function isGitSymlinkEntry(entry: WorkspaceEntry): boolean {
   return entry.metadata?.gitMode === "120000"
 }
 
+function isGitExecutableEntry(entry: WorkspaceEntry): boolean {
+  return entry.metadata?.gitMode === "100755"
+}
+
 function isLocalSymlinkTargetInside(root: string, linkPath: string, target: string): boolean {
   const rel = relative(resolve(root), resolve(dirname(linkPath), target))
   return rel === "" || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`))
 }
 
-async function readLocalFile(root: string, path: string, options: { allowGenerated?: boolean, preserveSymlink?: boolean } = {}): Promise<WorkspaceFile | undefined> {
+async function readLocalFile(root: string, path: string, options: { allowGenerated?: boolean, preserveGitMetadata?: boolean } = {}): Promise<WorkspaceFile | undefined> {
   const target = toLocalPath(root, path, options)
   try {
-    if (options.preserveSymlink && (await lstat(target)).isSymbolicLink()) {
+    const item = options.preserveGitMetadata ? await lstat(target) : undefined
+    if (item?.isSymbolicLink()) {
       return { content: await readlink(target), metadata: { gitMode: "120000" }, path: normalizeWorkspacePath(path) }
     }
-    return { content: await readFile(target), path: normalizeWorkspacePath(path) }
+    return { content: await readFile(target), metadata: item ? executableGitMetadata(item.mode) : undefined, path: normalizeWorkspacePath(path) }
   }
   catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined
@@ -179,6 +189,7 @@ async function materializeWorkspace(workspace: Workspace, root: string, options?
       continue
     }
     await writeFile(target, await workspace.readFile(entry.path, { encoding: "binary" }))
+    if (isGitExecutableEntry(entry)) await chmod(target, 0o755)
   }
   return await snapshotLocal(root, "local-open")
 }
@@ -207,7 +218,7 @@ async function commitLocalChanges(
       const before = entry.before?.type === "file"
         ? await workspace.stat(entry.path).catch(() => undefined)
         : undefined
-      const file = await readLocalFile(root, entry.path, { preserveSymlink: true })
+      const file = await readLocalFile(root, entry.path, { preserveGitMetadata: true })
       if (file)
         await workspace.writeFile(entry.path, file.content, { mediaType: file.mediaType || mediaTypes.get(entry.path) || before?.mediaType, metadata: file.metadata })
     }
@@ -327,6 +338,7 @@ export async function createTrustedHostWorkspaceSession(
       }
       else {
         await writeFile(target, content)
+        if (options?.metadata?.gitMode === "100755") await chmod(target, 0o755)
       }
       if (options?.mediaType)
         mediaTypes.set(workspacePath, options.mediaType)

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -360,6 +360,7 @@ export async function createTrustedHostWorkspaceSession(
     },
     async commit(options) {
       const diff = await currentDiff()
+      if (!diff.entries.length) return
       assertDiffInsideSessionPaths(diff, sessionPaths)
       await commitLocalChanges(root, workspace, diff, mediaTypes)
       baseline = await snapshotLocal(root, options?.message || "local-commit")

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -417,7 +417,12 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
         metadata: options?.metadata,
         operation: "writeFile",
         path,
-      }, async input => await workspace.fs.writeFile(input.path as never, input.content ?? content, { ...options, mediaType: input.mediaType, metadata: input.metadata })),
+      }, async (input) => {
+        const writeOptions = options === undefined && input.mediaType === undefined && input.metadata === undefined
+          ? undefined
+          : { ...options, mediaType: input.mediaType, metadata: input.metadata }
+        await workspace.fs.writeFile(input.path as never, input.content ?? content, writeOptions)
+      }),
     }, sourceRequestExecution)
     writeWorkspace = attachWorkspaceSourceRequestExecution({
       name: resolvedDefinition.name,

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -414,9 +414,10 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
       writeFile: async (path, content, options) => await writeWithPolicy({
         content,
         mediaType: options?.mediaType,
+        metadata: options?.metadata,
         operation: "writeFile",
         path,
-      }, async input => await workspace.fs.writeFile(input.path as never, input.content ?? content, input.mediaType === undefined ? options : { ...options, mediaType: input.mediaType })),
+      }, async input => await workspace.fs.writeFile(input.path as never, input.content ?? content, { ...options, mediaType: input.mediaType, metadata: input.metadata })),
     }, sourceRequestExecution)
     writeWorkspace = attachWorkspaceSourceRequestExecution({
       name: resolvedDefinition.name,

--- a/packages/workspace/src/sources/view.ts
+++ b/packages/workspace/src/sources/view.ts
@@ -357,7 +357,7 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
         workspace: definition.name,
       })
       try {
-        await store.writeFile(input.path, { path: input.path, content: input.content ?? content, mediaType: input.mediaType })
+        await store.writeFile(input.path, { path: input.path, content: input.content ?? content, mediaType: input.mediaType, metadata: options?.metadata })
         await writePolicy.after(input)
       }
       catch (error) {

--- a/packages/workspace/src/sources/view.ts
+++ b/packages/workspace/src/sources/view.ts
@@ -351,13 +351,14 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
       const input = await writePolicy.before({
         content,
         mediaType: options?.mediaType,
+        metadata: options?.metadata,
         operation: "writeFile",
         path: resolution.workspacePath,
         previous: await previousStat(resolution.workspacePath),
         workspace: definition.name,
       })
       try {
-        await store.writeFile(input.path, { path: input.path, content: input.content ?? content, mediaType: input.mediaType, metadata: options?.metadata })
+        await store.writeFile(input.path, { path: input.path, content: input.content ?? content, mediaType: input.mediaType, metadata: input.metadata })
         await writePolicy.after(input)
       }
       catch (error) {

--- a/packages/workspace/src/storage/local.ts
+++ b/packages/workspace/src/storage/local.ts
@@ -154,6 +154,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
         return {
           ...existing,
           mediaType: file.mediaType,
+          metadata: file.metadata,
           size,
           digest,
         }
@@ -169,6 +170,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
         type: "file",
         size,
         mediaType: file.mediaType,
+        metadata: file.metadata,
         digest,
       }
     }
@@ -191,6 +193,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
       .map(entry => ({
         ...entry,
         mediaType: entry.type === "file" ? this.#files.get(entry.path)?.mediaType : entry.mediaType,
+        metadata: entry.type === "file" ? this.#files.get(entry.path)?.metadata : entry.metadata,
       }))
       .sort((a, b) => a.path.localeCompare(b.path))
   }
@@ -216,6 +219,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
       size: info.isFile() ? info.size : undefined,
       mtime: info.mtimeMs,
       mediaType: info.isFile() ? this.#files.get(normalized)?.mediaType : undefined,
+      metadata: info.isFile() ? this.#files.get(normalized)?.metadata : undefined,
       digest: info.isFile() ? await fileDigest(absolute) : undefined,
     }
     return entry
@@ -259,7 +263,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
       const after = to.entries[path]
       if (!before && after) entries.push({ path, type: "added", after })
       else if (before && !after) entries.push({ path, type: "removed", before })
-      else if (before && after && (before.digest !== after.digest || before.type !== after.type || before.size !== after.size)) {
+      else if (before && after && (before.digest !== after.digest || before.type !== after.type || before.size !== after.size || JSON.stringify(before.metadata) !== JSON.stringify(after.metadata))) {
         entries.push({ path, type: "modified", before, after })
       }
     }
@@ -283,6 +287,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
       entries[entry.path] = {
         type: entry.type,
         digest: entry.digest,
+        metadata: entry.metadata,
         size: entry.size,
       }
     }

--- a/packages/workspace/src/storage/memory.ts
+++ b/packages/workspace/src/storage/memory.ts
@@ -123,7 +123,7 @@ class MemoryWorkspaceStore implements WorkspaceStore {
       const after = to.entries[path]
       if (!before && after) entries.push({ path, type: "added", after })
       else if (before && !after) entries.push({ path, type: "removed", before })
-      else if (before && after && (before.digest !== after.digest || before.type !== after.type || before.size !== after.size)) {
+      else if (before && after && (before.digest !== after.digest || before.type !== after.type || before.size !== after.size || JSON.stringify(before.metadata) !== JSON.stringify(after.metadata))) {
         entries.push({ path, type: "modified", before, after })
       }
     }
@@ -155,6 +155,7 @@ class MemoryWorkspaceStore implements WorkspaceStore {
       size,
       mtime: node.mtime,
       mediaType: node.mediaType,
+      metadata: node.metadata,
       digest: node.type === "file" ? await sha256(content) : undefined,
     }
   }
@@ -167,6 +168,7 @@ class MemoryWorkspaceStore implements WorkspaceStore {
       entries[path] = {
         type: entry.type,
         digest: entry.digest,
+        metadata: entry.metadata,
         size: entry.size,
       }
     }

--- a/packages/workspace/src/storage/provider.ts
+++ b/packages/workspace/src/storage/provider.ts
@@ -75,6 +75,7 @@ export function resolveVercelBlobWorkspaceStore(
 export function resolveGitHubWorkspaceStore(
   config: Partial<GitHubWorkspaceStoreOptions> = {},
   env: Record<string, string | undefined> = process.env,
+  input: Pick<WorkspaceResolutionInput, "runtime"> = {},
 ): GitHubWorkspaceStoreOptions {
   return {
     branch: trimmed(config.branch) ?? readEnv(env, "WORKSPACE_GITHUB_BRANCH", "VITEHUB_WORKSPACE_GITHUB_BRANCH", "GITHUB_BRANCH") ?? "main",
@@ -83,7 +84,7 @@ export function resolveGitHubWorkspaceStore(
       ?? trimmed(config.repo)
       ?? readEnv(env, "WORKSPACE_GITHUB_REPOSITORY", "VITEHUB_WORKSPACE_GITHUB_REPOSITORY", "GITHUB_REPOSITORY"),
     root: trimmed(config.root) ?? readEnv(env, "WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT") ?? ".vitehub/workspaces/<workspace>",
-    token: MASKED_WORKSPACE_RUNTIME_VALUE,
+    token: input.runtime ? trimmed(config.token) ?? MASKED_WORKSPACE_RUNTIME_VALUE : MASKED_WORKSPACE_RUNTIME_VALUE,
   }
 }
 
@@ -103,7 +104,7 @@ export function normalizeWorkspaceStoreOptions(
   const hosting = input.hosting || ""
 
   if (store?.provider === "cloudflare-artifacts") return resolveCloudflareArtifactsStore(store, env)
-  if (store?.provider === "github") return resolveGitHubWorkspaceStore(store, env)
+  if (store?.provider === "github") return resolveGitHubWorkspaceStore(store, env, input)
   if (store?.provider === "memory") return store
   if (store?.provider === "vercel-blob") return resolveVercelBlobWorkspaceStore(store, env)
   if (store?.provider === "local" || store?.root) return defu(store, { provider: "local" as const }) as ResolvedWorkspaceStoreOptions

--- a/packages/workspace/src/storage/utils.ts
+++ b/packages/workspace/src/storage/utils.ts
@@ -7,6 +7,7 @@ export async function createSnapshotFromEntries(entries: WorkspaceEntry[], name?
   for (const entry of entries) {
     snapshotEntries[entry.path] = {
       digest: entry.digest,
+      metadata: entry.metadata,
       size: entry.size,
       type: entry.type,
     }
@@ -28,7 +29,7 @@ export function diffSnapshots(from: WorkspaceSnapshot | undefined, to: Workspace
     const after = to.entries[path]
     if (!before && after) entries.push({ path, type: "added", after })
     else if (before && !after) entries.push({ path, type: "removed", before })
-    else if (before && after && (before.digest !== after.digest || before.type !== after.type || before.size !== after.size)) {
+    else if (before && after && (before.digest !== after.digest || before.type !== after.type || before.size !== after.size || JSON.stringify(before.metadata) !== JSON.stringify(after.metadata))) {
       entries.push({ path, type: "modified", before, after })
     }
   }

--- a/packages/workspace/test/cli.test.ts
+++ b/packages/workspace/test/cli.test.ts
@@ -91,6 +91,9 @@ describe("workspace CLI", () => {
         "http://127.0.0.1:4321",
         "--timeout",
         "10000",
+        "--path",
+        "AGENTS.md",
+        "--path=backlog",
         "docs",
         "node",
         "-e",
@@ -123,6 +126,7 @@ describe("workspace CLI", () => {
         workspaceCommand: {
           args: ["-e", "console.log(process.argv[1])", "hello world", "--timeout=30000"],
           command: "node",
+          paths: ["AGENTS.md", "backlog"],
           timeout: 10000,
           workspace: "docs",
         },

--- a/packages/workspace/test/cli.test.ts
+++ b/packages/workspace/test/cli.test.ts
@@ -139,10 +139,11 @@ describe("workspace CLI", () => {
       stderr: "",
       stdout: "ok\n",
     }))
+    const diff = vi.fn(async () => ({ entries: [] }))
     const commit = vi.fn(async () => {})
     const close = vi.fn(async () => {})
     const workspace = {
-      startSession: vi.fn(async () => ({ close, commit, exec })),
+      startSession: vi.fn(async () => ({ close, commit, diff, exec })),
     }
 
     await expect(runWorkspaceDevCommand({
@@ -157,6 +158,33 @@ describe("workspace CLI", () => {
       abortSignal: undefined,
       timeout: undefined,
     })
+    expect(diff).toHaveBeenCalledOnce()
+    expect(commit).not.toHaveBeenCalled()
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it("commits changed Workspace Dev command sessions", async () => {
+    const exec = vi.fn(async () => ({
+      exitCode: 0,
+      stderr: "",
+      stdout: "ok\n",
+    }))
+    const diff = vi.fn(async () => ({ entries: [{ path: "README.md" }] }))
+    const commit = vi.fn(async () => {})
+    const close = vi.fn(async () => {})
+    const workspace = {
+      startSession: vi.fn(async () => ({ close, commit, diff, exec })),
+    }
+
+    await expect(runWorkspaceDevCommand({
+      command: "echo ok > README.md",
+      workspace: workspace as never,
+    })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "ok\n",
+    })
+
+    expect(diff).toHaveBeenCalledOnce()
     expect(commit).toHaveBeenCalledWith({ message: "workspace dev command" })
     expect(close).toHaveBeenCalledOnce()
   })

--- a/packages/workspace/test/cloudflare-artifacts-store.test.ts
+++ b/packages/workspace/test/cloudflare-artifacts-store.test.ts
@@ -167,6 +167,57 @@ describe("Cloudflare Artifacts workspace store", () => {
     expect(requests[0]?.headers.get("authorization")).toBe("Bearer github-token")
   })
 
+  it("preserves explicit GitHub tokens in the Cloudflare runtime", async () => {
+    const requests: Array<{ headers: Headers; method: string; path: string }> = []
+    setActiveCloudflareEnv({ GITHUB_TOKEN: "fallback-token" })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init: RequestInit = {}) => {
+        const url = new URL(input instanceof Request ? input.url : String(input))
+        const method = init.method || "GET"
+        requests.push({ headers: new Headers(init.headers), method, path: url.pathname })
+
+        if (url.pathname === "/repos/onmax/repo/git/ref/heads/main") {
+          return new Response(JSON.stringify({ object: { sha: "base-sha" } }), {
+            headers: { "content-type": "application/json" },
+          })
+        }
+        if (url.pathname === "/repos/onmax/repo/git/commits/base-sha") {
+          return new Response(JSON.stringify({ tree: { sha: "tree-sha" } }), {
+            headers: { "content-type": "application/json" },
+          })
+        }
+        if (url.pathname === "/repos/onmax/repo/git/trees/tree-sha") {
+          return new Response(JSON.stringify({
+            tree: [],
+          }), {
+            headers: { "content-type": "application/json" },
+          })
+        }
+        return new Response("not found", { status: 404 })
+      }),
+    )
+
+    const { configureCloudflareWorkspaceRuntime } = await import("../src/cloudflare.ts")
+    const { useWorkspace } = await import("../src/runtime.ts")
+    configureCloudflareWorkspaceRuntime({
+      store: {
+        branch: "main",
+        provider: "github",
+        repository: "onmax/repo",
+        root: "mirror",
+        token: "explicit-token",
+      },
+    })
+    setWorkspaceRegistry({
+      mirror: async () => ({ default: defineWorkspace({}) }),
+    })
+
+    const workspace = useWorkspace("mirror")
+    await expect(workspace.fs.list("", { recursive: true })).resolves.toEqual([])
+    expect(requests[0]?.headers.get("authorization")).toBe("Bearer explicit-token")
+  })
+
   it("rejects traversal and reserved public paths", async () => {
     const repo = {
       createToken: vi.fn(async () => ({ plaintext: "art_v1_secret?expires=999" })),

--- a/packages/workspace/test/config.test.ts
+++ b/packages/workspace/test/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { normalizeWorkspaceOptions, resolveRuntimeVercelBlobWorkspaceStore } from "../src/config.ts"
+import { normalizeWorkspaceOptions, normalizeWorkspaceStoreOptions, resolveRuntimeVercelBlobWorkspaceStore } from "../src/config.ts"
 import { defineWorkspace } from "../src/core/define.ts"
 
 describe("workspace config", () => {
@@ -209,6 +209,27 @@ describe("workspace config", () => {
       repository: "acme/app",
       root: ".vitehub/workspaces/<workspace>",
       token: "********",
+    })
+  })
+
+  it("preserves explicit GitHub tokens while resolving runtime definitions", () => {
+    const store = normalizeWorkspaceStoreOptions({
+      branch: "workspace-state",
+      provider: "github",
+      repository: "acme/app",
+      root: ".vitehub/workspaces/<workspace>",
+      token: "secret-token",
+    }, {
+      env: {},
+      runtime: true,
+    })
+
+    expect(store).toEqual({
+      branch: "workspace-state",
+      provider: "github",
+      repository: "acme/app",
+      root: ".vitehub/workspaces/<workspace>",
+      token: "secret-token",
     })
   })
 

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearActiveCloudflareEnv, setActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env";
 
 const requests: Array<{ body?: unknown; headers: Headers; method: string; path: string }> = [];
 let refSha = "base-sha";
@@ -112,6 +113,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   delete process.env.WORKSPACE_GITHUB_TOKEN;
+  clearActiveCloudflareEnv();
 });
 
 describe("GitHub workspace store", () => {
@@ -126,6 +128,27 @@ describe("GitHub workspace store", () => {
           repository: "onmax/repo",
           root: ".vitehub/workspaces/<workspace>",
           token: maskedToken,
+        },
+        "docs",
+      );
+
+      await expect(store.list("", { recursive: true })).resolves.toEqual([]);
+
+      expect(requests[0]?.headers.get("authorization")).toBe("Bearer env-token");
+    },
+  );
+
+  it.each(["********", "<redacted>", "[redacted]"])(
+    "falls back to env credentials for masked active binding %s",
+    async (maskedToken) => {
+      process.env.WORKSPACE_GITHUB_TOKEN = "env-token";
+      setActiveCloudflareEnv({ GITHUB_TOKEN: maskedToken });
+      const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+      const store = createGitHubWorkspaceStore(
+        {
+          provider: "github",
+          repository: "onmax/repo",
+          root: ".vitehub/workspaces/<workspace>",
         },
         "docs",
       );

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -114,6 +114,27 @@ afterEach(() => {
 });
 
 describe("GitHub workspace store", () => {
+  it.each(["********", "<redacted>", "[redacted]"])(
+    "falls back to env credentials for masked token %s",
+    async (maskedToken) => {
+      process.env.WORKSPACE_GITHUB_TOKEN = "env-token";
+      const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+      const store = createGitHubWorkspaceStore(
+        {
+          provider: "github",
+          repository: "onmax/repo",
+          root: ".vitehub/workspaces/<workspace>",
+          token: maskedToken,
+        },
+        "docs",
+      );
+
+      await expect(store.list("", { recursive: true })).resolves.toEqual([]);
+
+      expect(requests[0]?.headers.get("authorization")).toBe("Bearer env-token");
+    },
+  );
+
   it("reads, lists, stats, writes, snapshots, and persists metadata through GitHub", async () => {
     seedRemote(".vitehub/workspaces/docs/data/existing.json", '{"ok":true}\n');
     const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -409,6 +409,41 @@ describe("GitHub workspace store", () => {
     });
   });
 
+  it("commits GitHub symlink metadata as tree mode 120000", async () => {
+    seedRemote(".vitehub/workspaces/docs/CLAUDE.md", "AGENTS.md", "120000");
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await store.writeFile("CLAUDE.md", {
+      path: "CLAUDE.md",
+      content: "NEXT.md",
+      metadata: { gitMode: "120000" },
+    });
+    await store.snapshot({ name: "retarget symlink" });
+
+    expect(
+      requests.find((request) => request.path.endsWith("/git/trees") && request.method === "POST")
+        ?.body,
+    ).toMatchObject({
+      tree: expect.arrayContaining([
+        {
+          mode: "120000",
+          path: ".vitehub/workspaces/docs/CLAUDE.md",
+          sha: textSha("NEXT.md"),
+          type: "blob",
+        },
+      ]),
+    });
+  });
+
   it("fails dirty snapshots when the branch moved after load", async () => {
     const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
     const store = createGitHubWorkspaceStore(

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -56,7 +56,7 @@ beforeEach(() => {
               content?: string;
               force?: boolean;
               sha?: string | null;
-              tree?: Array<{ path: string; sha: string | null; type: "blob" }>;
+              tree?: Array<{ mode?: string; path: string; sha: string | null; type: "blob" }>;
             })
           : undefined;
       requests.push({ body, headers: new Headers(init.headers), method, path: url.pathname });
@@ -86,6 +86,7 @@ beforeEach(() => {
           if (entry.sha) {
             const bytes = blobs.get(entry.sha);
             remoteTree.push({
+              mode: entry.mode,
               path: entry.path,
               sha: entry.sha,
               size: bytes?.byteLength,
@@ -461,6 +462,35 @@ describe("GitHub workspace store", () => {
           sha: textSha("NEXT.md"),
           type: "blob",
         },
+      ]),
+    });
+  });
+
+  it("preserves remote executable file modes during unrelated snapshots", async () => {
+    seedRemote(".vitehub/workspaces/docs/bin/tool.sh", "#!/bin/sh\n", "100755");
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await expect(store.stat("bin/tool.sh")).resolves.toMatchObject({
+      metadata: { gitMode: "100755" },
+    });
+    await store.writeFile("notes.md", { path: "notes.md", content: "ok\n" });
+    await store.snapshot({ name: "write note" });
+
+    expect(
+      requests.find((request) => request.path.endsWith("/git/trees") && request.method === "POST")
+        ?.body,
+    ).toMatchObject({
+      tree: expect.not.arrayContaining([
+        expect.objectContaining({ path: ".vitehub/workspaces/docs/bin/tool.sh" }),
       ]),
     });
   });

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const requests: Array<{ body?: unknown; headers: Headers; method: string; path: string }> = [];
 let refSha = "base-sha";
 let remoteTreeSha = "base-tree";
-let remoteTree: Array<{ path: string; sha: string; size?: number; type: "blob" }> = [];
+let remoteTree: Array<{ mode?: string; path: string; sha: string; size?: number; type: "blob" }> = [];
 let commitIndex = 0;
 let treeIndex = 0;
 const blobs = new Map<string, Uint8Array>();
@@ -21,11 +21,11 @@ function textSha(content: string): string {
   return gitBlobSha(textBytes(content));
 }
 
-function seedRemote(path: string, content: string) {
+function seedRemote(path: string, content: string, mode?: string) {
   const bytes = textBytes(content);
   const sha = gitBlobSha(bytes);
   blobs.set(sha, bytes);
-  remoteTree.push({ path, sha, size: bytes.byteLength, type: "blob" });
+  remoteTree.push({ mode, path, sha, size: bytes.byteLength, type: "blob" });
 }
 
 function jsonResponse(value: unknown) {
@@ -382,6 +382,31 @@ describe("GitHub workspace store", () => {
         path: `/repos/onmax/repo/git/blobs/${textSha("# Docs\n")}`,
       }),
     ]);
+  });
+
+  it("marks GitHub symlink blobs from the remote tree", async () => {
+    seedRemote(".vitehub/workspaces/docs/AGENTS.md", "# Agents\n");
+    seedRemote(".vitehub/workspaces/docs/CLAUDE.md", "AGENTS.md", "120000");
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await expect(store.stat("CLAUDE.md")).resolves.toMatchObject({
+      metadata: { gitMode: "120000" },
+      path: "CLAUDE.md",
+      type: "file",
+    });
+    await expect(store.readFile("CLAUDE.md")).resolves.toMatchObject({
+      content: textBytes("AGENTS.md"),
+      metadata: { gitMode: "120000" },
+    });
   });
 
   it("fails dirty snapshots when the branch moved after load", async () => {

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -465,12 +465,12 @@ describe("Harness Workspace Session", () => {
     expect(workspaceSession.close).toHaveBeenCalledOnce()
   })
 
-  it("does not write harness symlink targets back as Workspace files", async () => {
+  it("commits harness symlinks as Git symlink blobs", async () => {
     const workspaceSession = {
       close: vi.fn(async () => {}),
       commit: vi.fn(async () => {}),
       diff: vi.fn(async () => ({
-        entries: [{ path: "result.txt", type: "added" }],
+        entries: [{ path: "linked.txt", type: "added" }],
         to: "next",
       })),
       mkdir: vi.fn(async () => {}),
@@ -479,18 +479,28 @@ describe("Harness Workspace Session", () => {
     }
     const readBinaryFile = vi.fn(async ({ path }: { path: string }) =>
       path.endsWith("linked.txt") ? bytes("target bytes") : bytes("result"))
+    const run = vi.fn(async ({ command }: { command: string }) => {
+      if (command.includes("-type d")) return ok()
+      if (command.includes("-type f")) return ok("./result.txt")
+      if (command.includes("-type l")) return ok("./CLAUDE.md\n./linked.txt")
+      if (command === "readlink -- 'CLAUDE.md'") return ok("NEXT.md\n")
+      if (command === "readlink -- 'linked.txt'") return ok("target.txt\n")
+      return ok()
+    })
 
     const session = await prepareHarnessWorkspaceSession({
       fs: {
-        list: vi.fn(async () => []),
-        readFile: vi.fn(async () => bytes("")),
+        list: vi.fn(async () => [
+          { metadata: { gitMode: "120000" }, path: "CLAUDE.md", type: "file" },
+        ]),
+        readFile: vi.fn(async () => bytes("AGENTS.md")),
       },
       startSession: vi.fn(async () => workspaceSession),
       tools: {},
     } as never, {
       session: {
         readBinaryFile,
-        run: sandboxRun(["result.txt"], [], ["linked.txt"]),
+        run,
         writeBinaryFile: vi.fn(async () => {}),
       },
       sessionWorkDir: "/work/agent",
@@ -500,7 +510,8 @@ describe("Harness Workspace Session", () => {
 
     expect(readBinaryFile).not.toHaveBeenCalledWith({ abortSignal: undefined, path: "/work/agent/linked.txt" })
     expect(workspaceSession.writeFile).toHaveBeenCalledWith("result.txt", bytes("result"), { mediaType: "text/plain" })
-    expect(workspaceSession.writeFile).not.toHaveBeenCalledWith("linked.txt", expect.anything(), expect.anything())
+    expect(workspaceSession.writeFile).toHaveBeenCalledWith("CLAUDE.md", bytes("NEXT.md"), { metadata: { gitMode: "120000" } })
+    expect(workspaceSession.writeFile).toHaveBeenCalledWith("linked.txt", bytes("target.txt"), { metadata: { gitMode: "120000" } })
     expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
   })
 

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -504,6 +504,46 @@ describe("Harness Workspace Session", () => {
     expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
   })
 
+  it("commits regular files that replace initial harness symlinks", async () => {
+    const workspaceSession = {
+      close: vi.fn(async () => {}),
+      commit: vi.fn(async () => {}),
+      diff: vi.fn(async () => ({
+        entries: [{ path: "CLAUDE.md", type: "modified" }],
+        to: "next",
+      })),
+      mkdir: vi.fn(async () => {}),
+      rm: vi.fn(async () => {}),
+      writeFile: vi.fn(async () => {}),
+    }
+    const replacement = bytes("# Local instructions\n")
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: {
+        list: vi.fn(async () => [
+          { path: "AGENTS.md", type: "file" },
+          { metadata: { gitMode: "120000" }, path: "CLAUDE.md", type: "file" },
+        ]),
+        readFile: vi.fn(async (path: string) => path === "CLAUDE.md" ? bytes("AGENTS.md") : bytes("# Agents\n")),
+      },
+      startSession: vi.fn(async () => workspaceSession),
+      tools: {},
+    } as never, {
+      session: {
+        readBinaryFile: vi.fn(async ({ path }: { path: string }) =>
+          path.endsWith("CLAUDE.md") ? replacement : bytes("# Agents\n")),
+        run: sandboxRun(["AGENTS.md", "CLAUDE.md"]),
+        writeBinaryFile: vi.fn(async () => {}),
+      },
+      sessionWorkDir: "/work/agent",
+    })
+
+    await session.close()
+
+    expect(workspaceSession.writeFile).toHaveBeenCalledWith("CLAUDE.md", replacement, { mediaType: "text/markdown" })
+    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
+  })
+
   it("does not recreate unchanged initial directories during write-back", async () => {
     const initial = bytes("unchanged")
     const summary = bytes("summary")

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -13,9 +13,10 @@ function ok(stdout = "") {
   return { exitCode: 0, stderr: "", stdout }
 }
 
-function sandboxRun(files: string[] = [], directories: string[] = []) {
+function sandboxRun(files: string[] = [], directories: string[] = [], symlinks: string[] = []) {
   return vi.fn(async ({ command }: { command: string }) => {
     if (command.includes("-type d")) return ok(directories.map(path => `./${path}`).join("\n"))
+    if (command.includes("-type l")) return ok(symlinks.map(path => `./${path}`).join("\n"))
     if (command.includes("-type f")) return ok(files.map(path => `./${path}`).join("\n"))
     return ok()
   })
@@ -450,13 +451,57 @@ describe("Harness Workspace Session", () => {
     expect(startSession).toHaveBeenCalledOnce()
     expect(run).toHaveBeenCalledWith({
       abortSignal: undefined,
-      command: "find . \\( -type f -o -type l \\) -print",
+      command: "find . -type f -print",
+      workingDirectory: "/work/agent",
+    })
+    expect(run).toHaveBeenCalledWith({
+      abortSignal: undefined,
+      command: "find . -type l -print",
       workingDirectory: "/work/agent",
     })
     expect(workspaceSession.writeFile).toHaveBeenCalledWith("README.md", updated, { mediaType: "text/markdown" })
     expect(workspaceSession.writeFile).toHaveBeenCalledWith("new.json", added, { mediaType: "application/json" })
     expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
     expect(workspaceSession.close).toHaveBeenCalledOnce()
+  })
+
+  it("does not write harness symlink targets back as Workspace files", async () => {
+    const workspaceSession = {
+      close: vi.fn(async () => {}),
+      commit: vi.fn(async () => {}),
+      diff: vi.fn(async () => ({
+        entries: [{ path: "result.txt", type: "added" }],
+        to: "next",
+      })),
+      mkdir: vi.fn(async () => {}),
+      rm: vi.fn(async () => {}),
+      writeFile: vi.fn(async () => {}),
+    }
+    const readBinaryFile = vi.fn(async ({ path }: { path: string }) =>
+      path.endsWith("linked.txt") ? bytes("target bytes") : bytes("result"))
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: {
+        list: vi.fn(async () => []),
+        readFile: vi.fn(async () => bytes("")),
+      },
+      startSession: vi.fn(async () => workspaceSession),
+      tools: {},
+    } as never, {
+      session: {
+        readBinaryFile,
+        run: sandboxRun(["result.txt"], [], ["linked.txt"]),
+        writeBinaryFile: vi.fn(async () => {}),
+      },
+      sessionWorkDir: "/work/agent",
+    })
+
+    await session.close()
+
+    expect(readBinaryFile).not.toHaveBeenCalledWith({ abortSignal: undefined, path: "/work/agent/linked.txt" })
+    expect(workspaceSession.writeFile).toHaveBeenCalledWith("result.txt", bytes("result"), { mediaType: "text/plain" })
+    expect(workspaceSession.writeFile).not.toHaveBeenCalledWith("linked.txt", expect.anything(), expect.anything())
+    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
   })
 
   it("does not recreate unchanged initial directories during write-back", async () => {

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -1,3 +1,4 @@
+import { gunzipSync } from "node:zlib"
 import { describe, expect, it, vi } from "vitest"
 
 import { prepareHarnessWorkspaceSession } from "../src/session/harness.ts"
@@ -51,6 +52,21 @@ function expectWorkDirReset(run: ReturnType<typeof vi.fn>, writeBinaryFile: Retu
   })
 }
 
+function archiveEntry(writeBinaryFile: ReturnType<typeof vi.fn>, path: string) {
+  const archive = writeBinaryFile.mock.calls.find(([input]) => input.path.endsWith(".vitehub-workspace.tar.gz"))?.[0].content
+  if (!archive) throw new Error("missing archive write")
+  const tar = gunzipSync(Buffer.from(archive))
+  for (let offset = 0; offset < tar.byteLength; offset += 512) {
+    const name = tar.subarray(offset, offset + 100).toString().replace(/\0.*$/, "")
+    if (!name) break
+    const sizeText = tar.subarray(offset + 124, offset + 136).toString().replace(/\0.*$/, "").trim()
+    const size = Number.parseInt(sizeText || "0", 8)
+    if (name === path) return tar.subarray(offset, offset + 512)
+    offset += Math.ceil(size / 512) * 512
+  }
+  throw new Error(`missing archive entry: ${path}`)
+}
+
 describe("Harness Workspace Session", () => {
   it("resets and materializes selected Workspace files into the harness sandbox", async () => {
     const readme = bytes("# Docs\n")
@@ -75,6 +91,30 @@ describe("Harness Workspace Session", () => {
     expect(readFile).toHaveBeenCalledWith("README.md", { encoding: "binary" })
     expectArchiveWrite(writeBinaryFile)
     expectArchiveExtract(run)
+
+    await session.close()
+  })
+
+  it("preserves GitHub symlinks in the harness archive", async () => {
+    const list = vi.fn(async () => [
+      { path: "AGENTS.md", type: "file" },
+      { metadata: { gitMode: "120000" }, path: "CLAUDE.md", type: "file" },
+    ])
+    const readFile = vi.fn(async (path: string) => path === "CLAUDE.md" ? bytes("AGENTS.md") : bytes("# Agents\n"))
+    const run = sandboxRun(["AGENTS.md", "CLAUDE.md"])
+    const writeBinaryFile = vi.fn(async () => {})
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: { list, readFile },
+      tools: {},
+    } as never, {
+      session: { readBinaryFile: vi.fn(async () => null), run, writeBinaryFile },
+      sessionWorkDir: "/work/agent",
+    })
+
+    const header = archiveEntry(writeBinaryFile, "CLAUDE.md")
+    expect(String.fromCharCode(header[156]!)).toBe("2")
+    expect(header.subarray(157, 257).toString().replace(/\0.*$/, "")).toBe("AGENTS.md")
 
     await session.close()
   })
@@ -410,7 +450,7 @@ describe("Harness Workspace Session", () => {
     expect(startSession).toHaveBeenCalledOnce()
     expect(run).toHaveBeenCalledWith({
       abortSignal: undefined,
-      command: "find . -type f -print",
+      command: "find . \\( -type f -o -type l \\) -print",
       workingDirectory: "/work/agent",
     })
     expect(workspaceSession.writeFile).toHaveBeenCalledWith("README.md", updated, { mediaType: "text/markdown" })

--- a/packages/workspace/test/rules.test.ts
+++ b/packages/workspace/test/rules.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { resolveWorkspaceAutoCommit } from "../src/core/rules.ts"
+import { createWorkspace } from "../src/core/workspace.ts"
 
 describe("workspace rules", () => {
   it("creates an auto-commit plan when every changed path matches a commit rule", () => {
@@ -38,5 +39,29 @@ describe("workspace rules", () => {
       ],
       to: "next",
     })).toBeUndefined()
+  })
+
+  it("passes write metadata through validators before storing", async () => {
+    const seen: unknown[] = []
+    const workspace = createWorkspace({
+      name: "docs",
+      rules: {
+        "**": {
+          validate(input) {
+            seen.push(input.metadata)
+            return { ...input, metadata: { gitMode: "100755" } }
+          },
+          write: true,
+        },
+      },
+      store: { provider: "memory" },
+    })
+
+    await workspace.writeFile("script.sh", "echo ok\n", { metadata: { gitMode: "120000" } })
+
+    expect(seen).toEqual([{ gitMode: "120000" }])
+    await expect(workspace.stat("script.sh")).resolves.toMatchObject({
+      metadata: { gitMode: "100755" },
+    })
   })
 })

--- a/packages/workspace/test/sandbox-runtime.test.ts
+++ b/packages/workspace/test/sandbox-runtime.test.ts
@@ -7,7 +7,7 @@ import { defineWorkspace } from "../src/index.ts"
 import { createWorkspace } from "../src/core/workspace.ts"
 import { setSandboxRuntimeConfig } from "@vite-hub/sandbox/runtime/state"
 
-type FakeEntry = { content?: string | Uint8Array, type: "directory" | "file" }
+type FakeEntry = { content?: string | Uint8Array, target?: string, type: "directory" | "file" | "symlink" }
 
 const tempDirs: string[] = []
 
@@ -63,7 +63,9 @@ function createFakeSandbox(provider: "cloudflare" | "vercel") {
       },
       async readFile(path: string, options?: { encoding?: "binary" | "utf8" }) {
         const entry = files.get(path)
-        if (!entry || entry.type !== "file") throw new Error(`missing file: ${path}`)
+        if (!entry || (entry.type !== "file" && entry.type !== "symlink")) throw new Error(`missing file: ${path}`)
+        if (entry.type === "symlink")
+          return await this.readFile(join(parent(path), entry.target || ""), options)
         const content = entry.content || ""
         if (options?.encoding === "binary")
           return typeof content === "string" ? new TextEncoder().encode(content) : content
@@ -80,7 +82,7 @@ function createFakeSandbox(provider: "cloudflare" | "vercel") {
           .map(([entryPath, entry]) => ({
             name: entryPath.split("/").at(-1) || entryPath,
             path: entryPath,
-            size: typeof entry.content === "string" ? entry.content.length : entry.content?.byteLength,
+            size: entry.type === "symlink" ? entry.target?.length : typeof entry.content === "string" ? entry.content.length : entry.content?.byteLength,
             type: entry.type,
           }))
       },
@@ -105,6 +107,13 @@ function createFakeSandbox(provider: "cloudflare" | "vercel") {
         if (command === "rm" && args[0] === "-rf") {
           for (const key of [...files.keys()].filter(key => key === args[1] || key.startsWith(`${args[1]}/`)))
             files.delete(key)
+        }
+        if (command === "ln" && args[0] === "-s" && args[1] && args[2]) {
+          files.set(args[2], { target: args[1], type: "symlink" })
+        }
+        if (command === "readlink" && args[0]) {
+          const entry = files.get(args[0])
+          return { code: entry?.type === "symlink" ? 0 : 1, ok: entry?.type === "symlink", stderr: entry?.type === "symlink" ? "" : "not a symlink", stdout: entry?.type === "symlink" ? `${entry.target}\n` : "" }
         }
         return { code: 0, ok: true, stderr: "", stdout: "ok\n" }
       },
@@ -220,6 +229,31 @@ describe("sandbox workspace runtime", () => {
     await session.close()
 
     await expect(workspace.exists("old.txt")).resolves.toBe(false)
+  })
+
+  it("commits session-written symlinks as GitHub symlink blobs", async () => {
+    const fake = createFakeSandbox("cloudflare")
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "cloudflare", binding: "SANDBOX" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "sandbox",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+
+    const session = await workspace.startSession()
+    await session.writeFile("AGENTS.md", "# Agents\n")
+    await session.writeFile("CLAUDE.md", "AGENTS.md", { metadata: { gitMode: "120000" } })
+    await session.commit()
+    await session.close()
+
+    await expect(workspace.stat("CLAUDE.md")).resolves.toEqual(expect.objectContaining({
+      metadata: { gitMode: "120000" },
+    }))
   })
 
   it("rejects changes outside scoped sandbox session paths", async () => {

--- a/packages/workspace/test/sandbox-runtime.test.ts
+++ b/packages/workspace/test/sandbox-runtime.test.ts
@@ -61,7 +61,7 @@ function createFakeSandbox(provider: "cloudflare" | "vercel") {
         await mkdir(parent(path))
         files.set(path, { content, type: "file" })
       },
-      async readFile(path: string, options?: { encoding?: "binary" | "utf8" }) {
+      async readFile(path: string, options?: { encoding?: "binary" | "utf8" }): Promise<string | Uint8Array> {
         const entry = files.get(path)
         if (!entry || (entry.type !== "file" && entry.type !== "symlink")) throw new Error(`missing file: ${path}`)
         if (entry.type === "symlink")

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -252,6 +252,30 @@ describe("trusted host workspace runtime", () => {
     await session.close()
   })
 
+  it("materializes unsafe GitHub symlink targets as regular files", async () => {
+    const workspace = {
+      name: "docs",
+      async list() {
+        return [
+          { metadata: { gitMode: "120000" }, path: "CLAUDE.md", type: "file" as const },
+        ]
+      },
+      async readFile(path: string) {
+        if (path === "CLAUDE.md") return "../../secret"
+        throw new Error(`unexpected read: ${path}`)
+      },
+    } as unknown as Workspace
+
+    const session = await createTrustedHostWorkspaceSession({ name: "docs", runtime: "trusted-host" }, workspace)
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "const fs = require('node:fs'); process.stdout.write(`${fs.lstatSync('CLAUDE.md').isSymbolicLink()}:${fs.readFileSync('CLAUDE.md', 'utf8')}`)",
+    ])
+
+    expect(result).toMatchObject({ exitCode: 0, stdout: "false:../../secret" })
+    await session.close()
+  })
+
   it("commits retargeted host symlinks as GitHub symlink blobs", async () => {
     const writeFile = vi.fn(async () => {})
     const workspace = {

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -293,6 +293,70 @@ describe("trusted host workspace runtime", () => {
     })
   })
 
+  it("diffs regular files that replace symlinks with matching bytes", async () => {
+    const writeFile = vi.fn(async () => {})
+    const workspace = {
+      name: "docs",
+      async list() {
+        return [
+          { path: "AGENTS.md", type: "file" as const },
+          { metadata: { gitMode: "120000" }, path: "CLAUDE.md", type: "file" as const },
+        ]
+      },
+      async readFile(path: string) {
+        if (path === "AGENTS.md") return "# Agents\n"
+        if (path === "CLAUDE.md") return "AGENTS.md"
+        throw new Error(`unexpected read: ${path}`)
+      },
+      async rm() {},
+      async mkdir() {},
+      async stat(path: string) {
+        if (path === "CLAUDE.md") return { metadata: { gitMode: "120000" }, path, type: "file" as const }
+        return { path, type: "file" as const }
+      },
+      writeFile,
+      snapshot: vi.fn(async () => ({ createdAt: new Date().toISOString(), entries: {}, id: "snapshot" })),
+    } as unknown as Workspace
+
+    const session = await createTrustedHostWorkspaceSession({ name: "docs", runtime: "trusted-host" }, workspace)
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "const fs = require('node:fs'); fs.unlinkSync('CLAUDE.md'); fs.writeFileSync('CLAUDE.md', 'AGENTS.md')",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect((await session.diff()).entries).toEqual([
+      expect.objectContaining({ path: "CLAUDE.md", type: "modified" }),
+    ])
+    await session.commit()
+    await session.close()
+
+    expect(writeFile).toHaveBeenCalledWith("CLAUDE.md", Buffer.from("AGENTS.md"), {
+      mediaType: undefined,
+      metadata: undefined,
+    })
+  })
+
+  it("commits session-written symlinks as GitHub symlink blobs", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+
+    const session = await workspace.startSession()
+    await session.writeFile("AGENTS.md", "# Agents\n")
+    await session.writeFile("CLAUDE.md", "AGENTS.md", { metadata: { gitMode: "120000" } })
+    await session.commit()
+    await session.close()
+
+    await expect(workspace.stat("CLAUDE.md")).resolves.toEqual(expect.objectContaining({
+      metadata: { gitMode: "120000" },
+    }))
+  })
+
   it("ignores git metadata when committing host session changes", async () => {
     const workspace = createWorkspace({
       ...defineWorkspace({

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -252,6 +252,47 @@ describe("trusted host workspace runtime", () => {
     await session.close()
   })
 
+  it("commits retargeted host symlinks as GitHub symlink blobs", async () => {
+    const writeFile = vi.fn(async () => {})
+    const workspace = {
+      name: "docs",
+      async list() {
+        return [
+          { path: "AGENTS.md", type: "file" as const },
+          { metadata: { gitMode: "120000" }, path: "CLAUDE.md", type: "file" as const },
+        ]
+      },
+      async readFile(path: string) {
+        if (path === "AGENTS.md") return "# Agents\n"
+        if (path === "CLAUDE.md") return "AGENTS.md"
+        throw new Error(`unexpected read: ${path}`)
+      },
+      async rm() {},
+      async mkdir() {},
+      async stat(path: string) {
+        if (path === "CLAUDE.md") return { metadata: { gitMode: "120000" }, path, type: "file" as const }
+        return { path, type: "file" as const }
+      },
+      writeFile,
+      snapshot: vi.fn(async () => ({ createdAt: new Date().toISOString(), entries: {}, id: "snapshot" })),
+    } as unknown as Workspace
+
+    const session = await createTrustedHostWorkspaceSession({ name: "docs", runtime: "trusted-host" }, workspace)
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "const fs = require('node:fs'); fs.unlinkSync('CLAUDE.md'); fs.symlinkSync('NEXT.md', 'CLAUDE.md')",
+    ])
+
+    expect(result.exitCode).toBe(0)
+    await session.commit()
+    await session.close()
+
+    expect(writeFile).toHaveBeenCalledWith("CLAUDE.md", "NEXT.md", {
+      mediaType: undefined,
+      metadata: { gitMode: "120000" },
+    })
+  })
+
   it("ignores git metadata when committing host session changes", async () => {
     const workspace = createWorkspace({
       ...defineWorkspace({

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -276,6 +276,34 @@ describe("trusted host workspace runtime", () => {
     await session.close()
   })
 
+  it("materializes and commits GitHub executable modes", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    await workspace.writeFile("scripts/setup", "#!/bin/sh\nprintf setup\n", { metadata: { gitMode: "100755" } })
+
+    const session = await workspace.startSession()
+    const run = await session.exec("./scripts/setup")
+    const update = await session.exec(process.execPath, [
+      "-e",
+      "require('node:fs').writeFileSync('scripts/setup', '#!/bin/sh\\nprintf next\\n')",
+    ])
+
+    expect(run).toMatchObject({ exitCode: 0, stdout: "setup" })
+    expect(update.exitCode).toBe(0)
+    await session.commit()
+    await session.close()
+
+    await expect(workspace.readFile("scripts/setup")).resolves.toBe("#!/bin/sh\nprintf next\n")
+    await expect(workspace.stat("scripts/setup")).resolves.toEqual(expect.objectContaining({
+      metadata: { gitMode: "100755" },
+    }))
+  })
+
   it("commits retargeted host symlinks as GitHub symlink blobs", async () => {
     const writeFile = vi.fn(async () => {})
     const workspace = {

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -226,6 +226,32 @@ describe("trusted host workspace runtime", () => {
     await session.close()
   })
 
+  it("materializes GitHub symlink metadata as local symlinks", async () => {
+    const workspace = {
+      name: "docs",
+      async list() {
+        return [
+          { path: "AGENTS.md", type: "file" as const },
+          { metadata: { gitMode: "120000" }, path: "CLAUDE.md", type: "file" as const },
+        ]
+      },
+      async readFile(path: string) {
+        if (path === "AGENTS.md") return "# Agents\n"
+        if (path === "CLAUDE.md") return "AGENTS.md"
+        throw new Error(`unexpected read: ${path}`)
+      },
+    } as unknown as Workspace
+
+    const session = await createTrustedHostWorkspaceSession({ name: "docs", runtime: "trusted-host" }, workspace)
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "const fs = require('node:fs'); process.stdout.write(`${fs.lstatSync('CLAUDE.md').isSymbolicLink()}:${fs.readFileSync('CLAUDE.md', 'utf8')}`)",
+    ])
+
+    expect(result).toMatchObject({ exitCode: 0, stdout: "true:# Agents\n" })
+    await session.close()
+  })
+
   it("ignores git metadata when committing host session changes", async () => {
     const workspace = createWorkspace({
       ...defineWorkspace({


### PR DESCRIPTION
Preserves GitHub symlink entries through workspace session materialization and write-back, including harness-backed sessions, so instruction aliases like `CLAUDE.md -> AGENTS.md` remain usable instead of being flattened.

Adds scoped path materialization and progress feedback to `vitehub workspace dev` / `vitehub agent dev` command execution, and falls back from redacted GitHub token options to environment credentials for local dev servers.

Also avoids mapping Claude Code harness runs to bypass permissions when the host process is running as root, which keeps containerized agents on the allowed-edit permission path instead of failing before startup.