### PR TITLE
fix(source): dedupe github source loads

### DIFF
--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -13,6 +13,21 @@ function normalizeGitHubRoot(path = "") {
   return normalizeSourcePath(path).split("/").filter(part => part && part !== ".").join("/")
 }
 
+function dedupeProviderPromise<TResult>(
+  promises: Map<string, Promise<TResult>>,
+  key: string,
+  load: () => Promise<TResult>,
+) {
+  const promise = promises.get(key)
+  if (promise) return promise
+  const nextPromise = load().catch((error: unknown) => {
+    promises.delete(key)
+    throw error
+  })
+  promises.set(key, nextPromise)
+  return nextPromise
+}
+
 export function github<const TKey extends string = string>(options: GitHubSourceOptions): Source<TKey> {
   const configuredRef = options.ref
   const root = normalizeGitHubRoot(options.root || "")
@@ -74,6 +89,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
     return error instanceof SourceError && error.message.includes(" request failed with 403 ")
   }
 
+  const resolvedRefs = new Map<string, Promise<string>>()
   const cachedResolveRef = providerCache
     ? defineCachedFunction(
         async (token: string | undefined) => await resolveRef(token),
@@ -83,7 +99,11 @@ export function github<const TKey extends string = string>(options: GitHubSource
           name: "github-source-ref",
         },
       )
-    : async (token: string | undefined) => await resolveRef(token)
+    : (token: string | undefined) => dedupeProviderPromise(
+        resolvedRefs,
+        cacheKey("ref", token || ""),
+        () => resolveRef(token),
+      )
 
   async function getRef(token = refreshAuth()) {
     return await cachedResolveRef(token)
@@ -110,6 +130,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
     return await loadArchiveFiles(token)
   }
 
+  const loadedFiles = new Map<string, Promise<GitHubFile<TKey>[]>>()
   const cachedLoadFiles = providerCache
     ? defineCachedFunction(
         async (token: string | undefined) => await loadFiles(token),
@@ -119,7 +140,11 @@ export function github<const TKey extends string = string>(options: GitHubSource
           name: "github-source-archive",
         },
       )
-    : async (token: string | undefined) => await loadFiles(token)
+    : (token: string | undefined) => dedupeProviderPromise(
+        loadedFiles,
+        cacheKey("archive", token || ""),
+        () => loadFiles(token),
+      )
 
   function getFiles(token = refreshAuth()) {
     return cachedLoadFiles(token)

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -20,9 +20,8 @@ function dedupeProviderPromise<TResult>(
 ) {
   const promise = promises.get(key)
   if (promise) return promise
-  const nextPromise = load().catch((error: unknown) => {
+  const nextPromise = load().finally(() => {
     promises.delete(key)
-    throw error
   })
   promises.set(key, nextPromise)
   return nextPromise

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -264,4 +264,37 @@ describe("@vite-hub/source GitHub source", () => {
     const archiveCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))
     expect(archiveCalls).toHaveLength(1)
   })
+
+  it("does not cache completed GitHub archive reads without provider cache", async () => {
+    const archives = [
+      createTarGz({ "docs/README.md": "first\n" }),
+      createTarGz({ "docs/README.md": "second\n" }),
+    ]
+
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url)
+      if (requestUrl.startsWith("https://codeload.github.com/")) {
+        const archive = archives.shift()
+        if (!archive) throw new Error("Unexpected extra GitHub archive request")
+        return new Response(archive)
+      }
+      throw new Error(`Unexpected GitHub request: ${requestUrl}`)
+    }))
+
+    registerSources({
+      docs: github({
+        ref: "main",
+        repo: "acme/app",
+        root: "docs",
+      }),
+    })
+
+    const docs = useSource("docs")
+
+    await expect(docs.read("README.md")).resolves.toBe("first\n")
+    await expect(docs.read("README.md")).resolves.toBe("second\n")
+
+    const archiveCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))
+    expect(archiveCalls).toHaveLength(2)
+  })
 })

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -241,4 +241,27 @@ describe("@vite-hub/source GitHub source", () => {
     const archiveCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))
     expect(archiveCalls).toHaveLength(1)
   })
+
+  it("dedupes concurrent GitHub archive reads without provider cache", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+
+    registerSources({
+      docs: github({
+        repo: "acme/app",
+        root: "docs",
+      }),
+    })
+
+    const docs = useSource("docs")
+
+    await expect(Promise.all([
+      docs.read("README.md"),
+      docs.read("README.md"),
+    ])).resolves.toEqual(["# Docs\n", "# Docs\n"])
+
+    const archiveCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))
+    expect(archiveCalls).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
Ports the Quiver-carried GitHub Source Loader dedupe into `@vite-hub/source`. Uncached GitHub sources now share per-provider ref and archive load promises, so concurrent reads do not start duplicate default-ref or archive requests when provider cache is not configured.

Adds a focused regression test for concurrent archive reads without `cache`.