### PR TITLE
fix(agent): support discord chat titles

### DIFF
--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1635,11 +1635,13 @@ function discordAdapterResolver<TRuntimeConfig extends AgentRuntimeConfig>(
     catch (error) {
       throw new Error("[vitehub] discord({ adapter: true }) requires @chat-adapter/discord to be installed.", { cause: error })
     }
+    const botToken = cleanSecret(adapterOptions.botToken)
     const adapter = createDiscordAdapter({
       ...adapterOptions,
-      ...(adapterOptions.botToken ? { botToken: cleanSecret(adapterOptions.botToken) } : {}),
+      ...(botToken ? { botToken } : {}),
       ...(adapterOptions.publicKey ? { publicKey: cleanSecret(adapterOptions.publicKey) } : {}),
     })
+    addDiscordThreadTitleSupport(adapter, adapterOptions, botToken)
     if (longContent?.mode === "split") {
       Object.defineProperty(adapter, Symbol.for("vitehub.discord.longContent.mode"), {
         configurable: true,
@@ -1648,6 +1650,37 @@ function discordAdapterResolver<TRuntimeConfig extends AgentRuntimeConfig>(
     }
     return adapter
   }
+}
+
+const discordApiBaseUrl = "https://discord.com/api/v10"
+
+function discordThreadIdFromAgentThreadId(threadId: string): string | undefined {
+  const parts = threadId.split(":")
+  return parts[0] === "discord" ? maybeString(parts[3]) : undefined
+}
+
+function addDiscordThreadTitleSupport(adapter: Adapter, options: DiscordAdapterOptions, botToken: string | undefined): void {
+  if (!botToken || adapterSetThreadTitle(adapter)) return
+  Object.defineProperty(adapter, "setThreadTitle", {
+    configurable: true,
+    value: async (threadId: string, title: string) => {
+      const discordThreadId = discordThreadIdFromAgentThreadId(threadId)
+      const name = title.replace(/\s+/g, " ").trim().slice(0, 100).trim()
+      if (!discordThreadId || !name) return
+      const response = await fetch(`${(options.apiUrl || discordApiBaseUrl).replace(/\/+$/, "")}/channels/${discordThreadId}`, {
+        body: JSON.stringify({ name }),
+        headers: {
+          Authorization: `Bot ${botToken}`,
+          "Content-Type": "application/json",
+        },
+        method: "PATCH",
+      })
+      if (!response.ok) {
+        const error = await response.text().catch(() => response.statusText)
+        throw new Error(`[vitehub] Discord thread title update failed: ${response.status}${error ? ` ${error}` : ""}`)
+      }
+    },
+  })
 }
 
 function isAdapter(value: unknown): value is Adapter {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -131,6 +131,7 @@ describe("agent channels", () => {
       const { discord } = await import("../src/channels.ts")
       const channel = discord({
         adapter: {
+          applicationId: "app-id",
           botToken: { unseal: () => "bot-token" },
           mentionRoleIds: ["role-1"],
           publicKey: { unseal: () => "public-key" },
@@ -141,6 +142,7 @@ describe("agent channels", () => {
       if (typeof channel.adapter !== "function") throw new Error("Expected Discord adapter resolver.")
       await expect(channel.adapter({} as never)).resolves.toEqual({ name: "discord" })
       expect(createDiscordAdapter).toHaveBeenCalledWith({
+        applicationId: "app-id",
         botToken: "bot-token",
         mentionRoleIds: ["role-1"],
         publicKey: "public-key",
@@ -174,6 +176,47 @@ describe("agent channels", () => {
       expect((resolved as unknown as { [key: symbol]: unknown })[Symbol.for("vitehub.discord.longContent.mode")]).toBe("split")
     }
     finally {
+      vi.doUnmock("@chat-adapter/discord")
+      vi.resetModules()
+    }
+  })
+
+  it("adds Discord thread title support when a bot token is available", async () => {
+    vi.resetModules()
+    const adapter = { name: "discord" }
+    const createDiscordAdapter = vi.fn(() => adapter)
+    const fetch = vi.fn(async () => new Response("{}", { status: 200 }))
+    vi.stubGlobal("fetch", fetch)
+    vi.doMock("@chat-adapter/discord", () => ({ createDiscordAdapter }))
+    try {
+      const { discord } = await import("../src/channels.ts")
+      const channel = discord({
+        adapter: {
+          apiUrl: "https://discord.test/api",
+          applicationId: "app-id",
+          botToken: { unseal: () => "bot-token" },
+          publicKey: "public-key",
+        },
+      })
+
+      if (typeof channel.adapter !== "function") throw new Error("Expected Discord adapter resolver.")
+      const resolved = await channel.adapter({} as never) as { setThreadTitle?: (threadId: string, title: string) => Promise<void> }
+      expect(resolved).toBe(adapter)
+      expect(typeof resolved.setThreadTitle).toBe("function")
+
+      await resolved.setThreadTitle?.("discord:guild:channel:thread-1", "  New   Thread   Title  ")
+
+      expect(fetch).toHaveBeenCalledWith("https://discord.test/api/channels/thread-1", {
+        body: JSON.stringify({ name: "New Thread Title" }),
+        headers: {
+          Authorization: "Bot bot-token",
+          "Content-Type": "application/json",
+        },
+        method: "PATCH",
+      })
+    }
+    finally {
+      vi.unstubAllGlobals()
       vi.doUnmock("@chat-adapter/discord")
       vi.resetModules()
     }


### PR DESCRIPTION
Adds Discord thread-title delivery support to the built-in Discord channel wrapper. When the underlying @chat-adapter/discord adapter does not expose setThreadTitle, ViteHub now attaches a non-enumerable title setter using the configured bot token and Discord channel PATCH API, so chatTitle() can detect support and rename Discord threads through the normal finish delivery path.

The test covers the wrapper-provided title setter, preserves adapter identity, and verifies the exact PATCH request shape.