### PR TITLE
fix: upstream quiver dependency patches

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -724,6 +724,7 @@ async function applyChannelDeliveryEffectIntents<
             effect: intent,
             ...(finish ? { finish: finish as never } : {}),
             input: context.input,
+            request: context.runtimeContext.request,
             run: context.run,
             trigger: {
               channelId: active.channelId,
@@ -1756,6 +1757,7 @@ async function resolveFinishDeliveryEffectIntents<
     ...context.runtimeContext,
     context: context.context,
     input: context.input,
+    request: context.runtimeContext.request,
     run: context.run,
     workspace: context.workspace,
   }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -234,6 +234,7 @@ export interface AgentChannelDeliveryEffectContext<
   effect: AgentChannelDeliveryEffectIntent
   finish?: AgentFinishEvent<TRuntimeConfig>
   input: AgentRunInput
+  request?: Request
   run?: AgentRunMetadata
   trigger?: {
     channelId: string
@@ -249,6 +250,7 @@ export interface AgentChannelDeliveryFinishEffectContext<
 > extends AgentCallbackContext<TRuntimeConfig> {
   context: AgentInvocationContextStore
   input: AgentRunInput<CALL_OPTIONS>
+  request?: Request
   run?: AgentRunMetadata
   workspace?: ReadonlyWorkspaceFacade
 }

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -684,11 +684,12 @@ describe("agent public types", () => {
       payload: event.result,
     })
     const renderBody = async (text: string, workspace?: ReadonlyWorkspaceFacade) => `${text}:${Boolean(workspace)}`
-    const typedFinishEffect = defineFinishEffect(async (event, { context, workspace }) => {
+    const typedFinishEffect = defineFinishEffect(async (event, { context, request, workspace }) => {
       expectTypeOf(event.text).toEqualTypeOf<string | undefined>()
       expectTypeOf(getAgentFinishText(event)).toEqualTypeOf<string | undefined>()
       expectTypeOf(context).toEqualTypeOf<AgentChannelDeliveryFinishEffectContext["context"]>()
       expectTypeOf(context.get<{ repository: string }>("review.context")).toEqualTypeOf<{ repository: string } | undefined>()
+      expectTypeOf(request).toEqualTypeOf<Request | undefined>()
       expectTypeOf(workspace).toEqualTypeOf<ReadonlyWorkspaceFacade | undefined>()
       if (event.error) return reply(`failed: ${event.errorMessage}`)
       const text = event.text
@@ -711,6 +712,7 @@ describe("agent public types", () => {
           expectTypeOf(context.effect).toEqualTypeOf<AgentChannelDeliveryEffectIntent>()
           expectTypeOf(context.effect.artifacts?.[0]).toEqualTypeOf<PublishedAgentDeliveryArtifact | undefined>()
           expectTypeOf(context.context).toEqualTypeOf<AgentChannelDeliveryEffectContext["context"]>()
+          expectTypeOf(context.request).toEqualTypeOf<Request | undefined>()
           expectTypeOf(context.workspace).toEqualTypeOf<AgentChannelDeliveryEffectContext["workspace"]>()
         },
       },
@@ -725,6 +727,7 @@ describe("agent public types", () => {
               delivery: {
                 finishEffects: (event, context) => {
                   expectTypeOf(context.context).toEqualTypeOf<AgentChannelDeliveryFinishEffectContext["context"]>()
+                  expectTypeOf(context.request).toEqualTypeOf<Request | undefined>()
                   expectTypeOf(context.workspace).toEqualTypeOf<AgentChannelDeliveryFinishEffectContext["workspace"]>()
                   return {
                     artifacts: [{ path: "screenshots/result.png", url: "https://assets.example/result.png" }],

--- a/packages/blob/src/config.ts
+++ b/packages/blob/src/config.ts
@@ -45,8 +45,12 @@ function resolveCloudflareStore(
 ): ResolvedCloudflareR2BlobStoreConfig {
   return defu(
     {
+      ...config,
+      accountId: resolveBuildRuntimeValue(config.accountId, env, "R2_ACCOUNT_ID", "CLOUDFLARE_R2_ACCOUNT_ID", "CLOUDFLARE_ACCOUNT_ID"),
+      accessKeyId: resolveBuildRuntimeValue(config.accessKeyId, env, "R2_ACCESS_KEY_ID", "CLOUDFLARE_R2_ACCESS_KEY_ID"),
       binding: trimmed(config.binding),
-      bucketName: trimmed(config.bucketName) ?? readEnv(env, "BLOB_BUCKET_NAME", "CLOUDFLARE_R2_BUCKET_NAME"),
+      bucketName: trimmed(config.bucketName) ?? readEnv(env, "BLOB_BUCKET_NAME", "CLOUDFLARE_R2_BUCKET_NAME", "R2_BUCKET_NAME"),
+      secretAccessKey: resolveBuildRuntimeValue(config.secretAccessKey, env, "R2_SECRET_ACCESS_KEY", "CLOUDFLARE_R2_SECRET_ACCESS_KEY"),
     },
     { binding: "BLOB", driver: "cloudflare-r2" as const },
   )

--- a/packages/blob/src/drivers/cloudflare.ts
+++ b/packages/blob/src/drivers/cloudflare.ts
@@ -7,6 +7,8 @@ import { createFilesSdkDriver } from "./files-sdk.ts"
 
 import type { BlobDriverAdapter, BlobListOptions, BlobListResult, BlobObject, BlobPutBody, BlobPutOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
 
+const s3PeerInstall = "files-sdk @aws-sdk/client-s3 @aws-sdk/s3-presigned-post @aws-sdk/s3-request-presigner"
+
 interface R2ObjectLike {
   arrayBuffer?: () => Promise<ArrayBuffer>
   body?: ReadableStream
@@ -58,7 +60,7 @@ function createHttpDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDri
     accessKeyId: runtimeValue(options.accessKeyId, "R2_ACCESS_KEY_ID", "CLOUDFLARE_R2_ACCESS_KEY_ID"),
     bucketName,
     secretAccessKey: runtimeValue(options.secretAccessKey, "R2_SECRET_ACCESS_KEY", "CLOUDFLARE_R2_SECRET_ACCESS_KEY"),
-  }, async resolved => (await importOptionalPeer<typeof import("files-sdk/r2")>("files-sdk/r2", resolved.driver, "files-sdk")).r2({
+  }, async resolved => (await importOptionalPeer<typeof import("files-sdk/r2")>("files-sdk/r2", resolved.driver, s3PeerInstall)).r2({
     ...resolved,
     bucket: resolved.bucketName,
   }))

--- a/packages/blob/src/drivers/cloudflare.ts
+++ b/packages/blob/src/drivers/cloudflare.ts
@@ -140,8 +140,7 @@ function createNativeDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobD
 
 export function createDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> {
   const nativeDriver = createNativeDriver(options)
-  let httpDriver: BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> | undefined
-  const activeDriver = () => getOptionalBucket(options) ? nativeDriver : (httpDriver ||= createHttpDriver(options))
+  const activeDriver = () => getOptionalBucket(options) ? nativeDriver : createHttpDriver(options)
 
   return {
     name: "cloudflare-r2",

--- a/packages/blob/src/drivers/cloudflare.ts
+++ b/packages/blob/src/drivers/cloudflare.ts
@@ -1,4 +1,9 @@
+import { readEnv, trimmed } from "@vite-hub/internal/env"
+
+import { isMaskedBlobRuntimeValue } from "../config.ts"
+import { importOptionalPeer } from "../internal/optional-peer.ts"
 import { getActiveCloudflareBinding } from "../runtime/state.ts"
+import { createFilesSdkDriver } from "./files-sdk.ts"
 
 import type { BlobDriverAdapter, BlobListOptions, BlobListResult, BlobObject, BlobPutBody, BlobPutOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
 
@@ -21,16 +26,42 @@ interface R2BucketLike {
   put(key: string, value: BlobPutBody, options?: { customMetadata?: Record<string, string>, httpMetadata?: { contentType?: string } }): Promise<R2ObjectLike>
 }
 
-function getBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike {
-  const binding = getActiveCloudflareBinding<R2BucketLike>(options.binding)
+function getOptionalBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike | undefined {
+  return getActiveCloudflareBinding<R2BucketLike>(options.binding)
     || (globalThis as any).__env__?.[options.binding]
     || (globalThis as any)[options.binding]
+}
 
+function getBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike {
+  const binding = getOptionalBucket(options)
   if (!binding) {
     throw new Error(`R2 binding "${options.binding}" not found`)
   }
 
   return binding
+}
+
+function runtimeValue(value: string | undefined, ...envNames: string[]): string | undefined {
+  const current = trimmed(value)
+  const env = typeof process === "undefined" ? {} : process.env
+  return isMaskedBlobRuntimeValue(current) ? readEnv(env, ...envNames) : current
+}
+
+function createHttpDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> {
+  const bucketName = runtimeValue(options.bucketName, "BLOB_BUCKET_NAME", "CLOUDFLARE_R2_BUCKET_NAME", "R2_BUCKET_NAME")
+  if (!bucketName) {
+    throw new Error("Missing runtime environment variable `BLOB_BUCKET_NAME`, `CLOUDFLARE_R2_BUCKET_NAME`, or `R2_BUCKET_NAME` for Cloudflare R2 Blob.")
+  }
+  return createFilesSdkDriver({
+    ...options,
+    accountId: runtimeValue(options.accountId, "R2_ACCOUNT_ID", "CLOUDFLARE_R2_ACCOUNT_ID", "CLOUDFLARE_ACCOUNT_ID"),
+    accessKeyId: runtimeValue(options.accessKeyId, "R2_ACCESS_KEY_ID", "CLOUDFLARE_R2_ACCESS_KEY_ID"),
+    bucketName,
+    secretAccessKey: runtimeValue(options.secretAccessKey, "R2_SECRET_ACCESS_KEY", "CLOUDFLARE_R2_SECRET_ACCESS_KEY"),
+  }, async resolved => (await importOptionalPeer<typeof import("files-sdk/r2")>("files-sdk/r2", resolved.driver, "files-sdk")).r2({
+    ...resolved,
+    bucket: resolved.bucketName,
+  }))
 }
 
 function mapObject(object: R2ObjectLike): BlobObject {
@@ -56,7 +87,7 @@ async function readArrayBuffer(object: R2ObjectLike): Promise<ArrayBuffer> {
   return new ArrayBuffer(0)
 }
 
-export function createDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> {
+function createNativeDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> {
   return {
     name: "cloudflare-r2",
     options,
@@ -101,5 +132,22 @@ export function createDriver(options: ResolvedCloudflareR2BlobStoreConfig): Blob
       })
       return mapObject(object)
     },
+  }
+}
+
+export function createDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> {
+  const nativeDriver = createNativeDriver(options)
+  let httpDriver: BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> | undefined
+  const activeDriver = () => getOptionalBucket(options) ? nativeDriver : (httpDriver ||= createHttpDriver(options))
+
+  return {
+    name: "cloudflare-r2",
+    options,
+    delete: pathnames => activeDriver().delete(pathnames),
+    get: pathname => activeDriver().get(pathname),
+    getArrayBuffer: pathname => activeDriver().getArrayBuffer(pathname),
+    head: pathname => activeDriver().head(pathname),
+    list: options => activeDriver().list(options),
+    put: (pathname, body, options) => activeDriver().put(pathname, body, options),
   }
 }

--- a/packages/blob/src/drivers/cloudflare.ts
+++ b/packages/blob/src/drivers/cloudflare.ts
@@ -2,7 +2,7 @@ import { readEnv, trimmed } from "@vite-hub/internal/env"
 
 import { isMaskedBlobRuntimeValue } from "../config.ts"
 import { importOptionalPeer } from "../internal/optional-peer.ts"
-import { getActiveCloudflareBinding } from "../runtime/state.ts"
+import { getActiveCloudflareBinding, getActiveCloudflareEnv } from "../runtime/state.ts"
 import { createFilesSdkDriver } from "./files-sdk.ts"
 
 import type { BlobDriverAdapter, BlobListOptions, BlobListResult, BlobObject, BlobPutBody, BlobPutOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
@@ -45,7 +45,8 @@ function getBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike {
 
 function runtimeValue(value: string | undefined, ...envNames: string[]): string | undefined {
   const current = trimmed(value)
-  const env = typeof process === "undefined" ? {} : process.env
+  const env = getActiveCloudflareEnv() as Record<string, string | undefined> | undefined
+    || (typeof process === "undefined" ? {} : process.env)
   return isMaskedBlobRuntimeValue(current) ? readEnv(env, ...envNames) : current
 }
 

--- a/packages/blob/src/drivers/cloudflare.ts
+++ b/packages/blob/src/drivers/cloudflare.ts
@@ -7,7 +7,7 @@ import { createFilesSdkDriver } from "./files-sdk.ts"
 
 import type { BlobDriverAdapter, BlobListOptions, BlobListResult, BlobObject, BlobPutBody, BlobPutOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
 
-const s3PeerInstall = "files-sdk @aws-sdk/client-s3 @aws-sdk/s3-presigned-post @aws-sdk/s3-request-presigner"
+const s3PeerInstall = "files-sdk @aws-sdk/client-s3 @aws-sdk/lib-storage @aws-sdk/s3-presigned-post @aws-sdk/s3-request-presigner"
 
 interface R2ObjectLike {
   arrayBuffer?: () => Promise<ArrayBuffer>

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -291,6 +291,10 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
       },
       conditions: ["workerd", "worker", "browser", "default"],
       external: [
+        "@aws-sdk/client-s3",
+        "@aws-sdk/s3-presigned-post",
+        "@aws-sdk/s3-request-presigner",
+        "files-sdk/r2",
         "node:async_hooks",
         "#vitehub/blob/config",
       ],

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -294,6 +294,7 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
         "@aws-sdk/client-s3",
         "@aws-sdk/s3-presigned-post",
         "@aws-sdk/s3-request-presigner",
+        "files-sdk",
         "files-sdk/r2",
         "node:async_hooks",
         "#vitehub/blob/config",

--- a/packages/blob/test/config.test.ts
+++ b/packages/blob/test/config.test.ts
@@ -46,6 +46,32 @@ describe("blob config", () => {
     })
   })
 
+  it("preserves Cloudflare R2 HTTP options and masks env credentials", () => {
+    expect(normalizeBlobOptions({
+      defaultUrlExpiresIn: 600,
+      driver: "cloudflare-r2",
+      publicBaseUrl: "https://assets.example",
+    }, {
+      env: {
+        CLOUDFLARE_ACCOUNT_ID: "account",
+        CLOUDFLARE_R2_ACCESS_KEY_ID: "access-key",
+        CLOUDFLARE_R2_SECRET_ACCESS_KEY: "secret-key",
+        R2_BUCKET_NAME: "runtime-assets",
+      },
+    })).toEqual({
+      store: {
+        accountId: "********",
+        accessKeyId: "********",
+        binding: "BLOB",
+        bucketName: "runtime-assets",
+        defaultUrlExpiresIn: 600,
+        driver: "cloudflare-r2",
+        publicBaseUrl: "https://assets.example",
+        secretAccessKey: "********",
+      },
+    })
+  })
+
   it("prefers Cloudflare hosting over Vercel env auto-resolution", () => {
     expect(normalizeBlobOptions({}, {
       env: { BLOB_READ_WRITE_TOKEN: "secret-token" },

--- a/packages/blob/test/runtime.test.ts
+++ b/packages/blob/test/runtime.test.ts
@@ -641,6 +641,37 @@ describe("blob runtime", () => {
     })
   })
 
+  it("rehydrates R2 HTTP fallback secrets from the Cloudflare worker env", async () => {
+    const worker = createBlobCloudflareWorker({
+      app: async () => Response.json(await blob.list()),
+      blob: {
+        store: {
+          accountId: "********",
+          accessKeyId: "********",
+          binding: "BLOB",
+          bucketName: "********",
+          driver: "cloudflare-r2",
+          secretAccessKey: "********",
+        },
+      },
+    })
+
+    await worker.fetch(new Request("https://example.com/list"), {
+      CLOUDFLARE_R2_ACCESS_KEY_ID: "worker-access-key",
+      CLOUDFLARE_R2_SECRET_ACCESS_KEY: "worker-secret-key",
+      R2_ACCOUNT_ID: "worker-account",
+      R2_BUCKET_NAME: "worker-assets",
+    }, {})
+
+    expect(filesSdkMock.r2).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: "worker-account",
+      accessKeyId: "worker-access-key",
+      bucket: "worker-assets",
+      bucketName: "worker-assets",
+      secretAccessKey: "worker-secret-key",
+    }))
+  })
+
   it("keeps the Cloudflare binding available for waitUntil Blob tasks", async () => {
     const waitUntilPromises: Promise<unknown>[] = []
     const worker = createBlobCloudflareWorker({

--- a/packages/blob/test/runtime.test.ts
+++ b/packages/blob/test/runtime.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { ensureBlob } from "../src/ensure.ts"
 import { blob } from "../src/runtime/storage.ts"
 import { createBlobCloudflareWorker } from "../src/runtime/cloudflare-vite.ts"
+import { createBlobStorage } from "../src/storage.ts"
 import {
   setActiveCloudflareEnv,
   setBlobRuntimeConfig,
@@ -60,6 +61,7 @@ const filesSdkMock = vi.hoisted(() => ({
     ],
   })),
   minio: vi.fn(() => ({ provider: "minio" })),
+  r2: vi.fn((options: unknown) => ({ options, provider: "r2" })),
   s3: vi.fn(() => ({ provider: "s3" })),
   vercelBlob: vi.fn((options: unknown) => ({ options, provider: "vercel-blob" })),
 }))
@@ -147,6 +149,10 @@ vi.mock("files-sdk/minio", () => ({
   minio: filesSdkMock.minio,
 }))
 
+vi.mock("files-sdk/r2", () => ({
+  r2: filesSdkMock.r2,
+}))
+
 vi.mock("files-sdk/vercel-blob", () => ({
   vercelBlob: filesSdkMock.vercelBlob,
 }))
@@ -162,13 +168,22 @@ afterEach(() => {
   vercelBlobMock.put.mockClear()
   filesSdkMock.list.mockClear()
   filesSdkMock.minio.mockClear()
+  filesSdkMock.r2.mockClear()
   filesSdkMock.s3.mockClear()
   filesSdkMock.vercelBlob.mockClear()
   delete process.env.BLOB_READ_WRITE_TOKEN
+  delete process.env.CLOUDFLARE_ACCOUNT_ID
+  delete process.env.CLOUDFLARE_R2_ACCOUNT_ID
+  delete process.env.CLOUDFLARE_R2_ACCESS_KEY_ID
+  delete process.env.CLOUDFLARE_R2_SECRET_ACCESS_KEY
   delete process.env.MINIO_ACCESS_KEY_ID
   delete process.env.MINIO_ROOT_PASSWORD
   delete process.env.MINIO_ROOT_USER
   delete process.env.MINIO_SECRET_ACCESS_KEY
+  delete process.env.R2_ACCOUNT_ID
+  delete process.env.R2_ACCESS_KEY_ID
+  delete process.env.R2_BUCKET_NAME
+  delete process.env.R2_SECRET_ACCESS_KEY
   vi.restoreAllMocks()
 })
 
@@ -411,9 +426,55 @@ describe("blob runtime", () => {
     expect(head.customMetadata).toEqual({ test: "true" })
     expect(body?.type).toBe("text/plain")
     expect(await body?.text()).toBe("hello")
+    expect(filesSdkMock.r2).not.toHaveBeenCalled()
 
     await blob.del("notes/hello.txt")
     await expect(blob.head("notes/hello.txt")).rejects.toThrow("Blob not found")
+  })
+
+  it("falls back to Files SDK R2 when no Cloudflare binding exists", async () => {
+    process.env.CLOUDFLARE_R2_ACCOUNT_ID = "account"
+    process.env.CLOUDFLARE_R2_ACCESS_KEY_ID = "access-key"
+    process.env.CLOUDFLARE_R2_SECRET_ACCESS_KEY = "secret-key"
+    process.env.R2_BUCKET_NAME = "runtime-assets"
+    setBlobRuntimeConfig({
+      store: {
+        accountId: "********",
+        accessKeyId: "********",
+        binding: "BLOB",
+        bucketName: "********",
+        driver: "cloudflare-r2",
+        secretAccessKey: "********",
+      },
+    })
+
+    const list = await blob.list()
+
+    expect(filesSdkMock.r2).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: "account",
+      accessKeyId: "access-key",
+      bucket: "runtime-assets",
+      bucketName: "runtime-assets",
+      secretAccessKey: "secret-key",
+    }))
+    expect(list.blobs).toEqual([
+      expect.objectContaining({ pathname: "notes/hello.txt" }),
+    ])
+  })
+
+  it("keeps Cloudflare binding mode when the binding appears after driver creation", async () => {
+    const { createDriver } = await import("../src/drivers/cloudflare.ts")
+    const storage = createBlobStorage(createDriver({
+      binding: "BLOB",
+      bucketName: "assets",
+      driver: "cloudflare-r2",
+    }))
+
+    setActiveCloudflareEnv({ BLOB: createMemoryBucket() })
+    await storage.put("notes/late-binding.txt", "hello")
+
+    expect(filesSdkMock.r2).not.toHaveBeenCalled()
+    expect(await (await storage.get("notes/late-binding.txt"))?.text()).toBe("hello")
   })
 
   it("returns folded folders from the active Cloudflare binding", async () => {

--- a/packages/blob/test/runtime.test.ts
+++ b/packages/blob/test/runtime.test.ts
@@ -672,6 +672,50 @@ describe("blob runtime", () => {
     }))
   })
 
+  it("keeps R2 HTTP fallback credentials isolated across worker envs", async () => {
+    const worker = createBlobCloudflareWorker({
+      app: async () => Response.json(await blob.list()),
+      blob: {
+        store: {
+          accountId: "********",
+          accessKeyId: "********",
+          binding: "BLOB",
+          bucketName: "********",
+          driver: "cloudflare-r2",
+          secretAccessKey: "********",
+        },
+      },
+    })
+
+    await worker.fetch(new Request("https://example.com/list"), {
+      CLOUDFLARE_R2_ACCESS_KEY_ID: "first-access-key",
+      CLOUDFLARE_R2_SECRET_ACCESS_KEY: "first-secret-key",
+      R2_ACCOUNT_ID: "first-account",
+      R2_BUCKET_NAME: "first-assets",
+    }, {})
+    await worker.fetch(new Request("https://example.com/list"), {
+      CLOUDFLARE_R2_ACCESS_KEY_ID: "second-access-key",
+      CLOUDFLARE_R2_SECRET_ACCESS_KEY: "second-secret-key",
+      R2_ACCOUNT_ID: "second-account",
+      R2_BUCKET_NAME: "second-assets",
+    }, {})
+
+    expect(filesSdkMock.r2).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      accountId: "first-account",
+      accessKeyId: "first-access-key",
+      bucket: "first-assets",
+      bucketName: "first-assets",
+      secretAccessKey: "first-secret-key",
+    }))
+    expect(filesSdkMock.r2).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      accountId: "second-account",
+      accessKeyId: "second-access-key",
+      bucket: "second-assets",
+      bucketName: "second-assets",
+      secretAccessKey: "second-secret-key",
+    }))
+  })
+
   it("keeps the Cloudflare binding available for waitUntil Blob tasks", async () => {
     const waitUntilPromises: Promise<unknown>[] = []
     const worker = createBlobCloudflareWorker({

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -237,6 +237,7 @@ describe("Vite provider outputs", () => {
     })
 
     const cloudflareWorker = await readFile(join(rootDir, "dist", toSafeAppName(rootDir), "index.js"), "utf8")
+    expect(cloudflareWorker).toContain("\"files-sdk\"")
     expect(cloudflareWorker).toContain("files-sdk/r2")
   })
 

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -224,6 +224,25 @@ describe("Vite provider outputs", () => {
     ])
   })
 
+  it("externalizes optional R2 HTTP peers from Cloudflare provider output", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-cloudflare-r2-externals-")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+
+    const { providerOutput } = await prepareProviderOutputs({
+      blob: { driver: "cloudflare-r2", bucketName: "assets" },
+      provider: "cloudflare",
+      rootDir,
+    })
+
+    expect(providerOutput.cloudflare?.bundleOptions.external).toEqual(expect.arrayContaining([
+      "@aws-sdk/client-s3",
+      "@aws-sdk/s3-presigned-post",
+      "@aws-sdk/s3-request-presigner",
+      "files-sdk/r2",
+    ]))
+  })
+
   it("skips provider output for local fs stores", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-local-fs-")
     await mkdir(join(rootDir, "src"), { recursive: true })

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -224,23 +224,20 @@ describe("Vite provider outputs", () => {
     ])
   })
 
-  it("externalizes optional R2 HTTP peers from Cloudflare provider output", async () => {
+  it("bundles Cloudflare provider output without resolving optional R2 HTTP peers", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-cloudflare-r2-externals-")
     await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist", "client"), { recursive: true })
     await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
 
-    const { providerOutput } = await prepareProviderOutputs({
+    await generateProviderOutputs({
       blob: { driver: "cloudflare-r2", bucketName: "assets" },
-      provider: "cloudflare",
+      clientOutDir: "dist/client",
       rootDir,
     })
 
-    expect(providerOutput.cloudflare?.bundleOptions.external).toEqual(expect.arrayContaining([
-      "@aws-sdk/client-s3",
-      "@aws-sdk/s3-presigned-post",
-      "@aws-sdk/s3-request-presigner",
-      "files-sdk/r2",
-    ]))
+    const cloudflareWorker = await readFile(join(rootDir, "dist", toSafeAppName(rootDir), "index.js"), "utf8")
+    expect(cloudflareWorker).toContain("files-sdk/r2")
   })
 
   it("skips provider output for local fs stores", async () => {


### PR DESCRIPTION
Upstreams the Quiver-carried ViteHub dependency patches now that #471 has merged: Agent Channel Delivery Effect contexts expose the originating `Request`, and Cloudflare R2 Blob Stores use the runtime binding when present or fall back to lazy `files-sdk/r2` HTTP access when no binding is available.

The Blob resolver now preserves R2 HTTP options and masks env-sourced runtime credentials so generated Provider Output can rehydrate them without committing secrets.

Refs #471