### PR TITLE
fix(agent): normalize git tool inputs

### DIFF
--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -528,6 +528,11 @@ function gitTools(
 function gitInputSchema(commandDescription: string) {
   return {
     additionalProperties: false,
+    anyOf: [
+      { required: ["command"] },
+      { required: ["cmd"] },
+      { required: ["args"] },
+    ],
     properties: {
       command: { description: commandDescription, type: "string" },
       cmd: { description: "Alias for command.", type: "string" },

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -454,6 +454,14 @@ function normalizeGitToolInput(input: unknown, defaultCwd: string | undefined): 
   }
 }
 
+function normalizeGitToolPolicy(policy: GitCapabilityToolPolicy | undefined, defaultCwd: string | undefined): GitCapabilityToolPolicy | undefined {
+  if (typeof policy !== "function") return policy
+  return context => policy({
+    ...context,
+    input: normalizeGitToolInput(context.input, defaultCwd),
+  })
+}
+
 function limitOutput(output: string, maxOutputLength: number): { output: string, truncated?: boolean } {
   if (output.length <= maxOutputLength) return { output }
   return {
@@ -518,7 +526,7 @@ function gitTools(
       execute: (input: unknown) => run(input, true),
       inputSchema: gitInputSchema("Local git command, for example `git fetch origin pull/123/head` or `git switch main`. Bare git subcommands are accepted and normalized to start with `git`. Pass one command only; do not use shell composition such as `&&` or `|`."),
       name: "git_write",
-      policy: options.policy || "require-approval",
+      policy: normalizeGitToolPolicy(options.policy, defaultCwd) || "require-approval",
     }
   }
 

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -24,6 +24,7 @@ export interface GitCapabilityOptions {
 
 interface GitCommandInput {
   args?: string[]
+  cmd?: string
   command?: string
   cwd?: string
 }
@@ -426,18 +427,29 @@ function defaultGitCwd(context: { context?: { get(key: string): unknown } }): st
   return pullRequestGitSetup(context)?.mount
 }
 
+function normalizeGitCommandString(command: string): string {
+  const trimmed = command.trim()
+  if (!trimmed || trimmed === "git" || trimmed.startsWith("git ")) return trimmed
+  const [subcommand] = trimmed.split(/\s+/, 1)
+  return readSubcommands.has(subcommand!) || writeSubcommands.has(subcommand!) ? `git ${trimmed}` : trimmed
+}
+
 function normalizeGitToolInput(input: unknown, defaultCwd: string | undefined): GitCommandInput {
   if (typeof input === "string") {
     return {
-      command: input,
+      command: normalizeGitCommandString(input),
       ...(defaultCwd ? { cwd: defaultCwd } : {}),
     }
   }
   if (!isGitRecord(input)) return {}
-  const command = typeof input.command === "string" ? input.command : gitCommandFromArgs(input.args)
+  const command = typeof input.command === "string"
+    ? input.command
+    : typeof input.cmd === "string"
+      ? input.cmd
+      : gitCommandFromArgs(input.args)
   return {
     ...input,
-    ...(command ? { command } : {}),
+    ...(command ? { command: normalizeGitCommandString(command) } : {}),
     ...(input.cwd === undefined && defaultCwd ? { cwd: defaultCwd } : {}),
   }
 }
@@ -494,8 +506,8 @@ function gitTools(
   const tools: AgentToolSet = {
     git_read: {
       description: "Run one read-only git command in the workspace.",
-      execute: (input: unknown) => run(input as GitCommandInput, false),
-      inputSchema: gitInputSchema("Read-only git command, for example `git status --short`, `git diff --stat`, or `git log --oneline -n 20`."),
+      execute: (input: unknown) => run(input, false),
+      inputSchema: gitInputSchema("Read-only git command, for example `git status --short`, `git diff --stat`, or `git log --oneline -n 20`. Bare git subcommands are accepted and normalized to start with `git`. Pass one command only; do not use shell composition such as `&&` or `|`."),
       name: "git_read",
     },
   }
@@ -503,8 +515,8 @@ function gitTools(
   if (mode === "write") {
     tools.git_write = {
       description: "Run one local git write command in the workspace. Supports fetch, checkout, and switch on a clean working tree.",
-      execute: (input: unknown) => run(input as GitCommandInput, true),
-      inputSchema: gitInputSchema("Local git command, for example `git fetch origin pull/123/head` or `git switch main`."),
+      execute: (input: unknown) => run(input, true),
+      inputSchema: gitInputSchema("Local git command, for example `git fetch origin pull/123/head` or `git switch main`. Bare git subcommands are accepted and normalized to start with `git`. Pass one command only; do not use shell composition such as `&&` or `|`."),
       name: "git_write",
       policy: options.policy || "require-approval",
     }
@@ -518,9 +530,14 @@ function gitInputSchema(commandDescription: string) {
     additionalProperties: false,
     properties: {
       command: { description: commandDescription, type: "string" },
+      cmd: { description: "Alias for command.", type: "string" },
+      args: {
+        description: "Git command argv. The leading `git` word is optional.",
+        items: { type: "string" },
+        type: "array",
+      },
       cwd: { description: "Workspace-relative directory. Defaults to the workspace root.", type: "string" },
     },
-    required: ["command"],
     type: "object",
   }
 }

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -75,6 +75,28 @@ describe("git capability", () => {
     expect(session.exec).toHaveBeenCalledWith("git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace", timeout: undefined }))
   })
 
+  it("normalizes common git tool input shapes", async () => {
+    const { session, tools } = await capabilityTools()
+
+    await expect(tools.git_read!.execute?.("status --short")).resolves.toMatchObject({
+      args: ["status", "--short"],
+      command: "git status --short",
+    })
+    await expect(tools.git_read!.execute?.({ cmd: "diff --stat" })).resolves.toMatchObject({
+      args: ["diff", "--stat"],
+      command: "git diff --stat",
+    })
+    await expect(tools.git_read!.execute?.({ args: ["show", "HEAD:README.md"] })).resolves.toMatchObject({
+      args: ["show", "HEAD:README.md"],
+      command: "git show HEAD:README.md",
+    })
+    await expect(tools.git_read!.execute?.({ command: "git diff --stat && git diff" })).rejects.toThrow("without shell composition")
+
+    expect(session.exec).toHaveBeenCalledWith("git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace" }))
+    expect(session.exec).toHaveBeenCalledWith("git", ["diff", "--stat"], expect.objectContaining({ cwd: "/workspace" }))
+    expect(session.exec).toHaveBeenCalledWith("git", ["show", "HEAD:README.md"], expect.objectContaining({ cwd: "/workspace" }))
+  })
+
   it("keeps workspace sessions scoped to each tool resolution", async () => {
     const capability = git()
     if (typeof capability.tools !== "function") throw new Error("git capability must expose tool resolver")

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -78,6 +78,13 @@ describe("git capability", () => {
   it("normalizes common git tool input shapes", async () => {
     const { session, tools } = await capabilityTools()
 
+    expect(tools.git_read!.inputSchema).toMatchObject({
+      anyOf: [
+        { required: ["command"] },
+        { required: ["cmd"] },
+        { required: ["args"] },
+      ],
+    })
     await expect(tools.git_read!.execute?.("status --short")).resolves.toMatchObject({
       args: ["status", "--short"],
       command: "git status --short",

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { git } from "../src/capabilities.ts"
+import { applyAgentToolPolicies } from "../src/tool-runtime.ts"
 
 import type { AgentToolSet } from "../src/types.ts"
 import type { WorkspaceSession } from "@vite-hub/workspace"
@@ -160,6 +161,29 @@ describe("git capability", () => {
     expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["status", "--porcelain"], expect.objectContaining({ cwd: "/workspace/portal", timeout: undefined }))
     expect(session.exec).toHaveBeenNthCalledWith(2, "git", ["switch", "feature/pr-1"], expect.objectContaining({ cwd: "/workspace/portal", timeout: undefined }))
     expect(session.commit).toHaveBeenCalledWith({ message: "git switch" })
+  })
+
+  it("evaluates custom write policies with normalized git inputs", async () => {
+    const session = gitSession()
+    const policy = vi.fn(({ input }: { input?: unknown }) => {
+      if (typeof input === "object" && input !== null && (input as { command?: unknown }).command === "git checkout main") return "deny"
+      return "allow"
+    })
+    const { tools } = await capabilityTools(git({ mode: "write", policy }), session)
+    const guardedTools = applyAgentToolPolicies(tools)!
+
+    await expect(guardedTools.git_write!.execute?.({ cmd: "checkout main" })).rejects.toThrow()
+    await expect(guardedTools.git_write!.execute?.({ args: ["checkout", "main"] })).rejects.toThrow()
+
+    expect(policy).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      input: expect.objectContaining({ cmd: "checkout main", command: "git checkout main" }),
+      name: "git_write",
+    }))
+    expect(policy).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      input: expect.objectContaining({ args: ["checkout", "main"], command: "git checkout main" }),
+      name: "git_write",
+    }))
+    expect(session.exec).not.toHaveBeenCalled()
   })
 
   it("fetches only configured remotes in write mode", async () => {


### PR DESCRIPTION
## Summary
- accept string, cmd, and argv-style git tool inputs in addition to command
- normalize bare git subcommands like diff --stat to git diff --stat
- keep rejecting shell composition such as && and |

## Tests
- pnpm exec vp test run test/git-capability.test.ts test/invocation-stream.test.ts --reporter=dot
- pnpm --dir packages/agent typecheck