### PR TITLE
feat(workspace): add standalone nitro config export

### DIFF
--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -89,7 +89,7 @@ export default defineWorkspaceFileHandler({
 
 ```ts
 // nitro.config.ts
-import { createWorkspaceNitroConfig } from "@vite-hub/workspace/vite"
+import { createWorkspaceNitroConfig } from "@vite-hub/workspace/nitro"
 
 export default createWorkspaceNitroConfig()
 ```

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -11,7 +11,7 @@
 ## Install
 
 ```sh
-pnpm add @vite-hub/workspace vite nitropack h3
+pnpm add @vite-hub/workspace vite nitro h3
 pnpm add -D typescript @types/node
 ```
 

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -56,6 +56,10 @@
       "types": "./dist/loader.d.ts",
       "import": "./dist/loader.js"
     },
+    "./nitro": {
+      "types": "./dist/nitro.d.ts",
+      "import": "./dist/nitro.js"
+    },
     "./nuxt": {
       "types": "./dist/nuxt.d.ts",
       "import": "./dist/nuxt.js"

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -264,9 +264,9 @@ function renderNitroWorkspacePlugin(config: false | ResolvedWorkspaceModuleOptio
   return [
     ...runtimeImports,
     `import registry from ${JSON.stringify(registryImport)}`,
-    "import { defineNitroPlugin } from 'nitropack/runtime'",
+    "import { definePlugin } from 'nitro'",
     "",
-    "export default defineNitroPlugin(() => {",
+    "export default definePlugin(() => {",
     "  setWorkspaceRuntimeRegistry(registry)",
     ...runtimeSetup,
     "})",

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -264,12 +264,11 @@ function renderNitroWorkspacePlugin(config: false | ResolvedWorkspaceModuleOptio
   return [
     ...runtimeImports,
     `import registry from ${JSON.stringify(registryImport)}`,
-    "import { definePlugin } from 'nitro'",
     "",
-    "export default definePlugin(() => {",
+    "export default function vitehubWorkspacePlugin() {",
     "  setWorkspaceRuntimeRegistry(registry)",
     ...runtimeSetup,
-    "})",
+    "}",
     "",
   ].join("\n")
 }

--- a/packages/workspace/src/nitro.ts
+++ b/packages/workspace/src/nitro.ts
@@ -1,0 +1,2 @@
+export { createWorkspaceNitroConfig } from "./vite.ts"
+export type { NitroConfig, WorkspaceNitroConfigOptions } from "./vite.ts"

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -582,8 +582,8 @@ describe("hubWorkspace", () => {
     })
 
     const pluginSource = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
-    expect(pluginSource).toContain("import { definePlugin } from 'nitro'")
-    expect(pluginSource).toContain("export default definePlugin(() => {")
+    expect(pluginSource).toContain("export default function vitehubWorkspacePlugin() {")
+    expect(pluginSource).not.toContain("from 'nitro'")
     expect(pluginSource).not.toContain("nitropack/runtime")
   })
 

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -573,6 +573,20 @@ describe("hubWorkspace", () => {
     await expect(readFile(join(root, ".vitehub", "nitro", "workspace", "registry.js"), "utf8")).rejects.toThrow()
   })
 
+  it("exposes standalone Nitro config through the Nitro subpath", async () => {
+    const root = await createViteRoot()
+    const { createWorkspaceNitroConfig } = await import("../src/nitro.ts")
+
+    await expect(createWorkspaceNitroConfig({ viteRoot: root })).resolves.toMatchObject({
+      plugins: [".vitehub/nitro/workspace/plugin.ts"],
+    })
+
+    const pluginSource = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(pluginSource).toContain("import { definePlugin } from 'nitro'")
+    expect(pluginSource).toContain("export default definePlugin(() => {")
+    expect(pluginSource).not.toContain("nitropack/runtime")
+  })
+
   it("uses discovered source roots from generated Nitro workspace registries", async () => {
     const testRoot = join(process.cwd(), "..", "..", ".vitest-tmp")
     await mkdir(testRoot, { recursive: true })

--- a/packages/workspace/vite.config.ts
+++ b/packages/workspace/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       "src/cli.ts",
       "src/index.ts",
       "src/loader.ts",
+      "src/nitro.ts",
       "src/nuxt.ts",
       "src/publish.ts",
       "src/runtime.ts",


### PR DESCRIPTION
Adds `@vite-hub/workspace/nitro` as the standalone Nitro config entrypoint for `createWorkspaceNitroConfig()` while keeping it a narrow re-export of the existing Workspace Vite helper. Generated Workspace Nitro plugins now export a plain Nitro plugin function, so Nitro 3 apps do not need the old `nitropack/runtime` shim.