### PR TITLE
fix(source): materialize sparse GitHub sources with git

### DIFF
--- a/packages/source/src/sources/github/git.ts
+++ b/packages/source/src/sources/github/git.ts
@@ -13,7 +13,7 @@ type GitRunner = (args: string[], options?: GitOptions) => Promise<string>
 
 interface GitCheckoutInput<TKey extends string> {
   keyForRepoPath: (path: string) => TKey | undefined
-  ref?: string
+  ref: string
   repo: string
   shouldInclude: (key: TKey) => boolean
   signal?: AbortSignal
@@ -69,7 +69,7 @@ function isGitSparsePattern(pattern: string) {
 
 export function getGitSparsePatterns(root: string, include?: string | string[]): string[] | undefined {
   const patterns = (include ? (Array.isArray(include) ? include : [include]) : [])
-    .map(pattern => normalizeSourcePath(root ? `${root}/${pattern}` : pattern))
+    .map(pattern => [root, normalizeSourcePath(pattern)].filter(Boolean).join("/"))
     .filter(Boolean)
   if (patterns.some(pattern => !isGitSparsePattern(pattern))) return
   if (patterns.length) return [...new Set(patterns)]
@@ -106,6 +106,7 @@ async function readCheckoutFiles<TKey extends string>(
         content: await readFile(path),
         key,
         path: key,
+        ref: input.ref,
         sha: input.sha,
       })
     }
@@ -145,7 +146,7 @@ export async function loadGitCheckoutFiles<TKey extends string>(
       "--filter=blob:none",
       "--no-tags",
       "origin",
-      input.ref ? `+${input.ref}` : "HEAD",
+      `+${input.ref}`,
     ], options)
     await executeGit(["-C", dir, "checkout", "--quiet", "--detach", "FETCH_HEAD"], options)
     const sha = (await executeGit(["-C", dir, "rev-parse", "HEAD"], options)).trim()

--- a/packages/source/src/sources/github/git.ts
+++ b/packages/source/src/sources/github/git.ts
@@ -27,10 +27,28 @@ interface GitCheckoutInput<TKey extends string> {
 
 function createGitEnv(home: string, token?: string, baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   const env = { ...baseEnv }
+  for (const key of [
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CONFIG",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_DIR",
+    "GIT_GRAFT_FILE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_PREFIX",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_SHALLOW_FILE",
+    "GIT_WORK_TREE",
+  ]) {
+    delete env[key]
+  }
   for (const key of Object.keys(env)) {
     if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(key)) delete env[key]
   }
-  delete env.GIT_CONFIG_PARAMETERS
 
   Object.assign(env, {
     GCM_INTERACTIVE: "Never",
@@ -159,7 +177,10 @@ async function readGitFiles<TKey extends string>(
     "-z",
     input.sha,
     "--",
-    ...input.sparsePatterns.map(pattern => pattern.endsWith("/**") ? pattern.slice(0, -3) : pattern),
+    ...input.sparsePatterns.map((pattern) => {
+      const path = pattern.endsWith("/**") ? pattern.slice(0, -3) : pattern
+      return `:(literal)${path}`
+    }),
   ], options)
   const entries = parseGitTree(Buffer.from(treeOutput), input)
   const oids = [...new Set(entries.map(entry => entry.oid))]

--- a/packages/source/src/sources/github/git.ts
+++ b/packages/source/src/sources/github/git.ts
@@ -1,0 +1,157 @@
+import { Buffer } from "node:buffer"
+
+import { normalizeSourcePath } from "../../core/path.ts"
+
+import type { GitHubFile } from "./types.ts"
+
+interface GitOptions {
+  env?: NodeJS.ProcessEnv
+  signal?: AbortSignal
+}
+
+type GitRunner = (args: string[], options?: GitOptions) => Promise<string>
+
+interface GitCheckoutInput<TKey extends string> {
+  keyForRepoPath: (path: string) => TKey | undefined
+  ref?: string
+  repo: string
+  shouldInclude: (key: TKey) => boolean
+  signal?: AbortSignal
+  sparsePatterns: string[]
+  token?: string
+}
+
+function createGitEnv(token?: string): NodeJS.ProcessEnv {
+  if (!token) return process.env
+  const configCount = /^\d+$/.test(process.env.GIT_CONFIG_COUNT || "")
+    ? Number(process.env.GIT_CONFIG_COUNT)
+    : 0
+  const credential = Buffer.from(`x-access-token:${token}`).toString("base64")
+  return {
+    ...process.env,
+    GIT_CONFIG_COUNT: String(configCount + 1),
+    [`GIT_CONFIG_KEY_${configCount}`]: "http.https://github.com/.extraheader",
+    [`GIT_CONFIG_VALUE_${configCount}`]: `AUTHORIZATION: basic ${credential}`,
+  }
+}
+
+async function runGit(args: string[], options: GitOptions = {}): Promise<string> {
+  const { spawn } = await import("node:child_process")
+  return await new Promise((resolve, reject) => {
+    const child = spawn("git", args, {
+      env: options.env,
+      signal: options.signal,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    const stdout: Buffer[] = []
+    child.stdout.on("data", chunk => stdout.push(chunk))
+    child.stderr.resume()
+    child.on("error", reject)
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(Buffer.concat(stdout).toString("utf8"))
+        return
+      }
+      const command = args[0] === "-C" ? args[2] : args[0]
+      reject(new Error(`git ${command || "command"} exited with ${code ?? "an unknown status"}.`))
+    })
+  })
+}
+
+function isGitSparsePattern(pattern: string) {
+  if (pattern.includes("\0") || pattern.includes("\r") || pattern.includes("\n")) return false
+  const segments = pattern.split("/")
+  if (segments.some(segment => segment === "." || segment === "..")) return false
+  if (!pattern.includes("*")) return !/[?[\]{}()!+@]/.test(pattern)
+  if (!pattern.endsWith("/**")) return false
+  return !/[*?[\]{}()!+@]/.test(pattern.slice(0, -3))
+}
+
+export function getGitSparsePatterns(root: string, include?: string | string[]): string[] | undefined {
+  const patterns = (include ? (Array.isArray(include) ? include : [include]) : [])
+    .map(pattern => normalizeSourcePath(root ? `${root}/${pattern}` : pattern))
+    .filter(Boolean)
+  if (patterns.some(pattern => !isGitSparsePattern(pattern))) return
+  if (patterns.length) return [...new Set(patterns)]
+  return root && isGitSparsePattern(root) ? [`${root}/**`] : undefined
+}
+
+async function readCheckoutFiles<TKey extends string>(
+  dir: string,
+  input: GitCheckoutInput<TKey> & { sha: string },
+): Promise<GitHubFile<TKey>[]> {
+  const [{ readdir, readFile }, { join, relative }] = await Promise.all([
+    import("node:fs/promises"),
+    import("node:path"),
+  ])
+  const files: GitHubFile<TKey>[] = []
+
+  async function walk(current: string): Promise<void> {
+    input.signal?.throwIfAborted()
+    const entries = await readdir(current, { withFileTypes: true })
+    entries.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0)
+    for (const entry of entries) {
+      if (entry.name === ".git") continue
+      const path = join(current, entry.name)
+      if (entry.isDirectory()) {
+        await walk(path)
+        continue
+      }
+      if (!entry.isFile()) continue
+      const repoPath = relative(dir, path).replaceAll("\\", "/")
+      const key = input.keyForRepoPath(repoPath)
+      if (!key || !input.shouldInclude(key)) continue
+      input.signal?.throwIfAborted()
+      files.push({
+        content: await readFile(path),
+        key,
+        path: key,
+        sha: input.sha,
+      })
+    }
+  }
+
+  await walk(dir)
+  return files
+}
+
+export async function loadGitCheckoutFiles<TKey extends string>(
+  input: GitCheckoutInput<TKey>,
+  executeGit: GitRunner = runGit,
+): Promise<GitHubFile<TKey>[]> {
+  const [{ mkdir, mkdtemp, rm, writeFile }, { tmpdir }, { join }] = await Promise.all([
+    import("node:fs/promises"),
+    import("node:os"),
+    import("node:path"),
+  ])
+  const dir = await mkdtemp(join(tmpdir(), "vitehub-github-"))
+  try {
+    const env = createGitEnv(input.token)
+    const options = { env, signal: input.signal }
+    await executeGit(["init", "--quiet", dir], options)
+    await executeGit(["-C", dir, "remote", "add", "origin", `https://github.com/${input.repo}.git`], options)
+    await executeGit(["-C", dir, "config", "core.sparseCheckout", "true"], options)
+    await executeGit(["-C", dir, "config", "core.sparseCheckoutCone", "false"], options)
+    await mkdir(join(dir, ".git", "info"), { recursive: true })
+    await writeFile(
+      join(dir, ".git", "info", "sparse-checkout"),
+      `${input.sparsePatterns.map(pattern => `/${pattern}`).join("\n")}\n`,
+    )
+    await executeGit([
+      "-C",
+      dir,
+      "fetch",
+      "--depth=1",
+      "--filter=blob:none",
+      "--no-tags",
+      "origin",
+      input.ref ? `+${input.ref}` : "HEAD",
+    ], options)
+    await executeGit(["-C", dir, "checkout", "--quiet", "--detach", "FETCH_HEAD"], options)
+    const sha = (await executeGit(["-C", dir, "rev-parse", "HEAD"], options)).trim()
+    return await readCheckoutFiles(dir, { ...input, sha })
+  }
+  finally {
+    await rm(dir, { force: true, recursive: true })
+  }
+}

--- a/packages/source/src/sources/github/git.ts
+++ b/packages/source/src/sources/github/git.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer"
+import { devNull } from "node:os"
 
 import { normalizeSourcePath } from "../../core/path.ts"
 
@@ -6,56 +7,123 @@ import type { GitHubFile } from "./types.ts"
 
 interface GitOptions {
   env?: NodeJS.ProcessEnv
+  input?: string
   signal?: AbortSignal
 }
 
