### PR TITLE
feat(agent): add pull request context git checkout

### DIFF
--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from "node:child_process"
+
 import {
   defineCapability,
   normalizeMode,
@@ -23,7 +25,8 @@ export interface GitCapabilityOptions {
 }
 
 interface GitCommandInput {
-  command: string
+  args?: string[]
+  command?: string
   cwd?: string
 }
 
@@ -38,7 +41,7 @@ interface GitCommandResult {
 }
 
 interface GitSessionState {
-  sessionPromise?: Promise<WorkspaceSession>
+  sessionPromises?: Map<string, Promise<WorkspaceSession>>
 }
 
 const readSubcommands = new Set([
@@ -71,9 +74,11 @@ const gitEnv = {
   GIT_TERMINAL_PROMPT: "0",
   PAGER: "cat",
 }
+const githubRepositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
+const gitRefPattern = /^[A-Za-z0-9._/-]+$/
 
 type GitSessionWorkspace = {
-  startSession: () => Promise<WorkspaceSession>
+  startSession: (options?: { paths?: readonly string[] }) => Promise<WorkspaceSession>
 }
 
 function isGitSessionWorkspace(workspace: unknown): workspace is GitSessionWorkspace {
@@ -234,6 +239,17 @@ function gitExecOptions(cwd: string, timeout: number | undefined) {
   return { cwd, env: gitEnv, timeout }
 }
 
+function gitShellExecOptions(cwd: string, timeout: number | undefined, env: Record<string, string | undefined>) {
+  return {
+    cwd,
+    env: {
+      ...gitEnv,
+      ...Object.fromEntries(Object.entries(env).filter(([, value]) => value !== undefined)),
+    },
+    timeout,
+  }
+}
+
 async function assertConfiguredFetchRemote(session: WorkspaceSession, cwd: string, timeout: number | undefined, args: string[]): Promise<void> {
   const remote = fetchRemote(args)
   if (!remote) return
@@ -253,6 +269,170 @@ function normalizeCwd(cwd: string | undefined): string {
   return parts.length ? `/workspace/${parts.join("/")}` : "/workspace"
 }
 
+function workspacePathFromGitCwd(cwd: string): string {
+  return cwd.replace(/^\/workspace(?:\/|$)/, "")
+}
+
+function pathContains(container: string, path: string): boolean {
+  return !container || path === container || path.startsWith(`${container}/`)
+}
+
+function isGitRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function safeGitHubRepository(repo: unknown): string | undefined {
+  return typeof repo === "string" && githubRepositoryPattern.test(repo) ? repo : undefined
+}
+
+function safeGitRef(ref: unknown): string | undefined {
+  if (typeof ref !== "string" || !ref || ref.length > 250) return
+  if (!gitRefPattern.test(ref) || ref.includes("..") || ref.includes("//") || ref.includes("@{") || ref.endsWith(".lock") || ref.endsWith("/") || ref.startsWith("/")) return
+  return ref
+}
+
+function safeWorkspacePath(path: unknown): string | undefined {
+  if (typeof path !== "string" || !path) return
+  try {
+    return workspacePathFromGitCwd(normalizeCwd(path)) || undefined
+  }
+  catch {
+    return
+  }
+}
+
+function gitRemoteRef(ref: string): string {
+  return ref.startsWith("refs/") ? ref : `refs/heads/${ref}`
+}
+
+function gitRemoteBranchRef(ref: string): string {
+  return ref.replace(/^refs\/heads\//, "")
+}
+
+function gitRemoteBranchTrackingRef(ref: string): string {
+  return `refs/remotes/origin/${gitRemoteBranchRef(ref)}`
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+function gitCommandFromArgs(args: unknown): string | undefined {
+  if (!Array.isArray(args) || !args.length || !args.every(arg => typeof arg === "string" && arg.length > 0)) return
+  const words = args[0] === "git" ? args : ["git", ...args]
+  return words.map(word => /^[A-Za-z0-9_./:@%+=,-]+$/.test(word) ? word : shellQuote(word)).join(" ")
+}
+
+function gitHubCliToken(): string | undefined {
+  try {
+    return execFileSync("gh", ["auth", "token", "--hostname", "github.com"], {
+      encoding: "utf8",
+      env: Object.fromEntries(Object.entries(process.env).filter(([key]) => key !== "GITHUB_TOKEN" && key !== "GH_TOKEN" && key !== "VITEHUB_GITHUB_TOKEN")),
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2_000,
+    }).trim() || undefined
+  }
+  catch {
+    return
+  }
+}
+
+function gitHubAuthHeader(): string | undefined {
+  const token = process.env.VITEHUB_GITHUB_TOKEN || process.env.GH_TOKEN || gitHubCliToken() || process.env.GITHUB_TOKEN
+  return token ? `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString("base64")}` : undefined
+}
+
+function pullRequestGitSetup(context: { context?: { get(key: string): unknown } }) {
+  const raw = context.context?.get("pullRequest")
+  const pullRequest = isGitRecord(raw) && isGitRecord(raw.pullRequest) ? raw.pullRequest : isGitRecord(raw) ? raw : undefined
+  if (!pullRequest) return
+
+  const source = isGitRecord(pullRequest.source) ? pullRequest.source : undefined
+  const base = isGitRecord(pullRequest.base) ? pullRequest.base : undefined
+  const head = isGitRecord(pullRequest.head) ? pullRequest.head : undefined
+  const repository = isGitRecord(raw) && isGitRecord(raw.repository) ? raw.repository : undefined
+  const repo = safeGitHubRepository(source?.repo)
+    || safeGitHubRepository(isGitRecord(raw) ? raw.repository : undefined)
+    || safeGitHubRepository(repository?.fullName)
+  const mount = safeWorkspacePath(source?.mount) || safeWorkspacePath(repository?.name)
+  const headRef = safeGitRef(source?.ref) || safeGitRef(head?.ref)
+  const baseRef = safeGitRef(base?.ref) || "main"
+  if (!repo || !mount || !headRef || !baseRef) return
+
+  return {
+    baseRef: gitRemoteRef(baseRef),
+    headRef: gitRemoteRef(headRef),
+    mount,
+    remoteUrl: `https://github.com/${repo}.git`,
+  }
+}
+
+function gitSessionWorkspacePath(cwd: string, context: { context?: { get(key: string): unknown } }): string {
+  const workspacePath = workspacePathFromGitCwd(cwd)
+  const setup = pullRequestGitSetup(context)
+  if (setup && pathContains(setup.mount, workspacePath)) return setup.mount
+  return workspacePath
+}
+
+async function preparePullRequestGitSession(
+  session: WorkspaceSession,
+  workspacePath: string,
+  context: { context?: { get(key: string): unknown } },
+  timeout: number | undefined,
+): Promise<void> {
+  const setup = pullRequestGitSetup(context)
+  if (!setup || workspacePath !== setup.mount) return
+
+  const cwd = `/workspace/${setup.mount}`
+  const existing = await session.exec("git", ["rev-parse", "--is-inside-work-tree"], gitExecOptions(cwd, timeout))
+  if (existing.exitCode === 0) return
+
+  const baseTrackingRef = gitRemoteBranchTrackingRef(setup.baseRef)
+  const authHeader = gitHubAuthHeader()
+  const script = [
+    "set -eu",
+    `rm -rf -- ${shellQuote(setup.mount)}`,
+    `mkdir -p -- ${shellQuote(setup.mount)}`,
+    `cd -- ${shellQuote(setup.mount)}`,
+    "git init -q",
+    `git remote add origin ${shellQuote(setup.remoteUrl)}`,
+    'if [ -n "${VITEHUB_GIT_AUTH_HEADER:-}" ]; then git config --local http.https://github.com/.extraheader "$VITEHUB_GIT_AUTH_HEADER"; fi',
+    `git fetch --depth=100 origin ${shellQuote(`${setup.headRef}:refs/vitehub/head`)} ${shellQuote(`${setup.baseRef}:${baseTrackingRef}`)}`,
+    "git checkout -q --detach refs/vitehub/head",
+    `git branch -f vitehub-base ${shellQuote(baseTrackingRef)} >/dev/null`,
+    "git branch -f vitehub-head HEAD >/dev/null",
+  ].join("\n")
+  const result = await session.exec("sh", ["-lc", script], gitShellExecOptions("/workspace", timeout, {
+    VITEHUB_GIT_AUTH_HEADER: authHeader,
+  }))
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || result.stdout || "[vitehub] git could not prepare pull request checkout.")
+  }
+}
+
+function defaultGitCwd(context: { context?: { get(key: string): unknown } }): string | undefined {
+  const raw = context.context?.get("pullRequest")
+  const pullRequest = isGitRecord(raw) && isGitRecord(raw.pullRequest) ? raw.pullRequest : isGitRecord(raw) ? raw : undefined
+  const source = isGitRecord(pullRequest?.source) ? pullRequest.source : undefined
+  return safeWorkspacePath(source?.mount)
+}
+
+function normalizeGitToolInput(input: unknown, defaultCwd: string | undefined): GitCommandInput {
+  if (typeof input === "string") {
+    return {
+      command: input,
+      ...(defaultCwd ? { cwd: defaultCwd } : {}),
+    }
+  }
+  if (!isGitRecord(input)) return {}
+  const command = typeof input.command === "string" ? input.command : gitCommandFromArgs(input.args)
+  return {
+    ...input,
+    ...(command ? { command } : {}),
+    ...(input.cwd === undefined && defaultCwd ? { cwd: defaultCwd } : {}),
+  }
+}
+
 function limitOutput(output: string, maxOutputLength: number): { output: string, truncated?: boolean } {
   if (output.length <= maxOutputLength) return { output }
   return {
@@ -270,16 +450,18 @@ async function cleanWorkingTree(session: WorkspaceSession, cwd: string, timeout:
 function gitTools(
   mode: AgentCapabilityMode,
   options: Required<Pick<GitCapabilityOptions, "maxOutputLength">> & Pick<GitCapabilityOptions, "policy" | "timeout">,
-  getSession: () => Promise<WorkspaceSession>,
+  getSession: (cwd: string) => Promise<WorkspaceSession>,
+  defaultCwd: string | undefined,
 ): AgentToolSet {
-  async function run(input: GitCommandInput, write: boolean): Promise<GitCommandResult> {
+  async function run(rawInput: unknown, write: boolean): Promise<GitCommandResult> {
+    const input = normalizeGitToolInput(rawInput, defaultCwd)
     if (typeof input?.command !== "string" || !input.command.trim()) {
       throw new Error("[vitehub] git command must be a non-empty string.")
     }
     const args = parseGitCommand(input.command)
     write ? assertGitWrite(args) : assertGitRead(args)
     const cwd = normalizeCwd(input.cwd)
-    const session = await getSession()
+    const session = await getSession(cwd)
     if (write && args[0] === "fetch") await assertConfiguredFetchRemote(session, cwd, options.timeout, args)
     if (write && writeSubcommands.has(args[0]!)) await cleanWorkingTree(session, cwd, options.timeout)
     const result = await session.exec("git", args, gitExecOptions(cwd, options.timeout))
@@ -347,27 +529,39 @@ export function git(options: GitCapabilityOptions = {}): AgentCapabilityDefiniti
     return state
   }
 
-  function getSessionResolver(context: { workspace?: unknown }): () => Promise<WorkspaceSession> {
-    return async () => {
+  function getSessionResolver(context: { context?: { get(key: string): unknown }, workspace?: unknown }): (cwd: string) => Promise<WorkspaceSession> {
+    return async (cwd) => {
       const workspace = context.workspace
       if (!isGitSessionWorkspace(workspace)) {
         throw new Error("[vitehub] git() requires a git-capable workspace session.")
       }
       const state = sessionState(context)
-      state.sessionPromise ??= workspace.startSession().catch((error) => {
-        state.sessionPromise = undefined
-        throw error
-      })
-      return await state.sessionPromise
+      const workspacePath = gitSessionWorkspacePath(cwd, context)
+      const key = workspacePath || ""
+      state.sessionPromises ??= new Map()
+      if (!state.sessionPromises.has(key)) {
+        state.sessionPromises.set(key, workspace.startSession(workspacePath ? { paths: [workspacePath] } : undefined).then(async (session) => {
+          await preparePullRequestGitSession(session, workspacePath, context, options.timeout)
+          return session
+        }).catch((error) => {
+          state.sessionPromises?.delete(key)
+          throw error
+        }))
+      }
+      const session = await state.sessionPromises.get(key)
+      if (!session) {
+        throw new Error("[vitehub] git() requires a git-capable workspace session.")
+      }
+      return session
     }
   }
 
   async function closeSession(context: object): Promise<void> {
     const state = sessionStates.get(context)
     sessionStates.delete(context)
-    const session = await state?.sessionPromise
-    if (state) state.sessionPromise = undefined
-    await session?.close()
+    const sessions = await Promise.all([...state?.sessionPromises?.values() || []])
+    if (state) state.sessionPromises = undefined
+    await Promise.all(sessions.map(session => session.close()))
   }
 
   return defineCapability({
@@ -379,7 +573,7 @@ export function git(options: GitCapabilityOptions = {}): AgentCapabilityDefiniti
       maxOutputLength,
       policy: options.policy,
       timeout: options.timeout,
-    }, getSessionResolver(context)),
+    }, getSessionResolver(context), defaultGitCwd(context)),
     close: closeSession,
   })
 }

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -1,5 +1,3 @@
-import { execFileSync } from "node:child_process"
-
 import {
   defineCapability,
   normalizeMode,
@@ -328,8 +326,9 @@ function gitCommandFromArgs(args: unknown): string | undefined {
   return words.map(word => /^[A-Za-z0-9_./:@%+=,-]+$/.test(word) ? word : shellQuote(word)).join(" ")
 }
 
-function gitHubCliToken(): string | undefined {
+async function gitHubCliToken(): Promise<string | undefined> {
   try {
+    const { execFileSync } = await import("node:child_process")
     return execFileSync("gh", ["auth", "token", "--hostname", "github.com"], {
       encoding: "utf8",
       env: Object.fromEntries(Object.entries(process.env).filter(([key]) => key !== "GITHUB_TOKEN" && key !== "GH_TOKEN" && key !== "VITEHUB_GITHUB_TOKEN")),
@@ -342,8 +341,8 @@ function gitHubCliToken(): string | undefined {
   }
 }
 
-function gitHubAuthHeader(): string | undefined {
-  const token = process.env.VITEHUB_GITHUB_TOKEN || process.env.GH_TOKEN || gitHubCliToken() || process.env.GITHUB_TOKEN
+async function gitHubAuthHeader(): Promise<string | undefined> {
+  const token = process.env.VITEHUB_GITHUB_TOKEN || process.env.GH_TOKEN || await gitHubCliToken() || process.env.GITHUB_TOKEN
   return token ? `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString("base64")}` : undefined
 }
 
@@ -396,7 +395,7 @@ async function preparePullRequestGitSession(
   if (existing.exitCode === 0) return false
 
   const baseTrackingRef = setup.baseRef ? gitRemoteBranchTrackingRef(setup.baseRef) : undefined
-  const authHeader = gitHubAuthHeader()
+  const authHeader = await gitHubAuthHeader()
   const fetchRefspecs = [
     `${setup.headRef}:refs/vitehub/head`,
     ...(setup.baseRef && baseTrackingRef ? [`${setup.baseRef}:${baseTrackingRef}`] : []),
@@ -552,8 +551,17 @@ export function git(options: GitCapabilityOptions = {}): AgentCapabilityDefiniti
       state.sessionPromises ??= new Map()
       if (!state.sessionPromises.has(key)) {
         state.sessionPromises.set(key, workspace.startSession(workspacePath ? { paths: [workspacePath] } : undefined).then(async (session) => {
-          const prepared = await preparePullRequestGitSession(session, workspacePath, context, options.timeout)
-          return { commitWrites: !prepared, session }
+          try {
+            const prepared = await preparePullRequestGitSession(session, workspacePath, context, options.timeout)
+            return { commitWrites: !prepared, session }
+          }
+          catch (error) {
+            try {
+              await session.close()
+            }
+            catch {}
+            throw error
+          }
         }).catch((error) => {
           state.sessionPromises?.delete(key)
           throw error

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -41,7 +41,12 @@ interface GitCommandResult {
 }
 
 interface GitSessionState {
-  sessionPromises?: Map<string, Promise<WorkspaceSession>>
+  sessionPromises?: Map<string, Promise<GitSessionHandle>>
+}
+
+interface GitSessionHandle {
+  commitWrites: boolean
+  session: WorkspaceSession
 }
 
 const readSubcommands = new Set([
@@ -347,6 +352,9 @@ function pullRequestGitSetup(context: { context?: { get(key: string): unknown } 
   const pullRequest = isGitRecord(raw) && isGitRecord(raw.pullRequest) ? raw.pullRequest : isGitRecord(raw) ? raw : undefined
   if (!pullRequest) return
 
+  const provider = isGitRecord(raw) ? raw.provider : undefined
+  if (typeof provider === "string" && provider !== "github") return
+
   const source = isGitRecord(pullRequest.source) ? pullRequest.source : undefined
   const base = isGitRecord(pullRequest.base) ? pullRequest.base : undefined
   const head = isGitRecord(pullRequest.head) ? pullRequest.head : undefined
@@ -355,12 +363,12 @@ function pullRequestGitSetup(context: { context?: { get(key: string): unknown } 
     || safeGitHubRepository(isGitRecord(raw) ? raw.repository : undefined)
     || safeGitHubRepository(repository?.fullName)
   const mount = safeWorkspacePath(source?.mount) || safeWorkspacePath(repository?.name)
-  const headRef = safeGitRef(source?.ref) || safeGitRef(head?.ref)
-  const baseRef = safeGitRef(base?.ref) || "main"
-  if (!repo || !mount || !headRef || !baseRef) return
+  const headRef = safeGitRef(source?.ref) || safeGitRef(head?.ref) || safeGitRef(pullRequest.headRef)
+  const baseRef = safeGitRef(base?.ref) || safeGitRef(pullRequest.baseRef)
+  if (!repo || !mount || !headRef) return
 
   return {
-    baseRef: gitRemoteRef(baseRef),
+    ...(baseRef ? { baseRef: gitRemoteRef(baseRef) } : {}),
     headRef: gitRemoteRef(headRef),
     mount,
     remoteUrl: `https://github.com/${repo}.git`,
@@ -371,7 +379,7 @@ function gitSessionWorkspacePath(cwd: string, context: { context?: { get(key: st
   const workspacePath = workspacePathFromGitCwd(cwd)
   const setup = pullRequestGitSetup(context)
   if (setup && pathContains(setup.mount, workspacePath)) return setup.mount
-  return workspacePath
+  return ""
 }
 
 async function preparePullRequestGitSession(
@@ -379,16 +387,20 @@ async function preparePullRequestGitSession(
   workspacePath: string,
   context: { context?: { get(key: string): unknown } },
   timeout: number | undefined,
-): Promise<void> {
+): Promise<boolean> {
   const setup = pullRequestGitSetup(context)
-  if (!setup || workspacePath !== setup.mount) return
+  if (!setup || workspacePath !== setup.mount) return false
 
   const cwd = `/workspace/${setup.mount}`
   const existing = await session.exec("git", ["rev-parse", "--is-inside-work-tree"], gitExecOptions(cwd, timeout))
-  if (existing.exitCode === 0) return
+  if (existing.exitCode === 0) return false
 
-  const baseTrackingRef = gitRemoteBranchTrackingRef(setup.baseRef)
+  const baseTrackingRef = setup.baseRef ? gitRemoteBranchTrackingRef(setup.baseRef) : undefined
   const authHeader = gitHubAuthHeader()
+  const fetchRefspecs = [
+    `${setup.headRef}:refs/vitehub/head`,
+    ...(setup.baseRef && baseTrackingRef ? [`${setup.baseRef}:${baseTrackingRef}`] : []),
+  ].map(shellQuote).join(" ")
   const script = [
     "set -eu",
     `rm -rf -- ${shellQuote(setup.mount)}`,
@@ -397,9 +409,9 @@ async function preparePullRequestGitSession(
     "git init -q",
     `git remote add origin ${shellQuote(setup.remoteUrl)}`,
     'if [ -n "${VITEHUB_GIT_AUTH_HEADER:-}" ]; then git config --local http.https://github.com/.extraheader "$VITEHUB_GIT_AUTH_HEADER"; fi',
-    `git fetch --depth=100 origin ${shellQuote(`${setup.headRef}:refs/vitehub/head`)} ${shellQuote(`${setup.baseRef}:${baseTrackingRef}`)}`,
+    `git fetch --depth=100 origin ${fetchRefspecs}`,
     "git checkout -q --detach refs/vitehub/head",
-    `git branch -f vitehub-base ${shellQuote(baseTrackingRef)} >/dev/null`,
+    ...(baseTrackingRef ? [`git branch -f vitehub-base ${shellQuote(baseTrackingRef)} >/dev/null`] : []),
     "git branch -f vitehub-head HEAD >/dev/null",
   ].join("\n")
   const result = await session.exec("sh", ["-lc", script], gitShellExecOptions("/workspace", timeout, {
@@ -408,13 +420,11 @@ async function preparePullRequestGitSession(
   if (result.exitCode !== 0) {
     throw new Error(result.stderr || result.stdout || "[vitehub] git could not prepare pull request checkout.")
   }
+  return true
 }
 
 function defaultGitCwd(context: { context?: { get(key: string): unknown } }): string | undefined {
-  const raw = context.context?.get("pullRequest")
-  const pullRequest = isGitRecord(raw) && isGitRecord(raw.pullRequest) ? raw.pullRequest : isGitRecord(raw) ? raw : undefined
-  const source = isGitRecord(pullRequest?.source) ? pullRequest.source : undefined
-  return safeWorkspacePath(source?.mount)
+  return pullRequestGitSetup(context)?.mount
 }
 
 function normalizeGitToolInput(input: unknown, defaultCwd: string | undefined): GitCommandInput {
@@ -450,7 +460,7 @@ async function cleanWorkingTree(session: WorkspaceSession, cwd: string, timeout:
 function gitTools(
   mode: AgentCapabilityMode,
   options: Required<Pick<GitCapabilityOptions, "maxOutputLength">> & Pick<GitCapabilityOptions, "policy" | "timeout">,
-  getSession: (cwd: string) => Promise<WorkspaceSession>,
+  getSession: (cwd: string) => Promise<GitSessionHandle>,
   defaultCwd: string | undefined,
 ): AgentToolSet {
   async function run(rawInput: unknown, write: boolean): Promise<GitCommandResult> {
@@ -461,11 +471,12 @@ function gitTools(
     const args = parseGitCommand(input.command)
     write ? assertGitWrite(args) : assertGitRead(args)
     const cwd = normalizeCwd(input.cwd)
-    const session = await getSession(cwd)
+    const handle = await getSession(cwd)
+    const { session } = handle
     if (write && args[0] === "fetch") await assertConfiguredFetchRemote(session, cwd, options.timeout, args)
     if (write && writeSubcommands.has(args[0]!)) await cleanWorkingTree(session, cwd, options.timeout)
     const result = await session.exec("git", args, gitExecOptions(cwd, options.timeout))
-    if (write && writeSubcommands.has(args[0]!) && result.exitCode === 0) {
+    if (handle.commitWrites && write && writeSubcommands.has(args[0]!) && result.exitCode === 0) {
       await session.commit({ message: `git ${args[0]}` })
     }
     const stdout = limitOutput(result.stdout, options.maxOutputLength)
@@ -529,7 +540,7 @@ export function git(options: GitCapabilityOptions = {}): AgentCapabilityDefiniti
     return state
   }
 
-  function getSessionResolver(context: { context?: { get(key: string): unknown }, workspace?: unknown }): (cwd: string) => Promise<WorkspaceSession> {
+  function getSessionResolver(context: { context?: { get(key: string): unknown }, workspace?: unknown }): (cwd: string) => Promise<GitSessionHandle> {
     return async (cwd) => {
       const workspace = context.workspace
       if (!isGitSessionWorkspace(workspace)) {
@@ -541,18 +552,18 @@ export function git(options: GitCapabilityOptions = {}): AgentCapabilityDefiniti
       state.sessionPromises ??= new Map()
       if (!state.sessionPromises.has(key)) {
         state.sessionPromises.set(key, workspace.startSession(workspacePath ? { paths: [workspacePath] } : undefined).then(async (session) => {
-          await preparePullRequestGitSession(session, workspacePath, context, options.timeout)
-          return session
+          const prepared = await preparePullRequestGitSession(session, workspacePath, context, options.timeout)
+          return { commitWrites: !prepared, session }
         }).catch((error) => {
           state.sessionPromises?.delete(key)
           throw error
         }))
       }
-      const session = await state.sessionPromises.get(key)
-      if (!session) {
+      const handle = await state.sessionPromises.get(key)
+      if (!handle) {
         throw new Error("[vitehub] git() requires a git-capable workspace session.")
       }
-      return session
+      return handle
     }
   }
 
@@ -561,7 +572,7 @@ export function git(options: GitCapabilityOptions = {}): AgentCapabilityDefiniti
     sessionStates.delete(context)
     const sessions = await Promise.all([...state?.sessionPromises?.values() || []])
     if (state) state.sessionPromises = undefined
-    await Promise.all(sessions.map(session => session.close()))
+    await Promise.all(sessions.map(({ session }) => session.close()))
   }
 
   return defineCapability({

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -246,10 +246,16 @@ export type {
   RepositoryHostWriteRequest,
 } from "./repository-host.ts"
 export type {
+  PullRequestContextCapabilityFactory,
+  PullRequestContextComment,
+  PullRequestContextFile,
+  PullRequestContextMetadata,
   PullRequestContextOptions,
+  PullRequestContextRef,
   PullRequestContextResolver,
   PullRequestContextRules,
   PullRequestContextSources,
+  PullRequestContextUser,
   PullRequestContextValue,
 } from "./pull-request-context.ts"
 export type {

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -18,15 +18,79 @@ import type {
   WorkspaceSourceInput,
 } from "@vite-hub/workspace"
 
-export interface PullRequestContextValue {
-  actor?: string
-  baseRef?: string
-  deliveryId?: string
-  headRef?: string
+export interface PullRequestContextUser {
   id?: number | string
+  login?: string
+  type?: string
+}
+
+export interface PullRequestContextComment {
+  authorAssociation?: string
+  body?: string
+  createdAt?: string
+  htmlUrl?: string
+  id?: number | string
+  nodeId?: string
+  updatedAt?: string
+  user?: PullRequestContextUser
+}
+
+export interface PullRequestContextFile {
+  additions?: number | string
+  deletions?: number | string
+  filename?: string
+  status?: string
+}
+
+export interface PullRequestContextRef {
+  ref?: string
+  repo?: string
+  sha?: string
+}
+
+export interface PullRequestContextMetadata {
+  omittedComments?: number | string
+  omittedFiles?: number | string
+  unavailable?: string
+}
+
+export interface PullRequestContextValue {
+  apiUrl?: string
+  base?: PullRequestContextRef
+  body?: string
+  comments?: PullRequestContextComment[]
+  files?: PullRequestContextFile[]
+  head?: PullRequestContextRef
+  htmlUrl?: string
+  id?: number | string
+  labels?: string[]
+  metadata?: PullRequestContextMetadata
   number: number | string
   provider?: string
   repository: string
+  run?: {
+    messageId?: string
+    origin?: string
+    runId?: string
+    threadId?: string
+  }
+  source?: {
+    mount?: string
+    ref?: string
+    repo?: string
+  }
+  title?: string
+  trigger?: {
+    action?: string
+    actor?: PullRequestContextUser
+    args?: string
+    command?: string
+    comment?: PullRequestContextComment
+    deliveryId?: string
+    event?: string
+    installationId?: number | string
+    sender?: PullRequestContextUser
+  }
 }
 
 export type PullRequestContextResolver<
@@ -68,7 +132,8 @@ type PullRequestContextCapabilityTypeContract<
 
 const defaultSourceKey = "pullRequestContext"
 const defaultSourceMount = "pull-request-context"
-const defaultSourcePath = "context.md"
+const defaultMarkdownSourcePath = "context.md"
+const defaultJsonSourcePath = "context.json"
 const defaultCapabilityId = "pull-request-context"
 
 async function resolveMaybeFunction<TValue, TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
@@ -81,7 +146,7 @@ async function resolveMaybeFunction<TValue, TRuntimeConfig extends AgentRuntimeC
   return resolved || undefined
 }
 
-function frontmatterValue(value: number | string): string {
+function frontmatterValue(value: unknown): string {
   return typeof value === "number" ? String(value) : JSON.stringify(value)
 }
 
@@ -97,112 +162,276 @@ function maybeContextValue(value: unknown): number | string | undefined {
   return typeof value === "number" || typeof value === "string" ? value : undefined
 }
 
+function maybeStrings(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return
+  const items = value.filter((item): item is string => typeof item === "string" && !!item)
+  return items.length ? items : undefined
+}
+
+function isPresent<T>(value: T | undefined): value is T {
+  return value !== undefined
+}
+
+function normalizedRef(value: unknown): PullRequestContextRef | undefined {
+  if (!isRecord(value)) return
+  const ref = maybeString(value.ref)
+  const repo = maybeString(value.repo)
+  const sha = maybeString(value.sha)
+  if (!ref && !repo && !sha) return
+  return {
+    ...(ref ? { ref } : {}),
+    ...(repo ? { repo } : {}),
+    ...(sha ? { sha } : {}),
+  }
+}
+
+function normalizedFlatRef(value: unknown, fallbackRef: string | undefined): PullRequestContextRef | undefined {
+  return normalizedRef(value) || (fallbackRef ? { ref: fallbackRef } : undefined)
+}
+
+function normalizedUser(value: unknown): PullRequestContextUser | undefined {
+  if (!isRecord(value)) return
+  const id = maybeContextValue(value.id)
+  const login = maybeString(value.login)
+  const type = maybeString(value.type)
+  if (id === undefined && !login && !type) return
+  return {
+    ...(id !== undefined ? { id } : {}),
+    ...(login ? { login } : {}),
+    ...(type ? { type } : {}),
+  }
+}
+
+function normalizedComment(value: unknown): PullRequestContextComment | undefined {
+  if (!isRecord(value)) return
+  const id = maybeContextValue(value.id)
+  const body = maybeString(value.body)
+  const user = normalizedUser(value.user)
+  if (id === undefined && !body && !user) return
+  return {
+    ...(maybeString(value.authorAssociation) ? { authorAssociation: maybeString(value.authorAssociation) } : {}),
+    ...(body ? { body } : {}),
+    ...(maybeString(value.createdAt) ? { createdAt: maybeString(value.createdAt) } : {}),
+    ...(maybeString(value.htmlUrl) ? { htmlUrl: maybeString(value.htmlUrl) } : {}),
+    ...(id !== undefined ? { id } : {}),
+    ...(maybeString(value.nodeId) ? { nodeId: maybeString(value.nodeId) } : {}),
+    ...(maybeString(value.updatedAt) ? { updatedAt: maybeString(value.updatedAt) } : {}),
+    ...(user ? { user } : {}),
+  }
+}
+
+function normalizedFile(value: unknown): PullRequestContextFile | undefined {
+  if (!isRecord(value)) return
+  const filename = maybeString(value.filename)
+  if (!filename) return
+  return {
+    ...(maybeContextValue(value.additions) !== undefined ? { additions: maybeContextValue(value.additions) } : {}),
+    ...(maybeContextValue(value.deletions) !== undefined ? { deletions: maybeContextValue(value.deletions) } : {}),
+    filename,
+    ...(maybeString(value.status) ? { status: maybeString(value.status) } : {}),
+  }
+}
+
+function normalizedMetadata(value: unknown): PullRequestContextMetadata | undefined {
+  if (!isRecord(value)) return
+  const omittedComments = maybeContextValue(value.omittedComments)
+  const omittedFiles = maybeContextValue(value.omittedFiles)
+  const unavailable = maybeString(value.unavailable)
+  if (omittedComments === undefined && omittedFiles === undefined && !unavailable) return
+  return {
+    ...(omittedComments !== undefined ? { omittedComments } : {}),
+    ...(omittedFiles !== undefined ? { omittedFiles } : {}),
+    ...(unavailable ? { unavailable } : {}),
+  }
+}
+
+function normalizedRun(value: unknown): PullRequestContextValue["run"] | undefined {
+  if (!isRecord(value)) return
+  const messageId = maybeString(value.messageId)
+  const origin = maybeString(value.origin)
+  const runId = maybeString(value.runId)
+  const threadId = maybeString(value.threadId)
+  if (!messageId && !origin && !runId && !threadId) return
+  return {
+    ...(messageId ? { messageId } : {}),
+    ...(origin ? { origin } : {}),
+    ...(runId ? { runId } : {}),
+    ...(threadId ? { threadId } : {}),
+  }
+}
+
+function normalizedSource(value: unknown): PullRequestContextValue["source"] | undefined {
+  if (!isRecord(value)) return
+  const mount = maybeString(value.mount)
+  const ref = maybeString(value.ref)
+  const repo = maybeString(value.repo)
+  if (!mount && !ref && !repo) return
+  return {
+    ...(mount ? { mount } : {}),
+    ...(ref ? { ref } : {}),
+    ...(repo ? { repo } : {}),
+  }
+}
+
+function normalizedTrigger(value: unknown): PullRequestContextValue["trigger"] | undefined {
+  if (!isRecord(value)) return
+  const action = maybeString(value.action)
+  const actor = normalizedUser(value.actor)
+  const args = maybeString(value.args)
+  const command = maybeString(value.command)
+  const comment = normalizedComment(value.comment)
+  const deliveryId = maybeString(value.deliveryId)
+  const event = maybeString(value.event)
+  const installationId = maybeContextValue(value.installationId)
+  const sender = normalizedUser(value.sender)
+  if (!action && !actor && !args && !command && !comment && !deliveryId && !event && installationId === undefined && !sender) return
+  return {
+    ...(action ? { action } : {}),
+    ...(actor ? { actor } : {}),
+    ...(args ? { args } : {}),
+    ...(command ? { command } : {}),
+    ...(comment ? { comment } : {}),
+    ...(deliveryId ? { deliveryId } : {}),
+    ...(event ? { event } : {}),
+    ...(installationId !== undefined ? { installationId } : {}),
+    ...(sender ? { sender } : {}),
+  }
+}
+
+function normalizedRepositoryFullName(value: unknown): string | undefined {
+  if (typeof value === "string" && value) return value
+  return isRecord(value) ? maybeString(value.fullName) : undefined
+}
+
 function normalizePullRequestContext(value: unknown): PullRequestContextValue | undefined {
   if (!isRecord(value)) return
 
   const flatNumber = maybeContextValue(value.number)
-  const flatRepository = maybeString(value.repository)
+  const flatRepository = normalizedRepositoryFullName(value.repository)
   if (flatNumber !== undefined && flatRepository) {
-    return {
-      ...(maybeString(value.actor) ? { actor: maybeString(value.actor) } : {}),
-      ...(maybeString(value.baseRef) ? { baseRef: maybeString(value.baseRef) } : {}),
+    const base = normalizedFlatRef(value.base, maybeString(value.baseRef))
+    const comments = Array.isArray(value.comments) ? value.comments.map(normalizedComment).filter(isPresent) : undefined
+    const files = Array.isArray(value.files) ? value.files.map(normalizedFile).filter(isPresent) : undefined
+    const head = normalizedFlatRef(value.head, maybeString(value.headRef))
+    const labels = maybeStrings(value.labels)
+    const metadata = normalizedMetadata(value.metadata)
+    const run = normalizedRun(value.run)
+    const source = normalizedSource(value.source)
+    const trigger = {
+      ...(normalizedTrigger(value.trigger) || {}),
+      ...(maybeString(value.actor) ? { actor: { login: maybeString(value.actor) } } : {}),
       ...(maybeString(value.deliveryId) ? { deliveryId: maybeString(value.deliveryId) } : {}),
-      ...(maybeString(value.headRef) ? { headRef: maybeString(value.headRef) } : {}),
+    }
+    return {
+      ...(maybeString(value.apiUrl) ? { apiUrl: maybeString(value.apiUrl) } : {}),
+      ...(base ? { base } : {}),
+      ...(maybeString(value.body) ? { body: maybeString(value.body) } : {}),
+      ...(comments?.length ? { comments } : {}),
+      ...(files?.length ? { files } : {}),
+      ...(head ? { head } : {}),
+      ...(maybeString(value.htmlUrl) ? { htmlUrl: maybeString(value.htmlUrl) } : {}),
       ...(maybeContextValue(value.id) !== undefined ? { id: maybeContextValue(value.id) } : {}),
+      ...(labels ? { labels } : {}),
+      ...(metadata ? { metadata } : {}),
       number: flatNumber,
       ...(maybeString(value.provider) ? { provider: maybeString(value.provider) } : {}),
       repository: flatRepository,
+      ...(run ? { run } : {}),
+      ...(source ? { source } : {}),
+      ...(maybeString(value.title) ? { title: maybeString(value.title) } : {}),
+      ...(Object.keys(trigger).length ? { trigger } : {}),
     }
   }
 
   const pullRequest = isRecord(value.pullRequest) ? value.pullRequest : undefined
   const repository = isRecord(value.repository) ? value.repository : undefined
-  const trigger = isRecord(value.trigger) ? value.trigger : undefined
-  const actor = isRecord(trigger?.actor) ? trigger.actor : undefined
-  const source = isRecord(pullRequest?.source) ? pullRequest.source : undefined
-  const base = isRecord(pullRequest?.base) ? pullRequest.base : undefined
-  const head = isRecord(pullRequest?.head) ? pullRequest.head : undefined
   const number = maybeContextValue(pullRequest?.number)
   const repositoryName = maybeString(repository?.fullName)
-  if (number === undefined || !repositoryName) return
-  const actorLogin = actor ? maybeString(actor.login) : undefined
-  const deliveryId = trigger ? maybeString(trigger.deliveryId) : undefined
-  const baseRef = base ? maybeString(base.ref) : undefined
-  const headRef = source ? maybeString(source.ref) : head ? maybeString(head.ref) : undefined
+  if (!pullRequest || number === undefined || !repositoryName) return
+  const comments = Array.isArray(pullRequest.comments) ? pullRequest.comments.map(normalizedComment).filter(isPresent) : undefined
+  const files = Array.isArray(pullRequest.files) ? pullRequest.files.map(normalizedFile).filter(isPresent) : undefined
+  const labels = maybeStrings(pullRequest.labels)
+  const metadata = normalizedMetadata(pullRequest.metadata)
+  const source = normalizedSource(pullRequest.source)
 
   return {
-    ...(actorLogin ? { actor: actorLogin } : {}),
-    ...(baseRef ? { baseRef } : {}),
-    ...(deliveryId ? { deliveryId } : {}),
-    ...(headRef ? { headRef } : {}),
+    ...(maybeString(pullRequest.apiUrl) ? { apiUrl: maybeString(pullRequest.apiUrl) } : {}),
+    ...(normalizedRef(pullRequest.base) ? { base: normalizedRef(pullRequest.base) } : {}),
+    ...(maybeString(pullRequest.body) ? { body: maybeString(pullRequest.body) } : {}),
+    ...(comments?.length ? { comments } : {}),
+    ...(files?.length ? { files } : {}),
+    ...(normalizedRef(pullRequest.head) ? { head: normalizedRef(pullRequest.head) } : {}),
+    ...(maybeString(pullRequest.htmlUrl) ? { htmlUrl: maybeString(pullRequest.htmlUrl) } : {}),
+    ...(maybeContextValue(pullRequest.id) !== undefined ? { id: maybeContextValue(pullRequest.id) } : {}),
+    ...(labels ? { labels } : {}),
+    ...(metadata ? { metadata } : {}),
     number,
-    provider: "github",
+    provider: maybeString(value.provider) || "github",
     repository: repositoryName,
+    ...(normalizedRun(value.run) ? { run: normalizedRun(value.run) } : {}),
+    ...(source ? { source } : {}),
+    ...(maybeString(pullRequest.title) ? { title: maybeString(pullRequest.title) } : {}),
+    ...(normalizedTrigger(value.trigger) ? { trigger: normalizedTrigger(value.trigger) } : {}),
   }
+}
+
+function readPullRequestContext(context: unknown, contextKey = "pullRequest"): PullRequestContextValue | undefined {
+  if (isRecord(context) && isRecord(context.context) && typeof context.context.get === "function") {
+    return normalizePullRequestContext(context.context.get(contextKey))
+  }
+  if (isRecord(context) && typeof context.get === "function") return normalizePullRequestContext(context.get(contextKey))
+  return normalizePullRequestContext(context)
 }
 
 function renderList(items: string[]): string {
   return items.length ? items.map(item => `- ${item}`).join("\n") : "- None recorded."
 }
 
-function renderPullRequestDetails(input: unknown): string {
-  if (!isRecord(input)) return ""
-  const pullRequest = isRecord(input.pullRequest) ? input.pullRequest : undefined
-  const trigger = isRecord(input.trigger) ? input.trigger : undefined
-  if (!pullRequest && !trigger) return ""
-
+function renderPullRequestDetails(value: PullRequestContextValue | undefined): string {
+  if (!value) return ""
   const lines: string[] = []
-  const body = maybeString(pullRequest?.body)
-  const base = isRecord(pullRequest?.base) ? pullRequest.base : undefined
-  const head = isRecord(pullRequest?.head) ? pullRequest.head : undefined
-  const metadata = isRecord(pullRequest?.metadata) ? pullRequest.metadata : undefined
-  const files = Array.isArray(pullRequest?.files) ? pullRequest.files.filter(isRecord) : []
-  const comments = Array.isArray(pullRequest?.comments) ? pullRequest.comments.filter(isRecord) : []
-  const triggerComment = isRecord(trigger?.comment) ? trigger.comment : undefined
-  const metadataUnavailable = maybeString(metadata?.unavailable)
-  const omittedComments = maybeContextValue(metadata?.omittedComments)
-  const omittedFiles = maybeContextValue(metadata?.omittedFiles)
 
-  if (metadataUnavailable) {
-    lines.push(`PR metadata unavailable: ${metadataUnavailable}`)
+  if (value.metadata?.unavailable) {
+    lines.push(`PR metadata unavailable: ${value.metadata.unavailable}`)
   }
 
-  if (base || head) {
+  const branchLines = [
+    ...(value.base?.ref || value.base?.sha ? [`Base: ${[value.base.ref, value.base.sha].filter(Boolean).join(" @ ")}`] : []),
+    ...(value.head?.ref || value.head?.sha || value.source?.ref ? [`Head: ${[value.source?.ref || value.head?.ref, value.head?.sha].filter(Boolean).join(" @ ")}`] : []),
+  ]
+  if (branchLines.length) {
     lines.push("## Branches")
-    lines.push(renderList([
-      ...(maybeString(base?.ref) || maybeString(base?.sha) ? [`Base: ${[maybeString(base?.ref), maybeString(base?.sha)].filter(Boolean).join(" @ ")}`] : []),
-      ...(maybeString(head?.ref) || maybeString(head?.sha) ? [`Head: ${[maybeString(head?.ref), maybeString(head?.sha)].filter(Boolean).join(" @ ")}`] : []),
-    ]))
+    lines.push(renderList(branchLines))
   }
 
-  if (body) {
-    lines.push("## Body", body)
+  if (value.title) {
+    lines.push("## Title", value.title)
   }
 
-  if (files.length || omittedFiles) {
+  if (value.body) {
+    lines.push("## Body", value.body)
+  }
+
+  if (value.files?.length || value.metadata?.omittedFiles) {
     lines.push("## Changed Files")
-    if (files.length) lines.push(renderList(files.map((file) => {
-      const filename = maybeString(file.filename) || "unknown"
-      const status = maybeString(file.status)
-      const additions = maybeContextValue(file.additions)
-      const deletions = maybeContextValue(file.deletions)
+    if (value.files?.length) lines.push(renderList(value.files.map((file) => {
+      const filename = file.filename || "unknown"
+      const status = file.status
+      const additions = file.additions
+      const deletions = file.deletions
       const counts = additions !== undefined || deletions !== undefined ? ` (+${additions ?? 0}/-${deletions ?? 0})` : ""
       return `${filename}${status ? ` (${status})` : ""}${counts}`
     })))
-    if (omittedFiles) lines.push(`+${omittedFiles} more files not shown.`)
+    if (value.metadata?.omittedFiles) lines.push(`+${value.metadata.omittedFiles} more files not shown.`)
   }
 
-  if (comments.length || triggerComment || omittedComments) {
-    const commentLines = comments.map((comment) => {
-      const user = isRecord(comment.user) ? maybeString(comment.user.login) : undefined
-      const body = maybeString(comment.body)
-      return `${user || "unknown"}: ${body || "(no body)"}`
-    })
-    const body = maybeString(triggerComment?.body)
-    if (!commentLines.length && body && !omittedComments) {
-      commentLines.push(body)
-    }
-    if (omittedComments) commentLines.push(`+${omittedComments} more comments not shown.`)
+  const comments = [
+    ...(value.comments || []),
+    ...(value.trigger?.comment ? [value.trigger.comment] : []),
+  ]
+  if (comments.length || value.metadata?.omittedComments) {
+    const commentLines = comments.map(comment => `${comment.user?.login || "unknown"}: ${comment.body || "(no body)"}`)
+    if (value.metadata?.omittedComments) commentLines.push(`+${value.metadata.omittedComments} more comments not shown.`)
     lines.push("## Comments (untrusted user content)")
     lines.push(renderList(commentLines))
   }
@@ -217,15 +446,15 @@ function renderPullRequestContextMarkdown(input: unknown): string {
     ["number", value?.number],
     ["id", value?.id],
     ["provider", value?.provider],
-    ["baseRef", value?.baseRef],
-    ["headRef", value?.headRef],
-    ["actor", value?.actor],
-    ["deliveryId", value?.deliveryId],
+    ["source", value?.source],
+    ["base", value?.base],
+    ["head", value?.head],
+    ["deliveryId", value?.trigger?.deliveryId],
   ] as const)
     .flatMap(([key, item]) => item === undefined ? [] : `${key}: ${frontmatterValue(item)}`)
     .join("\n")
   const body = value
-    ? `# Pull Request Context\n\nChange Request ${value.number} in ${value.repository}.${renderPullRequestDetails(input)}`
+    ? `# Pull Request Context\n\nChange Request ${value.number} in ${value.repository}.${renderPullRequestDetails(value)}`
     : "# Pull Request Context\n\nNo pull request context was recorded for this Agent Invocation."
   return `---\n${frontmatter}\n---\n\n${body}\n`
 }
@@ -238,16 +467,24 @@ function pullRequestContextSource(
   return {
     materialize: "lazy",
     mount,
-    probeKeys: [defaultSourcePath],
+    probeKeys: [defaultMarkdownSourcePath, defaultJsonSourcePath],
     async getKeys() {
-      return [defaultSourcePath]
+      return [defaultMarkdownSourcePath, defaultJsonSourcePath]
     },
     async getItem(key) {
-      if (key !== defaultSourcePath) {
+      if (key !== defaultMarkdownSourcePath && key !== defaultJsonSourcePath) {
         throw new Error(`[vitehub] Workspace file does not exist: ${mount}/${key}.`)
       }
+      const value = readPullRequestContext(context, contextKey)
+      if (key === defaultJsonSourcePath) {
+        return {
+          content: `${JSON.stringify(value || null, null, 2)}\n`,
+          key,
+          mediaType: "application/json",
+        }
+      }
       return {
-        content: renderPullRequestContextMarkdown(context.get(contextKey)),
+        content: renderPullRequestContextMarkdown(value),
         key,
         mediaType: "text/markdown",
       }
@@ -277,7 +514,19 @@ function defaultSourceIdentity(capabilityId: string) {
     : { key: `${capabilityId}-context`, mount: capabilityId }
 }
 
-export function pullRequestContext<
+export interface PullRequestContextCapabilityFactory {
+  <
+    TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+    Name extends WorkspaceName = WorkspaceName,
+    const TSourceMap extends Record<string, WorkspaceSourceInput> | undefined = undefined,
+    const TContextKey extends string = "pullRequest",
+  >(
+    options?: PullRequestContextOptions<TRuntimeConfig, Name> & { contextKey?: TContextKey, sources?: TSourceMap | PullRequestContextSources<TRuntimeConfig, Name> },
+  ): AgentCapabilityDefinition<TRuntimeConfig, Name, PullRequestContextCapabilityTypeContract<TContextKey>>
+  read(input: unknown, contextKey?: string): PullRequestContextValue | undefined
+}
+
+function createPullRequestContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
   const TSourceMap extends Record<string, WorkspaceSourceInput> | undefined = undefined,
@@ -316,7 +565,7 @@ export function pullRequestContext<
       if (sources && Object.hasOwn(sources, source.key)) {
         throw new Error(`[vitehub] ${capabilityId}() sources cannot use reserved Workspace Source key "${source.key}".`)
       }
-      grantSelectedWorkspaceScopePath(context.context, [source.mount, defaultSourcePath].join("/"))
+      grantSelectedWorkspaceScopePath(context.context, source.mount)
       return {
         ...(rules ? { rules } : {}),
         sources: {
@@ -327,3 +576,7 @@ export function pullRequestContext<
     },
   })
 }
+
+export const pullRequestContext = Object.assign(createPullRequestContext, {
+  read: readPullRequestContext,
+}) as PullRequestContextCapabilityFactory

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -55,12 +55,16 @@ export interface PullRequestContextMetadata {
 }
 
 export interface PullRequestContextValue {
+  actor?: string
   apiUrl?: string
   base?: PullRequestContextRef
+  baseRef?: string
   body?: string
   comments?: PullRequestContextComment[]
+  deliveryId?: string
   files?: PullRequestContextFile[]
   head?: PullRequestContextRef
+  headRef?: string
   htmlUrl?: string
   id?: number | string
   labels?: string[]
@@ -322,13 +326,19 @@ function normalizePullRequestContext(value: unknown): PullRequestContextValue | 
       ...(maybeString(value.actor) ? { actor: { login: maybeString(value.actor) } } : {}),
       ...(maybeString(value.deliveryId) ? { deliveryId: maybeString(value.deliveryId) } : {}),
     }
+    const actor = trigger.actor?.login
+    const deliveryId = trigger.deliveryId
     return {
+      ...(actor ? { actor } : {}),
       ...(maybeString(value.apiUrl) ? { apiUrl: maybeString(value.apiUrl) } : {}),
       ...(base ? { base } : {}),
+      ...(base?.ref ? { baseRef: base.ref } : {}),
       ...(maybeString(value.body) ? { body: maybeString(value.body) } : {}),
       ...(comments?.length ? { comments } : {}),
+      ...(deliveryId ? { deliveryId } : {}),
       ...(files?.length ? { files } : {}),
       ...(head ? { head } : {}),
+      ...(head?.ref ? { headRef: head.ref } : {}),
       ...(maybeString(value.htmlUrl) ? { htmlUrl: maybeString(value.htmlUrl) } : {}),
       ...(maybeContextValue(value.id) !== undefined ? { id: maybeContextValue(value.id) } : {}),
       ...(labels ? { labels } : {}),
@@ -352,15 +362,24 @@ function normalizePullRequestContext(value: unknown): PullRequestContextValue | 
   const files = Array.isArray(pullRequest.files) ? pullRequest.files.map(normalizedFile).filter(isPresent) : undefined
   const labels = maybeStrings(pullRequest.labels)
   const metadata = normalizedMetadata(pullRequest.metadata)
+  const base = normalizedRef(pullRequest.base)
+  const head = normalizedRef(pullRequest.head)
   const source = normalizedSource(pullRequest.source)
+  const trigger = normalizedTrigger(value.trigger)
+  const actor = trigger?.actor?.login
+  const deliveryId = trigger?.deliveryId
 
   return {
+    ...(actor ? { actor } : {}),
     ...(maybeString(pullRequest.apiUrl) ? { apiUrl: maybeString(pullRequest.apiUrl) } : {}),
-    ...(normalizedRef(pullRequest.base) ? { base: normalizedRef(pullRequest.base) } : {}),
+    ...(base ? { base } : {}),
+    ...(base?.ref ? { baseRef: base.ref } : {}),
     ...(maybeString(pullRequest.body) ? { body: maybeString(pullRequest.body) } : {}),
     ...(comments?.length ? { comments } : {}),
+    ...(deliveryId ? { deliveryId } : {}),
     ...(files?.length ? { files } : {}),
-    ...(normalizedRef(pullRequest.head) ? { head: normalizedRef(pullRequest.head) } : {}),
+    ...(head ? { head } : {}),
+    ...(source?.ref || head?.ref ? { headRef: source?.ref || head?.ref } : {}),
     ...(maybeString(pullRequest.htmlUrl) ? { htmlUrl: maybeString(pullRequest.htmlUrl) } : {}),
     ...(maybeContextValue(pullRequest.id) !== undefined ? { id: maybeContextValue(pullRequest.id) } : {}),
     ...(labels ? { labels } : {}),
@@ -371,7 +390,7 @@ function normalizePullRequestContext(value: unknown): PullRequestContextValue | 
     ...(normalizedRun(value.run) ? { run: normalizedRun(value.run) } : {}),
     ...(source ? { source } : {}),
     ...(maybeString(pullRequest.title) ? { title: maybeString(pullRequest.title) } : {}),
-    ...(normalizedTrigger(value.trigger) ? { trigger: normalizedTrigger(value.trigger) } : {}),
+    ...(trigger ? { trigger } : {}),
   }
 }
 
@@ -544,7 +563,7 @@ function createPullRequestContext<
     if (recordedContexts.has(context.context)) return
     const value = await resolveMaybeFunction(options.context, context)
     if (value !== undefined) {
-      context.context.set(contextKey, value)
+      context.context.set(contextKey, normalizePullRequestContext(value) || value)
       recordedContexts.add(context.context)
     }
   }

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -338,7 +338,7 @@ function normalizePullRequestContext(value: unknown): PullRequestContextValue | 
       ...(deliveryId ? { deliveryId } : {}),
       ...(files?.length ? { files } : {}),
       ...(head ? { head } : {}),
-      ...(head?.ref ? { headRef: head.ref } : {}),
+      ...(source?.ref || head?.ref ? { headRef: source?.ref || head?.ref } : {}),
       ...(maybeString(value.htmlUrl) ? { htmlUrl: maybeString(value.htmlUrl) } : {}),
       ...(maybeContextValue(value.id) !== undefined ? { id: maybeContextValue(value.id) } : {}),
       ...(labels ? { labels } : {}),

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -221,6 +221,36 @@ describe("git capability", () => {
     expect(session.exec).toHaveBeenNthCalledWith(3, "git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace/vitehub" }))
   })
 
+  it("closes pull request sessions when checkout preparation fails", async () => {
+    const session = gitSession()
+    session.exec.mockImplementation(async (command: string, args: string[] = []) => ({
+      args,
+      command,
+      exitCode: command === "sh" || args.join(" ") === "rev-parse --is-inside-work-tree" ? 1 : 0,
+      stderr: command === "sh" ? "fetch failed" : "",
+      stdout: "",
+    }))
+    const { tools } = await capabilityTools(git(), session, {
+      pullRequest: {
+        pullRequest: {
+          number: 42,
+          source: {
+            mount: "vitehub",
+            ref: "refs/pull/42/head",
+            repo: "vite-hub/vitehub",
+          },
+        },
+        repository: {
+          fullName: "vite-hub/vitehub",
+          name: "vitehub",
+        },
+      },
+    })
+
+    await expect(tools.git_read!.execute?.({ command: "git status --short" })).rejects.toThrow("fetch failed")
+    expect(session.close).toHaveBeenCalledOnce()
+  })
+
   it("does not guess a base branch when preparing pull request checkout", async () => {
     const session = gitSession()
     session.exec.mockImplementation(async (command: string, args: string[] = []) => ({

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -119,7 +119,7 @@ describe("git capability", () => {
 
   it("runs local write commands only on a clean tree", async () => {
     const session = gitSession()
-    const { tools } = await capabilityTools(git({ mode: "write", policy: "allow" }), session)
+    const { startSession, tools } = await capabilityTools(git({ mode: "write", policy: "allow" }), session)
 
     expect(Object.keys(tools)).toEqual(["git_read", "git_write"])
     expect(tools.git_write!.policy).toBe("allow")
@@ -127,6 +127,7 @@ describe("git capability", () => {
       args: ["switch", "feature/pr-1"],
       cwd: "/workspace/portal",
     })
+    expect(startSession).toHaveBeenCalledWith(undefined)
     expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["status", "--porcelain"], expect.objectContaining({ cwd: "/workspace/portal", timeout: undefined }))
     expect(session.exec).toHaveBeenNthCalledWith(2, "git", ["switch", "feature/pr-1"], expect.objectContaining({ cwd: "/workspace/portal", timeout: undefined }))
     expect(session.commit).toHaveBeenCalledWith({ message: "git switch" })
@@ -168,6 +169,19 @@ describe("git capability", () => {
     expect(dirty.commit).not.toHaveBeenCalled()
   })
 
+  it("keeps non-PR cwd commands in a full workspace session", async () => {
+    const session = gitSession()
+    const { startSession, tools } = await capabilityTools(git(), session)
+
+    await expect(tools.git_read!.execute?.({ command: "git status --short", cwd: "packages/agent" })).resolves.toMatchObject({
+      cwd: "/workspace/packages/agent",
+      stdout: "ok\n",
+    })
+
+    expect(startSession).toHaveBeenCalledWith(undefined)
+    expect(session.exec).toHaveBeenCalledWith("git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace/packages/agent" }))
+  })
+
   it("prepares pull request checkout and defaults cwd to the source mount", async () => {
     const session = gitSession()
     session.exec.mockImplementation(async (command: string, args: string[] = []) => ({
@@ -205,6 +219,101 @@ describe("git capability", () => {
     expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["rev-parse", "--is-inside-work-tree"], expect.objectContaining({ cwd: "/workspace/vitehub" }))
     expect(session.exec).toHaveBeenNthCalledWith(2, "sh", ["-lc", expect.stringContaining("git fetch --depth=100 origin 'refs/pull/42/head:refs/vitehub/head' 'refs/heads/main:refs/remotes/origin/main'")], expect.objectContaining({ cwd: "/workspace" }))
     expect(session.exec).toHaveBeenNthCalledWith(3, "git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace/vitehub" }))
+  })
+
+  it("does not guess a base branch when preparing pull request checkout", async () => {
+    const session = gitSession()
+    session.exec.mockImplementation(async (command: string, args: string[] = []) => ({
+      args,
+      command,
+      exitCode: command === "git" && args.join(" ") === "rev-parse --is-inside-work-tree" ? 1 : 0,
+      stderr: "",
+      stdout: "",
+    }))
+    const { tools } = await capabilityTools(git(), session, {
+      pullRequest: {
+        pullRequest: {
+          number: 42,
+          source: {
+            mount: "vitehub",
+            ref: "refs/pull/42/head",
+            repo: "vite-hub/vitehub",
+          },
+        },
+        repository: {
+          fullName: "vite-hub/vitehub",
+          name: "vitehub",
+        },
+      },
+    })
+
+    await expect(tools.git_read!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+      cwd: "/workspace/vitehub",
+    })
+
+    const setupScript = session.exec.mock.calls.find(([command]) => command === "sh")?.[1]?.[1]
+    expect(setupScript).toContain("git fetch --depth=100 origin 'refs/pull/42/head:refs/vitehub/head'")
+    expect(setupScript).not.toContain("refs/heads/main")
+    expect(setupScript).not.toContain("vitehub-base")
+  })
+
+  it("keeps internally prepared pull request checkouts out of write commits", async () => {
+    const session = gitSession()
+    session.exec.mockImplementation(async (command: string, args: string[] = []) => ({
+      args,
+      command,
+      exitCode: command === "git" && args.join(" ") === "rev-parse --is-inside-work-tree" ? 1 : 0,
+      stderr: "",
+      stdout: "",
+    }))
+    const { tools } = await capabilityTools(git({ mode: "write", policy: "allow" }), session, {
+      pullRequest: {
+        pullRequest: {
+          base: { ref: "main" },
+          number: 42,
+          source: {
+            mount: "vitehub",
+            ref: "refs/pull/42/head",
+            repo: "vite-hub/vitehub",
+          },
+        },
+        repository: {
+          fullName: "vite-hub/vitehub",
+          name: "vitehub",
+        },
+      },
+    })
+
+    await expect(tools.git_write!.execute?.({ command: "git switch vitehub-base" })).resolves.toMatchObject({
+      args: ["switch", "vitehub-base"],
+      cwd: "/workspace/vitehub",
+    })
+
+    expect(session.commit).not.toHaveBeenCalled()
+  })
+
+  it("skips pull request checkout for non-GitHub providers", async () => {
+    const session = gitSession()
+    const { startSession, tools } = await capabilityTools(git(), session, {
+      pullRequest: {
+        number: 42,
+        provider: "gitlab",
+        repository: "vite-hub/vitehub",
+        source: {
+          mount: "vitehub",
+          ref: "refs/merge-requests/42/head",
+          repo: "vite-hub/vitehub",
+        },
+      },
+    })
+
+    await expect(tools.git_read!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+      cwd: "/workspace",
+      stdout: "ok\n",
+    })
+
+    expect(startSession).toHaveBeenCalledWith(undefined)
+    expect(session.exec).toHaveBeenCalledOnce()
   })
 
   it("ignores unsafe pull request checkout values", async () => {

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -28,14 +28,22 @@ function gitSession(options: { remotes?: string, status?: string } = {}) {
   return session
 }
 
-async function capabilityTools(capability = git(), session = gitSession()): Promise<{ session: ReturnType<typeof gitSession>, tools: AgentToolSet }> {
+async function capabilityTools(
+  capability = git(),
+  session = gitSession(),
+  contextValues: Record<string, unknown> = {},
+): Promise<{ session: ReturnType<typeof gitSession>, startSession: ReturnType<typeof vi.fn>, tools: AgentToolSet }> {
   if (typeof capability.tools !== "function") throw new Error("git capability must expose tool resolver")
+  const startSession = vi.fn(async () => session)
   const tools = await capability.tools({
+    context: {
+      get: vi.fn((key: string) => contextValues[key]),
+    },
     workspace: {
-      startSession: vi.fn(async () => session),
+      startSession,
     },
   } as never) as AgentToolSet
-  return { session, tools }
+  return { session, startSession, tools }
 }
 
 describe("git capability", () => {
@@ -158,5 +166,73 @@ describe("git capability", () => {
     await expect(tools.git_write!.execute?.({ command: "git push origin main" })).rejects.toThrow("git push is not available")
     await expect(tools.git_write!.execute?.({ command: "git fetch https://example.com/repo.git main" })).rejects.toThrow("configured remotes")
     expect(dirty.commit).not.toHaveBeenCalled()
+  })
+
+  it("prepares pull request checkout and defaults cwd to the source mount", async () => {
+    const session = gitSession()
+    session.exec.mockImplementation(async (command: string, args: string[] = []) => ({
+      args,
+      command,
+      exitCode: command === "git" && args.join(" ") === "rev-parse --is-inside-work-tree" ? 1 : 0,
+      stderr: "",
+      stdout: command === "git" && args.join(" ") === "status --short" ? "ok\n" : "",
+    }))
+    const { startSession, tools } = await capabilityTools(git(), session, {
+      pullRequest: {
+        pullRequest: {
+          base: { ref: "main" },
+          head: { ref: "feature" },
+          number: 42,
+          source: {
+            mount: "vitehub",
+            ref: "refs/pull/42/head",
+            repo: "vite-hub/vitehub",
+          },
+        },
+        repository: {
+          fullName: "vite-hub/vitehub",
+          name: "vitehub",
+        },
+      },
+    })
+
+    await expect(tools.git_read!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+      cwd: "/workspace/vitehub",
+      stdout: "ok\n",
+    })
+
+    expect(startSession).toHaveBeenCalledWith({ paths: ["vitehub"] })
+    expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["rev-parse", "--is-inside-work-tree"], expect.objectContaining({ cwd: "/workspace/vitehub" }))
+    expect(session.exec).toHaveBeenNthCalledWith(2, "sh", ["-lc", expect.stringContaining("git fetch --depth=100 origin 'refs/pull/42/head:refs/vitehub/head' 'refs/heads/main:refs/remotes/origin/main'")], expect.objectContaining({ cwd: "/workspace" }))
+    expect(session.exec).toHaveBeenNthCalledWith(3, "git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace/vitehub" }))
+  })
+
+  it("ignores unsafe pull request checkout values", async () => {
+    const session = gitSession()
+    const { startSession, tools } = await capabilityTools(git(), session, {
+      pullRequest: {
+        pullRequest: {
+          number: 42,
+          source: {
+            mount: "../vitehub",
+            ref: "main..evil",
+            repo: "vite hub/vitehub",
+          },
+        },
+        repository: {
+          fullName: "vite hub/vitehub",
+          name: "vitehub",
+        },
+      },
+    })
+
+    await expect(tools.git_read!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+      cwd: "/workspace",
+      stdout: "ok\n",
+    })
+
+    expect(startSession).toHaveBeenCalledWith(undefined)
+    expect(session.exec).toHaveBeenCalledOnce()
+    expect(session.exec).toHaveBeenCalledWith("git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace" }))
   })
 })

--- a/packages/agent/test/pull-request-context.test.ts
+++ b/packages/agent/test/pull-request-context.test.ts
@@ -117,6 +117,7 @@ describe("pullRequestContext", () => {
 
     expect(context.get("pullRequest")).toEqual({
       head: { ref: "feature" },
+      headRef: "feature",
       number: 42,
       repository: "acme/app",
     })
@@ -230,6 +231,7 @@ describe("pullRequestContext", () => {
       'provider: "github"',
       'source: {"mount":"vitehub","ref":"refs/pull/42/head","repo":"acme/app"}',
       'base: {"ref":"main"}',
+      'head: {"ref":"refs/pull/42/head"}',
       'deliveryId: "delivery-1"',
       "---",
       "",

--- a/packages/agent/test/pull-request-context.test.ts
+++ b/packages/agent/test/pull-request-context.test.ts
@@ -69,6 +69,33 @@ describe("pullRequestContext", () => {
     })
   })
 
+  it("preserves flat source refs as compatible head refs", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { pullRequestContext } = await import("../src/capabilities.ts")
+
+    const agent = defineAgent({
+      capabilities: [
+        pullRequestContext({
+          context: {
+            number: 42,
+            repository: "acme/app",
+            source: {
+              mount: "app",
+              ref: "refs/pull/42/head",
+              repo: "acme/app",
+            },
+          },
+        }),
+      ],
+      driver: { run: ({ context }) => context.get("pullRequest"), },
+    })
+
+    await expect(runAgent(agent, runtime(), {})).resolves.toMatchObject({
+      headRef: "refs/pull/42/head",
+      source: { ref: "refs/pull/42/head" },
+    })
+  })
+
   it("records pull request metadata and contributes workspace inputs", async () => {
     const { pullRequestContext } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")

--- a/packages/agent/test/pull-request-context.test.ts
+++ b/packages/agent/test/pull-request-context.test.ts
@@ -79,7 +79,7 @@ describe("pullRequestContext", () => {
       capabilities: [
         pullRequestContext({
           context: {
-            headRef: "feature",
+            head: { ref: "feature" },
             number: 42,
             repository: "acme/app",
           },
@@ -116,7 +116,7 @@ describe("pullRequestContext", () => {
     })
 
     expect(context.get("pullRequest")).toEqual({
-      headRef: "feature",
+      head: { ref: "feature" },
       number: 42,
       repository: "acme/app",
     })
@@ -138,12 +138,15 @@ describe("pullRequestContext", () => {
       capabilities: [
         pullRequestContext({
           context: {
-            actor: "mona",
-            baseRef: "main",
-            headRef: "feature",
+            base: { ref: "main" },
+            head: { ref: "feature" },
             number: 42,
             provider: "github",
             repository: "acme/app",
+            trigger: {
+              actor: { login: "mona" },
+              deliveryId: "delivery-1",
+            },
           },
         }),
       ],
@@ -159,55 +162,59 @@ describe("pullRequestContext", () => {
       'repository: "acme/app"',
       "number: 42",
       'provider: "github"',
-      'baseRef: "main"',
-      'headRef: "feature"',
-      'actor: "mona"',
+      'base: {"ref":"main"}',
+      'head: {"ref":"feature"}',
+      'deliveryId: "delivery-1"',
       "---",
       "",
       "# Pull Request Context",
     ].join("\n"))
+    await expect(resolved.workspace?.fs.readFile("pull-request-context/context.json")).resolves.toContain('"deliveryId": "delivery-1"')
     await expect(resolved.workspace?.fs.readFile("pull-request-context/diff.md")).rejects.toThrow("Workspace file does not exist")
   })
 
   it("renders built-in GitHub pull request context values", async () => {
     const { pullRequestContext } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const rawPullRequestContext = {
+      pullRequest: {
+        apiUrl: "https://api.github.test/repos/acme/app/pulls/42",
+        base: { ref: "main" },
+        number: 42,
+        source: {
+          mount: "vitehub",
+          ref: "refs/pull/42/head",
+          repo: "acme/app",
+        },
+        title: "Review me",
+      },
+      repository: {
+        fullName: "acme/app",
+        name: "app",
+        owner: "acme",
+      },
+      run: {
+        messageId: "100",
+        origin: "github-pull-request-comment",
+        runId: "delivery-1",
+        threadId: "thread",
+      },
+      trigger: {
+        action: "created",
+        actor: { login: "mona" },
+        args: "",
+        command: "/review",
+        comment: { id: 100 },
+        deliveryId: "delivery-1",
+        event: "issue_comment",
+      },
+    } as const
 
     const resolved = await resolveAgentCapabilities({
       capabilities: [pullRequestContext()],
     }, runtime(), {
       context: {
-        pullRequest: {
-          pullRequest: {
-            apiUrl: "https://api.github.test/repos/acme/app/pulls/42",
-            number: 42,
-            source: {
-              mount: "vitehub",
-              ref: "refs/pull/42/head",
-              repo: "acme/app",
-            },
-          },
-          repository: {
-            fullName: "acme/app",
-            name: "app",
-            owner: "acme",
-          },
-          run: {
-            messageId: "100",
-            origin: "github-pull-request-comment",
-            runId: "delivery-1",
-            threadId: "thread",
-          },
-          trigger: {
-            action: "created",
-            actor: { login: "mona" },
-            args: "",
-            command: "/review",
-            comment: { id: 100 },
-            deliveryId: "delivery-1",
-            event: "issue_comment",
-          },
-        },
+        pullRequest: rawPullRequestContext,
       },
     }, emptyWorkspace() as never, "read", {
       workspaceDefinition: {
@@ -221,8 +228,8 @@ describe("pullRequestContext", () => {
       'repository: "acme/app"',
       "number: 42",
       'provider: "github"',
-      'headRef: "refs/pull/42/head"',
-      'actor: "mona"',
+      'source: {"mount":"vitehub","ref":"refs/pull/42/head","repo":"acme/app"}',
+      'base: {"ref":"main"}',
       'deliveryId: "delivery-1"',
       "---",
       "",
@@ -230,6 +237,32 @@ describe("pullRequestContext", () => {
       "",
       "Change Request 42 in acme/app.",
     ].join("\n"))
+
+    const json = JSON.parse(await resolved.workspace!.fs.readFile("pull-request-context/context.json"))
+    expect(json).toMatchObject({
+      base: { ref: "main" },
+      number: 42,
+      provider: "github",
+      repository: "acme/app",
+      run: { runId: "delivery-1" },
+      source: {
+        mount: "vitehub",
+        ref: "refs/pull/42/head",
+        repo: "acme/app",
+      },
+      title: "Review me",
+      trigger: {
+        actor: { login: "mona" },
+        deliveryId: "delivery-1",
+      },
+    })
+    expect(pullRequestContext.read({
+      context: { get: (key: string) => key === "pullRequest" ? rawPullRequestContext : undefined },
+    })).toMatchObject({
+      number: 42,
+      repository: "acme/app",
+      source: { mount: "vitehub" },
+    })
   })
 
   it("renders GitHub metadata gaps and bounded untrusted comments", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1908,7 +1908,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["public", "AGENTS.md", "CLAUDE.md", "pull-request-context/context.md"],
+      paths: ["public", "AGENTS.md", "CLAUDE.md", "pull-request-context"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
     })


### PR DESCRIPTION
Upstreams the Quiver-carried `@vite-hub/agent` patch for pull-request review context. `pullRequestContext` now normalizes structured GitHub PR payloads, exposes `pullRequestContext.read()`, writes `context.json` next to `context.md`, and grants the whole context mount so harness sessions can see both files.

`git()` now defaults to the trusted pull-request source mount and prepares a local checkout from safe GitHub repo/ref values inside the Workspace Session, without adding remote publication.