### PR TITLE
fix(agent): split long Discord chat replies

### DIFF
--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -332,6 +332,9 @@ export interface DiscordAdapterOptions {
   apiUrl?: string
   applicationId?: string
   botToken?: string | { unseal: () => string }
+  longContent?: {
+    mode: "split" | "truncate"
+  }
   mentionRoleIds?: string[]
   publicKey?: string | { unseal: () => string }
   userName?: string
@@ -1633,6 +1636,7 @@ function discordAdapterResolver<TRuntimeConfig extends AgentRuntimeConfig>(
     return input as AgentChannelOptions<TRuntimeConfig>["adapter"]
   }
   const options: DiscordAdapterOptions = input === true ? {} : input
+  const { longContent, ...adapterOptions } = options
   return async () => {
     let createDiscordAdapter: (options?: Record<string, unknown>) => Adapter
     try {
@@ -1641,11 +1645,18 @@ function discordAdapterResolver<TRuntimeConfig extends AgentRuntimeConfig>(
     catch (error) {
       throw new Error("[vitehub] discord({ adapter: true }) requires @chat-adapter/discord to be installed.", { cause: error })
     }
-    return createDiscordAdapter({
-      ...options,
-      ...(options.botToken ? { botToken: cleanSecret(options.botToken) } : {}),
-      ...(options.publicKey ? { publicKey: cleanSecret(options.publicKey) } : {}),
+    const adapter = createDiscordAdapter({
+      ...adapterOptions,
+      ...(adapterOptions.botToken ? { botToken: cleanSecret(adapterOptions.botToken) } : {}),
+      ...(adapterOptions.publicKey ? { publicKey: cleanSecret(adapterOptions.publicKey) } : {}),
     })
+    if (longContent?.mode === "split") {
+      Object.defineProperty(adapter, Symbol.for("vitehub.discord.longContent.mode"), {
+        configurable: true,
+        value: "split",
+      })
+    }
+    return adapter
   }
 }
 

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -737,7 +737,7 @@ async function finishDiscordSplitStream(thread: Thread, sent: unknown, markdown:
   if (!rendered || rendered.length <= discordMaxContentLength) return
   const [first, ...rest] = discordContentParts(rendered)
   if (first && sent && typeof sent === "object" && "edit" in sent && typeof sent.edit === "function") {
-    await sent.edit({ raw: first })
+    await sent.edit({ attachments: [], raw: first })
   }
   else if (first) {
     await thread.post({ raw: first })
@@ -1563,7 +1563,9 @@ async function handleChatSdkMessage(
       const result = await runAgentInline(agent as never, runContext as never, invocationInput as never)
       const text = await collectAgentOutput(result)
       if (text) {
-        await thread.post({ markdown: text })
+        if (!await postDiscordSplitContent(thread, { markdown: text })) {
+          await thread.post({ markdown: text })
+        }
       }
       await flushChatFinishExtensionMessages(thread, chatFinish)
     }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1,7 +1,7 @@
 import { parseStandardSchema } from "@vite-hub/internal/http-request"
 import { runWithActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { createRuntimeWaitUntilController } from "@vite-hub/runtime"
-import { Chat, StreamingPlan } from "chat"
+import { Chat, StreamingPlan, convertEmojiPlaceholders } from "chat"
 
 import { resolveAgentTriggerInvocation, resolveAgentTriggers, runAgent, runAgentInline, streamAgent, streamAgentTrigger } from "../index.ts"
 import { streamAgentOutputToEvents } from "../agent-output.ts"
@@ -554,6 +554,9 @@ type ChatTextStream = AsyncIterable<string> & {
   getText: () => string
 }
 
+const discordMaxContentLength = 2000
+const discordLongContentModeSymbol = Symbol.for("vitehub.discord.longContent.mode")
+
 function startChatTypingRefresh(thread: Thread, context: ViteAgentRouteRuntimeContext): ChatTypingRefresh {
   let stopped = false
   let timeout: ReturnType<typeof setTimeout> | undefined
@@ -654,13 +657,109 @@ function chatStreamPostable(thread: Thread, response: ChatTextStream): ChatTextS
     : response
 }
 
+function discordLongContentMode(adapter: Adapter): "split" | undefined {
+  return (adapter as Adapter & { [discordLongContentModeSymbol]?: "split" })[discordLongContentModeSymbol]
+}
+
+function splitContentAtLimit(content: string, limit: number): string[] {
+  const parts: string[] = []
+  let rest = content.trimEnd()
+  while (rest.length > limit) {
+    let index = -1
+    for (const marker of ["\n\n", "\n"]) {
+      index = rest.lastIndexOf(marker, limit)
+      if (index > 0) {
+        index += marker.length
+        break
+      }
+    }
+    if (index <= 0) {
+      for (let i = limit; i > 0; i--) {
+        if (/\s/.test(rest[i] || "")) {
+          index = i + 1
+          break
+        }
+      }
+    }
+    if (index <= 0) index = limit
+    parts.push(rest.slice(0, index).trimEnd())
+    rest = rest.slice(index).trimStart()
+  }
+  if (rest) parts.push(rest)
+  return parts
+}
+
+function discordContentParts(content: string): string[] {
+  if (content.length <= discordMaxContentLength) return [content]
+  let total = Math.ceil(content.length / (discordMaxContentLength - " (1/1)".length))
+  while (true) {
+    const markerLength = ` (${total}/${total})`.length
+    const parts = splitContentAtLimit(content, discordMaxContentLength - markerLength)
+    if (parts.length === total) {
+      return parts.map((part, index) => `${part} (${index + 1}/${total})`)
+    }
+    total = parts.length
+  }
+}
+
+function hasChatFiles(postable: AdapterPostableMessage): boolean {
+  if (typeof postable !== "object" || postable === null) return false
+  const value = postable as { attachments?: unknown[], files?: unknown[] }
+  return (Array.isArray(value.attachments) && value.attachments.length > 0)
+    || (Array.isArray(value.files) && value.files.length > 0)
+}
+
+function renderDiscordPostable(adapter: Adapter, postable: AdapterPostableMessage): string | undefined {
+  if (hasChatFiles(postable)) return undefined
+  if (typeof postable === "object" && postable !== null && ("card" in postable || "type" in postable)) return undefined
+  const converter = (adapter as Adapter & { formatConverter?: { renderPostable?: (message: AdapterPostableMessage) => string } }).formatConverter
+  if (converter?.renderPostable) {
+    return convertEmojiPlaceholders(converter.renderPostable(postable), "discord")
+  }
+  if (typeof postable === "string") return postable
+  if (typeof postable === "object" && postable !== null && "raw" in postable && typeof postable.raw === "string") return postable.raw
+  if (typeof postable === "object" && postable !== null && "markdown" in postable && typeof postable.markdown === "string") return postable.markdown
+}
+
+async function postDiscordSplitContent(thread: Thread, postable: AdapterPostableMessage): Promise<boolean> {
+  if (discordLongContentMode(thread.adapter) !== "split") return false
+  const rendered = renderDiscordPostable(thread.adapter, postable)
+  if (!rendered || rendered.length <= discordMaxContentLength) return false
+  for (const part of discordContentParts(rendered)) {
+    await thread.post({ raw: part })
+  }
+  return true
+}
+
+async function finishDiscordSplitStream(thread: Thread, sent: unknown, markdown: string): Promise<void> {
+  if (!markdown || discordLongContentMode(thread.adapter) !== "split") return
+  const rendered = renderDiscordPostable(thread.adapter, { markdown })
+  if (!rendered || rendered.length <= discordMaxContentLength) return
+  const [first, ...rest] = discordContentParts(rendered)
+  if (first && sent && typeof sent === "object" && "edit" in sent && typeof sent.edit === "function") {
+    await sent.edit({ raw: first })
+  }
+  else if (first) {
+    await thread.post({ raw: first })
+  }
+  for (const part of rest) {
+    await thread.post({ raw: part })
+  }
+}
+
+function sentMessageText(sent: unknown): string {
+  return sent && typeof sent === "object" && "text" in sent && typeof sent.text === "string" ? sent.text : ""
+}
+
 async function postChatStream(
   thread: Thread,
   response: ChatTextStream,
   fallback: string | null | undefined,
 ): Promise<void> {
+  let sent: unknown
   if (fallback === undefined) {
-    await thread.post(chatStreamPostable(thread, response) as never)
+    sent = await thread.post(chatStreamPostable(thread, response) as never)
+    await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent))
     return
   }
 
@@ -669,7 +768,8 @@ async function postChatStream(
   const previous = chatThread._fallbackStreamingPlaceholderText
   chatThread._fallbackStreamingPlaceholderText = fallback
   try {
-    await thread.post(chatStreamPostable(thread, response) as never)
+    sent = await thread.post(chatStreamPostable(thread, response) as never)
+    await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent))
   }
   finally {
     chatThread._fallbackStreamingPlaceholderText = previous
@@ -1283,13 +1383,16 @@ function chatMessageDeliveryArtifacts(message: AgentChatMessage): readonly Publi
 
 async function postChatMessage(thread: Thread, message: AgentChatMessage): Promise<void> {
   if (typeof message !== "object" || message === null) {
+    if (await postDiscordSplitContent(thread, message)) return
     await thread.post(message)
     return
   }
 
   const attachments = deliveryArtifactAttachments(chatMessageDeliveryArtifacts(message))
   if (!attachments.length) {
-    await thread.post(isTextChatMessage(message) ? message.text : message as AdapterPostableMessage)
+    const postable = isTextChatMessage(message) ? message.text : message as AdapterPostableMessage
+    if (await postDiscordSplitContent(thread, postable)) return
+    await thread.post(postable)
     return
   }
 

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -153,6 +153,32 @@ describe("agent channels", () => {
     }
   })
 
+  it("marks Discord adapters for long-content splitting without passing ViteHub options through", async () => {
+    vi.resetModules()
+    const adapter = { name: "discord" }
+    const createDiscordAdapter = vi.fn(() => adapter)
+    vi.doMock("@chat-adapter/discord", () => ({ createDiscordAdapter }))
+    try {
+      const { discord } = await import("../src/channels.ts")
+      const channel = discord({
+        adapter: {
+          botToken: "bot-token",
+          longContent: { mode: "split" },
+        },
+      })
+
+      if (typeof channel.adapter !== "function") throw new Error("Expected Discord adapter resolver.")
+      const resolved = await channel.adapter({} as never)
+      expect(resolved).toBe(adapter)
+      expect(createDiscordAdapter).toHaveBeenCalledWith({ botToken: "bot-token" })
+      expect((resolved as unknown as { [key: symbol]: unknown })[Symbol.for("vitehub.discord.longContent.mode")]).toBe("split")
+    }
+    finally {
+      vi.doUnmock("@chat-adapter/discord")
+      vi.resetModules()
+    }
+  })
+
   it("publishes explicit Workspace artifacts", async () => {
     const { publishWorkspaceArtifacts } = await import("../src/channels.ts")
     const content = new Uint8Array([1, 2, 3])

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2207,11 +2207,68 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "...")
     expect(adapter.editMessage).toHaveBeenNthCalledWith(1, "telegram:456", "sent-2", { markdown: replyText })
     expect(adapter.editMessage).toHaveBeenNthCalledWith(2, "telegram:456", "sent-2", {
+      attachments: [],
       raw: expect.stringMatching(/ \(1\/2\)$/),
     })
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", {
       raw: expect.stringMatching(/ \(2\/2\)$/),
     })
+  })
+
+  it("splits long non-streaming Discord chat output", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { discord } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter() as ReturnType<typeof createTestChatAdapter> & {
+      formatConverter: { renderPostable: (message: unknown) => string }
+      name: string
+    }
+    adapter.formatConverter = {
+      renderPostable(message: unknown) {
+        if (typeof message === "string") return message
+        if (typeof message === "object" && message && "raw" in message && typeof message.raw === "string") return message.raw
+        if (typeof message === "object" && message && "markdown" in message && typeof message.markdown === "string") return message.markdown
+        return ""
+      },
+    }
+    adapter.name = "discord"
+    Object.defineProperty(adapter, Symbol.for("vitehub.discord.longContent.mode"), { value: "split" })
+    const replyText = `${"word ".repeat(430)}done`
+    const agent = defineAgent({
+      channels: {
+        discord: discord({
+          adapter: () => adapter as never,
+          messages: { stream: false },
+        }),
+      },
+      driver: {
+        run: () => ({ text: replyText }),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/discord", {
+      body: JSON.stringify({
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { id: 123, username: "maxi" },
+          message_id: 9,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "discord")
+
+    expect(response.status).toBe(200)
+    expect(adapter.editMessage).not.toHaveBeenCalled()
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", {
+      raw: expect.stringMatching(/ \(1\/2\)$/),
+    })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", {
+      raw: expect.stringMatching(/ \(2\/2\)$/),
+    })
+    expect(adapter.postMessage).toHaveBeenCalledTimes(2)
   })
 
   it("does not map audio mime file attachments without transcribe()", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2149,6 +2149,71 @@ describe("server helpers", () => {
     }))
   })
 
