### PR TITLE
fix(agent): expose git as controlled shell tool

### DIFF
--- a/docs/content/docs/capabilities/git.md
+++ b/docs/content/docs/capabilities/git.md
@@ -17,8 +17,8 @@ The Agent must use a git-capable Workspace Session.
 
 ## What it adds
 
-The Capability adds `git_read` in read mode.
-In write mode it also adds `git_write` for a narrow set of local git operations.
+The Capability adds one model-facing `shell` tool for controlled Git commands.
+In write mode, the same tool can also run a narrow set of local Git operations.
 
 ## Configuration
 
@@ -37,10 +37,10 @@ export default defineAgent({
 
 ## Runtime behavior
 
-`git_read` accepts one `git` command without shell composition.
+`shell` accepts one `git` command without shell composition.
 Read mode allows source-history commands such as `status`, `diff`, `log`, `show`, `grep`, and ref inspection.
 
-`git_write` supports only `fetch`, `checkout`, and `switch` on a clean working tree.
+Write mode supports only `fetch`, `checkout`, and `switch` on a clean working tree.
 It blocks commit, push, reset, rebase, tag, arbitrary remote URLs, shell composition, and path escapes outside the Workspace.
 
 ## Requirements
@@ -52,7 +52,7 @@ The Workspace requirement is write-mode because ViteHub may need session-local G
 
 | Agent Driver | Support |
 | --- | --- |
-| Model-backed | Receives `git_read`, plus `git_write` in write mode. |
+| Model-backed | Receives one controlled Git `shell` tool. |
 | Harness-backed | Does not receive model-facing Git tools by default. |
 | Custom-run-backed | Can use the Workspace Session directly and may inspect Capability metadata. |
 
@@ -60,15 +60,15 @@ The Workspace requirement is write-mode because ViteHub may need session-local G
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `mode` | `"read" \| "write"` | `"read"` | Adds `git_write` when set to `"write"`. |
+| `mode` | `"read" \| "write"` | `"read"` | Allows local `fetch`, `checkout`, and `switch` commands through `shell` when set to `"write"`. |
 | `maxOutputLength` | `number` | `30000` | Maximum stdout/stderr characters returned per command. |
-| `policy` | `AgentToolPolicyDecision \| function` | `"require-approval"` | Policy for `git_write`. |
+| `policy` | `AgentToolPolicyDecision \| function` | `"require-approval"` | Policy for write-mode `shell` commands. Read-only Git commands are allowed without approval. |
 | `timeout` | `number` | none | Execution timeout passed to Workspace Session git commands. |
 
 ## Inspect and verify
 
 Inspect the Agent tool list in DevTools.
-Run `git status --short` through `git_read`, then verify unsupported commands such as `git push` are rejected.
+Run `git status --short` through `shell`, then verify unsupported commands such as `git push` are rejected.
 
 ## Reference
 

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -157,7 +157,7 @@ function assertGitRead(args: string[]): void {
   for (const arg of args.slice(1)) {
     const option = optionName(arg)
     if (blockedReadOptions.has(option) || arg === "-O" || arg.startsWith("-O")) {
-      throw new Error(`[vitehub] git ${subcommand} option ${option} is not available through git_read.`)
+      throw new Error(`[vitehub] git ${subcommand} option ${option} is not available through the controlled git shell.`)
     }
     assertWorkspaceArg(arg)
   }
@@ -194,7 +194,7 @@ function assertNoBlockedOptions(args: string[], blockedOptions: Set<string>): vo
   for (const arg of args.slice(1)) {
     const option = optionName(arg)
     if (blockedOptions.has(option) || blockedOptions.has(arg.slice(0, 2))) {
-      throw new Error(`[vitehub] git ${args[0]} option ${option} is not available through git_write.`)
+      throw new Error(`[vitehub] git ${args[0]} option ${option} is not available through the controlled git shell.`)
     }
     assertWorkspaceArg(arg)
   }
@@ -204,14 +204,14 @@ function assertGitFetch(args: string[]): void {
   for (const arg of args.slice(1)) {
     const option = optionName(arg)
     if (blockedFetchOptions.has(option) || blockedFetchOptions.has(arg.slice(0, 2))) {
-      throw new Error(`[vitehub] git fetch option ${option} is not available through git_write.`)
+      throw new Error(`[vitehub] git fetch option ${option} is not available through the controlled git shell.`)
     }
   }
   const [, ...refspecs] = fetchPositionals(args)
   for (const refspec of refspecs) {
     assertWorkspaceArg(refspec)
     if (refspec.startsWith("+") || refspec.includes(":")) {
-      throw new Error("[vitehub] git fetch cannot update local ref destinations through git_write.")
+      throw new Error("[vitehub] git fetch cannot update local ref destinations through the controlled git shell.")
     }
   }
 }
@@ -454,14 +454,6 @@ function normalizeGitToolInput(input: unknown, defaultCwd: string | undefined): 
   }
 }
 
-function normalizeGitToolPolicy(policy: GitCapabilityToolPolicy | undefined, defaultCwd: string | undefined): GitCapabilityToolPolicy | undefined {
-  if (typeof policy !== "function") return policy
-  return context => policy({
-    ...context,
-    input: normalizeGitToolInput(context.input, defaultCwd),
-  })
-}
-
 function limitOutput(output: string, maxOutputLength: number): { output: string, truncated?: boolean } {
   if (output.length <= maxOutputLength) return { output }
   return {
@@ -474,6 +466,27 @@ async function cleanWorkingTree(session: WorkspaceSession, cwd: string, timeout:
   const result = await session.exec("git", ["status", "--porcelain"], gitExecOptions(cwd, timeout))
   if (result.exitCode !== 0) throw new Error(result.stderr || result.stdout || "[vitehub] git status failed.")
   if (result.stdout.trim()) throw new Error("[vitehub] git write commands require a clean working tree.")
+}
+
+function gitShellPolicy(policy: GitCapabilityToolPolicy | undefined, defaultCwd: string | undefined): GitCapabilityToolPolicy {
+  return async (context) => {
+    let args: string[] | undefined
+    try {
+      const input = normalizeGitToolInput(context.input, defaultCwd)
+      args = typeof input.command === "string" ? parseGitCommand(input.command) : undefined
+    }
+    catch {
+      return "allow"
+    }
+    if (!args || !writeSubcommands.has(args[0]!)) return "allow"
+    if (typeof policy === "function") {
+      return policy({
+        ...context,
+        input: normalizeGitToolInput(context.input, defaultCwd),
+      })
+    }
+    return policy || "require-approval"
+  }
 }
 
 function gitTools(
@@ -511,46 +524,29 @@ function gitTools(
     }
   }
 
-  const tools: AgentToolSet = {
-    git_read: {
-      description: "Run one read-only git command in the workspace.",
-      execute: (input: unknown) => run(input, false),
-      inputSchema: gitInputSchema("Read-only git command, for example `git status --short`, `git diff --stat`, or `git log --oneline -n 20`. Bare git subcommands are accepted and normalized to start with `git`. Pass one command only; do not use shell composition such as `&&` or `|`."),
-      name: "git_read",
+  return {
+    shell: {
+      description: mode === "write"
+        ? "Run one controlled git command in the workspace shell. Supports read-only git commands plus local fetch, checkout, and switch on a clean working tree."
+        : "Run one controlled read-only git command in the workspace shell.",
+      execute: (input: unknown) => run(input, mode === "write"),
+      inputSchema: gitShellInputSchema(mode === "write"
+        ? "Git shell command, for example `git status --short`, `git diff --stat`, `git log --oneline -n 20`, `git fetch origin pull/123/head`, or `git switch main`. Bare git subcommands are accepted and normalized to start with `git`. Pass one command only; do not use shell composition such as `&&` or `|`."
+        : "Read-only git shell command, for example `git status --short`, `git diff --stat`, or `git log --oneline -n 20`. Bare git subcommands are accepted and normalized to start with `git`. Pass one command only; do not use shell composition such as `&&` or `|`."),
+      name: "shell",
+      ...(mode === "write" ? { policy: gitShellPolicy(options.policy, defaultCwd) } : {}),
     },
   }
-
-  if (mode === "write") {
-    tools.git_write = {
-      description: "Run one local git write command in the workspace. Supports fetch, checkout, and switch on a clean working tree.",
-      execute: (input: unknown) => run(input, true),
-      inputSchema: gitInputSchema("Local git command, for example `git fetch origin pull/123/head` or `git switch main`. Bare git subcommands are accepted and normalized to start with `git`. Pass one command only; do not use shell composition such as `&&` or `|`."),
-      name: "git_write",
-      policy: normalizeGitToolPolicy(options.policy, defaultCwd) || "require-approval",
-    }
-  }
-
-  return tools
 }
 
-function gitInputSchema(commandDescription: string) {
+function gitShellInputSchema(commandDescription: string) {
   return {
     additionalProperties: false,
-    anyOf: [
-      { required: ["command"] },
-      { required: ["cmd"] },
-      { required: ["args"] },
-    ],
     properties: {
       command: { description: commandDescription, type: "string" },
-      cmd: { description: "Alias for command.", type: "string" },
-      args: {
-        description: "Git command argv. The leading `git` word is optional.",
-        items: { type: "string" },
-        type: "array",
-      },
-      cwd: { description: "Workspace-relative directory. Defaults to the workspace root.", type: "string" },
+      cwd: { description: "Workspace-relative directory. Defaults to the pull request checkout when available, otherwise the workspace root.", type: "string" },
     },
+    required: ["command"],
     type: "object",
   }
 }

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -63,46 +63,43 @@ describe("git capability", () => {
     expect(() => git({ mode: "remote-write" as never })).toThrow("Git mode must be \"read\" or \"write\"")
   })
 
-  it("exposes only read git commands in read mode", async () => {
+  it("exposes a controlled read-only shell tool in read mode", async () => {
     const { session, tools } = await capabilityTools()
 
-    expect(Object.keys(tools)).toEqual(["git_read"])
-    await expect(tools.git_read!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+    expect(Object.keys(tools)).toEqual(["shell"])
+    await expect(tools.shell!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
       args: ["status", "--short"],
       cwd: "/workspace",
       stdout: "ok\n",
     })
-    await expect(tools.git_read!.execute?.({ command: "git switch main" })).rejects.toThrow("requires git({ mode: \"write\" })")
+    await expect(tools.shell!.execute?.({ command: "git switch main" })).rejects.toThrow("requires git({ mode: \"write\" })")
     expect(session.exec).toHaveBeenCalledWith("git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace", timeout: undefined }))
   })
 
-  it("normalizes common git tool input shapes", async () => {
+  it("exposes a command-only shell input schema", async () => {
     const { session, tools } = await capabilityTools()
+    const schema = tools.shell!.inputSchema as { anyOf?: unknown, properties?: Record<string, unknown>, required?: string[] }
 
-    expect(tools.git_read!.inputSchema).toMatchObject({
-      anyOf: [
-        { required: ["command"] },
-        { required: ["cmd"] },
-        { required: ["args"] },
-      ],
+    expect(schema).toMatchObject({
+      additionalProperties: false,
+      properties: {
+        command: { type: "string" },
+        cwd: { type: "string" },
+      },
+      required: ["command"],
+      type: "object",
     })
-    await expect(tools.git_read!.execute?.("status --short")).resolves.toMatchObject({
+    expect(schema.anyOf).toBeUndefined()
+    expect(schema.properties).not.toHaveProperty("cmd")
+    expect(schema.properties).not.toHaveProperty("args")
+    await expect(tools.shell!.execute?.({ command: "status --short" })).resolves.toMatchObject({
       args: ["status", "--short"],
       command: "git status --short",
     })
-    await expect(tools.git_read!.execute?.({ cmd: "diff --stat" })).resolves.toMatchObject({
-      args: ["diff", "--stat"],
-      command: "git diff --stat",
-    })
-    await expect(tools.git_read!.execute?.({ args: ["show", "HEAD:README.md"] })).resolves.toMatchObject({
-      args: ["show", "HEAD:README.md"],
-      command: "git show HEAD:README.md",
-    })
-    await expect(tools.git_read!.execute?.({ command: "git diff --stat && git diff" })).rejects.toThrow("without shell composition")
+    await expect(tools.shell!.execute?.({ command: "ls -la" })).rejects.toThrow("must start with `git`")
+    await expect(tools.shell!.execute?.({ command: "git diff --stat && git diff" })).rejects.toThrow("without shell composition")
 
     expect(session.exec).toHaveBeenCalledWith("git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace" }))
-    expect(session.exec).toHaveBeenCalledWith("git", ["diff", "--stat"], expect.objectContaining({ cwd: "/workspace" }))
-    expect(session.exec).toHaveBeenCalledWith("git", ["show", "HEAD:README.md"], expect.objectContaining({ cwd: "/workspace" }))
   })
 
   it("keeps workspace sessions scoped to each tool resolution", async () => {
@@ -118,10 +115,10 @@ describe("git capability", () => {
     const firstTools = await capability.tools(firstContext as never) as AgentToolSet
     const secondTools = await capability.tools(secondContext as never) as AgentToolSet
 
-    await expect(firstTools.git_read!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+    await expect(firstTools.shell!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
       stdout: "ok\n",
     })
-    await expect(secondTools.git_read!.execute?.({ command: "git log --oneline -n 1" })).resolves.toMatchObject({
+    await expect(secondTools.shell!.execute?.({ command: "git log --oneline -n 1" })).resolves.toMatchObject({
       stdout: "ok\n",
     })
 
@@ -141,19 +138,19 @@ describe("git capability", () => {
   it("blocks git read options that escape inspection boundaries", async () => {
     const { tools } = await capabilityTools()
 
-    await expect(tools.git_read!.execute?.({ command: "git grep -O=sh TODO" })).rejects.toThrow("not available through git_read")
-    await expect(tools.git_read!.execute?.({ command: "git grep --open-files-in-pager=sh TODO" })).rejects.toThrow("not available through git_read")
-    await expect(tools.git_read!.execute?.({ command: "git diff --no-index /etc/passwd README.md" })).rejects.toThrow("not available through git_read")
-    await expect(tools.git_read!.execute?.({ command: "git show /etc/passwd" })).rejects.toThrow("must stay inside the workspace")
+    await expect(tools.shell!.execute?.({ command: "git grep -O=sh TODO" })).rejects.toThrow("not available through the controlled git shell")
+    await expect(tools.shell!.execute?.({ command: "git grep --open-files-in-pager=sh TODO" })).rejects.toThrow("not available through the controlled git shell")
+    await expect(tools.shell!.execute?.({ command: "git diff --no-index /etc/passwd README.md" })).rejects.toThrow("not available through the controlled git shell")
+    await expect(tools.shell!.execute?.({ command: "git show /etc/passwd" })).rejects.toThrow("must stay inside the workspace")
   })
 
   it("runs local write commands only on a clean tree", async () => {
     const session = gitSession()
     const { startSession, tools } = await capabilityTools(git({ mode: "write", policy: "allow" }), session)
 
-    expect(Object.keys(tools)).toEqual(["git_read", "git_write"])
-    expect(tools.git_write!.policy).toBe("allow")
-    await expect(tools.git_write!.execute?.({ command: "git switch feature/pr-1", cwd: "portal" })).resolves.toMatchObject({
+    expect(Object.keys(tools)).toEqual(["shell"])
+    expect(typeof tools.shell!.policy).toBe("function")
+    await expect(tools.shell!.execute?.({ command: "git switch feature/pr-1", cwd: "portal" })).resolves.toMatchObject({
       args: ["switch", "feature/pr-1"],
       cwd: "/workspace/portal",
     })
@@ -161,6 +158,18 @@ describe("git capability", () => {
     expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["status", "--porcelain"], expect.objectContaining({ cwd: "/workspace/portal", timeout: undefined }))
     expect(session.exec).toHaveBeenNthCalledWith(2, "git", ["switch", "feature/pr-1"], expect.objectContaining({ cwd: "/workspace/portal", timeout: undefined }))
     expect(session.commit).toHaveBeenCalledWith({ message: "git switch" })
+  })
+
+  it("defaults write commands to approval and allows read commands without approval", async () => {
+    const { tools } = await capabilityTools(git({ mode: "write" }))
+    const policy = tools.shell!.policy
+
+    if (typeof policy !== "function") throw new Error("shell policy must be executable")
+
+    await expect(policy({ name: "shell", input: { command: "git status --short" } })).resolves.toBe("allow")
+    await expect(policy({ name: "shell", input: { command: "git fetch origin pull/123/head" } })).resolves.toBe("require-approval")
+    await expect(policy({ name: "shell", input: { command: "git checkout main" } })).resolves.toBe("require-approval")
+    await expect(policy({ name: "shell", input: { command: "git switch main" } })).resolves.toBe("require-approval")
   })
 
   it("evaluates custom write policies with normalized git inputs", async () => {
@@ -172,53 +181,52 @@ describe("git capability", () => {
     const { tools } = await capabilityTools(git({ mode: "write", policy }), session)
     const guardedTools = applyAgentToolPolicies(tools)!
 
-    await expect(guardedTools.git_write!.execute?.({ cmd: "checkout main" })).rejects.toThrow()
-    await expect(guardedTools.git_write!.execute?.({ args: ["checkout", "main"] })).rejects.toThrow()
+    await expect(guardedTools.shell!.execute?.({ command: "checkout main" })).rejects.toThrow()
+    await expect(guardedTools.shell!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+      args: ["status", "--short"],
+    })
 
-    expect(policy).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      input: expect.objectContaining({ cmd: "checkout main", command: "git checkout main" }),
-      name: "git_write",
+    expect(policy).toHaveBeenCalledOnce()
+    expect(policy).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({ command: "git checkout main" }),
+      name: "shell",
     }))
-    expect(policy).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      input: expect.objectContaining({ args: ["checkout", "main"], command: "git checkout main" }),
-      name: "git_write",
-    }))
-    expect(session.exec).not.toHaveBeenCalled()
+    expect(session.exec).toHaveBeenCalledOnce()
   })
 
   it("fetches only configured remotes in write mode", async () => {
     const session = gitSession({ remotes: "origin\nupstream\n" })
     const { tools } = await capabilityTools(git({ mode: "write" }), session)
 
-    await expect(tools.git_write!.execute?.({ command: "git fetch origin pull/123/head" })).resolves.toMatchObject({
+    await expect(tools.shell!.execute?.({ command: "git fetch origin pull/123/head" })).resolves.toMatchObject({
       args: ["fetch", "origin", "pull/123/head"],
     })
-    await expect(tools.git_write!.execute?.({ command: "git fetch /tmp/repo.git main" })).rejects.toThrow("configured remotes")
-    await expect(tools.git_write!.execute?.({ command: "git fetch user@example.com:repo main" })).rejects.toThrow("configured remotes")
+    await expect(tools.shell!.execute?.({ command: "git fetch /tmp/repo.git main" })).rejects.toThrow("configured remotes")
+    await expect(tools.shell!.execute?.({ command: "git fetch user@example.com:repo main" })).rejects.toThrow("configured remotes")
   })
 
   it("blocks destructive local git write flags and refspec destinations", async () => {
     const { tools } = await capabilityTools(git({ mode: "write" }))
 
-    await expect(tools.git_write!.execute?.({ command: "git switch -C review HEAD" })).rejects.toThrow("not available through git_write")
-    await expect(tools.git_write!.execute?.({ command: "git checkout -B review HEAD" })).rejects.toThrow("not available through git_write")
-    await expect(tools.git_write!.execute?.({ command: "git fetch origin pull/123/head:review" })).rejects.toThrow("cannot update local ref destinations")
-    await expect(tools.git_write!.execute?.({ command: "git fetch origin +pull/123/head" })).rejects.toThrow("cannot update local ref destinations")
-    await expect(tools.git_write!.execute?.({ command: "git fetch --refmap=refs/*:refs/* origin pull/123/head" })).rejects.toThrow("not available through git_write")
-    await expect(tools.git_write!.execute?.({ command: "git fetch --upload-pack=\"sh -c whoami\" origin" })).rejects.toThrow("not available through git_write")
-    await expect(tools.git_write!.execute?.({ command: "git fetch --upload-pack sh origin" })).rejects.toThrow("not available through git_write")
-    await expect(tools.git_write!.execute?.({ command: "git fetch --tags origin" })).rejects.toThrow("not available through git_write")
-    await expect(tools.git_write!.execute?.({ command: "git fetch -P origin" })).rejects.toThrow("not available through git_write")
-    await expect(tools.git_write!.execute?.({ command: "git fetch -u origin" })).rejects.toThrow("not available through git_write")
+    await expect(tools.shell!.execute?.({ command: "git switch -C review HEAD" })).rejects.toThrow("not available through the controlled git shell")
+    await expect(tools.shell!.execute?.({ command: "git checkout -B review HEAD" })).rejects.toThrow("not available through the controlled git shell")
+    await expect(tools.shell!.execute?.({ command: "git fetch origin pull/123/head:review" })).rejects.toThrow("cannot update local ref destinations")
+    await expect(tools.shell!.execute?.({ command: "git fetch origin +pull/123/head" })).rejects.toThrow("cannot update local ref destinations")
+    await expect(tools.shell!.execute?.({ command: "git fetch --refmap=refs/*:refs/* origin pull/123/head" })).rejects.toThrow("not available through the controlled git shell")
+    await expect(tools.shell!.execute?.({ command: "git fetch --upload-pack=\"sh -c whoami\" origin" })).rejects.toThrow("not available through the controlled git shell")
+    await expect(tools.shell!.execute?.({ command: "git fetch --upload-pack sh origin" })).rejects.toThrow("not available through the controlled git shell")
+    await expect(tools.shell!.execute?.({ command: "git fetch --tags origin" })).rejects.toThrow("not available through the controlled git shell")
+    await expect(tools.shell!.execute?.({ command: "git fetch -P origin" })).rejects.toThrow("not available through the controlled git shell")
+    await expect(tools.shell!.execute?.({ command: "git fetch -u origin" })).rejects.toThrow("not available through the controlled git shell")
   })
 
   it("rejects dirty write commands and remote publication commands", async () => {
     const dirty = gitSession({ status: "M README.md\n" })
     const { tools } = await capabilityTools(git({ mode: "write" }), dirty)
 
-    await expect(tools.git_write!.execute?.({ command: "git checkout main" })).rejects.toThrow("clean working tree")
-    await expect(tools.git_write!.execute?.({ command: "git push origin main" })).rejects.toThrow("git push is not available")
-    await expect(tools.git_write!.execute?.({ command: "git fetch https://example.com/repo.git main" })).rejects.toThrow("configured remotes")
+    await expect(tools.shell!.execute?.({ command: "git checkout main" })).rejects.toThrow("clean working tree")
+    await expect(tools.shell!.execute?.({ command: "git push origin main" })).rejects.toThrow("git push is not available")
+    await expect(tools.shell!.execute?.({ command: "git fetch https://example.com/repo.git main" })).rejects.toThrow("configured remotes")
     expect(dirty.commit).not.toHaveBeenCalled()
   })
 
@@ -226,7 +234,7 @@ describe("git capability", () => {
     const session = gitSession()
     const { startSession, tools } = await capabilityTools(git(), session)
 
-    await expect(tools.git_read!.execute?.({ command: "git status --short", cwd: "packages/agent" })).resolves.toMatchObject({
+    await expect(tools.shell!.execute?.({ command: "git status --short", cwd: "packages/agent" })).resolves.toMatchObject({
       cwd: "/workspace/packages/agent",
       stdout: "ok\n",
     })
@@ -263,7 +271,7 @@ describe("git capability", () => {
       },
     })
 
-    await expect(tools.git_read!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+    await expect(tools.shell!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
       cwd: "/workspace/vitehub",
       stdout: "ok\n",
     })
@@ -300,7 +308,7 @@ describe("git capability", () => {
       },
     })
 
-    await expect(tools.git_read!.execute?.({ command: "git status --short" })).rejects.toThrow("fetch failed")
+    await expect(tools.shell!.execute?.({ command: "git status --short" })).rejects.toThrow("fetch failed")
     expect(session.close).toHaveBeenCalledOnce()
   })
 
@@ -330,7 +338,7 @@ describe("git capability", () => {
       },
     })
 
-    await expect(tools.git_read!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+    await expect(tools.shell!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
       cwd: "/workspace/vitehub",
     })
 
@@ -367,7 +375,7 @@ describe("git capability", () => {
       },
     })
 
-    await expect(tools.git_write!.execute?.({ command: "git switch vitehub-base" })).resolves.toMatchObject({
+    await expect(tools.shell!.execute?.({ command: "git switch vitehub-base" })).resolves.toMatchObject({
       args: ["switch", "vitehub-base"],
       cwd: "/workspace/vitehub",
     })
@@ -390,7 +398,7 @@ describe("git capability", () => {
       },
     })
 
-    await expect(tools.git_read!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+    await expect(tools.shell!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
       cwd: "/workspace",
       stdout: "ok\n",
     })
@@ -418,7 +426,7 @@ describe("git capability", () => {
       },
     })
 
-    await expect(tools.git_read!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+    await expect(tools.shell!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
       cwd: "/workspace",
       stdout: "ok\n",
     })


### PR DESCRIPTION
Moves the remaining Quiver-carried `git()` pnpm patch into source. The Git Capability now exposes a single model-facing `shell` tool instead of separate `git_read` and `git_write` tools, while still parsing one controlled Git command and rejecting non-Git commands or shell composition.

Write mode keeps the existing guardrails: only `fetch`, `checkout`, and `switch` are allowed as local write commands, they require a clean working tree, fetch stays limited to configured remotes, and history mutation or publication commands remain blocked. Read-only Git commands are allowed without approval, while write-mode commands keep the default `require-approval` policy.

This intentionally moves the direct source behavior only; it does not introduce the broader order-independent command-contribution registry for multiple shell-shaped capabilities.