### PR TITLE
feat(workspace): stream source materialization progress

### DIFF
--- a/packages/source/src/core/types.ts
+++ b/packages/source/src/core/types.ts
@@ -8,6 +8,7 @@ export type ReadSourceResult<TOptions extends ReadSourceOptions | undefined = un
   TOptions extends { encoding: "binary" } ? Uint8Array : string
 
 export interface SourceContext {
+  abortSignal?: AbortSignal
   rootDir: string
   sourceRootDir?: string
   source?: string

--- a/packages/source/src/sources/github/client.ts
+++ b/packages/source/src/sources/github/client.ts
@@ -3,6 +3,7 @@ import { SourceError } from "../../core/errors.ts"
 export async function requestGitHubJson<T>(input: {
   ref: string
   repo: string
+  signal?: AbortSignal
   token?: string
   url: string
 }): Promise<T> {
@@ -13,6 +14,7 @@ export async function requestGitHubJson<T>(input: {
       "user-agent": "vitehub-source",
       "x-github-api-version": "2022-11-28",
     },
+    signal: input.signal,
   })
 
   if (!response.ok) {
@@ -28,6 +30,7 @@ export async function requestGitHubJson<T>(input: {
 export async function fetchGitHubArchive(input: {
   ref: string
   repo: string
+  signal?: AbortSignal
   token?: string
 }) {
   const response = await fetch(`https://codeload.github.com/${input.repo}/tar.gz/${encodeURIComponent(input.ref)}`, {
@@ -35,6 +38,7 @@ export async function fetchGitHubArchive(input: {
       ...(input.token ? { authorization: `Bearer ${input.token}` } : {}),
       "user-agent": "vitehub-source",
     },
+    signal: input.signal,
   })
 
   if (!response.ok) {

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer"
 import { defineCachedFunction } from "ocache"
 
 import { SourceError } from "../../core/errors.ts"
@@ -6,8 +7,8 @@ import { parseGitHubArchive } from "./archive.ts"
 import { createGitHubCacheKey, normalizeGitHubCache } from "./cache.ts"
 import { fetchGitHubArchive, requestGitHubJson } from "./client.ts"
 
-import type { Source } from "../../core/types.ts"
-import type { GitHubCommitResponse, GitHubFile, GitHubRepositoryResponse, GitHubSourceOptions } from "./types.ts"
+import type { Source, SourceContext } from "../../core/types.ts"
+import type { GitHubCommitResponse, GitHubContentResponse, GitHubFile, GitHubRepositoryResponse, GitHubSourceOptions } from "./types.ts"
 
 function normalizeGitHubRoot(path = "") {
   return normalizeSourcePath(path).split("/").filter(part => part && part !== ".").join("/")
@@ -53,19 +54,25 @@ export function github<const TKey extends string = string>(options: GitHubSource
     return normalized.slice(root.length + 1) as TKey
   }
 
+  function repoPathForKey(key: string) {
+    const normalized = normalizeSourcePath(key)
+    return root ? `${root}/${normalized}` : normalized
+  }
+
   function shouldInclude(key: string) {
     if (options.include && !matchesAny(key, options.include)) return false
     if (options.exclude && matchesAny(key, options.exclude)) return false
     return true
   }
 
-  async function resolveRef(token = auth) {
+  async function resolveRef(token = auth, signal?: AbortSignal) {
     if (configuredRef) return configuredRef
 
     try {
       const repo = await requestGitHubJson<GitHubRepositoryResponse>({
         ref: "default",
         repo: options.repo,
+        signal,
         token,
         url: `https://api.github.com/repos/${options.repo}`,
       })
@@ -73,6 +80,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
       const commit = await requestGitHubJson<GitHubCommitResponse>({
         ref: defaultBranch,
         repo: options.repo,
+        signal,
         token,
         url: `https://api.github.com/repos/${options.repo}/commits/${encodeURIComponent(defaultBranch)}`,
       })
@@ -104,13 +112,13 @@ export function github<const TKey extends string = string>(options: GitHubSource
         () => resolveRef(token),
       )
 
-  async function getRef(token = refreshAuth()) {
-    return await cachedResolveRef(token)
+  async function getRef(token = refreshAuth(), signal?: AbortSignal) {
+    return signal ? await resolveRef(token, signal) : await cachedResolveRef(token)
   }
 
-  async function loadArchiveFiles(token = auth) {
-    const ref = await getRef(token)
-    const archive = await fetchGitHubArchive({ ref, repo: options.repo, token })
+  async function loadArchiveFiles(token = auth, signal?: AbortSignal) {
+    const ref = await getRef(token, signal)
+    const archive = await fetchGitHubArchive({ ref, repo: options.repo, signal, token })
     return parseGitHubArchive(archive)
       .map((entry): GitHubFile<TKey> | undefined => {
         const key = keyForRepoPath(entry.path)
@@ -125,8 +133,8 @@ export function github<const TKey extends string = string>(options: GitHubSource
       .filter((file): file is GitHubFile<TKey> => Boolean(file))
   }
 
-  async function loadFiles(token = auth) {
-    return await loadArchiveFiles(token)
+  async function loadFiles(token = auth, signal?: AbortSignal) {
+    return await loadArchiveFiles(token, signal)
   }
 
   const loadedFiles = new Map<string, Promise<GitHubFile<TKey>[]>>()
@@ -147,6 +155,43 @@ export function github<const TKey extends string = string>(options: GitHubSource
 
   function getFiles(token = refreshAuth()) {
     return cachedLoadFiles(token)
+  }
+
+  async function loadFile(key: TKey, token = auth, signal?: AbortSignal): Promise<GitHubFile<TKey>> {
+    const normalizedKey = normalizeSourcePath(key) as TKey
+    if (!normalizedKey || !shouldInclude(normalizedKey)) {
+      throw new SourceError(`[vitehub] github(${JSON.stringify(options.repo)}) could not find ${JSON.stringify(key)}.`)
+    }
+    const ref = await getRef(token, signal)
+    const repoPath = repoPathForKey(normalizedKey)
+    const file = await requestGitHubJson<GitHubContentResponse | GitHubContentResponse[]>({
+      ref,
+      repo: options.repo,
+      signal,
+      token,
+      url: `https://api.github.com/repos/${options.repo}/contents/${encodeURIComponent(repoPath).replace(/%2F/g, "/")}?ref=${encodeURIComponent(ref)}`,
+    })
+    if (Array.isArray(file) || file.type === "dir") {
+      throw new SourceError(`[vitehub] github(${JSON.stringify(options.repo)}) expected ${JSON.stringify(key)} to be a file, but it is a directory.`)
+    }
+    if (file.encoding !== "base64" || typeof file.content !== "string") {
+      throw new SourceError(`[vitehub] github(${JSON.stringify(options.repo)}) did not include file content for ${JSON.stringify(key)}.`)
+    }
+    return {
+      content: new Uint8Array(Buffer.from(file.content.replace(/\s/g, ""), "base64")),
+      key: normalizedKey,
+      path: normalizedKey,
+      sha: file.sha || ref,
+    }
+  }
+
+  async function getFile(key: TKey, ctx?: SourceContext, token = refreshAuth()) {
+    if (ctx?.abortSignal) return await loadFile(key, token, ctx.abortSignal)
+    const file = (await getFiles(token)).find(file => file.key === key)
+    if (!file) {
+      throw new SourceError(`[vitehub] github(${JSON.stringify(options.repo)}) could not find ${JSON.stringify(key)}.`)
+    }
+    return file
   }
 
   function fetchContent(key: TKey, file: GitHubFile<TKey>) {
@@ -193,27 +238,26 @@ export function github<const TKey extends string = string>(options: GitHubSource
         },
       })))
     },
-    async getMeta(key) {
+    async getMeta(key, ctx) {
       const token = refreshAuth()
-      const file = (await getFiles(token)).find(file => file.key === key)
+      const file = ctx?.abortSignal
+        ? await loadFile(key, token, ctx.abortSignal).catch(() => undefined)
+        : (await getFiles(token)).find(file => file.key === key)
       if (!file) return
       return {
-        ref: await getRef(token),
+        ref: await getRef(token, ctx?.abortSignal),
         sha: file.sha,
       }
     },
-    async getItem(key) {
+    async getItem(key, ctx) {
       const token = refreshAuth()
-      const file = (await getFiles(token)).find(file => file.key === key)
-      if (!file) {
-        throw new SourceError(`[vitehub] github(${JSON.stringify(options.repo)}) could not find ${JSON.stringify(key)}.`)
-      }
+      const file = await getFile(key, ctx, token)
       return {
-        key,
+        key: file.key,
         path: file.path,
         content: await fetchContent(key, file),
         metadata: {
-          ref: await getRef(token),
+          ref: await getRef(token, ctx?.abortSignal),
           sha: file.sha,
         },
       }

--- a/packages/source/src/sources/github/types.ts
+++ b/packages/source/src/sources/github/types.ts
@@ -25,6 +25,14 @@ export interface GitHubFile<TKey extends string = string> {
   sha: string | undefined
 }
 
+export interface GitHubContentResponse {
+  content?: string
+  encoding?: string
+  path?: string
+  sha?: string
+  type?: "dir" | "file" | string
+}
+
 export interface GitHubArchiveFile {
   content: Uint8Array
   path: string

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -89,6 +89,28 @@ describe("@vite-hub/source GitHub source", () => {
     await expect(useSource("dbt").read("models/marts/orders.sql")).resolves.toBe("select 1\n")
   })
 
+  it("reads a single GitHub file through the contents API without downloading the archive", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+      "docs/guide.md": "# Guide\n",
+    })
+
+    const docs = github({ repo: "acme/app", root: "docs" })
+
+    await expect(docs.getItem("README.md", {
+      abortSignal: new AbortController().signal,
+      rootDir: process.cwd(),
+    })).resolves.toMatchObject({
+      content: new TextEncoder().encode("# Docs\n"),
+      key: "README.md",
+    })
+
+    const archiveCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))
+    const contentsCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).includes("/contents/docs/README.md"))
+    expect(archiveCalls).toHaveLength(0)
+    expect(contentsCalls).toHaveLength(1)
+  })
+
   it("reads non-ASCII paths from GitHub archive PAX headers", async () => {
     stubGitHubSource({
       "docs/café.md": "# Café\n",

--- a/packages/workspace/src/cli.ts
+++ b/packages/workspace/src/cli.ts
@@ -54,6 +54,26 @@ interface WorkspaceDevTarget {
   url: string
 }
 
+interface WorkspaceDevProgressEvent {
+  data?: Record<string, unknown>
+  durationMs?: number
+  error?: string
+  id: string
+  label: string
+  status: "started" | "updating" | "completed" | "failed"
+}
+
+type WorkspaceDevStreamLine =
+  | { event?: WorkspaceDevProgressEvent, type?: "progress" }
+  | { result?: WorkspaceDevCommandResult, type?: "result" }
+  | { error?: string, type?: "error" }
+
+interface WorkspaceDevCommandResult {
+  exitCode?: unknown
+  stderr?: unknown
+  stdout?: unknown
+}
+
 const workspaceCommandFeedbackIntervalMs = 15_000
 const workspaceCommandStartedMessage = "[workspace] command started; first run may materialize sources.\n"
 const workspaceCommandWaitingMessage = "[workspace] command still running; sources may still be materializing.\n"
@@ -67,6 +87,71 @@ function startWorkspaceCommandFeedback(context: WorkspaceCliContext): () => void
 
 function formatDurationMs(durationMs: number): string {
   return durationMs < 1000 ? `${durationMs}ms` : `${(durationMs / 1000).toFixed(1)}s`
+}
+
+function workspaceDevDataNumber(event: WorkspaceDevProgressEvent, key: string): number | undefined {
+  const value = event.data?.[key]
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function writeWorkspaceDevProgress(context: WorkspaceCliContext, event: WorkspaceDevProgressEvent): void {
+  const duration = typeof event.durationMs === "number" ? ` (${formatDurationMs(event.durationMs)})` : ""
+  if (event.status === "started") {
+    context.stderr.write(`[workspace] ${event.label}...\n`)
+    return
+  }
+  if (event.status === "updating") {
+    const files = workspaceDevDataNumber(event, "files")
+    const bytes = workspaceDevDataNumber(event, "bytes")
+    const detail = files === undefined ? "" : `: ${files} file${files === 1 ? "" : "s"}${bytes === undefined ? "" : `, ${bytes} bytes`}`
+    context.stderr.write(`[workspace] ${event.label}${detail}\n`)
+    return
+  }
+  if (event.status === "failed") {
+    context.stderr.write(`[workspace] ${event.label} failed${duration}${event.error ? `: ${event.error}` : ""}\n`)
+    return
+  }
+  context.stderr.write(`[workspace] ${event.label} completed${duration}\n`)
+}
+
+function isWorkspaceDevStream(response: Response): boolean {
+  return response.headers.get("content-type")?.toLowerCase().includes("application/x-ndjson") === true
+}
+
+function handleWorkspaceDevStreamLine(line: string, context: WorkspaceCliContext): WorkspaceDevCommandResult | undefined {
+  const parsed = JSON.parse(line) as WorkspaceDevStreamLine
+  if (parsed.type === "progress" && parsed.event) {
+    writeWorkspaceDevProgress(context, parsed.event)
+    return
+  }
+  if (parsed.type === "error") {
+    context.stderr.write(`${parsed.error || "Workspace Dev command failed."}\n`)
+    return { exitCode: 1, stderr: "", stdout: "" }
+  }
+  if (parsed.type === "result") return parsed.result || {}
+}
+
+async function readWorkspaceDevStream(response: Response, context: WorkspaceCliContext): Promise<WorkspaceDevCommandResult> {
+  const reader = response.body?.getReader()
+  if (!reader) return {}
+  const decoder = new TextDecoder()
+  let buffer = ""
+  let result: WorkspaceDevCommandResult | undefined
+  for (;;) {
+    const { done, value } = await reader.read()
+    buffer += decoder.decode(value, { stream: !done })
+    let newline = buffer.indexOf("\n")
+    while (newline >= 0) {
+      const line = buffer.slice(0, newline).trim()
+      buffer = buffer.slice(newline + 1)
+      if (line) result = handleWorkspaceDevStreamLine(line, context) ?? result
+      newline = buffer.indexOf("\n")
+    }
+    if (done) break
+  }
+  const line = buffer.trim()
+  if (line) result = handleWorkspaceDevStreamLine(line, context) ?? result
+  return result || {}
 }
 
 function writeWorkspaceDevUsage(context: WorkspaceCliContext): void {
@@ -229,6 +314,7 @@ async function sendWorkspaceCommand(
         },
       }),
       headers: {
+        accept: "application/x-ndjson, application/json",
         "content-type": "application/json",
         [workspaceDevHeader]: workspaceDevHeaderValue,
         [workspaceDevTokenHeader]: token,
@@ -239,7 +325,10 @@ async function sendWorkspaceCommand(
       context.stderr.write(`${await response.text()}\n`)
       return 1
     }
-    const result = await response.json().catch(() => ({})) as { exitCode?: unknown, stderr?: unknown, stdout?: unknown }
+    if (isWorkspaceDevStream(response)) stopFeedback()
+    const result = isWorkspaceDevStream(response)
+      ? await readWorkspaceDevStream(response, context)
+      : await response.json().catch(() => ({})) as WorkspaceDevCommandResult
     if (typeof result.stdout === "string") context.stdout.write(result.stdout)
     if (typeof result.stderr === "string" && result.stderr) context.stderr.write(result.stderr)
     context.stderr.write(`[workspace] command completed (${formatDurationMs(Date.now() - startedAt)})\n`)

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -297,6 +297,7 @@ export interface SourceContextWorkspaceFiles {
 }
 
 export interface SourceContext {
+  abortSignal?: AbortSignal
   mountPath?: string
   rootDir: string
   selectedWorkspaceScope?: WorkspaceSelectedScope
@@ -699,9 +700,32 @@ export interface WorkspaceSourceMaterializationStatus {
   error?: string
 }
 
+export interface WorkspaceMaterializeSourcesProgressEvent {
+  bytes?: number
+  directories?: number
+  durationMs?: number
+  error?: string
+  files?: number
+  mountPath: string
+  path: string
+  source: string
+  status: "started" | "updating" | "completed" | "failed"
+}
+
 export interface WorkspaceMaterializeSourcesOptions {
+  abortSignal?: AbortSignal
+  onProgress?: (event: WorkspaceMaterializeSourcesProgressEvent) => void | Promise<void>
   sources?: string[]
   path?: string
+}
+
+export interface WorkspacePrepareSessionProgressEvent {
+  data?: Record<string, unknown>
+  durationMs?: number
+  error?: string
+  id: string
+  label: string
+  status: "started" | "updating" | "completed" | "failed"
 }
 
 export interface WorkspaceMaterializeSourcesResult {

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -132,6 +132,11 @@ function validateWorkspaceDevRequest(server: ViteDevServer, req: IncomingMessage
   }
 }
 
+function acceptsWorkspaceDevStream(req: IncomingMessage): boolean {
+  const accept = Array.isArray(req.headers.accept) ? req.headers.accept.join(",") : req.headers.accept
+  return Boolean(accept?.includes("application/x-ndjson"))
+}
+
 async function readRequestBody(req: IncomingMessage): Promise<string> {
   let body = ""
   req.setEncoding("utf8")
@@ -172,6 +177,34 @@ async function writeResponse(res: ServerResponse, response: Response): Promise<v
 
 function isWorkspaceDevRoute(req: IncomingMessage): boolean {
   return new URL(req.url || "/", "http://localhost").pathname === workspaceDevRoute
+}
+
+function streamWorkspaceDevCommand(input: Parameters<typeof runWorkspaceDevCommand>[0]): Response {
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream({
+    async start(controller) {
+      const write = (value: unknown) => controller.enqueue(encoder.encode(`${JSON.stringify(value)}\n`))
+      try {
+        const result = await runWorkspaceDevCommand({
+          ...input,
+          onProgress: async event => write({ event, type: "progress" }),
+        })
+        write({ result, type: "result" })
+      }
+      catch (error) {
+        write({ error: error instanceof Error ? error.message : String(error), type: "error" })
+      }
+      finally {
+        controller.close()
+      }
+    },
+  })
+  return new Response(stream, {
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "application/x-ndjson; charset=utf-8",
+    },
+  })
 }
 
 async function handleWorkspaceDevRequest(server: ViteDevServer, req: IncomingMessage, workspaces: Array<{ name: string }>, tokenOptions: WorkspaceDevTokenOptions, abortSignal?: AbortSignal): Promise<Response> {
@@ -215,7 +248,7 @@ async function handleWorkspaceDevRequest(server: ViteDevServer, req: IncomingMes
   const args = command.args as string[] | undefined
   const paths = command.paths as string[] | undefined
   const timeout = typeof command.timeout === "number" && Number.isFinite(command.timeout) ? command.timeout : undefined
-  return Response.json(await runWorkspaceDevCommand({
+  const input = {
     abortSignal,
     ...(args ? { args } : {}),
     command: command.command,
@@ -223,7 +256,10 @@ async function handleWorkspaceDevRequest(server: ViteDevServer, req: IncomingMes
     ...(paths?.length ? { paths } : {}),
     ...(timeout ? { timeout } : {}),
     workspace: command.workspace,
-  }))
+  }
+  return acceptsWorkspaceDevStream(req)
+    ? streamWorkspaceDevCommand(input)
+    : Response.json(await runWorkspaceDevCommand(input))
 }
 
 function hasNitroPlugin(value: unknown): boolean {

--- a/packages/workspace/src/server.ts
+++ b/packages/workspace/src/server.ts
@@ -8,7 +8,7 @@ import { useWorkspace } from "./core/use.ts"
 
 import type { H3Event } from "h3"
 import type { ReadonlyWorkspaceFacade, WritableWorkspaceFacade } from "./core/use.ts"
-import type { ExecResult, WorkspaceDefinition, WorkspaceName, WorkspaceSession, WorkspaceSessionOptions } from "./core/types.ts"
+import type { ExecResult, WorkspaceDefinition, WorkspaceMaterializeSourcesOptions, WorkspaceName, WorkspacePrepareSessionProgressEvent, WorkspaceSession, WorkspaceSessionOptions } from "./core/types.ts"
 
 export const workspaceDevRoute = "/__vitehub/workspace/dev"
 export const workspaceDevHeader = "x-vitehub-workspace-dev"
@@ -23,6 +23,8 @@ type WorkspaceInput<Name extends WorkspaceName> =
 type WorkspaceSessionStarter = {
   startSession(options?: WorkspaceSessionOptions): Promise<WorkspaceSession>
 }
+type WorkspaceSourceMaterializer = (options?: WorkspaceMaterializeSourcesOptions) => Promise<unknown>
+type WorkspaceWithMaterializeSources = { materializeSources?: WorkspaceSourceMaterializer }
 type ResponseBody = ConstructorParameters<typeof Response>[0]
 type ResponseHeaders = ConstructorParameters<typeof Headers>[0]
 
@@ -52,6 +54,7 @@ export interface WorkspaceDevCommandInput<Name extends WorkspaceName = Workspace
   args?: string[]
   command: string
   definition?: WorkspaceDefinition
+  onProgress?: (event: WorkspacePrepareSessionProgressEvent) => void | Promise<void>
   paths?: readonly string[]
   timeout?: number
   workspace: Name | WritableWorkspaceFacade<Name> | (ReadonlyWorkspaceFacade<Name> & { fs: ReadonlyWorkspaceFacade<Name>["fs"] & Partial<WorkspaceSessionStarter> })
@@ -175,6 +178,70 @@ function workspaceSessionStarter(input: unknown): WorkspaceSessionStarter | unde
     : undefined
 }
 
+function workspaceSourceMaterializer(input: unknown): WorkspaceSourceMaterializer | undefined {
+  return input && typeof input === "object" && typeof (input as WorkspaceWithMaterializeSources).materializeSources === "function"
+    ? (input as WorkspaceWithMaterializeSources).materializeSources!.bind(input)
+    : undefined
+}
+
+async function withWorkspaceDevProgress<T>(
+  onProgress: WorkspaceDevCommandInput["onProgress"] | undefined,
+  event: Pick<WorkspacePrepareSessionProgressEvent, "id" | "label"> & { data?: Record<string, unknown> },
+  fn: () => Promise<T>,
+): Promise<T> {
+  const startedAt = Date.now()
+  await onProgress?.({ data: event.data, id: event.id, label: event.label, status: "started" })
+  try {
+    const result = await fn()
+    await onProgress?.({ data: event.data, durationMs: Date.now() - startedAt, id: event.id, label: event.label, status: "completed" })
+    return result
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    await onProgress?.({
+      data: { ...event.data, error: message },
+      durationMs: Date.now() - startedAt,
+      error: message,
+      id: event.id,
+      label: event.label,
+      status: "failed",
+    })
+    throw error
+  }
+}
+
+async function materializeWorkspaceDevSources(
+  workspace: Awaited<ReturnType<typeof resolveWorkspace>>,
+  input: WorkspaceDevCommandInput,
+) {
+  const materialize = workspaceSourceMaterializer(workspace) ?? workspaceSourceMaterializer(workspace.fs)
+  if (!materialize) return
+  const paths = input.paths?.length ? input.paths : [""]
+  await withWorkspaceDevProgress(input.onProgress, {
+    data: { paths },
+    id: "workspace.dev.materialize",
+    label: "Materializing workspace sources",
+  }, async () => {
+    await Promise.all(paths.map(async (path) => {
+      await materialize({
+        abortSignal: input.abortSignal,
+        onProgress: async event => await input.onProgress?.({
+          data: { ...event },
+          durationMs: event.durationMs,
+          error: event.error,
+          id: `workspace.dev.materialize.${event.source}`,
+          label: `Materializing source ${event.source}`,
+          status: event.status,
+        }),
+        path,
+      }).catch((error) => {
+        if (path && isNotFoundError(error)) return
+        throw error
+      })
+    }))
+  })
+}
+
 export async function readWorkspaceFileResponse<Name extends WorkspaceName>(
   options: WorkspaceFileResponseOptions<Name>,
 ): Promise<Response> {
@@ -241,7 +308,12 @@ export async function runWorkspaceDevCommand<Name extends WorkspaceName>(
   const starter = workspaceSessionStarter(workspace) ?? workspaceSessionStarter(workspace.fs)
   const startSession = starter?.startSession.bind(starter)
   if (!startSession) throw new Error("Workspace Dev command requires a Workspace Session.")
-  const session = await startSession(input.paths ? { paths: input.paths } : undefined)
+  await materializeWorkspaceDevSources(workspace, input)
+  const session = await withWorkspaceDevProgress(input.onProgress, {
+    data: { paths: input.paths ?? null },
+    id: "workspace.dev.start-session",
+    label: "Starting workspace session",
+  }, async () => await startSession(input.paths ? { paths: input.paths } : undefined))
   const execOptions = { abortSignal: input.abortSignal, timeout: input.timeout }
   try {
     const result = input.args

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -14,6 +14,8 @@ import type {
   WorkspaceDefinition,
   WorkspaceDiff,
   WorkspaceEntry,
+  WorkspaceMaterializeSourcesOptions,
+  WorkspacePrepareSessionProgressEvent,
   WorkspaceSession,
   WorkspaceSessionOptions,
 } from "../core/types.ts"
@@ -33,6 +35,8 @@ export interface PrepareHarnessWorkspaceSessionOptions {
   commit?: (diff: WorkspaceDiff) => { message?: string } | false | null | undefined
   definition?: WorkspaceDefinition
   ignoreWriteBackPaths?: readonly string[]
+  onMaterializeProgress?: WorkspaceMaterializeSourcesOptions["onProgress"]
+  onProgress?: (event: WorkspacePrepareSessionProgressEvent) => void | Promise<void>
   paths?: readonly string[]
   session: HarnessSandboxSession
   sessionWorkDir: string
@@ -45,8 +49,9 @@ type InitialTree = {
   directories: Set<string>
   files: Map<string, InitialFile>
 }
-type SourceMaterializer = (options?: { path?: string }) => Promise<unknown>
+type SourceMaterializer = (options?: WorkspaceMaterializeSourcesOptions) => Promise<unknown>
 type WorkspaceFsWithSources = { materializeSources?: SourceMaterializer }
+type PrepareProgressReporter = PrepareHarnessWorkspaceSessionOptions["onProgress"]
 const archivePath = ".vitehub-workspace.tar.gz"
 const tarBlockSize = 512
 const workspaceReadConcurrency = 16
@@ -102,6 +107,40 @@ async function runSandbox(
   return result
 }
 
+async function withPrepareProgress<T>(
+  onProgress: PrepareProgressReporter | undefined,
+  event: Pick<WorkspacePrepareSessionProgressEvent, "id" | "label"> & { data?: Record<string, unknown> },
+  fn: () => Promise<T>,
+): Promise<T> {
+  const startedAt = Date.now()
+  await onProgress?.({ data: event.data, id: event.id, label: event.label, status: "started" })
+  try {
+    const result = await fn()
+    await onProgress?.({
+      data: event.data,
+      durationMs: Date.now() - startedAt,
+      id: event.id,
+      label: event.label,
+      status: "completed",
+    })
+    return result
+  }
+  catch (error) {
+    await onProgress?.({
+      data: {
+        ...event.data,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      durationMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+      id: event.id,
+      label: event.label,
+      status: "failed",
+    })
+    throw error
+  }
+}
+
 function workspaceFiles(entries: WorkspaceEntry[]) {
   return entries
     .filter(entry => entry.type === "file")
@@ -149,13 +188,17 @@ async function workspaceEntries(workspace: WorkspaceFacade, paths: string[] | un
   return [...entries.values()].sort((left, right) => left.path.localeCompare(right.path))
 }
 
-async function materializeWorkspaceSourcesForSession(workspace: WorkspaceFacade, paths: string[] | undefined) {
+async function materializeWorkspaceSourcesForSession(
+  workspace: WorkspaceFacade,
+  paths: string[] | undefined,
+  options: Pick<WorkspaceMaterializeSourcesOptions, "abortSignal" | "onProgress"> = {},
+) {
   const materialize = workspaceSourceMaterializer(workspace)
   if (!materialize) return
 
   if (paths && !paths.length) return
   await Promise.all((paths || [""]).map(async (path) => {
-    await materialize({ path }).catch((error) => {
+    await materialize({ ...options, path }).catch((error) => {
       if (path && isMissingWorkspacePathError(error)) return
       throw error
     })
@@ -329,9 +372,24 @@ async function copyWorkspaceToSandbox(
   sessionWorkDir: string,
   abortSignal: AbortSignal | undefined,
   paths: string[] | undefined,
+  onMaterializeProgress: WorkspaceMaterializeSourcesOptions["onProgress"] | undefined,
+  onProgress: PrepareProgressReporter | undefined,
 ) {
-  await materializeWorkspaceSourcesForSession(workspace, paths)
-  const entries = await workspaceEntries(workspace, paths)
+  await withPrepareProgress(onProgress, {
+    data: { paths: paths ?? null },
+    id: "workspace.prepare.materialize",
+    label: "Materializing workspace sources",
+  }, async () => {
+    await materializeWorkspaceSourcesForSession(workspace, paths, {
+      ...(abortSignal ? { abortSignal } : {}),
+      ...(onMaterializeProgress ? { onProgress: onMaterializeProgress } : {}),
+    })
+  })
+  const entries = await withPrepareProgress(onProgress, {
+    data: { paths: paths ?? null },
+    id: "workspace.prepare.entries",
+    label: "Resolving workspace entries",
+  }, async () => await workspaceEntries(workspace, paths))
   const directoriesToCreate = new Set(workspaceDirectories(entries))
   const initialTree: InitialTree = {
     archiveDirectories: directoriesToCreate,
@@ -340,19 +398,36 @@ async function copyWorkspaceToSandbox(
   }
   const files = workspaceFiles(entries)
   for (const entry of files) addParentDirectories(directoriesToCreate, entry.path)
-  await forEachConcurrent(files, workspaceReadConcurrency, async (entry) => {
-    const content = await workspace.fs.readFile(entry.path, { encoding: "binary" })
-    const bytes = contentToBytes(content)
-    initialTree.files.set(entry.path, {
-      content: bytes,
-      mediaType: entry.mediaType,
-      symlinkTarget: entry.metadata?.gitMode === "120000"
-        ? typeof entry.metadata.symlinkTarget === "string" ? entry.metadata.symlinkTarget : new TextDecoder().decode(bytes)
-        : undefined,
+  await withPrepareProgress(onProgress, {
+    data: { files: files.length },
+    id: "workspace.prepare.read-files",
+    label: "Reading workspace files",
+  }, async () => {
+    await forEachConcurrent(files, workspaceReadConcurrency, async (entry) => {
+      const content = await workspace.fs.readFile(entry.path, { encoding: "binary" })
+      const bytes = contentToBytes(content)
+      initialTree.files.set(entry.path, {
+        content: bytes,
+        mediaType: entry.mediaType,
+        symlinkTarget: entry.metadata?.gitMode === "120000"
+          ? typeof entry.metadata.symlinkTarget === "string" ? entry.metadata.symlinkTarget : new TextDecoder().decode(bytes)
+          : undefined,
+      })
     })
   })
-  await resetSandboxWorkDir(sandbox, sessionWorkDir, abortSignal)
-  await extractWorkspaceArchive(sandbox, sessionWorkDir, initialTree, directoriesToCreate, abortSignal)
+  await withPrepareProgress(onProgress, {
+    id: "workspace.prepare.reset-sandbox",
+    label: "Resetting sandbox workspace",
+  }, async () => {
+    await resetSandboxWorkDir(sandbox, sessionWorkDir, abortSignal)
+  })
+  await withPrepareProgress(onProgress, {
+    data: { directories: directoriesToCreate.size, files: initialTree.files.size },
+    id: "workspace.prepare.extract-archive",
+    label: "Extracting workspace archive",
+  }, async () => {
+    await extractWorkspaceArchive(sandbox, sessionWorkDir, initialTree, directoriesToCreate, abortSignal)
+  })
   return initialTree
 }
 
@@ -426,10 +501,14 @@ export async function prepareHarnessWorkspaceSession(
 ): Promise<HarnessWorkspaceSession> {
   const paths = normalizeSessionPaths(options.paths)
   const ignoreWriteBackPaths = new Set((options.ignoreWriteBackPaths || []).map(normalizeHarnessWorkspacePath))
-  const initialTree = await copyWorkspaceToSandbox(workspace, options.session, options.sessionWorkDir, options.abortSignal, paths)
+  const initialTree = await copyWorkspaceToSandbox(workspace, options.session, options.sessionWorkDir, options.abortSignal, paths, options.onMaterializeProgress, options.onProgress)
   const sessionOptions: WorkspaceSessionOptions | undefined = paths ? { paths } : undefined
   const workspaceSession = isWritableWorkspaceFacade(workspace) && (paths === undefined || paths.length)
-    ? await workspace.startSession(sessionOptions)
+    ? await withPrepareProgress(options.onProgress, {
+        data: { paths: paths ?? null },
+        id: "workspace.prepare.start-session",
+        label: "Starting workspace write session",
+      }, async () => await workspace.startSession(sessionOptions))
     : undefined
 
   return {

--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -67,9 +67,10 @@ export function createSourceContext(
   definition: WorkspaceDefinition,
   source?: { key: string, mountPath: string },
   store?: WorkspaceStore,
-  options: { selectedWorkspaceScope?: WorkspaceSelectedScope } = {},
+  options: { abortSignal?: AbortSignal, selectedWorkspaceScope?: WorkspaceSelectedScope } = {},
 ): SourceContext {
   return {
+    abortSignal: options.abortSignal,
     mountPath: source?.mountPath,
     rootDir: definition.rootDir || process.cwd(),
     selectedWorkspaceScope: options.selectedWorkspaceScope,

--- a/packages/workspace/src/sources/materialization.ts
+++ b/packages/workspace/src/sources/materialization.ts
@@ -22,6 +22,7 @@ import type {
   WorkspaceStore,
   WorkspaceDefinition,
   WorkspaceMaterializeSourcesOptions,
+  WorkspaceMaterializeSourcesProgressEvent,
   WorkspaceMaterializeSourcesResult,
   WorkspaceSourceMaterializationStatus,
 } from "../core/types.ts"
@@ -132,6 +133,42 @@ function shouldMaterializeSource(source: ResolvedWorkspaceSource, options: Works
   return source.materialize === "build" && Boolean(options?.path)
 }
 
+function throwIfAborted(signal: AbortSignal | undefined) {
+  if (!signal?.aborted) return
+  throw signal.reason instanceof Error
+    ? signal.reason
+    : new WorkspaceError("[vitehub] Workspace source materialization aborted.")
+}
+
+async function reportMaterializationProgress(
+  options: WorkspaceMaterializeSourcesOptions | undefined,
+  source: ResolvedWorkspaceSource,
+  event: Omit<WorkspaceMaterializeSourcesProgressEvent, "mountPath" | "path" | "source">,
+) {
+  await options?.onProgress?.({
+    ...event,
+    mountPath: source.mountPath,
+    path: normalizeWorkspacePath(options?.path || ""),
+    source: source.key,
+  })
+}
+
+function shouldReportMaterializationUpdate(lastReportedAt: number, files: number) {
+  return files === 1 || files % 25 === 0 || Date.now() - lastReportedAt >= 1_000
+}
+
+function looksLikeConcreteFilePath(path: string) {
+  const name = posix.basename(path)
+  return name.includes(".") || ["Dockerfile", "LICENSE", "Makefile", "Procfile", "README"].includes(name)
+}
+
+function directMaterializationSourceKey(source: ResolvedWorkspaceSource, options: WorkspaceMaterializeSourcesOptions | undefined): string | undefined {
+  const requested = normalizeWorkspacePath(options?.path || "")
+  if (!requested || !sourceMountContainsPath(source, requested) || requested === source.mountPath) return
+  const sourcePath = source.mountPath ? requested.slice(source.mountPath.length + 1) : requested
+  return sourcePath && looksLikeConcreteFilePath(sourcePath) ? sourcePath : undefined
+}
+
 function parentDirectoryPaths(path: string) {
   const parts = normalizeWorkspacePath(path).split("/").filter(Boolean)
   const paths: string[] = []
@@ -222,6 +259,13 @@ async function* iterateMaterializationEntries(
   configHash: string,
   options: WorkspaceMaterializeSourcesOptions | undefined,
 ): AsyncGenerator<MaterializationEntry> {
+  const directKey = directMaterializationSourceKey(source, options)
+  if (directKey) {
+    const entry = createMaterializationEntry(source, await source.source.getItem(directKey, ctx), undefined)
+    if (materializationPathMatches(entry.path, options)) yield entry
+    return
+  }
+
   if (source.source.getItems) {
     for await (const item of iterateSourceItems(source, ctx)) {
       const entry = createMaterializationEntry(source, item, await source.source.getMeta?.(item.key, ctx))
@@ -264,6 +308,9 @@ export async function materializeWorkspaceSources(
   let bytes = 0
 
   for (const source of sources) {
+    throwIfAborted(options.abortSignal)
+    const sourceStarted = Date.now()
+    await reportMaterializationProgress(options, source, { status: "started" })
     const configHash = await sourceConfigHash(source)
     const existing = await readSourceSnapshotMetadata(store, source.key)
     const completeSource = materializesCompleteSource(source, options)
@@ -279,6 +326,12 @@ export async function materializeWorkspaceSources(
       })
       files += existing?.files || 0
       bytes += existing?.bytes || 0
+      await reportMaterializationProgress(options, source, {
+        bytes: existing?.bytes || 0,
+        durationMs: Date.now() - sourceStarted,
+        files: existing?.files || 0,
+        status: "completed",
+      })
       continue
     }
 
@@ -298,9 +351,12 @@ export async function materializeWorkspaceSources(
 
     let sourceFiles = 0
     let sourceBytes = 0
+    let lastProgressAt = 0
     try {
-      const ctx = createSourceContext(definition, source, store)
+      const ctx = createSourceContext(definition, source, store, { abortSignal: options.abortSignal })
+      throwIfAborted(options.abortSignal)
       await source.source.prepare?.(ctx)
+      throwIfAborted(options.abortSignal)
       if (source.mountPath) {
         await store.mkdir(source.mountPath, { recursive: true })
       }
@@ -309,6 +365,7 @@ export async function materializeWorkspaceSources(
       const directorySet = new Set<string>(source.mountPath ? [source.mountPath] : [])
       const nextPaths = new Set<string>()
       for await (const entry of iterateMaterializationEntries(source, ctx, store, existing, configHash, options)) {
+        throwIfAborted(options.abortSignal)
         const path = entry.path
         nextPaths.add(path)
         const parts = path.split("/")
@@ -329,6 +386,14 @@ export async function materializeWorkspaceSources(
               bytes: sourceBytes,
               items: checkpointItems(itemMetadata),
               cacheMaxAge: source.cache ? source.cache.maxAge : undefined,
+            })
+          }
+          if (shouldReportMaterializationUpdate(lastProgressAt, sourceFiles)) {
+            lastProgressAt = Date.now()
+            await reportMaterializationProgress(options, source, {
+              bytes: sourceBytes,
+              files: sourceFiles,
+              status: "updating",
             })
           }
           continue
@@ -362,7 +427,16 @@ export async function materializeWorkspaceSources(
             cacheMaxAge: source.cache ? source.cache.maxAge : undefined,
           })
         }
+        if (shouldReportMaterializationUpdate(lastProgressAt, sourceFiles)) {
+          lastProgressAt = Date.now()
+          await reportMaterializationProgress(options, source, {
+            bytes: sourceBytes,
+            files: sourceFiles,
+            status: "updating",
+          })
+        }
       }
+      throwIfAborted(options.abortSignal)
       await removeStaleMaterializedSourceFiles(store, source, nextPaths, options, { removeUntracked: Boolean(source.mountPath) })
       const readyItems = Object.fromEntries([...nextPaths].flatMap((path) => {
         const metadata = itemMetadata[path]
@@ -392,6 +466,13 @@ export async function materializeWorkspaceSources(
       files += sourceFiles
       bytes += sourceBytes
       directories += directorySet.size
+      await reportMaterializationProgress(options, source, {
+        bytes: sourceBytes,
+        directories: directorySet.size,
+        durationMs: Date.now() - sourceStarted,
+        files: sourceFiles,
+        status: "completed",
+      })
     }
     catch (error) {
       const failed: SourceSnapshotMetadata = {
@@ -405,8 +486,16 @@ export async function materializeWorkspaceSources(
         items: checkpointItems(itemMetadata),
         cacheMaxAge: source.cache ? source.cache.maxAge : undefined,
       }
-      await writeSourceSnapshotMetadata(store, failed)
+      if (!options.abortSignal?.aborted) await writeSourceSnapshotMetadata(store, failed)
       resultSources.push(failed)
+      await reportMaterializationProgress(options, source, {
+        bytes: sourceBytes,
+        durationMs: Date.now() - sourceStarted,
+        error: failed.error,
+        files: sourceFiles,
+        status: "failed",
+      })
+      if (options.abortSignal?.aborted) throw error
     }
   }
 

--- a/packages/workspace/src/sources/view.ts
+++ b/packages/workspace/src/sources/view.ts
@@ -338,6 +338,8 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
           const item = await resolution.source.source.getItem(resolution.sourcePath, getSourceContext(resolution.source))
           return decodeFile(await sourceItemContent(item), options)
         }
+        const file = await store.readFile(resolution.workspacePath)
+        if (file) return decodeFile(file.content, options)
         await ensureMaterialized(resolution.sourceKey)
         return await readResolvedSourceFile(resolution, store, sourceContext, options)
       }
@@ -405,6 +407,8 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
           if (!result) throw new WorkspaceError(`[vitehub] Workspace path does not exist: ${path}.`)
           return result
         }
+        const stored = await store.stat(resolution.workspacePath)
+        if (stored) return stored
         await ensureMaterialized(resolution.sourceKey)
         const result = await statVirtualSourcePath(resolution.source, resolution.workspacePath, store, getSourceContext(resolution.source))
         if (!result) throw new WorkspaceError(`[vitehub] Workspace path does not exist: ${path}.`)
@@ -433,6 +437,7 @@ export function createWorkspaceSourceView(definition: WorkspaceDefinition, store
           if (!resolution.workspacePath) return true
           return Boolean(liveSourceStat(resolution.source, resolution.workspacePath))
         }
+        if (await store.stat(resolution.workspacePath)) return true
         await ensureMaterialized(resolution.sourceKey)
         return Boolean(await statVirtualSourcePath(resolution.source, resolution.workspacePath, store, getSourceContext(resolution.source)))
       }

--- a/packages/workspace/test/cli.test.ts
+++ b/packages/workspace/test/cli.test.ts
@@ -19,6 +19,18 @@ function stream() {
   }
 }
 
+function ndjsonResponse(lines: unknown[]) {
+  const encoder = new TextEncoder()
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const line of lines) controller.enqueue(encoder.encode(`${JSON.stringify(line)}\n`))
+      controller.close()
+    },
+  }), {
+    headers: { "content-type": "application/x-ndjson; charset=utf-8" },
+  })
+}
+
 describe("workspace CLI", () => {
   it("keeps the private Workspace Dev token outside the Vite root", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vitehub-workspace-token-"))
@@ -71,13 +83,35 @@ describe("workspace CLI", () => {
     try {
       const fetchWorkspaceDev = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
         if (init?.method === "POST") {
-          return Response.json({
-            args: ["-e", "console.log(process.argv[1])", "hello world", "--timeout=30000"],
-            command: "node",
-            exitCode: 0,
-            stderr: "",
-            stdout: "ok\n",
-          })
+          return ndjsonResponse([
+            {
+              event: {
+                id: "workspace.dev.materialize",
+                label: "Materializing workspace sources",
+                status: "started",
+              },
+              type: "progress",
+            },
+            {
+              event: {
+                data: { bytes: 12, files: 1 },
+                id: "workspace.dev.materialize.docs",
+                label: "Materializing source docs",
+                status: "updating",
+              },
+              type: "progress",
+            },
+            {
+              result: {
+                args: ["-e", "console.log(process.argv[1])", "hello world", "--timeout=30000"],
+                command: "node",
+                exitCode: 0,
+                stderr: "",
+                stdout: "ok\n",
+              },
+              type: "result",
+            },
+          ])
         }
         return Response.json({
           root: rootDir,
@@ -110,6 +144,8 @@ describe("workspace CLI", () => {
 
       expect(exitCode).toBe(0)
       expect(stderr.output()).toContain("[workspace] command started; first run may materialize sources.\n")
+      expect(stderr.output()).toContain("[workspace] Materializing workspace sources...\n")
+      expect(stderr.output()).toContain("[workspace] Materializing source docs: 1 file, 12 bytes\n")
       expect(stderr.output()).toContain("[workspace] command completed")
       expect(stdout.output()).toBe("ok\n")
       const [get, post] = fetchWorkspaceDev.mock.calls
@@ -119,6 +155,7 @@ describe("workspace CLI", () => {
         [workspaceDevHeader]: workspaceDevHeaderValue,
       })
       expect(post?.[1]?.headers).toMatchObject({
+        accept: "application/x-ndjson, application/json",
         "content-type": "application/json",
         [workspaceDevHeader]: workspaceDevHeaderValue,
         [workspaceDevTokenHeader]: token,
@@ -136,6 +173,56 @@ describe("workspace CLI", () => {
     finally {
       await rm(rootDir, { force: true, recursive: true })
     }
+  })
+
+  it("reports Workspace Dev preparation progress while starting sessions", async () => {
+    const progress: unknown[] = []
+    const exec = vi.fn(async () => ({
+      exitCode: 0,
+      stderr: "",
+      stdout: "ok\n",
+    }))
+    const diff = vi.fn(async () => ({ entries: [] }))
+    const close = vi.fn(async () => {})
+    const materializeSources = vi.fn(async (options?: { onProgress?: (event: unknown) => void | Promise<void>, path?: string }) => {
+      await options?.onProgress?.({
+        bytes: 3,
+        files: 1,
+        mountPath: "docs",
+        path: options.path || "",
+        source: "docs",
+        status: "updating",
+      })
+      return { bytes: 3, directories: 1, durationMs: 1, files: 1, path: options?.path || "", sources: [] }
+    })
+    const workspace = {
+      materializeSources,
+      startSession: vi.fn(async () => ({ close, diff, exec })),
+    }
+
+    await expect(runWorkspaceDevCommand({
+      command: "echo ok",
+      onProgress: (event) => {
+        progress.push(event)
+      },
+      paths: ["docs/README.md"],
+      workspace: workspace as never,
+    })).resolves.toMatchObject({
+      exitCode: 0,
+      stdout: "ok\n",
+    })
+
+    expect(materializeSources).toHaveBeenCalledWith(expect.objectContaining({
+      path: "docs/README.md",
+    }))
+    expect(workspace.startSession).toHaveBeenCalledWith({ paths: ["docs/README.md"] })
+    expect(progress).toEqual([
+      expect.objectContaining({ id: "workspace.dev.materialize", status: "started" }),
+      expect.objectContaining({ data: expect.objectContaining({ source: "docs" }), id: "workspace.dev.materialize.docs", status: "updating" }),
+      expect.objectContaining({ id: "workspace.dev.materialize", status: "completed" }),
+      expect.objectContaining({ id: "workspace.dev.start-session", status: "started" }),
+      expect.objectContaining({ id: "workspace.dev.start-session", status: "completed" }),
+    ])
   })
 
   it("uses the portable Workspace shell for string Workspace Dev commands", async () => {

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -22,9 +22,9 @@ function sandboxRun(files: string[] = [], directories: string[] = [], symlinks: 
   })
 }
 
-function expectArchiveWrite(writeBinaryFile: ReturnType<typeof vi.fn>, root = "/work/agent") {
+function expectArchiveWrite(writeBinaryFile: ReturnType<typeof vi.fn>, root = "/work/agent", abortSignal: AbortSignal | undefined = undefined) {
   expect(writeBinaryFile).toHaveBeenCalledWith({
-    abortSignal: undefined,
+    abortSignal,
     content: expect.any(Uint8Array),
     path: `${root}/.vitehub-workspace.tar.gz`,
   })
@@ -289,6 +289,66 @@ describe("Harness Workspace Session", () => {
     expect(materializeSources).toHaveBeenCalledWith({ path: "" })
     expect(list).toHaveBeenCalledWith("", { recursive: true })
     expectArchiveWrite(writeBinaryFile)
+
+    await session.close()
+  })
+
+  it("passes materialization progress and abort signals to source materialization", async () => {
+    const abortController = new AbortController()
+    const onMaterializeProgress = vi.fn()
+    const sourceFile = bytes("Details\n")
+    const materializeSources = vi.fn(async (options?: Record<string, unknown>) => {
+      await (options?.onProgress as ((event: unknown) => Promise<void> | void) | undefined)?.({
+        mountPath: "portal",
+        path: options?.path,
+        source: "portal",
+        status: "started",
+      })
+      return {
+        bytes: sourceFile.byteLength,
+        directories: 1,
+        durationMs: 1,
+        files: 1,
+        path: options?.path || "",
+        sources: [{ mountPath: "portal", source: "portal", status: "ready" }],
+      }
+    })
+    const stat = vi.fn(async () => ({ path: "portal", type: "directory" }))
+    const list = vi.fn(async () => [
+      { path: "portal", type: "directory" },
+      { mediaType: "text/markdown", path: "portal/details.md", type: "file" },
+    ])
+    const readFile = vi.fn(async () => sourceFile)
+    const writeBinaryFile = vi.fn(async () => {})
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: { list, materializeSources, readFile, stat },
+      tools: {},
+    } as never, {
+      abortSignal: abortController.signal,
+      onMaterializeProgress,
+      paths: ["portal"],
+      session: {
+        run: sandboxRun(),
+        writeBinaryFile,
+      },
+      sessionWorkDir: "/work/agent",
+    })
+
+    expect(materializeSources).toHaveBeenCalledWith({
+      abortSignal: abortController.signal,
+      onProgress: onMaterializeProgress,
+      path: "portal",
+    })
+    expect(onMaterializeProgress).toHaveBeenCalledWith(expect.objectContaining({
+      mountPath: "portal",
+      path: "portal",
+      source: "portal",
+      status: "started",
+    }))
+    expect(stat).toHaveBeenCalledWith("portal")
+    expect(list).toHaveBeenCalledWith("portal", { recursive: true })
+    expectArchiveWrite(writeBinaryFile, "/work/agent", abortController.signal)
 
     await session.close()
   })

--- a/packages/workspace/test/lazy-sources.test.ts
+++ b/packages/workspace/test/lazy-sources.test.ts
@@ -280,6 +280,94 @@ describe("lazy sources", () => {
     ])
   })
 
+  it("reports source progress while materializing", async () => {
+    const progress: unknown[] = []
+    const view = createWorkspaceSourceView({
+      name: "lazy-progress",
+      sources: {
+        docs: custom({
+          materialize: "lazy",
+          async getKeys() {
+            return ["a.md"]
+          },
+          async getItem(key) {
+            return { key, path: key, content: "# A\n" }
+          },
+        }),
+      },
+    }, createMemoryWorkspaceStore())
+
+    await view.materializeSources({
+      onProgress(event) {
+        progress.push(event)
+      },
+      path: "docs",
+      sources: ["docs"],
+    })
+
+    expect(progress).toEqual([
+      expect.objectContaining({
+        mountPath: "docs",
+        path: "docs",
+        source: "docs",
+        status: "started",
+      }),
+      expect.objectContaining({
+        bytes: 4,
+        files: 1,
+        mountPath: "docs",
+        path: "docs",
+        source: "docs",
+        status: "updating",
+      }),
+      expect.objectContaining({
+        bytes: 4,
+        durationMs: expect.any(Number),
+        files: 1,
+        mountPath: "docs",
+        path: "docs",
+        source: "docs",
+        status: "completed",
+      }),
+    ])
+  })
+
+  it("materializes concrete source files without expanding the whole source", async () => {
+    const getKeys = vi.fn(async () => {
+      throw new Error("full source key expansion should not run")
+    })
+    const getItem = vi.fn(async (key: string) => ({ key, path: key, content: "# A\n" }))
+    const getItems = vi.fn(async () => {
+      throw new Error("full source expansion should not run")
+    })
+    const view = createWorkspaceSourceView({
+      name: "lazy-direct-file",
+      sources: {
+        docs: custom({
+          materialize: "lazy",
+          getKeys,
+          getItem,
+          getItems,
+        }),
+      },
+    }, createMemoryWorkspaceStore())
+
+    await expect(view.materializeSources({ path: "docs/a.md", sources: ["docs"] })).resolves.toMatchObject({
+      files: 1,
+      sources: [expect.objectContaining({ source: "docs", status: "ready" })],
+    })
+    expect(getItem).toHaveBeenCalledWith("a.md", expect.any(Object))
+    expect(getItem).toHaveBeenCalledTimes(1)
+    expect(getKeys).not.toHaveBeenCalled()
+    expect(getItems).not.toHaveBeenCalled()
+    await expect(view.stat("docs/a.md")).resolves.toMatchObject({ path: "docs/a.md", type: "file" })
+    await expect(view.exists("docs/a.md")).resolves.toBe(true)
+    await expect(view.readFile("docs/a.md")).resolves.toBe("# A\n")
+    expect(getItem).toHaveBeenCalledTimes(1)
+    expect(getKeys).not.toHaveBeenCalled()
+    expect(getItems).not.toHaveBeenCalled()
+  })
+
   it("lets sources read existing workspace files while materializing", async () => {
     let previousReport = ""
     const store = createMemoryWorkspaceStore()

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -11,7 +11,7 @@ import { getWorkspaceHostedStoreLoader, setWorkspaceHostedStoreLoader } from "..
 import type { IncomingMessage, ServerResponse } from "node:http"
 import type { Connect } from "vite"
 
-const runWorkspaceDevCommand = vi.hoisted(() => vi.fn(async (_input?: { abortSignal?: AbortSignal }) => ({
+const runWorkspaceDevCommand = vi.hoisted(() => vi.fn(async (_input?: { abortSignal?: AbortSignal, onProgress?: (event: { id: string, label: string, status: "started" | "completed" }) => void | Promise<void> }) => ({
   exitCode: 0,
   stderr: "",
   stdout: "ok\n",
@@ -263,6 +263,76 @@ describe("hubWorkspace", () => {
       }),
       workspace: "docs",
     }))
+  })
+
+  it("streams Workspace Dev command progress from the Vite endpoint", async () => {
+    const root = await createViteRoot()
+    const handlers: Connect.NextHandleFunction[] = []
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const { readWorkspaceDevToken, workspaceDevHeader, workspaceDevHeaderValue, workspaceDevRoute, workspaceDevTokenHeader, workspaceDevTokenServerId } = await import("../src/server.ts")
+    const plugin = hubWorkspace()
+    const configResolved = plugin.configResolved as (config: { command: "serve", root: string }) => Promise<void>
+
+    runWorkspaceDevCommand.mockImplementationOnce(async (input?: { onProgress?: (event: { id: string, label: string, status: "started" }) => void | Promise<void> }) => {
+      await input?.onProgress?.({
+        id: "workspace.dev.materialize",
+        label: "Materializing workspace sources",
+        status: "started",
+      })
+      return {
+        exitCode: 0,
+        stderr: "",
+        stdout: "ok\n",
+      }
+    })
+
+    await configResolved({ command: "serve", root })
+    await configurePluginServer(plugin, {
+      config: { root, server: { port: 3000 } },
+      middlewares: {
+        use: vi.fn((handler: Connect.NextHandleFunction) => handlers.push(handler)),
+      },
+      resolvedUrls: { local: ["http://localhost:3000/"] },
+      ssrLoadModule: vi.fn(async () => ({
+        default: {
+          docs: async () => ({ default: { store: { provider: "memory" } } }),
+        },
+      })),
+      watcher: { on: vi.fn() },
+    })
+    const token = await readWorkspaceDevToken(root, { serverId: workspaceDevTokenServerId(3000) })
+
+    const output = await invokeMiddleware(handlers[0]!, {
+      workspaceCommand: {
+        command: "pnpm",
+        workspace: "docs",
+      },
+    }, workspaceDevRoute, {
+      accept: "application/x-ndjson",
+      "content-type": "application/json",
+      [workspaceDevHeader]: workspaceDevHeaderValue,
+      [workspaceDevTokenHeader]: token,
+    })
+
+    const lines = output.trim().split("\n").map(line => JSON.parse(line))
+    expect(lines).toEqual([
+      {
+        event: {
+          id: "workspace.dev.materialize",
+          label: "Materializing workspace sources",
+          status: "started",
+        },
+        type: "progress",
+      },
+      {
+        result: {
+          exitCode: 0,
+          stderr: "",
+          stdout: "ok\n",
+        },
+        type: "result",
+      },
+    ])
   })
 
   it("aborts Workspace Dev commands when the client disconnects", async () => {


### PR DESCRIPTION
Adds Workspace-owned progress reporting for source materialization, Harness Workspace Session preparation, and `vitehub workspace dev` command preparation. Workspace Dev now uses a private newline-delimited stream from the Workspace Vite endpoint so the CLI can show materialization and session progress before the final command output.

Also lets GitHub Sources retrieve a concrete file through the contents API when Workspace materializes a specific Source-Backed Path, while propagating abort signals into Source retrieval. Workspace reads, stats, and exists checks reuse already materialized Source-backed files instead of forcing lazy-source enumeration.