### PR TITLE
fix(agent): preserve driver markers across module instances

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -374,9 +374,9 @@ export type {
 } from "./chat-trigger.ts"
 
 const syntheticWorkspaceRun = Symbol.for("vitehub.syntheticWorkspaceRun")
-const baseAgentResolve = Symbol("vitehub.baseAgentResolve")
-const baseAgentModel = Symbol("vitehub.baseAgentModel")
-const baseAgentDriverKind = Symbol("vitehub.baseAgentDriverKind")
+const baseAgentResolve = Symbol.for("vitehub.baseAgentResolve")
+const baseAgentModel = Symbol.for("vitehub.baseAgentModel")
+const baseAgentDriverKind = Symbol.for("vitehub.baseAgentDriverKind")
 const workflowSpecifier = "@vite-hub/workflow"
 const workflowRuntimeStateSpecifier = "@vite-hub/workflow/runtime/state"
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1209,6 +1209,51 @@ describe("agent message protocol", () => {
     expect(session.destroy).toHaveBeenCalledTimes(1)
   })
 
+  it("keeps harness driver markers across split Agent Package module instances", async () => {
+    const indexUrl = new URL("../src/index.ts", import.meta.url).href
+    const indexA = await import(`${indexUrl}?copy=agent-marker-a`) as typeof import("../src/index.ts")
+    const indexB = await import(`${indexUrl}?copy=agent-marker-b`) as typeof import("../src/index.ts")
+    const { access } = await import("../src/capabilities.ts")
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessStream.mockResolvedValueOnce({
+      fullStream: (async function* () {
+        yield { text: "harness ok", type: "text-delta" }
+      })(),
+    })
+
+    const agent = indexA.defineAgent({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "support",
+            scopes: {
+              support: { paths: [""] },
+            },
+          },
+        }),
+      ],
+      driver: {
+        harness: { provider: "codex" },
+      },
+      workspace: { mode: "write", store: { provider: "memory" } },
+    })
+
+    const output = await indexB.streamAgent(agent as never, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" }, { output: "events" })
+    const events = []
+    for await (const event of output as AsyncIterable<unknown>) events.push(event)
+
+    expect(events).toContainEqual({ text: "harness ok", type: "text-delta" })
+    expect(harnessStream).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: "hello",
+      session,
+    }))
+  })
+
   it("avoids Claude Code bypass permissions when the host process runs as root", async () => {
     const getuid = vi.spyOn(process, "getuid").mockReturnValue(0)
     try {


### PR DESCRIPTION
## Summary

Preserves the internal Agent Definition driver markers across Vite SSR/module-instance splits by moving the base marker symbols to the global symbol registry. This keeps harness-backed Agent Definitions harness-backed through dev trigger invocation paths, including write workspace capability preparation.

Adds a focused runtime regression test that creates a harness write-workspace Agent Definition from one imported Agent Package instance and streams it with another instance, so `access({ workspace })` must resolve the driver as `harness` instead of falling back to model execution.

Refs #499
Refs #500