+  it("splits long Discord chat output after stream finalization", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { discord } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter() as ReturnType<typeof createTestChatAdapter> & {
+      formatConverter: { renderPostable: (message: unknown) => string }
+      name: string
+    }
+    adapter.formatConverter = {
+      renderPostable(message: unknown) {
+        if (typeof message === "string") return message
+        if (typeof message === "object" && message && "raw" in message && typeof message.raw === "string") return message.raw
+        if (typeof message === "object" && message && "markdown" in message && typeof message.markdown === "string") return message.markdown
+        return ""
+      },
+    }
+    adapter.name = "discord"
+    Object.defineProperty(adapter, Symbol.for("vitehub.discord.longContent.mode"), { value: "split" })
+    let replyText = "short reply"
+    const agent = defineAgent({
+      channels: {
+        discord: discord({ adapter: () => adapter as never }),
+      },
+      driver: {
+        run: () => ({ text: replyText }),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    const request = (messageId: number) => new Request("https://example.com/api/_vitehub/agents/support/webhooks/discord", {
+      body: JSON.stringify({
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { id: 123, username: "maxi" },
+          message_id: messageId,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    })
+
+    const shortResponse = await handler(request(7), "discord")
+
+    expect(shortResponse.status).toBe(200)
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "...")
+    expect(adapter.postMessage).toHaveBeenCalledTimes(1)
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "short reply" })
+
+    adapter.postMessage.mockClear()
+    adapter.editMessage.mockClear()
+    replyText = `${"word ".repeat(430)}done`
+
+    const longResponse = await handler(request(8), "discord")
+
+    expect(longResponse.status).toBe(200)
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "...")
+    expect(adapter.editMessage).toHaveBeenNthCalledWith(1, "telegram:456", "sent-2", { markdown: replyText })
+    expect(adapter.editMessage).toHaveBeenNthCalledWith(2, "telegram:456", "sent-2", {
+      raw: expect.stringMatching(/ \(1\/2\)$/),
+    })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", {
+      raw: expect.stringMatching(/ \(2\/2\)$/),
+    })
+  })
+
   it("does not map audio mime file attachments without transcribe()", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")


### PR DESCRIPTION
Adds an opt-in Discord adapter long-content mode so streamed Agent replies can keep the normal Discord preview while final overflows are edited into chunk 1 and sent as inline continuation messages instead of being reduced to a truncated/file-style fallback.

The option stays on the Discord Channel adapter boundary as `discord({ adapter: { longContent: { mode: "split" } } })`; default behavior remains unchanged.