### PR TITLE
fix(agent): add GitHub pull request dev trigger

### DIFF
--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -552,7 +552,8 @@ function declaredInputCommand<TRuntimeConfig extends AgentRuntimeConfig>(
 function githubPullRequestCommandFromInput(input: unknown): GitHubPullRequestCommand | undefined {
   const payload = inputPayload(input)
   const facts = inputGithubFacts(input)
-  if (!payload || (facts && facts.event !== "issue_comment") || payload.action !== "created") return
+  const event = maybeString(facts?.event)
+  if (!payload || (event && event !== "issue_comment") || payload.action !== "created") return
   if (!payload.issue?.pull_request) return
   const body = maybeString(payload.comment?.body)
   const parsed = body ? parseSlashCommand(body) : undefined

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1573,7 +1573,9 @@ function githubCommandFromRunContext(value: GitHubPullRequestRunContext): GitHub
 }
 
 function githubPullRequestDevPrompt(input: Record<string, unknown>, pullRequest: GitHubPullRequestRunContext): string {
-  return maybeString(input.prompt) || maybeString(pullRequest.trigger.comment.body) || maybeString(pullRequest.trigger.command) || "/review"
+  const command = maybeString(pullRequest.trigger.command)
+  const args = maybeString(pullRequest.trigger.args)
+  return maybeString(input.prompt) || maybeString(pullRequest.trigger.comment.body) || (command && args ? `${command} ${args}` : command) || "/review"
 }
 
 function githubDevPayload(input: unknown): GitHubIssueCommentPayload | undefined {
@@ -1624,6 +1626,7 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
         }
         if (existingPullRequest) {
           const command = githubCommandFromUnknown(inputRecord.github) || githubCommandFromRunContext(existingPullRequest)
+          if (command && declaredInputCommand(context, command.command) === false) return options.ignored?.("not_command") || ignored("not_command")
           return {
             ...(finishEffects ? { delivery: { finishEffects } } : {}),
             input: {

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -552,7 +552,7 @@ function declaredInputCommand<TRuntimeConfig extends AgentRuntimeConfig>(
 function githubPullRequestCommandFromInput(input: unknown): GitHubPullRequestCommand | undefined {
   const payload = inputPayload(input)
   const facts = inputGithubFacts(input)
-  if (!payload || facts?.event !== "issue_comment" || payload.action !== "created") return
+  if (!payload || (facts && facts.event !== "issue_comment") || payload.action !== "created") return
   if (!payload.issue?.pull_request) return
   const body = maybeString(payload.comment?.body)
   const parsed = body ? parseSlashCommand(body) : undefined
@@ -1536,6 +1536,24 @@ function ignored(reason: string) {
   return Response.json({ accepted: false, ok: true, reason })
 }
 
+function githubPullRequestRunContextFromInput(input: unknown): GitHubPullRequestRunContext | undefined {
+  if (!isRecord(input)) return
+  const value = isRecord(input.pullRequest) && isRecord(input.pullRequest.pullRequest) ? input.pullRequest : input
+  if (!isRecord(value.pullRequest) || !isRecord(value.repository) || !isRecord(value.run) || !isRecord(value.trigger)) return
+  return value as unknown as GitHubPullRequestRunContext
+}
+
+function githubPullRequestDevPrompt(input: Record<string, unknown>, pullRequest: GitHubPullRequestRunContext): string {
+  return maybeString(input.prompt) || maybeString(pullRequest.trigger.comment.body) || maybeString(pullRequest.trigger.command) || "/review"
+}
+
+function githubDevPayload(input: unknown): GitHubIssueCommentPayload | undefined {
+  const payload = inputPayloadOrBody(input)
+  if (payload) return payload
+  if (!isRecord(input) || !isRecord(input.issue) || !isRecord(input.comment)) return
+  return input as GitHubIssueCommentPayload
+}
+
 function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
   pullRequest: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig> | undefined,
   app?: true | GitHubAppOptions<TRuntimeConfig>,
@@ -1561,6 +1579,59 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
           input: pullRequestCommandInput(command, pullRequest),
           run: {
             ...pullRequest.run,
+            channelId: context.trigger.channelId,
+          },
+        }
+      },
+    },
+    dev: {
+      async invoke(context, input): Promise<AgentTriggerInvokeResult> {
+        const inputRecord = isRecord(input) ? input : {}
+        const finishEffects = githubPullRequestCommentFinishEffects(options)
+        const existingPullRequest = githubPullRequestRunContextFromInput(input)
+        const controls = {
+          ...(inputRecord.abortSignal ? { abortSignal: inputRecord.abortSignal as AbortSignal } : {}),
+          ...(typeof inputRecord.timeout === "number" ? { timeout: inputRecord.timeout } : {}),
+        }
+        if (existingPullRequest) {
+          return {
+            ...(finishEffects ? { delivery: { finishEffects } } : {}),
+            input: {
+              ...controls,
+              context: { pullRequest: existingPullRequest },
+              prompt: githubPullRequestDevPrompt(inputRecord, existingPullRequest),
+            },
+            run: {
+              ...existingPullRequest.run,
+              ...(isRecord(inputRecord.run) ? inputRecord.run : {}),
+              channelId: context.trigger.channelId,
+            },
+          }
+        }
+
+        const payload = githubDevPayload(input)
+        const command = githubPullRequestCommandFromInput(isRecord(input) ? { ...input, payload } : { payload })
+        if (!payload && !command) return options.ignored?.("missing_payload") || ignored("missing_payload")
+        if (!command) return options.ignored?.("not_command") || ignored("not_command")
+        if (declaredInputCommand(context, command.command) === false) return options.ignored?.("not_command") || ignored("not_command")
+        const metadata = await githubPullRequestMetadata(app, context, command, options, payload)
+        const pullRequest = githubPullRequestRunContext(command, {
+          ...options,
+          threadId: options.threadId || maybeString(payload?.issue?.pull_request?.html_url) || maybeString(payload?.issue?.html_url) || command.pullRequestUrl,
+        }, payload, metadata)
+        return {
+          ...(finishEffects ? { delivery: { finishEffects } } : {}),
+          input: {
+            ...controls,
+            context: {
+              github: command,
+              pullRequest,
+            },
+            prompt: maybeString(inputRecord.prompt) || command.body,
+          },
+          run: {
+            ...pullRequest.run,
+            ...(isRecord(inputRecord.run) ? inputRecord.run : {}),
             channelId: context.trigger.channelId,
           },
         }

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1617,6 +1617,7 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
       },
     },
     dev: {
+      webhooks: [],
       async invoke(context, input): Promise<AgentTriggerInvokeResult> {
         const inputRecord = isRecord(input) ? input : {}
         const finishEffects = githubPullRequestCommentFinishEffects(options)

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -565,6 +565,7 @@ function githubPullRequestCommandFromInput(input: unknown): GitHubPullRequestCom
   const pullRequestUrl = maybeString(payload.issue.pull_request.url)
   if (!repository || !owner || !repo || !login || !issueNumber || !commentId || !pullRequestUrl) return
   const association = maybeString(payload.comment?.author_association) || maybeString(payload.issue.author_association)
+  const installationId = maybeNumber(facts?.installationId) ?? maybeNumber(payload.installation?.id)
   return {
     action: "created",
     actor: {
@@ -579,7 +580,7 @@ function githubPullRequestCommandFromInput(input: unknown): GitHubPullRequestCom
     commentId,
     ...(maybeString(payload.comment?.node_id) ? { commentNodeId: maybeString(payload.comment?.node_id) } : {}),
     ...(maybeString(facts?.deliveryId) ? { deliveryId: maybeString(facts?.deliveryId) } : {}),
-    ...(maybeNumber(facts?.installationId) ? { installationId: maybeNumber(facts?.installationId) } : {}),
+    ...(installationId ? { installationId } : {}),
     issueNumber,
     owner,
     pullRequestUrl,
@@ -1543,6 +1544,34 @@ function githubPullRequestRunContextFromInput(input: unknown): GitHubPullRequest
   return value as unknown as GitHubPullRequestRunContext
 }
 
+function githubCommandFromRunContext(value: GitHubPullRequestRunContext): GitHubPullRequestCommand | undefined {
+  const repository = maybeString(value.repository.fullName)
+  const [fallbackOwner, fallbackRepo] = repository?.split("/") || []
+  const owner = maybeString(value.repository.owner) || fallbackOwner
+  const repo = maybeString(value.repository.name) || fallbackRepo
+  const issueNumber = maybeNumber(value.pullRequest.number)
+  const commentId = maybeNumber(value.trigger.comment.id)
+  const pullRequestUrl = maybeString(value.pullRequest.apiUrl)
+  const login = maybeString(value.trigger.actor.login)
+  if (!repository || !owner || !repo || !issueNumber || !commentId || !pullRequestUrl || !login) return
+  return {
+    action: value.trigger.action,
+    actor: value.trigger.actor,
+    args: value.trigger.args,
+    body: maybeString(value.trigger.comment.body) || value.trigger.command,
+    command: value.trigger.command,
+    commentId,
+    ...(maybeString(value.trigger.comment.nodeId) ? { commentNodeId: maybeString(value.trigger.comment.nodeId) } : {}),
+    ...(maybeString(value.trigger.deliveryId) ? { deliveryId: maybeString(value.trigger.deliveryId) } : {}),
+    ...(maybeNumber(value.trigger.installationId) ? { installationId: maybeNumber(value.trigger.installationId) } : {}),
+    issueNumber,
+    owner,
+    pullRequestUrl,
+    repo,
+    repository,
+  }
+}
+
 function githubPullRequestDevPrompt(input: Record<string, unknown>, pullRequest: GitHubPullRequestRunContext): string {
   return maybeString(input.prompt) || maybeString(pullRequest.trigger.comment.body) || maybeString(pullRequest.trigger.command) || "/review"
 }
@@ -1594,16 +1623,19 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
           ...(typeof inputRecord.timeout === "number" ? { timeout: inputRecord.timeout } : {}),
         }
         if (existingPullRequest) {
+          const command = githubCommandFromUnknown(inputRecord.github) || githubCommandFromRunContext(existingPullRequest)
           return {
             ...(finishEffects ? { delivery: { finishEffects } } : {}),
             input: {
               ...controls,
-              context: { pullRequest: existingPullRequest },
+              context: {
+                ...(command ? { github: command } : {}),
+                pullRequest: existingPullRequest,
+              },
               prompt: githubPullRequestDevPrompt(inputRecord, existingPullRequest),
             },
             run: {
               ...existingPullRequest.run,
-              ...(isRecord(inputRecord.run) ? inputRecord.run : {}),
               channelId: context.trigger.channelId,
             },
           }
@@ -1631,7 +1663,6 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
           },
           run: {
             ...pullRequest.run,
-            ...(isRecord(inputRecord.run) ? inputRecord.run : {}),
             channelId: context.trigger.channelId,
           },
         }

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -199,7 +199,7 @@ describe("agent channels", () => {
       capabilities: [],
       channel,
       trigger: { channelId: "github", id: "github.dev", name: "dev", source: "channel" },
-    } as never
+    }
     const pullRequest = {
       pullRequest: {
         apiUrl: "https://api.github.test/repos/acme/app/pulls/42",
@@ -211,16 +211,16 @@ describe("agent channels", () => {
       trigger: {
         action: "created",
         actor: { login: "mona" },
-        args: "",
+        args: "docs",
         command: "/review",
-        comment: { body: "/review", id: 99, nodeId: "comment-node" },
+        comment: { id: 99, nodeId: "comment-node" },
         event: "issue_comment",
         installationId: 123,
       },
     }
     const devRun = { origin: "dev", runId: "dev:from-loop", threadId: "dev:agent" }
 
-    const fromContext = await trigger.invoke(context, { pullRequest, prompt: "manual prompt", run: devRun })
+    const fromContext = await trigger.invoke(context as never, { pullRequest, run: devRun })
     if (fromContext instanceof Response) throw new Error("Expected GitHub context invocation.")
     expect(fromContext.input).toMatchObject({
       context: {
@@ -233,7 +233,7 @@ describe("agent channels", () => {
         },
         pullRequest,
       },
-      prompt: "manual prompt",
+      prompt: "/review docs",
     })
     expect(fromContext.run).toMatchObject({
       channelId: "github",
@@ -242,7 +242,14 @@ describe("agent channels", () => {
       threadId: "pr-42",
     })
 
-    const fromPayload = await trigger.invoke(context, { ...githubIssueCommentPayload("/review raw payload"), run: devRun })
+    const blocked = await trigger.invoke({
+      ...context,
+      capabilities: [{ metadata: { commands: { review: { channels: ["other"] } }, trigger: "/" } }],
+    } as never, { pullRequest })
+    if (!(blocked instanceof Response)) throw new Error("Expected blocked GitHub context response.")
+    await expect(blocked.json()).resolves.toMatchObject({ reason: "not_command" })
+
+    const fromPayload = await trigger.invoke(context as never, { ...githubIssueCommentPayload("/review raw payload"), run: devRun })
     if (fromPayload instanceof Response) throw new Error("Expected GitHub payload invocation.")
     expect(fromPayload.input.context?.github).toMatchObject({
       args: "raw payload",

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -2,6 +2,30 @@ import { generateKeyPairSync } from "node:crypto"
 
 import { describe, expect, it, vi } from "vitest"
 
+function githubIssueCommentPayload(body = "/review please") {
+  return {
+    action: "created",
+    comment: {
+      body,
+      id: 99,
+      node_id: "comment-node",
+      user: { id: 1, login: "mona", type: "User" },
+    },
+    issue: {
+      html_url: "https://github.test/acme/app/issues/42",
+      number: 42,
+      pull_request: {
+        html_url: "https://github.test/acme/app/pull/42",
+        url: "https://api.github.test/repos/acme/app/pulls/42",
+      },
+      title: "Improve app",
+    },
+    repository: {
+      full_name: "acme/app",
+    },
+  }
+}
+
 describe("agent channels", () => {
   it("falls back to output fields when finish result text is empty", async () => {
     const { getAgentFinishText } = await import("../src/channels.ts")
@@ -138,6 +162,86 @@ describe("agent channels", () => {
       type: "file",
       url: "https://assets.example/reports/review.pdf",
     }])
+  })
+
+  it("accepts GitHub issue_comment payloads without delivery facts", async () => {
+    const { github } = await import("../src/channels.ts")
+    const channel = github({ pullRequest: { reply: false } })
+    const trigger = channel.triggers?.webhook
+    if (!trigger) throw new Error("Missing GitHub webhook trigger.")
+
+    const result = await trigger.invoke({
+      capabilities: [],
+      channel,
+      trigger: { channelId: "github", id: "github.webhook", name: "webhook", source: "channel" },
+    } as never, { payload: githubIssueCommentPayload() })
+    if (result instanceof Response) throw new Error("Expected GitHub webhook invocation.")
+
+    expect(result.input.context?.github).toMatchObject({
+      args: "please",
+      command: "/review",
+      repository: "acme/app",
+    })
+    expect(result.input.context?.pullRequest).toMatchObject({
+      pullRequest: { number: 42 },
+      repository: { fullName: "acme/app" },
+    })
+  })
+
+  it("invokes GitHub PR dev trigger from context and raw payload", async () => {
+    const { github } = await import("../src/channels.ts")
+    const channel = github({ pullRequest: { reply: false } })
+    const trigger = channel.triggers?.dev
+    if (!trigger) throw new Error("Missing GitHub dev trigger.")
+    const context = {
+      capabilities: [],
+      channel,
+      trigger: { channelId: "github", id: "github.dev", name: "dev", source: "channel" },
+    } as never
+    const pullRequest = {
+      pullRequest: {
+        apiUrl: "https://api.github.test/repos/acme/app/pulls/42",
+        number: 42,
+        source: { mount: "app", ref: "refs/pull/42/head", repo: "acme/app" },
+      },
+      repository: { fullName: "acme/app", name: "app", owner: "acme" },
+      run: { messageId: "99", origin: "github-pull-request-comment", runId: "github:acme/app#42:comment:99", threadId: "pr-42" },
+      trigger: {
+        action: "created",
+        actor: { login: "mona" },
+        args: "",
+        command: "/review",
+        comment: { body: "/review", id: 99 },
+        event: "issue_comment",
+      },
+    }
+
+    const fromContext = await trigger.invoke(context, { pullRequest, prompt: "manual prompt" })
+    if (fromContext instanceof Response) throw new Error("Expected GitHub context invocation.")
+    expect(fromContext.input).toMatchObject({
+      context: { pullRequest },
+      prompt: "manual prompt",
+    })
+    expect(fromContext.run).toMatchObject({
+      channelId: "github",
+      runId: "github:acme/app#42:comment:99",
+    })
+
+    const fromPayload = await trigger.invoke(context, githubIssueCommentPayload("/review raw payload"))
+    if (fromPayload instanceof Response) throw new Error("Expected GitHub payload invocation.")
+    expect(fromPayload.input.context?.github).toMatchObject({
+      args: "raw payload",
+      command: "/review",
+      repository: "acme/app",
+    })
+    expect(fromPayload.input.context?.pullRequest).toMatchObject({
+      pullRequest: { number: 42 },
+      repository: { fullName: "acme/app" },
+    })
+    expect(fromPayload.run).toMatchObject({
+      channelId: "github",
+      runId: "github:acme/app#42:comment:99",
+    })
   })
 
   it("posts GitHub PR reviews with inline published image artifacts", async () => {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -170,12 +170,13 @@ describe("agent channels", () => {
     const channel = github({ pullRequest: { reply: false } })
     const trigger = channel.triggers?.webhook
     if (!trigger) throw new Error("Missing GitHub webhook trigger.")
-
-    const result = await trigger.invoke({
+    const context = {
       capabilities: [],
       channel,
       trigger: { channelId: "github", id: "github.webhook", name: "webhook", source: "channel" },
-    } as never, { payload: githubIssueCommentPayload() })
+    }
+
+    const result = await trigger.invoke(context as never, { payload: githubIssueCommentPayload() })
     if (result instanceof Response) throw new Error("Expected GitHub webhook invocation.")
 
     expect(result.input.context?.github).toMatchObject({
@@ -187,6 +188,15 @@ describe("agent channels", () => {
     expect(result.input.context?.pullRequest).toMatchObject({
       pullRequest: { number: 42 },
       repository: { fullName: "acme/app" },
+    })
+
+    const withEmptyFacts = await trigger.invoke(context as never, { payload: githubIssueCommentPayload("/review generated route"), github: {} })
+    if (withEmptyFacts instanceof Response) throw new Error("Expected GitHub webhook invocation with empty facts.")
+    expect(withEmptyFacts.input.context?.github).toMatchObject({
+      args: "generated route",
+      command: "/review",
+      installationId: 123,
+      repository: "acme/app",
     })
   })
 

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -205,6 +205,7 @@ describe("agent channels", () => {
     const channel = github({ pullRequest: true })
     const trigger = channel.triggers?.dev
     if (!trigger) throw new Error("Missing GitHub dev trigger.")
+    expect(trigger.webhooks).toEqual([])
     const context = {
       capabilities: [],
       channel,

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -20,6 +20,7 @@ function githubIssueCommentPayload(body = "/review please") {
       },
       title: "Improve app",
     },
+    installation: { id: 123 },
     repository: {
       full_name: "acme/app",
     },
@@ -180,6 +181,7 @@ describe("agent channels", () => {
     expect(result.input.context?.github).toMatchObject({
       args: "please",
       command: "/review",
+      installationId: 123,
       repository: "acme/app",
     })
     expect(result.input.context?.pullRequest).toMatchObject({
@@ -190,7 +192,7 @@ describe("agent channels", () => {
 
   it("invokes GitHub PR dev trigger from context and raw payload", async () => {
     const { github } = await import("../src/channels.ts")
-    const channel = github({ pullRequest: { reply: false } })
+    const channel = github({ pullRequest: true })
     const trigger = channel.triggers?.dev
     if (!trigger) throw new Error("Missing GitHub dev trigger.")
     const context = {
@@ -211,27 +213,41 @@ describe("agent channels", () => {
         actor: { login: "mona" },
         args: "",
         command: "/review",
-        comment: { body: "/review", id: 99 },
+        comment: { body: "/review", id: 99, nodeId: "comment-node" },
         event: "issue_comment",
+        installationId: 123,
       },
     }
+    const devRun = { origin: "dev", runId: "dev:from-loop", threadId: "dev:agent" }
 
-    const fromContext = await trigger.invoke(context, { pullRequest, prompt: "manual prompt" })
+    const fromContext = await trigger.invoke(context, { pullRequest, prompt: "manual prompt", run: devRun })
     if (fromContext instanceof Response) throw new Error("Expected GitHub context invocation.")
     expect(fromContext.input).toMatchObject({
-      context: { pullRequest },
+      context: {
+        github: {
+          commentId: 99,
+          commentNodeId: "comment-node",
+          command: "/review",
+          installationId: 123,
+          repository: "acme/app",
+        },
+        pullRequest,
+      },
       prompt: "manual prompt",
     })
     expect(fromContext.run).toMatchObject({
       channelId: "github",
+      origin: "github-pull-request-comment",
       runId: "github:acme/app#42:comment:99",
+      threadId: "pr-42",
     })
 
-    const fromPayload = await trigger.invoke(context, githubIssueCommentPayload("/review raw payload"))
+    const fromPayload = await trigger.invoke(context, { ...githubIssueCommentPayload("/review raw payload"), run: devRun })
     if (fromPayload instanceof Response) throw new Error("Expected GitHub payload invocation.")
     expect(fromPayload.input.context?.github).toMatchObject({
       args: "raw payload",
       command: "/review",
+      installationId: 123,
       repository: "acme/app",
     })
     expect(fromPayload.input.context?.pullRequest).toMatchObject({
@@ -240,7 +256,9 @@ describe("agent channels", () => {
     })
     expect(fromPayload.run).toMatchObject({
       channelId: "github",
+      origin: "github-pull-request-comment",
       runId: "github:acme/app#42:comment:99",
+      threadId: "https://github.test/acme/app/pull/42",
     })
   })
 


### PR DESCRIPTION
Ports the Quiver-carried GitHub pull request dev invocation patch into `@vite-hub/agent`. The GitHub PR Channel now accepts `issue_comment` payloads when no delivery facts are present and exposes a `github.dev` trigger that can run from either a prebuilt pull-request context or a raw issue comment payload.

Focused channel tests cover the no-facts webhook admission and both dev trigger input shapes.