### PR TITLE
fix(agent): default input commands to args passthrough

### DIFF
--- a/docs/content/docs/capabilities/input-commands.md
+++ b/docs/content/docs/capabilities/input-commands.md
@@ -85,7 +85,7 @@ Check DevTools metadata for the `inputCommands` Capability and its command descr
 | `id` | `string` | `"inputCommands"` | Capability id. |
 | `trigger` | `string` | `"/"` | Non-whitespace command prefix. |
 | `commands.*.description` | `string` | required | Command description for metadata and inspection. |
-| `commands.*.call` | `(input) => AgentRunInput \| Response \| string \| void` | required | Handler that accepts, rejects, transforms, or enriches invocation input. |
+| `commands.*.call` | `(input) => AgentRunInput \| Response \| string \| void` | argument passthrough | Handler that accepts, rejects, transforms, or enriches invocation input. |
 | `commands.*.channels` | `string[]` | all channels | Optional configured Channel ID allowlist. |
 | `commands.*.hooks` | `{ 'agent:input'?, 'agent:finish'? }` | none | Command-scoped lifecycle hooks with `ctx.message.reply/update/react` delivery primitives. |
 

--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -299,7 +299,7 @@ function mergeInputCommandResult(input: AgentRunInput, result: Partial<AgentRunI
 }
 
 function inputCommandCall(command: InputCommand): InputCommandCall {
-  return command.call || command.run || (({ args, name }) => args || name)
+  return command.call || command.run || (({ args }) => args)
 }
 
 function activeChannelId(context: AgentCapabilityRuntimeContext): string | undefined {

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -62,7 +62,7 @@ describe("inputCommands", () => {
     expect(resolved.input.prompt).toBe("auth changes")
   })
 
-  it("uses command names for command-only default rewrites with descriptions", async () => {
+  it("keeps command-only default rewrites with descriptions", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 
@@ -76,10 +76,10 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/summary" })
 
-    expect(resolved.input.prompt).toBe("summary")
+    expect(resolved.input.prompt).toBe("/summary")
   })
 
-  it("uses the command name for command-only default rewrites without descriptions", async () => {
+  it("keeps command-only default rewrites without descriptions", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 
@@ -91,10 +91,10 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/summary" })
 
-    expect(resolved.input.prompt).toBe("summary")
+    expect(resolved.input.prompt).toBe("/summary")
   })
 
-  it("accepts hook-only commands and rewrites bare commands to the command name", async () => {
+  it("accepts hook-only commands and keeps bare commands", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const hook = vi.fn()
@@ -111,7 +111,7 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/summary" })
 
-    expect(resolved.input.prompt).toBe("summary")
+    expect(resolved.input.prompt).toBe("/summary")
     expect(hook).toHaveBeenCalledWith(expect.objectContaining({
       name: "summary",
       text: "/summary",


### PR DESCRIPTION
Defaults handlerless `inputCommands()` entries to pass through command arguments instead of falling back to the command name. That lets apps omit `run: ({ args }) => args` while keeping bare command-only text intact through the existing empty-string preservation path.

Updates the focused Agent Package tests and the Input Commands docs default for `commands.*.call`.