### PR TITLE
fix(agent): ack non-chat webhooks before runs finish

### DIFF
--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -16,7 +16,7 @@ import { createAgentRuntimeContext } from "../runtime/context.ts"
 import { createAgentUIMessageStreamResponse } from "../stream-output.ts"
 import { isResolvedAgentTriggerHandledInvocation, verifyAgentWebhookRequest } from "../trigger-runtime.ts"
 import { toHttpErrorResponse } from "../http-error.ts"
-import { isWorkflowRun, toAgentFetchResponse } from "../http-response.ts"
+import { isWorkflowRun } from "../http-response.ts"
 import { createChatDevtoolsStreamResponse } from "../chat/devtools-stream.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 
@@ -2318,10 +2318,11 @@ export function createChannelWebhookRouteHandler(
       return createBadRequest("Agent webhook route requires a webhook id.")
     }
 
+    const waitUntil = await resolveRuntimeWaitUntil(handlerOptions.waitUntil)
     const context = createRuntimeContext(
       request,
       undefined,
-      await resolveRuntimeWaitUntil(handlerOptions.waitUntil),
+      waitUntil,
       handlerOptions.cloudflare,
       handlerOptions.runtime,
     )
@@ -2351,14 +2352,20 @@ export function createChannelWebhookRouteHandler(
             await context.flushWaitUntil?.()
             return invocation.response
           }
