### PR TITLE
fix(workspace): fall back to github store without hosted loader

### DIFF
--- a/packages/workspace/src/storage/provider.ts
+++ b/packages/workspace/src/storage/provider.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path"
 import { readEnv, trimmed } from "@vite-hub/internal/env"
 
 import { WorkspaceError } from "../core/errors.ts"
+import { createGitHubWorkspaceStore } from "../providers/github/store.ts"
 import { getWorkspaceRuntimeConfig } from "../runtime/config.ts"
 import { getWorkspaceHostedStoreLoader } from "../runtime/hosted-store-loader.ts"
 import { createLocalWorkspaceStore } from "./local.ts"
@@ -138,6 +139,7 @@ export function createWorkspaceStoreFromProvider(definition: WorkspaceDefinition
   if (store?.provider === "memory") return createMemoryWorkspaceStore()
   if (store?.provider === "cloudflare-artifacts" || store?.provider === "github" || store?.provider === "vercel-blob") {
     const loader = getWorkspaceHostedStoreLoader()
+    if (!loader && store.provider === "github") return createGitHubWorkspaceStore(store, definition.name)
     if (!loader) throw new WorkspaceError(`[vitehub] Hosted workspace store "${store.provider}" is not available in this runtime.`)
     return loader(store, definition.name)
   }

--- a/packages/workspace/test/lifecycle.test.ts
+++ b/packages/workspace/test/lifecycle.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { installHostedWorkspaceRuntime } from "../src/hosted.ts"
 import { getWorkspaceHostedStoreLoader, setWorkspaceHostedStoreLoader } from "../src/runtime/state.ts"
 import { createWorkspaceStore } from "../src/lifecycle.ts"
+
+afterEach(() => {
+  setWorkspaceHostedStoreLoader(undefined)
+  vi.unstubAllGlobals()
+})
 
 describe("workspace lifecycle", () => {
   it("delegates hosted store creation through the runtime loader", async () => {
@@ -32,6 +37,44 @@ describe("workspace lifecycle", () => {
     finally {
       setWorkspaceHostedStoreLoader(undefined)
     }
+  })
+
+  it("creates GitHub workspace stores without a hosted runtime loader", async () => {
+    setWorkspaceHostedStoreLoader(undefined)
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(input instanceof Request ? input.url : String(input))
+      if (url.pathname === "/repos/acme/app/git/ref/heads/main") {
+        return new Response(JSON.stringify({ object: { sha: "commit-sha" } }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        })
+      }
+      if (url.pathname === "/repos/acme/app/git/commits/commit-sha") {
+        return new Response(JSON.stringify({ tree: { sha: "tree-sha" } }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        })
+      }
+      if (url.pathname === "/repos/acme/app/git/trees/tree-sha") {
+        return new Response(JSON.stringify({ tree: [] }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        })
+      }
+      return new Response("not found", { status: 404 })
+    }))
+
+    const store = createWorkspaceStore({
+      name: "docs",
+      store: {
+        provider: "github",
+        repository: "acme/app",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "github-token",
+      },
+    })
+
+    await expect(store.list("", { recursive: true })).resolves.toEqual([])
   })
 
   it("preserves an existing hosted loader when installing the generic hosted runtime", async () => {


### PR DESCRIPTION
Upstreams the Bitacora-carried `@vite-hub/workspace` generated-dist patch at the Workspace Store boundary. GitHub-backed Workspace Stores now instantiate the internal GitHub Store directly when no hosted store loader is installed, while Cloudflare Artifacts and Vercel Blob still require runtime loader wiring.

Adds a focused lifecycle regression covering `createWorkspaceStore()` with a GitHub provider and no hosted loader.