### PR TITLE
feat(agent): add devtools inspect host command

### DIFF
--- a/docs/content/docs/agents/devtools.md
+++ b/docs/content/docs/agents/devtools.md
@@ -38,6 +38,15 @@ Use the Agent DevTools Feature to answer the basic discovery questions before de
 
 If discovery is wrong, fix the Agent Definition before inspecting model output.
 
+## Inspect from chat
+
+Type `//inspect` in the Agent DevTools chat composer to add a local inspection summary to the transcript.
+It is a Host Command, so DevTools handles it before Agent Invocation and does not send it to the Agent.
+The summary points at the resolved Agent Definition surface: driver metadata, tool count, visible Workspace files and Sources, instruction documents, Agent Invoker Profiles, warnings, and metadata status.
+Use the side panel for the full config, files, tools, instructions, and metadata.
+
+Other `//...` Host Commands are handled locally and are not forwarded to the Agent.
+
 ## Inspect an invocation
 
 DevTools should show each Agent Invocation through the same public runtime boundaries used by server routes and trigger consumers.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -107,6 +107,12 @@ export default defineConfig({
 })
 ```
 
+## DevTools inspection
+
+With `hubAgent()` and the ViteHub DevTools shell active, open the Agent Chat feature and type `//inspect`.
+DevTools handles this Host Command locally and adds a transcript summary of the resolved Agent Definition surface without sending the command to the Agent.
+Use it to verify the selected driver, tools, Workspace files and Sources, instructions, Agent Invoker Profiles, warnings, and metadata status before debugging model output.
+
 ## Capabilities
 
 - `chat()` exposes the agent as a chat surface; see the [First Agent guide](https://vitehub.dev/docs/getting-started/first-agent).

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -109,6 +109,11 @@ interface ChatDevtoolsBridgeState {
   selected?: string
 }
 
+interface ChatDevtoolsHostCommand {
+  name: string
+  text: string
+}
+
 function normalizeChatDevtoolsAction(action: string): ChatDevtoolsAction | undefined {
   if (action === "get-state" || action === chatDevtoolsGetStateRpc) return "get-state"
   if (action === "send" || action === chatDevtoolsSendRpc) return "send"
@@ -552,8 +557,21 @@ function createUserUIMessage(text: string): UIMessage {
   }
 }
 
+function createAssistantUIMessage(text: string, metadata: Record<string, unknown> = {}): UIMessage {
+  return {
+    id: randomId("devtools-assistant"),
+    metadata,
+    parts: [{ text, type: "text" }],
+    role: "assistant",
+  }
+}
+
 function uiMessageMetadata(message: UIMessage): Record<string, unknown> | undefined {
   return isRecord(message.metadata) ? message.metadata : undefined
+}
+
+function isHostCommandUIMessage(message: UIMessage): boolean {
+  return isRecord(uiMessageMetadata(message)?.hostCommand)
 }
 
 function hasCompletedMetadata(message: UIMessage): boolean {
@@ -606,14 +624,111 @@ function isIncompleteAssistantHistoryMessage(message: UIMessage): boolean {
   return message.role === "assistant" && !hasCompletedMetadata(message) && hasIncompleteToolParts(message)
 }
 
-export function createChatDevtoolsPromptHistory(messages: UIMessage[]): UIMessage[] {
+function createChatDevtoolsVisibleHistory(messages: UIMessage[]): UIMessage[] {
   return messages.filter(message => !isIncompleteAssistantHistoryMessage(message))
+}
+
+export function createChatDevtoolsPromptHistory(messages: UIMessage[]): UIMessage[] {
+  return createChatDevtoolsVisibleHistory(messages).filter(message => !isHostCommandUIMessage(message))
 }
 
 function readableStreamFromResult(value: unknown): ReadableStream<never> {
   if (value instanceof ReadableStream) return value as ReadableStream<never>
   if (value instanceof Response && value.body) return value.body as ReadableStream<never>
   throw new Error("[vitehub] Chat DevTools expected a UI message stream.")
+}
+
+function parseChatDevtoolsHostCommand(text: string): ChatDevtoolsHostCommand | undefined {
+  if (!text.startsWith("//")) return
+  const raw = text.slice(2).trim()
+  const name = raw.split(/\s+/, 1)[0] || ""
+  return {
+    name,
+    text,
+  }
+}
+
+function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralLabel}`
+}
+
+function countDevtoolsFiles(files: NonNullable<ChatDevtoolsStateResult["files"]>): { directories: number, files: number, sources: number } {
+  const sources = new Set<string>()
+  let fileCount = 0
+  let directoryCount = 0
+  const pending = [...files]
+  while (pending.length) {
+    const file = pending.shift()!
+    if (file.kind === "directory") directoryCount += 1
+    else fileCount += 1
+    if (file.source) sources.add(file.source)
+    pending.push(...(file.children || []))
+  }
+  return { directories: directoryCount, files: fileCount, sources: sources.size }
+}
+
+function driverSummary(config: ChatDevtoolsStateResult["config"]): string {
+  const driver = config?.driver
+  if (!driver) return "unavailable"
+  if (driver.kind === "model") return driver.model?.id ? `Model-backed Agent Driver (${driver.model.id})` : "Model-backed Agent Driver"
+  if (driver.kind === "harness") return driver.harness?.provider ? `Harness-backed Agent Driver (${driver.harness.provider})` : "Harness-backed Agent Driver"
+  return "Custom-run Agent Driver"
+}
+
+function namesSummary(values: Array<{ name: string }>, fallback: string): string {
+  if (!values.length) return fallback
+  const names = values.slice(0, 5).map(value => value.name)
+  return values.length > names.length ? `${names.join(", ")}, +${values.length - names.length} more` : names.join(", ")
+}
+
+function inspectSummary(state: ChatDevtoolsStateResult): string {
+  const files = countDevtoolsFiles(state.files || [])
+  const metadata = state.metadataError
+    ? `${state.metadataStatus || "error"} (${state.metadataError})`
+    : state.metadataStatus || "ready"
+  return [
+    "### Agent inspection",
+    `- Agent: ${state.title || state.selected || "unknown"}`,
+    `- Metadata: ${metadata}`,
+    `- Driver: ${driverSummary(state.config)}`,
+    `- Tools: ${plural(state.tools?.length || 0, "tool")} (${namesSummary(state.tools || [], "none")})`,
+    `- Workspace files: ${plural(files.files, "file")}, ${plural(files.directories, "directory", "directories")}, ${plural(files.sources, "source")}`,
+    `- Instructions: ${plural(state.instructions?.length || 0, "document")}`,
+    `- Invoker profiles: ${plural(state.invokerProfiles?.length || 0, "profile")}`,
+    `- Warnings: ${plural(state.warnings?.length || 0, "warning")}`,
+    "",
+    "Use the side panel for full config, files, tools, instructions, and metadata.",
+  ].join("\n")
+}
+
+async function handleDevtoolsHostCommand(
+  state: ChatDevtoolsBridgeState,
+  selected: string,
+  entry: ChatDevtoolsAgentEntry,
+  session: ChatDevtoolsSession,
+  command: ChatDevtoolsHostCommand,
+  userMessage: UIMessage,
+  requestedSelection: ChatDevtoolsInvokerSelection,
+): Promise<ChatDevtoolsStateResult> {
+  if (command.name === "inspect" && entry.metadataTask) {
+    await entry.metadataTask.catch(() => {})
+  }
+  const now = new Date().toISOString()
+  const status = command.name === "inspect" ? "handled" : "unknown"
+  const assistantText = command.name === "inspect"
+    ? inspectSummary(await serializeState(state, selected, requestedSelection))
+    : `Unknown Host Command: \`${command.text}\`.\n\nAvailable Host Commands: \`//inspect\`.`
+  const metadata = {
+    completedAt: now,
+    createdAt: now,
+    hostCommand: { name: command.name || command.text, status },
+  }
+  session.uiMessages = [
+    ...createChatDevtoolsVisibleHistory(session.uiMessages),
+    { ...userMessage, metadata },
+    createAssistantUIMessage(assistantText, metadata),
+  ]
+  return await serializeState(state, selected, requestedSelection)
 }
 
 async function sendDevtoolsUIMessage(
@@ -662,10 +777,16 @@ async function sendDevtoolsUIMessage(
       : requestedProfileId || selectedEntry.metadata.invokerProfiles?.[0]?.id
   }
   const userMessage = createUserUIMessage(text)
-  const baseMessages = [...createChatDevtoolsPromptHistory(session.uiMessages), userMessage]
+  const hostCommand = parseChatDevtoolsHostCommand(text)
+  if (hostCommand) {
+    return await handleDevtoolsHostCommand(state, selected, selectedEntry, session, hostCommand, userMessage, requestedSelection)
+  }
+
+  const visibleBaseMessages = [...createChatDevtoolsVisibleHistory(session.uiMessages), userMessage]
+  const promptMessages = [...createChatDevtoolsPromptHistory(session.uiMessages), userMessage]
   const run = createRunMetadata(session, userMessage.id)
   const startedAt = new Date().toISOString()
-  session.uiMessages = baseMessages
+  session.uiMessages = visibleBaseMessages
   session.thinkingFallback = null
   await onChange?.(await serializeState(state, selected))
 
@@ -673,7 +794,7 @@ async function sendDevtoolsUIMessage(
   const triggerInput: AgentChatMessageTriggerInput = {
     ...(session.invokerProfileId ? { invokerProfileId: session.invokerProfileId } : {}),
     ...(requestedSelection.meta ? { meta: requestedSelection.meta } : {}),
-    messages: baseMessages,
+    messages: promptMessages,
     run,
     timeout: 90_000,
     user: chatDevtoolsUser,
@@ -710,7 +831,7 @@ async function sendDevtoolsUIMessage(
       },
     }
     session.title = titleFromUIMessage(latestAssistant) || session.title
-    session.uiMessages = [...baseMessages, latestAssistant]
+    session.uiMessages = [...visibleBaseMessages, latestAssistant]
     await refreshCompletedMaterializations(latestAssistant)
     await onChange?.(await serializeState(state, selected))
   }
@@ -723,7 +844,7 @@ async function sendDevtoolsUIMessage(
       },
     }
     session.title = titleFromUIMessage(latestAssistant) || session.title
-    session.uiMessages = [...baseMessages, latestAssistant]
+    session.uiMessages = [...visibleBaseMessages, latestAssistant]
     await onChange?.(await serializeState(state, selected))
   }
   await startMetadataResolution(selectedEntry, requestedSelection, { force: true })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -528,6 +528,59 @@ describe("agent chat capability discovery", () => {
     expect(textFromUiMessage(fallbackFinalState.uiMessages[1])).toBe("answered as devtools:maximo@quiver.dk with workspace")
   })
 
