### PR TITLE
feat(agent): resolve capability CLIs per invocation

### DIFF
--- a/docs/content/docs/capabilities/custom-capabilities.md
+++ b/docs/content/docs/capabilities/custom-capabilities.md
@@ -145,7 +145,7 @@ Do not create a `bash()` Capability or use `workspaceShell()` as the public owne
 ## Add a Capability CLI
 
 Use `cli` when the Capability owns a real command tree that agents and developers should run instead of a generic shell command.
-The public API is a flat object on the Capability Definition.
+The public API accepts a static command tree or an invocation resolver on the Capability Definition.
 
 ```ts [server/agents/capabilities/inventory-runtime.ts]
 import { defineCapability } from '@vite-hub/agent'
@@ -188,8 +188,26 @@ The `input` and `output.schema` values accept any Standard Schema-compatible val
 
 ViteHub exposes command metadata through the generated CLI-named tool. Keep `instructions.md` focused on policy and use `::capability{key="inventoryRuntime"}` when authored guidance should cover that Capability.
 
+Return `undefined` from a resolver when the CLI should not be available for the current invocation. The Capability remains attached and inspectable.
+
+```ts [server/agents/capabilities/inventory-runtime.ts]
+export const inventoryRuntime = defineCapability({
+  id: 'inventory-runtime',
+  cli: ({ actor }) => actor.kind === 'support'
+    ? {
+        name: 'inventory',
+        commands: {
+          list: {
+            run: () => listInventoryItems(),
+          },
+        },
+      }
+    : undefined,
+})
+```
+
 First-party adapters can generate the same CLI shape from their own metadata. For example, `openapi({ cli: { name: 'billing' }, ... })` creates one subcommand per allowed OpenAPI operation and preserves each operation summary or description in the tool contract.
-Custom Capability authors still pass a flat `cli` object; dynamic command generation belongs behind adapter-owned options such as `openapi({ cli })`.
+Use a resolver for invocation-specific availability, not to mutate command ownership after a run starts.
 
 During development, run the Capability CLI through the Agent Dev Loop.
 Agents expose attached Capability CLI Contributions to compatible Agent Driver and Agent Dev Loop surfaces by default; use `defineAgent({ cli: { capabilities: false } })` when an Agent should attach the Capability but keep its CLI hidden.

--- a/docs/content/docs/capabilities/openapi.md
+++ b/docs/content/docs/capabilities/openapi.md
@@ -134,6 +134,23 @@ openapi({
 })
 ```
 
+`cli` can also resolve from the current Agent Invocation. Return `false` or `undefined` to omit the generated CLI for that invocation without detaching the OpenAPI Capability or changing its lifecycle.
+
+```ts [server/agents/support.ts]
+openapi({
+  spec: 'https://portal.example.com/_openapi.json',
+  operations: ['portalProductSearch', 'portalPurchaseOrders'],
+  cli: ({ run }) => run?.channelId === 'portal'
+    ? {
+        name: 'portal-api',
+        description: 'Inspect live Portal data.',
+      }
+    : false,
+})
+```
+
+Treat Channel metadata as an availability hint, not authorization. Check trusted request, Agent Actor, or `access()` evidence before privileged API calls.
+
 Run the generated CLI through the Agent Dev Loop.
 Agents expose generated Capability CLI Contributions by default; use `defineAgent({ cli: { capabilities: false } })` to attach the OpenAPI Capability without exposing its CLI surface.
 
