### PR TITLE
fix(agent): include lazy source probe files

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -170,7 +170,7 @@ function workspaceSourceHarnessPaths(context: AgentAdapterRunContext): string[] 
     : undefined
   return normalizeAgentWorkspaceSources(sources).flatMap((source) => {
     if (source.scopes?.length && scope && !scope.all && !source.scopes.includes(scope.scope)) return []
-    if (source.materialize === "build" && source.probeKeys?.length) {
+    if (source.probeKeys?.length) {
       return source.probeKeys.map(key => [source.mountPath, key].filter(Boolean).join("/"))
     }
     return []

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1252,7 +1252,7 @@ describe("defineAgent workspace option", () => {
     })
   })
 
-  it("keeps lazy source mount roots out of initial Harness Workspace Sessions", async () => {
+  it("passes lazy source probe paths without mount roots into Harness Workspace Sessions", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { custom } = await import("@vite-hub/workspace")
     const harnessWorkspaceSession = { close: vi.fn() }
@@ -1268,8 +1268,9 @@ describe("defineAgent workspace option", () => {
           docs: custom({
             materialize: "lazy",
             mount: "docs",
+            probeKeys: ["context.md"],
             async getKeys() {
-              return ["guide.md"]
+              return ["context.md", "guide.md"]
             },
             async getItem(key) {
               return { content: "docs", key, mediaType: "text/markdown", path: key }
@@ -1297,7 +1298,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
-      paths: ["AGENTS.md", "CLAUDE.md"],
+      paths: ["AGENTS.md", "CLAUDE.md", "docs/context.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
     })


### PR DESCRIPTION
Includes explicit source probe files in Harness Agent startup paths even when the source is lazy. Lazy mount roots still stay out of the initial workspace session, but small generated context files such as pull request metadata can be visible to the model without eager source materialization.