### PR TITLE
feat(agent): ship Valibot schema default

### DIFF
--- a/docs/content/docs/capabilities/custom-capabilities.md
+++ b/docs/content/docs/capabilities/custom-capabilities.md
@@ -20,6 +20,11 @@ Use `defineCapability()` so ViteHub validates the id and composes the Capability
 
 ```ts [server/agents/capabilities/tickets.ts]
 import { defineCapability } from '@vite-hub/agent'
+import * as v from '@vite-hub/agent/valibot'
+
+const searchTicketsInput = v.object({
+  query: v.string(),
+})
 
 export function tickets() {
   return defineCapability({
@@ -28,12 +33,16 @@ export function tickets() {
       searchTickets: {
         name: 'searchTickets',
         description: 'Search support tickets by query.',
-        execute: async (input: { query: string }) => searchTickets(input.query),
+        inputSchema: searchTicketsInput,
+        execute: async (input: v.InferOutput<typeof searchTicketsInput>) => searchTickets(input.query),
       },
     },
   })
 }
 ```
+
+Agent tools accept any Standard Schema validator.
+ViteHub ships Valibot at `@vite-hub/agent/valibot` as the zero-install default; use Zod, ArkType, or another validator when the app already has one.
 
 Attach the custom Capability like any official Capability.
 Keep instructions explicit in the Agent Driver so Capability config does not become a hidden prompt bag.
@@ -149,14 +158,14 @@ The public API accepts a static command tree or an invocation resolver on the Ca
 
 ```ts [server/agents/capabilities/inventory-runtime.ts]
 import { defineCapability } from '@vite-hub/agent'
-import { z } from 'zod'
+import * as v from '@vite-hub/agent/valibot'
 
-const inventoryItemsInput = z.object({
-  limit: z.number().int().positive().optional(),
+const inventoryItemsInput = v.object({
+  limit: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
 })
 
-const inventoryItemsOutput = z.object({
-  items: z.array(z.object({ id: z.string() })),
+const inventoryItemsOutput = v.object({
+  items: v.array(v.object({ id: v.string() })),
 })
 
 export const inventoryRuntime = defineCapability({
@@ -184,7 +193,7 @@ export const inventoryRuntime = defineCapability({
 })
 ```
 
-The `input` and `output.schema` values accept any Standard Schema-compatible validation library. Use Zod, Valibot, ArkType, or the validator your app already uses.
+The `input` and `output.schema` values accept any Standard Schema-compatible validation library.
 
 ViteHub exposes command metadata through the generated CLI-named tool. Keep `instructions.md` focused on policy and use `::capability{key="inventoryRuntime"}` when authored guidance should cover that Capability.
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -121,6 +121,10 @@
       "types": "./dist/test.d.ts",
       "import": "./dist/test.js"
     },
+    "./valibot": {
+      "types": "./dist/valibot.d.ts",
+      "import": "./dist/valibot.js"
+    },
     "./vite": {
       "types": "./dist/vite.d.ts",
       "import": "./dist/vite.js"
@@ -147,6 +151,7 @@
     "esbuild": "catalog:esbuild-v27",
     "evalite": "catalog:ai",
     "hookable": "catalog:unjs",
+    "valibot": "catalog:runtime",
     "vitest": "catalog:tooling"
   },
   "devDependencies": {

--- a/packages/agent/src/valibot.ts
+++ b/packages/agent/src/valibot.ts
@@ -1,0 +1,1 @@
+export * from "valibot"

--- a/packages/agent/test/valibot.test.ts
+++ b/packages/agent/test/valibot.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+
+import * as v from "@vite-hub/agent/valibot"
+
+describe("agent Valibot export", () => {
+  it("provides a Standard Schema validator for tool inputs", () => {
+    const schema = v.object({
+      message: v.pipe(v.string(), v.minLength(1)),
+    })
+
+    expect(v.safeParse(schema, { message: "Small friction." }).success).toBe(true)
+    expect(v.safeParse(schema, { message: "" }).success).toBe(false)
+  })
+})

--- a/packages/agent/vite.config.ts
+++ b/packages/agent/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
       "src/server/internal.ts",
       "src/server/workspace.ts",
       "src/test.ts",
+      "src/valibot.ts",
       "src/vite.ts",
     ],
     exports: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,9 @@ importers:
       hookable:
         specifier: catalog:unjs
         version: 6.1.1
+      valibot:
+        specifier: catalog:runtime
+        version: 1.4.0(typescript@6.0.2)
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
         version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'


### PR DESCRIPTION
Ships Valibot through `@vite-hub/agent/valibot` as the optional zero-install default for Agent tool and Capability CLI schemas. The Standard Schema boundary remains validator-agnostic, so applications can still use Zod, ArkType, or another compatible validator directly.

Adds the package export, runtime dependency, build entry, and a public-import contract test. The custom Capability documentation now uses the built-in Valibot path for both direct tool inputs and Capability CLI schemas.