### PR TITLE
fix(workspace): require exec for dev one-shot commands

### DIFF
--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -137,13 +137,13 @@ Use `vitehub workspace dev` when you want a direct command against a Workspace w
 Start the app's Vite dev server first, then run the command from another terminal.
 
 ```bash [Terminal]
-pnpm vitehub workspace dev --url http://localhost:5173 docs pnpm test --filter api
-pnpm vitehub workspace dev --timeout 180000 docs "npm run lint"
+pnpm vitehub workspace dev --url http://localhost:5173 docs exec pnpm test --filter api
+pnpm vitehub workspace dev --timeout 180000 docs exec "npm run lint"
 ```
 
 The command runs through the Workspace dev endpoint exposed by `hubWorkspace()` on the Compatible Vite Development Server.
 ViteHub materializes a Workspace Session, executes the command, prints stdout and stderr, and commits the session when the command exits successfully.
-Put Workspace Dev options before the Workspace target; flags after the command begins are preserved for that command.
+Put Workspace Dev options before the Workspace target; use `exec` before one-shot command args.
 If you omit the command in an interactive terminal, the CLI opens a prompt for repeated Workspace commands.
 
 ```txt [Output]

--- a/docs/content/docs/server-primitives/workspace.md
+++ b/docs/content/docs/server-primitives/workspace.md
@@ -267,7 +267,7 @@ During local development, `vitehub workspace dev` runs commands through a Worksp
 Use it when you want the Workspace Runtime Surface to own materialization, command execution, and successful writeback.
 
 ```bash [Terminal]
