### PR TITLE
fix(agent): materialize global harness workspace rules

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -128,7 +128,7 @@ function workspaceRuleHarnessPaths(context: AgentAdapterRunContext): string[] {
     ...Object.entries(definition.rules || {}),
     ...(definition.plugins || []).flatMap(plugin => Object.entries(plugin.rules || {})),
   ]
-  return rules.flatMap(([pattern, rule]) => rule.write ? [staticWorkspaceRulePath(pattern)].filter((path): path is string => Boolean(path)) : [])
+  return rules.flatMap(([pattern, rule]) => rule.write ? [staticWorkspaceRulePath(pattern)].filter((path): path is string => path !== undefined) : [])
 }
 
 function workspaceSourceHarnessPaths(context: AgentAdapterRunContext): string[] {

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -117,7 +117,7 @@ function staticWorkspaceRulePath(pattern: string): string | undefined {
   const base = wildcard === -1 ? pattern : pattern.slice(0, wildcard)
   const normalized = base.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "").replace(/\/+/g, "/")
   const parts = normalized.split("/").filter(Boolean)
-  if (!normalized || parts.some(part => part === "." || part === "..")) return
+  if (parts.some(part => part === "." || part === "..")) return
   return normalized
 }
 

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -194,7 +194,7 @@ function selectedWorkspaceScopePaths(context: AgentAdapterRunContext): string[] 
   const scope = context.context.get("access")?.workspaceScope
   if (!scope) return harnessPaths.length ? harnessPaths : undefined
   if (scope.all) return [""]
