### PR TITLE
feat(agent): capture invocation data by default

### DIFF
--- a/docs/content/docs/agents/evals.md
+++ b/docs/content/docs/agents/evals.md
@@ -95,20 +95,20 @@ Use `--watch` while editing prompts or scenarios. Use `--threshold` and `--outpu
 ## Score useful behavior
 
 Good evals score source-grounded answers, refusal behavior, expected tool use, no source leakage, and regressions in usage or latency when Agent usage exists.
-When the behavior belongs to a Capability, assert its finish extension instead of duplicating host-specific hooks.
-Use `observability.usage` for the raw Agent Usage Record, or `usage-telemetry` for primitive usage JSON.
+Read normalized token usage from `observation.usage` and the finalized invocation trace from `observation.trace`.
+When behavior belongs to a Capability, assert its finish extension instead of duplicating host-specific hooks.
 
 ```ts [server/agents/support.eval.ts]
-import { defineEval, hasCapabilityExtension } from '@vite-hub/agent/eval'
+import { defineEval } from '@vite-hub/agent/eval'
 import support from './support'
 
 export default defineEval({
   agent: support,
   async test(t) {
-    await t.send('What changed in the order forecast?')
-    t.hasCapabilityExtension('observability')
-    t.expect(hasCapabilityExtension('observability', 'status'))
-    t.expect(hasCapabilityExtension('observability', 'usage'))
+    const observation = await t.send('What changed in the order forecast?')
+    if (observation.trace?.status !== 'completed') {
+      throw new Error('Expected a completed Agent Invocation trace.')
+    }
   },
 })
 ```

--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -70,6 +70,8 @@ Use `output: 'events'` when an internal caller wants ViteHub stream events. Use 
 
 Every Agent Invocation receives a trace context and a metadata-only in-memory Trace Event Log. Agent runtime callbacks can inspect `runtime.trace` and `runtime.traceLog`. A host can supply its own trace context or Trace Event Log when it needs request-trace continuity, a shared log, a different content policy, or an `onEntry` sink. ViteHub preserves the supplied objects; it does not persist the default log.
 
+That preservation applies to inline Agent Invocations. A workflow-backed invocation crosses a durable serialization boundary, so process-local Trace Event Logs and `onEntry` sinks are not carried into the Workflow Run. The workflow execution creates its own invocation trace instead.
+
 Agent Finish Hooks receive core completion facts without an observability Capability:
 
 ```ts [server/agents/support.ts]

