### PR TITLE
feat(agent): expose one cronjob tool

### DIFF
--- a/docs/content/docs/capabilities/schedule.md
+++ b/docs/content/docs/capabilities/schedule.md
@@ -1,6 +1,6 @@
 ---
 title: Schedule
-description: Declare Agent Schedules or expose Runtime Schedule tools to an Agent.
+description: Declare Agent Schedules or let an Agent manage Runtime Schedules through one cronjob tool.
 navigation.title: Schedule
 navigation.order: 110
 navigation.group: Runtime primitives
@@ -8,7 +8,7 @@ icon: i-lucide-calendar-clock
 ---
 
 `schedule()` covers two schedule-related Agent abilities.
-It can declare fixed Agent Schedules as Capability metadata, or it can expose Runtime Schedule read and edit tools when configured with a mode.
+It can declare fixed Agent Schedules as Capability metadata, or it can expose one `cronjob` tool for Runtime Schedules when configured with a mode.
 
 ## Installation
 
@@ -18,7 +18,7 @@ Use the configuration example below as the starting point, then tighten modes, p
 ## What it adds
 
 Static Agent Schedule mode records one or more five-field UTC cron expressions on the Capability.
-Runtime Schedule mode contributes `schedule_read` and, in write mode, `schedule_edit`.
+Runtime Schedule mode contributes one `cronjob` tool. Read mode supports `targets`, `list`, and `get`. Write mode also supports `create`, `edit`, `pause`, `resume`, `run`, and `delete`.
 
 ## Configuration
 
