### PR TITLE
fix(agent): surface dev stream progress

### DIFF
--- a/docs/content/docs/reference/runtime-events.md
+++ b/docs/content/docs/reference/runtime-events.md
@@ -55,12 +55,13 @@ An Approval Request is created only when policy requires external approval.
 ## Agent stream events
 
 Agent stream output is package-owned Agent behavior.
-The current event stream includes text deltas, data parts, tool input and result events, approval events, errors, finish events, and usage events.
+The current event stream includes text deltas, data parts, tool input and result events, progress events, approval events, errors, finish events, and usage events.
 
 | Event family | Use |
 | --- | --- |
 | `text-delta` | Stream assistant text. |
-| `tool-call` and `tool-result` | Represent model-facing tool execution. |
+| `tool-call` and `tool-result` | Represent model-facing tool execution. `tool-result.durationMs` can report elapsed tool time. |
+| `progress` | Represent non-tool runtime progress such as `workspace.prepare`. |
 | `approval-request` and `approval-decision` | Represent approval-shaped tool policy. |
 | `error` | Represent recoverable or terminal stream errors. |
 | `finish` | Mark completion. |

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -183,6 +183,10 @@ function optionalMessageId(messageId: string | undefined): { messageId?: string 
   return messageId ? { messageId } : {}
 }
 
