### PR TITLE
feat(agent): allow trusted-host command execution

### DIFF
--- a/docs/content/docs/capabilities/workspace-shell.md
+++ b/docs/content/docs/capabilities/workspace-shell.md
@@ -1,6 +1,6 @@
 ---
 title: Workspace shell
-description: Expose shell-shaped Workspace inspection, mutation, and allowlisted Workspace command tools.
+description: Expose Workspace inspection, mutation, and explicit executable tools.
 navigation.title: Workspace shell
 navigation.order: 50
 navigation.group: Workspace
@@ -8,7 +8,7 @@ icon: i-lucide-folder-search
 ---
 
 `workspaceShell()` adds model-facing Workspace tools to an Agent.
-It exposes shell-shaped inspection by default, write tools when the Agent's Workspace grants write mode, and optional allowlisted commands through the same Capability.
+It exposes shell-shaped inspection by default, write tools when the Agent's Workspace grants write mode, and optional executable commands through the same Capability.
 
 ## Installation
 
@@ -19,6 +19,7 @@ Use the configuration example below as the starting point, then tighten modes, p
 
 The Capability contributes Workspace inspection tools in read mode and structured Workspace mutation tools in write mode.
 When configured with `commands`, it also contributes a `workspace_exec` tool that can run only those executable names or absolute executable paths inside a trusted Workspace Session.
+Set `commands: 'trusted-host'` only when an Agent running on infrastructure you control should be able to select any executable available to the host service account.
 When Workspace Sources expose request descriptors, tool descriptions and generated metadata can describe controlled request access; broader usage guidance belongs in Agent Driver Instructions.
 
 ## Configuration
