### PR TITLE
feat(agent)!: rename chat trigger history option

### DIFF
--- a/.agents/adr/0029-chat-sessions-in-chat-capability.md
+++ b/.agents/adr/0029-chat-sessions-in-chat-capability.md
@@ -12,9 +12,9 @@ ViteHub will model Chat Sessions as Chat Capability behavior rather than as a st
 
 ## Consequences
 
-`chat()` may expose a `sessions` option alongside `history`. Manual, idle-timeout, semantic, and hybrid session strategies can be supported without changing the ownership boundary: Chat Sessions remain part of the Chat Capability.
+`chat()` may expose a `sessions` option alongside `triggerHistory`. Manual, idle-timeout, semantic, and hybrid session strategies can be supported without changing the ownership boundary: Chat Sessions remain part of the Chat Capability.
 
-The host persists messages and their Chat Session assignment. The Chat Capability selects messages from the active Chat Session, then applies the configured Chat History Window such as `history.maxMessages`. Session decisions do not erase previous messages.
+The host persists messages and their Chat Session assignment. The Chat Capability selects messages from the active Chat Session, then applies the configured Chat History Window such as `triggerHistory.maxMessages`. Session decisions do not erase previous messages.
 
 Manual session actions such as new, clear, continue, and switch are Host Commands. Hosts may render them with slash-style UI, but they are not Input Commands and do not belong to `inputCommands()`.
 

--- a/.agents/contexts/agents/CONTEXT.md
+++ b/.agents/contexts/agents/CONTEXT.md
@@ -180,6 +180,14 @@ _Avoid_: Agent Memory, Agent Run State
 The bounded number of prior Chat History messages included in an Agent Invocation.
 _Avoid_: memory size, transcript limit, context length
 
+**Chat Trigger History**:
+Message Channel Settings configured through `triggerHistory` that select the Chat History Window for one `chat.message` Agent Trigger input.
+_Avoid_: Thread History Cache, Agent Memory, full transcript
+
+**Chat Thread History Cache**:
+Adapter backfill and cache behavior configured through `threadHistory` for platforms that cannot reliably provide recent thread messages at trigger time.
+_Avoid_: Chat Trigger History, Agent Memory, model context
+
 **Chat Session**:
 A host-visible conversation boundary inside Chat History that determines which messages are eligible for the Chat History Window.
 _Avoid_: Agent Memory, Agent Run State, hidden slice
@@ -361,6 +369,8 @@ _Avoid_: Fake agent, dummy model, test bot
 - A **Chat Session** is part of Chat History behavior and is not **Agent Memory**.
 - Message-shaped **Channels** resolve the active **Chat Session** before applying the **Chat History Window**.
 - A **Chat History Window** is configured by the Agent Definition when the application wants bounded Chat History.
+- **Chat Trigger History** can be derived from an explicit **Chat Thread History Cache** max when the Agent Definition does not configure a trigger override.
+- A **Chat Thread History Cache** stores or backfills recent platform thread messages; it is not by itself the model-facing Chat History Window.
 - Message-shaped **Channels** can require state for **Chat History** through the Agent State Provider.
 - Every **Agent Invocation** has an **Agent Actor**; when no trusted identity is supplied, ViteHub provides an origin-specific anonymous fallback.
 - Message-shaped **Channels** can produce an **Agent Actor** from trusted Chat Platform Adapter identity before later Capabilities resolve.

--- a/docs/content/docs/agents/chat-history-sessions.md
+++ b/docs/content/docs/agents/chat-history-sessions.md
@@ -25,13 +25,14 @@ export default defineAgent({
   },
   capabilities: [
     chat({
-      history: { maxMessages: 20, source: 'thread' },
+      triggerHistory: { maxMessages: 20, source: 'thread' },
     }),
   ],
 })
 ```
 
 The Chat History Window limits how many prior messages enter the Agent Invocation. It does not delete the host's preserved history.
+When `threadHistory.maxMessages` is configured and `triggerHistory` is omitted, ViteHub derives a thread-backed Chat History Window from that explicit bound.
 
 ## Use threads as conversation boundaries
 
@@ -41,9 +42,9 @@ Use thread-scoped Chat History when the platform or application already has a vi
 import { chat } from '@vite-hub/agent/capabilities'
 
 export const supportChat = chat({
-  history: { maxMessages: 20, source: 'thread' },
   concurrency: 'queue',
   lockScope: 'thread',
+  threadHistory: { maxMessages: 20 },
 })
 ```
 
