### PR TITLE
fix(agent): require explicit input command rewrites

### DIFF
--- a/docs/content/docs/capabilities/input-commands.md
+++ b/docs/content/docs/capabilities/input-commands.md
@@ -19,6 +19,7 @@ Use the configuration example below as the starting point, then tighten modes, p
 
 The Capability scans the latest prompt or user message for configured Input Commands.
 Each command can replace text, update the Agent Run Input, or add invocation context before model execution.
+Commands that should produce model-facing text must return it explicitly; accepting without handler text removes the matched command text.
 
 ## Configuration
 
@@ -85,7 +86,7 @@ Check DevTools metadata for the `inputCommands` Capability and its command descr
 | `id` | `string` | `"inputCommands"` | Capability id. |
 | `trigger` | `string` | `"/"` | Non-whitespace command prefix. |
 | `commands.*.description` | `string` | required | Command description for metadata and inspection. |
-| `commands.*.call` | `(input) => AgentRunInput \| Response \| string \| void` | argument passthrough | Handler that accepts, rejects, transforms, or enriches invocation input. |
+| `commands.*.call` | `(input) => AgentRunInput \| Response \| string \| void` | remove command text | Handler that accepts, rejects, transforms, or enriches invocation input. |
 | `commands.*.channels` | `string[]` | all channels | Optional configured Channel ID allowlist. |
 | `commands.*.hooks` | `{ 'agent:input'?, 'agent:finish'? }` | none | Command-scoped lifecycle hooks with `ctx.message.reply/update/react` delivery primitives. |
 

--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -299,7 +299,7 @@ function mergeInputCommandResult(input: AgentRunInput, result: Partial<AgentRunI
 }
 
 function inputCommandCall(command: InputCommand): InputCommandCall {
-  return command.call || command.run || (({ args }) => args)
+  return command.call || command.run || (() => undefined)
 }
 
 function activeChannelId(context: AgentCapabilityRuntimeContext): string | undefined {

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -46,7 +46,7 @@ describe("inputCommands", () => {
     expect(resolved.input.prompt).toBe("/summary")
   })
 
-  it("uses command args as the default command rewrite", async () => {
+  it("removes accepted command text when no handler is configured", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 
@@ -59,10 +59,10 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/review auth changes" })
 
-    expect(resolved.input.prompt).toBe("auth changes")
+    expect(resolved.input.prompt).toBe("")
   })
 
-  it("keeps command-only default rewrites with descriptions", async () => {
+  it("removes command-only text when no handler is configured", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 
@@ -76,10 +76,10 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/summary" })
 
-    expect(resolved.input.prompt).toBe("/summary")
+    expect(resolved.input.prompt).toBe("")
   })
 
-  it("keeps command-only default rewrites without descriptions", async () => {
+  it("removes command-only text without using command names", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
 
@@ -91,10 +91,10 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/summary" })
 
-    expect(resolved.input.prompt).toBe("/summary")
+    expect(resolved.input.prompt).toBe("")
   })
 
-  it("accepts hook-only commands and keeps bare commands", async () => {
+  it("accepts hook-only commands and removes bare command text", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const hook = vi.fn()
@@ -111,7 +111,7 @@ describe("inputCommands", () => {
       })],
     }, runtime(), { prompt: "/summary" })
 
-    expect(resolved.input.prompt).toBe("/summary")
+    expect(resolved.input.prompt).toBe("")
     expect(hook).toHaveBeenCalledWith(expect.objectContaining({
       name: "summary",
       text: "/summary",


### PR DESCRIPTION
Removes the handlerless args passthrough added in #521 so accepted Input Commands without explicit handler text fall through to the existing command-text removal path. That keeps app-owned handlers responsible for model-facing prompt text instead of sending slash command args as a vague prompt.

Updates the focused Agent Package tests for handlerless `/review ...` and `/summary`, and adjusts the Input Commands docs to say model-facing text must be returned explicitly.

Refs #521