### PR TITLE
fix(agent): title chat threads once

### DIFF
--- a/docs/content/docs/capabilities/chat-title.md
+++ b/docs/content/docs/capabilities/chat-title.md
@@ -43,6 +43,8 @@ export default defineAgent({
 `chatTitle()` runs in the output phase.
 It wraps compatible async streams or UI message streams so the title can arrive alongside the response, and it provides `{ title }` in the finish extension.
 
+For framework-managed Chat SDK message Channels, ViteHub generates and delivers the title once per thread by default, even when each webhook contains only the current message or the handler is recreated. Follow-up Channel invocations skip title generation after successful delivery. Set `channelDelivery: "always"` when the platform title should be refreshed on every invocation. Plain `runAgent()` and UI invocations without framework-managed Chat SDK delivery still receive stream data and finish extensions per invocation.
+
 The Capability avoids wrapping the same result twice.
 
 ## Requirements
@@ -71,6 +73,7 @@ Test a vague first message and confirm the fallback title is used instead of an 
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
+| `channelDelivery` | `"once-per-thread" \| "always"` | `"once-per-thread"` | Deliver framework-managed Chat SDK Channel titles once per thread, or on every invocation. |
 | `execute` | `(input) => string \| { title?: string }` | none | Custom title generator. |
 | `fallback` | `string` | `"New Conversation"` | Title used when generation returns no usable text. |
 | `id` | `string` | `"chat-title"` | Capability id. |

--- a/packages/agent/src/capabilities/chat-title.ts
+++ b/packages/agent/src/capabilities/chat-title.ts
@@ -1,7 +1,13 @@
 import { capabilityInvocationStartSymbol, defineCapability } from "../capability-runtime.ts"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
 import { messageChannelTitleSupportContextKey } from "../channels.ts"
-import { createMessageChannelChatTitleEffectIntent, messageChannelTitleDeliveredContextKey } from "../internal/channels.ts"
+import {
+  claimMessageChannelChatTitleDelivery,
+  createMessageChannelChatTitleEffectIntent,
+  finishMessageChannelChatTitleDelivery,
+  messageChannelStateContextKey,
+  messageChannelTitleDeliveredContextKey,
+} from "../internal/channels.ts"
 import { getMessageText } from "../messages.ts"
 import { normalizeAgentDriver } from "../internal/agent-driver.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
@@ -22,6 +28,7 @@ import type {
   Message,
   StreamEvent,
 } from "../messages.ts"
+import type { MessageChannelChatTitleDeliveryAttempt, MessageChannelStateBinding } from "../internal/channels.ts"
 
 type ToUIMessageStream = (...args: unknown[]) => ReadableStream<unknown>
 const chatTitleApplied = Symbol("vitehub.chat-title.applied")
@@ -52,6 +59,7 @@ export type ChatTitleTemplateVariable =
   | ((input: ChatTitleTemplateInput) => MaybePromise<boolean | null | number | string | undefined>)
 
 export interface ChatTitleOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  channelDelivery?: "always" | "once-per-thread"
   driver?: AgentDriver<TRuntimeConfig>
   execute?: (input: ChatTitleExecuteInput) => MaybePromise<ChatTitleExecuteResult>
   fallback?: string
@@ -513,19 +521,44 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
   return Object.assign(defineCapability({
     id: capabilityId,
     output(context) {
+      let channelDeliveryAttempt: MessageChannelChatTitleDeliveryAttempt | Promise<MessageChannelChatTitleDeliveryAttempt> | undefined
+      const getChannelDeliveryAttempt = () => {
+        const state = context.context.get<MessageChannelStateBinding>(messageChannelStateContextKey)
+        channelDeliveryAttempt ??= options.channelDelivery === "always" || !supportsChatTitleDelivery(context) || !state || !context.run?.threadId
+          ? { deliver: true }
+          : claimMessageChannelChatTitleDelivery(context.context, context.run)
+              .catch(error => ({ deliver: true, error }))
+        return channelDeliveryAttempt
+      }
+      const releaseChannelDeliveryAttempt = async () => {
+        await finishMessageChannelChatTitleDelivery(await getChannelDeliveryAttempt(), false).catch(() => undefined)
+      }
       let title: Promise<string | undefined> | undefined
       const getTitle = () => {
         title ??= (async () => {
           const messages = context.input.messages()
           const message = firstUserMessage(messages)
           if (!message) return
-          return await generateChatTitle(context, options as ChatTitleOptions, {
-            input: context.input.get(),
-            message,
-            messages,
-            text: getMessageText(message),
-          })
-        })().catch(() => undefined)
+          const pendingAttempt = getChannelDeliveryAttempt()
+          const attempt = pendingAttempt instanceof Promise ? await pendingAttempt : pendingAttempt
+          if (!attempt.deliver) return
+          try {
+            const resolvedTitle = await generateChatTitle(context, options as ChatTitleOptions, {
+              input: context.input.get(),
+              message,
+              messages,
+              text: getMessageText(message),
+            })
+            if (!resolvedTitle) {
+              await finishMessageChannelChatTitleDelivery(attempt, false).catch(() => undefined)
+            }
+            return resolvedTitle
+          }
+          catch {
+            await finishMessageChannelChatTitleDelivery(attempt, false).catch(() => undefined)
+            return undefined
+          }
+        })()
         return title
       }
 
@@ -534,19 +567,33 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
         if (!shouldProvideChatTitleFinishExtension(context)) return
         if (context.context.get<boolean>(messageChannelTitleDeliveredContextKey) === true) return
         const resolvedTitle = await getTitle()
-        if (!resolvedTitle || !supportsChatTitleDelivery(context)) return
-        if (context.context.get<boolean>(messageChannelTitleDeliveredContextKey) === true) return
-        context.delivery.effect(createMessageChannelChatTitleEffectIntent(resolvedTitle.trim()))
+        if (!resolvedTitle || !supportsChatTitleDelivery(context)) {
+          await releaseChannelDeliveryAttempt()
+          return
+        }
+        if (context.context.get<boolean>(messageChannelTitleDeliveredContextKey) === true) {
+          await releaseChannelDeliveryAttempt()
+          return
+        }
+        context.delivery.effect(createMessageChannelChatTitleEffectIntent(
+          resolvedTitle.trim(),
+          options.channelDelivery,
+          await getChannelDeliveryAttempt(),
+        ))
       })
       context.finish.provide(async () => {
         if (!shouldProvideChatTitleFinishExtension(context)) return
         const resolvedTitle = await getTitle()
         return resolvedTitle ? { title: resolvedTitle } : undefined
       })
-      const titleDeliveryEffect: AgentChannelDeliveryFinishEffectCallback = (finish) => {
+      const titleDeliveryEffect: AgentChannelDeliveryFinishEffectCallback = async (finish) => {
         const resolvedTitle = finish.extensions.get(capabilityId, "title")
         return typeof resolvedTitle === "string" && resolvedTitle.trim()
-          ? { kind: "title", payload: { title: resolvedTitle.trim() } }
+          ? createMessageChannelChatTitleEffectIntent(
+              resolvedTitle.trim(),
+              options.channelDelivery,
+              await getChannelDeliveryAttempt(),
+            )
           : undefined
       }
       titleDeliveryEffect.active = finish =>

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,7 +11,14 @@ import { getMessageText } from "./messages.ts"
 import { resolveRuntimeContext } from "@vite-hub/runtime"
 import { isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent } from "./agent-output.ts"
 import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
-import { isMessageChannelChatTitleEffectIntent, messageChannelTitleDeliveredContextKey, resolveAgentChannelChatOptions } from "./internal/channels.ts"
+import {
+  finishMessageChannelChatTitleDelivery,
+  isMessageChannelChatTitleEffectIntent,
+  messageChannelTitleDeliveredContextKey,
+  prepareMessageChannelChatTitleDelivery,
+  resolveAgentChannelChatOptions,
+} from "./internal/channels.ts"
+import type { MessageChannelChatTitleDeliveryAttempt } from "./internal/channels.ts"
 import {
   channelHasCustomTitleEffect,
   messageChannelSupportsTitleEffect,
@@ -758,6 +765,29 @@ async function applyChannelDeliveryEffectIntents<
       continue
     }
 
+    const titleDelivery = isMessageChannelChatTitleEffectIntent(intent)
+      ? await prepareMessageChannelChatTitleDelivery(context.context, context.run, intent).catch(async (error) => {
+          await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, {
+            ...metadata,
+            "error.message": agentErrorMessage(error),
+          })
+          return { deliver: true } as MessageChannelChatTitleDeliveryAttempt
+        })
+      : undefined
+    if (titleDelivery?.error) {
+      await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, {
+        ...metadata,
+        "error.message": agentErrorMessage(titleDelivery.error),
+      })
+    }
+    if (titleDelivery && !titleDelivery.deliver) {
+      await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, {
+        ...metadata,
+        "channel.effect.skipped": titleDelivery.reason,
+      })
+      continue
+    }
+
     let delivered = true
     for (const handler of handlers) {
       try {
@@ -795,7 +825,18 @@ async function applyChannelDeliveryEffectIntents<
         })
       }
     }