@@ -58,7 +59,28 @@ Configured commands also require `workspace.mode: 'write'`, even when `workspace
 
 Workspace Shell is not Sandbox.
 It exposes Workspace file operations and optional Workspace-session commands, while `sandbox()` runs allowlisted executables in an isolated runtime.
-Keep arbitrary executable execution in `sandbox()` or a domain-specific Capability.
+Use `sandbox()` for untrusted execution and a domain-specific Capability when the executable set is known.
+
+For a Linux-hosted Agent that intentionally owns its machine or container, configure both unrestricted trusted-host commands and the trusted-host Workspace runtime:
+
+```ts [server/agents/operator.ts]
+export default defineAgent({
+  capabilities: [
+    workspaceShell({ commands: 'trusted-host', mode: 'write' }),
+  ],
+  driver: { model },
+  workspace: {
+    mode: 'write',
+    runtime: {
+      type: 'trusted-host',
+      allowProduction: true,
+    },
+    store,
+  },
+})
+```
+
+This is not isolation. The Agent can run `sh`, `gh`, `git`, generated scripts, and any other reachable executable with the filesystem, network, process, and inherited environment authority of the service account. Use a dedicated service account or container with narrowly scoped credentials, mounts, and network access.
 
 ## Driver support
 
@@ -72,7 +94,8 @@ Keep arbitrary executable execution in `sandbox()` or a domain-specific Capabili
 
 Open DevTools and inspect the Agent's tool list.
 Read mode should expose inspection tools, and write mode should expose mutation tools only when the Workspace is writable.
-Agents with configured commands should expose `workspace_exec` with only the configured command names.
+Agents with a command array should expose `workspace_exec` with only the configured command names.
+Trusted-host command mode should expose a free executable field only when the resolved Workspace runtime is trusted-host.
 
 Try reading outside an `access()` Workspace Scope when both Capabilities are attached.
 The scoped Workspace should hide or reject paths outside the selected grants.
@@ -82,7 +105,7 @@ The scoped Workspace should hide or reject paths outside the selected grants.
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `mode` | `"read" \| "write"` | `"read"` | Selects Workspace inspection tools or write-capable Workspace tools. |
-| `commands` | `string[]` | - | Optional executable names or absolute executable paths allowed through the `workspace_exec` tool. |
+| `commands` | `string[] \| "trusted-host"` | - | Executable allowlist, or explicit unrestricted host execution for a trusted-host Workspace. |
 | `timeout` | `number` | - | Optional default timeout in milliseconds for configured command execution. |
 
 ## Reference

--- a/packages/agent/src/capabilities/workspace-command.ts
+++ b/packages/agent/src/capabilities/workspace-command.ts
@@ -135,24 +135,29 @@ function assertWorkspace(workspace: unknown, message: string): asserts workspace
 }
 
 export function workspaceCommandTools(
-  commands: readonly (string | WorkspaceCommandEntry)[],
+  commands: readonly (string | WorkspaceCommandEntry)[] | "trusted-host",
   mode: AgentCapabilityMode,
   timeout: number | undefined,
   workspace: unknown,
   options: WorkspaceCommandToolOptions = {},
 ): AgentToolSet {
-  const entries = commands.map(command => typeof command === "string" ? { command } : command)
+  const unrestricted = commands === "trusted-host"
+  const entries = unrestricted ? [] : commands.map(command => typeof command === "string" ? { command } : command)
   const commandNames = entries.map(entry => entry.command)
   const toolName = options.toolName || "workspace_exec"
   const summary = entries.map(entry => entry.description ? `${entry.command} (${entry.description})` : entry.command).join(", ")
   return {
     [toolName]: defineInternalTool({
-      description: options.description || `Run one configured command in a trusted Workspace Session at the workspace root. Allowed commands: ${summary}.`,
+      description: options.description || (unrestricted
+        ? "Run any executable in a trusted Workspace Session with the host service account's authority."
+        : `Run one configured command in a trusted Workspace Session at the workspace root. Allowed commands: ${summary}.`),
       inputSchema: {
         additionalProperties: false,
         properties: {
           args: { items: { type: "string" }, type: "array" },
-          command: { enum: commandNames, type: "string" },
+          command: unrestricted
+            ? { description: "Executable name or absolute executable path.", type: "string" }
+            : { enum: commandNames, type: "string" },
           cwd: { description: "Workspace-relative directory. Defaults to the workspace root.", type: "string" },
           env: { additionalProperties: { type: "string" }, type: "object" },
           timeout: { type: "number" },
@@ -164,7 +169,8 @@ export function workspaceCommandTools(
       async execute(input: unknown) {
         const value = input as WorkspaceCommandInput
         if (!value || typeof value.command !== "string") throw new TypeError(`[vitehub] ${toolName} requires a command.`)
-        if (!commandNames.includes(value.command)) throw new Error(`[vitehub] Workspace command "${value.command}" is not allowed.`)
+        if (unrestricted) normalizeWorkspaceCommandEntries([value.command], `${toolName} command`)
+        else if (!commandNames.includes(value.command)) throw new Error(`[vitehub] Workspace command "${value.command}" is not allowed.`)
         const args = stringArray(value.args, "args")
         const cwd = normalizeCwd(value.cwd)
         const env = envRecord(value.env)

--- a/packages/agent/src/capabilities/workspace-shell.ts
+++ b/packages/agent/src/capabilities/workspace-shell.ts
@@ -14,23 +14,31 @@ import type {
   AgentRuntimeConfig,
   AgentToolSet,
 } from "../types.ts"
-import type { WorkspaceName } from "@vite-hub/workspace"
+import type { WorkspaceDefinition, WorkspaceName } from "@vite-hub/workspace"
 
 type WorkspaceShellCapabilityTypeContract = {
   workspaceScopes: never
 }
 
 export interface WorkspaceShellOptions {
-  commands?: string[]
+  commands?: string[] | "trusted-host"
   mode?: AgentCapabilityMode
   timeout?: number
+}
+
+function isTrustedHostRuntime(definition: WorkspaceDefinition | undefined): boolean {
+  const runtime = definition?.runtime
+  return runtime === "trusted-host"
+    || typeof runtime === "object" && runtime !== null && runtime.type === "trusted-host"
 }
 
 export function workspaceShell(options: WorkspaceShellOptions = {}): AgentCapabilityDefinition<AgentRuntimeConfig, WorkspaceName, WorkspaceShellCapabilityTypeContract> {
   const mode = normalizeMode(options.mode, "Workspace Shell")
   const commands = options.commands === undefined
     ? undefined
-    : validateWorkspaceCommands(options.commands)
+    : options.commands === "trusted-host"
+      ? options.commands
+      : validateWorkspaceCommands(options.commands)
   const timeout = normalizeWorkspaceCommandTimeout(options.timeout, "workspaceShell({ timeout })")
 
   return defineCapability({
@@ -38,11 +46,16 @@ export function workspaceShell(options: WorkspaceShellOptions = {}): AgentCapabi
     metadata: commands ? { commands, mode, ...(timeout ? { timeout } : {}) } : undefined,
     mode,
     requires: [{ primitive: "workspace", workspace: { mode: commands ? "write" : mode, required: true } }],
-    tools: ({ workspace }) => ({
-      ...(mode === "write" && "write" in workspace.tools
-        ? (workspace.tools as unknown as { write: () => AgentToolSet }).write()
-        : workspace.tools.inspect()) as AgentToolSet,
-      ...(commands ? workspaceCommandTools(commands, mode, timeout, workspace) : {}),
-    }),
+    tools: ({ workspace, workspaceDefinition }) => {
+      if (commands === "trusted-host" && !isTrustedHostRuntime(workspaceDefinition)) {
+        throw new Error("[vitehub] workspaceShell({ commands: \"trusted-host\" }) requires workspace.runtime: \"trusted-host\".")
+      }
+      return {
+        ...(mode === "write" && "write" in workspace.tools
+          ? (workspace.tools as unknown as { write: () => AgentToolSet }).write()
+          : workspace.tools.inspect()) as AgentToolSet,
+        ...(commands ? workspaceCommandTools(commands, mode, timeout, workspace) : {}),
+      }
+    },
   })
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -845,7 +845,7 @@ function validateWorkspaceCapabilities<Name extends WorkspaceName>(options: Work
   for (const capability of capabilities) {
     if (capability.id === "workspace-shell") {
       const metadata = capability.metadata as { commands?: unknown } | undefined
-      const requiresWritableSession = Array.isArray(metadata?.commands)
+      const requiresWritableSession = metadata?.commands !== undefined
       if (requiresWritableSession && workspaceMode !== "write") {
         throw new Error("[vitehub] workspaceShell({ commands }) requires workspace.mode: \"write\".")
       }

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -386,12 +386,18 @@ function capabilityMetadataTool(capability: NormalizedCapability, options: { dri
   if (options.driverKind === "harness") return undefined
   if (capability.id === "workspace-shell") {
     const mode = normalizeMode(capability.mode, "Workspace Shell")
+    const trustedHostCommands = (capability.metadata as { commands?: unknown } | undefined)?.commands === "trusted-host"
     return {
       category: "workspace",
-      commands: workspaceShellMetadataCommands(mode, options.sourceRequests),
-      description: mode === "write"
-        ? "Run curated workspace read and write shell operations."
-        : "Run curated workspace read shell operations.",
+      commands: [
+        ...workspaceShellMetadataCommands(mode, options.sourceRequests),
+        ...(trustedHostCommands ? ["workspace_exec (any host executable)"] : []),
+      ],
+      description: trustedHostCommands
+        ? `Run workspace ${mode === "write" ? "read and write" : "read"} operations and any executable with the trusted host service account's authority.`
+        : mode === "write"
+          ? "Run curated workspace read and write shell operations."
+          : "Run curated workspace read shell operations.",
       icon: "i-lucide-terminal",
       name: "workspaceShell",
       status: "available",

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -188,6 +188,7 @@ describe("agent public types", () => {
         browser(),
         browser({ command: "agent-browser", skillContent: "# Browser\n", skillPath: "skills/browser/SKILL.md", sourceKey: "skill.browser" }),
         workspaceShell({ commands: ["agent-browser", "/Users/maxi/quiver/agents/node_modules/.bin/agent-browser"] }),
+        workspaceShell({ commands: "trusted-host", mode: "write" }),
         workspaceShell({ commands: ["agent-browser"], mode: "read", timeout: 1_000 }),
         workspaceShell({ commands: ["agent-browser"], mode: "write" }),
         inputCommands({

--- a/packages/agent/test/workspace-shell-capability.test.ts
+++ b/packages/agent/test/workspace-shell-capability.test.ts
@@ -26,10 +26,14 @@ function workspaceSession(options: { exitCode?: number } = {}) {
 async function capabilityTools(
   capability: AgentCapabilityDefinition = workspaceShell({ commands: ["agent-browser"] }),
   session = workspaceSession(),
+  runtime: "sandbox" | "trusted-host" | { allowProduction?: boolean, type: "trusted-host" } | null = "trusted-host",
 ): Promise<{ session: ReturnType<typeof workspaceSession>, startSession: ReturnType<typeof vi.fn>, tools: AgentToolSet }> {
   if (typeof capability.tools !== "function") throw new Error("workspaceShell capability must expose tool resolver")
   const startSession = vi.fn(async () => session)
-  const tools = await capability.tools({ workspace: { startSession, tools: { inspect: () => ({}) } } } as never) as AgentToolSet
+  const tools = await capability.tools({
+    workspace: { startSession, tools: { inspect: () => ({}) } },
+    workspaceDefinition: { name: "test", runtime: runtime ?? undefined },
+  } as never) as AgentToolSet
   return { session, startSession, tools }
 }
 
@@ -48,10 +52,45 @@ describe("workspaceShell capability", () => {
       metadata: { mode: "write" },
       requires: [{ workspace: { mode: "write", required: true } }],
     })
+    expect(workspaceShell({ commands: "trusted-host" })).toMatchObject({
+      metadata: { commands: "trusted-host", mode: "read" },
+      requires: [{ workspace: { mode: "write", required: true } }],
+    })
     expect(() => workspaceShell({ commands: [] })).toThrow("requires at least one command")
     expect(() => workspaceShell({ commands: ["pnpm test"] })).toThrow("without whitespace")
     expect(() => workspaceShell({ commands: ["./agent-browser"] })).toThrow("simple executable names or absolute paths")
     expect(() => workspaceShell({ commands: ["agent-browser\n"] })).toThrow("without whitespace")
+  })
+
+  it("runs arbitrary structured commands only in an explicit trusted-host runtime", async () => {
+    const capability = workspaceShell({ commands: "trusted-host", timeout: 5_000 })
+
+    await expect(capabilityTools(capability, workspaceSession(), null)).rejects.toThrow(
+      "requires workspace.runtime: \"trusted-host\"",
+    )
+    await expect(capabilityTools(capability, workspaceSession(), "sandbox")).rejects.toThrow(
+      "requires workspace.runtime: \"trusted-host\"",
+    )
+
+    const stringRuntime = await capabilityTools(capability)
+    await expect(stringRuntime.tools.workspace_exec!.execute?.({
+      args: ["issue", "list"],
+      command: "gh",
+    })).resolves.toMatchObject({ exitCode: 0 })
+    expect(stringRuntime.session.exec).toHaveBeenCalledWith("gh", ["issue", "list"], {
+      cwd: "/workspace",
+      env: undefined,
+      timeout: 5_000,
+    })
+
+    const objectRuntime = await capabilityTools(capability, workspaceSession(), { allowProduction: true, type: "trusted-host" })
+    await expect(objectRuntime.tools.workspace_exec!.execute?.({
+      args: ["-lc", "git status && mktemp"],
+      command: "sh",
+    })).resolves.toMatchObject({ exitCode: 0 })
+    await expect(objectRuntime.tools.workspace_exec!.execute?.({ command: "pnpm test" })).rejects.toThrow(
+      "without whitespace/control characters",
+    )
   })
 
   it("runs only allow-listed commands with structured exec options", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1109,6 +1109,12 @@ describe("defineAgent workspace option", () => {
       driver: { model: {} as never, },
       workspace: { mode: "read" },
     })).toThrow("workspaceShell({ commands }) requires workspace.mode: \"write\"")
+
+    expect(() => defineAgent({
+      capabilities: [workspaceShell({ commands: "trusted-host" })],
+      driver: { model: {} as never },
+      workspace: { mode: "read" },
+    })).toThrow("workspaceShell({ commands }) requires workspace.mode: \"write\"")
   })
 
   it("requires writable workspace for browser bash commands", async () => {
@@ -3959,6 +3965,24 @@ describe("defineAgent workspace option", () => {
         }),
       ]),
     })
