### PR TITLE
fix(workspace): hydrate bundled runtime source assets

### DIFF
--- a/packages/workspace/src/build/assets.ts
+++ b/packages/workspace/src/build/assets.ts
@@ -19,6 +19,7 @@ import type { ResolvedWorkspaceModuleOptions, WorkspaceContent, WorkspaceDefinit
 export interface WorkspaceAssetFile {
   content: WorkspaceContent
   mediaType?: string
+  metadata?: Record<string, unknown>
   path: string
 }
 
@@ -79,7 +80,7 @@ export async function collectWorkspaceStoreAssetBundle(name: string, store: Work
     const path = normalizeSafeWorkspacePath(entry.path)
     const file = await store.readFile(path)
     if (file) {
-      files.push({ content: file.content, mediaType: file.mediaType, path })
+      files.push({ content: file.content, mediaType: file.mediaType, metadata: file.metadata, path })
     }
   }
 
@@ -152,7 +153,7 @@ export function createWorkspaceAssetsRegistryContents(
       const entries = bundle.files.map((file) => {
         const modulePath = modulePaths.get(`${bundle.name}\0${file.path}`)
         const importPath = modulePath ? createImportPath(registryFile, modulePath) : pathToFileURL(file.path).href
-        return `      ${JSON.stringify(file.path)}: { load: async () => (await import(${JSON.stringify(importPath)})).default, mediaType: ${JSON.stringify(file.mediaType)} },`
+        return `      ${JSON.stringify(file.path)}: { load: async () => (await import(${JSON.stringify(importPath)})).default, mediaType: ${JSON.stringify(file.mediaType)}, metadata: ${JSON.stringify(file.metadata)} },`
       })
       return [
         `  ${JSON.stringify(bundle.name)}: createWorkspaceAssets({`,

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -104,10 +104,12 @@ async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: Wo
 
   const entries = await assets.list("", { recursive: true })
   const files = entries.filter(entry => entry.type === "file")
-  const bundledBuildSources = new Set<string>()
+  const bundledPaths = new Set(files.map(entry => entry.path))
+  const bundledBuildSources = new Set(currentSources
+    .filter(source => hasCompleteBundledBuildSource(source, bundledPaths))
+    .map(source => source.key))
   for (const entry of files) {
     const source = findBuildSourceForPath(entry.path, currentSources)
-    if (source) bundledBuildSources.add(source.key)
     await store.writeFile(entry.path, {
       path: entry.path,
       content: await assets.readFile(entry.path, { encoding: "binary" }),
@@ -116,6 +118,12 @@ async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: Wo
     })
   }
   return bundledBuildSources
+}
+
+function hasCompleteBundledBuildSource(source: ResolvedWorkspaceSource, bundledPaths: Set<string>): boolean {
+  const probeKeys = source.source.probeKeys
+  if (!probeKeys?.length) return false
+  return probeKeys.every(key => bundledPaths.has(normalizeWorkspacePath(`${source.mountPath}/${key}`)))
 }
 
 function findBuildSourceForPath(path: string, sources: ResolvedWorkspaceSource[]): ResolvedWorkspaceSource | undefined {

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -105,32 +105,45 @@ async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: Wo
   const entries = await assets.list("", { recursive: true })
   const files = entries.filter(entry => entry.type === "file")
   const bundledPaths = new Set(files.map(entry => entry.path))
+  const bundledSourceByPath = new Map<string, string>()
   const bundledBuildSources = new Set(currentSources
-    .filter(source => hasCompleteBundledBuildSource(source, bundledPaths, files))
+    .filter(source => hasCompleteBundledBuildSource(source, bundledPaths, files, bundledSourceByPath))
     .map(source => source.key))
   for (const entry of files) {
-    const source = findBuildSourceForPath(entry.path, currentSources)
+    const sourceKey = typeof entry.metadata?.source === "string"
+      ? entry.metadata.source
+      : bundledSourceByPath.get(entry.path) || findBuildSourceForPath(entry.path, currentSources)?.key
     await store.writeFile(entry.path, {
       path: entry.path,
       content: await assets.readFile(entry.path, { encoding: "binary" }),
       mediaType: entry.mediaType,
-      metadata: entry.metadata || (source ? { source: source.key } : undefined),
+      metadata: entry.metadata || (sourceKey ? { source: sourceKey } : undefined),
     })
   }
   return bundledBuildSources
 }
 
-function hasCompleteBundledBuildSource(source: ResolvedWorkspaceSource, bundledPaths: Set<string>, bundledFiles?: Array<{ metadata?: Record<string, unknown> }>): boolean {
+function hasCompleteBundledBuildSource(
+  source: ResolvedWorkspaceSource,
+  bundledPaths: Set<string>,
+  bundledFiles?: Array<{ path: string, metadata?: Record<string, unknown> }>,
+  bundledSourceByPath?: Map<string, string>,
+): boolean {
   if (bundledFiles?.some(entry => entry.metadata?.source === source.key)) return true
   const probeKeys = source.source.probeKeys
   if (!probeKeys?.length) return false
-  return probeKeys.every(key => bundledPaths.has(normalizeWorkspacePath(`${source.mountPath}/${key}`)))
+  const paths = probeKeys.map(key => normalizeWorkspacePath(`${source.mountPath}/${key}`))
+  if (!paths.every(path => bundledPaths.has(path))) return false
+  for (const path of paths) bundledSourceByPath?.set(path, source.key)
+  return true
 }
 
 function findBuildSourceForPath(path: string, sources: ResolvedWorkspaceSource[]): ResolvedWorkspaceSource | undefined {
-  return sources
+  const matches = sources
     .filter(source => !source.mountPath || path === source.mountPath || path.startsWith(`${source.mountPath}/`))
     .sort((left, right) => right.mountPath.length - left.mountPath.length)[0]
+  if (!matches?.mountPath && sources.filter(source => !source.mountPath).length > 1) return undefined
+  return matches
 }
 
 async function readSyncedBuildSources(store: WorkspaceStore): Promise<SyncedBuildSource[]> {

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -106,9 +106,12 @@ async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: Wo
   const files = entries.filter(entry => entry.type === "file")
   const bundledPaths = new Set(files.map(entry => entry.path))
   const bundledSourceByPath = new Map<string, string>()
-  const bundledBuildSources = new Set(currentSources
-    .filter(source => hasCompleteBundledBuildSource(source, bundledPaths, files, bundledSourceByPath))
-    .map(source => source.key))
+  const bundledBuildSources = new Set<string>()
+  for (const source of currentSources) {
+    if (await hasCompleteBundledBuildSource(definition, store, source, bundledPaths, files, bundledSourceByPath)) {
+      bundledBuildSources.add(source.key)
+    }
+  }
   for (const entry of files) {
     const sourceKey = typeof entry.metadata?.source === "string"
       ? entry.metadata.source
@@ -123,18 +126,44 @@ async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: Wo
   return bundledBuildSources
 }
 
-function hasCompleteBundledBuildSource(
+async function hasCompleteBundledBuildSource(
+  definition: WorkspaceDefinition,
+  store: WorkspaceStore,
   source: ResolvedWorkspaceSource,
   bundledPaths: Set<string>,
   bundledFiles?: Array<{ path: string, metadata?: Record<string, unknown> }>,
   bundledSourceByPath?: Map<string, string>,
-): boolean {
+): Promise<boolean> {
   const probeKeys = source.source.probeKeys
-  if (!probeKeys?.length) return false
+  if (!probeKeys?.length) {
+    const paths = bundledFiles
+      ?.filter(file => file.metadata?.source === source.key)
+      .map(file => file.path) ?? []
+    const sourcePaths = await tryListBuildSourcePaths(definition, store, source)
+    if (sourcePaths && !sourcePaths.every(path => paths.includes(path))) return false
+    for (const path of paths) bundledSourceByPath?.set(path, source.key)
+    return paths.length > 0
+  }
   const paths = probeKeys.map(key => normalizeWorkspacePath(`${source.mountPath}/${key}`))
   if (!paths.every(path => bundledPaths.has(path))) return false
   for (const path of paths) bundledSourceByPath?.set(path, source.key)
   return true
+}
+
+async function tryListBuildSourcePaths(
+  definition: WorkspaceDefinition,
+  store: WorkspaceStore,
+  source: ResolvedWorkspaceSource,
+): Promise<string[] | undefined> {
+  const ctx = createSourceContext(definition, { key: source.key, mountPath: source.mountPath }, store)
+  try {
+    await source.source.prepare?.(ctx)
+    return (await source.source.getKeys(ctx))
+      .map(key => normalizeWorkspacePath(`${source.mountPath}/${key}`))
+  }
+  catch {
+    return undefined
+  }
 }
 
 function findBuildSourceForPath(path: string, sources: ResolvedWorkspaceSource[]): ResolvedWorkspaceSource | undefined {

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -106,7 +106,7 @@ async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: Wo
   const files = entries.filter(entry => entry.type === "file")
   const bundledPaths = new Set(files.map(entry => entry.path))
   const bundledBuildSources = new Set(currentSources
-    .filter(source => hasCompleteBundledBuildSource(source, bundledPaths))
+    .filter(source => hasCompleteBundledBuildSource(source, bundledPaths, files))
     .map(source => source.key))
   for (const entry of files) {
     const source = findBuildSourceForPath(entry.path, currentSources)
@@ -114,13 +114,14 @@ async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: Wo
       path: entry.path,
       content: await assets.readFile(entry.path, { encoding: "binary" }),
       mediaType: entry.mediaType,
-      metadata: source ? { source: source.key } : undefined,
+      metadata: entry.metadata || (source ? { source: source.key } : undefined),
     })
   }
   return bundledBuildSources
 }
 
-function hasCompleteBundledBuildSource(source: ResolvedWorkspaceSource, bundledPaths: Set<string>): boolean {
+function hasCompleteBundledBuildSource(source: ResolvedWorkspaceSource, bundledPaths: Set<string>, bundledFiles?: Array<{ metadata?: Record<string, unknown> }>): boolean {
+  if (bundledFiles?.some(entry => entry.metadata?.source === source.key)) return true
   const probeKeys = source.source.probeKeys
   if (!probeKeys?.length) return false
   return probeKeys.every(key => bundledPaths.has(normalizeWorkspacePath(`${source.mountPath}/${key}`)))

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -36,14 +36,19 @@ export async function syncWorkspaceDefinition(definition: WorkspaceDefinition, s
   const buildSources = normalizeWorkspaceSources(definition.sources)
     .filter(source => source.materialize === "build")
   const hasBuildSourceState = await reconcileBuildSourceMounts(store, buildSources)
-  if (!hasExplicitLoaders && await syncRuntimeBuildAssets(definition, store, buildSources)) {
+  const bundledBuildSources = !hasExplicitLoaders
+    ? await syncRuntimeBuildAssets(definition, store, buildSources)
+    : undefined
+  if (bundledBuildSources && buildSources.every(source => bundledBuildSources.has(source.key))) {
     const snapshot = await store.snapshot({ name: "sync" })
     await publishWorkspaceSnapshot(definition, store, snapshot)
     return
   }
   if (!hasBuildSourceState && !hasExplicitLoaders) return
 
-  const normalizedSources = buildSources.map(source => createMountedBuildSource(source))
+  const normalizedSources = buildSources
+    .filter(source => !bundledBuildSources?.has(source.key))
+    .map(source => createMountedBuildSource(source))
   const ctx: LoaderContext = {
     workspace: definition.name,
     rootDir: ctxSource.rootDir,
@@ -85,24 +90,24 @@ async function reconcileBuildSourceMounts(store: WorkspaceStore, currentSources:
   return hasBuildSourceState
 }
 
-async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: WorkspaceStore, currentSources: ResolvedWorkspaceSource[]): Promise<boolean> {
-  if (!currentSources.length) return false
+async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: WorkspaceStore, currentSources: ResolvedWorkspaceSource[]): Promise<Set<string> | undefined> {
+  if (!currentSources.length) return undefined
 
   let assets: WorkspaceAssets
   try {
     assets = useWorkspaceAssets(definition.name)
   }
   catch (error) {
-    if (error instanceof WorkspaceNotFoundError) return false
+    if (error instanceof WorkspaceNotFoundError) return undefined
     throw error
   }
 
   const entries = await assets.list("", { recursive: true })
   const files = entries.filter(entry => entry.type === "file")
-  let hasBundledSourceAsset = false
+  const bundledBuildSources = new Set<string>()
   for (const entry of files) {
     const source = findBuildSourceForPath(entry.path, currentSources)
-    if (source) hasBundledSourceAsset = true
+    if (source) bundledBuildSources.add(source.key)
     await store.writeFile(entry.path, {
       path: entry.path,
       content: await assets.readFile(entry.path, { encoding: "binary" }),
@@ -110,7 +115,7 @@ async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: Wo
       metadata: source ? { source: source.key } : undefined,
     })
   }
-  return hasBundledSourceAsset
+  return bundledBuildSources
 }
 
 function findBuildSourceForPath(path: string, sources: ResolvedWorkspaceSource[]): ResolvedWorkspaceSource | undefined {

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -99,10 +99,10 @@ async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: Wo
 
   const entries = await assets.list("", { recursive: true })
   const files = entries.filter(entry => entry.type === "file")
-  const coveredSources = new Set<string>()
+  let hasBundledSourceAsset = false
   for (const entry of files) {
     const source = findBuildSourceForPath(entry.path, currentSources)
-    if (source) coveredSources.add(source.key)
+    if (source) hasBundledSourceAsset = true
     await store.writeFile(entry.path, {
       path: entry.path,
       content: await assets.readFile(entry.path, { encoding: "binary" }),
@@ -110,7 +110,7 @@ async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: Wo
       metadata: source ? { source: source.key } : undefined,
     })
   }
-  return currentSources.every(source => coveredSources.has(source.key))
+  return hasBundledSourceAsset
 }
 
 function findBuildSourceForPath(path: string, sources: ResolvedWorkspaceSource[]): ResolvedWorkspaceSource | undefined {

--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -117,7 +117,7 @@ async function syncRuntimeBuildAssets(definition: WorkspaceDefinition, store: Wo
       path: entry.path,
       content: await assets.readFile(entry.path, { encoding: "binary" }),
       mediaType: entry.mediaType,
-      metadata: entry.metadata || (sourceKey ? { source: sourceKey } : undefined),
+      metadata: sourceKey ? { ...entry.metadata, source: sourceKey } : entry.metadata,
     })
   }
   return bundledBuildSources
@@ -129,7 +129,6 @@ function hasCompleteBundledBuildSource(
   bundledFiles?: Array<{ path: string, metadata?: Record<string, unknown> }>,
   bundledSourceByPath?: Map<string, string>,
 ): boolean {
-  if (bundledFiles?.some(entry => entry.metadata?.source === source.key)) return true
   const probeKeys = source.source.probeKeys
   if (!probeKeys?.length) return false
   const paths = probeKeys.map(key => normalizeWorkspacePath(`${source.mountPath}/${key}`))

--- a/packages/workspace/src/runtime/assets.ts
+++ b/packages/workspace/src/runtime/assets.ts
@@ -15,6 +15,7 @@ import type {
 interface WorkspaceAssetFile {
   load: () => Promise<WorkspaceContent>
   mediaType?: string
+  metadata?: Record<string, unknown>
 }
 
 type WorkspaceAssetFiles<TKey extends string = string> = Record<TKey, WorkspaceAssetFile>
@@ -88,6 +89,7 @@ export function createWorkspaceAssets<TKey extends string = string>(files: Works
       return {
         digest: await sha256(content),
         mediaType: entry.mediaType,
+        metadata: entry.metadata,
         path,
         size: contentSize(content),
         type: "file" as const,

--- a/packages/workspace/src/sources/markdown.ts
+++ b/packages/workspace/src/sources/markdown.ts
@@ -1,9 +1,12 @@
 import { markdown as createMarkdownSource } from "@vite-hub/source"
 
+import { normalizeSafeWorkspacePath } from "../core/path.ts"
+
 import type { FileSourceOptions } from "./file.ts"
 import type { WorkspaceSource } from "../core/types.ts"
 
 export function markdown(options: FileSourceOptions): WorkspaceSource {
+  const key = normalizeSafeWorkspacePath(options.workspacePath || options.path || "")
   const source = createMarkdownSource(options)
   delete (source as typeof source & { instructions?: unknown }).instructions
   return {
@@ -11,6 +14,7 @@ export function markdown(options: FileSourceOptions): WorkspaceSource {
     cache: options.cache,
     materialize: options.materialize,
     mount: options.mount,
+    probeKeys: options.probeKeys || [key],
     sync: options.sync,
     validate: options.validate,
   }

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -756,6 +756,48 @@ describe("sources, loaders, and publishers", () => {
     })
   })
 
+  it("preserves source identity for bundled root-mounted build source assets", async () => {
+    const root = await createRoot()
+    setWorkspaceRuntimeAssetsRegistry({
+      support: createWorkspaceAssets({
+        "AGENTS.md": {
+          load: async () => "# Agents\n",
+          mediaType: "text/markdown",
+        },
+        "README.md": {
+          load: async () => "# Readme\n",
+          mediaType: "text/markdown",
+        },
+      }),
+    })
+
+    const store = createMemoryWorkspaceStore()
+    await syncWorkspaceDefinition({
+      name: "support",
+      rootDir: root,
+      sourceRootDir: join(root, "missing"),
+      sources: {
+        agents: file({
+          content: "# Agents\n",
+          mediaType: "text/markdown",
+          workspacePath: "AGENTS.md",
+        }),
+        readme: file({
+          content: "# Readme\n",
+          mediaType: "text/markdown",
+          workspacePath: "README.md",
+        }),
+      },
+    }, store)
+
+    await expect(store.readFile("AGENTS.md")).resolves.toMatchObject({
+      metadata: { source: "agents" },
+    })
+    await expect(store.readFile("README.md")).resolves.toMatchObject({
+      metadata: { source: "readme" },
+    })
+  })
+
   it("loads omitted files from partially bundled multi-file build sources", async () => {
     const root = await createRoot()
     setWorkspaceRuntimeAssetsRegistry({

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { collectWorkspaceStoreAssetBundle, syncDiscoveredWorkspaceAssetBundles, writeWorkspaceAssetsRegistry } from "../src/build/assets.ts"
 import { initializeWorkspaceAssetRegistry, syncWorkspaceBuildAssets } from "../src/build/integration.ts"
 import { resetWorkspaceAssetsRegistry } from "../src/asset-registry.ts"
-import { custom, defineWorkspace, file, github, glob, useWorkspace } from "../src/index.ts"
+import { custom, defineWorkspace, file, github, glob, markdown, useWorkspace } from "../src/index.ts"
 import * as loader from "../src/loader.ts"
 import * as publish from "../src/publish.ts"
 import { registerWorkspace } from "../src/test.ts"
@@ -663,6 +663,58 @@ describe("sources, loaders, and publishers", () => {
 
     await expect(store.readFile("AGENTS.md")).resolves.toMatchObject({
       content: new TextEncoder().encode("# Bundled Support\n"),
+    })
+  })
+
+  it("syncs bundled markdown sources without probe keys when the original source root is absent", async () => {
+    const root = await createRoot()
+    const directory = join(root, "server", "agents", "support")
+    const sourceRoot = join(directory, "workspace")
+    await mkdir(sourceRoot, { recursive: true })
+    await writeFile(join(sourceRoot, "README.md"), "# Bundled Markdown\n")
+    await writeFile(join(directory, "config.mjs"), [
+      `import { markdown } from '${workspaceSourceImport}'`,
+      "export default {",
+      "  sources: { readme: markdown({ mount: '', path: 'README.md', workspacePath: 'README.md' }) },",
+      "}",
+      "",
+    ].join("\n"))
+
+    const [bundle] = await syncDiscoveredWorkspaceAssetBundles([{
+      handler: join(directory, "config.mjs"),
+      name: "support",
+      path: join(directory, "config.mjs"),
+      source: "test",
+      sourceRootDir: sourceRoot,
+    }], root, {
+      root: join(root, ".vitehub", "workspaces"),
+      store: { provider: "memory" },
+      assets: true,
+    })
+    await rm(sourceRoot, { recursive: true, force: true })
+    setWorkspaceRuntimeAssetsRegistry({
+      support: createWorkspaceAssets(Object.fromEntries(bundle!.files.map(file => [
+        file.path,
+        {
+          load: async () => file.content,
+          mediaType: file.mediaType,
+          metadata: file.metadata,
+        },
+      ]))),
+    })
+
+    const store = createMemoryWorkspaceStore()
+    await syncWorkspaceDefinition({
+      name: "support",
+      rootDir: root,
+      sourceRootDir: sourceRoot,
+      sources: { readme: markdown({ mount: "", path: "README.md", workspacePath: "README.md" }) },
+    }, store)
+
+    await expect(store.readFile("README.md")).resolves.toMatchObject({
+      content: new TextEncoder().encode("# Bundled Markdown\n"),
+      mediaType: "text/markdown",
+      metadata: { source: "readme" },
     })
   })
 

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -666,7 +666,8 @@ describe("sources, loaders, and publishers", () => {
     })
   })
 
-  it("falls back to loaders when runtime assets miss a current build source", async () => {
+  it("hydrates bundled runtime assets when assets miss a current build source", async () => {
+    const root = await createRoot()
     setWorkspaceRuntimeAssetsRegistry({
       support: createWorkspaceAssets({
         "skills/agent-browser/SKILL.md": {
@@ -679,25 +680,20 @@ describe("sources, loaders, and publishers", () => {
     const store = createMemoryWorkspaceStore()
     await syncWorkspaceDefinition({
       name: "support",
+      rootDir: root,
+      sourceRootDir: join(root, "missing"),
       sources: {
         agentBrowserSkill: file({
           content: "# Browser\n",
           mediaType: "text/markdown",
           workspacePath: "skills/agent-browser/SKILL.md",
         }),
-        instructions: file({
-          content: "# Agent\n",
-          mediaType: "text/markdown",
-          workspacePath: "AGENTS.md",
-        }),
+        instructions: file("AGENTS.md"),
       },
     }, store)
 
     await expect(store.readFile("skills/agent-browser/SKILL.md")).resolves.toMatchObject({
       content: "# Browser\n",
-    })
-    await expect(store.readFile("AGENTS.md")).resolves.toMatchObject({
-      content: "# Agent\n",
     })
   })
 

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -666,7 +666,7 @@ describe("sources, loaders, and publishers", () => {
     })
   })
 
-  it("hydrates bundled runtime assets when assets miss a current build source", async () => {
+  it("hydrates bundled runtime assets and loads unbundled build sources", async () => {
     const root = await createRoot()
     setWorkspaceRuntimeAssetsRegistry({
       support: createWorkspaceAssets({
@@ -688,12 +688,19 @@ describe("sources, loaders, and publishers", () => {
           mediaType: "text/markdown",
           workspacePath: "skills/agent-browser/SKILL.md",
         }),
-        instructions: file("AGENTS.md"),
+        instructions: file({
+          content: "# Instructions\n",
+          mediaType: "text/markdown",
+          workspacePath: "AGENTS.md",
+        }),
       },
     }, store)
 
     await expect(store.readFile("skills/agent-browser/SKILL.md")).resolves.toMatchObject({
       content: "# Browser\n",
+    })
+    await expect(store.readFile("AGENTS.md")).resolves.toMatchObject({
+      content: "# Instructions\n",
     })
   })
 

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -704,6 +704,55 @@ describe("sources, loaders, and publishers", () => {
     })
   })
 
+  it("loads omitted files from partially bundled multi-file build sources", async () => {
+    const root = await createRoot()
+    setWorkspaceRuntimeAssetsRegistry({
+      support: createWorkspaceAssets({
+        "docs/README.md": {
+          load: async () => "# Bundled Docs\n",
+          mediaType: "text/markdown",
+        },
+      }),
+    })
+
+    const store = createMemoryWorkspaceStore()
+    await syncWorkspaceDefinition({
+      name: "support",
+      rootDir: root,
+      sourceRootDir: join(root, "missing"),
+      sources: {
+        docs: custom({
+          mount: "docs",
+          async getKeys() {
+            return ["README.md", "TODO.md"]
+          },
+          async getItem(key) {
+            return {
+              key,
+              content: key === "README.md" ? "# Source Docs\n" : "# Todo\n",
+              mediaType: "text/markdown",
+            }
+          },
+        }),
+        instructions: file({
+          content: "# Instructions\n",
+          mediaType: "text/markdown",
+          workspacePath: "AGENTS.md",
+        }),
+      },
+    }, store)
+
+    await expect(store.readFile("docs/README.md")).resolves.toMatchObject({
+      content: "# Source Docs\n",
+    })
+    await expect(store.readFile("docs/TODO.md")).resolves.toMatchObject({
+      content: "# Todo\n",
+    })
+    await expect(store.readFile("AGENTS.md")).resolves.toMatchObject({
+      content: "# Instructions\n",
+    })
+  })
+
   it("purges stale build source files when source maps change", async () => {
     const store = createMemoryWorkspaceStore()
     let keys = ["README.md", "stale.md"]

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -847,6 +847,58 @@ describe("sources, loaders, and publishers", () => {
     })
   })
 
+  it("loads omitted files from partially bundled multi-file build sources with preserved metadata", async () => {
+    const root = await createRoot()
+    setWorkspaceRuntimeAssetsRegistry({
+      support: createWorkspaceAssets({
+        "docs/README.md": {
+          load: async () => "# Bundled Docs\n",
+          mediaType: "text/markdown",
+          metadata: { source: "docs" },
+        },
+      }),
+    })
+
+    const store = createMemoryWorkspaceStore()
+    await syncWorkspaceDefinition({
+      name: "support",
+      rootDir: root,
+      sourceRootDir: join(root, "missing"),
+      sources: {
+        docs: custom({
+          mount: "docs",
+          async getKeys() {
+            return ["README.md", "TODO.md"]
+          },
+          async getItem(key) {
+            return {
+              key,
+              content: key === "README.md" ? "# Source Docs\n" : "# Todo\n",
+              mediaType: "text/markdown",
+            }
+          },
+        }),
+        instructions: file({
+          content: "# Instructions\n",
+          mediaType: "text/markdown",
+          workspacePath: "AGENTS.md",
+        }),
+      },
+    }, store)
+
+    await expect(store.readFile("docs/README.md")).resolves.toMatchObject({
+      content: "# Source Docs\n",
+      metadata: { source: "docs" },
+    })
+    await expect(store.readFile("docs/TODO.md")).resolves.toMatchObject({
+      content: "# Todo\n",
+      metadata: { source: "docs" },
+    })
+    await expect(store.readFile("AGENTS.md")).resolves.toMatchObject({
+      content: "# Instructions\n",
+    })
+  })
+
   it("purges stale build source files when source maps change", async () => {
     const store = createMemoryWorkspaceStore()
     let keys = ["README.md", "stale.md"]

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -718,6 +718,43 @@ describe("sources, loaders, and publishers", () => {
     })
   })
 
+  it("trusts complete bundled build source assets without probe keys when the original source root is absent", async () => {
+    const root = await createRoot()
+    setWorkspaceRuntimeAssetsRegistry({
+      support: createWorkspaceAssets({
+        "docs/README.md": {
+          load: async () => "# Bundled Docs\n",
+          mediaType: "text/markdown",
+          metadata: { source: "docs" },
+        },
+      }),
+    })
+
+    const store = createMemoryWorkspaceStore()
+    await syncWorkspaceDefinition({
+      name: "support",
+      rootDir: root,
+      sourceRootDir: join(root, "missing"),
+      sources: {
+        docs: custom({
+          mount: "docs",
+          async getKeys() {
+            throw new Error("source root is unavailable")
+          },
+          async getItem() {
+            throw new Error("source root is unavailable")
+          },
+        }),
+      },
+    }, store)
+
+    await expect(store.readFile("docs/README.md")).resolves.toMatchObject({
+      content: "# Bundled Docs\n",
+      mediaType: "text/markdown",
+      metadata: { source: "docs" },
+    })
+  })
+
   it("hydrates bundled runtime assets and loads unbundled build sources", async () => {
     const root = await createRoot()
     setWorkspaceRuntimeAssetsRegistry({


### PR DESCRIPTION
Updates Workspace runtime asset hydration so a bundled build asset is enough to complete sync even when another current build Source is not present in the bundle. This lets generated Workspace Asset Surface output hydrate Source-backed files without falling back to local Source loaders that may not exist at runtime.

The regression covers a mixed Source map where bundled runtime assets contain one Source and a second file Source points at an absent Source root.