### PR TITLE
fix(agent): move finish delivery output into context

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -155,12 +155,12 @@ Adapter-backed message channels, such as Slack, Telegram, Teams, Discord, and cu
 
 ```ts [server/agents/support.ts]
 import { defineAgent, defineCapability } from '@vite-hub/agent'
-import { defineFinishEffect, reply, telegram } from '@vite-hub/agent/channels'
+import { defineFinishEffect, telegram } from '@vite-hub/agent/channels'
 
 const screenshotDelivery = defineCapability({
   id: 'screenshot-delivery',
   prepare(context) {
-    context.delivery.finishEffect(defineFinishEffect(() => reply({
+    context.delivery.finishEffect(defineFinishEffect(context => context.reply({
       body: 'See attached screenshot.',
       artifacts: [{
         mediaType: 'image/png',
@@ -186,11 +186,11 @@ export default defineAgent({
 
 GitHub comments and reviews need hosted markdown URLs instead of channel-native file uploads. The GitHub channel publishes workspace image paths that appear in reply or review bodies, then rewrites those paths to hosted raw URLs. Use `publishWorkspaceArtifacts()` from `@vite-hub/agent/channels` inside a finish effect when explicit GitHub artifacts need public URLs before delivery.
 
-Finish effects receive the final output event plus `context.workspace`, `context.run`, and `context.context` so app-side delivery code can read Workspace files and typed Agent Invocation Context values without re-parsing the stream.
+Finish effects receive a delivery context with `context.output`, normalized `context.result`, `context.text`, `context.workspace`, `context.run`, and `context.context` so app-side delivery code can read final output, Workspace files, and typed Agent Invocation Context values without re-parsing the stream.
 
 ```ts [server/agents/review.ts]
 import { defineAgent } from '@vite-hub/agent'
