### PR TITLE
fix(agent): normalize capability cli input stream events

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -29,7 +29,7 @@ import {
 } from "./capability-runtime.ts"
 import type { AgentCapabilityRegistries, ResolvedAgentFinishExtensionProvider, ResolvedAgentOutputExtensionProvider } from "./capability-runtime.ts"
 import { formatUnknownAgentMessage } from "./registry-error.ts"
-import { finalizeUiMessageStreamOutput, isUIMessageStreamResult } from "./stream-output.ts"
+import { finalizeUiMessageStreamOutput, isUIMessageStreamResult, normalizeUiMessageStream } from "./stream-output.ts"
 import {
   applyAgentToolPolicies,
   withAgentToolStepReporting,
@@ -1587,7 +1587,7 @@ function maybeTraceUiMessageStreamResult<
     toUIMessageStream: {
       configurable: true,
       enumerable: false,
-      value: (...args: unknown[]) => traceUiMessageStream(toUIMessageStream.apply(rendered, args), context),
+      value: (...args: unknown[]) => traceUiMessageStream(normalizeUiMessageStream(toUIMessageStream.apply(rendered, args)), context),
     },
   })
 }

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -158,6 +158,33 @@ function uiMessageTextDelta(event: unknown): string | undefined {
   return typeof text === "string" ? text : undefined
 }
 
