### PR TITLE
fix(agent): default transcript identity per channel

### DIFF
--- a/docs/content/docs/agents/chat-history-sessions.md
+++ b/docs/content/docs/agents/chat-history-sessions.md
@@ -106,9 +106,9 @@ export default defineEventHandler(async (event) => {
 
 DevTools can select configured Agent Invoker Profiles before a new Chat Session starts. It should not switch invokers in the middle of one conversation.
 
-## Partition transcripts by adapter
+## Partition transcripts by Channel
 
-When you enable `transcripts` without an explicit `identity` resolver, ViteHub uses `${adapter}:${author.userId}` as the transcript key for human authors. Qualifying the platform user ID with the adapter prevents identical IDs from colliding across adapters. The default does not link the same person across platforms and does not replace Agent Actor identity.
+When you enable `transcripts` without an explicit `identity` resolver, ViteHub uses `${channel}:${author.userId}` as the transcript key for human authors. The `channel` portion is the Channel key from your Agent Definition, not the underlying adapter's name. Qualifying the platform user ID with the Channel prevents identical IDs from colliding across Channels, including multiple Channels backed by the same kind of adapter. The default does not link the same person across platforms and does not replace Agent Actor identity.
 
 The default resolver returns `null` for bot authors, so Chat SDK does not associate their messages with a user transcript. Provide an explicit `identity` resolver when your application has a verified cross-platform or internal user ID. An explicit resolver always overrides the default.
 

--- a/docs/content/docs/agents/chat-history-sessions.md
+++ b/docs/content/docs/agents/chat-history-sessions.md
@@ -106,6 +106,12 @@ export default defineEventHandler(async (event) => {
 
 DevTools can select configured Agent Invoker Profiles before a new Chat Session starts. It should not switch invokers in the middle of one conversation.
 
+## Partition transcripts by adapter
+
+When you enable `transcripts` without an explicit `identity` resolver, ViteHub uses `${adapter}:${author.userId}` as the transcript key for human authors. Qualifying the platform user ID with the adapter prevents identical IDs from colliding across adapters. The default does not link the same person across platforms and does not replace Agent Actor identity.
+
+The default resolver returns `null` for bot authors, so Chat SDK does not associate their messages with a user transcript. Provide an explicit `identity` resolver when your application has a verified cross-platform or internal user ID. An explicit resolver always overrides the default.
+
 ## Persist state deliberately
 
 Chat History and the Concurrent Invocation Guard need an Agent State Provider when they should survive process restarts. Development state providers are useful locally, but hosted runtimes should configure durable state.

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -959,7 +959,8 @@ function chatSdkOption<T>(options: AgentChatOptions | undefined, key: string): T
 }
 
 function createChatSdkConfig(
-  adapters: Record<string, Adapter>,
+  adapterName: string,
+  adapter: Adapter,
   state: StateAdapter,
   options: AgentChatOptions | undefined,
 ): ChatConfig {
@@ -967,10 +968,10 @@ function createChatSdkConfig(
     ? options.fallbackStreamingPlaceholderText
     : options?.fallbackStreamingPlaceholderText === null ? null : undefined
   const identity: ChatConfig["identity"] = options?.identity ?? (options?.transcripts
-    ? ({ adapter, author }) => author.isBot === true ? null : `${adapter}:${author.userId}`
+    ? ({ author }) => author.isBot === true ? null : `${adapterName}:${author.userId}`
     : undefined)
   return objectWithoutUndefined({
-    adapters,
+    adapters: { [adapterName]: adapter },
     concurrency: chatSdkOption<ChatConfig["concurrency"]>(options, "concurrency"),
     dedupeTtlMs: chatSdkOption<number>(options, "dedupeTtlMs"),
     fallbackStreamingPlaceholderText,
@@ -1610,9 +1611,12 @@ async function createChatWebhookHandler(
   options: AgentChatOptions | undefined,
   handlerOptions: AgentChannelWebhookRouteOptions,
 ): Promise<(request: Request, webhookOptions: WebhookOptions) => Promise<Response>> {
-  const chat = new Chat(createChatSdkConfig({
-    [adapterName]: adapter,
-  }, await resolveChatState(options, context, registration, handlerOptions), options))
+  const chat = new Chat(createChatSdkConfig(
+    adapterName,
+    adapter,
+    await resolveChatState(options, context, registration, handlerOptions),
+    options,
+  ))
 
   chat.onDirectMessage((thread, message, _channel, messageContext) =>
     handleChatSdkMessage(agent, context, registration, thread, message, options, messageContext))
@@ -2671,7 +2675,7 @@ export function createDiscordGatewayRouteHandler(
           id: adapterName,
           provider: "discord",
         }, handlerOptions)
-        const chat = new Chat(createChatSdkConfig({ [adapterName]: adapter }, state, chatOptions))
+        const chat = new Chat(createChatSdkConfig(adapterName, adapter, state, chatOptions))
         await (chat as { initialize?: () => Promise<void> }).initialize?.()
         const registration = await resolveDiscordWebhookRegistration(agent, context, adapters, adapterName)
         const webhookId = registration?.id || adapterName

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -966,12 +966,15 @@ function createChatSdkConfig(
   const fallbackStreamingPlaceholderText = typeof options?.fallbackStreamingPlaceholderText === "string"
     ? options.fallbackStreamingPlaceholderText
     : options?.fallbackStreamingPlaceholderText === null ? null : undefined
+  const identity: ChatConfig["identity"] = options?.identity ?? (options?.transcripts
+    ? ({ adapter, author }) => author.isBot === true ? null : `${adapter}:${author.userId}`
+    : undefined)
   return objectWithoutUndefined({
     adapters,
     concurrency: chatSdkOption<ChatConfig["concurrency"]>(options, "concurrency"),
     dedupeTtlMs: chatSdkOption<number>(options, "dedupeTtlMs"),
     fallbackStreamingPlaceholderText,
-    identity: options?.identity,
+    identity,
     lockScope: chatSdkOption<ChatConfig["lockScope"]>(options, "lockScope"),
     logger: chatSdkOption<ChatConfig["logger"]>(options, "logger"),
     messageHistory: chatSdkOption<ChatConfig["messageHistory"]>(options, "messageHistory"),

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2022,7 +2022,7 @@ describe("server helpers", () => {
     const run = vi.fn(() => "ok")
     const agent = defineAgent({
       channels: {
-        telegram: telegram({ adapter: () => adapter as never }),
+        support: telegram({ adapter: () => adapter as never }),
       },
       driver: { run },
       messages: {
@@ -2043,7 +2043,7 @@ describe("server helpers", () => {
         },
       }),
       method: "POST",
-    }), "telegram", { agentName: "transcript-identity" })
+    }), "support", { agentName: "transcript-identity" })
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ ok: true })
@@ -2053,7 +2053,7 @@ describe("server helpers", () => {
   }
 
   it("defaults transcript identity for human authors", async () => {
-    await expect(chatTranscriptUserKey({ messageId: 7, transcripts: true })).resolves.toBe("telegram:123")
+    await expect(chatTranscriptUserKey({ messageId: 7, transcripts: true })).resolves.toBe("support:123")
   })
 
   it("omits default transcript identity for bot authors", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -48,7 +48,7 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
         return Response.json({ ignored: true, ok: true })
       }
       const chat = rawMessage.chat as { id?: number | string } | undefined
-      const from = rawMessage.from as { email?: string, id?: number | string, mail?: string, userPrincipalName?: string, username?: string } | undefined
+      const from = rawMessage.from as { email?: string, id?: number | string, is_bot?: boolean, mail?: string, userPrincipalName?: string, username?: string } | undefined
       const document = rawMessage.document as { content?: string, file_id?: string, file_name?: string, file_size?: number, mime_type?: string, url?: string } | undefined
       const photos = rawMessage.photo as Array<{ file_id?: string, file_size?: number, height?: number, width?: number }> | undefined
       const photo = photos?.at(-1)
@@ -99,7 +99,7 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
           ...(from?.email ? { email: from.email } : {}),
           ...(from?.mail ? { mail: from.mail } : {}),
           ...(from?.userPrincipalName ? { userPrincipalName: from.userPrincipalName } : {}),
-          isBot: false,
+          isBot: from?.is_bot === true,
           isMe: false,
           userId: String(from?.id ?? "123"),
           userName: String(from?.username ?? "maxi"),
@@ -2007,6 +2007,69 @@ describe("server helpers", () => {
     expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
     await expect(response.text()).resolves.toContain("portal portal customer:acme acme user@example.com technical")
     expect(run).toHaveBeenCalled()
+  })
+
+  async function chatTranscriptUserKey(options: {
+    identity?: () => string | null
+    isBot?: boolean
+    messageId: number
+    transcripts?: boolean
+  }): Promise<string | undefined> {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const run = vi.fn(() => "ok")
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({ adapter: () => adapter as never }),
+      },
+      driver: { run },
+      messages: {
+        ...(options.identity ? { identity: options.identity } : {}),
+        ...(options.transcripts ? { transcripts: { maxPerUser: 50, retention: "30d" as const } } : {}),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 42,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, is_bot: options.isBot, username: "maxi" },
+          message_id: options.messageId,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "telegram", { agentName: "transcript-identity" })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(run).toHaveBeenCalledOnce()
+    const history = await adapter.fetchMessages("telegram:456")
+    return history.messages[0]?.userKey
+  }
+
+  it("defaults transcript identity for human authors", async () => {
+    await expect(chatTranscriptUserKey({ messageId: 7, transcripts: true })).resolves.toBe("telegram:123")
+  })
+
+  it("omits default transcript identity for bot authors", async () => {
+    await expect(chatTranscriptUserKey({ isBot: true, messageId: 8, transcripts: true })).resolves.toBeUndefined()
+  })
+
+  it("prefers explicit transcript identity", async () => {
+    await expect(chatTranscriptUserKey({
+      identity: () => "account:verified",
+      messageId: 9,
+      transcripts: true,
+    })).resolves.toBe("account:verified")
+  })
+
+  it("does not default identity when transcripts are disabled", async () => {
+    await expect(chatTranscriptUserKey({ messageId: 10 })).resolves.toBeUndefined()
   })
 
   it("handles Chat SDK webhooks through the chat capability", async () => {


### PR DESCRIPTION
Supplies a channel-qualified transcript key when Chat SDK transcript persistence is enabled without an explicit identity resolver. Human authors use `${adapter}:${author.userId}`, bot authors get no key, and explicit application identity still wins.

This lets applications enable transcripts without repeating adapter plumbing while preventing raw platform IDs from colliding across adapters. The docs clarify that the default does not link people across platforms or replace Agent Actor identity, and webhook coverage exercises the human, bot, explicit-override, and transcripts-disabled branches.