### PR TITLE
refactor(agent)!: remove agent defaults

### DIFF
--- a/docs/content/docs/concepts/definitions-and-discovery.md
+++ b/docs/content/docs/concepts/definitions-and-discovery.md
@@ -15,7 +15,7 @@ Location-derived identity makes generated registries, Provider Output, DevTools,
 
 This matters for agents because an Agent File Name or agent folder name becomes the discovered Agent identity. `defineAgent({ name })` is not the discovery identity override.
 
-Generated Agent hosts carry that discovery identity as `context.agentIdentity`, typed as `AgentHostIdentity`. An explicit `workflow("name")` binding wins for Workflow identity; otherwise `defineAgent({ name })` takes precedence over host identity for Workflow and implicit Workspace names. Definition configuration does not change the host's route or registry key. Generated hosts pass runtime identity directly instead of preparing cloned definitions with `withAgentDefaults`; that helper remains available for compatibility with custom hosts.
+Generated Agent hosts carry that discovery identity as `context.agentIdentity`, typed as `AgentHostIdentity`. An explicit `workflow("name")` binding wins for Workflow identity; otherwise `defineAgent({ name })` takes precedence over host identity for Workflow and implicit Workspace names. Definition configuration does not change the host's route or registry key. Custom hosts pass the same runtime identity when they invoke an Agent Definition.
 
 ## Current discovery examples
 

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -40,7 +40,6 @@ import type {
   AgentRuntimeConfig,
   AgentRuntimeContext,
   DiscoveredAgentDefinition,
-  WorkspaceAgentDefaults,
 } from "../../index.ts"
 
 type ReadUIMessageStream = typeof import("ai").readUIMessageStream
