### PR TITLE
fix(agent): trust chat route timeouts after admission

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -111,7 +111,7 @@ export default defineAgent({
           },
         },
         input: {
-          trust: ['meta', 'user', 'session'],
+          trust: ['meta', 'user', 'session', 'timeout'],
         },
       },
     }),
@@ -120,7 +120,7 @@ export default defineAgent({
 })
 ```
 
-ViteHub reads the raw request body once, parses the JSON object, runs `authenticate` with `rawBody`, then validates `admission.body` when a Standard Schema is provided. `input.trust` lists request body fields that may be copied after authentication. Use `admission.context` only when the route needs to derive or validate different `chat.message` input.
+ViteHub reads the raw request body once, parses the JSON object, runs `authenticate` with `rawBody`, then validates `admission.body` when a Standard Schema is provided. `input.trust` lists request body fields that may be copied after authentication. Add `timeout` only when authenticated callers may control Agent Invocation duration; ViteHub forwards positive, finite numeric values and ignores invalid timeouts. Use `admission.context` only when the route needs to derive or validate different `chat.message` input.
 
 ## Add identity separately
 

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -124,6 +124,7 @@ type AgentChannelChatRouteInputPatch = Omit<Partial<AgentChatMessageTriggerInput
 export type AgentChannelChatRouteTrustedInputField =
   | "meta"
   | "session"
+  | "timeout"
   | "user"
 
 export interface AgentChannelChatRouteContext<TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody, TAuth = unknown>
@@ -1639,6 +1640,7 @@ export type AgentChannelChatRouteBody = {
   messages?: unknown
   run?: unknown
   session?: unknown
+  timeout?: unknown
   trigger?: string
   triggerHistory?: AgentChatMessageTriggerInput["triggerHistory"]
   user?: unknown
@@ -2025,7 +2027,7 @@ function agentChannelChatRouteInput(
   if (!Array.isArray(body.messages)) {
     throw createRouteBodyError("Agent chat payload requires a messages array.")
   }
-  if (!allowTrustedInput && ("invoker" in body || "invokerProfileId" in body || "meta" in body || "run" in body || "session" in body || "user" in body)) {
+  if (!allowTrustedInput && ("invoker" in body || "invokerProfileId" in body || "meta" in body || "run" in body || "session" in body || "timeout" in body || "user" in body)) {
     throw createRouteBodyError("Agent chat route identity must be derived server-side with defineAgent({ invoker }).")
   }
   const messages = body.messages as UIMessage[]
@@ -2088,6 +2090,7 @@ function trustAgentChannelChatRouteInput(
   for (const field of options.trust) {
     if (field === "meta" && body.meta !== undefined) patch.meta = optionalBodyRecord(body.meta, "meta")
     else if (field === "session" && body.session !== undefined) patch.session = optionalBodyRecord(body.session, "session") as AgentChatMessageTriggerInput["session"]
+    else if (field === "timeout" && typeof body.timeout === "number" && Number.isFinite(body.timeout) && body.timeout > 0) patch.timeout = body.timeout
     else if (field === "user" && body.user !== undefined) patch.user = optionalBodyRecord(body.user, "user")
   }
   return Object.keys(patch).length ? patch : undefined

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1749,7 +1749,7 @@ describe("server helpers", () => {
     })
   })
 
-  it("rejects client-provided identity on generated AI SDK chat routes", async () => {
+  it("rejects client-provided protected input on generated AI SDK chat routes", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
@@ -1764,6 +1764,7 @@ describe("server helpers", () => {
       meta: { customer: "acme" },
       run: { origin: "portal" },
       session: { id: "portal-session" },
+      timeout: 120_000,
       user: { id: "spoofed" },
     }
 
@@ -1792,16 +1793,16 @@ describe("server helpers", () => {
     const { webChat } = await import("../src/channels.ts")
     const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const authenticate = vi.fn(({ request }) => request.headers.get("x-quiver-chat-token") === "trusted" ? true : false)
-    const run = vi.fn(({ context, invoker, run }) => {
+    const run = vi.fn(({ context, input, invoker, run }) => {
       const chatContext = context.get("chat") as { meta?: { audience?: string }, session?: { id?: string }, user?: { email?: string } } | undefined
-      return `trusted ${run.channelId} ${run.origin} ${run.threadId} ${invoker.id} ${chatContext?.user?.email} ${chatContext?.meta?.audience} ${chatContext?.session?.id}`
+      return `trusted ${run.channelId} ${run.origin} ${run.threadId} ${invoker.id} ${chatContext?.user?.email} ${chatContext?.meta?.audience} ${chatContext?.session?.id} ${input.timeout ?? "no-timeout"}`
     })
     const handler = createChannelChatRouteHandler(defineAgent({
       channels: {
         portal: webChat({
           route: {
             admission: { authenticate },
-            input: { trust: ["meta", "user", "session"] },
+            input: { trust: ["meta", "user", "session", "timeout"] },
           },
         }),
       },
@@ -1819,6 +1820,7 @@ describe("server helpers", () => {
         meta: { audience: "technical", customer: "acme" },
         run: { origin: "spoofed" },
         session: { id: "portal-session" },
+        timeout: 120_000,
         user: { email: "user@example.com" },
       }),
       headers: {
@@ -1829,18 +1831,34 @@ describe("server helpers", () => {
     }), { agentName: "support" })
 
     expect(response.status).toBe(200)
-    await expect(response.text()).resolves.toContain("trusted portal web-chat portal:portal-thread web-chat:user@example.com user@example.com technical portal-session")
+    await expect(response.text()).resolves.toContain("trusted portal web-chat portal:portal-thread web-chat:user@example.com user@example.com technical portal-session 120000")
     expect(authenticate).toHaveBeenCalled()
     expect(run).toHaveBeenCalled()
+
+    for (const body of [
+      JSON.stringify({ messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }], timeout: 0 }),
+      JSON.stringify({ messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }], timeout: -1 }),
+      JSON.stringify({ messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }], timeout: "120000" }),
+      "{\"messages\":[{\"parts\":[{\"text\":\"hello\",\"type\":\"text\"}],\"role\":\"user\"}],\"timeout\":1e400}",
+    ]) {
+      const invalidResponse = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+        body,
+        headers: { "x-quiver-chat-token": "trusted" },
+        method: "POST",
+      }), { agentName: "support" })
+
+      expect(invalidResponse.status).toBe(200)
+      await expect(invalidResponse.text()).resolves.toContain("no-timeout")
+    }
   })
 
-  it("does not copy untrusted session input after admission", async () => {
+  it("does not copy untrusted webChat route input after admission", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { webChat } = await import("../src/channels.ts")
     const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
-    const run = vi.fn(({ context }) => {
+    const run = vi.fn(({ context, input }) => {
       const chatContext = context.get("chat") as { meta?: { audience?: string }, session?: { id?: string }, user?: { email?: string } } | undefined
-      return `trusted ${chatContext?.user?.email} ${chatContext?.meta?.audience} ${chatContext?.session?.id ?? "no-session"}`
+      return `trusted ${chatContext?.user?.email} ${chatContext?.meta?.audience} ${chatContext?.session?.id ?? "no-session"} ${input.timeout ?? "no-timeout"}`
     })
     const handler = createChannelChatRouteHandler(defineAgent({
       channels: {
@@ -1863,13 +1881,14 @@ describe("server helpers", () => {
         }],
         meta: { audience: "technical" },
         session: { id: "portal-session" },
+        timeout: 120_000,
         user: { email: "user@example.com" },
       }),
       method: "POST",
     }), { agentName: "support" })
 
     expect(response.status).toBe(200)
-    await expect(response.text()).resolves.toContain("trusted user@example.com technical no-session")
+    await expect(response.text()).resolves.toContain("trusted user@example.com technical no-session no-timeout")
   })
 
   it("keeps admission context authoritative over trusted route input", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -829,7 +829,7 @@ describe("agent public types", () => {
               },
             },
             input: {
-              trust: ["meta", "user", "session"],
+              trust: ["meta", "user", "session", "timeout"],
             },
           },
         }),


### PR DESCRIPTION
Adds `timeout` to authenticated Channel route input trust so app-owned chat routes can forward caller-selected Agent Invocation timeouts after admission. Only positive, finite numeric values are copied; invalid, unlisted, and unauthenticated timeout values never reach the Agent Driver.

This replaces the downstream Quiver patch that forwarded timeout values from every generated route, while preserving the Channel Delivery Admission boundary introduced in #435. The public docs and runtime/type coverage now describe and protect that contract.