-          const result = await runAgent(agent as never, {
-            ...context,
-            ...(invocation.run ? { run: invocation.run } : {}),
-          } as never, invocation.input as never)
-          if (!isWorkflowRun(result) || result.status !== "queued") {
-            await context.flushWaitUntil?.()
-          }
-          return toAgentFetchResponse(result, false)
+          const runContext = createRuntimeContext(
+            request,
+            invocation.run,
+            waitUntil,
+            handlerOptions.cloudflare,
+            handlerOptions.runtime,
+          )
+          context.waitUntil(runWithRuntimeCloudflareEnv(runContext, async () => {
+            const result = await runAgent(agent as never, runContext as never, invocation.input as never)
+            if (!isWorkflowRun(result) || result.status !== "queued") {
+              await runContext.flushWaitUntil?.()
+            }
+          }))
+          return Response.json({ accepted: true, ok: true })
         }
         catch (error) {
           const response = toHttpErrorResponse(error)

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2709,6 +2709,7 @@ describe("server helpers", () => {
       },
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
+    const waitUntilTasks: Promise<unknown>[] = []
     const payload = {
       action: "created",
       comment: { body: "/review", id: 12 },
@@ -2728,10 +2729,12 @@ describe("server helpers", () => {
       method: "POST",
     })
 
-    const response = await handler(request(githubSignature("secret-token", body)))
+    const response = await handler(request(githubSignature("secret-token", body)), undefined, {
+      waitUntil: task => waitUntilTasks.push(task),
+    })
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toMatchObject({ text: "accepted" })
+    await expect(response.json()).resolves.toEqual({ accepted: true, ok: true })
     expect(triggerInputs).toHaveLength(1)
     expect(triggerInputs[0]).toMatchObject({
       github: {
@@ -2752,6 +2755,7 @@ describe("server helpers", () => {
         provider: "github",
       },
     })
+    await Promise.all(waitUntilTasks)
     expect(run).toHaveBeenCalledWith(expect.objectContaining({
       run: expect.objectContaining({
         channelId: "github",
@@ -2802,6 +2806,7 @@ describe("server helpers", () => {
       },
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
+    const waitUntilTasks: Promise<unknown>[] = []
     const body = JSON.stringify({ action: "opened" })
     const response = await handler(new Request("https://example.com/api/github/webhook", {
       body,
@@ -2812,10 +2817,71 @@ describe("server helpers", () => {
         "x-hub-signature-256": githubSignature("secret-token", body),
       },
       method: "POST",
-    }), "")
+    }), "", { waitUntil: task => waitUntilTasks.push(task) })
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toBe("accepted")
+    await expect(response.json()).resolves.toEqual({ accepted: true, ok: true })
+    await Promise.all(waitUntilTasks)
+    expect(run).toHaveBeenCalledOnce()
+  })
+
+  it("acks slow GitHub channel webhooks before the background run completes", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { github } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    let releaseRun!: () => void
+    let completed = false
+    const runFinished = new Promise<void>(resolve => {
+      releaseRun = resolve
+    })
+    const run = vi.fn(async () => {
+      await runFinished
+      completed = true
+      return "accepted"
+    })
+    const agent = defineAgent({
+      channels: {
+        github: github({
+          triggers: {
+            webhook: {
+              invoke: () => ({ input: { prompt: "github delivery" } }),
+            },
+          },
+          webhooks: { secretToken: false },
+        }),
+      },
+      driver: {
+        run
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    const waitUntilTasks: Promise<unknown>[] = []
+    const responsePromise = handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/github", {
+      body: JSON.stringify({ action: "opened" }),
+      headers: {
+        "content-type": "application/json",
+        "x-github-delivery": "delivery-slow",
+        "x-github-event": "pull_request",
+      },
+      method: "POST",
+    }), "github", { waitUntil: task => waitUntilTasks.push(task) })
+    const response = await Promise.race([
+      responsePromise,
+      new Promise<"blocked">(resolve => setTimeout(() => resolve("blocked"), 25)),
+    ])
+
+    if (response === "blocked") {
+      releaseRun()
+      await responsePromise
+      throw new Error("GitHub webhook response waited for background run completion.")
+    }
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ accepted: true, ok: true })
+    expect(completed).toBe(false)
+
+    releaseRun()
+    await Promise.all(waitUntilTasks)
+    expect(completed).toBe(true)
     expect(run).toHaveBeenCalledOnce()
   })
 
@@ -2846,6 +2912,7 @@ describe("server helpers", () => {
       },
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
+    const waitUntilTasks: Promise<unknown>[] = []
     const body = JSON.stringify({ action: "opened" })
     const response = await handler(new Request("https://example.com/api/github/webhook", {
       body,
@@ -2856,10 +2923,11 @@ describe("server helpers", () => {
         "x-hub-signature-256": githubSignature("secret-token", body),
       },
       method: "POST",
-    }), "")
+    }), "", { waitUntil: task => waitUntilTasks.push(task) })
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({})
+    await expect(response.json()).resolves.toEqual({ accepted: true, ok: true })
+    await Promise.all(waitUntilTasks)
     expect(flushed).toBe(true)
     expect(run).toHaveBeenCalledOnce()
   })
@@ -2898,6 +2966,7 @@ describe("server helpers", () => {
       runtime: workflow("support-agent"),
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
+    const waitUntilTasks: Promise<unknown>[] = []
     const body = JSON.stringify({ action: "opened" })
     setWorkflowRuntimeConfig({ provider: "vercel" })
 
@@ -2911,7 +2980,7 @@ describe("server helpers", () => {
           "x-hub-signature-256": githubSignature("secret-token", body),
         },
         method: "POST",
-      }), "")
+      }), "", { waitUntil: task => waitUntilTasks.push(task) })
       const response = await Promise.race([
         responsePromise,
         new Promise<"blocked">(resolve => setTimeout(() => resolve("blocked"), 25)),
@@ -2926,12 +2995,8 @@ describe("server helpers", () => {
       const json = await response.json()
 
       expect(response.status).toBe(200)
-      expect(json).toMatchObject({
-        id: "github:delivery-workflow",
-        provider: "vercel",
-        status: "queued",
-      })
-      expect(json).not.toHaveProperty("payload")
+      expect(json).toEqual({ accepted: true, ok: true })
+      await Promise.all(waitUntilTasks)
       releaseRun()
       await vi.waitFor(async () => {
         await expect(getWorkflowRun("support-agent", "github:delivery-workflow")).resolves.toMatchObject({


### PR DESCRIPTION
Non-chat Agent Webhook Handler deliveries now accept verified/admitted webhook requests, schedule the Agent Invocation through the runtime `waitUntil`, and return `{ accepted: true, ok: true }` instead of waiting for the full run result. Handled trigger responses and chat webhooks keep their existing inline behavior.

Adds provider coverage for a slow GitHub webhook returning before the background run completes, while existing non-chat GitHub webhook tests now await the captured background task before asserting run-side effects.