@@ -93,7 +92,6 @@ interface ChatDevtoolsSession {
 
 interface ChatDevtoolsAgentEntry {
   agent: AgentInput<ViteAgentDevtoolsRuntimeContext>
-  defaults?: WorkspaceAgentDefaults
   identity: AgentHostIdentity
   metadata: ChatDevtoolsMetadata
   metadataError?: string
@@ -135,12 +133,6 @@ function resolveAgentModule(module: unknown): AgentInput<ViteAgentDevtoolsRuntim
     return module.default as AgentInput<ViteAgentDevtoolsRuntimeContext> | undefined
   }
   return module as AgentInput<ViteAgentDevtoolsRuntimeContext> | undefined
-}
-
-function workspaceDefaults(definition: DiscoveredAgentDefinition): WorkspaceAgentDefaults | undefined {
-  return definition.workspace
-    ? { name: definition.name, workspace: definition.workspace }
-    : undefined
 }
 
 function resolveWorkspaceSourceRoot(file: string): string {
@@ -313,21 +305,18 @@ function createChatDevtoolsAgentEntry(
   name: string,
   agent: AgentInput<ViteAgentDevtoolsRuntimeContext>,
   identity: AgentHostIdentity,
-  defaults: WorkspaceAgentDefaults | undefined,
   previous: ChatDevtoolsAgentEntry | undefined,
 ): ChatDevtoolsAgentEntry {
   const metadata = createStaticDevtoolsMetadata(name, agent)
   const staticKey = metadataStaticKey(metadata)
   if (previous?.metadataStaticKey === staticKey) {
     previous.agent = agent
-    previous.defaults = defaults
     previous.identity = identity
     previous.name = name
     return previous
   }
   return {
     agent,
-    defaults,
     identity,
     metadata,
     metadataStaticKey: staticKey,
@@ -380,7 +369,6 @@ async function startMetadataResolution(
 
   const run = createDevtoolsMetadataRunMetadata(entry.name)
   const task = resolveAgentDevtoolsMetadata(entry.agent as never, {
-    ...entry.defaults,
     input: createDevtoolsMetadataInput(metadataSelection, run),
     runtime: { agentIdentity: entry.identity, run },
   } as never)
@@ -427,7 +415,6 @@ async function discoverChatAgents(server: ViteDevServer, state: ChatDevtoolsBrid
       definition.name,
       agent,
       identity,
-      workspaceDefaults(definition),
       state.entries.get(definition.name),
     ))
   }
@@ -915,11 +902,10 @@ async function materializeDevtoolsSource(
   try {
     const run = createDevtoolsMetadataRunMetadata(entry.name)
     const metadata = await materializeAgentDevtoolsSourceMetadata(entry.agent as never, {
-      ...entry.defaults,
       input: createDevtoolsMetadataInput(metadataSelection, run),
       ...(input.path ? { path: input.path } : {}),
       ...(input.source ? { source: input.source } : {}),
-      runtime: { run },
+      runtime: { agentIdentity: entry.identity, run },
       sources: materializedSourceKeys(entry.metadata),
     } as never)
     entry.metadata = metadataWithAgentName(metadata, entry.name)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -110,7 +110,6 @@ import type {
   AgentFinishEvent,
   AgentFinishExtensions,
   AgentChatOptions,
-  AgentHandlerOptions,
   AgentHostIdentity,
   AgentInput,
   AgentInputHook,
@@ -252,7 +251,6 @@ export type {
   AgentFinishExtensions,
   AgentFinishExtensionValues,
   AgentFinishHook,
-  AgentHandlerOptions,
   AgentHostIdentity,
   AgentHarnessCredentialSource,
   AgentHarnessDriver,
@@ -586,8 +584,7 @@ function resolveAgentWorkflowName<TRuntimeConfig extends AgentRuntimeConfig>(
   context: AgentRuntimeContext<TRuntimeConfig>,
 ): string {
   const definition = hasAgentDefinition(agent) ? agent : undefined
-  const legacyDefaults = (definition as Partial<WorkspaceAgentDefinition> | undefined)?.__vitehubWorkspaceAgentDefaults
-  const name = binding.name || definition?.name || context.agentIdentity?.name || legacyDefaults?.name
+  const name = binding.name || definition?.name || context.agentIdentity?.name
   if (name) return name
   throw new Error("[vitehub] Agent runtime workflow() requires a name when invoked directly. A stable Workflow Definition target requires workflow(\"name\").")
 }
@@ -995,11 +992,6 @@ export function workflow(name?: string): AgentWorkflowRuntimeBinding {
   }
 }
 
-function withAgentWorkflowRuntimeName(runtime: AgentRuntimeBinding | undefined, name: string | undefined): AgentRuntimeBinding | undefined {
-  if (!name || runtime?.kind !== "workflow" || runtime.name) return runtime
-  return { ...runtime, name }
-}
-
 function createSyntheticWorkspaceRun<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -1015,53 +1007,6 @@ function createSyntheticWorkspaceRun<
       : result
   }
   return Object.assign(run, { [syntheticWorkspaceRun]: true })
-}
-
-function cloneAgentDefinitionWithDefaults<TContext extends AgentRuntimeContext>(
-  agent: AgentInput<TContext>,
-  defaults: WorkspaceAgentDefaults | undefined,
-  runtime: AgentRuntimeBinding | undefined,
-): AgentInput<TContext> {
-  const clone = Object.create(Object.getPrototypeOf(agent)) as AgentDefinition
-  Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
-  if (defaults) {
-    (clone as Partial<WorkspaceAgentDefinition>).__vitehubWorkspaceAgentDefaults = defaults
-  }
-  if (runtime) {
-    clone.runtime = runtime
-  }
-  if (clone.run && syntheticWorkspaceRun in clone.run) {
-    clone.run = createSyntheticWorkspaceRun(clone as never) as typeof clone.run
-  }
-  return clone as AgentInput<TContext>
-}
-
-export function withAgentDefaults<TContext extends AgentRuntimeContext>(
-  agent: AgentInput<TContext>,
-  options?: AgentHandlerOptions<TContext>,
-): AgentInput<TContext>
-export function withAgentDefaults<TContext extends AgentRuntimeContext>(
-  agent: AgentInput<TContext> | undefined,
-  options?: AgentHandlerOptions<TContext>,
-): AgentInput<TContext> | undefined
-export function withAgentDefaults<TContext extends AgentRuntimeContext>(
-  agent: AgentInput<TContext> | undefined,
-  options: AgentHandlerOptions<TContext> = {},
-): AgentInput<TContext> | undefined {
-  if (!agent || !hasAgentDefinition(agent)) return agent
-  const workspaceDefinition = agent as Partial<WorkspaceAgentDefinition>
-  const existingWorkspaceDefaults = workspaceDefinition.__vitehubWorkspaceAgentDefaults
-  const workspaceDefaults = workspaceDefinition.__vitehubWorkspaceAgent && (options.inferredName || options.workspace)
-    ? {
-        ...existingWorkspaceDefaults,
-        ...(options.inferredName ? { name: options.inferredName } : {}),
-        ...(options.workspace ? { workspace: options.workspace } : {}),
-      }
-    : undefined
-  const runtime = withAgentWorkflowRuntimeName(agent.runtime, agent.name ? undefined : options.inferredName)
-  return !workspaceDefaults && (!runtime || runtime === agent.runtime)
-    ? agent
-    : cloneAgentDefinitionWithDefaults(agent, workspaceDefaults, runtime === agent.runtime ? undefined : runtime)
 }
 
 export interface DefineAgent {
@@ -1112,7 +1057,6 @@ function createWorkspaceAgentDefinition<
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
 >(
   options: WorkspaceAgentOptions<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile>,
-  defaults: WorkspaceAgentDefaults<Name> = {},
 ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS> {
   const workspaceDefinition = workspaceDefinitionFromOptions(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>)
   validateWorkspaceCapabilities(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>, workspaceDefinition)
@@ -1120,7 +1064,7 @@ function createWorkspaceAgentDefinition<
     ...options,
     description: options.description,
     hooks: options.hooks,
-    runtime: withAgentWorkflowRuntimeName(options.runtime, defaults.name),
+    runtime: options.runtime,
     version: options.version,
     workspace: workspaceDefinition,
   } as never) as WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>
@@ -1131,7 +1075,6 @@ function createWorkspaceAgentDefinition<
 
   Object.assign(definition, workspaceDefinition, {
     __vitehubWorkspaceAgent: true,
-    __vitehubWorkspaceAgentDefaults: defaults,
     __vitehubWorkspaceAgentOptions: options,
   })
   return definition
@@ -1187,7 +1130,7 @@ export async function getAgentFromRegistry<TContext extends AgentRuntimeContext>
     throw new Error(`[vitehub] Agent "${name}" did not export a valid default agent.`)
   }
 
-  return withAgentDefaults(agent, { inferredName: name }) as AgentInput<TContext>
+  return agent
 }
 
 export async function resolveAgentTriggers<
@@ -1387,8 +1330,8 @@ async function createAgentInvocationContext<
     const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig>> | undefined
     const workspaceOptions = workspaceDefinition?.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<AgentRuntimeConfig> | undefined
     const workspaceName = workspaceOptions
-      ? workspaceNameFromOptions(workspaceOptions, workspaceDefinition?.__vitehubWorkspaceAgentDefaults, context.agentIdentity)
-      : workspaceDefinition?.__vitehubWorkspaceAgentDefaults?.workspace
+      ? workspaceNameFromOptions(workspaceOptions, {}, context.agentIdentity)
+      : undefined
     const workspaceMode = workspaceOptions ? workspaceModeFromOptions(workspaceOptions) : "read"
     const configuredWorkspaceDefinition = workspaceOptions && workspaceName
       ? { ...workspaceDefinitionFromOptions(workspaceOptions), name: workspaceName }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -48,7 +48,6 @@ import type {
   ResolvedAgentTriggerDefinition,
 } from "../types.ts"
 import type { AudioData, MessagePart } from "../messages.ts"
-import type { WorkspaceAgentDefaults } from "../workspace-agent.ts"
 import type {
   ChatDevtoolsConversation,
   ChatDevtoolsMetadata,
@@ -1697,7 +1696,6 @@ interface AgentChannelDevtoolsRouteState {
 }
 
 export interface AgentChannelDevtoolsRouteHandlerOptions extends AgentRouteRuntimeOptions {
-  defaults?: WorkspaceAgentDefaults
   emptyAssistantText?: string
   name?: string
 }
@@ -1871,7 +1869,6 @@ async function startAgentDevtoolsMetadataResolution(
   const { resolveAgentDevtoolsMetadata } = await import("../workspace-agent.ts")
   const run = createDevtoolsMetadataRunMetadata(name)
   const task = resolveAgentDevtoolsMetadata(agent as never, {
-    ...options.defaults,
     input: createDevtoolsMetadataInput(metadataSelection, run),
     runtime: { ...runtime, run },
   } as never)
@@ -2280,7 +2277,6 @@ async function materializeDevtoolsSource(
     const name = agentChannelDevtoolsName(agent, options)
     const run = createDevtoolsMetadataRunMetadata(name)
     const metadata = await materializeAgentDevtoolsSourceMetadata(agent as never, {
-      ...options.defaults,
       input: createDevtoolsMetadataInput(metadataSelection, run),
       ...(input.path ? { path: input.path } : {}),
       ...(input.source ? { source: input.source } : {}),

--- a/packages/agent/src/server/workspace.ts
+++ b/packages/agent/src/server/workspace.ts
@@ -1,16 +1,17 @@
 import { registerWorkspace } from "@vite-hub/workspace/runtime"
 
-import { withAgentDefaults, workspaceAgentOwnsWorkspaceDefinition } from "../index.ts"
-import { workspaceDefinitionFromOptions, workspaceNameFromOptions } from "../workspace-agent.ts"
+import { workspaceAgentOwnsWorkspaceDefinition, workspaceAgentWithSourceRoot, workspaceNameFromOptions } from "../workspace-agent.ts"
 
 import type { AgentRuntimeConfig } from "../types.ts"
-import type { WorkspaceAgentDefaults, WorkspaceAgentDefinition } from "../workspace-agent.ts"
+import type { WorkspaceAgentDefinition } from "../workspace-agent.ts"
 import type { WorkspaceName } from "@vite-hub/workspace"
 
 export { setWorkspaceRuntimeRegistry } from "@vite-hub/workspace/runtime"
 
-export interface RegisterWorkspaceAgentOptions<Name extends WorkspaceName = WorkspaceName> extends WorkspaceAgentDefaults<Name> {
+export interface RegisterWorkspaceAgentOptions<Name extends WorkspaceName = WorkspaceName> {
+  name?: string
   sourceRootDir?: string
+  workspace?: Name
 }
 
 export function registerWorkspaceAgent<
@@ -21,33 +22,13 @@ export function registerWorkspaceAgent<
   agent: WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>,
   options: RegisterWorkspaceAgentOptions<Name> = {},
 ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS> {
-  const preparedAgent = withAgentDefaults(agent as never, {
-    inferredName: options.name,
-    workspace: options.workspace,
-  }) as WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>
-  const workspaceOptions = preparedAgent.__vitehubWorkspaceAgentOptions
-  if (!workspaceAgentOwnsWorkspaceDefinition(preparedAgent)) return preparedAgent
-  const sourceRootDir = preparedAgent.sourceRootDir ?? options.sourceRootDir
-  if (sourceRootDir !== undefined) {
-    const configuredWorkspace = workspaceOptions.workspace as Record<string, unknown> & { sourceRootDir?: string }
-    const workspace = {
-      ...configuredWorkspace,
-      sourceRootDir: configuredWorkspace.sourceRootDir ?? sourceRootDir,
-    }
-    Object.assign(preparedAgent, workspaceDefinitionFromOptions({
-      ...workspaceOptions,
-      workspace,
-    } as never), {
-      __vitehubWorkspaceAgentOptions: {
-        ...workspaceOptions,
-        workspace,
-      },
-    })
-  }
-  const workspaceName = workspaceNameFromOptions(preparedAgent.__vitehubWorkspaceAgentOptions as never, preparedAgent.__vitehubWorkspaceAgentDefaults)
+  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return agent
+  const sourceRootDir = agent.sourceRootDir ?? options.sourceRootDir
+  const registeredAgent = sourceRootDir === undefined ? agent : workspaceAgentWithSourceRoot(agent, sourceRootDir)
+  const workspaceName = workspaceNameFromOptions(agent.__vitehubWorkspaceAgentOptions as never, options)
   registerWorkspace(workspaceName, {
-    ...preparedAgent,
+    ...registeredAgent,
     sourceRootDir,
   } as never)
-  return preparedAgent
+  return agent
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1134,12 +1134,6 @@ export interface ResolvedAgentModuleOptions {
   runtime: AgentRuntime
 }
 
-export interface AgentHandlerOptions<TRuntimeContext extends AgentRuntimeContext = AgentRuntimeContext> {
-  inferredName?: string
-  lifecycleHooks?: AgentRuntimeHooks<TRuntimeContext>
-  workspace?: WorkspaceName
-}
-
 export interface AgentRegistryHandlerOptions<TRuntimeContext extends AgentRuntimeContext = AgentRuntimeContext> {
   agentParam?: string
   lifecycleHooks?: AgentRuntimeHooks<TRuntimeContext>

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -382,21 +382,19 @@ async function discoverStreamAgents(server: ViteDevServer): Promise<AgentInvocat
 
 function agentWorkspaceName(entry: AgentInvocationStreamEntry): string | undefined {
   const agent = entry.agent as Partial<{
-    __vitehubWorkspaceAgentDefaults: Parameters<typeof workspaceNameFromOptions>[1]
     __vitehubWorkspaceAgentOptions: Parameters<typeof workspaceNameFromOptions>[0]
   }>
   return agent.__vitehubWorkspaceAgentOptions
-    ? workspaceNameFromOptions(agent.__vitehubWorkspaceAgentOptions, agent.__vitehubWorkspaceAgentDefaults, entry.identity)
+    ? workspaceNameFromOptions(agent.__vitehubWorkspaceAgentOptions, {}, entry.identity)
     : undefined
 }
 
 function agentWorkspaceOptions(entry: AgentInvocationStreamEntry) {
   const agent = entry.agent as Partial<{
-    __vitehubWorkspaceAgentDefaults: Parameters<typeof workspaceNameFromOptions>[1]
     __vitehubWorkspaceAgentOptions: Parameters<typeof workspaceNameFromOptions>[0]
   }>
   return agent.__vitehubWorkspaceAgentOptions
-    ? { defaults: agent.__vitehubWorkspaceAgentDefaults, options: agent.__vitehubWorkspaceAgentOptions }
+    ? { options: agent.__vitehubWorkspaceAgentOptions }
     : undefined
 }
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -107,7 +107,6 @@ export type WorkspaceAgentDefinition<
   TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined = AgentCapabilityDefinition<TRuntimeConfig>[] | undefined,
 > = AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues> & WorkspaceAgentWorkspaceOptions & {
   __vitehubWorkspaceAgent: true
-  __vitehubWorkspaceAgentDefaults?: WorkspaceAgentDefaults<Name>
   __vitehubWorkspaceAgentOptions: WorkspaceAgentOptions<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities>
 }
 
@@ -636,7 +635,6 @@ function workspaceMetadataFiles<
   Name extends WorkspaceName,
 >(
   options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
-  _defaults: WorkspaceAgentDefaults<Name>,
 ): AgentDevtoolsFileTreeItem[] {
   const sources = normalizedSourcesFromOptions(options)
   return sources.sort((left, right) => left.key.localeCompare(right.key)).map((source) => {
@@ -844,7 +842,6 @@ function clearReadyMaterializationHints(item: AgentDevtoolsFileTreeItem) {
 
 async function resolveWorkspaceMetadataFiles<Name extends WorkspaceName>(
   options: WorkspaceAgentOptions<AgentRuntimeConfig, Name>,
-  _defaults: WorkspaceAgentDefaults<Name>,
   workspace: ReadonlyWorkspaceFacade<Name>,
 ): Promise<AgentDevtoolsFileTreeItem[]> {
   const root: AgentDevtoolsFileTreeItem = {
@@ -1150,7 +1147,7 @@ async function createDevtoolsMetadataWorkspace<
   defaultsOverride: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name> = {},
 ) {
   const defaults = {
-    ...(definition.__vitehubWorkspaceAgentDefaults || definition as WorkspaceAgentDefaults<Name>),
+    ...(typeof definition.name === "string" ? { name: definition.name } : {}),
     ...defaultsOverride,
   }
   if (!definition.__vitehubWorkspaceAgentOptions) return
@@ -1162,11 +1159,11 @@ async function createDevtoolsMetadataWorkspace<
   const workspaceDefinition = workspaceDefinitionWithNameFromOptions(options, defaults, defaultsOverride.runtime?.agentIdentity)
 
   if (hasAccessCapability(options)) {
-    return { defaults, options, workspace }
+    return { options, workspace }
   }
 
   if (!hasWorkspaceSourceResolvers(workspaceDefinition)) {
-    return { defaults, options, workspace }
+    return { options, workspace }
   }
 
   const resolved = await createWorkspaceSourceResolutionFacade(workspace, workspaceDefinition, {
@@ -1176,7 +1173,6 @@ async function createDevtoolsMetadataWorkspace<
   })
 
   return {
-    defaults,
     options: workspaceOptionsFromDefinition(options, resolved.definition),
     workspace: resolved.workspace,
   }
@@ -1271,7 +1267,7 @@ export function createAgentDevtoolsMetadata<
 
   const options = workspaceDefinition.__vitehubWorkspaceAgentOptions as unknown as WorkspaceAgentOptions<TRuntimeConfig, Name>
   return {
-    files: workspaceMetadataFiles(options, workspaceDefinition.__vitehubWorkspaceAgentDefaults || workspaceDefinition as WorkspaceAgentDefaults<Name>),
+    files: workspaceMetadataFiles(options),
     instructions: workspaceMetadataInstructions(options),
     ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
     tools: workspaceMetadataTools(options),
@@ -1317,7 +1313,7 @@ export async function resolveAgentDevtoolsMetadata<
   )
 
   return {
-    files: await resolveWorkspaceMetadataFiles(metadataOptions as never, metadataWorkspace.defaults as never, capabilityContext.workspace as never),
+    files: await resolveWorkspaceMetadataFiles(metadataOptions as never, capabilityContext.workspace as never),
     instructions: instructionMetadata.instructions,
     ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
     ...(config ? { config } : {}),
@@ -1384,7 +1380,7 @@ export async function materializeAgentDevtoolsSourceMetadata<
   )
 
   return {
-    files: await resolveWorkspaceMetadataFiles(metadataOptions as never, metadataWorkspace.defaults as never, capabilityContext.workspace as never),
+    files: await resolveWorkspaceMetadataFiles(metadataOptions as never, capabilityContext.workspace as never),
     instructions: instructionMetadata.instructions,
     ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
     ...(config ? { config } : {}),

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -1948,7 +1948,7 @@ describe("agent capability runtime", () => {
   })
 
   it("round-trips Capability CLI exposure through resolved Agent Definitions", async () => {
-    const { defineAgent, defineCapability, runAgentInline, withAgentDefaults } = await import("../src/index.ts")
+    const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
     const inventory = defineCapability({
       cli: {
         commands: {
@@ -1960,15 +1960,17 @@ describe("agent capability runtime", () => {
       },
       id: "inventory-runtime",
     })
-    const exposed = withAgentDefaults(defineAgent({
+    const exposed = defineAgent({
       capabilities: [inventory],
+      name: "chat",
       driver: { run: context => Object.keys(context.tools || {}) },
-    }), { inferredName: "chat" })
-    const hidden = withAgentDefaults(defineAgent({
+    })
+    const hidden = defineAgent({
       capabilities: [inventory],
       cli: { capabilities: false },
+      name: "chat",
       driver: { run: context => Object.keys(context.tools || {}) },
-    }), { inferredName: "chat" })
+    })
 
     await expect(runAgentInline(exposed, runtime(), {}, { output: "raw" })).resolves.toEqual(["inventory"])
     await expect(runAgentInline(hidden, runtime(), {}, { output: "raw" })).resolves.toEqual([])

--- a/packages/agent/test/config.test.ts
+++ b/packages/agent/test/config.test.ts
@@ -85,9 +85,10 @@ describe("agent config", () => {
     try {
       const agent = await import("../src/index.ts")
       expect(agent.defineAgent).toBeTypeOf("function")
-      expect(agent.withAgentDefaults(agent.defineAgent({
+      expect(agent.defineAgent({
         driver: { run: async () => "ok", },
-      }))?.run).toBeTypeOf("function")
+      }).run).toBeTypeOf("function")
+      expect(agent).not.toHaveProperty("withAgentDefaults")
     }
     finally {
       vi.doUnmock("@vite-hub/workspace")

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -13,8 +13,6 @@ import type { IncomingMessage, ServerResponse } from "node:http"
 import type { Connect } from "vite"
 import type { AgentRunInput } from "../src/index.ts"
 
-const { withAgentDefaults } = await import("../src/index.ts")
-
 async function createTempRoot(prefix: string) {
   return await mkdtemp(join(tmpdir(), prefix))
 }
@@ -397,7 +395,7 @@ describe("agent chat capability discovery", () => {
     const devtoolsMeta = { email: "maximo@quiver.dk" }
     const technicalEmails = new Set(["maximo@quiver.dk"])
     const observedMetadataChannel = vi.fn()
-    const agent = withAgentDefaults(defineAgent({
+    const agent = defineAgent({
       invoker: {
         profiles: [
           { id: "support-customer", kind: "customer", label: "Customer", meta: { audience: "customer", scope: "customer" } },
@@ -422,6 +420,7 @@ describe("agent chat capability discovery", () => {
         }),
         chat(),
       ],
+      name: "support",
       driver: {
         run: (context: { invoker: { kind?: string, meta?: Record<string, unknown> }, workspace?: unknown }) => {
           const email = typeof context.invoker.meta?.email === "string" ? `:${context.invoker.meta.email}` : ""
@@ -429,7 +428,7 @@ describe("agent chat capability discovery", () => {
         },
       },
       workspace: {},
-    }), { workspace: "support" })
+    })
     const { handlers, server } = createFakeServer(root, { default: agent })
     const plugin = (await import("../src/vite.ts")).hubAgent()
 
@@ -1908,18 +1907,19 @@ describe("agent chat capability discovery", () => {
       resolveInstructions = resolve
     })
     const readInstructions = vi.fn(async () => await instructionsReady)
-    const agent = withAgentDefaults(defineAgent({
+    const agent = defineAgent({
       capabilities: [chat()],
       driver: {
         instructions: readInstructions,
         model: {} as never,
       },
+      name: "support",
       workspace: {
         sources: {
           docs: { name: "docs" } as never,
         },
       },
-    }), { workspace: "support" })
+    })
     const { handlers, server } = createFakeServer(root, { default: agent })
     const plugin = (await import("../src/vite.ts")).hubAgent()
 
@@ -1954,7 +1954,7 @@ describe("agent chat capability discovery", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { custom } = await import("@vite-hub/workspace")
     const { registerWorkspace } = await import("@vite-hub/workspace/test")
-    const agent = withAgentDefaults(defineAgent({
+    const agent = defineAgent({
       capabilities: [chat()],
       driver: {
         async run({ workspace }) {
@@ -1963,6 +1963,7 @@ describe("agent chat capability discovery", () => {
           return "materialized ingestion"
         }
       },
+      name: "support",
       workspace: {
         store: { provider: "memory" },
         sources: {
@@ -1979,7 +1980,7 @@ describe("agent chat capability discovery", () => {
           }),
         },
       },
-    }), { workspace: "support" })
+    })
     registerWorkspace("support", agent as never)
     const { handlers, server } = createFakeServer(root, { default: agent })
     const plugin = (await import("../src/vite.ts")).hubAgent()
@@ -2041,11 +2042,12 @@ describe("agent chat capability discovery", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { custom } = await import("@vite-hub/workspace")
     const { registerWorkspace } = await import("@vite-hub/workspace/test")
-    const agent = withAgentDefaults(defineAgent({
+    const agent = defineAgent({
       capabilities: [chat()],
       driver: {
         run: () => "ok"
       },
+      name: "support",
       workspace: {
         store: { provider: "memory" },
         sources: {
@@ -2087,7 +2089,7 @@ describe("agent chat capability discovery", () => {
           }),
         },
       },
-    }), { workspace: "support" })
+    })
     registerWorkspace("support", agent as never)
     const { handlers, server } = createFakeServer(root, { default: agent })
     const plugin = (await import("../src/vite.ts")).hubAgent()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1076,12 +1076,12 @@ describe("server helpers", () => {
     await writeFile(join(sourceRoot, "AGENTS.md"), "# Support\n")
 
     try {
-      const { defineAgent } = await import("../src/index.ts")
+      const { defineAgent, runAgentInline } = await import("../src/index.ts")
       const { registerWorkspaceAgent } = await import("../src/server/workspace.ts")
       const { defineWorkspace, file, useWorkspace } = await import("@vite-hub/workspace")
       const agent = defineAgent({
-        driver: { async run() {
-            return "ok"
+        driver: { async run({ workspace }) {
+            return await (workspace as { fs: { readFile(path: string): Promise<string> } }).fs.readFile("AGENTS.md")
           } },
         workspace: defineWorkspace({
           store: { provider: "memory" },
@@ -1097,10 +1097,15 @@ describe("server helpers", () => {
       })
       const workspace = useWorkspace("support-runtime")
 
-      expect(preparedAgent.__vitehubWorkspaceAgentDefaults?.workspace).toBe("support-runtime")
-      expect(preparedAgent.sourceRootDir).toBe(sourceRoot)
-      expect((preparedAgent.__vitehubWorkspaceAgentOptions.workspace as { sourceRootDir?: string }).sourceRootDir).toBe(sourceRoot)
+      expect(preparedAgent).toBe(agent)
+      expect(preparedAgent).not.toHaveProperty("__vitehubWorkspaceAgentDefaults")
       expect(await workspace.fs.readFile("AGENTS.md")).toBe("# Support\n")
+      await expect(runAgentInline(preparedAgent, {
+        agentIdentity: { name: "support", workspace: "support-runtime" },
+        memo: vi.fn(),
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, {})).resolves.toBe("# Support\n")
     }
     finally {
       await rm(root, { force: true, recursive: true })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -48,8 +48,6 @@ vi.mock("../src/internal/ai-sdk-runtime.ts", () => ({
 }))
 loadAiSdk.mockImplementation(async () => await import("ai"))
 
-const { withAgentDefaults } = await import("../src/index.ts")
-
 afterEach(() => {
   harnessAgentSettings.length = 0
   harnessCreateSession.mockReset()
@@ -987,6 +985,7 @@ describe("agent message protocol", () => {
     }), { workspace: workspaceName })
 
     await expect(runAgent(reviewerAgent, {
+      agentIdentity: { name: "reviewer", workspace: workspaceName },
       memo: vi.fn(),
       runtime: "unknown",
       waitUntil: vi.fn(),
@@ -4089,11 +4088,11 @@ describe("agent message protocol", () => {
       capabilities: [{ id: "custom" }],
       channels: { web: webChat() },
       driver: { run: () => "ok" },
+      name: "docs",
       workspace: {},
     })
-    const registered = withAgentDefaults(agent as never, { workspace: "docs" })
 
-    await expect(resolveAgentTriggers(registered, { memo: vi.fn(), runtime: "unknown" as const, runtimeConfig: {}, waitUntil: vi.fn() })).resolves.toMatchObject({
+    await expect(resolveAgentTriggers(agent, { memo: vi.fn(), runtime: "unknown" as const, runtimeConfig: {}, waitUntil: vi.fn() })).resolves.toMatchObject({
       "chat.message": {
         capabilityId: "chat",
       },
@@ -7402,7 +7401,6 @@ describe("agent message protocol", () => {
         workspace: {},
       })
       const originalRuntime = agent.runtime
-      const originalDefaults = agent.__vitehubWorkspaceAgentDefaults
       const docsIdentity = { name: "identity-docs-agent", workspace: "identity-docs-workspace" }
       const supportIdentity = { name: "identity-support-agent", workspace: "identity-support-workspace" }
       const docsRun = await runAgent(agent, {
@@ -7430,12 +7428,10 @@ describe("agent message protocol", () => {
       await expect(resolveRegisteredWorkspaceDefinition(docsIdentity.workspace)).resolves.toMatchObject({ name: docsIdentity.workspace })
       await expect(resolveRegisteredWorkspaceDefinition(supportIdentity.workspace)).resolves.toMatchObject({ name: supportIdentity.workspace })
       expect(agent.runtime).toBe(originalRuntime)
-      expect(agent.__vitehubWorkspaceAgentDefaults).toBe(originalDefaults)
-      expect(agent.__vitehubWorkspaceAgentDefaults).toEqual({})
     })
 
     it("resolves workflow names from explicit binding, definition, then host identity", async () => {
-      const { defineAgent, runAgent, withAgentDefaults, workflow } = await import("../src/index.ts")
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")
       const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
       const waitUntilTasks: Array<Promise<unknown>> = []
@@ -7455,10 +7451,6 @@ describe("agent message protocol", () => {
         runtime: workflow(),
         driver: { run: context => context.agentIdentity },
       })
-      const legacyAgent = withAgentDefaults(defineAgent({
-        runtime: workflow(),
-        driver: { run: context => context.agentIdentity },
-      }), { inferredName: "identity-legacy-fallback" })!
 
       const bindingRun = await runAgent(bindingAgent, {
         agentIdentity: hostIdentity,
@@ -7478,17 +7470,10 @@ describe("agent message protocol", () => {
         runtime: "vercel",
         waitUntil: promise => waitUntilTasks.push(promise),
       }, {}) as { id: string }
-      const legacyRun = await runAgent(legacyAgent, {
-        memo: vi.fn(),
-        runtime: "vercel",
-        waitUntil: promise => waitUntilTasks.push(promise),
-      }, {}) as { id: string }
-
       await Promise.all(waitUntilTasks)
       await expect(getWorkflowRun("identity-binding-wins", bindingRun.id)).resolves.toMatchObject({ result: hostIdentity })
       await expect(getWorkflowRun("identity-definition-wins", definitionRun.id)).resolves.toMatchObject({ result: hostIdentity })
       await expect(getWorkflowRun(hostIdentity.name, hostRun.id)).resolves.toMatchObject({ result: hostIdentity })
-      await expect(getWorkflowRun("identity-legacy-fallback", legacyRun.id)).resolves.toMatchObject({ status: "completed" })
     })
 
     it("resolves workspace names from explicit configuration before host identity", async () => {
@@ -7506,14 +7491,15 @@ describe("agent message protocol", () => {
       expect(workspaceNameFromOptions(stringWorkspace.__vitehubWorkspaceAgentOptions, {}, hostIdentity)).toBe("identity-explicit-string")
     })
 
-    it("preserves Agent Definition metadata when applying discovered defaults", async () => {
-      const { createAgentDevtoolsMetadata, defineAgent, withAgentDefaults, workflow } = await import("../src/index.ts")
-      const agent = withAgentDefaults(defineAgent({
+    it("preserves Agent Definition metadata for explicitly named definitions", async () => {
+      const { createAgentDevtoolsMetadata, defineAgent, workflow } = await import("../src/index.ts")
+      const agent = defineAgent({
         driver: { model: { id: "test-model" } as never },
+        name: "browser",
         runtime: workflow(),
-      }), { inferredName: "browser" })
+      })
 
-      expect(createAgentDevtoolsMetadata(agent!)).toMatchObject({
+      expect(createAgentDevtoolsMetadata(agent)).toMatchObject({
         config: {
           driver: {
             kind: "model",
@@ -7523,52 +7509,19 @@ describe("agent message protocol", () => {
       })
     })
 
-    it("keeps workspace defaults scoped to each prepared Agent Definition", async () => {
-      const { defineAgent } = await import("../src/index.ts")
-      const defaults = (agent: unknown) => (agent as { __vitehubWorkspaceAgentDefaults?: { name?: string, workspace?: string } }).__vitehubWorkspaceAgentDefaults
-      const agent = defineAgent({
-        driver: { run: () => "ok" },
-        workspace: {},
-      })
-
-      const docsAgent = withAgentDefaults(agent, { inferredName: "docs-agent", workspace: "docs" })
-      const supportAgent = withAgentDefaults(agent, { inferredName: "support-agent", workspace: "support" })
-
-      expect(docsAgent).not.toBe(agent)
-      expect(supportAgent).not.toBe(agent)
-      expect(docsAgent).not.toBe(supportAgent)
-      expect(defaults(agent)).toEqual({})
-      expect(defaults(docsAgent)).toEqual({ name: "docs-agent", workspace: "docs" })
-      expect(defaults(supportAgent)).toEqual({ name: "support-agent", workspace: "support" })
-    })
-
-    it("preserves existing workspace defaults when applying an inferred registry name", async () => {
-      const { defineAgent } = await import("../src/index.ts")
-      const defaults = (agent: unknown) => (agent as { __vitehubWorkspaceAgentDefaults?: { name?: string, workspace?: string } }).__vitehubWorkspaceAgentDefaults
-      const agent = defineAgent({
-        driver: { run: () => "ok" },
-        workspace: {},
-      })
-
-      const preparedAgent = withAgentDefaults(agent, { inferredName: "support-agent", workspace: "support" })
-      const registryAgent = withAgentDefaults(preparedAgent, { inferredName: "registry-support" })
-
-      expect(registryAgent).not.toBe(preparedAgent)
-      expect(defaults(registryAgent)).toEqual({ name: "registry-support", workspace: "support" })
-    })
-
-    it("uses workspace Agent defaults for unnamed workflow runtime bindings", async () => {
+    it("uses explicit Agent Definition names for unnamed workflow runtime bindings", async () => {
       const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")
       const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
       const waitUntilTasks: Array<Promise<unknown>> = []
       setWorkflowRuntimeConfig({ provider: "vercel" })
 
-      const agent = withAgentDefaults(defineAgent({
+      const agent = defineAgent({
+        name: "reviewer",
         runtime: workflow(),
         driver: { run: context => `received ${context.prompt}` },
         workspace: {},
-      }), { inferredName: "reviewer", workspace: "reviewer" })
+      })
       const run = await runAgent(agent, {
         memo: vi.fn(),
         runtime: "vercel",

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -130,7 +130,17 @@ vi.mock("@vite-hub/workspace/runtime", async (importOriginal) => {
   }
 })
 
-const { withAgentDefaults } = await import("../src/index.ts")
+const { defineAgent: defineNamedWorkspaceTestAgent } = await import("../src/index.ts")
+
+function withExplicitWorkspaceName<
+  TAgent extends { name?: string, __vitehubWorkspaceAgentOptions: Record<string, unknown> },
+>(agent: TAgent, options: { workspace?: string }): TAgent {
+  if (!options.workspace || agent.name) return agent
+  return defineNamedWorkspaceTestAgent({
+    ...agent.__vitehubWorkspaceAgentOptions,
+    name: options.workspace,
+  } as never) as unknown as TAgent
+}
 
 function context(runtimeConfig: Record<string, unknown> = {}) {
   return {
@@ -299,7 +309,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
     exists.mockResolvedValue(true)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [skills({ path: "skills/agent-browser", shellExecution: "write" })],
       driver: {
         harness: { provider: "codex" },
@@ -363,7 +373,7 @@ describe("defineAgent workspace option", () => {
       return { finishReason: "stop", text: "ok" }
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [blob({ mode: "write", policy: "allow" })],
       driver: {
         harness: { provider: "codex" },
@@ -464,7 +474,7 @@ describe("defineAgent workspace option", () => {
       },
     ))
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [
         blob({ assetPaths: ["artifacts"], mode: "write", policy: "deny" }),
         defineCapability({
@@ -550,7 +560,7 @@ describe("defineAgent workspace option", () => {
       }),
     } as unknown as WritableWorkspaceFacade)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [
         access({
           workspace: {
@@ -607,7 +617,7 @@ describe("defineAgent workspace option", () => {
       })(),
     } as never)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -634,7 +644,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -666,7 +676,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1202,7 +1212,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
     exists.mockResolvedValue(true)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1251,7 +1261,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [{
         id: "support-tools",
         tools: {
@@ -1287,7 +1297,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce(harnessSession)
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1327,7 +1337,7 @@ describe("defineAgent workspace option", () => {
     })
     exists.mockResolvedValue(true)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1361,7 +1371,7 @@ describe("defineAgent workspace option", () => {
     exists.mockResolvedValueOnce(true)
     readFile.mockResolvedValueOnce(document)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1405,7 +1415,7 @@ describe("defineAgent workspace option", () => {
     readFile.mockResolvedValueOnce("# Support\n")
     harnessFileSession.writeBinaryFile.mockRejectedValueOnce(error)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1423,7 +1433,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1466,7 +1476,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1518,7 +1528,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1547,7 +1557,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1592,7 +1602,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1635,7 +1645,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1684,7 +1694,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1721,7 +1731,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -1761,7 +1771,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [
         access({
           workspace: {
@@ -1809,7 +1819,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [
         access({
           workspace: {
@@ -1854,7 +1864,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [
         access({
           workspace: {
@@ -1901,7 +1911,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [
         access({
           workspace: {
@@ -1949,7 +1959,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [
         access({
           workspace: {
@@ -1999,7 +2009,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
     exists.mockImplementation(async path => path === "README.md")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [
         {
           id: "workspace-scope",
@@ -2049,7 +2059,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [
         access({
           workspace: {
@@ -2091,7 +2101,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -2128,7 +2138,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
       },
@@ -2205,7 +2215,7 @@ describe("defineAgent workspace option", () => {
     })
     const { defineAgent, runAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         mode: "write",
         rules: {
@@ -2242,7 +2252,7 @@ describe("defineAgent workspace option", () => {
     })
     const { defineAgent, runAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         commit: "chore: archive notes",
         mode: "write",
@@ -2276,7 +2286,7 @@ describe("defineAgent workspace option", () => {
     })
     const { defineAgent, runAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         commit: "chore: archive notes",
         mode: "write",
@@ -2316,7 +2326,7 @@ describe("defineAgent workspace option", () => {
     })
     const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [
         defineCapability({
           id: "review-rules",
@@ -2363,7 +2373,7 @@ describe("defineAgent workspace option", () => {
     })
     const { defineAgent, streamAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         mode: "write",
         rules: {
@@ -2396,7 +2406,7 @@ describe("defineAgent workspace option", () => {
     })
     const { defineAgent, runAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         mode: "write",
         rules: {
@@ -2419,7 +2429,7 @@ describe("defineAgent workspace option", () => {
   it("uses string instructions", async () => {
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         instructions: "Use workspace sources.",
@@ -2439,7 +2449,7 @@ describe("defineAgent workspace option", () => {
     readFile.mockResolvedValueOnce("Use colocated workspace instructions.\n")
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: { sourceRootDir },
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -2489,7 +2499,7 @@ describe("defineAgent workspace option", () => {
     readFile.mockResolvedValueOnce("Use colocated workspace instructions.\n")
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         sourceRootDir,
         sources: { docs: { name: "docs" } as never },
@@ -2530,7 +2540,7 @@ describe("defineAgent workspace option", () => {
     readFile.mockResolvedValueOnce(document)
     const { defineAgent, defineCapability } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [
         defineCapability({
           id: "support-context",
@@ -2569,7 +2579,7 @@ describe("defineAgent workspace option", () => {
 
     try {
       const { defineAgent } = await import("../src/index.ts")
-      const agent = withAgentDefaults(defineAgent({
+      const agent = withExplicitWorkspaceName(defineAgent({
         workspace: {
           sourceRootDir: "/runtime/server/agents/support",
           sources: {
@@ -2600,7 +2610,7 @@ describe("defineAgent workspace option", () => {
     await writeLocalFile(join(sourceRootDir, "instructions.md"), "Use colocated workspace instructions.\n")
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: { sourceRootDir },
       driver: {
         instructions: "Use explicit instructions.",
@@ -2620,7 +2630,7 @@ describe("defineAgent workspace option", () => {
     await writeLocalFile(join(sourceRootDir, "instructions.md"), "Use colocated workspace instructions.\n")
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: { sourceRootDir },
       driver: {
         instructions: "Use explicit driver instructions.",
@@ -2638,7 +2648,7 @@ describe("defineAgent workspace option", () => {
     readFile.mockResolvedValueOnce("Ordinary workspace instructions.\n")
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         sources: {
           guide: { path: "AGENTS.md" },
@@ -2661,7 +2671,7 @@ describe("defineAgent workspace option", () => {
     })
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         bindings: {
           policy: { path: "policy.md" },
@@ -2692,10 +2702,10 @@ describe("defineAgent workspace option", () => {
     ].join("\n\n"))
   })
 
-  it("rebinds synthetic workspace runs when applying discovered defaults", async () => {
+  it("rebinds synthetic workspace runs with an explicit workspace name", async () => {
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -2719,7 +2729,7 @@ describe("defineAgent workspace option", () => {
   it("joins array instructions", async () => {
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         instructions: [" First ", "", "Second"],
@@ -2736,7 +2746,7 @@ describe("defineAgent workspace option", () => {
     readFile.mockResolvedValueOnce("Workspace instructions")
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         instructions: [
@@ -2757,7 +2767,7 @@ describe("defineAgent workspace option", () => {
     readFile.mockResolvedValueOnce("Workspace instructions")
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         instructions: async ({ fs }) => await fs.readFile("AGENTS.md"),
@@ -2821,7 +2831,7 @@ describe("defineAgent workspace option", () => {
       instructions: "Use support capability guidance." as never,
     } as never)).toThrow("Capability instructions were removed")
 
-    expect(() => withAgentDefaults(defineAgent({
+    expect(() => withExplicitWorkspaceName(defineAgent({
       workspace: {
         sources: {
           docs: { instructions: "Use docs for product behavior.", name: "docs" } as never,
@@ -2838,7 +2848,7 @@ describe("defineAgent workspace option", () => {
     const { defineAgent } = await import("../src/index.ts")
     const model = { id: "driver-model" }
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         execution: {
           callSettings: {
@@ -2870,7 +2880,7 @@ describe("defineAgent workspace option", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { workspaceShell } = await import("../src/capabilities.ts")
 
-    const sourceSlotAgent = withAgentDefaults(defineAgent({
+    const sourceSlotAgent = withExplicitWorkspaceName(defineAgent({
       workspace: { sources: { docs: { name: "docs" } as never } },
       driver: {
         instructions: "Answer from the workspace.\n\n{{ workspace.sources }}",
@@ -2879,7 +2889,7 @@ describe("defineAgent workspace option", () => {
     }), { workspace: "docs" })
     await expect(sourceSlotAgent.run!(context())).rejects.toThrow("{{ workspace.sources }}\" is no longer supported")
 
-    const capabilitySlotAgent = withAgentDefaults(defineAgent({
+    const capabilitySlotAgent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       capabilities: [workspaceShell()],
       driver: {
@@ -2904,7 +2914,7 @@ describe("defineAgent workspace option", () => {
       text: "",
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -2927,7 +2937,7 @@ describe("defineAgent workspace option", () => {
       })(),
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -2958,7 +2968,7 @@ describe("defineAgent workspace option", () => {
       })(),
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -2989,7 +2999,7 @@ describe("defineAgent workspace option", () => {
       })(),
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -3025,7 +3035,7 @@ describe("defineAgent workspace option", () => {
       })(),
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -3064,7 +3074,7 @@ describe("defineAgent workspace option", () => {
       }
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -3103,7 +3113,7 @@ describe("defineAgent workspace option", () => {
       }
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -3133,7 +3143,7 @@ describe("defineAgent workspace option", () => {
       }
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
       capabilities: [{
@@ -3170,7 +3180,7 @@ describe("defineAgent workspace option", () => {
       })(),
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -3201,7 +3211,7 @@ describe("defineAgent workspace option", () => {
       })(),
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -3232,7 +3242,7 @@ describe("defineAgent workspace option", () => {
       })(),
     } as never)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -3261,7 +3271,7 @@ describe("defineAgent workspace option", () => {
       yield { finishReason: "tool-calls", type: "finish" }
     })() as never)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -3306,7 +3316,7 @@ describe("defineAgent workspace option", () => {
     }
     agentStream.mockResolvedValueOnce(new StreamResult())
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -3329,7 +3339,7 @@ describe("defineAgent workspace option", () => {
     const onStepEnd = vi.fn()
     const telemetry = { integrations: [], isEnabled: true }
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         execution: {
@@ -3363,7 +3373,7 @@ describe("defineAgent workspace option", () => {
     const resolveModel = vi.fn((metadata: { channel?: { meta?: { customer?: string } } }) => ({
       id: `model-${metadata.channel?.meta?.customer}`,
     }))
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: resolveModel as never },
     }), { workspace: "docs" })
@@ -3386,7 +3396,7 @@ describe("defineAgent workspace option", () => {
     const { webSearch } = await import("../src/capabilities.ts")
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       capabilities: [webSearch({ mode: "model" })],
       driver: { model: {} as never },
@@ -3410,7 +3420,7 @@ describe("defineAgent workspace option", () => {
       yield { text: "ok", type: "text-delta" }
     })()
     const run = vi.fn(async () => stream)
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         run
       },
@@ -3427,7 +3437,7 @@ describe("defineAgent workspace option", () => {
     const wrappedModel = { id: "wrapped" }
     const instrumentModel = vi.fn(() => wrappedModel as never)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         execution: {
@@ -3478,7 +3488,7 @@ describe("defineAgent workspace option", () => {
       metadata: { topK: callSettings.topK },
     }))
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       capabilities: [
         observability({
@@ -3542,7 +3552,7 @@ describe("defineAgent workspace option", () => {
     const { defineAgent } = await import("../src/index.ts")
     const model = { id: "base" }
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         execution: {
@@ -3594,7 +3604,7 @@ describe("defineAgent workspace option", () => {
     const { defineAgent } = await import("../src/index.ts")
     const settingsStart = agentSettings.length
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         execution: {
@@ -3628,7 +3638,7 @@ describe("defineAgent workspace option", () => {
     const onRunToolCallStart = vi.fn()
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         execution: {
@@ -3677,7 +3687,7 @@ describe("defineAgent workspace option", () => {
   it("passes workspace to callback instructions", async () => {
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         instructions: ({ fs, workspace }) => {
@@ -3697,7 +3707,7 @@ describe("defineAgent workspace option", () => {
     readFile.mockResolvedValueOnce("Workspace instructions")
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -3712,7 +3722,7 @@ describe("defineAgent workspace option", () => {
     readFile.mockRejectedValueOnce(new Error("missing"))
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         instructions: ({ fs }) => fs.readFile("MISSING.md"),
@@ -3726,7 +3736,7 @@ describe("defineAgent workspace option", () => {
   it("does not attach workspace tools unless explicitly requested", async () => {
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
@@ -3746,7 +3756,7 @@ describe("defineAgent workspace option", () => {
       return { shell }
     })
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
       capabilities: [{ id: "workspace-tools", tools: toolResolver as never }],
@@ -3765,7 +3775,7 @@ describe("defineAgent workspace option", () => {
     const { defineAgent } = await import("../src/index.ts")
     const search = { execute: vi.fn() }
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
       capabilities: [{ id: "workspace-tools", tools: () => ({ search }) }],
@@ -3799,7 +3809,7 @@ describe("defineAgent workspace option", () => {
     })
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
       capabilities: [{ id: "workspace-shell", tools: ({ workspace }) => workspace.tools.inspect() }],
@@ -3835,7 +3845,7 @@ describe("defineAgent workspace option", () => {
     })
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: { sources: { docs: { cache: { maxAge: 60 }, source: {} } as never } },
       driver: { model: {} as never },
       capabilities: [{ id: "workspace-shell", tools: ({ workspace }) => workspace.tools.inspect() }],
@@ -3871,7 +3881,7 @@ describe("defineAgent workspace option", () => {
     })
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: { sources: { docs: { cache: { maxAge: 60 }, source: {} } as never } },
       driver: { model: {} as never },
       capabilities: [{ id: "bash", tools: ({ workspace }) => workspace.tools.inspect() }],
@@ -3892,7 +3902,7 @@ describe("defineAgent workspace option", () => {
     })
     const { defineAgent } = await import("../src/index.ts")
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: { sources: { docs: { cache: { maxAge: 60 }, source: {} } as never } },
       driver: { model: {} as never },
       capabilities: [{ id: "workspace-shell", tools: ({ workspace }) => workspace.tools.inspect() }],
@@ -3915,7 +3925,7 @@ describe("defineAgent workspace option", () => {
   it("derives DevTools metadata from workspace agents", async () => {
     const { createAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const model = { modelId: "openai/gpt-test", provider: "openai" }
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         sources: {
           docs: { name: "docs" } as never,
@@ -3963,7 +3973,7 @@ describe("defineAgent workspace option", () => {
 
   it("composes static DevTools instruction metadata", async () => {
     const { createAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         instructions: [
@@ -3984,7 +3994,7 @@ describe("defineAgent workspace option", () => {
   it("includes skill sources in DevTools file metadata", async () => {
     const { createAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
       capabilities: [
@@ -4016,7 +4026,7 @@ describe("defineAgent workspace option", () => {
     const { skills } = await import("../src/capabilities.ts")
     exists.mockResolvedValue(true)
 
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       capabilities: [skills({ path: "skills/agent-browser", shellExecution: "write" })],
       driver: {
         harness: { provider: "codex" },
@@ -4040,7 +4050,7 @@ describe("defineAgent workspace option", () => {
 
   it("includes explicit driver.sandbox in harness DevTools metadata", async () => {
     const { defineAgent, resolveAgentDevtoolsMetadata } = await import("../src/index.ts")
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
         harness: { provider: "codex" },
         sandbox: { providerId: "local-test", specificationVersion: "harness-sandbox-v1" },
@@ -4062,7 +4072,7 @@ describe("defineAgent workspace option", () => {
       : [])
     const { defineAgent, resolveAgentDevtoolsMetadata } = await import("../src/index.ts")
     const { workspaceShell } = await import("../src/capabilities.ts")
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: {} as never },
       capabilities: [workspaceShell()],
@@ -4084,7 +4094,7 @@ describe("defineAgent workspace option", () => {
       modelId: `test/${context.invoker.kind || "unknown"}/${context.channel?.meta?.customer || "unknown"}`,
       provider: "test",
     }))
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { model: resolveModel as never },
     }), { workspace: "support" })
@@ -4119,7 +4129,7 @@ describe("defineAgent workspace option", () => {
   it("marks dynamic DevTools instruction metadata without resolving it", async () => {
     const { createAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const readInstructions = vi.fn(async () => "Workspace instructions")
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         instructions: readInstructions,
@@ -4138,7 +4148,7 @@ describe("defineAgent workspace option", () => {
     readFile.mockResolvedValue("# Workspace instructions\n")
     exists.mockResolvedValue(true)
     list.mockResolvedValue([{ path: "AGENTS.md", type: "file" }])
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: {
         instructions: readInstructions,
@@ -4163,7 +4173,7 @@ describe("defineAgent workspace option", () => {
     const { skills, workspaceShell } = await import("../src/capabilities.ts")
     exists.mockResolvedValue(true)
     list.mockResolvedValue([{ path: "AGENTS.md", type: "file" }])
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         sources: {
           docs: { name: "docs" } as never,
@@ -4206,7 +4216,7 @@ describe("defineAgent workspace option", () => {
     ].join("\n"))
     exists.mockResolvedValue(true)
     list.mockResolvedValue([{ path: "AGENTS.md", type: "file" }])
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         sources: {
           docs: { name: "docs" } as never,
@@ -4248,7 +4258,7 @@ describe("defineAgent workspace option", () => {
       "Use tracked capability metadata.",
       "::",
     ].join("\n"))
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       invoker: {
         profiles: [{ id: "support", kind: "support", label: "Support" }],
         resolve: invokerResolve,
@@ -4300,7 +4310,7 @@ describe("defineAgent workspace option", () => {
       { path: "docs/guides", type: "directory" },
       { path: "docs/guides/start.md", type: "file" },
     ])
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         sources: {
           docs: { cache: { maxAge: 60 }, mount: "docs", name: "docs" } as never,
@@ -4355,7 +4365,7 @@ describe("defineAgent workspace option", () => {
       { path: "customers/globex/orders.sql", type: "file" },
       { path: "portal", type: "directory" },
     ])
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       invoker: {
         profiles: [
           { id: "customer", kind: "customer", label: "Customer", meta: { scope: "customer" } },
@@ -4402,7 +4412,7 @@ describe("defineAgent workspace option", () => {
     const { access } = await import("../src/capabilities.ts")
     useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
     exists.mockImplementation(async path => path === "ingestion/acme")
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         sources: {
           ingestion: {
@@ -4463,7 +4473,7 @@ describe("defineAgent workspace option", () => {
       definition,
       workspace: metadataWorkspace,
     }))
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       capabilities: [
         access({
@@ -4530,7 +4540,7 @@ describe("defineAgent workspace option", () => {
       { path: "instructions/AGENTS.md", type: "file" },
       { path: "instructions/private.md", type: "file" },
     ])
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         sources: {
           "forecasting-engine": { name: "forecasting-engine" } as never,
@@ -4566,7 +4576,7 @@ describe("defineAgent workspace option", () => {
     list.mockResolvedValue([
       { mtime: 1710000000000, path: "docs/guides/start.md", size: 128, type: "file" },
     ])
-    const agent = withAgentDefaults(defineAgent({
+    const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {
         sources: {
           docs: { cache: { maxAge: 60 }, mount: "docs", name: "docs" } as never,

--- a/packages/workspace/src/core/registry.ts
+++ b/packages/workspace/src/core/registry.ts
@@ -32,7 +32,6 @@ function workspaceRegistryState(): WorkspaceRegistryState {
 function pickWorkspaceFields(definition: WorkspaceDefinitionInput | Record<string, unknown>): WorkspaceDefinitionInput {
   const {
     __vitehubWorkspaceAgent: _agent,
-    __vitehubWorkspaceAgentDefaults: _agentDefaults,
     __vitehubWorkspaceAgentOptions: _agentOptions,
     description: _description,
     fallback: _fallback,

--- a/test/local/deno-real-project.mjs
+++ b/test/local/deno-real-project.mjs
@@ -186,7 +186,6 @@ async function assertGeneratedOutput() {
   assert(existsSync(denoServer), "missing .vitehub/agent/deno-server.ts")
   const source = await readFile(denoServer, "utf8")
   for (const expected of [
-    "import { withAgentDefaults } from '@vite-hub/agent'",
     "import { createAgentChatRouteHandler, createAgentWebhookRouteHandler } from '@vite-hub/agent/server'",
     "await import('../schedule/deno-cron.mjs').catch",
     "const chatRoutePattern = new RegExp",
@@ -195,6 +194,7 @@ async function assertGeneratedOutput() {
     assert(source.includes(expected), `Deno server output missing ${expected}`)
   }
   for (const forbidden of [
+    "withAgentDefaults",
     "from \"@/",
     "from '@/",
     "import { setWorkspaceRuntimeRegistry } from '@vite-hub/workspace/runtime'",


### PR DESCRIPTION
## Summary

- remove the public `withAgentDefaults()` helper, `AgentHandlerOptions`, and hidden `__vitehubWorkspaceAgentDefaults` metadata
- make explicit `defineAgent({ name })` and runtime `agentIdentity` the only identity paths
- delete redundant DevTools/default plumbing while keeping workspace registration payloads isolated from returned definitions

## Context

This breaking draft is stacked on #561, which first moves generated hosts, workflows, tests, and DevTools to discovered runtime identity. Keeping the old cloning helper after that migration would preserve two competing identity models.

Custom hosts now pass `agentIdentity` when invoking a discovered Agent. `registerWorkspaceAgent()` returns the original definition and registers a source-root-enriched workspace payload; a regression test invokes that returned definition with runtime identity and reads its colocated workspace file.

## Validation

- `corepack pnpm --filter @vite-hub/agent typecheck`
- `corepack pnpm --filter @vite-hub/agent test` — 42 files, 1022 tests
- Agent build and publint
- Oxlint on the changed runtime and tests — no errors
- `git diff --check`

The diff is net deletion: 189 additions / 323 deletions. The only non-implementation references to `withAgentDefaults` are negative assertions proving it is absent from public and generated output.