### PR TITLE
fix(agent): scope harness workspace access

### DIFF
--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -859,10 +859,10 @@ function createScopedWorkspaceFacade<Name extends WorkspaceName>(
     tools,
   }
   if (facadeStarter) {
-    facade.startSession = async function (this: { fs?: ReadonlyWorkspaceFacade["fs"] } | void, options?: WorkspaceSessionOptions) {
+    facade.startSession = async (options?: WorkspaceSessionOptions) => {
       return await facadeStarter.startSession({
         ...options,
-        paths: await scopedSessionPaths(scope, options?.paths, this?.fs),
+        paths: await scopedSessionPaths(scope, options?.paths, fs),
       })
     }
   }

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -757,7 +757,7 @@ function workspaceSessionStarter(input: object): WorkspaceSessionStarter | undef
     : undefined
 }
 
-function scopedSessionPaths(scope: ResolvedWorkspaceScope, paths: readonly string[] | undefined): string[] | undefined {
+async function scopedSessionPaths(scope: ResolvedWorkspaceScope, paths: readonly string[] | undefined, fs?: ReadonlyWorkspaceFacade["fs"]): Promise<string[] | undefined> {
   if (scope.all) return paths ? [...paths] : undefined
   const requestedPaths = paths?.length ? paths : [""]
   const scopedPaths = new Set<string>()
@@ -767,6 +767,9 @@ function scopedSessionPaths(scope: ResolvedWorkspaceScope, paths: readonly strin
       const grantPath = normalizeScopePath(grant.path)
       if (pathContains(grantPath, requested)) scopedPaths.add(requested)
       else if (!requested || pathContains(requested, grantPath)) scopedPaths.add(grantPath)
+    }
+    if (paths?.length && fs && !scopedPaths.has(requested) && await fs.exists(requested)) {
+      scopedPaths.add(requested)
     }
   }
   if (!scopedPaths.size) throw notFound(requestedPaths[0] || "")
@@ -827,7 +830,7 @@ function createScopedWorkspaceFacade<Name extends WorkspaceName>(
           async startSession(options?: WorkspaceSessionOptions) {
             return await starter.startSession({
               ...options,
-              paths: scopedSessionPaths(scope, options?.paths),
+              paths: await scopedSessionPaths(scope, options?.paths),
             })
           },
         }
@@ -856,10 +859,12 @@ function createScopedWorkspaceFacade<Name extends WorkspaceName>(
     tools,
   }
   if (facadeStarter) {
-    facade.startSession = async (options?: WorkspaceSessionOptions) => await facadeStarter.startSession({
-      ...options,
-      paths: scopedSessionPaths(scope, options?.paths),
-    })
+    facade.startSession = async function (this: { fs?: ReadonlyWorkspaceFacade["fs"] } | void, options?: WorkspaceSessionOptions) {
+      return await facadeStarter.startSession({
+        ...options,
+        paths: await scopedSessionPaths(scope, options?.paths, this?.fs),
+      })
+    }
   }
   return facade
 }

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -314,8 +314,8 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
       if (!context.workspace) {
         throw new Error("[vitehub] access({ workspace }) requires an explicit workspace.")
       }
