### PR TITLE
fix(agent): map text chat attachments

### DIFF
--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -1,3 +1,7 @@
+export {
+  createDiscordGatewayRouteHandler,
+} from "./server/routes.ts"
+
 export type {
   AgentChannelChatRouteAdmissionContext,
   AgentChannelChatRouteAdmissionOptions,
@@ -14,4 +18,5 @@ export type {
   AgentChannelDevtoolsRouteHandlerOptions,
   AgentChannelDevtoolsRouteRequestOptions,
   AgentChannelWebhookRouteOptions,
+  AgentDiscordGatewayRouteOptions,
 } from "./server/routes.ts"

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -931,6 +931,44 @@ function checkedTextAttachmentBytes(value: unknown, options: { rejectOversizedTe
   return bytes
 }
 
+async function fetchTextAttachmentBytes(url: string, options: { rejectOversizedTextAttachments?: boolean } = {}): Promise<Uint8Array | undefined> {
+  const response = await fetch(url)
+  if (!response.ok) return
+  const contentLengthHeader = response.headers.get("content-length")
+  const contentLength = contentLengthHeader === null ? undefined : Number(contentLengthHeader)
+  if (typeof contentLength === "number" && Number.isFinite(contentLength) && contentLength > chatTextAttachmentMaxBytes) {
+    if (!options.rejectOversizedTextAttachments) return
+    throw new Error(`[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`)
+  }
+  if (!response.body) {
+    return checkedTextAttachmentBytes(await response.arrayBuffer(), options)
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let byteLength = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    const chunk = value instanceof Uint8Array ? value : new Uint8Array(value)
+    byteLength += chunk.byteLength
+    if (byteLength > chatTextAttachmentMaxBytes) {
+      await reader.cancel().catch(() => undefined)
+      if (!options.rejectOversizedTextAttachments) return
+      throw new Error(`[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`)
+    }
+    chunks.push(chunk)
+  }
+
+  const bytes = new Uint8Array(byteLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
+}
+
 async function textAttachmentBytes(attachment: Attachment, options: { rejectOversizedTextAttachments?: boolean } = {}): Promise<Uint8Array | undefined> {
   if (typeof attachment.size === "number" && attachment.size > chatTextAttachmentMaxBytes) {
     if (!options.rejectOversizedTextAttachments) return
@@ -942,7 +980,11 @@ async function textAttachmentBytes(attachment: Attachment, options: { rejectOver
   if (attachment.data instanceof Blob) {
     return checkedTextAttachmentBytes(await attachment.data.arrayBuffer(), options)
   }
-  return checkedTextAttachmentBytes(attachment.data, options)
+  const bytes = checkedTextAttachmentBytes(attachment.data, options)
+  if (bytes) return bytes
+  return typeof attachment.url === "string" && attachment.url
+    ? await fetchTextAttachmentBytes(attachment.url, options)
+    : undefined
 }
 
 async function textPartFromAttachment(attachment: Attachment, index: number, options: { rejectOversizedTextAttachments?: boolean } = {}): Promise<MessagePart | undefined> {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2454,8 +2454,8 @@ export function createDiscordGatewayRouteHandler(
   agent: AgentInput<ViteAgentRouteRuntimeContext>,
 ): (request: Request, options: AgentDiscordGatewayRouteOptions) => Promise<Response> {
   return async (request, handlerOptions) => {
-    if (request.method !== "GET" && request.method !== "POST") {
-      return createJsonErrorResponse(405, "Discord Gateway route only accepts GET or POST requests.")
+    if (request.method !== "GET") {
+      return createJsonErrorResponse(405, "Discord Gateway route only accepts GET requests.")
     }
 
     const context = createRuntimeContext(

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -919,33 +919,35 @@ function isTextAttachment(attachment: Attachment): boolean {
   return !!extension && textAttachmentExtensions.has(extension)
 }
 
-function checkedTextAttachmentBytes(value: unknown): Uint8Array | undefined {
+function checkedTextAttachmentBytes(value: unknown, options: { rejectOversizedTextAttachments?: boolean } = {}): Uint8Array | undefined {
   const bytes = value instanceof ArrayBuffer
     ? new Uint8Array(value)
     : value instanceof Uint8Array ? value : undefined
   if (!bytes) return
   if (bytes.byteLength > chatTextAttachmentMaxBytes) {
+    if (!options.rejectOversizedTextAttachments) return
     throw new Error(`[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`)
   }
   return bytes
 }
 
-async function textAttachmentBytes(attachment: Attachment): Promise<Uint8Array | undefined> {
+async function textAttachmentBytes(attachment: Attachment, options: { rejectOversizedTextAttachments?: boolean } = {}): Promise<Uint8Array | undefined> {
   if (typeof attachment.size === "number" && attachment.size > chatTextAttachmentMaxBytes) {
+    if (!options.rejectOversizedTextAttachments) return
     throw new Error(`[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`)
   }
   if (typeof attachment.fetchData === "function") {
-    return checkedTextAttachmentBytes(await attachment.fetchData())
+    return checkedTextAttachmentBytes(await attachment.fetchData(), options)
   }
   if (attachment.data instanceof Blob) {
-    return checkedTextAttachmentBytes(await attachment.data.arrayBuffer())
+    return checkedTextAttachmentBytes(await attachment.data.arrayBuffer(), options)
   }
-  return checkedTextAttachmentBytes(attachment.data)
+  return checkedTextAttachmentBytes(attachment.data, options)
 }
 
-async function textPartFromAttachment(attachment: Attachment, index: number): Promise<MessagePart | undefined> {
+async function textPartFromAttachment(attachment: Attachment, index: number, options: { rejectOversizedTextAttachments?: boolean } = {}): Promise<MessagePart | undefined> {
   if (!isTextAttachment(attachment)) return undefined
-  const bytes = await textAttachmentBytes(attachment)
+  const bytes = await textAttachmentBytes(attachment, options)
   if (!bytes?.byteLength) return undefined
   const name = attachment.name || `attachment-${index + 1}`
   return {
@@ -1013,13 +1015,13 @@ function attachmentFallbackText(attachments: Attachment[]): string {
   return `Sent attachments: ${summary}.`
 }
 
-async function chatMessageParts(message: ChatSdkMessage, options: { includeAudioAttachments?: boolean } = {}): Promise<MessagePart[]> {
+async function chatMessageParts(message: ChatSdkMessage, options: { includeAudioAttachments?: boolean, rejectOversizedTextAttachments?: boolean } = {}): Promise<MessagePart[]> {
   const parts: MessagePart[] = []
   if (message.text) {
     parts.push({ id: "text-0", text: message.text, type: "text" })
   }
   for (const [index, attachment] of message.attachments.entries()) {
-    const part = await textPartFromAttachment(attachment, index)
+    const part = await textPartFromAttachment(attachment, index, options)
     if (part) parts.push(part)
   }
   if (options.includeAudioAttachments) {
@@ -1057,7 +1059,7 @@ function chatMessageMetadata(thread: Thread, message: ChatSdkMessage, messageCon
 async function chatSdkMessageToUiMessage(
   message: ChatSdkMessage,
   metadata?: Record<string, unknown>,
-  options?: { includeAudioAttachments?: boolean },
+  options?: { includeAudioAttachments?: boolean, rejectOversizedTextAttachments?: boolean },
 ): Promise<UIMessageLike> {
   return {
     createdAt: isoDate(message.metadata.dateSent),
@@ -1096,7 +1098,10 @@ async function chatTriggerMessages(
   messageContext?: MessageContext,
   messageOptions?: { includeAudioAttachments?: boolean },
 ): Promise<UIMessageLike[]> {
-  const current = await chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext), messageOptions)
+  const current = await chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext), {
+    ...messageOptions,
+    rejectOversizedTextAttachments: true,
+  })
   const limit = chatTriggerHistoryLimit(resolveChatTriggerHistory(options))
   if (!limit) return [current]
 

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -903,6 +903,58 @@ function audioData(value: unknown): AudioData | undefined {
   return undefined
 }
 
+const chatTextAttachmentMaxBytes = 1024 * 1024
+const textAttachmentExtensions = new Set(["csv", "json", "log", "md", "txt", "yaml", "yml"])
+const textAttachmentMimeTypes = new Set(["application/json", "application/x-yaml", "application/yaml", "text/csv"])
+
+function isTextAttachment(attachment: Attachment): boolean {
+  if (attachment.type !== "file") return false
+  const mimeType = typeof attachment.mimeType === "string"
+    ? attachment.mimeType.split(";")[0]?.trim().toLowerCase()
+    : undefined
+  if (mimeType?.startsWith("text/") || (mimeType && textAttachmentMimeTypes.has(mimeType)) || mimeType?.endsWith("+json") || mimeType?.endsWith("+yaml")) {
+    return true
+  }
+  const extension = attachment.name?.split(".").pop()?.toLowerCase()
+  return !!extension && textAttachmentExtensions.has(extension)
+}
+
+function checkedTextAttachmentBytes(value: unknown): Uint8Array | undefined {
+  const bytes = value instanceof ArrayBuffer
+    ? new Uint8Array(value)
+    : value instanceof Uint8Array ? value : undefined
+  if (!bytes) return
+  if (bytes.byteLength > chatTextAttachmentMaxBytes) {
+    throw new Error(`[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`)
+  }
+  return bytes
+}
+
+async function textAttachmentBytes(attachment: Attachment): Promise<Uint8Array | undefined> {
+  if (typeof attachment.size === "number" && attachment.size > chatTextAttachmentMaxBytes) {
+    throw new Error(`[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`)
+  }
+  if (typeof attachment.fetchData === "function") {
+    return checkedTextAttachmentBytes(await attachment.fetchData())
+  }
+  if (attachment.data instanceof Blob) {
+    return checkedTextAttachmentBytes(await attachment.data.arrayBuffer())
+  }
+  return checkedTextAttachmentBytes(attachment.data)
+}
+
+async function textPartFromAttachment(attachment: Attachment, index: number): Promise<MessagePart | undefined> {
+  if (!isTextAttachment(attachment)) return undefined
+  const bytes = await textAttachmentBytes(attachment)
+  if (!bytes?.byteLength) return undefined
+  const name = attachment.name || `attachment-${index + 1}`
+  return {
+    id: `attachment-${index + 1}`,
+    text: `\n\nText attachment (${name}):\n\n${new TextDecoder().decode(bytes).trimEnd()}`,
+    type: "text",
+  }
+}
+
 function audioPartFromAttachment(attachment: Attachment, index: number): MessagePart | undefined {
   const mediaType = typeof attachment.mimeType === "string" && attachment.mimeType.startsWith("audio/")
     ? attachment.mimeType
@@ -961,10 +1013,14 @@ function attachmentFallbackText(attachments: Attachment[]): string {
   return `Sent attachments: ${summary}.`
 }
 
-function chatMessageParts(message: ChatSdkMessage, options: { includeAudioAttachments?: boolean } = {}): MessagePart[] {
+async function chatMessageParts(message: ChatSdkMessage, options: { includeAudioAttachments?: boolean } = {}): Promise<MessagePart[]> {
   const parts: MessagePart[] = []
   if (message.text) {
     parts.push({ id: "text-0", text: message.text, type: "text" })
+  }
+  for (const [index, attachment] of message.attachments.entries()) {
+    const part = await textPartFromAttachment(attachment, index)
+    if (part) parts.push(part)
   }
   if (options.includeAudioAttachments) {
     for (const [index, attachment] of message.attachments.entries()) {
@@ -998,16 +1054,16 @@ function chatMessageMetadata(thread: Thread, message: ChatSdkMessage, messageCon
   })
 }
 
-function chatSdkMessageToUiMessage(
+async function chatSdkMessageToUiMessage(
   message: ChatSdkMessage,
   metadata?: Record<string, unknown>,
   options?: { includeAudioAttachments?: boolean },
-): UIMessageLike {
+): Promise<UIMessageLike> {
   return {
     createdAt: isoDate(message.metadata.dateSent),
     id: message.id,
     ...(metadata ? { metadata } : {}),
-    parts: chatMessageParts(message, options),
+    parts: await chatMessageParts(message, options),
     role: message.author.isMe ? "assistant" : "user",
   }
 }
@@ -1040,21 +1096,21 @@ async function chatTriggerMessages(
   messageContext?: MessageContext,
   messageOptions?: { includeAudioAttachments?: boolean },
 ): Promise<UIMessageLike[]> {
-  const current = chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext), messageOptions)
+  const current = await chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext), messageOptions)
   const limit = chatTriggerHistoryLimit(resolveChatTriggerHistory(options))
   if (!limit) return [current]
 
   const fetchedNewestFirst: UIMessageLike[] = []
   try {
     for await (const item of thread.messages) {
-      fetchedNewestFirst.push(item.id && message.id && item.id === message.id ? current : chatSdkMessageToUiMessage(item, undefined, messageOptions))
+      fetchedNewestFirst.push(item.id && message.id && item.id === message.id ? current : await chatSdkMessageToUiMessage(item, undefined, messageOptions))
       if (fetchedNewestFirst.length >= limit) break
     }
   } catch {}
 
   const durable = await durableChatThreadMessages(thread, limit)
   const messages = [
-    ...durable.map(item => item.id && message.id && item.id === message.id ? current : chatSdkMessageToUiMessage(item, undefined, messageOptions)),
+    ...(await Promise.all(durable.map(item => item.id && message.id && item.id === message.id ? current : chatSdkMessageToUiMessage(item, undefined, messageOptions)))),
     ...fetchedNewestFirst.slice().reverse(),
   ].reduce<UIMessageLike[]>((deduped, item) => {
     if (!item.id) {
@@ -1319,7 +1375,9 @@ async function handleChatSdkMessage(
       }),
     }
     const messages = await chatTriggerMessages(thread, message, options, messageContext, messageOptions)
-    const currentMessage = chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext), messageOptions)
+    const currentMessage = message.id
+      ? messages.find(item => item.id === message.id)
+      : messages.at(-1)
     if (!currentMessage || !Array.isArray(currentMessage.parts) || currentMessage.parts.length === 0) return
     input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, messages, messageContext, registration.channelId)
     const invocation = await resolveAgentTriggerInvocation(agent as never, context as never, "chat.message", input)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -906,6 +906,7 @@ function audioData(value: unknown): AudioData | undefined {
 const chatTextAttachmentMaxBytes = 1024 * 1024
 const textAttachmentExtensions = new Set(["csv", "json", "log", "md", "txt", "yaml", "yml"])
 const textAttachmentMimeTypes = new Set(["application/json", "application/x-yaml", "application/yaml", "text/csv"])
+const chatTextAttachmentOversizeMessage = `[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`
 
 function isTextAttachment(attachment: Attachment): boolean {
   if (attachment.type !== "file") return false
@@ -926,9 +927,13 @@ function checkedTextAttachmentBytes(value: unknown, options: { rejectOversizedTe
   if (!bytes) return
   if (bytes.byteLength > chatTextAttachmentMaxBytes) {
     if (!options.rejectOversizedTextAttachments) return
-    throw new Error(`[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`)
+    throw new Error(chatTextAttachmentOversizeMessage)
   }
   return bytes
+}
+
+function isTextAttachmentOversizeError(error: unknown): boolean {
+  return error instanceof Error && error.message === chatTextAttachmentOversizeMessage
 }
 
 async function fetchTextAttachmentBytes(url: string, options: { rejectOversizedTextAttachments?: boolean } = {}): Promise<Uint8Array | undefined> {
@@ -938,7 +943,7 @@ async function fetchTextAttachmentBytes(url: string, options: { rejectOversizedT
   const contentLength = contentLengthHeader === null ? undefined : Number(contentLengthHeader)
   if (typeof contentLength === "number" && Number.isFinite(contentLength) && contentLength > chatTextAttachmentMaxBytes) {
     if (!options.rejectOversizedTextAttachments) return
-    throw new Error(`[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`)
+    throw new Error(chatTextAttachmentOversizeMessage)
   }
   if (!response.body) {
     return checkedTextAttachmentBytes(await response.arrayBuffer(), options)
@@ -955,7 +960,7 @@ async function fetchTextAttachmentBytes(url: string, options: { rejectOversizedT
     if (byteLength > chatTextAttachmentMaxBytes) {
       await reader.cancel().catch(() => undefined)
       if (!options.rejectOversizedTextAttachments) return
-      throw new Error(`[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`)
+      throw new Error(chatTextAttachmentOversizeMessage)
     }
     chunks.push(chunk)
   }
@@ -972,19 +977,30 @@ async function fetchTextAttachmentBytes(url: string, options: { rejectOversizedT
 async function textAttachmentBytes(attachment: Attachment, options: { rejectOversizedTextAttachments?: boolean } = {}): Promise<Uint8Array | undefined> {
   if (typeof attachment.size === "number" && attachment.size > chatTextAttachmentMaxBytes) {
     if (!options.rejectOversizedTextAttachments) return
-    throw new Error(`[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`)
+    throw new Error(chatTextAttachmentOversizeMessage)
   }
   if (typeof attachment.fetchData === "function") {
-    return checkedTextAttachmentBytes(await attachment.fetchData(), options)
+    try {
+      return checkedTextAttachmentBytes(await attachment.fetchData(), options)
+    }
+    catch (error) {
+      if (isTextAttachmentOversizeError(error)) throw error
+      return undefined
+    }
   }
   if (attachment.data instanceof Blob) {
     return checkedTextAttachmentBytes(await attachment.data.arrayBuffer(), options)
   }
   const bytes = checkedTextAttachmentBytes(attachment.data, options)
   if (bytes) return bytes
-  return typeof attachment.url === "string" && attachment.url
-    ? await fetchTextAttachmentBytes(attachment.url, options)
-    : undefined
+  if (typeof attachment.url !== "string" || !attachment.url) return undefined
+  try {
+    return await fetchTextAttachmentBytes(attachment.url, options)
+  }
+  catch (error) {
+    if (isTextAttachmentOversizeError(error)) throw error
+    return undefined
+  }
 }
 
 async function textPartFromAttachment(attachment: Attachment, index: number, options: { rejectOversizedTextAttachments?: boolean } = {}): Promise<MessagePart | undefined> {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -677,7 +677,7 @@ async function generateAgentDiscordGatewayRouteHandler(
 
   return [
     `import { withAgentDefaults, workspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
-    `import { createDiscordGatewayRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
+    `import { createDiscordGatewayRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server"))}`,
     "import { createError, defineEventHandler, getRequestHeader, getRequestHeaders, getRequestURL, getRouterParam } from 'h3'",
     imports,
     "",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -458,6 +458,7 @@ describe("agent Vite plugin", () => {
 
       const gatewayRoute = await readFile(join(root, ".vitehub/agent/discord-gateway-route.ts"), "utf8")
 
+      expect(gatewayRoute).toContain("import { createDiscordGatewayRouteHandler } from \"@vite-hub/agent/server\"")
       expect(gatewayRoute).toContain("createDiscordGatewayRouteHandler")
       expect(gatewayRoute).toContain("VITEHUB_DISCORD_GATEWAY_SECRET")
       expect(gatewayRoute).toContain("VITEHUB_DISCORD_GATEWAY_DURATION_MS")
@@ -2560,7 +2561,7 @@ describe("server helpers", () => {
   it("forwards Discord Gateway events to the registered webhook id", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { discord } = await import("../src/channels.ts")
-    const { createDiscordGatewayRouteHandler } = await import("../src/server/internal.ts")
+    const { createDiscordGatewayRouteHandler } = await import("../src/server.ts")
     const startGatewayListener = vi.fn(async () => Response.json({ ok: true }))
     const adapter = {
       ...createTestChatAdapter(),
@@ -2593,10 +2594,103 @@ describe("server helpers", () => {
     )
   })
 
+  it("rejects non-GET Discord Gateway requests", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { discord } = await import("../src/channels.ts")
+    const { createDiscordGatewayRouteHandler } = await import("../src/server.ts")
+    const adapter = {
+      ...createTestChatAdapter(),
+      name: "discord",
+      startGatewayListener: vi.fn(async () => Response.json({ ok: true })),
+    }
+    const agent = defineAgent({
+      channels: {
+        discord: discord({ adapter: () => adapter as never }),
+      },
+      driver: {
+        run: vi.fn(),
+      },
+    })
+    const handler = createDiscordGatewayRouteHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/discord/gateway", {
+      method: "POST",
+    }), { webhookUrl: "https://example.com/api/_vitehub/agents/support/webhooks/discord" })
+
+    expect(response.status).toBe(405)
+    await expect(response.json()).resolves.toMatchObject({
+      message: "Discord Gateway route only accepts GET requests.",
+    })
+    expect(adapter.startGatewayListener).not.toHaveBeenCalled()
+  })
+
+  it("maps Discord Gateway text file attachments through the registered webhook", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { discord } = await import("../src/channels.ts")
+    const { createDiscordGatewayRouteHandler } = await import("../src/server.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = {
+      ...createTestChatAdapter(),
+      name: "discord",
+      startGatewayListener: vi.fn(async (_options, _durationMs, _abortSignal, webhookUrl) => {
+        if (!webhookUrl) return Response.json({ ok: false }, { status: 500 })
+        return await webhookHandler(new Request(webhookUrl, {
+          body: JSON.stringify({
+            message: {
+              chat: { id: "support" },
+              document: {
+                content: "expanded Discord prompt\n",
+                file_id: "prompt-file",
+                file_name: "message.txt",
+                file_size: 24,
+                mime_type: "text/plain",
+              },
+              from: { id: "42", username: "maxi" },
+              message_id: "msg-1",
+            },
+          }),
+          method: "POST",
+        }), "discord-events")
+      }),
+    }
+    const run = vi.fn(() => "ok")
+    const agent = defineAgent({
+      channels: {
+        discord: discord({
+          adapter: () => adapter as never,
+          webhooks: { id: "discord-events" },
+        }),
+      },
+      driver: {
+        run,
+      },
+    })
+    const webhookHandler = createChannelWebhookRouteHandler(agent as never)
+    const gatewayHandler = createDiscordGatewayRouteHandler(agent as never)
+
+    const response = await gatewayHandler(new Request("https://example.com/api/_vitehub/agents/support/discord/gateway"), {
+      webhookUrl: webhook => `https://example.com/api/_vitehub/agents/support/webhooks/${webhook}`,
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(adapter.startGatewayListener).toHaveBeenCalledOnce()
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({
+      messages: [expect.objectContaining({
+        parts: [
+          expect.objectContaining({
+            text: "\n\nText attachment (message.txt):\n\nexpanded Discord prompt",
+            type: "text",
+          }),
+        ],
+      })],
+    }))
+  })
+
   it("starts Discord Gateway listeners for every Discord channel", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { discord } = await import("../src/channels.ts")
-    const { createDiscordGatewayRouteHandler } = await import("../src/server/internal.ts")
+    const { createDiscordGatewayRouteHandler } = await import("../src/server.ts")
     let resolveSupportGateway!: (response: Response) => void
     let markSupportGatewayStarted!: () => void
     const supportGatewayStarted = new Promise<void>(resolve => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -4246,6 +4246,86 @@ describe("server helpers", () => {
     }
   })
 
+  it("falls back when durable thread history text attachment URLs fail", async () => {
+    const { telegram } = await import("../src/channels.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { getMessageText } = await import("../src/messages.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const fetch = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("stale attachment"))
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-history-stale-attachment-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const runs: string[][] = []
+    try {
+      await state.connect?.()
+      await state.appendToList("msg-history:telegram:456", new Message({
+        attachments: [{
+          mimeType: "text/plain",
+          name: "old.txt",
+          size: 12,
+          type: "file",
+          url: "https://cdn.example/old.txt",
+        }],
+        author: {
+          fullName: "Maxi",
+          isBot: false,
+          isMe: false,
+          userId: "123",
+          userName: "maxi",
+        },
+        formatted: { children: [], type: "root" },
+        id: "40",
+        metadata: { dateSent: new Date("2026-06-10T12:00:00.000Z"), edited: false },
+        raw: null,
+        text: "",
+        threadId: "telegram:456",
+      }).toJSON(), { maxLength: 25 })
+      const adapter = createTestChatAdapter({ persistThreadHistory: true })
+      const agent = defineAgent({
+        channels: {
+          telegram: telegram({ adapter: () => adapter as never }),
+        },
+        driver: {
+          run: ({ messages }) => {
+            runs.push(messages.map(getMessageText))
+            return "ok"
+          },
+        },
+        messages: {
+          state: () => state,
+          stream: false,
+          threadHistory: { maxMessages: 25 },
+          triggerHistory: { maxMessages: 25, source: "thread" },
+        },
+      })
+      const handler = createChannelWebhookRouteHandler(agent as never)
+
+      const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+        body: JSON.stringify({
+          update_id: 42,
+          message: {
+            chat: { id: 456, type: "private" },
+            date: 1781092842,
+            from: { first_name: "Maxi", id: 123, username: "maxi" },
+            message_id: 42,
+            text: "current after stale history",
+          },
+        }),
+        method: "POST",
+      }), "telegram")
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ ok: true })
+      expect(fetch).toHaveBeenCalledWith("https://cdn.example/old.txt")
+      expect(runs).toEqual([["Sent a file attachment.", "current after stale history"]])
+    }
+    finally {
+      fetch.mockRestore()
+      await state.disconnect?.()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
   it("runs non-streaming chat webhooks inline for workflow-backed agents", async () => {
     const { workflow } = await import("../src/index.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -43,7 +43,7 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
       }
       const chat = rawMessage.chat as { id?: number | string } | undefined
       const from = rawMessage.from as { email?: string, id?: number | string, mail?: string, userPrincipalName?: string, username?: string } | undefined
-      const document = rawMessage.document as { content?: string, file_id?: string, file_name?: string, file_size?: number, mime_type?: string } | undefined
+      const document = rawMessage.document as { content?: string, file_id?: string, file_name?: string, file_size?: number, mime_type?: string, url?: string } | undefined
       const photos = rawMessage.photo as Array<{ file_id?: string, file_size?: number, height?: number, width?: number }> | undefined
       const photo = photos?.at(-1)
       const date = typeof rawMessage.date === "number"
@@ -68,14 +68,15 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
                 size: document.file_size,
                 type: "file",
               }]
-          : typeof document?.file_id === "string"
+          : document && (typeof document.file_id === "string" || typeof document.url === "string" || typeof document.content === "string")
             ? [{
-                fetchData: async () => Buffer.from(document.content ?? ""),
-                fetchMetadata: { fileId: document.file_id },
+                ...(typeof document.content === "string" ? { fetchData: async () => Buffer.from(document.content ?? "") } : {}),
+                ...(typeof document.file_id === "string" ? { fetchMetadata: { fileId: document.file_id } } : {}),
                 ...(document.mime_type ? { mimeType: document.mime_type } : {}),
                 name: document.file_name,
                 size: document.file_size,
                 type: "file",
+                ...(typeof document.url === "string" ? { url: document.url } : {}),
               }]
           : typeof photo?.file_id === "string"
             ? [{
@@ -2624,11 +2625,14 @@ describe("server helpers", () => {
     expect(adapter.startGatewayListener).not.toHaveBeenCalled()
   })
 
-  it("maps Discord Gateway text file attachments through the registered webhook", async () => {
+  it("maps Discord Gateway URL-only text file attachments through the registered webhook", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { discord } = await import("../src/channels.ts")
     const { createDiscordGatewayRouteHandler } = await import("../src/server.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("expanded Discord prompt\n", {
+      headers: { "content-length": "24", "content-type": "text/plain" },
+    }))
     const adapter = {
       ...createTestChatAdapter(),
       name: "discord",
@@ -2639,11 +2643,10 @@ describe("server helpers", () => {
             message: {
               chat: { id: "support" },
               document: {
-                content: "expanded Discord prompt\n",
-                file_id: "prompt-file",
                 file_name: "message.txt",
                 file_size: 24,
                 mime_type: "text/plain",
+                url: "https://cdn.example/message.txt",
               },
               from: { id: "42", username: "maxi" },
               message_id: "msg-1",
@@ -2668,23 +2671,29 @@ describe("server helpers", () => {
     const webhookHandler = createChannelWebhookRouteHandler(agent as never)
     const gatewayHandler = createDiscordGatewayRouteHandler(agent as never)
 
-    const response = await gatewayHandler(new Request("https://example.com/api/_vitehub/agents/support/discord/gateway"), {
-      webhookUrl: webhook => `https://example.com/api/_vitehub/agents/support/webhooks/${webhook}`,
-    })
+    try {
+      const response = await gatewayHandler(new Request("https://example.com/api/_vitehub/agents/support/discord/gateway"), {
+        webhookUrl: webhook => `https://example.com/api/_vitehub/agents/support/webhooks/${webhook}`,
+      })
 
-    expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ ok: true })
-    expect(adapter.startGatewayListener).toHaveBeenCalledOnce()
-    expect(run).toHaveBeenCalledWith(expect.objectContaining({
-      messages: [expect.objectContaining({
-        parts: [
-          expect.objectContaining({
-            text: "\n\nText attachment (message.txt):\n\nexpanded Discord prompt",
-            type: "text",
-          }),
-        ],
-      })],
-    }))
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ ok: true })
+      expect(adapter.startGatewayListener).toHaveBeenCalledOnce()
+      expect(fetch).toHaveBeenCalledWith("https://cdn.example/message.txt")
+      expect(run).toHaveBeenCalledWith(expect.objectContaining({
+        messages: [expect.objectContaining({
+          parts: [
+            expect.objectContaining({
+              text: "\n\nText attachment (message.txt):\n\nexpanded Discord prompt",
+              type: "text",
+            }),
+          ],
+        })],
+      }))
+    }
+    finally {
+      fetch.mockRestore()
+    }
   })
 
   it("starts Discord Gateway listeners for every Discord channel", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -43,7 +43,7 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
       }
       const chat = rawMessage.chat as { id?: number | string } | undefined
       const from = rawMessage.from as { email?: string, id?: number | string, mail?: string, userPrincipalName?: string, username?: string } | undefined
-      const document = rawMessage.document as { file_id?: string, file_name?: string, file_size?: number, mime_type?: string } | undefined
+      const document = rawMessage.document as { content?: string, file_id?: string, file_name?: string, file_size?: number, mime_type?: string } | undefined
       const photos = rawMessage.photo as Array<{ file_id?: string, file_size?: number, height?: number, width?: number }> | undefined
       const photo = photos?.at(-1)
       const date = typeof rawMessage.date === "number"
@@ -64,6 +64,15 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
                 fetchData: async () => Buffer.from([1, 2, 3]),
                 fetchMetadata: { fileId: document.file_id },
                 mimeType: document.mime_type,
+                name: document.file_name,
+                size: document.file_size,
+                type: "file",
+              }]
+          : typeof document?.file_id === "string"
+            ? [{
+                fetchData: async () => Buffer.from(document.content ?? ""),
+                fetchMetadata: { fileId: document.file_id },
+                ...(document.mime_type ? { mimeType: document.mime_type } : {}),
                 name: document.file_name,
                 size: document.file_size,
                 type: "file",
@@ -2202,6 +2211,105 @@ describe("server helpers", () => {
         ],
       })],
     }))
+  })
+
+  it("maps text-like file attachments to text parts", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const run = vi.fn(({ messages }) => messages.at(-1)?.parts
+      .filter((part: { type?: string }) => part.type === "text")
+      .map((part: { text?: string }) => part.text)
+      .join(""))
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({ adapter: () => adapter as never }),
+      },
+      driver: { run },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 42,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          document: {
+            content: "# Notes\n- first\n",
+            file_id: "notes-file",
+            file_name: "notes.md",
+            file_size: 16,
+            mime_type: "text/markdown; charset=utf-8",
+          },
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 1010,
+          text: "see attached",
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({
+      messages: [expect.objectContaining({
+        parts: [
+          expect.objectContaining({ text: "see attached", type: "text" }),
+          expect.objectContaining({
+            text: "\n\nText attachment (notes.md):\n\n# Notes\n- first",
+            type: "text",
+          }),
+        ],
+      })],
+    }))
+  })
+
+  it("rejects oversized text-like file attachments before chat access", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { access } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const admitChat = vi.fn(() => true)
+    const run = vi.fn(() => "ok")
+    const agent = defineAgent({
+      capabilities: [access({ chat: { resolve: admitChat } })],
+      channels: {
+        telegram: telegram({ adapter: () => adapter as never }),
+      },
+      driver: { run },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      await expect(handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+        body: JSON.stringify({
+          update_id: 42,
+          message: {
+            chat: { id: 456, type: "private" },
+            date: 1781092800,
+            document: {
+              content: "small",
+              file_id: "large-log",
+              file_name: "large.log",
+              file_size: 1024 * 1024 + 1,
+              mime_type: "text/plain",
+            },
+            from: { first_name: "Maxi", id: 123, username: "maxi" },
+            message_id: 1011,
+          },
+        }),
+        method: "POST",
+      }), "telegram")).rejects.toThrow("[vitehub] Chat text attachment exceeds 1048576 bytes.")
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+    expect(admitChat).not.toHaveBeenCalled()
+    expect(run).not.toHaveBeenCalled()
   })
 
   it("maps audio mime file attachments for custom audio capabilities", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -4160,6 +4160,83 @@ describe("server helpers", () => {
     }
   })
 
+  it("skips oversized text attachments from durable thread history", async () => {
+    const { telegram } = await import("../src/channels.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { getMessageText } = await import("../src/messages.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-history-oversized-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const runs: string[][] = []
+    try {
+      await state.connect?.()
+      await state.appendToList("msg-history:telegram:456", new Message({
+        attachments: [{
+          fetchMetadata: { fileId: "old-log" },
+          mimeType: "text/plain",
+          name: "old.log",
+          size: 1024 * 1024 + 1,
+          type: "file",
+        }],
+        author: {
+          fullName: "Maxi",
+          isBot: false,
+          isMe: false,
+          userId: "123",
+          userName: "maxi",
+        },
+        formatted: { children: [], type: "root" },
+        id: "40",
+        metadata: { dateSent: new Date("2026-06-10T12:00:00.000Z"), edited: false },
+        raw: null,
+        text: "old context",
+        threadId: "telegram:456",
+      }).toJSON(), { maxLength: 25 })
+      const adapter = createTestChatAdapter({ persistThreadHistory: true })
+      const agent = defineAgent({
+        channels: {
+          telegram: telegram({ adapter: () => adapter as never }),
+        },
+        driver: {
+          run: ({ messages }) => {
+            runs.push(messages.map(getMessageText))
+            return "ok"
+          },
+        },
+        messages: {
+          state: () => state,
+          stream: false,
+          threadHistory: { maxMessages: 25 },
+          triggerHistory: { maxMessages: 25, source: "thread" },
+        },
+      })
+      const handler = createChannelWebhookRouteHandler(agent as never)
+
+      const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+        body: JSON.stringify({
+          update_id: 41,
+          message: {
+            chat: { id: 456, type: "private" },
+            date: 1781092841,
+            from: { first_name: "Maxi", id: 123, username: "maxi" },
+            message_id: 41,
+            text: "current after large history",
+          },
+        }),
+        method: "POST",
+      }), "telegram")
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({ ok: true })
+      expect(runs).toEqual([["old context", "current after large history"]])
+    }
+    finally {
+      await state.disconnect?.()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
   it("runs non-streaming chat webhooks inline for workflow-backed agents", async () => {
     const { workflow } = await import("../src/index.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -882,6 +882,7 @@ describe("agent public types", () => {
     type _PublicTeams = ChannelExports["teams"]
 
     type ServerExports = typeof import("../src/server.ts")
+    type _PublicDiscordGatewayRouteHandler = ServerExports["createDiscordGatewayRouteHandler"]
     // @ts-expect-error generated route handler factories are internal Provider Output plumbing.
     type _PublicChannelChatRouteHandler = ServerExports["createChannelChatRouteHandler"]
     // @ts-expect-error generated route handler factories are internal Provider Output plumbing.


### PR DESCRIPTION
Ports the Bitacora-carried chat text attachment patch into Agent Package source. Chat SDK file attachments with text-like MIME types or txt/md/json/yaml/log/csv filenames now become text parts before chat access and agent execution, with a 1 MiB cap.

The Agent Package also exposes the Discord Gateway route handler through `@vite-hub/agent/server`, and generated Discord Gateway routes import that public handler so apps can rely on the ViteHub-owned route instead of carrying their own Nitro route.

Adds provider coverage for text attachment mapping, oversized text attachment rejection before chat access, GET-only Discord Gateway admission, and the gateway-started webhook path for Discord `.txt` attachments.