### PR TITLE
fix(agent): pass rest capability cli argv as input

### DIFF
--- a/packages/agent/src/capability-cli.ts
+++ b/packages/agent/src/capability-cli.ts
@@ -272,9 +272,6 @@ function resolveCommand<TRuntimeConfig extends AgentRuntimeConfig, Name extends 
   if (!isLeaf(node as AgentCapabilityCliCommand<TRuntimeConfig, Name>)) {
     throw new Error(`Missing ${cli.name} subcommand. Run \`${cli.name}${path.length ? ` ${path.join(" ")}` : ""} --help\`.`)
   }
-  if (argv.slice(index).some(isHelpFlag)) {
-    return { help: nodeHelp(cli, path), json: execution.json === true, path }
-  }
   const command = node as LeafCliCommand<TRuntimeConfig, Name>
   if (command.rest === true) {
     return {
@@ -284,6 +281,9 @@ function resolveCommand<TRuntimeConfig extends AgentRuntimeConfig, Name extends 
       json: execution.json === true,
       path,
     }
+  }
+  if (argv.slice(index).some(isHelpFlag)) {
+    return { help: nodeHelp(cli, path), json: execution.json === true, path }
   }
   return {
     argv,

--- a/packages/agent/src/capability-cli.ts
+++ b/packages/agent/src/capability-cli.ts
@@ -275,9 +275,19 @@ function resolveCommand<TRuntimeConfig extends AgentRuntimeConfig, Name extends 
   if (argv.slice(index).some(isHelpFlag)) {
     return { help: nodeHelp(cli, path), json: execution.json === true, path }
   }
+  const command = node as LeafCliCommand<TRuntimeConfig, Name>
+  if (command.rest === true) {
+    return {
+      argv,
+      command,
+      input: { argv: argv.slice(index) },
+      json: execution.json === true,
+      path,
+    }
+  }
   return {
     argv,
-    command: node as LeafCliCommand<TRuntimeConfig, Name>,
+    command,
     path,
     ...parseFlags(argv.slice(index), execution.input, execution.json),
   }

--- a/packages/agent/src/capability-cli.ts
+++ b/packages/agent/src/capability-cli.ts
@@ -149,7 +149,7 @@ function commandLeaves<TRuntimeConfig extends AgentRuntimeConfig, Name extends W
 
 function firstExample(cliName: string, path: string[], command: AgentCapabilityCliCommand): string {
   const example = command.examples?.[0]
-  return example || `${cliName} ${path.join(" ")}${outputFormat(command.output, false) === "json" ? " --json" : ""}`
+  return example || `${cliName} ${path.join(" ")}${command.rest !== true && outputFormat(command.output, false) === "json" ? " --json" : ""}`
 }
 
 function toolInputExample(cliName: string, path: string[], command: AgentCapabilityCliCommand): string {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -558,6 +558,7 @@ export interface AgentCapabilityCliCommand<
   examples?: readonly string[]
   input?: AgentCapabilityCliStandardSchemaV1<TInput>
   output?: AgentCapabilityCliStandardSchemaV1<TOutput> | AgentCapabilityCliOutputDefinition<TOutput>
+  rest?: true
   run?: {
     bivarianceHack(context: AgentCapabilityCliRunContext<TRuntimeConfig, Name, TInput>): MaybePromise<TOutput>
   }["bivarianceHack"]

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -378,14 +378,14 @@ describe("agent capability runtime", () => {
     }, runtime(), {})
 
     const result = await resolved.tools?.workspace?.execute?.({
-      argv: ["run", "pnpm", "test", "--filter", "api"],
+      argv: ["run", "pnpm", "test", "--help", "--filter", "api"],
       json: true,
     })
 
     expect(result).toMatchObject({
       exitCode: 0,
       json: {
-        input: { argv: ["pnpm", "test", "--filter", "api"] },
+        input: { argv: ["pnpm", "test", "--help", "--filter", "api"] },
         json: true,
       },
     })

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -377,6 +377,9 @@ describe("agent capability runtime", () => {
       ],
     }, runtime(), {})
 
+    expect(resolved.tools?.workspace?.description).toContain("`run`")
+    expect(resolved.tools?.workspace?.description).not.toContain("`run --json`")
+
     const result = await resolved.tools?.workspace?.execute?.({
       argv: ["run", "pnpm", "test", "--help", "--filter", "api"],
       json: true,

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -354,6 +354,43 @@ describe("agent capability runtime", () => {
     })
   })
 
+  it("passes rest Capability CLI argv as input", async () => {
+    const {
+      defineCapability,
+      resolveAgentCapabilities,
+    } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          cli: {
+            commands: {
+              run: {
+                rest: true,
+                run: ({ input, json }) => ({ input, json }),
+              },
+            },
+            name: "workspace",
+          },
+          id: "workspace-runtime",
+        }),
+      ],
+    }, runtime(), {})
+
+    const result = await resolved.tools?.workspace?.execute?.({
+      argv: ["run", "pnpm", "test", "--filter", "api"],
+      json: true,
+    })
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      json: {
+        input: { argv: ["pnpm", "test", "--filter", "api"] },
+        json: true,
+      },
+    })
+  })
+
   it("rejects invalid Capability CLI output formats", async () => {
     const { defineCapability } = await import("../src/capability-runtime.ts")
 


### PR DESCRIPTION
Moves the Quiver-carried Capability CLI rest-command behavior into Agent Package source. Commands marked `rest: true` now receive leftover argv as `input.argv` instead of parsing those args as Capability CLI flags, while preserving the command path and explicit JSON mode.

Adds focused runtime coverage for a rest command receiving `--filter` as command input.