### PR TITLE
fix(agent): timeout workspace bash commands

### DIFF
--- a/packages/agent/src/capabilities/workspace-command.ts
+++ b/packages/agent/src/capabilities/workspace-command.ts
@@ -37,6 +37,7 @@ const blockedEnvKeys = new Set([
   "NODE_PATH",
   "PATH",
 ])
+const defaultWorkspaceCommandTimeout = 60_000
 
 export function normalizeWorkspaceCommandEntries(commands: unknown, label = "workspaceShell({ commands })"): WorkspaceCommandEntry[] {
   if (!Array.isArray(commands) || !commands.length) {
@@ -167,7 +168,7 @@ export function workspaceCommandTools(
         const args = stringArray(value.args, "args")
         const cwd = normalizeCwd(value.cwd)
         const env = envRecord(value.env)
-        const commandTimeout = normalizeWorkspaceCommandTimeout(value.timeout, `${toolName} timeout`) ?? timeout
+        const commandTimeout = normalizeWorkspaceCommandTimeout(value.timeout, `${toolName} timeout`) ?? timeout ?? defaultWorkspaceCommandTimeout
         assertWorkspace(workspace, options.missingWorkspaceMessage || "[vitehub] workspaceShell({ commands }) requires an executable Workspace Session. Trusted workspace/session execution requires a writable workspace.")
         const session = await workspace.startSession()
         try {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -574,7 +574,7 @@ describe("agent capability runtime", () => {
     expect(session.exec).toHaveBeenCalledWith("agent-browser", ["--help"], {
       cwd: "/workspace/screenshots",
       env: undefined,
-      timeout: undefined,
+      timeout: 60_000,
     })
     expect(session.commit).toHaveBeenCalledWith({ message: "bash command" })
     expect(session.close).toHaveBeenCalledOnce()

--- a/packages/agent/test/workspace-shell-capability.test.ts
+++ b/packages/agent/test/workspace-shell-capability.test.ts
@@ -96,7 +96,7 @@ describe("workspaceShell capability", () => {
 
     await expect(tools.workspace_exec!.execute?.({ command: "agent-browser" })).resolves.toMatchObject({ exitCode: 0 })
 
-    expect(session.exec).toHaveBeenCalledWith("agent-browser", [], { cwd: "/workspace", env: undefined, timeout: undefined })
+    expect(session.exec).toHaveBeenCalledWith("agent-browser", [], { cwd: "/workspace", env: undefined, timeout: 60_000 })
     expect(session.commit).toHaveBeenCalledWith({ message: "workspace shell command" })
     expect(session.close).toHaveBeenCalledOnce()
   })


### PR DESCRIPTION
Gives the shared workspace command tool a 60s default timeout so capability-contributed bash commands cannot hang agent runs indefinitely when the model invokes a command that never returns. Explicit command timeouts and capability-level timeouts still override the default.

Refs #514