### PR TITLE
fix(agent): quiet invocation stream abort cleanup

### DIFF
--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -74,7 +74,7 @@ export function createAgentInvocationStreamResponse(
   function fail(controller: ReadableStreamDefaultController<Uint8Array>, cause: unknown): void {
     if (closed) return
     clearTimeoutSignal()
-    abortController.abort(cause)
+    abort(cause)
     try {
       write(controller, {
         error: cause instanceof Error ? cause.message : "Agent Invocation Stream event could not be serialized.",
@@ -85,6 +85,15 @@ export function createAgentInvocationStreamResponse(
     catch {
       closed = true
       controller.error(cause)
+    }
+  }
+
+  function abort(cause?: unknown): void {
+    try {
+      abortController.abort(cause)
+    }
+    catch (error) {
+      if (!isAbortError(error)) throw error
     }
   }
 
@@ -125,9 +134,13 @@ export function createAgentInvocationStreamResponse(
     cancel() {
       clearTimeoutSignal()
       closed = true
-      abortController.abort()
+      abort()
     },
   }), {
     headers: { "content-type": "application/x-ndjson" },
   })
+}
+
+function isAbortError(error: unknown): error is Error {
+  return error instanceof Error && error.name === "AbortError"
 }

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -736,8 +736,9 @@ export async function writeResponse(res: ServerResponse, response: Response): Pr
     res.end()
   }
   catch (error) {
+    const wasClosed = closed
     closed = true
-    if (isAbortError(error)) return
+    if (wasClosed && isAbortError(error)) return
     res.destroy(error instanceof Error ? error : undefined)
   }
   finally {

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -708,7 +708,7 @@ function routeMatches(req: IncomingMessage): boolean {
   return new URL(req.url || "/", "http://localhost").pathname === agentInvocationStreamRoute
 }
 
-async function writeResponse(res: ServerResponse, response: Response): Promise<void> {
+export async function writeResponse(res: ServerResponse, response: Response): Promise<void> {
   res.statusCode = response.status
   for (const [name, value] of response.headers) {
     res.setHeader(name, value)
@@ -721,7 +721,9 @@ async function writeResponse(res: ServerResponse, response: Response): Promise<v
   const reader = response.body.getReader()
   let closed = false
   const cancel = () => {
-    if (!closed) void reader.cancel().catch(() => {})
+    if (closed) return
+    closed = true
+    Promise.resolve().then(() => reader.cancel()).catch(() => {})
   }
   res.once("close", cancel)
   try {
@@ -735,6 +737,7 @@ async function writeResponse(res: ServerResponse, response: Response): Promise<v
   }
   catch (error) {
     closed = true
+    if (isAbortError(error)) return
     res.destroy(error instanceof Error ? error : undefined)
   }
   finally {
@@ -742,6 +745,10 @@ async function writeResponse(res: ServerResponse, response: Response): Promise<v
     res.off("close", cancel)
     reader.releaseLock()
   }
+}
+
+function isAbortError(error: unknown): error is Error {
+  return error instanceof Error && error.name === "AbortError"
 }
 
 function errorResponse(error: unknown): Response {

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -58,7 +58,7 @@ describe("Agent Invocation Stream", () => {
     }
   })
 
-  it("does not destroy Vite responses for AbortError body failures", async () => {
+  it("only treats closed-response AbortError body failures as cleanup", async () => {
     const destroy = vi.fn()
     const res = {
       destroy,
@@ -72,6 +72,29 @@ describe("Agent Invocation Stream", () => {
 
     await writeResponse(res, new Response(new ReadableStream<Uint8Array>({
       pull() {
+        throw new DOMException("aborted", "AbortError")
+      },
+    })))
+
+    expect(destroy).toHaveBeenCalledWith(expect.any(DOMException))
+    destroy.mockClear()
+
+    let close: (() => void) | undefined
+    const closedRes = {
+      destroy,
+      end: vi.fn(),
+      off: vi.fn(),
+      once: vi.fn((_event: string, callback: () => void) => {
+        close = callback
+      }),
+      setHeader: vi.fn(),
+      statusCode: 200,
+      write: vi.fn(() => true),
+    } as unknown as ServerResponse
+
+    await writeResponse(closedRes, new Response(new ReadableStream<Uint8Array>({
+      pull() {
+        close?.()
         throw new DOMException("aborted", "AbortError")
       },
     })))

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { createAgentInvocationStreamResponse, readAgentInvocationStream } from "../src/invocation-stream.ts"
+import { writeResponse } from "../src/vite/invocation-stream-endpoint.ts"
+
+import type { ServerResponse } from "node:http"
 
 describe("Agent Invocation Stream", () => {
   it("closes timed-out streams even when the run does not settle", async () => {
@@ -22,6 +25,58 @@ describe("Agent Invocation Stream", () => {
       { type: "done" },
     ])
     expect(aborted).toBe(true)
+  })
+
+  it("treats AbortError from cancellation aborts as cleanup", async () => {
+    const NativeAbortController = globalThis.AbortController
+
+    class ThrowingAbortController extends NativeAbortController {
+      override abort(reason?: unknown): void {
+        super.abort(reason)
+        throw new DOMException("aborted", "AbortError")
+      }
+    }
+
+    Object.defineProperty(globalThis, "AbortController", {
+      configurable: true,
+      value: ThrowingAbortController,
+      writable: true,
+    })
+    try {
+      const response = createAgentInvocationStreamResponse(async () => {
+        await new Promise(() => {})
+      })
+
+      await expect(response.body!.cancel()).resolves.toBeUndefined()
+    }
+    finally {
+      Object.defineProperty(globalThis, "AbortController", {
+        configurable: true,
+        value: NativeAbortController,
+        writable: true,
+      })
+    }
+  })
+
+  it("does not destroy Vite responses for AbortError body failures", async () => {
+    const destroy = vi.fn()
+    const res = {
+      destroy,
+      end: vi.fn(),
+      off: vi.fn(),
+      once: vi.fn(),
+      setHeader: vi.fn(),
+      statusCode: 200,
+      write: vi.fn(() => true),
+    } as unknown as ServerResponse
+
+    await writeResponse(res, new Response(new ReadableStream<Uint8Array>({
+      pull() {
+        throw new DOMException("aborted", "AbortError")
+      },
+    })))
+
+    expect(destroy).not.toHaveBeenCalled()
   })
 
   it("closes with an error when event serialization fails", async () => {


### PR DESCRIPTION
Upstreams the Quiver-carried invocation stream abort cleanup into Agent Package source. Agent Invocation Stream cancellation now treats `AbortError` from abort cleanup as non-fatal, and the Vite Agent Invocation Stream Endpoint cancels response bodies once on a later tick while ignoring abort-shaped body failures.

Adds focused tests for cancellation abort cleanup and Vite response `AbortError` handling.