### PR TITLE
fix(agent): mention harness in missing driver diagnostic

### DIFF
--- a/packages/agent/src/internal/agent-driver.ts
+++ b/packages/agent/src/internal/agent-driver.ts
@@ -157,5 +157,5 @@ export function normalizeAgentDriver<
     return normalizeExplicitAgentDriver<TRuntimeConfig, CALL_OPTIONS>(record.driver)
   }
 
-  throw new Error("[vitehub] Agent Driver is required. Expected defineAgent({ driver: { model } }) or defineAgent({ driver: { run } }).")
+  throw new Error("[vitehub] Agent Driver is required. Expected defineAgent({ driver: { model } }), defineAgent({ driver: { harness } }), or defineAgent({ driver: { run } }).")
 }


### PR DESCRIPTION
Updates the missing Agent Driver diagnostic to include `driver.harness`, matching the current Agent Driver boundary and `chatTitle({ driver })` harness support.

The implementation already accepts harness-backed drivers; this keeps the fallback guidance from pointing users only to model-backed and custom-run-backed drivers.
