### PR TITLE
fix(agent): pass sqlite state to generated webhooks

### DIFF
--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -84,7 +84,9 @@ function subpath(base: string, path: string): string {
 
 type NitroConfig = Record<string, unknown> & CloudflareAgentStateRollupTarget & CloudflareAgentStateTarget
 type RollupExternalFunction = (source: string, importer?: string, isResolved?: boolean) => boolean | null | undefined | void
-type GeneratedLibsqlAgentStateOptions = Pick<ResolvedAgentModuleOptions["providers"]["state"], "tablePrefix" | "url">
+type GeneratedLibsqlAgentStateOptions = Pick<ResolvedAgentModuleOptions["providers"]["state"], "tablePrefix" | "url"> & {
+  authTokenEnvName?: string
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
@@ -96,11 +98,19 @@ function shouldInstallCloudflareAgentState(options: false | ResolvedAgentModuleO
   return provider === "auto" || provider === "cloudflare" || provider === "cloudflare-agents"
 }
 
+function resolveEnvNameForValue(value: string | undefined): string | undefined {
+  if (!value) return
+  return Object.entries(process.env)
+    .find(([name, envValue]) => name && envValue === value)?.[0]
+}
+
 function resolveLibsqlAgentState(options: false | ResolvedAgentModuleOptions): GeneratedLibsqlAgentStateOptions | undefined {
   if (!options) return
-  const { provider, tablePrefix, url } = options.providers.state
+  const { authToken, provider, tablePrefix, url } = options.providers.state
   if (provider !== "sqlite" && provider !== "libsql") return
+  const authTokenEnvName = resolveEnvNameForValue(authToken)
   return {
+    ...(authTokenEnvName ? { authTokenEnvName } : {}),
     ...(tablePrefix ? { tablePrefix } : {}),
     ...(url ? { url } : {}),
   }
@@ -308,11 +318,16 @@ function generatedCloudflareChatStateHelper(): string[] {
 }
 
 function generatedLibsqlChatStateHelper(state: GeneratedLibsqlAgentStateOptions): string[] {
+  const { authTokenEnvName, ...stateOptions } = state
+  const configuredAuthTokenOption = authTokenEnvName
+    ? [`  ...(typeof process === 'object' && process?.env?.${authTokenEnvName} ? { authToken: process.env.${authTokenEnvName} } : {}),`]
+    : []
   return [
     "",
-    `const viteHubChatStateOptions = ${JSON.stringify(state)}`,
+    `const viteHubChatStateOptions = ${JSON.stringify(stateOptions)}`,
     "const viteHubChatState = createLibsqlAgentState({",
     "  ...viteHubChatStateOptions,",
+    ...configuredAuthTokenOption,
     "  ...(typeof process === 'object' && process?.env?.VITEHUB_AGENT_STATE_AUTH_TOKEN ? { authToken: process.env.VITEHUB_AGENT_STATE_AUTH_TOKEN } : {}),",
     "  ...(typeof process === 'object' && process?.env?.VITEHUB_AGENT_STATE_URL ? { url: process.env.VITEHUB_AGENT_STATE_URL } : {}),",
     "})",

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -106,6 +106,10 @@ function resolveLibsqlAgentState(options: false | ResolvedAgentModuleOptions): G
   }
 }
 
+function resolveWebhookLibsqlAgentState(options: ResolvedAgentModuleOptions): GeneratedLibsqlAgentStateOptions | undefined {
+  return options.routes.webhooks ? resolveLibsqlAgentState(options) : undefined
+}
+
 function cloneStringArray(value: unknown): string[] | undefined {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : undefined
 }
@@ -922,7 +926,7 @@ async function writeNetlifyAgentProviderOutput(
     ...generatedOptions,
     chatRoute: options.routes.chat,
     discordGatewayRoute: options.routes.discordGateway,
-    libsqlState: generatedOptions.libsqlState ?? resolveLibsqlAgentState(options),
+    libsqlState: generatedOptions.libsqlState ?? resolveWebhookLibsqlAgentState(options),
     webhookRoute: options.routes.webhooks,
   })
   await writeProviderDeploymentOutputs({
@@ -1052,7 +1056,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
               agentImportBase: getAgentImportBase(agent),
               chatRoute: normalized.routes.chat,
               cloudflareState: shouldInstallCloudflareAgentState(normalized),
-              libsqlState: resolveLibsqlAgentState(normalized),
+              libsqlState: resolveWebhookLibsqlAgentState(normalized),
               ...(config.command === "serve" ? { runtime: "vite" as const } : {}),
               workspaceImportBase: getWorkspaceImportBase(agent),
               webhookRoute: normalized.routes.webhooks,
@@ -1070,7 +1074,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
           if (config.command === "serve" && isNetlifyHosting(config)) {
             await writeNetlifyAgentProviderOutput(config, normalized, {
               agentImportBase: getAgentImportBase(agent),
-              libsqlState: resolveLibsqlAgentState(normalized),
+              libsqlState: resolveWebhookLibsqlAgentState(normalized),
               runtime: "vite",
               workspaceImportBase: getWorkspaceImportBase(agent),
             })
@@ -1109,7 +1113,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         if (normalized && isNetlifyHosting(resolved) && (normalized.routes.chat || normalized.routes.webhooks || normalized.routes.discordGateway)) {
           await writeNetlifyAgentProviderOutput(resolved, normalized, {
             agentImportBase: getAgentImportBase(agent),
-            libsqlState: resolveLibsqlAgentState(normalized),
+            libsqlState: resolveWebhookLibsqlAgentState(normalized),
             workspaceImportBase: getWorkspaceImportBase(agent),
           })
         } else if (isNetlifyHosting(resolved)) {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -320,7 +320,7 @@ function generatedCloudflareChatStateHelper(): string[] {
 function generatedLibsqlChatStateHelper(state: GeneratedLibsqlAgentStateOptions): string[] {
   const { authTokenEnvName, ...stateOptions } = state
   const configuredAuthTokenOption = authTokenEnvName
-    ? [`  ...(typeof process === 'object' && process?.env?.${authTokenEnvName} ? { authToken: process.env.${authTokenEnvName} } : {}),`]
+    ? [`  ...(typeof process === 'object' && process?.env?.[${JSON.stringify(authTokenEnvName)}] ? { authToken: process.env[${JSON.stringify(authTokenEnvName)}] } : {}),`]
     : []
   return [
     "",

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -97,7 +97,7 @@ function shouldInstallCloudflareAgentState(options: false | ResolvedAgentModuleO
 }
 
 function resolveLibsqlAgentState(options: false | ResolvedAgentModuleOptions): GeneratedLibsqlAgentStateOptions | undefined {
-  if (!options || !options.routes.webhooks) return
+  if (!options) return
   const { provider, tablePrefix, url } = options.providers.state
   if (provider !== "sqlite" && provider !== "libsql") return
   return {
@@ -510,9 +510,11 @@ async function generateAgentNetlifyFunctionRouteHandler(
     .join(",\n  ")
   const hostedWorkspaceRuntime = generatedHostedWorkspaceRuntimeSetup(definitions, workspaceImportBase)
   const webhookSelector = routeUsesParam(options.webhookRoute, "webhook") ? "netlifyParam(context, 'webhook')" : "''"
+  const webhookStateOption = options.libsqlState ? "state: chatStateFromLibsql(), " : ""
 
   return [
     `import { withAgentDefaults, workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
+    ...(options.libsqlState ? [`import { createLibsqlAgentState } from ${JSON.stringify(subpath(agentImportBase, "state/sqlite"))}`] : []),
     `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler, createDiscordGatewayRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
     `import { setWorkspaceRuntimeRegistry } from ${JSON.stringify(subpath(agentImportBase, "server/workspace"))}`,
     ...hostedWorkspaceRuntime.imports,
@@ -559,6 +561,7 @@ async function generateAgentNetlifyFunctionRouteHandler(
     "}",
     "",
     ...hostedWorkspaceRuntime.setup,
+    ...(options.libsqlState ? generatedLibsqlChatStateHelper(options.libsqlState) : []),
     ...generatedNetlifyRuntimeHelpers(),
     "",
     `setWorkspaceRuntimeRegistry(Object.fromEntries([${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}].filter(Boolean)))`,
@@ -604,7 +607,7 @@ async function generateAgentNetlifyFunctionRouteHandler(
     "    }",
     `    return await handler(request, { agentName: agent, durationMs${runtimeRouteOption}, waitUntil, webhookUrl })`,
     "  }",
-    `  return isWebhookRoute ? await handler(request, webhook, { agentName: agent${runtimeRouteOption}, waitUntil }) : await handler(request, { agentName: agent${runtimeRouteOption}, waitUntil })`,
+    `  return isWebhookRoute ? await handler(request, webhook, { agentName: agent${runtimeRouteOption}, ${webhookStateOption}waitUntil }) : await handler(request, { agentName: agent${runtimeRouteOption}, waitUntil })`,
     "}",
     "",
   ].join("\n")
@@ -884,7 +887,7 @@ async function writeAgentDenoServer(
 
 async function writeAgentNetlifyFunctionRouteHandler(
   root: string,
-  options: { chatRoute?: false | string, discordGatewayRoute?: false | string, runtime?: "vite", webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
+  options: { chatRoute?: false | string, discordGatewayRoute?: false | string, libsqlState?: GeneratedLibsqlAgentStateOptions, runtime?: "vite", webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
 ): Promise<string> {
   const handlerPath = join(root, generatedAgentNetlifyFunction)
   const definitions = discoverAgentDefinitions({
@@ -910,11 +913,16 @@ function createNetlifyAgentFunctionConfig(options: { chatRoute?: false | string,
   }
 }
 
-async function writeNetlifyAgentProviderOutput(config: ResolvedConfig, options: ResolvedAgentModuleOptions, generatedOptions: AgentGeneratedImportOptions & { runtime?: "vite" } = {}): Promise<void> {
+async function writeNetlifyAgentProviderOutput(
+  config: ResolvedConfig,
+  options: ResolvedAgentModuleOptions,
+  generatedOptions: AgentGeneratedImportOptions & { libsqlState?: GeneratedLibsqlAgentStateOptions, runtime?: "vite" } = {},
+): Promise<void> {
   const handlerPath = await writeAgentNetlifyFunctionRouteHandler(config.root, {
     ...generatedOptions,
     chatRoute: options.routes.chat,
     discordGatewayRoute: options.routes.discordGateway,
+    libsqlState: generatedOptions.libsqlState ?? resolveLibsqlAgentState(options),
     webhookRoute: options.routes.webhooks,
   })
   await writeProviderDeploymentOutputs({
@@ -1062,6 +1070,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
           if (config.command === "serve" && isNetlifyHosting(config)) {
             await writeNetlifyAgentProviderOutput(config, normalized, {
               agentImportBase: getAgentImportBase(agent),
+              libsqlState: resolveLibsqlAgentState(normalized),
               runtime: "vite",
               workspaceImportBase: getWorkspaceImportBase(agent),
             })
@@ -1100,6 +1109,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         if (normalized && isNetlifyHosting(resolved) && (normalized.routes.chat || normalized.routes.webhooks || normalized.routes.discordGateway)) {
           await writeNetlifyAgentProviderOutput(resolved, normalized, {
             agentImportBase: getAgentImportBase(agent),
+            libsqlState: resolveLibsqlAgentState(normalized),
             workspaceImportBase: getWorkspaceImportBase(agent),
           })
         } else if (isNetlifyHosting(resolved)) {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -84,6 +84,7 @@ function subpath(base: string, path: string): string {
 
 type NitroConfig = Record<string, unknown> & CloudflareAgentStateRollupTarget & CloudflareAgentStateTarget
 type RollupExternalFunction = (source: string, importer?: string, isResolved?: boolean) => boolean | null | undefined | void
+type GeneratedLibsqlAgentStateOptions = Pick<ResolvedAgentModuleOptions["providers"]["state"], "authToken" | "tablePrefix" | "url">
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
@@ -93,6 +94,17 @@ function shouldInstallCloudflareAgentState(options: false | ResolvedAgentModuleO
   if (!options || !options.routes.webhooks) return false
   const provider = options.providers.state.provider
   return provider === "auto" || provider === "cloudflare" || provider === "cloudflare-agents"
+}
+
+function resolveLibsqlAgentState(options: false | ResolvedAgentModuleOptions): GeneratedLibsqlAgentStateOptions | undefined {
+  if (!options || !options.routes.webhooks) return
+  const { authToken, provider, tablePrefix, url } = options.providers.state
+  if (provider !== "sqlite" && provider !== "libsql") return
+  return {
+    ...(authToken ? { authToken } : {}),
+    ...(tablePrefix ? { tablePrefix } : {}),
+    ...(url ? { url } : {}),
+  }
 }
 
 function cloneStringArray(value: unknown): string[] | undefined {
@@ -292,6 +304,21 @@ function generatedCloudflareChatStateHelper(): string[] {
   ]
 }
 
+function generatedLibsqlChatStateHelper(state: GeneratedLibsqlAgentStateOptions): string[] {
+  return [
+    "",
+    `const viteHubChatStateOptions = ${JSON.stringify(state)}`,
+    "const viteHubChatState = createLibsqlAgentState({",
+    "  ...viteHubChatStateOptions,",
+    "  ...(typeof process === 'object' && process?.env?.VITEHUB_AGENT_STATE_URL ? { url: process.env.VITEHUB_AGENT_STATE_URL } : {}),",
+    "})",
+    "",
+    "function chatStateFromLibsql() {",
+    "  return viteHubChatState",
+    "}",
+  ]
+}
+
 function generatedNetlifyRuntimeHelpers(): string[] {
   return [
     "function waitUntilFromContext(context) {",
@@ -335,7 +362,7 @@ function generatedHostedWorkspaceRuntimeSetup(definitions: DiscoveredAgentDefini
 async function generateAgentWebhookRouteHandler(
   definitions: DiscoveredAgentDefinition[],
   handlerPath: string,
-  options: { chatRoute?: false | string, cloudflareState?: boolean, runtime?: "vite", webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
+  options: { chatRoute?: false | string, cloudflareState?: boolean, libsqlState?: GeneratedLibsqlAgentStateOptions, runtime?: "vite", webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
 ): Promise<string> {
   const agentImportBase = options.agentImportBase ?? agentPackageName
   const workspaceImportBase = options.workspaceImportBase ?? workspacePackageName
@@ -366,10 +393,16 @@ async function generateAgentWebhookRouteHandler(
   const hostedWorkspaceRuntime = generatedHostedWorkspaceRuntimeSetup(definitions, workspaceImportBase)
   const webhookRoute = typeof options.webhookRoute === "string" ? options.webhookRoute : ""
   const webhookSelector = webhookRoute.includes("[webhook]") ? "getRouterParam(event, 'webhook')" : "''"
+  const webhookStateOption = options.cloudflareState
+    ? "state: chatStateFromCloudflare(cloudflare), "
+    : options.libsqlState
+      ? "state: chatStateFromLibsql(), "
+      : ""
 
   return [
     `import { withAgentDefaults, workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
     ...(options.cloudflareState ? [`import { createCloudflareAgentState } from ${JSON.stringify(subpath(agentImportBase, "cloudflare"))}`] : []),
+    ...(options.libsqlState ? [`import { createLibsqlAgentState } from ${JSON.stringify(subpath(agentImportBase, "state/sqlite"))}`] : []),
     `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
     `import { setWorkspaceRuntimeRegistry } from ${JSON.stringify(subpath(workspaceImportBase, "runtime"))}`,
     ...hostedWorkspaceRuntime.imports,
@@ -417,6 +450,7 @@ async function generateAgentWebhookRouteHandler(
     "",
     ...generatedRuntimeHelpers(),
     ...(options.cloudflareState ? generatedCloudflareChatStateHelper() : []),
+    ...(options.libsqlState ? generatedLibsqlChatStateHelper(options.libsqlState) : []),
     "",
     `setWorkspaceRuntimeRegistry(Object.fromEntries([${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}].filter(Boolean)))`,
     "",
@@ -438,9 +472,7 @@ async function generateAgentWebhookRouteHandler(
     "    throw createError({ statusCode: 404, statusMessage: 'Unknown ViteHub agent.' })",
     "  }",
     "  const cloudflare = cloudflareFromEvent(event)",
-    options.cloudflareState
-      ? `  return isWebhookRoute ? await handler(await toRequest(event), webhook, { agentName: agent, cloudflare${runtimeRouteOption}, state: chatStateFromCloudflare(cloudflare), waitUntil: waitUntilFromEvent(event) }) : await handler(await toRequest(event), { agentName: agent, cloudflare${runtimeRouteOption}, waitUntil: waitUntilFromEvent(event) })`
-      : `  return isWebhookRoute ? await handler(await toRequest(event), webhook, { agentName: agent, cloudflare${runtimeRouteOption}, waitUntil: waitUntilFromEvent(event) }) : await handler(await toRequest(event), { agentName: agent, cloudflare${runtimeRouteOption}, waitUntil: waitUntilFromEvent(event) })`,
+    `  return isWebhookRoute ? await handler(await toRequest(event), webhook, { agentName: agent, cloudflare${runtimeRouteOption}, ${webhookStateOption}waitUntil: waitUntilFromEvent(event) }) : await handler(await toRequest(event), { agentName: agent, cloudflare${runtimeRouteOption}, waitUntil: waitUntilFromEvent(event) })`,
     "})",
     "",
   ].join("\n")
@@ -580,7 +612,7 @@ async function generateAgentNetlifyFunctionRouteHandler(
 
 async function writeAgentWebhookRouteHandler(
   root: string,
-  options: { chatRoute?: false | string, cloudflareState?: boolean, runtime?: "vite", webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
+  options: { chatRoute?: false | string, cloudflareState?: boolean, libsqlState?: GeneratedLibsqlAgentStateOptions, runtime?: "vite", webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
 ): Promise<void> {
   const handlerPath = join(root, generatedAgentWebhookRouteHandler)
   const definitions = discoverAgentDefinitions({
@@ -1012,6 +1044,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
               agentImportBase: getAgentImportBase(agent),
               chatRoute: normalized.routes.chat,
               cloudflareState: shouldInstallCloudflareAgentState(normalized),
+              libsqlState: resolveLibsqlAgentState(normalized),
               ...(config.command === "serve" ? { runtime: "vite" as const } : {}),
               workspaceImportBase: getWorkspaceImportBase(agent),
               webhookRoute: normalized.routes.webhooks,

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -481,7 +481,7 @@ async function generateAgentWebhookRouteHandler(
 async function generateAgentNetlifyFunctionRouteHandler(
   definitions: DiscoveredAgentDefinition[],
   handlerPath: string,
-  options: { chatRoute?: false | string, discordGatewayRoute?: false | string, runtime?: "vite", webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
+  options: { chatRoute?: false | string, discordGatewayRoute?: false | string, libsqlState?: GeneratedLibsqlAgentStateOptions, runtime?: "vite", webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
 ): Promise<string> {
   const agentImportBase = options.agentImportBase ?? agentPackageName
   const workspaceImportBase = options.workspaceImportBase ?? workspacePackageName

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -84,7 +84,7 @@ function subpath(base: string, path: string): string {
 
 type NitroConfig = Record<string, unknown> & CloudflareAgentStateRollupTarget & CloudflareAgentStateTarget
 type RollupExternalFunction = (source: string, importer?: string, isResolved?: boolean) => boolean | null | undefined | void
-type GeneratedLibsqlAgentStateOptions = Pick<ResolvedAgentModuleOptions["providers"]["state"], "authToken" | "tablePrefix" | "url">
+type GeneratedLibsqlAgentStateOptions = Pick<ResolvedAgentModuleOptions["providers"]["state"], "tablePrefix" | "url">
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
@@ -98,10 +98,9 @@ function shouldInstallCloudflareAgentState(options: false | ResolvedAgentModuleO
 
 function resolveLibsqlAgentState(options: false | ResolvedAgentModuleOptions): GeneratedLibsqlAgentStateOptions | undefined {
   if (!options || !options.routes.webhooks) return
-  const { authToken, provider, tablePrefix, url } = options.providers.state
+  const { provider, tablePrefix, url } = options.providers.state
   if (provider !== "sqlite" && provider !== "libsql") return
   return {
-    ...(authToken ? { authToken } : {}),
     ...(tablePrefix ? { tablePrefix } : {}),
     ...(url ? { url } : {}),
   }
@@ -310,6 +309,7 @@ function generatedLibsqlChatStateHelper(state: GeneratedLibsqlAgentStateOptions)
     `const viteHubChatStateOptions = ${JSON.stringify(state)}`,
     "const viteHubChatState = createLibsqlAgentState({",
     "  ...viteHubChatStateOptions,",
+    "  ...(typeof process === 'object' && process?.env?.VITEHUB_AGENT_STATE_AUTH_TOKEN ? { authToken: process.env.VITEHUB_AGENT_STATE_AUTH_TOKEN } : {}),",
     "  ...(typeof process === 'object' && process?.env?.VITEHUB_AGENT_STATE_URL ? { url: process.env.VITEHUB_AGENT_STATE_URL } : {}),",
     "})",
     "",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -684,6 +684,7 @@ describe("agent Vite plugin", () => {
     for (const provider of ["sqlite", "libsql"] as const) {
       const root = await mkdtemp(join(tmpdir(), `vitehub-agent-${provider}-state-routes-`))
       try {
+        vi.stubEnv("TURSO_AUTH_TOKEN", "build-token")
         await mkdir(join(root, "server", "agents"), { recursive: true })
         await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
         const plugin = hubAgent({
@@ -708,6 +709,7 @@ describe("agent Vite plugin", () => {
         expect(webhookRoute).toContain("const viteHubChatStateOptions = {\"tablePrefix\":\"agent_state_\",\"url\":\"file:build-state.sqlite\"}")
         expect(webhookRoute).not.toContain("build-token")
         expect(webhookRoute).toContain("const viteHubChatState = createLibsqlAgentState({")
+        expect(webhookRoute).toContain("process.env.TURSO_AUTH_TOKEN")
         expect(webhookRoute).toContain("process.env.VITEHUB_AGENT_STATE_AUTH_TOKEN")
         expect(webhookRoute).toContain("process.env.VITEHUB_AGENT_STATE_URL")
         expect(webhookRoute).toContain("function chatStateFromLibsql()")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -218,12 +218,24 @@ describe("agent Vite plugin", () => {
       delete process.env.NETLIFY
       await mkdir(join(root, "server", "agents"), { recursive: true })
       await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
-      const plugin = hubAgent({ routes: { chat: true, discordGateway: true, webhooks: "api/hooks/[webhook]" } })
-      const configResolved = plugin.configResolved as (config: { build?: { outDir?: string }, command: "build", resolve: { alias: Array<{ find: string, replacement: string }> }, root: string }) => Promise<void>
+      const agentOptions = {
+        providers: {
+          state: {
+            authToken: "build-token",
+            provider: "libsql",
+            tablePrefix: "agent_state_",
+            url: "file:build-state.sqlite",
+          },
+        },
+        routes: { chat: true, discordGateway: true, webhooks: "api/hooks/[webhook]" },
+      }
+      const plugin = hubAgent(agentOptions)
+      const configResolved = plugin.configResolved as (config: { agent?: unknown, build?: { outDir?: string }, command: "build", resolve: { alias: Array<{ find: string, replacement: string }> }, root: string }) => Promise<void>
       const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
       vi.mocked(writeProviderDeploymentOutputs).mockClear()
 
       await configResolved({
+        agent: agentOptions,
         build: { outDir: "dist/client" },
         command: "build",
         resolve: { alias: [{ find: "#support", replacement: join(root, "support.ts") }] },
@@ -245,6 +257,11 @@ describe("agent Vite plugin", () => {
       expect(wrapper).toContain("VITEHUB_DISCORD_GATEWAY_WEBHOOK_URL")
       expect(wrapper).toContain("const webhookRoute = \"/api/hooks/:webhook\"")
       expect(wrapper).toContain("routePath(webhookRoute, { agent, webhook })")
+      expect(wrapper).toContain("import { createLibsqlAgentState } from \"@vite-hub/agent/state/sqlite\"")
+      expect(wrapper).toContain("const viteHubChatStateOptions = {\"tablePrefix\":\"agent_state_\",\"url\":\"file:build-state.sqlite\"}")
+      expect(wrapper).not.toContain("build-token")
+      expect(wrapper).toContain("function chatStateFromLibsql()")
+      expect(wrapper).toContain("handler(request, webhook, { agentName: agent, state: chatStateFromLibsql(), waitUntil })")
       expect(wrapper).not.toContain("runtime: 'vite'")
       expect(writeProviderDeploymentOutputs).toHaveBeenCalledWith({
         clientOutDir: "dist/client",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -684,13 +684,13 @@ describe("agent Vite plugin", () => {
     for (const provider of ["sqlite", "libsql"] as const) {
       const root = await mkdtemp(join(tmpdir(), `vitehub-agent-${provider}-state-routes-`))
       try {
-        vi.stubEnv("TURSO_AUTH_TOKEN", "build-token")
+        vi.stubEnv("TURSO-AUTH-TOKEN", "build-token-with-hyphen-env")
         await mkdir(join(root, "server", "agents"), { recursive: true })
         await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
         const plugin = hubAgent({
           providers: {
             state: {
-              authToken: "build-token",
+              authToken: "build-token-with-hyphen-env",
               provider,
               tablePrefix: "agent_state_",
               url: "file:build-state.sqlite",
@@ -707,9 +707,10 @@ describe("agent Vite plugin", () => {
         expect(webhookRoute).toContain("import { createLibsqlAgentState } from \"@vite-hub/agent/state/sqlite\"")
         expect(webhookRoute).not.toContain("import { createCloudflareAgentState }")
         expect(webhookRoute).toContain("const viteHubChatStateOptions = {\"tablePrefix\":\"agent_state_\",\"url\":\"file:build-state.sqlite\"}")
-        expect(webhookRoute).not.toContain("build-token")
+        expect(webhookRoute).not.toContain("build-token-with-hyphen-env")
         expect(webhookRoute).toContain("const viteHubChatState = createLibsqlAgentState({")
-        expect(webhookRoute).toContain("process.env.TURSO_AUTH_TOKEN")
+        expect(webhookRoute).toContain("process.env[\"TURSO-AUTH-TOKEN\"]")
+        expect(webhookRoute).not.toContain("process.env.TURSO-AUTH-TOKEN")
         expect(webhookRoute).toContain("process.env.VITEHUB_AGENT_STATE_AUTH_TOKEN")
         expect(webhookRoute).toContain("process.env.VITEHUB_AGENT_STATE_URL")
         expect(webhookRoute).toContain("function chatStateFromLibsql()")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -661,6 +661,44 @@ describe("agent Vite plugin", () => {
     }
   })
 
+  it("writes generated Nitro webhook handlers with sqlite state providers", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+
+    for (const provider of ["sqlite", "libsql"] as const) {
+      const root = await mkdtemp(join(tmpdir(), `vitehub-agent-${provider}-state-routes-`))
+      try {
+        await mkdir(join(root, "server", "agents"), { recursive: true })
+        await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+        const plugin = hubAgent({
+          providers: {
+            state: {
+              provider,
+              tablePrefix: "agent_state_",
+              url: "file:build-state.sqlite",
+            },
+          },
+          routes: { chat: true, webhooks: true },
+        })
+        if (typeof plugin.configResolved === "function") {
+          await plugin.configResolved.call({} as never, { command: "build", root } as never)
+        }
+
+        const webhookRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
+
+        expect(webhookRoute).toContain("import { createLibsqlAgentState } from \"@vite-hub/agent/state/sqlite\"")
+        expect(webhookRoute).not.toContain("import { createCloudflareAgentState }")
+        expect(webhookRoute).toContain("const viteHubChatStateOptions = {\"tablePrefix\":\"agent_state_\",\"url\":\"file:build-state.sqlite\"}")
+        expect(webhookRoute).toContain("const viteHubChatState = createLibsqlAgentState({")
+        expect(webhookRoute).toContain("process.env.VITEHUB_AGENT_STATE_URL")
+        expect(webhookRoute).toContain("function chatStateFromLibsql()")
+        expect(webhookRoute).toContain("return isWebhookRoute ? await handler(await toRequest(event), webhook, { agentName: agent, cloudflare, state: chatStateFromLibsql(), waitUntil: waitUntilFromEvent(event) }) : await handler(await toRequest(event), { agentName: agent, cloudflare, waitUntil: waitUntilFromEvent(event) })")
+      }
+      finally {
+        await rm(root, { force: true, recursive: true })
+      }
+    }
+  })
+
   it("lets built generated Nitro handlers detect the host runtime", async () => {
     const { hubAgent } = await import("../src/vite.ts")
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-routes-build-runtime-"))

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -719,6 +719,36 @@ describe("agent Vite plugin", () => {
     }
   })
 
+  it("does not emit sqlite state helpers for chat-only generated routes", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-chat-only-state-routes-"))
+    try {
+      await mkdir(join(root, "server", "agents"), { recursive: true })
+      await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+      const plugin = hubAgent({
+        providers: {
+          state: {
+            provider: "libsql",
+            url: "file:build-state.sqlite",
+          },
+        },
+        routes: { chat: true, webhooks: false },
+      })
+      if (typeof plugin.configResolved === "function") {
+        await plugin.configResolved.call({} as never, { command: "build", root } as never)
+      }
+
+      const webhookRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
+
+      expect(webhookRoute).not.toContain("import { createLibsqlAgentState }")
+      expect(webhookRoute).not.toContain("const viteHubChatStateOptions")
+      expect(webhookRoute).not.toContain("function chatStateFromLibsql()")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("lets built generated Nitro handlers detect the host runtime", async () => {
     const { hubAgent } = await import("../src/vite.ts")
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-routes-build-runtime-"))

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -672,6 +672,7 @@ describe("agent Vite plugin", () => {
         const plugin = hubAgent({
           providers: {
             state: {
+              authToken: "build-token",
               provider,
               tablePrefix: "agent_state_",
               url: "file:build-state.sqlite",
@@ -688,7 +689,9 @@ describe("agent Vite plugin", () => {
         expect(webhookRoute).toContain("import { createLibsqlAgentState } from \"@vite-hub/agent/state/sqlite\"")
         expect(webhookRoute).not.toContain("import { createCloudflareAgentState }")
         expect(webhookRoute).toContain("const viteHubChatStateOptions = {\"tablePrefix\":\"agent_state_\",\"url\":\"file:build-state.sqlite\"}")
+        expect(webhookRoute).not.toContain("build-token")
         expect(webhookRoute).toContain("const viteHubChatState = createLibsqlAgentState({")
+        expect(webhookRoute).toContain("process.env.VITEHUB_AGENT_STATE_AUTH_TOKEN")
         expect(webhookRoute).toContain("process.env.VITEHUB_AGENT_STATE_URL")
         expect(webhookRoute).toContain("function chatStateFromLibsql()")
         expect(webhookRoute).toContain("return isWebhookRoute ? await handler(await toRequest(event), webhook, { agentName: agent, cloudflare, state: chatStateFromLibsql(), waitUntil: waitUntilFromEvent(event) }) : await handler(await toRequest(event), { agentName: agent, cloudflare, waitUntil: waitUntilFromEvent(event) })")


### PR DESCRIPTION
Generated Nitro webhook routes now materialize a singleton libSQL-backed Agent state when `hubAgent({ providers: { state: { provider: "sqlite" | "libsql" } }, routes: { webhooks } })` is configured, then pass it to webhook handler calls.

This keeps the existing `VITEHUB_AGENT_STATE_URL` runtime override path for Docker/Node deployments while preserving configured state defaults such as `tablePrefix` and `url`.

Draft until CI finishes on the pushed branch.