### PR TITLE
feat(agent): add Claude Code harness driver

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -24,10 +24,12 @@ pnpm add @vite-hub/agent @vite-hub/workspace ai
 
 Add the AI SDK model provider you pass to `model`.
 
-For AI SDK harness drivers, add the harness packages:
+For AI SDK harness drivers, add the harness package you use:
 
 ```sh
 pnpm add @ai-sdk/harness @ai-sdk/harness-codex
+# or
+pnpm add @ai-sdk/harness @ai-sdk/harness-claude-code
 ```
 
 For non-local omitted sandbox fallback, also add `@ai-sdk/sandbox-vercel`.
@@ -87,6 +89,8 @@ export default defineAgent({
   ],
 })
 ```
+
+For Claude Code, use `claudeCodeDriver()` from `@vite-hub/agent/harness/claude-code`. It accepts `createClaudeCode()` settings such as `auth`, `model`, and `maxTurns`, and uses the same local sandbox default unless `sandbox: false` is set.
 
 `driver.harness` is the AI SDK harness adapter instance. Workspace-backed harness drivers in Vite dev use ViteHub's local harness sandbox by default and receive a Harness Workspace Session prepared from the selected Workspace. Outside the local workspace path, ViteHub uses the AI SDK Vercel Sandbox default when `@ai-sdk/sandbox-vercel` is installed. Harness sandbox provider setup is Agent Package runtime plumbing; use `driver.sandbox` when an Agent needs a specific harness process or session provider. Add `sandbox({ commands })` only when the model should receive `sandbox_exec`. `driver.harness`, `driver.sessionKey`, and `driver.sandbox` can be callbacks when one Agent Definition needs invocation-scoped harness setup. When `access()` narrows Workspace Scope, ViteHub materializes only that selected scope plus generated source descriptors. Read mode materializes files and discards sandbox changes; write mode syncs additions, updates, and deletions back through Workspace rules. V1 configures built-in harness permissions internally with the no-approval policy and does not expose a public permission option. Skills stay a Capability through `skills()` rather than becoming a root Agent Definition field. For harness drivers, `skills()` relies on mounted Workspace files and does not inject model instructions or Workspace Shell tools. Put harness guidance in Workspace files such as `AGENTS.md`; Sources, Capabilities, and Skills do not inject extra model instructions by default.
 

--- a/packages/agent/src/harness/claude-code.ts
+++ b/packages/agent/src/harness/claude-code.ts
@@ -1,4 +1,8 @@
+import { join } from "node:path"
+
 import { createClaudeCode as createAiSdkClaudeCode } from "@ai-sdk/harness-claude-code"
+
+import { createLocalHarnessSandbox, type LocalHarnessSandboxOptions } from "./local-sandbox.ts"
 
 import type {
   HarnessV1Bootstrap,
@@ -8,6 +12,38 @@ import type {
   HarnessV1StreamPart,
 } from "@ai-sdk/harness"
 import type { ClaudeCodeHarnessSettings } from "@ai-sdk/harness-claude-code"
+import type { AgentHarnessCredentialSource, AgentHarnessDriver } from "../types.ts"
+
+export interface ClaudeCodeDriverOptions extends ClaudeCodeHarnessSettings {
+  credentials?: AgentHarnessCredentialSource
+  env?: Record<string, string | undefined>
+  sandbox?: false | LocalHarnessSandboxOptions
+}
+
+export function claudeCodeDriver(options: ClaudeCodeDriverOptions = {}): AgentHarnessDriver {
+  const {
+    credentials,
+    env,
+    sandbox,
+    ...settings
+  } = options
+
+  return {
+    credentials: credentials ?? { label: "Claude Code", source: "ambient" },
+    harness: createClaudeCode(settings),
+    ...(sandbox === false
+      ? {}
+      : {
+          sandbox: createLocalHarnessSandbox({
+            ...sandbox,
+            env: claudeCodeLocalEnv({
+              ...env,
+              ...sandbox?.env,
+            }),
+          }),
+        }),
+  }
+}
 
 export function createClaudeCode(settings: ClaudeCodeHarnessSettings = {}): ReturnType<typeof createAiSdkClaudeCode> {
   const harness = createAiSdkClaudeCode({
@@ -28,6 +64,24 @@ export function createClaudeCode(settings: ClaudeCodeHarnessSettings = {}): Retu
     async doStart(options) {
       return guardEmptyClaudeCodeSession(await harness.doStart(options))
     },
+  }
+}
+
+function claudeCodeLocalEnv(env: Record<string, string | undefined> = {}): Record<string, string | undefined> {
+  const hostEnv = { ...process.env }
+  delete hostEnv.ANTHROPIC_API_KEY
+  delete hostEnv.ANTHROPIC_AUTH_TOKEN
+  delete hostEnv.ANTHROPIC_BASE_URL
+  const home = env.HOME ?? hostEnv.HOME
+
+  return {
+    ...hostEnv,
+    ...env,
+    PATH: [
+      join(process.cwd(), "node_modules", ".bin"),
+      home ? join(home, ".local", "bin") : undefined,
+      env.PATH ?? hostEnv.PATH,
+    ].filter(Boolean).join(":"),
   }
 }
 

--- a/packages/agent/test/claude-code-harness.test.ts
+++ b/packages/agent/test/claude-code-harness.test.ts
@@ -50,6 +50,93 @@ vi.mock("@ai-sdk/harness-claude-code", () => ({
   createClaudeCode: createAiSdkClaudeCode,
 }))
 
+describe("claudeCodeDriver", () => {
+  it("defaults to ambient Claude Code auth and local sandbox credentials", async () => {
+    const { claudeCodeDriver } = await import("../src/harness/claude-code.ts")
+
+    const driver = claudeCodeDriver()
+
+    expect(createAiSdkClaudeCode).toHaveBeenLastCalledWith({ auth: { anthropic: {} } })
+    expect(driver).toMatchObject({
+      credentials: { label: "Claude Code", source: "ambient" },
+      harness: { settings: { auth: { anthropic: {} } } },
+      sandbox: { providerId: "local" },
+    })
+  })
+
+  it("keeps host Anthropic env out of the default local Claude Code sandbox", async () => {
+    const originalApiKey = process.env.ANTHROPIC_API_KEY
+    const originalAuthToken = process.env.ANTHROPIC_AUTH_TOKEN
+    const originalBaseUrl = process.env.ANTHROPIC_BASE_URL
+    process.env.ANTHROPIC_API_KEY = "host-key"
+    process.env.ANTHROPIC_AUTH_TOKEN = "host-token"
+    process.env.ANTHROPIC_BASE_URL = "https://host.example"
+
+    try {
+      const { claudeCodeDriver } = await import("../src/harness/claude-code.ts")
+      const driver = claudeCodeDriver({ env: { EXTRA_CLAUDE_ENV: "1" } }) as { sandbox?: { createSession: () => Promise<{ destroy: () => Promise<void>, env: Record<string, string> }> } }
+      const session = await driver.sandbox?.createSession()
+
+      try {
+        expect(session?.env.ANTHROPIC_API_KEY).toBeUndefined()
+        expect(session?.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+        expect(session?.env.ANTHROPIC_BASE_URL).toBeUndefined()
+        expect(session?.env.EXTRA_CLAUDE_ENV).toBe("1")
+        expect(session?.env.PATH).toContain("node_modules/.bin")
+      }
+      finally {
+        await session?.destroy()
+      }
+    }
+    finally {
+      restoreEnv("ANTHROPIC_API_KEY", originalApiKey)
+      restoreEnv("ANTHROPIC_AUTH_TOKEN", originalAuthToken)
+      restoreEnv("ANTHROPIC_BASE_URL", originalBaseUrl)
+    }
+  })
+
+  it("preserves explicit Claude Code auth settings and sandbox env", async () => {
+    const originalApiKey = process.env.ANTHROPIC_API_KEY
+    process.env.ANTHROPIC_API_KEY = "host-key"
+
+    try {
+      const { claudeCodeDriver } = await import("../src/harness/claude-code.ts")
+      const driver = claudeCodeDriver({
+        auth: { anthropic: { apiKey: "explicit-auth-key" } },
+        maxTurns: 3,
+        model: "claude-sonnet-4-5",
+        sandbox: {
+          env: { ANTHROPIC_API_KEY: "explicit-sandbox-key" },
+        },
+      }) as { sandbox?: { createSession: () => Promise<{ destroy: () => Promise<void>, env: Record<string, string> }> } }
+      const session = await driver.sandbox?.createSession()
+
+      try {
+        expect(createAiSdkClaudeCode).toHaveBeenLastCalledWith({
+          auth: { anthropic: { apiKey: "explicit-auth-key" } },
+          maxTurns: 3,
+          model: "claude-sonnet-4-5",
+        })
+        expect(session?.env.ANTHROPIC_API_KEY).toBe("explicit-sandbox-key")
+      }
+      finally {
+        await session?.destroy()
+      }
+    }
+    finally {
+      restoreEnv("ANTHROPIC_API_KEY", originalApiKey)
+    }
+  })
+
+  it("can disable the default local Claude Code sandbox", async () => {
+    const { claudeCodeDriver } = await import("../src/harness/claude-code.ts")
+
+    const driver = claudeCodeDriver({ sandbox: false })
+
+    expect(driver).not.toHaveProperty("sandbox")
+  })
+})
+
 describe("createClaudeCode", () => {
   it("defaults to direct Anthropic auth so host AI Gateway env does not leak into Claude Code", async () => {
     const { createClaudeCode } = await import("../src/harness/claude-code.ts")
@@ -99,3 +186,11 @@ describe("createClaudeCode", () => {
     })
   })
 })
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}


### PR DESCRIPTION
Adds a first-party `claudeCodeDriver()` helper for `@vite-hub/agent/harness/claude-code`, matching the Codex helper by returning an `AgentHarnessDriver` with ambient Claude Code credentials and a default local harness sandbox. The sandbox env starts from host env with Anthropic credential vars stripped unless explicitly supplied, so downstream apps can pass `auth`, `model`, `maxTurns`, or sandbox env without re-implementing driver plumbing.

Refs #486