### PR TITLE
feat(agent): add Codex harness driver

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -66,18 +66,16 @@ Harness-backed agents use AI SDK `HarnessAgent` behind the ViteHub Agent Driver 
 
 ```ts
 // server/agents/codex/config.ts
-import { createCodex } from "@ai-sdk/harness-codex"
 import { defineAgent } from "@vite-hub/agent"
 import { skills } from "@vite-hub/agent/capabilities"
+import { codexDriver } from "@vite-hub/agent/harness/codex"
 import { file } from "@vite-hub/workspace"
 
 export default defineAgent({
-  driver: {
-    harness: createCodex({
-      model: "gpt-5.5",
-      reasoningEffort: "low",
-    }),
-  },
+  driver: codexDriver({
+    model: "gpt-5.5",
+    reasoningEffort: "low",
+  }),
   workspace: {
     mode: "write",
     sources: {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -69,6 +69,10 @@
       "types": "./dist/harness/claude-code.d.ts",
       "import": "./dist/harness/claude-code.js"
     },
+    "./harness/codex": {
+      "types": "./dist/harness/codex.d.ts",
+      "import": "./dist/harness/codex.js"
+    },
     "./harness/local-sandbox": {
       "types": "./dist/harness/local-sandbox.d.ts",
       "import": "./dist/harness/local-sandbox.js"

--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -36,7 +36,6 @@ export function codexDriver(options: CodexDriverOptions = {}): AgentHarnessDrive
       ? {}
       : {
           sandbox: createLocalHarnessSandbox({
-            rootDir: "/tmp",
             ...sandbox,
             env: codexLocalEnv({
               authJson,

--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -1,0 +1,100 @@
+import { chmodSync, existsSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { createCodex } from "@ai-sdk/harness-codex"
+
+import { createLocalHarnessSandbox, type LocalHarnessSandboxOptions } from "./local-sandbox.ts"
+
+import type { CodexHarnessSettings } from "@ai-sdk/harness-codex"
+import type { AgentHarnessCredentialSource, AgentHarnessDriver } from "../types.ts"
+
+export interface CodexDriverOptions extends CodexHarnessSettings {
+  authJson?: string
+  authJsonPath?: string
+  credentials?: AgentHarnessCredentialSource
+  env?: Record<string, string | undefined>
+  sandbox?: false | LocalHarnessSandboxOptions
+}
+
+export function codexDriver(options: CodexDriverOptions = {}): AgentHarnessDriver {
+  const {
+    authJson,
+    authJsonPath,
+    credentials,
+    env,
+    sandbox,
+    ...settings
+  } = options
+  const defaultOpenAIAuth = settings.auth === undefined
+  const auth = settings.auth ?? { openai: {} }
+
+  return {
+    credentials: credentials ?? { label: "Codex", source: "ambient" },
+    harness: createCodex({ ...settings, auth }),
+    ...(sandbox === false
+      ? {}
+      : {
+          sandbox: createLocalHarnessSandbox({
+            rootDir: "/tmp",
+            ...sandbox,
+            env: codexLocalEnv({
+              authJson,
+              authJsonPath,
+              env: {
+                ...env,
+                ...sandbox?.env,
+              },
+              preferOpenAI: defaultOpenAIAuth,
+            }),
+          }),
+        }),
+  }
+}
+
+function codexLocalEnv(options: {
+  authJson?: string
+  authJsonPath?: string
+  env?: Record<string, string | undefined>
+  preferOpenAI: boolean
+}): Record<string, string | undefined> {
+  const env = {
+    ...process.env,
+    ...options.env,
+  }
+
+  if (options.preferOpenAI) {
+    delete env.AI_GATEWAY_API_KEY
+    delete env.AI_GATEWAY_BASE_URL
+  }
+
+  const codexHome = codexHomeFromAuth({
+    authJson: options.authJson ?? env.CODEX_AUTH_JSON,
+    authJsonPath: options.authJsonPath,
+  })
+  if (codexHome) env.CODEX_HOME = codexHome
+  env.PATH = [
+    join(process.cwd(), "node_modules", ".bin"),
+    env.HOME ? join(env.HOME, ".local", "bin") : undefined,
+    env.PATH,
+  ].filter(Boolean).join(":")
+  return env
+}
+
+function codexHomeFromAuth(options: { authJson?: string, authJsonPath?: string }): string | undefined {
+  const authJson = options.authJson?.trim()
+  const authJsonPath = options.authJsonPath?.trim()
+  if (!authJson && !authJsonPath) return
+
+  const dir = mkdtempSync(join(tmpdir(), "vitehub-codex-home-"))
+  chmodSync(dir, 0o700)
+  writeFileSync(join(dir, "config.toml"), "")
+  if (authJson) {
+    writeFileSync(join(dir, "auth.json"), authJson.endsWith("\n") ? authJson : `${authJson}\n`, { mode: 0o600 })
+  } else if (authJsonPath && existsSync(authJsonPath)) {
+    symlinkSync(authJsonPath, join(dir, "auth.json"))
+  } else if (authJsonPath) {
+    throw new Error(`[vitehub] Codex auth JSON path does not exist: ${authJsonPath}`)
+  }
+  return dir
+}

--- a/packages/agent/test/codex-harness.test.ts
+++ b/packages/agent/test/codex-harness.test.ts
@@ -47,6 +47,23 @@ describe("codexDriver", () => {
     }
   })
 
+  it("creates isolated default local sandbox sessions", async () => {
+    const { codexDriver } = await import("../src/harness/codex.ts")
+    const driver = codexDriver() as { sandbox?: { createSession: () => Promise<{ defaultWorkingDirectory: string, destroy: () => Promise<void> }> } }
+    const first = await driver.sandbox?.createSession()
+    const second = await driver.sandbox?.createSession()
+
+    try {
+      expect(first?.defaultWorkingDirectory).toContain("vitehub-harness-")
+      expect(second?.defaultWorkingDirectory).toContain("vitehub-harness-")
+      expect(first?.defaultWorkingDirectory).not.toBe(second?.defaultWorkingDirectory)
+    }
+    finally {
+      await first?.destroy()
+      await second?.destroy()
+    }
+  })
+
   it("preserves explicit Codex auth settings", async () => {
     const { codexDriver } = await import("../src/harness/codex.ts")
 

--- a/packages/agent/test/codex-harness.test.ts
+++ b/packages/agent/test/codex-harness.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest"
+
+const createCodex = vi.hoisted(() => vi.fn(settings => ({ provider: "codex", settings })))
+
+vi.mock("@ai-sdk/harness-codex", () => ({
+  createCodex,
+}))
+
+describe("codexDriver", () => {
+  it("defaults to direct OpenAI auth and local sandbox credentials", async () => {
+    const { codexDriver } = await import("../src/harness/codex.ts")
+
+    const driver = codexDriver()
+
+    expect(createCodex).toHaveBeenLastCalledWith({ auth: { openai: {} } })
+    expect(driver).toMatchObject({
+      credentials: { label: "Codex", source: "ambient" },
+      harness: { provider: "codex" },
+      sandbox: { providerId: "local" },
+    })
+  })
+
+  it("keeps host AI Gateway env out of the default local Codex sandbox", async () => {
+    const originalGatewayKey = process.env.AI_GATEWAY_API_KEY
+    const originalGatewayBaseUrl = process.env.AI_GATEWAY_BASE_URL
+    process.env.AI_GATEWAY_API_KEY = "host-key"
+    process.env.AI_GATEWAY_BASE_URL = "https://gateway.example"
+
+    try {
+      const { codexDriver } = await import("../src/harness/codex.ts")
+      const driver = codexDriver({ env: { EXTRA_CODEX_ENV: "1" } }) as { sandbox?: { createSession: () => Promise<{ destroy: () => Promise<void>, env: Record<string, string> }> } }
+      const session = await driver.sandbox?.createSession()
+
+      try {
+        expect(session?.env.AI_GATEWAY_API_KEY).toBeUndefined()
+        expect(session?.env.AI_GATEWAY_BASE_URL).toBeUndefined()
+        expect(session?.env.EXTRA_CODEX_ENV).toBe("1")
+        expect(session?.env.PATH).toContain("node_modules/.bin")
+      }
+      finally {
+        await session?.destroy()
+      }
+    }
+    finally {
+      restoreEnv("AI_GATEWAY_API_KEY", originalGatewayKey)
+      restoreEnv("AI_GATEWAY_BASE_URL", originalGatewayBaseUrl)
+    }
+  })
+
+  it("preserves explicit Codex auth settings", async () => {
+    const { codexDriver } = await import("../src/harness/codex.ts")
+
+    codexDriver({ auth: { gateway: { apiKey: "gateway-key" } }, sandbox: false })
+
+    expect(createCodex).toHaveBeenLastCalledWith({ auth: { gateway: { apiKey: "gateway-key" } } })
+  })
+})
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -978,6 +978,17 @@ describe("agent Vite plugin", () => {
     })
   })
 
+  it("publishes the Codex harness driver subpath", async () => {
+    const pkg = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8")) as {
+      exports?: Record<string, unknown>
+    }
+
+    expect(pkg.exports?.["./harness/codex"]).toEqual({
+      types: "./dist/harness/codex.d.ts",
+      import: "./dist/harness/codex.js",
+    })
+  })
+
   it("publishes the internal generated Agent route handler subpath", async () => {
     const pkg = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8")) as {
       exports?: Record<string, unknown>

--- a/packages/agent/vite.config.ts
+++ b/packages/agent/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
       "src/cli.ts",
       "src/eval.ts",
       "src/harness/claude-code.ts",
+      "src/harness/codex.ts",
       "src/harness/local-sandbox.ts",
       "src/state/sqlite.ts",
       "src/cloudflare/state.ts",


### PR DESCRIPTION
Adds a first-party `@vite-hub/agent/harness/codex` helper that wraps the AI SDK Codex harness with ViteHub's local harness sandbox defaults. The helper keeps the common Codex setup inside the Agent Package boundary instead of making downstream apps wire raw harness and local sandbox details themselves.

Updates the Agent Package export map, pack entries, README example, and focused coverage for the helper and published subpath.