### PR TITLE
fix(agent): honor webhook runtimes

### DIFF
--- a/packages/agent/src/http-response.ts
+++ b/packages/agent/src/http-response.ts
@@ -17,7 +17,7 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
 const workflowProviders = new Set(["cloudflare", "openworkflow", "vercel"])
 const workflowRunStatuses = new Set(["completed", "failed", "queued", "running", "unknown"])
 
-function isWorkflowRun(value: unknown): value is { id: string, metadata?: unknown, provider: string, result?: unknown, status: string } {
+export function isWorkflowRun(value: unknown): value is { id: string, metadata?: unknown, provider: string, result?: unknown, status: string } {
   if (typeof value !== "object" || value === null) return false
   const run = value as { id?: unknown, provider?: unknown, status?: unknown }
   const provider = run.provider

--- a/packages/agent/src/http-response.ts
+++ b/packages/agent/src/http-response.ts
@@ -14,6 +14,21 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
   return !!value && typeof value === "object" && Symbol.asyncIterator in value
 }
 
+const workflowProviders = new Set(["cloudflare", "openworkflow", "vercel"])
+const workflowRunStatuses = new Set(["completed", "failed", "queued", "running", "unknown"])
+
+function isWorkflowRun(value: unknown): value is { id: string, metadata?: unknown, provider: string, result?: unknown, status: string } {
+  if (typeof value !== "object" || value === null) return false
+  const run = value as { id?: unknown, provider?: unknown, status?: unknown }
+  const provider = run.provider
+  const status = run.status
+  return typeof run.id === "string"
+    && typeof provider === "string"
+    && workflowProviders.has(provider)
+    && typeof status === "string"
+    && workflowRunStatuses.has(status)
+}
+
 export function toAgentEventStreamResponse(stream: AsyncIterable<unknown>): Response {
   const encoder = new TextEncoder()
   return new Response(new ReadableStream({
@@ -38,6 +53,16 @@ export function toAgentEventStreamResponse(stream: AsyncIterable<unknown>): Resp
 export function toJsonSafeAgentResult(value: unknown) {
   if (typeof value !== "object" || value === null) {
     return value
+  }
+
+  if (isWorkflowRun(value)) {
+    return {
+      id: value.id,
+      ...(value.metadata !== undefined ? { metadata: value.metadata } : {}),
+      provider: value.provider,
+      ...(value.result !== undefined ? { result: value.result } : {}),
+      status: value.status,
+    }
   }
 
   const result = value as Record<string, unknown>

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -254,6 +254,14 @@ function createBadRequest(message: string): Response {
   return createJsonErrorResponse(400, message)
 }
 
+function isQueuedWorkflowRun(value: unknown): value is { provider: string, status: "queued" } {
+  return typeof value === "object"
+    && value !== null
+    && "provider" in value
+    && "status" in value
+    && (value as { status?: unknown }).status === "queued"
+}
+
 function serializeErrorForLog(error: unknown, seen = new WeakSet<object>()): unknown {
   if (!(error instanceof Error)) {
     return error
@@ -2355,7 +2363,9 @@ export function createChannelWebhookRouteHandler(
             ...context,
             ...(invocation.run ? { run: invocation.run } : {}),
           } as never, invocation.input as never)
-          await context.flushWaitUntil?.()
+          if (!isQueuedWorkflowRun(result)) {
+            await context.flushWaitUntil?.()
+          }
           return toAgentFetchResponse(result, false)
         }
         catch (error) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -16,7 +16,7 @@ import { createAgentRuntimeContext } from "../runtime/context.ts"
 import { createAgentUIMessageStreamResponse } from "../stream-output.ts"
 import { isResolvedAgentTriggerHandledInvocation, verifyAgentWebhookRequest } from "../trigger-runtime.ts"
 import { toHttpErrorResponse } from "../http-error.ts"
-import { toAgentFetchResponse } from "../http-response.ts"
+import { isWorkflowRun, toAgentFetchResponse } from "../http-response.ts"
 import { createChatDevtoolsStreamResponse } from "../chat/devtools-stream.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 
@@ -252,14 +252,6 @@ function createJsonErrorResponse(status: number, message: string): Response {
 
 function createBadRequest(message: string): Response {
   return createJsonErrorResponse(400, message)
-}
-
-function isQueuedWorkflowRun(value: unknown): value is { provider: string, status: "queued" } {
-  return typeof value === "object"
-    && value !== null
-    && "provider" in value
-    && "status" in value
-    && (value as { status?: unknown }).status === "queued"
 }
 
 function serializeErrorForLog(error: unknown, seen = new WeakSet<object>()): unknown {
@@ -2363,7 +2355,7 @@ export function createChannelWebhookRouteHandler(
             ...context,
             ...(invocation.run ? { run: invocation.run } : {}),
           } as never, invocation.input as never)
-          if (!isQueuedWorkflowRun(result)) {
+          if (!isWorkflowRun(result) || result.status !== "queued") {
             await context.flushWaitUntil?.()
           }
           return toAgentFetchResponse(result, false)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3,7 +3,7 @@ import { runWithActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflar
 import { createRuntimeWaitUntilController } from "@vite-hub/runtime"
 import { Chat, StreamingPlan } from "chat"
 
-import { resolveAgentTriggerInvocation, resolveAgentTriggers, runAgentInline, streamAgent, streamAgentTrigger } from "../index.ts"
+import { resolveAgentTriggerInvocation, resolveAgentTriggers, runAgent, runAgentInline, streamAgent, streamAgentTrigger } from "../index.ts"
 import { streamAgentOutputToEvents } from "../agent-output.ts"
 import { getAccessCapabilityOptions } from "../capabilities/access-metadata.ts"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions } from "../chat-trigger.ts"
@@ -2351,7 +2351,7 @@ export function createChannelWebhookRouteHandler(
             await context.flushWaitUntil?.()
             return invocation.response
           }
-          const result = await runAgentInline(agent as never, {
+          const result = await runAgent(agent as never, {
             ...context,
             ...(invocation.run ? { run: invocation.run } : {}),
           } as never, invocation.input as never)

--- a/packages/agent/test/http-response.test.ts
+++ b/packages/agent/test/http-response.test.ts
@@ -24,6 +24,23 @@ describe("agent HTTP response helpers", () => {
     })
   })
 
+  it("keeps JSON-safe Workflow Run fields", () => {
+    expect(toJsonSafeAgentResult({
+      id: "github:delivery",
+      metadata: { workflow: "support-agent" },
+      payload: { prompt: "private input" },
+      provider: "vercel",
+      result: "accepted",
+      status: "queued",
+    })).toEqual({
+      id: "github:delivery",
+      metadata: { workflow: "support-agent" },
+      provider: "vercel",
+      result: "accepted",
+      status: "queued",
+    })
+  })
+
   it("returns host-native Response objects unchanged", () => {
     const response = Response.json({ ok: true })
 

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2723,6 +2723,51 @@ describe("server helpers", () => {
     expect(run).toHaveBeenCalledOnce()
   })
 
+  it("flushes waitUntil for non-workflow webhook results shaped like queued provider responses", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { github } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    let flushed = false
+    const run = vi.fn((context) => {
+      context.waitUntil(Promise.resolve().then(() => {
+        flushed = true
+      }))
+      return { provider: "github", status: "queued" }
+    })
+    const agent = defineAgent({
+      channels: {
+        github: github({
+          triggers: {
+            webhook: {
+              invoke: () => ({ input: { prompt: "github delivery" } }),
+            },
+          },
+          webhooks: { secretToken: "secret-token" },
+        }),
+      },
+      driver: {
+        run
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    const body = JSON.stringify({ action: "opened" })
+    const response = await handler(new Request("https://example.com/api/github/webhook", {
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-github-delivery": "delivery-direct",
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": githubSignature("secret-token", body),
+      },
+      method: "POST",
+    }), "")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({})
+    expect(flushed).toBe(true)
+    expect(run).toHaveBeenCalledOnce()
+  })
+
   it("runs GitHub channel webhooks through workflow-backed agents", async () => {
     const { defineAgent, workflow } = await import("../src/index.ts")
     const { github } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2729,7 +2729,14 @@ describe("server helpers", () => {
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const { getWorkflowRun } = await import("@vite-hub/workflow")
     const { resetWorkflowRuntime, setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
-    const run = vi.fn(context => `accepted ${context.prompt}`)
+    let releaseRun!: () => void
+    const runFinished = new Promise<void>(resolve => {
+      releaseRun = resolve
+    })
+    const run = vi.fn(async (context) => {
+      await runFinished
+      return `accepted ${context.prompt}`
+    })
     const agent = defineAgent({
       channels: {
         github: github({
@@ -2754,7 +2761,7 @@ describe("server helpers", () => {
     setWorkflowRuntimeConfig({ provider: "vercel" })
 
     try {
-      const response = await handler(new Request("https://example.com/api/github/webhook", {
+      const responsePromise = handler(new Request("https://example.com/api/github/webhook", {
         body,
         headers: {
           "content-type": "application/json",
@@ -2764,6 +2771,17 @@ describe("server helpers", () => {
         },
         method: "POST",
       }), "")
+      const response = await Promise.race([
+        responsePromise,
+        new Promise<"blocked">(resolve => setTimeout(() => resolve("blocked"), 25)),
+      ])
+
+      if (response === "blocked") {
+        releaseRun()
+        await responsePromise
+      }
+      expect(response).not.toBe("blocked")
+      if (response === "blocked") throw new Error("Workflow webhook response waited for deferred workflow completion.")
       const json = await response.json()
 
       expect(response.status).toBe(200)
@@ -2773,11 +2791,14 @@ describe("server helpers", () => {
         status: "queued",
       })
       expect(json).not.toHaveProperty("payload")
-      expect(run).toHaveBeenCalledOnce()
-      await expect(getWorkflowRun("support-agent", "github:delivery-workflow")).resolves.toMatchObject({
-        result: "accepted github delivery",
-        status: "completed",
+      releaseRun()
+      await vi.waitFor(async () => {
+        await expect(getWorkflowRun("support-agent", "github:delivery-workflow")).resolves.toMatchObject({
+          result: "accepted github delivery",
+          status: "completed",
+        })
       })
+      expect(run).toHaveBeenCalledOnce()
     }
     finally {
       resetWorkflowRuntime()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2723,6 +2723,67 @@ describe("server helpers", () => {
     expect(run).toHaveBeenCalledOnce()
   })
 
+  it("runs GitHub channel webhooks through workflow-backed agents", async () => {
+    const { defineAgent, workflow } = await import("../src/index.ts")
+    const { github } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { getWorkflowRun } = await import("@vite-hub/workflow")
+    const { resetWorkflowRuntime, setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+    const run = vi.fn(context => `accepted ${context.prompt}`)
+    const agent = defineAgent({
+      channels: {
+        github: github({
+          triggers: {
+            webhook: {
+              invoke: () => ({
+                input: { prompt: "github delivery" },
+                run: { channelId: "github", origin: "github", runId: "github:delivery-workflow" },
+              }),
+            },
+          },
+          webhooks: { secretToken: "secret-token" },
+        }),
+      },
+      driver: {
+        run
+      },
+      runtime: workflow("support-agent"),
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    const body = JSON.stringify({ action: "opened" })
+    setWorkflowRuntimeConfig({ provider: "vercel" })
+
+    try {
+      const response = await handler(new Request("https://example.com/api/github/webhook", {
+        body,
+        headers: {
+          "content-type": "application/json",
+          "x-github-delivery": "delivery-workflow",
+          "x-github-event": "pull_request",
+          "x-hub-signature-256": githubSignature("secret-token", body),
+        },
+        method: "POST",
+      }), "")
+      const json = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(json).toMatchObject({
+        id: "github:delivery-workflow",
+        provider: "vercel",
+        status: "queued",
+      })
+      expect(json).not.toHaveProperty("payload")
+      expect(run).toHaveBeenCalledOnce()
+      await expect(getWorkflowRun("support-agent", "github:delivery-workflow")).resolves.toMatchObject({
+        result: "accepted github delivery",
+        status: "completed",
+      })
+    }
+    finally {
+      resetWorkflowRuntime()
+    }
+  })
+
   it("lets signed GitHub channel webhooks return a handled response without running the agent", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { github } = await import("../src/channels.ts")


### PR DESCRIPTION
## What changed

Quiver carried a dist-level patch for `@vite-hub/agent` that swapped the channel webhook path from `runAgentInline` to `runAgent`. This moves that fix upstream.

Webhook-triggered non-chat Agent Invocations now go through `runAgent`, so an Agent Definition with `runtime: workflow(...)` starts a Workflow Run. Agents without a workflow runtime still fall back to inline through `runAgent`.

The shared HTTP response helper now preserves safe Workflow Run fields (`id`, `provider`, `status`, optional `metadata`/`result`) and omits `payload` from JSON responses.

## Call sites

Changed: non-chat `createChannelWebhookRouteHandler` Agent Trigger Consumer. Bypassing `runAgent` there ignored the Agent Definition runtime.

Left inline: chat webhook handling and DevTools/live chat streaming paths. Those paths post or stream platform responses inside the chat adapter flow, and the existing non-streaming chat webhook workflow test still asserts inline behavior.

## Validation

- `pnpm --filter @vite-hub/agent test`
- `pnpm --filter @vite-hub/agent typecheck`