-type GitRunner = (args: string[], options?: GitOptions) => Promise<string>
+type GitRunner = (args: string[], options?: GitOptions) => Promise<string | Uint8Array>
 
 interface GitCheckoutInput<TKey extends string> {
+  env?: NodeJS.ProcessEnv
   keyForRepoPath: (path: string) => TKey | undefined
   ref: string
   repo: string
+  repositoryUrl?: string
   shouldInclude: (key: TKey) => boolean
   signal?: AbortSignal
   sparsePatterns: string[]
   token?: string
 }
 
-function createGitEnv(token?: string): NodeJS.ProcessEnv {
-  if (!token) return process.env
-  const configCount = /^\d+$/.test(process.env.GIT_CONFIG_COUNT || "")
-    ? Number(process.env.GIT_CONFIG_COUNT)
-    : 0
-  const credential = Buffer.from(`x-access-token:${token}`).toString("base64")
-  return {
-    ...process.env,
-    GIT_CONFIG_COUNT: String(configCount + 1),
-    [`GIT_CONFIG_KEY_${configCount}`]: "http.https://github.com/.extraheader",
-    [`GIT_CONFIG_VALUE_${configCount}`]: `AUTHORIZATION: basic ${credential}`,
+function createGitEnv(home: string, token?: string, baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...baseEnv }
+  for (const key of Object.keys(env)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(key)) delete env[key]
   }
+  delete env.GIT_CONFIG_PARAMETERS
+
+  Object.assign(env, {
+    GCM_INTERACTIVE: "Never",
+    GIT_ASKPASS: "",
+    GIT_CONFIG_COUNT: token ? "1" : "0",
+    GIT_CONFIG_GLOBAL: devNull,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_TERMINAL_PROMPT: "0",
+    HOME: home,
+    SSH_ASKPASS: "",
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: home,
+  })
+
+  if (!token) return env
+  const credential = Buffer.from(`x-access-token:${token}`).toString("base64")
+  env.GIT_CONFIG_KEY_0 = "http.https://github.com/.extraheader"
+  env.GIT_CONFIG_VALUE_0 = `AUTHORIZATION: basic ${credential}`
+  return env
 }
 