-      if ("diff" in context.workspace) {
-        throw new Error("[vitehub] access({ workspace }) is read-only in the first version and requires workspace.mode: \"read\".")
+      if ("diff" in context.workspace && context.driver?.kind !== "harness") {
+        throw new Error("[vitehub] access({ workspace }) with workspace.mode: \"write\" is only supported for harness Agent Drivers.")
       }
       const workspaceRuntime = await loadWorkspaceAccessRuntime()
       const scope = await resolveWorkspaceScope(options.workspace, context, workspaceRuntime)
@@ -781,6 +781,7 @@ function createScopedWorkspaceFacade<Name extends WorkspaceName>(
   let fs: ReadonlyWorkspaceFacade<Name>["fs"]
   const sourceRequestExecution = workspaceRuntime.getWorkspaceSourceRequestExecution(workspace.fs)
   const starter = workspaceSessionStarter(workspace.fs)
+  const facadeStarter = workspaceSessionStarter(workspace as object)
   fs = workspaceRuntime.attachWorkspaceSourceRequestExecution({
     async readFile(path, options) {
       const normalized = normalizeScopePath(path)
@@ -850,10 +851,17 @@ function createScopedWorkspaceFacade<Name extends WorkspaceName>(
   tools.inspect = createTools as ReadonlyWorkspaceFacade<Name>["tools"]["inspect"]
   tools.none = () => ({})
 
-  return {
+  const facade: ReadonlyWorkspaceFacade<Name> & Partial<WorkspaceSessionStarter> = {
     fs,
     tools,
   }
+  if (facadeStarter) {
+    facade.startSession = async (options?: WorkspaceSessionOptions) => await facadeStarter.startSession({
+      ...options,
+      paths: scopedSessionPaths(scope, options?.paths),
+    })
+  }
+  return facade
 }
 
 function scopedSourceRequestExecution(

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -768,7 +768,7 @@ async function scopedSessionPaths(scope: ResolvedWorkspaceScope, paths: readonly
       if (pathContains(grantPath, requested)) scopedPaths.add(requested)
       else if (!requested || pathContains(requested, grantPath)) scopedPaths.add(grantPath)
     }
-    if (paths?.length && fs && !scopedPaths.has(requested) && await fs.exists(requested)) {
+    if (paths?.length && fs && !scopedPaths.has(requested) && isReadablePath(scope, requested) && await fs.exists(requested)) {
       scopedPaths.add(requested)
     }
   }

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -584,7 +584,8 @@ function createPullRequestContext<
       if (sources && Object.hasOwn(sources, source.key)) {
         throw new Error(`[vitehub] ${capabilityId}() sources cannot use reserved Workspace Source key "${source.key}".`)
       }
-      grantSelectedWorkspaceScopePath(context.context, source.mount)
+      grantSelectedWorkspaceScopePath(context.context, `${source.mount}/${defaultMarkdownSourcePath}`)
+      grantSelectedWorkspaceScopePath(context.context, `${source.mount}/${defaultJsonSourcePath}`)
       return {
         ...(rules ? { rules } : {}),
         sources: {

--- a/packages/agent/test/pull-request-context.test.ts
+++ b/packages/agent/test/pull-request-context.test.ts
@@ -370,6 +370,8 @@ describe("pullRequestContext", () => {
   it("grants the default source to the selected Workspace Scope", async () => {
     const { access, pullRequestContext } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { createAgentInvocationContextStore } = await import("../src/invocation-context.ts")
+    const context = createAgentInvocationContextStore()
 
     const resolved = await resolveAgentCapabilities({
       capabilities: [
@@ -389,6 +391,7 @@ describe("pullRequestContext", () => {
         }),
       ],
     }, runtime(), {}, emptyWorkspace() as never, "read", {
+      context,
       workspaceDefinition: {
         name: "review",
         sources: {},
@@ -396,6 +399,11 @@ describe("pullRequestContext", () => {
     })
 
     await expect(resolved.workspace?.fs.readFile("pull-request-context/context.md")).resolves.toContain("Change Request 42 in acme/app.")
+    expect(context.get("access")).toMatchObject({
+      workspaceScope: {
+        paths: ["src", "pull-request-context/context.md", "pull-request-context/context.json"],
+      },
+    })
   })
 
   it("grants the default source to an inline Workspace Scope selection", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2025,18 +2025,15 @@ describe("defineAgent workspace option", () => {
 
     const scopedWorkspace = prepareHarnessWorkspaceSession.mock.calls[0]?.[0] as Record<string, unknown>
     expect(scopedWorkspace.startSession).toBeTypeOf("function")
-    const overlay = {
+    const forgedReceiver = {
       fs: {
-        exists: vi.fn(async (path: string) => path === "pull-request-context/context.md"),
+        exists: vi.fn(async () => true),
       },
     }
-    await expect((scopedWorkspace.startSession as (this: typeof overlay, options?: { paths?: string[] }) => Promise<unknown>).call(overlay, {
-      paths: ["pull-request-context/context.md"],
-    })).resolves.toBeDefined()
-    await expect((scopedWorkspace.startSession as (this: typeof overlay, options?: { paths?: string[] }) => Promise<unknown>).call(overlay, {
+    await expect((scopedWorkspace.startSession as (this: typeof forgedReceiver, options?: { paths?: string[] }) => Promise<unknown>).call(forgedReceiver, {
       paths: ["private/secret.md"],
     })).rejects.toThrow("Workspace path does not exist")
-    expect(startSession).toHaveBeenCalledWith({ paths: ["pull-request-context/context.md"] })
+    expect(forgedReceiver.fs.exists).not.toHaveBeenCalled()
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2034,6 +2034,12 @@ describe("defineAgent workspace option", () => {
       paths: ["private/secret.md"],
     })).rejects.toThrow("Workspace path does not exist")
     expect(forgedReceiver.fs.exists).not.toHaveBeenCalled()
+    exists.mockImplementation(async (path: string) => path === "pull-request-context" || path === "pull-request-context/context.md")
+    const callsBeforeParentRequest = startSession.mock.calls.length
+    await expect((scopedWorkspace.startSession as (options?: { paths?: string[] }) => Promise<unknown>)({
+      paths: ["pull-request-context"],
+    })).rejects.toThrow("Workspace path does not exist")
+    expect(startSession).toHaveBeenCalledTimes(callsBeforeParentRequest)
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -338,6 +338,63 @@ describe("defineAgent workspace option", () => {
     expect(harnessWorkspaceSession.close).toHaveBeenCalledWith(undefined)
   })
 
+  it("scopes write-mode harness Workspace Sessions through access()", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { access } = await import("../src/capabilities.ts")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    const startSession = vi.fn(async () => ({ close: vi.fn() }))
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+    useWorkspace.mockReturnValueOnce({
+      diff,
+      fs: { exists, list, readFile, stat, writeFile },
+      materializeSources: vi.fn(),
+      snapshot,
+      startSession,
+      sync: vi.fn(),
+      tools: Object.assign(tools, {
+        inspect: inspectTools,
+        none: vi.fn(() => ({})),
+        readonly: inspectTools,
+        write: writeTools,
+      }),
+    } as unknown as WritableWorkspaceFacade)
+
+    const agent = withAgentDefaults(defineAgent({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "review",
+            scopes: {
+              review: { paths: ["src"] },
+            },
+          },
+        }),
+      ],
+      driver: {
+        harness: { provider: "codex" },
+      },
+      workspace: { mode: "write" },
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    const scopedWorkspace = prepareHarnessWorkspaceSession.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(scopedWorkspace.startSession).toBeTypeOf("function")
+    await (scopedWorkspace.startSession as (options?: { paths?: string[] }) => Promise<unknown>)({
+      paths: ["src/app.ts", "private/secret.md"],
+    })
+    expect(startSession).toHaveBeenCalledWith({ paths: ["src/app.ts"] })
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+      paths: ["src", "AGENTS.md", "CLAUDE.md"],
+      session: harnessFileSession,
+      sessionWorkDir: "/workspace/codex-session",
+    }))
+  })
+
   it("keeps harness workspace sessions open through text fallback", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const harnessSession = { destroy: vi.fn() }
@@ -1955,7 +2012,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["public", "AGENTS.md", "CLAUDE.md", "pull-request-context"],
+      paths: ["public", "AGENTS.md", "CLAUDE.md", "pull-request-context/context.md", "pull-request-context/context.json"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
     })

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1977,9 +1977,23 @@ describe("defineAgent workspace option", () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { access, pullRequestContext } = await import("../src/capabilities.ts")
     const harnessWorkspaceSession = { close: vi.fn() }
-    useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
+    const startSession = vi.fn(async () => ({ close: vi.fn() }))
+    useWorkspace.mockReturnValueOnce({
+      diff,
+      fs: { exists, list, readFile, stat, writeFile },
+      snapshot,
+      startSession,
+      sync: vi.fn(),
+      tools: Object.assign(tools, {
+        inspect: inspectTools,
+        none: vi.fn(() => ({})),
+        readonly: inspectTools,
+        write: writeTools,
+      }),
+    } as unknown as WritableWorkspaceFacade)
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+    exists.mockImplementation(async (path: string) => path === "pull-request-context/context.md")
 
     const agent = withAgentDefaults(defineAgent({
       capabilities: [
@@ -2001,7 +2015,7 @@ describe("defineAgent workspace option", () => {
       driver: {
         harness: { provider: "codex" },
       },
-      workspace: {},
+      workspace: { mode: "write" },
     }), { workspace: "docs" })
 
     await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
@@ -2009,6 +2023,20 @@ describe("defineAgent workspace option", () => {
       text: "ok",
     })
 
+    const scopedWorkspace = prepareHarnessWorkspaceSession.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(scopedWorkspace.startSession).toBeTypeOf("function")
+    const overlay = {
+      fs: {
+        exists: vi.fn(async (path: string) => path === "pull-request-context/context.md"),
+      },
+    }
+    await expect((scopedWorkspace.startSession as (this: typeof overlay, options?: { paths?: string[] }) => Promise<unknown>).call(overlay, {
+      paths: ["pull-request-context/context.md"],
+    })).resolves.toBeDefined()
+    await expect((scopedWorkspace.startSession as (this: typeof overlay, options?: { paths?: string[] }) => Promise<unknown>).call(overlay, {
+      paths: ["private/secret.md"],
+    })).rejects.toThrow("Workspace path does not exist")
+    expect(startSession).toHaveBeenCalledWith({ paths: ["pull-request-context/context.md"] })
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -65,6 +65,12 @@ function isWritableWorkspaceFacade<Name extends WorkspaceName>(workspace: Readon
   return typeof (workspace as WritableWorkspaceFacade<Name>).fs.writeFile === "function"
 }
 
+function workspaceSessionStarter<Name extends WorkspaceName>(workspace: ReadonlyWorkspaceFacade<Name>): Pick<Workspace, "startSession"> | undefined {
+  return typeof (workspace as ReadonlyWorkspaceFacade<Name> & Partial<Pick<Workspace, "startSession">>).startSession === "function"
+    ? workspace as ReadonlyWorkspaceFacade<Name> & Pick<Workspace, "startSession">
+    : undefined
+}
+
 function writeOperations(options: WritableWorkspaceFacadeToolOptions | undefined) {
   return {
     appendFile: options?.appendFile !== false,
@@ -496,12 +502,18 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
     }
   }
 
+  const readonlyWorkspace: ReadonlyWorkspaceFacade<Name> & Partial<Pick<Workspace, "startSession">> = {
+    fs,
+    tools,
+  }
+  const starter = workspaceSessionStarter(workspace)
+  if (starter) {
+    readonlyWorkspace.startSession = async options => await starter.startSession(options)
+  }
+
   return {
     definition: resolvedDefinition,
-    workspace: {
-      fs,
-      tools,
-    },
+    workspace: readonlyWorkspace,
   }
 }
 

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -1156,6 +1156,41 @@ describe("Workspace Source Resolution", () => {
     }
   })
 
+  it("preserves top-level Workspace Session starters on readonly source overlays", async () => {
+    const base = createWorkspace({ name: "support", store: { provider: "memory" } })
+    const startSession = vi.fn(async () => ({ close: vi.fn() }))
+    const scopedFacade = {
+      ...facade(base),
+      startSession,
+    }
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        pullRequest: custom({
+          materialize: "lazy",
+          mount: "pull-request",
+          async getKeys() {
+            return ["body.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "# Pull request\n" }
+          },
+        }),
+      },
+    }
+
+    const { workspace } = await createWorkspaceSourceResolutionFacade(scopedFacade, definition, {
+      invocation,
+      overlay: true,
+    })
+
+    expect(workspace).toHaveProperty("startSession")
+    await (workspace as ReadonlyWorkspaceFacade & { startSession(options?: { paths?: string[] }): Promise<unknown> }).startSession({
+      paths: ["public"],
+    })
+    expect(startSession).toHaveBeenCalledWith({ paths: ["public"] })
+  })
+
   it("starts writable overlay sessions from contributed sources and rules", async () => {
     const base = createWorkspace({ name: "support", store: { provider: "memory" } })
     const definition: WorkspaceDefinition = {


### PR DESCRIPTION
Allows `access({ workspace })` to scope writable harness-backed Workspace Sessions without introducing generic scoped write grants. Scoped workspace facades now preserve a top-level `startSession` wrapper so harness writeback still flows through selected Workspace Scope paths and Workspace rules.

Narrows `pullRequestContext()` automatic access widening to the two generated context files, `context.md` and `context.json`, instead of granting the whole generated mount. Extra review material still needs explicit Sources, source membership, or path grants.