### PR TITLE
docs: separate agents and server primitives

### DIFF
--- a/.agents/adr/0076-agents-and-server-primitives-are-product-lanes.md
+++ b/.agents/adr/0076-agents-and-server-primitives-are-product-lanes.md
@@ -1,0 +1,47 @@
+# Agents and Server Primitives Are Product Lanes
+
+## Status
+
+Accepted.
+
+## Context
+
+ViteHub has two independently valuable public surfaces. Server Primitives give ordinary Vite server applications portable state and work across hosts. Agents define, invoke, inspect, and deploy server-side Agents that may compose those primitives.
+
+The shared repository, Vite Integration vocabulary, Provider Output contracts, CLI, and verification system make coordinated development faster. They do not require one undifferentiated product story or an all-inclusive application API.
+
+The previous landing-page decision in ADR 0073 correctly made Agents the acquisition wedge, but equal real estate on one page did not make the package and product boundary obvious enough.
+
+## Decision
+
+ViteHub is one platform with two public product lanes:
+
+- **ViteHub Agents** owns Agent Definitions, Agent Drivers, Agent Invocations, Channels, Capabilities, Workspace context, inspection, and Agent deployment behavior.
+- **ViteHub Server Primitives** owns portable server state and work through package-owned Definitions, Runtime Helpers, Vite Integrations, and Provider Output.
+
+Agents may compose Server Primitives. Server Primitives must not require Agents. Agent-specific bridges to Auth, Workflow, Workspace, storage, or other primitives belong to Agent-owned or explicit bridge surfaces rather than primitive package cores.
+
+Keep one repository, package scope, release system, documentation site, and root landing page. The root leads with Agents and routes users directly to focused Agents and Server Primitives journeys. Repository topology does not define the product boundary.
+
+Owner-package imports remain the canonical application API. A preset Vite Integration may compose package-owned integrations, but it must not become a second mirrored runtime API.
+
+This decision supersedes ADR 0073 where that ADR requires the two lanes to share one undifferentiated landing narrative or gives the preset facade first-class application API ownership.
+
+## Proof
+
+The boundary is proven by executable consumer stories rather than an export-name snapshot:
+
+1. A primitive-only application builds and runs without Agent in its runtime graph.
+2. A minimal Agent application runs without enabling unrelated primitives or DevTools.
+3. An Agent application explicitly composes selected Workspace, Workflow, storage, or Auth behavior.
+4. Public documentation examples compile against package-owned exports.
+5. Package graph checks reject new Server Primitive imports from `@vite-hub/agent`.
+
+## Consequences
+
+- Marketing and docs use the names **Agents** and **Server Primitives** instead of inventing a generic public `Core` product.
+- The main landing page may lead with Agents while the header and docs home keep Server Primitives directly reachable.
+- Primitive-specific setup does not teach Agent concepts unless the task is Agent composition.
+- Agent guides introduce primitives only at the point where an Agent needs them.
+- `@vite-hub/vite` facade exports, primitive-to-Agent dependencies, and default-on integrations require follow-up migrations.
+- A repository split remains possible if teams, governance, or release cadences diverge, but it is not part of the current product design.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  Server primitives for any host.
+  Portable Agents. Server Primitives for any host.
 </p>
 
 <p align="center">
@@ -20,17 +20,23 @@
   <a href="https://vitehub.dev/docs/server-primitives">Server primitives</a>
 </p>
 
-ViteHub gives Vite apps portable server primitives and Agent Definitions. Use primitives directly from routes, handlers, jobs, and workers; expose them to agents only through explicit Capabilities when model behavior needs controlled access.
+ViteHub is one platform with two product lanes. ViteHub Agents defines, invokes, and deploys server-side Agents. ViteHub Server Primitives provide ordinary Vite applications with portable state and work across hosts.
 
-## Server Primitives and Agents
+## Choose a product lane
 
-Server primitives give app code stable Runtime Helpers for auth, environment values, storage, queues, workflows, schedules, sandboxes, workspace files, and provider output.
+### Agents
 
