### PR TITLE
fix(agent): upload blob assets from harness workspaces

### DIFF
--- a/packages/agent/src/capabilities/browser.ts
+++ b/packages/agent/src/capabilities/browser.ts
@@ -14,7 +14,7 @@ const defaultBrowserSkillContent = `# Browser
 Use the \`agent-browser\` CLI through the bash tool for headless browser work.
 
 - Run \`agent-browser --help\` before non-trivial browser work.
-- Save screenshots inside the workspace, usually under \`screenshots/\`.
+- Create \`screenshots/\` before screenshots, then save screenshots inside that workspace directory.
 `
 
 function normalizeSkillPath(path: string): string {

--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -113,8 +113,11 @@ async function resolveBlobStore(context: AgentCapabilityContext, options: BlobCa
 }
 
 async function readWorkspaceBlobBody(context: AgentCapabilityContext, path: string) {
-  const activeBody = await readActiveHarnessWorkspaceFile(context.context, path)
-  if (activeBody !== undefined) return activeBody
+  const activeRead = await readActiveHarnessWorkspaceFile(context.context, path)
+  if (activeRead) {
+    if (activeRead.body !== undefined) return activeRead.body
+    throw new Error(`[vitehub] blob_edit workspacePath was not found in the active Harness Workspace Session: "${path}".`)
+  }
   if (!context.fs?.readFile) throw new Error("[vitehub] blob_edit workspacePath requires a Workspace file system.")
   return await context.fs.readFile(path as never, { encoding: "binary" })
 }

--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -81,8 +81,8 @@ function normalizeAssetPath(path: string): string {
 }
 
 function normalizeAssetPaths(mode: AgentCapabilityMode, value: BlobCapabilityOptions["assetPaths"]): string[] {
-  if (mode !== "write" || value === false) return []
-  const paths = value === undefined || value === true
+  if (mode !== "write" || value === undefined || value === false) return []
+  const paths = value === true
     ? ["screenshots"]
     : Array.isArray(value)
       ? value

--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -1,4 +1,5 @@
-import { defineCapability, normalizeMode } from "../../capability-runtime.ts"
+import { defineCapability, normalizeMode, workspaceMaterializationPathsSymbol } from "../../capability-runtime.ts"
+import { readActiveHarnessWorkspaceFile } from "../../harness-runtime.ts"
 import {
   assertString,
   createTool,
@@ -17,11 +18,16 @@ import type {
 } from "../../types.ts"
 import type { PrimitiveStorageCapabilityOptions } from "./shared.ts"
 
-export interface BlobCapabilityOptions extends PrimitiveStorageCapabilityOptions {}
+export interface BlobCapabilityOptions extends PrimitiveStorageCapabilityOptions {
+  assetPaths?: boolean | string | readonly string[]
+}
 
 export function blob(options: BlobCapabilityOptions = {}): AgentCapabilityDefinition {
   const mode = normalizeMode(options.mode, "Blob")
-  return defineCapability({ id: "blob", mode, requires: [{ primitive: "blob" }], tools: blobTools(mode, options) })
+  const assetPaths = normalizeAssetPaths(mode, options.assetPaths)
+  return Object.assign(defineCapability({ id: "blob", mode, requires: [{ primitive: "blob" }], tools: blobTools(mode, options) }), assetPaths.length
+    ? { [workspaceMaterializationPathsSymbol]: assetPaths }
+    : {})
 }
 
 interface BlobReadInput {
@@ -65,6 +71,25 @@ const blobEditInputSchema = jsonObjectSchema({
   },
 }, ["operation", "pathname"])
 
+function normalizeAssetPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "").replace(/\/+/g, "/")
+  const parts = normalized.split("/").filter(Boolean)
+  if (!normalized || parts.some(part => part === "." || part === "..")) {
+    throw new TypeError(`[vitehub] Blob asset path must be a workspace-relative path: "${path}".`)
+  }
+  return parts.join("/")
+}
+
+function normalizeAssetPaths(mode: AgentCapabilityMode, value: BlobCapabilityOptions["assetPaths"]): string[] {
+  if (mode !== "write" || value === false) return []
+  const paths = value === undefined || value === true
+    ? ["screenshots"]
+    : Array.isArray(value)
+      ? value
+      : [value]
+  return [...new Set(paths.map(path => normalizeAssetPath(path)))]
+}
+
 function normalizeListLimit(limit: unknown): number {
   if (limit === undefined) return defaultListLimit
   if (typeof limit !== "number" || !Number.isFinite(limit) || limit < 1) {
@@ -85,6 +110,13 @@ async function resolveBlobPrimitive(context: AgentCapabilityContext) {
 
 async function resolveBlobStore(context: AgentCapabilityContext, options: BlobCapabilityOptions) {
   return selectStore(await resolveBlobPrimitive(context), "Blob", options.store)
+}
+
+async function readWorkspaceBlobBody(context: AgentCapabilityContext, path: string) {
+  const activeBody = await readActiveHarnessWorkspaceFile(context.context, path)
+  if (activeBody !== undefined) return activeBody
+  if (!context.fs?.readFile) throw new Error("[vitehub] blob_edit workspacePath requires a Workspace file system.")
+  return await context.fs.readFile(path as never, { encoding: "binary" })
 }
 
 function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): AgentCapabilityDefinition["tools"] {
@@ -116,8 +148,7 @@ function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): A
             const sourcePath = typeof workspacePath === "string" && workspacePath.trim() ? workspacePath : undefined
             if (sourcePath && body !== undefined) throw new Error("[vitehub] blob_edit put accepts body or workspacePath, not both.")
             if (sourcePath) {
-              if (!context.fs?.readFile) throw new Error("[vitehub] blob_edit workspacePath requires a Workspace file system.")
-              return method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(path, await context.fs.readFile(sourcePath as never, { encoding: "binary" }), putOptions)
+              return method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(path, await readWorkspaceBlobBody(context, sourcePath), putOptions)
             }
             if (body === undefined) throw new Error("[vitehub] blob_edit put requires body or workspacePath.")
             return method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(path, body, putOptions)

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -4,6 +4,7 @@ import {
 } from "./internal/agent-usage-metadata.ts"
 import { hasTrustedWorkspaceAccessScope } from "./access-runtime.ts"
 import { streamAgentOutputToEvents } from "./agent-output.ts"
+import { setActiveHarnessWorkspaceFiles } from "./harness-runtime.ts"
 import { composeInstructionDocument } from "./instruction-composition.ts"
 import {
   colocatedAgentInstructionsSourceKey,
@@ -53,6 +54,10 @@ type HarnessWorkspaceMaterializationContext = AgentAdapterRunContext & {
 
 type HarnessInstructionSandbox = {
   writeBinaryFile(options: { abortSignal?: AbortSignal, content: Uint8Array, path: string }): MaybePromise<void>
+}
+
+type HarnessFileSandbox = {
+  readBinaryFile?(options: { abortSignal?: AbortSignal, path: string }): MaybePromise<Uint8Array | null>
 }
 
 type HarnessAgentConstructor = new (settings: Record<string, unknown>) => HarnessAgentLike
@@ -191,6 +196,33 @@ function hasLazyWorkspaceSources(context: AgentAdapterRunContext): boolean {
 
 function pathContains(container: string, path: string): boolean {
   return !container || path === container || path.startsWith(`${container}/`)
+}
+
+function normalizeActiveHarnessWorkspacePath(path: string): string {
+  const stripped = path.replace(/\\/g, "/").replace(/^\/workspace(?:\/|$)/, "").replace(/^\/+|\/+$/g, "").replace(/\/+/g, "/")
+  const parts = stripped.split("/").filter(Boolean)
+  if (parts.some(part => part === "." || part === "..")) {
+    throw new Error(`[vitehub] Workspace path must stay inside the workspace: "${path}".`)
+  }
+  return parts.join("/")
+}
+
+function joinHarnessSessionPath(sessionWorkDir: string, workspacePath: string): string {
+  return [sessionWorkDir.replace(/\/+$/, ""), workspacePath].filter(Boolean).join("/")
+}
+
+function activeHarnessWorkspaceFiles(session: HarnessFileSandbox, sessionWorkDir: string, abortSignal: AbortSignal | undefined) {
+  if (!session.readBinaryFile) return
+  return {
+    async readFile(path: string) {
+      const workspacePath = normalizeActiveHarnessWorkspacePath(path)
+      if (!workspacePath) return
+      return await session.readBinaryFile?.({
+        abortSignal,
+        path: joinHarnessSessionPath(sessionWorkDir, workspacePath),
+      }) ?? undefined
+    },
+  }
 }
 
 function compactWorkspacePaths(paths: readonly string[]): string[] {
@@ -441,6 +473,7 @@ async function createHarnessAgent<
     harness,
     sandboxConfig: {
       onSession: async ({ abortSignal, session, sessionWorkDir }: { abortSignal?: AbortSignal, session: unknown, sessionWorkDir: string }) => {
+        setActiveHarnessWorkspaceFiles(context.context, activeHarnessWorkspaceFiles(session as HarnessFileSandbox, sessionWorkDir, abortSignal))
         await prepareWorkspaceSession(session, sessionWorkDir, abortSignal)
       },
     },
@@ -665,6 +698,9 @@ export function createHarnessAgentAdapter<
       }
       catch (nextError) {
         closeError = nextError
+      }
+      finally {
+        setActiveHarnessWorkspaceFiles(context.context, undefined)
       }
       if (!sessionId || closeError) {
         if (sessionId) resumeStates.delete(sessionId)

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -198,9 +198,14 @@ function pathContains(container: string, path: string): boolean {
   return !container || path === container || path.startsWith(`${container}/`)
 }
 
-function normalizeActiveHarnessWorkspacePath(path: string): string {
-  const stripped = path.replace(/\\/g, "/").replace(/^\/workspace(?:\/|$)/, "").replace(/^\/+|\/+$/g, "").replace(/\/+/g, "/")
-  const parts = stripped.split("/").filter(Boolean)
+function normalizeActiveHarnessWorkspacePath(sessionWorkDir: string, path: string): string {
+  const normalizedWorkDir = sessionWorkDir.replace(/\\/g, "/").replace(/\/+$/g, "").replace(/\/+/g, "/")
+  const normalizedPath = path.replace(/\\/g, "/").replace(/\/+/g, "/")
+  const stripped = normalizedPath.startsWith(`${normalizedWorkDir}/`) || normalizedPath === normalizedWorkDir
+    ? normalizedPath.slice(normalizedWorkDir.length)
+    : normalizedPath.replace(/^\/workspace(?:\/|$)/, "")
+  const workspacePath = stripped.replace(/^\/+|\/+$/g, "").replace(/\/+/g, "/")
+  const parts = workspacePath.split("/").filter(Boolean)
   if (parts.some(part => part === "." || part === "..")) {
     throw new Error(`[vitehub] Workspace path must stay inside the workspace: "${path}".`)
   }
@@ -215,12 +220,13 @@ function activeHarnessWorkspaceFiles(session: HarnessFileSandbox, sessionWorkDir
   if (!session.readBinaryFile) return
   return {
     async readFile(path: string) {
-      const workspacePath = normalizeActiveHarnessWorkspacePath(path)
-      if (!workspacePath) return
-      return await session.readBinaryFile?.({
+      const workspacePath = normalizeActiveHarnessWorkspacePath(sessionWorkDir, path)
+      if (!workspacePath) return { active: true as const, body: undefined }
+      const body = await session.readBinaryFile?.({
         abortSignal,
         path: joinHarnessSessionPath(sessionWorkDir, workspacePath),
       }) ?? undefined
+      return { active: true as const, body }
     },
   }
 }

--- a/packages/agent/src/harness-runtime.ts
+++ b/packages/agent/src/harness-runtime.ts
@@ -1,0 +1,16 @@
+import type { AgentInvocationContextStore } from "./types.ts"
+
+export interface ActiveHarnessWorkspaceFiles {
+  readFile(path: string): Promise<Uint8Array | undefined>
+}
+
+const activeHarnessWorkspaceFiles = new WeakMap<AgentInvocationContextStore, ActiveHarnessWorkspaceFiles>()
+
+export function setActiveHarnessWorkspaceFiles(context: AgentInvocationContextStore, files: ActiveHarnessWorkspaceFiles | undefined) {
+  if (files) activeHarnessWorkspaceFiles.set(context, files)
+  else activeHarnessWorkspaceFiles.delete(context)
+}
+
+export async function readActiveHarnessWorkspaceFile(context: AgentInvocationContextStore, path: string): Promise<Uint8Array | undefined> {
+  return await activeHarnessWorkspaceFiles.get(context)?.readFile(path)
+}

--- a/packages/agent/src/harness-runtime.ts
+++ b/packages/agent/src/harness-runtime.ts
@@ -1,7 +1,12 @@
 import type { AgentInvocationContextStore } from "./types.ts"
 
 export interface ActiveHarnessWorkspaceFiles {
-  readFile(path: string): Promise<Uint8Array | undefined>
+  readFile(path: string): Promise<ActiveHarnessWorkspaceFileRead>
+}
+
+export interface ActiveHarnessWorkspaceFileRead {
+  active: true
+  body: Uint8Array | undefined
 }
 
 const activeHarnessWorkspaceFiles = new WeakMap<AgentInvocationContextStore, ActiveHarnessWorkspaceFiles>()
@@ -11,6 +16,6 @@ export function setActiveHarnessWorkspaceFiles(context: AgentInvocationContextSt
   else activeHarnessWorkspaceFiles.delete(context)
 }
 
-export async function readActiveHarnessWorkspaceFile(context: AgentInvocationContextStore, path: string): Promise<Uint8Array | undefined> {
+export async function readActiveHarnessWorkspaceFile(context: AgentInvocationContextStore, path: string): Promise<ActiveHarnessWorkspaceFileRead | undefined> {
   return await activeHarnessWorkspaceFiles.get(context)?.readFile(path)
 }

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -627,9 +627,26 @@ describe("agent capability runtime", () => {
     expect(source).not.toBeNull()
     if (!source || typeof source !== "object") throw new Error("Expected browser skill source object.")
     const content = (source as { content?: unknown }).content
-    expect(content).toContain("Save screenshots inside the workspace")
+    expect(content).toContain("save screenshots inside that workspace directory")
     expect(content).not.toContain("blob_edit")
     expect(content).not.toContain("Blob")
+  })
+
+  it("adds default Blob asset paths for Harness workspace materialization", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { blob } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [blob({ mode: "write" })],
+    }, runtime(), {}, emptyWorkspace() as never, "write", {
+      driverKind: "harness",
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    expect(resolved.workspaceMaterializationPaths).toEqual(["screenshots"])
   })
 
   it("requires Access when capability workspace contributions add scoped sources", async () => {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -632,12 +632,29 @@ describe("agent capability runtime", () => {
     expect(content).not.toContain("Blob")
   })
 
-  it("adds default Blob asset paths for Harness workspace materialization", async () => {
+  it("keeps default Blob writes out of Harness workspace materialization", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { blob } = await import("../src/capabilities.ts")
 
     const resolved = await resolveAgentCapabilities({
       capabilities: [blob({ mode: "write" })],
+    }, runtime(), {}, emptyWorkspace() as never, "write", {
+      driverKind: "harness",
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    expect(resolved.workspaceMaterializationPaths).toEqual([])
+  })
+
+  it("adds explicit Blob asset paths for Harness workspace materialization", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { blob } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [blob({ mode: "write", assetPaths: true })],
     }, runtime(), {}, emptyWorkspace() as never, "write", {
       driverKind: "harness",
       workspaceDefinition: {

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -236,6 +236,44 @@ describe("storage capabilities", () => {
     expect(store.del).toHaveBeenCalledWith("images/a.png")
   })
 
+  it("uploads workspacePath from the active Harness workspace when available", async () => {
+    const { blob } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { createAgentInvocationContextStore } = await import("../src/invocation-context.ts")
+    const { setActiveHarnessWorkspaceFiles } = await import("../src/harness-runtime.ts")
+    const harnessBytes = new Uint8Array([4, 5, 6])
+    const workspaceBytes = new Uint8Array([1, 2, 3])
+    const context = createAgentInvocationContextStore()
+    const readFile = vi.fn(async () => harnessBytes)
+    setActiveHarnessWorkspaceFiles(context, { readFile })
+    const workspace = {
+      fs: {
+        readFile: vi.fn(async () => workspaceBytes),
+      },
+    } as unknown as ReadonlyWorkspaceFacade
+    const store = {
+      del: vi.fn(),
+      get: vi.fn(),
+      head: vi.fn(),
+      list: vi.fn(async () => ({ blobs: [], hasMore: false })),
+      put: vi.fn(async () => ({ pathname: "images/from-harness.png" })),
+    }
+
+    const resolved = await resolveAgentCapabilities(
+      { capabilities: [blob({ mode: "write" })] },
+      runtime({ blob: store }),
+      {},
+      workspace as never,
+      "write",
+      { context },
+    )
+
+    await resolved.tools!.blob_edit!.execute?.({ operation: "put", pathname: "images/from-harness.png", workspacePath: "screenshots/result.png" })
+    expect(readFile).toHaveBeenCalledWith("screenshots/result.png")
+    expect(workspace.fs.readFile).not.toHaveBeenCalled()
+    expect(store.put).toHaveBeenCalledWith("images/from-harness.png", harnessBytes, undefined)
+  })
+
   it("falls back to the installed Blob primitive at tool execution time", async () => {
     const store = {
       list: vi.fn(async () => ({ blobs: [], hasMore: false })),

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -244,7 +244,7 @@ describe("storage capabilities", () => {
     const harnessBytes = new Uint8Array([4, 5, 6])
     const workspaceBytes = new Uint8Array([1, 2, 3])
     const context = createAgentInvocationContextStore()
-    const readFile = vi.fn(async () => harnessBytes)
+    const readFile = vi.fn(async () => ({ active: true as const, body: harnessBytes }))
     setActiveHarnessWorkspaceFiles(context, { readFile })
     const workspace = {
       fs: {
@@ -272,6 +272,42 @@ describe("storage capabilities", () => {
     expect(readFile).toHaveBeenCalledWith("screenshots/result.png")
     expect(workspace.fs.readFile).not.toHaveBeenCalled()
     expect(store.put).toHaveBeenCalledWith("images/from-harness.png", harnessBytes, undefined)
+  })
+
+  it("does not fall back to persisted Workspace FS when the active Harness workspace misses a file", async () => {
+    const { blob } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { createAgentInvocationContextStore } = await import("../src/invocation-context.ts")
+    const { setActiveHarnessWorkspaceFiles } = await import("../src/harness-runtime.ts")
+    const context = createAgentInvocationContextStore()
+    const readFile = vi.fn(async () => ({ active: true as const, body: undefined }))
+    setActiveHarnessWorkspaceFiles(context, { readFile })
+    const workspace = {
+      fs: {
+        readFile: vi.fn(async () => new Uint8Array([1, 2, 3])),
+      },
+    } as unknown as ReadonlyWorkspaceFacade
+    const store = {
+      del: vi.fn(),
+      get: vi.fn(),
+      head: vi.fn(),
+      list: vi.fn(async () => ({ blobs: [], hasMore: false })),
+      put: vi.fn(),
+    }
+
+    const resolved = await resolveAgentCapabilities(
+      { capabilities: [blob({ mode: "write" })] },
+      runtime({ blob: store }),
+      {},
+      workspace as never,
+      "write",
+      { context },
+    )
+
+    await expect(resolved.tools!.blob_edit!.execute?.({ operation: "put", pathname: "images/missing.png", workspacePath: "screenshots/missing.png" })).rejects.toThrow("active Harness Workspace Session")
+    expect(readFile).toHaveBeenCalledWith("screenshots/missing.png")
+    expect(workspace.fs.readFile).not.toHaveBeenCalled()
+    expect(store.put).not.toHaveBeenCalled()
   })
 
   it("falls back to the installed Blob primitive at tool execution time", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -357,7 +357,7 @@ describe("defineAgent workspace option", () => {
       await tools.blob_edit.execute({
         operation: "put",
         pathname: "screenshots/result.png",
-        workspacePath: "screenshots/result.png",
+        workspacePath: "/workspace/codex-session/screenshots/result.png",
       })
       return { finishReason: "stop", text: "ok" }
     })

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -379,7 +379,7 @@ describe("defineAgent workspace option", () => {
     })
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
-      paths: ["AGENTS.md", "CLAUDE.md", "screenshots"],
+      paths: undefined,
     }))
     expect(harnessFileSession.readBinaryFile).toHaveBeenCalledWith({
       abortSignal: undefined,
@@ -390,7 +390,7 @@ describe("defineAgent workspace option", () => {
 
   it("scopes write-mode harness Workspace Sessions through access()", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
-    const { access } = await import("../src/capabilities.ts")
+    const { access, blob } = await import("../src/capabilities.ts")
     const harnessWorkspaceSession = { close: vi.fn() }
     const startSession = vi.fn(async () => ({ close: vi.fn() }))
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
@@ -420,6 +420,7 @@ describe("defineAgent workspace option", () => {
             },
           },
         }),
+        blob({ mode: "write" }),
       ],
       driver: {
         harness: { provider: "codex" },

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -338,6 +338,56 @@ describe("defineAgent workspace option", () => {
     expect(harnessWorkspaceSession.close).toHaveBeenCalledWith(undefined)
   })
 
+  it("lets Blob tools upload files from the active Harness workspace", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { blob } = await import("../src/capabilities.ts")
+    const harnessWorkspaceSession = { close: vi.fn() }
+    const screenshot = new Uint8Array([7, 8, 9])
+    const store = {
+      del: vi.fn(),
+      get: vi.fn(),
+      head: vi.fn(),
+      list: vi.fn(async () => ({ blobs: [], hasMore: false })),
+      put: vi.fn(async () => ({ pathname: "screenshots/result.png" })),
+    }
+    harnessFileSession.readBinaryFile.mockResolvedValueOnce(screenshot)
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
+    harnessGenerate.mockImplementationOnce(async function (this: { settings: { tools: Record<string, { execute: (input: unknown) => Promise<unknown> }> } }) {
+      const tools = this.settings.tools
+      await tools.blob_edit.execute({
+        operation: "put",
+        pathname: "screenshots/result.png",
+        workspacePath: "screenshots/result.png",
+      })
+      return { finishReason: "stop", text: "ok" }
+    })
+
+    const agent = withAgentDefaults(defineAgent({
+      capabilities: [blob({ mode: "write", policy: "allow" })],
+      driver: {
+        harness: { provider: "codex" },
+      },
+      workspace: {
+        mode: "write",
+      },
+    }), { workspace: "review" })
+
+    const runtimeContext = context() as Record<string, unknown>
+    await expect(runAgent(agent, { ...runtimeContext, capabilities: { blob: store } } as never, { prompt: "hello" })).resolves.toMatchObject({
+      finishReason: "stop",
+      text: "ok",
+    })
+
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+      paths: ["AGENTS.md", "CLAUDE.md", "screenshots"],
+    }))
+    expect(harnessFileSession.readBinaryFile).toHaveBeenCalledWith({
+      abortSignal: undefined,
+      path: "/workspace/codex-session/screenshots/result.png",
+    })
+    expect(store.put).toHaveBeenCalledWith("screenshots/result.png", screenshot, undefined)
+  })
+
   it("scopes write-mode harness Workspace Sessions through access()", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { access } = await import("../src/capabilities.ts")


### PR DESCRIPTION
Lets blob tools upload files created inside an active Harness workspace before the session is written back. Blob write mode now stages a default screenshot asset path for harness runs, and the browser skill tells agents to create the screenshot directory before saving evidence.

This keeps screenshot upload in the generic blob capability instead of requiring app-owned asset routes or browser-specific upload wrappers.