### PR TITLE
fix(agent): start chat titles before drivers

### DIFF
--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -513,8 +513,6 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
   return Object.assign(defineCapability({
     id: capabilityId,
     output(context) {
-      if (!firstUserMessage(context.input.messages())) return
-
       let title: Promise<string | undefined> | undefined
       const getTitle = () => {
         title ??= (async () => {
@@ -532,6 +530,7 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
       }
 
       invocationStarts.set(context.context, async () => {
+        if (!firstUserMessage(context.input.messages())) return
         if (!shouldProvideChatTitleFinishExtension(context)) return
         if (context.context.get<boolean>(messageChannelTitleDeliveredContextKey) === true) return
         const resolvedTitle = await getTitle()
@@ -552,6 +551,7 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
       }
       titleDeliveryEffect.active = finish =>
         Boolean(finish.channel)
+        && Boolean(firstUserMessage(context.input.messages()))
         && finish.context.get<boolean>(messageChannelTitleSupportContextKey) !== false
         && finish.context.get<boolean>(messageChannelTitleDeliveredContextKey) !== true
       titleDeliveryEffect.kind = "title"

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -513,6 +513,8 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
   return Object.assign(defineCapability({
     id: capabilityId,
     output(context) {
+      if (!firstUserMessage(context.input.messages())) return
+
       let title: Promise<string | undefined> | undefined
       const getTitle = () => {
         title ??= (async () => {

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -1,6 +1,7 @@
-import { defineCapability } from "../capability-runtime.ts"
+import { capabilityInvocationStartSymbol, defineCapability } from "../capability-runtime.ts"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
 import { messageChannelTitleSupportContextKey } from "../channels.ts"
+import { messageChannelTitleDeliveredContextKey } from "../internal/channels.ts"
 import { getMessageText } from "../messages.ts"
 import { normalizeAgentDriver } from "../internal/agent-driver.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
@@ -508,25 +509,34 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
   options: ChatTitleOptions<TRuntimeConfig> = {},
 ): AgentCapabilityDefinition<TRuntimeConfig> {
   const capabilityId = options.id || "chat-title"
-  return defineCapability({
+  const invocationStarts = new WeakMap<object, () => Promise<void>>()
+  return Object.assign(defineCapability({
     id: capabilityId,
     output(context) {
-      const messages = context.input.messages()
-      const message = firstUserMessage(messages)
-      if (!message) return
-
-      const text = getMessageText(message)
       let title: Promise<string | undefined> | undefined
       const getTitle = () => {
-        title ??= generateChatTitle(context, options as ChatTitleOptions, {
-          input: context.input.get(),
-          message,
-          messages,
-          text,
-        }).catch(() => undefined)
+        title ??= (async () => {
+          const messages = context.input.messages()
+          const message = firstUserMessage(messages)
+          if (!message) return
+          return await generateChatTitle(context, options as ChatTitleOptions, {
+            input: context.input.get(),
+            message,
+            messages,
+            text: getMessageText(message),
+          })
+        })().catch(() => undefined)
         return title
       }
 
+      invocationStarts.set(context.context, async () => {
+        if (!shouldProvideChatTitleFinishExtension(context)) return
+        if (context.context.get<boolean>(messageChannelTitleDeliveredContextKey) === true) return
+        const resolvedTitle = await getTitle()
+        if (!resolvedTitle || !supportsChatTitleDelivery(context)) return
+        if (context.context.get<boolean>(messageChannelTitleDeliveredContextKey) === true) return
+        context.delivery.effect({ kind: "title", payload: { title: resolvedTitle.trim() } })
+      })
       context.finish.provide(async () => {
         if (!shouldProvideChatTitleFinishExtension(context)) return
         const resolvedTitle = await getTitle()
@@ -539,7 +549,9 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
           : undefined
       }
       titleDeliveryEffect.active = finish =>
-        Boolean(finish.channel) && finish.context.get<boolean>(messageChannelTitleSupportContextKey) !== false
+        Boolean(finish.channel)
+        && finish.context.get<boolean>(messageChannelTitleSupportContextKey) !== false
+        && finish.context.get<boolean>(messageChannelTitleDeliveredContextKey) !== true
       titleDeliveryEffect.kind = "title"
       context.delivery.finishEffect(titleDeliveryEffect)
       context.output.render((result) => {
@@ -575,6 +587,10 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
         if (!isAsyncIterable(result)) return result
         return withChatTitleEvent(result, getTitle())
       })
+    },
+  }), {
+    [capabilityInvocationStartSymbol](context: AgentCapabilityRuntimeContext<TRuntimeConfig>) {
+      return invocationStarts.get(context.context)?.()
     },
   })
 }

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -558,6 +558,7 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
       context.delivery.finishEffect(titleDeliveryEffect)
       context.output.render((result) => {
         if (hasChatTitleApplied(result)) return result
+        if (!firstUserMessage(context.input.messages())) return result
         if (isStreamTextResult(result)) {
           const toUIMessageStream = result.toUIMessageStream?.bind(result)
           if (result.stream || result.fullStream) {

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -1,7 +1,7 @@
 import { capabilityInvocationStartSymbol, defineCapability } from "../capability-runtime.ts"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
 import { messageChannelTitleSupportContextKey } from "../channels.ts"
-import { messageChannelTitleDeliveredContextKey } from "../internal/channels.ts"
+import { createMessageChannelChatTitleEffectIntent, messageChannelTitleDeliveredContextKey } from "../internal/channels.ts"
 import { getMessageText } from "../messages.ts"
 import { normalizeAgentDriver } from "../internal/agent-driver.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
@@ -537,7 +537,7 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
         const resolvedTitle = await getTitle()
         if (!resolvedTitle || !supportsChatTitleDelivery(context)) return
         if (context.context.get<boolean>(messageChannelTitleDeliveredContextKey) === true) return
-        context.delivery.effect({ kind: "title", payload: { title: resolvedTitle.trim() } })
+        context.delivery.effect(createMessageChannelChatTitleEffectIntent(resolvedTitle.trim()))
       })
       context.finish.provide(async () => {
         if (!shouldProvideChatTitleFinishExtension(context)) return

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -63,10 +63,12 @@ type ResolvedAgentOutputRenderer = ((result: unknown, extensions?: AgentOutputEx
   providerCount: number
 }
 export const workspaceMaterializationPathsSymbol: unique symbol = Symbol("vitehub.agent.workspaceMaterializationPaths")
+export const capabilityInvocationStartSymbol: unique symbol = Symbol("vitehub.agent.capabilityInvocationStart")
 type InternalAgentCapabilityDefinition<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > = AgentCapabilityDefinition<TRuntimeConfig, Name> & {
+  [capabilityInvocationStartSymbol]?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   [workspaceMaterializationPathsSymbol]?: readonly string[]
 }
 type AgentCapabilityBashEntry = Extract<AgentCapabilityBashCommand, { command: string }>
@@ -136,6 +138,7 @@ export interface ResolvedAgentCapabilities {
   messages: Message[]
   response?: Response
   registries: AgentCapabilityRegistries
+  start?: () => Promise<AgentChannelDeliveryEffectIntent[]>
   toolTransforms: AgentToolTransform[]
   tools?: AgentToolSet
   workspaceMaterializationPaths: readonly string[]
@@ -825,6 +828,20 @@ export async function resolveAgentCapabilities<
     if (errors.length > 1) throw new AggregateError(errors, "[vitehub] Multiple capability close callbacks failed.")
   }
 
+  let invocationStarted = false
+  async function startInvocationCallbacks() {
+    if (invocationStarted) return []
+    invocationStarted = true
+    const deliveryEffectCount = registries.deliveryEffectIntents.length
+    for (const { capability, context } of capabilityContexts) {
+      await (capability as InternalAgentCapabilityDefinition<TRuntimeConfig, Name>)[capabilityInvocationStartSymbol]?.(context)
+    }
+    return registries.deliveryEffectIntents.slice(deliveryEffectCount)
+  }
+  const start = capabilities.some(capability => capabilityInvocationStartSymbol in capability)
+    ? startInvocationCallbacks
+    : undefined
+
   function syncCapabilityWorkspaceContext(context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) {
     if (currentWorkspace) {
       context.fs = currentWorkspace.fs
@@ -1055,6 +1072,7 @@ export async function resolveAgentCapabilities<
             messages,
             response: result,
             registries,
+            start,
             toolTransforms,
             tools,
             workspaceMaterializationPaths,
@@ -1118,6 +1136,7 @@ export async function resolveAgentCapabilities<
     input: currentInput,
     messages,
     registries,
+    start,
     toolTransforms,
     tools,
     workspaceMaterializationPaths,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1511,18 +1511,10 @@ async function createAgentInvocationContext<
     await applyChannelDeliveryEffectIntents(invocation, invocation.deliveryEffectIntents)
     const startCapabilities = capabilities.start
     if (!invocation.handledResponse && startCapabilities) {
-      const eventBase = {
-        actor: invocation.actor,
-        input: invocation.input,
-        invoker: invocation.invoker,
-        invocation: {
-          durationMs: Date.now() - invocation.startedAt,
-          ...(invocation.run ? { run: invocation.run } : {}),
-        },
-        runtime: invocation.runtimeContext,
-      } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       try {
-        await prepareProvisionalTitleDeliverySupport(invocation, eventBase)
+        if (hasTitleDeliveryEffectProvider(invocation.finishDeliveryEffectProviders)) {
+          await setChannelDeliverySupportContext(invocation.channels, invocation.context, invocation.runtimeContext, invocation.input, invocation.run)
+        }
         invocation.startTask = (async () => {
           await applyChannelDeliveryEffectIntents(invocation, await startCapabilities())
         })().catch(error => traceAgentInvocationError(toTraceContext(invocation), error))

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1512,7 +1512,7 @@ async function createAgentInvocationContext<
     const startCapabilities = capabilities.start
     if (!invocation.handledResponse && startCapabilities) {
       try {
-        if (hasTitleDeliveryEffectProvider(invocation.finishDeliveryEffectProviders)) {
+        if (invocation.messages.some(message => message.role === "user") && hasTitleDeliveryEffectProvider(invocation.finishDeliveryEffectProviders)) {
           await setChannelDeliverySupportContext(invocation.channels, invocation.context, invocation.runtimeContext, invocation.input, invocation.run)
         }
         invocation.startTask = (async () => {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,7 +11,7 @@ import { getMessageText } from "./messages.ts"
 import { resolveRuntimeContext } from "@vite-hub/runtime"
 import { isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent } from "./agent-output.ts"
 import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
-import { resolveAgentChannelChatOptions } from "./internal/channels.ts"
+import { messageChannelTitleDeliveredContextKey, resolveAgentChannelChatOptions } from "./internal/channels.ts"
 import {
   channelHasCustomTitleEffect,
   messageChannelSupportsTitleEffect,
@@ -781,6 +781,9 @@ async function applyChannelDeliveryEffectIntents<
             },
             workspace: context.workspace,
           })
+          if (intent.kind === "title") {
+            context.context.set(messageChannelTitleDeliveredContextKey, true, { overwrite: true })
+          }
           await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, metadata)
         })
       }
@@ -1262,6 +1265,7 @@ type AgentInvocationContext<
   outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
   outputRenderers: AgentCapabilityRegistries["outputRenderers"]
   runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
+  startTask?: Promise<void>
   instructions?: string
   startedAt: number
   actor: AgentInvoker
@@ -1490,6 +1494,7 @@ async function createAgentInvocationContext<
       providerTools: capabilities.registries.providerTools,
       run: context.run,
       runtimeContext,
+      startTask: undefined as Promise<void> | undefined,
       startedAt,
       tools,
       workspace: activeWorkspace,
@@ -1499,8 +1504,32 @@ async function createAgentInvocationContext<
       workspaceMaterializationPaths: capabilities.workspaceMaterializationPaths,
       workspaceMode,
     }
+    invocationContext.set("agent.finishHook", Boolean(invocation.finishHook), { overwrite: true })
     await traceAgentInvocationStart(toTraceContext(invocation))
     await applyChannelDeliveryEffectIntents(invocation, invocation.deliveryEffectIntents)
+    const startCapabilities = capabilities.start
+    if (!invocation.handledResponse && startCapabilities) {
+      const eventBase = {
+        actor: invocation.actor,
+        input: invocation.input,
+        invoker: invocation.invoker,
+        invocation: {
+          durationMs: Date.now() - invocation.startedAt,
+          ...(invocation.run ? { run: invocation.run } : {}),
+        },
+        runtime: invocation.runtimeContext,
+      } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
+      try {
+        await prepareProvisionalTitleDeliverySupport(invocation, eventBase)
+        invocation.startTask = (async () => {
+          await applyChannelDeliveryEffectIntents(invocation, await startCapabilities())
+        })().catch(error => traceAgentInvocationError(toTraceContext(invocation), error))
+        runtimeContext.waitUntil?.(invocation.startTask)
+      }
+      catch (error) {
+        await traceAgentInvocationError(toTraceContext(invocation), error)
+      }
+    }
     return invocation
   }
   catch (error) {
@@ -1530,6 +1559,7 @@ type InvocationRunContext<
   hooks?: AgentHookObserverHooks
   input: AgentRunInput<CALL_OPTIONS>
   outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
+  startTask?: Promise<void>
   actor: AgentInvoker
   invoker: AgentInvoker
   runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
@@ -1951,6 +1981,7 @@ async function finishAgentInvocation<
   const runResult = failed || result === undefined ? undefined : toAgentRunResult(result)
   const text = runResult?.text
   try {
+    await context.startTask
     await context.close()
     if (hasFinishWork(context)) {
       const details = failed ? agentErrorDetails(error) : undefined
@@ -1968,7 +1999,6 @@ async function finishAgentInvocation<
         runtime: context.runtimeContext,
         ...(text !== undefined ? { text } : {}),
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
-      context.context.set("agent.finishHook", Boolean(context.finishHook), { overwrite: true })
       const provisionalActiveDeliveryProviders = await prepareProvisionalTitleDeliverySupport(context, eventBase)
       if (context.finishHook || provisionalActiveDeliveryProviders.length || hasDeferredFinishDeliveryEffectProvider(context.finishDeliveryEffectProviders)) {
         const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,7 +11,7 @@ import { getMessageText } from "./messages.ts"
 import { resolveRuntimeContext } from "@vite-hub/runtime"
 import { isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent } from "./agent-output.ts"
 import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
-import { messageChannelTitleDeliveredContextKey, resolveAgentChannelChatOptions } from "./internal/channels.ts"
+import { isMessageChannelChatTitleEffectIntent, messageChannelTitleDeliveredContextKey, resolveAgentChannelChatOptions } from "./internal/channels.ts"
 import {
   channelHasCustomTitleEffect,
   messageChannelSupportsTitleEffect,
@@ -793,7 +793,7 @@ async function applyChannelDeliveryEffectIntents<
         })
       }
     }
-    if (intent.kind === "title" && delivered) {
+    if (isMessageChannelChatTitleEffectIntent(intent) && delivered) {
       context.context.set(messageChannelTitleDeliveredContextKey, true, { overwrite: true })
     }
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -756,6 +756,7 @@ async function applyChannelDeliveryEffectIntents<
       continue
     }
 
+    let delivered = true
     for (const handler of handlers) {
       try {
         await runObservedAgentHook(context.hooks, {
@@ -781,18 +782,19 @@ async function applyChannelDeliveryEffectIntents<
             },
             workspace: context.workspace,
           })
-          if (intent.kind === "title") {
-            context.context.set(messageChannelTitleDeliveredContextKey, true, { overwrite: true })
-          }
           await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, metadata)
         })
       }
       catch (error) {
+        delivered = false
         await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, {
           ...metadata,
           "error.message": agentErrorMessage(error),
         })
       }
+    }
+    if (intent.kind === "title" && delivered) {
+      context.context.set(messageChannelTitleDeliveredContextKey, true, { overwrite: true })
     }
   }
 }

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentChannelDeliveryEffectIntent,
   AgentChannels,
   AgentChatOptions,
   AgentChatPlatformResolver,
@@ -8,6 +9,17 @@ import type {
 } from "../types.ts"
 
 export const messageChannelTitleDeliveredContextKey = "channel.delivery.titleDelivered"
+const messageChannelChatTitleEffectIntents = new WeakSet<AgentChannelDeliveryEffectIntent>()
+
+export function createMessageChannelChatTitleEffectIntent(title: string): AgentChannelDeliveryEffectIntent {
+  const intent = { kind: "title", payload: { title } }
+  messageChannelChatTitleEffectIntents.add(intent)
+  return intent
+}
+
+export function isMessageChannelChatTitleEffectIntent(intent: AgentChannelDeliveryEffectIntent): boolean {
+  return messageChannelChatTitleEffectIntents.has(intent)
+}
 
 function withChannelWebhookProvider<TRuntimeConfig extends AgentRuntimeConfig>(
   channelId: string,

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -7,6 +7,8 @@ import type {
   AgentRuntimeConfig,
 } from "../types.ts"
 
+export const messageChannelTitleDeliveredContextKey = "channel.delivery.titleDelivered"
+
 function withChannelWebhookProvider<TRuntimeConfig extends AgentRuntimeConfig>(
   channelId: string,
   kind: string,

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2581,6 +2581,11 @@ describe("agent message protocol", () => {
       releaseDriver = resolve
     })
     const order: string[] = []
+    const resultDependentEffect: AgentChannelDeliveryFinishEffectCallback = context => context.reply(context.result!.text!)
+    resultDependentEffect.active = context => {
+      if (!context.result) throw new Error("finish effect evaluated before the driver result")
+      return false
+    }
     const execute = vi.fn(({ text }) => {
       order.push("title")
       return `Title: ${text}`
@@ -2594,6 +2599,12 @@ describe("agent message protocol", () => {
           id: "transcribed-input",
           input(context) {
             context.input.setMessages([createMessage({ role: "user", text: "Transcribed request" })])
+          },
+        }),
+        defineCapability({
+          id: "result-dependent-delivery",
+          prepare(context) {
+            context.delivery.finishEffect(resultDependentEffect)
           },
         }),
       ],
@@ -2759,6 +2770,36 @@ describe("agent message protocol", () => {
 
     await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
     expect(adapter).not.toHaveBeenCalled()
+  })
+
+  it("does not resolve message Channel title adapters without user messages", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const adapter = vi.fn(() => {
+      throw new Error("adapter should not resolve")
+    })
+    const execute = vi.fn(() => "Unused title")
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute })],
+      channels: {
+        portal: defineChannel("portal", {
+          adapter,
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "system", text: "system context" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
+    expect(adapter).not.toHaveBeenCalled()
+    expect(execute).not.toHaveBeenCalled()
   })
 
   it("does not resolve message Channel title adapters for inactive title finish effects", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2571,7 +2571,7 @@ describe("agent message protocol", () => {
     expect(setAssistantTitle).toHaveBeenCalledWith("thread-1", "thread-1", "Prepared title")
   })
 
-  it("starts and delivers chat titles while the main driver is pending", async () => {
+  it("starts and replaces provisional chat titles while the main driver is pending", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     let releaseDriver: () => void = () => {}
@@ -2617,6 +2617,7 @@ describe("agent message protocol", () => {
           triggers: {
             message: {
               invoke: context => ({
+                delivery: { effects: [{ kind: "title", payload: { title: "Provisional title" } }] },
                 input: { messages: [createMessage({ role: "user", text: "Audio attachment" })] },
                 run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
               }),
@@ -2643,8 +2644,13 @@ describe("agent message protocol", () => {
     })
 
     await vi.waitFor(() => {
+      expect(titleEffect).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        effect: { kind: "title", payload: { title: "Provisional title" } },
+      }))
+    })
+    await vi.waitFor(() => {
       expect(driverStarted).toBe(true)
-      expect(titleEffect).toHaveBeenCalledWith(expect.objectContaining({
+      expect(titleEffect).toHaveBeenNthCalledWith(2, expect.objectContaining({
         effect: { kind: "title", payload: { title: "Title: Transcribed request" } },
       }))
     })
@@ -2655,7 +2661,7 @@ describe("agent message protocol", () => {
     await expect(invocation).resolves.toBe("ok")
     await Promise.all(waitUntilTasks)
     expect(execute).toHaveBeenCalledOnce()
-    expect(titleEffect).toHaveBeenCalledOnce()
+    expect(titleEffect).toHaveBeenCalledTimes(2)
   })
 
   it("retries chat title delivery at finish when any early delivery handler fails", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -13,6 +13,7 @@ const harnessAgentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
 const harnessCreateSession = vi.hoisted(() => vi.fn())
 const harnessGenerate = vi.hoisted(() => vi.fn())
 const harnessStream = vi.hoisted(() => vi.fn())
+const loadAiSdk = vi.hoisted(() => vi.fn())
 const vercelSandboxSettings = vi.hoisted(() => [] as Record<string, unknown>[])
 
 vi.mock("@ai-sdk/harness/agent", () => ({
@@ -42,6 +43,11 @@ vi.mock("@ai-sdk/sandbox-vercel", () => ({
   },
 }))
 
+vi.mock("../src/internal/ai-sdk-runtime.ts", () => ({
+  loadAiSdk,
+}))
+loadAiSdk.mockImplementation(async () => await import("ai"))
+
 const { withAgentDefaults } = await import("../src/index.ts")
 
 afterEach(() => {
@@ -49,6 +55,8 @@ afterEach(() => {
   harnessCreateSession.mockReset()
   harnessGenerate.mockReset()
   harnessStream.mockReset()
+  loadAiSdk.mockReset()
+  loadAiSdk.mockImplementation(async () => await import("ai"))
   vercelSandboxSettings.length = 0
 })
 
@@ -2561,6 +2569,134 @@ describe("agent message protocol", () => {
 
     await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
     expect(setAssistantTitle).toHaveBeenCalledWith("thread-1", "thread-1", "Prepared title")
+  })
+
+  it("starts and delivers chat titles while the main driver is pending", async () => {
+    const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    let releaseDriver: () => void = () => {}
+    let driverStarted = false
+    let invocationSettled = false
+    const driverPending = new Promise<void>((resolve) => {
+      releaseDriver = resolve
+    })
+    const order: string[] = []
+    const execute = vi.fn(({ text }) => {
+      order.push("title")
+      return `Title: ${text}`
+    })
+    const titleEffect = vi.fn()
+    const waitUntilTasks: Promise<unknown>[] = []
+    const agent = defineAgent({
+      capabilities: [
+        chatTitle({ execute }),
+        defineCapability({
+          id: "transcribed-input",
+          input(context) {
+            context.input.setMessages([createMessage({ role: "user", text: "Transcribed request" })])
+          },
+        }),
+      ],
+      channels: {
+        portal: defineChannel("portal", {
+          effects: {
+            title: titleEffect,
+          },
+          messages: false,
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "Audio attachment" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: {
+        async run() {
+          order.push("driver")
+          driverStarted = true
+          await driverPending
+          return "ok"
+        },
+      },
+    })
+
+    const invocation = runAgentTrigger(agent, {
+      memo: vi.fn(),
+      runtime: "unknown" as const,
+      waitUntil: task => waitUntilTasks.push(task),
+    }, "portal.message", {}).finally(() => {
+      invocationSettled = true
+    })
+
+    await vi.waitFor(() => {
+      expect(driverStarted).toBe(true)
+      expect(titleEffect).toHaveBeenCalledWith(expect.objectContaining({
+        effect: { kind: "title", payload: { title: "Title: Transcribed request" } },
+      }))
+    })
+    expect(invocationSettled).toBe(false)
+    expect(order.slice(0, 2)).toEqual(["title", "driver"])
+
+    releaseDriver()
+    await expect(invocation).resolves.toBe("ok")
+    await Promise.all(waitUntilTasks)
+    expect(execute).toHaveBeenCalledOnce()
+    expect(titleEffect).toHaveBeenCalledOnce()
+  })
+
+  it("retries chat title delivery at finish when early delivery fails", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    let releaseDriver: () => void = () => {}
+    const driverPending = new Promise<void>((resolve) => {
+      releaseDriver = resolve
+    })
+    const titleEffect = vi.fn()
+      .mockRejectedValueOnce(new Error("temporary title failure"))
+      .mockResolvedValue(undefined)
+    const execute = vi.fn(() => "Prepared title")
+    const waitUntilTasks: Promise<unknown>[] = []
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute })],
+      channels: {
+        portal: defineChannel("portal", {
+          effects: {
+            title: titleEffect,
+          },
+          messages: false,
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "prepare title" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: {
+        async run() {
+          await driverPending
+          return "ok"
+        },
+      },
+    })
+
+    const invocation = runAgentTrigger(agent, {
+      memo: vi.fn(),
+      runtime: "unknown" as const,
+      waitUntil: task => waitUntilTasks.push(task),
+    }, "portal.message", {})
+
+    await vi.waitFor(() => expect(titleEffect).toHaveBeenCalledOnce())
+    releaseDriver()
+    await expect(invocation).resolves.toBe("ok")
+    await Promise.all(waitUntilTasks)
+    expect(execute).toHaveBeenCalledOnce()
+    expect(titleEffect).toHaveBeenCalledTimes(2)
   })
 
   it("delivers chat titles through Slack Assistant message Channels", async () => {
@@ -5282,7 +5418,7 @@ describe("agent message protocol", () => {
 
   it("generates chat titles with the default template and agent model", async () => {
     const generateText = vi.fn(async () => ({ text: '"Generated invoice title"' }))
-    vi.doMock("ai", () => ({
+    const aiSdk = {
       generateText,
       isStepCount: vi.fn(count => ({ count })),
       jsonSchema: vi.fn(schema => schema),
@@ -5291,8 +5427,9 @@ describe("agent message protocol", () => {
           return { finishReason: "stop", text: "ok" }
         }
       },
-    }))
-
+    }
+    vi.doMock("ai", () => aiSdk)
+    loadAiSdk.mockResolvedValue(aiSdk)
     try {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const finish = vi.fn()
@@ -5334,7 +5471,7 @@ describe("agent message protocol", () => {
 
   it("cleans generated chat titles without cutting words", async () => {
     const generateText = vi.fn(async () => ({ text: "Compare Quiet Rainy Morning Cafe Museum Plans" }))
-    vi.doMock("ai", () => ({
+    const aiSdk = {
       generateText,
       isStepCount: vi.fn(count => ({ count })),
       jsonSchema: vi.fn(schema => schema),
@@ -5343,7 +5480,9 @@ describe("agent message protocol", () => {
           return { finishReason: "stop", text: "ok" }
         }
       },
-    }))
+    }
+    vi.doMock("ai", () => aiSdk)
+    loadAiSdk.mockResolvedValue(aiSdk)
 
     try {
       const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5815,6 +5815,39 @@ describe("agent message protocol", () => {
     expect(finish.mock.calls[0]![0].result).toBe(result)
   })
 
+  it("does not wrap stream results when input transforms remove user messages", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => "Unused title")
+    class TextStreamResult {
+      metadata = { usage: "kept" }
+      textStream = (async function* () {
+        yield "hello"
+      })()
+    }
+    const nativeResult = new TextStreamResult()
+    const agent = defineAgent({
+      capabilities: [
+        chatTitle({ execute }),
+        defineCapability({
+          id: "remove-user-message",
+          input(context) {
+            context.input.setMessages([createMessage({ role: "system", text: "system context" })])
+          },
+        }),
+      ],
+      driver: { run: () => nativeResult },
+    })
+
+    const result = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "First user request" })],
+    }) as TextStreamResult & { stream?: AsyncIterable<unknown> }
+
+    expect(result).toBe(nativeResult)
+    expect(result.metadata).toBe(nativeResult.metadata)
+    expect(result.stream).toBeUndefined()
+    expect(execute).not.toHaveBeenCalled()
+  })
+
   it("emits chat title data for UI message streams", async () => {
     const { createUIMessageStream, readUIMessageStream } = await import("ai")
     const { defineAgent, streamAgent } = await import("../src/index.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2618,7 +2618,7 @@ describe("agent message protocol", () => {
             message: {
               invoke: context => ({
                 delivery: { effects: [{ kind: "title", payload: { title: "Provisional title" } }] },
-                input: { messages: [createMessage({ role: "user", text: "Audio attachment" })] },
+                input: { messages: [createMessage({ role: "system", text: "Audio attachment" })] },
                 run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
               }),
             },
@@ -2778,22 +2778,30 @@ describe("agent message protocol", () => {
     expect(adapter).not.toHaveBeenCalled()
   })
 
-  it("does not resolve message Channel title adapters without user messages", async () => {
-    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+  it("does not resolve message Channel title adapters when input transforms remove user messages", async () => {
+    const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     const adapter = vi.fn(() => {
       throw new Error("adapter should not resolve")
     })
     const execute = vi.fn(() => "Unused title")
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute })],
+      capabilities: [
+        chatTitle({ execute }),
+        defineCapability({
+          id: "remove-user-message",
+          input(context) {
+            context.input.setMessages([createMessage({ role: "system", text: "system context" })])
+          },
+        }),
+      ],
       channels: {
         portal: defineChannel("portal", {
           adapter,
           triggers: {
             message: {
               invoke: context => ({
-                input: { messages: [createMessage({ role: "system", text: "system context" })] },
+                input: { messages: [createMessage({ role: "user", text: "prepare title" })] },
                 run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
               }),
             },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2647,7 +2647,7 @@ describe("agent message protocol", () => {
     expect(titleEffect).toHaveBeenCalledOnce()
   })
 
-  it("retries chat title delivery at finish when early delivery fails", async () => {
+  it("retries chat title delivery at finish when any early delivery handler fails", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     let releaseDriver: () => void = () => {}
@@ -2655,6 +2655,7 @@ describe("agent message protocol", () => {
       releaseDriver = resolve
     })
     const titleEffect = vi.fn()
+    const retryingTitleEffect = vi.fn()
       .mockRejectedValueOnce(new Error("temporary title failure"))
       .mockResolvedValue(undefined)
     const execute = vi.fn(() => "Prepared title")
@@ -2664,7 +2665,7 @@ describe("agent message protocol", () => {
       channels: {
         portal: defineChannel("portal", {
           effects: {
-            title: titleEffect,
+            title: [titleEffect, retryingTitleEffect],
           },
           messages: false,
           triggers: {
@@ -2691,12 +2692,16 @@ describe("agent message protocol", () => {
       waitUntil: task => waitUntilTasks.push(task),
     }, "portal.message", {})
 
-    await vi.waitFor(() => expect(titleEffect).toHaveBeenCalledOnce())
+    await vi.waitFor(() => {
+      expect(titleEffect).toHaveBeenCalledOnce()
+      expect(retryingTitleEffect).toHaveBeenCalledOnce()
+    })
     releaseDriver()
     await expect(invocation).resolves.toBe("ok")
     await Promise.all(waitUntilTasks)
     expect(execute).toHaveBeenCalledOnce()
     expect(titleEffect).toHaveBeenCalledTimes(2)
+    expect(retryingTitleEffect).toHaveBeenCalledTimes(2)
   })
 
   it("delivers chat titles through Slack Assistant message Channels", async () => {


### PR DESCRIPTION
Starts eligible chat-title generation through an internal invocation-start callback after Capability and Agent input transforms, before the main Agent Driver and harness workspace materialization. The task uses the existing runtime lifetime and Channel title-effect machinery, so materialization no longer gates the visible thread rename.

Successful early delivery suppresses duplicate finish delivery, while a failed early update retries through the existing finish path. Unsupported Channels and plain runs still skip unused generation, with regression coverage for transformed input, pre-driver ordering, single delivery, and failure fallback.