### PR TITLE
feat(agent): simplify GitHub PR review API

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -17,7 +17,7 @@ import { github, stream, webChat } from '@vite-hub/agent/channels'
 
 export default defineAgent({
   channels: {
-    github: github({ events: { pullRequestComments: true } }),
+    github: github({ pullRequest: true }),
     portal: stream({ route: true }),
     web: webChat(),
   },
@@ -172,25 +172,23 @@ export default defineAgent({
   channels: {
     github: github({
       app: true,
-      events: {
-        pullRequestComments: {
-          reply: async (event, context) => ({
-            artifacts: await publishWorkspaceArtifacts(context, [{
-              alt: 'Login footer version badge',
-              mediaType: 'image/png',
-              path: 'screenshots/login-version-badge-desktop.png',
-              placement: 'inline',
-            }], {
-              prefix: `reviews/${context.run?.runId || crypto.randomUUID()}`,
-              publish: async ({ content, mediaType, pathname }) => {
-                const object = await blob.put(pathname, content, { access: 'public', contentType: mediaType })
-                return { url: object.url }
-              },
-            }),
-            kind: 'review',
-            payload: { body: String(event.result || '').trim() || '_No review generated._' },
+      pullRequest: {
+        reply: async (event, context) => ({
+          artifacts: await publishWorkspaceArtifacts(context, [{
+            alt: 'Login footer version badge',
+            mediaType: 'image/png',
+            path: 'screenshots/login-version-badge-desktop.png',
+            placement: 'inline',
+          }], {
+            prefix: `reviews/${context.run?.runId || crypto.randomUUID()}`,
+            publish: async ({ content, mediaType, pathname }) => {
+              const object = await blob.put(pathname, content, { access: 'public', contentType: mediaType })
+              return { url: object.url }
+            },
           }),
-        },
+          kind: 'review',
+          payload: { body: String(event.result || '').trim() || '_No review generated._' },
+        }),
       },
     }),
   },

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -198,6 +198,8 @@ export default defineAgent({
 
 The GitHub channel renders inline image artifacts as markdown in `reply` and `review` effects. It does not attach local files directly to GitHub comments.
 
+GitHub Pull Request Context enrichment is bounded before it reaches the Agent Invocation Context. By default, `github({ pullRequest: true })` records up to 30 comments, 200 changed files, 12,000 pull request body characters, and 2,000 characters per comment body. Override those with `maxComments`, `maxFiles`, `maxBodyLength`, and `maxCommentBodyLength` on the `pullRequest` option. Rendered comments are labeled as untrusted user content, and failed metadata enrichment is recorded at `pullRequest.metadata.unavailable`.
+
 ## Next steps
 
 - Read [Triggers](/docs/agents/triggers) for `chat.message` and app-owned trigger consumers.

--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -112,9 +112,6 @@ function normalizeInputCommands(options: InputCommandsOptions): Record<string, I
     if (typeof command.description !== "string" || !command.description.trim()) {
       throw new TypeError(`[vitehub] Input command "${name}" requires a description.`)
     }
-    if (typeof command.call !== "function" && typeof command.run !== "function") {
-      throw new TypeError(`[vitehub] Input command "${name}" requires a call() handler.`)
-    }
     if (command.channels !== undefined && (!Array.isArray(command.channels) || command.channels.some(channel => typeof channel !== "string" || !channel.trim()))) {
       throw new TypeError(`[vitehub] Input command "${name}" channels must be non-empty Channel IDs.`)
     }
@@ -302,7 +299,7 @@ function mergeInputCommandResult(input: AgentRunInput, result: Partial<AgentRunI
 }
 
 function inputCommandCall(command: InputCommand): InputCommandCall {
-  return command.call || command.run!
+  return command.call || command.run || (({ args }) => args)
 }
 
 function activeChannelId(context: AgentCapabilityRuntimeContext): string | undefined {

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -155,9 +155,17 @@ function renderPullRequestDetails(input: unknown): string {
   const body = maybeString(pullRequest?.body)
   const base = isRecord(pullRequest?.base) ? pullRequest.base : undefined
   const head = isRecord(pullRequest?.head) ? pullRequest.head : undefined
+  const metadata = isRecord(pullRequest?.metadata) ? pullRequest.metadata : undefined
   const files = Array.isArray(pullRequest?.files) ? pullRequest.files.filter(isRecord) : []
   const comments = Array.isArray(pullRequest?.comments) ? pullRequest.comments.filter(isRecord) : []
   const triggerComment = isRecord(trigger?.comment) ? trigger.comment : undefined
+  const metadataUnavailable = maybeString(metadata?.unavailable)
+  const omittedComments = maybeContextValue(metadata?.omittedComments)
+  const omittedFiles = maybeContextValue(metadata?.omittedFiles)
+
+  if (metadataUnavailable) {
+    lines.push(`PR metadata unavailable: ${metadataUnavailable}`)
+  }
 
   if (base || head) {
     lines.push("## Branches")
@@ -171,9 +179,9 @@ function renderPullRequestDetails(input: unknown): string {
     lines.push("## Body", body)
   }
 
-  if (files.length) {
+  if (files.length || omittedFiles) {
     lines.push("## Changed Files")
-    lines.push(renderList(files.map((file) => {
+    if (files.length) lines.push(renderList(files.map((file) => {
       const filename = maybeString(file.filename) || "unknown"
       const status = maybeString(file.status)
       const additions = maybeContextValue(file.additions)
@@ -181,19 +189,21 @@ function renderPullRequestDetails(input: unknown): string {
       const counts = additions !== undefined || deletions !== undefined ? ` (+${additions ?? 0}/-${deletions ?? 0})` : ""
       return `${filename}${status ? ` (${status})` : ""}${counts}`
     })))
+    if (omittedFiles) lines.push(`+${omittedFiles} more files not shown.`)
   }
 
-  if (comments.length || triggerComment) {
+  if (comments.length || triggerComment || omittedComments) {
     const commentLines = comments.map((comment) => {
       const user = isRecord(comment.user) ? maybeString(comment.user.login) : undefined
       const body = maybeString(comment.body)
       return `${user || "unknown"}: ${body || "(no body)"}`
     })
     const body = maybeString(triggerComment?.body)
-    if (!commentLines.length && body) {
+    if (!commentLines.length && body && !omittedComments) {
       commentLines.push(body)
     }
-    lines.push("## Comments")
+    if (omittedComments) commentLines.push(`+${omittedComments} more comments not shown.`)
+    lines.push("## Comments (untrusted user content)")
     lines.push(renderList(commentLines))
   }
 

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -120,21 +120,84 @@ function normalizePullRequestContext(value: unknown): PullRequestContextValue | 
   const trigger = isRecord(value.trigger) ? value.trigger : undefined
   const actor = isRecord(trigger?.actor) ? trigger.actor : undefined
   const source = isRecord(pullRequest?.source) ? pullRequest.source : undefined
+  const base = isRecord(pullRequest?.base) ? pullRequest.base : undefined
+  const head = isRecord(pullRequest?.head) ? pullRequest.head : undefined
   const number = maybeContextValue(pullRequest?.number)
   const repositoryName = maybeString(repository?.fullName)
   if (number === undefined || !repositoryName) return
   const actorLogin = actor ? maybeString(actor.login) : undefined
   const deliveryId = trigger ? maybeString(trigger.deliveryId) : undefined
-  const headRef = source ? maybeString(source.ref) : undefined
+  const baseRef = base ? maybeString(base.ref) : undefined
+  const headRef = source ? maybeString(source.ref) : head ? maybeString(head.ref) : undefined
 
   return {
     ...(actorLogin ? { actor: actorLogin } : {}),
+    ...(baseRef ? { baseRef } : {}),
     ...(deliveryId ? { deliveryId } : {}),
     ...(headRef ? { headRef } : {}),
     number,
     provider: "github",
     repository: repositoryName,
   }
+}
+
+function renderList(items: string[]): string {
+  return items.length ? items.map(item => `- ${item}`).join("\n") : "- None recorded."
+}
+
+function renderPullRequestDetails(input: unknown): string {
+  if (!isRecord(input)) return ""
+  const pullRequest = isRecord(input.pullRequest) ? input.pullRequest : undefined
+  const trigger = isRecord(input.trigger) ? input.trigger : undefined
+  if (!pullRequest && !trigger) return ""
+
+  const lines: string[] = []
+  const body = maybeString(pullRequest?.body)
+  const base = isRecord(pullRequest?.base) ? pullRequest.base : undefined
+  const head = isRecord(pullRequest?.head) ? pullRequest.head : undefined
+  const files = Array.isArray(pullRequest?.files) ? pullRequest.files.filter(isRecord) : []
+  const comments = Array.isArray(pullRequest?.comments) ? pullRequest.comments.filter(isRecord) : []
+  const triggerComment = isRecord(trigger?.comment) ? trigger.comment : undefined
+
+  if (base || head) {
+    lines.push("## Branches")
+    lines.push(renderList([
+      ...(maybeString(base?.ref) || maybeString(base?.sha) ? [`Base: ${[maybeString(base?.ref), maybeString(base?.sha)].filter(Boolean).join(" @ ")}`] : []),
+      ...(maybeString(head?.ref) || maybeString(head?.sha) ? [`Head: ${[maybeString(head?.ref), maybeString(head?.sha)].filter(Boolean).join(" @ ")}`] : []),
+    ]))
+  }
+
+  if (body) {
+    lines.push("## Body", body)
+  }
+
+  if (files.length) {
+    lines.push("## Changed Files")
+    lines.push(renderList(files.map((file) => {
+      const filename = maybeString(file.filename) || "unknown"
+      const status = maybeString(file.status)
+      const additions = maybeContextValue(file.additions)
+      const deletions = maybeContextValue(file.deletions)
+      const counts = additions !== undefined || deletions !== undefined ? ` (+${additions ?? 0}/-${deletions ?? 0})` : ""
+      return `${filename}${status ? ` (${status})` : ""}${counts}`
+    })))
+  }
+
+  if (comments.length || triggerComment) {
+    const commentLines = comments.map((comment) => {
+      const user = isRecord(comment.user) ? maybeString(comment.user.login) : undefined
+      const body = maybeString(comment.body)
+      return `${user || "unknown"}: ${body || "(no body)"}`
+    })
+    const body = maybeString(triggerComment?.body)
+    if (!commentLines.length && body) {
+      commentLines.push(body)
+    }
+    lines.push("## Comments")
+    lines.push(renderList(commentLines))
+  }
+
+  return lines.length ? `\n\n${lines.join("\n\n")}` : ""
 }
 
 function renderPullRequestContextMarkdown(input: unknown): string {
@@ -152,7 +215,7 @@ function renderPullRequestContextMarkdown(input: unknown): string {
     .flatMap(([key, item]) => item === undefined ? [] : `${key}: ${frontmatterValue(item)}`)
     .join("\n")
   const body = value
-    ? `# Pull Request Context\n\nChange Request ${value.number} in ${value.repository}.`
+    ? `# Pull Request Context\n\nChange Request ${value.number} in ${value.repository}.${renderPullRequestDetails(input)}`
     : "# Pull Request Context\n\nNo pull request context was recorded for this Agent Invocation."
   return `---\n${frontmatter}\n---\n\n${body}\n`
 }

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -127,6 +127,7 @@ export type GitHubIssueCommentPayload = {
   installation?: { id?: unknown }
   issue?: {
     author_association?: unknown
+    body?: unknown
     html_url?: unknown
     labels?: unknown
     number?: unknown
@@ -163,9 +164,47 @@ export interface GitHubPullRequestCommand {
   repository: string
 }
 
+export interface GitHubPullRequestFileMetadata {
+  additions?: number
+  blobUrl?: string
+  changes?: number
+  contentsUrl?: string
+  deletions?: number
+  filename: string
+  previousFilename?: string
+  rawUrl?: string
+  status?: string
+}
+
+export interface GitHubPullRequestCommentMetadata {
+  authorAssociation?: string
+  body?: string
+  createdAt?: string
+  htmlUrl?: string
+  id: number
+  nodeId?: string
+  updatedAt?: string
+  user?: {
+    id?: number
+    login?: string
+    type?: string
+  }
+}
+
+export interface GitHubPullRequestRefMetadata {
+  ref?: string
+  repo?: string
+  sha?: string
+}
+
 export interface GitHubPullRequestRunContext {
   pullRequest: {
     apiUrl: string
+    base?: GitHubPullRequestRefMetadata
+    body?: string
+    comments?: GitHubPullRequestCommentMetadata[]
+    files?: GitHubPullRequestFileMetadata[]
+    head?: GitHubPullRequestRefMetadata
     htmlUrl?: string
     labels?: string[]
     number: number
@@ -240,6 +279,7 @@ export interface GitHubChannelOptions<TRuntimeConfig extends AgentRuntimeConfig 
   extends AgentChannelOptions<TRuntimeConfig> {
   app?: true | GitHubAppOptions<TRuntimeConfig>
   events?: GitHubChannelEventsOptions<TRuntimeConfig>
+  pullRequest?: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig>
 }
 
 interface GitHubPullRequestEffectsOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
@@ -275,6 +315,69 @@ function maybeStrings(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return
   const strings = value.filter((item): item is string => typeof item === "string" && Boolean(item))
   return strings.length ? strings : undefined
+}
+
+function githubUserMetadata(value: unknown): GitHubPullRequestCommentMetadata["user"] | undefined {
+  if (!isRecord(value)) return
+  const login = maybeString(value.login)
+  const id = maybeNumber(value.id)
+  const type = maybeString(value.type)
+  if (!login && !id && !type) return
+  return {
+    ...(id !== undefined ? { id } : {}),
+    ...(login ? { login } : {}),
+    ...(type ? { type } : {}),
+  }
+}
+
+function githubCommentMetadata(value: unknown): GitHubPullRequestCommentMetadata | undefined {
+  if (!isRecord(value)) return
+  const id = maybeNumber(value.id)
+  if (id === undefined) return
+  const user = githubUserMetadata(value.user)
+  return {
+    ...(maybeString(value.author_association) ? { authorAssociation: maybeString(value.author_association) } : {}),
+    ...(maybeString(value.body) ? { body: maybeString(value.body) } : {}),
+    ...(maybeString(value.created_at) ? { createdAt: maybeString(value.created_at) } : {}),
+    ...(maybeString(value.html_url) ? { htmlUrl: maybeString(value.html_url) } : {}),
+    id,
+    ...(maybeString(value.node_id) ? { nodeId: maybeString(value.node_id) } : {}),
+    ...(maybeString(value.updated_at) ? { updatedAt: maybeString(value.updated_at) } : {}),
+    ...(user ? { user } : {}),
+  }
+}
+
+function githubFileMetadata(value: unknown): GitHubPullRequestFileMetadata | undefined {
+  if (!isRecord(value)) return
+  const filename = maybeString(value.filename)
+  if (!filename) return
+  const additions = maybeNumber(value.additions)
+  const changes = maybeNumber(value.changes)
+  const deletions = maybeNumber(value.deletions)
+  return {
+    ...(additions !== undefined ? { additions } : {}),
+    ...(maybeString(value.blob_url) ? { blobUrl: maybeString(value.blob_url) } : {}),
+    ...(changes !== undefined ? { changes } : {}),
+    ...(maybeString(value.contents_url) ? { contentsUrl: maybeString(value.contents_url) } : {}),
+    ...(deletions !== undefined ? { deletions } : {}),
+    filename,
+    ...(maybeString(value.previous_filename) ? { previousFilename: maybeString(value.previous_filename) } : {}),
+    ...(maybeString(value.raw_url) ? { rawUrl: maybeString(value.raw_url) } : {}),
+    ...(maybeString(value.status) ? { status: maybeString(value.status) } : {}),
+  }
+}
+
+function githubRefMetadata(value: unknown): GitHubPullRequestRefMetadata | undefined {
+  if (!isRecord(value)) return
+  const ref = maybeString(value.ref)
+  const repo = isRecord(value.repo) ? maybeString(value.repo.full_name) : undefined
+  const sha = maybeString(value.sha)
+  if (!ref && !repo && !sha) return
+  return {
+    ...(ref ? { ref } : {}),
+    ...(repo ? { repo } : {}),
+    ...(sha ? { sha } : {}),
+  }
 }
 
 function chatFinishExtension(input: AgentRunInput): AgentChatFinishExtension | undefined {
@@ -434,10 +537,46 @@ function githubPullRequestCommandFromInput(input: unknown): GitHubPullRequestCom
   }
 }
 
+async function githubPullRequestMetadata<TRuntimeConfig extends AgentRuntimeConfig>(
+  app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
+  context: AgentCallbackContext<TRuntimeConfig>,
+  command: GitHubPullRequestCommand,
+  payload?: GitHubIssueCommentPayload,
+): Promise<Pick<GitHubPullRequestRunContext["pullRequest"], "base" | "body" | "comments" | "files" | "head">> {
+  const fallback = {
+    ...(maybeString(payload?.issue?.body) ? { body: maybeString(payload?.issue?.body) } : {}),
+  }
+  if (!app) return fallback
+
+  try {
+    const options = githubAppOptions(app) || {}
+    const fetcher = options.fetch || fetch
+    const headers = githubApiHeaders(await githubAppInstallationToken(app, context, command.installationId), options.userAgent)
+    const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
+    const [pullRequest, comments, files] = await Promise.all([
+      githubApiJson(fetcher, command.pullRequestUrl, headers),
+      githubApiJson(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/issues/${command.issueNumber}/comments?per_page=100`, headers),
+      githubApiJson(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/pulls/${command.issueNumber}/files?per_page=100`, headers),
+    ])
+    return {
+      ...fallback,
+      ...(isRecord(pullRequest) && maybeString(pullRequest.body) ? { body: maybeString(pullRequest.body) } : {}),
+      ...(isRecord(pullRequest) && githubRefMetadata(pullRequest.base) ? { base: githubRefMetadata(pullRequest.base) } : {}),
+      ...(isRecord(pullRequest) && githubRefMetadata(pullRequest.head) ? { head: githubRefMetadata(pullRequest.head) } : {}),
+      ...(Array.isArray(comments) ? { comments: comments.map(githubCommentMetadata).filter((comment): comment is GitHubPullRequestCommentMetadata => Boolean(comment)) } : {}),
+      ...(Array.isArray(files) ? { files: files.map(githubFileMetadata).filter((file): file is GitHubPullRequestFileMetadata => Boolean(file)) } : {}),
+    }
+  }
+  catch {
+    return fallback
+  }
+}
+
 function githubPullRequestRunContext(
   command: GitHubPullRequestCommand,
   options: GitHubPullRequestCommentEventOptions = {},
   payload?: GitHubIssueCommentPayload,
+  metadata: Pick<GitHubPullRequestRunContext["pullRequest"], "base" | "body" | "comments" | "files" | "head"> = {},
 ): GitHubPullRequestRunContext {
   const runId = command.deliveryId || `github:${command.repository}#${command.issueNumber}:comment:${command.commentId}`
   const labels = maybeStrings(Array.isArray(payload?.issue?.labels)
@@ -446,6 +585,7 @@ function githubPullRequestRunContext(
   return {
     pullRequest: {
       apiUrl: command.pullRequestUrl,
+      ...metadata,
       ...(maybeString(payload?.issue?.pull_request?.html_url) || maybeString(payload?.issue?.html_url)
         ? { htmlUrl: maybeString(payload?.issue?.pull_request?.html_url) || maybeString(payload?.issue?.html_url) }
         : {}),
@@ -662,12 +802,14 @@ const githubAppTokenCache = new Map<string, { expiresAt: number, token: string }
 
 async function githubAppInstallationToken<TRuntimeConfig extends AgentRuntimeConfig>(
   app: true | GitHubAppOptions<TRuntimeConfig>,
-  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
+  context: GitHubAppContext<TRuntimeConfig>,
+  installation?: number,
 ) {
   const options = githubAppOptions(app) || {}
   const env = await githubEnv(context)
   const appId = requiredString(await githubAppSetting(options, env, "appId", "appId", context), "appId")
-  const installationId = githubCommandFromEffect(context)?.installationId
+  const installationId = installation
+    ?? ("effect" in context ? githubCommandFromEffect(context as AgentChannelDeliveryEffectContext<TRuntimeConfig>)?.installationId : undefined)
     ?? requiredNumber(await githubAppSetting(options, env, "installationId", "appInstallationId", context), "installationId")
   const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
   const cacheKey = `${apiBaseUrl}:${appId}:${installationId}`
@@ -731,6 +873,12 @@ async function githubApi(fetcher: typeof fetch, url: string, init: RequestInit):
     throw new Error(`[vitehub] GitHub delivery effect failed with ${response.status}.`)
   }
   return response
+}
+
+async function githubApiJson(fetcher: typeof fetch, url: string, headers: Record<string, string>): Promise<unknown> {
+  const response = await fetcher(url, { headers, method: "GET" })
+  if (!response.ok) return
+  return await response.json().catch(() => undefined)
 }
 
 function reactionContent<TRuntimeConfig extends AgentRuntimeConfig>(
@@ -1252,11 +1400,11 @@ function ignored(reason: string) {
 }
 
 function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
-  events: GitHubChannelEventsOptions<TRuntimeConfig> | undefined,
+  pullRequest: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig> | undefined,
+  app?: true | GitHubAppOptions<TRuntimeConfig>,
 ): AgentChannelDefinition<TRuntimeConfig>["triggers"] {
-  const pullRequestComments = events?.pullRequestComments
-  if (!pullRequestComments) return undefined
-  const options = pullRequestComments === true ? {} : pullRequestComments
+  if (!pullRequest) return undefined
+  const options = pullRequest === true ? {} : pullRequest
   return {
     webhook: {
       async invoke(context, input): Promise<AgentTriggerInvokeResult> {
@@ -1265,10 +1413,11 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
         if (!payload && !command) return options.ignored?.("missing_payload") || ignored("missing_payload")
         if (!command) return options.ignored?.("not_command") || ignored("not_command")
         if (declaredInputCommand(context, command.command) === false) return options.ignored?.("not_command") || ignored("not_command")
+        const metadata = await githubPullRequestMetadata(app, context, command, payload)
         const pullRequest = githubPullRequestRunContext(command, {
           ...options,
           threadId: options.threadId || maybeString(payload?.issue?.pull_request?.html_url) || maybeString(payload?.issue?.html_url) || command.pullRequestUrl,
-        }, payload)
+        }, payload, metadata)
         const finishEffects = githubPullRequestCommentFinishEffects(options)
         return {
           ...(finishEffects ? { delivery: { finishEffects } } : {}),
@@ -1312,8 +1461,9 @@ export function discord<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntime
 export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   options: GitHubChannelOptions<TRuntimeConfig> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {
-  const { app: appOptions, events, ...channelOptions } = options
+  const { app: appOptions, events, pullRequest, ...channelOptions } = options
   const app = githubAppOptions(appOptions)
+  const pullRequestOptions = "pullRequest" in options ? pullRequest : events?.pullRequestComments
   const appEffects: AgentChannelDeliveryEffects<TRuntimeConfig> | undefined = appOptions
     ? githubPullRequestEffects<TRuntimeConfig>({
         apiBaseUrl: app?.apiBaseUrl,
@@ -1329,7 +1479,7 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
     effects: appEffects ? { ...appEffects, ...options.effects } as AgentChannelDeliveryEffects<TRuntimeConfig> : options.effects,
     messages: false,
     triggers: {
-      ...githubEventTriggers(events),
+      ...githubEventTriggers(pullRequestOptions, appOptions),
       ...options.triggers,
     },
     webhooks: githubWebhookDefaults(options.webhooks, appOptions),

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -585,8 +585,8 @@ async function githubPullRequestMetadata<TRuntimeConfig extends AgentRuntimeConf
     const apiBaseUrl = appOptions.apiBaseUrl || "https://api.github.com"
     const [pullRequest, comments, files] = await Promise.all([
       githubApiJson(fetcher, command.pullRequestUrl, headers),
-      githubApiJson(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/issues/${command.issueNumber}/comments?per_page=100`, headers),
-      githubApiJson(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/pulls/${command.issueNumber}/files?per_page=100`, headers),
+      githubApiJsonPages(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/issues/${command.issueNumber}/comments`, headers, maxComments + 1),
+      githubApiJsonPages(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/pulls/${command.issueNumber}/files`, headers, maxFiles + 1),
     ])
     const commentMetadata = Array.isArray(comments)
       ? comments.map(githubCommentMetadata).filter((comment): comment is GitHubPullRequestCommentMetadata => Boolean(comment))
@@ -929,6 +929,33 @@ async function githubApiJson(fetcher: typeof fetch, url: string, headers: Record
   const response = await fetcher(url, { headers, method: "GET" })
   if (!response.ok) throw new Error(`[vitehub] GitHub metadata request failed with ${response.status}.`)
   return await response.json().catch(() => undefined)
+}
+
+async function githubApiJsonPages(fetcher: typeof fetch, url: string, headers: Record<string, string>, limit: number): Promise<unknown[]> {
+  const items: unknown[] = []
+  let page = 1
+  let nextUrl: string | undefined = githubApiPageUrl(url, page)
+  while (nextUrl && (limit <= 0 || items.length < limit)) {
+    const response = await fetcher(nextUrl, { headers, method: "GET" })
+    if (!response.ok) throw new Error(`[vitehub] GitHub metadata request failed with ${response.status}.`)
+    const pageItems = await response.json().catch(() => undefined)
+    if (!Array.isArray(pageItems) || !pageItems.length) break
+    items.push(...pageItems)
+    if (limit > 0 && items.length >= limit) break
+    nextUrl = githubApiNextPageUrl(response.headers.get("link")) || githubApiPageUrl(url, ++page)
+  }
+  return limit > 0 ? items.slice(0, limit) : []
+}
+
+function githubApiPageUrl(url: string, page: number): string {
+  const parsed = new URL(url)
+  parsed.searchParams.set("per_page", "100")
+  if (page > 1) parsed.searchParams.set("page", String(page))
+  return parsed.toString()
+}
+
+function githubApiNextPageUrl(link: string | null): string | undefined {
+  return link?.split(",").map(part => part.trim()).find(part => part.endsWith(`rel="next"`))?.match(/^<([^>]+)>/)?.[1]
 }
 
 function reactionContent<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -197,6 +197,12 @@ export interface GitHubPullRequestRefMetadata {
   sha?: string
 }
 
+export interface GitHubPullRequestMetadata {
+  omittedComments?: number
+  omittedFiles?: number
+  unavailable?: string
+}
+
 export interface GitHubPullRequestRunContext {
   pullRequest: {
     apiUrl: string
@@ -207,6 +213,7 @@ export interface GitHubPullRequestRunContext {
     head?: GitHubPullRequestRefMetadata
     htmlUrl?: string
     labels?: string[]
+    metadata?: GitHubPullRequestMetadata
     number: number
     source: {
       mount: string
@@ -264,6 +271,10 @@ declare global {
 
 export interface GitHubPullRequestCommentEventOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   ignored?: (reason: string) => Response
+  maxBodyLength?: number
+  maxCommentBodyLength?: number
+  maxComments?: number
+  maxFiles?: number
   origin?: string
   reply?: boolean | AgentChannelDeliveryFinishEffect
   sourceMount?: string
@@ -271,14 +282,9 @@ export interface GitHubPullRequestCommentEventOptions<TRuntimeConfig extends Age
   threadId?: string
 }
 
-export interface GitHubChannelEventsOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
-  pullRequestComments?: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig>
-}
-
 export interface GitHubChannelOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
   extends AgentChannelOptions<TRuntimeConfig> {
   app?: true | GitHubAppOptions<TRuntimeConfig>
-  events?: GitHubChannelEventsOptions<TRuntimeConfig>
   pullRequest?: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig>
 }
 
@@ -379,6 +385,24 @@ function githubRefMetadata(value: unknown): GitHubPullRequestRefMetadata | undef
     ...(sha ? { sha } : {}),
   }
 }
+
+const defaultGitHubPullRequestMaxBodyLength = 12_000
+const defaultGitHubPullRequestMaxCommentBodyLength = 2_000
+const defaultGitHubPullRequestMaxComments = 30
+const defaultGitHubPullRequestMaxFiles = 200
+
+function githubPullRequestLimit(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.floor(value) : fallback
+}
+
+function truncateGitHubPullRequestText(value: string | undefined, maxLength: number): string | undefined {
+  if (!value || value.length <= maxLength) return value
+  return maxLength > 0
+    ? `${value.slice(0, maxLength)}\n[truncated ${value.length - maxLength} characters]`
+    : `[truncated ${value.length} characters]`
+}
+
+type GitHubPullRequestMetadataFields = Pick<GitHubPullRequestRunContext["pullRequest"], "base" | "body" | "comments" | "files" | "head" | "metadata">
 
 function chatFinishExtension(input: AgentRunInput): AgentChatFinishExtension | undefined {
   const value = isRecord(input.context) ? input.context[CHAT_FINISH_EXTENSION_CONTEXT_KEY] : undefined
@@ -541,34 +565,60 @@ async function githubPullRequestMetadata<TRuntimeConfig extends AgentRuntimeConf
   app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
   context: AgentCallbackContext<TRuntimeConfig>,
   command: GitHubPullRequestCommand,
+  options: GitHubPullRequestCommentEventOptions<TRuntimeConfig>,
   payload?: GitHubIssueCommentPayload,
-): Promise<Pick<GitHubPullRequestRunContext["pullRequest"], "base" | "body" | "comments" | "files" | "head">> {
+): Promise<GitHubPullRequestMetadataFields> {
+  const maxBodyLength = githubPullRequestLimit(options.maxBodyLength, defaultGitHubPullRequestMaxBodyLength)
+  const maxCommentBodyLength = githubPullRequestLimit(options.maxCommentBodyLength, defaultGitHubPullRequestMaxCommentBodyLength)
+  const maxComments = githubPullRequestLimit(options.maxComments, defaultGitHubPullRequestMaxComments)
+  const maxFiles = githubPullRequestLimit(options.maxFiles, defaultGitHubPullRequestMaxFiles)
+  const fallbackBody = truncateGitHubPullRequestText(maybeString(payload?.issue?.body), maxBodyLength)
   const fallback = {
-    ...(maybeString(payload?.issue?.body) ? { body: maybeString(payload?.issue?.body) } : {}),
+    ...(fallbackBody ? { body: fallbackBody } : {}),
   }
   if (!app) return fallback
 
   try {
-    const options = githubAppOptions(app) || {}
-    const fetcher = options.fetch || fetch
-    const headers = githubApiHeaders(await githubAppInstallationToken(app, context, command.installationId), options.userAgent)
-    const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
+    const appOptions = githubAppOptions(app) || {}
+    const fetcher = appOptions.fetch || fetch
+    const headers = githubApiHeaders(await githubAppInstallationToken(app, context, command.installationId), appOptions.userAgent)
+    const apiBaseUrl = appOptions.apiBaseUrl || "https://api.github.com"
     const [pullRequest, comments, files] = await Promise.all([
       githubApiJson(fetcher, command.pullRequestUrl, headers),
       githubApiJson(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/issues/${command.issueNumber}/comments?per_page=100`, headers),
       githubApiJson(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/pulls/${command.issueNumber}/files?per_page=100`, headers),
     ])
+    const commentMetadata = Array.isArray(comments)
+      ? comments.map(githubCommentMetadata).filter((comment): comment is GitHubPullRequestCommentMetadata => Boolean(comment))
+      : []
+    const fileMetadata = Array.isArray(files)
+      ? files.map(githubFileMetadata).filter((file): file is GitHubPullRequestFileMetadata => Boolean(file))
+      : []
+    const metadata = {
+      ...(commentMetadata.length > maxComments ? { omittedComments: commentMetadata.length - maxComments } : {}),
+      ...(fileMetadata.length > maxFiles ? { omittedFiles: fileMetadata.length - maxFiles } : {}),
+    }
+    const body = isRecord(pullRequest) ? truncateGitHubPullRequestText(maybeString(pullRequest.body), maxBodyLength) : undefined
     return {
       ...fallback,
-      ...(isRecord(pullRequest) && maybeString(pullRequest.body) ? { body: maybeString(pullRequest.body) } : {}),
+      ...(body ? { body } : {}),
       ...(isRecord(pullRequest) && githubRefMetadata(pullRequest.base) ? { base: githubRefMetadata(pullRequest.base) } : {}),
       ...(isRecord(pullRequest) && githubRefMetadata(pullRequest.head) ? { head: githubRefMetadata(pullRequest.head) } : {}),
-      ...(Array.isArray(comments) ? { comments: comments.map(githubCommentMetadata).filter((comment): comment is GitHubPullRequestCommentMetadata => Boolean(comment)) } : {}),
-      ...(Array.isArray(files) ? { files: files.map(githubFileMetadata).filter((file): file is GitHubPullRequestFileMetadata => Boolean(file)) } : {}),
+      ...(commentMetadata.length ? { comments: commentMetadata.slice(0, maxComments).map(comment => ({
+        ...comment,
+        ...(comment.body ? { body: truncateGitHubPullRequestText(comment.body, maxCommentBodyLength)! } : {}),
+      })) } : {}),
+      ...(fileMetadata.length ? { files: fileMetadata.slice(0, maxFiles) } : {}),
+      ...(Object.keys(metadata).length ? { metadata } : {}),
     }
   }
-  catch {
-    return fallback
+  catch (error) {
+    return {
+      ...fallback,
+      metadata: {
+        unavailable: error instanceof Error && error.message ? error.message : "unknown",
+      },
+    }
   }
 }
 
@@ -576,7 +626,7 @@ function githubPullRequestRunContext(
   command: GitHubPullRequestCommand,
   options: GitHubPullRequestCommentEventOptions = {},
   payload?: GitHubIssueCommentPayload,
-  metadata: Pick<GitHubPullRequestRunContext["pullRequest"], "base" | "body" | "comments" | "files" | "head"> = {},
+  metadata: GitHubPullRequestMetadataFields = {},
 ): GitHubPullRequestRunContext {
   const runId = command.deliveryId || `github:${command.repository}#${command.issueNumber}:comment:${command.commentId}`
   const labels = maybeStrings(Array.isArray(payload?.issue?.labels)
@@ -877,7 +927,7 @@ async function githubApi(fetcher: typeof fetch, url: string, init: RequestInit):
 
 async function githubApiJson(fetcher: typeof fetch, url: string, headers: Record<string, string>): Promise<unknown> {
   const response = await fetcher(url, { headers, method: "GET" })
-  if (!response.ok) return
+  if (!response.ok) throw new Error(`[vitehub] GitHub metadata request failed with ${response.status}.`)
   return await response.json().catch(() => undefined)
 }
 
@@ -1413,7 +1463,7 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
         if (!payload && !command) return options.ignored?.("missing_payload") || ignored("missing_payload")
         if (!command) return options.ignored?.("not_command") || ignored("not_command")
         if (declaredInputCommand(context, command.command) === false) return options.ignored?.("not_command") || ignored("not_command")
-        const metadata = await githubPullRequestMetadata(app, context, command, payload)
+        const metadata = await githubPullRequestMetadata(app, context, command, options, payload)
         const pullRequest = githubPullRequestRunContext(command, {
           ...options,
           threadId: options.threadId || maybeString(payload?.issue?.pull_request?.html_url) || maybeString(payload?.issue?.html_url) || command.pullRequestUrl,
@@ -1461,9 +1511,8 @@ export function discord<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntime
 export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   options: GitHubChannelOptions<TRuntimeConfig> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {
-  const { app: appOptions, events, pullRequest, ...channelOptions } = options
+  const { app: appOptions, pullRequest, ...channelOptions } = options
   const app = githubAppOptions(appOptions)
-  const pullRequestOptions = "pullRequest" in options ? pullRequest : events?.pullRequestComments
   const appEffects: AgentChannelDeliveryEffects<TRuntimeConfig> | undefined = appOptions
     ? githubPullRequestEffects<TRuntimeConfig>({
         apiBaseUrl: app?.apiBaseUrl,
@@ -1479,7 +1528,7 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
     effects: appEffects ? { ...appEffects, ...options.effects } as AgentChannelDeliveryEffects<TRuntimeConfig> : options.effects,
     messages: false,
     triggers: {
-      ...githubEventTriggers(pullRequestOptions, appOptions),
+      ...githubEventTriggers(pullRequest, appOptions),
       ...options.triggers,
     },
     webhooks: githubWebhookDefaults(options.webhooks, appOptions),

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1403,7 +1403,7 @@ describe("agent chat capability discovery", () => {
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
       channels: {
-        github: github({ events: { pullRequestComments: { reply: false } }, webhooks: { secretToken: "secret-token" } }),
+        github: github({ pullRequest: { reply: false }, webhooks: { secretToken: "secret-token" } }),
       },
       driver: { run: ({ context, input }) => {
           const github = context.get<{ command: string, repository: string }>("github")

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -46,6 +46,23 @@ describe("inputCommands", () => {
     expect(resolved.input.prompt).toBe("/summary")
   })
 
+  it("uses command args as the default command rewrite", async () => {
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [inputCommands({
+        commands: {
+          review: {
+            description: "Review the request.",
+          },
+        },
+      })],
+    }, runtime(), { prompt: "/review auth changes" })
+
+    expect(resolved.input.prompt).toBe("auth changes")
+  })
+
   it("keeps command-only message text when a string handler returns empty args", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
@@ -391,12 +408,6 @@ describe("inputCommands", () => {
         review: { run: () => undefined } as never,
       },
     })).toThrow("requires a description")
-
-    expect(() => inputCommands({
-      commands: {
-        review: { description: "Review." } as never,
-      },
-    })).toThrow("requires a call() handler")
 
     expect(() => inputCommands({
       commands: {

--- a/packages/agent/test/pull-request-context.test.ts
+++ b/packages/agent/test/pull-request-context.test.ts
@@ -232,6 +232,79 @@ describe("pullRequestContext", () => {
     ].join("\n"))
   })
 
+  it("renders GitHub metadata gaps and bounded untrusted comments", async () => {
+    const { pullRequestContext } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [pullRequestContext()],
+    }, runtime(), {
+      context: {
+        pullRequest: {
+          pullRequest: {
+            apiUrl: "https://api.github.test/repos/acme/app/pulls/42",
+            body: "PR body\n[truncated 8 characters]",
+            comments: [{
+              body: "Looks risky.\n[truncated 20 characters]",
+              id: 1,
+              user: { login: "mona" },
+            }],
+            files: [{
+              additions: 1,
+              deletions: 0,
+              filename: "src/app.ts",
+              status: "modified",
+            }],
+            metadata: {
+              omittedComments: 2,
+              omittedFiles: 1,
+              unavailable: "[vitehub] GitHub metadata request failed with 403.",
+            },
+            number: 42,
+            source: {
+              mount: "app",
+              ref: "refs/pull/42/head",
+              repo: "acme/app",
+            },
+          },
+          repository: {
+            fullName: "acme/app",
+            name: "app",
+            owner: "acme",
+          },
+          run: {
+            messageId: "100",
+            origin: "github-pull-request-comment",
+            runId: "delivery-1",
+            threadId: "thread",
+          },
+          trigger: {
+            action: "created",
+            actor: { login: "mona" },
+            args: "",
+            command: "/review",
+            comment: { id: 100 },
+            event: "issue_comment",
+          },
+        },
+      },
+    }, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    const markdown = await resolved.workspace?.fs.readFile("pull-request-context/context.md")
+
+    expect(markdown).toContain("PR metadata unavailable: [vitehub] GitHub metadata request failed with 403.")
+    expect(markdown).toContain("## Body\n\nPR body\n[truncated 8 characters]")
+    expect(markdown).toContain("- src/app.ts (modified) (+1/-0)\n\n+1 more files not shown.")
+    expect(markdown).toContain("## Comments (untrusted user content)")
+    expect(markdown).toContain("- mona: Looks risky.\n[truncated 20 characters]")
+    expect(markdown).toContain("- +2 more comments not shown.")
+  })
+
   it("grants the default source to the selected Workspace Scope", async () => {
     const { access, pullRequestContext } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2972,7 +2972,7 @@ describe("agent message protocol", () => {
       channels: {
         github: github({
           app: { webhookSecret: "secret-token" },
-          events: { pullRequestComments: true },
+          pullRequest: true,
           webhooks: { path: "/api/github/webhook" },
         }),
       },
@@ -3004,9 +3004,7 @@ describe("agent message protocol", () => {
     const agent = defineAgent({
       channels: {
         github: github({
-          events: {
-            pullRequestComments: true,
-          },
+          pullRequest: true,
         }),
       },
       driver: { run: () => "ok" },
@@ -3032,7 +3030,30 @@ describe("agent message protocol", () => {
         return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
       }
       if (href.endsWith("/pulls/42")) {
-        return Response.json({ head: { sha: "abc123" } })
+        return Response.json({
+          base: { ref: "main", repo: { full_name: "vite-hub/vitehub" }, sha: "base123" },
+          body: "PR body",
+          head: { ref: "feature", repo: { full_name: "onmax/vitehub" }, sha: "abc123" },
+        })
+      }
+      if (href.endsWith("/issues/42/comments?per_page=100")) {
+        return Response.json([{
+          author_association: "MEMBER",
+          body: "/review please",
+          html_url: "https://github.test/vite-hub/vitehub/pull/42#issuecomment-99",
+          id: 99,
+          user: { id: 1, login: "onmax", type: "User" },
+        }])
+      }
+      if (href.endsWith("/pulls/42/files?per_page=100")) {
+        return Response.json([{
+          additions: 12,
+          changes: 15,
+          deletions: 3,
+          filename: "packages/agent/src/channels.ts",
+          patch: "not included in context",
+          status: "modified",
+        }])
       }
       if (href.endsWith("/issues/comments/99/reactions") && init?.method === "POST") {
         return Response.json({ id: 777 }, { status: 201 })
@@ -3088,6 +3109,11 @@ describe("agent message protocol", () => {
               expect(command.actor).toMatchObject({ association: "MEMBER" })
               expect(pullRequest).toMatchObject({
                 pullRequest: {
+                  base: { ref: "main", sha: "base123" },
+                  body: "PR body",
+                  comments: [expect.objectContaining({ body: "/review please", user: { id: 1, login: "onmax", type: "User" } })],
+                  files: [expect.objectContaining({ additions: 12, deletions: 3, filename: "packages/agent/src/channels.ts", status: "modified" })],
+                  head: { ref: "feature", sha: "abc123" },
                   htmlUrl: "https://github.test/vite-hub/vitehub/pull/42",
                   labels: ["agent"],
                   number: 42,
@@ -3133,10 +3159,8 @@ describe("agent message protocol", () => {
             privateKey: privateKeyPem,
             statusContext: "ViteHub Review",
           },
-          events: {
-            pullRequestComments: {
-              origin: "github-review",
-            },
+          pullRequest: {
+            origin: "github-review",
           },
         }),
       },
@@ -3226,7 +3250,7 @@ describe("agent message protocol", () => {
       channels: {
         github: github({
           app: { webhookSecret: false },
-          events: { pullRequestComments: true },
+          pullRequest: true,
         }),
       },
       driver: {
@@ -3282,7 +3306,7 @@ describe("agent message protocol", () => {
       channels: {
         github: github({
           app: { webhookSecret: false },
-          events: { pullRequestComments: true },
+          pullRequest: true,
         }),
       },
       driver: {
@@ -3345,11 +3369,11 @@ describe("agent message protocol", () => {
       channels: {
         github: github({
           app: { webhookSecret: false },
-          events: { pullRequestComments: true },
+          pullRequest: true,
         }),
         triage: github({
           app: { webhookSecret: false },
-          events: { pullRequestComments: true },
+          pullRequest: true,
         }),
       },
       driver: { run: context => `ran:${context.prompt}` },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3318,6 +3318,94 @@ describe("agent message protocol", () => {
     })
   })
 
+  it("pages GitHub PR metadata until it can mark omitted context", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
+    let pullRequestContext: unknown
+    const commentsPageOne = Array.from({ length: 100 }, (_, index) => ({ body: `comment ${index}`, id: index + 1 }))
+    const filesPageOne = Array.from({ length: 100 }, (_, index) => ({ filename: `src/${index}.ts` }))
+    const fetcher = vi.fn(async (url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith("/app/installations/123/access_tokens")) {
+        return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
+      }
+      if (href.endsWith("/pulls/42")) return Response.json({})
+      if (href.endsWith("/issues/42/comments?per_page=100")) {
+        return Response.json(commentsPageOne, {
+          headers: { link: `<https://api.github.test/repos/acme/app/issues/42/comments?per_page=100&page=2>; rel="next"` },
+        })
+      }
+      if (href.endsWith("/issues/42/comments?per_page=100&page=2")) {
+        return Response.json([{ body: "extra", id: 101 }])
+      }
+      if (href.endsWith("/pulls/42/files?per_page=100")) {
+        return Response.json(filesPageOne, {
+          headers: { link: `<https://api.github.test/repos/acme/app/pulls/42/files?per_page=100&page=2>; rel="next"` },
+        })
+      }
+      if (href.endsWith("/pulls/42/files?per_page=100&page=2")) {
+        return Response.json([{ filename: "src/extra.ts" }])
+      }
+      throw new Error(`Unexpected GitHub API call: ${href}`)
+    })
+    const agent = defineAgent({
+      capabilities: [inputCommands({
+        commands: {
+          review: {
+            description: "Review a pull request.",
+            call({ input }) {
+              pullRequestContext = input.context?.pullRequest
+            },
+          },
+        },
+      })],
+      channels: {
+        github: github({
+          app: {
+            apiBaseUrl: "https://api.github.test",
+            appId: "metadata-pages",
+            fetch: fetcher as typeof fetch,
+            installationId: 123,
+            privateKey: privateKeyPem,
+          },
+          pullRequest: {
+            maxComments: 100,
+            maxFiles: 100,
+            reply: false,
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "github.webhook", {
+      github: { event: "issue_comment", installationId: 123 },
+      payload: {
+        action: "created",
+        comment: { body: "/review", id: 99, user: { login: "mona" } },
+        issue: {
+          number: 42,
+          pull_request: { url: "https://api.github.test/repos/acme/app/pulls/42" },
+        },
+        repository: { full_name: "acme/app" },
+      },
+    })).resolves.toBe("ok")
+
+    expect(pullRequestContext).toMatchObject({
+      pullRequest: {
+        comments: expect.arrayContaining([{ body: "comment 99", id: 100 }]),
+        files: expect.arrayContaining([{ filename: "src/99.ts" }]),
+        metadata: {
+          omittedComments: 1,
+          omittedFiles: 1,
+        },
+      },
+    })
+  })
+
   it("marks unavailable GitHub PR metadata", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { inputCommands } = await import("../src/capabilities.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3227,6 +3227,165 @@ describe("agent message protocol", () => {
     )
   })
 
+  it("bounds GitHub PR metadata before input commands", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
+    let pullRequestContext: unknown
+    const fetcher = vi.fn(async (url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith("/app/installations/123/access_tokens")) {
+        return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
+      }
+      if (href.endsWith("/pulls/42")) {
+        return Response.json({
+          body: "0123456789",
+          base: { ref: "main", sha: "base123" },
+          head: { ref: "feature", sha: "head123" },
+        })
+      }
+      if (href.endsWith("/issues/42/comments?per_page=100")) {
+        return Response.json([
+          { body: "abcdefghij", id: 1, user: { login: "mona" } },
+          { body: "second", id: 2, user: { login: "octo" } },
+        ])
+      }
+      if (href.endsWith("/pulls/42/files?per_page=100")) {
+        return Response.json([
+          { filename: "src/one.ts", status: "modified" },
+          { filename: "src/two.ts", status: "added" },
+        ])
+      }
+      throw new Error(`Unexpected GitHub API call: ${href}`)
+    })
+    const agent = defineAgent({
+      capabilities: [inputCommands({
+        commands: {
+          review: {
+            description: "Review a pull request.",
+            call({ input }) {
+              pullRequestContext = input.context?.pullRequest
+            },
+          },
+        },
+      })],
+      channels: {
+        github: github({
+          app: {
+            apiBaseUrl: "https://api.github.test",
+            appId: "metadata-caps",
+            fetch: fetcher as typeof fetch,
+            installationId: 123,
+            privateKey: privateKeyPem,
+          },
+          pullRequest: {
+            maxBodyLength: 4,
+            maxCommentBodyLength: 5,
+            maxComments: 1,
+            maxFiles: 1,
+            reply: false,
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "github.webhook", {
+      github: { event: "issue_comment", installationId: 123 },
+      payload: {
+        action: "created",
+        comment: { body: "/review", id: 99, user: { login: "mona" } },
+        issue: {
+          number: 42,
+          pull_request: { url: "https://api.github.test/repos/acme/app/pulls/42" },
+        },
+        repository: { full_name: "acme/app" },
+      },
+    })).resolves.toBe("ok")
+
+    expect(pullRequestContext).toMatchObject({
+      pullRequest: {
+        body: "0123\n[truncated 6 characters]",
+        comments: [{ body: "abcde\n[truncated 5 characters]", id: 1 }],
+        files: [{ filename: "src/one.ts" }],
+        metadata: {
+          omittedComments: 1,
+          omittedFiles: 1,
+        },
+      },
+    })
+  })
+
+  it("marks unavailable GitHub PR metadata", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
+    let pullRequestContext: unknown
+    const fetcher = vi.fn(async (url: string | URL) => {
+      const href = String(url)
+      if (href.endsWith("/app/installations/321/access_tokens")) {
+        return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
+      }
+      if (href.endsWith("/pulls/42")) return Response.json({ message: "forbidden" }, { status: 403 })
+      if (href.endsWith("/issues/42/comments?per_page=100") || href.endsWith("/pulls/42/files?per_page=100")) {
+        return Response.json([])
+      }
+      throw new Error(`Unexpected GitHub API call: ${href}`)
+    })
+    const agent = defineAgent({
+      capabilities: [inputCommands({
+        commands: {
+          review: {
+            description: "Review a pull request.",
+            call({ input }) {
+              pullRequestContext = input.context?.pullRequest
+            },
+          },
+        },
+      })],
+      channels: {
+        github: github({
+          app: {
+            apiBaseUrl: "https://api.github.test",
+            appId: "metadata-unavailable",
+            fetch: fetcher as typeof fetch,
+            installationId: 321,
+            privateKey: privateKeyPem,
+          },
+          pullRequest: { reply: false },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "github.webhook", {
+      github: { event: "issue_comment", installationId: 321 },
+      payload: {
+        action: "created",
+        comment: { body: "/review", id: 99, user: { login: "mona" } },
+        issue: {
+          body: "fallback body",
+          number: 42,
+          pull_request: { url: "https://api.github.test/repos/acme/app/pulls/42" },
+        },
+        repository: { full_name: "acme/app" },
+      },
+    })).resolves.toBe("ok")
+
+    expect(pullRequestContext).toMatchObject({
+      pullRequest: {
+        body: "fallback body",
+        metadata: {
+          unavailable: "[vitehub] GitHub metadata request failed with 403.",
+        },
+      },
+    })
+  })
+
   it("handles unauthorized GitHub PR comment commands without running the agent", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { inputCommands } = await import("../src/capabilities.ts")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -722,6 +722,7 @@ describe("agent public types", () => {
               expectTypeOf(input.context?.github).toEqualTypeOf<GitHubPullRequestCommand | undefined>()
               const pullRequest = input.context?.pullRequest
               expectTypeOf(pullRequest).toEqualTypeOf<GitHubPullRequestRunContext | undefined>()
+              expectTypeOf(pullRequest?.pullRequest.metadata?.unavailable).toEqualTypeOf<string | undefined>()
               return { prompt: args }
             },
             hooks: {
@@ -739,6 +740,10 @@ describe("agent public types", () => {
         github: github({
           app: true,
           pullRequest: {
+            maxBodyLength: 12_000,
+            maxCommentBodyLength: 2_000,
+            maxComments: 30,
+            maxFiles: 200,
             origin: "github-review",
             reply: reviewFinishEffect,
           },
@@ -1264,6 +1269,9 @@ describe("agent public types", () => {
       },
       driver: { model: {} as never },
     })
+
+    // @ts-expect-error GitHub Channel PR comments are configured through pullRequest, not legacy events.
+    github({ events: { pullRequestComments: true } })
 
     // @ts-expect-error non-Access capabilities do not satisfy Workspace Source scopes
     defineAgent({

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -738,11 +738,9 @@ describe("agent public types", () => {
       channels: {
         github: github({
           app: true,
-          events: {
-            pullRequestComments: {
-              origin: "github-review",
-              reply: reviewFinishEffect,
-            },
+          pullRequest: {
+            origin: "github-review",
+            reply: reviewFinishEffect,
           },
         }),
         portal: http({
@@ -860,9 +858,7 @@ describe("agent public types", () => {
           expectTypeOf(pullRequest).toEqualTypeOf<GitHubPullRequestRunContext | undefined>()
           if (!pullRequest) return false
           return {
-            repo: pullRequest.pullRequest.source.repo,
-            ref: pullRequest.pullRequest.source.ref,
-            mount: pullRequest.pullRequest.source.mount,
+            root: "portal",
           }
         }),
       },

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -9,6 +9,7 @@ type SourceScopes<T> = T extends { scopes?: infer TScopes } ? { scopes?: TScopes
 type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
 type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
 type GitHubAuth = NonNullable<SourcePackageGitHubSourceOptions["auth"]>
+type GitHubResolvedSourceOptions = Omit<GitHubSourceOptions, "repo"> & Partial<Pick<GitHubSourceOptions, "repo">>
 
 export interface GitHubSourceOptions extends Omit<SourcePackageGitHubSourceOptions, "auth">, SourceRuntimeOptions {
   auth?: GitHubAuth
@@ -16,7 +17,7 @@ export interface GitHubSourceOptions extends Omit<SourcePackageGitHubSourceOptio
 
 export type GitHubSourceResolver = (
   context: WorkspaceSourceResolutionContext,
-) => MaybePromise<GitHubSourceOptions | false | null | undefined>
+) => MaybePromise<GitHubResolvedSourceOptions | false | null | undefined>
 
 export type GitHubSourceInput = GitHubSourceOptions | GitHubSourceResolver
 
@@ -112,8 +113,34 @@ function resolvableGitHubSource(resolve: GitHubSourceResolver): WorkspaceSource 
     },
     async resolve(ctx) {
       const options = await resolve(ctx)
-      return options ? github(options) : false
+      return options ? github(githubResolutionDefaults(options, ctx)) : false
     },
+  }
+}
+
+function githubResolutionDefaults(options: GitHubResolvedSourceOptions, ctx: WorkspaceSourceResolutionContext): GitHubSourceOptions {
+  const source = pullRequestSource(ctx.invocation.context.get("pullRequest"))
+  const repo = options.repo || source?.repo
+  if (!repo) throw new Error("[vitehub] github() resolver requires repo or typed pullRequest source context.")
+  return {
+    ...options,
+    mount: options.mount ?? ctx.source.mountPath,
+    ref: options.ref ?? source?.ref,
+    repo,
+  }
+}
+
+function pullRequestSource(value: unknown): { ref?: string, repo?: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return
+  const pullRequest = (value as { pullRequest?: unknown }).pullRequest
+  if (!pullRequest || typeof pullRequest !== "object" || Array.isArray(pullRequest)) return
+  const source = (pullRequest as { source?: unknown }).source
+  if (!source || typeof source !== "object" || Array.isArray(source)) return
+  const ref = (source as { ref?: unknown }).ref
+  const repo = (source as { repo?: unknown }).repo
+  return {
+    ...(typeof ref === "string" && ref ? { ref } : {}),
+    ...(typeof repo === "string" && repo ? { repo } : {}),
   }
 }
 

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -132,6 +132,14 @@ function githubResolutionDefaults(options: GitHubResolvedSourceOptions, ctx: Wor
 
 function pullRequestSource(value: unknown): { ref?: string, repo?: string } | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) return
+  const flatRef = (value as { headRef?: unknown }).headRef
+  const flatRepo = (value as { repository?: unknown }).repository
+  if (typeof flatRepo === "string" && flatRepo) {
+    return {
+      ...(typeof flatRef === "string" && flatRef ? { ref: flatRef } : {}),
+      repo: flatRepo,
+    }
+  }
   const pullRequest = (value as { pullRequest?: unknown }).pullRequest
   if (!pullRequest || typeof pullRequest !== "object" || Array.isArray(pullRequest)) return
   const source = (pullRequest as { source?: unknown }).source

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -304,6 +304,52 @@ describe("Workspace Source Resolution", () => {
     })
   })
 
+  it("defaults resolved GitHub sources from pull request context", async () => {
+    const definition: WorkspaceDefinition = {
+      name: "review",
+      sources: {
+        portal: github(() => ({
+          root: "portal",
+        })),
+      },
+    }
+    const resolved = await resolveWorkspaceSources(definition, {
+      invocation: {
+        context: {
+          entries: () => new Map<string, unknown>().entries(),
+          get: (id: string) => id === "pullRequest"
+            ? {
+                pullRequest: {
+                  source: {
+                    ref: "refs/pull/42/head",
+                    repo: "quiver/portal",
+                  },
+                },
+              }
+            : undefined,
+          has: (id: string) => id === "pullRequest",
+          toJSON: () => ({}),
+        },
+      },
+    })
+    const [portal] = normalizeWorkspaceSources(resolved.sources)
+
+    expect(portal).toMatchObject({
+      key: "portal",
+      materialize: "lazy",
+      mountPath: "portal",
+      source: {
+        fingerprint: {
+          source: {
+            ref: "refs/pull/42/head",
+            repo: "quiver/portal",
+            root: "portal",
+          },
+        },
+      },
+    })
+  })
+
   it("resolves fetch sources from fetch resolvers", async () => {
     const resolveFetch = vi.fn(({ selectedWorkspaceScope }) => ({
       body: { customer: selectedWorkspaceScope?.name },

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -350,6 +350,48 @@ describe("Workspace Source Resolution", () => {
     })
   })
 
+  it("defaults resolved GitHub sources from flat pull request context", async () => {
+    const definition: WorkspaceDefinition = {
+      name: "review",
+      sources: {
+        portal: github(() => ({
+          root: "portal",
+        })),
+      },
+    }
+    const resolved = await resolveWorkspaceSources(definition, {
+      invocation: {
+        context: {
+          entries: () => new Map<string, unknown>().entries(),
+          get: (id: string) => id === "pullRequest"
+            ? {
+                headRef: "refs/pull/42/head",
+                repository: "quiver/portal",
+              }
+            : undefined,
+          has: (id: string) => id === "pullRequest",
+          toJSON: () => ({}),
+        },
+      },
+    })
+    const [portal] = normalizeWorkspaceSources(resolved.sources)
+
+    expect(portal).toMatchObject({
+      key: "portal",
+      materialize: "lazy",
+      mountPath: "portal",
+      source: {
+        fingerprint: {
+          source: {
+            ref: "refs/pull/42/head",
+            repo: "quiver/portal",
+            root: "portal",
+          },
+        },
+      },
+    })
+  })
+
   it("resolves fetch sources from fetch resolvers", async () => {
     const resolveFetch = vi.fn(({ selectedWorkspaceScope }) => ({
       body: { customer: selectedWorkspaceScope?.name },

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -21,6 +21,7 @@ declare global {
 
   interface ViteHubWorkspaceSourceResolutionContextMap {
     "support.customerScope": { customers: Array<"acme" | "globex"> }
+    pullRequest: { pullRequest: { source: { ref: string, repo: string } } }
   }
 
   interface ViteHubWorkspaceScopeNameMap {
@@ -122,6 +123,10 @@ describe("workspace types", () => {
         root: `dbt/${customer}`,
         mount: `ingestion/${customer}`,
       }
+    })
+    github(({ invocation }) => {
+      expectTypeOf(invocation.context.get("pullRequest")?.pullRequest.source.repo).toEqualTypeOf<string | undefined>()
+      return { root: "portal" }
     })
     glob({
       cwd: "docs",


### PR DESCRIPTION
## Summary

- add `github({ pullRequest: true })` as the public PR channel shorthand while keeping the old nested event option as compatibility
- let description-only `inputCommands()` pass command args through by default
- default resolved GitHub workspace sources from typed pull request context so PR consumers can omit repo, ref, and mount glue

## Why

Review agents should get their PR-ness from the channel registration and their workspace source defaults from the typed invocation context. That lets Quiver remove `reviewWorkspaceSources`, `portal.mount`, repeated repo/ref wiring, and the no-op `review.run: ({ args }) => args` handler after repinning.

## Validation

- `node_modules/.bin/vp run -t @vite-hub/agent#build`
- focused agent/workspace tests and typechecks passed in the implementation worktree
- `git diff --check`