### PR TITLE
fix(agent): expose channel context and align workspace scopes

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -90,7 +90,11 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
-The `run` fields are first-class Agent Run metadata, not Chat context. They help DevTools, traces, and finish hooks explain where the invocation came from.
+The `run` fields are first-class Agent Run metadata, not legacy Chat context. They help DevTools, traces, and finish hooks explain where the invocation came from.
+
+Message-shaped Channels also record a canonical `channel` Agent Invocation Context Value. Capability callbacks, dynamic model metadata callbacks, and Source resolvers receive it directly as `context.channel`; instruction composition can read it as `context.channel`. It contains the current `message`, `meta`, `run`, `session`, and `user` values when available.
+
+The legacy `chat` context value remains available through `context.get('chat')` for compatibility, but it does not receive Agent Run metadata. Augment `ViteHubAgentChannelMeta` and `ViteHubAgentChannelUser` in application code to type app-owned metadata and user fields.
 
 ## Admit web chat requests
 

--- a/docs/content/docs/capabilities/access.md
+++ b/docs/content/docs/capabilities/access.md
@@ -52,6 +52,8 @@ export default defineAgent({
 The Capability records the selected Workspace Scope in invocation context and replaces the active Workspace facade with a scoped facade.
 Put model-facing guidance for each Access scope in Agent Driver Instructions or an imported instruction file, and cover the Access Capability with an explicit `::capability{key="access"}` block when that guidance depends on Access.
 
+A Workspace Source without `scopes` is available in every selected Workspace Scope. Adding `scopes` restricts that Source to matching names. `resolve` and `defaultScope` may select those names without duplicating empty entries in `workspace.scopes`; declare a named scope only when it needs explicit paths, Source grants, `all`, or a role.
+
 ## Requirements
 
 `access({ workspace })` requires an explicit Workspace and currently applies read-only Workspace Scope.
@@ -74,7 +76,7 @@ Run an Agent Invocation that includes `access()` and inspect DevTools for the `a
 Verify that `access.workspaceScope` appears in invocation context and that later Workspace tools cannot read outside the selected paths.
 
 Trigger a scope failure during development.
-Unknown scopes, root-mounted Source grants, missing Workspace definitions, and invalid path escapes should fail before model execution.
+Missing scope selection, root-mounted Source grants, missing Workspace definitions, and invalid path escapes should fail before model execution.
 
 ## Options
 
@@ -83,7 +85,7 @@ Unknown scopes, root-mounted Source grants, missing Workspace definitions, and i
 | `chat.resolve` | `(context) => boolean \| void` | none | Allow or reject trusted Chat Platform traffic before the Agent Invocation runs. |
 | `workspace.defaultScope` | `string` | none | Fallback Workspace Scope name when `resolve` does not choose one. |
 | `workspace.resolve` | `string \| selection \| function` | none | Select a Workspace Scope from trusted invocation context. |
-| `workspace.scopes` | `Record<string, scope>` | none | Named Workspace Scope definitions. |
+| `workspace.scopes` | `Record<string, scope>` | none | Optional named Workspace Scope definitions for explicit grants, roles, or full access. |
 | `scope.all` | `boolean` | `false` | Grant the full Workspace for that scope. |
 | `scope.path` / `scope.paths` | `string \| string[]` | none | Grant Workspace paths. |
 | `scope.source` / `scope.sources` | `string \| string[]` | none | Grant Workspace Sources. |

--- a/docs/content/docs/server-primitives/workspace.md
+++ b/docs/content/docs/server-primitives/workspace.md
@@ -150,6 +150,7 @@ Workspace Source Bindings can wrap Source Package loaders and add Workspace beha
 | `cache` | `false or WorkspaceCacheOptions` | Source cache policy. Use `false` to disable caching or `{ maxAge }` to set a TTL. |
 | `validate` | `WorkspaceValidateMode` | Request validation mode for API-backed Sources. Use `false` or `request`. |
 | `sync` | `WorkspaceSourceSyncConfig` | Enables explicit Workspace Source Sync. Accepts `true`, `false`, or a sync policy. |
+| `scopes` | `string[]` | Restricts the Source to matching selected Workspace Scope names. Omit it to make the Source available to every scope. |
 | `resolve` | `WorkspaceSourceResolver` | Invocation-aware source resolution. |
 
 ## Use it at runtime
@@ -228,9 +229,15 @@ Custom Sources can read existing materialized Workspace files through `ctx.works
 Sources can resolve their concrete origin and Mount for one invocation from trusted runtime context. Use this when the same Source key should point at a narrowed origin after Access has selected a Workspace Scope.
 
 ```ts
-github(({ invocation }) => {
+declare global {
+  interface ViteHubWorkspaceSourceResolutionContextMap {
+    channel: { meta?: { customer?: string } }
+  }
+}
+
+github(({ channel, invocation }) => {
   const scope = invocation.context.get<{ customers: string[] }>('support.customerScope')
-  const customer = scope?.customers[0]
+  const customer = channel?.meta?.customer ?? scope?.customers[0]
   if (!customer)
     return false
 
@@ -242,7 +249,7 @@ github(({ invocation }) => {
 })
 ```
 
-The resolver reads Agent Invocation Context Values and the Selected Workspace Scope, not model output. Access still enforces visibility, and scope-affecting resolved options are fingerprinted so source caches do not reuse data across scopes.
+The resolver receives registered invocation context values directly and can still read them through `invocation.context`. Register app-owned values through `ViteHubWorkspaceSourceResolutionContextMap`; the Agent package registers its canonical `channel` value automatically. Agent integrations omit legacy and internal aliases from the direct view. The resolver reads trusted Agent Invocation Context Values and the Selected Workspace Scope, not model output. Access still enforces visibility, and scope-affecting resolved options are fingerprinted so source caches do not reuse data across scopes.
 
 Resolved Sources are evaluated at invocation time and default to lazy materialization. A resolver can return a narrowed GitHub `repo`, `root`, and `mount` without also declaring build-time materialization or cache options; the resolved fingerprint includes the Selected Workspace Scope so one scope cannot reuse another scope's source data.
 

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -8,6 +8,7 @@ import { loadAiSdk } from "./internal/ai-sdk-runtime.ts"
 import {
   applyCapabilityToolTransforms,
 } from "./capability-runtime.ts"
+import { agentInvocationCallbackContextValues } from "./invocation-context.ts"
 import { composeInstructionDocument } from "./instruction-composition.ts"
 import {
   applyAgentToolPolicies,
@@ -820,6 +821,7 @@ async function createAgent(
   const execution = options.execution ?? options.modelExecution
   const { runtimeConfig: _runtimeConfig, ...runtime } = context.runtime
   const metadataContext = {
+    ...agentInvocationCallbackContextValues(context.context),
     ...runtime,
     actor: context.actor,
     context: context.context,

--- a/packages/agent/src/capabilities/access.ts
+++ b/packages/agent/src/capabilities/access.ts
@@ -1,6 +1,7 @@
 import { markTrustedWorkspaceAccessScope, markTrustedWorkspaceSourceResolutionDefinition, workspaceOverrideSymbol } from "../access-runtime.ts"
 import { defineCapability } from "../capability-runtime.ts"
-import { workspaceSourceKeysForScope, workspaceSourceScopeNames, workspaceSourceScopePaths } from "../workspace-source-metadata.ts"
+import { agentInvocationSourceContext } from "../invocation-context.ts"
+import { workspaceSourceKeysForScope, workspaceSourceScopePaths } from "../workspace-source-metadata.ts"
 import type { AccessCapabilityMetadata } from "./access-metadata.ts"
 
 import type {
@@ -285,7 +286,7 @@ export function access<
   Name extends WorkspaceName = WorkspaceName,
   TInputContext extends object = Record<string, unknown>,
   const TWorkspace extends AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext> = AccessWorkspaceOptions<TRuntimeConfig, Name, string, TInputContext>,
->(options: { chat?: AccessChatOptions<TRuntimeConfig>, input?: undefined, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext, AccessWorkspaceScopeNameOrString<TWorkspace>, AccessWorkspaceStaticScopeName<TWorkspace>>>
+>(options: { chat?: AccessChatOptions<TRuntimeConfig>, input?: undefined, workspace: TWorkspace }): AgentCapabilityDefinition<TRuntimeConfig, Name, AccessCapabilityTypeContract<AccessWorkspaceScopeSourceName<TWorkspace>, TInputContext, AccessWorkspaceScopeNameOrString<TWorkspace>, AccessWorkspaceScopeName<TWorkspace>>>
 export function access<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
@@ -322,7 +323,7 @@ export function access(options: AccessCapabilityOptions): AgentCapabilityDefinit
       const sourceResolutionScope = withHarnessWorkspacePaths(scope, workspaceMaterializationPaths(context))
       const sourceResolutionOptions = {
         invocation: {
-          context: context.context,
+          context: agentInvocationSourceContext(context.context),
           run: context.run,
         },
         selectedWorkspaceScope: toWorkspaceSelectedScope(sourceResolutionScope),
@@ -390,11 +391,7 @@ async function resolveWorkspaceScope<
     throw new Error("[vitehub] access({ workspace }) could not resolve a Workspace Scope. defaultScope or resolve() must produce a Workspace Scope.")
   }
 
-  validateWorkspaceSourceScopeNames(options, context.workspaceDefinition)
-  const definition = selection.definition || options.scopes?.[selection.scope]
-  if (!definition) {
-    throw new Error(`[vitehub] access({ workspace }) resolved unknown Workspace Scope "${selection.scope}". scopes.${selection.scope} or an inline scope definition must define it.`)
-  }
+  const definition = selection.definition || options.scopes?.[selection.scope] || {}
   assertNoLegacyWorkspaceScopeInstructions(definition, `Workspace Scope "${selection.scope}"`)
   const scopedDefinition = withWorkspaceSourceScopeGrants(definition, selection.scope, context.workspaceDefinition)
 
@@ -411,23 +408,6 @@ async function resolveWorkspaceScope<
     paths: all ? [""] : scopePaths(scopedDefinition, context.workspaceDefinition, workspaceRuntime),
     role,
     scope: selection.scope,
-  }
-}
-
-function validateWorkspaceSourceScopeNames(
-  options: { scopes?: Record<string, unknown> },
-  workspaceDefinition: WorkspaceDefinition | undefined,
-): void {
-  const scopes = workspaceSourceScopeNames(workspaceDefinition?.sources)
-  if (!scopes.length) return
-  if (!options.scopes) {
-    throw new Error("[vitehub] Workspace Source scopes require access({ workspace }).scopes.")
-  }
-  const allowed = new Set(Object.keys(options.scopes))
-  for (const scope of scopes) {
-    if (!allowed.has(scope)) {
-      throw new Error(`[vitehub] Workspace Source scope "${scope}" is not defined in access({ workspace }).scopes.`)
-    }
   }
 }
 

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -126,6 +126,7 @@ export type {
 } from "./access.ts"
 export type {
   AgentChatCapabilityOrigin,
+  AgentChannelContext,
   AgentChatContext,
   AgentChatMessageTriggerInput,
   AgentChatOptionsOrigin,

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -5,10 +5,9 @@ import {
   assertCapabilityCliContribution,
   createCapabilityCliTool,
 } from "./capability-cli.ts"
-import { getAccessCapabilityOptions } from "./capabilities/access-metadata.ts"
 import { normalizeWorkspaceCommandEntries, workspaceCommandTools } from "./capabilities/workspace-command.ts"
 import { createMessage } from "./messages.ts"
-import { createAgentInvocationContextStore } from "./invocation-context.ts"
+import { agentInvocationCallbackContextValues, agentInvocationSourceContext, createAgentInvocationContextStore } from "./invocation-context.ts"
 import { normalizeAgentWorkspaceSource, workspaceSourceScopeNames, workspaceSourceScopePaths } from "./workspace-source-metadata.ts"
 import {
   createFallbackAgentInvoker,
@@ -665,17 +664,6 @@ function assertWorkspaceSourceScopesRequireAccess(
   if (!capabilities.some(capabilityUsesWorkspaceAccess)) {
     throw new Error("[vitehub] Workspace Source scopes require access({ workspace }).")
   }
-  const accessScopeNames = new Set(getAccessCapabilityOptions<AgentRuntimeConfig>(capabilities).flatMap(options =>
-    options.workspace?.scopes ? Object.keys(options.workspace.scopes) : [],
-  ))
-  if (!accessScopeNames.size) {
-    throw new Error("[vitehub] Workspace Source scopes require access({ workspace }).scopes.")
-  }
-  for (const scope of sourceScopes) {
-    if (!accessScopeNames.has(scope)) {
-      throw new Error(`[vitehub] Workspace Source scope "${scope}" is not defined in access({ workspace }).scopes.`)
-    }
-  }
 }
 
 async function applyCapabilityWorkspaceContributions<
@@ -727,7 +715,7 @@ async function applyCapabilityWorkspaceContributions<
   assertStaticWorkspaceContributionSourcesInScope(registries, definition, selectedWorkspaceScope, workspaceRuntime)
   const resolvedDefinition = await workspaceRuntime.resolveWorkspaceSources(definition, {
     invocation: {
-      context: context.context,
+      context: agentInvocationSourceContext(context.context),
       run: context.run,
     },
     selectedWorkspaceScope,
@@ -736,7 +724,7 @@ async function applyCapabilityWorkspaceContributions<
   setSelectedWorkspaceScopeContext(context.context, selectedWorkspaceScope)
   const sourceResolution = await workspaceRuntime.createWorkspaceSourceResolutionFacade(context.workspace as never, resolvedDefinition, {
     invocation: {
-      context: context.context,
+      context: agentInvocationSourceContext(context.context),
       run: context.run,
     },
     overlay: true,
@@ -864,6 +852,7 @@ export async function resolveAgentCapabilities<
     if (sourceResolvedDefinition) currentWorkspaceDefinition = sourceResolvedDefinition
     assertWorkspaceSourceScopesRequireAccess(currentWorkspaceDefinition, capabilities)
     const workspaceContribution = await applyCapabilityWorkspaceContributions(capabilities, {
+      ...agentInvocationCallbackContextValues(invocationContext),
       ...runtimeContext,
       actor: invoker,
       context: invocationContext,
@@ -889,6 +878,7 @@ export async function resolveAgentCapabilities<
       await validateCapabilityRuntimeRequirement(capability as AgentCapabilityDefinition, currentWorkspace, workspaceMode)
       const phases = invocationOptions.phases || defaultCapabilityRuntimePhases
       const metadataContext = {
+        ...agentInvocationCallbackContextValues(invocationContext),
         ...runtimeContext,
         actor: invoker,
         context: invocationContext,
@@ -1167,6 +1157,7 @@ export async function resolveStaticCapabilityTools<
     await validateCapabilityRuntimeRequirement(capability as AgentCapabilityDefinition, workspace, workspaceMode)
     if (!capability.tools) continue
     const capabilityContext = {
+      ...agentInvocationCallbackContextValues(invocationContext),
       ...runtimeContext,
       actor: invoker,
       context: invocationContext,

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -331,6 +331,13 @@ export function createChatMessageTriggerInput<TRuntimeConfig extends AgentRuntim
       context: {
         ...(invoker ? { invoker } : {}),
         ...(triggerInput?.invokerProfileId ? { invokerProfileId: triggerInput.invokerProfileId } : {}),
+        channel: {
+          message: hookArgs.message,
+          run: triggerInput?.run,
+          session: triggerInput?.session,
+          meta: triggerInput?.meta,
+          user: triggerInput?.user,
+        },
         chat: {
           message: hookArgs.message,
           session: triggerInput?.session,

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -11,6 +11,7 @@ import type {
   AgentChatPlatformResolver,
   AgentChannelWebhookRegistrationDefinition,
   AgentInvocationContextStore,
+  AgentRunMetadata,
   AgentRuntimeConfig,
   AgentTriggerDefinition,
   AgentWebhookRegistrationDefinition,
@@ -89,6 +90,23 @@ export type AgentChatContext<
   TUser extends object = Record<string, unknown>,
   TMessageMetadata extends object = Record<string, unknown>,
 > = NonNullable<AgentChatRunContext<TMessageMetadata, TUser, TMeta>["chat"]>
+
+export type AgentChannelContext<
+  TMeta extends object = Record<string, unknown>,
+  TUser extends object = Record<string, unknown>,
+  TMessageMetadata extends object = Record<string, unknown>,
+> = AgentChatContext<TMeta, TUser, TMessageMetadata> & { run?: AgentRunMetadata }
+
+declare global {
+  interface ViteHubAgentChannelMeta {}
+  interface ViteHubAgentChannelUser {}
+  interface ViteHubAgentInvocationContextValues {
+    channel: AgentChannelContext<ViteHubAgentChannelMeta, ViteHubAgentChannelUser>
+  }
+  interface ViteHubWorkspaceSourceResolutionContextMap {
+    channel: AgentChannelContext<ViteHubAgentChannelMeta, ViteHubAgentChannelUser>
+  }
+}
 
 export function getAgentChatContext<
   TMeta extends object = Record<string, unknown>,

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -50,7 +50,7 @@ const chatDevtoolsInvoker = {
   kind: "devtools" as const,
   label: "DevTools User",
 }
-const chatDevtoolsUser = {
+const chatDevtoolsUser: Record<string, unknown> = {
   id: "devtools",
   name: "DevTools User",
 }
@@ -223,8 +223,12 @@ function createDevtoolsMetadataRunMetadata(name: string): AgentRunMetadata<"devt
   }
 }
 
-function createDevtoolsMetadataInput(selection: ChatDevtoolsInvokerSelection = {}): AgentRunInput {
+function createDevtoolsMetadataInput(
+  selection: ChatDevtoolsInvokerSelection = {},
+  run: AgentRunMetadata,
+): AgentRunInput {
   const meta = optionalRecord(selection.meta)
+  const message = { metadata: {}, text: "" }
   return {
     context: {
       invoker: {
@@ -232,8 +236,14 @@ function createDevtoolsMetadataInput(selection: ChatDevtoolsInvokerSelection = {
         ...(meta ? { meta } : {}),
       },
       ...(!selection.invokerFallback && selection.invokerProfileId ? { invokerProfileId: selection.invokerProfileId } : {}),
+      channel: {
+        message,
+        ...(meta ? { meta } : {}),
+        run,
+        user: chatDevtoolsUser,
+      },
       chat: {
-        message: { metadata: {} },
+        message,
         ...(meta ? { meta } : {}),
         user: chatDevtoolsUser,
       },
@@ -356,10 +366,11 @@ async function startMetadataResolution(
   entry.metadataSelectionKey = selectionKey
   entry.metadataStatus = "loading"
 
+  const run = createDevtoolsMetadataRunMetadata(entry.name)
   const task = resolveAgentDevtoolsMetadata(entry.agent as never, {
     ...entry.defaults,
-    input: createDevtoolsMetadataInput(metadataSelection),
-    runtime: { run: createDevtoolsMetadataRunMetadata(entry.name) },
+    input: createDevtoolsMetadataInput(metadataSelection, run),
+    runtime: { run },
   } as never)
     .then((metadata) => {
       if (entry.metadataTask !== task || entry.metadataSelectionKey !== selectionKey) return
@@ -888,12 +899,13 @@ async function materializeDevtoolsSource(
   entry.metadataError = undefined
 
   try {
+    const run = createDevtoolsMetadataRunMetadata(entry.name)
     const metadata = await materializeAgentDevtoolsSourceMetadata(entry.agent as never, {
       ...entry.defaults,
-      input: createDevtoolsMetadataInput(metadataSelection),
+      input: createDevtoolsMetadataInput(metadataSelection, run),
       ...(input.path ? { path: input.path } : {}),
       ...(input.source ? { source: input.source } : {}),
-      runtime: { run: createDevtoolsMetadataRunMetadata(entry.name) },
+      runtime: { run },
       sources: materializedSourceKeys(entry.metadata),
     } as never)
     entry.metadata = metadataWithAgentName(metadata, entry.name)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -380,6 +380,7 @@ export {
 } from "./chat-trigger.ts"
 
 export type {
+  AgentChannelContext,
   AgentChatContext,
   AgentChatRunContext,
 } from "./chat-trigger.ts"

--- a/packages/agent/src/invocation-context.ts
+++ b/packages/agent/src/invocation-context.ts
@@ -1,5 +1,35 @@
 import type { AgentInvocationContextStore } from "./types.ts"
 
+function isCallbackContextValue(id: string): boolean {
+  return id !== "actor"
+    && id !== "invoker"
+    && id !== "chat"
+    && !id.startsWith("agent.")
+    && !id.startsWith("channel.delivery.")
+    && !id.startsWith("chat.")
+    && !id.startsWith("workspace.")
+}
+
+function* callbackContextEntries(context: AgentInvocationContextStore): IterableIterator<[string, unknown]> {
+  for (const entry of context.entries()) {
+    if (isCallbackContextValue(entry[0])) yield entry
+  }
+}
+
+export function agentInvocationCallbackContextValues(context: AgentInvocationContextStore): Record<string, unknown> {
+  return Object.fromEntries(callbackContextEntries(context))
+}
+
+export function agentInvocationSourceContext(context: AgentInvocationContextStore): AgentInvocationContextStore {
+  return {
+    entries: () => callbackContextEntries(context),
+    get: context.get.bind(context),
+    has: context.has.bind(context),
+    set: context.set.bind(context),
+    toJSON: context.toJSON.bind(context),
+  }
+}
+
 function assertContextId(id: unknown): asserts id is string {
   if (typeof id !== "string" || !id.trim()) {
     throw new TypeError("[vitehub] Invocation context values require a non-empty string id.")

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1748,8 +1748,13 @@ function chatDevtoolsUser(meta: Record<string, unknown> | undefined): Record<str
   }
 }
 
-function createDevtoolsMetadataInput(selection: AgentChatDevtoolsInvokerSelection = {}): AgentRunInput {
+function createDevtoolsMetadataInput(
+  selection: AgentChatDevtoolsInvokerSelection = {},
+  run: AgentRunMetadata,
+): AgentRunInput {
   const meta = optionalRecord(selection.meta)
+  const message = { metadata: {}, text: "" }
+  const user = chatDevtoolsUser(meta)
   return {
     context: {
       invoker: {
@@ -1759,10 +1764,16 @@ function createDevtoolsMetadataInput(selection: AgentChatDevtoolsInvokerSelectio
         ...(meta ? { meta } : {}),
       },
       ...(!selection.invokerFallback && selection.invokerProfileId ? { invokerProfileId: selection.invokerProfileId } : {}),
-      chat: {
-        message: { metadata: {} },
+      channel: {
+        message,
         ...(meta ? { meta } : {}),
-        user: chatDevtoolsUser(meta),
+        run,
+        user,
+      },
+      chat: {
+        message,
+        ...(meta ? { meta } : {}),
+        user,
       },
     },
     messages: [],
@@ -1850,10 +1861,11 @@ async function startAgentDevtoolsMetadataResolution(
   state.metadataStatus = "loading"
 
   const { resolveAgentDevtoolsMetadata } = await import("../workspace-agent.ts")
+  const run = createDevtoolsMetadataRunMetadata(name)
   const task = resolveAgentDevtoolsMetadata(agent as never, {
     ...options.defaults,
-    input: createDevtoolsMetadataInput(metadataSelection),
-    runtime: { ...runtime, run: createDevtoolsMetadataRunMetadata(name) },
+    input: createDevtoolsMetadataInput(metadataSelection, run),
+    runtime: { ...runtime, run },
   } as never)
     .then((metadata) => {
       if (state.metadataTask !== task || state.metadataSelectionKey !== selectionKey) return
@@ -2258,12 +2270,13 @@ async function materializeDevtoolsSource(
   try {
     const { materializeAgentDevtoolsSourceMetadata } = await import("../workspace-agent.ts")
     const name = agentChannelDevtoolsName(agent, options)
+    const run = createDevtoolsMetadataRunMetadata(name)
     const metadata = await materializeAgentDevtoolsSourceMetadata(agent as never, {
       ...options.defaults,
-      input: createDevtoolsMetadataInput(metadataSelection),
+      input: createDevtoolsMetadataInput(metadataSelection, run),
       ...(input.path ? { path: input.path } : {}),
       ...(input.source ? { source: input.source } : {}),
-      runtime: { ...runtime, run: createDevtoolsMetadataRunMetadata(name) },
+      runtime: { ...runtime, run },
       sources: materializedSourceKeys(state.metadata),
     } as never)
     state.metadata = metadataWithAgentName(metadata, name)

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -101,6 +101,18 @@ export interface AgentInvocationContextValues extends ViteHubAgentInvocationCont
   invoker: AgentInvoker
 }
 
+type AgentInvocationCallbackContextKey = {
+  [Key in keyof ViteHubAgentInvocationContextValues]: Key extends string
+    ? Key extends "actor" | "chat" | "invoker" | `agent.${string}` | `channel.delivery.${string}` | `chat.${string}` | `workspace.${string}`
+      ? never
+      : Key
+    : never
+}[keyof ViteHubAgentInvocationContextValues]
+
+interface AgentInvocationCallbackContextValues extends Partial<Pick<ViteHubAgentInvocationContextValues, AgentInvocationCallbackContextKey>> {
+  access?: AgentAccessInvocationContextValue
+}
+
 export type AgentRunInputContextValues = Partial<AgentInvocationContextValues> & Record<string, unknown>
 
 export interface AgentInvocationContextStore<TValues extends object = AgentInvocationContextValues> {
@@ -1449,7 +1461,7 @@ export interface AgentUsageRecord {
 export interface AgentAdapterMetadataContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
-> extends AgentCallbackContext<TRuntimeConfig> {
+> extends AgentCallbackContext<TRuntimeConfig>, AgentInvocationCallbackContextValues {
   actor: AgentActor
   context: AgentInvocationContextStore
   driver?: {

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -4,7 +4,7 @@ import {
   normalizeMode,
   resolveAgentCapabilities,
 } from "./capability-runtime.ts"
-import { createAgentInvocationContextStore } from "./invocation-context.ts"
+import { agentInvocationCallbackContextValues, agentInvocationSourceContext, createAgentInvocationContextStore } from "./invocation-context.ts"
 import {
   normalizeAgentInvokerProfiles,
   resolveAgentInvoker,
@@ -1109,19 +1109,7 @@ function skillCoverageWarnings(
 }
 
 function createDevtoolsSourceResolutionContext(input: AgentRunInput | undefined): WorkspaceSourceResolutionContextValueReader<object> {
-  const values = new Map<string, unknown>()
-  if (input?.context && typeof input.context === "object") {
-    for (const [key, value] of Object.entries(input.context as Record<string, unknown>)) {
-      values.set(key, value)
-    }
-  }
-
-  return {
-    entries: () => values.entries(),
-    get: (key: string) => values.get(key) as never,
-    has: key => values.has(key),
-    toJSON: () => Object.fromEntries(values),
-  }
+  return agentInvocationSourceContext(createAgentInvocationContextStore(input?.context))
 }
 
 function workspaceOptionsFromDefinition<
@@ -1254,6 +1242,7 @@ async function resolveWorkspaceMetadataCapabilityContext<
   return {
     definition: capabilities.workspaceDefinition || sourceResolvedDefinition || workspaceDefinition,
     metadataContext: {
+      ...agentInvocationCallbackContextValues(invocationContext),
       ...agentCallbackContext(runtime),
       actor: invoker,
       context: invocationContext,

--- a/packages/agent/test/access-capability.test.ts
+++ b/packages/agent/test/access-capability.test.ts
@@ -803,6 +803,7 @@ describe("access capability", () => {
           private: custom({
             materialize: "lazy",
             mount: "ingestion/acme/private",
+            scopes: ["private"],
             async getKeys() {
               return []
             },
@@ -862,6 +863,7 @@ describe("access capability", () => {
       name: "support",
       sources: {
         ingestion: custom({
+          scopes: ["globex"],
           async resolve() {
             return custom({
               mount: "ingestion/globex",
@@ -1131,7 +1133,13 @@ describe("access capability", () => {
           },
         }),
       ],
-    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace(), "read", {
+    }, { ...runtime(), runtimeConfig: {} }, {
+      context: {
+        channel: { meta: { customer: "acme" } },
+        chat: { user: { id: "legacy-user" } },
+      },
+      prompt: "check",
+    }, createWorkspace(), "read", {
       workspaceDefinition: {
         name: "support",
         sources: {
@@ -1154,8 +1162,11 @@ describe("access capability", () => {
     })
 
     expect(resolveSource).toHaveBeenCalledWith(expect.objectContaining({
+      channel: { meta: { customer: "acme" } },
       selectedWorkspaceScope: expect.objectContaining({ name: "acme" }),
     }))
+    expect(resolveSource.mock.calls[0]?.[0]).not.toHaveProperty("chat")
+    expect(resolveSource.mock.calls[0]?.[0].invocation.context.get("chat")).toEqual({ user: { id: "legacy-user" } })
     await expect(resolved.workspace!.fs.readFile("customers/acme/resolved.md")).resolves.toBe("resolved for acme")
     await expect(resolved.workspace!.fs.exists("customers/globex/brief.md")).resolves.toBe(false)
   })
@@ -1189,18 +1200,15 @@ describe("access capability", () => {
     await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(false)
   })
 
-  it("fails closed when Workspace Source scopes are not declared in Access", async () => {
+  it("keeps sources outside resolver-selected scopes without matching names or paths", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
 
-    await expect(resolveAgentCapabilities({
+    const resolved = await resolveAgentCapabilities({
       capabilities: [
         access({
           workspace: {
-            defaultScope: "support",
-            scopes: {
-              support: { paths: ["public"] },
-            },
+            resolve: () => "support",
           },
         }),
       ],
@@ -1208,23 +1216,53 @@ describe("access capability", () => {
       workspaceDefinition: {
         name: "support",
         sources: {
-          customerDocs: { mount: "customers/acme", scopes: ["missing"] } as never,
+          customerDocs: { mount: "customers/acme", scopes: ["technical"] } as never,
+          publicDocs: { mount: "public" } as never,
         },
       },
-    })).rejects.toThrow("Workspace Source scope \"missing\"")
+    })
+
+    await expect(resolved.workspace!.fs.exists("public/readme.md")).resolves.toBe(false)
+    await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(false)
   })
 
-  it("fails closed when Workspace Source scopes use inline Access definitions", async () => {
+  it("keeps unscoped sources available on selected paths and grants matching sources", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
 
-    await expect(resolveAgentCapabilities({
+    const resolved = await resolveAgentCapabilities({
       capabilities: [
         access({
           workspace: {
-            resolve: {
-              scope: "support",
-              paths: ["customers/acme"],
+            resolve: () => ({ paths: ["public"], scope: "technical" }),
+          },
+        }),
+      ],
+    }, { ...runtime(), runtimeConfig: {} }, { prompt: "check" }, createWorkspace(), "read", {
+      workspaceDefinition: {
+        name: "support",
+        sources: {
+          customerDocs: { mount: "customers/acme", scopes: ["technical"] } as never,
+          publicDocs: { mount: "public" } as never,
+        },
+      },
+    })
+
+    await expect(resolved.workspace!.fs.exists("public/readme.md")).resolves.toBe(true)
+    await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(true)
+  })
+
+  it("does not convert unscoped root-mounted sources into source grants", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { access } = await import("../src/capabilities.ts")
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        access({
+          workspace: {
+            defaultScope: "customer",
+            scopes: {
+              customer: { paths: ["public"] },
             },
           },
         }),
@@ -1233,10 +1271,13 @@ describe("access capability", () => {
       workspaceDefinition: {
         name: "support",
         sources: {
-          customerDocs: { mount: "customers/acme", scopes: ["support"] } as never,
+          rootDocs: { mount: "" } as never,
         },
       },
-    })).rejects.toThrow("Workspace Source scopes require access({ workspace }).scopes")
+    })
+
+    await expect(resolved.workspace!.fs.exists("public/readme.md")).resolves.toBe(true)
+    await expect(resolved.workspace!.fs.exists("customers/acme/brief.md")).resolves.toBe(false)
   })
 
   it("fails closed when Workspace Source scopes are configured without Access", async () => {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -438,12 +438,29 @@ describe("agent capability runtime", () => {
 
   it("passes named invocation context values through capabilities and custom runs", async () => {
     const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const observedContext = vi.fn()
 
     const agent = defineAgent({
       capabilities: [
         defineCapability({
           id: "mode",
           configure(context) {
+            const values = context as typeof context & {
+              "agent.secret"?: unknown
+              channel?: unknown
+              "channel.delivery.supportsTitle"?: unknown
+              chat?: unknown
+              "chat.secret"?: unknown
+              "workspace.secret"?: unknown
+            }
+            observedContext({
+              agentSecret: values["agent.secret"],
+              channel: values.channel,
+              channelDelivery: values["channel.delivery.supportsTitle"],
+              chat: values.chat,
+              chatSecret: values["chat.secret"],
+              workspaceSecret: values["workspace.secret"],
+            })
             context.context.set("mode", { choice: "support" })
           },
         }),
@@ -457,11 +474,67 @@ describe("agent capability runtime", () => {
     })
 
     await expect(runAgent(agent, runtime(), {
-      context: { chat: { user: { id: "user_1" } } },
+      context: {
+        "agent.secret": "internal",
+        channel: { user: { email: "user@example.com" } },
+        "channel.delivery.supportsTitle": true,
+        chat: { user: { id: "legacy-user" } },
+        "chat.secret": "legacy",
+        "workspace.secret": "internal",
+      },
     })).resolves.toEqual({
-      chat: { user: { id: "user_1" } },
+      chat: { user: { id: "legacy-user" } },
       mode: { choice: "support" },
     })
+    expect(observedContext).toHaveBeenCalledWith({
+      agentSecret: undefined,
+      channel: { user: { email: "user@example.com" } },
+      channelDelivery: undefined,
+      chat: undefined,
+      chatSecret: undefined,
+      workspaceSecret: undefined,
+    })
+  })
+
+  it("preserves prototype invocation context methods when filtering source context", async () => {
+    const { agentInvocationSourceContext } = await import("../src/invocation-context.ts")
+
+    class PrototypeContextStore {
+      private readonly values = new Map<string, unknown>([
+        ["channel", { user: { email: "user@example.com" } }],
+        ["chat", { user: { id: "legacy-user" } }],
+      ])
+
+      entries() {
+        return this.values.entries()
+      }
+
+      get<T = unknown>(id: string): T | undefined {
+        return this.values.get(id) as T | undefined
+      }
+
+      has(id: string): boolean {
+        return this.values.has(id)
+      }
+
+      set(id: string, value: unknown): void {
+        this.values.set(id, value)
+      }
+
+      toJSON(): Record<string, unknown> {
+        return Object.fromEntries(this.values)
+      }
+    }
+
+    const sourceContext = agentInvocationSourceContext(new PrototypeContextStore())
+
+    expect(Object.fromEntries(sourceContext.entries())).toEqual({
+      channel: { user: { email: "user@example.com" } },
+    })
+    expect(sourceContext.get("chat")).toEqual({ user: { id: "legacy-user" } })
+    expect(sourceContext.has("channel")).toBe(true)
+    sourceContext.set("customer", "acme")
+    expect(sourceContext.toJSON()).toMatchObject({ customer: "acme" })
   })
 
   it("records Channel Delivery Effect Intents from capabilities", async () => {
@@ -697,18 +770,15 @@ describe("agent capability runtime", () => {
     })).rejects.toThrow("Workspace Source scopes require access({ workspace })")
   })
 
-  it("requires contributed source scopes to be declared in Access", async () => {
+  it("accepts contributed source scopes without duplicate Access declarations", async () => {
     const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { access } = await import("../src/capabilities.ts")
 
-    await expect(resolveAgentCapabilities({
+    const resolved = await resolveAgentCapabilities({
       capabilities: [
         access({
           workspace: {
-            defaultScope: "review",
-            scopes: {
-              review: { paths: ["pull-request"] },
-            },
+            defaultScope: "missing",
           },
         }),
         defineCapability({
@@ -734,7 +804,9 @@ describe("agent capability runtime", () => {
         name: "review",
         sources: {},
       },
-    })).rejects.toThrow('Workspace Source scope "missing"')
+    })
+
+    expect(resolved.workspaceDefinition?.sources).toHaveProperty("pullRequest")
   })
 
   it("derives grants for scoped capability workspace contribution sources", async () => {

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -22,6 +22,11 @@ describe("chat message trigger input", () => {
       session: { id: "b" },
       user: { id: "user_1" },
     })
+    expect(result.input.context?.channel).toMatchObject({
+      meta: { email: "support@example.com" },
+      session: { id: "b" },
+      user: { id: "user_1" },
+    })
     expect(result.input.context).not.toHaveProperty("chat.identity")
     expect(result.input.context?.invoker).toMatchObject({
       email: {
@@ -139,6 +144,11 @@ describe("chat message trigger input", () => {
       user: { email: "support@example.com" },
     })
     expect(result.input.context?.chat).not.toHaveProperty("run")
+    expect(result.input.context?.channel).toMatchObject({
+      meta: { portal: { activePage: "/orders" } },
+      run: { origin: "portal", runId: "portal-run" },
+      user: { email: "support@example.com" },
+    })
     expect(result.input.context?.invoker).toEqual({
       email: {
         address: "support@example.com",
@@ -184,6 +194,9 @@ describe("chat message trigger input", () => {
       meta: { email: "maximo@quiver.dk" },
     })
     expect(result.input.context?.chat).not.toHaveProperty("run")
+    expect(result.input.context?.channel).toMatchObject({
+      run: { origin: "devtools", runId: "devtools-run" },
+    })
   })
 
   it("preserves completed UI tool calls", () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -136,7 +136,7 @@ async function waitForMetadataState(
   for (let attempt = 0; attempt < 50; attempt++) {
     latest = await invokeState(handler, body)
     if (latest.metadataStatus === status) return latest
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await new Promise(resolve => setTimeout(resolve, 10))
   }
   throw new Error(`Expected chat devtools metadata status ${status}, received ${String(latest?.metadataStatus)}`)
 }
@@ -396,6 +396,7 @@ describe("agent chat capability discovery", () => {
     const { defineAgent } = await import("../src/index.ts")
     const devtoolsMeta = { email: "maximo@quiver.dk" }
     const technicalEmails = new Set(["maximo@quiver.dk"])
+    const observedMetadataChannel = vi.fn()
     const agent = withAgentDefaults(defineAgent({
       invoker: {
         profiles: [
@@ -406,7 +407,8 @@ describe("agent chat capability discovery", () => {
       capabilities: [
         access({
           workspace: {
-            resolve({ invoker, run }) {
+            resolve({ channel, invoker, run }) {
+              if (run?.runId.endsWith(":metadata")) observedMetadataChannel(channel)
               const email = typeof invoker.meta?.email === "string" ? invoker.meta.email.toLowerCase() : undefined
               return run?.origin === "devtools" && (invoker.meta?.scope === "support" || (email && technicalEmails.has(email)))
                 ? { role: "admin", scope: "support" }
@@ -506,6 +508,13 @@ describe("agent chat capability discovery", () => {
       metadataStatus: "ready",
       selected: "support",
     })
+    expect(observedMetadataChannel).toHaveBeenCalledWith(expect.objectContaining({
+      meta: devtoolsMeta,
+      run: expect.objectContaining({
+        origin: "devtools",
+        runId: "devtools:support:metadata",
+      }),
+    }))
     expect(resolvedFallbackState.invokerProfileId).toBeUndefined()
 
     const fallbackSendResponse = await invokeMiddleware(handlers[0]!, {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1296,12 +1296,19 @@ describe("server helpers", () => {
   })
 
   it("threads hosted Chat DevTools runtime overrides through metadata resolution", async () => {
-    const { defineAgent, defineAgentInvoker } = await import("../src/index.ts")
+    const { defineAgent, defineAgentInvoker, defineCapability } = await import("../src/index.ts")
     const { createChannelDevtoolsRouteHandler } = await import("../src/server/internal.ts")
     const { registerWorkspaceAgent } = await import("../src/server/workspace.ts")
     const { custom, defineWorkspace } = await import("@vite-hub/workspace")
     const runtimeEvents: string[] = []
+    const observedMetadataChannel = vi.fn()
     const agent = registerWorkspaceAgent(defineAgent({
+      capabilities: [defineCapability({
+        id: "observe-channel",
+        prepare({ channel }) {
+          observedMetadataChannel(channel)
+        },
+      })],
       driver: { run: () => "unused" },
       invoker: defineAgentInvoker({
         resolve({ defaultInvoker, runtime }) {
@@ -1333,6 +1340,7 @@ describe("server helpers", () => {
     const response = await handler(new Request("https://example.com/__vitehub/agent/chat/devtools", {
       body: JSON.stringify({
         action: "materialize-source",
+        meta: { email: "user@example.com" },
         path: "docs",
         source: "docs",
       }),
@@ -1342,6 +1350,14 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     expect(runtimeEvents).toContain("metadata:vite")
+    expect(observedMetadataChannel).toHaveBeenCalledWith(expect.objectContaining({
+      meta: { email: "user@example.com" },
+      run: expect.objectContaining({
+        origin: "devtools",
+        runId: "devtools:support:metadata",
+      }),
+      user: expect.objectContaining({ email: "user@example.com" }),
+    }))
   })
 
   it("serves AI SDK UI message chat requests through the chat trigger", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -12,6 +12,18 @@ import type { MCPClient } from "@ai-sdk/mcp"
 import { fetch as fetchSource, file, github as githubSource, type ReadonlyWorkspaceFacade } from "@vite-hub/workspace"
 import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatRunContext, FetchCapabilityToolOptions, PullRequestContextValue, RepositoryHostClient, RepositoryHostContextValue, TranscriptionResult } from "../src/capabilities.ts"
 
+declare global {
+  interface ViteHubAgentInvocationContextValues {
+    "chat.secret": string
+  }
+  interface ViteHubAgentChannelMeta {
+    customer?: string
+  }
+  interface ViteHubAgentChannelUser {
+    email?: string
+  }
+}
+
 describe("agent public types", () => {
   it("accepts capabilities from the capabilities entry", () => {
     const openAPISpec = {
@@ -1194,6 +1206,25 @@ describe("agent public types", () => {
       driver: { model: {} as never },
     })
 
+    defineAgent({
+      workspace: {
+        sources: {
+          docs: file("README.md"),
+          ingestion: githubSource({ repo: "acme/ingestion", scopes: ["technical"] as const }),
+        },
+      },
+      capabilities: [
+        access({
+          workspace: {
+            resolve() {
+              return "technical" as const
+            },
+          },
+        }),
+      ],
+      driver: { model: {} as never },
+    })
+
     // @ts-expect-error source-local scopes are checked against access workspace scope keys
     defineAgent({
       workspace: {
@@ -1461,11 +1492,21 @@ describe("agent public types", () => {
         }),
         {
           id: "support-audience",
-          prepare({ actor, invoker }) {
+          prepare({ actor, channel, invoker }) {
+            expectTypeOf(channel?.meta?.customer).toEqualTypeOf<string | undefined>()
+            expectTypeOf(channel?.run?.origin).toEqualTypeOf<string | undefined>()
+            expectTypeOf(channel?.user?.email).toEqualTypeOf<string | undefined>()
             expectTypeOf(actor.id).toEqualTypeOf<string>()
             expectTypeOf(invoker.id).toEqualTypeOf<string>()
           },
         },
+        defineCapability({
+          id: "internal-context-filter",
+          prepare(context) {
+            // @ts-expect-error legacy namespaced values stay on context.context
+            expectTypeOf(context["chat.secret"]).toBeString()
+          },
+        }),
       ],
       hooks: {
         "agent:finish"({ actor, invoker }) {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1627,7 +1627,7 @@ describe("defineAgent workspace option", () => {
       },
       workspace: {
         sources: {
-          private: { mount: "private", name: "private" } as never,
+          private: { mount: "private", name: "private", scopes: ["private"] } as never,
           public: { mount: "public", name: "public" } as never,
         },
       },
@@ -3201,6 +3201,30 @@ describe("defineAgent workspace option", () => {
     })
   })
 
+  it("passes direct channel context to dynamic AI SDK model callbacks", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const resolveModel = vi.fn((metadata: { channel?: { meta?: { customer?: string } } }) => ({
+      id: `model-${metadata.channel?.meta?.customer}`,
+    }))
+    const agent = withAgentDefaults(defineAgent({
+      workspace: {},
+      driver: { model: resolveModel as never },
+    }), { workspace: "docs" })
+
+    await agent.run!({
+      ...(context() as Record<string, unknown>),
+      input: {
+        context: { channel: { meta: { customer: "acme" } } },
+        messages: [],
+      },
+    } as never)
+
+    expect(resolveModel).toHaveBeenCalledWith(expect.objectContaining({
+      channel: { meta: { customer: "acme" } },
+    }))
+    expect(agentSettings.at(-1)?.model).toEqual({ id: "model-acme" })
+  })
+
   it("passes provider-defined capability tools to AI SDK agents", async () => {
     const { webSearch } = await import("../src/capabilities.ts")
     const { defineAgent } = await import("../src/index.ts")
@@ -3899,8 +3923,8 @@ describe("defineAgent workspace option", () => {
 
   it("resolves dynamic model metadata for DevTools", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
-    const resolveModel = vi.fn((context: { invoker: { kind?: string } }) => ({
-      modelId: `test/${context.invoker.kind || "unknown"}`,
+    const resolveModel = vi.fn((context: { channel?: { meta?: { customer?: string } }, invoker: { kind?: string } }) => ({
+      modelId: `test/${context.invoker.kind || "unknown"}/${context.channel?.meta?.customer || "unknown"}`,
       provider: "test",
     }))
     const agent = withAgentDefaults(defineAgent({
@@ -3911,6 +3935,7 @@ describe("defineAgent workspace option", () => {
     expect(await resolveAgentDevtoolsMetadata(agent, {
       input: {
         context: {
+          channel: { meta: { customer: "acme" } },
           invoker: {
             id: "devtools",
             kind: "devtools",
@@ -3923,13 +3948,15 @@ describe("defineAgent workspace option", () => {
           kind: "model",
           model: {
             dynamic: true,
-            id: "test/devtools",
+            id: "test/devtools/acme",
             provider: "test",
           },
         },
       },
     })
-    expect(resolveModel).toHaveBeenCalledOnce()
+    expect(resolveModel).toHaveBeenCalledWith(expect.objectContaining({
+      channel: { meta: { customer: "acme" } },
+    }))
   })
 
   it("marks dynamic DevTools instruction metadata without resolving it", async () => {
@@ -4180,8 +4207,8 @@ describe("defineAgent workspace option", () => {
       },
       workspace: {
         sources: {
-          customers: { mount: "customers", name: "customers" } as never,
-          portal: { mount: "portal", name: "portal" } as never,
+          customers: { mount: "customers", name: "customers", scopes: ["support"] } as never,
+          portal: { mount: "portal", name: "portal", scopes: ["support"] } as never,
         },
       },
       capabilities: [

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -335,10 +335,10 @@ export interface WorkspaceSourceResolutionInvocation<TContextMap extends object 
   }
 }
 
-export interface WorkspaceSourceResolutionContext<
+export type WorkspaceSourceResolutionContext<
   TContextMap extends object = WorkspaceSourceResolutionContextMap,
   TScopeName extends string = WorkspaceScopeName,
-> {
+> = Partial<TContextMap> & {
   invocation: WorkspaceSourceResolutionInvocation<TContextMap>
   selectedWorkspaceScope?: WorkspaceSelectedScope<TScopeName>
   source: {

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -528,6 +528,7 @@ async function resolveWorkspaceSource(
   if (!source.resolve) return selectedScopeIntersectsSource(options.selectedWorkspaceScope, declared) ? input : undefined
 
   const context: WorkspaceSourceResolutionContext<object, string> = {
+    ...Object.fromEntries(options.invocation.context.entries()),
     invocation: options.invocation,
     selectedWorkspaceScope: options.selectedWorkspaceScope,
     source: {
@@ -720,7 +721,9 @@ function scopedWorkspaceSource(
         }
       : {}),
   }
-  copyWorkspaceSourceMetadata(source.source, scoped)
+  if (!source.requestDescriptor || selectedScopeCanRead(scope, workspaceSourceRequestDescriptorPath(source.key))) {
+    copyWorkspaceSourceMetadata(source.source, scoped)
+  }
   if (scopedLivePaths) markLiveWorkspaceSource(scoped, scopedLivePaths)
   return scoped
 }
@@ -796,11 +799,11 @@ function selectedScopeIntersectsSource(
   source: ReturnType<typeof normalizeWorkspaceSources>[number],
 ): boolean {
   if (!scope || scope.all) return true
-  if (scope.name && source.scopes?.includes(scope.name)) return true
-  return Boolean(scope.paths?.some((path) => {
-    if (source.requestDescriptor && pathIntersects(path, workspaceSourceRequestDescriptorPath(source.key))) return true
-    return !source.requestOnly && pathIntersects(path, source.mountPath)
-  }))
+  if (source.scopes?.length) return Boolean(scope.name && source.scopes.includes(scope.name))
+  if (source.requestOnly) {
+    return Boolean(scope.paths?.some(path => pathIntersects(path, workspaceSourceRequestDescriptorPath(source.key))))
+  }
+  return true
 }
 
 function pathContains(container: string, path: string): boolean {

--- a/packages/workspace/test/source-resolution.test.ts
+++ b/packages/workspace/test/source-resolution.test.ts
@@ -13,6 +13,7 @@ import {
   type ReadonlyWorkspaceFacade,
   type WritableWorkspaceFacade,
   type WorkspaceDefinition,
+  type WorkspaceSourceResolutionContext,
 } from "../src/index.ts"
 import {
   createWorkspaceSourceResolutionFacade,
@@ -158,6 +159,49 @@ afterEach(() => {
 })
 
 describe("Workspace Source Resolution", () => {
+  it("exposes invocation context values directly to source resolvers", async () => {
+    const values = new Map<string, unknown>([
+      ["channel", { meta: { customer: "acme" } }],
+    ])
+    let resolvedContext: WorkspaceSourceResolutionContext | undefined
+    const resolve = vi.fn((context: WorkspaceSourceResolutionContext) => {
+      resolvedContext = context
+      return false as const
+    })
+
+    await resolveWorkspaceSources({
+      name: "support",
+      sources: {
+        ingestion: custom({
+          resolve,
+          async getKeys() {
+            return []
+          },
+          async getItem(key: string) {
+            throw new Error(`unresolved source read: ${key}`)
+          },
+        }),
+      },
+    }, {
+      invocation: {
+        context: {
+          entries: () => values.entries(),
+          get: (id: string) => values.get(id) as never,
+          has: id => values.has(id),
+          toJSON: () => Object.fromEntries(values),
+        },
+      },
+    })
+
+    expect(resolve).toHaveBeenCalledWith(expect.objectContaining({
+      channel: { meta: { customer: "acme" } },
+      invocation: expect.objectContaining({ context: expect.any(Object) }),
+      source: expect.objectContaining({ key: "ingestion" }),
+      workspace: expect.objectContaining({ name: "support" }),
+    }))
+    expect(resolvedContext?.invocation.context.get("channel")).toEqual({ meta: { customer: "acme" } })
+  })
+
   it("resolves source origin, mount, and scope-aware fingerprint", async () => {
     const definition: WorkspaceDefinition = {
       name: "support",
@@ -725,7 +769,28 @@ describe("Workspace Source Resolution", () => {
     expect(request).toHaveBeenCalledOnce()
   })
 
-  it("requires descriptor visibility for scoped controlled curl", async () => {
+  it("requires descriptor visibility for request-only sources", async () => {
+    const definition: WorkspaceDefinition = {
+      name: "support",
+      sources: {
+        inventory: fetch({
+          url: "https://portal.example.com/runtime/inventory-health",
+        }),
+      },
+    }
+
+    const { definition: resolvedDefinition, workspace } = await createWorkspaceSourceResolutionFacade(
+      facade(createWorkspace({ name: "support", store: { provider: "memory" } })),
+      definition,
+      scope("status", ["status/summary.json"]),
+    )
+
+    expect(resolvedDefinition.sources).not.toHaveProperty("inventory")
+    expect(getWorkspaceSourceRequestExecution(workspace.fs)).toBeUndefined()
+    await expect(workspace.fs.list(".vitehub/sources")).resolves.toEqual([])
+  })
+
+  it("keeps finite request sources while hiding unselected request descriptors", async () => {
     const definition: WorkspaceDefinition = {
       name: "support",
       sources: {
@@ -736,17 +801,19 @@ describe("Workspace Source Resolution", () => {
       },
     }
 
-    const { workspace } = await createWorkspaceSourceResolutionFacade(
+    const { definition: resolvedDefinition, workspace } = await createWorkspaceSourceResolutionFacade(
       facade(createWorkspace({ name: "support", store: { provider: "memory" } })),
       definition,
       scope("status", ["status/summary.json"]),
     )
 
+    expect(resolvedDefinition.sources).toHaveProperty("inventory")
+    await expect(workspace.fs.exists("status/summary.json")).resolves.toBe(true)
     expect(getWorkspaceSourceRequestExecution(workspace.fs)).toBeUndefined()
     await expect(workspace.fs.list(".vitehub/sources")).resolves.toEqual([])
   })
 
-  it("fails closed when a resolved source mount is outside the Selected Workspace Scope", async () => {
+  it("keeps universal resolved sources outside the selected path set", async () => {
     const definition: WorkspaceDefinition = {
       name: "support",
       sources: {
@@ -774,10 +841,10 @@ describe("Workspace Source Resolution", () => {
 
     const resolved = await resolveWorkspaceSources(definition, scope("acme", ["ingestion/acme"]))
 
-    expect(resolved.sources).toEqual({})
+    expect(resolved.sources).toHaveProperty("ingestion")
   })
 
-  it("keeps scoped-out static sources hidden in overlays", async () => {
+  it("keeps unscoped sources available while scoped sources require matching names", async () => {
     const base = createWorkspace({ name: "support", store: { provider: "memory" } })
     const definition: WorkspaceDefinition = {
       name: "support",
@@ -802,6 +869,19 @@ describe("Workspace Source Resolution", () => {
             return { key, path: key, content: "public\n" }
           },
         }),
+        restrictedDocs: {
+          source: custom({
+            materialize: "lazy",
+            mount: "public/restricted",
+            async getKeys() {
+              return ["secret.md"]
+            },
+            async getItem(key) {
+              return { key, path: key, content: "restricted\n" }
+            },
+          }),
+          scopes: ["private"],
+        },
       },
     }
 
@@ -812,9 +892,11 @@ describe("Workspace Source Resolution", () => {
     )
 
     expect(resolvedDefinition.sources).toHaveProperty("publicDocs")
-    expect(resolvedDefinition.sources).not.toHaveProperty("privateDocs")
+    expect(resolvedDefinition.sources).toHaveProperty("privateDocs")
+    expect(resolvedDefinition.sources).not.toHaveProperty("restrictedDocs")
     await expect(workspace.fs.readFile("public/README.md")).resolves.toBe("public\n")
     await expect(workspace.fs.exists("private/secret.md")).resolves.toBe(false)
+    await expect(workspace.fs.exists("public/restricted/secret.md")).resolves.toBe(false)
   })
 
   it("keeps scoped-out source subpaths hidden in overlays", async () => {

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -20,6 +20,7 @@ declare global {
   }
 
   interface ViteHubWorkspaceSourceResolutionContextMap {
+    channel: { meta?: { customer?: string } }
     "support.customerScope": { customers: Array<"acme" | "globex"> }
     pullRequest: { pullRequest: { source: { ref: string, repo: string } } }
   }
@@ -147,7 +148,8 @@ describe("workspace types", () => {
         mount: `ingestion/${customer}`,
       }
     })
-    github(({ invocation }) => {
+    github(({ channel, invocation }) => {
+      expectTypeOf(channel?.meta?.customer).toEqualTypeOf<string | undefined>()
       expectTypeOf(invocation.context.get("pullRequest")?.pullRequest.source.repo).toEqualTypeOf<string | undefined>()
       return { root: "portal" }
     })


### PR DESCRIPTION
Adds a canonical typed `channel` Agent Invocation Context Value for message-shaped Channels and exposes registered invocation values directly to Capability callbacks, dynamic model metadata callbacks, instruction composition, and Workspace Source resolvers. Legacy and internal aliases remain available through `context.get(...)` without leaking into the direct callback object.

Aligns Workspace Source scope selection with that context path: unscoped Sources are available in every selected scope, scoped Sources match by name, and named Source scopes no longer require duplicate empty `access.workspace.scopes` entries. DevTools inputs, documentation, runtime and type contracts, and focused regression coverage are updated together.