+function isCapabilityCliInput(input: unknown): input is { argv: string[] } {
+  if (typeof input !== "object" || input === null) return false
+  const argv = (input as { argv?: unknown }).argv
+  return Array.isArray(argv) && argv.every(arg => typeof arg === "string")
+}
+
+function normalizeUiMessageStreamChunk(chunk: unknown): unknown {
+  if (typeof chunk !== "object" || chunk === null) return chunk
+  const record = chunk as Record<string, unknown>
+  if (record.type !== "tool-input-error") return chunk
+  const metadata = typeof record.toolMetadata === "object" && record.toolMetadata !== null
+    ? record.toolMetadata as Record<string, unknown>
+    : undefined
+  if (metadata?.vitehubCapabilityCli !== true || !isCapabilityCliInput(record.input)) return chunk
+
+  const { errorText: _errorText, ...available } = record
+  return { ...available, type: "tool-input-available" }
+}
+
+function normalizeUiMessageStream(stream: ReadableStream<unknown>): ReadableStream<unknown> {
+  return stream.pipeThrough(new TransformStream<unknown, unknown>({
+    transform(chunk, controller) {
+      controller.enqueue(normalizeUiMessageStreamChunk(chunk))
+    },
+  }))
+}
+
 function uiDataType(data: unknown): `data-${string}` {
   const rawType = typeof data === "object" && data !== null && typeof (data as { type?: unknown }).type === "string"
     ? (data as { type: string }).type
@@ -226,7 +253,7 @@ export async function finalizeUiMessageStreamOutput(
   if (!hasUiMessageStream && !hasAsyncIterable && text === undefined) {
     throw new Error("[vitehub] Agent stream output \"ui-message-stream\" requires a result with toUIMessageStream().")
   }
-  const stream = hasUiMessageStream
+  const stream = normalizeUiMessageStream(hasUiMessageStream
     ? rendered.toUIMessageStream()
     : hasAsyncIterable
       ? createAgentUIMessageStream({
@@ -241,7 +268,7 @@ export async function finalizeUiMessageStreamOutput(
           writer.write({ type: "text-end", id: messageId })
           writer.write({ type: "finish", finishReason: "stop" })
         },
-      })
+      }))
   let streamedText = ""
   return {
     deferFinish: shouldWrapOutput,

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -158,10 +158,14 @@ function uiMessageTextDelta(event: unknown): string | undefined {
   return typeof text === "string" ? text : undefined
 }
 
-function isCapabilityCliInput(input: unknown): input is { argv: string[] } {
-  if (typeof input !== "object" || input === null) return false
-  const argv = (input as { argv?: unknown }).argv
-  return Array.isArray(argv) && argv.every(arg => typeof arg === "string")
+function isCapabilityCliInput(input: unknown): input is { argv: string[], input?: unknown, json?: boolean } {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return false
+  const record = input as Record<string, unknown>
+  const argv = record.argv
+  return Object.keys(record).every(key => key === "argv" || key === "input" || key === "json")
+    && Array.isArray(argv)
+    && argv.every(arg => typeof arg === "string")
+    && (record.json === undefined || typeof record.json === "boolean")
 }
 
 function normalizeUiMessageStreamChunk(chunk: unknown): unknown {

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -177,7 +177,7 @@ function normalizeUiMessageStreamChunk(chunk: unknown): unknown {
   return { ...available, type: "tool-input-available" }
 }
 
-function normalizeUiMessageStream(stream: ReadableStream<unknown>): ReadableStream<unknown> {
+export function normalizeUiMessageStream(stream: ReadableStream<unknown>): ReadableStream<unknown> {
   return stream.pipeThrough(new TransformStream<unknown, unknown>({
     transform(chunk, controller) {
       controller.enqueue(normalizeUiMessageStreamChunk(chunk))

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4843,6 +4843,7 @@ describe("agent message protocol", () => {
   it("normalizes valid capability CLI input errors in native UI message streams", async () => {
     const { createUIMessageStream } = await import("ai")
     const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const traceLog = createTraceEventLog()
     const agent = defineAgent({
       driver: { run: () => ({
           toUIMessageStream() {
@@ -4875,7 +4876,7 @@ describe("agent message protocol", () => {
         }) },
     })
 
-    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", traceLog, waitUntil: vi.fn() }, {}, { output: "ui-message-stream" }) as ReadableStream<unknown>
     const chunks: unknown[] = []
     for await (const chunk of stream) chunks.push(chunk)
 
@@ -4888,6 +4889,14 @@ describe("agent message protocol", () => {
     expect(chunks).not.toContainEqual(expect.objectContaining({
       toolCallId: "cli-1",
       type: "tool-input-error",
+    }))
+    expect(traceLog.entries()).toContainEqual(expect.objectContaining({
+      attributes: expect.objectContaining({
+        "tool.hasInput": true,
+        "tool.id": "cli-1",
+        "tool.name": "portal-api",
+      }),
+      name: "agent.tool.start",
     }))
   })
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4862,6 +4862,17 @@ describe("agent message protocol", () => {
                   type: "tool-input-error",
                 } as never)
                 writer.write({
+                  errorText: "Invalid input.",
+                  input: { argv: ["list"], extra: true, json: "true" },
+                  toolCallId: "cli-invalid",
+                  toolMetadata: {
+                    cli: "portal-api",
+                    vitehubCapabilityCli: true,
+                  },
+                  toolName: "portal-api",
+                  type: "tool-input-error",
+                } as never)
+                writer.write({
                   output: {
                     command: "portal-api purchase-orders --json",
                     exitCode: 0,
@@ -4890,12 +4901,21 @@ describe("agent message protocol", () => {
       toolCallId: "cli-1",
       type: "tool-input-error",
     }))
+    expect(chunks).toContainEqual(expect.objectContaining({
+      input: { argv: ["list"], extra: true, json: "true" },
+      toolCallId: "cli-invalid",
+      type: "tool-input-error",
+    }))
     expect(traceLog.entries()).toContainEqual(expect.objectContaining({
       attributes: expect.objectContaining({
         "tool.hasInput": true,
         "tool.id": "cli-1",
         "tool.name": "portal-api",
       }),
+      name: "agent.tool.start",
+    }))
+    expect(traceLog.entries()).not.toContainEqual(expect.objectContaining({
+      attributes: expect.objectContaining({ "tool.id": "cli-invalid" }),
       name: "agent.tool.start",
     }))
   })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4840,6 +4840,57 @@ describe("agent message protocol", () => {
     ])
   })
 
+  it("normalizes valid capability CLI input errors in native UI message streams", async () => {
+    const { createUIMessageStream } = await import("ai")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return createUIMessageStream({
+              execute({ writer }) {
+                writer.write({ type: "start", messageId: "assistant-1" })
+                writer.write({
+                  errorText: "An error occurred.",
+                  input: { argv: ["purchase-orders", "--json"] },
+                  toolCallId: "cli-1",
+                  toolMetadata: {
+                    cli: "portal-api",
+                    vitehubCapabilityCli: true,
+                  },
+                  toolName: "portal-api",
+                  type: "tool-input-error",
+                } as never)
+                writer.write({
+                  output: {
+                    command: "portal-api purchase-orders --json",
+                    exitCode: 0,
+                  },
+                  toolCallId: "cli-1",
+                  type: "tool-output-available",
+                })
+                writer.write({ type: "finish", finishReason: "stop" })
+              },
+            })
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    const chunks: unknown[] = []
+    for await (const chunk of stream) chunks.push(chunk)
+
+    expect(chunks).toContainEqual(expect.objectContaining({
+      input: { argv: ["purchase-orders", "--json"] },
+      toolCallId: "cli-1",
+      toolName: "portal-api",
+      type: "tool-input-available",
+    }))
+    expect(chunks).not.toContainEqual(expect.objectContaining({
+      toolCallId: "cli-1",
+      type: "tool-input-error",
+    }))
+  })
+
   it("traces fullStream results when UI message streams are requested", async () => {
     const { createUIMessageStream, readUIMessageStream } = await import("ai")
     const { defineAgent, streamAgent } = await import("../src/index.ts")


### PR DESCRIPTION
Normalizes native UI-message stream chunks for Capability CLI tools so valid CLI argv input renders as normal tool input even when the upstream AI SDK stream labels it as a tool input error. This keeps dev chat and streamed chat output command-shaped for OpenAPI and other capability-defined CLIs instead of showing raw argv JSON noise.

The existing dev CLI command rendering tests still cover tool command lines, and this adds a focused regression for native UI streams.