### PR TITLE
feat(agent): improve finish hooks and chat errors

### DIFF
--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -173,6 +173,19 @@ export default defineAgent({
 })
 ```
 
+Finish hooks can also return channel delivery effects. Use `event.reply()`, `event.reaction()`, or `event.status()` and return one effect or an array; ViteHub delivers them after Capability finish effects.
+
+```ts [server/agents/support.ts]
+export default defineAgent({
+  driver: { run: () => 'Done' },
+  hooks: {
+    'agent:finish'(event) {
+      return event.reply('Usage recorded.')
+    },
+  },
+})
+```
+
 Finish hooks should not quietly grant new abilities. Capabilities and Agent Drivers remain the authority boundaries.
 
 ### Handle failures

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -115,6 +115,7 @@ import type {
   AgentDriverContribution,
   AgentDriverKind,
   AgentFinishEvent,
+  AgentFinishHookEvent,
   AgentFinishExtensions,
   AgentChatOptions,
   AgentHostIdentity,
@@ -259,6 +260,7 @@ export type {
   AgentFinishExtensions,
   AgentFinishExtensionValues,
   AgentFinishHook,
+  AgentFinishHookEvent,
   AgentHostIdentity,
   AgentHarnessCredentialSource,
   AgentHarnessDriver,
@@ -1256,7 +1258,7 @@ type AgentInvocationContext<
   finalOutputRenderers: AgentCapabilityRegistries["finalOutputRenderers"]
   finishDeliveryEffectProviders: AgentChannelDeliveryFinishEffect[]
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
-  finishHook?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS> extends infer TEvent ? (event: TEvent) => MaybePromise<void> : never
+  finishHook?: (event: AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
   hasCapabilityCleanup: boolean
   harnessSandboxProvider?: unknown
   hooks?: AgentHookObserverHooks
@@ -1552,7 +1554,7 @@ type InvocationRunContext<
   finishDeliveryEffectProviders: AgentChannelDeliveryFinishEffect[]
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
   finalOutputRenderers: AgentCapabilityRegistries["finalOutputRenderers"]
-  finishHook?: (event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void>
+  finishHook?: (event: AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
   hooks?: AgentHookObserverHooks
   input: AgentRunInput<CALL_OPTIONS>
   outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
@@ -1929,6 +1931,22 @@ function createFinishDeliveryEffectContext<
   }
 }
 
+function createAgentFinishHookEvent<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+): AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS> {
+  const delivery = createFinishDeliveryEffectContext(event, context)
+  return {
+    ...event,
+    reaction: delivery.reaction,
+    reply: delivery.reply,
+    status: delivery.status,
+  }
+}
+
 function activeFinishDeliveryEffectProviders<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -2033,14 +2051,20 @@ async function finishAgentInvocation<
         const finishEvent = { ...eventBase, extensions }
         const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, finishEvent as never)
         await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context), finishEvent as never)
+        let finishHookResult: void | AgentChannelDeliveryFinishEffectResult
         await runObservedAgentHook(context.hooks, {
           ids: { runId: context.run?.runId },
           name: "agent:finish",
           owner: "agent",
           phase: "finish",
         }, async () => {
-          await context.finishHook?.(finishEvent)
+          finishHookResult = await context.finishHook?.(createAgentFinishHookEvent(finishEvent, context))
         })
+        if (finishHookResult) {
+          const finishHookIntents: AgentChannelDeliveryEffectIntent[] = []
+          appendDeliveryEffectIntent(finishHookIntents, finishHookResult)
+          await applyChannelDeliveryEffectIntents(context, finishHookIntents, finishEvent)
+        }
       }
     }
     if (!failed) await commitWorkspaceChanges(context)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -6,6 +6,7 @@ import { Chat, StreamingPlan, convertEmojiPlaceholders } from "chat"
 import { resolveAgentTriggerInvocation, resolveAgentTriggers, runAgent, runAgentInline, streamAgent, streamAgentTrigger } from "../index.ts"
 import { streamAgentOutputToEvents } from "../agent-output.ts"
 import { getAccessCapabilityOptions } from "../capabilities/access-metadata.ts"
+import { RateLimitRejectedError } from "../capabilities/rate-limit.ts"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions } from "../chat-trigger.ts"
 import { chatTriggerHistoryLimit, resolveChatTriggerHistory, uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { normalizeCapabilities } from "../capability-runtime.ts"
@@ -1485,6 +1486,7 @@ async function resolveChatErrorFallbackText(
     return resolved || undefined
   }
   if (typeof fallback === "string") return fallback
+  if (args.error instanceof RateLimitRejectedError) return args.error.message
   return defaultChatErrorFallbackText
 }
 

--- a/packages/agent/src/test.ts
+++ b/packages/agent/src/test.ts
@@ -10,6 +10,8 @@ import { registerWorkspace } from "@vite-hub/workspace/test"
 import type {
   AgentInput,
   AgentFinishEvent,
+  AgentFinishHook,
+  AgentFinishHookEvent,
   AgentFinishExtensions,
   AgentModelExecutionOptions,
   AgentModelInstrumentation,
@@ -132,12 +134,12 @@ function withTestFinishCapture<TRuntimeConfig extends AgentRuntimeConfig>(
   const clone = Object.create(Object.getPrototypeOf(agent)) as AgentInput<AgentRuntimeContext<TRuntimeConfig>> & { hooks?: Record<string, unknown> }
   Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
   const hooks = clone.hooks || {}
-  const finishHook = hooks["agent:finish"] as ((event: AgentFinishEvent<TRuntimeConfig>) => MaybePromise<void>) | undefined
+  const finishHook = hooks["agent:finish"] as AgentFinishHook<TRuntimeConfig> | undefined
   clone.hooks = {
     ...hooks,
-    async "agent:finish"(event: AgentFinishEvent<TRuntimeConfig>) {
+    async "agent:finish"(event: AgentFinishHookEvent<TRuntimeConfig>) {
       capture(event)
-      await finishHook?.(event)
+      return await finishHook?.(event)
     },
   }
   return clone

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -479,10 +479,19 @@ export interface AgentFinishEvent<
   text?: string
 }
 
+export interface AgentFinishHookEvent<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> extends AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS> {
+  reaction: (input: AgentChannelDeliveryReactionInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reaction">
+  reply: (input: AgentChannelDeliveryReplyInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reply">
+  status: (input: AgentChannelDeliveryStatusInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"status">
+}
+
 export type AgentFinishHook<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
-> = (event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void>
+> = (event: AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
 
 export type AgentInputHook<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -4694,6 +4694,83 @@ describe("server helpers", () => {
     }
   })
 
+  it("posts default and configured rate-limit messages to chat", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { RateLimitRejectedError } = await import("../src/capabilities.ts")
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+
+    try {
+      for (const [index, message] of [undefined, "You've reached today's limit."].entries()) {
+        const adapter = createTestChatAdapter({ deferMessageProcessing: true })
+        const agent = defineAgent({
+          capabilities: [
+            defineChatCapability({
+              platforms: { telegram: () => adapter as never },
+              webhooks: { telegram: {} },
+            }),
+          ],
+          driver: {
+            run: () => {
+              throw new RateLimitRejectedError("rate-limit", {} as never, message)
+            },
+          },
+        })
+        const handler = createChannelWebhookRouteHandler(agent as never)
+
+        const tasks: Promise<unknown>[] = []
+        const response = await handler(chatWebhookRequest(2001 + index), "telegram", {
+          waitUntil: task => tasks.push(task),
+        })
+        expect(response.status).toBe(200)
+        await Promise.all(tasks)
+
+        expect(adapter.postMessage).toHaveBeenLastCalledWith(
+          "telegram:456",
+          message ?? "Rate limit exceeded. Try again later.",
+        )
+      }
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it("keeps name-spoofed rate-limit errors behind the generic chat fallback", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter({ deferMessageProcessing: true })
+    const waitUntilTasks: Promise<unknown>[] = []
+    const error = new Error("internal details")
+    error.name = "RateLimitRejectedError"
+    const agent = defineAgent({
+      capabilities: [
+        defineChatCapability({
+          platforms: { telegram: () => adapter as never },
+          webhooks: { telegram: {} },
+        }),
+      ],
+      driver: { run: () => { throw error } },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = await handler(chatWebhookRequest(2003), "telegram", {
+        waitUntil: task => waitUntilTasks.push(task),
+      })
+      expect(response.status).toBe(200)
+      await Promise.all(waitUntilTasks)
+      expect(adapter.postMessage).toHaveBeenLastCalledWith("telegram:456", "Sorry, I couldn't process that message.")
+      expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", "internal details")
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("lets chat webhooks opt out of streaming model execution", async () => {
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2630,6 +2630,62 @@ describe("agent message protocol", () => {
     expect(order).toEqual(["run", "effect:result:ok:done:42"])
   })
 
+  it("lets agent finish hooks return delivery effects after capability finish effects", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const order: string[] = []
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "feedback",
+          prepare(context) {
+            context.delivery.finishEffect(context => context.reply("capability"))
+          },
+        }),
+      ],
+      channels: {
+        portal: defineChannel("portal", {
+          effects: {
+            reaction({ effect }) {
+              order.push(`reaction:${effect.payload}`)
+            },
+            reply({ effect }) {
+              order.push(`reply:${effect.payload}`)
+            },
+            status({ effect }) {
+              order.push(`status:${(effect.payload as { state?: string } | undefined)?.state}`)
+            },
+          },
+          messages: false,
+        }),
+      },
+      driver: { run: () => "ok" },
+      hooks: {
+        "agent:finish"(event) {
+          return [
+            event.reply("hook"),
+            event.reaction("done"),
+            event.status("completed"),
+          ]
+        },
+      },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { channelId: "portal", runId: "portal-run" },
+      runtime: "unknown" as const,
+      waitUntil: vi.fn(),
+    }, {})).resolves.toBe("ok")
+
+    expect(order).toEqual([
+      "reply:capability",
+      "reply:hook",
+      "reaction:done",
+      "status:completed",
+    ])
+  })
+
   it("carries result artifacts through custom finish replies", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/test-runner.test.ts
+++ b/packages/agent/test/test-runner.test.ts
@@ -187,6 +187,33 @@ describe("agent test runner", () => {
     expect(JSON.stringify(result.extensions)).toBe('{"review-output":{"resultKind":"object","runId":"run-extensions"}}')
   })
 
+  it("preserves finish hook delivery effects while capturing test results", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const { createAgentTestRunner } = await import("../src/test.ts")
+    const reply = vi.fn()
+    const runner = createAgentTestRunner(defineAgent({
+      channels: {
+        portal: defineChannel("portal", {
+          effects: { reply },
+          messages: false,
+        }),
+      },
+      driver: { run: () => "done" },
+      hooks: {
+        "agent:finish": event => event.reply("usage"),
+      },
+    }), {
+      run: { channelId: "portal", runId: "test-run" },
+      runtimeConfig: {},
+    })
+
+    await expect(runner.run({ prompt: "hello" })).resolves.toMatchObject({ text: "done" })
+    expect(reply).toHaveBeenCalledWith(expect.objectContaining({
+      effect: expect.objectContaining({ kind: "reply", payload: "usage" }),
+    }))
+  })
+
   it("applies workspace defaults and collects workspace tool steps", async () => {
     const { registerWorkspace } = await import("@vite-hub/workspace/test")
     const execute = vi.fn(async () => "workspace result")


### PR DESCRIPTION
Allows `agent:finish` hooks to return reply, reaction, and status delivery effects, which are delivered after capability finish effects. Agent definitions can add post-run channel behavior through the same delivery contract as capabilities instead of wiring channel-specific callbacks.

Chat webhooks now preserve the message from a canonical `RateLimitRejectedError`, so applications can give users useful retry guidance while unrelated failures still use the generic fallback. The default, configured, and spoofed-error paths are covered by regression tests.