-    if (isMessageChannelChatTitleEffectIntent(intent) && delivered) {
+    if (titleDelivery) {
+      try {
+        await finishMessageChannelChatTitleDelivery(titleDelivery, delivered, Boolean(finish))
+      }
+      catch (error) {
+        await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, {
+          ...metadata,
+          "error.message": agentErrorMessage(error),
+        })
+      }
+    }
+    if (titleDelivery && delivered) {
       context.context.set(messageChannelTitleDeliveredContextKey, true, { overwrite: true })
     }
   }

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -4,21 +4,128 @@ import type {
   AgentChatOptions,
   AgentChatPlatformResolver,
   AgentChannelWebhookRegistrationDefinition,
+  AgentInvocationContextStore,
   AgentMessageChannelSettings,
+  AgentRunMetadata,
   AgentRuntimeConfig,
 } from "../types.ts"
+import type { Lock, StateAdapter } from "chat"
 
 export const messageChannelTitleDeliveredContextKey = "channel.delivery.titleDelivered"
+export const messageChannelStateContextKey = "chat.channelState"
+const messageChannelTitleClaimTtlMs = 5 * 60 * 1000
 const messageChannelChatTitleEffectIntents = new WeakSet<AgentChannelDeliveryEffectIntent>()
+const messageChannelChatTitleDeliveryPolicies = new WeakMap<AgentChannelDeliveryEffectIntent, "always" | "once-per-thread">()
+const messageChannelChatTitleDeliveryAttempts = new WeakMap<AgentChannelDeliveryEffectIntent, MessageChannelChatTitleDeliveryAttempt>()
 