-import { defineFinishEffect, github, publishWorkspaceArtifacts, reply } from '@vite-hub/agent/channels'
+import { defineFinishEffect, github, publishWorkspaceArtifacts } from '@vite-hub/agent/channels'
 import { blob } from '@vite-hub/blob'
 
 export default defineAgent({
@@ -198,9 +198,9 @@ export default defineAgent({
     github: github({
       app: true,
       pullRequest: {
-        reply: defineFinishEffect(async (event, context) => {
-          if (event.error) return reply(`Review failed: ${event.errorMessage}`)
-          const body = event.text?.trim() || '_No review generated._'
+        reply: defineFinishEffect(async (context) => {
+          if (context.error) return context.reply(`Review failed: ${context.errorMessage}`)
+          const body = context.text?.trim() || '_No review generated._'
           return {
             kind: 'review',
             payload: { body },

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -14,30 +14,41 @@ function textFromContent(content: unknown): string | undefined {
     if (!part || typeof part !== "object") return []
 
     const record = part as Record<string, unknown>
-    if (record.type !== "text" && record.type !== "text-delta") return []
+    const type = ownValue(record, "type")
+    if (type !== "text" && type !== "text-delta") return []
 
-    const value = record.text ?? record.textDelta ?? record.delta
+    const value = ownValue(record, "text") ?? ownValue(record, "textDelta") ?? ownValue(record, "delta")
     return typeof value === "string" ? [value] : []
   }).join("")
 
   return text ? text : undefined
 }
 
+function ownValue(record: Record<string, unknown>, key: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(record, key)
+  return descriptor && "value" in descriptor ? descriptor.value : undefined
+}
+
 function textFromResult(result: Record<string, unknown>): string | undefined {
-  if (typeof result.text === "string") return result.text
-  if (typeof result.output === "string") return result.output
-  if (typeof result._output === "string") return result._output
-  const contentText = textFromContent(result.content)
+  const text = ownValue(result, "text")
+  if (typeof text === "string" && text) return text
+  const output = ownValue(result, "output")
+  if (typeof output === "string" && output) return output
+  const rawOutput = ownValue(result, "_output")
+  if (typeof rawOutput === "string" && rawOutput) return rawOutput
+  const contentText = textFromContent(ownValue(result, "content"))
   if (contentText) return contentText
 
-  const steps = result.steps
+  const steps = ownValue(result, "steps")
   if (Array.isArray(steps)) {
     for (const step of steps.slice().reverse()) {
-      if (step && typeof step === "object" && typeof (step as { text?: unknown }).text === "string") {
-        return (step as { text: string }).text
+      if (step && typeof step === "object") {
+        const record = step as Record<string, unknown>
+        const stepText = ownValue(record, "text")
+        if (typeof stepText === "string" && stepText) return stepText
+        const stepContentText = textFromContent(ownValue(record, "content"))
+        if (stepContentText) return stepContentText
       }
-      const stepContentText = textFromContent((step as { content?: unknown }).content)
-      if (stepContentText) return stepContentText
     }
   }
 }
@@ -49,12 +60,12 @@ export function toAgentRunResult(value: unknown): AgentRunResult {
 
   const result = value as Record<string, unknown>
   return {
-    finishReason: result.finishReason,
+    finishReason: ownValue(result, "finishReason"),
     raw: value,
     text: textFromResult(result),
-    usage: result.usage,
-    usageRecord: result.usageRecord as AgentUsageRecord | undefined,
-    warnings: result.warnings,
+    usage: ownValue(result, "usage"),
+    usageRecord: ownValue(result, "usageRecord") as AgentUsageRecord | undefined,
+    warnings: ownValue(result, "warnings"),
   }
 }
 

--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -299,7 +299,7 @@ function mergeInputCommandResult(input: AgentRunInput, result: Partial<AgentRunI
 }
 
 function inputCommandCall(command: InputCommand): InputCommandCall {
-  return command.call || command.run || (({ args }) => args)
+  return command.call || command.run || (({ args, command }) => args || command.description)
 }
 
 function activeChannelId(context: AgentCapabilityRuntimeContext): string | undefined {
@@ -380,10 +380,10 @@ function scheduleInputCommandFinishHook(
 ): void {
   const hook = command.hooks?.["agent:finish"]
   if (!hook) return
-  context.delivery.finishEffect(async (event) => {
+  context.delivery.finishEffect(async (context) => {
     const effects: AgentChannelDeliveryEffectIntent[] = []
     await hook({
-      ...event,
+      ...context.event,
       args: invocation.args,
       command,
       message: finishPhaseMessage(effects),

--- a/packages/agent/src/capabilities/observability.ts
+++ b/packages/agent/src/capabilities/observability.ts
@@ -148,10 +148,11 @@ export function observability<
       if (options.instrumentation) context.modelExecution.instrument(options.instrumentation as never)
       if (options.onEvent) {
         // Returning false reuses finish-time lifecycle scheduling without creating a Channel Delivery Effect.
-        context.delivery.finishEffect(async (event): Promise<false> => {
+        context.delivery.finishEffect(async (context): Promise<false> => {
+          const event = context.event as AgentFinishEvent<TRuntimeConfig>
           if (event.errorMessage !== undefined) {
             await notify(options.onEvent, {
-              ...finishEventBase(event as AgentFinishEvent<TRuntimeConfig>),
+              ...finishEventBase(event),
               durationMs: event.invocation.durationMs,
               error: event.error,
               status: "failed",
@@ -161,7 +162,7 @@ export function observability<
           }
 
           await notify(options.onEvent, {
-            ...finishEventBase(event as AgentFinishEvent<TRuntimeConfig>),
+            ...finishEventBase(event),
             durationMs: event.invocation.durationMs,
             result: event.result,
             status: "completed",

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1,7 +1,6 @@
 import { createHash, createSign } from "node:crypto"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY } from "./chat-trigger.ts"
 import { deliveryArtifactAttachments } from "./delivery-artifacts.ts"
-import { getAgentFinishText } from "./delivery-effects.ts"
 
 import type {
   AgentCallbackContext,
@@ -13,6 +12,7 @@ import type {
   AgentChannelDeliveryEffectIntent,
   AgentChannelDeliveryEffects,
   AgentChannelDeliveryFinishEffect,
+  AgentChannelDeliveryFinishEffectContext,
   AgentDeliveryArtifact,
   AgentChannelWebhookRegistrationDefinition,
   AgentFinishEvent,
@@ -30,12 +30,12 @@ import type { AgentChannelChatRouteBody, AgentChannelChatRouteHandlerOptions } f
 import type { Adapter, FileUpload } from "chat"
 
 export { deliveryArtifactAttachments } from "./delivery-artifacts.ts"
-export { defineFinishEffect, getAgentFinishText, reaction, reply, status } from "./delivery-effects.ts"
-export type { AgentChannelDeliveryEffectIntentOptions } from "./delivery-effects.ts"
+export { defineFinishEffect } from "./delivery-effects.ts"
 export type {
   AgentChannelDeliveryEffectContext,
   AgentChannelDeliveryEffectHandler,
   AgentChannelDeliveryEffectIntent,
+  AgentChannelDeliveryEffectIntentOptions,
   AgentChannelDeliveryEffectPayload,
   AgentChannelDeliveryEffectKind,
   AgentChannelDeliveryEffects,
@@ -1340,8 +1340,8 @@ async function githubBodyWithArtifacts<TRuntimeConfig extends AgentRuntimeConfig
   return rewrittenBody ? `${rewrittenBody}\n\n${explicitArtifacts.join("\n")}` : explicitArtifacts.join("\n")
 }
 
-function finishUsageSummary(event: AgentFinishEvent): string | undefined {
-  const usage = event.extensions.get("usage-telemetry")
+function finishUsageSummary(context: AgentChannelDeliveryFinishEffectContext): string | undefined {
+  const usage = context.extensions.get("usage-telemetry")
   return maybeString(usage?.summary)
 }
 
@@ -1349,15 +1349,12 @@ function githubNote(body: string): string {
   return `> [!NOTE]\n${body.split("\n").map(line => `> ${line}`).join("\n")}`
 }
 
-function githubPullRequestCommentReplyEffect(event: AgentFinishEvent): AgentChannelDeliveryEffectIntent | undefined {
-  const text = getAgentFinishText(event)
+function githubPullRequestCommentReplyEffect(context: AgentChannelDeliveryFinishEffectContext): AgentChannelDeliveryEffectIntent | undefined {
+  const text = context.result?.text ?? context.text
   if (!text) return
   const body = text.trim() || "_No reply generated._"
-  const summary = finishUsageSummary(event)
-  return {
-    kind: "reply",
-    payload: summary ? `${body}\n\n${githubNote(summary)}` : body,
-  }
+  const summary = finishUsageSummary(context)
+  return context.reply(summary ? `${body}\n\n${githubNote(summary)}` : body)
 }
 
 function githubPullRequestCommentFinishEffects(

--- a/packages/agent/src/delivery-effects.ts
+++ b/packages/agent/src/delivery-effects.ts
@@ -1,19 +1,12 @@
 import type {
+  AgentChannelDeliveryEffectIntentOptions,
   AgentChannelDeliveryEffectIntent,
   AgentChannelDeliveryFinishEffectCallback,
   AgentChannelDeliveryReactionInput,
   AgentChannelDeliveryReplyInput,
   AgentChannelDeliveryStatusInput,
-  AgentFinishEvent,
   AgentRuntimeConfig,
-  PublishedAgentDeliveryArtifact,
 } from "./types.ts"
-
-export interface AgentChannelDeliveryEffectIntentOptions {
-  artifacts?: readonly PublishedAgentDeliveryArtifact[]
-  intent?: string
-  metadata?: Record<string, unknown>
-}
 
 function intent<TKind extends "reaction" | "reply" | "status">(
   kind: TKind,
@@ -38,60 +31,7 @@ export function defineFinishEffect<
   return effect
 }
 
-export function getAgentFinishText(event: Pick<AgentFinishEvent, "result" | "text">): string | undefined {
-  if (typeof event.text === "string" && event.text) return event.text
-  if (typeof event.result === "string" && event.result) return event.result
-  if (!event.result || typeof event.result !== "object" || event.result instanceof Response) return
-  return textFromResult(event.result as Record<string, unknown>)
-}
-
-function ownValue(record: Record<string, unknown>, key: string): unknown {
-  const descriptor = Object.getOwnPropertyDescriptor(record, key)
-  return descriptor && "value" in descriptor ? descriptor.value : undefined
-}
-
-function textFromContent(content: unknown): string | undefined {
-  if (!Array.isArray(content)) return
-  const text = content.flatMap((part) => {
-    if (typeof part === "string") return [part]
-    if (!part || typeof part !== "object") return []
-    const record = part as Record<string, unknown>
-    const type = ownValue(record, "type")
-    if (type !== "text" && type !== "text-delta") return []
-    const value = ownValue(record, "text") ?? ownValue(record, "textDelta") ?? ownValue(record, "delta")
-    return typeof value === "string" ? [value] : []
-  }).join("")
-  return text || undefined
-}
-
-function stringValue(record: Record<string, unknown>, key: string): string | undefined {
-  const value = ownValue(record, key)
-  return typeof value === "string" ? value : undefined
-}
-
-function nonEmptyStringValue(record: Record<string, unknown>, key: string): string | undefined {
-  const value = stringValue(record, key)
-  return value || undefined
-}
-
-function textFromResult(result: Record<string, unknown>): string | undefined {
-  const text = nonEmptyStringValue(result, "text")
-    ?? nonEmptyStringValue(result, "output")
-    ?? nonEmptyStringValue(result, "_output")
-  if (text) return text
-  const contentText = textFromContent(ownValue(result, "content"))
-  if (contentText) return contentText
-  const steps = ownValue(result, "steps")
-  if (!Array.isArray(steps)) return
-  for (const step of steps.slice().reverse()) {
-    if (!step || typeof step !== "object") continue
-    const record = step as Record<string, unknown>
-    const stepText = nonEmptyStringValue(record, "text") ?? textFromContent(ownValue(record, "content"))
-    if (stepText) return stepText
-  }
-}
-
-export function reply(
+export function createReplyDeliveryEffectIntent(
   input: AgentChannelDeliveryReplyInput,
   options: AgentChannelDeliveryEffectIntentOptions = {},
 ): AgentChannelDeliveryEffectIntent<"reply"> {
@@ -100,14 +40,14 @@ export function reply(
   return intent("reply", payload, { ...options, artifacts: options.artifacts ?? artifacts })
 }
 
-export function reaction(
+export function createReactionDeliveryEffectIntent(
   input: AgentChannelDeliveryReactionInput,
   options: AgentChannelDeliveryEffectIntentOptions = {},
 ): AgentChannelDeliveryEffectIntent<"reaction"> {
   return intent("reaction", input, options)
 }
 
-export function status(
+export function createStatusDeliveryEffectIntent(
   input: AgentChannelDeliveryStatusInput,
   options: AgentChannelDeliveryEffectIntentOptions = {},
 ): AgentChannelDeliveryEffectIntent<"status"> {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,7 +2,11 @@ import agentRegistry from "#vitehub/agent/registry"
 import { normalizeAgentDriver } from "./internal/agent-driver.ts"
 import { cloneWithPropertyDescriptors } from "./internal/stream-result.ts"
 import { agentErrorDetails, agentErrorMessage } from "./agent-error.ts"
-import { getAgentFinishText } from "./delivery-effects.ts"
+import {
+  createReactionDeliveryEffectIntent,
+  createReplyDeliveryEffectIntent,
+  createStatusDeliveryEffectIntent,
+} from "./delivery-effects.ts"
 import { getMessageText } from "./messages.ts"
 import { resolveRuntimeContext } from "@vite-hub/runtime"
 import { isAsyncIterable, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent } from "./agent-output.ts"
@@ -188,6 +192,7 @@ export type {
   AgentChannelDeliveryEffectHandler,
   AgentChannelDeliveryFinishEffect,
   AgentChannelDeliveryEffectIntent,
+  AgentChannelDeliveryEffectIntentOptions,
   AgentChannelDeliveryEffectPayload,
   AgentChannelDeliveryEffectKind,
   AgentChannelDeliveryEffects,
@@ -757,8 +762,7 @@ function once<TArgs extends unknown[]>(callback: (...args: TArgs) => Promise<voi
 
 export { applyAgentToolPolicies, withAgentToolStepReporting } from "./tool-runtime.ts"
 export { defineCapability } from "./capability-runtime.ts"
-export { defineFinishEffect, getAgentFinishText, reaction, reply, status } from "./delivery-effects.ts"
-export type { AgentChannelDeliveryEffectIntentOptions } from "./delivery-effects.ts"
+export { defineFinishEffect } from "./delivery-effects.ts"
 export { isResolvedAgentTriggerHandledInvocation, verifyAgentWebhookRequest } from "./trigger-runtime.ts"
 export type { AgentWebhookVerificationResult, ResolvedAgentTriggerHandledInvocation, ResolvedAgentTriggerInvocation, ResolvedAgentTriggerInvocationResult } from "./trigger-runtime.ts"
 export * from "./messages.ts"
@@ -1753,16 +1757,30 @@ async function resolveFinishDeliveryEffectIntents<
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
 ): Promise<AgentChannelDeliveryEffectIntent[]> {
   const intents: AgentChannelDeliveryEffectIntent[] = []
+  const result = event.result === undefined ? undefined : toAgentRunResult(event.result)
   const finishContext = {
     ...context.runtimeContext,
+    actor: context.actor,
     context: context.context,
+    ...(event.error !== undefined ? { error: event.error } : {}),
+    ...(event.errorMessage !== undefined ? { errorMessage: event.errorMessage } : {}),
+    event,
+    extensions: event.extensions,
     input: context.input,
+    invocation: event.invocation,
+    invoker: context.invoker,
+    ...(event.result !== undefined ? { output: event.result } : {}),
+    reaction: createReactionDeliveryEffectIntent,
+    reply: createReplyDeliveryEffectIntent,
+    ...(result !== undefined ? { result } : {}),
     request: context.runtimeContext.request,
     run: context.run,
+    status: createStatusDeliveryEffectIntent,
+    ...(event.text !== undefined ? { text: event.text } : {}),
     workspace: context.workspace,
   }
   for (const provider of providers) {
-    const intent = typeof provider === "function" ? await provider(event, finishContext) : provider
+    const intent = typeof provider === "function" ? await provider(finishContext, event) : provider
     if (!intent) continue
     appendDeliveryEffectIntent(intents, intent)
   }
@@ -1780,7 +1798,7 @@ async function finishAgentInvocation<
   const failed = outcome.status === "error"
   const error = failed ? outcome.error : undefined
   const result = outcome.status === "success" ? outcome.result : undefined
-  const text = failed ? undefined : getAgentFinishText({ result })
+  const text = failed || result === undefined ? undefined : toAgentRunResult(result).text
   try {
     await context.close()
     if (hasFinishWork(context)) {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -192,6 +192,12 @@ export interface AgentChannelDeliveryEffectIntent<
   payload?: TPayload
 }
 
+export interface AgentChannelDeliveryEffectIntentOptions {
+  artifacts?: readonly PublishedAgentDeliveryArtifact[]
+  intent?: string
+  metadata?: Record<string, unknown>
+}
+
 export interface AgentChannelDeliveryReplyPayload {
   artifacts?: readonly PublishedAgentDeliveryArtifact[]
   body?: string
@@ -247,11 +253,19 @@ export interface AgentChannelDeliveryEffectContext<
 export interface AgentChannelDeliveryFinishEffectContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
-> extends AgentCallbackContext<TRuntimeConfig> {
-  context: AgentInvocationContextStore
-  input: AgentRunInput<CALL_OPTIONS>
+> extends AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS> {
+  error?: unknown
+  errorMessage?: string
+  event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>
+  extensions: AgentFinishExtensions
+  invocation: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>["invocation"]
+  output?: unknown
+  reaction: (input: AgentChannelDeliveryReactionInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reaction">
+  reply: (input: AgentChannelDeliveryReplyInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reply">
+  result?: AgentRunResult
   request?: Request
-  run?: AgentRunMetadata
+  status: (input: AgentChannelDeliveryStatusInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"status">
+  text?: string
   workspace?: ReadonlyWorkspaceFacade
 }
 
@@ -267,7 +281,7 @@ export type AgentChannelDeliveryFinishEffectResult =
 export type AgentChannelDeliveryFinishEffectCallback<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
-> = (event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, context: AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<AgentChannelDeliveryFinishEffectResult>
+> = (context: AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS>, event?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<AgentChannelDeliveryFinishEffectResult>
 export type AgentChannelDeliveryFinishEffect<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -43,6 +43,19 @@ describe("agent output helpers", () => {
     })
   })
 
+  it("falls back to output fields when result text is empty", () => {
+    expect(toAgentRunResult({
+      _output: "structured fallback",
+      output: "output fallback",
+      text: "",
+    }).text).toBe("output fallback")
+
+    expect(toAgentRunResult({
+      _output: "structured fallback",
+      text: "",
+    }).text).toBe("structured fallback")
+  })
+
   it("falls back to the latest step text for AI SDK result objects", () => {
     const value = {
       finishReason: "stop",
@@ -68,6 +81,18 @@ describe("agent output helpers", () => {
     }
 
     expect(toAgentRunResult(value).text).toBe("latest result")
+  })
+
+  it("falls back to top-level content text for AI SDK result objects", () => {
+    const value = {
+      content: [
+        { text: "final", type: "text" },
+        { textDelta: " result", type: "text-delta" },
+      ],
+      finishReason: "stop",
+    }
+
+    expect(toAgentRunResult(value).text).toBe("final result")
   })
 
   it("tracks tool names across stream events", () => {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -31,23 +31,46 @@ function githubIssueCommentPayload(body = "/review please") {
 }
 
 describe("agent channels", () => {
-  it("falls back to output fields when finish result text is empty", async () => {
-    const { getAgentFinishText } = await import("../src/channels.ts")
+  it("uses normalized finish context text for default GitHub PR replies", async () => {
+    const { github } = await import("../src/channels.ts")
+    const channel = github({ pullRequest: true })
+    const trigger = channel.triggers?.dev
+    if (!trigger) throw new Error("Missing GitHub dev trigger.")
 
-    expect(getAgentFinishText({
-      result: {
-        _output: "structured fallback",
-        output: "output fallback",
-        text: "",
+    const result = await trigger.invoke({
+      capabilities: [],
+      channel,
+      trigger: { channelId: "github", id: "github.dev", name: "dev", source: "channel" },
+    } as never, {
+      pullRequest: {
+        pullRequest: {
+          apiUrl: "https://api.github.test/repos/acme/app/pulls/42",
+          number: 42,
+          source: { mount: "app", ref: "refs/pull/42/head", repo: "acme/app" },
+        },
+        repository: { fullName: "acme/app", name: "app", owner: "acme" },
+        run: { messageId: "99", origin: "github-pull-request-comment", runId: "github:acme/app#42:comment:99", threadId: "pr-42" },
+        trigger: {
+          action: "created",
+          actor: { login: "mona" },
+          args: "",
+          command: "/review",
+          comment: { id: 99, nodeId: "comment-node" },
+          event: "issue_comment",
+          installationId: 123,
+        },
       },
-    })).toBe("output fallback")
+    })
+    if (result instanceof Response) throw new Error("Expected GitHub context invocation.")
+    const finishEffect = result.delivery?.finishEffects
+    if (typeof finishEffect !== "function") throw new Error("Missing GitHub finish effect.")
 
-    expect(getAgentFinishText({
-      result: {
-        _output: "structured fallback",
-        text: "",
-      },
-    })).toBe("structured fallback")
+    await expect(Promise.resolve(finishEffect({
+      extensions: { get: () => undefined },
+      reply: (input: string) => ({ kind: "reply", payload: input }),
+      result: { text: "output fallback" },
+      text: "event fallback",
+    } as never))).resolves.toEqual({ kind: "reply", payload: "output fallback" })
   })
 
   it("creates Discord adapters from provider defaults", async () => {

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -62,6 +62,38 @@ describe("inputCommands", () => {
     expect(resolved.input.prompt).toBe("auth changes")
   })
 
+  it("uses command descriptions for command-only default rewrites", async () => {
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [inputCommands({
+        commands: {
+          summary: {
+            description: "Summarize the request.",
+          },
+        },
+      })],
+    }, runtime(), { prompt: "/summary" })
+
+    expect(resolved.input.prompt).toBe("Summarize the request.")
+  })
+
+  it("removes command-only text for the default command rewrite", async () => {
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [inputCommands({
+        commands: {
+          summary: {},
+        },
+      })],
+    }, runtime(), { prompt: "/summary" })
+
+    expect(resolved.input.prompt).toBe("")
+  })
+
   it("keeps command-only message text when a string handler returns empty args", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2526,7 +2526,7 @@ describe("agent message protocol", () => {
 
   it("lets Channel triggers expose finish delivery effects", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
-    const { defineChannel, defineFinishEffect, reply } = await import("../src/channels.ts")
+    const { defineChannel, defineFinishEffect } = await import("../src/channels.ts")
     const order: string[] = []
     const effect = vi.fn((context) => {
       order.push(`effect:${context.effect.payload}`)
@@ -2551,10 +2551,13 @@ describe("agent message protocol", () => {
             message: {
               invoke: context => ({
                 delivery: {
-                  finishEffects: defineFinishEffect((event, finishContext) => {
-                    const reviewContext = finishContext.context.get<{ number: number }>("review.context")
+                  finishEffects: defineFinishEffect((context, event) => {
+                    const reviewContext = context.context.get<{ number: number }>("review.context")
                     expect(reviewContext).toEqual({ number: 42 })
-                    return reply(`result:${event.text}:${(event.extensions.get("marker") as { value?: string } | undefined)?.value}:${reviewContext?.number}`)
+                    expect(context.event).toBe(event)
+                    expect(context.output).toBe("ok")
+                    expect(context.result?.text).toBe("ok")
+                    return context.reply(`result:${context.text}:${(context.extensions.get("marker") as { value?: string } | undefined)?.value}:${reviewContext?.number}`)
                   }),
                 },
                 input: { context: { "review.context": { number: 42 } }, prompt: "hello" },
@@ -2599,8 +2602,8 @@ describe("agent message protocol", () => {
             message: {
               invoke: context => ({
                 delivery: {
-                  finishEffects: async (_event, finishContext) => ({
-                    artifacts: await publishWorkspaceArtifacts(finishContext, [{
+                  finishEffects: async context => ({
+                    artifacts: await publishWorkspaceArtifacts(context, [{
                       mediaType: "image/png",
                       path: "screenshots/result.png",
                       placement: "inline",
@@ -2647,7 +2650,7 @@ describe("agent message protocol", () => {
         defineCapability({
           id: "feedback",
           prepare(context) {
-            context.delivery.finishEffect(event => ({ kind: "reply", payload: `done:${event.result}` }))
+            context.delivery.finishEffect(context => context.reply(`done:${context.output}`))
           },
         }),
       ],
@@ -4294,10 +4297,7 @@ describe("agent message protocol", () => {
                 text: `${(result as { text?: string }).text}\n${usage?.summary}`,
               }
             })
-            context.delivery.finishEffect(event => ({
-              kind: "reply",
-              payload: (event.result as { text?: string }).text,
-            }))
+            context.delivery.finishEffect(context => context.reply(context.result!.text!))
           },
         }),
       ],
@@ -4373,10 +4373,7 @@ describe("agent message protocol", () => {
               ...result as Record<string, unknown>,
               text: `${(result as { text?: string }).text}:final`,
             }))
-            context.delivery.finishEffect(event => ({
-              kind: "reply",
-              payload: (event.result as { text?: string }).text,
-            }))
+            context.delivery.finishEffect(context => context.reply(context.result!.text!))
           },
         }),
       ],
@@ -4439,10 +4436,7 @@ describe("agent message protocol", () => {
                 text: `${(result as { text?: string }).text}\n${usage?.summary}`,
               }
             })
-            context.delivery.finishEffect(event => ({
-              kind: "reply",
-              payload: (event.result as { text?: string }).text,
-            }))
+            context.delivery.finishEffect(context => context.reply(context.result!.text!))
           },
         }),
       ],
@@ -4544,10 +4538,7 @@ describe("agent message protocol", () => {
                 text: `${(result as { text?: string }).text}\n${usage?.summary}`,
               }
             })
-            context.delivery.finishEffect(event => ({
-              kind: "reply",
-              payload: (event.result as { text?: string }).text,
-            }))
+            context.delivery.finishEffect(context => context.reply(context.result!.text!))
           },
         }),
       ],
@@ -4677,10 +4668,7 @@ describe("agent message protocol", () => {
                 text: `${(result as { text?: string }).text}\n${usage?.summary}`,
               }
             })
-            context.delivery.finishEffect(event => ({
-              kind: "reply",
-              payload: (event.result as { text?: string }).text,
-            }))
+            context.delivery.finishEffect(context => context.reply(context.result!.text!))
           },
         }),
       ],

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, getAgentFinishText, reaction, reply, status, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentDeliveryArtifact, type AgentDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, getUsageTelemetry, git, inputCommands, kv, mcp, observability, openapi, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -678,28 +678,33 @@ describe("agent public types", () => {
     }
     const channel: AgentChannelDefinition = teams()
     expectTypeOf(channel.kind).toEqualTypeOf<string>()
-    const reviewFinishEffect: AgentChannelDeliveryFinishEffect = event => ({
+    const reviewFinishEffect: AgentChannelDeliveryFinishEffect = context => ({
       kind: "reply",
-      payload: event.result,
+      payload: context.output,
     })
     const renderBody = async (text: string, workspace?: ReadonlyWorkspaceFacade) => `${text}:${Boolean(workspace)}`
-    const typedFinishEffect = defineFinishEffect(async (event, { context, request, workspace }) => {
-      expectTypeOf(event.text).toEqualTypeOf<string | undefined>()
-      expectTypeOf(getAgentFinishText(event)).toEqualTypeOf<string | undefined>()
-      expectTypeOf(context).toEqualTypeOf<AgentChannelDeliveryFinishEffectContext["context"]>()
-      expectTypeOf(context.get<{ repository: string }>("review.context")).toEqualTypeOf<{ repository: string } | undefined>()
-      expectTypeOf(request).toEqualTypeOf<Request | undefined>()
-      expectTypeOf(workspace).toEqualTypeOf<ReadonlyWorkspaceFacade | undefined>()
-      if (event.error) return reply(`failed: ${event.errorMessage}`)
-      const text = event.text
+    const typedFinishEffect = defineFinishEffect(async (context, event) => {
+      expectTypeOf(event).toEqualTypeOf<AgentFinishEvent | undefined>()
+      expectTypeOf(context.event).toEqualTypeOf<AgentFinishEvent>()
+      expectTypeOf(context.output).toEqualTypeOf<unknown>()
+      expectTypeOf(context.result).toEqualTypeOf<AgentRunResult | undefined>()
+      expectTypeOf(context.text).toEqualTypeOf<string | undefined>()
+      expectTypeOf(context.context).toEqualTypeOf<AgentChannelDeliveryFinishEffectContext["context"]>()
+      expectTypeOf(context.context.get<{ repository: string }>("review.context")).toEqualTypeOf<{ repository: string } | undefined>()
+      expectTypeOf(context.request).toEqualTypeOf<Request | undefined>()
+      expectTypeOf(context.workspace).toEqualTypeOf<ReadonlyWorkspaceFacade | undefined>()
+      if (context.error) return context.reply(`failed: ${context.errorMessage}`)
+      const text = context.result?.text
       if (!text) return
-      return reply(await renderBody(text, workspace))
+      return context.reply(await renderBody(text, context.workspace))
     })
     expectTypeOf(typedFinishEffect).toMatchTypeOf<AgentChannelDeliveryFinishEffect>()
-    expectTypeOf(reply("done")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"reply">>()
-    expectTypeOf(reaction("eyes")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"reaction">>()
-    expectTypeOf(status("pending")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"status">>()
-    expectTypeOf(reply({ markdown: "done" }).payload).toEqualTypeOf<AgentChannelDeliveryReplyPayload | string | undefined>()
+    defineFinishEffect((context) => {
+      expectTypeOf(context.reply("done")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"reply">>()
+      expectTypeOf(context.reaction("eyes")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"reaction">>()
+      expectTypeOf(context.status("pending")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"status">>()
+      expectTypeOf(context.reply({ markdown: "done" }).payload).toEqualTypeOf<AgentChannelDeliveryReplyPayload | string | undefined>()
+    })
     // @ts-expect-error Development samples belong in CLI payload files, not Channel options.
     teams({ dev: { samples: {} } })
     // @ts-expect-error Development samples belong in CLI payload files, not Channel Definitions.
@@ -724,15 +729,14 @@ describe("agent public types", () => {
             expectTypeOf(input.text).toEqualTypeOf<string>()
             return {
               delivery: {
-                finishEffects: (event, context) => {
+                finishEffects: (context, event) => {
+                  expectTypeOf(event).toEqualTypeOf<AgentFinishEvent | undefined>()
                   expectTypeOf(context.context).toEqualTypeOf<AgentChannelDeliveryFinishEffectContext["context"]>()
                   expectTypeOf(context.request).toEqualTypeOf<Request | undefined>()
                   expectTypeOf(context.workspace).toEqualTypeOf<AgentChannelDeliveryFinishEffectContext["workspace"]>()
-                  return {
+                  return context.reply(String(context.output), {
                     artifacts: [{ path: "screenshots/result.png", url: "https://assets.example/result.png" }],
-                    kind: "reply",
-                    payload: event.result,
-                  }
+                  })
                 },
               },
               input: { prompt: input.text },
@@ -749,7 +753,7 @@ describe("agent public types", () => {
         id: "feedback",
         prepare(context) {
           context.delivery.effect({ intent: "started", kind: "reaction" })
-          context.delivery.finishEffect(event => ({ kind: "reply", payload: event.result }))
+          context.delivery.finishEffect(context => context.reply(String(context.output)))
         },
       }, inputCommands({
         commands: {


### PR DESCRIPTION
Moves Channel finish delivery to a context-first contract. Finish effects now receive raw `context.output`, normalized `context.result`, `context.text`, and contextual `reply`, `reaction`, and `status` methods, while the raw finish event remains available as `context.event`/the optional second callback argument.

Removes public `getAgentFinishText`, `reply`, `reaction`, and `status` exports from the root and channel entrypoints, and routes default GitHub PR replies through the normalized finish context. Also updates the default input command rewrite so command args become the generated prompt, bare commands fall back to the command description when present, and commands without either are stripped.