### PR TITLE
docs(workspace): clarify trusted-host service account boundary

### DIFF
--- a/docs/content/docs/capabilities/workspace-shell.md
+++ b/docs/content/docs/capabilities/workspace-shell.md
@@ -50,6 +50,7 @@ In read mode, the Agent receives inspection tools from the active Workspace faca
 In write mode, the Agent receives writable Workspace tools when the Workspace exposes them.
 When `commands` is set, ViteHub starts a Workspace Session for each `workspace_exec` call.
 Read mode runs the command without committing Workspace changes; write mode commits successful command results back to the Workspace Store.
+The mode controls Workspace tools and writeback only. It does not make an executed command read-only or prevent side effects on the host.
 
 ## Requirements
 
@@ -80,7 +81,9 @@ export default defineAgent({
 })
 ```
 
-This is not isolation. The Agent can run `sh`, `gh`, `git`, generated scripts, and any other reachable executable with the filesystem, network, process, and inherited environment authority of the service account. Use a dedicated service account or container with narrowly scoped credentials, mounts, and network access.
+Trusted-host commands run as the ViteHub service account and inherit its full process environment. Tools such as `git`, `gh`, and `ssh` therefore use values such as `HOME`, `XDG_CONFIG_HOME`, `GH_CONFIG_DIR`, and `SSH_AUTH_SOCK`; application secrets in the process environment are inherited too.
+
+Workspace rules and Workspace Scope constrain materialization and the diff ViteHub commits back to the Workspace Store. They do not constrain direct host effects through absolute paths or child processes. This is not isolation: the Agent can run `sh`, `gh`, `git`, generated scripts, and any other reachable executable with the service account's filesystem, network, credential, and process authority. Use a dedicated service account or container with narrowly scoped credentials, mounts, and network access.
 
 ## Driver support
 

--- a/docs/content/docs/server-primitives/workspace.md
+++ b/docs/content/docs/server-primitives/workspace.md
@@ -137,7 +137,7 @@ Source keys identify named origins inside the Workspace Source Map. A Source-Bac
 | `plugins` | `WorkspacePlugin[]` | Bundled rules and hooks. |
 | `loaders` | `WorkspaceLoader[]` | Build-time or runtime loaders. |
 | `publish` | `WorkspacePublisher[]` | Publication behavior after snapshots or sync. |
-| `runtime` | `'sandbox'` | Runtime mode hint for sandbox-backed execution. |
+| `runtime` | `WorkspaceRuntime` | Runtime for executable Workspace Sessions, including sandbox and explicitly trusted host execution. |
 
 ## Source Binding options
 
@@ -294,7 +294,7 @@ export async function testDocs() {
 
 Workspace owns the file tree and commit behavior. [Shell](/docs/server-primitives/shell) owns controlled command sessions, and [Sandbox](/docs/server-primitives/sandbox) owns isolated execution providers.
 
-`runtime: 'trusted-host'` runs commands on the host machine in a temporary materialized Workspace directory and is rejected when `NODE_ENV=production`. Use it only for projects and Sources you trust.
+`runtime: 'trusted-host'` runs commands on the host machine in a temporary materialized Workspace directory and is rejected when `NODE_ENV=production` unless configured as `{ type: 'trusted-host', allowProduction: true }`. Use it only for projects and Sources you trust.
 
 ### Run sessions from the CLI
 

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -42,6 +42,38 @@ describe("trusted host workspace runtime", () => {
     await expect(workspace.readFile("generated/result.txt")).resolves.toBe("done\n")
   })
 
+  it("inherits the host service account environment", async () => {
+    const serviceEnvironment = {
+      GH_CONFIG_DIR: "/home/vitehub/.config/gh",
+      HOME: "/home/vitehub",
+      SSH_AUTH_SOCK: "/run/user/1000/ssh-agent",
+      XDG_CONFIG_HOME: "/home/vitehub/.config",
+    }
+    for (const [key, value] of Object.entries(serviceEnvironment)) vi.stubEnv(key, value)
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+
+    const session = await workspace.startSession()
+    const result = await session.exec(process.execPath, [
+      "-e",
+      `process.stdout.write(JSON.stringify({
+        GH_CONFIG_DIR: process.env.GH_CONFIG_DIR,
+        HOME: process.env.HOME,
+        SSH_AUTH_SOCK: process.env.SSH_AUTH_SOCK,
+        XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+      }))`,
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(JSON.parse(result.stdout)).toEqual(serviceEnvironment)
+    await session.close()
+  })
+
   it("rejects changes outside scoped session paths", async () => {
     const workspace = createWorkspace({
       ...defineWorkspace({


### PR DESCRIPTION
Documents the trusted-host service-account boundary and locks the existing environment inheritance contract with a real Workspace Session regression test. Commands run as the ViteHub service account and inherit `HOME`, XDG and GitHub CLI configuration, the SSH agent socket, and other process secrets, so tools such as `git`, `gh`, and `ssh` can reuse that account's setup.

Clarifies that read mode controls Workspace tools and writeback rather than host side effects, and that Workspace rules and Workspace Scope do not sandbox arbitrary host processes. Also corrects the Workspace runtime reference to include trusted-host execution and its explicit `allowProduction` opt-in.

Validated with the complete `@vite-hub/workspace` suite (25 files, 374 tests), package type checking and build/publint, the documentation production build, focused Oxlint, strict review, and `git diff --check`.