-async function runGit(args: string[], options: GitOptions = {}): Promise<string> {
+async function runGit(args: string[], options: GitOptions = {}): Promise<Uint8Array> {
   const { spawn } = await import("node:child_process")
   return await new Promise((resolve, reject) => {
     const child = spawn("git", args, {
       env: options.env,
       signal: options.signal,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe"],
     })
     const stdout: Buffer[] = []
     child.stdout.on("data", chunk => stdout.push(chunk))
     child.stderr.resume()
+    child.stdin.on("error", () => {})
+    child.stdin.end(options.input)
     child.on("error", reject)
     child.on("close", (code) => {
       if (code === 0) {
-        resolve(Buffer.concat(stdout).toString("utf8"))
+        resolve(Buffer.concat(stdout))
         return
       }
       const command = args[0] === "-C" ? args[2] : args[0]
       reject(new Error(`git ${command || "command"} exited with ${code ?? "an unknown status"}.`))
     })
   })
+}
+
+interface GitTreeEntry<TKey extends string> {
+  key: TKey
+  oid: string
+}
+
+function parseGitTree<TKey extends string>(
+  output: Uint8Array,
+  input: GitCheckoutInput<TKey>,
+): GitTreeEntry<TKey>[] {
+  return Buffer.from(output).toString("utf8").split("\0")
+    .filter(Boolean)
+    .map((record): GitTreeEntry<TKey> | undefined => {
+      const tab = record.indexOf("\t")
+      if (tab === -1) return
+      const [mode, type, oid] = record.slice(0, tab).split(" ")
+      if (!mode?.startsWith("100") || type !== "blob" || !oid) return
+      const repoPath = record.slice(tab + 1)
+      const key = input.keyForRepoPath(repoPath)
+      if (!key || !input.shouldInclude(key)) return
+      return { key, oid }
+    })
+    .filter(entry => entry !== undefined)
+}
+
+function parseGitBlobs(output: Uint8Array, oids: string[]) {
+  const bytes = Buffer.from(output)
+  const blobs = new Map<string, Buffer>()
+  let offset = 0
+
+  for (const expectedOid of oids) {
+    const newline = bytes.indexOf(10, offset)
+    if (newline === -1) throw new Error("git cat-file returned a truncated header.")
+    const [oid, type, rawSize] = bytes.subarray(offset, newline).toString("ascii").split(" ")
+    const size = Number(rawSize)
+    if (oid !== expectedOid || type !== "blob" || !Number.isSafeInteger(size) || size < 0) {
+      throw new Error("git cat-file returned an unexpected object.")
+    }
+    const contentStart = newline + 1
+    const contentEnd = contentStart + size
+    if (contentEnd >= bytes.length || bytes[contentEnd] !== 10) {
+      throw new Error("git cat-file returned truncated object content.")
+    }
+    blobs.set(oid, Buffer.from(bytes.subarray(contentStart, contentEnd)))
+    offset = contentEnd + 1
+  }
+
+  return blobs
 }
 
 function isGitSparsePattern(pattern: string) {
@@ -76,68 +144,66 @@ export function getGitSparsePatterns(root: string, include?: string | string[]):
   return root && isGitSparsePattern(root) ? [`${root}/**`] : undefined
 }
 
-async function readCheckoutFiles<TKey extends string>(
+async function readGitFiles<TKey extends string>(
   dir: string,
   input: GitCheckoutInput<TKey> & { sha: string },
+  executeGit: GitRunner,
+  options: GitOptions,
 ): Promise<GitHubFile<TKey>[]> {
-  const [{ readdir, readFile }, { join, relative }] = await Promise.all([
-    import("node:fs/promises"),
-    import("node:path"),
-  ])
-  const files: GitHubFile<TKey>[] = []
+  input.signal?.throwIfAborted()
+  const treeOutput = await executeGit([
+    "-C",
+    dir,
+    "ls-tree",
+    "-r",
+    "-z",
+    input.sha,
+    "--",
+    ...input.sparsePatterns.map(pattern => pattern.endsWith("/**") ? pattern.slice(0, -3) : pattern),
+  ], options)
+  const entries = parseGitTree(Buffer.from(treeOutput), input)
+  const oids = [...new Set(entries.map(entry => entry.oid))]
+  if (!oids.length) return []
 
-  async function walk(current: string): Promise<void> {
-    input.signal?.throwIfAborted()
-    const entries = await readdir(current, { withFileTypes: true })
-    entries.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0)
-    for (const entry of entries) {
-      if (entry.name === ".git") continue
-      const path = join(current, entry.name)
-      if (entry.isDirectory()) {
-        await walk(path)
-        continue
-      }
-      if (!entry.isFile()) continue
-      const repoPath = relative(dir, path).replaceAll("\\", "/")
-      const key = input.keyForRepoPath(repoPath)
-      if (!key || !input.shouldInclude(key)) continue
-      input.signal?.throwIfAborted()
-      files.push({
-        content: await readFile(path),
-        key,
-        path: key,
-        ref: input.ref,
-        sha: input.sha,
-      })
-    }
-  }
-
-  await walk(dir)
-  return files
+  input.signal?.throwIfAborted()
+  const blobOutput = await executeGit(["-C", dir, "cat-file", "--batch"], {
+    ...options,
+    input: `${oids.join("\n")}\n`,
+  })
+  const blobs = parseGitBlobs(Buffer.from(blobOutput), oids)
+  return entries.map(entry => ({
+    content: blobs.get(entry.oid),
+    key: entry.key,
+    path: entry.key,
+    ref: input.ref,
+    sha: input.sha,
+  }))
 }
 
 export async function loadGitCheckoutFiles<TKey extends string>(
   input: GitCheckoutInput<TKey>,
   executeGit: GitRunner = runGit,
 ): Promise<GitHubFile<TKey>[]> {
-  const [{ mkdir, mkdtemp, rm, writeFile }, { tmpdir }, { join }] = await Promise.all([
+  const [{ mkdtemp, rm }, { tmpdir }, { join }] = await Promise.all([
     import("node:fs/promises"),
     import("node:os"),
     import("node:path"),
   ])
   const dir = await mkdtemp(join(tmpdir(), "vitehub-github-"))
   try {
-    const env = createGitEnv(input.token)
+    const env = createGitEnv(dir, input.token, input.env)
     const options = { env, signal: input.signal }
     await executeGit(["init", "--quiet", dir], options)
-    await executeGit(["-C", dir, "remote", "add", "origin", `https://github.com/${input.repo}.git`], options)
-    await executeGit(["-C", dir, "config", "core.sparseCheckout", "true"], options)
-    await executeGit(["-C", dir, "config", "core.sparseCheckoutCone", "false"], options)
-    await mkdir(join(dir, ".git", "info"), { recursive: true })
-    await writeFile(
-      join(dir, ".git", "info", "sparse-checkout"),
-      `${input.sparsePatterns.map(pattern => `/${pattern}`).join("\n")}\n`,
-    )
+    await executeGit([
+      "-C",
+      dir,
+      "remote",
+      "add",
+      "origin",
+      input.repositoryUrl || `https://github.com/${input.repo}.git`,
+    ], options)
+    await executeGit(["-C", dir, "config", "remote.origin.promisor", "true"], options)
+    await executeGit(["-C", dir, "config", "remote.origin.partialclonefilter", "blob:none"], options)
     await executeGit([
       "-C",
       dir,
@@ -145,12 +211,12 @@ export async function loadGitCheckoutFiles<TKey extends string>(
       "--depth=1",
       "--filter=blob:none",
       "--no-tags",
+      "--",
       "origin",
       `+${input.ref}`,
     ], options)
-    await executeGit(["-C", dir, "checkout", "--quiet", "--detach", "FETCH_HEAD"], options)
-    const sha = (await executeGit(["-C", dir, "rev-parse", "HEAD"], options)).trim()
-    return await readCheckoutFiles(dir, { ...input, sha })
+    const sha = Buffer.from(await executeGit(["-C", dir, "rev-parse", "FETCH_HEAD"], options)).toString("utf8").trim()
+    return await readGitFiles(dir, { ...input, sha }, executeGit, options)
   }
   finally {
     await rm(dir, { force: true, recursive: true })

--- a/packages/source/src/sources/github/git.ts
+++ b/packages/source/src/sources/github/git.ts
@@ -2,18 +2,18 @@ import { Buffer } from "node:buffer"
 import { devNull } from "node:os"
 
 import { normalizeSourcePath } from "../../core/path.ts"
+import { parseGitHubArchive } from "./archive.ts"
 
 import type { GitHubFile } from "./types.ts"
 
 interface GitOptions {
   env?: NodeJS.ProcessEnv
-  input?: string
   signal?: AbortSignal
 }
 
 type GitRunner = (args: string[], options?: GitOptions) => Promise<string | Uint8Array>
 
-interface GitCheckoutInput<TKey extends string> {
+interface GitArchiveInput<TKey extends string> {
   env?: NodeJS.ProcessEnv
   keyForRepoPath: (path: string) => TKey | undefined
   ref: string
@@ -82,7 +82,7 @@ async function runGit(args: string[], options: GitOptions = {}): Promise<Uint8Ar
     child.stdout.on("data", chunk => stdout.push(chunk))
     child.stderr.resume()
     child.stdin.on("error", () => {})
-    child.stdin.end(options.input)
+    child.stdin.end()
     child.on("error", reject)
     child.on("close", (code) => {
       if (code === 0) {
@@ -93,55 +93,6 @@ async function runGit(args: string[], options: GitOptions = {}): Promise<Uint8Ar
       reject(new Error(`git ${command || "command"} exited with ${code ?? "an unknown status"}.`))
     })
   })
-}
-
-interface GitTreeEntry<TKey extends string> {
-  key: TKey
-  oid: string
-}
-
-function parseGitTree<TKey extends string>(
-  output: Uint8Array,
-  input: GitCheckoutInput<TKey>,
-): GitTreeEntry<TKey>[] {
-  return Buffer.from(output).toString("utf8").split("\0")
-    .filter(Boolean)
-    .map((record): GitTreeEntry<TKey> | undefined => {
-      const tab = record.indexOf("\t")
-      if (tab === -1) return
-      const [mode, type, oid] = record.slice(0, tab).split(" ")
-      if (!mode?.startsWith("100") || type !== "blob" || !oid) return
-      const repoPath = record.slice(tab + 1)
-      const key = input.keyForRepoPath(repoPath)
-      if (!key || !input.shouldInclude(key)) return
-      return { key, oid }
-    })
-    .filter(entry => entry !== undefined)
-}
-
-function parseGitBlobs(output: Uint8Array, oids: string[]) {
-  const bytes = Buffer.from(output)
-  const blobs = new Map<string, Buffer>()
-  let offset = 0
-
-  for (const expectedOid of oids) {
-    const newline = bytes.indexOf(10, offset)
-    if (newline === -1) throw new Error("git cat-file returned a truncated header.")
-    const [oid, type, rawSize] = bytes.subarray(offset, newline).toString("ascii").split(" ")
-    const size = Number(rawSize)
-    if (oid !== expectedOid || type !== "blob" || !Number.isSafeInteger(size) || size < 0) {
-      throw new Error("git cat-file returned an unexpected object.")
-    }
-    const contentStart = newline + 1
-    const contentEnd = contentStart + size
-    if (contentEnd >= bytes.length || bytes[contentEnd] !== 10) {
-      throw new Error("git cat-file returned truncated object content.")
-    }
-    blobs.set(oid, Buffer.from(bytes.subarray(contentStart, contentEnd)))
-    offset = contentEnd + 1
-  }
-
-  return blobs
 }
 
 function isGitSparsePattern(pattern: string) {
@@ -162,19 +113,27 @@ export function getGitSparsePatterns(root: string, include?: string | string[]):
   return root && isGitSparsePattern(root) ? [`${root}/**`] : undefined
 }
 
-async function readGitFiles<TKey extends string>(
+function isGitLfsPointer(content: Uint8Array) {
+  if (content.byteLength > 64 * 1024) return false
+  const lines = Buffer.from(content).toString("utf8").split(/\r?\n/)
+  return lines[0] === "version https://git-lfs.github.com/spec/v1"
+    && lines.some(line => /^oid sha256:[0-9a-f]{64}$/.test(line))
+    && lines.some(line => /^size \d+$/.test(line))
+}
+
+async function readGitArchiveFiles<TKey extends string>(
   dir: string,
-  input: GitCheckoutInput<TKey> & { sha: string },
+  input: GitArchiveInput<TKey> & { sha: string },
   executeGit: GitRunner,
   options: GitOptions,
 ): Promise<GitHubFile<TKey>[]> {
   input.signal?.throwIfAborted()
-  const treeOutput = await executeGit([
+  const archive = await executeGit([
     "-C",
     dir,
-    "ls-tree",
-    "-r",
-    "-z",
+    "archive",
+    "--format=tar.gz",
+    "--prefix=archive/",
     input.sha,
     "--",
     ...input.sparsePatterns.map((pattern) => {
@@ -182,27 +141,26 @@ async function readGitFiles<TKey extends string>(
       return `:(literal)${path}`
     }),
   ], options)
-  const entries = parseGitTree(Buffer.from(treeOutput), input)
-  const oids = [...new Set(entries.map(entry => entry.oid))]
-  if (!oids.length) return []
-
-  input.signal?.throwIfAborted()
-  const blobOutput = await executeGit(["-C", dir, "cat-file", "--batch"], {
-    ...options,
-    input: `${oids.join("\n")}\n`,
-  })
-  const blobs = parseGitBlobs(Buffer.from(blobOutput), oids)
-  return entries.map(entry => ({
-    content: blobs.get(entry.oid),
-    key: entry.key,
-    path: entry.key,
-    ref: input.ref,
-    sha: input.sha,
-  }))
+  return parseGitHubArchive(Buffer.from(archive))
+    .map((entry): GitHubFile<TKey> | undefined => {
+      const key = input.keyForRepoPath(entry.path)
+      if (!key || !input.shouldInclude(key)) return
+      if (isGitLfsPointer(entry.content)) {
+        throw new Error("git archive contained a Git LFS pointer; use the GitHub archive instead.")
+      }
+      return {
+        content: entry.content,
+        key,
+        path: key,
+        ref: input.ref,
+        sha: input.sha,
+      }
+    })
+    .filter((file): file is GitHubFile<TKey> => Boolean(file))
 }
 
-export async function loadGitCheckoutFiles<TKey extends string>(
-  input: GitCheckoutInput<TKey>,
+export async function loadGitArchiveFiles<TKey extends string>(
+  input: GitArchiveInput<TKey>,
   executeGit: GitRunner = runGit,
 ): Promise<GitHubFile<TKey>[]> {
   const [{ mkdtemp, rm }, { tmpdir }, { join }] = await Promise.all([
@@ -237,7 +195,7 @@ export async function loadGitCheckoutFiles<TKey extends string>(
       `+${input.ref}`,
     ], options)
     const sha = Buffer.from(await executeGit(["-C", dir, "rev-parse", "FETCH_HEAD"], options)).toString("utf8").trim()
-    return await readGitFiles(dir, { ...input, sha }, executeGit, options)
+    return await readGitArchiveFiles(dir, { ...input, sha }, executeGit, options)
   }
   finally {
     await rm(dir, { force: true, recursive: true })

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -6,6 +6,7 @@ import { matchesAny, normalizeSourcePath } from "../../core/path.ts"
 import { parseGitHubArchive } from "./archive.ts"
 import { createGitHubCacheKey, normalizeGitHubCache } from "./cache.ts"
 import { fetchGitHubArchive, requestGitHubJson } from "./client.ts"
+import { getGitSparsePatterns, loadGitCheckoutFiles } from "./git.ts"
 
 import type { Source, SourceContext } from "../../core/types.ts"
 import type { GitHubCommitResponse, GitHubContentResponse, GitHubFile, GitHubRepositoryResponse, GitHubSourceOptions } from "./types.ts"
@@ -31,6 +32,7 @@ function dedupeProviderPromise<TResult>(
 export function github<const TKey extends string = string>(options: GitHubSourceOptions): Source<TKey> {
   const configuredRef = options.ref
   const root = normalizeGitHubRoot(options.root || "")
+  const sparsePatterns = getGitSparsePatterns(root, options.include)
   let auth: string | undefined
   const providerCache = normalizeGitHubCache(options)
 
@@ -149,6 +151,22 @@ export function github<const TKey extends string = string>(options: GitHubSource
   }
 
   async function loadFiles(token = auth, signal?: AbortSignal) {
+    if (sparsePatterns) {
+      try {
+        return await loadGitCheckoutFiles({
+          keyForRepoPath,
+          ref: configuredRef,
+          repo: options.repo,
+          shouldInclude,
+          signal,
+          sparsePatterns,
+          token,
+        })
+      }
+      catch (error) {
+        if (signal?.aborted) throw error
+      }
+    }
     return await loadArchiveFiles(token, signal)
   }
 

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -6,7 +6,7 @@ import { matchesAny, normalizeSourcePath } from "../../core/path.ts"
 import { parseGitHubArchive } from "./archive.ts"
 import { createGitHubCacheKey, normalizeGitHubCache } from "./cache.ts"
 import { fetchGitHubArchive, requestGitHubJson } from "./client.ts"
-import { getGitSparsePatterns, loadGitCheckoutFiles } from "./git.ts"
+import { getGitSparsePatterns, loadGitArchiveFiles } from "./git.ts"
 
 import type { Source, SourceContext } from "../../core/types.ts"
 import type { GitHubCommitResponse, GitHubContentResponse, GitHubFile, GitHubRepositoryResponse, GitHubSourceOptions } from "./types.ts"
@@ -155,7 +155,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
     const ref = await getRef(token, signal)
     if (sparsePatterns) {
       try {
-        return await loadGitCheckoutFiles({
+        return await loadGitArchiveFiles({
           keyForRepoPath,
           ref,
           repo: options.repo,

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -133,8 +133,8 @@ export function github<const TKey extends string = string>(options: GitHubSource
     })
   }
 
-  async function loadArchiveFiles(token = auth, signal?: AbortSignal) {
-    const ref = await getRef(token, signal)
+  async function loadArchiveFiles(token = auth, signal?: AbortSignal, resolvedRef?: string) {
+    const ref = resolvedRef ?? await getRef(token, signal)
     const archive = await fetchGitHubArchive({ ref, repo: options.repo, signal, token })
     return parseGitHubArchive(archive)
       .map((entry): GitHubFile<TKey> | undefined => {
@@ -144,6 +144,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
           content: entry.content,
           key,
           path: key,
+          ref,
           sha: ref,
         }
       })
@@ -151,11 +152,12 @@ export function github<const TKey extends string = string>(options: GitHubSource
   }
 
   async function loadFiles(token = auth, signal?: AbortSignal) {
+    const ref = await getRef(token, signal)
     if (sparsePatterns) {
       try {
         return await loadGitCheckoutFiles({
           keyForRepoPath,
-          ref: configuredRef,
+          ref,
           repo: options.repo,
           shouldInclude,
           signal,
@@ -167,7 +169,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
         if (signal?.aborted) throw error
       }
     }
-    return await loadArchiveFiles(token, signal)
+    return await loadArchiveFiles(token, signal, ref)
   }
 
   const loadedFiles = new Map<string, Promise<GitHubFile<TKey>[]>>()
@@ -211,7 +213,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
         return
       }
       if (shouldResolveMainFallback(error)) {
-        const files = signal ? await loadArchiveFiles(token, signal) : await getFiles(token)
+        const files = signal ? await loadArchiveFiles(token, signal, ref) : await getFiles(token)
         return files.find(file => file.key === normalizedKey)
       }
       throw error
@@ -221,6 +223,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
     return {
       key: normalizedKey,
       path: normalizedKey,
+      ref,
       sha: file.sha || ref,
     }
   }
@@ -269,6 +272,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
       content: new Uint8Array(Buffer.from(file.content.replace(/\s/g, ""), "base64")),
       key: normalizedKey,
       path: normalizedKey,
+      ref,
       sha: file.sha || ref,
     }
   }
@@ -315,13 +319,12 @@ export function github<const TKey extends string = string>(options: GitHubSource
     },
     async getItems() {
       const token = refreshAuth()
-      const ref = await getRef(token)
       return await Promise.all((await getFiles(token)).map(async file => ({
         key: file.key,
         path: file.path,
         content: await fetchContent(file.key, file),
         metadata: {
-          ref,
+          ref: file.ref,
           sha: file.sha,
         },
       })))
@@ -333,7 +336,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
         : await cachedLoadFileMetadata(key, token)
       if (!file) return
       return {
-        ref: await getRef(token, ctx?.abortSignal),
+        ref: file.ref,
         sha: file.sha,
       }
     },
@@ -345,7 +348,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
         path: file.path,
         content: await fetchContent(key, file),
         metadata: {
-          ref: await getRef(token, ctx?.abortSignal),
+          ref: file.ref,
           sha: file.sha,
         },
       }

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -188,8 +188,8 @@ export function github<const TKey extends string = string>(options: GitHubSource
         () => loadFiles(token),
       )
 
-  function getFiles(token = refreshAuth()) {
-    return cachedLoadFiles(token)
+  function getFiles(token = refreshAuth(), signal?: AbortSignal) {
+    return signal ? loadFiles(token, signal) : cachedLoadFiles(token)
   }
 
   async function loadFileMetadata(key: TKey, token = auth, signal?: AbortSignal): Promise<GitHubFile<TKey> | undefined> {
@@ -314,12 +314,12 @@ export function github<const TKey extends string = string>(options: GitHubSource
       root,
     },
     name: "github",
-    async getKeys() {
-      return (await getFiles()).map(file => file.key)
+    async getKeys(ctx) {
+      return (await getFiles(refreshAuth(), ctx.abortSignal)).map(file => file.key)
     },
-    async getItems() {
+    async getItems(ctx) {
       const token = refreshAuth()
-      return await Promise.all((await getFiles(token)).map(async file => ({
+      return await Promise.all((await getFiles(token, ctx.abortSignal)).map(async file => ({
         key: file.key,
         path: file.path,
         content: await fetchContent(file.key, file),

--- a/packages/source/src/sources/github/types.ts
+++ b/packages/source/src/sources/github/types.ts
@@ -22,6 +22,7 @@ export interface GitHubFile<TKey extends string = string> {
   content?: Uint8Array
   key: TKey
   path: string
+  ref: string
   sha: string | undefined
 }
 

--- a/packages/source/test/sources/github-git.test.ts
+++ b/packages/source/test/sources/github-git.test.ts
@@ -36,6 +36,13 @@ describe("@vite-hub/source GitHub git materialization", () => {
     }
 
     const files = await loadGitCheckoutFiles({
+      env: {
+        ...process.env,
+        GIT_COMMON_DIR: "/outside/common",
+        GIT_DIR: "/outside/repository",
+        GIT_INDEX_FILE: "/outside/index",
+        GIT_WORK_TREE: "/outside/worktree",
+      },
       keyForRepoPath(path) {
         const root = "server/workspaces/mirror/"
         return path.startsWith(root) ? path.slice(root.length) : undefined
@@ -82,6 +89,10 @@ describe("@vite-hub/source GitHub git materialization", () => {
     expect(env?.GIT_CONFIG_GLOBAL).toBe(devNull)
     expect(env?.GIT_CONFIG_NOSYSTEM).toBe("1")
     expect(env?.GIT_TERMINAL_PROMPT).toBe("0")
+    expect(env?.GIT_COMMON_DIR).toBeUndefined()
+    expect(env?.GIT_DIR).toBeUndefined()
+    expect(env?.GIT_INDEX_FILE).toBeUndefined()
+    expect(env?.GIT_WORK_TREE).toBeUndefined()
     expect(env?.GIT_CONFIG_VALUE_0).toBe(
       `AUTHORIZATION: basic ${Buffer.from("x-access-token:github-token").toString("base64")}`,
     )
@@ -104,8 +115,8 @@ describe("@vite-hub/source GitHub git materialization", () => {
       "-z",
       "checkout-sha",
       "--",
-      "server/workspaces/mirror/data/tasks.jsonl",
-      "server/workspaces/mirror/docs",
+      ":(literal)server/workspaces/mirror/data/tasks.jsonl",
+      ":(literal)server/workspaces/mirror/docs",
     ])
     expect(calls.find(call => call.args[2] === "cat-file")?.options.input).toBe(
       `${"a".repeat(40)}\n${"b".repeat(40)}\n`,
@@ -177,6 +188,28 @@ describe("@vite-hub/source GitHub git materialization", () => {
     }
   })
 
+  it("treats selected Source paths beginning with a colon as literal Git paths", async () => {
+    const fixture = await createGitRemote()
+    try {
+      const files = await loadGitCheckoutFiles({
+        keyForRepoPath: path => path,
+        ref: "main",
+        repo: "local/fixture",
+        repositoryUrl: fixture.remote,
+        shouldInclude: () => true,
+        sparsePatterns: [":README.md", ":/README.md"],
+      })
+
+      expect(files.map(file => [file.path, Buffer.from(file.content || []).toString("utf8")])).toEqual([
+        [":/README.md", "nested colon\n"],
+        [":README.md", "colon\n"],
+      ])
+    }
+    finally {
+      await rm(fixture.root, { force: true, recursive: true })
+    }
+  })
+
   it("does not send ambient Git credentials when no Source token is configured", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-git-auth-test-"))
     const helperMarker = join(root, "credential-helper-ran")
@@ -241,12 +274,15 @@ async function createGitRemote() {
   const remote = join(root, "remote.git")
   const execute = promisify(execFile)
   await mkdir(join(source, "docs"), { recursive: true })
+  await mkdir(join(source, ":"), { recursive: true })
   await execute("git", ["init", "--quiet", "--initial-branch=main", source])
   await execute("git", ["-C", source, "config", "user.email", "fixture@example.com"])
   await execute("git", ["-C", source, "config", "user.name", "Fixture"])
   await writeFile(join(source, ".gitattributes"), "*.txt text eol=crlf\n*.dat filter=danger\n")
   await writeFile(join(source, "docs", "filter.dat"), "original\n")
   await writeFile(join(source, "docs", "lines.txt"), "line one\nline two\n")
+  await writeFile(join(source, ":README.md"), "colon\n")
+  await writeFile(join(source, ":", "README.md"), "nested colon\n")
   await execute("git", ["-C", source, "add", "."])
   await execute("git", ["-C", source, "commit", "--quiet", "-m", "fixture"])
   await execute("git", ["clone", "--quiet", "--bare", source, remote])

--- a/packages/source/test/sources/github-git.test.ts
+++ b/packages/source/test/sources/github-git.test.ts
@@ -7,35 +7,30 @@ import { promisify } from "node:util"
 
 import { describe, expect, it } from "vitest"
 
-import { getGitSparsePatterns, loadGitCheckoutFiles } from "../../src/sources/github/git.ts"
+import { getGitSparsePatterns, loadGitArchiveFiles } from "../../src/sources/github/git.ts"
+import { createTarGz } from "./fixtures/github.ts"
 
 describe("@vite-hub/source GitHub git materialization", () => {
-  it("reads simple sparse source paths from Git objects without putting auth in git arguments", async () => {
+  it("archives simple sparse source paths without putting auth in git arguments", async () => {
     const calls: Array<{
       args: string[]
-      options: { env?: NodeJS.ProcessEnv, input?: string, signal?: AbortSignal }
+      options: { env?: NodeJS.ProcessEnv, signal?: AbortSignal }
     }> = []
     const signal = new AbortController().signal
-    const runGit: NonNullable<Parameters<typeof loadGitCheckoutFiles>[1]> = async (args, options = {}) => {
+    const runGit: NonNullable<Parameters<typeof loadGitArchiveFiles>[1]> = async (args, options = {}) => {
       calls.push({ args, options })
       if (args[2] === "rev-parse") return "checkout-sha\n"
-      if (args[2] === "ls-tree") {
-        return createGitTree([
-          ["a".repeat(40), "server/workspaces/mirror/data/tasks.jsonl"],
-          ["b".repeat(40), "server/workspaces/mirror/docs/guide.md"],
-          ["c".repeat(40), "server/workspaces/mirror/docs/private.md"],
-        ])
-      }
-      if (args[2] === "cat-file") {
-        return createGitBatch([
-          ["a".repeat(40), Buffer.from("{\"id\":1}\n")],
-          ["b".repeat(40), Buffer.from("# Guide\n")],
-        ])
+      if (args[2] === "archive") {
+        return createTarGz({
+          "server/workspaces/mirror/data/tasks.jsonl": "{\"id\":1}\n",
+          "server/workspaces/mirror/docs/guide.md": "# Guide\n",
+          "server/workspaces/mirror/docs/private.md": "private\n",
+        })
       }
       return ""
     }
 
-    const files = await loadGitCheckoutFiles({
+    const files = await loadGitArchiveFiles({
       env: {
         ...process.env,
         GIT_COMMON_DIR: "/outside/common",
@@ -60,14 +55,14 @@ describe("@vite-hub/source GitHub git materialization", () => {
 
     expect(files).toEqual([
       {
-        content: Buffer.from("{\"id\":1}\n"),
+        content: new Uint8Array(Buffer.from("{\"id\":1}\n")),
         key: "data/tasks.jsonl",
         path: "data/tasks.jsonl",
         ref: "main",
         sha: "checkout-sha",
       },
       {
-        content: Buffer.from("# Guide\n"),
+        content: new Uint8Array(Buffer.from("# Guide\n")),
         key: "docs/guide.md",
         path: "docs/guide.md",
         ref: "main",
@@ -110,17 +105,14 @@ describe("@vite-hub/source GitHub git materialization", () => {
     expect(calls.map(call => call.args)).toContainEqual([
       "-C",
       expect.any(String),
-      "ls-tree",
-      "-r",
-      "-z",
+      "archive",
+      "--format=tar.gz",
+      "--prefix=archive/",
       "checkout-sha",
       "--",
       ":(literal)server/workspaces/mirror/data/tasks.jsonl",
       ":(literal)server/workspaces/mirror/docs",
     ])
-    expect(calls.find(call => call.args[2] === "cat-file")?.options.input).toBe(
-      `${"a".repeat(40)}\n${"b".repeat(40)}\n`,
-    )
     expect(calls.some(call => call.args.includes("checkout"))).toBe(false)
   })
 
@@ -137,13 +129,13 @@ describe("@vite-hub/source GitHub git materialization", () => {
   it("propagates aborts and removes the temporary checkout", async () => {
     const controller = new AbortController()
     let checkoutDir: string | undefined
-    const runGit: NonNullable<Parameters<typeof loadGitCheckoutFiles>[1]> = async (args) => {
+    const runGit: NonNullable<Parameters<typeof loadGitArchiveFiles>[1]> = async (args) => {
       checkoutDir = args.at(-1)
       controller.abort()
       throw controller.signal.reason
     }
 
-    await expect(loadGitCheckoutFiles({
+    await expect(loadGitArchiveFiles({
       keyForRepoPath: path => path,
       ref: "main",
       repo: "acme/app",
@@ -156,11 +148,11 @@ describe("@vite-hub/source GitHub git materialization", () => {
     await expect(access(checkoutDir)).rejects.toMatchObject({ code: "ENOENT" })
   })
 
-  it("uses committed bytes without checkout conversions or ambient smudge filters", async () => {
+  it("honors Git archive attributes without running ambient smudge filters", async () => {
     const fixture = await createGitRemote()
     const marker = join(fixture.root, "smudge-ran")
     try {
-      const files = await loadGitCheckoutFiles({
+      const files = await loadGitArchiveFiles({
         env: {
           ...process.env,
           GIT_CONFIG_COUNT: "2",
@@ -179,7 +171,8 @@ describe("@vite-hub/source GitHub git materialization", () => {
 
       expect(files.map(file => [file.path, Buffer.from(file.content || [])])).toEqual([
         ["docs/filter.dat", Buffer.from("original\n")],
-        ["docs/lines.txt", Buffer.from("line one\nline two\n")],
+        ["docs/lines.txt", Buffer.from("line one\r\nline two\r\n")],
+        ["docs/template.txt", Buffer.from(`${fixture.sha}\r\n`)],
       ])
       await expect(access(marker)).rejects.toMatchObject({ code: "ENOENT" })
     }
@@ -191,7 +184,7 @@ describe("@vite-hub/source GitHub git materialization", () => {
   it("treats selected Source paths beginning with a colon as literal Git paths", async () => {
     const fixture = await createGitRemote()
     try {
-      const files = await loadGitCheckoutFiles({
+      const files = await loadGitArchiveFiles({
         keyForRepoPath: path => path,
         ref: "main",
         repo: "local/fixture",
@@ -204,6 +197,23 @@ describe("@vite-hub/source GitHub git materialization", () => {
         [":/README.md", "nested colon\n"],
         [":README.md", "colon\n"],
       ])
+    }
+    finally {
+      await rm(fixture.root, { force: true, recursive: true })
+    }
+  })
+
+  it("falls back instead of returning a Git LFS pointer", async () => {
+    const fixture = await createGitRemote()
+    try {
+      await expect(loadGitArchiveFiles({
+        keyForRepoPath: path => path,
+        ref: "main",
+        repo: "local/fixture",
+        repositoryUrl: fixture.remote,
+        shouldInclude: () => true,
+        sparsePatterns: ["assets/**"],
+      })).rejects.toThrow("Git LFS pointer")
     }
     finally {
       await rm(fixture.root, { force: true, recursive: true })
@@ -227,7 +237,7 @@ describe("@vite-hub/source GitHub git materialization", () => {
     if (!address || typeof address === "string") throw new Error("Expected an HTTP fixture port.")
 
     try {
-      await expect(loadGitCheckoutFiles({
+      await expect(loadGitArchiveFiles({
         env: {
           ...process.env,
           GIT_CONFIG_COUNT: "2",
@@ -256,36 +266,42 @@ describe("@vite-hub/source GitHub git materialization", () => {
   })
 })
 
-function createGitTree(entries: Array<[oid: string, path: string]>) {
-  return Buffer.from(entries.map(([oid, path]) => `100644 blob ${oid}\t${path}\0`).join(""))
-}
-
-function createGitBatch(entries: Array<[oid: string, content: Uint8Array]>) {
-  return Buffer.concat(entries.flatMap(([oid, content]) => [
-    Buffer.from(`${oid} blob ${content.byteLength}\n`),
-    Buffer.from(content),
-    Buffer.from("\n"),
-  ]))
-}
-
 async function createGitRemote() {
   const root = await mkdtemp(join(tmpdir(), "vitehub-git-bytes-test-"))
   const source = join(root, "source")
   const remote = join(root, "remote.git")
   const execute = promisify(execFile)
   await mkdir(join(source, "docs"), { recursive: true })
+  await mkdir(join(source, "assets"), { recursive: true })
   await mkdir(join(source, ":"), { recursive: true })
   await execute("git", ["init", "--quiet", "--initial-branch=main", source])
   await execute("git", ["-C", source, "config", "user.email", "fixture@example.com"])
   await execute("git", ["-C", source, "config", "user.name", "Fixture"])
-  await writeFile(join(source, ".gitattributes"), "*.txt text eol=crlf\n*.dat filter=danger\n")
+  await writeFile(join(source, ".gitattributes"), [
+    "*.txt text eol=crlf",
+    "*.dat filter=danger",
+    "docs/private.md export-ignore",
+    "docs/template.txt export-subst",
+    "assets/*.bin filter=lfs diff=lfs merge=lfs -text",
+    "",
+  ].join("\n"))
+  await writeFile(join(source, "assets", "large.bin"), [
+    "version https://git-lfs.github.com/spec/v1",
+    `oid sha256:${"a".repeat(64)}`,
+    "size 1234",
+    "",
+  ].join("\n"))
   await writeFile(join(source, "docs", "filter.dat"), "original\n")
   await writeFile(join(source, "docs", "lines.txt"), "line one\nline two\n")
+  await writeFile(join(source, "docs", "private.md"), "private\n")
+  await writeFile(join(source, "docs", "template.txt"), "$Format:%H$\n")
   await writeFile(join(source, ":README.md"), "colon\n")
   await writeFile(join(source, ":", "README.md"), "nested colon\n")
   await execute("git", ["-C", source, "add", "."])
   await execute("git", ["-C", source, "commit", "--quiet", "-m", "fixture"])
+  const { stdout } = await execute("git", ["-C", source, "rev-parse", "HEAD"])
+  const sha = stdout.trim()
   await execute("git", ["clone", "--quiet", "--bare", source, remote])
   await execute("git", ["--git-dir", remote, "config", "uploadpack.allowFilter", "true"])
-  return { remote, root }
+  return { remote, root, sha }
 }

--- a/packages/source/test/sources/github-git.test.ts
+++ b/packages/source/test/sources/github-git.test.ts
@@ -1,28 +1,38 @@
-import { access, mkdir, readFile, writeFile } from "node:fs/promises"
-import { dirname, join } from "node:path"
+import { execFile } from "node:child_process"
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { createServer } from "node:http"
+import { devNull, tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
 
 import { describe, expect, it } from "vitest"
 
 import { getGitSparsePatterns, loadGitCheckoutFiles } from "../../src/sources/github/git.ts"
 
 describe("@vite-hub/source GitHub git materialization", () => {
-  it("checks out and reads simple sparse source paths without putting auth in git arguments", async () => {
-    const calls: Array<{ args: string[], options: { env?: NodeJS.ProcessEnv, signal?: AbortSignal } }> = []
-    let sparseCheckout = ""
+  it("reads simple sparse source paths from Git objects without putting auth in git arguments", async () => {
+    const calls: Array<{
+      args: string[]
+      options: { env?: NodeJS.ProcessEnv, input?: string, signal?: AbortSignal }
+    }> = []
     const signal = new AbortController().signal
     const runGit: NonNullable<Parameters<typeof loadGitCheckoutFiles>[1]> = async (args, options = {}) => {
       calls.push({ args, options })
-      const dir = args[0] === "-C" ? args[1] : undefined
-      if (args[2] === "fetch" && dir) {
-        sparseCheckout = await readFile(join(dir, ".git", "info", "sparse-checkout"), "utf8")
+      if (args[2] === "rev-parse") return "checkout-sha\n"
+      if (args[2] === "ls-tree") {
+        return createGitTree([
+          ["a".repeat(40), "server/workspaces/mirror/data/tasks.jsonl"],
+          ["b".repeat(40), "server/workspaces/mirror/docs/guide.md"],
+          ["c".repeat(40), "server/workspaces/mirror/docs/private.md"],
+        ])
       }
-      if (args[2] === "checkout" && dir) {
-        await writeCheckoutFile(dir, "server/workspaces/mirror/data/tasks.jsonl", "{\"id\":1}\n")
-        await writeCheckoutFile(dir, "server/workspaces/mirror/docs/guide.md", "# Guide\n")
-        await writeCheckoutFile(dir, "server/workspaces/mirror/docs/private.md", "# Private\n")
-        await writeCheckoutFile(dir, "outside.md", "outside\n")
+      if (args[2] === "cat-file") {
+        return createGitBatch([
+          ["a".repeat(40), Buffer.from("{\"id\":1}\n")],
+          ["b".repeat(40), Buffer.from("# Guide\n")],
+        ])
       }
-      return args[2] === "rev-parse" ? "checkout-sha\n" : ""
+      return ""
     }
 
     const files = await loadGitCheckoutFiles({
@@ -57,11 +67,6 @@ describe("@vite-hub/source GitHub git materialization", () => {
         sha: "checkout-sha",
       },
     ])
-    expect(sparseCheckout).toBe([
-      "/server/workspaces/mirror/data/tasks.jsonl",
-      "/server/workspaces/mirror/docs/**",
-      "",
-    ].join("\n"))
     expect(calls.map(call => call.args)).toContainEqual([
       "-C",
       expect.any(String),
@@ -73,8 +78,11 @@ describe("@vite-hub/source GitHub git materialization", () => {
     expect(calls.every(call => call.options.signal === signal)).toBe(true)
     expect(JSON.stringify(calls.map(call => call.args))).not.toContain("github-token")
     const env = calls[0]?.options.env
-    const credentialIndex = Number(env?.GIT_CONFIG_COUNT) - 1
-    expect(env?.[`GIT_CONFIG_VALUE_${credentialIndex}`]).toBe(
+    expect(env?.GIT_CONFIG_COUNT).toBe("1")
+    expect(env?.GIT_CONFIG_GLOBAL).toBe(devNull)
+    expect(env?.GIT_CONFIG_NOSYSTEM).toBe("1")
+    expect(env?.GIT_TERMINAL_PROMPT).toBe("0")
+    expect(env?.GIT_CONFIG_VALUE_0).toBe(
       `AUTHORIZATION: basic ${Buffer.from("x-access-token:github-token").toString("base64")}`,
     )
     expect(calls.map(call => call.args)).toContainEqual([
@@ -84,9 +92,25 @@ describe("@vite-hub/source GitHub git materialization", () => {
       "--depth=1",
       "--filter=blob:none",
       "--no-tags",
+      "--",
       "origin",
       "+main",
     ])
+    expect(calls.map(call => call.args)).toContainEqual([
+      "-C",
+      expect.any(String),
+      "ls-tree",
+      "-r",
+      "-z",
+      "checkout-sha",
+      "--",
+      "server/workspaces/mirror/data/tasks.jsonl",
+      "server/workspaces/mirror/docs",
+    ])
+    expect(calls.find(call => call.args[2] === "cat-file")?.options.input).toBe(
+      `${"a".repeat(40)}\n${"b".repeat(40)}\n`,
+    )
+    expect(calls.some(call => call.args.includes("checkout"))).toBe(false)
   })
 
   it("only accepts sparse patterns that preserve Source include semantics", () => {
@@ -120,10 +144,112 @@ describe("@vite-hub/source GitHub git materialization", () => {
     if (!checkoutDir) throw new Error("Expected git init to receive the temporary checkout path.")
     await expect(access(checkoutDir)).rejects.toMatchObject({ code: "ENOENT" })
   })
+
+  it("uses committed bytes without checkout conversions or ambient smudge filters", async () => {
+    const fixture = await createGitRemote()
+    const marker = join(fixture.root, "smudge-ran")
+    try {
+      const files = await loadGitCheckoutFiles({
+        env: {
+          ...process.env,
+          GIT_CONFIG_COUNT: "2",
+          GIT_CONFIG_KEY_0: "filter.danger.smudge",
+          GIT_CONFIG_KEY_1: "filter.danger.required",
+          GIT_CONFIG_VALUE_0: `touch ${marker}; cat`,
+          GIT_CONFIG_VALUE_1: "true",
+        },
+        keyForRepoPath: path => path,
+        ref: "main",
+        repo: "local/fixture",
+        repositoryUrl: fixture.remote,
+        shouldInclude: () => true,
+        sparsePatterns: ["docs/**"],
+      })
+
+      expect(files.map(file => [file.path, Buffer.from(file.content || [])])).toEqual([
+        ["docs/filter.dat", Buffer.from("original\n")],
+        ["docs/lines.txt", Buffer.from("line one\nline two\n")],
+      ])
+      await expect(access(marker)).rejects.toMatchObject({ code: "ENOENT" })
+    }
+    finally {
+      await rm(fixture.root, { force: true, recursive: true })
+    }
+  })
+
+  it("does not send ambient Git credentials when no Source token is configured", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-git-auth-test-"))
+    const helperMarker = join(root, "credential-helper-ran")
+    const requests: Array<Record<string, string | string[] | undefined>> = []
+    const server = createServer((request, response) => {
+      requests.push(request.headers)
+      response.writeHead(401, { "WWW-Authenticate": "Basic realm=fixture" })
+      response.end()
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject)
+      server.listen(0, "127.0.0.1", resolve)
+    })
+    const address = server.address()
+    if (!address || typeof address === "string") throw new Error("Expected an HTTP fixture port.")
+
+    try {
+      await expect(loadGitCheckoutFiles({
+        env: {
+          ...process.env,
+          GIT_CONFIG_COUNT: "2",
+          GIT_CONFIG_KEY_0: "http.extraHeader",
+          GIT_CONFIG_KEY_1: "credential.helper",
+          GIT_CONFIG_VALUE_0: "X-Ambient-Credential: secret",
+          GIT_CONFIG_VALUE_1: `!touch ${helperMarker}`,
+        },
+        keyForRepoPath: path => path,
+        ref: "main",
+        repo: "local/auth-fixture",
+        repositoryUrl: `http://127.0.0.1:${address.port}/repo.git`,
+        shouldInclude: () => true,
+        sparsePatterns: ["README.md"],
+      })).rejects.toThrow("git fetch exited")
+
+      expect(requests.length).toBeGreaterThan(0)
+      expect(requests.every(headers => headers["x-ambient-credential"] === undefined)).toBe(true)
+      expect(requests.every(headers => headers.authorization === undefined)).toBe(true)
+      await expect(access(helperMarker)).rejects.toMatchObject({ code: "ENOENT" })
+    }
+    finally {
+      await new Promise<void>(resolve => server.close(() => resolve()))
+      await rm(root, { force: true, recursive: true })
+    }
+  })
 })
 
-async function writeCheckoutFile(dir: string, path: string, content: string) {
-  const file = join(dir, path)
-  await mkdir(dirname(file), { recursive: true })
-  await writeFile(file, content)
+function createGitTree(entries: Array<[oid: string, path: string]>) {
+  return Buffer.from(entries.map(([oid, path]) => `100644 blob ${oid}\t${path}\0`).join(""))
+}
+
+function createGitBatch(entries: Array<[oid: string, content: Uint8Array]>) {
+  return Buffer.concat(entries.flatMap(([oid, content]) => [
+    Buffer.from(`${oid} blob ${content.byteLength}\n`),
+    Buffer.from(content),
+    Buffer.from("\n"),
+  ]))
+}
+
+async function createGitRemote() {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-git-bytes-test-"))
+  const source = join(root, "source")
+  const remote = join(root, "remote.git")
+  const execute = promisify(execFile)
+  await mkdir(join(source, "docs"), { recursive: true })
+  await execute("git", ["init", "--quiet", "--initial-branch=main", source])
+  await execute("git", ["-C", source, "config", "user.email", "fixture@example.com"])
+  await execute("git", ["-C", source, "config", "user.name", "Fixture"])
+  await writeFile(join(source, ".gitattributes"), "*.txt text eol=crlf\n*.dat filter=danger\n")
+  await writeFile(join(source, "docs", "filter.dat"), "original\n")
+  await writeFile(join(source, "docs", "lines.txt"), "line one\nline two\n")
+  await execute("git", ["-C", source, "add", "."])
+  await execute("git", ["-C", source, "commit", "--quiet", "-m", "fixture"])
+  await execute("git", ["clone", "--quiet", "--bare", source, remote])
+  await execute("git", ["--git-dir", remote, "config", "uploadpack.allowFilter", "true"])
+  return { remote, root }
 }

--- a/packages/source/test/sources/github-git.test.ts
+++ b/packages/source/test/sources/github-git.test.ts
@@ -1,0 +1,125 @@
+import { access, mkdir, readFile, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import { getGitSparsePatterns, loadGitCheckoutFiles } from "../../src/sources/github/git.ts"
+
+describe("@vite-hub/source GitHub git materialization", () => {
+  it("checks out and reads simple sparse source paths without putting auth in git arguments", async () => {
+    const calls: Array<{ args: string[], options: { env?: NodeJS.ProcessEnv, signal?: AbortSignal } }> = []
+    let sparseCheckout = ""
+    const signal = new AbortController().signal
+    const runGit: NonNullable<Parameters<typeof loadGitCheckoutFiles>[1]> = async (args, options = {}) => {
+      calls.push({ args, options })
+      const dir = args[0] === "-C" ? args[1] : undefined
+      if (args[2] === "fetch" && dir) {
+        sparseCheckout = await readFile(join(dir, ".git", "info", "sparse-checkout"), "utf8")
+      }
+      if (args[2] === "checkout" && dir) {
+        await writeCheckoutFile(dir, "server/workspaces/mirror/data/tasks.jsonl", "{\"id\":1}\n")
+        await writeCheckoutFile(dir, "server/workspaces/mirror/docs/guide.md", "# Guide\n")
+        await writeCheckoutFile(dir, "server/workspaces/mirror/docs/private.md", "# Private\n")
+        await writeCheckoutFile(dir, "outside.md", "outside\n")
+      }
+      return args[2] === "rev-parse" ? "checkout-sha\n" : ""
+    }
+
+    const files = await loadGitCheckoutFiles({
+      keyForRepoPath(path) {
+        const root = "server/workspaces/mirror/"
+        return path.startsWith(root) ? path.slice(root.length) : undefined
+      },
+      ref: "main",
+      repo: "acme/private",
+      shouldInclude: key => key !== "docs/private.md",
+      signal,
+      sparsePatterns: [
+        "server/workspaces/mirror/data/tasks.jsonl",
+        "server/workspaces/mirror/docs/**",
+      ],
+      token: "github-token",
+    }, runGit)
+
+    expect(files).toEqual([
+      {
+        content: Buffer.from("{\"id\":1}\n"),
+        key: "data/tasks.jsonl",
+        path: "data/tasks.jsonl",
+        sha: "checkout-sha",
+      },
+      {
+        content: Buffer.from("# Guide\n"),
+        key: "docs/guide.md",
+        path: "docs/guide.md",
+        sha: "checkout-sha",
+      },
+    ])
+    expect(sparseCheckout).toBe([
+      "/server/workspaces/mirror/data/tasks.jsonl",
+      "/server/workspaces/mirror/docs/**",
+      "",
+    ].join("\n"))
+    expect(calls.map(call => call.args)).toContainEqual([
+      "-C",
+      expect.any(String),
+      "remote",
+      "add",
+      "origin",
+      "https://github.com/acme/private.git",
+    ])
+    expect(calls.every(call => call.options.signal === signal)).toBe(true)
+    expect(JSON.stringify(calls.map(call => call.args))).not.toContain("github-token")
+    const env = calls[0]?.options.env
+    const credentialIndex = Number(env?.GIT_CONFIG_COUNT) - 1
+    expect(env?.[`GIT_CONFIG_VALUE_${credentialIndex}`]).toBe(
+      `AUTHORIZATION: basic ${Buffer.from("x-access-token:github-token").toString("base64")}`,
+    )
+    expect(calls.map(call => call.args)).toContainEqual([
+      "-C",
+      expect.any(String),
+      "fetch",
+      "--depth=1",
+      "--filter=blob:none",
+      "--no-tags",
+      "origin",
+      "+main",
+    ])
+  })
+
+  it("only accepts sparse patterns that preserve Source include semantics", () => {
+    expect(getGitSparsePatterns("docs", undefined)).toEqual(["docs/**"])
+    expect(getGitSparsePatterns("", ["README.md", "docs/**", "docs/**"])).toEqual(["README.md", "docs/**"])
+    expect(getGitSparsePatterns("dbt", ["models/**/*.sql"])).toBeUndefined()
+    expect(getGitSparsePatterns("", ["src/*.{ts,tsx}"])).toBeUndefined()
+    expect(getGitSparsePatterns("", ["docs/**\noutside/**"])).toBeUndefined()
+    expect(getGitSparsePatterns("", undefined)).toBeUndefined()
+  })
+
+  it("propagates aborts and removes the temporary checkout", async () => {
+    const controller = new AbortController()
+    let checkoutDir: string | undefined
+    const runGit: NonNullable<Parameters<typeof loadGitCheckoutFiles>[1]> = async (args) => {
+      checkoutDir = args.at(-1)
+      controller.abort()
+      throw controller.signal.reason
+    }
+
+    await expect(loadGitCheckoutFiles({
+      keyForRepoPath: path => path,
+      repo: "acme/app",
+      shouldInclude: () => true,
+      signal: controller.signal,
+      sparsePatterns: ["docs/**"],
+    }, runGit)).rejects.toMatchObject({ name: "AbortError" })
+
+    if (!checkoutDir) throw new Error("Expected git init to receive the temporary checkout path.")
+    await expect(access(checkoutDir)).rejects.toMatchObject({ code: "ENOENT" })
+  })
+})
+
+async function writeCheckoutFile(dir: string, path: string, content: string) {
+  const file = join(dir, path)
+  await mkdir(dirname(file), { recursive: true })
+  await writeFile(file, content)
+}

--- a/packages/source/test/sources/github-git.test.ts
+++ b/packages/source/test/sources/github-git.test.ts
@@ -46,12 +46,14 @@ describe("@vite-hub/source GitHub git materialization", () => {
         content: Buffer.from("{\"id\":1}\n"),
         key: "data/tasks.jsonl",
         path: "data/tasks.jsonl",
+        ref: "main",
         sha: "checkout-sha",
       },
       {
         content: Buffer.from("# Guide\n"),
         key: "docs/guide.md",
         path: "docs/guide.md",
+        ref: "main",
         sha: "checkout-sha",
       },
     ])
@@ -89,6 +91,7 @@ describe("@vite-hub/source GitHub git materialization", () => {
 
   it("only accepts sparse patterns that preserve Source include semantics", () => {
     expect(getGitSparsePatterns("docs", undefined)).toEqual(["docs/**"])
+    expect(getGitSparsePatterns("docs", "/README.md")).toEqual(["docs/README.md"])
     expect(getGitSparsePatterns("", ["README.md", "docs/**", "docs/**"])).toEqual(["README.md", "docs/**"])
     expect(getGitSparsePatterns("dbt", ["models/**/*.sql"])).toBeUndefined()
     expect(getGitSparsePatterns("", ["src/*.{ts,tsx}"])).toBeUndefined()
@@ -107,6 +110,7 @@ describe("@vite-hub/source GitHub git materialization", () => {
 
     await expect(loadGitCheckoutFiles({
       keyForRepoPath: path => path,
+      ref: "main",
       repo: "acme/app",
       shouldInclude: () => true,
       signal: controller.signal,

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -30,6 +30,7 @@ describe("@vite-hub/source GitHub source", () => {
         content: new TextEncoder().encode("# Docs\n"),
         key: "docs/README.md",
         path: "docs/README.md",
+        ref: "main",
         sha: "checkout-sha",
       },
     ])
@@ -56,6 +57,43 @@ describe("@vite-hub/source GitHub source", () => {
       token: "github-token",
     }))
     expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("pins cached default-ref git materialization to the resolved commit", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url)
+      if (requestUrl === "https://api.github.com/repos/acme/app") {
+        return jsonResponse({ default_branch: "main" })
+      }
+      if (requestUrl.endsWith("/commits/main")) {
+        return jsonResponse({ sha: "first-commit" })
+      }
+      throw new Error(`Unexpected GitHub request: ${requestUrl}`)
+    }))
+    loadGitCheckoutFiles.mockImplementationOnce(async input => [{
+      content: new TextEncoder().encode("first\n"),
+      key: "README.md",
+      path: "README.md",
+      ref: input.ref,
+      sha: "first-commit",
+    }])
+
+    const source = github({
+      cache: { maxAge: 3600 },
+      include: "README.md",
+      repo: "acme/app",
+    })
+
+    await expect(source.getKeys({ rootDir: process.cwd() })).resolves.toEqual(["README.md"])
+    await expect(source.getItems?.({ rootDir: process.cwd() })).resolves.toEqual([{
+      content: new TextEncoder().encode("first\n"),
+      key: "README.md",
+      metadata: { ref: "first-commit", sha: "first-commit" },
+      path: "README.md",
+    }])
+    expect(loadGitCheckoutFiles).toHaveBeenCalledOnce()
+    expect(loadGitCheckoutFiles).toHaveBeenCalledWith(expect.objectContaining({ ref: "first-commit" }))
+    expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith("/commits/main"))).toHaveLength(1)
   })
 
   it("falls back to the GitHub archive when git materialization fails", async () => {

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -4,16 +4,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { clearSources, github, registerSources, useSource } from "../../src/index.ts"
 import { createTarGz, jsonResponse, stubGitHubSource } from "./fixtures/github.ts"
 
-const loadGitCheckoutFiles = vi.hoisted(() => vi.fn())
+const loadGitArchiveFiles = vi.hoisted(() => vi.fn())
 
 vi.mock("../../src/sources/github/git.ts", async (importOriginal) => ({
   ...await importOriginal<typeof import("../../src/sources/github/git.ts")>(),
-  loadGitCheckoutFiles,
+  loadGitArchiveFiles,
 }))
 
 beforeEach(() => {
-  loadGitCheckoutFiles.mockReset()
-  loadGitCheckoutFiles.mockRejectedValue(new Error("git unavailable"))
+  loadGitArchiveFiles.mockReset()
+  loadGitArchiveFiles.mockRejectedValue(new Error("git unavailable"))
 })
 
 afterEach(() => {
@@ -25,7 +25,7 @@ afterEach(() => {
 describe("@vite-hub/source GitHub source", () => {
   it("materializes simple GitHub source paths with git", async () => {
     vi.stubGlobal("fetch", vi.fn())
-    loadGitCheckoutFiles.mockResolvedValueOnce([
+    loadGitArchiveFiles.mockResolvedValueOnce([
       {
         content: new TextEncoder().encode("# Docs\n"),
         key: "docs/README.md",
@@ -50,7 +50,7 @@ describe("@vite-hub/source GitHub source", () => {
         path: "docs/README.md",
       },
     ])
-    expect(loadGitCheckoutFiles).toHaveBeenCalledWith(expect.objectContaining({
+    expect(loadGitArchiveFiles).toHaveBeenCalledWith(expect.objectContaining({
       ref: "main",
       repo: "acme/app",
       sparsePatterns: ["docs/**"],
@@ -62,7 +62,7 @@ describe("@vite-hub/source GitHub source", () => {
   it("passes bulk Source abort signals to git materialization", async () => {
     vi.stubGlobal("fetch", vi.fn())
     const controller = new AbortController()
-    loadGitCheckoutFiles.mockResolvedValue([{
+    loadGitArchiveFiles.mockResolvedValue([{
       content: new TextEncoder().encode("# Docs\n"),
       key: "docs/README.md",
       path: "docs/README.md",
@@ -75,8 +75,8 @@ describe("@vite-hub/source GitHub source", () => {
     await expect(docs.getKeys(ctx)).resolves.toEqual(["docs/README.md"])
     await expect(docs.getItems?.(ctx)).resolves.toHaveLength(1)
 
-    expect(loadGitCheckoutFiles).toHaveBeenCalledTimes(2)
-    expect(loadGitCheckoutFiles.mock.calls.every(([input]) => input.signal === controller.signal)).toBe(true)
+    expect(loadGitArchiveFiles).toHaveBeenCalledTimes(2)
+    expect(loadGitArchiveFiles.mock.calls.every(([input]) => input.signal === controller.signal)).toBe(true)
   })
 
   it("pins cached default-ref git materialization to the resolved commit", async () => {
@@ -90,7 +90,7 @@ describe("@vite-hub/source GitHub source", () => {
       }
       throw new Error(`Unexpected GitHub request: ${requestUrl}`)
     }))
-    loadGitCheckoutFiles.mockImplementationOnce(async input => [{
+    loadGitArchiveFiles.mockImplementationOnce(async input => [{
       content: new TextEncoder().encode("first\n"),
       key: "README.md",
       path: "README.md",
@@ -111,8 +111,8 @@ describe("@vite-hub/source GitHub source", () => {
       metadata: { ref: "first-commit", sha: "first-commit" },
       path: "README.md",
     }])
-    expect(loadGitCheckoutFiles).toHaveBeenCalledOnce()
-    expect(loadGitCheckoutFiles).toHaveBeenCalledWith(expect.objectContaining({ ref: "first-commit" }))
+    expect(loadGitArchiveFiles).toHaveBeenCalledOnce()
+    expect(loadGitArchiveFiles).toHaveBeenCalledWith(expect.objectContaining({ ref: "first-commit" }))
     expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith("/commits/main"))).toHaveLength(1)
   })
 
@@ -124,7 +124,7 @@ describe("@vite-hub/source GitHub source", () => {
     const docs = github({ ref: "main", repo: "acme/app", root: "docs" })
 
     await expect(docs.getKeys({ rootDir: process.cwd() })).resolves.toEqual(["README.md"])
-    expect(loadGitCheckoutFiles).toHaveBeenCalledOnce()
+    expect(loadGitArchiveFiles).toHaveBeenCalledOnce()
     expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))).toHaveLength(1)
   })
 
@@ -136,7 +136,7 @@ describe("@vite-hub/source GitHub source", () => {
     const docs = github({ include: "docs/**/*.md", ref: "main", repo: "acme/app" })
 
     await expect(docs.getKeys({ rootDir: process.cwd() })).resolves.toEqual(["docs/guides/setup.md"])
-    expect(loadGitCheckoutFiles).not.toHaveBeenCalled()
+    expect(loadGitArchiveFiles).not.toHaveBeenCalled()
     expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))).toHaveLength(1)
   })
 

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -1,8 +1,20 @@
 import { createMemoryStorage, setStorage } from "ocache"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { clearSources, github, registerSources, useSource } from "../../src/index.ts"
 import { createTarGz, jsonResponse, stubGitHubSource } from "./fixtures/github.ts"
+
+const loadGitCheckoutFiles = vi.hoisted(() => vi.fn())
+
+vi.mock("../../src/sources/github/git.ts", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../src/sources/github/git.ts")>(),
+  loadGitCheckoutFiles,
+}))
+
+beforeEach(() => {
+  loadGitCheckoutFiles.mockReset()
+  loadGitCheckoutFiles.mockRejectedValue(new Error("git unavailable"))
+})
 
 afterEach(() => {
   clearSources()
@@ -11,6 +23,65 @@ afterEach(() => {
 })
 
 describe("@vite-hub/source GitHub source", () => {
+  it("materializes simple GitHub source paths with git", async () => {
+    vi.stubGlobal("fetch", vi.fn())
+    loadGitCheckoutFiles.mockResolvedValueOnce([
+      {
+        content: new TextEncoder().encode("# Docs\n"),
+        key: "docs/README.md",
+        path: "docs/README.md",
+        sha: "checkout-sha",
+      },
+    ])
+
+    const docs = github({
+      auth: () => "github-token",
+      include: ["docs/**"],
+      ref: "main",
+      repo: "acme/app",
+    })
+
+    await expect(docs.getItems?.({ rootDir: process.cwd() })).resolves.toEqual([
+      {
+        content: new TextEncoder().encode("# Docs\n"),
+        key: "docs/README.md",
+        metadata: { ref: "main", sha: "checkout-sha" },
+        path: "docs/README.md",
+      },
+    ])
+    expect(loadGitCheckoutFiles).toHaveBeenCalledWith(expect.objectContaining({
+      ref: "main",
+      repo: "acme/app",
+      sparsePatterns: ["docs/**"],
+      token: "github-token",
+    }))
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("falls back to the GitHub archive when git materialization fails", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    })
+
+    const docs = github({ ref: "main", repo: "acme/app", root: "docs" })
+
+    await expect(docs.getKeys({ rootDir: process.cwd() })).resolves.toEqual(["README.md"])
+    expect(loadGitCheckoutFiles).toHaveBeenCalledOnce()
+    expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))).toHaveLength(1)
+  })
+
+  it("uses the GitHub archive directly for unsupported sparse patterns", async () => {
+    stubGitHubSource({
+      "docs/guides/setup.md": "# Setup\n",
+    })
+
+    const docs = github({ include: "docs/**/*.md", ref: "main", repo: "acme/app" })
+
+    await expect(docs.getKeys({ rootDir: process.cwd() })).resolves.toEqual(["docs/guides/setup.md"])
+    expect(loadGitCheckoutFiles).not.toHaveBeenCalled()
+    expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).startsWith("https://codeload.github.com/"))).toHaveLength(1)
+  })
+
   it("lists GitHub files under the configured root with relative keys", async () => {
     stubGitHubSource({
       "dbt/dbt_project.yml": "name: app\n",

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -59,6 +59,26 @@ describe("@vite-hub/source GitHub source", () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
+  it("passes bulk Source abort signals to git materialization", async () => {
+    vi.stubGlobal("fetch", vi.fn())
+    const controller = new AbortController()
+    loadGitCheckoutFiles.mockResolvedValue([{
+      content: new TextEncoder().encode("# Docs\n"),
+      key: "docs/README.md",
+      path: "docs/README.md",
+      ref: "main",
+      sha: "checkout-sha",
+    }])
+    const docs = github({ include: ["docs/**"], ref: "main", repo: "acme/app" })
+    const ctx = { abortSignal: controller.signal, rootDir: process.cwd() }
+
+    await expect(docs.getKeys(ctx)).resolves.toEqual(["docs/README.md"])
+    await expect(docs.getItems?.(ctx)).resolves.toHaveLength(1)
+
+    expect(loadGitCheckoutFiles).toHaveBeenCalledTimes(2)
+    expect(loadGitCheckoutFiles.mock.calls.every(([input]) => input.signal === controller.signal)).toBe(true)
+  })
+
   it("pins cached default-ref git materialization to the resolved commit", async () => {
     vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
       const requestUrl = String(url)


### PR DESCRIPTION
GitHub Source enumeration currently downloads a repository archive even when `root` or `include` selects one file or subtree. This adds credential-safe sparse Git materialization for simple Source Paths, reading a temporary shallow checkout while preserving root mapping, include/exclude semantics, and provider caching.

Unsupported glob forms, unavailable Git, or checkout failures fall back to the existing GitHub archive loader. Tokens stay out of argv, remotes, persisted config, and errors, while aborts clean up the temporary checkout.

Focused Source tests cover successful Git materialization, archive fallback, conservative pattern selection, credential handling, and abort cleanup. The Contents API metadata path introduced in #518 remains unchanged.