@@ -63,12 +64,12 @@ Sessions select which messages belong to the active conversation before the Chat
 import { chat } from '@vite-hub/agent/capabilities'
 
 export const supportChat = chat({
-  history: { maxMessages: 20, source: 'thread' },
   sessions: {
     idleTimeoutMs: 30 * 60 * 1000,
     metadataKey: 'sessionId',
     strategy: 'hybrid',
   },
+  triggerHistory: { maxMessages: 20, source: 'thread' },
 })
 ```
 

--- a/docs/content/docs/agents/triggers.md
+++ b/docs/content/docs/agents/triggers.md
@@ -44,8 +44,8 @@ export default defineAgent({
   },
   capabilities: [
     chat({
-      history: { maxMessages: 20, source: 'thread' },
       sessions: true,
+      threadHistory: { maxMessages: 20 },
     }),
   ],
 })

--- a/docs/content/docs/capabilities/chat.md
+++ b/docs/content/docs/capabilities/chat.md
@@ -70,7 +70,8 @@ When adapters are configured, inspect generated webhook registrations for the ex
 | `webhooks` | `Record<string, webhook \| webhook[] \| false>` | inferred | Explicit Chat Webhook registrations by platform. |
 | `hooks` | `AgentChatEventHooks` | none | Chat event hooks such as `onDirectMessage`. |
 | `event` | `"directMessage"` | none | Chat event binding hint. |
-| `history` | `boolean \| "none" \| { source: "thread"; maxMessages?: number }` | inherited | Chat History selection for message input. |
+| `triggerHistory` | `"none" \| { source: "thread"; maxMessages?: number }` | last 20 messages, or `threadHistory.maxMessages` when derived | Chat History Window sent into the `chat.message` Agent Trigger. |
+| `threadHistory` | `{ maxMessages?: number; ttlMs?: number }` | inherited | Adapter thread backfill/cache; stores messages but does not by itself define model input. |
 | `sessions` | `boolean \| AgentChatSessionOptions` | inherited | Chat Session behavior, including `strategy`, `idleTimeoutMs`, and `metadataKey`. |
 | `state` | `AgentChatStateResolver` | runtime state | Chat State adapter override. |
 | `stream` | `boolean` | inherited | Whether the chat trigger should stream output. |

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -140,6 +140,7 @@ export type {
   AgentChatSessionOptions,
   AgentChatStateContext,
   AgentChatStateResolver,
+  AgentChatTriggerHistory,
   AgentChannelWebhookRegistrationDefinition,
 } from "../types.ts"
 export type {

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -5,6 +5,7 @@ import type {
   AgentChatAgentHookArgs,
   AgentChatOptions,
   AgentChatSessionOptions,
+  AgentChatTriggerHistory,
   AgentInvoker,
   AgentRunInput,
   AgentRunMetadata,
@@ -22,7 +23,6 @@ export type UIMessageLike = {
 
 export interface AgentChatMessageTriggerInput {
   abortSignal?: AbortSignal
-  history?: AgentChatOptions["history"]
   invoker?: AgentInvoker
   invokerProfileId?: string
   meta?: Record<string, unknown>
@@ -33,6 +33,7 @@ export interface AgentChatMessageTriggerInput {
     id?: string
   }
   timeout?: number
+  triggerHistory?: AgentChatTriggerHistory
   user?: Record<string, unknown>
 }
 
@@ -230,12 +231,38 @@ function selectChatSession(messages: UIMessageLike[], sessions: AgentChatOptions
   return selectIdleSession(selectManualSession(messages, options, triggerSession), options)
 }
 
-function selectChatHistory(messages: UIMessageLike[], history: AgentChatOptions["history"], sessions?: AgentChatOptions["sessions"], triggerSession?: AgentChatMessageTriggerInput["session"]): UIMessageLike[] {
+function normalizedMaxMessages(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(1, Math.floor(value))
+    : undefined
+}
+
+function threadHistoryMaxMessages(threadHistory: unknown): number | undefined {
+  if (!threadHistory || typeof threadHistory !== "object" || Array.isArray(threadHistory)) return
+  return normalizedMaxMessages((threadHistory as { maxMessages?: unknown }).maxMessages)
+}
+
+export function resolveChatTriggerHistory(
+  options: Pick<AgentChatOptions, "threadHistory" | "triggerHistory"> | undefined,
+  triggerHistory?: AgentChatTriggerHistory,
+): AgentChatTriggerHistory | undefined {
+  if (triggerHistory !== undefined) return triggerHistory
+  if (options?.triggerHistory !== undefined) return options.triggerHistory
+  const maxMessages = threadHistoryMaxMessages(options?.threadHistory)
+  return maxMessages === undefined ? undefined : { maxMessages, source: "thread" }
+}
+
+export function chatTriggerHistoryLimit(triggerHistory: AgentChatTriggerHistory | undefined): number | undefined {
+  if (triggerHistory === "none") return
+  if (!triggerHistory || triggerHistory.source !== "thread") return
+  return normalizedMaxMessages(triggerHistory.maxMessages) ?? 20
+}
+
+function selectChatHistory(messages: UIMessageLike[], triggerHistory: AgentChatTriggerHistory | undefined, sessions?: AgentChatOptions["sessions"], triggerSession?: AgentChatMessageTriggerInput["session"]): UIMessageLike[] {
   const sessionMessages = selectChatSession(messages, sessions, triggerSession)
-  if (history === false || history === "none") return sessionMessages.slice(-1)
-  if (typeof history === "object" && history.source === "thread" && typeof history.maxMessages === "number") {
-    return sessionMessages.slice(-Math.max(1, history.maxMessages))
-  }
+  if (triggerHistory === "none") return sessionMessages.slice(-1)
+  const limit = chatTriggerHistoryLimit(triggerHistory)
+  if (limit) return sessionMessages.slice(-limit)
   return sessionMessages.slice(-20)
 }
 
@@ -269,7 +296,8 @@ export function createChatMessageTriggerInput<TRuntimeConfig extends AgentRuntim
   if (!messages.length) {
     throw new TypeError("[vitehub] chat.message trigger requires at least one UI message.")
   }
-  const selectedMessages = selectChatHistory(messages, triggerInput?.history ?? options.history, options.sessions, triggerInput?.session)
+  const triggerHistory = resolveChatTriggerHistory(options, triggerInput?.triggerHistory)
+  const selectedMessages = selectChatHistory(messages, triggerHistory, options.sessions, triggerInput?.session)
   const hookArgs = createChatTriggerHookArgs<TRuntimeConfig>(selectedMessages, triggerInput?.run, triggerInput?.session)
   const userMeta: Record<string, unknown> = {}
   for (const key of ["id", "sub", "email", "username", "name", "customer"]) {

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -192,6 +192,12 @@ function createChatMessageTrigger<TRuntimeConfig extends AgentRuntimeConfig>(
   }
 }
 
+function assertNoLegacyChatHistoryOption(options: AgentChatOptions): void {
+  if (Object.prototype.hasOwnProperty.call(options, "history")) {
+    throw new TypeError("[vitehub] messages.history was replaced by messages.triggerHistory. Use triggerHistory to configure the chat.message trigger input window.")
+  }
+}
+
 export function getChatCapabilityOptions<TRuntimeConfig extends AgentRuntimeConfig>(
   capabilities: AgentCapabilityDefinition[],
 ): AgentChatOptions<TRuntimeConfig> | undefined {
@@ -205,6 +211,7 @@ export function chat<
 >(
   options: TOptions = {} as TOptions,
 ): AgentCapabilityDefinition<TRuntimeConfig, WorkspaceName, ChatCapabilityTypeContract<AgentChatOptionsOrigin<TOptions>>> {
+  assertNoLegacyChatHistoryOption(options)
   return defineCapability({
     id: "chat",
     metadata: {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -191,6 +191,7 @@ export type {
   AgentChatPlatformsResolver,
   AgentChatSendMessage,
   AgentChatSessionOptions,
+  AgentChatTriggerHistory,
   AgentChannelDefinition,
   AgentChannelTriggerContext,
   AgentChannels,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -7,7 +7,7 @@ import { resolveAgentTriggerInvocation, resolveAgentTriggers, runAgentInline, st
 import { streamAgentOutputToEvents } from "../agent-output.ts"
 import { getAccessCapabilityOptions } from "../capabilities/access-metadata.ts"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions } from "../chat-trigger.ts"
-import { uiMessagesToAgentMessages } from "../chat-message-input.ts"
+import { chatTriggerHistoryLimit, resolveChatTriggerHistory, uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { deliveryArtifactAttachments } from "../delivery-artifacts.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
 import { normalizeAgentInvokerProfiles, resolveAgentInvoker, withResolvedAgentInvokerInput } from "../invoker.ts"
@@ -974,12 +974,6 @@ async function durableChatThreadMessages(thread: Thread, limit: number): Promise
   }
 }
 
-function chatHistoryLimit(history: AgentChatOptions["history"]): number | undefined {
-  if (history === false || history === "none") return
-  if (!history || typeof history !== "object" || history.source !== "thread") return
-  return Math.max(1, typeof history.maxMessages === "number" ? history.maxMessages : 20)
-}
-
 async function chatTriggerMessages(
   thread: Thread,
   message: ChatSdkMessage,
@@ -987,7 +981,7 @@ async function chatTriggerMessages(
   messageContext?: MessageContext,
 ): Promise<UIMessageLike[]> {
   const current = chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext))
-  const limit = chatHistoryLimit(options?.history)
+  const limit = chatTriggerHistoryLimit(resolveChatTriggerHistory(options))
   if (!limit) return [current]
 
   const fetchedNewestFirst: UIMessageLike[] = []
@@ -1345,7 +1339,6 @@ type AgentChatDevtoolsAction = "clear" | "get-state" | "materialize-source" | "s
 type ReadUIMessageStream = typeof import("ai").readUIMessageStream
 
 export type AgentChannelChatRouteBody = {
-  history?: AgentChatMessageTriggerInput["history"]
   id?: string
   invoker?: unknown
   invokerProfileId?: unknown
@@ -1355,6 +1348,7 @@ export type AgentChannelChatRouteBody = {
   run?: unknown
   session?: unknown
   trigger?: string
+  triggerHistory?: AgentChatMessageTriggerInput["triggerHistory"]
   user?: unknown
 }
 
@@ -1744,9 +1738,9 @@ function agentChannelChatRouteInput(
   }
   const messages = body.messages as UIMessage[]
   return {
-    ...(body.history !== undefined ? { history: body.history } : {}),
     messages,
     run: createHttpChatRunMetadata(agentName, body, messages, options),
+    ...(body.triggerHistory !== undefined ? { triggerHistory: body.triggerHistory } : {}),
   }
 }
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1042,8 +1042,9 @@ export interface AgentToolStep {
 
 export interface AgentChatAgentBindingOptions {
   event?: "directMessage"
-  history?: boolean | "none" | { maxMessages?: number, source: "thread" }
 }
+
+export type AgentChatTriggerHistory = "none" | { maxMessages?: number, source: "thread" }
 
 export interface AgentChatSessionOptions {
   idleTimeoutMs?: number
@@ -1120,7 +1121,6 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
   dedupeTtlMs?: number
   errorFallbackText?: string | null | ((context: AgentChatErrorHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   fallbackStreamingPlaceholderText?: string | readonly string[] | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
-  history?: AgentChatAgentBindingOptions["history"]
   identity?: IdentityResolver
   lockScope?: AgentMessageLockScope
   messageHistory?: unknown
@@ -1130,6 +1130,7 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
   streamingUpdateIntervalMs?: number
   threadHistory?: unknown
   transcripts?: TranscriptsConfig
+  triggerHistory?: AgentChatTriggerHistory
   userName?: string
   [key: string]: unknown
 }

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -5,8 +5,8 @@ import { createChatMessageTriggerInput } from "../src/chat-message-input.ts"
 describe("chat message trigger input", () => {
   it("selects manual Chat Session history and carries chat context", () => {
     const result = createChatMessageTriggerInput({
-      history: { maxMessages: 10, source: "thread" },
       sessions: true,
+      triggerHistory: { maxMessages: 10, source: "thread" },
     }, {
       messages: [
         { metadata: { sessionId: "a" }, parts: [{ text: "session a", type: "text" }], role: "user" },
@@ -36,6 +36,57 @@ describe("chat message trigger input", () => {
       .map(part => part.text)
       .join(""))).toEqual(["session b"])
     expect(result.hookArgs.message.text).toBe("session b")
+  })
+
+  it("derives trigger history from explicit thread history", () => {
+    const result = createChatMessageTriggerInput({
+      threadHistory: { maxMessages: 2 },
+    }, {
+      messages: [
+        { parts: [{ text: "one", type: "text" }], role: "user" },
+        { parts: [{ text: "two", type: "text" }], role: "assistant" },
+        { parts: [{ text: "three", type: "text" }], role: "user" },
+      ],
+    })
+
+    expect(result.input.messages?.map(message => message.parts
+      .filter((part): part is { text: string, type: "text" } => part.type === "text")
+      .map(part => part.text)
+      .join(""))).toEqual(["two", "three"])
+  })
+
+  it("lets trigger history override derived thread history", () => {
+    const result = createChatMessageTriggerInput({
+      threadHistory: { maxMessages: 10 },
+      triggerHistory: { maxMessages: 1, source: "thread" },
+    }, {
+      messages: [
+        { parts: [{ text: "one", type: "text" }], role: "user" },
+        { parts: [{ text: "two", type: "text" }], role: "assistant" },
+      ],
+    })
+
+    expect(result.input.messages?.map(message => message.parts
+      .filter((part): part is { text: string, type: "text" } => part.type === "text")
+      .map(part => part.text)
+      .join(""))).toEqual(["two"])
+  })
+
+  it("keeps stateless trigger history explicit", () => {
+    const result = createChatMessageTriggerInput({
+      threadHistory: { maxMessages: 10 },
+      triggerHistory: "none",
+    }, {
+      messages: [
+        { parts: [{ text: "one", type: "text" }], role: "user" },
+        { parts: [{ text: "two", type: "text" }], role: "assistant" },
+      ],
+    })
+
+    expect(result.input.messages?.map(message => message.parts
+      .filter((part): part is { text: string, type: "text" } => part.type === "text")
+      .map(part => part.text)
+      .join(""))).toEqual(["two"])
   })
 
   it("uses Chat Trigger metadata to enrich a user-derived invoker", () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2896,7 +2896,7 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "generated ok" })
   })
 
-  it("passes configured thread history into chat webhook runs", async () => {
+  it("derives trigger history from thread history in chat webhook runs", async () => {
     const { chat } = await import("../src/capabilities.ts")
     const { defineAgent } = await import("../src/index.ts")
     const { getMessageText } = await import("../src/messages.ts")
@@ -2906,7 +2906,6 @@ describe("server helpers", () => {
     const agent = defineAgent({
       capabilities: [
         chat({
-          history: { maxMessages: 25, source: "thread" },
           platforms: {
             telegram: () => adapter as never,
           },
@@ -2976,11 +2975,11 @@ describe("server helpers", () => {
     const agent = defineAgent({
       capabilities: [
         chat({
-          history: { maxMessages: 10, source: "thread" },
           platforms: {
             telegram: () => adapter as never,
           },
           stream: false,
+          triggerHistory: { maxMessages: 10, source: "thread" },
           webhooks: {
             telegram: {},
           },
@@ -3036,11 +3035,11 @@ describe("server helpers", () => {
     const agent = defineAgent({
       capabilities: [
         chat({
-          history: { maxMessages: 10, source: "thread" },
           platforms: {
             telegram: () => adapter as never,
           },
           stream: false,
+          triggerHistory: { maxMessages: 10, source: "thread" },
           webhooks: {
             telegram: {},
           },
@@ -3095,7 +3094,6 @@ describe("server helpers", () => {
       const agent = defineAgent({
         capabilities: [
           chat({
-            history: { maxMessages: 25, source: "thread" },
             platforms: {
               telegram: () => adapter as never,
             },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2862,16 +2862,16 @@ describe("agent message protocol", () => {
       },
       messages: {
         concurrency: "queue",
-        history: { maxMessages: 20, source: "thread" },
         sessions: true,
+        triggerHistory: { maxMessages: 20, source: "thread" },
       },
       driver: { run: () => "ok" },
     })
 
     expect(agent.chat).toMatchObject({
       concurrency: "queue",
-      history: { maxMessages: 20, source: "thread" },
       sessions: true,
+      triggerHistory: { maxMessages: 20, source: "thread" },
       webhooks: {
         support: {
           id: "support",
@@ -3477,6 +3477,26 @@ describe("agent message protocol", () => {
     })).toThrow("[vitehub] Channel webhooks require an adapter-backed Channel.")
   })
 
+  it("rejects legacy message history settings", async () => {
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { webChat } = await import("../src/channels.ts")
+
+    expect(() => chat({
+      history: { maxMessages: 20, source: "thread" },
+    })).toThrow("messages.history was replaced by messages.triggerHistory")
+
+    expect(() => defineAgent({
+      channels: {
+        web: webChat(),
+      },
+      messages: {
+        history: { maxMessages: 20, source: "thread" },
+      },
+      driver: { run: () => "ok" },
+    })).toThrow("messages.history was replaced by messages.triggerHistory")
+  })
+
   it("preserves channel ids for same-kind webhook registrations", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { teams } = await import("../src/channels.ts")
@@ -3507,8 +3527,8 @@ describe("agent message protocol", () => {
       channels: {
         web: webChat({
           messages: {
-            history: false,
             sessions: false,
+            triggerHistory: "none",
           },
         }),
       },
@@ -3516,8 +3536,8 @@ describe("agent message protocol", () => {
     })
 
     expect(agent.chat).toMatchObject({
-      history: false,
       sessions: false,
+      triggerHistory: "none",
     })
   })
 
@@ -3528,7 +3548,7 @@ describe("agent message protocol", () => {
     expect(() => defineAgent({
       channels: {
         teams: teams({ adapter: () => ({}) as never }),
-        web: webChat({ messages: { history: false } }),
+        web: webChat({ messages: { triggerHistory: "none" } }),
       },
       driver: { run: () => "ok" },
     })).toThrow("Channel-local messages options are only supported when an Agent defines one message-shaped Channel")
@@ -5651,8 +5671,8 @@ describe("agent message protocol", () => {
     const { defineAgent, resolveAgentTriggerInvocation } = await import("../src/index.ts")
     const agent = defineAgent({
       capabilities: [chat({
-        history: { maxMessages: 10, source: "thread" },
         sessions: { idleTimeoutMs: 30 * 60 * 1000, strategy: "idle-timeout" },
+        triggerHistory: { maxMessages: 10, source: "thread" },
       })],
       driver: { run: () => "ok" },
     })
@@ -5797,8 +5817,8 @@ describe("agent message protocol", () => {
     const { defineAgent, resolveAgentTriggerInvocation } = await import("../src/index.ts")
     const agent = defineAgent({
       capabilities: [chat({
-        history: { maxMessages: 10, source: "thread" },
         sessions: true,
+        triggerHistory: { maxMessages: 10, source: "thread" },
       })],
       driver: { run: () => "ok" },
     })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -650,8 +650,8 @@ describe("agent public types", () => {
   it("accepts message settings and channels from the Agent Definition", () => {
     const messages: AgentMessageChannelSettings = {
       concurrency: "queue",
-      history: { maxMessages: 20, source: "thread" },
       sessions: true,
+      triggerHistory: { maxMessages: 20, source: "thread" },
     }
     const channel: AgentChannelDefinition = teams()
     expectTypeOf(channel.kind).toEqualTypeOf<string>()
@@ -804,7 +804,7 @@ describe("agent public types", () => {
     defineAgent({
       channels: {
         web: webChat({
-          messages: { history: false },
+          messages: { triggerHistory: "none" },
         }),
       },
       driver: { run: () => "ok" },

--- a/playground/vite/server/agents/devtools-demo.ts
+++ b/playground/vite/server/agents/devtools-demo.ts
@@ -111,7 +111,7 @@ export default defineAgent({
     chat({
       concurrency: "queue",
       fallbackStreamingPlaceholderText: ["Thinking...", "Reading the workspace...", "Checking the run context..."],
-      history: { maxMessages: 8, source: "thread" },
+      triggerHistory: { maxMessages: 8, source: "thread" },
     }),
     transcribe({
       execute: () => "Transcribed playground voice input.",


### PR DESCRIPTION
Renames the chat trigger input window from `messages.history` to `messages.triggerHistory` and fails legacy history config with a migration error. The runtime now derives a thread-backed trigger window from explicit `threadHistory.maxMessages` when no override is set, while `triggerHistory: "none"` remains the stateless path and explicit `triggerHistory` can diverge from the thread cache size.

Updates Agent package types/exports, webhook and route handling, regression coverage, docs, and `.agents` language so thread cache/backfill stays separate from the model-facing Chat History Window.