-  const paths = [...new Set([...(scope.paths || []), ...harnessSupportWorkspacePaths(context)])]
+  const paths = [...new Set([...(scope.paths || []), ...harnessSupportWorkspacePaths(context).filter(path => path !== "")])]
   return paths.length ? withHarnessInstructionPaths(paths) : []
 }
 

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -125,9 +125,11 @@ function assertSupportedHarnessDriverContributions(context: AgentAdapterRunConte
 }
 
 function staticWorkspaceRulePath(pattern: string): string | undefined {
-  const wildcard = pattern.search(/[*{[(?]/)
-  const base = wildcard === -1 ? pattern : pattern.slice(0, wildcard)
-  const normalized = base.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "").replace(/\/+/g, "/")
+  const normalizedPattern = pattern.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+/g, "/")
+  const wildcard = normalizedPattern.search(/[*{[(?]/)
+  if (wildcard === 0 && normalizedPattern !== "**" && !normalizedPattern.startsWith("**/")) return
+  const base = wildcard === -1 ? normalizedPattern : normalizedPattern.slice(0, wildcard)
+  const normalized = base.replace(/\/+$/, "")
   const parts = normalized.split("/").filter(Boolean)
   if (parts.some(part => part === "." || part === "..")) return
   return normalized

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1259,7 +1259,7 @@ async function handleChatSdkMessage(
   let typing: ChatTypingRefresh | undefined
   try {
     const messages = await chatTriggerMessages(thread, message, options, messageContext)
-    const currentMessage = messages.find(item => item.id === message.id) || messages.at(-1)
+    const currentMessage = chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext))
     if (!currentMessage || !Array.isArray(currentMessage.parts) || currentMessage.parts.length === 0) return
     input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, messages, messageContext, registration.channelId)
     const invocation = await resolveAgentTriggerInvocation(agent as never, context as never, "chat.message", input)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -20,6 +20,7 @@ import { createChatDevtoolsStreamResponse } from "../chat/devtools-stream.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 
 import type { AgentChatMessageTriggerInput } from "../chat-trigger.ts"
+import type { UIMessageLike } from "../chat-message-input.ts"
 import type {
   AgentChatStateResolver,
   AgentCapabilityDefinition,
@@ -923,15 +924,9 @@ function chatMessageParts(message: ChatSdkMessage): MessagePart[] {
   return parts
 }
 
-function createChatTriggerInput(
-  provider: string,
-  thread: Thread,
-  message: ChatSdkMessage,
-  messageContext?: MessageContext,
-  channelId?: string,
-): AgentChatMessageTriggerInput {
+function chatMessageMetadata(thread: Thread, message: ChatSdkMessage, messageContext?: MessageContext): Record<string, unknown> | undefined {
   const platformChannelId = thread.adapter.channelIdFromThreadId(message.threadId)
-  const metadata = objectWithoutUndefined({
+  return objectWithoutUndefined({
     chat: objectWithoutUndefined({
       edited: message.metadata.edited,
       editedAt: isoDate(message.metadata.editedAt),
@@ -946,6 +941,93 @@ function createChatTriggerInput(
       totalSinceLastHandler: messageContext?.totalSinceLastHandler,
     }),
   })
+}
+
+function chatSdkMessageToUiMessage(message: ChatSdkMessage, metadata?: Record<string, unknown>): UIMessageLike {
+  return {
+    createdAt: isoDate(message.metadata.dateSent),
+    id: message.id,
+    ...(metadata ? { metadata } : {}),
+    parts: chatMessageParts(message),
+    role: message.author.isMe ? "assistant" : "user",
+  }
+}
+
+interface ChatThreadHistoryCache {
+  getMessages(threadId: string, limit?: number): Promise<ChatSdkMessage[]>
+}
+
+function chatThreadHistoryCache(thread: Thread): ChatThreadHistoryCache | undefined {
+  const history = (thread as { _threadHistory?: unknown })._threadHistory
+  if (!history || typeof history !== "object") return
+  const getMessages = (history as { getMessages?: unknown }).getMessages
+  if (typeof getMessages !== "function") return
+  return history as ChatThreadHistoryCache
+}
+
+async function durableChatThreadMessages(thread: Thread, limit: number): Promise<ChatSdkMessage[]> {
+  try {
+    return await chatThreadHistoryCache(thread)?.getMessages(thread.id, limit) ?? []
+  }
+  catch {
+    return []
+  }
+}
+
+function chatHistoryLimit(history: AgentChatOptions["history"]): number | undefined {
+  if (history === false || history === "none") return
+  if (!history || typeof history !== "object" || history.source !== "thread") return
+  return Math.max(1, typeof history.maxMessages === "number" ? history.maxMessages : 20)
+}
+
+async function chatTriggerMessages(
+  thread: Thread,
+  message: ChatSdkMessage,
+  options: AgentChatOptions | undefined,
+  messageContext?: MessageContext,
+): Promise<UIMessageLike[]> {
+  const current = chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext))
+  const limit = chatHistoryLimit(options?.history)
+  if (!limit) return [current]
+
+  const fetchedNewestFirst: UIMessageLike[] = []
+  try {
+    for await (const item of thread.messages) {
+      fetchedNewestFirst.push(item.id && message.id && item.id === message.id ? current : chatSdkMessageToUiMessage(item))
+      if (fetchedNewestFirst.length >= limit) break
+    }
+  } catch {}
+
+  const durable = await durableChatThreadMessages(thread, limit)
+  const messages = [
+    ...durable.map(item => item.id && message.id && item.id === message.id ? current : chatSdkMessageToUiMessage(item)),
+    ...fetchedNewestFirst.slice().reverse(),
+  ].reduce<UIMessageLike[]>((deduped, item) => {
+    if (!item.id) {
+      deduped.push(item)
+      return deduped
+    }
+    const existing = deduped.findIndex(message => message.id === item.id)
+    if (existing === -1) deduped.push(item)
+    else deduped[existing] = item
+    return deduped
+  }, [])
+
+  if (!current.id || !messages.some(item => item.id === current.id)) {
+    messages.push(current)
+  }
+  return messages.slice(-limit)
+}
+
+function createChatTriggerInput(
+  provider: string,
+  thread: Thread,
+  message: ChatSdkMessage,
+  messages: UIMessageLike[],
+  messageContext?: MessageContext,
+  channelId?: string,
+): AgentChatMessageTriggerInput {
+  const platformChannelId = thread.adapter.channelIdFromThreadId(message.threadId)
   const user = objectWithoutUndefined({
     id: message.author.userId,
     isBot: message.author.isBot,
@@ -956,13 +1038,7 @@ function createChatTriggerInput(
   const email = chatMessageAuthorEmail(message)
   return {
     ...(email ? { meta: { email } } : {}),
-    messages: [{
-      createdAt: isoDate(message.metadata.dateSent),
-      id: message.id,
-      metadata,
-      parts: chatMessageParts(message),
-      role: "user",
-    }],
+    messages,
     run: {
       channelId: channelId || platformChannelId,
       messageId: message.id,
@@ -1182,9 +1258,10 @@ async function handleChatSdkMessage(
   let run: AgentRunMetadata | undefined
   let typing: ChatTypingRefresh | undefined
   try {
-    input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, messageContext, registration.channelId)
-    const firstMessage = input.messages[0]
-    if (!firstMessage || !Array.isArray(firstMessage.parts) || firstMessage.parts.length === 0) return
+    const messages = await chatTriggerMessages(thread, message, options, messageContext)
+    const currentMessage = messages.find(item => item.id === message.id) || messages.at(-1)
+    if (!currentMessage || !Array.isArray(currentMessage.parts) || currentMessage.parts.length === 0) return
+    input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, messages, messageContext, registration.channelId)
     const invocation = await resolveAgentTriggerInvocation(agent as never, context as never, "chat.message", input)
     if (isResolvedAgentTriggerHandledInvocation(invocation)) return
     const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, invocation.input as AgentRunInput, invocation.run, messageContext)

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2874,6 +2874,69 @@ describe("server helpers", () => {
     ])
   })
 
+  it("keeps fetched thread history when the current chat message has no id", async () => {
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { getMessageText } = await import("../src/messages.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter({ missingIncomingMessageId: true })
+    adapter.fetchMessages.mockResolvedValue({
+      messages: [new Message({
+        attachments: [],
+        author: {
+          fullName: "Maxi",
+          isBot: false,
+          isMe: false,
+          userId: "123",
+          userName: "maxi",
+        },
+        formatted: { children: [], type: "root" },
+        id: undefined as unknown as string,
+        metadata: { dateSent: new Date("2026-06-10T12:00:00.000Z"), edited: false },
+        raw: {},
+        text: "previous id-less",
+        threadId: "telegram:456",
+      })],
+    })
+    const runs: string[][] = []
+    const agent = defineAgent({
+      capabilities: [
+        chat({
+          history: { maxMessages: 10, source: "thread" },
+          platforms: {
+            telegram: () => adapter as never,
+          },
+          stream: false,
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      driver: {
+        run: ({ messages }) => {
+          runs.push(messages.map(getMessageText))
+          return "ok"
+        },
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    await expect(handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 22,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092822,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          text: "current id-less",
+        },
+      }),
+      method: "POST",
+    }), "telegram")).resolves.toMatchObject({ status: 200 })
+
+    expect(runs).toEqual([["previous id-less", "current id-less"]])
+  })
+
   it("passes durable thread history into chat webhook runs after adapter cache resets", async () => {
     const { chat } = await import("../src/capabilities.ts")
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -23,8 +23,13 @@ function githubSignature(secret: string, body: string) {
   return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`
 }
 
-function createTestChatAdapter(options: { deferMessageProcessing?: boolean, secret?: string } = {}) {
+function createTestChatAdapter(options: { deferMessageProcessing?: boolean, missingIncomingMessageId?: boolean, persistThreadHistory?: boolean, secret?: string } = {}) {
   let chatInstance: ChatInstance | undefined
+  let sentMessageId = 0
+  const cachedMessages = new Map<string, Message[]>()
+  const cacheMessage = (message: Message) => {
+    cachedMessages.set(message.threadId, [...(cachedMessages.get(message.threadId) ?? []), message])
+  }
   const adapter = {
     channelIdFromThreadId: vi.fn((threadId: string) => threadId),
     handleWebhook: vi.fn(async (request: Request, webhookOptions?: WebhookOptions) => {
@@ -63,12 +68,13 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, secr
           userName: String(from?.username ?? "maxi"),
         },
         formatted: { children: [], type: "root" },
-        id: String(rawMessage.message_id ?? "7"),
+        id: options.missingIncomingMessageId ? undefined as unknown as string : String(rawMessage.message_id ?? "7"),
         metadata: { dateSent: date, edited: false },
         raw: body,
         text: typeof rawMessage.text === "string" ? rawMessage.text : "",
         threadId: `telegram:${String(chat?.id ?? "456")}`,
       })
+      cacheMessage(message)
       const task = chatInstance.processMessage(adapter as unknown as Adapter, message.threadId, message, webhookOptions)
       if (!options.deferMessageProcessing) {
         await task
@@ -83,14 +89,40 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, secr
     }),
     isDM: vi.fn(() => true),
     editMessage: vi.fn(async (threadId: string, messageId: string, message: unknown) => ({ id: messageId, raw: { message }, threadId })),
+    fetchMessages: vi.fn(async (threadId: string) => ({ messages: cachedMessages.get(threadId) ?? [] })),
     name: "telegram",
-    postMessage: vi.fn(async (threadId: string, message: unknown) => ({ id: "sent-1", raw: { message }, threadId })),
+    persistThreadHistory: options.persistThreadHistory,
+    postMessage: vi.fn(async (threadId: string, message: unknown) => {
+      const id = `sent-${++sentMessageId}`
+      cacheMessage(new Message({
+        attachments: [],
+        author: {
+          fullName: "vitehub",
+          isBot: true,
+          isMe: true,
+          userId: "self",
+          userName: "vitehub",
+        },
+        formatted: { children: [], type: "root" },
+        id,
+        metadata: { dateSent: new Date("2026-06-10T12:00:00.000Z"), edited: false },
+        raw: { message },
+        text: typeof message === "string"
+          ? message
+          : typeof message === "object" && message && "markdown" in message && typeof message.markdown === "string"
+            ? message.markdown
+            : "",
+        threadId,
+      }))
+      return { id, raw: { message }, threadId }
+    }),
     startTyping: vi.fn(async () => {}),
     userName: "vitehub",
   }
   return adapter as unknown as Adapter & {
     handleWebhook: ReturnType<typeof vi.fn>
     editMessage: ReturnType<typeof vi.fn>
+    fetchMessages: ReturnType<typeof vi.fn>
     postMessage: ReturnType<typeof vi.fn>
     startTyping: ReturnType<typeof vi.fn>
   }
@@ -2788,6 +2820,120 @@ describe("server helpers", () => {
     expect(model.generate).toHaveBeenCalledOnce()
     expect(model.stream).not.toHaveBeenCalled()
     expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "generated ok" })
+  })
+
+  it("passes configured thread history into chat webhook runs", async () => {
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { getMessageText } = await import("../src/messages.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter({ persistThreadHistory: true })
+    const runs: string[][] = []
+    const agent = defineAgent({
+      capabilities: [
+        chat({
+          history: { maxMessages: 25, source: "thread" },
+          platforms: {
+            telegram: () => adapter as never,
+          },
+          stream: false,
+          threadHistory: { maxMessages: 25 },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      driver: {
+        run: ({ messages }) => {
+          runs.push(messages.map(getMessageText))
+          return `reply ${runs.length}`
+        },
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    const request = (messageId: number, text: string) => new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: messageId,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800 + messageId,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: messageId,
+          text,
+        },
+      }),
+      method: "POST",
+    })
+
+    await expect(handler(request(20, "remember BROWSER-HISTORY"), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(request(21, "what marker did I ask you to remember?"), "telegram")).resolves.toMatchObject({ status: 200 })
+
+    expect(runs).toEqual([
+      ["remember BROWSER-HISTORY"],
+      ["remember BROWSER-HISTORY", "reply 1", "what marker did I ask you to remember?"],
+    ])
+  })
+
+  it("passes durable thread history into chat webhook runs after adapter cache resets", async () => {
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { getMessageText } = await import("../src/messages.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-history-state-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const runs: string[][] = []
+    const request = (messageId: number, text: string) => new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: messageId,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800 + messageId,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: messageId,
+          text,
+        },
+      }),
+      method: "POST",
+    })
+    const handler = (adapter: ReturnType<typeof createTestChatAdapter>) => {
+      const agent = defineAgent({
+        capabilities: [
+          chat({
+            history: { maxMessages: 25, source: "thread" },
+            platforms: {
+              telegram: () => adapter as never,
+            },
+            state: () => state,
+            stream: false,
+            threadHistory: { maxMessages: 25 },
+            webhooks: {
+              telegram: {},
+            },
+          }),
+        ],
+        driver: {
+          run: ({ messages }) => {
+            runs.push(messages.map(getMessageText))
+            return `reply ${runs.length}`
+          },
+        },
+      })
+      return createChannelWebhookRouteHandler(agent as never)
+    }
+
+    try {
+      await expect(handler(createTestChatAdapter({ persistThreadHistory: true }))(request(30, "remember DEPLOY-HISTORY"), "telegram")).resolves.toMatchObject({ status: 200 })
+      await expect(handler(createTestChatAdapter({ persistThreadHistory: true }))(request(31, "what marker did I ask you to remember?"), "telegram")).resolves.toMatchObject({ status: 200 })
+
+      expect(runs).toEqual([
+        ["remember DEPLOY-HISTORY"],
+        ["remember DEPLOY-HISTORY", "reply 1", "what marker did I ask you to remember?"],
+      ])
+    }
+    finally {
+      await rm(stateDir, { force: true, recursive: true })
+    }
   })
 
   it("runs non-streaming chat webhooks inline for workflow-backed agents", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2937,6 +2937,64 @@ describe("server helpers", () => {
     expect(runs).toEqual([["previous id-less", "current id-less"]])
   })
 
+  it("does not run id-less chat deliveries without current message parts", async () => {
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter({ missingIncomingMessageId: true })
+    const idLessHistory = (text: string) => new Message({
+      attachments: [],
+      author: {
+        fullName: "Maxi",
+        isBot: false,
+        isMe: false,
+        userId: "123",
+        userName: "maxi",
+      },
+      formatted: { children: [], type: "root" },
+      id: undefined as unknown as string,
+      metadata: { dateSent: new Date("2026-06-10T12:00:00.000Z"), edited: false },
+      raw: {},
+      text,
+      threadId: "telegram:456",
+    })
+    const run = vi.fn(() => "ok")
+    const agent = defineAgent({
+      capabilities: [
+        chat({
+          history: { maxMessages: 10, source: "thread" },
+          platforms: {
+            telegram: () => adapter as never,
+          },
+          stream: false,
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      driver: {
+        run,
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    const request = (updateId: number, text?: string) => new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: updateId,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800 + updateId,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          ...(text !== undefined ? { text } : {}),
+        },
+      }),
+      method: "POST",
+    })
+
+    adapter.fetchMessages.mockResolvedValueOnce({ messages: [idLessHistory("previous id-less")] })
+    await expect(handler(request(23), "telegram")).resolves.toMatchObject({ status: 200 })
+    expect(run).not.toHaveBeenCalled()
+  })
+
   it("passes durable thread history into chat webhook runs after adapter cache resets", async () => {
     const { chat } = await import("../src/capabilities.ts")
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1093,6 +1093,52 @@ describe("defineAgent workspace option", () => {
     })
   })
 
+  it("does not widen non-global leading-wildcard rules for harness Workspace Sessions", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { custom } = await import("@vite-hub/workspace")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+
+    const agent = withAgentDefaults(defineAgent({
+      driver: {
+        harness: { provider: "codex" },
+      },
+      workspace: {
+        mode: "write",
+        rules: {
+          "*.md": { write: true },
+          "{drafts,notes}/**": { write: true },
+        },
+        sources: {
+          docs: custom({
+            materialize: "lazy",
+            mount: "docs",
+            async getKeys() {
+              return ["guide.md"]
+            },
+            async getItem(key) {
+              return { content: "docs", key, mediaType: "text/markdown", path: key }
+            },
+          }),
+        },
+      },
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
+      abortSignal: undefined,
+      ignoreWriteBackPaths: [],
+      paths: ["docs", "AGENTS.md", "CLAUDE.md"],
+      session: harnessSandboxSession,
+      sessionWorkDir: "/workspace/codex-session",
+    })
+  })
+
   it("scopes workspace instruction files into harness Agent calls without passing them as prompt instructions", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1262,6 +1262,94 @@ describe("defineAgent workspace option", () => {
     expect(harnessWorkspaceSession.close).toHaveBeenCalledWith(undefined)
   })
 
+  it("does not widen selected Workspace Scope paths for global write rules", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { access } = await import("../src/capabilities.ts")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+
+    const agent = withAgentDefaults(defineAgent({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "public",
+            scopes: {
+              public: { paths: ["public"] },
+            },
+          },
+        }),
+      ],
+      driver: {
+        harness: { provider: "codex" },
+      },
+      workspace: {
+        mode: "write",
+        rules: {
+          "**/*.md": { write: true },
+        },
+      },
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
+      abortSignal: undefined,
+      ignoreWriteBackPaths: [],
+      paths: ["public", "AGENTS.md", "CLAUDE.md"],
+      session: harnessSandboxSession,
+      sessionWorkDir: "/workspace/codex-session",
+    })
+  })
+
+  it("keeps all-scope Workspace Sessions unrestricted for global write rules", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { access } = await import("../src/capabilities.ts")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+
+    const agent = withAgentDefaults(defineAgent({
+      capabilities: [
+        access({
+          workspace: {
+            resolve: { role: "admin", scope: "support" },
+            scopes: {
+              support: { all: true },
+            },
+          },
+        }),
+      ],
+      driver: {
+        harness: { provider: "codex" },
+      },
+      workspace: {
+        mode: "write",
+        rules: {
+          "**/*.md": { write: true },
+        },
+      },
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
+      abortSignal: undefined,
+      ignoreWriteBackPaths: [],
+      paths: [""],
+      session: harnessSandboxSession,
+      sessionWorkDir: "/workspace/codex-session",
+    })
+  })
+
   it("does not pass other scoped file sources into Harness Workspace Sessions", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { access } = await import("../src/capabilities.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1050,6 +1050,7 @@ describe("defineAgent workspace option", () => {
 
   it("keeps global write rules unrestricted for harness Workspace Sessions", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { custom } = await import("@vite-hub/workspace")
     const harnessWorkspaceSession = { close: vi.fn() }
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
@@ -1063,6 +1064,18 @@ describe("defineAgent workspace option", () => {
         rules: {
           "**/*.md": { write: true },
         },
+        sources: {
+          docs: custom({
+            materialize: "lazy",
+            mount: "docs",
+            async getKeys() {
+              return ["guide.md"]
+            },
+            async getItem(key) {
+              return { content: "docs", key, mediaType: "text/markdown", path: key }
+            },
+          }),
+        },
       },
     }), { workspace: "docs" })
 
@@ -1074,7 +1087,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: undefined,
+      paths: [""],
       session: harnessSandboxSession,
       sessionWorkDir: "/workspace/codex-session",
     })

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1048,6 +1048,38 @@ describe("defineAgent workspace option", () => {
     })
   })
 
+  it("keeps global write rules unrestricted for harness Workspace Sessions", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+
+    const agent = withAgentDefaults(defineAgent({
+      driver: {
+        harness: { provider: "codex" },
+      },
+      workspace: {
+        mode: "write",
+        rules: {
+          "**/*.md": { write: true },
+        },
+      },
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
+      abortSignal: undefined,
+      ignoreWriteBackPaths: [],
+      paths: undefined,
+      session: harnessSandboxSession,
+      sessionWorkDir: "/workspace/codex-session",
+    })
+  })
+
   it("scopes workspace instruction files into harness Agent calls without passing them as prompt instructions", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))


### PR DESCRIPTION
Reopens `codex/chat-thread-history-input` after the post-merge branch pushes. The branch carries the id-less thread-history coverage plus the harness workspace rule materialization change on top of the earlier chat webhook history work.

Coordination note: this overlaps the harness materialization area also touched by #453, so keep it draft until the branch diff is reconciled against the current stack.