### PR TITLE
fix(agent): preserve prefixed data stream events

### DIFF
--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -274,8 +274,8 @@ export function toAgentStreamEvent(chunk: unknown, toolNames?: Map<string, strin
   if (type === "text-delta" || type === "text") {
     return { id: value.id as string | undefined, ...optionalMessageId(messageId), ...(typeof value.role === "string" ? { role: value.role as never } : {}), text: String(value.text || value.textDelta || value.delta || ""), type: "text-delta" }
   }
-  if (type === "data") {
-    return { data: value.data, id: value.id as string | undefined, ...optionalMessageId(messageId), type: "data" }
+  if (type === "data" || type.startsWith("data-")) {
+    return { data: value.data, id: value.id as string | undefined, ...optionalMessageId(messageId), type: type as "data" | `data-${string}` }
   }
   if (type === "tool-input-start") {
     const id = String(value.id || value.toolCallId)

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -275,7 +275,7 @@ export function toAgentStreamEvent(chunk: unknown, toolNames?: Map<string, strin
     return { id: value.id as string | undefined, ...optionalMessageId(messageId), ...(typeof value.role === "string" ? { role: value.role as never } : {}), text: String(value.text || value.textDelta || value.delta || ""), type: "text-delta" }
   }
   if (type === "data" || type.startsWith("data-")) {
-    return { data: value.data, id: value.id as string | undefined, ...optionalMessageId(messageId), type: type as "data" | `data-${string}` }
+    return { data: value.data, id: value.id as string | undefined, ...optionalMessageId(messageId), ...(typeof value.transient === "boolean" ? { transient: value.transient } : {}), type: type as "data" | `data-${string}` }
   }
   if (type === "tool-input-start") {
     const id = String(value.id || value.toolCallId)

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -83,11 +83,15 @@ export interface AiSdkWorkspaceFallbackOptions {
   maxToolResults?: number
 }
 
+function isDataMessagePart(part: MessagePart): part is Extract<MessagePart, { type: "data" | `data-${string}` }> {
+  return part.type === "data" || part.type.startsWith("data-")
+}
+
 function toTextModelMessageContent(parts: MessagePart[]): string {
   return parts.map((part) => {
     if (part.type === "text") return part.text
     if (part.type === "error") return part.error
-    if (part.type === "data") return JSON.stringify(part.data)
+    if (isDataMessagePart(part)) return JSON.stringify(part.data)
     if (part.type === "tool-call") return JSON.stringify({ input: part.input, toolCallId: part.id, toolName: part.name, type: "tool-call" })
     if (part.type === "tool-result") return JSON.stringify({ error: part.error, output: part.output, toolCallId: part.id, toolName: part.name, type: "tool-result" })
     if (part.type === "approval-request") return JSON.stringify({ input: part.input, reason: part.reason, toolCallId: part.id, toolName: part.name, type: "approval-request" })

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -115,6 +115,13 @@ function uiMessagePartsToAgentParts(message: UIMessageLike): Array<MessagePart |
     if (!part || typeof part !== "object") return []
     const record = part as Record<string, unknown>
     if (record.type === "text" && typeof record.text === "string") return [record.text]
+    if ((record.type === "data" || (typeof record.type === "string" && record.type.startsWith("data-"))) && "data" in record) {
+      return [{
+        data: record.data,
+        ...(typeof record.id === "string" ? { id: record.id } : {}),
+        type: record.type as "data" | `data-${string}`,
+      }]
+    }
     if (record.type === "audio") return uiAudioPartToAgentPart(record)
     if (record.type === "dynamic-tool" || (typeof record.type === "string" && record.type.startsWith("tool-"))) {
       const state = typeof record.state === "string" ? record.state : undefined

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -112,7 +112,7 @@ export interface Message {
 
 export type StreamEvent =
   | { id?: string, messageId?: string, role?: MessageRole, text: string, type: "text-delta" }
-  | { data: unknown, id?: string, messageId?: string, type: "data" | `data-${string}` }
+  | { data: unknown, id?: string, messageId?: string, transient?: boolean, type: "data" | `data-${string}` }
   | { id: string, input?: unknown, messageId?: string, name: string, type: "tool-call" | "tool-input-start" }
   | { durationMs?: number, error?: string, id: string, messageId?: string, name: string, output?: unknown, type: "tool-result" }
   | { id: string, input?: unknown, messageId?: string, name: string, reason?: string, type: "approval-request" }
@@ -359,6 +359,9 @@ function findOrCreateMessage(messages: Message[], event: StreamEvent): Message {
 export function applyStreamEvent(messages: Message[], event: StreamEvent): Message[] {
   const next = messages.map(message => ({ ...message, parts: [...message.parts] }))
   if (event.type === "finish" || event.type === "usage") {
+    return next
+  }
+  if ((event.type === "data" || event.type.startsWith("data-")) && event.transient) {
     return next
   }
 

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -336,6 +336,10 @@ export function validateMessage(message: Message): void {
       case "error":
         break
       default:
+        if (typeof part.type === "string" && part.type.startsWith("data-")) {
+          if (!("data" in part)) throw new TypeError("[vitehub:messages] data part requires data.")
+          break
+        }
         throw new TypeError(`[vitehub:messages] Unsupported message part type: ${String((part as { type?: unknown }).type)}.`)
     }
   }

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -15,7 +15,7 @@ export interface TextPart {
 export interface DataPart {
   data: unknown
   id?: string
-  type: "data"
+  type: "data" | `data-${string}`
 }
 
 export type AudioData = ArrayBuffer | Blob | string | Uint8Array
@@ -112,7 +112,7 @@ export interface Message {
 
 export type StreamEvent =
   | { id?: string, messageId?: string, role?: MessageRole, text: string, type: "text-delta" }
-  | { data: unknown, id?: string, messageId?: string, type: "data" }
+  | { data: unknown, id?: string, messageId?: string, type: "data" | `data-${string}` }
   | { id: string, input?: unknown, messageId?: string, name: string, type: "tool-call" | "tool-input-start" }
   | { durationMs?: number, error?: string, id: string, messageId?: string, name: string, output?: unknown, type: "tool-result" }
   | { id: string, input?: unknown, messageId?: string, name: string, reason?: string, type: "approval-request" }
@@ -370,8 +370,8 @@ export function applyStreamEvent(messages: Message[], event: StreamEvent): Messa
       message.parts.push(omitUndefined({ id: event.id, text: event.text, type: "text" }) as TextPart)
     }
   }
-  else if (event.type === "data") {
-    message.parts.push({ ...omitUndefined({ id: event.id, type: "data" }), data: event.data } as DataPart)
+  else if ("data" in event && (event.type === "data" || event.type.startsWith("data-"))) {
+    message.parts.push({ ...omitUndefined({ id: event.id, type: event.type }), data: event.data } as DataPart)
   }
   else if (event.type === "tool-input-start") {
     message.parts.push(omitUndefined({ id: event.id, input: event.input, name: event.name, state: "running", type: "tool-call" }) as ToolCallPart)

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -361,7 +361,7 @@ export function applyStreamEvent(messages: Message[], event: StreamEvent): Messa
   if (event.type === "finish" || event.type === "usage") {
     return next
   }
-  if ((event.type === "data" || event.type.startsWith("data-")) && event.transient) {
+  if ("data" in event && event.transient) {
     return next
   }
 

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -211,6 +211,7 @@ async function writeEventsToUiMessageStream(
     const usageRecord = usageRecordFromStreamChunk(event, events)
     if (usageRecord) options.onUsageRecord?.(usageRecord)
     const type = streamEventType(event)
+    if (!type) continue
     if (type === "text-delta") {
       const text = (event as { delta?: unknown, text?: unknown }).text ?? (event as { delta?: unknown }).delta
       if (typeof text !== "string" || !text) continue

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -237,8 +237,8 @@ async function writeEventsToUiMessageStream(
       continue
     }
     if (type === "data" || type.startsWith("data-")) {
-      const dataEvent = event as { data?: unknown, id?: unknown }
-      writer.write({ type: type === "data" ? uiDataType(dataEvent.data) : type, data: dataEvent.data, id: dataEvent.id })
+      const dataEvent = event as { data?: unknown, id?: unknown, transient?: unknown }
+      writer.write({ type: type === "data" ? uiDataType(dataEvent.data) : type, data: dataEvent.data, id: dataEvent.id, ...(typeof dataEvent.transient === "boolean" ? { transient: dataEvent.transient } : {}) })
       continue
     }
     if (type === "finish") {

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -237,8 +237,8 @@ async function writeEventsToUiMessageStream(
       continue
     }
     if (type === "data" || type.startsWith("data-")) {
-      const data = (event as { data?: unknown }).data
-      writer.write({ type: type === "data" ? uiDataType(data) : type, data })
+      const dataEvent = event as { data?: unknown, id?: unknown }
+      writer.write({ type: type === "data" ? uiDataType(dataEvent.data) : type, data: dataEvent.data, id: dataEvent.id })
       continue
     }
     if (type === "finish") {

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -235,9 +235,9 @@ async function writeEventsToUiMessageStream(
       writer.write({ type: "tool-output-available", toolCallId: tool.id, toolName: tool.name, output: tool.output })
       continue
     }
-    if (type === "data") {
+    if (type === "data" || type.startsWith("data-")) {
       const data = (event as { data?: unknown }).data
-      writer.write({ type: uiDataType(data), data })
+      writer.write({ type: type === "data" ? uiDataType(data) : type, data })
       continue
     }
     if (type === "finish") {

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -201,7 +201,7 @@ describe("agent output helpers", () => {
 
   it("preserves data-prefixed stream events before text and finish", async () => {
     const output = (async function* () {
-      yield { data: { title: "Chat title", type: "chat-title" }, type: "data-chat-title" }
+      yield { data: { title: "Chat title", type: "chat-title" }, transient: true, type: "data-chat-title" }
       yield { text: "ok", type: "text-delta" }
       yield { finishReason: "stop", type: "finish" }
     })()
@@ -212,7 +212,7 @@ describe("agent output helpers", () => {
     }
 
     expect(events).toEqual([
-      { data: { title: "Chat title", type: "chat-title" }, id: undefined, type: "data-chat-title" },
+      { data: { title: "Chat title", type: "chat-title" }, id: undefined, transient: true, type: "data-chat-title" },
       { text: "ok", type: "text-delta" },
       { reason: "stop", type: "finish" },
     ])
@@ -229,6 +229,14 @@ describe("agent output helpers", () => {
       parts: [{ data: { title: "Chat title", type: "chat-title" }, type: "data-chat-title" }],
       role: "assistant",
     }])
+  })
+
+  it("does not fold transient data events into messages", () => {
+    expect(applyStreamEvent([], {
+      data: { progress: 50 },
+      transient: true,
+      type: "data-progress",
+    })).toEqual([])
   })
 
   it("does not duplicate an existing raw async iterable finish event", async () => {

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -198,6 +198,25 @@ describe("agent output helpers", () => {
     ])
   })
 
+  it("preserves data-prefixed stream events before text and finish", async () => {
+    const output = (async function* () {
+      yield { data: { title: "Chat title", type: "chat-title" }, type: "data-chat-title" }
+      yield { text: "ok", type: "text-delta" }
+      yield { finishReason: "stop", type: "finish" }
+    })()
+
+    const events: unknown[] = []
+    for await (const event of streamAgentOutputToEvents(output)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      { data: { title: "Chat title", type: "chat-title" }, id: undefined, type: "data-chat-title" },
+      { text: "ok", type: "text-delta" },
+      { reason: "stop", type: "finish" },
+    ])
+  })
+
   it("does not duplicate an existing raw async iterable finish event", async () => {
     const output = (async function* () {
       yield { text: "ok", type: "text-delta" }

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { applyStreamEvent } from "../src/messages.ts"
 import {
   streamAgentOutputToEvents,
   toAgentRunResult,
@@ -215,6 +216,19 @@ describe("agent output helpers", () => {
       { text: "ok", type: "text-delta" },
       { reason: "stop", type: "finish" },
     ])
+  })
+
+  it("folds data-prefixed stream events into messages", () => {
+    const messages = applyStreamEvent([], {
+      data: { title: "Chat title", type: "chat-title" },
+      type: "data-chat-title",
+    })
+
+    expect(messages).toEqual([{
+      id: expect.any(String),
+      parts: [{ data: { title: "Chat title", type: "chat-title" }, type: "data-chat-title" }],
+      role: "assistant",
+    }])
   })
 
   it("does not duplicate an existing raw async iterable finish event", async () => {

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -191,6 +191,23 @@ describe("chat message trigger input", () => {
     ])
   })
 
+  it("preserves UI data parts in follow-up history", () => {
+    const result = createChatMessageTriggerInput({}, {
+      messages: [{
+        parts: [
+          { data: { city: "Seattle" }, id: "weather-1", type: "data-weather" },
+          { text: "The forecast is ready.", type: "text" },
+        ],
+        role: "assistant",
+      }],
+    })
+
+    expect(result.input.messages?.[0]?.parts).toEqual([
+      { data: { city: "Seattle" }, id: "weather-1", type: "data-weather" },
+      { id: "text-1", text: "The forecast is ready.", type: "text" },
+    ])
+  })
+
   it("preserves failed UI tool calls", () => {
     const result = createChatMessageTriggerInput({}, {
       messages: [{

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2083,6 +2083,20 @@ describe("agent message protocol", () => {
     ])
   })
 
+  it("preserves prefixed data parts during model conversion", async () => {
+    const { toAiSdkModelMessages } = await import("../src/ai-sdk.ts")
+
+    expect(toAiSdkModelMessages([
+      createMessage({
+        id: "m1",
+        parts: [{ data: { city: "Seattle" }, type: "data-weather" }],
+        role: "user",
+      }),
+    ])).toEqual([
+      { content: "{\"city\":\"Seattle\"}", role: "user" },
+    ])
+  })
+
   it("drops empty ViteHub messages before model conversion", async () => {
     const { toAiSdkModelMessages } = await import("../src/ai-sdk.ts")
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5994,6 +5994,30 @@ describe("agent message protocol", () => {
     expect(messages.at(-1)?.parts.map(part => part.type).sort()).toEqual(["data-chat-title", "text"])
   })
 
+  it("preserves data part ids when async event streams become UI message streams", async () => {
+    const { readUIMessageStream } = await import("ai")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      driver: { run: () => (async function* () {
+          yield { data: { city: "Seattle" }, id: "weather-1", type: "data-weather" }
+          yield { text: "answer", type: "text-delta" }
+          yield { type: "finish" }
+        })() },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Weather?" })],
+    }, { output: "ui-message-stream" }) as ReadableStream<never>
+    const messages = []
+    for await (const message of readUIMessageStream({ stream })) {
+      messages.push(message)
+    }
+
+    expect(messages.at(-1)?.parts.filter(part => part.type === "data-weather")).toEqual([
+      { data: { city: "Seattle" }, id: "weather-1", type: "data-weather" },
+    ])
+  })
+
   it("renders custom async event streams returned from runAgent", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const agent = defineAgent({

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -6032,6 +6032,29 @@ describe("agent message protocol", () => {
     ])
   })
 
+  it("keeps transient async data events out of UI message history", async () => {
+    const { readUIMessageStream } = await import("ai")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      driver: { run: () => (async function* () {
+          yield { data: { progress: 50 }, transient: true, type: "data-progress" }
+          yield { text: "answer", type: "text-delta" }
+          yield { type: "finish" }
+        })() },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Status?" })],
+    }, { output: "ui-message-stream" }) as ReadableStream<never>
+    const messages = []
+    for await (const message of readUIMessageStream({ stream })) {
+      messages.push(message)
+    }
+
+    expect(messages.at(-1)?.parts.filter(part => part.type === "data-progress")).toEqual([])
+    expect(messages.at(-1)?.parts).toContainEqual({ text: "answer", type: "text" })
+  })
+
   it("renders custom async event streams returned from runAgent", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const agent = defineAgent({

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -6536,7 +6536,7 @@ describe("agent message protocol", () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const agent = defineAgent({
       driver: { run: () => (async function* () {
-          yield { data: { title: "Async title", type: "chat-title" }, type: "data" }
+          yield { data: { title: "Async title" }, type: "data-chat-title" }
           yield { text: "hello", type: "text-delta" }
           yield { id: "tool-1", input: { query: "users" }, name: "search", type: "tool-call" }
           yield { id: "tool-1", name: "search", output: "42", type: "tool-result" }
@@ -6554,7 +6554,7 @@ describe("agent message protocol", () => {
 
     expect(messages.at(-1)?.parts.map(part => part.type)).toEqual(["data-chat-title", "text", "tool-search"])
     expect(messages.at(-1)?.parts[0]).toEqual({
-      data: { title: "Async title", type: "chat-title" },
+      data: { title: "Async title" },
       type: "data-chat-title",
     })
   })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -6052,7 +6052,7 @@ describe("agent message protocol", () => {
     }
 
     expect(messages.at(-1)?.parts.filter(part => part.type === "data-progress")).toEqual([])
-    expect(messages.at(-1)?.parts).toContainEqual({ text: "answer", type: "text" })
+    expect(messages.at(-1)?.parts).toContainEqual(expect.objectContaining({ text: "answer", type: "text" }))
   })
 
   it("renders custom async event streams returned from runAgent", async () => {


### PR DESCRIPTION
Preserves `data-*` Agent Invocation Stream events when normalizing agent output, so chat-title data events and similar UI data chunks survive alongside text and finish events.

This keeps the public stream/message event type aligned with the data-prefixed events ViteHub already emits and adds a focused agent-output regression for the downstream Bitacora escape.