### PR TITLE
feat(workspace): add custom source file shorthand

### DIFF
--- a/docs/content/docs/server-primitives/workspace.md
+++ b/docs/content/docs/server-primitives/workspace.md
@@ -195,6 +195,34 @@ export default defineEventHandler(async (event) => {
 
 ## Custom Sources and source resolution
 
+Use `custom({ files })` when a Custom Source knows its Workspace paths before it loads their content. The shorthand enumerates those paths without resolving content, and path-scoped materialization resolves only the requested file's content callback.
+
+```ts [server/workspaces/support.ts]
+import { custom, defineWorkspace } from '@vite-hub/workspace'
+
+const guideSlugs = ['getting-started', 'inventory-planning']
+
+export default defineWorkspace({
+  sources: {
+    guides: custom({
+      cache: { maxAge: 3600 },
+      materialize: 'lazy',
+      files: guideSlugs.map(slug => ({
+        path: `${slug}.md`,
+        async content() {
+          const response = await fetch(`https://docs.example.com/${slug}.md`)
+          if (!response.ok)
+            throw new Error(`Failed to load ${slug}: ${response.status}`)
+          return await response.text()
+        },
+      })),
+    }),
+  },
+})
+```
+
+ViteHub infers each file's media type from its path unless the descriptor provides `mediaType`. Use a full Custom Source with `getKeys()` and `getItem()` when retrieval needs behavior beyond a fixed file list.
+
 Custom Sources can read existing materialized Workspace files through `ctx.workspaceFiles`. Use this when a Source needs previous generated output, such as a sync report or cached asset metadata, while producing the next materialized files. The view is read-only and does not expose Workspace Stores, provider adapters, snapshots, diffs, or Source materialization.
 
 Sources can resolve their concrete origin and Mount for one invocation from trusted runtime context. Use this when the same Source key should point at a narrowed origin after Access has selected a Workspace Scope.

--- a/packages/workspace/src/sources/custom.ts
+++ b/packages/workspace/src/sources/custom.ts
@@ -1,8 +1,47 @@
-import type { WorkspaceSource } from "../core/types.ts"
+import { lookup } from "mrmime"
+
+import { WorkspaceError } from "../core/errors.ts"
+import { normalizeSafeWorkspacePath } from "../core/path.ts"
+
+import type { MaybePromise, SourceContext, WorkspaceContent, WorkspaceSource, WorkspaceSourceItem } from "../core/types.ts"
 
 type SourceScopes<T> = T extends { scopes?: infer TScopes } ? { scopes?: TScopes } : {}
 type TypedWorkspaceSource<T> = WorkspaceSource & SourceScopes<T>
+type WorkspaceSourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "materialize" | "mount" | "probeKeys" | "scopes" | "sync" | "validate">
+type CustomWorkspaceSourceFile = Omit<WorkspaceSourceItem, "content" | "contentStream" | "key" | "path"> & {
+  content: WorkspaceContent | ((context: SourceContext) => MaybePromise<WorkspaceContent>)
+  path: string
+}
+type CustomWorkspaceSourceFiles = WorkspaceSourceRuntimeOptions & {
+  files: readonly CustomWorkspaceSourceFile[]
+}
 
-export function custom<const TSource extends WorkspaceSource>(source: TSource): TypedWorkspaceSource<TSource> {
-  return source as unknown as TypedWorkspaceSource<TSource>
+export function custom<const TSource extends CustomWorkspaceSourceFiles>(source: TSource): TypedWorkspaceSource<TSource>
+export function custom<const TSource extends WorkspaceSource>(source: TSource): TypedWorkspaceSource<TSource>
+export function custom(source: WorkspaceSource | CustomWorkspaceSourceFiles): WorkspaceSource {
+  if (!("files" in source) || !Array.isArray(source.files)) return source as WorkspaceSource
+
+  const { files: inputFiles, ...options } = source
+  const files = inputFiles.map(file => ({
+    ...file,
+    path: normalizeSafeWorkspacePath(file.path),
+  }))
+
+  return {
+    ...options,
+    async getKeys() {
+      return files.map(file => file.path)
+    },
+    async getItem(key, context) {
+      const file = files.find(file => file.path === key)
+      if (!file) throw new WorkspaceError(`[vitehub] Custom Workspace Source file does not exist: ${key}.`)
+      const { content, ...item } = file
+      return {
+        ...item,
+        content: typeof content === "function" ? await content(context) : content,
+        key,
+        mediaType: item.mediaType || lookup(key) || undefined,
+      }
+    },
+  }
 }

--- a/packages/workspace/test/lazy-sources.test.ts
+++ b/packages/workspace/test/lazy-sources.test.ts
@@ -31,6 +31,69 @@ afterEach(async () => {
 })
 
 describe("lazy sources", () => {
+  it("indexes custom file lists without resolving other content", async () => {
+    const guideContent = vi.fn(async (context: { workspace: string }) => {
+      expect(context.workspace).toBe("custom-files")
+      return "# Guide\n"
+    })
+    const referenceContent = vi.fn(async () => "# Reference\n")
+    const source = custom({
+      cache: { maxAge: 3600 },
+      files: [
+        { content: guideContent, path: "guides/start.md" },
+        { content: referenceContent, path: "reference/api.md" },
+      ],
+      materialize: "lazy",
+      mount: "docs",
+      scopes: ["support"],
+      sync: { stale: "remove" },
+      validate: "request",
+    })
+
+    await expect(source.getKeys({} as never)).resolves.toEqual(["guides/start.md", "reference/api.md"])
+    expect(guideContent).not.toHaveBeenCalled()
+    expect(referenceContent).not.toHaveBeenCalled()
+    expect(source).toMatchObject({
+      cache: { maxAge: 3600 },
+      materialize: "lazy",
+      mount: "docs",
+      scopes: ["support"],
+      sync: { stale: "remove" },
+      validate: "request",
+    })
+    expect(custom({
+      files: [],
+      probeKeys: ["guides/start.md"],
+    })).toMatchObject({ probeKeys: ["guides/start.md"] })
+
+    const view = createWorkspaceSourceView({ name: "custom-files", sources: { docs: source } }, createMemoryWorkspaceStore())
+    await expect(view.materializeSources({
+      path: "docs/guides/start.md",
+      sources: ["docs"],
+    })).resolves.toMatchObject({
+      files: 1,
+      sources: [expect.objectContaining({ source: "docs", status: "ready" })],
+    })
+    await expect(view.readFile("docs/guides/start.md")).resolves.toBe("# Guide\n")
+    await expect(view.stat("docs/guides/start.md")).resolves.toMatchObject({ mediaType: "text/markdown" })
+    expect(guideContent).toHaveBeenCalledOnce()
+    expect(referenceContent).not.toHaveBeenCalled()
+    await expect(source.getItem("missing.md", {} as never)).rejects.toThrow("Custom Workspace Source file does not exist")
+
+    await expect(view.list("docs", { recursive: true })).resolves.toEqual([
+      expect.objectContaining({ path: "docs/guides", type: "directory" }),
+      expect.objectContaining({ path: "docs/guides/start.md", type: "file" }),
+      expect.objectContaining({ path: "docs/reference", type: "directory" }),
+      expect.objectContaining({ path: "docs/reference/api.md", type: "file" }),
+    ])
+  })
+
+  it("rejects unsafe custom file-list paths", () => {
+    expect(() => custom({
+      files: [{ content: "private", path: "../private.md" }],
+    })).toThrow("Workspace path escapes the workspace root")
+  })
+
   it("exposes source-backed behavior through the source view seam", async () => {
     const definition = {
       name: "source-view",

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -10,7 +10,7 @@ import { createWorkspaceTools, type WorkspaceMaterializeSourcesResult, type Work
 import { createWorkspaceAssets } from "../src/runtime/assets.ts"
 import * as loader from "../src/loader.ts"
 import * as publish from "../src/publish.ts"
-import { fetch, file, github, glob, markdown, mcpResources, source, type FetchSourceOptions, type GitHubSourceOptions, type GlobSourceOptions, type McpResourcesSourceOptions } from "../src/index.ts"
+import { custom, fetch, file, github, glob, markdown, mcpResources, source, type FetchSourceOptions, type GitHubSourceOptions, type GlobSourceOptions, type McpResourcesSourceOptions } from "../src/index.ts"
 import { hubWorkspace } from "../src/vite.ts"
 import type { GitHubWorkspaceStoreOptions, Workspace, WorkspaceModuleOptions, WorkspacePlugin, WorkspaceSourceSyncResult, WorkspaceWriteInput } from "../src/core/types.ts"
 
@@ -32,6 +32,29 @@ declare global {
 }
 
 describe("workspace types", () => {
+  it("types custom file-list sources", () => {
+    const docs = custom({
+      files: [{
+        content(context) {
+          expectTypeOf(context.workspace).toEqualTypeOf<string>()
+          return "# Guide\n"
+        },
+        path: "guides/start.md",
+      }, {
+        content: new Uint8Array([1, 2, 3]),
+        mediaType: "application/octet-stream",
+        metadata: { kind: "fixture" },
+        path: "assets/example.bin",
+      }],
+      materialize: "lazy",
+      scopes: ["support"] as const,
+    })
+
+    expectTypeOf(docs.scopes).toMatchTypeOf<readonly ["support"] | undefined>()
+    // @ts-expect-error custom file content must be Workspace content or a lazy content callback
+    custom({ files: [{ content: 42, path: "invalid.txt" }] })
+  })
+
   it("exports source helper option types from the root", () => {
     const fetchOptions = { url: "https://status.example.com/api/summary" } satisfies FetchSourceOptions
     const githubOptions = { auth: false, repo: "acme/docs" } satisfies GitHubSourceOptions


### PR DESCRIPTION
Adds `custom({ files })` as a lazy multi-file Workspace Source shorthand. Known paths become `getKeys()` entries without resolving content, while each content callback resolves through `getItem()` during path-scoped materialization. Workspace runtime options remain intact, paths use the canonical safety checks, and MIME types are inferred from file paths.

This removes repeated source-indexing boilerplate for path-known remote content while preserving the full Custom Source contract.