-Agents are named server-side actors. Each Agent Definition picks an Agent Driver, receives Agent Invocations, can read explicit Workspace context, and gains abilities through Capabilities.
+Agents are named server-side actors. Each Agent Definition picks an Agent Driver, receives Agent Invocations, can read explicit Workspace context, and gains abilities through Capabilities. Start with [your first Agent](https://vitehub.dev/docs/getting-started/first-agent).
+
+### Server Primitives
+
+Server Primitives give app code stable Runtime Helpers for auth, environment values, storage, queues, workflows, schedules, sandboxes, workspace files, and Provider Output. They work without an Agent Definition. Start with [your first Server Primitive](https://vitehub.dev/docs/getting-started/first-server-primitive).
+
+Agents may compose Server Primitives. Server Primitives never require Agents.
 
 ## Installation
 
-ViteHub starts with the Vite preset. Add direct primitive, Agent Package, or provider packages only when your app imports them.
+The current full-platform setup starts with the Vite preset. Focused guides use the package that owns the Agent or Server Primitive surface.
 
 ```bash
 pnpm add @vite-hub/vite

--- a/docs/app/components/AppHeader.vue
+++ b/docs/app/components/AppHeader.vue
@@ -3,6 +3,8 @@ const route = useRoute();
 const isDocsRoute = computed(() => route.path.startsWith("/docs"));
 
 const navLinks = [
+  { label: "Agents", to: "/docs/agents" },
+  { label: "Primitives", to: "/docs/server-primitives" },
   { label: "Docs", to: "/docs" },
   { label: "Blog", to: "/blog" },
 ];

--- a/docs/app/components/landing/AnyHost.vue
+++ b/docs/app/components/landing/AnyHost.vue
@@ -74,7 +74,7 @@ const highlightedSnippets = [snippetA, snippetB, snippetC];
       </ul>
 
       <div class="mt-10 grid gap-4 lg:grid-cols-3">
-        <article v-for="(snippet, index) in snippets" :key="snippet.path" class="flex flex-col">
+        <article v-for="(snippet, index) in snippets" :key="snippet.path" class="flex min-w-0 flex-col">
           <div class="flex items-baseline justify-between gap-2">
             <h3 class="text-base font-medium text-highlighted">{{ snippet.label }}</h3>
             <span v-if="snippet.poweredBy" class="shrink-0 font-mono text-xs text-dimmed">Powered by {{ snippet.poweredBy }}</span>

--- a/docs/app/components/landing/Cta.vue
+++ b/docs/app/components/landing/Cta.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 const pillars = [
-  { icon: "i-lucide-blocks", label: "Composable" },
+  { icon: "i-lucide-bot", label: "Agents" },
+  { icon: "i-lucide-server-cog", label: "Server Primitives" },
   { icon: "i-lucide-globe", label: "Provider-agnostic" },
-  { icon: "i-simple-icons-vite", label: "Just a Vite plugin" },
 ] as const;
 </script>
 
@@ -10,25 +10,25 @@ const pillars = [
   <section class="border-t border-default bg-muted/30">
     <div class="mx-auto max-w-7xl px-4 py-20 text-center sm:px-8 lg:px-12 lg:py-28">
       <h2 class="mx-auto max-w-[24ch] text-4xl font-semibold tracking-tight text-highlighted text-balance sm:text-5xl">
-        One plugin. Any agent. Any host.
+        Build Agents. Keep the server portable.
       </h2>
       <p class="mx-auto mt-5 max-w-[46ch] text-lg text-muted text-pretty">
-        Install ViteHub, define an agent, and ship the same code anywhere.
+        Start with one product lane. Compose the other only when your application needs it.
       </p>
 
       <div class="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
         <NuxtLink
-          to="/docs/getting-started/installation"
+          to="/docs/getting-started/first-agent"
           class="inline-flex items-center justify-center gap-2 rounded-sm bg-inverted px-4 py-2.5 text-sm font-medium text-inverted transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
         >
           <UIcon name="i-lucide-rocket" class="size-4 shrink-0" aria-hidden="true" />
-          Start building
+          Build an Agent
         </NuxtLink>
         <NuxtLink
-          to="/docs"
+          to="/docs/getting-started/first-server-primitive"
           class="inline-flex items-center justify-center gap-2 rounded-sm border border-default px-4 py-2.5 text-sm font-medium text-highlighted transition-colors hover:bg-muted/50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
         >
-          Read the docs
+          Use Server Primitives
         </NuxtLink>
       </div>
 

--- a/docs/app/components/landing/Hero.vue
+++ b/docs/app/components/landing/Hero.vue
@@ -1,40 +1,6 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref } from "vue";
+import { computed, ref } from "vue";
 import { useHighlightedCode } from "../../composables/useHighlightedCode";
-
-const installAudiences = [
-  { label: "For humans", value: "humans", icon: "i-lucide-user" },
-  { label: "For agents", value: "agents", icon: "i-lucide-bot" },
-] as const;
-
-const packageManagers = [
-  { label: "pnpm", value: "pnpm", icon: "i-simple-icons-pnpm", command: "pnpm add @vite-hub/vite" },
-  { label: "npm", value: "npm", icon: "i-simple-icons-npm", command: "npm install @vite-hub/vite" },
-  { label: "bun", value: "bun", icon: "i-simple-icons-bun", command: "bun add @vite-hub/vite" },
-  { label: "yarn", value: "yarn", icon: "i-simple-icons-yarn", command: "yarn add @vite-hub/vite" },
-] as const;
-
-const agentInstallCommand = "npx skills add https://vitehub.dev";
-
-type InstallAudience = (typeof installAudiences)[number]["value"];
-type PackageManager = (typeof packageManagers)[number]["value"];
-
-const activeAudience = ref<InstallAudience>("humans");
-const activeManager = ref<PackageManager>("pnpm");
-const copied = ref(false);
-let copiedTimer: ReturnType<typeof setTimeout> | undefined;
-
-const selectedManager = computed(() => packageManagers.find(m => m.value === activeManager.value) ?? packageManagers[0]!);
-const installText = computed(() => (activeAudience.value === "humans" ? selectedManager.value.command : agentInstallCommand));
-
-async function copyInstall() {
-  try {
-    await navigator.clipboard?.writeText(installText.value);
-    copied.value = true;
-    if (copiedTimer) clearTimeout(copiedTimer);
-    copiedTimer = setTimeout(() => (copied.value = false), 1500);
-  } catch {}
-}
 
 const agents = [
   {
@@ -89,10 +55,6 @@ const agents = [
 const activeId = ref<string>(agents[0]!.id);
 const activeAgent = computed(() => agents.find(a => a.id === activeId.value) ?? agents[0]!);
 const { data: highlighted } = useHighlightedCode(() => activeAgent.value.id, () => activeAgent.value.code, "ts");
-
-onBeforeUnmount(() => {
-  if (copiedTimer) clearTimeout(copiedTimer);
-});
 </script>
 
 <template>
@@ -103,78 +65,20 @@ onBeforeUnmount(() => {
           Agents for any host.
         </h1>
         <p class="mt-6 max-w-[48ch] text-lg text-muted text-pretty">
-          Define any agent, compose it from capabilities, and ship the same code to any host. Built on server primitives, wired with one Vite plugin.
+          Choose a model-backed, harness-backed, or custom Agent Driver. Add Channels, Capabilities, Workspace context, and Server Primitives only when the product needs them, then ship to any Vite host.
         </p>
 
-        <div class="mt-9 flex w-full max-w-xl flex-col gap-3">
-          <div class="flex flex-wrap items-center justify-between gap-3">
-            <div class="inline-flex rounded-sm bg-muted/70 p-1 ring-1 ring-default" role="tablist" aria-label="Install audience">
-              <button
-                v-for="audience in installAudiences"
-                :key="audience.value"
-                type="button"
-                role="tab"
-                :aria-selected="activeAudience === audience.value"
-                class="inline-flex items-center gap-1.5 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                :class="activeAudience === audience.value ? 'bg-default text-highlighted ring-1 ring-default' : 'text-muted hover:text-default'"
-                @click="activeAudience = audience.value"
-              >
-                <UIcon :name="audience.icon" class="size-3.5 shrink-0" aria-hidden="true" />
-                <span>{{ audience.label }}</span>
-              </button>
-            </div>
-
-            <div
-              v-show="activeAudience === 'humans'"
-              class="inline-flex items-center gap-1 rounded-sm bg-muted/70 p-1 ring-1 ring-default"
-              role="radiogroup"
-              aria-label="Package manager"
-            >
-              <button
-                v-for="manager in packageManagers"
-                :key="manager.value"
-                type="button"
-                role="radio"
-                :aria-checked="activeManager === manager.value"
-                :aria-label="manager.label"
-                class="inline-flex h-7 items-center justify-center overflow-hidden rounded-sm text-sm font-medium transition-[width,color,background-color] duration-200 ease-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                :class="activeManager === manager.value ? 'w-20 bg-default px-2.5 text-highlighted ring-1 ring-default' : 'w-7 px-0 text-muted hover:text-default'"
-                @click="activeManager = manager.value"
-              >
-                <UIcon :name="manager.icon" class="size-3.5 shrink-0" aria-hidden="true" />
-                <span
-                  class="overflow-hidden whitespace-nowrap transition-[max-width,opacity,margin-left] duration-150 ease-out"
-                  :class="activeManager === manager.value ? 'ml-1.5 max-w-12 opacity-100' : 'ml-0 max-w-0 opacity-0'"
-                >{{ manager.label }}</span>
-              </button>
-            </div>
-          </div>
-
-          <button
-            type="button"
-            class="group inline-flex w-full items-center gap-2 rounded-sm bg-default px-3 py-2.5 text-left ring-1 ring-default transition-colors hover:ring-accented focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-            :aria-label="copied ? 'Copied' : 'Copy install command'"
-            @click="copyInstall"
-          >
-            <span class="font-mono text-base text-dimmed select-none sm:text-sm" aria-hidden="true">$</span>
-            <code class="min-w-0 flex-1 overflow-x-auto font-mono text-base whitespace-nowrap text-highlighted sm:text-sm [scrollbar-width:none]">{{ installText }}</code>
-            <UIcon
-              :name="copied ? 'i-lucide-check' : 'i-lucide-copy'"
-              class="size-4 shrink-0 transition-colors"
-              :class="copied ? 'text-primary' : 'text-muted group-hover:text-default'"
-              aria-hidden="true"
-            />
-          </button>
-
-          <div class="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
-            <NuxtLink to="/docs/getting-started/first-agent" class="inline-flex items-center gap-1 font-medium text-highlighted hover:text-primary">
-              Build your first agent
-              <UIcon name="i-lucide-arrow-right" class="size-4 shrink-0" aria-hidden="true" />
-            </NuxtLink>
-            <NuxtLink to="/docs" class="inline-flex items-center gap-1 font-medium text-muted hover:text-default">
-              Read the docs
-            </NuxtLink>
-          </div>
+        <div class="mt-9 flex flex-wrap items-center gap-x-5 gap-y-3 text-sm">
+          <NuxtLink to="/docs/getting-started/first-agent" class="inline-flex items-center gap-1 font-medium text-highlighted hover:text-primary">
+            Build your first Agent
+            <UIcon name="i-lucide-arrow-right" class="size-4 shrink-0" aria-hidden="true" />
+          </NuxtLink>
+          <NuxtLink to="/docs/server-primitives" class="inline-flex items-center gap-1 font-medium text-muted hover:text-default">
+            Use Server Primitives
+          </NuxtLink>
+          <NuxtLink to="/docs" class="inline-flex items-center gap-1 font-medium text-muted hover:text-default">
+            Read the docs
+          </NuxtLink>
         </div>
       </div>
 

--- a/docs/app/components/landing/Showcase.vue
+++ b/docs/app/components/landing/Showcase.vue
@@ -27,7 +27,7 @@ export default defineConfig({
 
 const installAudiences = [
   { label: "For humans", value: "humans", icon: "i-lucide-user" },
-  { label: "For agents", value: "agents", icon: "i-lucide-bot" },
+  { label: "For coding agents", value: "agents", icon: "i-lucide-bot" },
 ] as const;
 
 const packageManagers = [

--- a/docs/app/pages/index.vue
+++ b/docs/app/pages/index.vue
@@ -6,7 +6,7 @@ useHead({ titleTemplate: () => "ViteHub" });
 useSeoMeta({
   title: "ViteHub — Agents for any host",
   ogTitle: "ViteHub — Agents for any host · ViteHub",
-  description: "Define any agent, compose it from capabilities, and ship it to any host — built on server primitives, wired with one Vite plugin.",
+  description: "Build portable Agents, or use the same Server Primitives directly in any Vite application.",
 });
 </script>
 

--- a/docs/content/docs/index.md
+++ b/docs/content/docs/index.md
@@ -1,34 +1,26 @@
 ---
 title: ViteHub docs
-description: Build server primitives for any host, then compose them into agents with controlled capabilities.
+description: Choose ViteHub Agents or ViteHub Server Primitives, then follow one focused path.
 navigation: false
 icon: i-lucide-book-open
 ---
 
-ViteHub is a server layer for Vite apps that need host-independent primitives and inspectable agent infrastructure. It gives application code stable Runtime Helpers and gives Agent Definitions controlled Capabilities instead of raw access to every server resource.
+ViteHub is one platform with two product lanes. **ViteHub Agents** defines, invokes, and deploys server-side Agents. **ViteHub Server Primitives** provide ordinary Vite applications with portable state and work across hosts.
 
-Use Start for the first install, Concepts for the mental model, Server primitives for app-code APIs, and Agents when model-backed behavior becomes part of the product.
+Agents may compose Server Primitives through explicit Capabilities and Workspaces. Server Primitives work without an Agent Definition.
 
 ::u-page-grid{class="not-prose mt-8"}
   :::u-page-card
   ---
-  title: Start
-  description: Install one package, register its Vite Integration, and run the first primitive or Agent.
-  icon: i-lucide-rocket
-  to: /docs/getting-started
+  title: Agents
+  description: Define Agents, attach Capabilities and Workspaces, run Agent Invocations, and inspect behavior.
+  icon: i-lucide-bot
+  to: /docs/agents
   ---
   :::
   :::u-page-card
   ---
-  title: Concepts
-  description: Learn Definitions, discovery, Provider Output, Runtime Helpers, Workspaces, Sources, Capabilities, and Agent Invokers.
-  icon: i-lucide-map
-  to: /docs/concepts
-  ---
-  :::
-  :::u-page-card
-  ---
-  title: Server primitives
+  title: Server Primitives
   description: Use Auth, Env, KV, Database, Blob, Workspace, Queue, Workflow, Schedule, Sandbox, and Shell from server code.
   icon: i-lucide-server-cog
   to: /docs/server-primitives
@@ -36,10 +28,18 @@ Use Start for the first install, Concepts for the mental model, Server primitive
   :::
   :::u-page-card
   ---
-  title: Agents
-  description: Define Agents, attach Capabilities, run Agent Invocations, add Workspace context, and inspect behavior.
-  icon: i-lucide-bot
-  to: /docs/agents
+  title: Start
+  description: Install the packages for one lane and reach a visible first success.
+  icon: i-lucide-rocket
+  to: /docs/getting-started
+  ---
+  :::
+  :::u-page-card
+  ---
+  title: Shared concepts
+  description: Learn Definitions, discovery, Provider Output, Runtime Helpers, Workspaces, Sources, and Capabilities.
+  icon: i-lucide-map
+  to: /docs/concepts
   ---
   :::
 ::

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,11 +1,11 @@
 ---
 title: ViteHub
-description: Agents for any host, composed with server primitives through one Vite plugin.
+description: Portable Agents and Server Primitives for any Vite host.
 ---
 
 # ViteHub
 
-ViteHub provides Agent Definitions and server primitives for Vite applications that need host-independent runtime behavior.
+ViteHub is one platform with two product lanes. Build portable Agents, or use Server Primitives directly from routes, handlers, jobs, and workers.
 
 - [Browse docs](/docs)
 - [Create agents](/docs/agents)


### PR DESCRIPTION
Defines ViteHub Agents and ViteHub Server Primitives as independent product lanes on one platform and records the dependency rule that primitives never require Agents.

Updates the README, docs entry points, header, hero, and closing CTA so Agents lead acquisition while Server Primitives stay directly reachable. Removes the ambiguous human/agent installer switch and fixes the narrow-screen server-example overflow found during browser verification.