### PR TITLE
feat(schedule): add runtime inputs and targets

### DIFF
--- a/docs/content/docs/server-primitives/schedule.md
+++ b/docs/content/docs/server-primitives/schedule.md
@@ -50,6 +50,7 @@ export default defineSchedule({
 | Import | Use |
 | --- | --- |
 | `defineSchedule` from `@vite-hub/schedule` | Declare a Static Schedule Definition. |
+| `defineScheduleTarget` from `@vite-hub/schedule` | Declare a cronless target for Runtime Schedules. |
 | `schedules`, `validateRuntimeScheduleCron` from `@vite-hub/schedule` or `@vite-hub/schedule/runtime` | Manage Runtime Schedules and validate cron strings. |
 | `executeSchedule`, `executeStaticSchedule`, `executeRuntimeSchedule`, `createScheduleRun` from `@vite-hub/schedule` | Execute schedules from provider hooks or custom runtime wiring. |
 | `startScheduleRunner` from `@vite-hub/schedule` | Run due Runtime Schedules on long-running hosts. |
@@ -122,11 +123,25 @@ Cron expressions use the Schedule Time Base, currently UTC. The discovered file 
 | `handler` | `ScheduleHandler` | Yes | Function called with Schedule Run Context. |
 | `allowRuntimeSchedules` | `boolean` | No | Allows Runtime Schedules to target this definition. |
 
-`ScheduleRunContext` includes `id`, `scheduledAt`, optional `attemptId`, optional `runId`, optional Runtime Schedule id, and optional Runtime Schedule target.
+`ScheduleRunContext` includes `id`, `scheduledAt`, optional `attemptId`, optional `runId`, optional Runtime Schedule id, optional Runtime Schedule target, and optional Runtime Schedule `input`.
 
 ## Create recurring Runtime Schedules
 
 Runtime Schedules are dynamic cron schedules stored by ViteHub. A Runtime Schedule can target only a Runtime Schedule Target that opted into runtime reuse. Set an IANA `timeZone` when the cron should follow local civil time and daylight-saving changes; omit it to keep UTC behavior.
+
+Use `defineScheduleTarget()` when the handler should run only through Runtime Schedules and does not need its own build-time cron. These targets are runtime-eligible by construction and do not emit static provider output.
+
+```ts [server/schedules/report.ts]
+import { defineScheduleTarget } from '@vite-hub/schedule'
+
+export default defineScheduleTarget<{ prompt: string }>({
+  async handler({ input }) {
+    if (input) await generateReport(input.prompt)
+  },
+})
+```
+
+`defineSchedule()` remains cron-required and can opt into runtime reuse with `allowRuntimeSchedules`:
 
 ```ts [server/schedules/daily-report.ts]
 import { defineSchedule } from '@vite-hub/schedule'
@@ -149,7 +164,8 @@ export default defineEventHandler(async () => {
   return schedules.create({
     cron: '30 8 * * 1-5',
     id: 'weekday-report',
-    target: 'daily-report',
+    input: { prompt: 'Summarize yesterday' },
+    target: 'report',
     timeZone: 'Europe/Copenhagen',
   })
 })
@@ -160,12 +176,13 @@ export default defineEventHandler(async () => {
 | Input | Type | Required | Description |
 | --- | --- | --- | --- |
 | `cron` | `string` | create only | Five-field cron expression evaluated in `timeZone`, or UTC when `timeZone` is omitted. |
-| `target` | `ScheduleTargetName` | create only | Static Schedule Definition that set `allowRuntimeSchedules: true`. |
+| `target` | `ScheduleTargetName` | create only | A `defineScheduleTarget()` declaration or Static Schedule Definition that set `allowRuntimeSchedules: true`. |
 | `id` | `string` | No | Stable Runtime Schedule id. ViteHub generates one when omitted. |
 | `enabled` | `boolean` | No | Whether the Runtime Schedule should execute. Defaults to `true` on create. |
+| `input` | `unknown` | No | Opaque input passed to the target handler as `context.input`. |
 | `timeZone` | `string` | No | Named IANA time zone used to evaluate the cron expression. Numeric offsets such as `+01:00` are rejected. Defaults to UTC. |
 
-`RuntimeScheduleUpdateInput` accepts `cron`, `target`, `enabled`, and `timeZone`. Omitting `timeZone` on update preserves the stored zone; set it explicitly to `UTC` to reset UTC evaluation.
+`RuntimeScheduleUpdateInput` accepts `cron`, `target`, `enabled`, `input`, and `timeZone`. Create stores an input snapshot. Providing `input` on update replaces the complete snapshot; omitting it preserves the existing value. Schedule does not merge or interpret input, and the configured store must support the value's serialization requirements. Omitting `timeZone` on update preserves the stored zone; set it explicitly to `UTC` to reset UTC evaluation.
 
 Local cron matching follows conventional daylight-saving behavior: a local time missing during a DST gap is skipped, while both distinct instants in a repeated local time during a DST overlap run.
 

--- a/packages/schedule/README.md
+++ b/packages/schedule/README.md
@@ -33,6 +33,17 @@ export default defineSchedule({
 ```
 
 ```ts
+// server/schedules/report.ts
+import { defineScheduleTarget } from "@vite-hub/schedule"
+
+export default defineScheduleTarget<{ prompt: string }>({
+  handler: async ({ input }) => {
+    if (input) await generateReport(input.prompt)
+  },
+})
+```
+
+```ts
 // server/api/schedules.post.ts
 import { schedules } from "@vite-hub/schedule/runtime"
 import { defineEventHandler } from "h3"
@@ -40,7 +51,8 @@ import { defineEventHandler } from "h3"
 export default defineEventHandler(() => {
   return schedules.create({
     cron: "30 3 * * 1",
-    target: "daily-report",
+    input: { prompt: "Summarize yesterday" },
+    target: "report",
     timeZone: "Europe/Copenhagen",
   })
 })
@@ -60,7 +72,9 @@ export default defineConfig({
 
 ## Vite Integration
 
-Use `hubSchedule()` in Vite to discover `server/schedules/<name>.ts` and `src/<name>.schedule.ts`. Static schedules can produce provider cron output, including [Vercel Cron Jobs](https://vercel.com/docs/cron-jobs/). For Nitro apps on Cloudflare, Schedule Provider Wake writes generated `.vitehub/nitro/schedule/*` files so Nitro can register the `cloudflare:scheduled` runtime hook and emit `cloudflare.wrangler.triggers.crons` during standalone `nitro build`. In Nuxt apps, install `@vite-hub/schedule/nuxt` so the same Provider Wake output is merged into Nuxt's top-level Nitro config. In automatic mode, `server/schedules/*` routes through Nitro Provider Wake while suffix schedules keep standalone provider output.
+Use `hubSchedule()` in Vite to discover `server/schedules/<name>.ts` and `src/<name>.schedule.ts`. `defineSchedule()` declarations can produce provider cron output, including [Vercel Cron Jobs](https://vercel.com/docs/cron-jobs/). Cronless `defineScheduleTarget()` declarations are available only to Runtime Schedules and never emit static provider output. For Nitro apps on Cloudflare, Schedule Provider Wake writes generated `.vitehub/nitro/schedule/*` files so Nitro can register the `cloudflare:scheduled` runtime hook and emit `cloudflare.wrangler.triggers.crons` during standalone `nitro build`. In Nuxt apps, install `@vite-hub/schedule/nuxt` so the same Provider Wake output is merged into Nuxt's top-level Nitro config. In automatic mode, `server/schedules/*` routes through Nitro Provider Wake while suffix schedules keep standalone provider output.
+
+Runtime Schedule `input` is opaque to Schedule. Create stores a snapshot; update replaces the complete snapshot when `input` is provided and preserves it when omitted. The configured store must support the value's serialization requirements.
 
 When a host owns its own Cloudflare scheduled-event bridge, use the runtime helper instead of reimplementing registry matching:
 

--- a/packages/schedule/src/definition.ts
+++ b/packages/schedule/src/definition.ts
@@ -1,7 +1,8 @@
-import type { ScheduleDefinition, ScheduleDefinitionInput } from "./types.ts"
+import type { ScheduleDefinition, ScheduleDefinitionInput, ScheduleTargetDefinition, ScheduleTargetDefinitionInput } from "./types.ts"
 
 const cronFieldPattern = /^[^\s]+$/
 const scheduleDefinitionKeys = new Set(["allowRuntimeSchedules", "cron", "handler"])
+const scheduleTargetDefinitionKeys = new Set(["handler"])
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
@@ -46,4 +47,24 @@ export function defineSchedule<TResult = unknown>(input: ScheduleDefinitionInput
     definition.options = { allowRuntimeSchedules: input.allowRuntimeSchedules }
   }
   return definition
+}
+
+export function defineScheduleTarget<TInput = unknown, TResult = unknown>(input: ScheduleTargetDefinitionInput<TInput, TResult>): ScheduleTargetDefinition<TInput, TResult> {
+  if (!isPlainObject(input)) {
+    throw new TypeError("`defineScheduleTarget()` expects an object with `handler`.")
+  }
+
+  const unknownKey = Object.keys(input).find(key => !scheduleTargetDefinitionKeys.has(key))
+  if (unknownKey) {
+    throw new TypeError(`\`defineScheduleTarget()\` does not support the "${unknownKey}" option.`)
+  }
+
+  if (typeof input.handler !== "function") {
+    throw new TypeError("`defineScheduleTarget()` requires a schedule handler.")
+  }
+
+  return {
+    handler: input.handler,
+    options: { allowRuntimeSchedules: true },
+  }
 }

--- a/packages/schedule/src/discovery.ts
+++ b/packages/schedule/src/discovery.ts
@@ -231,7 +231,12 @@ function findTypeParametersEnd(source: string, index: number): number {
   return -1
 }
 
-function readDefineScheduleObjectAfterDefault(source: string, index: number): string | undefined {
+interface ParsedScheduleDefinition {
+  objectSource: string
+  runtimeOnly: boolean
+}
+
+function readDefineScheduleObjectAfterDefault(source: string, index: number): ParsedScheduleDefinition | undefined {
   let cursor = skipIgnorable(source, index)
   let openParens = 0
   while (source[cursor] === "(") {
@@ -239,8 +244,13 @@ function readDefineScheduleObjectAfterDefault(source: string, index: number): st
     cursor = skipIgnorable(source, cursor + 1)
   }
 
-  if (!source.startsWith("defineSchedule", cursor)) return undefined
-  cursor += "defineSchedule".length
+  const factory = source.startsWith("defineScheduleTarget", cursor)
+    ? "defineScheduleTarget"
+    : source.startsWith("defineSchedule", cursor)
+      ? "defineSchedule"
+      : undefined
+  if (!factory) return undefined
+  cursor += factory.length
 
   cursor = skipIgnorable(source, cursor)
   if (source[cursor] === "<") {
@@ -260,31 +270,38 @@ function readDefineScheduleObjectAfterDefault(source: string, index: number): st
     openParens -= 1
     afterObject = skipIgnorable(source, afterObject + 1)
   }
-  return openParens === 0 ? objectSource : undefined
+  return openParens === 0 ? { objectSource, runtimeOnly: factory === "defineScheduleTarget" } : undefined
 }
 
-function readDefaultDefineScheduleObject(source: string): string | undefined {
+function readDefaultDefineScheduleObject(source: string): ParsedScheduleDefinition | undefined {
   let match: RegExpExecArray | null
   const pattern = /\bexport\s+default\b/g
   while ((match = pattern.exec(source))) {
     if (isInsideNonCode(source, match.index)) continue
-    const objectSource = readDefineScheduleObjectAfterDefault(source, match.index + match[0].length)
-    if (objectSource) return objectSource
+    const definition = readDefineScheduleObjectAfterDefault(source, match.index + match[0].length)
+    if (definition) return definition
   }
 }
 
-function readAllowRuntimeSchedules(file: string): boolean {
-  const objectSource = readDefaultDefineScheduleObject(readFileSync(file, "utf8"))
-  return objectSource ? readTopLevelBooleanProperty(objectSource, "allowRuntimeSchedules") === true : false
+function readScheduleDiscoveryMetadata(file: string): Pick<DiscoveredScheduleDefinition, "allowRuntimeSchedules" | "runtimeOnly"> {
+  const definition = readDefaultDefineScheduleObject(readFileSync(file, "utf8"))
+  if (!definition) return { allowRuntimeSchedules: false }
+  if (definition.runtimeOnly) {
+    return { allowRuntimeSchedules: true, runtimeOnly: true }
+  }
+  return { allowRuntimeSchedules: readTopLevelBooleanProperty(definition.objectSource, "allowRuntimeSchedules") === true }
 }
 
 function createDiscoveredScheduleDefinition(source: DiscoveredScheduleDefinition["source"]) {
-  return (context: { file: string, name: string }): DiscoveredScheduleDefinition => ({
-    allowRuntimeSchedules: readAllowRuntimeSchedules(context.file),
-    handler: context.file,
-    name: context.name,
-    source,
-  })
+  return (context: { file: string, name: string }): DiscoveredScheduleDefinition => {
+    const metadata = readScheduleDiscoveryMetadata(context.file)
+    return {
+      ...metadata,
+      handler: context.file,
+      name: context.name,
+      source,
+    }
+  }
 }
 
 function normalizeSuffixScheduleName(rootDir: string, file: string) {

--- a/packages/schedule/src/index.ts
+++ b/packages/schedule/src/index.ts
@@ -1,4 +1,4 @@
-export { defineSchedule } from "./definition.ts"
+export { defineSchedule, defineScheduleTarget } from "./definition.ts"
 export { discoverScheduleDefinitions } from "./discovery.ts"
 export type {} from "./registry-module.d.ts"
 export { ScheduleError } from "./errors.ts"
@@ -35,12 +35,15 @@ export type {
   ScheduleDefinitionInput,
   ScheduleDefinitionRegistry,
   ScheduleHandler,
+  ScheduleRegistryDefinition,
   ScheduleRunContext,
   ScheduleRunError,
   ScheduleRunRecord,
   ScheduleRunStatus,
   ScheduleRunStore,
   ScheduleTargetName,
+  ScheduleTargetDefinition,
+  ScheduleTargetDefinitionInput,
 } from "./types.ts"
 
 export type {

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -53,6 +53,10 @@ export function resolveScheduleDefinitionEntry(metaUrl = import.meta.url) {
 const scheduleRuntimeEntry = resolveScheduleRuntimeEntry()
 const scheduleDefinitionEntry = resolveScheduleDefinitionEntry()
 
+function staticScheduleDefinitions(definitions: DiscoveredScheduleDefinition[]): DiscoveredScheduleDefinition[] {
+  return definitions.filter(definition => definition.runtimeOnly !== true)
+}
+
 interface GeneratedScheduleArtifacts {
   cloudflareWorkerFile: string
   denoCronFile: string
@@ -573,6 +577,7 @@ async function writeProviderEntries(rootDir: string, source?: DiscoveredSchedule
   const registryFile = resolve(generatedDir, generatedRegistryFileName)
   const definitions = discoverScheduleDefinitions({ rootDir })
     .filter(definition => !source || definition.source === source)
+    .filter(definition => definition.runtimeOnly !== true)
   await writeFile(registryFile, createRuntimeRegistryContents(registryFile, definitions), "utf8")
 
   const cloudflareWorkerFile = resolve(generatedDir, "cloudflare-worker.mjs")
@@ -586,7 +591,7 @@ async function writeProviderEntries(rootDir: string, source?: DiscoveredSchedule
 
 export async function readDefinitionCrons(definitions: DiscoveredScheduleDefinition[]) {
   const crons = new Map<string, string>()
-  for (const definition of definitions) {
+  for (const definition of staticScheduleDefinitions(definitions)) {
     const cron = readStaticScheduleCron(definition.handler, definition.name)
     validateProviderCron(cron, definition.name)
     crons.set(definition.name, cron)
@@ -601,12 +606,13 @@ export async function writeVercelScheduleFunctions(options: {
   registryFile: string
   rootDir: string
 }, crons: Map<string, string>) {
+  const definitions = staticScheduleDefinitions(options.definitions)
   const outputRoot = options.outputRoot
   const functionRoot = resolve(outputRoot, "functions", "api", "vitehub", "schedules", "vercel")
   await rm(functionRoot, { force: true, recursive: true })
 
   const emittedFunctionNames = new Map<string, string>()
-  for (const definition of options.definitions) {
+  for (const definition of definitions) {
     const safeName = definition.name.replace(/[^a-z0-9/_-]+/gi, "_").split("/").filter(Boolean).join("/")
     const existingName = emittedFunctionNames.get(safeName)
     if (existingName) {
@@ -640,7 +646,7 @@ export async function writeVercelScheduleFunctions(options: {
   }
   const schedulePathPrefix = "/api/vitehub/schedules/vercel/"
   const existingCrons = vercelConfig.crons?.filter(cron => !cron.path.startsWith(schedulePathPrefix)) ?? []
-  vercelConfig.crons = [...existingCrons, ...options.definitions.map(definition => ({
+  vercelConfig.crons = [...existingCrons, ...definitions.map(definition => ({
     path: getVercelSchedulePath(definition.name),
     schedule: crons.get(definition.name)!,
   }))]
@@ -652,9 +658,10 @@ export async function createNetlifyScheduleFunctionOutputs(options: {
   functionRoot: string
   registryFile: string
 }): Promise<NetlifyScheduleFunctionOutput[]> {
-  const crons = await readDefinitionCrons(options.definitions)
+  const definitions = staticScheduleDefinitions(options.definitions)
+  const crons = await readDefinitionCrons(definitions)
   const emitted = new Map<string, string>()
-  return options.definitions.map((definition) => {
+  return definitions.map((definition) => {
     const fileName = sanitizeNetlifyScheduleFunctionName(definition.name)
     const existingName = emitted.get(fileName)
     if (existingName) {

--- a/packages/schedule/src/runtime.ts
+++ b/packages/schedule/src/runtime.ts
@@ -22,6 +22,9 @@ export type {
   ScheduleDefinitionOptions,
   ScheduleDefinitionRegistry,
   ScheduleHandler,
+  ScheduleRegistryDefinition,
   ScheduleRunContext,
+  ScheduleTargetDefinition,
+  ScheduleTargetDefinitionInput,
   ScheduleTargetName,
 } from "./types.ts"

--- a/packages/schedule/src/runtime/client.ts
+++ b/packages/schedule/src/runtime/client.ts
@@ -23,8 +23,8 @@ const cronFieldRanges = [
   cronRange.dayOfWeek,
 ] as const
 
-const runtimeScheduleCreateInputKeys = new Set(["cron", "enabled", "id", "target", "timeZone"])
-const runtimeScheduleUpdateInputKeys = new Set(["cron", "enabled", "target", "timeZone"])
+const runtimeScheduleCreateInputKeys = new Set(["cron", "enabled", "id", "input", "target", "timeZone"])
+const runtimeScheduleUpdateInputKeys = new Set(["cron", "enabled", "input", "target", "timeZone"])
 
 function parseCronNumber(value: string, range: { min: number, max: number }): number {
   if (!/^\d+$/.test(value)) {
@@ -207,7 +207,7 @@ async function validateUpdateInput(input: RuntimeScheduleUpdateInput): Promise<v
   }
 }
 
-async function updateRuntimeSchedule<TTarget extends ScheduleTargetName>(id: string, input: RuntimeScheduleUpdateInput<TTarget>): Promise<RuntimeScheduleRecord> {
+async function updateRuntimeSchedule<TTarget extends ScheduleTargetName, TInput>(id: string, input: RuntimeScheduleUpdateInput<TTarget, TInput>): Promise<RuntimeScheduleRecord<TInput>> {
   await validateUpdateInput(input)
   const updated = await getRuntimeScheduleStore().update(id, {
     ...input,
@@ -220,11 +220,11 @@ async function updateRuntimeSchedule<TTarget extends ScheduleTargetName>(id: str
       httpStatus: 404,
     })
   }
-  return updated
+  return updated as RuntimeScheduleRecord<TInput>
 }
 
 export const schedules = {
-  async create<TTarget extends ScheduleTargetName>(input: RuntimeScheduleCreateInput<TTarget>): Promise<RuntimeScheduleRecord> {
+  async create<TTarget extends ScheduleTargetName, TInput = unknown>(input: RuntimeScheduleCreateInput<TTarget, TInput>): Promise<RuntimeScheduleRecord<TInput>> {
     await validateCreateInput(input)
     const now = new Date()
     return await getRuntimeScheduleStore().create({
@@ -232,10 +232,11 @@ export const schedules = {
       cron: input.cron,
       enabled: input.enabled ?? true,
       id: input.id ?? randomId("sched"),
+      ...(input.input !== undefined ? { input: input.input } : {}),
       target: input.target,
       ...(input.timeZone ? { timeZone: input.timeZone } : {}),
       updatedAt: now,
-    })
+    }) as RuntimeScheduleRecord<TInput>
   },
   async delete(id: string): Promise<boolean> {
     return await getRuntimeScheduleStore().delete(id)
@@ -264,7 +265,7 @@ export const schedules = {
   async run(id: string, options: { scheduledAt?: Date } = {}): Promise<ScheduleRunRecord> {
     return await executeRuntimeSchedule({ id, scheduledAt: options.scheduledAt })
   },
-  async update<TTarget extends ScheduleTargetName>(id: string, input: RuntimeScheduleUpdateInput<TTarget>): Promise<RuntimeScheduleRecord> {
+  async update<TTarget extends ScheduleTargetName, TInput = unknown>(id: string, input: RuntimeScheduleUpdateInput<TTarget, TInput>): Promise<RuntimeScheduleRecord<TInput>> {
     return await updateRuntimeSchedule(id, input)
   },
 }

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -3,10 +3,11 @@ import { randomId } from "@vite-hub/internal/runtime/random"
 import { ScheduleError } from "../errors.ts"
 import { getRuntimeScheduleStore, getScheduleRunStore, loadScheduleDefinition } from "./state.ts"
 
-import type { RuntimeScheduleRecord, RuntimeScheduleStore, ScheduleDefinition, ScheduleRunAttemptRecord, ScheduleRunContext, ScheduleRunError, ScheduleRunRecord, ScheduleRunStore, ScheduleTargetName } from "../types.ts"
+import type { RuntimeScheduleRecord, RuntimeScheduleStore, ScheduleDefinition, ScheduleRegistryDefinition, ScheduleRunAttemptRecord, ScheduleRunContext, ScheduleRunError, ScheduleRunRecord, ScheduleRunStore, ScheduleTargetName } from "../types.ts"
 
 interface ExecuteScheduleOptions {
-  definition: ScheduleDefinition
+  definition: ScheduleRegistryDefinition
+  input?: unknown
   runStore?: ScheduleRunStore
   scheduleId: string
   source?: "direct" | "runtime" | "static"
@@ -132,10 +133,11 @@ async function startAttempt(run: ScheduleRunRecord, store: ScheduleRunStore = ge
   return attempt
 }
 
-function toHandlerContext(run: ScheduleRunRecord, attempt: ScheduleRunAttemptRecord): ScheduleRunContext {
+function toHandlerContext(run: ScheduleRunRecord, attempt: ScheduleRunAttemptRecord, input?: unknown): ScheduleRunContext {
   return {
     attemptId: attempt.id,
     id: run.id,
+    ...(input !== undefined ? { input } : {}),
     runId: run.id,
     scheduleId: run.scheduleId,
     scheduledAt: run.scheduledAt,
@@ -192,7 +194,7 @@ export async function executeSchedule(options: ExecuteScheduleOptions): Promise<
   const runStore = options.runStore ?? getScheduleRunStore()
   const attempt = await startAttempt(run, runStore)
   try {
-    await options.definition.handler(toHandlerContext(run, attempt))
+    await options.definition.handler(toHandlerContext(run, attempt, options.input))
     return await completeRun(run, attempt, runStore)
   }
   catch (error) {
@@ -261,6 +263,7 @@ export async function executeRuntimeSchedule(options: ExecuteRuntimeScheduleOpti
 
   return await executeSchedule({
     definition,
+    input: schedule.input,
     runStore: scheduleRunStore,
     scheduleId: schedule.id,
     source: "runtime",

--- a/packages/schedule/src/runtime/state.ts
+++ b/packages/schedule/src/runtime/state.ts
@@ -2,21 +2,21 @@ import { AsyncLocalStorage } from "node:async_hooks"
 
 import { createMemoryRuntimeScheduleStore, createMemoryScheduleRunStore } from "./store.ts"
 
-import type { RuntimeScheduleStore, ScheduleDefinition, ScheduleDefinitionRegistry, ScheduleRunStore } from "../types.ts"
+import type { RuntimeScheduleStore, ScheduleDefinitionRegistry, ScheduleRegistryDefinition, ScheduleRunStore } from "../types.ts"
 
 let runtimeRegistry: ScheduleDefinitionRegistry | undefined
 let runtimeStore: RuntimeScheduleStore | undefined
 let runtimeRegistryVersion = 0
 let runStore: ScheduleRunStore | undefined
-const loadedRegistryEntries = new Map<string, ScheduleDefinition | undefined>()
+const loadedRegistryEntries = new Map<string, ScheduleRegistryDefinition | undefined>()
 const loadingRegistryEntries = new Map<string, {
-  promise: Promise<ScheduleDefinition | undefined>
+  promise: Promise<ScheduleRegistryDefinition | undefined>
   version: number
 }>()
 const loadingRegistryStorage = new AsyncLocalStorage<Set<string>>()
 
-function isScheduleDefinition(value: unknown): value is ScheduleDefinition {
-  return Boolean(value) && typeof value === "object" && typeof (value as ScheduleDefinition).handler === "function"
+function isScheduleDefinition(value: unknown): value is ScheduleRegistryDefinition {
+  return Boolean(value) && typeof value === "object" && typeof (value as ScheduleRegistryDefinition).handler === "function"
 }
 
 export function setScheduleRuntimeRegistry(registry: ScheduleDefinitionRegistry | undefined): void {
@@ -46,7 +46,7 @@ export function getScheduleRunStore(): ScheduleRunStore {
   return runStore ??= createMemoryScheduleRunStore()
 }
 
-export async function loadScheduleDefinition(name: string): Promise<ScheduleDefinition | undefined> {
+export async function loadScheduleDefinition(name: string): Promise<ScheduleRegistryDefinition | undefined> {
   const entry = runtimeRegistry && Object.hasOwn(runtimeRegistry, name) ? runtimeRegistry[name] : undefined
   if (typeof entry !== "function") {
     return undefined

--- a/packages/schedule/src/runtime/static.ts
+++ b/packages/schedule/src/runtime/static.ts
@@ -1,4 +1,4 @@
-import type { ScheduleDefinition, ScheduleDefinitionRegistry, ScheduleRunContext } from "../types.ts"
+import type { ScheduleDefinition, ScheduleDefinitionRegistry, ScheduleRegistryDefinition, ScheduleRunContext } from "../types.ts"
 
 export interface ExecuteStaticScheduleOptions {
   cron: string
@@ -27,7 +27,7 @@ interface CloudflareScheduledEventLike {
   scheduledTime?: number | string | Date
 }
 
-type LoadedScheduleModule = ScheduleDefinition | { default?: ScheduleDefinition }
+type LoadedScheduleModule = ScheduleRegistryDefinition | { default?: ScheduleRegistryDefinition }
 
 export interface StaticScheduleRun extends ScheduleRunContext {
   cron: string
@@ -145,6 +145,6 @@ function readCloudflareEventEnv(event: CloudflareScheduledEventLike): Record<str
 }
 
 function unwrapScheduleDefinition(loaded: LoadedScheduleModule): ScheduleDefinition | undefined {
-  if (typeof loaded === "object" && loaded !== null && "default" in loaded) return loaded.default
-  return loaded as ScheduleDefinition
+  const definition = typeof loaded === "object" && loaded !== null && "default" in loaded ? loaded.default : loaded
+  return definition && "cron" in definition ? definition : undefined
 }

--- a/packages/schedule/src/runtime/store.ts
+++ b/packages/schedule/src/runtime/store.ts
@@ -105,7 +105,7 @@ function omitUndefinedPatch(patch: RuntimeScheduleUpdateInput): RuntimeScheduleU
   return {
     ...(patch.cron !== undefined ? { cron: patch.cron } : {}),
     ...(patch.enabled !== undefined ? { enabled: patch.enabled } : {}),
-    ...(patch.input !== undefined ? { input: structuredClone(patch.input) } : {}),
+    ...(Object.hasOwn(patch, "input") ? { input: structuredClone(patch.input) } : {}),
     ...(patch.target !== undefined ? { target: patch.target } : {}),
     ...(patch.timeZone !== undefined ? { timeZone: patch.timeZone } : {}),
   }

--- a/packages/schedule/src/runtime/store.ts
+++ b/packages/schedule/src/runtime/store.ts
@@ -74,10 +74,11 @@ async function resolveDefaultKVStore(): Promise<ScheduleKVStorage> {
   return module.kv
 }
 
-function cloneRuntimeSchedule(record: RuntimeScheduleRecord): RuntimeScheduleRecord {
+function cloneRuntimeSchedule<TInput>(record: RuntimeScheduleRecord<TInput>): RuntimeScheduleRecord<TInput> {
   return {
     ...record,
     createdAt: new Date(record.createdAt),
+    ...(record.input !== undefined ? { input: structuredClone(record.input) } : {}),
     updatedAt: new Date(record.updatedAt),
   }
 }
@@ -86,6 +87,7 @@ function serializeRuntimeSchedule(record: RuntimeScheduleRecord): StoredRuntimeS
   return {
     ...record,
     createdAt: record.createdAt.toISOString(),
+    ...(record.input !== undefined ? { input: structuredClone(record.input) } : {}),
     updatedAt: record.updatedAt.toISOString(),
   }
 }
@@ -94,6 +96,7 @@ function deserializeRuntimeSchedule(record: StoredRuntimeScheduleRecord): Runtim
   return {
     ...record,
     createdAt: new Date(record.createdAt),
+    ...(record.input !== undefined ? { input: structuredClone(record.input) } : {}),
     updatedAt: new Date(record.updatedAt),
   }
 }
@@ -102,6 +105,7 @@ function omitUndefinedPatch(patch: RuntimeScheduleUpdateInput): RuntimeScheduleU
   return {
     ...(patch.cron !== undefined ? { cron: patch.cron } : {}),
     ...(patch.enabled !== undefined ? { enabled: patch.enabled } : {}),
+    ...(patch.input !== undefined ? { input: structuredClone(patch.input) } : {}),
     ...(patch.target !== undefined ? { target: patch.target } : {}),
     ...(patch.timeZone !== undefined ? { timeZone: patch.timeZone } : {}),
   }

--- a/packages/schedule/src/types.ts
+++ b/packages/schedule/src/types.ts
@@ -1,13 +1,16 @@
-export interface ScheduleRunContext {
+export interface ScheduleRunContext<TInput = unknown> {
   id: string
   attemptId?: string
+  input?: TInput
   runId?: string
   scheduleId?: string
   scheduledAt: Date
   target?: ScheduleTargetName
 }
 
-export type ScheduleHandler<TResult = unknown> = (context: ScheduleRunContext) => TResult | Promise<TResult>
+export type ScheduleHandler<TResult = unknown, TInput = unknown> = {
+  bivarianceHack(context: ScheduleRunContext<TInput>): TResult | Promise<TResult>
+}["bivarianceHack"]
 
 export interface ScheduleDefinitionInput<TResult = unknown> {
   allowRuntimeSchedules?: boolean
@@ -25,8 +28,21 @@ export interface ScheduleDefinition<TResult = unknown> {
   options?: ScheduleDefinitionOptions
 }
 
+export interface ScheduleTargetDefinitionInput<TInput = unknown, TResult = unknown> {
+  handler: ScheduleHandler<TResult, TInput>
+}
+
+export interface ScheduleTargetDefinition<TInput = unknown, TResult = unknown> {
+  handler: ScheduleHandler<TResult, TInput>
+  options: {
+    allowRuntimeSchedules: true
+  }
+}
+
+export type ScheduleRegistryDefinition = ScheduleDefinition | ScheduleTargetDefinition
+
 export interface ScheduleDefinitionRegistry {
-  [name: string]: () => Promise<{ default?: ScheduleDefinition } | ScheduleDefinition>
+  [name: string]: () => Promise<{ default?: ScheduleRegistryDefinition } | ScheduleRegistryDefinition>
 }
 
 export type ScheduleTargetName = string & {}
@@ -36,25 +52,28 @@ export interface RuntimeScheduleMetadata {
   updatedAt: Date
 }
 
-export interface RuntimeScheduleRecord extends RuntimeScheduleMetadata {
+export interface RuntimeScheduleRecord<TInput = unknown> extends RuntimeScheduleMetadata {
   cron: string
   enabled: boolean
   id: string
+  input?: TInput
   target: ScheduleTargetName
   timeZone?: string
 }
 
-export interface RuntimeScheduleCreateInput<TTarget extends ScheduleTargetName = ScheduleTargetName> {
+export interface RuntimeScheduleCreateInput<TTarget extends ScheduleTargetName = ScheduleTargetName, TInput = unknown> {
   cron: string
   enabled?: boolean
   id?: string
+  input?: TInput
   target: TTarget
   timeZone?: string
 }
 
-export interface RuntimeScheduleUpdateInput<TTarget extends ScheduleTargetName = ScheduleTargetName> {
+export interface RuntimeScheduleUpdateInput<TTarget extends ScheduleTargetName = ScheduleTargetName, TInput = unknown> {
   cron?: string
   enabled?: boolean
+  input?: TInput
   target?: TTarget
   timeZone?: string
 }
@@ -117,5 +136,6 @@ export interface DiscoveredScheduleDefinition {
   allowRuntimeSchedules?: boolean
   handler: string
   name: string
+  runtimeOnly?: boolean
   source?: "server-schedules" | "vite-suffix"
 }

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -175,9 +175,9 @@ function renderNitroCloudflareModule(crons: string[]): string {
 
 function renderScheduleRegistryTypes(): string {
   return [
-    "import type { ScheduleDefinition } from '@vite-hub/schedule'",
+    "import type { ScheduleRegistryDefinition } from '@vite-hub/schedule'",
     "",
-    "declare const registry: Record<string, () => Promise<ScheduleDefinition | { default?: ScheduleDefinition }>>",
+    "declare const registry: Record<string, () => Promise<ScheduleRegistryDefinition | { default?: ScheduleRegistryDefinition }>>",
     "export default registry",
     "",
   ].join("\n")
@@ -200,17 +200,18 @@ async function writeNitroCloudflarePlugin(root: string, definitions: DiscoveredS
 }
 
 function hasServerScheduleDefinitions(definitions: DiscoveredScheduleDefinition[]): boolean {
-  return definitions.some(definition => definition.source === "server-schedules")
+  return definitions.some(definition => definition.runtimeOnly !== true && definition.source === "server-schedules")
 }
 
 function hasViteSuffixScheduleDefinitions(definitions: DiscoveredScheduleDefinition[]): boolean {
-  return definitions.some(definition => definition.source === "vite-suffix")
+  return definitions.some(definition => definition.runtimeOnly !== true && definition.source === "vite-suffix")
 }
 
 function selectNitroScheduleDefinitions(definitions: DiscoveredScheduleDefinition[], options: ScheduleVitePluginOptions): DiscoveredScheduleDefinition[] {
   if (options.providerOutput === false || options.providerOutput === "standalone") return []
-  if (options.providerOutput === "nitro") return definitions
-  return definitions.filter(definition => definition.source === "server-schedules")
+  const staticDefinitions = definitions.filter(definition => definition.runtimeOnly !== true)
+  if (options.providerOutput === "nitro") return staticDefinitions
+  return staticDefinitions.filter(definition => definition.source === "server-schedules")
 }
 
 function selectStandaloneProviderSource(definitions: DiscoveredScheduleDefinition[], options: ScheduleVitePluginOptions): DiscoveredScheduleDefinition["source"] | undefined {
@@ -225,9 +226,9 @@ function shouldInstallNitroSchedulePlugin(definitions: DiscoveredScheduleDefinit
 
 function shouldEmitStandaloneProviderOutput(definitions: DiscoveredScheduleDefinition[], options: ScheduleVitePluginOptions): boolean {
   if (options.providerOutput === false || options.providerOutput === "nitro") return false
-  if (options.providerOutput === "standalone") return true
+  if (options.providerOutput === "standalone") return definitions.some(definition => definition.runtimeOnly !== true)
   if (hasServerScheduleDefinitions(definitions)) return hasViteSuffixScheduleDefinitions(definitions)
-  return definitions.length > 0
+  return definitions.some(definition => definition.runtimeOnly !== true)
 }
 
 export async function createScheduleNitroConfig(options: ScheduleNitroConfigOptions = {}): Promise<NitroConfig | null> {

--- a/packages/schedule/test/definition.test.ts
+++ b/packages/schedule/test/definition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { defineSchedule } from "../src/definition.ts"
+import { defineSchedule, defineScheduleTarget } from "../src/definition.ts"
 
 describe("defineSchedule", () => {
   it("creates a cron Schedule Definition", () => {
@@ -20,5 +20,22 @@ describe("defineSchedule", () => {
     expect(() => defineSchedule({ cron: "0 9 * * *", handler: "handler" as never })).toThrow(/schedule handler/)
     expect(() => defineSchedule({ cron: "0 9 * * *", handler: () => {}, id: "daily" } as never)).toThrow(/does not support the "id" option/)
     expect(() => defineSchedule({ cron: "0 9 * * *", handler: () => {}, timeZone: "Europe/Copenhagen" } as never)).toThrow(/does not support the "timeZone" option/)
+  })
+})
+
+describe("defineScheduleTarget", () => {
+  it("creates a cronless Runtime Schedule target", () => {
+    const handler = () => "ok"
+
+    expect(defineScheduleTarget({ handler })).toEqual({
+      handler,
+      options: { allowRuntimeSchedules: true },
+    })
+  })
+
+  it("rejects invalid target inputs", () => {
+    expect(() => defineScheduleTarget(undefined as never)).toThrow(/expects an object/)
+    expect(() => defineScheduleTarget({ handler: "handler" as never })).toThrow(/schedule handler/)
+    expect(() => defineScheduleTarget({ cron: "0 9 * * *", handler: () => {} } as never)).toThrow(/does not support the "cron" option/)
   })
 })

--- a/packages/schedule/test/discovery.test.ts
+++ b/packages/schedule/test/discovery.test.ts
@@ -113,6 +113,25 @@ describe("discoverScheduleDefinitions", () => {
     ])
   })
 
+  it("discovers defineScheduleTarget calls as runtime-only targets", async () => {
+    const rootDir = await createTempDir("vitehub-schedule-runtime-target-")
+    await writeFile(
+      join(rootDir, "agent-turn.schedule.ts"),
+      "export default defineScheduleTarget<{ prompt: string }>({ handler: context => context.input?.prompt })\n",
+      "utf8",
+    )
+
+    expect(discoverScheduleDefinitions({
+      mode: "vite-suffix",
+      rootDir,
+    })).toMatchObject([{
+      allowRuntimeSchedules: true,
+      name: "agent-turn",
+      runtimeOnly: true,
+      source: "vite-suffix",
+    }])
+  })
+
   it("reads runtime opt-in from generic defineSchedule calls", async () => {
     const rootDir = await createTempDir("vitehub-schedule-runtime-generic-opt-in-")
     await writeFile(

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -49,6 +49,12 @@ describe("schedule provider output", () => {
 
   it("emits Cloudflare, Vercel, and Netlify schedule provider wake output", async () => {
     const rootDir = await createTempProject("vitehub-schedule-output-")
+    await writeFile(join(rootDir, "src", "agent-turn.schedule.ts"), [
+      "import { defineScheduleTarget } from '@vite-hub/schedule'",
+      "",
+      "export default defineScheduleTarget({ handler: () => 'ok' })",
+      "",
+    ].join("\n"), "utf8")
 
     await generateProviderOutputs({
       clientOutDir: "dist/client",
@@ -69,9 +75,12 @@ describe("schedule provider output", () => {
       schedule: "0 0 * * *",
     }])
     expect(await readFile(vercelFunction, "utf8")).toContain("executeStaticSchedule")
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "schedules", "vercel", "agent-turn.func"))).toBe(false)
     await expect(readFile(netlifyFunction, "utf8")).resolves.toContain("export const config = {")
+    expect(existsSync(join(createDefaultNetlifyOutputRoot(rootDir), "functions", "vitehub-schedule-agent-turn.mjs"))).toBe(false)
     await expect(readFile(netlifyFunction, "utf8")).resolves.toContain("schedule: \"0 0 * * *\"")
     await expect(readFile(netlifyFunction, "utf8")).resolves.toContain("executeStaticSchedule")
+    await expect(readFile(join(rootDir, ".vitehub", "schedule", "registry.mjs"), "utf8")).resolves.not.toContain("agent-turn")
   })
 
   it("creates Netlify scheduled function output contributions", async () => {

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { createKVRuntimeScheduleStore, createKVScheduleRunStore, createMemoryRuntimeScheduleStore, createMemoryScheduleRunStore, createScheduleRun, executeRuntimeSchedule, executeStaticSchedule, ScheduleError, schedules, startScheduleRunner } from "../src/index.ts"
+import { createKVRuntimeScheduleStore, createKVScheduleRunStore, createMemoryRuntimeScheduleStore, createMemoryScheduleRunStore, createScheduleRun, defineScheduleTarget, executeRuntimeSchedule, executeStaticSchedule, ScheduleError, schedules, startScheduleRunner } from "../src/index.ts"
 import { loadScheduleDefinition, resetScheduleRuntime, setScheduleRunStore, setScheduleRuntimeRegistry } from "../src/runtime/state.ts"
 import type { KVStorage } from "@vite-hub/kv"
 
@@ -93,6 +93,34 @@ describe("Runtime Schedule helper", () => {
     expect(created.updatedAt).toBeInstanceOf(Date)
     expect(await schedules.get("schedule-1")).toEqual(created)
     expect(await schedules.list()).toEqual([created])
+  })
+
+  it("stores Runtime Schedule input as replaceable snapshots", async () => {
+    setScheduleRuntimeRegistry({
+      report: async () => defineScheduleTarget({ handler: async () => {} }),
+    })
+    const input = { prompt: "Morning report", settings: { concise: true } }
+
+    const created = await schedules.create({
+      cron: "0 9 * * *",
+      id: "schedule-1",
+      input,
+      target: "report",
+    })
+    input.settings.concise = false
+    expect(created.input).toEqual({ prompt: "Morning report", settings: { concise: true } })
+
+    const read = await schedules.get("schedule-1")
+    ;(read!.input as typeof input).settings.concise = false
+    expect((await schedules.get("schedule-1"))?.input).toEqual({ prompt: "Morning report", settings: { concise: true } })
+
+    const replacement = { prompt: "Evening report", settings: { concise: false } }
+    const updated = await schedules.update("schedule-1", { input: replacement })
+    replacement.prompt = "mutated"
+    expect(updated.input).toEqual({ prompt: "Evening report", settings: { concise: false } })
+
+    await schedules.update("schedule-1", { cron: "0 18 * * *" })
+    expect((await schedules.get("schedule-1"))?.input).toEqual({ prompt: "Evening report", settings: { concise: false } })
   })
 
   it("updates, disables, enables, and deletes schedules through the same store", async () => {
@@ -392,6 +420,7 @@ describe("KV Runtime Schedule Store", () => {
       cron: "0 9 * * *",
       enabled: true,
       id: "schedule/1",
+      input: { prompt: "Daily report", settings: { concise: true } },
       target: "daily/report",
       timeZone: "Europe/Copenhagen",
       updatedAt,
@@ -402,6 +431,7 @@ describe("KV Runtime Schedule Store", () => {
       cron: "0 9 * * *",
       enabled: true,
       id: "schedule/1",
+      input: { prompt: "Daily report", settings: { concise: true } },
       target: "daily/report",
       timeZone: "Europe/Copenhagen",
       updatedAt,
@@ -410,12 +440,16 @@ describe("KV Runtime Schedule Store", () => {
     expect(await store.list()).toEqual([created])
 
     created.cron = "mutated"
+    ;(created.input as { settings: { concise: boolean } }).settings.concise = false
     expect((await store.get("schedule/1"))?.cron).toBe("0 9 * * *")
+    expect((await store.get("schedule/1"))?.input).toEqual({ prompt: "Daily report", settings: { concise: true } })
 
     const changedAt = new Date("2026-05-23T10:00:00.000Z")
     await expect(store.update("missing", { enabled: false, updatedAt: changedAt })).resolves.toBeUndefined()
-    const updated = await store.update("schedule/1", { cron: "30 10 * * *", enabled: false, timeZone: "Asia/Bangkok", updatedAt: changedAt })
-    expect(updated).toMatchObject({ cron: "30 10 * * *", enabled: false, id: "schedule/1", timeZone: "Asia/Bangkok" })
+    const replacement = { prompt: "Updated report", settings: { concise: false } }
+    const updated = await store.update("schedule/1", { cron: "30 10 * * *", enabled: false, input: replacement, timeZone: "Asia/Bangkok", updatedAt: changedAt })
+    replacement.prompt = "mutated"
+    expect(updated).toMatchObject({ cron: "30 10 * * *", enabled: false, id: "schedule/1", input: { prompt: "Updated report", settings: { concise: false } }, timeZone: "Asia/Bangkok" })
     expect(updated?.createdAt).toEqual(createdAt)
     expect(updated?.updatedAt).toEqual(changedAt)
     expect((await store.get("schedule/1"))?.timeZone).toBe("Asia/Bangkok")
@@ -517,14 +551,12 @@ describe("Schedule Run bookkeeping", () => {
   it("records a run and one successful attempt for a Runtime Schedule", async () => {
     const seen: unknown[] = []
     setScheduleRuntimeRegistry({
-      report: async () => ({
-        cron: "0 9 * * *",
+      report: async () => defineScheduleTarget<{ prompt: string }>({
         handler: async context => seen.push(context),
-        options: { allowRuntimeSchedules: true },
       }),
     })
 
-    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", input: { prompt: "Daily report" }, target: "report" })
     const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
     const run = await schedules.run("schedule-1", { scheduledAt })
     const attempts = await schedules.listAttempts(run.id)
@@ -543,6 +575,7 @@ describe("Schedule Run bookkeeping", () => {
       expect.objectContaining({
         attemptId: attempts[0]!.id,
         id: run.id,
+        input: { prompt: "Daily report" },
         runId: run.id,
         scheduleId: "schedule-1",
         scheduledAt,

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -121,6 +121,10 @@ describe("Runtime Schedule helper", () => {
 
     await schedules.update("schedule-1", { cron: "0 18 * * *" })
     expect((await schedules.get("schedule-1"))?.input).toEqual({ prompt: "Evening report", settings: { concise: false } })
+
+    const cleared = await schedules.update("schedule-1", { input: undefined })
+    expect(cleared.input).toBeUndefined()
+    expect((await schedules.get("schedule-1"))?.input).toBeUndefined()
   })
 
   it("updates, disables, enables, and deletes schedules through the same store", async () => {
@@ -456,6 +460,10 @@ describe("KV Runtime Schedule Store", () => {
 
     const unchanged = await store.update("schedule/1", { cron: undefined, target: undefined, updatedAt: changedAt } as never)
     expect(unchanged).toMatchObject({ cron: "30 10 * * *", target: "daily/report" })
+
+    const cleared = await store.update("schedule/1", { input: undefined, updatedAt: changedAt })
+    expect(cleared?.input).toBeUndefined()
+    expect((await store.get("schedule/1"))?.input).toBeUndefined()
 
     await expect(store.create({
       createdAt,

--- a/packages/schedule/test/static-runtime.test.ts
+++ b/packages/schedule/test/static-runtime.test.ts
@@ -18,6 +18,10 @@ describe("Static Schedule runtime", () => {
         cron: "0 4 * * *",
         handler: async ({ scheduledAt }) => calls.push(`report:${scheduledAt.toISOString()}`),
       }),
+      runtimeOnly: async () => ({
+        handler: async () => calls.push("runtime-only"),
+        options: { allowRuntimeSchedules: true },
+      }),
       skipped: async () => ({
         default: {
           cron: "0 5 * * *",

--- a/packages/schedule/test/types.test-d.ts
+++ b/packages/schedule/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf, it } from "vitest"
 
-import { defineSchedule, schedules } from "../src/index.ts"
+import { defineSchedule, defineScheduleTarget, schedules } from "../src/index.ts"
 import "../src/runtime.ts"
 import registry from "#vitehub/schedule/registry"
 import type { ScheduleDefinitionRegistry } from "../src/types.ts"
@@ -38,9 +38,28 @@ it("types the defineSchedule helper signature", () => {
   defineSchedule({ cron: "0 9 * * *", handler: () => {}, timeZone: "Europe/Copenhagen" })
 })
 
+it("types cronless Runtime Schedule targets", () => {
+  const target = defineScheduleTarget<{ prompt: string }>({
+    handler: async (context) => {
+      expectTypeOf(context.input).toEqualTypeOf<{ prompt: string } | undefined>()
+      return context.input?.prompt
+    },
+  })
+
+  expectTypeOf(target.handler).parameters.toEqualTypeOf<[ScheduleRunContext<{ prompt: string }>]>()
+
+  // @ts-expect-error handler is required.
+  defineScheduleTarget({})
+
+  // @ts-expect-error cron belongs to defineSchedule, not defineScheduleTarget.
+  defineScheduleTarget({ cron: "0 9 * * *", handler: () => {} })
+})
+
 it("types Runtime Schedule helper inputs", async () => {
-  await schedules.create({ cron: "0 9 * * *", target: "daily-report", timeZone: "Europe/Copenhagen" })
-  await schedules.update("schedule-1", { cron: "15 10 * * *", enabled: false, target: "daily-report", timeZone: "Asia/Bangkok" })
+  const created = await schedules.create({ cron: "0 9 * * *", input: { prompt: "Daily report" }, target: "daily-report", timeZone: "Europe/Copenhagen" })
+  expectTypeOf(created.input).toEqualTypeOf<{ prompt: string } | undefined>()
+  const updated = await schedules.update("schedule-1", { cron: "15 10 * * *", enabled: false, input: { prompt: "Weekday report" }, target: "daily-report", timeZone: "Asia/Bangkok" })
+  expectTypeOf(updated.input).toEqualTypeOf<{ prompt: string } | undefined>()
 
   // @ts-expect-error create requires a target.
   await schedules.create({ cron: "0 9 * * *" })

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -35,6 +35,28 @@ describe("Vite schedule integration", () => {
     expect(plugin.enforce).toBe("pre")
   })
 
+  it("registers runtime-only targets without emitting static provider output", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-runtime-target-"))
+    await mkdir(join(root, "server", "schedules"), { recursive: true })
+    await writeFile(join(root, "server", "schedules", "agent-turn.ts"), [
+      "import { defineScheduleTarget } from '@vite-hub/schedule'",
+      "export default defineScheduleTarget({ handler: () => {} })",
+      "",
+    ].join("\n"), "utf8")
+
+    const plugin = hubSchedule()
+    const config = await (plugin.config as (config: Record<string, unknown>, env: { command: "build", mode: string }) => unknown)(
+      { root },
+      { command: "build", mode: "production" },
+    )
+    expect(config).toBeNull()
+
+    resolvePluginConfig(plugin, root)
+    await expect(loadScheduleRegistry(plugin)).resolves.toContain("server/schedules/agent-turn.ts")
+    await expect(loadScheduleTargets(plugin)).resolves.toContain('"agent-turn"')
+    expect(existsSync(join(root, ".vitehub", "nitro", "schedule", "plugin.ts"))).toBe(false)
+  })
+
   it("contributes discovered schedules to the in-flight Nitro config before framework plugins consume it", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-nitro-config-"))
     await mkdir(join(root, "server", "schedules"), { recursive: true })
@@ -89,7 +111,7 @@ describe("Vite schedule integration", () => {
     await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("dedupeCloudflareCrons")
     await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("\"*/10 * * * *\"")
     await expect(readFile(join(root, ".vitehub", "schedule", "registry.js"), "utf8")).resolves.toContain("\"mirror\": async () => import(")
-    await expect(readFile(join(root, ".vitehub", "schedule", "registry.d.ts"), "utf8")).resolves.toContain("ScheduleDefinition")
+    await expect(readFile(join(root, ".vitehub", "schedule", "registry.d.ts"), "utf8")).resolves.toContain("ScheduleRegistryDefinition")
   })
 
   it("installs Schedule Provider Wake through the Nuxt module", async () => {


### PR DESCRIPTION
Adds opaque, generic `input` to Runtime Schedule records, create/update calls, and handler context. Built-in memory and KV stores snapshot input deeply; providing input on update replaces the whole value, while omitting it preserves the stored snapshot.

Adds `defineScheduleTarget({ handler })` for cronless Runtime Schedule targets. These definitions are runtime-eligible by construction and remain discoverable through the runtime registry and target list, while static Nitro, Cloudflare, Vercel, Netlify, and Deno provider output ignores them. `defineSchedule()` remains cron-required.

This PR is stacked on #554 so the combined Runtime Schedule record contract keeps both `timeZone` and generic input.