### PR TITLE
feat(agent): expose capability cli

### DIFF
--- a/docs/content/docs/capabilities/custom-capabilities.md
+++ b/docs/content/docs/capabilities/custom-capabilities.md
@@ -164,6 +164,7 @@ First-party adapters can generate the same CLI shape from their own metadata. Fo
 Custom Capability authors still pass a flat `cli` object; dynamic command generation belongs behind adapter-owned options such as `openapi({ cli })`.
 
 During development, run the Capability CLI through the Agent Dev Loop.
+Agents expose attached Capability CLI Contributions to compatible Agent Driver and Agent Dev Loop surfaces by default; use `defineAgent({ cli: { capabilities: false } })` when an Agent should attach the Capability but keep its CLI hidden.
 
 ```bash [Terminal]
 pnpm vitehub agent dev --url http://localhost:3000 --agent support --cli inventory -- items list --json

--- a/docs/content/docs/capabilities/openapi.md
+++ b/docs/content/docs/capabilities/openapi.md
@@ -135,6 +135,7 @@ openapi({
 ```
 
 Run the generated CLI through the Agent Dev Loop.
+Agents expose generated Capability CLI Contributions by default; use `defineAgent({ cli: { capabilities: false } })` to attach the OpenAPI Capability without exposing its CLI surface.
 
 ```bash [Terminal]
 pnpm vitehub agent dev --url http://localhost:3000 --agent support --cli billing -- list-customers --json

--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -97,6 +97,7 @@ pnpm vitehub agent dev --agent support --timeout 180000 -p "/summary"
 
 Use `--cli` when a Capability attached to the Agent declares a Capability CLI.
 Everything after `--` is parsed as the nested Capability CLI command.
+Attached Capability CLI Contributions are available to the Agent Dev Loop by default, including for harness-backed Agents; set `defineAgent({ cli: { capabilities: false } })` to hide them from this surface.
 During Agent runs, ViteHub renders operation tool calls as command lines, such as `api listCustomers --query '{"status":"active"}'`, instead of dumping the raw input object.
 
 ```bash [Terminal]

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -737,7 +737,7 @@ export async function resolveAgentCapabilities<
   const invocationContext = invocationOptions.context || createAgentInvocationContextStore(input.context)
   const invoker = invocationOptions.invoker || resolveInputAgentInvoker(input.context) || createFallbackAgentInvoker(runtime.run)
   const driverKind = invocationOptions.driverKind || "model"
-  const resolveCapabilityCli = driverKind !== "harness" || invocationOptions.resolveCapabilityCli === true
+  const resolveCapabilityCli = invocationOptions.resolveCapabilityCli ?? driverKind !== "harness"
   ensureAgentInvokerContext(invocationContext, invoker)
   const capabilities = normalizeCapabilities(options?.capabilities as AgentCapabilityDefinition[] | undefined) as AgentCapabilityDefinition<TRuntimeConfig, Name>[]
   assertWorkspaceSourceScopesRequireAccess(invocationOptions.workspaceDefinition, capabilities)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -199,6 +199,7 @@ export type {
   AgentDeliveryArtifact,
   AgentDeliveryArtifactPlacement,
   AgentDefinition,
+  AgentDefinitionCliOptions,
   AgentDevtoolsConfigMetadata,
   AgentDevtoolsConfigValue,
   AgentDevtoolsDriverMetadata,
@@ -348,7 +349,6 @@ export type {
 } from "./chat-trigger.ts"
 
 const syntheticWorkspaceRun = Symbol.for("vitehub.syntheticWorkspaceRun")
-const capabilityCliRunSurface = Symbol.for("vitehub.capabilityCliRunSurface")
 const baseAgentResolve = Symbol("vitehub.baseAgentResolve")
 const baseAgentModel = Symbol("vitehub.baseAgentModel")
 const baseAgentDriverKind = Symbol("vitehub.baseAgentDriverKind")
@@ -791,6 +791,11 @@ function capabilityWorkspaceIsOptional(capability: NormalizedCapability): boolea
     && (metadata as { [optionalWorkspaceCapabilitySymbol]?: unknown })[optionalWorkspaceCapabilitySymbol] === true
 }
 
