### PR TITLE
fix(agent): resolve evalite setup file from package

### DIFF
--- a/packages/agent/src/evalite-runner.ts
+++ b/packages/agent/src/evalite-runner.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import process from "node:process"
 import path from "node:path"
+import { fileURLToPath } from "node:url"
 
 import type { Writable } from "node:stream"
 import type { Evalite } from "evalite/types"
@@ -140,7 +141,7 @@ export async function runAgentEvalite(options: RunAgentEvaliteOptions): Promise<
   server.start(serverPort)
 
   let exitCode: number | undefined
-  const setupFiles = ["evalite/env-setup-file", ...(options.setupFiles || [])]
+  const setupFiles = [fileURLToPath(import.meta.resolve("evalite/env-setup-file")), ...(options.setupFiles || [])]
   const forceRerunTriggers = options.forceRerunTriggers ?? configDefaults.forceRerunTriggers
 
   process.env.EVALITE_REPORT_TRACES = "true"

--- a/packages/agent/test/evalite-runner.test.ts
+++ b/packages/agent/test/evalite-runner.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { runAgentEvalite } from "../src/evalite-runner.ts"
+
+const createVitestCalls = vi.hoisted(() => [] as Array<{ setupFiles?: string[] }>)
+
+vi.mock("evalite/backend-only-constants", () => ({
+  FILES_LOCATION: ".evalite",
+}))
+
+vi.mock("evalite/constants", () => ({
+  DEFAULT_SERVER_PORT: 3006,
+}))
+
+vi.mock("evalite/reporter", () => ({
+  default: class EvaliteReporter {},
+}))
+
+vi.mock("evalite/server", () => ({
+  createServer: () => ({
+    setRerunFn: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    updateState: vi.fn(),
+  }),
+}))
+
+vi.mock("evalite/in-memory-storage", () => ({
+  createInMemoryStorage: () => ({}),
+}))
+
+vi.mock("vitest/config", () => ({
+  configDefaults: {
+    forceRerunTriggers: [],
+  },
+}))
+
+vi.mock("vitest/node", () => ({
+  createVitest: vi.fn(async (_mode: string, options: { setupFiles?: string[] }) => {
+    createVitestCalls.push(options)
+    return {
+      close: vi.fn(),
+      getModuleSpecifications: vi.fn(() => []),
+      provide: vi.fn(),
+      shouldKeepServer: vi.fn(() => false),
+      start: vi.fn(),
+      state: {
+        getFilepaths: vi.fn(() => []),
+      },
+    }
+  }),
+  registerConsoleShortcuts: vi.fn(() => vi.fn()),
+}))
+
+describe("Agent Evalite runner", () => {
+  afterEach(() => {
+    createVitestCalls.length = 0
+  })
+
+  it("resolves Evalite setup file from the Agent Package before app setup files", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "vitehub-agent-evalite-"))
+    try {
+      await runAgentEvalite({
+        cwd,
+        forceRerunTriggers: [],
+        mode: "run-once-and-exit",
+        setupFiles: ["./app-setup.ts"],
+      })
+
+      const setupFiles = createVitestCalls[0]?.setupFiles ?? []
+      const evaliteSetupFile = setupFiles[0] ?? ""
+      expect(evaliteSetupFile).not.toBe("evalite/env-setup-file")
+      expect(path.isAbsolute(evaliteSetupFile)).toBe(true)
+      expect(evaliteSetupFile).toMatch(/node_modules\/evalite\/setup-files\/env\.js$/)
+      expect(setupFiles.slice(1)).toEqual(["./app-setup.ts"])
+    }
+    finally {
+      await rm(cwd, { force: true, recursive: true })
+    }
+  })
+})


### PR DESCRIPTION
Resolves the Evalite env setup file from the Agent Package before passing it to Vitest, so apps using `vitehub agent eval` do not need Evalite as a direct dependency just to bootstrap the runner.

The previous Vitest `setupFiles` entry used the bare `evalite/env-setup-file` specifier from the app root. When Evalite is only transitive under `@vite-hub/agent`, Vitest resolved that as an app dependency and failed before cases were discovered. App-provided setup files still append after the package-resolved Evalite setup file.

Adds a focused runner test that inspects the Vitest config and proves the Evalite setup path is absolute/package-resolved.