### PR TITLE
feat(agent): add finish effect helpers

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -186,6 +186,8 @@ export default defineAgent({
 
 GitHub comments and reviews need hosted markdown URLs instead of channel-native file uploads. The GitHub channel publishes workspace image paths that appear in reply or review bodies, then rewrites those paths to hosted raw URLs. Use `publishWorkspaceArtifacts()` from `@vite-hub/agent/channels` inside a finish effect when explicit GitHub artifacts need public URLs before delivery.
 
+Finish effects receive the final output event plus `context.workspace`, `context.run`, and `context.context` so app-side delivery code can read Workspace files and typed Agent Invocation Context values without re-parsing the stream.
+
 ```ts [server/agents/review.ts]
 import { defineAgent } from '@vite-hub/agent'
 import { defineFinishEffect, github, publishWorkspaceArtifacts, reply } from '@vite-hub/agent/channels'

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -155,20 +155,19 @@ Adapter-backed message channels, such as Slack, Telegram, Teams, Discord, and cu
 
 ```ts [server/agents/support.ts]
 import { defineAgent, defineCapability } from '@vite-hub/agent'
-import { telegram } from '@vite-hub/agent/channels'
+import { defineFinishEffect, reply, telegram } from '@vite-hub/agent/channels'
 
 const screenshotDelivery = defineCapability({
   id: 'screenshot-delivery',
   prepare(context) {
-    context.delivery.finishEffect(() => ({
+    context.delivery.finishEffect(defineFinishEffect(() => reply({
+      body: 'See attached screenshot.',
       artifacts: [{
         mediaType: 'image/png',
         path: 'screenshots/login.png',
         placement: 'attachment',
       }],
-      kind: 'reply',
-      payload: { body: 'See attached screenshot.' },
-    }))
+    })))
   },
 })
 
@@ -189,7 +188,7 @@ GitHub comments and reviews need hosted markdown URLs instead of channel-native 
 
 ```ts [server/agents/review.ts]
 import { defineAgent } from '@vite-hub/agent'
-import { github, publishWorkspaceArtifacts } from '@vite-hub/agent/channels'
+import { defineFinishEffect, github, publishWorkspaceArtifacts, reply } from '@vite-hub/agent/channels'
 import { blob } from '@vite-hub/blob'
 
 export default defineAgent({
@@ -197,21 +196,24 @@ export default defineAgent({
     github: github({
       app: true,
       pullRequest: {
-        reply: async (event, context) => ({
-          artifacts: await publishWorkspaceArtifacts(context, [{
-            alt: 'Login footer version badge',
-            mediaType: 'image/png',
-            path: 'screenshots/login-version-badge-desktop.png',
-            placement: 'inline',
-          }], {
-            prefix: `reviews/${context.run?.runId || crypto.randomUUID()}`,
-            publish: async ({ content, mediaType, pathname }) => {
-              const object = await blob.put(pathname, content, { access: 'public', contentType: mediaType })
-              return { url: object.url }
-            },
+        reply: defineFinishEffect(async (event, context) => {
+          if (event.error) return reply(`Review failed: ${event.errorMessage}`)
+          const body = event.text?.trim() || '_No review generated._'
+          return reply({
+            body,
+            artifacts: await publishWorkspaceArtifacts(context, [{
+              alt: 'Login footer version badge',
+              mediaType: 'image/png',
+              path: 'screenshots/login-version-badge-desktop.png',
+              placement: 'inline',
+            }], {
+              prefix: `reviews/${context.run?.runId || crypto.randomUUID()}`,
+              publish: async ({ content, mediaType, pathname }) => {
+                const object = await blob.put(pathname, content, { access: 'public', contentType: mediaType })
+                return { url: object.url }
+              },
+            }),
           }),
-          kind: 'review',
-          payload: { body: String(event.result || '').trim() || '_No review generated._' },
         }),
       },
     }),

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -199,8 +199,9 @@ export default defineAgent({
         reply: defineFinishEffect(async (event, context) => {
           if (event.error) return reply(`Review failed: ${event.errorMessage}`)
           const body = event.text?.trim() || '_No review generated._'
-          return reply({
-            body,
+          return {
+            kind: 'review',
+            payload: { body },
             artifacts: await publishWorkspaceArtifacts(context, [{
               alt: 'Login footer version badge',
               mediaType: 'image/png',
@@ -213,7 +214,7 @@ export default defineAgent({
                 return { url: object.url }
               },
             }),
-          }),
+          }
         }),
       },
     }),

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1336,7 +1336,11 @@ function statusPayload<TRuntimeConfig extends AgentRuntimeConfig>(
   context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
   defaultContext: string,
 ): GitHubPullRequestStatusPayload {
-  const payload = isRecord(context.effect.payload) ? context.effect.payload : {}
+  const payload = isRecord(context.effect.payload)
+    ? context.effect.payload
+    : typeof context.effect.payload === "string"
+      ? { state: context.effect.payload }
+      : {}
   return {
     context: payload.context || context.effect.metadata?.context || defaultContext,
     description: payload.description || context.effect.metadata?.description,

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1,6 +1,7 @@
 import { createHash, createSign } from "node:crypto"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY } from "./chat-trigger.ts"
 import { deliveryArtifactAttachments } from "./delivery-artifacts.ts"
+import { getAgentFinishText } from "./delivery-effects.ts"
 
 import type {
   AgentCallbackContext,
@@ -29,14 +30,26 @@ import type { AgentChannelChatRouteBody, AgentChannelChatRouteHandlerOptions } f
 import type { Adapter, FileUpload } from "chat"
 
 export { deliveryArtifactAttachments } from "./delivery-artifacts.ts"
+export { defineFinishEffect, getAgentFinishText, reaction, reply, status } from "./delivery-effects.ts"
+export type { AgentChannelDeliveryEffectIntentOptions } from "./delivery-effects.ts"
 export type {
   AgentChannelDeliveryEffectContext,
   AgentChannelDeliveryEffectHandler,
   AgentChannelDeliveryEffectIntent,
+  AgentChannelDeliveryEffectPayload,
   AgentChannelDeliveryEffectKind,
   AgentChannelDeliveryEffects,
   AgentChannelDeliveryFinishEffect,
+  AgentChannelDeliveryFinishEffectCallback,
+  AgentChannelDeliveryFinishEffectResult,
   AgentChannelDeliveryFinishEffectContext,
+  AgentChannelDeliveryReactionInput,
+  AgentChannelDeliveryReactionPayload,
+  AgentChannelDeliveryReplyInput,
+  AgentChannelDeliveryReplyPayload,
+  AgentChannelDeliveryStatusInput,
+  AgentChannelDeliveryStatusPayload,
+  AgentChannelDeliveryStatusState,
   AgentChannelDefinition,
   AgentChannels,
   AgentDeliveryArtifact,
@@ -977,6 +990,7 @@ function reactionContent<TRuntimeConfig extends AgentRuntimeConfig>(
 ): string {
   if (typeof context.effect.payload === "string") return context.effect.payload
   if (isRecord(context.effect.payload) && typeof context.effect.payload.content === "string") return context.effect.payload.content
+  if (isRecord(context.effect.payload) && typeof context.effect.payload.emoji === "string") return context.effect.payload.emoji
   if (context.effect.intent === "completed") return "hooray"
   if (context.effect.intent === "failed") return "confused"
   return "eyes"
@@ -1011,7 +1025,9 @@ function replyBody<TRuntimeConfig extends AgentRuntimeConfig>(
 ): string | undefined {
   if (typeof context.effect.payload === "string") return context.effect.payload
   if (isRecord(context.effect.payload) && typeof context.effect.payload.body === "string") return context.effect.payload.body
+  if (isRecord(context.effect.payload) && typeof context.effect.payload.markdown === "string") return context.effect.payload.markdown
   if (typeof context.effect.metadata?.body === "string") return context.effect.metadata.body
+  if (typeof context.effect.metadata?.markdown === "string") return context.effect.metadata.markdown
 }
 
 function replyBodyWithLinkArtifacts(body: string | undefined, artifacts: readonly PublishedAgentDeliveryArtifact[]): string | undefined {
@@ -1287,12 +1303,6 @@ async function githubBodyWithArtifacts<TRuntimeConfig extends AgentRuntimeConfig
   return rewrittenBody ? `${rewrittenBody}\n\n${explicitArtifacts.join("\n")}` : explicitArtifacts.join("\n")
 }
 
-function finishResultText(result: unknown): string | undefined {
-  if (typeof result === "string") return result
-  if (result instanceof Response) return
-  return isRecord(result) ? maybeString(result.text) : undefined
-}
-
 function finishUsageSummary(event: AgentFinishEvent): string | undefined {
   const usage = event.extensions.get("usage-telemetry")
   return maybeString(usage?.summary)
@@ -1303,7 +1313,7 @@ function githubNote(body: string): string {
 }
 
 function githubPullRequestCommentReplyEffect(event: AgentFinishEvent): AgentChannelDeliveryEffectIntent | undefined {
-  const text = finishResultText(event.result)
+  const text = getAgentFinishText(event)
   if (!text) return
   const body = text.trim() || "_No reply generated._"
   const summary = finishUsageSummary(event)

--- a/packages/agent/src/delivery-effects.ts
+++ b/packages/agent/src/delivery-effects.ts
@@ -39,8 +39,8 @@ export function defineFinishEffect<
 }
 
 export function getAgentFinishText(event: Pick<AgentFinishEvent, "result" | "text">): string | undefined {
-  if (typeof event.text === "string") return event.text
-  if (typeof event.result === "string") return event.result
+  if (typeof event.text === "string" && event.text) return event.text
+  if (typeof event.result === "string" && event.result) return event.result
   if (!event.result || typeof event.result !== "object" || event.result instanceof Response) return
   return textFromResult(event.result as Record<string, unknown>)
 }
@@ -69,8 +69,15 @@ function stringValue(record: Record<string, unknown>, key: string): string | und
   return typeof value === "string" ? value : undefined
 }
 
+function nonEmptyStringValue(record: Record<string, unknown>, key: string): string | undefined {
+  const value = stringValue(record, key)
+  return value || undefined
+}
+
 function textFromResult(result: Record<string, unknown>): string | undefined {
-  const text = stringValue(result, "text") ?? stringValue(result, "output") ?? stringValue(result, "_output")
+  const text = nonEmptyStringValue(result, "text")
+    ?? nonEmptyStringValue(result, "output")
+    ?? nonEmptyStringValue(result, "_output")
   if (text) return text
   const contentText = textFromContent(ownValue(result, "content"))
   if (contentText) return contentText
@@ -79,7 +86,7 @@ function textFromResult(result: Record<string, unknown>): string | undefined {
   for (const step of steps.slice().reverse()) {
     if (!step || typeof step !== "object") continue
     const record = step as Record<string, unknown>
-    const stepText = stringValue(record, "text") ?? textFromContent(ownValue(record, "content"))
+    const stepText = nonEmptyStringValue(record, "text") ?? textFromContent(ownValue(record, "content"))
     if (stepText) return stepText
   }
 }

--- a/packages/agent/src/delivery-effects.ts
+++ b/packages/agent/src/delivery-effects.ts
@@ -1,0 +1,108 @@
+import type {
+  AgentChannelDeliveryEffectIntent,
+  AgentChannelDeliveryFinishEffectCallback,
+  AgentChannelDeliveryReactionInput,
+  AgentChannelDeliveryReplyInput,
+  AgentChannelDeliveryStatusInput,
+  AgentFinishEvent,
+  AgentRuntimeConfig,
+  PublishedAgentDeliveryArtifact,
+} from "./types.ts"
+
+export interface AgentChannelDeliveryEffectIntentOptions {
+  artifacts?: readonly PublishedAgentDeliveryArtifact[]
+  intent?: string
+  metadata?: Record<string, unknown>
+}
+
+function intent<TKind extends "reaction" | "reply" | "status">(
+  kind: TKind,
+  payload: AgentChannelDeliveryEffectIntent<TKind>["payload"],
+  options: AgentChannelDeliveryEffectIntentOptions = {},
+): AgentChannelDeliveryEffectIntent<TKind> {
+  return {
+    kind,
+    ...(options.artifacts?.length ? { artifacts: options.artifacts } : {}),
+    ...(options.intent ? { intent: options.intent } : {}),
+    ...(options.metadata ? { metadata: options.metadata } : {}),
+    ...(payload !== undefined ? { payload } : {}),
+  }
+}
+
+export function defineFinishEffect<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+>(
+  effect: AgentChannelDeliveryFinishEffectCallback<TRuntimeConfig, CALL_OPTIONS>,
+): AgentChannelDeliveryFinishEffectCallback<TRuntimeConfig, CALL_OPTIONS> {
+  return effect
+}
+
+export function getAgentFinishText(event: Pick<AgentFinishEvent, "result" | "text">): string | undefined {
+  if (typeof event.text === "string") return event.text
+  if (typeof event.result === "string") return event.result
+  if (!event.result || typeof event.result !== "object" || event.result instanceof Response) return
+  return textFromResult(event.result as Record<string, unknown>)
+}
+
+function ownValue(record: Record<string, unknown>, key: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(record, key)
+  return descriptor && "value" in descriptor ? descriptor.value : undefined
+}
+
+function textFromContent(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return
+  const text = content.flatMap((part) => {
+    if (typeof part === "string") return [part]
+    if (!part || typeof part !== "object") return []
+    const record = part as Record<string, unknown>
+    const type = ownValue(record, "type")
+    if (type !== "text" && type !== "text-delta") return []
+    const value = ownValue(record, "text") ?? ownValue(record, "textDelta") ?? ownValue(record, "delta")
+    return typeof value === "string" ? [value] : []
+  }).join("")
+  return text || undefined
+}
+
+function stringValue(record: Record<string, unknown>, key: string): string | undefined {
+  const value = ownValue(record, key)
+  return typeof value === "string" ? value : undefined
+}
+
+function textFromResult(result: Record<string, unknown>): string | undefined {
+  const text = stringValue(result, "text") ?? stringValue(result, "output") ?? stringValue(result, "_output")
+  if (text) return text
+  const contentText = textFromContent(ownValue(result, "content"))
+  if (contentText) return contentText
+  const steps = ownValue(result, "steps")
+  if (!Array.isArray(steps)) return
+  for (const step of steps.slice().reverse()) {
+    if (!step || typeof step !== "object") continue
+    const record = step as Record<string, unknown>
+    const stepText = stringValue(record, "text") ?? textFromContent(ownValue(record, "content"))
+    if (stepText) return stepText
+  }
+}
+
+export function reply(
+  input: AgentChannelDeliveryReplyInput,
+  options: AgentChannelDeliveryEffectIntentOptions = {},
+): AgentChannelDeliveryEffectIntent<"reply"> {
+  if (typeof input === "string") return intent("reply", input, options)
+  const { artifacts, ...payload } = input
+  return intent("reply", payload, { ...options, artifacts: options.artifacts ?? artifacts })
+}
+
+export function reaction(
+  input: AgentChannelDeliveryReactionInput,
+  options: AgentChannelDeliveryEffectIntentOptions = {},
+): AgentChannelDeliveryEffectIntent<"reaction"> {
+  return intent("reaction", input, options)
+}
+
+export function status(
+  input: AgentChannelDeliveryStatusInput,
+  options: AgentChannelDeliveryEffectIntentOptions = {},
+): AgentChannelDeliveryEffectIntent<"status"> {
+  return intent("status", typeof input === "string" ? { state: input } : input, options)
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,6 +2,7 @@ import agentRegistry from "#vitehub/agent/registry"
 import { normalizeAgentDriver } from "./internal/agent-driver.ts"
 import { cloneWithPropertyDescriptors } from "./internal/stream-result.ts"
 import { agentErrorDetails, agentErrorMessage } from "./agent-error.ts"
+import { getAgentFinishText } from "./delivery-effects.ts"
 import { getMessageText } from "./messages.ts"
 import { resolveRuntimeContext } from "@vite-hub/runtime"
 import { isAsyncIterable, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent } from "./agent-output.ts"
@@ -80,8 +81,18 @@ import type {
   AgentCapabilityTypeContract,
   AgentChannelDeliveryEffectHandler,
   AgentChannelDeliveryEffectIntent,
+  AgentChannelDeliveryEffectPayload,
   AgentChannelDeliveryFinishEffect,
+  AgentChannelDeliveryFinishEffectCallback,
+  AgentChannelDeliveryFinishEffectResult,
   AgentChannelDeliveryFinishEffectContext,
+  AgentChannelDeliveryReactionInput,
+  AgentChannelDeliveryReactionPayload,
+  AgentChannelDeliveryReplyInput,
+  AgentChannelDeliveryReplyPayload,
+  AgentChannelDeliveryStatusInput,
+  AgentChannelDeliveryStatusPayload,
+  AgentChannelDeliveryStatusState,
   AgentDeliveryArtifact,
   AgentDeliveryArtifactPlacement,
   AgentDefinition,
@@ -177,9 +188,19 @@ export type {
   AgentChannelDeliveryEffectHandler,
   AgentChannelDeliveryFinishEffect,
   AgentChannelDeliveryEffectIntent,
+  AgentChannelDeliveryEffectPayload,
   AgentChannelDeliveryEffectKind,
   AgentChannelDeliveryEffects,
+  AgentChannelDeliveryFinishEffectCallback,
+  AgentChannelDeliveryFinishEffectResult,
   AgentChannelDeliveryFinishEffectContext,
+  AgentChannelDeliveryReactionInput,
+  AgentChannelDeliveryReactionPayload,
+  AgentChannelDeliveryReplyInput,
+  AgentChannelDeliveryReplyPayload,
+  AgentChannelDeliveryStatusInput,
+  AgentChannelDeliveryStatusPayload,
+  AgentChannelDeliveryStatusState,
   AgentChatAgentHookArgs,
   AgentChatErrorHookArgs,
   AgentChatEventHookArgs,
@@ -734,6 +755,8 @@ function once<TArgs extends unknown[]>(callback: (...args: TArgs) => Promise<voi
 
 export { applyAgentToolPolicies, withAgentToolStepReporting } from "./tool-runtime.ts"
 export { defineCapability } from "./capability-runtime.ts"
+export { defineFinishEffect, getAgentFinishText, reaction, reply, status } from "./delivery-effects.ts"
+export type { AgentChannelDeliveryEffectIntentOptions } from "./delivery-effects.ts"
 export { isResolvedAgentTriggerHandledInvocation, verifyAgentWebhookRequest } from "./trigger-runtime.ts"
 export type { AgentWebhookVerificationResult, ResolvedAgentTriggerHandledInvocation, ResolvedAgentTriggerInvocation, ResolvedAgentTriggerInvocationResult } from "./trigger-runtime.ts"
 export * from "./messages.ts"
@@ -1501,8 +1524,15 @@ function withStreamResultProperties<T extends AsyncIterable<StreamEvent>>(stream
 function resultWithStreamedText(result: unknown, text: string): unknown {
   if (!text || typeof result === "string") return result
   if (result && typeof result === "object" && !(result instanceof Response)) {
-    const current = (result as { text?: unknown }).text
-    return typeof current === "string" && current ? result : { ...result, text }
+    const descriptor = Object.getOwnPropertyDescriptor(result, "text")
+    const current = descriptor && "value" in descriptor ? descriptor.value : undefined
+    return typeof current === "string" && current ? result : cloneWithPropertyDescriptors(result, {
+      text: {
+        configurable: true,
+        enumerable: true,
+        value: text,
+      },
+    })
   }
   return { raw: result, text }
 }
@@ -1746,6 +1776,7 @@ async function finishAgentInvocation<
   const failed = outcome.status === "error"
   const error = failed ? outcome.error : undefined
   const result = outcome.status === "success" ? outcome.result : undefined
+  const text = failed ? undefined : getAgentFinishText({ result })
   try {
     await context.close()
     if (hasFinishWork(context)) {
@@ -1762,6 +1793,7 @@ async function finishAgentInvocation<
         },
         ...(result !== undefined ? { result } : {}),
         runtime: context.runtimeContext,
+        ...(text !== undefined ? { text } : {}),
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
       const finishEvent = { ...eventBase, extensions }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -720,6 +720,7 @@ async function applyChannelDeliveryEffectIntents<
           await handler({
             ...context.runtimeContext,
             channel: active.channel,
+            context: context.context,
             effect: intent,
             ...(finish ? { finish: finish as never } : {}),
             input: context.input,
@@ -1753,6 +1754,7 @@ async function resolveFinishDeliveryEffectIntents<
   const intents: AgentChannelDeliveryEffectIntent[] = []
   const finishContext = {
     ...context.runtimeContext,
+    context: context.context,
     input: context.input,
     run: context.run,
     workspace: context.workspace,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -183,13 +183,48 @@ export interface PublishedAgentDeliveryArtifact extends AgentDeliveryArtifact {
 
 export interface AgentChannelDeliveryEffectIntent<
   TKind extends AgentChannelDeliveryEffectKind = AgentChannelDeliveryEffectKind,
+  TPayload = AgentChannelDeliveryEffectPayload<TKind>,
 > {
   artifacts?: readonly PublishedAgentDeliveryArtifact[]
   intent?: string
   kind: TKind
   metadata?: Record<string, unknown>
-  payload?: unknown
+  payload?: TPayload
 }
+
+export interface AgentChannelDeliveryReplyPayload {
+  artifacts?: readonly PublishedAgentDeliveryArtifact[]
+  body?: string
+  markdown?: string
+}
+
+export type AgentChannelDeliveryReplyInput = string | AgentChannelDeliveryReplyPayload
+
+export interface AgentChannelDeliveryReactionPayload {
+  action?: "remove" | (string & {})
+  content?: string
+  emoji?: string
+}
+
+export type AgentChannelDeliveryReactionInput = string | AgentChannelDeliveryReactionPayload
+
+export type AgentChannelDeliveryStatusState = "error" | "failure" | "pending" | "success" | (string & {})
+
+export interface AgentChannelDeliveryStatusPayload {
+  context?: string
+  description?: string
+  sha?: string
+  state?: AgentChannelDeliveryStatusState
+  target_url?: string
+}
+
+export type AgentChannelDeliveryStatusInput = AgentChannelDeliveryStatusState | AgentChannelDeliveryStatusPayload
+
+export type AgentChannelDeliveryEffectPayload<TKind extends AgentChannelDeliveryEffectKind> =
+  TKind extends "reaction" ? AgentChannelDeliveryReactionInput
+    : TKind extends "reply" ? AgentChannelDeliveryReplyInput
+      : TKind extends "status" ? AgentChannelDeliveryStatusInput
+        : unknown
 
 export interface AgentChannelDeliveryEffectContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -209,10 +244,11 @@ export interface AgentChannelDeliveryEffectContext<
 
 export interface AgentChannelDeliveryFinishEffectContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
 > extends AgentCallbackContext<TRuntimeConfig> {
-  input: AgentRunInput
+  input: AgentRunInput<CALL_OPTIONS>
   run?: AgentRunMetadata
-  workspace?: ReadonlyWorkspaceFacade | WritableWorkspaceFacade
+  workspace?: ReadonlyWorkspaceFacade
 }
 
 export type AgentChannelDeliveryEffectHandler<
@@ -222,10 +258,19 @@ export type AgentChannelDeliveryEffectHandler<
 export type AgentChannelDeliveryEffects<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
 > = Partial<Record<AgentChannelDeliveryEffectKind, AgentChannelDeliveryEffectHandler<TRuntimeConfig> | readonly AgentChannelDeliveryEffectHandler<TRuntimeConfig>[]>>
-export type AgentChannelDeliveryFinishEffect =
+export type AgentChannelDeliveryFinishEffectResult =
+  AgentChannelDeliveryEffectIntent | readonly AgentChannelDeliveryEffectIntent[] | false | null | undefined
+export type AgentChannelDeliveryFinishEffectCallback<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> = (event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, context: AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<AgentChannelDeliveryFinishEffectResult>
+export type AgentChannelDeliveryFinishEffect<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> =
   | AgentChannelDeliveryEffectIntent
   | readonly AgentChannelDeliveryEffectIntent[]
-  | ((event: AgentFinishEvent, context: AgentChannelDeliveryFinishEffectContext) => MaybePromise<AgentChannelDeliveryEffectIntent | readonly AgentChannelDeliveryEffectIntent[] | false | null | undefined>)
+  | AgentChannelDeliveryFinishEffectCallback<TRuntimeConfig, CALL_OPTIONS>
 
 export interface AgentTriggerRunInvokeResult<CALL_OPTIONS = unknown> {
   delivery?: {
@@ -379,6 +424,7 @@ export interface AgentFinishEvent<
   }
   result?: unknown
   runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>
+  text?: string
 }
 
 export type AgentFinishHook<

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -230,6 +230,7 @@ export interface AgentChannelDeliveryEffectContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
 > extends AgentCallbackContext<TRuntimeConfig> {
   channel: AgentChannelDefinition<TRuntimeConfig>
+  context: AgentInvocationContextStore
   effect: AgentChannelDeliveryEffectIntent
   finish?: AgentFinishEvent<TRuntimeConfig>
   input: AgentRunInput
@@ -246,6 +247,7 @@ export interface AgentChannelDeliveryFinishEffectContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
 > extends AgentCallbackContext<TRuntimeConfig> {
+  context: AgentInvocationContextStore
   input: AgentRunInput<CALL_OPTIONS>
   run?: AgentRunMetadata
   workspace?: ReadonlyWorkspaceFacade

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -302,6 +302,72 @@ describe("agent channels", () => {
     expect(postedBodies[0]).not.toContain("[result](![")
   })
 
+  it("normalizes hand-written GitHub PR status string payloads", async () => {
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
+    const statusBodies: Array<Record<string, unknown>> = []
+    const fetcher = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url)
+      if (href.endsWith("/app/installations/789/access_tokens")) {
+        return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
+      }
+      if (href.endsWith("/pulls/42")) return Response.json({ base: { sha: "base-sha" }, head: { sha: "head-sha" } })
+      if (href.endsWith("/statuses/head-sha")) {
+        statusBodies.push(JSON.parse(String(init?.body)))
+        return Response.json({ ok: true }, { status: 201 })
+      }
+      throw new Error(`Unexpected GitHub API call: ${href}`)
+    })
+    const channel = github({
+      app: {
+        apiBaseUrl: "https://api.github.test",
+        appId: "4",
+        fetch: fetcher as typeof fetch,
+        installationId: 789,
+        privateKey: privateKeyPem,
+        statusContext: "ViteHub Test",
+      },
+    })
+    const statusEffect = channel.effects?.status
+    if (typeof statusEffect !== "function") throw new Error("Missing GitHub status effect.")
+
+    await statusEffect({
+      channel,
+      effect: {
+        kind: "status",
+        payload: "success",
+      },
+      input: {
+        context: {
+          github: {
+            action: "created",
+            actor: { login: "onmax" },
+            args: "",
+            body: "/review",
+            command: "/review",
+            commentId: 99,
+            installationId: 789,
+            issueNumber: 42,
+            owner: "vite-hub",
+            pullRequestUrl: "https://api.github.test/repos/vite-hub/vitehub/pulls/42",
+            repo: "vitehub",
+            repository: "vite-hub/vitehub",
+          },
+        },
+        prompt: "/review",
+      },
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)
+
+    expect(statusBodies).toEqual([{
+      context: "ViteHub Test",
+      state: "success",
+    }])
+  })
+
   it("ignores GitHub PR delivery effects without pull request context", async () => {
     const { github } = await import("../src/channels.ts")
     const channel = github({

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -3,6 +3,25 @@ import { generateKeyPairSync } from "node:crypto"
 import { describe, expect, it, vi } from "vitest"
 
 describe("agent channels", () => {
+  it("falls back to output fields when finish result text is empty", async () => {
+    const { getAgentFinishText } = await import("../src/channels.ts")
+
+    expect(getAgentFinishText({
+      result: {
+        _output: "structured fallback",
+        output: "output fallback",
+        text: "",
+      },
+    })).toBe("output fallback")
+
+    expect(getAgentFinishText({
+      result: {
+        _output: "structured fallback",
+        text: "",
+      },
+    })).toBe("structured fallback")
+  })
+
   it("creates Discord adapters from provider defaults", async () => {
     vi.resetModules()
     const createDiscordAdapter = vi.fn(() => ({ name: "discord" }))

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2481,7 +2481,7 @@ describe("agent message protocol", () => {
 
   it("lets Channel triggers expose finish delivery effects", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
-    const { defineChannel } = await import("../src/channels.ts")
+    const { defineChannel, defineFinishEffect, reply } = await import("../src/channels.ts")
     const order: string[] = []
     const effect = vi.fn((context) => {
       order.push(`effect:${context.effect.payload}`)
@@ -2505,10 +2505,7 @@ describe("agent message protocol", () => {
             message: {
               invoke: context => ({
                 delivery: {
-                  finishEffects: event => ({
-                    kind: "reply",
-                    payload: `result:${event.result}:${(event.extensions.get("marker") as { value?: string } | undefined)?.value}`,
-                  }),
+                  finishEffects: defineFinishEffect(event => reply(`result:${event.text}:${(event.extensions.get("marker") as { value?: string } | undefined)?.value}`)),
                 },
                 input: { prompt: "hello" },
                 run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run" },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2485,6 +2485,7 @@ describe("agent message protocol", () => {
     const order: string[] = []
     const effect = vi.fn((context) => {
       order.push(`effect:${context.effect.payload}`)
+      expect(context.context.get("review.context")).toEqual({ number: 42 })
       expect(context.finish?.result).toBe("ok")
       expect(context.finish?.extensions.get("marker")).toEqual({ value: "done" })
     })
@@ -2505,9 +2506,13 @@ describe("agent message protocol", () => {
             message: {
               invoke: context => ({
                 delivery: {
-                  finishEffects: defineFinishEffect(event => reply(`result:${event.text}:${(event.extensions.get("marker") as { value?: string } | undefined)?.value}`)),
+                  finishEffects: defineFinishEffect((event, finishContext) => {
+                    const reviewContext = finishContext.context.get<{ number: number }>("review.context")
+                    expect(reviewContext).toEqual({ number: 42 })
+                    return reply(`result:${event.text}:${(event.extensions.get("marker") as { value?: string } | undefined)?.value}:${reviewContext?.number}`)
+                  }),
                 },
-                input: { prompt: "hello" },
+                input: { context: { "review.context": { number: 42 } }, prompt: "hello" },
                 run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run" },
               }),
             },
@@ -2522,7 +2527,7 @@ describe("agent message protocol", () => {
 
     await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
     expect(effect).toHaveBeenCalledOnce()
-    expect(order).toEqual(["run", "effect:result:ok:done"])
+    expect(order).toEqual(["run", "effect:result:ok:done:42"])
   })
 
   it("lets finish delivery effects publish Workspace artifacts", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentDeliveryArtifact, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, getUsageTelemetry, git, inputCommands, kv, mcp, observability, openapi, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, getAgentFinishText, reaction, reply, status, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentDeliveryArtifact, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, observability, openapi, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -9,7 +9,7 @@ import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../src/output.ts"
 import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentUsageRecord, StreamEvent } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
-import { fetch as fetchSource, file, github as githubSource } from "@vite-hub/workspace"
+import { fetch as fetchSource, file, github as githubSource, type ReadonlyWorkspaceFacade } from "@vite-hub/workspace"
 import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatRunContext, FetchCapabilityToolOptions, PullRequestContextValue, RepositoryHostClient, TranscriptionResult, UsageTelemetryOutputExtension, UsageTelemetrySummaryOptions } from "../src/capabilities.ts"
 
 describe("agent public types", () => {
@@ -683,6 +683,21 @@ describe("agent public types", () => {
       kind: "reply",
       payload: event.result,
     })
+    const renderBody = async (text: string, workspace?: ReadonlyWorkspaceFacade) => `${text}:${Boolean(workspace)}`
+    const typedFinishEffect = defineFinishEffect(async (event, { workspace }) => {
+      expectTypeOf(event.text).toEqualTypeOf<string | undefined>()
+      expectTypeOf(getAgentFinishText(event)).toEqualTypeOf<string | undefined>()
+      expectTypeOf(workspace).toEqualTypeOf<ReadonlyWorkspaceFacade | undefined>()
+      if (event.error) return reply(`failed: ${event.errorMessage}`)
+      const text = event.text
+      if (!text) return
+      return reply(await renderBody(text, workspace))
+    })
+    expectTypeOf(typedFinishEffect).toMatchTypeOf<AgentChannelDeliveryFinishEffect>()
+    expectTypeOf(reply("done")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"reply">>()
+    expectTypeOf(reaction("eyes")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"reaction">>()
+    expectTypeOf(status("pending")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"status">>()
+    expectTypeOf(reply({ markdown: "done" }).payload).toEqualTypeOf<AgentChannelDeliveryReplyPayload | string | undefined>()
     // @ts-expect-error Development samples belong in CLI payload files, not Channel options.
     teams({ dev: { samples: {} } })
     // @ts-expect-error Development samples belong in CLI payload files, not Channel Definitions.

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, getAgentFinishText, reaction, reply, status, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentDeliveryArtifact, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, observability, openapi, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, getUsageTelemetry, git, inputCommands, kv, mcp, observability, openapi, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -684,9 +684,11 @@ describe("agent public types", () => {
       payload: event.result,
     })
     const renderBody = async (text: string, workspace?: ReadonlyWorkspaceFacade) => `${text}:${Boolean(workspace)}`
-    const typedFinishEffect = defineFinishEffect(async (event, { workspace }) => {
+    const typedFinishEffect = defineFinishEffect(async (event, { context, workspace }) => {
       expectTypeOf(event.text).toEqualTypeOf<string | undefined>()
       expectTypeOf(getAgentFinishText(event)).toEqualTypeOf<string | undefined>()
+      expectTypeOf(context).toEqualTypeOf<AgentChannelDeliveryFinishEffectContext["context"]>()
+      expectTypeOf(context.get<{ repository: string }>("review.context")).toEqualTypeOf<{ repository: string } | undefined>()
       expectTypeOf(workspace).toEqualTypeOf<ReadonlyWorkspaceFacade | undefined>()
       if (event.error) return reply(`failed: ${event.errorMessage}`)
       const text = event.text
@@ -708,6 +710,7 @@ describe("agent public types", () => {
           expectTypeOf(context.effect.kind).toEqualTypeOf<AgentChannelDeliveryEffectKind>()
           expectTypeOf(context.effect).toEqualTypeOf<AgentChannelDeliveryEffectIntent>()
           expectTypeOf(context.effect.artifacts?.[0]).toEqualTypeOf<PublishedAgentDeliveryArtifact | undefined>()
+          expectTypeOf(context.context).toEqualTypeOf<AgentChannelDeliveryEffectContext["context"]>()
           expectTypeOf(context.workspace).toEqualTypeOf<AgentChannelDeliveryEffectContext["workspace"]>()
         },
       },
@@ -721,6 +724,7 @@ describe("agent public types", () => {
             return {
               delivery: {
                 finishEffects: (event, context) => {
+                  expectTypeOf(context.context).toEqualTypeOf<AgentChannelDeliveryFinishEffectContext["context"]>()
                   expectTypeOf(context.workspace).toEqualTypeOf<AgentChannelDeliveryFinishEffectContext["workspace"]>()
                   return {
                     artifacts: [{ path: "screenshots/result.png", url: "https://assets.example/result.png" }],


### PR DESCRIPTION
What we had: finish and delivery effects could see the final finish event and Workspace, while usage telemetry was available through finish extensions. App-side delivery code still had to dig through raw input to read typed Agent Invocation Context values.

What we expected: app-side finish and delivery effects should receive the final output text, normalized usage via `usageTelemetry.from(event)`, Workspace filesystem access, run metadata, and typed Agent Invocation Context access in the same callback path.

The change: keeps the finish-effect helpers from this PR, rebases them onto the merged usage telemetry accessor, and exposes `context.context` to finish-effect resolvers and delivery-effect handlers. Downstream apps can now compose replies from `event.text`, `usageTelemetry.from(event)`, `context.workspace`, `context.run`, and `context.context` without re-parsing streams.