+  })
+
+  it("marks unrestricted trusted-host execution in DevTools metadata", async () => {
+    const { createAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
+    const { workspaceShell } = await import("../src/capabilities.ts")
+    const agent = withAgentDefaults(defineAgent({
+      capabilities: [workspaceShell({ commands: "trusted-host", mode: "write" })],
+      driver: { model: {} as never },
+      workspace: { mode: "write", runtime: "trusted-host" },
+    }), { workspace: "support" })
+
+    expect(createAgentDevtoolsMetadata(agent).tools).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        commands: expect.arrayContaining(["workspace_exec (any host executable)"]),
+        description: expect.stringContaining("trusted host service account's authority"),
+        name: "workspaceShell",
+      }),
+    ]))
   })
 
   it("composes static DevTools instruction metadata", async () => {


### PR DESCRIPTION
Adds an explicit `workspaceShell({ commands: "trusted-host" })` mode for Linux-hosted agents that need to discover and run executables such as `gh`, `git`, interpreters, and generated scripts without an application-maintained allowlist. The capability refuses this mode unless the resolved Workspace runtime is also `trusted-host`; existing executable arrays and sandbox behavior remain unchanged.

Execution keeps the structured `command` plus `args` contract, Workspace-relative cwd validation, environment restrictions, timeouts, session cleanup, and write-mode commits. The underlying trusted-host runtime still rejects production unless the Workspace explicitly sets `allowProduction: true`. Documentation and DevTools state the boundary directly: this is the host service account's filesystem, network, credential, and process authority, not isolation.

Validated with the full `@vite-hub/agent` suite (42 files, 1,023 tests), package type checking, build/publint, focused Oxlint, strict review, `git diff --check`, and the existing real-session Workspace production-guard tests.