--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -66,6 +66,26 @@ export default defineEventHandler(async (event) => {
 
 Use `output: 'events'` when an internal caller wants ViteHub stream events. Use `output: 'ui-message-stream'` when a chat UI expects UI message stream chunks.
 
+## Inspect invocation data
+
+Every Agent Invocation receives a trace context and a metadata-only in-memory Trace Event Log. Agent runtime callbacks can inspect `runtime.trace` and `runtime.traceLog`. A host can supply its own trace context or Trace Event Log when it needs request-trace continuity, a shared log, a different content policy, or an `onEntry` sink. ViteHub preserves the supplied objects; it does not persist the default log.
+
+Agent Finish Hooks receive core completion facts without an observability Capability:
+
+```ts [server/agents/support.ts]
+export default defineAgent({
+  driver: { model },
+  hooks: {
+    'agent:finish'(event) {
+      const { durationMs, resultKind, usage } = event.invocation
+      event.runtime.waitUntil(recordInvocation({ durationMs, resultKind, usage }))
+    },
+  },
+})
+```
+
+The finish hook runs before the invocation's terminal Trace Event. Agent tests and eval observations expose the finalized `TraceRunView` as `result.trace` or `observation.trace` after completion. Stream and Response traces become terminal when the caller consumes, cancels, or encounters an error from the output.
+
 ## Invoke a trigger
 
 Use `runAgentTrigger` or `streamAgentTrigger` when a Capability owns the product event shape. The trigger prepares Agent Invocation input, metadata, and run state before the Agent Driver starts.

--- a/docs/content/docs/capabilities/observability.md
+++ b/docs/content/docs/capabilities/observability.md
@@ -10,7 +10,11 @@ icon: i-lucide-radar
 `observability()` gives an Agent Definition one place to attach runtime telemetry.
 It can instrument model execution, emit lifecycle events, and provide a finish extension with invocation status, duration, result kind, and structured usage when the Agent Driver reports it.
 
-## Installation
+::warning
+`observability()` is deprecated. Agent Invocations now capture metadata-only Trace Events by default, and Agent Finish Hooks receive result kind and normalized usage on `event.invocation`. Supply a Runtime `traceLog` with `onEntry` when the host needs an external sink.
+::
+
+## Legacy installation
 
 Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 
@@ -28,7 +32,7 @@ export default defineAgent({
 })
 ```
 
-## What it adds
+## Legacy behavior
 
 The Capability emits a `start` event before driver execution.
 When `onEvent` is configured, it also emits a `finish` or `error` event after the invocation completes.

--- a/docs/content/docs/capabilities/official-capabilities.md
+++ b/docs/content/docs/capabilities/official-capabilities.md
@@ -73,8 +73,8 @@ import {
 | Rate limit | [`rateLimit()`](/docs/capabilities/rate-limit) | A trusted invocation budget should be checked or consumed before the Agent runs. |
 | Chat title | [`chatTitle()`](/docs/capabilities/chat-title) | Chat streams and finish extensions should include a generated conversation title. |
 | Chat summary | [`chatSummary()`](/docs/capabilities/chat-summary) | A summary command should replace explicit input with a conversation summary. |
-| Observability | [`observability()`](/docs/capabilities/observability) | Lifecycle events, model instrumentation, and finish metadata should be attached to Agent Invocations. |
-| Usage telemetry | [`usageTelemetry()`](/docs/capabilities/usage-telemetry) | Finish hooks or Channel Delivery finish effects should receive primitive usage JSON. |
+| Observability (deprecated) | [`observability()`](/docs/capabilities/observability) | Existing code still needs the legacy lifecycle callback or finish extension while migrating to built-in invocation traces. |
+| Usage telemetry (deprecated) | [`usageTelemetry()`](/docs/capabilities/usage-telemetry) | Existing code still needs the legacy flat primitive usage extension while migrating to `invocation.usage`. |
 
 ## Read capability pages first
 

--- a/docs/content/docs/capabilities/usage-telemetry.md
+++ b/docs/content/docs/capabilities/usage-telemetry.md
@@ -10,7 +10,11 @@ icon: i-lucide-gauge
 `usageTelemetry()` exposes usage as data at the end of an Agent Invocation.
 It does not format messages, comments, markdown, web UI, billing notes, or summaries.
 
-## Installation
+::warning
+`usageTelemetry()` is deprecated. Read the normalized Agent Usage Record from `event.invocation.usage` in Agent Finish Hooks or `context.invocation.usage` in Channel Delivery finish effects. Keep this Capability only while migrating consumers that require its legacy flat primitive extension.
+::
+
+## Legacy installation
 
 Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
 
@@ -33,7 +37,7 @@ export default defineAgent({
 })
 ```
 
-## What it adds
+## Legacy behavior
 
 The Capability provides a `usage-telemetry` finish extension when the Agent result contains usage.
 Read the same extension in Channel Delivery finish effects with `context.extensions.get("usage-telemetry")`.

--- a/docs/content/docs/reference/runtime-events.md
+++ b/docs/content/docs/reference/runtime-events.md
@@ -73,8 +73,8 @@ Agent Usage Records normalize usage across model-backed, harness-backed, and cus
 Token fields appear only when the provider reports them or ViteHub can derive them safely.
 
 Streams can carry the full Agent Usage Record through `{ type: "usage", usageRecord }`.
-At finish time, enable `usageTelemetry()` and read primitive JSON from `event.extensions.get("usage-telemetry")` or `context.extensions.get("usage-telemetry")`.
-Applications format that JSON when a product surface needs text, UI, notes, billing records, or comments.
+At finish time, read the normalized Agent Usage Record from `event.invocation.usage` in an Agent Finish Hook or `context.invocation.usage` in a Channel Delivery finish effect.
+Applications format that data when a product surface needs text, UI, notes, billing records, or comments.
 
 ## Related
 

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -8,6 +8,13 @@ import type { AgentRunMetadata, AgentRunResult, AgentUsage, AgentUsageRecord } f
 
 export { isAsyncIterable } from "./internal/stream-result.ts"
 
+export function agentResultKind(result: unknown): string {
+  if (result === null) return "null"
+  if (isAsyncIterable(result)) return "stream"
+  if (Array.isArray(result)) return "array"
+  return typeof result
+}
+
 function textFromContent(content: unknown): string | undefined {
   if (!Array.isArray(content)) return
 

--- a/packages/agent/src/capabilities/observability.ts
+++ b/packages/agent/src/capabilities/observability.ts
@@ -1,4 +1,4 @@
-import { resolveAgentUsageRecord } from "../agent-output.ts"
+import { agentResultKind, resolveAgentUsageRecord } from "../agent-output.ts"
 import { defineCapability } from "../capability-runtime.ts"
 
 import type {
@@ -75,17 +75,6 @@ interface AgentObservabilityCapabilityMetadata<
   observability: AgentObservabilityOptions<TRuntimeConfig, CALL_OPTIONS>
 }
 
-function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
-  return Boolean(value && typeof value === "object" && Symbol.asyncIterator in value)
-}
-
-function resultKind(result: unknown): string {
-  if (result === null) return "null"
-  if (isAsyncIterable(result)) return "stream"
-  if (Array.isArray(result)) return "array"
-  return typeof result
-}
-
 function capabilityEventBase<TRuntimeConfig extends AgentRuntimeConfig>(
   context: AgentCapabilityRuntimeContext<TRuntimeConfig>,
 ): AgentObservabilityEventBase<TRuntimeConfig> {
@@ -122,6 +111,9 @@ async function notify<TRuntimeConfig extends AgentRuntimeConfig>(
   }
 }
 
+/**
+ * @deprecated Agent invocations now capture runtime Trace Events and finish data by default. Use a host TraceEventLog sink and model execution instrumentation directly.
+ */
 export function observability<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -161,7 +153,7 @@ export function observability<
       }
     },
     async finish(event: AgentFinishEvent<TRuntimeConfig>) {
-      const usage = await resolveAgentUsageRecord(event.result, event.invocation.run)
+      const usage = event.invocation.usage ?? await resolveAgentUsageRecord(event.result, event.invocation.run)
       if (event.errorMessage !== undefined) {
         return {
           durationMs: event.invocation.durationMs,
@@ -172,7 +164,7 @@ export function observability<
 
       return {
         durationMs: event.invocation.durationMs,
-        resultKind: resultKind(event.result),
+        resultKind: event.invocation.resultKind ?? agentResultKind(event.result),
         status: "completed",
         ...(usage ? { usage } : {}),
       } satisfies AgentObservabilityFinishExtension

--- a/packages/agent/src/capabilities/usage-telemetry.ts
+++ b/packages/agent/src/capabilities/usage-telemetry.ts
@@ -79,6 +79,9 @@ function usageTelemetryRecord(record: AgentUsageRecord | undefined): UsageTeleme
   return Object.keys(telemetry).length ? telemetry : undefined
 }
 
+/**
+ * @deprecated Normalized usage is now available as event.invocation.usage in Agent Finish Hooks and Channel Delivery finish effects.
+ */
 export function usageTelemetry<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(): AgentCapabilityDefinition<TRuntimeConfig> {
   return defineCapability<TRuntimeConfig>({
     id: "usage-telemetry",
@@ -86,7 +89,7 @@ export function usageTelemetry<TRuntimeConfig extends AgentRuntimeConfig = Agent
       kind: "usage-telemetry",
     } satisfies UsageTelemetryCapabilityMetadata,
     async finish(event: AgentFinishEvent<TRuntimeConfig>) {
-      return usageTelemetryRecord(await resolveAgentUsageRecord(event.result, event.invocation.run))
+      return usageTelemetryRecord(event.invocation.usage ?? await resolveAgentUsageRecord(event.result, event.invocation.run))
     },
   })
 }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1290,6 +1290,33 @@ type CapabilityCleanupOutcome =
   | { failed: false }
   | { error: unknown, failed: true }
 
+async function closeCapabilityStreamIterator(
+  iterator: AsyncIterator<unknown>,
+  completed: boolean,
+  outcome: CapabilityCleanupOutcome,
+  close: (outcome: CapabilityCleanupOutcome) => Promise<void>,
+): Promise<void> {
+  if (!completed) {
+    const returnTask = iterator.return?.()
+    if (outcome.failed) void returnTask?.catch(() => {})
+    else {
+      try {
+        await returnTask
+      }
+      catch (returnError) {
+        try {
+          await close({ error: returnError, failed: true })
+        }
+        catch (closeError) {
+          throw new AggregateError([returnError, closeError], "[vitehub] Agent stream return failed and finish lifecycle also failed.")
+        }
+        throw returnError
+      }
+    }
+  }
+  await close(outcome)
+}
+
 export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(
   stream: T,
   close: (outcome: CapabilityCleanupOutcome) => Promise<void>,
@@ -1316,12 +1343,7 @@ export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(
       throw caught
     }
     finally {
-      if (!completed) {
-        const returnTask = iterator.return?.()
-        if (failed) void returnTask?.catch(() => {})
-        else await returnTask
-      }
-      await close(failed ? { error, failed: true } : { failed: false })
+      await closeCapabilityStreamIterator(iterator, completed, failed ? { error, failed: true } : { failed: false }, close)
     }
   })()
 }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1297,12 +1297,16 @@ export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(
 ): AsyncIterable<unknown> {
   return (async function* () {
     const iterator = stream[Symbol.asyncIterator]()
+    let completed = false
     let error: unknown
     let failed = false
     try {
       for (;;) {
         const result = await nextWithAbort(iterator.next(), options.abortSignal, "[vitehub] Agent Invocation stream aborted.")
-        if (result.done) break
+        if (result.done) {
+          completed = true
+          break
+        }
         yield result.value
       }
     }
@@ -1312,7 +1316,11 @@ export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(
       throw caught
     }
     finally {
-      if (failed) void iterator.return?.().catch(() => {})
+      if (!completed) {
+        const returnTask = iterator.return?.()
+        if (failed) void returnTask?.catch(() => {})
+        else await returnTask
+      }
       await close(failed ? { error, failed: true } : { failed: false })
     }
   })()
@@ -1329,7 +1337,7 @@ export function withResponseCleanup(response: Response, close: (outcome: Capabil
     closed = true
     await close(outcome)
   }
-  return new Response(new ReadableStream({
+  const wrapped = new Response(new ReadableStream({
     async cancel(reason) {
       let cancelOutcome: CapabilityCleanupOutcome = reason === undefined ? { failed: false } : { error: reason, failed: true }
       try {
@@ -1359,4 +1367,10 @@ export function withResponseCleanup(response: Response, close: (outcome: Capabil
       }
     },
   }), response)
+  Object.defineProperties(wrapped, {
+    redirected: { configurable: true, enumerable: true, value: response.redirected },
+    type: { configurable: true, enumerable: true, value: response.type },
+    url: { configurable: true, enumerable: true, value: response.url },
+  })
+  return wrapped
 }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1297,7 +1297,13 @@ async function closeCapabilityStreamIterator(
   close: (outcome: CapabilityCleanupOutcome) => Promise<void>,
 ): Promise<void> {
   if (!completed) {
-    const returnTask = iterator.return?.()
+    let returnTask: Promise<IteratorResult<unknown>> | undefined
+    try {
+      returnTask = iterator.return?.()
+    }
+    catch (returnError) {
+      returnTask = Promise.reject(returnError)
+    }
     if (outcome.failed) void returnTask?.catch(() => {})
     else {
       try {

--- a/packages/agent/src/eval.ts
+++ b/packages/agent/src/eval.ts
@@ -27,6 +27,7 @@ import {
   type Message,
 } from "./messages.ts"
 import type { WorkspaceName } from "@vite-hub/workspace"
+import type { TraceRunView } from "@vite-hub/runtime"
 
 export interface AgentScore {
   metadata?: unknown
@@ -43,6 +44,7 @@ export interface AgentObservation {
   scenario: string
   text: string
   toolSteps: AgentToolStep[]
+  trace?: TraceRunView
   usage?: unknown
   variant: string
   warnings?: unknown
@@ -366,6 +368,7 @@ function toObservation(result: AgentTestRunResult, scenario: { metadata?: unknow
     scenario: scenario.name,
     text: result.text,
     toolSteps: result.toolSteps,
+    ...(result.trace ? { trace: result.trace } : {}),
     usage: result.usage,
     variant: variant.name,
     warnings: result.warnings,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1799,7 +1799,7 @@ async function resolveFinishUsageRecord<
 }
 
 type AgentInvocationFinishOutcome =
-  | { result?: unknown, status: "success" }
+  | { result?: unknown, status: "success", usage?: AgentUsageRecord }
   | { error: unknown, status: "error" }
 
 function finishOutcomeFromCleanup(outcome: { failed: false } | { error: unknown, failed: true }, result?: unknown): AgentInvocationFinishOutcome {
@@ -2002,11 +2002,11 @@ async function finishAgentInvocation<
     await context.startTask
     await context.close()
     let resultKind: string | undefined
-    let usage: AgentUsageRecord | undefined
+    let usage = failed ? undefined : outcome.usage
     if (!failed) {
       try {
         resultKind = agentResultKind(result)
-        usage = await resolveAgentUsageRecord(result, context.run)
+        usage ??= await resolveAgentUsageRecord(result, context.run)
       }
       catch {
         // Invocation data must not change Agent output or mask the original failure.
@@ -2089,7 +2089,7 @@ async function finalizeAgentInvocationResult<
 >(
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS> & { hasCapabilityCleanup: boolean },
   result: unknown,
-  finalizeObject: (result: unknown) => MaybePromise<{ deferFinish?: boolean, finishResult: unknown, value: TResult }>,
+  finalizeObject: (result: unknown) => MaybePromise<{ deferFinish?: boolean, finishResult: unknown, finishUsage?: AgentUsageRecord, value: TResult }>,
   failureMessage: string,
   options: {
     finalizeRawStreams?: boolean
@@ -2117,7 +2117,7 @@ async function finalizeAgentInvocationResult<
     const finalized = await finalizeObject(result)
     finishLifecycleStarted = true
     if (!finalized.deferFinish) {
-      await finishAgentInvocation(context, { result: finalized.finishResult, status: "success" })
+      await finishAgentInvocation(context, { result: finalized.finishResult, status: "success", usage: finalized.finishUsage })
     }
     return finalized.value
   }
@@ -2167,7 +2167,11 @@ export async function runAgentInline<
         ? renderedResult ? result : await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders, outputExtensions)
         : result
       const final = renderOutput ? await applyFinalOutputRenderers(rendered, runContext, outputExtensions) : rendered
-      return { finishResult: resultWithUsageRecord(final, driverUsageRecord), value: final }
+      return {
+        finishResult: hasFinishWork(runContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
+        finishUsage: driverUsageRecord,
+        value: final,
+      }
     }, "[vitehub] Agent run failed and finish lifecycle also failed.", {
       outputExtensions,
       wrapStream: stream => maybeTraceAgentStream(stream as AsyncIterable<StreamEvent>, runContext),
@@ -2194,7 +2198,11 @@ export async function runAgentInline<
     const rendered = renderOutput ? await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders, outputExtensions) : result
     const final = renderOutput ? await applyFinalOutputRenderers(rendered, adapterContext, outputExtensions) : rendered
     const runResult = renderOutput ? toAgentRunResult(final) : final
-    return { finishResult: resultWithUsageRecord(final, driverUsageRecord), value: runResult }
+    return {
+      finishResult: hasFinishWork(adapterContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
+      finishUsage: driverUsageRecord,
+      value: runResult,
+    }
   }, "[vitehub] Agent run failed and finish lifecycle also failed.")
 }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1663,6 +1663,9 @@ function withStreamedResult(
     finishResult() {
       return resultWithStreamedTextAndUsage(result, streamedText, usageRecord, fallbackUsageRecord)
     },
+    finishUsage() {
+      return usageRecord ?? fallbackUsageRecord
+    },
     stream: (async function* () {
       for await (const chunk of stream) {
         const event = toAgentStreamEvent(chunk, toolNames)
@@ -2108,11 +2111,20 @@ async function finalizeAgentInvocationResult<
     if (isAsyncIterable(result) && !hasTraceableStreamResult(result) && !options.finalizeRawStreams) {
       finishLifecycleStarted = shouldWrapOutput
       const stream = options.wrapStream?.(result) || result
-      if (shouldWrapOutput && context.finalOutputRenderers.length) {
+      if (shouldWrapOutput) {
         const streamed = withStreamedResult(stream, result)
+        if (!context.finalOutputRenderers.length) {
+          return withCapabilityCleanup(streamed.stream, async (outcome) => {
+            const finishOutcome = finishOutcomeFromCleanup(outcome, result)
+            const usage = streamed.finishUsage()
+            return finishAgentInvocation(context, finishOutcome.status === "success"
+              ? { ...finishOutcome, usage: usage ? await resolveAgentUsageRecord({ usageRecord: usage }, context.run) : undefined }
+              : finishOutcome)
+          }, { abortSignal: context.input.abortSignal })
+        }
         return withCapabilityCleanup(streamed.stream, outcome => finishStreamAgentInvocation(context, streamed.finishResult(), finishOutcomeFromCleanup(outcome), failureMessage, options.outputExtensions), { abortSignal: context.input.abortSignal })
       }
-      return shouldWrapOutput ? withCapabilityCleanup(stream, outcome => finishAgentInvocation(context, finishOutcomeFromCleanup(outcome, result)), { abortSignal: context.input.abortSignal }) : stream
+      return stream
     }
     const finalized = await finalizeObject(result)
     finishLifecycleStarted = true

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1787,7 +1787,15 @@ async function resolveFinishUsageRecord<
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
   result: unknown,
 ): Promise<Extract<StreamEvent, { type: "usage" }>["usageRecord"] | undefined> {
-  return hasFinishWork(context) ? await resolveAgentUsageRecord(result, context.run) : undefined
+  if (hasFinishWork(context)) return await resolveAgentUsageRecord(result, context.run)
+  if (!context.runtimeContext.traceLog) return undefined
+  try {
+    return await resolveAgentUsageRecord(result, context.run)
+  }
+  catch {
+    // Core tracing is best-effort and must not change Agent output.
+    return undefined
+  }
 }
 
 type AgentInvocationFinishOutcome =

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -8,8 +8,8 @@ import {
   createStatusDeliveryEffectIntent,
 } from "./delivery-effects.ts"
 import { getMessageText } from "./messages.ts"
-import { resolveRuntimeContext } from "@vite-hub/runtime"
-import { isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent } from "./agent-output.ts"
+import { createTraceEventLog, resolveRuntimeContext } from "@vite-hub/runtime"
+import { agentResultKind, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent } from "./agent-output.ts"
 import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
 import { isMessageChannelChatTitleEffectIntent, messageChannelTitleDeliveredContextKey, resolveAgentChannelChatOptions } from "./internal/channels.ts"
 import {
@@ -136,6 +136,7 @@ import type {
   AgentRuntimeContext,
   AgentSettings,
   AgentUsageCost,
+  AgentUsageRecord,
   AgentWorkflowRuntimeBinding,
   AgentToolDefinition,
   MaybePromise,
@@ -1368,7 +1369,13 @@ async function createAgentInvocationContext<
 ): Promise<AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>> {
   const startedAt = Date.now()
   const resolvedContext = createResolvedRuntimeContext(context)
-  const runtimeContext = resolvedContext.trace || !resolvedContext.traceLog ? resolvedContext : { ...resolvedContext, trace: { id: createTraceId(context.run) } }
+  const runtimeContext = resolvedContext.trace && resolvedContext.traceLog
+    ? resolvedContext
+    : {
+        ...resolvedContext,
+        trace: resolvedContext.trace || { id: createTraceId(context.run) },
+        traceLog: resolvedContext.traceLog || createTraceEventLog(),
+      }
   const callbackContext = createAgentCallbackContext(runtimeContext)
   const invocationContext = createAgentInvocationContextStore(input.context)
   let invoker = createFallbackAgentInvoker(context.run)
@@ -1986,6 +1993,17 @@ async function finishAgentInvocation<
   try {
     await context.startTask
     await context.close()
+    let resultKind: string | undefined
+    let usage: AgentUsageRecord | undefined
+    if (!failed) {
+      try {
+        resultKind = agentResultKind(result)
+        usage = await resolveAgentUsageRecord(result, context.run)
+      }
+      catch {
+        // Invocation data must not change Agent output or mask the original failure.
+      }
+    }
     if (hasFinishWork(context)) {
       const details = failed ? agentErrorDetails(error) : undefined
       const eventBase = {
@@ -1996,7 +2014,9 @@ async function finishAgentInvocation<
         invoker: context.invoker,
         invocation: {
           durationMs,
+          ...(resultKind !== undefined ? { resultKind } : {}),
           ...(context.run ? { run: context.run } : {}),
+          ...(usage ? { usage } : {}),
         },
         ...(result !== undefined ? { result } : {}),
         runtime: context.runtimeContext,
@@ -2023,6 +2043,8 @@ async function finishAgentInvocation<
       await traceAgentInvocationFinish(toTraceContext(context), {
         "invocation.durationMs": durationMs,
         "result.hasValue": result !== undefined,
+        ...(resultKind !== undefined ? { "result.kind": resultKind } : {}),
+        ...(usage ? { "usage.record": usage } : {}),
       })
     }
     else {

--- a/packages/agent/src/test.ts
+++ b/packages/agent/src/test.ts
@@ -5,6 +5,7 @@ import {
 } from "./index.ts"
 import { resolveAgentUsageRecord } from "./agent-output.ts"
 import { createAgentRuntimeContext } from "./runtime/context.ts"
+import { createTraceEventLog, deriveTraceRuns } from "@vite-hub/runtime"
 import { registerWorkspace } from "@vite-hub/workspace/test"
 
 import type {
@@ -25,6 +26,7 @@ import type {
   WorkspaceAgentDefinition,
 } from "./index.ts"
 import type { WorkspaceName } from "@vite-hub/workspace"
+import type { TraceEventLog, TraceRunView } from "@vite-hub/runtime"
 
 export { createAgentRuntimeContext }
 
@@ -45,6 +47,7 @@ export interface AgentTestRunResult {
   raw: unknown
   text: string
   toolSteps: AgentToolStep[]
+  trace?: TraceRunView
   usage?: unknown
   warnings?: unknown
 }
@@ -302,13 +305,16 @@ async function normalizeAgentTestResult(
   value: unknown,
   toolSteps: AgentToolStep[],
   getFinishEvent: () => AgentFinishEvent | undefined,
+  getTrace: () => TraceRunView | undefined,
 ): Promise<AgentTestRunResult> {
-  const finishEvent = getFinishEvent()
-  const usage = (await resolveAgentUsageRecord(value, finishEvent?.invocation.run))?.usage
   if (value instanceof Response) {
     const text = await value.clone().text()
+    const finishEvent = getFinishEvent()
+    const trace = getTrace()
+    const usage = await normalizedTestUsage(value, finishEvent)
     return {
       ...(finishEvent?.extensions ? { extensions: finishEvent.extensions } : {}),
+      ...(trace ? { trace } : {}),
       ...(usage ? { usage } : {}),
       raw: value,
       text,
@@ -319,6 +325,9 @@ async function normalizeAgentTestResult(
   const result = typeof value === "object" && value !== null
     ? value as AgentRunResult
     : undefined
+  const finishEvent = getFinishEvent()
+  const trace = getTrace()
+  const usage = await normalizedTestUsage(value, finishEvent)
 
   return {
     ...(finishEvent?.extensions ? { extensions: finishEvent.extensions } : {}),
@@ -326,9 +335,20 @@ async function normalizeAgentTestResult(
     raw: value,
     text: textFromRaw(value),
     toolSteps: [...toolSteps, ...toolStepsFromRaw(value)],
+    ...(trace ? { trace } : {}),
     usage: usage ?? result?.usage,
     warnings: result?.warnings,
   }
+}
+
+async function normalizedTestUsage(value: unknown, event: AgentFinishEvent | undefined) {
+  return event?.invocation.usage?.usage ?? (await resolveAgentUsageRecord(value, event?.invocation.run))?.usage
+}
+
+function completedTraceRun(traceLog: TraceEventLog, run: AgentRunMetadata | undefined): TraceRunView | undefined {
+  const runs = deriveTraceRuns(traceLog.entries())
+  const trace = run?.runId ? runs.find(item => item.id === run.runId) : runs.length === 1 ? runs[0] : undefined
+  return trace?.status === "running" ? undefined : trace
 }
 
 export function createAgentTestRunner<
@@ -355,6 +375,8 @@ export function createAgentTestRunner<
       const toolSteps: AgentToolStep[] = []
       let workspaceInspectionGuardrails = 0
       let finishEvent: AgentFinishEvent | undefined
+      const run = await resolveRun(options.name, options.run)
+      const traceLog = createTraceEventLog()
       const context = createAgentRuntimeContext({
         devtools: {
           reportToolStep(step) {
@@ -371,9 +393,10 @@ export function createAgentTestRunner<
           },
         },
         request: options.request,
-        run: await resolveRun(options.name, options.run),
+        run,
         runtime: options.runtime || (options.workspace || isWorkspaceAgentDefinition(agent) ? "vite" : "unknown"),
         runtimeConfig: await resolveRuntimeConfig(options.runtimeConfig),
+        traceLog,
         waitUntil: options.waitUntil || createWaitUntil(),
       })
 
@@ -384,7 +407,7 @@ export function createAgentTestRunner<
         context,
         input,
       )
-      return await normalizeAgentTestResult(raw, toolSteps, () => finishEvent)
+      return await normalizeAgentTestResult(raw, toolSteps, () => finishEvent, () => completedTraceRun(traceLog, run))
     },
   }
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -464,7 +464,9 @@ export interface AgentFinishEvent<
   invoker: AgentInvoker
   invocation: {
     durationMs: number
+    resultKind?: string
     run?: AgentRunMetadata
+    usage?: AgentUsageRecord
   }
   result?: unknown
   runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -1800,6 +1800,26 @@ describe("agent capability runtime", () => {
     expect(close).toHaveBeenCalledWith({ failed: false })
   })
 
+  it("closes streamed output as failed when source iterator return rejects", async () => {
+    const { withCapabilityCleanup } = await import("../src/capability-runtime.ts")
+    const returnError = new Error("return failed")
+    const close = vi.fn(async () => {})
+    const iterator = {
+      next: vi.fn(async () => ({ done: false as const, value: "hello" })),
+      return: vi.fn(async () => { throw returnError }),
+    }
+    const stream = {
+      [Symbol.asyncIterator]: () => iterator,
+    }
+
+    const consume = async () => {
+      for await (const _chunk of withCapabilityCleanup(stream, close)) break
+    }
+
+    await expect(consume()).rejects.toThrow("return failed")
+    expect(close).toHaveBeenCalledWith({ error: returnError, failed: true })
+  })
+
   it("preserves read-only Response metadata while wrapping body cleanup", async () => {
     const { withResponseCleanup } = await import("../src/capability-runtime.ts")
     const source = await fetch("data:text/plain,ok")

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -1783,6 +1783,34 @@ describe("agent capability runtime", () => {
     expect(order).toEqual(["close"])
   })
 
+  it("returns the source iterator when streamed output consumption stops early", async () => {
+    const { withCapabilityCleanup } = await import("../src/capability-runtime.ts")
+    const close = vi.fn(async () => {})
+    const iterator = {
+      next: vi.fn(async () => ({ done: false as const, value: "hello" })),
+      return: vi.fn(async () => ({ done: true as const, value: undefined })),
+    }
+    const stream = {
+      [Symbol.asyncIterator]: () => iterator,
+    }
+
+    for await (const _chunk of withCapabilityCleanup(stream, close)) break
+
+    expect(iterator.return).toHaveBeenCalledTimes(1)
+    expect(close).toHaveBeenCalledWith({ failed: false })
+  })
+
+  it("preserves read-only Response metadata while wrapping body cleanup", async () => {
+    const { withResponseCleanup } = await import("../src/capability-runtime.ts")
+    const source = await fetch("data:text/plain,ok")
+    const response = await withResponseCleanup(source, async () => {}) as Response
+
+    expect(response.url).toBe(source.url)
+    expect(response.redirected).toBe(source.redirected)
+    expect(response.type).toBe(source.type)
+    await expect(response.text()).resolves.toBe("ok")
+  })
+
   it("closes Response outputs when the body is canceled", async () => {
     const { withResponseCleanup } = await import("../src/capability-runtime.ts")
     const order: string[] = []

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -1820,6 +1820,26 @@ describe("agent capability runtime", () => {
     expect(close).toHaveBeenCalledWith({ error: returnError, failed: true })
   })
 
+  it("closes streamed output as failed when source iterator return throws synchronously", async () => {
+    const { withCapabilityCleanup } = await import("../src/capability-runtime.ts")
+    const returnError = new Error("return failed")
+    const close = vi.fn(async () => {})
+    const iterator = {
+      next: vi.fn(async () => ({ done: false as const, value: "hello" })),
+      return: vi.fn(() => { throw returnError }),
+    }
+    const stream = {
+      [Symbol.asyncIterator]: () => iterator,
+    }
+
+    const consume = async () => {
+      for await (const _chunk of withCapabilityCleanup(stream, close)) break
+    }
+
+    await expect(consume()).rejects.toThrow("return failed")
+    expect(close).toHaveBeenCalledWith({ error: returnError, failed: true })
+  })
+
   it("preserves read-only Response metadata while wrapping body cleanup", async () => {
     const { withResponseCleanup } = await import("../src/capability-runtime.ts")
     const source = await fetch("data:text/plain,ok")

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -282,6 +282,9 @@ describe("agent eval", () => {
       outputTokens: 5,
       totalTokens: 9,
     })
+    expect(output.trace).toMatchObject({
+      status: "completed",
+    })
     expect(output.scores[0]).toMatchObject({
       passed: true,
       score: 1,

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -477,6 +477,42 @@ describe("agent message protocol", () => {
     }
   })
 
+  it("preserves driver usage for traces before rendering output", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    let traceLog: ReturnType<typeof createTraceEventLog> | undefined
+    const agent = defineAgent({
+      capabilities: [{
+        id: "plain-output",
+        output(context) {
+          context.output.render(() => "rendered")
+        },
+      }],
+      driver: { run(context) {
+          traceLog = context.traceLog
+          return {
+            text: "provider output",
+            usageRecord: {
+              usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+            },
+          }
+        } },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-rendered-usage" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).resolves.toBe("rendered")
+
+    expect(traceLog!.entries().at(-1)?.attributes).toMatchObject({
+      "usage.record": {
+        run: { runId: "run-rendered-usage" },
+        usage: { totalTokens: 5 },
+      },
+    })
+  })
+
   it("preserves caller-supplied Trace Event logs, trace context, and entry sinks", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const onEntry = vi.fn()

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -6,7 +6,7 @@ import { createTraceEventLog, deriveTraceRuns, emitTraceEvent } from "@vite-hub/
 import { chat, chatTitle, observability, schedule, subagents, usageTelemetry } from "../src/capabilities.ts"
 import { toJsonCompatibleValue } from "../src/tool-runtime.ts"
 
-import type { AgentChannelDeliveryFinishEffectCallback } from "../src/index.ts"
+import type { AgentChannelDeliveryFinishEffectCallback, AgentFinishEvent } from "../src/index.ts"
 import type { WritableWorkspaceFacade } from "@vite-hub/workspace"
 
 const harnessAgentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
@@ -287,9 +287,11 @@ describe("agent message protocol", () => {
       },
     })
 
-    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+    const response = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
       prompt: "review",
-    })).resolves.toBe(handled)
+    }) as Response
+    expect(response).not.toBe(handled)
+    await expect(response.text()).resolves.toBe("handled")
     expect(inputHook).not.toHaveBeenCalled()
     expect(run).not.toHaveBeenCalled()
   })
@@ -415,6 +417,130 @@ describe("agent message protocol", () => {
       "runtime.name": "unknown",
     })
     expect(JSON.stringify(traceLog.entries())).not.toContain("secret prompt")
+  })
+
+  it("captures metadata-only invocation data without an observability capability", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finishEvents: AgentFinishEvent[] = []
+    const agent = defineAgent({
+      hooks: {
+        "agent:finish": (event) => {
+          finishEvents.push(event)
+        },
+      },
+      driver: { run: () => ({
+          text: "ok",
+          usageRecord: {
+            raw: { prompt: "provider secret" },
+            usage: { inputTokens: 4, outputTokens: 6, totalTokens: 10 },
+          },
+        }) },
+    })
+    const host = {
+      memo: vi.fn(),
+      run: { runId: "run-default-trace" },
+      runtime: "unknown" as const,
+      waitUntil: vi.fn(),
+    }
+
+    await runAgent(agent, host, { prompt: "first secret prompt" })
+    await runAgent(agent, host, { prompt: "second secret prompt" })
+
+    expect(finishEvents).toHaveLength(2)
+    expect(finishEvents[0]!.runtime.trace).toEqual({ id: "run-default-trace" })
+    expect(finishEvents[0]!.runtime.traceLog).not.toBe(finishEvents[1]!.runtime.traceLog)
+    expect(finishEvents[0]!.invocation).toMatchObject({
+      resultKind: "object",
+      usage: {
+        run: { runId: "run-default-trace" },
+        usage: { inputTokens: 4, outputTokens: 6, totalTokens: 10 },
+      },
+    })
+    for (const event of finishEvents) {
+      const traceLog = event.runtime.traceLog!
+      expect(traceLog.entries().map(entry => entry.name)).toEqual([
+        "agent.invocation.start",
+        "agent.invocation.finish",
+      ])
+      expect(deriveTraceRuns(traceLog.entries())).toMatchObject([
+        { id: "run-default-trace", status: "completed" },
+      ])
+      expect(traceLog.entries().at(-1)?.attributes).toMatchObject({
+        "result.kind": "object",
+        "usage.record": {
+          run: { runId: "run-default-trace" },
+          usage: { totalTokens: 10 },
+        },
+      })
+      expect(JSON.stringify(traceLog.entries())).not.toContain("secret prompt")
+      expect(JSON.stringify(traceLog.entries())).not.toContain("provider secret")
+    }
+  })
+
+  it("preserves caller-supplied Trace Event logs, trace context, and entry sinks", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const onEntry = vi.fn()
+    const trace = { id: "request-trace", parentId: "request-parent" }
+    const traceLog = createTraceEventLog({ onEntry })
+    const finish = vi.fn()
+    const agent = defineAgent({
+      hooks: { "agent:finish": finish },
+      driver: { run: () => "ok" },
+    })
+
+    await runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-supplied-trace" },
+      runtime: "unknown",
+      trace,
+      traceLog,
+      waitUntil: vi.fn(),
+    }, {})
+
+    expect(finish.mock.calls[0]![0].runtime.trace).toBe(trace)
+    expect(finish.mock.calls[0]![0].runtime.traceLog).toBe(traceLog)
+    expect(onEntry).toHaveBeenCalledTimes(2)
+    expect(new Set(traceLog.entries().map(entry => entry.trace))).toEqual(new Set([trace]))
+  })
+
+  it("records driver and finish-hook failures in default invocation traces", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    let driverTraceLog: ReturnType<typeof createTraceEventLog> | undefined
+    const driverFailure = defineAgent({
+      driver: { run(context) {
+          driverTraceLog = context.traceLog
+          throw new Error("driver failed")
+        } },
+    })
+
+    await expect(runAgent(driverFailure, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).rejects.toThrow("driver failed")
+    expect(deriveTraceRuns(driverTraceLog!.entries())).toMatchObject([{ status: "failed" }])
+
+    let finishTraceLog: ReturnType<typeof createTraceEventLog> | undefined
+    const finishFailure = defineAgent({
+      hooks: {
+        "agent:finish"(event) {
+          finishTraceLog = event.runtime.traceLog
+          throw new Error("finish failed")
+        },
+      },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgent(finishFailure, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).rejects.toThrow("finish failed")
+    expect(finishTraceLog!.entries().map(entry => entry.name)).toEqual([
+      "agent.invocation.start",
+      "agent.invocation.error",
+    ])
+    expect(deriveTraceRuns(finishTraceLog!.entries())).toMatchObject([{ status: "failed" }])
   })
 
   it("records a failed invocation when Agent Finish Hooks fail", async () => {
@@ -6241,8 +6367,11 @@ describe("agent message protocol", () => {
     let pulls = 0
     let cancelReason: unknown
     let releaseBlockedPull: (() => void) | undefined
+    let traceLog: ReturnType<typeof createTraceEventLog> | undefined
     const agent = defineAgent({
-      driver: { run: () => ({
+      driver: { run: (context) => {
+        traceLog = context.traceLog
+        return {
           fullStream: (async function* () {
             yield { type: "finish" }
           })(),
@@ -6264,15 +6393,14 @@ describe("agent message protocol", () => {
               },
             })
           },
-        }) },
+        }
+      } },
     })
 
     const stream = await streamAgent(agent, {
       memo: vi.fn(),
       run: { runId: "run-1" },
       runtime: "unknown",
-      trace: { id: "request-1" },
-      traceLog: createTraceEventLog(),
       waitUntil: vi.fn(),
     }, {
       messages: [createMessage({ role: "user", text: "Explain availability" })],
@@ -6289,6 +6417,12 @@ describe("agent message protocol", () => {
 
     expect(cancelResult).toBe("cancelled")
     expect(cancelReason).toBe("client disconnected")
+    expect(traceLog!.entries().map(event => event.name)).toEqual([
+      "agent.invocation.start",
+      "agent.stream.finish",
+      "agent.invocation.error",
+    ])
+    expect(deriveTraceRuns(traceLog!.entries())).toMatchObject([{ status: "failed" }])
   })
 
   it("emits one chat title data part when async event streams become UI message streams", async () => {
@@ -6365,12 +6499,18 @@ describe("agent message protocol", () => {
 
   it("renders custom async event streams returned from runAgent", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
+    let traceLog: ReturnType<typeof createTraceEventLog> | undefined
+    const finish = vi.fn()
     const agent = defineAgent({
       capabilities: [chatTitle({ execute: () => "Run title" })],
-      driver: { run: () => (async function* () {
+      hooks: { "agent:finish": finish },
+      driver: { run: (context) => {
+        traceLog = context.traceLog
+        return (async function* () {
           yield { text: "answer", type: "text-delta" }
           yield { type: "finish" }
-        })() },
+        })()
+      } },
     })
 
     const result = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
@@ -6383,6 +6523,8 @@ describe("agent message protocol", () => {
 
     expect(events).toContainEqual({ data: { title: "Run title", type: "chat-title" }, type: "data" })
     expect(events).toContainEqual({ text: "answer", type: "text-delta" })
+    expect(finish.mock.calls[0]![0].invocation.resultKind).toBe("stream")
+    expect(deriveTraceRuns(traceLog!.entries())).toMatchObject([{ status: "completed" }])
   })
 
   it("exposes chat title finish extension without registering command metadata", async () => {
@@ -6442,6 +6584,7 @@ describe("agent message protocol", () => {
       error,
     }))
     expect(finish.mock.calls[0]![0]).not.toHaveProperty("result")
+    expect(deriveTraceRuns(finish.mock.calls[0]![0].runtime.traceLog.entries())).toMatchObject([{ status: "failed" }])
   })
 
   it("runs agent finish hooks when Response bodies are canceled", async () => {
@@ -6461,6 +6604,7 @@ describe("agent message protocol", () => {
     const response = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}) as Response
     await response.body?.cancel()
     expect(finish).toHaveBeenCalledTimes(1)
+    expect(deriveTraceRuns(finish.mock.calls[0]![0].runtime.traceLog.entries())).toMatchObject([{ status: "completed" }])
   })
 
   it("runs agent finish hooks when Response wrapping fails", async () => {
@@ -6482,31 +6626,53 @@ describe("agent message protocol", () => {
     expect(finish.mock.calls[0]![0]).not.toHaveProperty("result")
   })
 
-  it("returns generated Response results unchanged", async () => {
+  it("preserves generated Response payload and metadata while tracing completion", async () => {
     const { runAgent } = await import("../src/index.ts")
-    const response = Response.json({ ok: true })
+    const response = Response.json({ ok: true }, {
+      headers: { "x-agent": "generated" },
+      status: 202,
+      statusText: "Accepted",
+    })
     const agent = {
       generate: vi.fn(async () => response),
       name: "response-agent",
     }
 
-    await expect(runAgent(agent as never, {} as never, {
+    const result = await runAgent(agent as never, {} as never, {
       messages: [createMessage({ role: "user", text: "hello" })],
-    })).resolves.toBe(response)
+    }) as Response
+
+    expect(result).not.toBe(response)
+    expect(result.status).toBe(response.status)
+    expect(result.statusText).toBe(response.statusText)
+    expect(result.headers.get("content-type")).toBe(response.headers.get("content-type"))
+    expect(result.headers.get("x-agent")).toBe("generated")
+    await expect(result.json()).resolves.toEqual({ ok: true })
   })
 
-  it("returns streamed Response results unchanged", async () => {
+  it("preserves streamed Response payload and metadata while tracing completion", async () => {
     const { streamAgent } = await import("../src/index.ts")
-    const response = new Response("ok")
+    const response = new Response("ok", {
+      headers: { "x-agent": "streamed" },
+      status: 206,
+      statusText: "Partial Content",
+    })
     const agent = {
       generate: vi.fn(),
       name: "response-agent",
       stream: vi.fn(async () => response),
     }
 
-    await expect(streamAgent(agent as never, {} as never, {
+    const result = await streamAgent(agent as never, {} as never, {
       messages: [createMessage({ role: "user", text: "hello" })],
-    })).resolves.toBe(response)
+    }) as Response
+
+    expect(result).not.toBe(response)
+    expect(result.status).toBe(response.status)
+    expect(result.statusText).toBe(response.statusText)
+    expect(result.headers.get("content-type")).toBe(response.headers.get("content-type"))
+    expect(result.headers.get("x-agent")).toBe("streamed")
+    await expect(result.text()).resolves.toBe("ok")
   })
 
   it("converts text streams into ViteHub stream events", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -951,6 +951,38 @@ describe("agent message protocol", () => {
     expect(JSON.stringify(traceLog.entries())).not.toContain("secret")
   })
 
+  it("captures yielded usage in runAgent invocation data", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      hooks: { "agent:finish": finish },
+      driver: { run: () => (async function* () {
+          yield { text: "hello", type: "text-delta" }
+          yield { type: "usage", usageRecord: { usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 } } }
+          yield { type: "finish" }
+        })() },
+    })
+
+    const stream = await runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-streamed-usage" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {}) as AsyncIterable<unknown>
+    for await (const _event of stream) {}
+
+    expect(finish.mock.calls[0]![0].invocation.usage).toMatchObject({
+      run: { runId: "run-streamed-usage" },
+      usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+    })
+    expect(finish.mock.calls[0]![0].runtime.traceLog.entries().at(-1)?.attributes).toMatchObject({
+      "usage.record": {
+        run: { runId: "run-streamed-usage" },
+        usage: { totalTokens: 5 },
+      },
+    })
+  })
+
   it("derives yielded stream error Trace Events as failed runs", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const traceLog = createTraceEventLog()

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -477,6 +477,32 @@ describe("agent message protocol", () => {
     }
   })
 
+  it("does not mutate non-extensible results while capturing trace usage", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    let traceLog: ReturnType<typeof createTraceEventLog> | undefined
+    const result = Object.freeze({
+      text: "ok",
+      usage: { inputTokens: 4, outputTokens: 6, totalTokens: 10 },
+    })
+    const agent = defineAgent({
+      driver: { run: (context) => {
+          traceLog = context.traceLog
+          return result
+        } },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).resolves.toBe(result)
+    expect(traceLog!.entries().at(-1)?.attributes).toMatchObject({
+      "usage.record": {
+        usage: { totalTokens: 10 },
+      },
+    })
+  })
+
   it("preserves driver usage for traces before rendering output", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     let traceLog: ReturnType<typeof createTraceEventLog> | undefined

--- a/packages/agent/test/test-runner.test.ts
+++ b/packages/agent/test/test-runner.test.ts
@@ -92,8 +92,33 @@ describe("agent test runner", () => {
       finishReason: "stop",
       text: "done",
       toolSteps: [],
+      trace: {
+        status: "completed",
+      },
       usage: { outputTokens: 2 },
     })
+  })
+
+  it("captures a terminal trace after reading Response output", async () => {
+    const { runAgentForTest } = await import("../src/test.ts")
+    const agent = {
+      generate: vi.fn(async () => new Response("done", { status: 202 })),
+      stream: vi.fn(),
+      tools: {},
+      version: "agent-v1",
+    }
+
+    const result = await runAgentForTest(agent as never, {
+      runtimeConfig: {},
+    }, {
+      prompt: "hello",
+    })
+
+    expect(result.text).toBe("done")
+    expect(result.trace).toMatchObject({
+      status: "completed",
+    })
+    expect(result.trace?.events.at(-1)?.name).toBe("agent.invocation.finish")
   })
 
   it("collects harness-native raw tool steps for eval scorers", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -3353,7 +3353,10 @@ describe("defineAgent workspace option", () => {
       onStepEnd,
       stopWhen,
       temperature: 0.2,
-      telemetry,
+      telemetry: {
+        integrations: expect.any(Array),
+        isEnabled: true,
+      },
       toolChoice: "auto",
     })
   })
@@ -3417,7 +3420,11 @@ describe("defineAgent workspace option", () => {
       workspace: {},
     }), { workspace: "docs" })
 
-    await expect(streamAgent(agent as never, context(), { messages: [] })).resolves.toBe(stream)
+    const result = await streamAgent(agent as never, context(), { messages: [] }) as AsyncIterable<unknown>
+    const events = []
+    for await (const event of result) events.push(event)
+
+    expect(events).toEqual([{ text: "ok", type: "text-delta" }])
     expect(run).toHaveBeenCalled()
   })
 


### PR DESCRIPTION
Makes invocation observability core data instead of an opt-in capability. Every Agent Invocation now receives a per-invocation metadata-only Trace Event Log and trace context when the host did not supply them; caller-provided trace objects and sinks remain authoritative. Agent Finish events expose normalized `resultKind` and `usage`, and terminal trace events carry the same completion facts without persisting content.

Agent test results and eval observations now expose a finalized `TraceRunView`. `observability()` and `usageTelemetry()` remain compatible but are deprecated and consume the core finish data first, giving applications a migration path without another capability layer.

Completion-correct tracing wraps bare `Response` and async-iterable outputs, so object identity is intentionally not preserved. Payloads, status, headers, streaming, cancellation, and error propagation remain covered and preserved. The full Agent suite passes (42 files, 1,025 tests), along with docs tests/typechecks/build, Agent typecheck/build/publint, focused Oxlint, strict review, and `git diff --check`.