### PR TITLE
fix(agent): serialize sqlite state connect

### DIFF
--- a/packages/agent/src/state/sqlite.ts
+++ b/packages/agent/src/state/sqlite.ts
@@ -150,6 +150,10 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   }
 
   async connect(): Promise<void> {
+    if (this.connectPromise) {
+      await this.connectPromise
+      return
+    }
     if (this.connected) return
     this.connectPromise ??= this.doConnect().finally(() => {
       this.connectPromise = undefined

--- a/packages/agent/src/state/sqlite.ts
+++ b/packages/agent/src/state/sqlite.ts
@@ -94,6 +94,7 @@ async function execute(executor: SqliteAgentStateExecutor, statement: string, ar
 
 export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   private connected = false
+  private connectPromise?: Promise<void>
   private readonly driver: SqliteAgentStateDriver
   private nextCleanupAt = 0
   private readonly tables: StateTables
@@ -149,6 +150,14 @@ export class ViteHubSqliteAgentStateAdapter implements StateAdapter {
   }
 
   async connect(): Promise<void> {
+    if (this.connected) return
+    this.connectPromise ??= this.doConnect().finally(() => {
+      this.connectPromise = undefined
+    })
+    await this.connectPromise
+  }
+
+  private async doConnect(): Promise<void> {
     await this.driver.connect?.()
     this.connected = true
     try {

--- a/packages/agent/test/sqlite-state-provider.test.ts
+++ b/packages/agent/test/sqlite-state-provider.test.ts
@@ -117,6 +117,42 @@ describe("SQLite Agent State Provider", () => {
     await adapter.disconnect()
   })
 
+  it("awaits in-flight setup after the driver connects", async () => {
+    let finishMigration: (() => void) | undefined
+    let startMigration!: () => void
+    const migrationStarted = new Promise<void>((resolve) => {
+      startMigration = resolve
+    })
+    const driver: SqliteAgentStateDriver = {
+      async execute(statement: string) {
+        if (statement.includes("COALESCE(MAX(version)")) return { rows: [{ version: 2 }] }
+        return { rows: [] }
+      },
+      async transaction(run) {
+        startMigration()
+        await new Promise<void>((finish) => {
+          finishMigration = finish
+        })
+        return await run(driver)
+      },
+    }
+    const adapter = new ViteHubSqliteAgentStateAdapter({ driver })
+    const firstConnect = adapter.connect()
+
+    await migrationStarted
+    const secondConnect = adapter.connect()
+    let secondResolved = false
+    void secondConnect.then(() => {
+      secondResolved = true
+    })
+    await Promise.resolve()
+    expect(secondResolved).toBe(false)
+
+    finishMigration?.()
+    await expect(Promise.all([firstConnect, secondConnect])).resolves.toEqual([undefined, undefined])
+    await adapter.disconnect()
+  })
+
   it("creates parent directories for local libSQL file URLs", async () => {
     const dir = await mkdtemp(join(tmpdir(), "vitehub-agent-state-"))
     tempDirs.push(dir)

--- a/packages/agent/test/sqlite-state-provider.test.ts
+++ b/packages/agent/test/sqlite-state-provider.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { createClient } from "@libsql/client"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { createLibsqlAgentState, createSqliteAgentState, ViteHubSqliteAgentStateAdapter } from "../src/state/sqlite.ts"
+import { createLibsqlAgentState, createSqliteAgentState, type SqliteAgentStateDriver, ViteHubSqliteAgentStateAdapter } from "../src/state/sqlite.ts"
 
 import type { QueueEntry, StateAdapter } from "chat"
 
@@ -87,6 +87,34 @@ describe("SQLite Agent State Provider", () => {
     await state.connect()
     await expect(state.get("seen")).resolves.toBe("yes")
     await state.disconnect()
+  })
+
+  it("shares concurrent connect attempts", async () => {
+    let inTransaction = false
+    let migrations = 0
+    const driver: SqliteAgentStateDriver = {
+      async execute(statement: string) {
+        if (statement.includes("COALESCE(MAX(version)")) return { rows: [{ version: 2 }] }
+        return { rows: [] }
+      },
+      async transaction(run) {
+        if (inTransaction) throw new Error("concurrent migration")
+        inTransaction = true
+        try {
+          migrations += 1
+          await new Promise(resolve => setTimeout(resolve, 10))
+          return await run(driver)
+        }
+        finally {
+          inTransaction = false
+        }
+      },
+    }
+    const adapter = new ViteHubSqliteAgentStateAdapter({ driver })
+
+    await expect(Promise.all([adapter.connect(), adapter.connect()])).resolves.toEqual([undefined, undefined])
+    expect(migrations).toBe(1)
+    await adapter.disconnect()
   })
 
   it("creates parent directories for local libSQL file URLs", async () => {


### PR DESCRIPTION
## Summary

- make the SQLite Agent State Provider share concurrent `connect()` calls
- skip reconnect work when the adapter is already connected
- add a regression test for concurrent connect attempts using the existing injected driver surface

## Root Cause

Discord Gateway startup can forward `READY` and `GUILD_CREATE` into the same Agent Definition at the same time. Both Chat instances can call the same SQLite state adapter's `connect()` concurrently. The adapter set `connected = true` before migration/cleanup, but did not guard duplicate migrations, so local libSQL could hit `SQLITE_BUSY` or a later cleanup could observe a half-connected state.

## Validation

- `corepack pnpm exec vp test run test/sqlite-state-provider.test.ts` from `packages/agent`
- `corepack pnpm exec vp run -t @vite-hub/agent#build`
- `corepack pnpm --filter @vite-hub/agent typecheck`
- `git diff --check`