### PR TITLE
fix(agent): deliver chat titles to message channels

### DIFF
--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -1,13 +1,18 @@
 import { defineCapability } from "../capability-runtime.ts"
+import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
 import { messageChannelTitleSupportContextKey } from "../channels.ts"
 import { getMessageText } from "../messages.ts"
+import { normalizeAgentDriver } from "../internal/agent-driver.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 
 import type {
+  AgentAdapterRunContext,
   AgentCapabilityDefinition,
   AgentCapabilityRuntimeContext,
+  AgentDriver,
   AgentModelResolver,
   AgentRunInput,
+  AgentRunContext,
   AgentRuntimeConfig,
   MaybePromise,
 } from "../types.ts"
@@ -45,6 +50,7 @@ export type ChatTitleTemplateVariable =
   | ((input: ChatTitleTemplateInput) => MaybePromise<boolean | null | number | string | undefined>)
 
 export interface ChatTitleOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  driver?: AgentDriver<TRuntimeConfig>
   execute?: (input: ChatTitleExecuteInput) => MaybePromise<ChatTitleExecuteResult>
   fallback?: string
   id?: string
@@ -61,6 +67,7 @@ const defaultChatTitleTemplate = [
   "Generate a short chat title from the user's first message.",
   "Return only the title.",
   "Use 2-5 words when possible.",
+  "Ignore chat platform mention/channel markup, bot names, and user IDs.",
   `Use "{{ fallback }}" when the message is too vague.`,
   "",
   "User message:",
@@ -103,6 +110,14 @@ function cleanGeneratedTitle(value: unknown, maxLength: number, fallback: string
 function heuristicTitle(text: string, maxLength: number, fallback: string): string {
   const words = text.replace(/\s+/g, " ").trim().split(" ").filter(Boolean).slice(0, 6).join(" ")
   return cleanGeneratedTitle(words, maxLength, fallback)
+}
+
+function stripChatEntityMarkup(text: string): string {
+  const clean = text
+    .replace(/<[@#!&][^>\s]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+  return clean || text
 }
 
 function chatTitleData(title: string) {
@@ -166,6 +181,87 @@ async function resolveChatTitleModel(context: AgentCapabilityRuntimeContext, opt
   }
 }
 
+function chatTitleDriverInput(input: ChatTitleExecuteInput, prompt: string): AgentRunInput {
+  const { message: _message, messages: _messages, prompt: _prompt, ...base } = input.input
+  return { ...base, prompt }
+}
+
+function chatTitleAdapterRunContext(
+  context: AgentCapabilityRuntimeContext,
+  input: ChatTitleExecuteInput,
+  prompt: string,
+): AgentAdapterRunContext {
+  if (!context.runtimeContext) {
+    throw new Error("[vitehub] chatTitle({ driver }) requires an agent runtime context.")
+  }
+  return {
+    actor: context.actor,
+    context: context.context,
+    devtools: context.runtimeContext.devtools,
+    input: chatTitleDriverInput(input, prompt),
+    invoker: context.invoker,
+    messages: [],
+    prompt,
+    runtime: context.runtimeContext,
+  }
+}
+
+function chatTitleRunContext(
+  context: AgentCapabilityRuntimeContext,
+  input: ChatTitleExecuteInput,
+  prompt: string,
+): AgentRunContext {
+  if (!context.runtimeContext) {
+    throw new Error("[vitehub] chatTitle({ driver }) requires an agent runtime context.")
+  }
+  const { runtimeConfig: _runtimeConfig, ...runtime } = context.runtimeContext
+  return {
+    ...runtime,
+    actor: context.actor,
+    context: context.context,
+    input: chatTitleDriverInput(input, prompt),
+    invoker: context.invoker,
+    messages: [],
+    prompt,
+  }
+}
+
+async function chatTitleResultText(result: unknown): Promise<string | undefined> {
+  if (result instanceof Response) return await result.text()
+  if (result && typeof result === "object" && Symbol.asyncIterator in result) {
+    let text = ""
+    for await (const event of streamAgentOutputToEvents(result)) {
+      if (event.type === "text-delta") text += event.text
+    }
+    return text || undefined
+  }
+  return toAgentRunResult(result).text
+}
+
+async function generateChatTitleWithDriver(
+  context: AgentCapabilityRuntimeContext,
+  options: ChatTitleOptions,
+  input: ChatTitleExecuteInput,
+  prompt: string,
+): Promise<string | undefined> {
+  if (!options.driver) return
+  const driver = normalizeAgentDriver({ driver: options.driver } as never)
+  if (driver.kind === "run") {
+    return await chatTitleResultText(await driver.run(chatTitleRunContext(context, input, prompt) as never))
+  }
+  const runContext = chatTitleAdapterRunContext(context, input, prompt)
+  if (driver.kind === "harness") {
+    const { createHarnessAgentAdapter } = await import("../harness-agent.ts")
+    return await chatTitleResultText(await createHarnessAgentAdapter(driver as never).generate(runContext as never))
+  }
+  const { createAiSdkAdapter } = await import("../ai-sdk.ts")
+  return await chatTitleResultText(await createAiSdkAdapter({
+    execution: driver.execution,
+    instructions: options.instructions ?? driver.instructions,
+    model: driver.model,
+  } as never).generate(runContext as never))
+}
+
 async function generateChatTitle(context: AgentCapabilityRuntimeContext, options: ChatTitleOptions, input: ChatTitleExecuteInput): Promise<string | undefined> {
   const fallback = options.fallback ?? "New Conversation"
   const maxLength = options.maxLength ?? 80
@@ -173,6 +269,7 @@ async function generateChatTitle(context: AgentCapabilityRuntimeContext, options
     ...input,
     fallback,
     maxLength,
+    text: stripChatEntityMarkup(input.text),
     trigger: agentTriggerId(context),
   }
 
@@ -184,17 +281,21 @@ async function generateChatTitle(context: AgentCapabilityRuntimeContext, options
     return cleanGeneratedTitle(typeof result === "string" ? result : result.title, maxLength, fallback)
   }
 
+  const prompt = await renderChatTitleTemplate(options, templateInput)
+  if (options.driver) {
+    return cleanGeneratedTitle(await generateChatTitleWithDriver(context, options, input, prompt), maxLength, fallback)
+  }
+
   const model = await resolveChatTitleModel(context, options)
   if (model) {
     const { generateText } = await loadAiSdk()
-    const prompt = await renderChatTitleTemplate(options, templateInput)
     const result = await generateText(options.instructions
       ? { instructions: options.instructions, model: model as never, prompt }
       : { model: model as never, prompt })
     return cleanGeneratedTitle(result.text, maxLength, fallback)
   }
 
-  return heuristicTitle(input.text, maxLength, fallback)
+  return heuristicTitle(templateInput.text, maxLength, fallback)
 }
 
 function withChatTitleParallel<T>(

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -140,6 +140,10 @@ function supportsChatTitleDelivery(context: AgentCapabilityRuntimeContext): bool
   return context.context.get<boolean>(messageChannelTitleSupportContextKey) !== false
 }
 
+function shouldProvideChatTitleFinishExtension(context: AgentCapabilityRuntimeContext): boolean {
+  return supportsChatTitleDelivery(context) || context.context.get<boolean>("agent.finishHook") === true
+}
+
 async function resolveTemplateVariables(options: ChatTitleOptions, input: ChatTitleTemplateInput): Promise<Record<string, unknown>> {
   const variables: Record<string, unknown> = {}
   for (const [name, value] of Object.entries(options.variables || {})) {
@@ -516,7 +520,7 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
       }
 
       context.finish.provide(async () => {
-        if (!supportsChatTitleDelivery(context)) return
+        if (!shouldProvideChatTitleFinishExtension(context)) return
         const resolvedTitle = await getTitle()
         return resolvedTitle ? { title: resolvedTitle } : undefined
       })
@@ -526,7 +530,8 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
           ? { kind: "title", payload: { title: resolvedTitle.trim() } }
           : undefined
       }
-      titleDeliveryEffect.active = finish => Boolean(finish.channel)
+      titleDeliveryEffect.active = finish =>
+        Boolean(finish.channel) && finish.context.get<boolean>(messageChannelTitleSupportContextKey) !== false
       context.delivery.finishEffect(titleDeliveryEffect)
       context.output.render((result) => {
         if (hasChatTitleApplied(result)) return result

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -532,6 +532,7 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
       }
       titleDeliveryEffect.active = finish =>
         Boolean(finish.channel) && finish.context.get<boolean>(messageChannelTitleSupportContextKey) !== false
+      titleDeliveryEffect.kind = "title"
       context.delivery.finishEffect(titleDeliveryEffect)
       context.output.render((result) => {
         if (hasChatTitleApplied(result)) return result

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -282,13 +282,14 @@ async function generateChatTitle(context: AgentCapabilityRuntimeContext, options
     return cleanGeneratedTitle(typeof result === "string" ? result : result.title, maxLength, fallback)
   }
 
-  const prompt = await renderChatTitleTemplate(options, templateInput)
   if (options.driver) {
+    const prompt = await renderChatTitleTemplate(options, templateInput)
     return cleanGeneratedTitle(await generateChatTitleWithDriver(context, options, input, prompt), maxLength, fallback)
   }
 
   const model = await resolveChatTitleModel(context, options)
   if (model) {
+    const prompt = await renderChatTitleTemplate(options, templateInput)
     const { generateText } = await loadAiSdk()
     const result = await generateText(options.instructions
       ? { instructions: options.instructions, model: model as never, prompt }

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -1,7 +1,7 @@
 import { defineCapability } from "../capability-runtime.ts"
+import { messageChannelTitleSupportContextKey } from "../channels.ts"
 import { getMessageText } from "../messages.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
-import { supportsMessageChannelTitleEffect } from "../channels.ts"
 
 import type {
   AgentCapabilityDefinition,
@@ -118,6 +118,10 @@ function shouldRunForTrigger(filter: ChatTitleOptions["trigger"], trigger: strin
 function agentTriggerId(context: AgentCapabilityRuntimeContext): string | undefined {
   const trigger = context.context.get<{ id?: unknown }>("agent.trigger")
   return typeof trigger?.id === "string" ? trigger.id : undefined
+}
+
+function supportsChatTitleDelivery(context: AgentCapabilityRuntimeContext): boolean {
+  return context.context.get<boolean>(messageChannelTitleSupportContextKey) !== false
 }
 
 async function resolveTemplateVariables(options: ChatTitleOptions, input: ChatTitleTemplateInput): Promise<Record<string, unknown>> {
@@ -412,11 +416,11 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
       }
 
       context.finish.provide(async () => {
+        if (!supportsChatTitleDelivery(context)) return
         const resolvedTitle = await getTitle()
         return resolvedTitle ? { title: resolvedTitle } : undefined
       })
-      context.delivery.finishEffect(async (finish) => {
-        if (finish.channel && !await supportsMessageChannelTitleEffect({ channel: finish.channel, run: finish.run })) return
+      context.delivery.finishEffect((finish) => {
         const resolvedTitle = finish.extensions.get(capabilityId, "title")
         return typeof resolvedTitle === "string" && resolvedTitle.trim()
           ? { kind: "title", payload: { title: resolvedTitle.trim() } }

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -1,6 +1,7 @@
 import { defineCapability } from "../capability-runtime.ts"
 import { getMessageText } from "../messages.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
+import { supportsMessageChannelTitleEffect } from "../channels.ts"
 
 import type {
   AgentCapabilityDefinition,
@@ -414,7 +415,8 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
         const resolvedTitle = await getTitle()
         return resolvedTitle ? { title: resolvedTitle } : undefined
       })
-      context.delivery.finishEffect((finish) => {
+      context.delivery.finishEffect(async (finish) => {
+        if (finish.channel && !await supportsMessageChannelTitleEffect({ channel: finish.channel, run: finish.run })) return
         const resolvedTitle = finish.extensions.get(capabilityId, "title")
         return typeof resolvedTitle === "string" && resolvedTitle.trim()
           ? { kind: "title", payload: { title: resolvedTitle.trim() } }

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -137,7 +137,7 @@ function agentTriggerId(context: AgentCapabilityRuntimeContext): string | undefi
 }
 
 function supportsChatTitleDelivery(context: AgentCapabilityRuntimeContext): boolean {
-  return context.context.get<boolean>(messageChannelTitleSupportContextKey) !== false
+  return context.context.get<boolean>(messageChannelTitleSupportContextKey) === true
 }
 
 function shouldProvideChatTitleFinishExtension(context: AgentCapabilityRuntimeContext): boolean {

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -9,6 +9,7 @@ import type {
   AgentAdapterRunContext,
   AgentCapabilityDefinition,
   AgentCapabilityRuntimeContext,
+  AgentChannelDeliveryFinishEffectCallback,
   AgentDriver,
   AgentModelResolver,
   AgentRunInput,
@@ -521,12 +522,14 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
         const resolvedTitle = await getTitle()
         return resolvedTitle ? { title: resolvedTitle } : undefined
       })
-      context.delivery.finishEffect((finish) => {
+      const titleDeliveryEffect: AgentChannelDeliveryFinishEffectCallback = (finish) => {
         const resolvedTitle = finish.extensions.get(capabilityId, "title")
         return typeof resolvedTitle === "string" && resolvedTitle.trim()
           ? { kind: "title", payload: { title: resolvedTitle.trim() } }
           : undefined
-      })
+      }
+      titleDeliveryEffect.active = finish => Boolean(finish.channel)
+      context.delivery.finishEffect(titleDeliveryEffect)
       context.output.render((result) => {
         if (hasChatTitleApplied(result)) return result
         if (isStreamTextResult(result)) {

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -390,8 +390,9 @@ function chatTitleUiMessageStreamOverride(toUIMessageStream: ToUIMessageStream |
 export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   options: ChatTitleOptions<TRuntimeConfig> = {},
 ): AgentCapabilityDefinition<TRuntimeConfig> {
+  const capabilityId = options.id || "chat-title"
   return defineCapability({
-    id: options.id || "chat-title",
+    id: capabilityId,
     output(context) {
       const messages = context.input.messages()
       const message = firstUserMessage(messages)
@@ -412,6 +413,12 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
       context.finish.provide(async () => {
         const resolvedTitle = await getTitle()
         return resolvedTitle ? { title: resolvedTitle } : undefined
+      })
+      context.delivery.finishEffect((finish) => {
+        const resolvedTitle = finish.extensions.get(capabilityId, "title")
+        return typeof resolvedTitle === "string" && resolvedTitle.trim()
+          ? { kind: "title", payload: { title: resolvedTitle.trim() } }
+          : undefined
       })
       context.output.render((result) => {
         if (hasChatTitleApplied(result)) return result

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -228,14 +228,11 @@ function chatTitleRunContext(
 }
 
 async function chatTitleResultText(result: unknown): Promise<string | undefined> {
-  if (result instanceof Response) return await result.text()
-  if (result && typeof result === "object" && Symbol.asyncIterator in result) {
-    let text = ""
-    for await (const event of streamAgentOutputToEvents(result)) {
-      if (event.type === "text-delta") text += event.text
-    }
-    return text || undefined
+  let text = ""
+  for await (const event of streamAgentOutputToEvents(result)) {
+    if (event.type === "text-delta") text += event.text
   }
+  if (text) return text
   return toAgentRunResult(result).text
 }
 

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -32,6 +32,7 @@ import type { AgentChannelChatRouteBody, AgentChannelChatRouteHandlerOptions } f
 import type { Adapter, FileUpload } from "chat"
 
 export const messageChannelTitleSupportContextKey = "channel.delivery.supportsTitle"
+const customTitleEffectChannels = new WeakSet<object>()
 
 export { deliveryArtifactAttachments } from "./delivery-artifacts.ts"
 export { defineFinishEffect } from "./delivery-effects.ts"
@@ -1226,6 +1227,12 @@ export async function messageChannelSupportsTitleEffect<TRuntimeConfig extends A
   return Boolean(adapterSetThreadTitle(adapter) || adapterSetAssistantTitle(adapter))
 }
 
+export function channelHasCustomTitleEffect<TRuntimeConfig extends AgentRuntimeConfig>(
+  channel: AgentChannelDefinition<TRuntimeConfig>,
+): boolean {
+  return customTitleEffectChannels.has(channel)
+}
+
 async function messageChannelTitleEffect<TRuntimeConfig extends AgentRuntimeConfig>(
   context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
 ): Promise<void> {
@@ -1799,12 +1806,14 @@ export function defineChannel<TRuntimeConfig extends AgentRuntimeConfig = AgentR
   const effects = messages !== false && options.adapter
     ? messageChannelDeliveryEffects(options.effects)
     : options.effects
-  return {
+  const channel: AgentChannelDefinition<TRuntimeConfig> = {
     ...options,
     ...(effects ? { effects } : {}),
     kind,
     messages,
   }
+  if (options.effects?.title) customTitleEffectChannels.add(channel)
+  return channel
 }
 
 export function discord<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1238,7 +1238,7 @@ async function messageChannelTitleEffect<TRuntimeConfig extends AgentRuntimeConf
     return
   }
   const setAssistantTitle = adapterSetAssistantTitle(adapter)
-  if (setAssistantTitle) {
+  if (adapter && setAssistantTitle) {
     await setAssistantTitle(adapter.channelIdFromThreadId(context.run.threadId), context.run.threadId, title)
   }
 }

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1190,16 +1190,32 @@ function titleEffectPayloadTitle(value: unknown): string | undefined {
   return typeof title === "string" ? maybeString(title.trim()) : undefined
 }
 
+type AssistantTitleAdapter = Adapter & {
+  setAssistantTitle?: (channelId: string, threadTs: string, title: string) => MaybePromise<unknown>
+}
+
+async function messageChannelTitleAdapter<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: Pick<AgentChannelDeliveryEffectContext<TRuntimeConfig>, "channel" | "run"> & Partial<AgentChannelDeliveryEffectContext<TRuntimeConfig>>,
+): Promise<AssistantTitleAdapter | undefined> {
+  if (!context.run?.threadId || !context.channel.adapter) return
+  const adapter = await resolveEffectOption(context.channel.adapter as MaybeResolvable<Adapter, AgentChannelDeliveryEffectContext<TRuntimeConfig>>, context as AgentChannelDeliveryEffectContext<TRuntimeConfig>)
+  const setAssistantTitle = (adapter as AssistantTitleAdapter | undefined)?.setAssistantTitle
+  return typeof setAssistantTitle === "function" ? adapter as AssistantTitleAdapter : undefined
+}
+
+export async function supportsMessageChannelTitleEffect<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: Pick<AgentChannelDeliveryEffectContext<TRuntimeConfig>, "channel" | "run"> & Partial<AgentChannelDeliveryEffectContext<TRuntimeConfig>>,
+): Promise<boolean> {
+  return Boolean(await messageChannelTitleAdapter(context))
+}
+
 async function messageChannelTitleEffect<TRuntimeConfig extends AgentRuntimeConfig>(
   context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
 ): Promise<void> {
   const title = titleEffectPayloadTitle(context.effect.payload)
   if (!title || !context.run?.threadId) return
-  const adapter = context.channel.adapter
-    ? await resolveEffectOption(context.channel.adapter as MaybeResolvable<Adapter, AgentChannelDeliveryEffectContext<TRuntimeConfig>>, context)
-    : undefined
-  const setThreadTitle = (adapter as (Adapter & { setThreadTitle?: (threadId: string, title: string) => MaybePromise<unknown> }) | undefined)?.setThreadTitle
-  if (typeof setThreadTitle === "function") await setThreadTitle(context.run.threadId, title)
+  const adapter = await messageChannelTitleAdapter(context)
+  if (adapter) await adapter.setAssistantTitle!(adapter.channelIdFromThreadId(context.run.threadId), context.run.threadId, title)
 }
 
 function messageChannelDeliveryEffects<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -31,6 +31,8 @@ import type { PullRequestContextValue } from "./capabilities/pull-request-contex
 import type { AgentChannelChatRouteBody, AgentChannelChatRouteHandlerOptions } from "./server.ts"
 import type { Adapter, FileUpload } from "chat"
 
+export const messageChannelTitleSupportContextKey = "channel.delivery.supportsTitle"
+
 export { deliveryArtifactAttachments } from "./delivery-artifacts.ts"
 export { defineFinishEffect } from "./delivery-effects.ts"
 export type {
@@ -1190,23 +1192,38 @@ function titleEffectPayloadTitle(value: unknown): string | undefined {
   return typeof title === "string" ? maybeString(title.trim()) : undefined
 }
 
+type ThreadTitleAdapter = Adapter & {
+  setThreadTitle?: (threadId: string, title: string) => MaybePromise<unknown>
+}
+
 type AssistantTitleAdapter = Adapter & {
   setAssistantTitle?: (channelId: string, threadTs: string, title: string) => MaybePromise<unknown>
 }
 
-async function messageChannelTitleAdapter<TRuntimeConfig extends AgentRuntimeConfig>(
-  context: Pick<AgentChannelDeliveryEffectContext<TRuntimeConfig>, "channel" | "run"> & Partial<AgentChannelDeliveryEffectContext<TRuntimeConfig>>,
-): Promise<AssistantTitleAdapter | undefined> {
-  if (!context.run?.threadId || !context.channel.adapter) return
-  const adapter = await resolveEffectOption(context.channel.adapter as MaybeResolvable<Adapter, AgentChannelDeliveryEffectContext<TRuntimeConfig>>, context as AgentChannelDeliveryEffectContext<TRuntimeConfig>)
-  const setAssistantTitle = (adapter as AssistantTitleAdapter | undefined)?.setAssistantTitle
-  return typeof setAssistantTitle === "function" ? adapter as AssistantTitleAdapter : undefined
+function adapterSetThreadTitle(adapter: Adapter | undefined) {
+  const setThreadTitle = (adapter as ThreadTitleAdapter | undefined)?.setThreadTitle
+  return typeof setThreadTitle === "function" ? setThreadTitle.bind(adapter) : undefined
 }
 
-export async function supportsMessageChannelTitleEffect<TRuntimeConfig extends AgentRuntimeConfig>(
-  context: Pick<AgentChannelDeliveryEffectContext<TRuntimeConfig>, "channel" | "run"> & Partial<AgentChannelDeliveryEffectContext<TRuntimeConfig>>,
+function adapterSetAssistantTitle(adapter: Adapter | undefined) {
+  const setAssistantTitle = (adapter as AssistantTitleAdapter | undefined)?.setAssistantTitle
+  return typeof setAssistantTitle === "function" ? setAssistantTitle.bind(adapter) : undefined
+}
+
+async function messageChannelTitleAdapter<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
+): Promise<Adapter | undefined> {
+  return context.channel.adapter
+    ? await resolveEffectOption(context.channel.adapter as MaybeResolvable<Adapter, AgentChannelDeliveryEffectContext<TRuntimeConfig>>, context)
+    : undefined
+}
+
+export async function messageChannelSupportsTitleEffect<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
 ): Promise<boolean> {
-  return Boolean(await messageChannelTitleAdapter(context))
+  if (!context.run?.threadId) return false
+  const adapter = await messageChannelTitleAdapter(context)
+  return Boolean(adapterSetThreadTitle(adapter) || adapterSetAssistantTitle(adapter))
 }
 
 async function messageChannelTitleEffect<TRuntimeConfig extends AgentRuntimeConfig>(
@@ -1215,7 +1232,15 @@ async function messageChannelTitleEffect<TRuntimeConfig extends AgentRuntimeConf
   const title = titleEffectPayloadTitle(context.effect.payload)
   if (!title || !context.run?.threadId) return
   const adapter = await messageChannelTitleAdapter(context)
-  if (adapter) await adapter.setAssistantTitle!(adapter.channelIdFromThreadId(context.run.threadId), context.run.threadId, title)
+  const setThreadTitle = adapterSetThreadTitle(adapter)
+  if (setThreadTitle) {
+    await setThreadTitle(context.run.threadId, title)
+    return
+  }
+  const setAssistantTitle = adapterSetAssistantTitle(adapter)
+  if (setAssistantTitle) {
+    await setAssistantTitle(adapter.channelIdFromThreadId(context.run.threadId), context.run.threadId, title)
+  }
 }
 
 function messageChannelDeliveryEffects<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1230,7 +1230,9 @@ export async function messageChannelSupportsTitleEffect<TRuntimeConfig extends A
 export function channelHasCustomTitleEffect<TRuntimeConfig extends AgentRuntimeConfig>(
   channel: AgentChannelDefinition<TRuntimeConfig>,
 ): boolean {
+  const titleEffect = channel.effects?.title
   return customTitleEffectChannels.has(channel)
+    || Boolean(titleEffect && titleEffect !== messageChannelTitleEffect)
 }
 
 async function messageChannelTitleEffect<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1185,12 +1185,30 @@ async function messageChannelReplyEffect<TRuntimeConfig extends AgentRuntimeConf
   }
 }
 
+function titleEffectPayloadTitle(value: unknown): string | undefined {
+  const title = typeof value === "string" ? value : isRecord(value) ? value.title : undefined
+  return typeof title === "string" ? maybeString(title.trim()) : undefined
+}
+
+async function messageChannelTitleEffect<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
+): Promise<void> {
+  const title = titleEffectPayloadTitle(context.effect.payload)
+  if (!title || !context.run?.threadId) return
+  const adapter = context.channel.adapter
+    ? await resolveEffectOption(context.channel.adapter as MaybeResolvable<Adapter, AgentChannelDeliveryEffectContext<TRuntimeConfig>>, context)
+    : undefined
+  const setThreadTitle = (adapter as (Adapter & { setThreadTitle?: (threadId: string, title: string) => MaybePromise<unknown> }) | undefined)?.setThreadTitle
+  if (typeof setThreadTitle === "function") await setThreadTitle(context.run.threadId, title)
+}
+
 function messageChannelDeliveryEffects<TRuntimeConfig extends AgentRuntimeConfig>(
   effects: AgentChannelDeliveryEffects<TRuntimeConfig> | undefined,
 ): AgentChannelDeliveryEffects<TRuntimeConfig> {
   return {
     ...effects,
     reply: effects?.reply ?? messageChannelReplyEffect,
+    title: effects?.title ?? messageChannelTitleEffect,
   }
 }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1883,8 +1883,8 @@ function hasTitleDeliveryEffectProvider(providers: readonly AgentChannelDelivery
   })
 }
 
-function hasUnknownFinishDeliveryEffectProvider(providers: readonly AgentChannelDeliveryFinishEffect[]): boolean {
-  return providers.some(provider => typeof provider === "function" && provider.kind === undefined)
+function hasDeferredFinishDeliveryEffectProvider(providers: readonly AgentChannelDeliveryFinishEffect[]): boolean {
+  return providers.some(provider => typeof provider === "function" && (provider.kind === undefined || Boolean(provider.active)))
 }
 
 async function prepareProvisionalTitleDeliverySupport<
@@ -1932,7 +1932,7 @@ async function finishAgentInvocation<
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       context.context.set("agent.finishHook", Boolean(context.finishHook), { overwrite: true })
       const provisionalActiveDeliveryProviders = await prepareProvisionalTitleDeliverySupport(context, eventBase)
-      if (context.finishHook || provisionalActiveDeliveryProviders.length || hasUnknownFinishDeliveryEffectProvider(context.finishDeliveryEffectProviders)) {
+      if (context.finishHook || provisionalActiveDeliveryProviders.length || hasDeferredFinishDeliveryEffectProvider(context.finishDeliveryEffectProviders)) {
         const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
         const finishEvent = { ...eventBase, extensions }
         const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, finishEvent as never)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1717,7 +1717,7 @@ function hasFinishWork<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>): boolean {
-  return Boolean(context.finishHook || activeFinishDeliveryEffectProviders(context).length)
+  return Boolean(context.finishHook || context.finishDeliveryEffectProviders.length)
 }
 
 type AgentInvocationFinishOutcome =

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1906,6 +1906,7 @@ async function finishAgentInvocation<
       if (context.finishDeliveryEffectProviders.length) {
         await setChannelDeliverySupportContext(context.channels, context.context, context.runtimeContext, context.input, context.run)
       }
+      context.context.set("agent.finishHook", Boolean(context.finishHook), { overwrite: true })
       const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, {
         ...eventBase,
         extensions: { get: () => undefined } as unknown as AgentFinishExtensions,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1910,18 +1910,19 @@ async function finishAgentInvocation<
         ...eventBase,
         extensions: { get: () => undefined } as unknown as AgentFinishExtensions,
       } as AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>)
-      if (!context.finishHook && !activeDeliveryProviders.length) return
-      const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
-      const finishEvent = { ...eventBase, extensions }
-      await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context), finishEvent as never)
-      await runObservedAgentHook(context.hooks, {
-        ids: { runId: context.run?.runId },
-        name: "agent:finish",
-        owner: "agent",
-        phase: "finish",
-      }, async () => {
-        await context.finishHook?.(finishEvent)
-      })
+      if (context.finishHook || activeDeliveryProviders.length) {
+        const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
+        const finishEvent = { ...eventBase, extensions }
+        await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context), finishEvent as never)
+        await runObservedAgentHook(context.hooks, {
+          ids: { runId: context.run?.runId },
+          name: "agent:finish",
+          owner: "agent",
+          phase: "finish",
+        }, async () => {
+          await context.finishHook?.(finishEvent)
+        })
+      }
     }
     if (!failed) await commitWorkspaceChanges(context)
     if (!failed) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1408,7 +1408,6 @@ async function createAgentInvocationContext<
     const agentModel = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentModel] as AgentModelResolver<TRuntimeConfig> | undefined
     const driverKind = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentDriverKind]
     const resolveCapabilityCli = resolveCapabilityCliRunSurface(definition)
-    await setChannelDeliverySupportContext(definition?.channels, invocationContext, runtimeContext, input, context.run)
     const capabilities = await resolveAgentCapabilities(capabilityOptions, runtimeContext, input, workspace as never, workspaceMode, {
       context: invocationContext,
       driverKind,
@@ -1867,6 +1866,9 @@ async function finishAgentInvocation<
         runtime: context.runtimeContext,
         ...(text !== undefined ? { text } : {}),
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
+      if (context.finishDeliveryEffectProviders.length) {
+        await setChannelDeliverySupportContext(context.channels, context.context, context.runtimeContext, context.input, context.run)
+      }
       const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
       const finishEvent = { ...eventBase, extensions }
       await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(context.finishDeliveryEffectProviders, finishEvent as never, context), finishEvent as never)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1760,14 +1760,16 @@ async function resolveFinishDeliveryEffectIntents<
   CALL_OPTIONS,
 >(
   providers: readonly AgentChannelDeliveryFinishEffect[],
-  event: AgentFinishEvent,
+  event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
 ): Promise<AgentChannelDeliveryEffectIntent[]> {
   const intents: AgentChannelDeliveryEffectIntent[] = []
   const result = event.result === undefined ? undefined : toAgentRunResult(event.result)
+  const active = activeDeliveryChannel(context.channels, context.context, context.run)
   const finishContext = {
     ...context.runtimeContext,
     actor: context.actor,
+    ...(active ? { channel: active.channel } : {}),
     context: context.context,
     ...(event.error !== undefined ? { error: event.error } : {}),
     ...(event.errorMessage !== undefined ? { errorMessage: event.errorMessage } : {}),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1852,25 +1852,52 @@ function activeFinishDeliveryEffectProviders<
   CALL_OPTIONS,
 >(
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
-  event?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
+  event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
 ): AgentChannelDeliveryFinishEffect[] {
   if (!context.finishDeliveryEffectProviders.length) return []
-  const active = event ? createFinishDeliveryEffectContext(event, context) : undefined
+  const active = createFinishDeliveryEffectContext(event, context)
   return context.finishDeliveryEffectProviders.filter((provider) => {
     if (typeof provider !== "function" || !provider.active) return true
-    const activeContext = active ?? createFinishDeliveryEffectContext({
-      actor: context.actor,
-      extensions: { get: () => undefined } as unknown as AgentFinishExtensions,
-      input: context.input,
-      invocation: {
-        durationMs: Date.now() - context.startedAt,
-        ...(context.run ? { run: context.run } : {}),
-      },
-      invoker: context.invoker,
-      runtime: context.runtimeContext,
-    } as AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, context)
-    return provider.active(activeContext)
+    return provider.active(active)
   })
+}
+
+function provisionalFinishEvent<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+  eventBase: Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">,
+): AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS> {
+  return {
+    ...eventBase,
+    extensions: { get: () => undefined } as unknown as AgentFinishExtensions,
+  } as AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>
+}
+
+function hasTitleDeliveryEffectProvider(providers: readonly AgentChannelDeliveryFinishEffect[]): boolean {
+  return providers.some((provider) => {
+    if (typeof provider === "function") return provider.kind === "title"
+    const effects = Array.isArray(provider) ? provider : [provider]
+    return effects.some(effect => effect.kind === "title")
+  })
+}
+
+function hasUnknownFinishDeliveryEffectProvider(providers: readonly AgentChannelDeliveryFinishEffect[]): boolean {
+  return providers.some(provider => typeof provider === "function" && provider.kind === undefined)
+}
+
+async function prepareProvisionalTitleDeliverySupport<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+  eventBase: Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">,
+): Promise<AgentChannelDeliveryFinishEffect[]> {
+  const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, provisionalFinishEvent(context, eventBase))
+  if (!hasTitleDeliveryEffectProvider(activeDeliveryProviders)) return activeDeliveryProviders
+  await setChannelDeliverySupportContext(context.channels, context.context, context.runtimeContext, context.input, context.run)
+  return activeFinishDeliveryEffectProviders(context, provisionalFinishEvent(context, eventBase))
 }
 
 async function finishAgentInvocation<
@@ -1903,17 +1930,12 @@ async function finishAgentInvocation<
         runtime: context.runtimeContext,
         ...(text !== undefined ? { text } : {}),
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
-      if (context.finishDeliveryEffectProviders.length) {
-        await setChannelDeliverySupportContext(context.channels, context.context, context.runtimeContext, context.input, context.run)
-      }
       context.context.set("agent.finishHook", Boolean(context.finishHook), { overwrite: true })
-      const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, {
-        ...eventBase,
-        extensions: { get: () => undefined } as unknown as AgentFinishExtensions,
-      } as AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>)
-      if (context.finishHook || activeDeliveryProviders.length) {
+      const provisionalActiveDeliveryProviders = await prepareProvisionalTitleDeliverySupport(context, eventBase)
+      if (context.finishHook || provisionalActiveDeliveryProviders.length || hasUnknownFinishDeliveryEffectProvider(context.finishDeliveryEffectProviders)) {
         const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
         const finishEvent = { ...eventBase, extensions }
+        const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, finishEvent as never)
         await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context), finishEvent as never)
         await runObservedAgentHook(context.hooks, {
           ids: { runId: context.run?.runId },

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1906,9 +1906,14 @@ async function finishAgentInvocation<
       if (context.finishDeliveryEffectProviders.length) {
         await setChannelDeliverySupportContext(context.channels, context.context, context.runtimeContext, context.input, context.run)
       }
+      const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, {
+        ...eventBase,
+        extensions: { get: () => undefined } as unknown as AgentFinishExtensions,
+      } as AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>)
+      if (!context.finishHook && !activeDeliveryProviders.length) return
       const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
       const finishEvent = { ...eventBase, extensions }
-      await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(activeFinishDeliveryEffectProviders(context, finishEvent as never), finishEvent as never, context), finishEvent as never)
+      await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context), finishEvent as never)
       await runObservedAgentHook(context.hooks, {
         ids: { runId: context.run?.runId },
         name: "agent:finish",

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,6 +12,10 @@ import { resolveRuntimeContext } from "@vite-hub/runtime"
 import { isAsyncIterable, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent } from "./agent-output.ts"
 import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
 import { resolveAgentChannelChatOptions } from "./internal/channels.ts"
+import {
+  messageChannelSupportsTitleEffect,
+  messageChannelTitleSupportContextKey,
+} from "./channels.ts"
 import { createAgentInvocationContextStore } from "./invocation-context.ts"
 import {
   createFallbackAgentInvoker,
@@ -680,6 +684,37 @@ function activeDeliveryChannel<TRuntimeConfig extends AgentRuntimeConfig, CALL_O
   const channelId = run?.channelId || trigger?.channelId
   const channel = channelId ? channels?.[channelId] : undefined
   return channel && channelId ? { channel, channelId, trigger } : undefined
+}
+
+async function setChannelDeliverySupportContext<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+  channels: AgentChannels<TRuntimeConfig> | undefined,
+  invocationContext: AgentInvocationContextStore,
+  runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>,
+  input: AgentRunInput<CALL_OPTIONS>,
+  run?: AgentRunMetadata,
+): Promise<void> {
+  const active = activeDeliveryChannel(channels, invocationContext, run)
+  if (!active) return
+  if (!channelDeliveryEffectHandlers(active.channel, { kind: "title" }).length) {
+    invocationContext.set(messageChannelTitleSupportContextKey, false, { overwrite: true })
+    return
+  }
+  const { runtimeConfig: _runtimeConfig, ...callbackContext } = runtimeContext
+  const supported = await messageChannelSupportsTitleEffect({
+    ...callbackContext,
+    channel: active.channel,
+    context: invocationContext,
+    effect: { kind: "title" },
+    input,
+    request: runtimeContext.request,
+    run,
+    trigger: {
+      channelId: active.channelId,
+      ...(active.trigger?.id ? { id: active.trigger.id } : {}),
+      ...(active.trigger?.name ? { name: active.trigger.name } : {}),
+    },
+  })
+  invocationContext.set(messageChannelTitleSupportContextKey, supported, { overwrite: true })
 }
 
 async function applyChannelDeliveryEffectIntents<
@@ -1368,6 +1403,7 @@ async function createAgentInvocationContext<
     const agentModel = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentModel] as AgentModelResolver<TRuntimeConfig> | undefined
     const driverKind = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentDriverKind]
     const resolveCapabilityCli = resolveCapabilityCliRunSurface(definition)
+    await setChannelDeliverySupportContext(definition?.channels, invocationContext, runtimeContext, input, context.run)
     const capabilities = await resolveAgentCapabilities(capabilityOptions, runtimeContext, input, workspace as never, workspaceMode, {
       context: invocationContext,
       driverKind,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -13,6 +13,7 @@ import { isAsyncIterable, streamAgentOutputToEvents, toAgentRunResult, toAgentSt
 import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
 import { resolveAgentChannelChatOptions } from "./internal/channels.ts"
 import {
+  channelHasCustomTitleEffect,
   messageChannelSupportsTitleEffect,
   messageChannelTitleSupportContextKey,
 } from "./channels.ts"
@@ -697,6 +698,10 @@ async function setChannelDeliverySupportContext<TRuntimeConfig extends AgentRunt
   if (!active) return
   if (!channelDeliveryEffectHandlers(active.channel, { kind: "title" }).length) {
     invocationContext.set(messageChannelTitleSupportContextKey, false, { overwrite: true })
+    return
+  }
+  if (channelHasCustomTitleEffect(active.channel)) {
+    invocationContext.set(messageChannelTitleSupportContextKey, true, { overwrite: true })
     return
   }
   const { runtimeConfig: _runtimeConfig, ...callbackContext } = runtimeContext

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -108,6 +108,7 @@ import type {
   AgentDriverContribution,
   AgentDriverKind,
   AgentFinishEvent,
+  AgentFinishExtensions,
   AgentChatOptions,
   AgentHandlerOptions,
   AgentInput,
@@ -1716,7 +1717,7 @@ function hasFinishWork<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>): boolean {
-  return Boolean(context.finishHook || context.finishDeliveryEffectProviders.length)
+  return Boolean(context.finishHook || activeFinishDeliveryEffectProviders(context).length)
 }
 
 type AgentInvocationFinishOutcome =
@@ -1804,9 +1805,25 @@ async function resolveFinishDeliveryEffectIntents<
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
 ): Promise<AgentChannelDeliveryEffectIntent[]> {
   const intents: AgentChannelDeliveryEffectIntent[] = []
+  const finishContext = createFinishDeliveryEffectContext(event, context)
+  for (const provider of providers) {
+    const intent = typeof provider === "function" ? await provider(finishContext, event) : provider
+    if (!intent) continue
+    appendDeliveryEffectIntent(intents, intent)
+  }
+  return intents
+}
+
+function createFinishDeliveryEffectContext<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+): AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS> {
   const result = event.result === undefined ? undefined : toAgentRunResult(event.result)
   const active = activeDeliveryChannel(context.channels, context.context, context.run)
-  const finishContext = {
+  return {
     ...context.runtimeContext,
     actor: context.actor,
     ...(active ? { channel: active.channel } : {}),
@@ -1828,12 +1845,32 @@ async function resolveFinishDeliveryEffectIntents<
     ...(event.text !== undefined ? { text: event.text } : {}),
     workspace: context.workspace,
   }
-  for (const provider of providers) {
-    const intent = typeof provider === "function" ? await provider(finishContext, event) : provider
-    if (!intent) continue
-    appendDeliveryEffectIntent(intents, intent)
-  }
-  return intents
+}
+
+function activeFinishDeliveryEffectProviders<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+  event?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
+): AgentChannelDeliveryFinishEffect[] {
+  if (!context.finishDeliveryEffectProviders.length) return []
+  const active = event ? createFinishDeliveryEffectContext(event, context) : undefined
+  return context.finishDeliveryEffectProviders.filter((provider) => {
+    if (typeof provider !== "function" || !provider.active) return true
+    const activeContext = active ?? createFinishDeliveryEffectContext({
+      actor: context.actor,
+      extensions: { get: () => undefined } as unknown as AgentFinishExtensions,
+      input: context.input,
+      invocation: {
+        durationMs: Date.now() - context.startedAt,
+        ...(context.run ? { run: context.run } : {}),
+      },
+      invoker: context.invoker,
+      runtime: context.runtimeContext,
+    } as AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, context)
+    return provider.active(activeContext)
+  })
 }
 
 async function finishAgentInvocation<
@@ -1871,7 +1908,7 @@ async function finishAgentInvocation<
       }
       const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
       const finishEvent = { ...eventBase, extensions }
-      await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(context.finishDeliveryEffectProviders, finishEvent as never, context), finishEvent as never)
+      await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(activeFinishDeliveryEffectProviders(context, finishEvent as never), finishEvent as never, context), finishEvent as never)
       await runObservedAgentHook(context.hooks, {
         ids: { runId: context.run?.runId },
         name: "agent:finish",

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -287,6 +287,7 @@ export type AgentChannelDeliveryFinishEffectCallback<
 > = {
   (context: AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS>, event?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>): MaybePromise<AgentChannelDeliveryFinishEffectResult>
   active?: (context: AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS>) => boolean
+  kind?: AgentChannelDeliveryEffectKind
 }
 export type AgentChannelDeliveryFinishEffect<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -92,6 +92,7 @@ export interface AgentInvocationContextValues extends ViteHubAgentInvocationCont
   actor: AgentActor
   "channel.delivery.effects": AgentChannelDeliveryEffectIntent[]
   "channel.delivery.finishEffects": AgentChannelDeliveryFinishEffect[]
+  "channel.delivery.supportsTitle": boolean
   invoker: AgentInvoker
 }
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -254,6 +254,7 @@ export interface AgentChannelDeliveryFinishEffectContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
 > extends AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS> {
+  channel?: AgentChannelDefinition<any>
   error?: unknown
   errorMessage?: string
   event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -90,6 +90,7 @@ declare global {
 export interface AgentInvocationContextValues extends ViteHubAgentInvocationContextValues {
   access: AgentAccessInvocationContextValue
   actor: AgentActor
+  "agent.finishHook": boolean
   "channel.delivery.effects": AgentChannelDeliveryEffectIntent[]
   "channel.delivery.finishEffects": AgentChannelDeliveryFinishEffect[]
   "channel.delivery.supportsTitle": boolean

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -283,7 +283,10 @@ export type AgentChannelDeliveryFinishEffectResult =
 export type AgentChannelDeliveryFinishEffectCallback<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
-> = (context: AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS>, event?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<AgentChannelDeliveryFinishEffectResult>
+> = {
+  (context: AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS>, event?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>): MaybePromise<AgentChannelDeliveryFinishEffectResult>
+  active?: (context: AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS>) => boolean
+}
 export type AgentChannelDeliveryFinishEffect<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -90,13 +90,14 @@ function subpath(base: string, path: string): string {
 
 type NitroConfig = Record<string, unknown> & CloudflareAgentStateRollupTarget & CloudflareAgentStateTarget
 type RollupExternalFunction = (source: string, importer?: string, isResolved?: boolean) => boolean | null | undefined | void
+type RollupExternalOption = string | RegExp | (string | RegExp)[] | RollupExternalFunction
 type BuildWithRollupOptions = {
   build?: {
     rolldownOptions?: {
-      external?: unknown
+      external?: RollupExternalOption
     }
     rollupOptions?: {
-      external?: unknown
+      external?: RollupExternalOption
     }
   }
 }
@@ -153,9 +154,9 @@ function cloneCloudflareAgentStateMigrations(value: unknown): CloudflareAgentSta
   })
 }
 
-function mergeRollupExternals(external: unknown, additions: readonly string[]): unknown {
+function mergeRollupExternals(external: RollupExternalOption | undefined, additions: readonly string[]): RollupExternalOption | undefined {
   if (external === undefined) return [...additions]
-  if (typeof external === "string") return additions.includes(external) ? additions : [external, ...additions]
+  if (typeof external === "string") return additions.includes(external) ? [...additions] : [external, ...additions]
   if (external instanceof RegExp) return [external, ...additions]
   if (Array.isArray(external)) {
     const missing = additions.filter(source => !external.includes(source))
@@ -169,7 +170,7 @@ function mergeRollupExternals(external: unknown, additions: readonly string[]): 
   return external
 }
 
-function mergeCloudflareWorkersExternal(external: unknown): unknown {
+function mergeCloudflareWorkersExternal(external: RollupExternalOption | undefined): RollupExternalOption | undefined {
   return mergeRollupExternals(external, ["cloudflare:workers", ...optionalMessageAdapterRuntimeExternals])
 }
 
@@ -225,7 +226,7 @@ function mergeCloudflareAgentStateNitroConfig(value: unknown): NitroConfig {
   configureCloudflareAgentState(nitro)
   installCloudflareAgentStateEntrypoint(nitro)
   nitro.rollupConfig ||= {}
-  nitro.rollupConfig.external = mergeCloudflareWorkersExternal(nitro.rollupConfig.external)
+  nitro.rollupConfig.external = mergeCloudflareWorkersExternal(nitro.rollupConfig.external as RollupExternalOption | undefined)
   return nitro
 }
 

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -39,6 +39,11 @@ const generatedAgentWebhookRouteHandler = ".vitehub/agent/chat-webhook-route.ts"
 const generatedAgentNetlifyFunction = ".vitehub/agent/netlify-function.mjs"
 const netlifyAgentFunctionName = "vitehub-agent"
 const workspacePackageName = "@vite-hub/workspace"
+const optionalMessageAdapterRuntimeExternals = [
+  "bufferutil",
+  "utf-8-validate",
+  "zlib-sync",
+]
 const optionalNetlifyAgentBundleExternals = [
   "@ai-sdk/harness",
   "@ai-sdk/harness/*",
@@ -53,6 +58,7 @@ const optionalNetlifyAgentBundleExternals = [
   "@vite-hub/workflow/*",
   "agents",
   "evalite/*",
+  ...optionalMessageAdapterRuntimeExternals,
   "vitest/*",
 ]
 
@@ -84,6 +90,16 @@ function subpath(base: string, path: string): string {
 
 type NitroConfig = Record<string, unknown> & CloudflareAgentStateRollupTarget & CloudflareAgentStateTarget
 type RollupExternalFunction = (source: string, importer?: string, isResolved?: boolean) => boolean | null | undefined | void
+type BuildWithRollupOptions = {
+  build?: {
+    rolldownOptions?: {
+      external?: unknown
+    }
+    rollupOptions?: {
+      external?: unknown
+    }
+  }
+}
 type GeneratedLibsqlAgentStateOptions = Pick<ResolvedAgentModuleOptions["providers"]["state"], "tablePrefix" | "url"> & {
   authTokenEnvName?: string
 }
@@ -137,19 +153,38 @@ function cloneCloudflareAgentStateMigrations(value: unknown): CloudflareAgentSta
   })
 }
 
-function mergeCloudflareWorkersExternal(external: unknown): unknown {
-  if (external === undefined) return ["cloudflare:workers"]
-  if (typeof external === "string") return external === "cloudflare:workers" ? external : [external, "cloudflare:workers"]
-  if (external instanceof RegExp) return [external, "cloudflare:workers"]
+function mergeRollupExternals(external: unknown, additions: readonly string[]): unknown {
+  if (external === undefined) return [...additions]
+  if (typeof external === "string") return additions.includes(external) ? additions : [external, ...additions]
+  if (external instanceof RegExp) return [external, ...additions]
   if (Array.isArray(external)) {
-    return external.includes("cloudflare:workers") ? external : [...external, "cloudflare:workers"]
+    const missing = additions.filter(source => !external.includes(source))
+    return missing.length ? [...external, ...missing] : external
   }
   if (typeof external === "function") {
     const externalFunction = external as RollupExternalFunction
     return (source: string, importer?: string, isResolved?: boolean) =>
-      source === "cloudflare:workers" || Boolean(externalFunction(source, importer, isResolved))
+      additions.includes(source) || Boolean(externalFunction(source, importer, isResolved))
   }
   return external
+}
+
+function mergeCloudflareWorkersExternal(external: unknown): unknown {
+  return mergeRollupExternals(external, ["cloudflare:workers", ...optionalMessageAdapterRuntimeExternals])
+}
+
+function mergeBuildExternal(config: BuildWithRollupOptions, additions: readonly string[]): BuildWithRollupOptions["build"] {
+  return {
+    ...config.build,
+    rolldownOptions: {
+      ...config.build?.rolldownOptions,
+      external: mergeRollupExternals(config.build?.rolldownOptions?.external, additions),
+    },
+    rollupOptions: {
+      ...config.build?.rollupOptions,
+      external: mergeRollupExternals(config.build?.rollupOptions?.external, additions),
+    },
+  }
 }
 
 function cloneNitroConfig(value: unknown): NitroConfig {
@@ -1049,6 +1084,11 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       const mergedNitro = mergeNitroHandlers(nitro, nitroHandlers)
       return {
         ...(typeof agent !== "undefined" ? { agent } : {}),
+        ...(nitroHandlers.length
+          ? {
+              build: mergeBuildExternal(config as BuildWithRollupOptions, optionalMessageAdapterRuntimeExternals),
+            }
+          : {}),
         ...(nitroHandlers.length || installCloudflareState
           ? {
               nitro: mergedNitro,

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -23,6 +23,12 @@ function githubSignature(secret: string, body: string) {
   return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`
 }
 
+const optionalMessageAdapterRuntimeExternals = [
+  "bufferutil",
+  "utf-8-validate",
+  "zlib-sync",
+]
+
 function createTestChatAdapter(options: { deferMessageProcessing?: boolean, missingIncomingMessageId?: boolean, persistThreadHistory?: boolean, secret?: string } = {}) {
   let chatInstance: ChatInstance | undefined
   let sentMessageId = 0
@@ -294,6 +300,7 @@ describe("agent Vite plugin", () => {
                 "@vite-hub/workflow/*",
                 "agents",
                 "evalite/*",
+                ...optionalMessageAdapterRuntimeExternals,
                 "vitest/*",
               ],
               format: "esm",
@@ -584,9 +591,12 @@ describe("agent Vite plugin", () => {
     expect(output.nitro?.cloudflare?.wrangler?.migrations).not.toContainEqual(expect.objectContaining({
       deleted_classes: ["ViteHubAgentStateDO"],
     }))
-    expect(output.nitro?.rollupConfig?.external).toEqual(["cloudflare:workers"])
+    expect(output.nitro?.rollupConfig?.external).toEqual(["cloudflare:workers", ...optionalMessageAdapterRuntimeExternals])
     expect(output.nitro?.rollupConfig?.plugins?.some(plugin => plugin.name === "vitehub-agent-cloudflare-state-exports:ViteHubAgentStateDO")).toBe(true)
-    expect(output.build).toBeUndefined()
+    expect(output.build).toEqual({
+      rolldownOptions: { external: ["existing", ...optionalMessageAdapterRuntimeExternals] },
+      rollupOptions: { external: optionalMessageAdapterRuntimeExternals },
+    })
   })
 
   it("keeps Cloudflare chat state opt-out when the state provider is memory", async () => {
@@ -614,7 +624,10 @@ describe("agent Vite plugin", () => {
     })
     expect(output.nitro?.cloudflare).toBeUndefined()
     expect(output.nitro?.rollupConfig).toBeUndefined()
-    expect(output.build).toBeUndefined()
+    expect(output.build).toEqual({
+      rolldownOptions: { external: optionalMessageAdapterRuntimeExternals },
+      rollupOptions: { external: optionalMessageAdapterRuntimeExternals },
+    })
   })
 
   it("skips Nitro handlers for Deno generated output", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5172,6 +5172,36 @@ describe("agent message protocol", () => {
     expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Como Estas" })
   })
 
+  it("generates chat titles from stream-result title drivers", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [
+        chatTitle({
+          driver: {
+            run: () => ({
+              stream: (async function* () {
+                yield { text: "Streamed ", type: "text-delta" }
+                yield { text: "title", type: "text-delta" }
+              })(),
+            }),
+          },
+          fallback: "Fallback title",
+        }),
+      ],
+      driver: { run: () => ({ text: "ok" }) },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Need a sidebar title" })],
+    })
+
+    expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Streamed title" })
+  })
+
   it("renders custom chat title templates and skips unmatched triggers", async () => {
     const generateText = vi.fn(async () => ({ text: "Portal Forecast Help" }))
     vi.doMock("ai", () => ({ generateText, jsonSchema: vi.fn(schema => schema) }))

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2764,6 +2764,42 @@ describe("agent message protocol", () => {
     expect(execute).not.toHaveBeenCalled()
   })
 
+  it("delivers chat titles through custom message Channel title effects", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const execute = vi.fn(() => "Prepared title")
+    const titleEffect = vi.fn()
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute })],
+      channels: {
+        portal: defineChannel("portal", {
+          adapter: {
+            channelIdFromThreadId: (threadId: string) => threadId,
+            postMessage: vi.fn(),
+          } as never,
+          effects: {
+            title: titleEffect,
+          },
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "prepare title" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
+    expect(execute).toHaveBeenCalledOnce()
+    expect(titleEffect).toHaveBeenCalledWith(expect.objectContaining({
+      effect: { kind: "title", payload: { title: "Prepared title" } },
+    }))
+  })
+
   it("ignores unsupported delivery effect intents with observer metadata", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2830,6 +2830,40 @@ describe("agent message protocol", () => {
     expect(execute).not.toHaveBeenCalled()
   })
 
+  it("preserves chat title finish extensions when message Channel title delivery is unsupported", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const execute = vi.fn(() => "Prepared title")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute })],
+      channels: {
+        portal: defineChannel("portal", {
+          adapter: {
+            channelIdFromThreadId: (threadId: string) => threadId,
+            postMessage: vi.fn(),
+          } as never,
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "prepare title" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
+    expect(execute).toHaveBeenCalledOnce()
+    expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Prepared title" })
+  })
+
   it("delivers chat titles through custom message Channel title effects", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2675,6 +2675,63 @@ describe("agent message protocol", () => {
     expect(effect).toHaveBeenCalledOnce()
   })
 
+  it("delivers chat titles through message Channels", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const setThreadTitle = vi.fn()
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute: () => "Prepared title", id: "thread-title" })],
+      channels: {
+        portal: defineChannel("portal", {
+          adapter: {
+            channelIdFromThreadId: (threadId: string) => threadId,
+            postMessage: vi.fn(),
+            setThreadTitle,
+          } as never,
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "prepare title" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
+    expect(setThreadTitle).toHaveBeenCalledWith("thread-1", "Prepared title")
+  })
+
+  it("ignores chat title delivery when message Channel adapters cannot set titles", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute: () => "Prepared title" })],
+      channels: {
+        portal: defineChannel("portal", {
+          adapter: {
+            channelIdFromThreadId: (threadId: string) => threadId,
+            postMessage: vi.fn(),
+          } as never,
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "prepare title" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
+  })
+
   it("ignores unsupported delivery effect intents with observer metadata", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2801,6 +2801,44 @@ describe("agent message protocol", () => {
     expect(adapter).not.toHaveBeenCalled()
   })
 
+  it("does not resolve message Channel title adapters for inactive title finish effects", async () => {
+    const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const adapter = vi.fn(() => {
+      throw new Error("adapter should not resolve")
+    })
+    const titleEffect = (() => ({ kind: "title", payload: { title: "Inactive title" } })) as AgentChannelDeliveryFinishEffectCallback
+    titleEffect.active = () => false
+    titleEffect.kind = "title"
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "inactive-title",
+          prepare(context) {
+            context.delivery.finishEffect(titleEffect)
+          },
+        }),
+      ],
+      channels: {
+        portal: defineChannel("portal", {
+          adapter,
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "plain message" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
+    expect(adapter).not.toHaveBeenCalled()
+  })
+
   it("ignores chat title delivery when message Channel adapters cannot set titles", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
@@ -2931,6 +2969,44 @@ describe("agent message protocol", () => {
     expect(titleEffect).toHaveBeenCalledWith(expect.objectContaining({
       effect: { kind: "title", payload: { title: "Prepared title" } },
     }))
+  })
+
+  it("evaluates finish delivery active predicates after finish extensions resolve", async () => {
+    const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const delivered = vi.fn()
+    const finishEffect = ((finish) => finish.reply("Extension enabled")) as AgentChannelDeliveryFinishEffectCallback
+    finishEffect.active = finish => finish.extensions.get("extension-gated-delivery", "enabled") === true
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "extension-gated-delivery",
+          prepare(context) {
+            context.finish.provide(() => ({ enabled: true }))
+            context.delivery.finishEffect(finishEffect)
+          },
+        }),
+      ],
+      channels: {
+        portal: defineChannel("portal", {
+          effects: {
+            reply: ({ effect }) => delivered(effect.payload),
+          },
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "deliver reply" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
+    expect(delivered).toHaveBeenCalledWith("Extension enabled")
   })
 
   it("ignores unsupported delivery effect intents with observer metadata", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5056,6 +5056,35 @@ describe("agent message protocol", () => {
     ])
   })
 
+  it("does not render chat title templates for heuristic fallback titles", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const template = vi.fn(() => "Rendered template")
+    const variable = vi.fn(() => "Rendered variable")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [
+        chatTitle({
+          template,
+          variables: {
+            area: variable,
+          },
+        }),
+      ],
+      driver: { run: () => ({ text: "ok" }) },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Need help with invoices today" })],
+    })
+
+    expect(template).not.toHaveBeenCalled()
+    expect(variable).not.toHaveBeenCalled()
+    expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Need help with invoices today" })
+  })
+
   it("generates chat titles with the default template and agent model", async () => {
     const generateText = vi.fn(async () => ({ text: '"Generated invoice title"' }))
     vi.doMock("ai", () => ({

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4207,6 +4207,45 @@ describe("agent message protocol", () => {
     expect(execute).not.toHaveBeenCalled()
   })
 
+  it("auto-commits workspace writes when finish delivery effects are inactive", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const { defineWorkspace, useWorkspace } = await import("@vite-hub/workspace")
+    const { registerWorkspace } = await import("@vite-hub/workspace/test")
+    const workspaceName = `inactive-finish-auto-commit-${Math.random().toString(36).slice(2)}`
+    const inactiveFinishEffect: AgentChannelDeliveryFinishEffectCallback = context => context.reply("unused")
+    inactiveFinishEffect.active = () => false
+    registerWorkspace(workspaceName, defineWorkspace({
+      commit: true,
+      store: { provider: "memory" },
+    }))
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "inactive-finish-effect",
+          prepare(context) {
+            context.delivery.finishEffect(inactiveFinishEffect)
+          },
+        }),
+      ],
+      driver: { async run({ workspace }) {
+          await (workspace as WritableWorkspaceFacade).fs.writeFile("notes.md", "committed")
+          return { text: "ok" }
+        } },
+      workspace: {
+        mode: "write",
+        name: workspaceName,
+      },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).resolves.toMatchObject({ text: "ok" })
+
+    await expect(useWorkspace(workspaceName, { mode: "write" }).diff()).resolves.toMatchObject({ entries: [] })
+  })
+
   it("does not rerun finish lifecycle when a finish hook fails", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finishError = new Error("finish failed")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -6,6 +6,7 @@ import { createTraceEventLog, deriveTraceRuns, emitTraceEvent } from "@vite-hub/
 import { chat, chatTitle, observability, schedule, subagents } from "../src/capabilities.ts"
 import { toJsonCompatibleValue } from "../src/tool-runtime.ts"
 
+import type { AgentChannelDeliveryFinishEffectCallback } from "../src/index.ts"
 import type { WritableWorkspaceFacade } from "@vite-hub/workspace"
 
 const harnessAgentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
@@ -2673,6 +2674,44 @@ describe("agent message protocol", () => {
 
     await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
     expect(effect).toHaveBeenCalledOnce()
+  })
+
+  it("evaluates result-dependent finish delivery effects with the finished result", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const delivered = vi.fn()
+    const finishEffect: AgentChannelDeliveryFinishEffectCallback = context => context.reply(context.result!.text!)
+    finishEffect.active = context => context.result?.text === "deliver me"
+
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "result-dependent-delivery",
+          prepare(context) {
+            context.delivery.finishEffect(finishEffect)
+          },
+        }),
+      ],
+      channels: {
+        portal: defineChannel("portal", {
+          effects: {
+            reply({ effect }) {
+              delivered(effect.payload)
+            },
+          },
+          messages: false,
+        }),
+      },
+      driver: { run: () => ({ text: "deliver me" }) },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { channelId: "portal", runId: "portal-run" },
+      runtime: "unknown" as const,
+      waitUntil: vi.fn(),
+    }, {})).resolves.toEqual({ text: "deliver me" })
+    expect(delivered).toHaveBeenCalledWith("deliver me")
   })
 
   it("delivers chat titles through message Channels", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5034,7 +5034,7 @@ describe("agent message protocol", () => {
       })
 
       await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
-        messages: [createMessage({ role: "user", text: "Need help with invoices" })],
+        messages: [createMessage({ role: "user", text: "<@1523327881886040225> Need help with invoices" })],
       })
 
       expect(generateText).toHaveBeenCalledWith({
@@ -5043,6 +5043,7 @@ describe("agent message protocol", () => {
           "Generate a short chat title from the user's first message.",
           "Return only the title.",
           "Use 2-5 words when possible.",
+          "Ignore chat platform mention/channel markup, bot names, and user IDs.",
           `Use "New Conversation" when the message is too vague.`,
           "",
           "User message:",
@@ -5054,6 +5055,45 @@ describe("agent message protocol", () => {
     finally {
       vi.doUnmock("ai")
     }
+  })
+
+  it("generates chat titles with a harness title driver", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const session = { destroy: vi.fn() }
+    const sandbox = { providerId: "local-test", specificationVersion: "harness-sandbox-v1" }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessGenerate.mockResolvedValueOnce({ text: "Como Estas" })
+
+    const agent = defineAgent({
+      capabilities: [
+        chatTitle({
+          driver: {
+            harness: { provider: "codex" },
+            sandbox,
+          },
+          fallback: "Bitacora",
+        }),
+      ],
+      driver: { run: () => ({ text: "ok" }) },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "<@1523327881886040225> como estas tio" })],
+    })
+
+    const prompt = (harnessGenerate.mock.calls[0]![0] as { prompt: string }).prompt
+    expect(prompt).toContain("como estas tio")
+    expect(prompt).not.toContain("<@1523327881886040225>")
+    expect(harnessGenerate).toHaveBeenCalledWith(expect.objectContaining({ session }))
+    expect(harnessAgentSettings.at(-1)).toMatchObject({
+      harness: { provider: "codex" },
+      sandbox,
+    })
+    expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Como Estas" })
   })
 
   it("renders custom chat title templates and skips unmatched triggers", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4115,6 +4115,26 @@ describe("agent message protocol", () => {
     expect(extension).not.toHaveBeenCalled()
   })
 
+  it("does not generate chat titles for plain agent runs without title delivery", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => {
+      throw new Error("title should not run")
+    })
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute })],
+      driver: { run: () => ({ text: "ok" }) },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {
+      messages: [createMessage({ role: "user", text: "Name this chat" })],
+    })).resolves.toMatchObject({ text: "ok" })
+    expect(execute).not.toHaveBeenCalled()
+  })
+
   it("does not rerun finish lifecycle when a finish hook fails", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finishError = new Error("finish failed")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2678,7 +2678,7 @@ describe("agent message protocol", () => {
   it("delivers chat titles through message Channels", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
-    const setThreadTitle = vi.fn()
+    const setAssistantTitle = vi.fn()
     const agent = defineAgent({
       capabilities: [chatTitle({ execute: () => "Prepared title", id: "thread-title" })],
       channels: {
@@ -2686,7 +2686,7 @@ describe("agent message protocol", () => {
           adapter: {
             channelIdFromThreadId: (threadId: string) => threadId,
             postMessage: vi.fn(),
-            setThreadTitle,
+            setAssistantTitle,
           } as never,
           triggers: {
             message: {
@@ -2702,14 +2702,15 @@ describe("agent message protocol", () => {
     })
 
     await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
-    expect(setThreadTitle).toHaveBeenCalledWith("thread-1", "Prepared title")
+    expect(setAssistantTitle).toHaveBeenCalledWith("thread-1", "thread-1", "Prepared title")
   })
 
   it("ignores chat title delivery when message Channel adapters cannot set titles", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
+    const execute = vi.fn(() => "Prepared title")
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => "Prepared title" })],
+      capabilities: [chatTitle({ execute })],
       channels: {
         portal: defineChannel("portal", {
           adapter: {
@@ -2730,6 +2731,7 @@ describe("agent message protocol", () => {
     })
 
     await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
+    expect(execute).not.toHaveBeenCalled()
   })
 
   it("ignores unsupported delivery effect intents with observer metadata", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2705,6 +2705,36 @@ describe("agent message protocol", () => {
     expect(setAssistantTitle).toHaveBeenCalledWith("thread-1", "thread-1", "Prepared title")
   })
 
+  it("delivers chat titles through Slack Assistant message Channels", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const setAssistantTitle = vi.fn()
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute: () => "Prepared title", id: "thread-title" })],
+      channels: {
+        slack: defineChannel("slack", {
+          adapter: {
+            channelIdFromThreadId: (threadId: string) => `channel:${threadId}`,
+            postMessage: vi.fn(),
+            setAssistantTitle,
+          } as never,
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "prepare title" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "slack-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "slack.message", {})).resolves.toBe("ok")
+    expect(setAssistantTitle).toHaveBeenCalledWith("channel:thread-1", "thread-1", "Prepared title")
+  })
+
   it("ignores chat title delivery when message Channel adapters cannot set titles", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2971,12 +2971,13 @@ describe("agent message protocol", () => {
     }))
   })
 
-  it("evaluates finish delivery active predicates after finish extensions resolve", async () => {
+  it("evaluates known-kind finish delivery active predicates after finish extensions resolve", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     const delivered = vi.fn()
     const finishEffect = ((finish) => finish.reply("Extension enabled")) as AgentChannelDeliveryFinishEffectCallback
     finishEffect.active = finish => finish.extensions.get("extension-gated-delivery", "enabled") === true
+    finishEffect.kind = "reply"
     const agent = defineAgent({
       capabilities: [
         defineCapability({

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2735,6 +2735,33 @@ describe("agent message protocol", () => {
     expect(setAssistantTitle).toHaveBeenCalledWith("channel:thread-1", "thread-1", "Prepared title")
   })
 
+  it("does not resolve message Channel title adapters without title finish effects", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const adapter = vi.fn(() => {
+      throw new Error("adapter should not resolve")
+    })
+    const agent = defineAgent({
+      channels: {
+        portal: defineChannel("portal", {
+          adapter,
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "plain message" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
+    expect(adapter).not.toHaveBeenCalled()
+  })
+
   it("ignores chat title delivery when message Channel adapters cannot set titles", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2866,6 +2866,39 @@ describe("agent message protocol", () => {
     }))
   })
 
+  it("delivers chat titles through raw custom Channel title effects", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const execute = vi.fn(() => "Prepared title")
+    const titleEffect = vi.fn()
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute })],
+      channels: {
+        portal: {
+          effects: {
+            title: titleEffect,
+          },
+          kind: "portal",
+          messages: {},
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "prepare title" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        },
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
+    expect(execute).toHaveBeenCalledOnce()
+    expect(titleEffect).toHaveBeenCalledWith(expect.objectContaining({
+      effect: { kind: "title", payload: { title: "Prepared title" } },
+    }))
+  })
+
   it("ignores unsupported delivery effect intents with observer metadata", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")


### PR DESCRIPTION
Adds generated chat-title delivery for message channels: `chatTitle()` now emits title intents to adapters that support `setThreadTitle(threadId, title)`, while unsupported adapters no-op.

Extends `chatTitle()` so title generation can use the same driver shapes as agents (`model`, `harness`, or `run`) instead of only the legacy `model` shortcut or custom `execute`. The built-in prompt path also strips chat entity markup such as Discord mentions before asking for the title.

Also externalizes optional native message-adapter packages from generated hosted bundles and covers those provider outputs in tests.