### PR TITLE
fix(agent): preserve native chat title delivery

### DIFF
--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -370,10 +370,10 @@ function withChatTitleReadableStreamParallel<T>(
   title: Promise<string | undefined>,
   renderTitle: (title: string) => T,
 ): AsyncIterable<T> & ReadableStream<T> {
-  const reader = result.getReader()
+  let reader: ReadableStreamDefaultReader<T> | undefined
   let cancelled = false
   let closed = false
-  let streamNext: ReturnType<typeof reader.read> | undefined
+  let streamNext: ReturnType<ReadableStreamDefaultReader<T>["read"]> | undefined
   let titlePending = true
   const titleNext = title
     .then(value => ({ title: value, type: "title" as const }))
@@ -381,14 +381,19 @@ function withChatTitleReadableStreamParallel<T>(
   const releaseReader = () => {
     if (closed) return
     closed = true
-    reader.releaseLock()
+    reader?.releaseLock()
   }
 
   return markChatTitleApplied(withAsyncIterator(new ReadableStream<T>({
     async cancel(reason) {
       cancelled = true
       try {
-        await reader.cancel(reason)
+        if (reader) {
+          await reader.cancel(reason)
+        }
+        else {
+          await result.cancel(reason)
+        }
       }
       finally {
         releaseReader()
@@ -396,6 +401,7 @@ function withChatTitleReadableStreamParallel<T>(
     },
     async pull(controller) {
       if (cancelled || closed) return
+      reader ??= result.getReader()
       streamNext ??= reader.read()
       try {
         while (!cancelled) {
@@ -439,7 +445,7 @@ function withChatTitleReadableStreamParallel<T>(
         throw error
       }
     },
-  })))
+  }, { highWaterMark: 0 })))
 }
 
 function withChatTitleEvent(result: AsyncIterable<StreamEvent>, title: Promise<string | undefined>): AsyncIterable<StreamEvent> {

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -5,6 +5,7 @@ import { createMessageChannelChatTitleEffectIntent, messageChannelTitleDelivered
 import { getMessageText } from "../messages.ts"
 import { normalizeAgentDriver } from "../internal/agent-driver.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
+import { withAsyncIterator } from "../internal/stream-result.ts"
 
 import type {
   AgentAdapterRunContext,
@@ -315,6 +316,9 @@ function withChatTitleParallel<T>(
   title: Promise<string | undefined>,
   renderTitle: (title: string) => T,
 ): AsyncIterable<T> {
+  if (typeof (result as ReadableStream<T>).pipeThrough === "function") {
+    return withChatTitleReadableStreamParallel(result as ReadableStream<T>, title, renderTitle)
+  }
   const iterable = (async function* () {
     const iterator = result[Symbol.asyncIterator]()
     let streamNext = iterator.next()
@@ -361,6 +365,83 @@ function withChatTitleParallel<T>(
   return markChatTitleApplied(iterable)
 }
 
+function withChatTitleReadableStreamParallel<T>(
+  result: ReadableStream<T>,
+  title: Promise<string | undefined>,
+  renderTitle: (title: string) => T,
+): AsyncIterable<T> & ReadableStream<T> {
+  const reader = result.getReader()
+  let cancelled = false
+  let closed = false
+  let streamNext: ReturnType<typeof reader.read> | undefined
+  let titlePending = true
+  const titleNext = title
+    .then(value => ({ title: value, type: "title" as const }))
+    .catch(() => ({ title: undefined, type: "title" as const }))
+  const releaseReader = () => {
+    if (closed) return
+    closed = true
+    reader.releaseLock()
+  }
+
+  return markChatTitleApplied(withAsyncIterator(new ReadableStream<T>({
+    async cancel(reason) {
+      cancelled = true
+      try {
+        await reader.cancel(reason)
+      }
+      finally {
+        releaseReader()
+      }
+    },
+    async pull(controller) {
+      if (cancelled || closed) return
+      streamNext ??= reader.read()
+      try {
+        while (!cancelled) {
+          const next = titlePending
+            ? await Promise.race([
+                streamNext.then(value => ({ type: "stream" as const, value })),
+                titleNext,
+              ])
+            : { type: "stream" as const, value: await streamNext }
+
+          if (cancelled) return
+          if (next.type === "title") {
+            titlePending = false
+            if (next.title) {
+              controller.enqueue(renderTitle(next.title))
+              return
+            }
+            continue
+          }
+
+          streamNext = undefined
+          if (!next.value.done) {
+            controller.enqueue(next.value.value)
+            return
+          }
+          if (titlePending) {
+            const resolvedTitle = await titleNext
+            titlePending = false
+            if (cancelled) return
+            if (resolvedTitle.title) {
+              controller.enqueue(renderTitle(resolvedTitle.title))
+            }
+          }
+          controller.close()
+          releaseReader()
+          return
+        }
+      }
+      catch (error) {
+        releaseReader()
+        throw error
+      }
+    },
+  })))
+}
+
 function withChatTitleEvent(result: AsyncIterable<StreamEvent>, title: Promise<string | undefined>): AsyncIterable<StreamEvent> {
   return withChatTitleParallel(result, title, resolvedTitle => ({ data: chatTitleData(resolvedTitle), type: "data" }))
 }
@@ -382,61 +463,11 @@ function withChatTitleTextStream(result: AsyncIterable<string>, title: Promise<s
 }
 
 function withChatTitleUiMessageStream(result: ReadableStream<unknown>, title: Promise<string | undefined>): ReadableStream<unknown> {
-  const reader = result.getReader()
-  let cancelled = false
-  const titleNext = title
-    .then(value => ({ title: value, type: "title" as const }))
-    .catch(() => ({ title: undefined, type: "title" as const }))
-
-  return markChatTitleApplied(new ReadableStream<unknown>({
-    async start(controller) {
-      let streamNext = reader.read()
-      let titlePending = true
-      try {
-        while (!cancelled) {
-          const next = titlePending
-            ? await Promise.race([
-                streamNext.then(value => ({ type: "stream" as const, value })),
-                titleNext,
-              ])
-            : { type: "stream" as const, value: await streamNext }
-
-          if (next.type === "title") {
-            titlePending = false
-            if (next.title) {
-              controller.enqueue({ data: chatTitleData(next.title), type: "data-chat-title" })
-            }
-            continue
-          }
-
-          if (next.value.done) {
-            break
-          }
-          controller.enqueue(next.value.value)
-          streamNext = reader.read()
-        }
-
-        if (!cancelled && titlePending) {
-          const resolvedTitle = await titleNext
-          if (resolvedTitle.title) {
-            controller.enqueue({ data: chatTitleData(resolvedTitle.title), type: "data-chat-title" })
-          }
-        }
-        if (!cancelled) {
-          controller.close()
-        }
-      }
-      catch (error) {
-        if (!cancelled) {
-          controller.error(error)
-        }
-      }
-    },
-    cancel(reason) {
-      cancelled = true
-      return reader.cancel(reason)
-    },
-  }))
+  return withChatTitleReadableStreamParallel(
+    result,
+    title,
+    resolvedTitle => ({ data: chatTitleData(resolvedTitle), type: "data-chat-title" }),
+  )
 }
 
 function isAsyncIterable(value: unknown): value is AsyncIterable<StreamEvent> {

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -205,12 +205,21 @@ function deliveryReactionAction(payload: unknown): string | undefined {
   return isRecord(payload) && typeof payload.action === "string" ? payload.action : undefined
 }
 
+function deliveryTitleContent(payload: unknown): string | undefined {
+  if (typeof payload === "string") return payload.trim()
+  return isRecord(payload) && typeof payload.title === "string" ? payload.title.trim() : undefined
+}
+
 function deliveryPreviewHeader(event: { channelId?: string, effect: { kind: string, payload?: unknown } }): string {
   const channel = event.channelId ? ` on ${event.channelId}` : ""
   if (event.effect.kind === "reaction") {
     const content = deliveryReactionContent(event.effect.payload)
     if (deliveryReactionAction(event.effect.payload) === "remove") return `[delivery] remove reaction${content ? ` ${content}` : ""}${channel}`
     return `[delivery] reaction${content ? ` ${content}` : ""}${channel}`
+  }
+  if (event.effect.kind === "title") {
+    const title = deliveryTitleContent(event.effect.payload)
+    return `[delivery] title${title ? ` ${title}` : ""}${channel}`
   }
   return `[delivery preview] would ${event.effect.kind}${channel}`
 }
@@ -999,7 +1008,9 @@ async function sendDevMessage(
         writeDeliveryPreviewArtifacts(context, event)
         context.stderr.write(`\n${deliveryPreviewHeader(event)}\n`)
         writeDevPayload(context, "intent", event.effect.intent)
-        if (event.effect.kind !== "reaction") writeDeliveryPreviewPayload(context, event.effect.payload)
+        if (event.effect.kind !== "reaction" && (event.effect.kind !== "title" || !deliveryTitleContent(event.effect.payload))) {
+          writeDeliveryPreviewPayload(context, event.effect.payload)
+        }
         writeDevPayload(context, "metadata", event.effect.metadata)
         continue
       }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -210,6 +210,11 @@ function deliveryTitleContent(payload: unknown): string | undefined {
   return isRecord(payload) && typeof payload.title === "string" ? payload.title.trim() : undefined
 }
 
+function isRedundantDeliveryTitlePayload(payload: unknown): boolean {
+  if (!deliveryTitleContent(payload)) return false
+  return typeof payload === "string" || (isRecord(payload) && Object.keys(payload).length === 1)
+}
+
 function deliveryPreviewHeader(event: { channelId?: string, effect: { kind: string, payload?: unknown } }): string {
   const channel = event.channelId ? ` on ${event.channelId}` : ""
   if (event.effect.kind === "reaction") {
@@ -1008,7 +1013,7 @@ async function sendDevMessage(
         writeDeliveryPreviewArtifacts(context, event)
         context.stderr.write(`\n${deliveryPreviewHeader(event)}\n`)
         writeDevPayload(context, "intent", event.effect.intent)
-        if (event.effect.kind !== "reaction" && (event.effect.kind !== "title" || !deliveryTitleContent(event.effect.payload))) {
+        if (event.effect.kind !== "reaction" && (event.effect.kind !== "title" || !isRedundantDeliveryTitlePayload(event.effect.payload))) {
           writeDeliveryPreviewPayload(context, event.effect.payload)
         }
         writeDevPayload(context, "metadata", event.effect.metadata)

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -816,6 +816,8 @@ describe("agent CLI", () => {
         return ndjson([
           { agent: "review", trigger: "github.webhook", type: "start" },
           { channelId: "github", effect: { kind: "reaction", payload: { content: "eyes" } }, type: "delivery-preview" },
+          { channelId: "discord", effect: { kind: "title", payload: { title: "Review agent summary" } }, type: "delivery-preview" },
+          { channelId: "custom", effect: { kind: "title", payload: { value: "Inspect title payload" } }, type: "delivery-preview" },
           { text: "verbose review prose", type: "text-delta" },
           { channelId: "github", effect: { artifacts: [{ path: "screenshots/login.png", url: "https://assets.example/login.png" }], kind: "reply", payload: { body: "**Summary:** Short review.\n\n<details>\n<summary>Usage telemetry</summary>\n\nlarge table\n</details>" } }, type: "delivery-preview" },
           { channelId: "github", effect: { kind: "reaction", payload: { action: "remove", content: "eyes" } }, type: "delivery-preview" },
@@ -849,12 +851,17 @@ describe("agent CLI", () => {
 
     expect(stdout.output()).toBe(`Loaded payload: ${join(rootDir, "payload.json")}\nverbose review prose\n`)
     expect(stderr.output()).toContain("[delivery] reaction eyes on github")
+    expect(stderr.output()).toContain("[delivery] title Review agent summary on discord")
+    expect(stderr.output()).toContain("[delivery] title on custom")
+    expect(stderr.output()).toContain('payload: {"value":"Inspect title payload"}')
     expect(stderr.output()).toContain("[delivery] asset screenshots/login.png on github")
     expect(stderr.output()).toContain("url: https://assets.example/login.png")
     expect(stderr.output()).toContain("[delivery preview] would reply on github")
     expect(stderr.output()).toContain("[delivery] remove reaction eyes on github")
     expect(stderr.output()).not.toContain("[tool] reaction")
+    expect(stderr.output()).not.toContain("[tool] title")
     expect(stderr.output()).not.toContain("[tool] reply")
+    expect(stderr.output()).not.toContain("[delivery preview] would title")
     expect(stderr.output()).toContain("body: **Summary:** Short review.")
     expect(stderr.output()).toContain("Usage telemetry")
     expect(stderr.output()).toContain("large table")

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -816,7 +816,8 @@ describe("agent CLI", () => {
         return ndjson([
           { agent: "review", trigger: "github.webhook", type: "start" },
           { channelId: "github", effect: { kind: "reaction", payload: { content: "eyes" } }, type: "delivery-preview" },
-          { channelId: "discord", effect: { kind: "title", payload: { title: "Review agent summary" } }, type: "delivery-preview" },
+          { channelId: "discord", effect: { kind: "title", payload: { targetId: "thread-1", title: "Review agent summary" } }, type: "delivery-preview" },
+          { channelId: "slack", effect: { kind: "title", payload: { title: "Title only" } }, type: "delivery-preview" },
           { channelId: "custom", effect: { kind: "title", payload: { value: "Inspect title payload" } }, type: "delivery-preview" },
           { text: "verbose review prose", type: "text-delta" },
           { channelId: "github", effect: { artifacts: [{ path: "screenshots/login.png", url: "https://assets.example/login.png" }], kind: "reply", payload: { body: "**Summary:** Short review.\n\n<details>\n<summary>Usage telemetry</summary>\n\nlarge table\n</details>" } }, type: "delivery-preview" },
@@ -852,6 +853,9 @@ describe("agent CLI", () => {
     expect(stdout.output()).toBe(`Loaded payload: ${join(rootDir, "payload.json")}\nverbose review prose\n`)
     expect(stderr.output()).toContain("[delivery] reaction eyes on github")
     expect(stderr.output()).toContain("[delivery] title Review agent summary on discord")
+    expect(stderr.output()).toContain('payload: {"targetId":"thread-1","title":"Review agent summary"}')
+    expect(stderr.output()).toContain("[delivery] title Title only on slack")
+    expect(stderr.output()).not.toContain('payload: {"title":"Title only"}')
     expect(stderr.output()).toContain("[delivery] title on custom")
     expect(stderr.output()).toContain('payload: {"value":"Inspect title payload"}')
     expect(stderr.output()).toContain("[delivery] asset screenshots/login.png on github")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5848,6 +5848,59 @@ describe("agent message protocol", () => {
     expect(events).toContainEqual({ text: "hello", type: "text-delta" })
   })
 
+  it("leaves readable stream results unlocked and unread until consumption", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const pull = vi.fn()
+    const source = new ReadableStream<unknown>({ pull }, { highWaterMark: 0 })
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute: () => "Lazy title" })],
+      driver: { run: () => ({ stream: source }) },
+    })
+
+    const result = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "First user request" })],
+    }) as { stream: ReadableStream<unknown> }
+
+    expect(source.locked).toBe(false)
+    expect(pull).not.toHaveBeenCalled()
+    await result.stream.cancel("unused")
+  })
+
+  it("keeps native UI message stream conversion available after chat title decoration", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    class StreamResult {
+      stream = new ReadableStream<unknown>({
+        start(controller) {
+          controller.enqueue({ messageId: "message-1", type: "start" })
+          controller.enqueue({ id: "text-1", type: "text-start" })
+          controller.enqueue({ delta: "hello", id: "text-1", type: "text-delta" })
+          controller.enqueue({ id: "text-1", type: "text-end" })
+          controller.enqueue({ finishReason: "stop", type: "finish" })
+          controller.close()
+        },
+      })
+
+      toUIMessageStream() {
+        return this.stream.pipeThrough(new TransformStream<unknown, unknown>())
+      }
+    }
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute: () => "Native UI title" })],
+      driver: { run: () => new StreamResult() },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "First user request" })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    const events = []
+    for await (const event of stream) {
+      events.push(event)
+    }
+
+    expect(events).toContainEqual({ data: { title: "Native UI title", type: "chat-title" }, type: "data-chat-title" })
+    expect(events).toContainEqual({ delta: "hello", id: "text-1", type: "text-delta" })
+  })
+
   it("cancels readable stream results while a source read is pending", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     let sourcePullStarted!: () => void
@@ -5855,14 +5908,15 @@ describe("agent message protocol", () => {
       sourcePullStarted = resolve
     })
     const cancel = vi.fn()
+    const pull = vi.fn(() => {
+      sourcePullStarted()
+      return new Promise<void>(() => {})
+    })
     class StreamResult {
       stream = new ReadableStream<unknown>({
         cancel,
-        pull() {
-          sourcePullStarted()
-          return new Promise<void>(() => {})
-        },
-      })
+        pull,
+      }, { highWaterMark: 0 })
     }
     const agent = defineAgent({
       capabilities: [chatTitle({ execute: () => new Promise<string>(() => {}) })],
@@ -5872,9 +5926,13 @@ describe("agent message protocol", () => {
     const result = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
       messages: [createMessage({ role: "user", text: "First user request" })],
     }) as StreamResult
+    expect(pull).not.toHaveBeenCalled()
+    const reader = result.stream.getReader()
+    const read = reader.read()
     await sourcePull
 
-    await expect(result.stream.cancel("client disconnected")).resolves.toBeUndefined()
+    await expect(reader.cancel("client disconnected")).resolves.toBeUndefined()
+    await expect(read).resolves.toEqual({ done: true, value: undefined })
     expect(cancel).toHaveBeenCalledWith("client disconnected")
   })
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5813,6 +5813,71 @@ describe("agent message protocol", () => {
     expect(finish.mock.calls[0]![0].result).toBe(result)
   })
 
+  it("preserves readable stream results when adding chat title data", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    class StreamResult {
+      stream = new ReadableStream<unknown>({
+        start(controller) {
+          controller.enqueue({ text: "hello", type: "text-delta" })
+          controller.close()
+        },
+      })
+
+      get textStream() {
+        return this.stream.pipeThrough(new TransformStream<unknown, unknown>())
+      }
+    }
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute: () => "Readable title" })],
+      driver: { run: () => new StreamResult() },
+    })
+
+    const result = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "First user request" })],
+    }) as StreamResult
+    const stream = result.textStream
+    const events = []
+    for await (const event of stream) {
+      events.push(event)
+    }
+
+    expect(result).toBeInstanceOf(StreamResult)
+    expect(result.stream).toBeInstanceOf(ReadableStream)
+    expect(stream).toBeInstanceOf(ReadableStream)
+    expect(events).toContainEqual({ data: { title: "Readable title", type: "chat-title" }, type: "data" })
+    expect(events).toContainEqual({ text: "hello", type: "text-delta" })
+  })
+
+  it("cancels readable stream results while a source read is pending", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    let sourcePullStarted!: () => void
+    const sourcePull = new Promise<void>((resolve) => {
+      sourcePullStarted = resolve
+    })
+    const cancel = vi.fn()
+    class StreamResult {
+      stream = new ReadableStream<unknown>({
+        cancel,
+        pull() {
+          sourcePullStarted()
+          return new Promise<void>(() => {})
+        },
+      })
+    }
+    const agent = defineAgent({
+      capabilities: [chatTitle({ execute: () => new Promise<string>(() => {}) })],
+      driver: { run: () => new StreamResult() },
+    })
+
+    const result = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "First user request" })],
+    }) as StreamResult
+    await sourcePull
+
+    await expect(result.stream.cancel("client disconnected")).resolves.toBeUndefined()
+    expect(cancel).toHaveBeenCalledWith("client disconnected")
+  })
+
   it("preserves text stream result metadata when adding chat title data", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finish = vi.fn()


### PR DESCRIPTION
Moves `chatTitle()` stream decoration onto a reader-backed `ReadableStream` merger. The previous async-generator wrapper changed `result.stream` from a `ReadableStream` into a plain async iterable, which broke result getters that call `pipeThrough()`. It could also delay cancellation behind a pending provider read; cancellation now reaches the source reader immediately and preserves the disconnect reason.

The Agent Dev Loop now renders title effects as `[delivery] title …`, alongside reactions, while retaining the raw payload for malformed or custom title effects. Provider-native Discord title mutation is proposed separately in [vercel/chat#693](https://github.com/vercel/chat/pull/693), so applications using lazy official adapter factories do not need app-local REST wrappers.

Validated with the full `@vite-hub/agent` suite (42 files, 1,023 tests), type checking, focused Oxlint, package build/publint, and a patch-first Bitacora reproduction of the original `pipeThrough()` failure.