-export function createMessageChannelChatTitleEffectIntent(title: string): AgentChannelDeliveryEffectIntent {
+export interface MessageChannelStateBinding {
+  keyPrefix: string
+  state: StateAdapter
+}
+
+interface MessageChannelChatTitleDeliveryClaim {
+  lock: Lock
+  markerKey: string
+  settled?: boolean
+  state: StateAdapter
+}
+
+export interface MessageChannelChatTitleDeliveryAttempt {
+  claim?: MessageChannelChatTitleDeliveryClaim
+  deliver: boolean
+  error?: unknown
+  reason?: "already-delivered" | "pending"
+}
+
+export function createMessageChannelChatTitleEffectIntent(
+  title: string,
+  channelDelivery: "always" | "once-per-thread" = "once-per-thread",
+  attempt?: MessageChannelChatTitleDeliveryAttempt,
+): AgentChannelDeliveryEffectIntent {
   const intent = { kind: "title", payload: { title } }
   messageChannelChatTitleEffectIntents.add(intent)
+  messageChannelChatTitleDeliveryPolicies.set(intent, channelDelivery)
+  if (attempt) messageChannelChatTitleDeliveryAttempts.set(intent, attempt)
   return intent
 }
 
 export function isMessageChannelChatTitleEffectIntent(intent: AgentChannelDeliveryEffectIntent): boolean {
   return messageChannelChatTitleEffectIntents.has(intent)
+}
+
+export async function prepareMessageChannelChatTitleDelivery(
+  context: AgentInvocationContextStore,
+  run: AgentRunMetadata | undefined,
+  intent: AgentChannelDeliveryEffectIntent,
+): Promise<MessageChannelChatTitleDeliveryAttempt> {
+  const prepared = messageChannelChatTitleDeliveryAttempts.get(intent)
+  if (prepared) return prepared
+  if (messageChannelChatTitleDeliveryPolicies.get(intent) === "always") {
+    return { deliver: true }
+  }
+  return await claimMessageChannelChatTitleDelivery(context, run)
+}
+
+export async function claimMessageChannelChatTitleDelivery(
+  context: AgentInvocationContextStore,
+  run: AgentRunMetadata | undefined,
+): Promise<MessageChannelChatTitleDeliveryAttempt> {
+  const binding = context.get<MessageChannelStateBinding>(messageChannelStateContextKey)
+  if (!binding || !run?.threadId) return { deliver: true }
+
+  const markerKey = `${binding.keyPrefix}channel-title:${run.threadId}:delivered`
+  if (await binding.state.get(markerKey) !== null) {
+    return { deliver: false, reason: "already-delivered" }
+  }
+
+  const lock = await binding.state.acquireLock(`${binding.keyPrefix}channel-title:${run.threadId}:pending`, messageChannelTitleClaimTtlMs)
+  if (!lock) return { deliver: false, reason: "pending" }
+  let delivered: boolean
+  try {
+    delivered = await binding.state.get(markerKey) !== null
+  }
+  catch (error) {
+    try {
+      await binding.state.releaseLock(lock)
+      return { deliver: true, error }
+    }
+    catch (releaseError) {
+      return {
+        deliver: true,
+        error: new AggregateError([error, releaseError], "Chat title delivery state check and lock release failed."),
+      }
+    }
+  }
+  if (delivered) {
+    try {
+      await binding.state.releaseLock(lock)
+      return { deliver: false, reason: "already-delivered" }
+    }
+    catch (error) {
+      return { deliver: false, error, reason: "already-delivered" }
+    }
+  }
+  return {
+    claim: { lock, markerKey, state: binding.state },
+    deliver: true,
+  }
+}
+
+export async function finishMessageChannelChatTitleDelivery(
+  attempt: MessageChannelChatTitleDeliveryAttempt,
+  delivered: boolean,
+  final = true,
+): Promise<void> {
+  if (!attempt.claim) return
+  if (attempt.claim.settled) return
+  if (!delivered && !final) return
+  attempt.claim.settled = true
+  try {
+    if (delivered) await attempt.claim.state.set(attempt.claim.markerKey, true)
+  }
+  finally {
+    await attempt.claim.state.releaseLock(attempt.claim.lock)
+  }
 }
 
 function withChannelWebhookProvider<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -19,6 +19,7 @@ import { toHttpErrorResponse } from "../http-error.ts"
 import { isWorkflowRun } from "../http-response.ts"
 import { createChatDevtoolsStreamResponse } from "../chat/devtools-stream.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
+import { messageChannelStateContextKey } from "../internal/channels.ts"
 
 import type { AgentChatMessageTriggerInput } from "../chat-trigger.ts"
 import type { UIMessageLike } from "../chat-message-input.ts"
@@ -972,7 +973,7 @@ async function resolveChatState(
   context: ViteAgentRouteRuntimeContext,
   registration: AgentWebhookRegistrationDefinition,
   handlerOptions: AgentChannelWebhookRouteOptions,
-): Promise<StateAdapter> {
+): Promise<{ state: StateAdapter, titleKeyPrefix: string }> {
   const agentName = handlerOptions.agentName || "agent"
   const origin = chatRegistrationOrigin(registration)
   const stateKeyPrefix = `chat:${agentName}:${origin}:`
@@ -986,10 +987,19 @@ async function resolveChatState(
       },
     } as never,
   )
