### PR TITLE
fix(agent): allow blob puts from workspace files

### DIFF
--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -10,6 +10,7 @@ import {
 
 import type {
   AgentCapabilityDefinition,
+  AgentCapabilityContext,
   AgentCapabilityMode,
   AgentToolSet,
   MaybePromise,
@@ -37,10 +38,12 @@ interface BlobEditInput {
   operation: "delete" | "put"
   options?: Record<string, unknown>
   pathname: string
+  workspacePath?: string
 }
 
 const defaultListLimit = 25
 const maxListLimit = 100
+const blobPackageName: string = "@vite-hub/blob"
 
 const blobReadInputSchema = jsonObjectSchema({
   cursor: { type: "string" },
@@ -56,6 +59,10 @@ const blobEditInputSchema = jsonObjectSchema({
   operation: { enum: ["delete", "put"], type: "string" },
   options: { additionalProperties: true, type: "object" },
   pathname: { type: "string" },
+  workspacePath: {
+    description: "Upload this Workspace file instead of inline body.",
+    type: "string",
+  },
 }, ["operation", "pathname"])
 
 function normalizeListLimit(limit: unknown): number {
@@ -66,13 +73,27 @@ function normalizeListLimit(limit: unknown): number {
   return Math.min(Math.floor(limit), maxListLimit)
 }
 
+async function resolveBlobPrimitive(context: AgentCapabilityContext) {
+  if (context.capabilities?.blob !== undefined) return requirePrimitive(context as never, "blob")
+  try {
+    return ((await import(blobPackageName)) as { blob: unknown }).blob
+  }
+  catch (error) {
+    throw new Error(`[vitehub] Capability "blob" requires the blob primitive to be configured or @vite-hub/blob to be installed. ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+async function resolveBlobStore(context: AgentCapabilityContext, options: BlobCapabilityOptions) {
+  return selectStore(await resolveBlobPrimitive(context), "Blob", options.store)
+}
+
 function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): AgentCapabilityDefinition["tools"] {
   return (context) => {
-    const store = selectStore(requirePrimitive(context as never, "blob"), "Blob", options.store)
     const tools: AgentToolSet = {
       blob_read: createTool<BlobReadInput>({
         description: "Read one Blob object, read object metadata, or list objects under a developer-provided prefix.",
-        execute: ({ cursor, folded, limit, operation, pathname, prefix }: BlobReadInput) => {
+        execute: async ({ cursor, folded, limit, operation, pathname, prefix }: BlobReadInput) => {
+          const store = await resolveBlobStore(context, options)
           if (operation === "get") return method<(pathname: string) => MaybePromise<unknown>>(store, "blob", "get")(assertString(pathname, "blob_read pathname"))
           if (operation === "head") return method<(pathname: string) => MaybePromise<unknown>>(store, "blob", "head")(assertString(pathname, "blob_read pathname"))
           if (operation === "list") {
@@ -87,9 +108,20 @@ function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): A
     }
     if (mode === "write") {
       tools.blob_edit = createTool<BlobEditInput>({
-        description: "Put or delete Blob objects.",
-        execute: ({ body, operation, options: putOptions, pathname }) => {
-          if (operation === "put") return method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(assertString(pathname, "blob_edit pathname"), body, putOptions)
+        description: "Put or delete Blob objects. Use workspacePath to upload a Workspace file.",
+        execute: async ({ body, operation, options: putOptions, pathname, workspacePath }) => {
+          const store = await resolveBlobStore(context, options)
+          if (operation === "put") {
+            const path = assertString(pathname, "blob_edit pathname")
+            const sourcePath = typeof workspacePath === "string" && workspacePath.trim() ? workspacePath : undefined
+            if (sourcePath && body !== undefined) throw new Error("[vitehub] blob_edit put accepts body or workspacePath, not both.")
+            if (sourcePath) {
+              if (!context.fs?.readFile) throw new Error("[vitehub] blob_edit workspacePath requires a Workspace file system.")
+              return method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(path, await context.fs.readFile(sourcePath as never, { encoding: "binary" }), putOptions)
+            }
+            if (body === undefined) throw new Error("[vitehub] blob_edit put requires body or workspacePath.")
+            return method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(path, body, putOptions)
+          }
           if (operation === "delete") {
             return method<(pathname: string) => MaybePromise<unknown>>(store, "blob", "del")(assertString(pathname, "blob_edit pathname"))
           }

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
+import type { ReadonlyWorkspaceFacade } from "@vite-hub/workspace"
+
 const runtime = (capabilities: Record<string, unknown>) => ({
   capabilities,
   memo: vi.fn(),
@@ -8,9 +10,9 @@ const runtime = (capabilities: Record<string, unknown>) => ({
   waitUntil: vi.fn(),
 })
 
-async function resolveTools(capabilities: unknown[], handles: Record<string, unknown>) {
+async function resolveTools(capabilities: unknown[], handles: Record<string, unknown>, workspace?: ReadonlyWorkspaceFacade) {
   const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
-  const resolved = await resolveAgentCapabilities({ capabilities: capabilities as never }, runtime(handles), {})
+  const resolved = await resolveAgentCapabilities({ capabilities: capabilities as never }, runtime(handles), {}, workspace as never)
   return resolved.tools!
 }
 
@@ -196,6 +198,12 @@ describe("storage capabilities", () => {
 
   it("exposes curated Blob read and edit tools", async () => {
     const { blob } = await import("../src/capabilities.ts")
+    const workspaceBytes = new Uint8Array([1, 2, 3])
+    const workspace = {
+      fs: {
+        readFile: vi.fn(async () => workspaceBytes),
+      },
+    } as unknown as ReadonlyWorkspaceFacade
     const store = {
       del: vi.fn(async () => undefined),
       get: vi.fn(async () => new Blob(["body"])),
@@ -206,7 +214,7 @@ describe("storage capabilities", () => {
 
     await expect(resolveTools([blob()], { blob: store }).then(tools => Object.keys(tools).sort())).resolves.toEqual(["blob_read"])
 
-    const tools = await resolveTools([blob({ mode: "write" })], { blob: store })
+    const tools = await resolveTools([blob({ mode: "write" })], { blob: store }, workspace)
     expect(Object.keys(tools).sort()).toEqual(["blob_edit", "blob_read"])
     expect(tools.blob_edit?.policy).toBe("require-approval")
 
@@ -218,9 +226,31 @@ describe("storage capabilities", () => {
 
     const body = new Blob(["data"], { type: "image/png" })
     await tools.blob_edit!.execute?.({ body, operation: "put", options: { contentType: "image/png" }, pathname: "images/a.png" })
+    await tools.blob_edit!.execute?.({ operation: "put", pathname: "images/from-workspace.png", workspacePath: "screenshots/result.png" })
+    await expect(Promise.resolve().then(() => tools.blob_edit!.execute?.({ body: "inline", operation: "put", pathname: "images/a.png", workspacePath: "screenshots/result.png" }))).rejects.toThrow("body or workspacePath")
+    await expect(Promise.resolve().then(() => tools.blob_edit!.execute?.({ operation: "put", pathname: "images/a.png" }))).rejects.toThrow("body or workspacePath")
     await tools.blob_edit!.execute?.({ operation: "delete", pathname: "images/a.png" })
     expect(store.put).toHaveBeenCalledWith("images/a.png", body, { contentType: "image/png" })
+    expect(workspace.fs.readFile).toHaveBeenCalledWith("screenshots/result.png", { encoding: "binary" })
+    expect(store.put).toHaveBeenCalledWith("images/from-workspace.png", workspaceBytes, undefined)
     expect(store.del).toHaveBeenCalledWith("images/a.png")
+  })
+
+  it("falls back to the installed Blob primitive at tool execution time", async () => {
+    const store = {
+      list: vi.fn(async () => ({ blobs: [], hasMore: false })),
+    }
+    vi.doMock("@vite-hub/blob", () => ({ blob: store }))
+    try {
+      const { blob } = await import("../src/capabilities.ts")
+      const tools = await resolveTools([blob()], {})
+
+      await tools.blob_read!.execute?.({ operation: "list", prefix: "images/" })
+      expect(store.list).toHaveBeenCalledWith({ cursor: undefined, folded: undefined, limit: 25, prefix: "images/" })
+    }
+    finally {
+      vi.doUnmock("@vite-hub/blob")
+    }
   })
 
   it("defaults DB to schema and query tools and selects named databases", async () => {


### PR DESCRIPTION
Adds `workspacePath` as an alternate `blob_edit` put body so agents can upload a Workspace file directly to Blob storage while still requiring exactly one of `body` or `workspacePath`.

Blob capability tools now resolve the Blob primitive only when a tool executes, using the runtime primitive when present and falling back to an installed `@vite-hub/blob` runtime export when no primitive was injected.