### PR TITLE
fix(agent): label dev stream progress events

### DIFF
--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -467,10 +467,11 @@ function writeToolTextOutput(context: AgentCliContext, output: unknown, duration
 }
 
 function progressTag(phase: string): string {
+  if (phase.startsWith("agent.harness")) return "harness"
   return phase.startsWith("workspace.") ? "workspace" : "internal"
 }
 
-function writeProgress(context: AgentCliContext, event: { data?: Record<string, unknown>, durationMs?: number, label?: string, phase: string, status: "completed" | "failed" | "started" }): void {
+function writeProgress(context: AgentCliContext, event: { data?: Record<string, unknown>, durationMs?: number, label?: string, phase: string, status: "completed" | "failed" | "started" | "updating" }): void {
   const duration = formatDurationMs(event.durationMs)
   const status = event.status === "started" ? "" : ` ${event.status}`
   context.stderr.write(`\n[${progressTag(event.phase)}] ${event.label || event.phase}${status}${duration ? ` (${duration})` : ""}\n`)

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -10,7 +10,7 @@ export type AgentInvocationStreamEvent =
   | StreamEvent
   | { channelId?: string, effect: AgentChannelDeliveryEffectIntent, run?: AgentRunMetadata, type: "delivery-preview" }
   | { error: string, type: "error" }
-  | { data?: Record<string, unknown>, durationMs?: number, id: string, label?: string, phase: "workspace.prepare", status: "completed" | "failed" | "started", type: "progress" }
+  | { data?: Record<string, unknown>, durationMs?: number, id: string, label?: string, phase: "workspace.prepare" | (string & {}), status: "completed" | "failed" | "started" | "updating", type: "progress" }
   | { agent: string, metadata?: Record<string, unknown>, run?: unknown, trigger?: string, type: "start" }
   | { type: "done" }
 

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -158,7 +158,15 @@ function withDeliveryPreviewChannels(
     }]))
     return [channelId, { ...channel, effects }]
   }))
-  return { ...agent, channels } as AgentInput<ViteAgentDevRuntimeContext>
+  const clone = Object.create(Object.getPrototypeOf(agent)) as AgentInput<ViteAgentDevRuntimeContext>
+  Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
+  Object.defineProperty(clone, "channels", {
+    configurable: true,
+    enumerable: true,
+    value: channels,
+    writable: true,
+  })
+  return clone
 }
 
 function formatCliDeliveryPreview(event: Extract<AgentInvocationStreamEvent, { type: "delivery-preview" }>): string {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -727,6 +727,9 @@ describe("agent CLI", () => {
           { agent: "review", trigger: "github.webhook", type: "start" },
           { id: "workspace.prepare:review", label: "Preparing workspace", phase: "workspace.prepare", status: "started", type: "progress" },
           { durationMs: 1500, id: "workspace.prepare:review", label: "Preparing workspace", phase: "workspace.prepare", status: "completed", type: "progress" },
+          { id: "agent.harness:create", label: "Creating harness agent", phase: "agent.harness", status: "started", type: "progress" },
+          { durationMs: 250, id: "agent.harness:create", label: "Creating harness agent", phase: "agent.harness", status: "updating", type: "progress" },
+          { durationMs: 42, id: "runtime.inspect", phase: "runtime.inspect", status: "completed", type: "progress" },
           { type: "finish" },
           { type: "done" },
         ])
@@ -749,7 +752,12 @@ describe("agent CLI", () => {
     expect(exitCodeWithPrompt).toBe(0)
     expect(progressStderr.output()).toContain("[workspace] Preparing workspace\n")
     expect(progressStderr.output()).toContain("[workspace] Preparing workspace completed (1.5s)")
+    expect(progressStderr.output()).toContain("[harness] Creating harness agent\n")
+    expect(progressStderr.output()).toContain("[harness] Creating harness agent updating (250ms)")
+    expect(progressStderr.output()).toContain("[internal] runtime.inspect completed (42ms)")
     expect(progressStderr.output()).not.toContain("[tool] Preparing workspace")
+    expect(progressStderr.output()).not.toContain("[tool] Creating harness agent")
+    expect(progressStderr.output()).not.toContain("[tool] runtime.inspect")
   })
 
   it("adds best-effort pricing to Agent Dev Loop usage notes", async () => {
@@ -845,6 +853,8 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain("url: https://assets.example/login.png")
     expect(stderr.output()).toContain("[delivery preview] would reply on github")
     expect(stderr.output()).toContain("[delivery] remove reaction eyes on github")
+    expect(stderr.output()).not.toContain("[tool] reaction")
+    expect(stderr.output()).not.toContain("[tool] reply")
     expect(stderr.output()).toContain("body: **Summary:** Short review.")
     expect(stderr.output()).toContain("Usage telemetry")
     expect(stderr.output()).toContain("large table")

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -760,6 +760,82 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     ]))
   })
 
+  it("keeps harness driver metadata when wrapping channel streams for delivery previews", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-invocation-stream-harness-preview-metadata-"))
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "review.ts"), "export default {}", "utf8")
+
+    harnessStreamResult.mockReturnValueOnce({
+      fullStream: (async function* () {
+        yield { text: "Scoped review completed.", type: "text-delta" }
+        yield { type: "finish" }
+      })(),
+    })
+
+    const { access } = await import("../src/capabilities.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const agent = defineAgent({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "changed",
+            scopes: {
+              changed: { paths: ["public"] },
+            },
+          },
+        }),
+      ],
+      channels: {
+        github: defineChannel("github", {
+          effects: { reaction: () => {} },
+          messages: false,
+          triggers: {
+            webhook: {
+              invoke: (context, input) => ({
+                input,
+                run: { channelId: context.trigger.channelId, origin: "github-pull-request-comment", runId: "github-run" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: {
+        harness: { provider: "codex" },
+      },
+      workspace: { mode: "write" },
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent({ devtools: false })
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      agent: "review",
+      payload: { prompt: "review" },
+      trigger: "github.webhook",
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    })
+    const events = response.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+
+    expect(events).toEqual([
+      expect.objectContaining({ agent: "review", trigger: "github.webhook", type: "start" }),
+      expect.objectContaining({ id: "workspace.prepare:review", phase: "workspace.prepare", status: "started", type: "progress" }),
+      expect.objectContaining({ durationMs: expect.any(Number), id: "workspace.prepare:review", phase: "workspace.prepare", status: "completed", type: "progress" }),
+      { text: "Scoped review completed.", type: "text-delta" },
+      { type: "finish" },
+      { type: "done" },
+    ])
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+      paths: ["public", "AGENTS.md", "CLAUDE.md"],
+    }))
+  })
+
   it("sends Agent Dev Loop chat history to harness agents over payload fixture messages", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-invocation-stream-harness-history-"))
     await mkdir(join(root, "server", "agents"), { recursive: true })


### PR DESCRIPTION
Labels Agent Dev Loop progress events by stream owner, so workspace, harness, and internal progress render outside `[tool]` output. It also preserves Agent Definition metadata when the invocation stream endpoint wraps Channel effects for delivery previews, keeping harness workspace scope behavior intact.

Adds focused coverage for existing tool duration output, non-tool progress labels, delivery preview labels, and the harness metadata regression.

Dependency note: the broader Workspace materialization/preparation progress callbacks from the source worktree are intentionally excluded because they depend on the Workspace/Source PR.