-  if (!state) return getInMemoryChatState(`${agentName}:${origin}`)
-  return options?.state === undefined && !chatStateOwnsScope(handlerOptions.state)
-    ? withChatStateScope(state, stateKeyPrefix)
-    : state
+  if (!state) {
+    return {
+      state: getInMemoryChatState(`${agentName}:${origin}`),
+      titleKeyPrefix: stateKeyPrefix,
+    }
+  }
+  if (options?.state === undefined && !chatStateOwnsScope(handlerOptions.state)) {
+    return {
+      state: withChatStateScope(state, stateKeyPrefix),
+      titleKeyPrefix: "",
+    }
+  }
+  return { state, titleKeyPrefix: stateKeyPrefix }
 }
 
 function chatSdkOption<T>(options: AgentChatOptions | undefined, key: string): T | undefined {
@@ -1570,6 +1580,7 @@ async function handleChatSdkMessage(
   thread: Thread,
   message: ChatSdkMessage,
   options: AgentChatOptions | undefined,
+  state: { keyPrefix: string, state: StateAdapter },
   messageContext?: MessageContext,
 ): Promise<void> {
   let input: AgentChatMessageTriggerInput | undefined
@@ -1600,7 +1611,13 @@ async function handleChatSdkMessage(
       ...(invocation.run ? { run: invocation.run } : {}),
     }
     const chatFinish = createChatFinishExtension(input, registration)
-    const invocationInput = withChatFinishExtension(withResolvedAgentInvokerInput(invocation.input as AgentRunInput, invoker), chatFinish)
+    const invocationInput = withChatFinishExtension(withResolvedAgentInvokerInput({
+      ...(invocation.input as AgentRunInput),
+      context: {
+        ...(invocation.input as AgentRunInput).context,
+        [messageChannelStateContextKey]: state,
+      },
+    }, invoker), chatFinish)
     if (options?.stream === false) {
       const result = await runAgentInline(agent as never, runContext as never, invocationInput as never)
       const text = await collectAgentOutput(result)
@@ -1649,21 +1666,23 @@ async function createChatWebhookHandler(
   options: AgentChatOptions | undefined,
   handlerOptions: AgentChannelWebhookRouteOptions,
 ): Promise<(request: Request, webhookOptions: WebhookOptions) => Promise<Response>> {
+  const resolvedState = await resolveChatState(options, context, registration, handlerOptions)
   const chat = new Chat(createChatSdkConfig(
     adapterName,
     adapter,
-    await resolveChatState(options, context, registration, handlerOptions),
+    resolvedState.state,
     options,
   ))
+  const state = { keyPrefix: resolvedState.titleKeyPrefix, state: resolvedState.state }
 
   chat.onDirectMessage((thread, message, _channel, messageContext) =>
-    handleChatSdkMessage(agent, context, registration, thread, message, options, messageContext))
+    handleChatSdkMessage(agent, context, registration, thread, message, options, state, messageContext))
   chat.onNewMention(async (thread, message, messageContext) => {
     await thread.subscribe().catch(() => undefined)
-    await handleChatSdkMessage(agent, context, registration, thread, message, options, messageContext)
+    await handleChatSdkMessage(agent, context, registration, thread, message, options, state, messageContext)
   })
   chat.onSubscribedMessage((thread, message, messageContext) =>
-    handleChatSdkMessage(agent, context, registration, thread, message, options, messageContext))
+    handleChatSdkMessage(agent, context, registration, thread, message, options, state, messageContext))
 
   const handler = chat.webhooks[adapterName]
   if (!handler) {
@@ -2722,7 +2741,7 @@ export function createDiscordGatewayRouteHandler(
           return createJsonErrorResponse(500, `Discord chat adapter "${adapterName}" does not expose startGatewayListener().`)
         }
 
-        const state = await resolveChatState(chatOptions, context, {
+        const { state } = await resolveChatState(chatOptions, context, {
           adapter: adapterName,
           channelId: adapterName,
           id: adapterName,

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -165,6 +165,24 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
   }
 }
 
+function createTitleChatAdapter(setThreadTitle: (threadId: string, title: string) => Promise<void>) {
+  return Object.assign(createTestChatAdapter(), { setThreadTitle })
+}
+
+function chatWebhookRequest(messageId: number, threadId = 456, text = "hello") {
+  return new Request("https://example.com/api/_vitehub/agents/support/webhooks/channel", {
+    body: JSON.stringify({
+      message: {
+        chat: { id: threadId, type: "private" },
+        from: { id: 123, username: "maxi" },
+        message_id: messageId,
+        text,
+      },
+    }),
+    method: "POST",
+  })
+}
+
 describe("agent Vite plugin", () => {
   it("ignores generated ViteHub files in the Vite dev watcher", async () => {
     const { hubAgent } = await import("../src/vite.ts")
@@ -3711,6 +3729,314 @@ describe("server helpers", () => {
       await expect(handler(explicitRun, state)(request(), "discord", { agentName: "explicit", state })).resolves.toMatchObject({ status: 200 })
       expect(explicitRun).toHaveBeenCalledOnce()
       await expect(state.get("dedupe:telegram:7")).resolves.toBe(true)
+    }
+    finally {
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
+  it("delivers state-backed Chat SDK titles once per thread across handler recreation", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chatTitle } = await import("../src/capabilities.ts")
+    const { http } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-once-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const setThreadTitle = vi.fn(async () => undefined)
+    const execute = vi.fn(({ text }: { text: string }) => `Title: ${text}`)
+    const run = vi.fn(() => "ok")
+    const finish = vi.fn()
+    const createHandler = () => createChannelWebhookRouteHandler(defineAgent({
+      capabilities: [chatTitle({ execute })],
+      channels: {
+        channel: http({ adapter: () => createTitleChatAdapter(setThreadTitle) as never }),
+      },
+      driver: { run },
+      hooks: { "agent:finish": finish },
+      messages: { state, stream: false, triggerHistory: "none" },
+    }) as never)
+
+    try {
+      const first = createHandler()
+      await expect(first(chatWebhookRequest(101, 456, "first"), "channel", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
+      await expect(first(chatWebhookRequest(102, 456, "second"), "channel", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
+      expect(run).toHaveBeenCalledTimes(2)
+      expect(execute).toHaveBeenCalledOnce()
+      expect(setThreadTitle).toHaveBeenCalledOnce()
+      expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Title: first" })
+      expect(finish.mock.calls[1]![0].extensions.get("chat-title")).toBeUndefined()
+
+      const recreated = createHandler()
+      await expect(recreated(chatWebhookRequest(103, 456, "third"), "channel", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
+      await expect(recreated(chatWebhookRequest(104, 789, "other thread"), "channel", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
+
+      expect(setThreadTitle).toHaveBeenCalledTimes(2)
+      expect(setThreadTitle).toHaveBeenNthCalledWith(1, "telegram:456", "Title: first")
+      expect(setThreadTitle).toHaveBeenNthCalledWith(2, "telegram:789", "Title: other thread")
+      expect(execute).toHaveBeenCalledTimes(2)
+      await expect(state.get("chat:mini:channel:channel-title:telegram:456:delivered")).resolves.toBe(true)
+      await expect(state.get("chat:mini:channel:channel-title:telegram:789:delivered")).resolves.toBe(true)
+    }
+    finally {
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
+  it("releases a Chat title claim when the post-lock marker read fails", async () => {
+    const {
+      claimMessageChannelChatTitleDelivery,
+      messageChannelStateContextKey,
+    } = await import("../src/internal/channels.ts")
+    const { createAgentInvocationContextStore } = await import("../src/invocation-context.ts")
+    const readError = new Error("title marker read failed")
+    const lock = { expiresAt: Date.now() + 60_000, threadId: "title:pending", token: "lock" }
+    const state = {
+      acquireLock: vi.fn(async () => lock),
+      get: vi.fn()
+        .mockResolvedValueOnce(null)
+        .mockRejectedValueOnce(readError),
+      releaseLock: vi.fn(async () => undefined),
+    }
+    const context = createAgentInvocationContextStore()
+    context.set(messageChannelStateContextKey, { keyPrefix: "chat:mini:discord:", state })
+
+    await expect(claimMessageChannelChatTitleDelivery(context, { threadId: "discord:123" } as never)).resolves.toEqual({
+      deliver: true,
+      error: readError,
+    })
+    expect(state.releaseLock).toHaveBeenCalledWith(lock)
+  })
+
+  it("does not redeliver a Chat title when marker observation succeeds but lock release fails", async () => {
+    const {
+      claimMessageChannelChatTitleDelivery,
+      messageChannelStateContextKey,
+    } = await import("../src/internal/channels.ts")
+    const { createAgentInvocationContextStore } = await import("../src/invocation-context.ts")
+    const releaseError = new Error("title lock release failed")
+    const lock = { expiresAt: Date.now() + 60_000, threadId: "title:pending", token: "lock" }
+    const state = {
+      acquireLock: vi.fn(async () => lock),
+      get: vi.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(true),
+      releaseLock: vi.fn(async () => { throw releaseError }),
+    }
+    const context = createAgentInvocationContextStore()
+    context.set(messageChannelStateContextKey, { keyPrefix: "chat:mini:discord:", state })
+
+    await expect(claimMessageChannelChatTitleDelivery(context, { threadId: "discord:123" } as never)).resolves.toEqual({
+      deliver: false,
+      error: releaseError,
+      reason: "already-delivered",
+    })
+  })
+
+  it("releases failed title delivery claims for finish and later webhook retries", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chatTitle } = await import("../src/capabilities.ts")
+    const { http } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-retry-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const setThreadTitle = vi.fn()
+      .mockRejectedValueOnce(new Error("early delivery failed"))
+      .mockRejectedValueOnce(new Error("finish delivery failed"))
+      .mockResolvedValue(undefined)
+    const handler = createChannelWebhookRouteHandler(defineAgent({
+      capabilities: [chatTitle({ execute: ({ text }) => `Title: ${text}` })],
+      channels: {
+        channel: http({ adapter: () => createTitleChatAdapter(setThreadTitle) as never }),
+      },
+      driver: { run: () => "ok" },
+      messages: { state, stream: false, triggerHistory: "none" },
+    }) as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(111, 456, "first"), "channel", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
+      await expect(state.get("chat:mini:channel:channel-title:telegram:456:delivered")).resolves.toBeNull()
+
+      await expect(handler(chatWebhookRequest(112, 456, "retry"), "channel", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
+      expect(setThreadTitle).toHaveBeenCalledTimes(3)
+      expect(setThreadTitle).toHaveBeenLastCalledWith("telegram:456", "Title: retry")
+      await expect(state.get("chat:mini:channel:channel-title:telegram:456:delivered")).resolves.toBe(true)
+    }
+    finally {
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
+  it("claims concurrent Chat SDK title delivery atomically", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chatTitle } = await import("../src/capabilities.ts")
+    const { http } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-concurrent-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    let releaseDelivery: () => void = () => {}
+    const deliveryPending = new Promise<void>((resolve) => {
+      releaseDelivery = resolve
+    })
+    const setThreadTitle = vi.fn(async () => await deliveryPending)
+    const execute = vi.fn(({ text }: { text: string }) => `Title: ${text}`)
+    const messageState = (prefix: string) => new Proxy(state, {
+      get(target, property) {
+        if (property === "acquireLock") {
+          return (threadId: string, ttlMs: number) => target.acquireLock(
+            threadId.includes("channel-title:") ? threadId : `${prefix}:${threadId}`,
+            ttlMs,
+          )
+        }
+        if (property === "forceReleaseLock") {
+          return (threadId: string) => target.forceReleaseLock(
+            threadId.includes("channel-title:") ? threadId : `${prefix}:${threadId}`,
+          )
+        }
+        const value = Reflect.get(target, property)
+        return typeof value === "function" ? value.bind(target) : value
+      },
+    })
+    const createHandler = (prefix: string, adapter: ReturnType<typeof createTitleChatAdapter>) => createChannelWebhookRouteHandler(defineAgent({
+      capabilities: [chatTitle({ execute })],
+      channels: {
+        channel: http({ adapter: () => adapter as never }),
+      },
+      driver: { run: () => "ok" },
+      messages: { state: messageState(prefix), stream: false, triggerHistory: "none" },
+    }) as never)
+    const firstAdapter = createTitleChatAdapter(setThreadTitle)
+    const secondAdapter = createTitleChatAdapter(setThreadTitle)
+    const firstHandler = createHandler("first", firstAdapter)
+    const secondHandler = createHandler("second", secondAdapter)
+
+    try {
+      const first = firstHandler(chatWebhookRequest(121, 456, "first"), "channel", { agentName: "mini" })
+      await vi.waitFor(() => expect(setThreadTitle).toHaveBeenCalledOnce())
+      const second = secondHandler(chatWebhookRequest(122, 456, "second"), "channel", { agentName: "mini" })
+      await vi.waitFor(() => expect(secondAdapter.postMessage).toHaveBeenCalled())
+      expect(setThreadTitle).toHaveBeenCalledOnce()
+      expect(execute).toHaveBeenCalledOnce()
+
+      releaseDelivery()
+      await expect(Promise.all([first, second])).resolves.toHaveLength(2)
+      expect(setThreadTitle).toHaveBeenCalledOnce()
+      expect(execute).toHaveBeenCalledOnce()
+      await expect(state.get("chat:mini:channel:channel-title:telegram:456:delivered")).resolves.toBe(true)
+    }
+    finally {
+      releaseDelivery()
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
+  it("isolates title delivery by agent and channel on shared explicit state", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chatTitle } = await import("../src/capabilities.ts")
+    const { http } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-scope-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const setThreadTitle = vi.fn(async () => undefined)
+    const handler = (channel: string) => createChannelWebhookRouteHandler(defineAgent({
+      capabilities: [chatTitle({ execute: () => `${channel} title` })],
+      channels: {
+        [channel]: http({ adapter: () => createTitleChatAdapter(setThreadTitle) as never }),
+      },
+      driver: { run: () => "ok" },
+      messages: { state, stream: false, triggerHistory: "none" },
+    }) as never)
+
+    try {
+      await expect(handler("discord")(chatWebhookRequest(131), "discord", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
+      await expect(handler("slack")(chatWebhookRequest(132), "slack", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
+      await expect(handler("discord")(chatWebhookRequest(133), "discord", { agentName: "work-coordinator" })).resolves.toMatchObject({ status: 200 })
+
+      expect(setThreadTitle).toHaveBeenCalledTimes(3)
+      await expect(state.get("chat:mini:discord:channel-title:telegram:456:delivered")).resolves.toBe(true)
+      await expect(state.get("chat:mini:slack:channel-title:telegram:456:delivered")).resolves.toBe(true)
+      await expect(state.get("chat:work-coordinator:discord:channel-title:telegram:456:delivered")).resolves.toBe(true)
+    }
+    finally {
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
+  it("can deliver state-backed Chat SDK titles on every invocation", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chatTitle } = await import("../src/capabilities.ts")
+    const { http } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-always-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const setThreadTitle = vi.fn(async () => undefined)
+    const handler = createChannelWebhookRouteHandler(defineAgent({
+      capabilities: [chatTitle({ channelDelivery: "always", execute: ({ text }) => `Title: ${text}` })],
+      channels: {
+        channel: http({ adapter: () => createTitleChatAdapter(setThreadTitle) as never }),
+      },
+      driver: { run: () => "ok" },
+      messages: { state, stream: false, triggerHistory: "none" },
+    }) as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(141, 456, "first"), "channel", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
+      await expect(handler(chatWebhookRequest(142, 456, "second"), "channel", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
+
+      expect(setThreadTitle).toHaveBeenCalledTimes(2)
+      expect(setThreadTitle).toHaveBeenNthCalledWith(1, "telegram:456", "Title: first")
+      expect(setThreadTitle).toHaveBeenNthCalledWith(2, "telegram:456", "Title: second")
+    }
+    finally {
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
+  it("keeps Chat SDK output and best-effort title delivery when title state coordination fails", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { chatTitle } = await import("../src/capabilities.ts")
+    const { http } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-state-failure-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const failingState = new Proxy(state, {
+      get(target, property) {
+        if (property === "get") {
+          return async (key: string) => {
+            if (key.includes("channel-title:")) throw new Error("title state unavailable")
+            return await target.get(key)
+          }
+        }
+        const value = Reflect.get(target, property)
+        return typeof value === "function" ? value.bind(target) : value
+      },
+    })
+    const setThreadTitle = vi.fn(async () => undefined)
+    const adapter = createTitleChatAdapter(setThreadTitle)
+    const handler = createChannelWebhookRouteHandler(defineAgent({
+      capabilities: [chatTitle({ execute: () => "Best effort title" })],
+      channels: {
+        channel: http({ adapter: () => adapter as never }),
+      },
+      driver: { run: () => "ok" },
+      messages: { state: failingState, stream: false, triggerHistory: "none" },
+    }) as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(151), "channel", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
+      expect(setThreadTitle).toHaveBeenCalledOnce()
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "ok" })
     }
     finally {
       await state.disconnect()

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5423,6 +5423,42 @@ describe("agent message protocol", () => {
     expect(events).toContainEqual({ type: "finish" })
   })
 
+  it("keeps plain stream titles per invocation with once-per-thread Channel delivery", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const execute = vi.fn(({ text }) => `Title: ${text}`)
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [chatTitle({ channelDelivery: "once-per-thread", execute })],
+      driver: { run: () => (async function* () {
+          yield { text: "hello", type: "text-delta" }
+          yield { type: "finish" }
+        })() },
+      hooks: { "agent:finish": finish },
+    })
+
+    for (const id of ["user-1", "user-2"]) {
+      const stream = await streamAgent(agent, {
+        memo: vi.fn(),
+        run: { runId: id, threadId: "thread-1" },
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, {
+        messages: [createMessage({ id, role: "user", text: id })],
+      })
+      const events = []
+      for await (const event of stream as AsyncIterable<unknown>) events.push(event)
+      expect(events).toContainEqual({
+        data: { title: `Title: ${id}`, type: "chat-title" },
+        type: "data",
+      })
+    }
+    expect(execute).toHaveBeenCalledTimes(2)
+    expect(finish.mock.calls.map(([event]) => event.extensions.get("chat-title"))).toEqual([
+      { title: "Title: user-1" },
+      { title: "Title: user-2" },
+    ])
+  })
+
   it("streams agent output while chat title generation is pending", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     let resolveTitle: (title: string) => void = () => {}

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -276,6 +276,7 @@ describe("agent public types", () => {
           },
         }),
         chatTitle({
+          channelDelivery: "once-per-thread",
           model: () => ({}),
           template({ fallback, maxLength, text, trigger }) {
             expectTypeOf(fallback).toEqualTypeOf<string>()


### PR DESCRIPTION
## Summary

- make `chatTitle()` generate and deliver once per thread by default for framework-managed Chat SDK channels
- coordinate concurrent webhooks with the configured Chat state, including retry and failure-safe lock cleanup
- keep plain run/UI titles per invocation and expose `channelDelivery: "always"` for intentional retitling

## Context

A webhook may contain only the current message, so message-count heuristics cannot reliably identify a new thread. The delivery marker belongs beside Chat state and is scoped by agent, channel origin, and thread.

This draft is stacked on #557 for framework-owned Chat state scoping. It also depends on the stream-safe title delivery and CLI visibility in #555; the overlapping `chat-title.ts` work should be rebased after those foundations settle.

## Validation

- `corepack pnpm --filter @vite-hub/agent typecheck`
- `corepack pnpm --filter @vite-hub/agent test` — 42 files, 1031 tests
- Oxlint on the changed runtime and provider-test files — no errors
- `git diff --check`

Coverage includes sequential and concurrent webhooks, handler recreation, separate agents/channels/threads, early and final delivery failures, post-lock state failures, the `always` policy, and unchanged plain-stream behavior.