@@ -42,7 +42,7 @@ export default defineAgent({
 ## Runtime behavior
 
 Static schedules add metadata that framework integrations and schedule-aware runtime behavior can inspect.
-Runtime Schedule mode reads visible Runtime Schedules and can create, update, enable, disable, or delete scoped schedules when write mode is enabled.
+Runtime Schedule mode reads visible Runtime Schedules and can create, edit, pause, resume, run, or delete scoped schedules when write mode is enabled.
 
 ## Requirements
 
@@ -63,7 +63,7 @@ Self-targeting requires explicit self-target permission.
 ## Inspect and verify
 
 Inspect Capability metadata for static schedule ids and cron expressions.
-For Runtime Schedule mode, inspect the tool list and verify `schedule_edit` appears only in write mode.
+For Runtime Schedule mode, inspect the tool list and verify it contains only `cronjob` for scheduling. Its schema exposes only read operations in read mode.
 
 Run a schedule with a six-field cron expression during development.
 The Capability should reject it before the Agent starts.
@@ -77,7 +77,7 @@ The Capability should reject it before the Agent starts.
 | `targets` | `string[]` | all visible targets | Allowlist of Runtime Schedule target names. |
 | `selfTarget` | `string` | none | Target name of the owning Agent. |
 | `allowSelfTarget` | `boolean` | `false` | Allows Runtime Schedule tools to target the owning Agent. |
-| `policy` | `AgentToolPolicyDecision \| function` | `"require-approval"` | Policy for `schedule_edit`. |
+| `policy` | `AgentToolPolicyDecision \| function` | `"require-approval"` | Policy for mutating `cronjob` operations. Read operations remain allowed. |
 
 ## Reference
 

--- a/packages/agent/src/capabilities/schedule.ts
+++ b/packages/agent/src/capabilities/schedule.ts
@@ -65,18 +65,17 @@ interface RuntimeScheduleClientLike {
   enable: (id: string) => MaybePromise<RuntimeScheduleRecordLike>
   get: (id: string) => MaybePromise<RuntimeScheduleRecordLike | undefined>
   list: () => MaybePromise<RuntimeScheduleRecordLike[]>
+  run: (id: string) => MaybePromise<unknown>
   update: (id: string, input: { cron?: string, enabled?: boolean, target?: string }) => MaybePromise<RuntimeScheduleRecordLike>
 }
 
-interface RuntimeScheduleReadInput {
+interface RuntimeScheduleToolInput {
+  cron?: string
+  enabled?: boolean
   id?: string
-  operation?: "get" | "list" | "targets"
+  operation?: "create" | "delete" | "edit" | "get" | "list" | "pause" | "resume" | "run" | "targets"
+  target?: string
 }
-
-type RuntimeScheduleEditInput =
-  | { cron: string, enabled?: boolean, id?: string, operation: "create", target: string }
-  | { cron?: string, enabled?: boolean, id: string, operation: "update", target?: string }
-  | { id: string, operation: "delete" | "disable" | "enable" }
 
 type NormalizedRuntimeScheduleCapabilityOptions = Omit<RuntimeScheduleCapabilityOptions<string>, "allowSelfTarget" | "targets"> & {
   allowSelfTarget: boolean
@@ -89,7 +88,7 @@ function scheduleClient(context: AgentCapabilityContext, mode: AgentCapabilityMo
     ? (handle as { schedules?: unknown }).schedules
     : handle
   const methods = mode === "write"
-    ? ["create", "delete", "disable", "enable", "get", "list", "update"] as const
+    ? ["create", "delete", "disable", "enable", "get", "list", "run", "update"] as const
     : ["get", "list"] as const
   if (!client || typeof client !== "object" || methods.some(method => typeof (client as Record<string, unknown>)[method] !== "function")) {
     throw new Error(`[vitehub] schedule primitive must expose the Runtime Schedule ${mode} client methods.`)
@@ -219,7 +218,7 @@ function assertRuntimeScheduleInputKeys(input: Record<string, unknown> | undefin
 function visibleRuntimeSchedules(records: RuntimeScheduleRecordLike[], options: Pick<RuntimeScheduleCapabilityOptions, "allowSelfTarget" | "selfTarget" | "targets">): RuntimeScheduleRecordLike[] {
   return records.filter((record) => {
     try {
-      assertAllowedRuntimeScheduleTarget(record.target, options, "schedule_read")
+      assertAllowedRuntimeScheduleTarget(record.target, options, "cronjob")
       return true
     }
     catch {
@@ -231,7 +230,7 @@ function visibleRuntimeSchedules(records: RuntimeScheduleRecordLike[], options: 
 function visibleRuntimeScheduleTargets(options: Pick<RuntimeScheduleCapabilityOptions, "allowSelfTarget" | "selfTarget" | "targets">): readonly string[] | undefined {
   return options.targets?.filter((target) => {
     try {
-      assertAllowedRuntimeScheduleTarget(target, options, "schedule_read")
+      assertAllowedRuntimeScheduleTarget(target, options, "cronjob")
       return true
     }
     catch {
@@ -243,109 +242,112 @@ function visibleRuntimeScheduleTargets(options: Pick<RuntimeScheduleCapabilityOp
 async function requireScopedRuntimeSchedule(client: RuntimeScheduleClientLike, id: string, options: Pick<RuntimeScheduleCapabilityOptions, "allowSelfTarget" | "selfTarget" | "targets">): Promise<RuntimeScheduleRecordLike> {
   const record = await client.get(id)
   if (!record) throw new Error(`[vitehub] Runtime Schedule not found: ${id}`)
-  assertAllowedRuntimeScheduleTarget(record.target, options, "schedule_edit")
+  assertAllowedRuntimeScheduleTarget(record.target, options, "cronjob")
   return record
 }
 
 const runtimeScheduleTargetSchema = { description: "Runtime Schedule target name.", type: "string" }
 const runtimeScheduleCronSchema = { description: "Five-field UTC cron expression.", type: "string" }
 
-const runtimeScheduleReadInputSchema = jsonObjectSchema({
-  id: { description: "Runtime Schedule id for get.", type: "string" },
-  operation: { default: "list", enum: ["get", "list", "targets"], type: "string" },
-})
-
-const runtimeScheduleEditInputSchema = {
-  oneOf: [
+function runtimeScheduleInputSchema(mode: AgentCapabilityMode) {
+  const variants = [
     jsonObjectSchema({
-      cron: runtimeScheduleCronSchema,
-      enabled: { type: "boolean" },
-      id: { type: "string" },
-      operation: { const: "create", type: "string" },
-      target: runtimeScheduleTargetSchema,
-    }, ["cron", "operation", "target"]),
-    jsonObjectSchema({
-      cron: runtimeScheduleCronSchema,
-      enabled: { type: "boolean" },
-      id: { type: "string" },
-      operation: { const: "update", type: "string" },
-      target: runtimeScheduleTargetSchema,
-    }, ["id", "operation"]),
-    jsonObjectSchema({
-      id: { type: "string" },
-      operation: { enum: ["delete", "disable", "enable"], type: "string" },
-    }, ["id", "operation"]),
-  ],
+      id: { description: "Runtime Schedule id for get.", type: "string" },
+      operation: { default: "list", enum: ["get", "list", "targets"], type: "string" },
+    }),
+  ]
+  if (mode === "write") {
+    variants.push(
+      jsonObjectSchema({
+        cron: runtimeScheduleCronSchema,
+        enabled: { type: "boolean" },
+        id: { type: "string" },
+        operation: { const: "create", type: "string" },
+        target: runtimeScheduleTargetSchema,
+      }, ["cron", "operation", "target"]),
+      jsonObjectSchema({
+        cron: runtimeScheduleCronSchema,
+        enabled: { type: "boolean" },
+        id: { type: "string" },
+        operation: { const: "edit", type: "string" },
+        target: runtimeScheduleTargetSchema,
+      }, ["id", "operation"]),
+      jsonObjectSchema({
+        id: { type: "string" },
+        operation: { enum: ["delete", "pause", "resume", "run"], type: "string" },
+      }, ["id", "operation"]),
+    )
+  }
+  return { oneOf: variants }
 }
 
 function runtimeScheduleTools(options: NormalizedRuntimeScheduleCapabilityOptions): AgentCapabilityDefinition["tools"] {
   return (context) => {
     const client = scheduleClient(context as never, options.mode)
+    const writeOperations = new Set(["create", "delete", "edit", "pause", "resume", "run"])
+    const writePolicy = options.policy || "require-approval"
     const tools: AgentToolSet = {
-      schedule_read: createTool<RuntimeScheduleReadInput>({
-        description: "Read visible Runtime Schedules or the Schedule Capability target allowlist.",
-        async execute(input: RuntimeScheduleReadInput = {}) {
-          assertRuntimeScheduleInputKeys(input as Record<string, unknown>, ["id", "operation"], "schedule_read")
+      cronjob: createTool<RuntimeScheduleToolInput>({
+        description: "List, inspect, create, edit, pause, resume, run, or delete scoped cron jobs.",
+        async execute(input: RuntimeScheduleToolInput = {}) {
           const operation = input.operation || "list"
+          if (writeOperations.has(operation) && options.mode !== "write") {
+            throw new Error(`[vitehub] cronjob ${operation} requires Schedule Capability write mode.`)
+          }
+          assertRuntimeScheduleInputKeys(input as Record<string, unknown>, operation === "create" || operation === "edit" ? ["cron", "enabled", "id", "operation", "target"] : ["id", "operation"], "cronjob")
           if (operation === "targets") return { targets: visibleRuntimeScheduleTargets(options) }
           if (operation === "get") {
-            const record = await client.get(assertRuntimeScheduleId(input.id, "schedule_read"))
+            const record = await client.get(assertRuntimeScheduleId(input.id, "cronjob get"))
             if (!record) return undefined
-            assertAllowedRuntimeScheduleTarget(record.target, options, "schedule_read")
+            assertAllowedRuntimeScheduleTarget(record.target, options, "cronjob get")
             return record
           }
           if (operation === "list") return visibleRuntimeSchedules(await client.list(), options)
-          throw new Error(`[vitehub] Unsupported schedule_read operation: ${String(operation)}`)
-        },
-        inputSchema: runtimeScheduleReadInputSchema,
-        name: "schedule_read",
-      }),
-    }
-
-    if (options.mode === "write") {
-      tools.schedule_edit = createTool<RuntimeScheduleEditInput>({
-        description: "Create, update, enable, disable, or delete scoped Runtime Schedules.",
-        async execute(input) {
-          assertRuntimeScheduleInputKeys(input as Record<string, unknown> | undefined, ["cron", "enabled", "id", "operation", "target"], "schedule_edit")
-          const operation = input?.operation
           if (operation === "create") {
             return await client.create({
-              cron: assertRuntimeScheduleCron(input.cron, "schedule_edit create"),
-              enabled: assertOptionalRuntimeScheduleEnabled(input.enabled, "schedule_edit create"),
-              id: assertOptionalRuntimeScheduleId(input.id, "schedule_edit create"),
-              target: assertAllowedRuntimeScheduleTarget(input.target, options, "schedule_edit create"),
+              cron: assertRuntimeScheduleCron(input.cron, "cronjob create"),
+              enabled: assertOptionalRuntimeScheduleEnabled(input.enabled, "cronjob create"),
+              id: assertOptionalRuntimeScheduleId(input.id, "cronjob create"),
+              target: assertAllowedRuntimeScheduleTarget(input.target, options, "cronjob create"),
             })
           }
-          if (operation === "update") {
-            const id = assertRuntimeScheduleId(input.id, "schedule_edit update")
+          if (operation === "edit") {
+            const id = assertRuntimeScheduleId(input.id, "cronjob edit")
             await requireScopedRuntimeSchedule(client, id, options)
             const update: { cron?: string, enabled?: boolean, target?: string } = {}
-            if (input.cron !== undefined) update.cron = assertRuntimeScheduleCron(input.cron, "schedule_edit update")
-            if (input.enabled !== undefined) update.enabled = assertOptionalRuntimeScheduleEnabled(input.enabled, "schedule_edit update")
-            if (input.target !== undefined) update.target = assertAllowedRuntimeScheduleTarget(input.target, options, "schedule_edit update")
+            if (input.cron !== undefined) update.cron = assertRuntimeScheduleCron(input.cron, "cronjob edit")
+            if (input.enabled !== undefined) update.enabled = assertOptionalRuntimeScheduleEnabled(input.enabled, "cronjob edit")
+            if (input.target !== undefined) update.target = assertAllowedRuntimeScheduleTarget(input.target, options, "cronjob edit")
             return await client.update(id, update)
           }
-          if (operation === "enable") {
-            const id = assertRuntimeScheduleId(input.id, "schedule_edit enable")
+          if (operation === "resume") {
+            const id = assertRuntimeScheduleId(input.id, "cronjob resume")
             await requireScopedRuntimeSchedule(client, id, options)
             return await client.enable(id)
           }
-          if (operation === "disable") {
-            const id = assertRuntimeScheduleId(input.id, "schedule_edit disable")
+          if (operation === "pause") {
+            const id = assertRuntimeScheduleId(input.id, "cronjob pause")
             await requireScopedRuntimeSchedule(client, id, options)
             return await client.disable(id)
           }
+          if (operation === "run") {
+            const id = assertRuntimeScheduleId(input.id, "cronjob run")
+            await requireScopedRuntimeSchedule(client, id, options)
+            return await client.run(id)
+          }
           if (operation === "delete") {
-            const id = assertRuntimeScheduleId(input.id, "schedule_edit delete")
+            const id = assertRuntimeScheduleId(input.id, "cronjob delete")
             await requireScopedRuntimeSchedule(client, id, options)
             return await client.delete(id)
           }
-          throw new Error(`[vitehub] Unsupported schedule_edit operation: ${String(operation)}`)
+          throw new Error(`[vitehub] Unsupported cronjob operation: ${String(operation)}`)
         },
-        inputSchema: runtimeScheduleEditInputSchema,
-        name: "schedule_edit",
-        policy: options.policy || "require-approval",
-      })
+        inputSchema: runtimeScheduleInputSchema(options.mode),
+        name: "cronjob",
+        policy: async policyContext => writeOperations.has((policyContext.input as { operation?: unknown } | undefined)?.operation as string)
+          ? typeof writePolicy === "function" ? await writePolicy(policyContext) : writePolicy
+          : "allow",
+      }),
     }
 
     return tools

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -30,7 +30,7 @@ describe("storage capabilities", () => {
         schedule({ schedules: ["0 9 * * *"] }),
         schedule({ mode: "read", targets: ["reports"] }),
       ],
-    }, runtime({ schedule: { schedules } }), {}).then(resolved => Object.keys(resolved.tools!).sort())).resolves.toEqual(["schedule_read"])
+    }, runtime({ schedule: { schedules } }), {}).then(resolved => Object.keys(resolved.tools!).sort())).resolves.toEqual(["cronjob"])
   })
 
   it("exposes scoped Runtime Schedule read and edit tools", async () => {
@@ -46,32 +46,38 @@ describe("storage capabilities", () => {
       enable: vi.fn(async id => ({ ...records.find(record => record.id === id)!, enabled: true })),
       get: vi.fn(async id => records.find(record => record.id === id)),
       list: vi.fn(async () => records),
+      run: vi.fn(async id => ({ id: `run-${id}`, scheduleId: id })),
       update: vi.fn(async (id, input) => ({ ...records.find(record => record.id === id)!, ...input })),
     }
 
-    await expect(resolveTools([schedule({ mode: "read", targets: ["reports"] })], { schedule: { schedules } }).then(tools => Object.keys(tools).sort())).resolves.toEqual(["schedule_read"])
+    await expect(resolveTools([schedule({ mode: "read", targets: ["reports"] })], { schedule: { schedules } }).then(tools => Object.keys(tools).sort())).resolves.toEqual(["cronjob"])
 
     const tools = await resolveTools([schedule({ mode: "write", policy: "allow", targets: ["reports"] })], { schedule: { schedules } })
-    expect(Object.keys(tools).sort()).toEqual(["schedule_edit", "schedule_read"])
-    expect(tools.schedule_edit?.policy).toBe("allow")
+    expect(Object.keys(tools)).toEqual(["cronjob"])
+    expect(await (tools.cronjob!.policy as (context: { input?: unknown, name: string }) => unknown)({ input: { operation: "list" }, name: "cronjob" })).toBe("allow")
 
-    await expect(tools.schedule_read!.execute?.({ operation: "targets" })).resolves.toEqual({ targets: ["reports"] })
-    await expect(tools.schedule_read!.execute?.({ operation: "list" })).resolves.toEqual([records[0]])
-    await expect(tools.schedule_read!.execute?.({ id: "daily", operation: "get" })).resolves.toEqual(records[0])
-    await expect(tools.schedule_read!.execute?.({ id: "private", operation: "get" })).rejects.toThrow("allowlist")
+    await expect(tools.cronjob!.execute?.({ operation: "targets" })).resolves.toEqual({ targets: ["reports"] })
+    await expect(tools.cronjob!.execute?.({ operation: "list" })).resolves.toEqual([records[0]])
+    await expect(tools.cronjob!.execute?.({ id: "daily", operation: "get" })).resolves.toEqual(records[0])
+    await expect(tools.cronjob!.execute?.({ id: "private", operation: "get" })).rejects.toThrow("allowlist")
 
-    await tools.schedule_edit!.execute?.({ cron: "15 9 * * *", id: "new-daily", operation: "create", target: "reports" })
+    await tools.cronjob!.execute?.({ cron: "15 9 * * *", id: "new-daily", operation: "create", target: "reports" })
     expect(schedules.create).toHaveBeenCalledWith({ cron: "15 9 * * *", enabled: undefined, id: "new-daily", target: "reports" })
 
-    await expect(tools.schedule_edit!.execute?.({ cron: "0 8 * * *", operation: "create", target: "private" })).rejects.toThrow("allowlist")
-    await expect(tools.schedule_edit!.execute?.({ cron: "0 8 * * *", operation: "create", target: "reports", timezone: "UTC" } as never)).rejects.toThrow()
-    await expect(tools.schedule_edit!.execute?.({ cron: "0 8 * * *", enabled: "false", operation: "create", target: "reports" } as never)).rejects.toThrow("enabled must be a boolean")
-    await expect(tools.schedule_edit!.execute?.({ cron: "0 8 * * *", id: 123, operation: "create", target: "reports" } as never)).rejects.toThrow("id must be a non-empty Runtime Schedule id")
-    await expect(tools.schedule_edit!.execute?.({ cron: "0 8 * * *", id: "", operation: "create", target: "reports" })).rejects.toThrow("id must be a non-empty Runtime Schedule id")
-    await tools.schedule_edit!.execute?.({ cron: "30 9 * * *", id: "daily", operation: "update" })
+    await expect(tools.cronjob!.execute?.({ cron: "0 8 * * *", operation: "create", target: "private" })).rejects.toThrow("allowlist")
+    await expect(tools.cronjob!.execute?.({ cron: "0 8 * * *", operation: "create", target: "reports", timezone: "UTC" } as never)).rejects.toThrow()
+    await expect(tools.cronjob!.execute?.({ cron: "0 8 * * *", enabled: "false", operation: "create", target: "reports" } as never)).rejects.toThrow("enabled must be a boolean")
+    await expect(tools.cronjob!.execute?.({ cron: "0 8 * * *", id: 123, operation: "create", target: "reports" } as never)).rejects.toThrow("id must be a non-empty Runtime Schedule id")
+    await expect(tools.cronjob!.execute?.({ cron: "0 8 * * *", id: "", operation: "create", target: "reports" })).rejects.toThrow("id must be a non-empty Runtime Schedule id")
+    await tools.cronjob!.execute?.({ cron: "30 9 * * *", id: "daily", operation: "edit" })
     expect(schedules.update).toHaveBeenCalledWith("daily", { cron: "30 9 * * *" })
-    await expect(tools.schedule_edit!.execute?.({ enabled: "false", id: "daily", operation: "update" } as never)).rejects.toThrow("enabled must be a boolean")
-    await expect(tools.schedule_edit!.execute?.({ id: "private", operation: "delete" })).rejects.toThrow("allowlist")
+    await tools.cronjob!.execute?.({ id: "daily", operation: "pause" })
+    expect(schedules.disable).toHaveBeenCalledWith("daily")
+    await tools.cronjob!.execute?.({ id: "daily", operation: "resume" })
+    expect(schedules.enable).toHaveBeenCalledWith("daily")
+    await expect(tools.cronjob!.execute?.({ id: "daily", operation: "run" })).resolves.toEqual({ id: "run-daily", scheduleId: "daily" })
+    await expect(tools.cronjob!.execute?.({ enabled: "false", id: "daily", operation: "edit" } as never)).rejects.toThrow("enabled must be a boolean")
+    await expect(tools.cronjob!.execute?.({ id: "private", operation: "delete" })).rejects.toThrow("allowlist")
   })
 
   it("blocks self-targeting Runtime Schedules unless explicitly allowed", async () => {
@@ -83,14 +89,15 @@ describe("storage capabilities", () => {
       enable: vi.fn(),
       get: vi.fn(),
       list: vi.fn(async () => []),
+      run: vi.fn(),
       update: vi.fn(),
     }
 
     const blocked = await resolveTools([schedule({ mode: "write", selfTarget: "agent/daily", targets: ["agent/daily"] })], { schedule: schedules })
-    await expect(blocked.schedule_edit!.execute?.({ cron: "0 9 * * *", operation: "create", target: "agent/daily" })).rejects.toThrow("Self Schedule Permission")
+    await expect(blocked.cronjob!.execute?.({ cron: "0 9 * * *", operation: "create", target: "agent/daily" })).rejects.toThrow("Self Schedule Permission")
 
     const allowed = await resolveTools([schedule({ allowSelfTarget: true, mode: "write", selfTarget: "agent/daily", targets: ["agent/daily"] })], { schedule: schedules })
-    await expect(allowed.schedule_edit!.execute?.({ cron: "0 9 * * *", operation: "create", target: "agent/daily" })).resolves.toMatchObject({ target: "agent/daily" })
+    await expect(allowed.cronjob!.execute?.({ cron: "0 9 * * *", operation: "create", target: "agent/daily" })).resolves.toMatchObject({ target: "agent/daily" })
   })
 
   it("applies self-target permissions to Runtime Schedule list results", async () => {
@@ -106,8 +113,8 @@ describe("storage capabilities", () => {
       },
     })
 
-    await expect(tools.schedule_read!.execute?.({ operation: "targets" })).resolves.toEqual({ targets: ["reports"] })
-    await expect(tools.schedule_read!.execute?.({ operation: "list" })).resolves.toEqual([records[1]])
+    await expect(tools.cronjob!.execute?.({ operation: "targets" })).resolves.toEqual({ targets: ["reports"] })
+    await expect(tools.cronjob!.execute?.({ operation: "list" })).resolves.toEqual([records[1]])
   })
 
   it("accepts read-only Runtime Schedule clients in read mode", async () => {
@@ -119,7 +126,7 @@ describe("storage capabilities", () => {
       },
     })
 
-    expect(Object.keys(tools)).toEqual(["schedule_read"])
+    expect(Object.keys(tools)).toEqual(["cronjob"])
   })
 
   it("uses strict Runtime Schedule tool schemas", async () => {
@@ -132,11 +139,12 @@ describe("storage capabilities", () => {
         enable: vi.fn(),
         get: vi.fn(),
         list: vi.fn(),
+        run: vi.fn(),
         update: vi.fn(),
       },
     })
 
-    expect(tools.schedule_edit!.inputSchema).toMatchObject({
+    expect(tools.cronjob!.inputSchema).toMatchObject({
       oneOf: expect.arrayContaining([
         expect.objectContaining({
           additionalProperties: false,


### PR DESCRIPTION
Replaces the separate `schedule_read` and `schedule_edit` tools with one `cronjob` tool. Read mode exposes `targets`, `list`, and `get`; write mode adds `create`, `edit`, `pause`, `resume`, `run`, and `delete`, including immediate execution through the existing Runtime Schedule client.

Read operations remain automatically allowed while mutating operations retain the configured policy and default approval requirement. Target allowlists and explicit self-target permission continue to apply to every operation.

## Coordination

This PR and #554 can merge independently, but both touch the Schedule Capability implementation, tests, and docs. The later merge will need a focused rebase.