+function optionalDurationMs(durationMs: number | undefined): { durationMs?: number } {
+  return durationMs === undefined ? {} : { durationMs }
+}
+
 export function toAgentStreamEvent(chunk: unknown, toolNames?: Map<string, string>): StreamEvent | undefined {
   if (typeof chunk === "string") {
     return { text: chunk, type: "text-delta" }
@@ -214,7 +218,7 @@ export function toAgentStreamEvent(chunk: unknown, toolNames?: Map<string, strin
   }
   if (type === "tool-result" || type === "tool-output-available") {
     const id = String(value.toolCallId ?? value.id)
-    return { error: typeof value.error === "string" ? value.error : undefined, id, ...optionalMessageId(messageId), name: String(value.toolName ?? value.name ?? toolNames?.get(id) ?? "tool"), output: value.output ?? value.result, type: "tool-result" }
+    return { ...optionalDurationMs(readNumber(value, "durationMs", "duration")), error: typeof value.error === "string" ? value.error : undefined, id, ...optionalMessageId(messageId), name: String(value.toolName ?? value.name ?? toolNames?.get(id) ?? "tool"), output: value.output ?? value.result, type: "tool-result" }
   }
   if (type === "tool-error" || type === "tool-output-error") {
     const id = String(value.toolCallId ?? value.id)
@@ -223,7 +227,7 @@ export function toAgentStreamEvent(chunk: unknown, toolNames?: Map<string, strin
       : typeof value.errorText === "string"
         ? value.errorText
         : String(value.error || "Unknown tool error")
-    return { error, id, ...optionalMessageId(messageId), name: String(value.toolName ?? value.name ?? toolNames?.get(id) ?? "tool"), output: value.output ?? value.result, type: "tool-result" }
+    return { ...optionalDurationMs(readNumber(value, "durationMs", "duration")), error, id, ...optionalMessageId(messageId), name: String(value.toolName ?? value.name ?? toolNames?.get(id) ?? "tool"), output: value.output ?? value.result, type: "tool-result" }
   }
   if (type === "approval-request") {
     return { id: String(value.id), input: value.input, ...optionalMessageId(messageId), name: String(value.name || "approval"), reason: typeof value.reason === "string" ? value.reason : undefined, type: "approval-request" }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -80,8 +80,8 @@ interface WorkspaceCommandInput {
 }
 
 const workspaceCommandFeedbackIntervalMs = 15_000
-const workspaceCommandStartedMessage = "[vitehub] Workspace command started; first run may materialize sources.\n"
-const workspaceCommandWaitingMessage = "[vitehub] Workspace command still running; sources may still be materializing.\n"
+const workspaceCommandStartedMessage = "[workspace] command started; first run may materialize sources.\n"
+const workspaceCommandWaitingMessage = "[workspace] command still running; sources may still be materializing.\n"
 
 function startWorkspaceCommandFeedback(context: AgentCliContext): () => void {
   context.stderr.write(workspaceCommandStartedMessage)
@@ -252,6 +252,12 @@ function thinkingFallback(metadata: Record<string, unknown> | undefined): string
 
 function usageNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.trunc(value) : undefined
+}
+
+function formatDurationMs(durationMs: unknown): string | undefined {
+  const finite = usageNumber(durationMs)
+  if (finite === undefined) return
+  return finite < 1000 ? `${finite}ms` : `${(finite / 1000).toFixed(1)}s`
 }
 
 function formatUsageNumber(value: number): string {
@@ -433,7 +439,12 @@ function toolHeader(name: string, input?: unknown, output?: unknown): string {
   return `[tool] ${name}${formattedInput ? ` ${formattedInput}` : ""}`
 }
 
-function writeShellOutput(context: AgentCliContext, output: unknown, error: unknown): boolean {
+function writeToolDuration(context: AgentCliContext, durationMs: unknown): void {
+  const duration = formatDurationMs(durationMs)
+  if (duration) context.stderr.write(`  duration: ${duration}\n`)
+}
+
+function writeShellOutput(context: AgentCliContext, output: unknown, error: unknown, durationMs?: number): boolean {
   if (!isRecord(output)) return false
   const stdout = typeof output.stdout === "string" && output.stdout ? output.stdout : undefined
   const stderr = typeof output.stderr === "string" && output.stderr ? output.stderr : undefined
@@ -441,16 +452,29 @@ function writeShellOutput(context: AgentCliContext, output: unknown, error: unkn
   if (stdout) writeDevText(context, stdout)
   if (stderr) writeDevPayload(context, "stderr", stderr)
   writeDevPayload(context, "error", error)
+  writeToolDuration(context, durationMs)
   context.stderr.write("---\n")
   return true
 }
 
-function writeToolTextOutput(context: AgentCliContext, output: unknown): boolean {
+function writeToolTextOutput(context: AgentCliContext, output: unknown, durationMs?: number): boolean {
   const text = toolTextOutput(output)
   if (!text) return false
   writeDevText(context, text)
+  writeToolDuration(context, durationMs)
   context.stderr.write("---\n")
   return true
+}
+
+function progressTag(phase: string): string {
+  return phase.startsWith("workspace.") ? "workspace" : "internal"
+}
+
+function writeProgress(context: AgentCliContext, event: { data?: Record<string, unknown>, durationMs?: number, label?: string, phase: string, status: "completed" | "failed" | "started" }): void {
+  const duration = formatDurationMs(event.durationMs)
+  const status = event.status === "started" ? "" : ` ${event.status}`
+  context.stderr.write(`\n[${progressTag(event.phase)}] ${event.label || event.phase}${status}${duration ? ` (${duration})` : ""}\n`)
+  if (event.status === "failed") writeDevPayload(context, "error", event.data?.error)
 }
 
 function readOptionValue(args: string[], index: number, flag: string): string {
@@ -863,6 +887,7 @@ async function sendDevMessage(
   let previewSeen = false
   const visibleTools = new Set<string>()
   const visibleToolInputs = new Map<string, string | undefined>()
+  const visibleToolStarts = new Map<string, number>()
   const writeUsageNote = () => {
     if (previewSeen) return
     if (!lastUsageRecord || wroteUsageNote) return
@@ -911,6 +936,7 @@ async function sendDevMessage(
       if (event.type === "tool-call" || event.type === "tool-input-start") {
         clearPendingFallback()
         if (event.type === "tool-input-start" && event.input === undefined) continue
+        visibleToolStarts.set(event.id, visibleToolStarts.get(event.id) ?? Date.now())
         if (!visibleTools.has(event.id)) {
           visibleTools.add(event.id)
           visibleToolInputs.set(event.id, toolCommand(event.name, event.input) ?? formatDevPayload(event.input))
@@ -935,15 +961,24 @@ async function sendDevMessage(
       }
       if (event.type === "tool-result") {
         clearPendingFallback()
+        const startedAt = visibleToolStarts.get(event.id)
+        const durationMs = usageNumber(event.durationMs) ?? (startedAt === undefined ? undefined : Date.now() - startedAt)
         if (!visibleTools.has(event.id)) {
           visibleTools.add(event.id)
           context.stderr.write(`\n${toolHeader(event.name, undefined, event.output)}\n`)
         }
         visibleToolInputs.delete(event.id)
-        if (!writeShellOutput(context, event.output, event.error) && !writeToolTextOutput(context, event.output)) {
+        visibleToolStarts.delete(event.id)
+        if (!writeShellOutput(context, event.output, event.error, durationMs) && !writeToolTextOutput(context, event.output, durationMs)) {
           writeDevPayload(context, "output", event.output)
           writeDevPayload(context, "error", event.error)
+          writeToolDuration(context, durationMs)
         }
+        continue
+      }
+      if (event.type === "progress") {
+        clearPendingFallback()
+        writeProgress(context, event)
         continue
       }
       if (event.type === "usage") {
@@ -1049,6 +1084,7 @@ async function sendDevWorkspaceCommand(
     context.stderr.write("No private Agent Dev Loop command token found. Start the Compatible Vite Development Server first.\n")
     return 1
   }
+  const startedAt = Date.now()
   const stopFeedback = startWorkspaceCommandFeedback(context)
   try {
     const response = await fetchImpl(url, {
@@ -1077,6 +1113,7 @@ async function sendDevWorkspaceCommand(
     const result = await response.json().catch(() => ({})) as { exitCode?: unknown, stderr?: unknown, stdout?: unknown }
     if (typeof result.stdout === "string") context.stdout.write(result.stdout)
     if (typeof result.stderr === "string" && result.stderr) context.stderr.write(result.stderr)
+    context.stderr.write(`[workspace] command completed (${formatDurationMs(Date.now() - startedAt)})\n`)
     return typeof result.exitCode === "number" ? result.exitCode : 0
   }
   catch (error) {

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -10,6 +10,7 @@ export type AgentInvocationStreamEvent =
   | StreamEvent
   | { channelId?: string, effect: AgentChannelDeliveryEffectIntent, run?: AgentRunMetadata, type: "delivery-preview" }
   | { error: string, type: "error" }
+  | { data?: Record<string, unknown>, durationMs?: number, id: string, label?: string, phase: "workspace.prepare", status: "completed" | "failed" | "started", type: "progress" }
   | { agent: string, metadata?: Record<string, unknown>, run?: unknown, trigger?: string, type: "start" }
   | { type: "done" }
 

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -114,7 +114,7 @@ export type StreamEvent =
   | { id?: string, messageId?: string, role?: MessageRole, text: string, type: "text-delta" }
   | { data: unknown, id?: string, messageId?: string, type: "data" }
   | { id: string, input?: unknown, messageId?: string, name: string, type: "tool-call" | "tool-input-start" }
-  | { error?: string, id: string, messageId?: string, name: string, output?: unknown, type: "tool-result" }
+  | { durationMs?: number, error?: string, id: string, messageId?: string, name: string, output?: unknown, type: "tool-result" }
   | { id: string, input?: unknown, messageId?: string, name: string, reason?: string, type: "approval-request" }
   | { approved: boolean, decidedAt?: Date | string, id: string, messageId?: string, reason?: string, type: "approval-decision" }
   | { error: string, id?: string, messageId?: string, recoverable?: boolean, type: "error" }

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -509,6 +509,43 @@ function devRun(agent: string): AgentRunMetadata {
   }
 }
 
+async function streamAgentWithWorkspaceProgress(
+  entry: AgentInvocationStreamEntry,
+  emit: (event: AgentInvocationStreamEvent) => void,
+  signal: AbortSignal,
+  run: () => ReturnType<typeof streamAgent>,
+): ReturnType<typeof streamAgent> {
+  const workspace = agentWorkspaceName(entry)
+  if (!workspace) return await run()
+
+  const startedAt = Date.now()
+  const id = `workspace.prepare:${workspace}`
+  const label = "Preparing workspace"
+  if (!signal.aborted) emit({ data: { workspace }, id, label, phase: "workspace.prepare", status: "started", type: "progress" })
+  try {
+    const output = await run()
+    if (!signal.aborted) emit({ data: { workspace }, durationMs: Date.now() - startedAt, id, label, phase: "workspace.prepare", status: "completed", type: "progress" })
+    return output
+  }
+  catch (error) {
+    if (!signal.aborted) {
+      emit({
+        data: {
+          error: error instanceof Error ? error.message : String(error),
+          workspace,
+        },
+        durationMs: Date.now() - startedAt,
+        id,
+        label,
+        phase: "workspace.prepare",
+        status: "failed",
+        type: "progress",
+      })
+    }
+    throw error
+  }
+}
+
 function exposesCapabilityCli(agent: AgentInput): boolean {
   const cli = (agent as { cli?: { capabilities?: boolean } }).cli
   return cli?.capabilities !== false
@@ -676,9 +713,9 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
         const previewAgent = withDeliveryPreviewChannels(entry.agent, event => {
           if (!signal.aborted) emit(event)
         })
-        output = await streamAgent(previewAgent as never, { ...context, ...(invocation.run ? { run: invocation.run } : {}) } as never, withDevLoopControls(invocation.input, signal, timeout) as never, {
+        output = await streamAgentWithWorkspaceProgress(entry, emit, signal, async () => await streamAgent(previewAgent as never, { ...context, ...(invocation.run ? { run: invocation.run } : {}) } as never, withDevLoopControls(invocation.input, signal, timeout) as never, {
           output: "events",
-        })
+        }))
       }
     }
     else {
@@ -687,7 +724,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
       const previewAgent = withDeliveryPreviewChannels(entry.agent, event => {
         if (!signal.aborted) emit(event)
       })
-      output = await streamAgent(previewAgent as never, context as never, {
+      output = await streamAgentWithWorkspaceProgress(entry, emit, signal, async () => await streamAgent(previewAgent as never, context as never, {
         ...payload,
         abortSignal: signal,
         ...(typeof body.invokerProfileId === "string" && payload?.invokerProfileId === undefined
@@ -695,7 +732,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
           : {}),
         messages: uiMessagesToAgentMessages(messages),
         timeout,
-      }, { output: "events" })
+      }, { output: "events" }))
     }
     for await (const event of streamAgentOutputToEvents(output)) {
       if (signal.aborted) return

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -92,7 +92,8 @@ describe("agent output helpers", () => {
       name: "confirm",
       type: "tool-call",
     })
-    expect(toAgentStreamEvent({ output: 0, toolCallId: "call-1", type: "tool-output-available" }, toolNames)).toEqual({
+    expect(toAgentStreamEvent({ duration: 42, output: 0, toolCallId: "call-1", type: "tool-output-available" }, toolNames)).toEqual({
+      durationMs: 42,
       error: undefined,
       id: "call-1",
       name: "confirm",

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -250,7 +250,8 @@ describe("agent CLI", () => {
 
       expect(exitCode).toBe(0)
       expect(stdout.output()).toBe("ok\n")
-      expect(stderr.output()).toBe(`Loaded payload: ${payloadPath}\n[vitehub] Workspace command started; first run may materialize sources.\n`)
+      expect(stderr.output()).toContain(`Loaded payload: ${payloadPath}\n[workspace] command started; first run may materialize sources.\n`)
+      expect(stderr.output()).toContain("[workspace] command completed")
       const post = fetchAgentStream.mock.calls[1]
       expect(post?.[1]?.headers).toMatchObject({
         [workspaceDevTokenHeader]: token,
@@ -637,17 +638,17 @@ describe("agent CLI", () => {
           { agent: "support", trigger: "chat.message", type: "start" },
           { id: "tool-1", name: "shell", type: "tool-input-start" },
           { id: "tool-1", input: { command: "cat file.md" }, name: "shell", type: "tool-call" },
-          { id: "tool-1", name: "shell", output: { command: "cat file.md", exitCode: 0, stderr: "", stdout: longOutput }, type: "tool-result" },
+          { durationMs: 1200, id: "tool-1", name: "shell", output: { command: "cat file.md", exitCode: 0, stderr: "", stdout: longOutput }, type: "tool-result" },
           { id: "tool-4", input: { cmd: "pnpm test" }, name: "bash", type: "tool-call" },
           { id: "tool-5", input: {}, name: "mcp_nuxt_get_documentation_page", type: "tool-input-start" },
           { id: "tool-5", input: { path: "/docs/4.x/api/composables/use-lazy-fetch" }, name: "mcp_nuxt_get_documentation_page", type: "tool-call" },
           { id: "tool-5", name: "mcp_nuxt_get_documentation_page", output: { content: "useLazyFetch docs" }, type: "tool-result" },
           { id: "tool-8", input: { command: "sleep 10" }, name: "shell", type: "tool-input-start" },
           { id: "tool-6", input: { query: "Agent Dev Loop" }, name: "search_docs", type: "tool-input-start" },
-          { id: "tool-6", name: "search_docs", output: { text: "search result" }, type: "tool-result" },
+          { durationMs: 42, id: "tool-6", name: "search_docs", output: { text: "search result" }, type: "tool-result" },
           { id: "tool-7", input: {}, name: "lookup_doc", type: "tool-call" },
           { id: "tool-7", input: { slug: "final" }, name: "lookup_doc", type: "tool-call" },
-          { id: "tool-7", name: "lookup_doc", output: { text: "lookup result" }, type: "tool-result" },
+          { durationMs: 7, id: "tool-7", name: "lookup_doc", output: { text: "lookup result" }, type: "tool-result" },
           { id: "tool-12", input: { argv: ["purchase-orders"] }, name: "portal", type: "tool-call" },
           { id: "tool-12", input: { argv: ["purchase-orders"], input: { limit: 100, planningGroupId: "demo" }, json: true }, name: "portal", type: "tool-call" },
           { id: "tool-15", input: { argv: ["post"], input: "abc" }, name: "portal", type: "tool-call" },
@@ -684,6 +685,7 @@ describe("agent CLI", () => {
 
     expect(exitCode).toBe(0)
     expect(stderr.output()).toContain("[tool] cat file.md")
+    expect(stderr.output()).toContain("duration: 1.2s")
     expect(stderr.output()).toContain("[tool] pnpm test")
     expect(stderr.output()).not.toContain("[tool] bash")
     expect(stderr.output()).not.toContain("[tool done]")
@@ -691,8 +693,8 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain(`\n[tool] mcp_nuxt_get_documentation_page\n  input: {"path":"/docs/4.x/api/composables/use-lazy-fetch"}\n`)
     expect(stderr.output()).toContain(`output: {"content":"useLazyFetch docs"}`)
     expect(stderr.output()).toContain(`\n[tool] sleep 10\n`)
-    expect(stderr.output()).toContain(`\n[tool] search_docs {"query":"Agent Dev Loop"}\nsearch result\n---\n`)
-    expect(stderr.output()).toContain(`\n[tool] lookup_doc\n  input: {"slug":"final"}\nlookup result\n---\n`)
+    expect(stderr.output()).toContain(`\n[tool] search_docs {"query":"Agent Dev Loop"}\nsearch result\n  duration: 42ms\n---\n`)
+    expect(stderr.output()).toContain(`\n[tool] lookup_doc\n  input: {"slug":"final"}\nlookup result\n  duration: 7ms\n---\n`)
     expect(stderr.output()).not.toContain(`\n[tool] lookup_doc {}\n`)
     expect(stderr.output()).toContain(`\n[tool] portal purchase-orders\n`)
     expect(stderr.output()).toContain(`\n[tool] portal purchase-orders --json --input '{"limit":100,"planningGroupId":"demo"}'\n`)
@@ -716,6 +718,38 @@ describe("agent CLI", () => {
     expect(stderr.output()).not.toContain("[usage]")
     expect(stderr.output().match(/\[tool\] cat file\.md/g)).toHaveLength(1)
     expect(stdout.output()).toContain("done\n\n> [!NOTE]\n> Usage: cost ~$0.000004; 17 tokens: 10 in / 7 out; 3 reasoning tokens; time 2.0s; speed 3.5 tok/s")
+  })
+
+  it("renders Agent Dev Loop workspace progress outside tool output", async () => {
+    const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return ndjson([
+          { agent: "review", trigger: "github.webhook", type: "start" },
+          { id: "workspace.prepare:review", label: "Preparing workspace", phase: "workspace.prepare", status: "started", type: "progress" },
+          { durationMs: 1500, id: "workspace.prepare:review", label: "Preparing workspace", phase: "workspace.prepare", status: "completed", type: "progress" },
+          { type: "finish" },
+          { type: "done" },
+        ])
+      }
+      return Response.json({
+        agents: [{ name: "review", triggers: ["github.webhook"] }],
+        root: "/repo",
+      })
+    })
+    const progressStderr = stream()
+    const exitCodeWithPrompt = await runAgentDevCli(["--agent", "review", "--trigger", "github.webhook", "-p", "/review"], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      spawn: vi.fn(),
+      stderr: progressStderr,
+      stdout: stream(),
+    }, { fetch: fetchAgentStream as never })
+
+    expect(exitCodeWithPrompt).toBe(0)
+    expect(progressStderr.output()).toContain("[workspace] Preparing workspace\n")
+    expect(progressStderr.output()).toContain("[workspace] Preparing workspace completed (1.5s)")
+    expect(progressStderr.output()).not.toContain("[tool] Preparing workspace")
   })
 
   it("adds best-effort pricing to Agent Dev Loop usage notes", async () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1547,6 +1547,8 @@ describe("agent chat capability discovery", () => {
 
       expect(events).toEqual([
         expect.objectContaining({ agent: "review", type: "start" }),
+        expect.objectContaining({ id: "workspace.prepare:summary", phase: "workspace.prepare", status: "started", type: "progress" }),
+        expect.objectContaining({ durationMs: expect.any(Number), id: "workspace.prepare:summary", phase: "workspace.prepare", status: "completed", type: "progress" }),
         { text: "ok", type: "text-delta" },
         { type: "finish" },
         { type: "done" },

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -731,6 +731,8 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
 
     expect(events).toEqual([
       expect.objectContaining({ agent: "review", trigger: "github.webhook", type: "start" }),
+      expect.objectContaining({ id: "workspace.prepare:review", phase: "workspace.prepare", status: "started", type: "progress" }),
+      expect.objectContaining({ durationMs: expect.any(Number), id: "workspace.prepare:review", phase: "workspace.prepare", status: "completed", type: "progress" }),
       { error: "Agent Invocation Stream timed out after 100ms.", type: "error" },
       { type: "done" },
     ])
@@ -813,6 +815,8 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
 
     expect(events).toEqual([
       expect.objectContaining({ agent: "chat", trigger: "chat.message", type: "start" }),
+      expect.objectContaining({ id: "workspace.prepare:chat", phase: "workspace.prepare", status: "started", type: "progress" }),
+      expect.objectContaining({ durationMs: expect.any(Number), id: "workspace.prepare:chat", phase: "workspace.prepare", status: "completed", type: "progress" }),
       { text: "kiwi-714", type: "text-delta" },
       { type: "finish" },
       { type: "done" },
@@ -883,6 +887,8 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
 
     expect(events).toEqual([
       expect.objectContaining({ agent: "review", trigger: "github.webhook", type: "start" }),
+      expect.objectContaining({ id: "workspace.prepare:review", phase: "workspace.prepare", status: "started", type: "progress" }),
+      expect.objectContaining({ durationMs: expect.any(Number), id: "workspace.prepare:review", phase: "workspace.prepare", status: "completed", type: "progress" }),
       { text: "Review completed.", type: "text-delta" },
       { type: "finish" },
       { type: "done" },

--- a/packages/workspace/src/cli.ts
+++ b/packages/workspace/src/cli.ts
@@ -55,14 +55,18 @@ interface WorkspaceDevTarget {
 }
 
 const workspaceCommandFeedbackIntervalMs = 15_000
-const workspaceCommandStartedMessage = "[vitehub] Workspace command started; first run may materialize sources.\n"
-const workspaceCommandWaitingMessage = "[vitehub] Workspace command still running; sources may still be materializing.\n"
+const workspaceCommandStartedMessage = "[workspace] command started; first run may materialize sources.\n"
+const workspaceCommandWaitingMessage = "[workspace] command still running; sources may still be materializing.\n"
 
 function startWorkspaceCommandFeedback(context: WorkspaceCliContext): () => void {
   context.stderr.write(workspaceCommandStartedMessage)
   const timer = setInterval(() => context.stderr.write(workspaceCommandWaitingMessage), workspaceCommandFeedbackIntervalMs)
   timer.unref?.()
   return () => clearInterval(timer)
+}
+
+function formatDurationMs(durationMs: number): string {
+  return durationMs < 1000 ? `${durationMs}ms` : `${(durationMs / 1000).toFixed(1)}s`
 }
 
 function writeWorkspaceDevUsage(context: WorkspaceCliContext): void {
@@ -211,6 +215,7 @@ async function sendWorkspaceCommand(
     context.stderr.write("No private Workspace Dev token found. Start the Compatible Vite Development Server first.\n")
     return 1
   }
+  const startedAt = Date.now()
   const stopFeedback = startWorkspaceCommandFeedback(context)
   try {
     const response = await fetchImpl(target.url, {
@@ -237,6 +242,7 @@ async function sendWorkspaceCommand(
     const result = await response.json().catch(() => ({})) as { exitCode?: unknown, stderr?: unknown, stdout?: unknown }
     if (typeof result.stdout === "string") context.stdout.write(result.stdout)
     if (typeof result.stderr === "string" && result.stderr) context.stderr.write(result.stderr)
+    context.stderr.write(`[workspace] command completed (${formatDurationMs(Date.now() - startedAt)})\n`)
     return typeof result.exitCode === "number" ? result.exitCode : 0
   }
   finally {

--- a/packages/workspace/test/cli.test.ts
+++ b/packages/workspace/test/cli.test.ts
@@ -109,7 +109,8 @@ describe("workspace CLI", () => {
       }, { fetch: fetchWorkspaceDev as never })
 
       expect(exitCode).toBe(0)
-      expect(stderr.output()).toBe("[vitehub] Workspace command started; first run may materialize sources.\n")
+      expect(stderr.output()).toContain("[workspace] command started; first run may materialize sources.\n")
+      expect(stderr.output()).toContain("[workspace] command completed")
       expect(stdout.output()).toBe("ok\n")
       const [get, post] = fetchWorkspaceDev.mock.calls
       expect(String(get?.[0])).toBe("http://127.0.0.1:4321/__vitehub/workspace/dev")


### PR DESCRIPTION
## Summary

- emit narrow `progress` stream events for workspace-backed Agent Dev Loop setup with `phase: "workspace.prepare"`
- render workspace prep as `[workspace] Preparing workspace` instead of a model-facing `[tool]`
- carry `tool-result.durationMs` through stream normalization and render compact tool duration lines in the dev CLI
- show workspace dev command start/wait/complete feedback with elapsed time in both agent and workspace CLIs

## Validation

- evidence-research and validate-direction completed in temp artifacts before hardening the public stream shape
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --filter @vite-hub/agent test`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --filter @vite-hub/workspace test`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --filter @vite-hub/agent typecheck`
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --filter @vite-hub/workspace typecheck`

## Notes

- `progress.phase` is intentionally narrowed to `"workspace.prepare"`; future phases should be validated before widening this public stream event shape.
- This does not touch the access or `pullRequestContext` scope.