+  it("handles chat devtools Host Commands before agent invocation", async () => {
+    const root = await createTempRoot("vitehub-agent-devtools-host-command-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const run = vi.fn(() => "agent response")
+    const agent = defineAgent({
+      capabilities: [chat()],
+      driver: { run },
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent()
+
+    await configurePluginServer(plugin, server)
+
+    const inspectResponse = await invokeMiddleware(handlers[0]!, {
+      action: "send",
+      chat: "support",
+      stream: true,
+      text: "//inspect",
+    })
+    const inspectEvents = inspectResponse.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+    const inspectState = inspectEvents.filter(event => event.type === "state").at(-1)?.state
+
+    expect(inspectEvents.at(-1)).toEqual({ type: "done" })
+    expect(run).not.toHaveBeenCalled()
+    expect(textFromUiMessage(inspectState.uiMessages[0])).toBe("//inspect")
+    expect(textFromUiMessage(inspectState.uiMessages[1])).toContain("Agent inspection")
+    expect(textFromUiMessage(inspectState.uiMessages[1])).toContain("Driver: Custom-run Agent Driver")
+
+    const unknownResponse = await invokeMiddleware(handlers[0]!, {
+      action: "send",
+      chat: "support",
+      stream: true,
+      text: "//wat",
+    })
+    const unknownEvents = unknownResponse.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+    const unknownState = unknownEvents.filter(event => event.type === "state").at(-1)?.state
+
+    expect(unknownEvents.at(-1)).toEqual({ type: "done" })
+    expect(run).not.toHaveBeenCalled()
+    expect(textFromUiMessage(unknownState.uiMessages.at(-1))).toContain("Unknown Host Command: `//wat`")
+    expect(textFromUiMessage(unknownState.uiMessages.at(-1))).toContain("//inspect")
+  })
+
   it("serves Agent Invocation Stream events from the Vite endpoint", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-")
     await mkdir(join(root, "server", "agents"), { recursive: true })
@@ -2142,6 +2195,12 @@ describe("agent chat capability discovery", () => {
           { text: "done", type: "text" },
         ],
         role: "assistant",
+      },
+      {
+        id: "host-command",
+        metadata: { hostCommand: { name: "inspect", status: "handled" } },
+        parts: [{ text: "//inspect", type: "text" }],
+        role: "user",
       },
     ])
 


### PR DESCRIPTION
Adds a DevTools Host Command, `//inspect`, that the chat bridge handles before Agent Invocation and records as a local transcript summary of the resolved Agent Definition surface. Unknown `//...` inputs now stay local as unavailable Host Commands instead of reaching `chat.message`.

Updates the Agent DevTools docs and package README with the Host Command boundary.