### PR TITLE
feat(agent): support review agent final config

### DIFF
--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -72,7 +72,8 @@ const blockedCheckoutOptions = new Set(["--force", "--merge", "--orphan", "--pat
 const blockedFetchOptions = new Set(["--force", "--prune-tags", "--refmap", "--tags", "--update-head-ok", "--upload-pack", "-P", "-f", "-t", "-u"])
 const fetchOptionsWithValue = new Set(["--deepen", "--depth", "--filter", "--jobs", "--negotiation-tip", "--refmap", "--recurse-submodules", "--server-option", "--shallow-exclude", "--shallow-since", "--upload-pack"])
 const blockedSwitchOptions = new Set(["--create", "--discard-changes", "--force", "--force-create", "--guess", "--merge", "--orphan", "--track", "-C", "-c", "-f", "-m", "-t"])
-const defaultMaxOutputLength = 30_000
+const defaultMaxOutputLength = Number.POSITIVE_INFINITY
+const defaultTimeout = 60_000
 const gitEnv = {
   GIT_PAGER: "cat",
   GIT_TERMINAL_PROMPT: "0",
@@ -554,6 +555,7 @@ function gitShellInputSchema(commandDescription: string) {
 export function git(options: GitCapabilityOptions = {}): AgentCapabilityDefinition {
   const mode = normalizeMode(options.mode, "Git")
   const maxOutputLength = options.maxOutputLength ?? defaultMaxOutputLength
+  const timeout = options.timeout ?? defaultTimeout
   const sessionStates = new WeakMap<object, GitSessionState>()
 
   function sessionState(context: object): GitSessionState {
@@ -578,7 +580,7 @@ export function git(options: GitCapabilityOptions = {}): AgentCapabilityDefiniti
       if (!state.sessionPromises.has(key)) {
         state.sessionPromises.set(key, workspace.startSession(workspacePath ? { paths: [workspacePath] } : undefined).then(async (session) => {
           try {
-            const prepared = await preparePullRequestGitSession(session, workspacePath, context, options.timeout)
+            const prepared = await preparePullRequestGitSession(session, workspacePath, context, timeout)
             return { commitWrites: !prepared, session }
           }
           catch (error) {
@@ -617,7 +619,7 @@ export function git(options: GitCapabilityOptions = {}): AgentCapabilityDefiniti
     tools: context => gitTools(mode, {
       maxOutputLength,
       policy: options.policy,
-      timeout: options.timeout,
+      timeout,
     }, getSessionResolver(context), defaultGitCwd(context)),
     close: closeSession,
   })

--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -299,7 +299,7 @@ function mergeInputCommandResult(input: AgentRunInput, result: Partial<AgentRunI
 }
 
 function inputCommandCall(command: InputCommand): InputCommandCall {
-  return command.call || command.run || (({ args, command }) => args || command.description)
+  return command.call || command.run || (({ args, name }) => args || name)
 }
 
 function activeChannelId(context: AgentCapabilityRuntimeContext): string | undefined {

--- a/packages/agent/src/capabilities/observability.ts
+++ b/packages/agent/src/capabilities/observability.ts
@@ -1,5 +1,5 @@
 import { defineCapability } from "../capability-runtime.ts"
-import { getUsageTelemetry, usageTelemetry } from "./usage-telemetry.ts"
+import { usageTelemetry } from "./usage-telemetry.ts"
 
 import type {
   AgentActor,
@@ -89,7 +89,7 @@ function resultKind(result: unknown): string {
 }
 
 function usageRecordFromFinishEvent(event: AgentFinishEvent): AgentUsageRecord | undefined {
-  return getUsageTelemetry(event)
+  return usageTelemetry.from(event)
 }
 
 function capabilityEventBase<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -394,7 +394,7 @@ function normalizePullRequestContext(value: unknown): PullRequestContextValue | 
   }
 }
 
-function readPullRequestContext(context: unknown, contextKey = "pullRequest"): PullRequestContextValue | undefined {
+export function readPullRequestContext(context: unknown, contextKey = "pullRequest"): PullRequestContextValue | undefined {
   if (isRecord(context) && isRecord(context.context) && typeof context.context.get === "function") {
     return normalizePullRequestContext(context.context.get(contextKey))
   }

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -331,12 +331,7 @@ function normalizeUsageSummaryOptions(summary: UsageTelemetryOptions["summary"])
   return typeof summary === "object" && summary !== null ? summary : {}
 }
 
-async function formatUsageSummary(record: AgentUsageRecord, options: UsageTelemetrySummaryOptions = {}): Promise<string | undefined> {
-  const subject = typeof options.subject === "string" && options.subject.trim() ? options.subject.trim() : "This invocation"
-  if (options.format) {
-    const summary = await options.format(record, { subject })
-    return summary || undefined
-  }
+function formatDefaultUsageSummary(record: AgentUsageRecord, subject: string): string | undefined {
   const cost = formatUsageCost(record.cost)
   const tokens = formatUsageTokens(record.usage)
   const details = formatUsageDetails(record.usage?.details)
@@ -348,6 +343,15 @@ async function formatUsageSummary(record: AgentUsageRecord, options: UsageTeleme
   if (tokens) return `${subject} used ${tokens}${run ? ` ${run}` : ""}.`
   if (details) return `${subject} ${details}${run ? ` ${run}` : ""}.`
   if (run) return `${subject} ran ${run}.`
+}
+
+async function formatUsageSummary(record: AgentUsageRecord, options: UsageTelemetrySummaryOptions = {}): Promise<string | undefined> {
+  const subject = typeof options.subject === "string" && options.subject.trim() ? options.subject.trim() : "This invocation"
+  if (options.format) {
+    const summary = await options.format(record, { subject })
+    return summary || undefined
+  }
+  return formatDefaultUsageSummary(record, subject)
 }
 
 async function usageRecordForFinish(
@@ -545,13 +549,19 @@ function cloneWithUsageTelemetryStream<T extends UnknownRecord>(
 
 export type UsageTelemetryFinishEvent = Pick<AgentFinishEvent, "extensions">
 
-export function getUsageTelemetry(event: UsageTelemetryFinishEvent | undefined): AgentUsageRecord | undefined {
+function getUsageTelemetryRecord(event: UsageTelemetryFinishEvent | undefined): AgentUsageRecord | undefined {
   return event?.extensions.get("usage-telemetry")
+}
+
+export function getUsageTelemetry(event: UsageTelemetryFinishEvent | undefined): string | undefined {
+  const record = getUsageTelemetryRecord(event)
+  if (!record) return
+  return record.summary || formatDefaultUsageSummary(record, "This invocation")
 }
 
 export interface UsageTelemetryCapabilityFactory {
   (options?: UsageTelemetryOptions): AgentCapabilityDefinition
-  from: typeof getUsageTelemetry
+  from: typeof getUsageTelemetryRecord
 }
 
 export const usageTelemetry: UsageTelemetryCapabilityFactory = Object.assign((options: UsageTelemetryOptions = {}): AgentCapabilityDefinition => {
@@ -587,7 +597,7 @@ export const usageTelemetry: UsageTelemetryCapabilityFactory = Object.assign((op
       })
     },
   })
-}, { from: getUsageTelemetry })
+}, { from: getUsageTelemetryRecord })
 
 function decimalToParts(value: string): { scale: bigint, units: bigint } {
   const trimmed = value.trim()

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1,5 +1,6 @@
 import { createHash, createSign } from "node:crypto"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY } from "./chat-trigger.ts"
+import { readPullRequestContext } from "./capabilities/pull-request-context.ts"
 import { deliveryArtifactAttachments } from "./delivery-artifacts.ts"
 
 import type {
@@ -26,6 +27,7 @@ import type {
   MaybeResolvable,
   PublishedAgentDeliveryArtifact,
 } from "./types.ts"
+import type { PullRequestContextValue } from "./capabilities/pull-request-context.ts"
 import type { AgentChannelChatRouteBody, AgentChannelChatRouteHandlerOptions } from "./server.ts"
 import type { Adapter, FileUpload } from "chat"
 
@@ -272,6 +274,12 @@ export interface GitHubPullRequestRunContext {
   }
 }
 
+export interface GitHubPullRequestReadInvocation {
+  context: {
+    get: (key: string) => unknown
+  }
+}
+
 declare global {
   interface ViteHubWorkspaceSourceResolutionContextMap {
     github: GitHubPullRequestCommand
@@ -281,6 +289,21 @@ declare global {
     github: GitHubPullRequestCommand
     pullRequest: GitHubPullRequestRunContext
   }
+}
+
+function githubPullRequestRunContextFromUnknown(input: unknown): GitHubPullRequestRunContext | undefined {
+  if (!isRecord(input)) return
+  const value = isRecord(input.pullRequest) && isRecord(input.pullRequest.pullRequest) ? input.pullRequest : input
+  if (!isRecord(value.pullRequest) || !isRecord(value.repository) || !isRecord(value.run) || !isRecord(value.trigger)) return
+  return value as unknown as GitHubPullRequestRunContext
+}
+
+export const pullRequest = {
+  read(invocation: GitHubPullRequestReadInvocation): PullRequestContextValue {
+    const context = readPullRequestContext(invocation)
+    if (!context) throw new Error("[vitehub] pullRequest.read() requires pull request invocation context.")
+    return context
+  },
 }
 
 export interface GitHubPullRequestCommentEventOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
@@ -1571,10 +1594,7 @@ function ignored(reason: string) {
 }
 
 function githubPullRequestRunContextFromInput(input: unknown): GitHubPullRequestRunContext | undefined {
-  if (!isRecord(input)) return
-  const value = isRecord(input.pullRequest) && isRecord(input.pullRequest.pullRequest) ? input.pullRequest : input
-  if (!isRecord(value.pullRequest) || !isRecord(value.repository) || !isRecord(value.run) || !isRecord(value.trigger)) return
-  return value as unknown as GitHubPullRequestRunContext
+  return githubPullRequestRunContextFromUnknown(input)
 }
 
 function githubCommandFromRunContext(value: GitHubPullRequestRunContext): GitHubPullRequestCommand | undefined {

--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -1,5 +1,5 @@
 import { chmodSync, existsSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
+import { homedir, tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { createCodex } from "@ai-sdk/harness-codex"
@@ -86,10 +86,11 @@ function codexLocalEnv(options: {
   env?: Record<string, string | undefined>
   preferOpenAI: boolean
 }): Record<string, string | undefined> {
-  const env = {
+  const env: Record<string, string | undefined> = {
     ...process.env,
     ...options.env,
   }
+  stripGitHubSecrets(env)
 
   if (options.preferOpenAI) {
     delete env.AI_GATEWAY_API_KEY
@@ -98,7 +99,7 @@ function codexLocalEnv(options: {
 
   const codexHome = codexHomeFromAuth({
     authJson: options.authJson ?? env.CODEX_AUTH_JSON,
-    authJsonPath: options.authJsonPath,
+    authJsonPath: options.authJsonPath ?? env.CODEX_AUTH_JSON_PATH ?? ambientCodexAuthJsonPath(),
   })
   if (codexHome) env.CODEX_HOME = codexHome
   env.PATH = [
@@ -107,6 +108,19 @@ function codexLocalEnv(options: {
     env.PATH,
   ].filter(Boolean).join(":")
   return env
+}
+
+function stripGitHubSecrets(env: Record<string, string | undefined>): void {
+  for (const key of Object.keys(env)) {
+    if (/^(?:GITHUB|GH|VITEHUB_GITHUB)_/.test(key) && /(?:TOKEN|SECRET|PRIVATE_KEY|WEBHOOK|APP_ID)/.test(key)) {
+      delete env[key]
+    }
+  }
+}
+
+function ambientCodexAuthJsonPath(): string | undefined {
+  const path = join(homedir(), ".codex", "auth.json")
+  return existsSync(path) ? path : undefined
 }
 
 function codexHomeFromAuth(options: { authJson?: string, authJsonPath?: string }): string | undefined {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -45,8 +45,13 @@ describe("agent channels", () => {
       pullRequest: {
         pullRequest: {
           apiUrl: "https://api.github.test/repos/acme/app/pulls/42",
+          body: "Review body",
+          comments: [{ body: "Looks good", id: 100, user: { login: "hubot" } }],
+          files: [{ additions: 5, deletions: 2, filename: "src/app.ts", status: "modified" }],
+          labels: ["review"],
           number: 42,
           source: { mount: "app", ref: "refs/pull/42/head", repo: "acme/app" },
+          title: "Improve app",
         },
         repository: { fullName: "acme/app", name: "app", owner: "acme" },
         run: { messageId: "99", origin: "github-pull-request-comment", runId: "github:acme/app#42:comment:99", threadId: "pr-42" },
@@ -71,6 +76,51 @@ describe("agent channels", () => {
       result: { text: "output fallback" },
       text: "event fallback",
     } as never))).resolves.toEqual({ kind: "reply", payload: "output fallback" })
+  })
+
+  it("exposes a GitHub pull request reader for invocation context", async () => {
+    const { pullRequest } = await import("../src/channels.ts")
+    const context = {
+      pullRequest: {
+        pullRequest: {
+          apiUrl: "https://api.github.test/repos/acme/app/pulls/42",
+          body: "Review body",
+          comments: [{ body: "Looks good", id: 100, user: { login: "hubot" } }],
+          files: [{ additions: 5, deletions: 2, filename: "src/app.ts", status: "modified" }],
+          labels: ["review"],
+          number: 42,
+          source: { mount: "app", ref: "refs/pull/42/head", repo: "acme/app" },
+          title: "Improve app",
+        },
+        repository: { fullName: "acme/app", name: "app", owner: "acme" },
+        run: { messageId: "99", origin: "github-pull-request-comment", runId: "github:acme/app#42:comment:99", threadId: "pr-42" },
+        trigger: {
+          action: "created",
+          actor: { login: "mona" },
+          args: "",
+          command: "/review",
+          comment: { id: 99 },
+          event: "issue_comment",
+        },
+      },
+    }
+
+    expect(pullRequest.read({
+      context: {
+        get: key => context[key as keyof typeof context],
+      },
+    })).toMatchObject({
+      body: "Review body",
+      comments: [{ body: "Looks good", id: 100, user: { login: "hubot" } }],
+      files: [{ additions: 5, deletions: 2, filename: "src/app.ts", status: "modified" }],
+      labels: ["review"],
+      number: 42,
+      provider: "github",
+      repository: "acme/app",
+      source: { mount: "app", ref: "refs/pull/42/head", repo: "acme/app" },
+      title: "Improve app",
+    })
+    expect(() => pullRequest.read({ context: { get: () => undefined } })).toThrow("requires pull request invocation context")
   })
 
   it("creates Discord adapters from provider defaults", async () => {

--- a/packages/agent/test/codex-harness.test.ts
+++ b/packages/agent/test/codex-harness.test.ts
@@ -1,3 +1,7 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
 import { describe, expect, it, vi } from "vitest"
 
 const createCodex = vi.hoisted(() => vi.fn(settings => ({ provider: "codex", settings })))
@@ -23,8 +27,14 @@ describe("codexDriver", () => {
   it("keeps host AI Gateway env out of the default local Codex sandbox", async () => {
     const originalGatewayKey = process.env.AI_GATEWAY_API_KEY
     const originalGatewayBaseUrl = process.env.AI_GATEWAY_BASE_URL
+    const originalGitHubToken = process.env.GITHUB_TOKEN
+    const originalGitHubPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY
+    const originalGitHubWebhookSecret = process.env.VITEHUB_GITHUB_WEBHOOK_SECRET
     process.env.AI_GATEWAY_API_KEY = "host-key"
     process.env.AI_GATEWAY_BASE_URL = "https://gateway.example"
+    process.env.GITHUB_TOKEN = "github-token"
+    process.env.GITHUB_APP_PRIVATE_KEY = "github-private-key"
+    process.env.VITEHUB_GITHUB_WEBHOOK_SECRET = "github-webhook-secret"
 
     try {
       const { codexDriver } = await import("../src/harness/codex.ts")
@@ -34,6 +44,9 @@ describe("codexDriver", () => {
       try {
         expect(session?.env.AI_GATEWAY_API_KEY).toBeUndefined()
         expect(session?.env.AI_GATEWAY_BASE_URL).toBeUndefined()
+        expect(session?.env.GITHUB_TOKEN).toBeUndefined()
+        expect(session?.env.GITHUB_APP_PRIVATE_KEY).toBeUndefined()
+        expect(session?.env.VITEHUB_GITHUB_WEBHOOK_SECRET).toBeUndefined()
         expect(session?.env.EXTRA_CODEX_ENV).toBe("1")
         expect(session?.env.PATH).toContain("node_modules/.bin")
       }
@@ -44,6 +57,35 @@ describe("codexDriver", () => {
     finally {
       restoreEnv("AI_GATEWAY_API_KEY", originalGatewayKey)
       restoreEnv("AI_GATEWAY_BASE_URL", originalGatewayBaseUrl)
+      restoreEnv("GITHUB_TOKEN", originalGitHubToken)
+      restoreEnv("GITHUB_APP_PRIVATE_KEY", originalGitHubPrivateKey)
+      restoreEnv("VITEHUB_GITHUB_WEBHOOK_SECRET", originalGitHubWebhookSecret)
+    }
+  })
+
+  it("uses ambient local Codex auth when explicit auth is omitted", async () => {
+    const originalHome = process.env.HOME
+    const home = await mkdtemp(join(tmpdir(), "vitehub-codex-home-"))
+    await mkdir(join(home, ".codex"), { recursive: true })
+    await writeFile(join(home, ".codex", "auth.json"), "{\"token\":\"local\"}\n")
+    process.env.HOME = home
+
+    try {
+      const { codexDriver } = await import("../src/harness/codex.ts")
+      const driver = codexDriver() as { sandbox?: { createSession: () => Promise<{ destroy: () => Promise<void>, env: Record<string, string> }> } }
+      const session = await driver.sandbox?.createSession()
+
+      try {
+        expect(session?.env.CODEX_HOME).toContain("vitehub-codex-home-")
+        await expect(readFile(join(session!.env.CODEX_HOME, "auth.json"), "utf8")).resolves.toBe("{\"token\":\"local\"}\n")
+      }
+      finally {
+        await session?.destroy()
+      }
+    }
+    finally {
+      restoreEnv("HOME", originalHome)
+      await rm(home, { force: true, recursive: true })
     }
   })
 

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -73,7 +73,25 @@ describe("git capability", () => {
       stdout: "ok\n",
     })
     await expect(tools.shell!.execute?.({ command: "git switch main" })).rejects.toThrow("requires git({ mode: \"write\" })")
-    expect(session.exec).toHaveBeenCalledWith("git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace", timeout: undefined }))
+    expect(session.exec).toHaveBeenCalledWith("git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace", timeout: 60_000 }))
+  })
+
+  it("does not truncate git output by default", async () => {
+    const session = gitSession()
+    const output = "x".repeat(40_000)
+    session.exec.mockResolvedValueOnce({
+      args: ["show"],
+      command: "git",
+      exitCode: 0,
+      stderr: "",
+      stdout: output,
+    })
+    const { tools } = await capabilityTools(git(), session)
+
+    await expect(tools.shell!.execute?.({ command: "git show HEAD" })).resolves.toMatchObject({
+      outputTruncated: undefined,
+      stdout: output,
+    })
   })
 
   it("exposes a command-only shell input schema", async () => {
@@ -155,8 +173,8 @@ describe("git capability", () => {
       cwd: "/workspace/portal",
     })
     expect(startSession).toHaveBeenCalledWith(undefined)
-    expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["status", "--porcelain"], expect.objectContaining({ cwd: "/workspace/portal", timeout: undefined }))
-    expect(session.exec).toHaveBeenNthCalledWith(2, "git", ["switch", "feature/pr-1"], expect.objectContaining({ cwd: "/workspace/portal", timeout: undefined }))
+    expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["status", "--porcelain"], expect.objectContaining({ cwd: "/workspace/portal", timeout: 60_000 }))
+    expect(session.exec).toHaveBeenNthCalledWith(2, "git", ["switch", "feature/pr-1"], expect.objectContaining({ cwd: "/workspace/portal", timeout: 60_000 }))
     expect(session.commit).toHaveBeenCalledWith({ message: "git switch" })
   })
 

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -62,7 +62,7 @@ describe("inputCommands", () => {
     expect(resolved.input.prompt).toBe("auth changes")
   })
 
-  it("uses command descriptions for command-only default rewrites", async () => {
+  it("uses command names for command-only default rewrites with descriptions", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 
@@ -76,10 +76,10 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/summary" })
 
-    expect(resolved.input.prompt).toBe("Summarize the request.")
+    expect(resolved.input.prompt).toBe("summary")
   })
 
-  it("removes command-only text for the default command rewrite", async () => {
+  it("uses the command name for command-only default rewrites without descriptions", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 
@@ -91,7 +91,31 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/summary" })
 
-    expect(resolved.input.prompt).toBe("")
+    expect(resolved.input.prompt).toBe("summary")
+  })
+
+  it("accepts hook-only commands and rewrites bare commands to the command name", async () => {
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const hook = vi.fn()
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [inputCommands({
+        commands: {
+          summary: {
+            hooks: {
+              "agent:input": hook,
+            },
+          },
+        },
+      })],
+    }, runtime(), { prompt: "/summary" })
+
+    expect(resolved.input.prompt).toBe("summary")
+    expect(hook).toHaveBeenCalledWith(expect.objectContaining({
+      name: "summary",
+      text: "/summary",
+    }))
   })
 
   it("keeps command-only message text when a string handler returns empty args", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, getUsageTelemetry, git, inputCommands, kv, mcp, observability, openapi, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
-import { defineChannel, github, http, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
+import { defineChannel, github, http, pullRequest, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
@@ -375,7 +375,7 @@ describe("agent public types", () => {
           expectTypeOf(event.extensions.get<TranscriptionResult[]>("transcribe")).toEqualTypeOf<TranscriptionResult[] | undefined>()
           expectTypeOf(event.extensions.get("usage-telemetry")).toEqualTypeOf<AgentUsageRecord | undefined>()
           expectTypeOf(event.extensions.get("usage-telemetry", "usage")).toEqualTypeOf<AgentUsageRecord["usage"] | undefined>()
-          expectTypeOf(getUsageTelemetry(event)).toEqualTypeOf<AgentUsageRecord | undefined>()
+          expectTypeOf(getUsageTelemetry(event)).toEqualTypeOf<string | undefined>()
           expectTypeOf(usageTelemetry.from(event)).toEqualTypeOf<AgentUsageRecord | undefined>()
           expectTypeOf(event.errorMessage).toEqualTypeOf<string | undefined>()
         },
@@ -903,10 +903,13 @@ describe("agent public types", () => {
         docs: file("AGENTS.md"),
         forecastingEngine: githubSource({ repo: "acme/forecasting-engine" }),
         pullRequest: githubSource(({ invocation }) => {
-          const pullRequest = invocation.context.get("pullRequest")
-          expectTypeOf(pullRequest).toEqualTypeOf<GitHubPullRequestRunContext | undefined>()
-          if (!pullRequest) return false
+          const source = pullRequest.read(invocation).source
+          if (!source?.repo || !source.ref) return false
+          expectTypeOf(source.repo).toEqualTypeOf<string>()
+          expectTypeOf(source.ref).toEqualTypeOf<string>()
           return {
+            repo: source.repo,
+            ref: source.ref,
             root: "portal",
           }
         }),

--- a/packages/agent/test/usage-telemetry.test.ts
+++ b/packages/agent/test/usage-telemetry.test.ts
@@ -98,7 +98,7 @@ describe("usage telemetry", () => {
     const usageRecord = (result as { usageRecord?: unknown }).usageRecord
     const finishEvent = finish.mock.calls[0]![0]
     expect(finishEvent.extensions.get("usage-telemetry")).toEqual(usageRecord)
-    expect(getUsageTelemetry(finishEvent)).toEqual(usageRecord)
+    expect(getUsageTelemetry(finishEvent)).toBe("This invocation cost about $0.000002 using openai/gpt-test (15 tokens: 10 in / 5 out).")
     expect(usageTelemetry.from(finishEvent)).toEqual(usageRecord)
     expect(deliveryUsage).toHaveBeenCalledWith(usageRecord)
   })
@@ -185,7 +185,7 @@ describe("usage telemetry", () => {
       latency: {
         durationMs: expect.any(Number),
       },
-      summary: expect.stringMatching(/^Review run cost about \$0\.00015 using openai\/gpt-test in \d+\.\ds at \d+\.\d tok\/s \(1,250 tokens: 1,000 in \/ 250 out\)\.$/),
+      summary: expect.stringMatching(/^Review run cost about \$0\.00015 using openai\/gpt-test in \d+\.\ds(?: at \d+\.\d tok\/s)? \(1,250 tokens: 1,000 in \/ 250 out\)\.$/),
     })
   })
 


### PR DESCRIPTION
Makes the Agent Package support the final Quiver Review configuration directly: safer default Codex local env/auth, command-name fallback for bare input commands, Review-ready git defaults, concat-able usage telemetry text with raw access preserved, and a GitHub pull-request reader for workspace source resolvers.

Also keeps GitHub pull-request finish delivery on the normalized final text path from PR #504 and adds focused coverage for the changed public surfaces.