### PR TITLE
fix(agent)!: remove input command args fallback

### DIFF
--- a/docs/content/docs/capabilities/input-commands.md
+++ b/docs/content/docs/capabilities/input-commands.md
@@ -48,6 +48,7 @@ export default defineAgent({
 
 `inputCommands()` runs during the input phase.
 It finds command invocations in the latest user text, calls the matching command handler, and updates the Agent Run Input before other model-facing behavior consumes it.
+Commands without a handler are accepted and removed from model input; they do not implicitly pass arguments or command names through as prompts.
 Command `agent:input` hooks run after the command updates the input and before the Agent Driver runs.
 Command `agent:finish` hooks run for completed and failed Agent Invocations.
 
@@ -85,7 +86,7 @@ Check DevTools metadata for the `inputCommands` Capability and its command descr
 | `id` | `string` | `"inputCommands"` | Capability id. |
 | `trigger` | `string` | `"/"` | Non-whitespace command prefix. |
 | `commands.*.description` | `string` | required | Command description for metadata and inspection. |
-| `commands.*.call` | `(input) => AgentRunInput \| Response \| string \| void` | argument passthrough | Handler that accepts, rejects, transforms, or enriches invocation input. |
+| `commands.*.call` | `(input) => AgentRunInput \| Response \| string \| void` | accept and remove | Handler that accepts, rejects, transforms, or enriches invocation input. |
 | `commands.*.channels` | `string[]` | all channels | Optional configured Channel ID allowlist. |
 | `commands.*.hooks` | `{ 'agent:input'?, 'agent:finish'? }` | none | Command-scoped lifecycle hooks with `ctx.message.reply/update/react` delivery primitives. |
 

--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -299,7 +299,7 @@ function mergeInputCommandResult(input: AgentRunInput, result: Partial<AgentRunI
 }
 
 function inputCommandCall(command: InputCommand): InputCommandCall {
-  return command.call || command.run || (({ args }) => args)
+  return command.call || command.run || (() => undefined)
 }
 
 function activeChannelId(context: AgentCapabilityRuntimeContext): string | undefined {

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -46,7 +46,7 @@ describe("inputCommands", () => {
     expect(resolved.input.prompt).toBe("/summary")
   })
 
-  it("uses command args as the default command rewrite", async () => {
+  it("removes matched command text when a command has no handler", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 
@@ -59,10 +59,10 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/review auth changes" })
 
-    expect(resolved.input.prompt).toBe("auth changes")
+    expect(resolved.input.prompt).toBe("")
   })
 
-  it("keeps command-only default rewrites with descriptions", async () => {
+  it("removes command-only text for handlerless commands with descriptions", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 
@@ -76,10 +76,10 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/summary" })
 
-    expect(resolved.input.prompt).toBe("/summary")
+    expect(resolved.input.prompt).toBe("")
   })
 
-  it("keeps command-only default rewrites without descriptions", async () => {
+  it("removes command-only text for handlerless commands without descriptions", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 
@@ -91,10 +91,10 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/summary" })
 
-    expect(resolved.input.prompt).toBe("/summary")
+    expect(resolved.input.prompt).toBe("")
   })
 
-  it("accepts hook-only commands and keeps bare commands", async () => {
+  it("accepts hook-only commands and removes bare commands", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const hook = vi.fn()
@@ -111,7 +111,7 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/summary" })
 
-    expect(resolved.input.prompt).toBe("/summary")
+    expect(resolved.input.prompt).toBe("")
     expect(hook).toHaveBeenCalledWith(expect.objectContaining({
       name: "summary",
       text: "/summary",


### PR DESCRIPTION
Removes the implicit `args` passthrough for handlerless `inputCommands()` so accepting a command without a handler uses the existing command-removal behavior instead of turning command args into the first prompt.

Updates the focused tests and docs to state handlerless commands are accepted and removed; app-owned handlers still opt into model-facing prompt text by returning a string or partial Agent Run Input.