### PR TITLE
feat(agent): expose normalized actor email

### DIFF
--- a/docs/content/docs/agents/invokers.md
+++ b/docs/content/docs/agents/invokers.md
@@ -5,7 +5,7 @@ navigation.order: 27
 icon: i-lucide-user-check
 ---
 
-An Agent Invoker is the trusted caller identity for one Agent Invocation. ViteHub exposes it as `context.invoker` with a stable `id`, optional `kind`, optional display `label`, and application-owned `meta`.
+An Agent Invoker is the trusted caller identity for one Agent Invocation. ViteHub exposes the resolved identity as both the Agent Actor and `context.invoker`, with a stable `id`, optional `kind`, optional display `label`, optional normalized `email`, and application-owned `meta`.
 
 Agent Invokers are not Auth Users, Channels, or Access roles. Auth and Channels may help produce an Agent Invoker, and Access may consume it, but the concepts stay separate.
 
@@ -92,6 +92,12 @@ export const supportInvoker = defineAgentInvoker({
 
 When a selected profile and a request-provided invoker both contain `meta`, ViteHub keeps request metadata and lets profile metadata override matching keys.
 
+## Read normalized email
+
+ViteHub exposes a valid identity email as `actor.email.address` and `actor.email.domain`. It lowercases the address, derives the domain, and omits the field when the address is malformed. This normalization does not verify that the address belongs to the actor.
+
+A valid top-level email takes precedence over `meta.email`. ViteHub falls back to `meta.email` when the top-level value is missing or malformed, and it preserves the original metadata.
+
 ## Use invokers for access
 
 Access decisions should use the Agent Invoker rather than channel identity. A shared channel can contain multiple users with different permissions.
@@ -117,6 +123,8 @@ export const supportAccess = access({
 ```
 
 Keep Access roles inside the Access Capability. Keep the caller identity on the Agent Invoker.
+
+Capability callbacks receive the same resolved identity as `actor` and `invoker`. Access resolvers can use `actor.email?.address` or `actor.email?.domain` without parsing application metadata.
 
 ## Next steps
 

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -318,11 +318,11 @@ export function createChatMessageTriggerInput<TRuntimeConfig extends AgentRuntim
   const invoker = triggerInput?.invoker
     ? normalizeAgentInvoker(triggerInput.invoker, "chat.message input.invoker")
     : invokerId
-      ? {
+      ? normalizeAgentInvoker({
           id: invokerId,
           kind: triggerInput?.run?.origin === "devtools" ? "devtools" as const : "chat" as const,
           ...(meta ? { meta } : {}),
-        } satisfies AgentInvoker
+        }, "chat.message input.user")
       : undefined
   return {
     hookArgs,

--- a/packages/agent/src/invoker.ts
+++ b/packages/agent/src/invoker.ts
@@ -47,6 +47,16 @@ function profileIdFromSelector(value: unknown): string | undefined {
   if (isRecord(value)) return stringValue(value.id)
 }
 
+function normalizeAgentEmail(value: unknown): AgentInvoker["email"] {
+  const address = stringValue(isRecord(value) ? value.address : value)?.toLowerCase()
+  if (!address || !/^[^@\s]+@[^@\s]+$/.test(address)) return
+
+  return {
+    address,
+    domain: address.slice(address.indexOf("@") + 1),
+  }
+}
+
 export function normalizeAgentInvoker(value: unknown, label = "Agent Invoker"): AgentInvoker {
   if (!isRecord(value)) {
     throw new TypeError(`[vitehub] ${label} must be an object with a non-empty string id.`)
@@ -63,8 +73,10 @@ export function normalizeAgentInvoker(value: unknown, label = "Agent Invoker"): 
   if (meta !== undefined && !isRecord(meta)) {
     throw new TypeError(`[vitehub] ${label}.meta must be an object when provided.`)
   }
+  const email = normalizeAgentEmail(value.email) || normalizeAgentEmail(meta?.email)
 
   return {
+    ...(email ? { email } : {}),
     id,
     ...(kind ? { kind } : {}),
     ...(displayLabel ? { label: displayLabel } : {}),
@@ -208,12 +220,14 @@ export async function resolveAgentInvoker<
   }
   const defaultInvoker = requestedInvoker || createFallbackAgentInvoker(run)
   const selectedProfile = selectAgentInvokerProfile(profiles, input.context)
-  const selectedInvoker = selectedProfile && defaultInvoker.meta
+  const selectedEmail = selectedProfile?.email || defaultInvoker.email
+  const selectedInvoker = selectedProfile
     ? {
         ...selectedProfile,
-        meta: { ...defaultInvoker.meta, ...selectedProfile.meta },
+        ...(selectedEmail ? { email: selectedEmail } : {}),
+        ...(defaultInvoker.meta ? { meta: { ...defaultInvoker.meta, ...selectedProfile.meta } } : {}),
       }
-    : selectedProfile
+    : undefined
   const resolved = await normalizedOptions?.resolve?.({
     ...callbackContext,
     context: invocationContext,

--- a/packages/agent/src/invoker.ts
+++ b/packages/agent/src/invoker.ts
@@ -225,7 +225,9 @@ export async function resolveAgentInvoker<
     ? {
         ...selectedProfile,
         ...(selectedEmail ? { email: selectedEmail } : {}),
-        ...(defaultInvoker.meta ? { meta: { ...defaultInvoker.meta, ...selectedProfile.meta } } : {}),
+        ...(defaultInvoker.meta || selectedProfile.meta
+          ? { meta: { ...defaultInvoker.meta, ...selectedProfile.meta } }
+          : {}),
       }
     : undefined
   const resolved = await normalizedOptions?.resolve?.({

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -61,6 +61,10 @@ export type AgentCallbackContext<TRuntimeConfig extends AgentRuntimeConfig = Age
 export type AgentInvokerMeta = Record<string, unknown>
 
 export interface AgentInvoker<TMeta extends AgentInvokerMeta = AgentInvokerMeta> {
+  email?: {
+    address: string
+    domain: string
+  }
   id: string
   kind?: "anonymous" | "chat" | "devtools" | (string & {})
   label?: string

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -24,6 +24,10 @@ describe("chat message trigger input", () => {
     })
     expect(result.input.context).not.toHaveProperty("chat.identity")
     expect(result.input.context?.invoker).toMatchObject({
+      email: {
+        address: "support@example.com",
+        domain: "example.com",
+      },
       id: "user_1",
       kind: "chat",
       meta: {
@@ -101,6 +105,10 @@ describe("chat message trigger input", () => {
 
     expect(result.input.context).not.toHaveProperty("chat.identity")
     expect(result.input.context?.invoker).toEqual({
+      email: {
+        address: "support@example.com",
+        domain: "example.com",
+      },
       id: "support@example.com",
       kind: "chat",
       meta: {
@@ -132,6 +140,10 @@ describe("chat message trigger input", () => {
     })
     expect(result.input.context?.chat).not.toHaveProperty("run")
     expect(result.input.context?.invoker).toEqual({
+      email: {
+        address: "support@example.com",
+        domain: "example.com",
+      },
       id: "portal:acme:user_1",
       kind: "customerPortal",
       meta: {
@@ -163,6 +175,10 @@ describe("chat message trigger input", () => {
     })
 
     expect(result.input.context?.invoker).toMatchObject({
+      email: {
+        address: "maximo@quiver.dk",
+        domain: "quiver.dk",
+      },
       id: "devtools:maximo@quiver.dk",
       kind: "devtools",
       meta: { email: "maximo@quiver.dk" },

--- a/packages/agent/test/invoker.test.ts
+++ b/packages/agent/test/invoker.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizeAgentInvoker } from "../src/invoker.ts"
+
+describe("Agent Invoker", () => {
+  it("normalizes Agent Actor email without changing invoker metadata", () => {
+    const meta = {
+      email: "metadata@example.net",
+      scope: "acme",
+    }
+    const explicit = normalizeAgentInvoker({
+      email: { address: " Support@Example.COM " },
+      id: "tenant-1",
+      meta,
+    })
+
+    expect(explicit).toEqual({
+      email: {
+        address: "support@example.com",
+        domain: "example.com",
+      },
+      id: "tenant-1",
+      meta,
+    })
+    expect(explicit.meta).not.toBe(meta)
+
+    expect(normalizeAgentInvoker({
+      email: "invalid",
+      id: "tenant-1",
+      meta,
+    })).toEqual({
+      email: {
+        address: "metadata@example.net",
+        domain: "example.net",
+      },
+      id: "tenant-1",
+      meta,
+    })
+
+    expect(normalizeAgentInvoker({
+      email: "invalid",
+      id: "tenant-1",
+      meta: { email: "also invalid", scope: "acme" },
+    })).toEqual({
+      id: "tenant-1",
+      meta: { email: "also invalid", scope: "acme" },
+    })
+  })
+})

--- a/packages/agent/test/rate-limit.test.ts
+++ b/packages/agent/test/rate-limit.test.ts
@@ -178,16 +178,20 @@ describe("rateLimit capability", () => {
         invoker: {
           id: "chat:user_1",
           kind: "chat",
-          meta: { email: "user@example.com", scope: "customer" },
+          meta: { email: "User@Example.COM", scope: "customer" },
         },
         invokerProfileId: "support:acme",
       },
     })).resolves.toEqual({
+      email: {
+        address: "user@example.com",
+        domain: "example.com",
+      },
       id: "support:acme",
       kind: "customer",
       meta: {
         customer: "acme",
-        email: "user@example.com",
+        email: "User@Example.COM",
         scope: "support",
       },
     })

--- a/packages/agent/test/rate-limit.test.ts
+++ b/packages/agent/test/rate-limit.test.ts
@@ -197,6 +197,26 @@ describe("rateLimit capability", () => {
     })
   })
 
+  it("keeps profile metadata when selecting without a request invoker", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      invoker: {
+        profiles: [
+          { id: "support:acme", kind: "customer", meta: { customer: "acme" } },
+        ],
+      },
+      driver: { run: context => context.invoker },
+    })
+
+    await expect(runAgent(agent, runtime(), {
+      context: { invokerProfileId: "support:acme" },
+    })).resolves.toEqual({
+      id: "support:acme",
+      kind: "customer",
+      meta: { customer: "acme" },
+    })
+  })
+
   it("selects configured invoker profiles for rate limit identity", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const agent = defineAgent({

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1078,7 +1078,11 @@ describe("agent public types", () => {
         expectTypeOf(chat?.message?.metadata?.quiver?.customer).toEqualTypeOf<string | undefined>()
         expectTypeOf(run?.origin).toEqualTypeOf<string | undefined>()
         expectTypeOf(chat?.user?.email).toEqualTypeOf<string | undefined>()
+        expectTypeOf(actor.email?.address).toEqualTypeOf<string | undefined>()
+        expectTypeOf(actor.email?.domain).toEqualTypeOf<string | undefined>()
         expectTypeOf(actor.id).toEqualTypeOf<string>()
+        expectTypeOf(invoker.email?.address).toEqualTypeOf<string | undefined>()
+        expectTypeOf(invoker.email?.domain).toEqualTypeOf<string | undefined>()
         expectTypeOf(invoker.id).toEqualTypeOf<string>()
         expectTypeOf(invoker.meta?.customer).toEqualTypeOf<"acme" | undefined>()
         return actor.meta?.customer || "customer"


### PR DESCRIPTION
Adds normalized email identity to Agent Invokers and Agent Actors. A valid explicit email wins, otherwise ViteHub falls back to `meta.email`; addresses are lowercased, domains are derived, malformed values are omitted, and application metadata stays intact. Chat-derived identities now pass through the same normalizer, and selecting an invoker profile preserves the request email.

This gives capability and access callbacks a stable `actor.email.address` and `actor.email.domain` contract without making applications parse metadata themselves. The invoker docs and focused runtime and type coverage protect explicit normalization, metadata fallback, malformed values, chat input, and profile merging.