### PR TITLE
fix(agent): format dev loop stream errors

### DIFF
--- a/packages/agent/src/agent-error.ts
+++ b/packages/agent/src/agent-error.ts
@@ -21,6 +21,40 @@ function isError(error: object): boolean {
   }
 }
 
+function stringifyErrorValue(value: unknown): string | undefined {
+  const seen = new WeakSet<object>()
+  try {
+    return JSON.stringify(value, (_key, item) => {
+      if (typeof item === "bigint") return `${item}n`
+      if (typeof item === "function") return `[Function${item.name ? `: ${item.name}` : ""}]`
+      if (typeof item === "symbol") return String(item)
+      if (item && typeof item === "object") {
+        if (seen.has(item)) return "[Circular]"
+        seen.add(item)
+      }
+      return item
+    })
+  }
+  catch {
+    return undefined
+  }
+}
+
+export function formatAgentError(error: unknown, fallback = "Unknown error."): string {
+  if (error instanceof Error) return error.stack || error.message || error.name || fallback
+  if (typeof error === "string") return error || fallback
+  const text = stringifyErrorValue(error)
+  if (text) return text
+  if (error === undefined) return fallback
+  try {
+    const fallbackText = String(error)
+    return fallbackText && fallbackText !== "[object Object]" ? fallbackText : fallback
+  }
+  catch {
+    return fallback
+  }
+}
+
 export function agentErrorDetails(error: unknown, fallback = "Unknown error."): NormalizedAgentError {
   if (typeof error === "string") return { message: error || fallback }
   if (typeof error === "object" && error !== null) {

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path"
 
 import { readWorkspaceDevToken, workspaceDevTokenHeader } from "@vite-hub/workspace/server"
 
+import { formatAgentError } from "./agent-error.ts"
 import { vercelAiGatewayPricing, type AgentUsagePricing } from "./capabilities/usage-telemetry.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig, type ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, readAgentInvocationStream } from "./invocation-stream.ts"
@@ -848,7 +849,8 @@ async function sendDevMessage(
       context.stderr.write("\n[aborted]\n")
       return history
     }
-    throw error
+    context.stderr.write(`${formatAgentError(error, "Agent Dev Loop request failed.")}\n`)
+    return
   }
   if (!response.ok) {
     context.stderr.write(`${await response.text()}\n`)
@@ -991,7 +993,7 @@ async function sendDevMessage(
       }
       if (event.type === "error") {
         clearPendingFallback()
-        context.stderr.write(`\n${event.error}\n`)
+        context.stderr.write(`\n${formatAgentError(event.error, "Agent Invocation Stream failed.")}\n`)
         return
       }
     }
@@ -1002,7 +1004,8 @@ async function sendDevMessage(
       context.stderr.write("\n[aborted]\n")
       return history
     }
-    throw error
+    context.stderr.write(`\n${formatAgentError(error, "Agent Invocation Stream failed.")}\n`)
+    return
   }
   clearPendingFallback()
   if (delayTextForPreview && !previewSeen && output) {

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -1,3 +1,4 @@
+import { formatAgentError } from "./agent-error.ts"
 import type { StreamEvent } from "./messages.ts"
 import type { AgentChannelDeliveryEffectIntent, AgentRunMetadata } from "./types.ts"
 
@@ -115,7 +116,7 @@ export function createAgentInvocationStreamResponse(
           if (closed || abortController.signal.aborted) return
           clearTimeoutSignal()
           emit(controller, {
-            error: cause instanceof Error ? cause.message : "Agent Invocation Stream failed.",
+            error: cause instanceof Error ? cause.message : formatAgentError(cause, "Agent Invocation Stream failed."),
             type: "error",
           })
           if (emit(controller, { type: "done" })) close(controller)

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -821,6 +821,50 @@ describe("agent CLI", () => {
     expect(stderr.output()).not.toContain("verbose review prose")
   })
 
+  it("formats structured Agent Dev Loop stream errors", async () => {
+    async function runWithPost(response: Response) {
+      const stderr = stream()
+      const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        if (init?.method === "POST") return response
+        return Response.json({
+          agents: [{ name: "review", triggers: ["github.webhook"] }],
+          root: "/repo",
+        })
+      })
+
+      const exitCode = await runAgentDevCli(["--agent", "review", "--trigger", "github.webhook", "-p", "/review"], {
+        cwd: "/repo",
+        env: {},
+        rootDir: "/repo",
+        spawn: vi.fn(),
+        stderr,
+        stdout: stream(),
+      }, { fetch: fetchAgentStream as never })
+
+      return { exitCode, stderr: stderr.output() }
+    }
+
+    const emitted = await runWithPost(ndjson([
+      { agent: "review", trigger: "github.webhook", type: "start" },
+      { error: { code: "reaction_preview_failed", message: "GitHub reaction preview failed", status: 422 }, type: "error" },
+      { type: "done" },
+    ]))
+    expect(emitted.exitCode).toBe(1)
+    expect(emitted.stderr).toContain(`{"code":"reaction_preview_failed","message":"GitHub reaction preview failed","status":422}`)
+    expect(emitted.stderr).not.toContain("[object Object]")
+
+    const thrown = await runWithPost(new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error({ code: "stream_read_failed", message: "reader failed" })
+      },
+    }), {
+      headers: { "content-type": "application/x-ndjson" },
+    }))
+    expect(thrown.exitCode).toBe(1)
+    expect(thrown.stderr).toContain(`{"code":"stream_read_failed","message":"reader failed"}`)
+    expect(thrown.stderr).not.toContain("[object Object]")
+  })
+
   it("runs Evalite through the Node runner with ViteHub defaults", async () => {
     const runner = vi.fn(async () => ({ exitCode: undefined }))
     const exitCode = await runAgentEvalCli(["server/agents/support.eval.ts"], {

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -39,4 +39,20 @@ describe("Agent Invocation Stream", () => {
       { type: "done" },
     ])
   })
+
+  it("formats non-Error thrown values as stream errors", async () => {
+    const response = createAgentInvocationStreamResponse(async () => {
+      throw { code: "delivery_preview_failed", status: 422 }
+    })
+
+    const events = []
+    for await (const event of readAgentInvocationStream(response.body!)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { error: `{"code":"delivery_preview_failed","status":422}`, type: "error" },
+      { type: "done" },
+    ])
+  })
 })


### PR DESCRIPTION
Formats Agent Dev Loop and invocation-stream failures with structured details instead of letting non-Error values collapse to `[object Object]`.

The root cause was direct string interpolation of stream error payloads and thrown values. This keeps Error message/stack behavior, emits JSON for structured object payloads, and falls back without exposing `[object Object]` for unserializable values.

Validated with focused `@vite-hub/agent` build, CLI/invocation-stream tests, typecheck, and `git diff --check`.