+function resolveCapabilityCliRunSurface(definition: Pick<AgentDefinition, "cli"> | undefined): boolean {
+  if (definition?.cli?.capabilities !== undefined) return definition.cli.capabilities !== false
+  return true
+}
+
 function sandboxCapabilityRequiresWorkspace(capability: NormalizedCapability): boolean {
   if (capability.id !== "sandbox") return false
   const metadata = capability.metadata as { commands?: unknown } | undefined
@@ -815,7 +820,7 @@ function defineBaseAgent<
   options: AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile>,
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS> {
   const driver = normalizeAgentDriver(options)
-  const { capabilities, channels, description, hooks, messages, runtime, version, workspace } = options
+  const { capabilities, channels, cli, description, hooks, messages, runtime, version, workspace } = options
   const run = driver.kind === "run" ? driver.run : undefined
   const baseCapabilities = normalizeCapabilities(capabilities as AgentCapabilitiesList | undefined)
   const invoker = normalizeAgentInvokerOptions(options.invoker) as AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS> | undefined
@@ -855,6 +860,7 @@ function defineBaseAgent<
     [baseAgentResolve]: resolveBaseAgent,
     channels,
     chat,
+    cli,
     description,
     hooks,
     invoker,
@@ -1321,7 +1327,7 @@ async function createAgentInvocationContext<
         : undefined
     const agentModel = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentModel] as AgentModelResolver<TRuntimeConfig> | undefined
     const driverKind = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentDriverKind]
-    const resolveCapabilityCli = (definition as Record<PropertyKey, unknown> | undefined)?.[capabilityCliRunSurface] === true
+    const resolveCapabilityCli = resolveCapabilityCliRunSurface(definition)
     const capabilities = await resolveAgentCapabilities(capabilityOptions, runtimeContext, input, workspace as never, workspaceMode, {
       context: invocationContext,
       driverKind,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -858,6 +858,10 @@ export type AgentDriver<
   | AgentHarnessDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   | AgentRunDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
 
+export interface AgentDefinitionCliOptions {
+  capabilities?: boolean
+}
+
 type AgentSharedSettings<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -867,6 +871,7 @@ type AgentSharedSettings<
 > = {
   capabilities?: TCapabilities
   channels?: AgentChannels<TRuntimeConfig>
+  cli?: AgentDefinitionCliOptions
   description?: string
   hooks?: AgentCapabilityHooks<TRuntimeConfig> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
@@ -895,6 +900,7 @@ export interface AgentDefinition<
   capabilities?: AgentCapabilityDefinition<TRuntimeConfig>[]
   channels?: AgentChannels<TRuntimeConfig>
   chat?: AgentChatOptions<TRuntimeConfig>
+  cli?: AgentDefinitionCliOptions
   description?: string
   hooks?: AgentCapabilityHooks<TRuntimeConfig, WorkspaceName> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -499,10 +499,15 @@ function devRun(agent: string): AgentRunMetadata {
   }
 }
 
+function exposesCapabilityCli(agent: AgentInput): boolean {
+  const cli = (agent as { cli?: { capabilities?: boolean } }).cli
+  return cli?.capabilities !== false
+}
+
 function withCapabilityCliRun(agent: AgentInput, cli: string, execution: AgentCapabilityCliExecutionInput): AgentInput {
   const clone = Object.create(Object.getPrototypeOf(agent)) as AgentInput
   Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
-  Object.defineProperty(clone, capabilityCliRunSurface, { value: true })
+  if (exposesCapabilityCli(agent)) Object.defineProperty(clone, capabilityCliRunSurface, { value: true })
   clone.run = async (context) => {
     const tool = context.tools?.[cli]
     if (!tool || tool.metadata?.vitehubCapabilityCli !== true || typeof tool.execute !== "function") {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -1587,4 +1587,31 @@ describe("agent capability runtime", () => {
       vi.doUnmock("ai")
     }
   })
+
+  it("round-trips Capability CLI exposure through resolved Agent Definitions", async () => {
+    const { defineAgent, defineCapability, runAgentInline, withAgentDefaults } = await import("../src/index.ts")
+    const inventory = defineCapability({
+      cli: {
+        commands: {
+          list: {
+            run: () => [{ id: "item_1" }],
+          },
+        },
+        name: "inventory",
+      },
+      id: "inventory-runtime",
+    })
+    const exposed = withAgentDefaults(defineAgent({
+      capabilities: [inventory],
+      driver: { run: context => Object.keys(context.tools || {}) },
+    }), { inferredName: "chat" })
+    const hidden = withAgentDefaults(defineAgent({
+      capabilities: [inventory],
+      cli: { capabilities: false },
+      driver: { run: context => Object.keys(context.tools || {}) },
+    }), { inferredName: "chat" })
+
+    await expect(runAgentInline(exposed, runtime(), {}, { output: "raw" })).resolves.toEqual(["inventory"])
+    await expect(runAgentInline(hidden, runtime(), {}, { output: "raw" })).resolves.toEqual([])
+  })
 })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -797,6 +797,51 @@ describe("agent chat capability discovery", () => {
     })
   })
 