-pnpm vitehub workspace dev --url http://localhost:5173 docs pnpm test --filter api
+pnpm vitehub workspace dev --url http://localhost:5173 docs exec pnpm test --filter api
 ```
 
 `vitehub agent dev` also accepts `!` input for direct commands through the selected Agent's writable Workspace.

--- a/packages/workspace/src/cli.ts
+++ b/packages/workspace/src/cli.ts
@@ -156,9 +156,10 @@ async function readWorkspaceDevStream(response: Response, context: WorkspaceCliC
 
 function writeWorkspaceDevUsage(context: WorkspaceCliContext): void {
   context.stdout.write([
-    "Usage: vitehub workspace dev <workspace> [command...] [--url <url>] [--timeout <ms>]",
+    "Usage: vitehub workspace dev <workspace> [exec <command...>] [--url <url>] [--timeout <ms>]",
     "",
     "Run Workspace commands through a running Vite Development Server.",
+    "Omit exec to open the interactive command loop.",
     "",
     "Options:",
     "  --url <url>       Compatible Vite Development Server URL. Defaults to http://localhost:5173.",
@@ -225,12 +226,14 @@ function parseWorkspaceDevArgs(args: string[], env: NodeJS.ProcessEnv): ParsedWo
       parsed.workspace = arg
       continue
     }
-    const [command, ...commandArgs] = args.slice(index)
-    if (command?.trim()) {
+    if (arg === "exec") {
+      const [command, ...commandArgs] = args.slice(index + 1)
+      if (!command?.trim()) throw new Error("workspace dev exec requires a command.")
       parsed.command = command
       if (commandArgs.length) parsed.args = commandArgs
+      break
     }
-    break
+    throw new Error(`Unexpected argument: ${arg}. Use exec <command...> for one-shot commands.`)
   }
   return parsed
 }
@@ -399,7 +402,7 @@ export function createWorkspaceCliContributor(): WorkspaceCliContributor {
         description: "Run commands through a Workspace Session.",
         name: "dev",
         run: async (args, context) => await runWorkspaceDevCli(args, context),
-        usage: "vitehub workspace dev <workspace> [command...]",
+        usage: "vitehub workspace dev <workspace> [exec <command...>]",
       }],
       name: "workspace",
     }],

--- a/packages/workspace/test/cli.test.ts
+++ b/packages/workspace/test/cli.test.ts
@@ -68,10 +68,74 @@ describe("workspace CLI", () => {
     await expect(hubWorkspace().vitehub?.cli?.()).resolves.toEqual({
       namespaces: [{
         description: "Workspace development workflows.",
-        features: [expect.objectContaining({ name: "dev" })],
+        features: [expect.objectContaining({
+          name: "dev",
+          usage: "vitehub workspace dev <workspace> [exec <command...>]",
+        })],
         name: "workspace",
       }],
     })
+  })
+
+  it("prints Workspace Dev exec usage", async () => {
+    const stderr = stream()
+    const stdout = stream()
+
+    const exitCode = await runWorkspaceDevCli(["--help"], {
+      cwd: process.cwd(),
+      env: {},
+      rootDir: process.cwd(),
+      stderr,
+      stdout,
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stderr.output()).toBe("")
+    expect(stdout.output()).toContain("Usage: vitehub workspace dev <workspace> [exec <command...>]")
+    expect(stdout.output()).toContain("Omit exec to open the interactive command loop.")
+  })
+
+  it("opens the Workspace Dev command loop when no command is provided", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-workspace-cli-loop-"))
+    const stderr = stream()
+    const stdout = stream()
+    const close = vi.fn()
+    const question = vi.fn(async () => ".exit")
+    const originalIsTTY = process.stdin.isTTY
+    vi.doMock("node:readline/promises", () => ({
+      createInterface: vi.fn(() => ({ close, question })),
+    }))
+    process.stdin.isTTY = true
+    try {
+      const fetchWorkspaceDev = vi.fn(async () => Response.json({
+        root: rootDir,
+        workspaces: [{ name: "docs" }],
+      }))
+
+      const exitCode = await runWorkspaceDevCli([
+        "--url",
+        "http://127.0.0.1:4321",
+        "docs",
+      ], {
+        cwd: rootDir,
+        env: {},
+        rootDir,
+        stderr,
+        stdout,
+      }, { fetch: fetchWorkspaceDev as never })
+
+      expect(exitCode).toBe(0)
+      expect(stderr.output()).toBe("")
+      expect(stdout.output()).toContain("Connected to docs at http://127.0.0.1:4321\n")
+      expect(question).toHaveBeenCalledWith("> ")
+      expect(close).toHaveBeenCalledOnce()
+      expect(fetchWorkspaceDev).toHaveBeenCalledOnce()
+    }
+    finally {
+      process.stdin.isTTY = originalIsTTY
+      vi.doUnmock("node:readline/promises")
+      await rm(rootDir, { force: true, recursive: true })
+    }
   })
 
   it("runs Workspace Dev commands through the Workspace dev endpoint", async () => {
@@ -103,8 +167,8 @@ describe("workspace CLI", () => {
             },
             {
               result: {
-                args: ["-e", "console.log(process.argv[1])", "hello world", "--timeout=30000"],
-                command: "node",
+                args: ["README.md"],
+                command: "cat",
                 exitCode: 0,
                 stderr: "",
                 stdout: "ok\n",
@@ -129,11 +193,9 @@ describe("workspace CLI", () => {
         "AGENTS.md",
         "--path=backlog",
         "docs",
-        "node",
-        "-e",
-        "console.log(process.argv[1])",
-        "hello world",
-        "--timeout=30000",
+        "exec",
+        "cat",
+        "README.md",
       ], {
         cwd: rootDir,
         env: {},
@@ -162,8 +224,8 @@ describe("workspace CLI", () => {
       })
       expect(JSON.parse(String(post?.[1]?.body))).toEqual({
         workspaceCommand: {
-          args: ["-e", "console.log(process.argv[1])", "hello world", "--timeout=30000"],
-          command: "node",
+          args: ["README.md"],
+          command: "cat",
           paths: ["AGENTS.md", "backlog"],
           timeout: 10000,
           workspace: "docs",
@@ -173,6 +235,25 @@ describe("workspace CLI", () => {
     finally {
       await rm(rootDir, { force: true, recursive: true })
     }
+  })
+
+  it("rejects bare Workspace Dev command args with exec guidance", async () => {
+    const stderr = stream()
+    const stdout = stream()
+    const fetchWorkspaceDev = vi.fn()
+
+    const exitCode = await runWorkspaceDevCli(["docs", "cat", "README.md"], {
+      cwd: process.cwd(),
+      env: {},
+      rootDir: process.cwd(),
+      stderr,
+      stdout,
+    }, { fetch: fetchWorkspaceDev as never })
+
+    expect(exitCode).toBe(1)
+    expect(fetchWorkspaceDev).not.toHaveBeenCalled()
+    expect(stderr.output()).toContain("Unexpected argument: cat. Use exec <command...> for one-shot commands.")
+    expect(stdout.output()).toContain("Usage: vitehub workspace dev <workspace> [exec <command...>]")
   })
 
   it("reports Workspace Dev preparation progress while starting sessions", async () => {


### PR DESCRIPTION
Updates `vitehub workspace dev` so `exec` is the explicit one-shot command sentinel while leaving `vitehub workspace dev <workspace>` for the interactive loop. Bare positional command args now fail before discovery with guidance, and the docs/examples use the new shape.