### PR TITLE
fix(agent): avoid eager lazy source startup

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -173,8 +173,19 @@ function workspaceSourceHarnessPaths(context: AgentAdapterRunContext): string[] 
     if (source.materialize === "build" && source.probeKeys?.length) {
       return source.probeKeys.map(key => [source.mountPath, key].filter(Boolean).join("/"))
     }
-    if (source.materialize === "lazy") return [source.mountPath || ""]
     return []
+  })
+}
+
+function hasLazyWorkspaceSources(context: AgentAdapterRunContext): boolean {
+  const sources = context.workspaceDefinition?.sources
+  if (!sources) return false
+  const scope = hasTrustedWorkspaceAccessScope(context.context)
+    ? context.context.get("access")?.workspaceScope
+    : undefined
+  return normalizeAgentWorkspaceSources(sources).some((source) => {
+    if (source.scopes?.length && scope && !scope.all && !source.scopes.includes(scope.scope)) return false
+    return source.materialize === "lazy"
   })
 }
 
@@ -196,15 +207,15 @@ function harnessSupportWorkspacePaths(context: AgentAdapterRunContext, definitio
   ])
 }
 
-function withHarnessInstructionPaths(paths: readonly string[]): string[] {
-  return paths.length ? compactWorkspacePaths([...harnessInstructionFiles, ...paths]) : []
+function withHarnessInstructionPaths(paths: readonly string[], includeEmpty = false): string[] {
+  return paths.length || includeEmpty ? compactWorkspacePaths([...harnessInstructionFiles, ...paths]) : []
 }
 
 function explicitHarnessWorkspacePaths(context: AgentAdapterRunContext, definition = context.workspaceDefinition): string[] {
   return withHarnessInstructionPaths([
     ...harnessSupportWorkspacePaths(context, definition),
     ...workspaceSourceHarnessPaths(context),
-  ])
+  ], hasLazyWorkspaceSources(context))
 }
 
 function selectedWorkspaceScopePaths(context: AgentAdapterRunContext, definition = context.workspaceDefinition): string[] | undefined {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1252,7 +1252,7 @@ describe("defineAgent workspace option", () => {
     })
   })
 
-  it("passes lazy source mount roots into Harness Workspace Sessions", async () => {
+  it("keeps lazy source mount roots out of initial Harness Workspace Sessions", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { custom } = await import("@vite-hub/workspace")
     const harnessWorkspaceSession = { close: vi.fn() }
@@ -1297,7 +1297,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["docs", "portal", "AGENTS.md", "CLAUDE.md"],
+      paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -1457,7 +1457,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["docs", "AGENTS.md", "CLAUDE.md"],
+      paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
     }))


### PR DESCRIPTION
Stops Harness Agent startup from passing lazy source mount roots into the initial workspace session. Lazy sources stay lazy, while harness instruction files still keep startup materialization scoped instead of falling back to the full workspace.

This avoids dev CLI startup hangs when a review-style agent has large lazy sources that should only materialize when tools read them.