+  it("respects Capability CLI opt-out through the Vite endpoint", async () => {
+    const root = await createTempRoot("vitehub-agent-invocation-stream-cli-opt-out-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "chat.ts"), "export default {}", "utf8")
+
+    const { defineAgent, defineCapability } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          cli: {
+            commands: {
+              list: {
+                output: { format: "json" },
+                run: () => [{ id: "item_1" }],
+              },
+            },
+            name: "inventory",
+          },
+          id: "inventory-runtime",
+        }),
+      ],
+      cli: { capabilities: false },
+      driver: { harness: {} as never },
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
+
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      agent: "chat",
+      cli: {
+        argv: ["list", "--json"],
+        name: "inventory",
+      },
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    })
+
+    expect(response.statusCode).toBe(500)
+    expect(response.body).toContain("Agent Capability CLI \"inventory\" is not defined by this agent")
+  })
+
   it("preserves model driver context for Capability CLI dev runs", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-model-cli-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -552,6 +552,10 @@ describe("agent public types", () => {
     const _permissionModeDriver: AgentDriver = { harness: { provider: "codex" }, permissionMode: "allow-edits" }
 
     const _sandboxDriver: AgentDriver = { harness: { provider: "codex" }, sandbox: { provider: "sandbox" } }
+    defineAgent({
+      cli: { capabilities: false },
+      driver: { harness: { provider: "codex" } },
+    })
 
     defineAgent({
       driver: { harness: { provider: "codex" } },


### PR DESCRIPTION
## Before

Harness-backed Agents could expose Capability CLI Contributions only by setting `Symbol.for("vitehub.capabilityCliRunSurface")` on the Agent Definition. Canary evidence: `/Users/maxi/quiver/agents/server/agents/chat/config.ts:21` declares the symbol and line `168` assigns it to `chatAgent`.

## Expected

Agent Definitions should expose this through a typed public option, and the obvious Agent assumption should hold: an attached Capability CLI is available unless the Agent opts out.

## Changed

Added `defineAgent({ cli: { capabilities: false } })` as the typed opt-out. Capability CLI exposure now defaults on for resolved Agent Definitions, including harness-backed Agents, and the Vite Agent Invocation Stream Endpoint composes with the option instead of forcing the internal marker unconditionally.

Docs now mention the default and opt-out on the Capability CLI pages.

Note: ADR 0074 previously deferred harness Capability CLI exposure. This PR intentionally changes that contract to a default-on Agent Definition surface with an explicit opt-out.

## Checks

- `pnpm --filter @vite-hub/agent exec vp test run test/capability-runtime.test.ts test/discovery.test.ts`
- `pnpm --filter @vite-hub/agent exec vp test run test/discovery.test.ts`
- `pnpm --filter @vite-hub/agent exec vp test run test/capability-runtime.test.ts`
- `pnpm --filter @vite-hub/agent run typecheck`
- `pnpm --filter @vite-hub/agent run test`
- `git diff --check`