### PR TITLE
fix(workspace): prefer source keys for github mounts

### DIFF
--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -117,7 +117,7 @@ export function normalizeWorkspaceSource(key: string, input: WorkspaceSourceInpu
   const mount = normalizeSourceMount(source)
   const cache = mount.cache ?? normalizeSourceCache(source) ?? false
   const sync = normalizeSourceSync(source.sync)
-  const mountPath = typeof mount.path === "string" ? mount.path : key
+  const mountPath = typeof mount.path === "string" ? mount.path : defaultSourceMountPath(key, source)
   const requestDescriptor = getWorkspaceSourceRequestDescriptor(source)
   const scopes = normalizeSourceScopes(key, source.scopes)
   if (requestDescriptor) assertWorkspaceSourceRequestDescriptorKey(key)
@@ -306,10 +306,7 @@ function inferredSourceDefaults(family: WorkspaceSourceFamily, input: WorkspaceS
   }
 
   if (family === "github") {
-    const record = input as Record<string, unknown>
-    return copySourceRuntimeOptions(input, {
-      mount: input.mount ?? inferRepositoryMount(record.repo),
-    })
+    return copySourceRuntimeOptions(input)
   }
 
   if (family === "mcpResources") {
@@ -368,6 +365,19 @@ function inferFetchWorkspacePath(input: Record<string, unknown>) {
 
 function inferRepositoryMount(repo: unknown) {
   return typeof repo === "string" ? repo.split("/").filter(Boolean).at(-1) : undefined
+}
+
+function defaultSourceMountPath(key: string, source: WorkspaceSource) {
+  if (key && !/^\d+$/.test(key)) return key
+  return inferRepositoryMount(sourceFingerprintRepo(source)) ?? key
+}
+
+function sourceFingerprintRepo(source: WorkspaceSource) {
+  const fingerprint = source.fingerprint
+  if (!isPlainRecord(fingerprint)) return
+  if (typeof fingerprint.repo === "string") return fingerprint.repo
+  const options = fingerprint.options
+  if (isPlainRecord(options) && typeof options.repo === "string") return options.repo
 }
 
 function dirname(path: string) {

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -29,10 +29,7 @@ export function github(input: GitHubSourceInput): WorkspaceSource {
   if (typeof input === "function") return resolvableGitHubSource(input)
 
   const options = input
-  const resolvedOptions = {
-    ...options,
-    mount: options.mount ?? inferRepositoryMount(options.repo),
-  }
+  const resolvedOptions = { ...options }
   const baseSource = createGitHubSource({
     ...resolvedOptions,
     auth: createGitHubAuthResolver(resolvedOptions.auth),
@@ -152,10 +149,6 @@ function pullRequestSource(value: unknown): { ref?: string, repo?: string } | un
     ...(typeof ref === "string" && ref ? { ref } : {}),
     ...(typeof repo === "string" && repo ? { repo } : {}),
   }
-}
-
-function inferRepositoryMount(repo: string | undefined) {
-  return repo?.split("/").filter(Boolean).at(-1)
 }
 
 function createGitHubAuthResolver(auth: GitHubAuth | undefined) {

--- a/packages/workspace/test/lazy-sources.test.ts
+++ b/packages/workspace/test/lazy-sources.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { normalizeWorkspaceSources } from "../src/sources/config.ts"
+import { normalizeWorkspaceSource, normalizeWorkspaceSources } from "../src/sources/config.ts"
 import { createWorkspaceSourceView } from "../src/sources/view.ts"
 import { custom, defineWorkspace, github, glob } from "../src/index.ts"
 import { resetWorkspaceRegistry } from "../src/core/registry.ts"
@@ -148,7 +148,7 @@ describe("lazy sources", () => {
     await expect(view.readFile("skills/SKILL.md")).resolves.toBe("# Skills\n")
   })
 
-  it("defaults cached GitHub sources to lazy repo basename mounts", () => {
+  it("defaults keyed cached GitHub sources to source-key mounts", () => {
     const resolved = normalizeWorkspaceSources({
       forecastingEngine: githubSource({
         cache: { maxAge: 3600 },
@@ -159,11 +159,22 @@ describe("lazy sources", () => {
     expect(resolved).toEqual([
       expect.objectContaining({
         key: "forecastingEngine",
-        mountPath: "forecasting-engine",
+        mountPath: "forecastingEngine",
         materialize: "lazy",
         cache: { maxAge: 3600 },
       }),
     ])
+  })
+
+  it("falls back to GitHub repo basename mounts for numeric source keys", () => {
+    const resolved = normalizeWorkspaceSource("0", githubSource({
+      repo: "onmax/forecasting-engine",
+    }))
+
+    expect(resolved).toEqual(expect.objectContaining({
+      key: "0",
+      mountPath: "forecasting-engine",
+    }))
   })
 
   it("keeps explicit GitHub source mount and materialization options", () => {

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -64,6 +64,7 @@ function jsonResponse(value: unknown, status = 200) {
 interface StubGitHubSourceOptions {
   apiStatus?: number
   archiveStatus?: number
+  defaultBranch?: string
 }
 
 function createTarGz(files: Record<string, string>) {
@@ -94,6 +95,7 @@ function createTarGz(files: Record<string, string>) {
 function stubGitHubSource(files: Record<string, string>, options: StubGitHubSourceOptions | number = 200) {
   const apiStatus = typeof options === "number" ? options : options.apiStatus ?? 200
   const archiveStatus = typeof options === "number" ? options : options.archiveStatus ?? 200
+  const defaultBranch = typeof options === "number" ? "main" : options.defaultBranch ?? "main"
 
   vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
     const requestUrl = String(url)
@@ -108,10 +110,10 @@ function stubGitHubSource(files: Record<string, string>, options: StubGitHubSour
     }
 
     if (requestUrl === "https://api.github.com/repos/acme/app" || requestUrl === "https://api.github.com/repos/acme/private" || requestUrl === "https://api.github.com/repos/acme/public") {
-      return jsonResponse({ default_branch: "main" })
+      return jsonResponse({ default_branch: defaultBranch })
     }
 
-    if (requestUrl.endsWith("/commits/main")) {
+    if (requestUrl.endsWith(`/commits/${defaultBranch}`)) {
       return jsonResponse({ sha: "latest-commit-sha" })
     }
 
@@ -183,12 +185,12 @@ describe("sources, loaders, and publishers", () => {
   it("resolves default GitHub refs to a commit snapshot", async () => {
     stubGitHubSource({
       "docs/README.md": "# Docs\n",
-    })
+    }, { defaultBranch: "trunk" })
 
     const githubSource = github({ repo: "acme/app" })
 
     await expect(githubSource.getKeys({ rootDir: "", workspace: "github-default-ref" })).resolves.toEqual(["docs/README.md"])
-    expect(vi.mocked(fetch).mock.calls.some(([url]) => String(url).endsWith("/commits/main"))).toBe(true)
+    expect(vi.mocked(fetch).mock.calls.some(([url]) => String(url).endsWith("/commits/trunk"))).toBe(true)
     expect(vi.mocked(fetch).mock.calls.some(([url]) => String(url).includes("/tar.gz/latest-commit-sha"))).toBe(true)
   })
 


### PR DESCRIPTION
Updates Workspace GitHub source normalization so named source bindings use the binding key as their default mount while explicit mounts still win.

Numeric or opaque source keys still fall back to the GitHub repo slug, and the existing default-ref behavior is covered with a non-main default branch test.