@@ -163,7 +180,7 @@ openapi({
 
 | Old option | New shape |
 | --- | --- |
-| `enabled` | Attach `openapi()` only to Agents that should have the ability. Use `access()`, Agent Trigger routing, or separate Agent Definitions for channel or customer gating. |
+| `enabled` | Attach `openapi()` only to Agents that should have the ability. For invocation-specific CLI availability, use a `cli` resolver; keep authority in `access()`, Agent Trigger routing, request checks, or separate Agent Definitions. |
 | `operations: { allow: [...] }` | `operations: [...]` |
 | `baseUrl` | Use the OpenAPI `servers` entry. Use `server` only when the spec has no usable server. |
 | `headers` | Set headers in `hooks.request`. |

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -159,7 +159,7 @@ openapi({
 
 `spec` can be a callback when the OpenAPI document comes from the current Agent Invocation context. Request servers come from OpenAPI `servers`; use `server` only as an override escape hatch when the spec has no usable server.
 When `cli` is set, the operation tools are replaced by one CLI-named tool. ViteHub generates one subcommand per allowed operation, using the OpenAPI operation summary or description for command guidance.
-Custom Capability authors still define `cli` as a flat command tree; generated command trees stay behind adapter-owned options such as `openapi({ cli })`.
+Capability `cli` can be a static command tree or an invocation resolver that returns `undefined` when the CLI should not be available. Generated command trees stay behind adapter-owned options such as `openapi({ cli })`, whose resolver may return `false` or `undefined` for the current invocation.
 
 ## Chat state
 

--- a/packages/agent/src/capabilities/openapi.ts
+++ b/packages/agent/src/capabilities/openapi.ts
@@ -7,7 +7,6 @@ import type {
   AgentCapabilityCliContribution,
   AgentCapabilityCliStandardSchemaV1,
   AgentCapabilityDefinition,
-  AgentCapabilityRuntimeContext,
   AgentRuntimeConfig,
   AgentToolDefinition,
   AgentToolSet,
@@ -147,18 +146,11 @@ export interface OpenAPICliOptions {
   name: string
 }
 
-type OpenAPICapabilityDefinition<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  Name extends WorkspaceName,
-> = AgentCapabilityDefinition<TRuntimeConfig, Name> & {
-  resolveCli?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<AgentCapabilityCliContribution<TRuntimeConfig, Name> | undefined>
-}
-
 export interface OpenAPICapabilityOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > {
-  cli?: false | OpenAPICliOptions
+  cli?: OpenAPIContextValue<false | OpenAPICliOptions | undefined, TRuntimeConfig, Name>
   description?: string
   hooks?: OpenAPIHooks<TRuntimeConfig, Name>
   operations: readonly string[]
@@ -189,12 +181,14 @@ export function openapi<
         ? "dynamic"
         : typeof options.spec === "object" && !(options.spec instanceof URL) ? "inline" : String(options.spec),
     },
-    resolveCli: options.cli
+    cli: options.cli
       ? async (context) => {
+          const cli = await resolveContextValue(options.cli, context)
+          if (!cli) return undefined
           const resolved = dynamicOperations
             ? await loadOpenAPIOperations(options, context)
             : await (operations ||= loadOpenAPIOperations(options, context))
-          return createOpenAPICli(options.cli as OpenAPICliOptions, resolved.tools, resolved.baseUrl, options, context)
+          return createOpenAPICli(cli, resolved.tools, resolved.baseUrl, options, context)
         }
       : undefined,
     async tools(context) {
@@ -207,7 +201,7 @@ export function openapi<
         createOpenAPITool(operation, resolved.baseUrl, options, context),
       ])) as AgentToolSet
     },
-  } as OpenAPICapabilityDefinition<TRuntimeConfig, Name>)
+  })
 }
 
 function assertOpenAPIOptions(options: OpenAPICapabilityOptions): void {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -64,16 +64,10 @@ type ResolvedAgentOutputRenderer = ((result: unknown, extensions?: AgentOutputEx
   providerCount: number
 }
 export const workspaceMaterializationPathsSymbol: unique symbol = Symbol("vitehub.agent.workspaceMaterializationPaths")
-type InternalAgentCapabilityCliResolver<
-  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  Name extends WorkspaceName = WorkspaceName,
-> = (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<AgentCapabilityCliContribution<TRuntimeConfig, Name> | undefined>
-
-type InternalAgentCapabilityWithGeneratedCli<
+type InternalAgentCapabilityDefinition<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > = AgentCapabilityDefinition<TRuntimeConfig, Name> & {
-  resolveCli?: InternalAgentCapabilityCliResolver<TRuntimeConfig, Name>
   [workspaceMaterializationPathsSymbol]?: readonly string[]
 }
 type AgentCapabilityBashEntry = Extract<AgentCapabilityBashCommand, { command: string }>
@@ -82,9 +76,7 @@ type AgentCapabilityDefinitionInput<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
   TTypeContract extends AgentCapabilityTypeContract = AgentCapabilityTypeContract,
-> = AgentCapabilityDefinition<TRuntimeConfig, Name, TTypeContract> & {
-  resolveCli?: InternalAgentCapabilityCliResolver<TRuntimeConfig, Name>
-}
+> = AgentCapabilityDefinition<TRuntimeConfig, Name, TTypeContract>
 const defaultCapabilityRuntimePhases = ["configure", "prepare", "bind", "input", "resolve", "output"] as const
 export const channelDeliveryEffectsContextKey = "channel.delivery.effects"
 export const channelDeliveryFinishEffectsContextKey = "channel.delivery.finishEffects"
@@ -215,7 +207,7 @@ export function defineCapability<
   }
   assertCapabilityId((capability as { id?: unknown }).id)
   const cli = (capability as AgentCapabilityDefinition).cli
-  assertCapabilityCliContribution((capability as { id: string }).id, cli)
+  if (typeof cli !== "function") assertCapabilityCliContribution((capability as { id: string }).id, cli)
   if ((capability as AgentCapabilityDefinition).bash !== undefined) {
     normalizeWorkspaceCommandEntries((capability as AgentCapabilityDefinition).bash, `${(capability as { id: string }).id} bash`)
   }
@@ -779,7 +771,7 @@ export async function resolveAgentCapabilities<
   const workspaceMaterializationPaths = driverKind === "harness"
     ? compactWorkspacePaths(capabilities.flatMap(capability =>
         [
-          ...((capability as InternalAgentCapabilityWithGeneratedCli)[workspaceMaterializationPathsSymbol] || []),
+          ...((capability as InternalAgentCapabilityDefinition)[workspaceMaterializationPathsSymbol] || []),
           ...(capability.requires || []).flatMap(requirement => requirement.workspace?.paths || []),
         ],
       ))
@@ -1091,11 +1083,8 @@ export async function resolveAgentCapabilities<
     }
     for (const { capability, context } of capabilityContexts) {
       let cli: AgentCapabilityCliContribution<TRuntimeConfig, Name> | undefined
-      const resolveCli = (capability as InternalAgentCapabilityWithGeneratedCli<TRuntimeConfig, Name>).resolveCli
-      if ((capability.cli || resolveCli) && resolveCapabilityCli && invocationOptions.resolveTools !== false) {
-        cli = resolveCli
-          ? await resolveCli(context)
-          : capability.cli
+      if (capability.cli && resolveCapabilityCli && invocationOptions.resolveTools !== false) {
+        cli = await resolveRuntimeValue(capability.cli, context)
         assertCapabilityCliContribution(capability.id, cli)
       }
       if (invocationOptions.resolveTools !== false && cli && resolveCapabilityCli) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -187,6 +187,7 @@ export type {
   AgentCapabilityCliOutputDefinition,
   AgentCapabilityCliOutputFormat,
   AgentCapabilityCliRunContext,
+  AgentCapabilityCliResolver,
   AgentCapabilityCliStandardSchemaResultFailure,
   AgentCapabilityCliStandardSchemaResultSuccess,
   AgentCapabilityCliStandardSchemaV1,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -598,6 +598,13 @@ export interface AgentCapabilityCliContribution<
   name: string
 }
 
+export type AgentCapabilityCliResolver<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> =
+  | AgentCapabilityCliContribution<TRuntimeConfig, Name>
+  | ((context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<AgentCapabilityCliContribution<TRuntimeConfig, Name> | undefined>)
+
 export interface AgentCapabilityCliExecutionInput {
   argv?: readonly string[]
   input?: unknown
@@ -762,7 +769,7 @@ export interface AgentCapabilityDefinition<
   chatAttachments?: {
     audio?: boolean
   }
-  cli?: AgentCapabilityCliContribution<TRuntimeConfig, Name>
+  cli?: AgentCapabilityCliResolver<TRuntimeConfig, Name>
   close?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   configure?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   finish?: AgentFinishExtensionProvider<TRuntimeConfig>

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -286,6 +286,34 @@ describe("agent capability runtime", () => {
     })
   })
 
+  it("resolves Capability CLI contributions from invocation context", async () => {
+    const {
+      defineCapability,
+      resolveAgentCapabilities,
+    } = await import("../src/capability-runtime.ts")
+
+    const capability = defineCapability({
+      cli: context => context.run?.channelId === "portal"
+        ? {
+            commands: {
+              ping: { run: () => "pong" },
+            },
+            name: "portal",
+          }
+        : undefined,
+      id: "portal-runtime",
+    })
+    const portal = await resolveAgentCapabilities({
+      capabilities: [capability],
+    }, { ...runtime(), run: { channelId: "portal", runId: "portal-run" } }, {})
+    const teams = await resolveAgentCapabilities({
+      capabilities: [capability],
+    }, { ...runtime(), run: { channelId: "teams", runId: "teams-run" } }, {})
+
+    expect(Object.keys(portal.tools || {})).toEqual(["portal"])
+    expect(teams.tools).toBeUndefined()
+  })
+
   it("omits --json from generated text Capability CLI examples", async () => {
     const {
       defineCapability,

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -680,7 +680,7 @@ describe("agent chat capability discovery", () => {
     ])
   })
 
-  it("runs Capability CLI commands through the Vite endpoint", async () => {
+  it("runs invocation-resolved Capability CLI commands through the Vite endpoint", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-cli-")
     await mkdir(join(root, "server", "agents"), { recursive: true })
     await writeFile(join(root, "server", "agents", "chat.ts"), "export default {}", "utf8")
@@ -690,21 +690,23 @@ describe("agent chat capability discovery", () => {
     const agent = defineAgent({
       capabilities: [
         defineCapability({
-          cli: {
-            commands: {
-              items: {
+          cli: ({ run }) => run?.origin === "dev"
+            ? {
                 commands: {
-                  list: {
-                    description: "List inventory items.",
-                    output: { format: "json" },
-                    run: ({ json }) => ({ items: [{ id: "item_1" }], json }),
+                  items: {
+                    commands: {
+                      list: {
+                        description: "List inventory items.",
+                        output: { format: "json" },
+                        run: ({ json }) => ({ items: [{ id: "item_1" }], json }),
+                      },
+                    },
+                    description: "Inventory item data.",
                   },
                 },
-                description: "Inventory item data.",
-              },
-            },
-            name: "inventory",
-          },
+                name: "inventory",
+              }
+            : undefined,
           id: "inventory-runtime",
         }),
       ],

--- a/packages/agent/test/openapi-capability.test.ts
+++ b/packages/agent/test/openapi-capability.test.ts
@@ -293,6 +293,29 @@ describe("openapi capability", () => {
     expect(request.mock.calls[0]?.[0]).toBe("https://cli.example.com/runtime/customers?region=eu")
   })
 
+  it("resolves generated Capability CLI options per invocation", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+    const spec = vi.fn(() => portalSpec())
+    const capability = openapi({
+      cli: context => context.run?.channelId === "portal" ? { name: "portal" } : false,
+      operations: ["listCustomers"],
+      spec,
+    })
+
+    const teams = await resolveAgentCapabilities({
+      capabilities: [capability],
+    }, { ...runtime(), run: { channelId: "teams", runId: "teams-run" } }, {})
+    expect(teams.tools).toBeUndefined()
+    expect(spec).not.toHaveBeenCalled()
+
+    const portal = await resolveAgentCapabilities({
+      capabilities: [capability],
+    }, { ...runtime(), run: { channelId: "portal", runId: "portal-run" } }, {})
+    expect(Object.keys(portal.tools || {})).toEqual(["portal"])
+    expect(spec).toHaveBeenCalledOnce()
+  })
+
   it("prepares requests with runtime hook values before HTTP execution", async () => {
     const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ ok: true }))
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, observability, openapi, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput, type UsageTelemetryRecord } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -97,6 +97,16 @@ describe("agent public types", () => {
               },
             },
           },
+          spec: openAPISpec,
+        }),
+        openapi({
+          cli: context => context.run?.channelId === "portal"
+            ? {
+                description: "Inspect live Portal data.",
+                name: "portal-api",
+              }
+            : undefined,
+          operations: ["listCustomers"],
           spec: openAPISpec,
         }),
         git(),
@@ -627,7 +637,7 @@ describe("agent public types", () => {
       },
     })
 
-    expectTypeOf(inventoryRuntime.cli?.commands).toMatchTypeOf<Record<string, AgentCapabilityCliCommand> | undefined>()
+    expectTypeOf(inventoryRuntime.cli).toMatchTypeOf<AgentCapabilityCliResolver | undefined>()
     const audioRuntime = defineCapability({
       chatAttachments: { audio: true },
       id: "audio-runtime",
@@ -639,18 +649,20 @@ describe("agent public types", () => {
       // @ts-expect-error Capability instructions were removed from Capability definitions.
       instructions: "Use inventory only for runtime data.",
     })
-    defineCapability({
+    const dynamicInventoryRuntime = defineCapability({
       id: "dynamic-inventory-runtime",
-      // @ts-expect-error Capability CLI contributions are flat objects, not resolver functions
-      cli: () => ({
-        commands: {
-          list: {
-            run: () => ({ items: [] }),
-          },
-        },
-        name: "inventory",
-      }),
+      cli: context => context.run?.channelId === "portal"
+        ? {
+            commands: {
+              list: {
+                run: () => ({ items: [] }),
+              },
+            },
+            name: "inventory",
+          }
+        : undefined,
     })
+    expectTypeOf(dynamicInventoryRuntime.cli).toMatchTypeOf<AgentCapabilityCliResolver | undefined>()
     type RootAgentExports = typeof import("../src/index.ts")
     // @ts-expect-error Capability CLI builders are not root Agent Package exports
     type _RootCliBuilder = RootAgentExports["cli"]


### PR DESCRIPTION
Allows Capability CLI contributions to resolve from the current Agent Invocation while keeping the Capability statically attached to its Agent Definition. The OpenAPI Capability now uses that public resolver instead of the private `resolveCli` convention, and `openapi({ cli })` can return CLI options, `false`, or `undefined` without loading the OpenAPI spec for omitted invocations.

This lets multi-channel Agents expose a Portal-only CLI without making Channels own Capabilities or treating Channel metadata as authorization. Trusted request, Agent Actor, and `access()` checks remain the authority boundaries; runtime, generated OpenAPI CLI, Agent Dev Loop, and public-type coverage protect the new behavior.