### PR TITLE
fix(agent): ignore generated harness tool writeback

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -291,6 +291,13 @@ function toHarnessTools(context: AgentAdapterRunContext): AgentToolSet | undefin
   )
 }
 
+function harnessWriteBackIgnorePaths(context: AgentAdapterRunContext, instructions: string | undefined): string[] {
+  return [
+    ...(hasEntries(context.tools) ? harnessGeneratedFiles : []),
+    ...(instructions ? harnessInstructionFiles : []),
+  ]
+}
+
 function toRunCallbackContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -685,7 +692,7 @@ export function createHarnessAgentAdapter<
       workspaceSession = await prepareHarnessWorkspaceSession(context.workspace, {
         abortSignal,
         ...(hasWorkspaceCommitRules(commitDefinition) ? { definition: commitDefinition } : {}),
-        ignoreWriteBackPaths: [...harnessGeneratedFiles, ...(harnessInstructions ? harnessInstructionFiles : [])],
+        ignoreWriteBackPaths: harnessWriteBackIgnorePaths(context, harnessInstructions),
         paths: selectedWorkspaceScopePaths(context, commitDefinition),
         session: session as never,
         sessionWorkDir,

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -57,6 +57,7 @@ type HarnessInstructionSandbox = {
 
 type HarnessAgentConstructor = new (settings: Record<string, unknown>) => HarnessAgentLike
 const harnessResumeStates = new WeakMap<object, Map<string, unknown>>()
+const harnessGeneratedFiles = ["harness-tool.mjs"] as const
 const harnessInstructionFiles = ["AGENTS.md", "CLAUDE.md"] as const
 
 interface HarnessAgentAdapterOptions<
@@ -684,7 +685,7 @@ export function createHarnessAgentAdapter<
       workspaceSession = await prepareHarnessWorkspaceSession(context.workspace, {
         abortSignal,
         ...(hasWorkspaceCommitRules(commitDefinition) ? { definition: commitDefinition } : {}),
-        ignoreWriteBackPaths: harnessInstructions ? harnessInstructionFiles : [],
+        ignoreWriteBackPaths: [...harnessGeneratedFiles, ...(harnessInstructions ? harnessInstructionFiles : [])],
         paths: selectedWorkspaceScopePaths(context, commitDefinition),
         session: session as never,
         sessionWorkDir,

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -325,7 +325,7 @@ describe("defineAgent workspace option", () => {
     expect(writeTools).not.toHaveBeenCalled()
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["AGENTS.md", "CLAUDE.md", "skills/agent-browser"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -949,7 +949,7 @@ describe("defineAgent workspace option", () => {
     expect(useWorkspace).toHaveBeenCalledWith("docs")
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1069,7 +1069,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["AGENTS.md", "CLAUDE.md"],
+      ignoreWriteBackPaths: ["harness-tool.mjs", "AGENTS.md", "CLAUDE.md"],
       paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1141,7 +1141,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["AGENTS.md", "CLAUDE.md", "skills/SKILL.md", "skills/review-browser-evidence/SKILL.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1192,7 +1192,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["docs", "portal", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1219,7 +1219,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: undefined,
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1264,7 +1264,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: [""],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1352,7 +1352,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["docs", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1385,7 +1385,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1427,7 +1427,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["AGENTS.md", "CLAUDE.md", "summary.md", "artifacts/usage", "artifacts/browser", "pr-diff-summary.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1472,7 +1472,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["public", "AGENTS.md", "CLAUDE.md", ".vitehub/sources/public.json"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1519,7 +1519,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["public", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1563,7 +1563,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: [""],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1662,7 +1662,7 @@ describe("defineAgent workspace option", () => {
     }))
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["public", "AGENTS.md", "CLAUDE.md", "skills/agent-browser", ".vitehub/sources/public.json"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1710,7 +1710,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: [""],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1754,7 +1754,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["public", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1791,7 +1791,7 @@ describe("defineAgent workspace option", () => {
         },
         runtime: "trusted-host",
       }),
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
     }))
@@ -1907,7 +1907,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: [],
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
       paths: ["public", "AGENTS.md", "CLAUDE.md", "pull-request-context"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -325,7 +325,7 @@ describe("defineAgent workspace option", () => {
     expect(writeTools).not.toHaveBeenCalled()
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["AGENTS.md", "CLAUDE.md", "skills/agent-browser"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -949,7 +949,7 @@ describe("defineAgent workspace option", () => {
     expect(useWorkspace).toHaveBeenCalledWith("docs")
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -968,6 +968,38 @@ describe("defineAgent workspace option", () => {
     }))
     expect(harnessWorkspaceSession.close).toHaveBeenCalledWith(undefined)
     expect(harnessSession.destroy).toHaveBeenCalledOnce()
+  })
+
+  it("ignores generated harness tool writeback only when harness tools are generated", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+
+    const agent = withAgentDefaults(defineAgent({
+      capabilities: [{
+        id: "support-tools",
+        tools: {
+          lookup: { execute: vi.fn(async () => "ok") },
+        } as never,
+      }],
+      driver: {
+        harness: { provider: "codex" },
+      },
+      workspace: {},
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      session: harnessFileSession,
+      sessionWorkDir: "/workspace/codex-session",
+    }))
+    expect(harnessAgentSettings.at(-1)).toHaveProperty("tools")
   })
 
   it("passes workspace commit fallback into Harness Workspace Session commits", async () => {
@@ -1069,7 +1101,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs", "AGENTS.md", "CLAUDE.md"],
+      ignoreWriteBackPaths: ["AGENTS.md", "CLAUDE.md"],
       paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1141,7 +1173,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["AGENTS.md", "CLAUDE.md", "skills/SKILL.md", "skills/review-browser-evidence/SKILL.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1192,7 +1224,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["docs", "portal", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1219,7 +1251,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: undefined,
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1264,7 +1296,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: [""],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1352,7 +1384,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["docs", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1385,7 +1417,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1427,7 +1459,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["AGENTS.md", "CLAUDE.md", "summary.md", "artifacts/usage", "artifacts/browser", "pr-diff-summary.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1472,7 +1504,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["public", "AGENTS.md", "CLAUDE.md", ".vitehub/sources/public.json"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1519,7 +1551,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["public", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1563,7 +1595,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: [""],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1662,7 +1694,7 @@ describe("defineAgent workspace option", () => {
     }))
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["public", "AGENTS.md", "CLAUDE.md", "skills/agent-browser", ".vitehub/sources/public.json"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1710,7 +1742,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: [""],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1754,7 +1786,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["public", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -1791,7 +1823,7 @@ describe("defineAgent workspace option", () => {
         },
         runtime: "trusted-host",
       }),
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
     }))
@@ -1907,7 +1939,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
-      ignoreWriteBackPaths: ["harness-tool.mjs"],
+      ignoreWriteBackPaths: [],
       paths: ["public", "AGENTS.md", "CLAUDE.md", "pull-request-context"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",


### PR DESCRIPTION
Prevents the generated `harness-tool.mjs` helper from being written back into a Workspace after harness-backed Agent runs. The helper is runtime scaffolding, so it now joins the existing harness instruction files in the writeback ignore list.

Validated with the focused Agent workspace test and typecheck.