### PR TITLE
fix(agent): compare workspace source probe paths

### DIFF
--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -368,9 +368,11 @@ function sourceScopePath(runtime: WorkspaceContributionRuntime, key: string, sou
   return source.requestOnly ? runtime.workspaceSourceRequestDescriptorPath(key) : source.mountPath
 }
 
-function sourcesConflict(left: { mountPath: string, requestOnly: boolean }, right: { mountPath: string, requestOnly: boolean }): boolean {
+function sourcesConflict(left: { mountPath: string, probePaths?: string[], requestOnly: boolean }, right: { mountPath: string, probePaths?: string[], requestOnly: boolean }): boolean {
   if (left.requestOnly || right.requestOnly) return false
-  return pathsConflict(left.mountPath, right.mountPath)
+  const leftPaths = left.probePaths?.length ? left.probePaths : [left.mountPath]
+  const rightPaths = right.probePaths?.length ? right.probePaths : [right.mountPath]
+  return leftPaths.some(leftPath => rightPaths.some(rightPath => pathsConflict(leftPath, rightPath)))
 }
 
 function assertWorkspaceContribution(
@@ -383,7 +385,7 @@ function assertWorkspaceContribution(
   const rules = contribution.rules || {}
   const sourceEntries = Object.entries(sources)
   const rulePatterns = Object.keys(rules)
-  const contributionSources: Array<{ key: string, mountPath: string, requestOnly: boolean }> = []
+  const contributionSources: Array<{ key: string, mountPath: string, probePaths?: string[], requestOnly: boolean }> = []
 
   for (const [key, source] of sourceEntries) {
     if (definition.sources?.[key]) {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -729,6 +729,55 @@ describe("agent capability runtime", () => {
     })).rejects.toThrow('workspace contribution source "review" conflicts with contributed Workspace Source "files"')
   })
 
+  it("allows capability workspace sources with disjoint probe paths at the same mount", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              instructions: "AGENTS.md",
+              docs: "docs/README.md",
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    expect(resolved.workspaceDefinition?.sources).toHaveProperty("instructions")
+    expect(resolved.workspaceDefinition?.sources).toHaveProperty("docs")
+  })
+
+  it("rejects capability workspace sources with overlapping probe paths at the same mount", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          id: "review",
+          workspace: {
+            sources: {
+              instructions: "AGENTS.md",
+              docs: "AGENTS.md",
+            },
+          },
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow('workspace contribution source "docs" conflicts with contributed Workspace Source "instructions"')
+  })
+
   it("rejects overlapping capability workspace rules", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 


### PR DESCRIPTION
Fixes Capability Workspace Contribution conflict detection for finite Source-backed paths. Root-mounted file Sources now compare normalized probe paths when available, so two contributed Sources can share the root Mount when their known paths are disjoint, while overlapping probe paths still fail loudly.

This moves the Quiver-carried patch into Agent Package source and covers both allow and reject cases in capability runtime tests.