### PR TITLE
fix(agent): allow input commands without descriptions

### DIFF
--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -47,7 +47,7 @@ export type InputCommandCall = (input: InputCommandRunInput) => MaybePromise<Inp
 export interface InputCommand {
   call?: InputCommandCall
   channels?: readonly string[]
-  description: string
+  description?: string
   hooks?: InputCommandHooks
   run?: InputCommandCall
 }
@@ -109,8 +109,8 @@ function normalizeInputCommands(options: InputCommandsOptions): Record<string, I
     if (!command || typeof command !== "object") {
       throw new TypeError(`[vitehub] Input command "${name}" must be an object.`)
     }
-    if (typeof command.description !== "string" || !command.description.trim()) {
-      throw new TypeError(`[vitehub] Input command "${name}" requires a description.`)
+    if (command.description !== undefined && (typeof command.description !== "string" || !command.description.trim())) {
+      throw new TypeError(`[vitehub] Input command "${name}" description must be a non-empty string.`)
     }
     if (command.channels !== undefined && (!Array.isArray(command.channels) || command.channels.some(channel => typeof channel !== "string" || !channel.trim()))) {
       throw new TypeError(`[vitehub] Input command "${name}" channels must be non-empty Channel IDs.`)
@@ -402,7 +402,7 @@ export function inputCommands(options: InputCommandsOptions): AgentCapabilityDef
     metadata: {
       commands: Object.fromEntries(Object.entries(commands).map(([name, command]) => [name, {
         ...(command.channels?.length ? { channels: [...command.channels] } : {}),
-        description: command.description,
+        ...(command.description ? { description: command.description } : {}),
       }])),
       trigger,
     },

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -54,7 +54,6 @@ describe("inputCommands", () => {
       capabilities: [inputCommands({
         commands: {
           review: {
-            description: "Review the request.",
           },
         },
       })],
@@ -403,11 +402,17 @@ describe("inputCommands", () => {
       },
     })).toThrow("lowercase stable identifier")
 
+    expect(inputCommands({
+      commands: {
+        review: { run: () => undefined },
+      },
+    }).metadata).toMatchObject({ commands: { review: {} } })
+
     expect(() => inputCommands({
       commands: {
-        review: { run: () => undefined } as never,
+        review: { description: "", run: () => undefined },
       },
-    })).toThrow("requires a description")
+    })).toThrow("description must be a non-empty string")
 
     expect(() => inputCommands({
       commands: {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -575,7 +575,6 @@ describe("agent public types", () => {
 
     inputCommands({
       commands: {
-        // @ts-expect-error input commands require user-facing descriptions
         review: {
           run: () => undefined,
         },


### PR DESCRIPTION
Allows `inputCommands()` entries to omit description metadata while still rejecting empty descriptions when one is provided. This keeps command-only admission/rewrite definitions valid without publishing undefined description fields in capability metadata.

Validated with the focused Agent package input command test and typecheck.