### PR TITLE
fix(workspace): use GitHub CLI auth for sources

### DIFF
--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -44,7 +44,7 @@ export interface GitHubCommitResult {
   treeSha: string;
 }
 
-function processEnv(
+export function processEnv(
   env: Record<string, string | undefined>,
   ...keys: string[]
 ): string | undefined {
@@ -188,7 +188,7 @@ export function resolveGitHubTokenOption(
   const bindingToken = getActiveCloudflareBinding<string>("GITHUB_TOKEN");
   if (bindingToken && !isMaskedGitHubTokenOption(bindingToken)) return bindingToken;
   return (
-    processEnv(env, "WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN")
+    processEnv(env, "WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN")
   );
 }
 

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -2,6 +2,7 @@ import { getActiveCloudflareBinding } from "@vite-hub/internal/runtime/cloudflar
 import { github as createGitHubSource, type GitHubSourceOptions as SourcePackageGitHubSourceOptions } from "@vite-hub/source"
 
 import { resolveWorkspaceEnv } from "../env.ts"
+import { processEnv, resolveGitHubTokenOption } from "../providers/github/shared.ts"
 import type { MaybePromise, WorkspaceSource, WorkspaceSourceResolutionContext } from "../core/types.ts"
 
 type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "materialize" | "mount" | "scopes" | "sync" | "validate">
@@ -10,6 +11,7 @@ type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
 type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
 type GitHubAuth = NonNullable<SourcePackageGitHubSourceOptions["auth"]>
 type GitHubResolvedSourceOptions = Omit<GitHubSourceOptions, "repo"> & Partial<Pick<GitHubSourceOptions, "repo">>
+const githubTokenEnvNames = ["WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] as const
 
 export interface GitHubSourceOptions extends Omit<SourcePackageGitHubSourceOptions, "auth">, SourceRuntimeOptions {
   auth?: GitHubAuth
@@ -39,13 +41,13 @@ export function github(input: GitHubSourceInput): WorkspaceSource {
   const sourceByRootAndToken = new Map<string, typeof baseSource>()
 
   async function getSourceForRoot(rootDir: string) {
-    const envFileToken = await resolveWorkspaceEnv(rootDir, "GITHUB_TOKEN")
-    const cacheKey = `${rootDir}\0${envFileToken ?? ""}`
+    const token = await resolveGitHubAuth(resolvedOptions.auth, rootDir)
+    const cacheKey = `${rootDir}\0${token || ""}`
     const cachedSource = sourceByRootAndToken.get(cacheKey)
     if (cachedSource) return cachedSource
     const source = createGitHubSource({
       ...resolvedOptions,
-      auth: createGitHubAuthResolver(resolvedOptions.auth, envFileToken),
+      auth: token,
     })
     sourceByRootAndToken.set(cacheKey, source)
     return source
@@ -156,18 +158,44 @@ function inferRepositoryMount(repo: string | undefined) {
   return repo?.split("/").filter(Boolean).at(-1)
 }
 
-function createGitHubAuthResolver(auth: GitHubAuth | undefined, envFileToken?: string) {
+function createGitHubAuthResolver(auth: GitHubAuth | undefined) {
   if (auth === false) return false
   return () => {
-    return resolveGitHubAuth(auth)
+    return resolveExplicitGitHubAuth(auth)
       || getActiveCloudflareBinding<string>("GITHUB_TOKEN")
-      || process.env.GITHUB_TOKEN
-      || envFileToken
+      || processEnv(process.env, ...githubTokenEnvNames)
   }
 }
 
-function resolveGitHubAuth(auth: GitHubAuth | undefined): string | undefined {
+async function resolveGitHubAuth(auth: GitHubAuth | undefined, rootDir: string): Promise<GitHubAuth | undefined> {
+  if (auth === false) return false
+  return resolveExplicitGitHubAuth(auth)
+    || resolveGitHubTokenOption({})
+    || await resolveGitHubEnvFileToken(rootDir)
+    || await resolveGitHubCliToken()
+}
+
+function resolveExplicitGitHubAuth(auth: GitHubAuth | undefined): string | undefined {
   if (auth === false) return undefined
   if (typeof auth === "function") return auth()
   return typeof auth === "string" ? auth : undefined
+}
+
+async function resolveGitHubEnvFileToken(rootDir: string): Promise<string | undefined> {
+  const env = Object.fromEntries(await Promise.all(githubTokenEnvNames.map(async name => [name, await resolveWorkspaceEnv(rootDir, name)] as const)))
+  return processEnv(env, ...githubTokenEnvNames)
+}
+
+async function resolveGitHubCliToken(): Promise<string | undefined> {
+  try {
+    const { execFileSync } = await import("node:child_process")
+    return execFileSync("gh", ["auth", "token", "--hostname", "github.com"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2_000,
+    }).trim() || undefined
+  }
+  catch {
+    return
+  }
 }

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -23,8 +23,17 @@ import { createLocalWorkspaceStore } from "../src/storage/local.ts"
 import { createMemoryWorkspaceStore } from "../src/storage/memory.ts"
 import type { WorkspaceDefinition, WorkspaceStore } from "../src/core/types.ts"
 
+const ghAuthToken = vi.hoisted(() => vi.fn<(...args: unknown[]) => string>(() => {
+  throw new Error("missing gh")
+}))
+
+vi.mock("node:child_process", () => ({
+  execFileSync: ghAuthToken,
+}))
+
 const tempDirs: string[] = []
 const workspaceSourceImport = pathToFileURL(join(import.meta.dirname, "../src/index.ts")).href
+const githubTokenEnvNames = ["WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] as const
 
 async function createRoot() {
   const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-root-"))
@@ -33,7 +42,11 @@ async function createRoot() {
 }
 
 afterEach(async () => {
-  delete process.env.GITHUB_TOKEN
+  for (const name of githubTokenEnvNames) delete process.env[name]
+  ghAuthToken.mockReset()
+  ghAuthToken.mockImplementation(() => {
+    throw new Error("missing gh")
+  })
   delete (globalThis as { __env__?: Record<string, unknown> }).__env__
   setStorage(createMemoryStorage())
   resetWorkspaceAssetsRegistry()
@@ -233,6 +246,20 @@ describe("sources, loaders, and publishers", () => {
     expect(process.env.GITHUB_TOKEN).toBeUndefined()
   })
 
+  it.each(["WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GH_TOKEN"] as const)("resolves GitHub auth from %s before the GitHub CLI", async (name) => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+    process.env[name] = "runtime-token"
+    ghAuthToken.mockReturnValue("cli-token\n")
+
+    const githubSource = github({ repo: "acme/private" })
+
+    await githubSource.getKeys({ rootDir: "", workspace: "github-runtime-auth" })
+
+    expect(archiveRequestAuthorization()).toBe("Bearer runtime-token")
+  })
+
   it("re-reads GitHub auth from local env files", async () => {
     const root = await createRoot()
     await writeFile(join(root, ".env"), "GITHUB_TOKEN=first-env-file-token\n")
@@ -335,6 +362,22 @@ describe("sources, loaders, and publishers", () => {
     await githubSource.getKeys({ rootDir: "", workspace: "github-public" })
 
     expect(archiveRequestAuthorization()).toBeUndefined()
+    expect(ghAuthToken).toHaveBeenCalledWith("gh", ["auth", "token", "--hostname", "github.com"], expect.objectContaining({
+      stdio: ["ignore", "pipe", "ignore"],
+    }))
+  })
+
+  it("falls back to GitHub CLI auth when no configured token exists", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+    ghAuthToken.mockReturnValue("cli-token\n")
+
+    const githubSource = github({ repo: "acme/private" })
+
+    await githubSource.getKeys({ rootDir: "", workspace: "github-cli-auth" })
+
+    expect(archiveRequestAuthorization()).toBe("Bearer cli-token")
   })
 
   it("falls back to GitHub archives when the public tree API is rate limited", async () => {


### PR DESCRIPTION
Allows Workspace `github()` Sources to fall back to the local GitHub CLI token when no explicit auth, Cloudflare/runtime token, or env-file token is configured. The fallback is silent when `gh` is missing or unauthenticated, and the shared Workspace GitHub token env list now also accepts `GH_TOKEN`.

Validated with the focused Workspace source-loader test and package typecheck.