### PR TITLE
fix: prepare harness workspace git baseline

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -692,7 +692,7 @@ export function createHarnessAgentAdapter<
   }
 
   async function createAgentAndSession(context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>) {
-    let workspaceSession: { close: (error?: unknown) => MaybePromise<void> } | undefined
+    let workspaceSession: { close: (error?: unknown) => MaybePromise<void>, refreshGitBaseline?: () => MaybePromise<void> } | undefined
     const agent = await createHarnessAgent(options, context, async (session, sessionWorkDir, abortSignal) => {
       if (!context.workspace) return
       const harnessInstructions = await resolveHarnessInstructions(context)
@@ -710,6 +710,7 @@ export function createHarnessAgentAdapter<
       })
       try {
         await writeHarnessInstructionFiles(session as HarnessInstructionSandbox, sessionWorkDir, abortSignal, harnessInstructions)
+        if (harnessInstructions) await workspaceSession.refreshGitBaseline?.()
       }
       catch (error) {
         await workspaceSession.close(error)

--- a/packages/agent/src/harness/local-sandbox.ts
+++ b/packages/agent/src/harness/local-sandbox.ts
@@ -148,7 +148,7 @@ async function createSession(options: LocalHarnessSandboxOptions, sessionId: str
   const session = {
     cleanup: options.cleanup ?? !options.rootDir,
     defaultWorkingDirectory: rootDir,
-    description: `Local shell sandbox rooted at ${rootDir}.`,
+    description: "Workspace shell.",
     env,
     id: sessionId || randomUUID(),
     ports: options.ports || [4000],

--- a/packages/agent/test/local-sandbox.test.ts
+++ b/packages/agent/test/local-sandbox.test.ts
@@ -16,6 +16,7 @@ describe("local harness sandbox", () => {
 
       const result = await session.run({ command: "cat input.txt" })
 
+      expect(session.description).toBe("Workspace shell.")
       expect(result).toMatchObject({ exitCode: 0, stdout: "hello" })
       await expect(session.getPortUrl({ port: 4000, protocol: "ws" })).resolves.toBe("ws://127.0.0.1:4000")
     }

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1163,7 +1163,7 @@ describe("defineAgent workspace option", () => {
     const document = "# Support\n\n@./policy.md\n\n::source{key=\"docs\"}\nUse docs for source-backed answers.\n::\n"
     await writeLocalFile(join(sourceRootDir, "instructions.md"), document)
     await writeLocalFile(join(sourceRootDir, "policy.md"), "Use imported policy.\n")
-    const harnessWorkspaceSession = { close: vi.fn() }
+    const harnessWorkspaceSession = { close: vi.fn(), refreshGitBaseline: vi.fn() }
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
     exists.mockResolvedValueOnce(true)
     readFile.mockResolvedValueOnce(document)
@@ -1195,6 +1195,7 @@ describe("defineAgent workspace option", () => {
       expect.objectContaining({ path: "/workspace/codex-session/CLAUDE.md" }),
     ]))
     expect(new TextDecoder().decode(writes[0]!.content)).toBe("# Support\n\nUse imported policy.\n\nUse docs for source-backed answers.\n")
+    expect(harnessWorkspaceSession.refreshGitBaseline).toHaveBeenCalledOnce()
     expect(harnessWorkspaceSession.close).toHaveBeenCalledWith(undefined)
   })
 

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -353,7 +353,7 @@ async function initializeSandboxGitBaseline(
 ) {
   await runSandbox(sandbox, {
     abortSignal,
-    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A && git commit --allow-empty --no-gpg-sign -qm workspace-baseline || true; fi",
+    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A -f && git commit --allow-empty --no-gpg-sign -qm workspace-baseline || true; fi",
     workingDirectory: sessionWorkDir,
   })
 }

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -96,6 +96,13 @@ function normalizeSessionPaths(paths?: readonly string[]): string[] | undefined 
   return normalized.sort((left, right) => left.length - right.length || left.localeCompare(right))
 }
 
+function isIgnoredWriteBackPath(path: string, ignoreWriteBackPaths: Set<string>) {
+  for (const ignoredPath of ignoreWriteBackPaths) {
+    if (path === ignoredPath || path.startsWith(`${ignoredPath}/`)) return true
+  }
+  return false
+}
+
 async function runSandbox(
   sandbox: HarnessSandboxSession,
   options: { abortSignal?: AbortSignal, command: string, workingDirectory?: string },
@@ -338,6 +345,18 @@ async function extractWorkspaceArchive(
   })
 }
 
+async function initializeSandboxGitBaseline(
+  sandbox: HarnessSandboxSession,
+  sessionWorkDir: string,
+  abortSignal: AbortSignal | undefined,
+) {
+  await runSandbox(sandbox, {
+    abortSignal,
+    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A && git commit --allow-empty --no-gpg-sign -qm workspace-baseline || true; fi",
+    workingDirectory: sessionWorkDir,
+  })
+}
+
 async function listSandboxPaths(
   sandbox: HarnessSandboxSession,
   sessionWorkDir: string,
@@ -428,6 +447,12 @@ async function copyWorkspaceToSandbox(
   }, async () => {
     await extractWorkspaceArchive(sandbox, sessionWorkDir, initialTree, directoriesToCreate, abortSignal)
   })
+  await withPrepareProgress(onProgress, {
+    id: "workspace.prepare.git-status",
+    label: "Preparing workspace status",
+  }, async () => {
+    await initializeSandboxGitBaseline(sandbox, sessionWorkDir, abortSignal)
+  })
   return initialTree
 }
 
@@ -445,23 +470,26 @@ async function copySandboxChangesToWorkspace(
     throw new Error("[vitehub] Harness Workspace Session write mode requires sandbox.readBinaryFile.")
   }
 
+  const ignoredWriteBackPaths = new Set([...ignoreWriteBackPaths, ".git"])
   const sandboxDirectories = await listSandboxPaths(sandbox, sessionWorkDir, "d", abortSignal)
   const sandboxFiles = await listSandboxPaths(sandbox, sessionWorkDir, "f", abortSignal)
   const sandboxSymlinks = await listSandboxPaths(sandbox, sessionWorkDir, "l", abortSignal)
   const sandboxFileEntries = new Set([...sandboxFiles, ...sandboxSymlinks])
   for (const path of initialTree.files.keys()) {
-    if (ignoreWriteBackPaths.has(path)) continue
+    if (isIgnoredWriteBackPath(path, ignoredWriteBackPaths)) continue
     if (!sandboxFileEntries.has(path)) await session.rm(path, { force: true })
   }
   for (const path of [...initialTree.directories].sort((left, right) => right.length - left.length)) {
+    if (isIgnoredWriteBackPath(path, ignoredWriteBackPaths)) continue
     if (!sandboxDirectories.has(path)) await session.rm(path, { force: true, recursive: true })
   }
   for (const path of sandboxDirectories) {
+    if (isIgnoredWriteBackPath(path, ignoredWriteBackPaths)) continue
     if (initialTree.archiveDirectories.has(path)) continue
     await session.mkdir(path, { recursive: true } satisfies MkdirOptions)
   }
   for (const path of sandboxFiles) {
-    if (ignoreWriteBackPaths.has(path)) continue
+    if (isIgnoredWriteBackPath(path, ignoredWriteBackPaths)) continue
     const initial = initialTree.files.get(path)
     const content = await sandbox.readBinaryFile({
       abortSignal,
@@ -473,7 +501,7 @@ async function copySandboxChangesToWorkspace(
     })
   }
   for (const path of sandboxSymlinks) {
-    if (ignoreWriteBackPaths.has(path)) continue
+    if (isIgnoredWriteBackPath(path, ignoredWriteBackPaths)) continue
     const initial = initialTree.files.get(path)
     const target = await readSandboxSymlinkTarget(sandbox, sessionWorkDir, path, abortSignal)
     if (initial?.symlinkTarget === target) continue

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -353,7 +353,7 @@ async function initializeSandboxGitBaseline(
 ) {
   await runSandbox(sandbox, {
     abortSignal,
-    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A -f && git commit --allow-empty --no-gpg-sign -qm workspace-baseline || true; fi",
+    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A -f && git commit --allow-empty --no-gpg-sign --no-verify -qm workspace-baseline || true; fi",
     workingDirectory: sessionWorkDir,
   })
 }

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -28,6 +28,7 @@ export interface HarnessSandboxSession {
 
 export interface HarnessWorkspaceSession {
   close(error?: unknown): Promise<void>
+  refreshGitBaseline(): Promise<void>
 }
 
 export interface PrepareHarnessWorkspaceSessionOptions {
@@ -558,6 +559,14 @@ export async function prepareHarnessWorkspaceSession(
       finally {
         await workspaceSession?.close()
       }
+    },
+    async refreshGitBaseline() {
+      await withPrepareProgress(options.onProgress, {
+        id: "workspace.prepare.git-status",
+        label: "Preparing workspace status",
+      }, async () => {
+        await initializeSandboxGitBaseline(options.session, options.sessionWorkDir, options.abortSignal)
+      })
     },
   }
 }

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -38,6 +38,14 @@ function expectArchiveExtract(run: ReturnType<typeof vi.fn>, root = "/work/agent
   })
 }
 
+function expectGitBaseline(run: ReturnType<typeof vi.fn>, root = "/work/agent") {
+  expect(run).toHaveBeenCalledWith({
+    abortSignal: undefined,
+    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A && git commit --allow-empty --no-gpg-sign -qm workspace-baseline || true; fi",
+    workingDirectory: root,
+  })
+}
+
 function expectWorkDirReset(run: ReturnType<typeof vi.fn>, writeBinaryFile: ReturnType<typeof vi.fn>, root = "/work/agent") {
   const parent = root.replace(/\/[^/]+$/, "") || "/"
   const name = root.split("/").filter(Boolean).at(-1) || root
@@ -92,6 +100,7 @@ describe("Harness Workspace Session", () => {
     expect(readFile).toHaveBeenCalledWith("README.md", { encoding: "binary" })
     expectArchiveWrite(writeBinaryFile)
     expectArchiveExtract(run)
+    expectGitBaseline(run)
 
     await session.close()
   })
@@ -729,7 +738,7 @@ describe("Harness Workspace Session", () => {
     expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
   })
 
-  it("does not write ignored harness instruction files back to Workspace", async () => {
+  it("does not write ignored harness support paths back to Workspace", async () => {
     const workspaceSession = {
       close: vi.fn(async () => {}),
       commit: vi.fn(async () => {}),
@@ -744,16 +753,23 @@ describe("Harness Workspace Session", () => {
 
     const session = await prepareHarnessWorkspaceSession({
       fs: {
-        list: vi.fn(async () => [{ mediaType: "text/markdown", path: "AGENTS.md", type: "file" }]),
+        list: vi.fn(async () => [
+          { mediaType: "text/markdown", path: "AGENTS.md", type: "file" },
+          { path: "notes", type: "directory" },
+          { mediaType: "text/markdown", path: "notes/keep.md", type: "file" },
+        ]),
         readFile: vi.fn(async () => bytes("old instructions")),
       },
       startSession: vi.fn(async () => workspaceSession),
       tools: {},
     } as never, {
-      ignoreWriteBackPaths: ["AGENTS.md", "CLAUDE.md"],
+      ignoreWriteBackPaths: ["AGENTS.md", "CLAUDE.md", "notes"],
       session: {
         readBinaryFile: vi.fn(async ({ path }: { path: string }) => bytes(path)),
-        run: sandboxRun(["AGENTS.md", "CLAUDE.md", "summary.md"]),
+        run: sandboxRun(
+          [".git/config", "AGENTS.md", "CLAUDE.md", "notes/generated.md", "summary.md"],
+          [".git", ".git/refs", "notes"],
+        ),
         writeBinaryFile: vi.fn(async () => {}),
       },
       sessionWorkDir: "/work/agent",
@@ -764,6 +780,11 @@ describe("Harness Workspace Session", () => {
     expect(workspaceSession.writeFile).toHaveBeenCalledWith("summary.md", bytes("/work/agent/summary.md"), { mediaType: "text/markdown" })
     expect(workspaceSession.writeFile).not.toHaveBeenCalledWith("AGENTS.md", expect.anything(), expect.anything())
     expect(workspaceSession.writeFile).not.toHaveBeenCalledWith("CLAUDE.md", expect.anything(), expect.anything())
+    expect(workspaceSession.writeFile).not.toHaveBeenCalledWith(".git/config", expect.anything(), expect.anything())
+    expect(workspaceSession.writeFile).not.toHaveBeenCalledWith("notes/generated.md", expect.anything(), expect.anything())
+    expect(workspaceSession.rm).not.toHaveBeenCalledWith("notes/keep.md", expect.anything())
+    expect(workspaceSession.mkdir).not.toHaveBeenCalledWith(".git", expect.anything())
+    expect(workspaceSession.mkdir).not.toHaveBeenCalledWith("notes", expect.anything())
     expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
   })
 

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -41,7 +41,7 @@ function expectArchiveExtract(run: ReturnType<typeof vi.fn>, root = "/work/agent
 function expectGitBaseline(run: ReturnType<typeof vi.fn>, root = "/work/agent") {
   expect(run).toHaveBeenCalledWith({
     abortSignal: undefined,
-    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A -f && git commit --allow-empty --no-gpg-sign -qm workspace-baseline || true; fi",
+    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A -f && git commit --allow-empty --no-gpg-sign --no-verify -qm workspace-baseline || true; fi",
     workingDirectory: root,
   })
 }

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -41,7 +41,7 @@ function expectArchiveExtract(run: ReturnType<typeof vi.fn>, root = "/work/agent
 function expectGitBaseline(run: ReturnType<typeof vi.fn>, root = "/work/agent") {
   expect(run).toHaveBeenCalledWith({
     abortSignal: undefined,
-    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A && git commit --allow-empty --no-gpg-sign -qm workspace-baseline || true; fi",
+    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A -f && git commit --allow-empty --no-gpg-sign -qm workspace-baseline || true; fi",
     workingDirectory: root,
   })
 }
@@ -121,6 +121,31 @@ describe("Harness Workspace Session", () => {
 
     expect(run).toHaveBeenCalledTimes(3)
     expectGitBaseline(run)
+
+    await session.close()
+  })
+
+  it("force-adds materialized files to the harness git baseline", async () => {
+    const run = sandboxRun()
+    const writeBinaryFile = vi.fn(async () => {})
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: {
+        list: vi.fn(async () => [
+          { path: ".gitignore", type: "file" },
+          { path: "app.log", type: "file" },
+        ]),
+        readFile: vi.fn(async (path: string) => path === ".gitignore" ? bytes("*.log\n") : bytes("tracked log\n")),
+      },
+      tools: {},
+    } as never, {
+      session: { run, writeBinaryFile },
+      sessionWorkDir: "/work/agent",
+    })
+
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({
+      command: expect.stringContaining("git add -A -f"),
+    }))
 
     await session.close()
   })

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -105,6 +105,26 @@ describe("Harness Workspace Session", () => {
     await session.close()
   })
 
+  it("refreshes the harness git baseline after support files are written", async () => {
+    const run = sandboxRun()
+    const writeBinaryFile = vi.fn(async () => {})
+
+    const session = await prepareHarnessWorkspaceSession({
+      fs: { list: vi.fn(async () => []), readFile: vi.fn() },
+      tools: {},
+    } as never, {
+      session: { run, writeBinaryFile },
+      sessionWorkDir: "/work/agent",
+    })
+
+    await session.refreshGitBaseline()
+
+    expect(run).toHaveBeenCalledTimes(3)
+    expectGitBaseline(run)
+
+    await session.close()
+  })
+
   it("preserves GitHub symlinks in the harness archive", async () => {
     const list = vi.fn(async () => [
       { path: "AGENTS.md", type: "file" },


### PR DESCRIPTION
Initializes a git baseline after Harness Workspace Session materialization so harness agents can use ordinary git status and commit workflows inside the prepared workspace. Writeback now treats ignored paths as subtree ignores and always keeps the sandbox `.git` tree out of Workspace commits or deletes.

Also neutralizes the local harness sandbox description to `Workspace shell.` so agents do not see host temporary-root wording.