### PR TITLE
fix(source): avoid archive fetch for github metadata

### DIFF
--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -177,7 +177,10 @@ export function github<const TKey extends string = string>(options: GitHubSource
       })
     }
     catch (error) {
-      if (error instanceof SourceError && error.message.includes(" could not access the repository or ref ")) return undefined
+      if (isGitHubAccessError(error)) {
+        const files = signal ? await loadArchiveFiles(token, signal) : await getFiles(token)
+        return files.find(file => file.key === normalizedKey)
+      }
       if (shouldResolveMainFallback(error)) {
         const files = signal ? await loadArchiveFiles(token, signal) : await getFiles(token)
         return files.find(file => file.key === normalizedKey)
@@ -191,6 +194,26 @@ export function github<const TKey extends string = string>(options: GitHubSource
       path: normalizedKey,
       sha: file.sha || ref,
     }
+  }
+
+  const loadedFileMetadata = new Map<string, Promise<GitHubFile<TKey> | undefined>>()
+  const cachedLoadFileMetadata = providerCache
+    ? defineCachedFunction(
+        async (key: TKey, token: string | undefined) => await loadFileMetadata(key, token),
+        {
+          ...providerCache,
+          getKey: (key, token) => cacheKey("metadata", token || "", key),
+          name: "github-source-metadata",
+        },
+      )
+    : (key: TKey, token: string | undefined) => dedupeProviderPromise(
+        loadedFileMetadata,
+        cacheKey("metadata", token || "", key),
+        () => loadFileMetadata(key, token),
+      )
+
+  function isGitHubAccessError(error: unknown) {
+    return error instanceof SourceError && error.message.includes(" could not access the repository or ref ")
   }
 
   async function loadFile(key: TKey, token = auth, signal?: AbortSignal): Promise<GitHubFile<TKey>> {
@@ -276,7 +299,9 @@ export function github<const TKey extends string = string>(options: GitHubSource
     },
     async getMeta(key, ctx) {
       const token = refreshAuth()
-      const file = await loadFileMetadata(key, token, ctx?.abortSignal)
+      const file = ctx?.abortSignal
+        ? await loadFileMetadata(key, token, ctx.abortSignal)
+        : await cachedLoadFileMetadata(key, token)
       if (!file) return
       return {
         ref: await getRef(token, ctx?.abortSignal),

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -59,6 +59,10 @@ export function github<const TKey extends string = string>(options: GitHubSource
     return root ? `${root}/${normalized}` : normalized
   }
 
+  function contentsUrl(repoPath: string, ref: string) {
+    return `https://api.github.com/repos/${options.repo}/contents/${encodeURIComponent(repoPath).replace(/%2F/g, "/")}?ref=${encodeURIComponent(ref)}`
+  }
+
   function shouldInclude(key: string) {
     if (options.include && !matchesAny(key, options.include)) return false
     if (options.exclude && matchesAny(key, options.exclude)) return false
@@ -157,6 +161,38 @@ export function github<const TKey extends string = string>(options: GitHubSource
     return cachedLoadFiles(token)
   }
 
+  async function loadFileMetadata(key: TKey, token = auth, signal?: AbortSignal): Promise<GitHubFile<TKey> | undefined> {
+    const normalizedKey = normalizeSourcePath(key) as TKey
+    if (!normalizedKey || !shouldInclude(normalizedKey)) return
+    const ref = await getRef(token, signal)
+    const repoPath = repoPathForKey(normalizedKey)
+    let file: GitHubContentResponse | GitHubContentResponse[] | undefined
+    try {
+      file = await requestGitHubJson<GitHubContentResponse | GitHubContentResponse[]>({
+        ref,
+        repo: options.repo,
+        signal,
+        token,
+        url: contentsUrl(repoPath, ref),
+      })
+    }
+    catch (error) {
+      if (error instanceof SourceError && error.message.includes(" could not access the repository or ref ")) return undefined
+      if (shouldResolveMainFallback(error)) {
+        const files = signal ? await loadArchiveFiles(token, signal) : await getFiles(token)
+        return files.find(file => file.key === normalizedKey)
+      }
+      throw error
+    }
+    if (!file || Array.isArray(file)) return
+    if (file.type === "dir") return
+    return {
+      key: normalizedKey,
+      path: normalizedKey,
+      sha: file.sha || ref,
+    }
+  }
+
   async function loadFile(key: TKey, token = auth, signal?: AbortSignal): Promise<GitHubFile<TKey>> {
     const normalizedKey = normalizeSourcePath(key) as TKey
     if (!normalizedKey || !shouldInclude(normalizedKey)) {
@@ -169,7 +205,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
       repo: options.repo,
       signal,
       token,
-      url: `https://api.github.com/repos/${options.repo}/contents/${encodeURIComponent(repoPath).replace(/%2F/g, "/")}?ref=${encodeURIComponent(ref)}`,
+      url: contentsUrl(repoPath, ref),
     })
     if (Array.isArray(file) || file.type === "dir") {
       throw new SourceError(`[vitehub] github(${JSON.stringify(options.repo)}) expected ${JSON.stringify(key)} to be a file, but it is a directory.`)
@@ -240,9 +276,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
     },
     async getMeta(key, ctx) {
       const token = refreshAuth()
-      const file = ctx?.abortSignal
-        ? await loadFile(key, token, ctx.abortSignal).catch(() => undefined)
-        : (await getFiles(token)).find(file => file.key === key)
+      const file = await loadFileMetadata(key, token, ctx?.abortSignal)
       if (!file) return
       return {
         ref: await getRef(token, ctx?.abortSignal),

--- a/packages/source/test/sources/fixtures/github.ts
+++ b/packages/source/test/sources/fixtures/github.ts
@@ -115,6 +115,9 @@ export function stubGitHubSource(files: Record<string, string>, options: StubGit
     return jsonResponse({
       content: Buffer.from(files[path] || "").toString("base64"),
       encoding: "base64",
+      path,
+      sha: `sha-${path}`,
+      type: "file",
     })
   }))
 }

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -130,6 +130,27 @@ describe("@vite-hub/source GitHub source", () => {
     expect(contentsCalls).toHaveLength(1)
   })
 
+  it("caches GitHub metadata reads when provider cache is configured", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+      "docs/guide.md": "# Guide\n",
+    })
+
+    const docs = github({ cache: { maxAge: 3600 }, repo: "acme/app", root: "docs" })
+
+    await expect(docs.getMeta?.("README.md", { rootDir: process.cwd() })).resolves.toEqual({
+      ref: "latest-commit-sha",
+      sha: "sha-docs/README.md",
+    })
+    await expect(docs.getMeta?.("README.md", { rootDir: process.cwd() })).resolves.toEqual({
+      ref: "latest-commit-sha",
+      sha: "sha-docs/README.md",
+    })
+
+    const contentsCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).includes("/contents/docs/README.md"))
+    expect(contentsCalls).toHaveLength(1)
+  })
+
   it("falls back to GitHub archive metadata when the contents API is rate limited", async () => {
     stubGitHubSource({
       "docs/README.md": "# Docs\n",
@@ -144,6 +165,21 @@ describe("@vite-hub/source GitHub source", () => {
 
     const archiveCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))
     expect(archiveCalls).toHaveLength(1)
+  })
+
+  it("does not hide invalid GitHub refs as missing metadata", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url)
+      if (requestUrl.includes("/contents/") || requestUrl.startsWith("https://codeload.github.com/")) {
+        return jsonResponse({ message: "not found" }, 404)
+      }
+      throw new Error(`Unexpected GitHub request: ${requestUrl}`)
+    }))
+
+    const docs = github({ ref: "missing-ref", repo: "acme/app", root: "docs" })
+
+    await expect(docs.getMeta?.("README.md", { rootDir: process.cwd() }))
+      .rejects.toThrow("could not access the repository or ref")
   })
 
   it("reads non-ASCII paths from GitHub archive PAX headers", async () => {

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -111,6 +111,41 @@ describe("@vite-hub/source GitHub source", () => {
     expect(contentsCalls).toHaveLength(1)
   })
 
+  it("reads GitHub file metadata through the contents API without downloading the archive", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+      "docs/guide.md": "# Guide\n",
+    })
+
+    const docs = github({ repo: "acme/app", root: "docs" })
+
+    await expect(docs.getMeta?.("README.md", { rootDir: process.cwd() })).resolves.toEqual({
+      ref: "latest-commit-sha",
+      sha: "sha-docs/README.md",
+    })
+
+    const archiveCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))
+    const contentsCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).includes("/contents/docs/README.md"))
+    expect(archiveCalls).toHaveLength(0)
+    expect(contentsCalls).toHaveLength(1)
+  })
+
+  it("falls back to GitHub archive metadata when the contents API is rate limited", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    }, { apiStatus: 403 })
+
+    const docs = github({ repo: "acme/app", root: "docs" })
+
+    await expect(docs.getMeta?.("README.md", { rootDir: process.cwd() })).resolves.toEqual({
+      ref: "main",
+      sha: "main",
+    })
+
+    const archiveCalls = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))
+    expect(archiveCalls).toHaveLength(1)
+  })
+
   it("reads non-ASCII paths from GitHub archive PAX headers", async () => {
     stubGitHubSource({
       "docs/café.md": "# Café\n",


### PR DESCRIPTION
## Summary
- read GitHub source metadata through the Contents API instead of downloading the archive
- keep archive fallback when the GitHub JSON API is rate limited
- cover both paths in GitHub source tests

## Verification
- corepack pnpm --filter @vite-hub/source test
- corepack pnpm --filter @vite-hub/source typecheck
- corepack pnpm --filter @vite-hub/workspace test

## Benchmark
Mocked 2,000-file GitHub source, median of 7 getMeta runs:
- before: 3.68 ms, 1 codeload archive request per run
- after: 0.23 ms, 0 codeload archive requests per run