### PR TITLE
feat(agent): add browser bash capability

### DIFF
--- a/docs/content/docs/capabilities/blob.md
+++ b/docs/content/docs/capabilities/blob.md
@@ -19,6 +19,7 @@ Use the configuration example below as the starting point, then tighten modes, p
 
 The Capability contributes `blob_read` for get, head, and list operations.
 When configured with write mode, it also contributes `blob_edit` for putting or deleting objects.
+`blob_edit` can upload inline content or a Workspace file through `workspacePath`.
 
 ## Configuration
 
@@ -42,6 +43,8 @@ export default defineAgent({
 ViteHub selects the configured Blob store and exposes a small Storage Capability Tool Surface.
 Read mode supports one object read, metadata read, or prefix list operation per tool call.
 Write mode adds put/delete operations with approval required by default.
+Put operations accept either `body` or `workspacePath`, not both.
+Delete operations return `{ pathname, deleted: true }`.
 
 ## Requirements
 
@@ -73,6 +76,20 @@ The Capability should fail before exposing tools.
 | `mode` | `"read" \| "write"` | `"read"` | Adds `blob_edit` when set to `"write"`. |
 | `store` | `string` | default store | Selects a named Blob store when the Blob primitive supports `store()`. |
 | `policy` | `AgentToolPolicyDecision \| function` | `"require-approval"` | Policy for `blob_edit`. |
+
+## Workspace uploads
+
+Use `workspacePath` when another Capability writes an artifact into the Workspace and the Agent should upload that file to Blob storage.
+The path is Workspace-relative.
+
+```ts [Agent tool call]
+await blob_edit({
+  operation: 'put',
+  pathname: 'review/screenshots/home.png',
+  workspacePath: 'screenshots/home.png',
+  options: { contentType: 'image/png' },
+})
+```
 
 ## Reference
 

--- a/docs/content/docs/capabilities/browser.md
+++ b/docs/content/docs/capabilities/browser.md
@@ -1,0 +1,104 @@
+---
+title: Browser
+description: Give an Agent headless browser access through the global bash tool.
+navigation.title: Browser
+navigation.order: 62
+navigation.group: Workspace
+icon: i-lucide-monitor
+---
+
+`browser()` lets an Agent run the `agent-browser` CLI through ViteHub's global `bash` tool.
+Use it when a model-backed Agent needs browser evidence, screenshots, or DOM inspection during an invocation.
+
+## Installation
+
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+The application must make the configured browser command available before the Agent runs.
+
+## What it adds
+
+The Capability contributes `agent-browser` to the global `bash` tool with the description `Run headless browser.`
+It also contributes a Workspace Source at `skills/browser/SKILL.md`.
+The skill file explains how the Agent should call the CLI and save browser artifacts in the Workspace.
+
+`browser()` does not add a custom `agent_browser` tool.
+It also does not install packages during an invocation.
+
+## Configuration
+
+Attach `browser()` to an Agent with a writable Workspace.
+
+```ts [server/agents/review.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { browser } from '@vite-hub/agent/capabilities'
+
+export default defineAgent({
+  driver: { model },
+  workspace: { name: 'review', mode: 'write' },
+  capabilities: [
+    browser(),
+  ],
+})
+```
+
+Use `command` only when the executable name differs from `agent-browser`.
+
+## Runtime behavior
+
+ViteHub merges Capability `bash` contributions into one model-facing `bash` tool.
+The browser command appears beside other registered commands, and the tool schema restricts calls to registered executable names.
+
+The Agent can run the command with structured args:
+
+```ts [Agent tool call]
+await bash({
+  command: 'agent-browser',
+  args: ['--help'],
+})
+```
+
+When another Capability uploads browser artifacts, keep that upload behavior with that Capability.
+For example, Blob write tools document Workspace file uploads through `workspacePath`.
+
+## Requirements
+
+`browser()` requires an explicit Workspace with `workspace.mode: 'write'`.
+The configured command must resolve in the Workspace Session environment before the invocation starts.
+
+The browser skill is a Workspace Source contribution.
+ViteHub materializes it through the normal Workspace Source flow, so it remains inspectable with other contributed Sources.
+
+## Driver support
+
+| Agent Driver | Support |
+| --- | --- |
+| Model-backed | Receives the global `bash` tool with the browser command registered. |
+| Harness-backed | Receives the contributed browser skill file through Workspace materialization. Model-facing `bash` tools are not passed by default. |
+| Custom-run-backed | Receives prepared Workspace context; `driver.run` decides whether to use Workspace APIs directly. |
+
+## Inspect and verify
+
+Inspect the Agent tool list in DevTools.
+An Agent with `browser()` should expose `bash`, and the `bash` schema should list `agent-browser` as an allowed command.
+
+Inspect the Workspace Sources for `skill.browser`.
+The source should materialize `skills/browser/SKILL.md`.
+
+Run one invocation that calls `agent-browser --help` through `bash`.
+Then save a screenshot under `screenshots/` and verify the Workspace contains the artifact.
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `command` | `string` | `"agent-browser"` | Executable name registered on the global `bash` tool. |
+| `skillContent` | `string` | built-in browser skill | Markdown content for `skills/browser/SKILL.md`. |
+| `skillPath` | `string` | `"skills/browser/SKILL.md"` | Workspace path for the contributed browser skill. |
+| `sourceKey` | `string` | `"skill.browser"` | Workspace Source key for the contributed skill file. |
+
+## Reference
+
+- [Blob](/docs/capabilities/blob)
+- [Workspace shell](/docs/capabilities/workspace-shell)
+- [Custom capabilities](/docs/capabilities/custom-capabilities)
+- Source: `packages/agent/src/capabilities/browser.ts`

--- a/docs/content/docs/capabilities/custom-capabilities.md
+++ b/docs/content/docs/capabilities/custom-capabilities.md
@@ -114,6 +114,34 @@ export function ticketContext() {
 
 For harness-backed Agents, declare files a Capability needs through `requires.workspace.paths` or contribute them through Workspace Sources. The harness Workspace Session materializes the selected Workspace scope; applications should not maintain a separate harness-specific path list.
 
+## Contribute bash commands
+
+Use `bash` when a Capability owns a real executable that should appear in ViteHub's global model-facing `bash` tool.
+Each entry can be an executable name or an object with a command, description, and optional install package name.
+
+```ts [server/agents/capabilities/browser-preview.ts]
+import { defineCapability } from '@vite-hub/agent'
+
+export function browserPreview() {
+  return defineCapability({
+    id: 'browser-preview',
+    bash: [
+      {
+        command: 'agent-browser',
+        description: 'Run headless browser.',
+        install: 'agent-browser',
+      },
+    ],
+  })
+}
+```
+
+ViteHub merges all Capability `bash` entries into one `bash` tool.
+The tool schema only accepts registered executable names, and each call runs inside a trusted Workspace Session.
+
+`bash` is a runtime tool surface, not a Capability factory.
+Do not create a `bash()` Capability or use `workspaceShell()` as the public owner for product-specific executables.
+
 ## Add a Capability CLI
 
 Use `cli` when the Capability owns a real command tree that agents and developers should run instead of a generic shell command.

--- a/docs/content/docs/capabilities/official-capabilities.md
+++ b/docs/content/docs/capabilities/official-capabilities.md
@@ -14,6 +14,7 @@ Use them when the Agent needs a named ability that ViteHub owns end to end, incl
 import {
   access,
   blob,
+  browser,
   chat,
   chatSummary,
   chatTitle,
@@ -50,6 +51,7 @@ import {
 | Chat behavior | [`chat()`](/docs/capabilities/chat) | A chat surface should start Agent Invocations and manage Chat History behavior. |
 | Input commands | [`inputCommands()`](/docs/capabilities/input-commands) | Explicit user commands should transform or enrich input before the Agent runs. |
 | Subagents | [`subagents()`](/docs/capabilities/subagents) | A model-backed Agent should delegate bounded work to named Agent Definitions through model-facing tools. |
+| Browser automation | [`browser()`](/docs/capabilities/browser) | The Agent needs headless browser evidence through the global `bash` tool and an included browser skill file. |
 | Workspace files | [`workspaceShell()`](/docs/capabilities/workspace-shell) | The Agent should inspect or edit Workspace files, or run allowlisted Workspace-session commands, through constrained Workspace tools. |
 | Git source history | [`git()`](/docs/capabilities/git) | The Agent needs bounded Git source-history inspection or local Workspace Session git state selection. |
 | Pull Request context | [`pullRequestContext()`](/docs/capabilities/pull-request-context) | A trigger or host already knows the current Change Request and the Agent should inspect that normalized context in the Workspace. |

--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -13,7 +13,7 @@ They may resolve to Runtime Registries, generated files, virtual modules, or pac
 | Import path | Owner | Use |
 | --- | --- | --- |
 | `@vite-hub/agent` | Agent Package | Agent Definition helpers, invocation helpers, trigger helpers, Agent Actor types, and legacy Agent Invoker compatibility types. |
-| `@vite-hub/agent/capabilities` | Agent Package | Official Capability factories such as `access()`, `workspaceShell()`, `inputCommands()`, and `subagents()`. |
+| `@vite-hub/agent/capabilities` | Agent Package | Official Capability factories such as `access()`, `browser()`, `workspaceShell()`, `inputCommands()`, and `subagents()`. |
 | `@vite-hub/agent/channels` | Agent Package | Official Channel Kind helpers such as `github()`, `stream()`, `teams()`, `telegram()`, `webChat()`, and `defineChannel()`. |
 | `@vite-hub/agent/eval` | Agent Package | Agent Eval authoring helpers. |
 | `@vite-hub/agent/test` | Agent Package | Agent test runner helpers for local and CI Agent Invocation checks. |

--- a/docs/skills/vitehub/references/docs.md
+++ b/docs/skills/vitehub/references/docs.md
@@ -26,6 +26,7 @@ Use the smallest page that answers the current task. Prefer raw Markdown URLs fo
 | Workspace context | `https://vitehub.dev/raw/docs/agents/workspace-context.md` |
 | Capabilities overview | `https://vitehub.dev/raw/docs/capabilities/index.md` |
 | Official Capabilities | `https://vitehub.dev/raw/docs/capabilities/official-capabilities.md` |
+| Browser Capability | `https://vitehub.dev/raw/docs/capabilities/browser.md` |
 | Skills Capability | `https://vitehub.dev/raw/docs/capabilities/skills.md` |
 | Workspace Shell | `https://vitehub.dev/raw/docs/capabilities/workspace-shell.md` |
 | Git and repository hosts | `https://vitehub.dev/raw/docs/capabilities/git.md` and `https://vitehub.dev/raw/docs/capabilities/repository-host.md` |

--- a/packages/agent/src/capabilities/browser.ts
+++ b/packages/agent/src/capabilities/browser.ts
@@ -1,0 +1,56 @@
+import { defineCapability, workspaceMaterializationPathsSymbol } from "../capability-runtime.ts"
+
+import type { AgentCapabilityDefinition } from "../types.ts"
+
+export interface BrowserCapabilityOptions {
+  command?: string
+  skillContent?: string
+  skillPath?: string
+  sourceKey?: string
+}
+
+const defaultBrowserSkillContent = `# Browser
+
+Use the \`agent-browser\` CLI through the bash tool for headless browser work.
+
+- Run \`agent-browser --help\` before non-trivial browser work.
+- Save screenshots inside the workspace, usually under \`screenshots/\`.
+- Upload selected screenshots with \`blob_edit\` using \`workspacePath\`.
+- Include the public URL returned by Blob when referencing uploaded assets.
+`
+
+function normalizeSkillPath(path: string): string {
+  return path.replace(/^\/+|\/+$/g, "") || "skills/browser/SKILL.md"
+}
+
+function assertCommand(command: string): string {
+  if (!command || /[\s\x00-\x1F\x7F/]/.test(command) || command === "." || command === "..") {
+    throw new TypeError("[vitehub] browser({ command }) must be a single executable name.")
+  }
+  return command
+}
+
+export function browser(options: BrowserCapabilityOptions = {}): AgentCapabilityDefinition {
+  const command = assertCommand(options.command || "agent-browser")
+  const skillPath = normalizeSkillPath(options.skillPath || "skills/browser/SKILL.md")
+  const sourceKey = options.sourceKey || "skill.browser"
+  const skillContent = options.skillContent || defaultBrowserSkillContent.replaceAll("agent-browser", command)
+
+  return Object.assign(defineCapability({
+    bash: [{ command, description: "Run headless browser." }],
+    id: "browser",
+    metadata: { command, skillPath, sourceKey },
+    requires: [{ primitive: "workspace", workspace: { mode: "write", required: true } }],
+    workspace: {
+      sources: {
+        [sourceKey]: {
+          content: skillContent,
+          mediaType: "text/markdown",
+          workspacePath: skillPath,
+        },
+      },
+    },
+  }), {
+    [workspaceMaterializationPathsSymbol]: [skillPath],
+  })
+}

--- a/packages/agent/src/capabilities/browser.ts
+++ b/packages/agent/src/capabilities/browser.ts
@@ -15,8 +15,6 @@ Use the \`agent-browser\` CLI through the bash tool for headless browser work.
 
 - Run \`agent-browser --help\` before non-trivial browser work.
 - Save screenshots inside the workspace, usually under \`screenshots/\`.
-- Upload selected screenshots with \`blob_edit\` using \`workspacePath\`.
-- Include the public URL returned by Blob when referencing uploaded assets.
 `
 
 function normalizeSkillPath(path: string): string {

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -7,6 +7,12 @@ export {
   getAgentChatContext,
 } from "../chat-trigger.ts"
 export {
+  browser,
+} from "./browser.ts"
+export type {
+  BrowserCapabilityOptions,
+} from "./browser.ts"
+export {
   chatSummary,
 } from "./chat-summary.ts"
 export {

--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -123,7 +123,9 @@ function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): A
             return method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(path, body, putOptions)
           }
           if (operation === "delete") {
-            return method<(pathname: string) => MaybePromise<unknown>>(store, "blob", "del")(assertString(pathname, "blob_edit pathname"))
+            const path = assertString(pathname, "blob_edit pathname")
+            await method<(pathname: string) => MaybePromise<unknown>>(store, "blob", "del")(path)
+            return { pathname: path, deleted: true }
           }
           throw new Error(`[vitehub] Unsupported blob_edit operation: ${String(operation)}`)
         },

--- a/packages/agent/src/capabilities/workspace-command.ts
+++ b/packages/agent/src/capabilities/workspace-command.ts
@@ -18,6 +18,19 @@ type WorkspaceCommandWorkspace = {
   startSession: () => Promise<WorkspaceSession>
 }
 
+export interface WorkspaceCommandEntry {
+  command: string
+  description?: string
+  install?: string
+}
+
+interface WorkspaceCommandToolOptions {
+  commitMessage?: string
+  description?: string
+  missingWorkspaceMessage?: string
+  toolName?: string
+}
+
 const unsafeCommand = /[\s\x00-\x1F\x7F]/
 const blockedEnvKeys = new Set([
   "NODE_OPTIONS",
@@ -25,16 +38,38 @@ const blockedEnvKeys = new Set([
   "PATH",
 ])
 
-export function validateWorkspaceCommands(commands: unknown, label = "workspaceShell({ commands })"): string[] {
+export function normalizeWorkspaceCommandEntries(commands: unknown, label = "workspaceShell({ commands })"): WorkspaceCommandEntry[] {
   if (!Array.isArray(commands) || !commands.length) {
     throw new TypeError(`[vitehub] ${label} requires at least one command.`)
   }
-  for (const command of commands) {
-    if (typeof command !== "string" || !isValidCommand(command)) {
+  return commands.map((entry) => {
+    if (typeof entry === "string") {
+      if (!isValidCommand(entry)) {
+        throw new TypeError(`[vitehub] ${label} accepts simple executable names or absolute paths without whitespace/control characters.`)
+      }
+      return { command: entry }
+    }
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
       throw new TypeError(`[vitehub] ${label} accepts simple executable names or absolute paths without whitespace/control characters.`)
     }
-  }
-  return commands
+    const command = (entry as WorkspaceCommandEntry).command
+    if (!isValidCommand(command)) {
+      throw new TypeError(`[vitehub] ${label} accepts simple executable names or absolute paths without whitespace/control characters.`)
+    }
+    const description = (entry as WorkspaceCommandEntry).description
+    const install = (entry as WorkspaceCommandEntry).install
+    if (description !== undefined && typeof description !== "string") {
+      throw new TypeError(`[vitehub] ${label} description must be a string.`)
+    }
+    if (install !== undefined && typeof install !== "string") {
+      throw new TypeError(`[vitehub] ${label} install must be a string.`)
+    }
+    return { command, ...(description ? { description } : {}), ...(install ? { install } : {}) }
+  })
+}
+
+export function validateWorkspaceCommands(commands: unknown, label = "workspaceShell({ commands })"): string[] {
+  return normalizeWorkspaceCommandEntries(commands, label).map(entry => entry.command)
 }
 
 function isValidCommand(command: string): boolean {
@@ -92,26 +127,31 @@ function normalizeCwd(cwd: unknown): string {
   return parts.length ? `/workspace/${parts.join("/")}` : "/workspace"
 }
 
-function assertWorkspace(workspace: unknown): asserts workspace is WorkspaceCommandWorkspace {
+function assertWorkspace(workspace: unknown, message: string): asserts workspace is WorkspaceCommandWorkspace {
   if (!workspace || typeof workspace !== "object" || typeof (workspace as { startSession?: unknown }).startSession !== "function") {
-    throw new Error("[vitehub] workspaceShell({ commands }) requires an executable Workspace Session. Trusted workspace/session execution requires a writable workspace.")
+    throw new Error(message)
   }
 }
 
 export function workspaceCommandTools(
-  commands: string[],
+  commands: readonly (string | WorkspaceCommandEntry)[],
   mode: AgentCapabilityMode,
   timeout: number | undefined,
   workspace: unknown,
+  options: WorkspaceCommandToolOptions = {},
 ): AgentToolSet {
+  const entries = commands.map(command => typeof command === "string" ? { command } : command)
+  const commandNames = entries.map(entry => entry.command)
+  const toolName = options.toolName || "workspace_exec"
+  const summary = entries.map(entry => entry.description ? `${entry.command} (${entry.description})` : entry.command).join(", ")
   return {
-    workspace_exec: defineInternalTool({
-      description: `Run one configured command in a trusted Workspace Session at the workspace root. Allowed commands: ${commands.join(", ")}.`,
+    [toolName]: defineInternalTool({
+      description: options.description || `Run one configured command in a trusted Workspace Session at the workspace root. Allowed commands: ${summary}.`,
       inputSchema: {
         additionalProperties: false,
         properties: {
           args: { items: { type: "string" }, type: "array" },
-          command: { enum: commands, type: "string" },
+          command: { enum: commandNames, type: "string" },
           cwd: { description: "Workspace-relative directory. Defaults to the workspace root.", type: "string" },
           env: { additionalProperties: { type: "string" }, type: "object" },
           timeout: { type: "number" },
@@ -119,20 +159,20 @@ export function workspaceCommandTools(
         required: ["command"],
         type: "object",
       },
-      name: "workspace_exec",
+      name: toolName,
       async execute(input: unknown) {
         const value = input as WorkspaceCommandInput
-        if (!value || typeof value.command !== "string") throw new TypeError("[vitehub] workspace_exec requires a command.")
-        if (!commands.includes(value.command)) throw new Error(`[vitehub] Workspace command "${value.command}" is not allowed.`)
+        if (!value || typeof value.command !== "string") throw new TypeError(`[vitehub] ${toolName} requires a command.`)
+        if (!commandNames.includes(value.command)) throw new Error(`[vitehub] Workspace command "${value.command}" is not allowed.`)
         const args = stringArray(value.args, "args")
         const cwd = normalizeCwd(value.cwd)
         const env = envRecord(value.env)
-        const commandTimeout = normalizeWorkspaceCommandTimeout(value.timeout, "workspace_exec timeout") ?? timeout
-        assertWorkspace(workspace)
+        const commandTimeout = normalizeWorkspaceCommandTimeout(value.timeout, `${toolName} timeout`) ?? timeout
+        assertWorkspace(workspace, options.missingWorkspaceMessage || "[vitehub] workspaceShell({ commands }) requires an executable Workspace Session. Trusted workspace/session execution requires a writable workspace.")
         const session = await workspace.startSession()
         try {
           const result = await session.exec(value.command, args, { cwd, env, timeout: commandTimeout })
-          if (mode === "write" && result.exitCode === 0) await session.commit({ message: "workspace shell command" })
+          if (mode === "write" && result.exitCode === 0) await session.commit({ message: options.commitMessage || "workspace shell command" })
           return result
         }
         finally {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -6,6 +6,7 @@ import {
   createCapabilityCliTool,
 } from "./capability-cli.ts"
 import { getAccessCapabilityOptions } from "./capabilities/access-metadata.ts"
+import { normalizeWorkspaceCommandEntries, workspaceCommandTools } from "./capabilities/workspace-command.ts"
 import { createMessage } from "./messages.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
 import { normalizeAgentWorkspaceSource, workspaceSourceScopeNames, workspaceSourceScopePaths } from "./workspace-source-metadata.ts"
@@ -20,6 +21,7 @@ import type {
   AgentCallbackContext,
   AgentCapabilityCliContribution,
   AgentCapabilityContext,
+  AgentCapabilityBashCommand,
   AgentCapabilityDefinition,
   AgentCapabilityWorkspaceContribution,
   AgentCapabilityTypeContract,
@@ -74,6 +76,7 @@ type InternalAgentCapabilityWithGeneratedCli<
   resolveCli?: InternalAgentCapabilityCliResolver<TRuntimeConfig, Name>
   [workspaceMaterializationPathsSymbol]?: readonly string[]
 }
+type AgentCapabilityBashEntry = Extract<AgentCapabilityBashCommand, { command: string }>
 type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
 type AgentCapabilityDefinitionInput<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -173,6 +176,29 @@ function capabilityUsesWorkspaceAccess(capability: AgentCapabilityDefinition): b
     && capability.metadata.workspace === true
 }
 
+function capabilityBashCommands(capabilities: readonly AgentCapabilityDefinition[]): AgentCapabilityBashEntry[] {
+  const commands = new Map<string, AgentCapabilityBashEntry>()
+  for (const capability of capabilities) {
+    if (!capability.bash?.length) continue
+    for (const entry of normalizeWorkspaceCommandEntries(capability.bash, `${capability.id} bash`)) {
+      if (!commands.has(entry.command)) commands.set(entry.command, entry)
+    }
+  }
+  return [...commands.values()]
+}
+
+function createBashTools(capabilities: readonly AgentCapabilityDefinition[], workspace: unknown): AgentToolSet | undefined {
+  const commands = capabilityBashCommands(capabilities)
+  if (!commands.length) return
+  const summary = commands.map(entry => entry.description ? `${entry.command} (${entry.description})` : entry.command).join(", ")
+  return workspaceCommandTools(commands, "write", undefined, workspace, {
+    commitMessage: "bash command",
+    description: `Run one registered command in a trusted Workspace Session. Available commands: ${summary}.`,
+    missingWorkspaceMessage: "[vitehub] bash requires an executable Workspace Session.",
+    toolName: "bash",
+  })
+}
+
 export function defineCapability<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
@@ -190,6 +216,9 @@ export function defineCapability<
   assertCapabilityId((capability as { id?: unknown }).id)
   const cli = (capability as AgentCapabilityDefinition).cli
   assertCapabilityCliContribution((capability as { id: string }).id, cli)
+  if ((capability as AgentCapabilityDefinition).bash !== undefined) {
+    normalizeWorkspaceCommandEntries((capability as AgentCapabilityDefinition).bash, `${(capability as { id: string }).id} bash`)
+  }
   return capability
 }
 
@@ -1053,6 +1082,13 @@ export async function resolveAgentCapabilities<
       }
     }
     await applyWorkspaceContributions()
+    if (invocationOptions.resolveTools !== false) {
+      const bashTools = createBashTools(capabilities, currentWorkspace)
+      if (bashTools) {
+        recordDriverContribution("Capability tools", "bash", Object.keys(bashTools))
+        tools = { ...tools, ...bashTools }
+      }
+    }
     for (const { capability, context } of capabilityContexts) {
       let cli: AgentCapabilityCliContribution<TRuntimeConfig, Name> | undefined
       const resolveCli = (capability as InternalAgentCapabilityWithGeneratedCli<TRuntimeConfig, Name>).resolveCli

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -803,6 +803,9 @@ function validateWorkspaceCapabilities<Name extends WorkspaceName>(options: Work
         throw new Error("[vitehub] workspaceShell({ mode: \"write\" }) requires workspace.mode: \"write\".")
       }
     }
+    if (capabilityRequiresBashWorkspace(capability) && workspaceMode !== "write") {
+      throw new Error(`[vitehub] ${capability.id}() bash requires workspace.mode: "write".`)
+    }
     if (capability.id === "sandbox") {
       validateSandboxCommands((capability.metadata as { commands?: unknown } | undefined)?.commands)
     }
@@ -835,10 +838,14 @@ function sandboxCapabilityRequiresWorkspace(capability: NormalizedCapability): b
   return Array.isArray(metadata?.commands)
 }
 
+function capabilityRequiresBashWorkspace(capability: NormalizedCapability): boolean {
+  return Boolean(capability.bash?.length)
+}
+
 function validateNonWorkspaceCapabilities(capabilities: NormalizedCapability[], hasWorkspace: boolean): void {
   if (hasWorkspace) return
   for (const capability of capabilities) {
-    if (capability.workspace && !capabilityWorkspaceIsOptional(capability) || capability.id === "workspace-shell" || sandboxCapabilityRequiresWorkspace(capability) || accessCapabilityRequiresWorkspace(capability)) {
+    if (capability.workspace && !capabilityWorkspaceIsOptional(capability) || capability.id === "workspace-shell" || sandboxCapabilityRequiresWorkspace(capability) || accessCapabilityRequiresWorkspace(capability) || capabilityRequiresBashWorkspace(capability)) {
       const name = capability.id === "workspace-shell" ? "workspaceShell" : capability.id
       throw new Error(`[vitehub] ${name}() requires an explicit workspace.`)
     }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -631,6 +631,14 @@ export type AgentCapabilityToolResolver<
   | Record<string, unknown>
   | ((context: AgentCapabilityContext<TRuntimeConfig, Name>) => MaybePromise<Record<string, unknown> | undefined>)
 
+export type AgentCapabilityBashCommand =
+  | string
+  | {
+      command: string
+      description?: string
+      install?: string
+    }
+
 export interface AgentCapabilityWorkspaceContribution {
   rules?: WorkspaceRules
   sources?: Record<string, WorkspaceSourceInput>
@@ -737,6 +745,7 @@ export interface AgentCapabilityDefinition<
   TTypeContract extends AgentCapabilityTypeContract = AgentCapabilityTypeContract,
 > {
   readonly __vitehubTypeContract?: TTypeContract
+  bash?: readonly AgentCapabilityBashCommand[]
   bind?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   capabilities?: readonly AgentCapabilityDefinition<TRuntimeConfig, Name>[]
   chatAttachments?: {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -539,6 +539,76 @@ describe("agent capability runtime", () => {
     ])
   })
 
+  it("creates one global bash tool from capability bash contributions", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const session = {
+      close: vi.fn(),
+      commit: vi.fn(),
+      exec: vi.fn(async (command: string, args: string[] = []) => ({ args, command, exitCode: 0, stderr: "", stdout: "ok\n" })),
+    }
+    const workspace = {
+      ...writableWorkspace(),
+      startSession: vi.fn(async () => session),
+    }
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({ id: "noop" }),
+        defineCapability({
+          bash: [
+            { command: "agent-browser", description: "Run headless browser." },
+            "node",
+          ],
+          id: "browser",
+        }),
+      ],
+    }, runtime(), {}, workspace as never, "write")
+
+    expect(Object.keys(resolved.tools || {})).toEqual(["bash"])
+    expect(resolved.tools?.bash?.description).toContain("agent-browser (Run headless browser.)")
+    await expect(resolved.tools?.bash?.execute?.({
+      args: ["--help"],
+      command: "agent-browser",
+      cwd: "screenshots",
+    })).resolves.toMatchObject({ exitCode: 0, stdout: "ok\n" })
+    expect(session.exec).toHaveBeenCalledWith("agent-browser", ["--help"], {
+      cwd: "/workspace/screenshots",
+      env: undefined,
+      timeout: undefined,
+    })
+    expect(session.commit).toHaveBeenCalledWith({ message: "bash command" })
+    expect(session.close).toHaveBeenCalledOnce()
+    await expect(resolved.tools?.bash?.execute?.({ command: "pnpm" })).rejects.toThrow("not allowed")
+  })
+
+  it("applies browser workspace source contributions", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { browser } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [browser({ skillContent: "# Browser\nUse bash.\n" })],
+    }, runtime(), {}, emptyWorkspace() as never, "write", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    expect(resolved.workspaceDefinition?.sources?.["skill.browser"]).toMatchObject({
+      materialize: "lazy",
+      mediaType: "text/markdown",
+      workspacePath: "skills/browser/SKILL.md",
+    })
+    expect(Object.keys(resolved.tools || {})).toEqual(["bash"])
+    expect(resolved.registries.workspaceContributions).toEqual([
+      {
+        capabilityId: "browser",
+        rules: [],
+        sources: ["skill.browser"],
+      },
+    ])
+  })
+
   it("requires Access when capability workspace contributions add scoped sources", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -609,6 +609,29 @@ describe("agent capability runtime", () => {
     ])
   })
 
+  it("does not mention Blob tools in the default browser skill", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { browser } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [browser()],
+    }, runtime(), {}, emptyWorkspace() as never, "write", {
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    const source = resolved.workspaceDefinition?.sources?.["skill.browser"]
+    expect(typeof source).toBe("object")
+    expect(source).not.toBeNull()
+    if (!source || typeof source !== "object") throw new Error("Expected browser skill source object.")
+    const content = (source as { content?: unknown }).content
+    expect(content).toContain("Save screenshots inside the workspace")
+    expect(content).not.toContain("blob_edit")
+    expect(content).not.toContain("Blob")
+  })
+
   it("requires Access when capability workspace contributions add scoped sources", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -229,7 +229,7 @@ describe("storage capabilities", () => {
     await tools.blob_edit!.execute?.({ operation: "put", pathname: "images/from-workspace.png", workspacePath: "screenshots/result.png" })
     await expect(Promise.resolve().then(() => tools.blob_edit!.execute?.({ body: "inline", operation: "put", pathname: "images/a.png", workspacePath: "screenshots/result.png" }))).rejects.toThrow("body or workspacePath")
     await expect(Promise.resolve().then(() => tools.blob_edit!.execute?.({ operation: "put", pathname: "images/a.png" }))).rejects.toThrow("body or workspacePath")
-    await tools.blob_edit!.execute?.({ operation: "delete", pathname: "images/a.png" })
+    await expect(tools.blob_edit!.execute?.({ operation: "delete", pathname: "images/a.png" })).resolves.toEqual({ pathname: "images/a.png", deleted: true })
     expect(store.put).toHaveBeenCalledWith("images/a.png", body, { contentType: "image/png" })
     expect(workspace.fs.readFile).toHaveBeenCalledWith("screenshots/result.png", { encoding: "binary" })
     expect(store.put).toHaveBeenCalledWith("images/from-workspace.png", workspaceBytes, undefined)

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
-import { access, blob, chat, chatTitle, db, fetch, getTranscriptionResults, getUsageTelemetry, git, inputCommands, kv, mcp, observability, openapi, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, browser, chat, chatTitle, db, fetch, getTranscriptionResults, getUsageTelemetry, git, inputCommands, kv, mcp, observability, openapi, pullRequestContext, repositoryHost, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -102,6 +102,8 @@ describe("agent public types", () => {
         git(),
         git({ mode: "read" }),
         git({ mode: "write", policy: "require-approval" }),
+        browser(),
+        browser({ command: "agent-browser", skillContent: "# Browser\n", skillPath: "skills/browser/SKILL.md", sourceKey: "skill.browser" }),
         workspaceShell({ commands: ["agent-browser", "/Users/maxi/quiver/agents/node_modules/.bin/agent-browser"] }),
         workspaceShell({ commands: ["agent-browser"], mode: "read", timeout: 1_000 }),
         workspaceShell({ commands: ["agent-browser"], mode: "write" }),

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -920,6 +920,17 @@ describe("defineAgent workspace option", () => {
     })).toThrow("workspaceShell({ commands }) requires workspace.mode: \"write\"")
   })
 
+  it("requires writable workspace for browser bash commands", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { browser } = await import("../src/capabilities.ts")
+
+    expect(() => defineAgent({
+      capabilities: [browser()],
+      driver: { model: {} as never },
+      workspace: { mode: "read" },
+    })).toThrow("browser() bash requires workspace.mode: \"write\"")
+  })
+
   it("uses write mode for named workspace references", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { workspaceShell } = await import("../src/capabilities.ts")


### PR DESCRIPTION
Adds capability-level bash command contributions and resolves them into one global model-facing `bash` tool backed by the existing workspace session command path.

Adds the official `browser()` capability from `@vite-hub/agent/capabilities`, contributing `agent-browser` plus a `skills/browser/SKILL.md` workspace source. Also makes `blob_edit` delete return `{ pathname, deleted: true }` for the proven Review workflow.

Documents `browser()`, custom Capability `bash` contributions, and Blob workspace uploads in the official docs.