### PR TITLE
docs: clarify landing agent story

### DIFF
--- a/docs/app/components/landing/AgentDiagram.vue
+++ b/docs/app/components/landing/AgentDiagram.vue
@@ -48,7 +48,7 @@ const files = [
         <div class="agent-connector hidden sm:block" aria-hidden="true"><span /></div>
 
         <div
-          class="agent-invocation flex min-h-28 flex-col justify-between border border-default bg-default p-4"
+          class="agent-invocation relative isolate flex min-h-28 flex-col justify-between overflow-hidden border border-default bg-default p-4"
         >
           <div class="flex items-center gap-2 text-muted">
             <UIcon name="i-lucide-message-square-code" class="size-4" aria-hidden="true" />
@@ -97,7 +97,7 @@ const files = [
   background: var(--ui-text-highlighted);
   content: "";
   opacity: 0.18;
-  animation: agent-file-read 4.8s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+  animation: agent-file-read 4.8s cubic-bezier(0.23, 1, 0.32, 1) infinite;
   animation-delay: var(--file-delay);
 }
 
@@ -113,10 +113,20 @@ const files = [
   left: 0;
   width: 35%;
   background: var(--ui-text-highlighted);
-  animation: agent-connect 3.6s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+  animation: agent-connect 3.6s cubic-bezier(0.77, 0, 0.175, 1) infinite;
 }
-.agent-invocation {
-  animation: agent-invoke 3.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+.agent-invocation::before {
+  position: absolute;
+  z-index: 0;
+  inset: 0;
+  background: color-mix(in srgb, var(--ui-text-highlighted) 5%, var(--ui-bg));
+  content: "";
+  opacity: 0;
+  animation: agent-invoke 3.6s cubic-bezier(0.23, 1, 0.32, 1) infinite;
+}
+.agent-invocation > * {
+  position: relative;
+  z-index: 1;
 }
 
 @keyframes agent-file-read {
@@ -124,12 +134,12 @@ const files = [
   14%,
   100% {
     opacity: 0.18;
-    transform: scale(0.8);
+    transform: scale(0.95);
   }
   5%,
   9% {
     opacity: 0.9;
-    transform: scale(1.15);
+    transform: scale(1);
   }
 }
 @keyframes agent-connect {
@@ -150,17 +160,17 @@ const files = [
   0%,
   42%,
   100% {
-    background: var(--ui-bg);
+    opacity: 0;
   }
   55%,
   74% {
-    background: color-mix(in srgb, var(--ui-text-highlighted) 5%, var(--ui-bg));
+    opacity: 1;
   }
 }
 @media (prefers-reduced-motion: reduce) {
   .agent-file::before,
   .agent-connector span,
-  .agent-invocation {
+  .agent-invocation::before {
     animation: none;
   }
   .agent-connector span {

--- a/docs/app/components/landing/AgentDiagram.vue
+++ b/docs/app/components/landing/AgentDiagram.vue
@@ -1,213 +1,227 @@
 <script setup lang="ts">
-const files = [
-  { label: "config.ts", icon: "i-lucide-file-code-2", kind: "Definition" },
-  { label: "instructions.md", icon: "i-lucide-file-text", kind: "Instructions" },
-  { label: "skills/review/", icon: "i-lucide-folder", kind: "Skill" },
-] as const;
-
-const attachments = [
-  { label: "Pull request checkout", icon: "i-lucide-folder-git-2", kind: "Workspace" },
-  { label: "workspaceShell()", icon: "i-lucide-square-terminal", kind: "Capability" },
+const parts = [
+  { label: "Instructions", value: "instructions.md", icon: "i-lucide-file-text" },
+  { label: "Skill", value: "review", icon: "i-lucide-folder" },
+  { label: "Workspace", value: "PR checkout", icon: "i-lucide-folder-git-2" },
+  { label: "Capability", value: "workspaceShell()", icon: "i-lucide-square-terminal" },
 ] as const;
 </script>
 
 <template>
   <figure
-    class="agent-diagram overflow-hidden border border-default bg-default"
+    class="agent-diagram overflow-hidden border border-default bg-default p-5 sm:p-7 lg:p-9"
     role="img"
-    aria-label="A review Agent Definition combines instructions and a review Skill with a pull request Workspace and workspace shell Capability, then handles a pull request invocation."
+    aria-label="Pull request 574 enters a Review Agent composed of instructions, a review Skill, a pull request Workspace, and a workspace shell Capability. The Agent returns three findings."
   >
-    <figcaption
-      class="flex min-h-11 items-center justify-between gap-4 border-b border-default bg-muted/40 px-4 font-mono text-xs text-muted"
-    >
-      <span>server/agents/review/</span>
-      <span class="hidden sm:inline">Agent Definition</span>
-    </figcaption>
-
-    <div class="relative p-4 sm:p-7 lg:p-9">
-      <div class="grid items-center gap-4 sm:grid-cols-[minmax(0,1fr)_3.5rem_minmax(8rem,.72fr)]">
-        <div class="agent-files border border-default bg-default p-3 sm:p-4">
-          <div
-            class="flex items-center gap-2 border-b border-default pb-3 font-mono text-xs font-medium text-highlighted"
-          >
-            <UIcon name="i-lucide-folder-open" class="size-4" aria-hidden="true" />
-            review/
-          </div>
-          <ul class="mt-2" role="list">
-            <li
-              v-for="(file, index) in files"
-              :key="file.label"
-              class="agent-file flex items-center gap-2.5 py-2"
-              :style="{ '--file-delay': `${index * 900}ms` }"
-            >
-              <UIcon :name="file.icon" class="size-4 shrink-0 text-muted" aria-hidden="true" />
-              <span class="font-mono text-xs text-highlighted sm:text-sm">{{ file.label }}</span>
-              <span
-                class="ml-auto hidden text-[0.625rem] uppercase tracking-[0.12em] text-dimmed sm:block"
-                >{{ file.kind }}</span
-              >
-            </li>
-          </ul>
-
-          <div class="mt-2 border-t border-default pt-2">
-            <p class="px-1 font-mono text-[0.625rem] uppercase tracking-[0.12em] text-dimmed">
-              Attached
-            </p>
-            <ul class="mt-1" role="list">
-              <li
-                v-for="(attachment, index) in attachments"
-                :key="attachment.label"
-                class="agent-file flex items-center gap-2.5 py-2"
-                :style="{ '--file-delay': `${(files.length + index) * 900}ms` }"
-              >
-                <UIcon
-                  :name="attachment.icon"
-                  class="size-4 shrink-0 text-muted"
-                  aria-hidden="true"
-                />
-                <span class="font-mono text-xs text-highlighted sm:text-sm">{{
-                  attachment.label
-                }}</span>
-                <span
-                  class="ml-auto hidden text-[0.625rem] uppercase tracking-[0.12em] text-dimmed sm:block"
-                  >{{ attachment.kind }}</span
-                >
-              </li>
-            </ul>
-          </div>
-        </div>
-
-        <div class="agent-connector hidden sm:block" aria-hidden="true"><span /></div>
-
-        <div
-          class="agent-invocation relative isolate flex min-h-28 flex-col justify-between overflow-hidden border border-default bg-default p-4"
-        >
-          <div class="flex items-center gap-2 text-muted">
-            <UIcon name="i-lucide-message-square-code" class="size-4" aria-hidden="true" />
-            <span class="font-mono text-[0.6875rem] uppercase tracking-[0.12em]"
-              >Agent Invocation</span
-            >
-          </div>
-          <div>
-            <p class="text-sm font-medium text-highlighted">Review pull request #574</p>
-            <p class="mt-1 font-mono text-xs text-muted">→ review Agent</p>
-          </div>
+    <div class="agent-flow">
+      <div class="agent-endpoint agent-input">
+        <UIcon name="i-lucide-git-pull-request" class="size-5 text-muted" aria-hidden="true" />
+        <div>
+          <p class="font-mono text-sm font-medium text-highlighted">PR #574</p>
+          <p class="mt-0.5 text-xs text-muted">GitHub</p>
         </div>
       </div>
 
-      <div
-        class="mt-6 flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-default pt-4 font-mono text-[0.6875rem] text-muted sm:mt-8"
-      >
-        <span class="uppercase tracking-[0.12em] text-dimmed">Choose a driver</span>
-        <span>Model</span>
-        <span>Harness</span>
-        <span>Custom</span>
+      <div class="agent-rail agent-rail-in" aria-hidden="true"><span /></div>
+
+      <div class="agent-definition">
+        <div class="flex items-center gap-2.5 border-b border-default px-4 py-3.5">
+          <UIcon name="i-lucide-bot" class="size-4 text-muted" aria-hidden="true" />
+          <span class="font-mono text-sm font-medium text-highlighted">Review Agent</span>
+        </div>
+
+        <ul class="p-2" role="list">
+          <li
+            v-for="(part, index) in parts"
+            :key="part.label"
+            class="agent-part grid grid-cols-1 items-center gap-1 px-2 py-2.5 sm:grid-cols-[1fr_auto] sm:gap-3"
+            :style="{ '--part-index': index }"
+          >
+            <span class="flex min-w-0 items-center gap-2 text-xs text-muted">
+              <UIcon :name="part.icon" class="size-3.5 shrink-0" aria-hidden="true" />
+              {{ part.label }}
+            </span>
+            <span class="pl-[1.375rem] font-mono text-xs text-highlighted sm:pl-0">{{
+              part.value
+            }}</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="agent-rail agent-rail-out" aria-hidden="true"><span /></div>
+
+      <div class="agent-endpoint agent-output">
+        <UIcon name="i-lucide-circle-check" class="size-5 text-muted" aria-hidden="true" />
+        <div>
+          <p class="font-mono text-sm font-medium text-highlighted">3 findings</p>
+          <p class="mt-0.5 text-xs text-muted">Review posted</p>
+        </div>
       </div>
     </div>
   </figure>
 </template>
 
 <style scoped>
-.agent-diagram {
-  background-image:
-    linear-gradient(
-      90deg,
-      color-mix(in srgb, var(--ui-border) 42%, transparent) 1px,
-      transparent 1px
-    ),
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--ui-border) 34%, transparent) 1px,
-      transparent 1px
-    );
-  background-position: center;
-  background-size: 4rem 4rem;
+.agent-flow {
+  display: grid;
+  align-items: center;
 }
 
-.agent-file::before {
-  width: 0.25rem;
-  height: 0.25rem;
-  border-radius: 999px;
-  background: var(--ui-text-highlighted);
-  content: "";
-  opacity: 0.18;
-  animation: agent-file-read 4.8s cubic-bezier(0.23, 1, 0.32, 1) infinite;
-  animation-delay: var(--file-delay);
+.agent-endpoint {
+  display: flex;
+  min-height: 5rem;
+  align-items: center;
+  gap: 0.75rem;
+  border: 1px solid var(--ui-border);
+  background: var(--ui-bg);
+  padding: 1rem;
 }
 
-.agent-connector {
+.agent-definition {
+  border: 1px solid var(--ui-border);
+  background: var(--ui-bg);
+}
+
+.agent-part {
   position: relative;
-  height: 1px;
+  isolation: isolate;
+}
+
+.agent-part::before {
+  position: absolute;
+  z-index: -1;
+  inset: 0;
+  background: color-mix(in srgb, var(--ui-text-highlighted) 6%, transparent);
+  content: "";
+  opacity: 0;
+  animation: agent-read 7.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+  animation-delay: calc(var(--part-index) * 320ms);
+}
+
+.agent-rail {
+  --flow-from: translateY(-130%);
+  --flow-to: translateY(390%);
+
+  position: relative;
+  width: 1px;
+  height: 2rem;
+  justify-self: center;
   overflow: hidden;
   background: var(--ui-border-accented);
 }
-.agent-connector span {
+
+.agent-rail span {
   position: absolute;
-  inset-block: -1px;
-  left: 0;
-  width: 35%;
+  top: 0;
+  left: -1px;
+  width: 3px;
+  height: 35%;
   background: var(--ui-text-highlighted);
-  animation: agent-connect 3.6s cubic-bezier(0.77, 0, 0.175, 1) infinite;
-}
-.agent-invocation::before {
-  position: absolute;
-  z-index: 0;
-  inset: 0;
-  background: color-mix(in srgb, var(--ui-text-highlighted) 5%, var(--ui-bg));
-  content: "";
-  opacity: 0;
-  animation: agent-invoke 3.6s cubic-bezier(0.23, 1, 0.32, 1) infinite;
-}
-.agent-invocation > * {
-  position: relative;
-  z-index: 1;
 }
 
-@keyframes agent-file-read {
-  0%,
-  14%,
-  100% {
-    opacity: 0.18;
-    transform: scale(0.95);
+.agent-rail-in span {
+  animation: agent-flow-in 7.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+}
+
+.agent-rail-out span {
+  animation: agent-flow-out 7.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+}
+
+.agent-output {
+  animation: agent-output 7.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+}
+
+@media (min-width: 40rem) {
+  .agent-flow {
+    grid-template-columns:
+      minmax(7rem, 0.72fr) minmax(1.5rem, 0.22fr) minmax(14rem, 1.5fr)
+      minmax(1.5rem, 0.22fr) minmax(7rem, 0.72fr);
   }
-  5%,
-  9% {
-    opacity: 0.9;
-    transform: scale(1);
+
+  .agent-rail {
+    --flow-from: translateX(-130%);
+    --flow-to: translateX(390%);
+
+    width: auto;
+    height: 1px;
+    justify-self: stretch;
+  }
+
+  .agent-rail span {
+    top: -1px;
+    left: 0;
+    width: 35%;
+    height: 3px;
   }
 }
-@keyframes agent-connect {
-  0% {
+
+@keyframes agent-read {
+  0%,
+  20%,
+  32%,
+  100% {
     opacity: 0;
-    transform: translateX(-110%);
   }
-  22%,
-  72% {
+  24%,
+  29% {
     opacity: 1;
   }
+}
+
+@keyframes agent-output {
+  0%,
+  61%,
   100% {
-    opacity: 0;
-    transform: translateX(390%);
+    background: var(--ui-bg);
+  }
+  69%,
+  88% {
+    background: color-mix(in srgb, var(--ui-text-highlighted) 6%, var(--ui-bg));
   }
 }
-@keyframes agent-invoke {
+
+@keyframes agent-flow-in {
   0%,
-  42%,
-  100% {
+  8% {
     opacity: 0;
+    transform: var(--flow-from);
   }
-  55%,
-  74% {
+  12%,
+  20% {
     opacity: 1;
   }
+  24%,
+  100% {
+    opacity: 0;
+    transform: var(--flow-to);
+  }
 }
+
+@keyframes agent-flow-out {
+  0%,
+  56% {
+    opacity: 0;
+    transform: var(--flow-from);
+  }
+  61%,
+  69% {
+    opacity: 1;
+  }
+  74%,
+  100% {
+    opacity: 0;
+    transform: var(--flow-to);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .agent-file::before,
-  .agent-connector span,
-  .agent-invocation::before {
+  .agent-part::before,
+  .agent-rail span,
+  .agent-output {
     animation: none;
   }
-  .agent-connector span {
+
+  .agent-rail span {
     display: none;
   }
 }

--- a/docs/app/components/landing/AgentDiagram.vue
+++ b/docs/app/components/landing/AgentDiagram.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-const boundaries = [
-  { label: "Driver", value: "Application code", icon: "i-lucide-cpu" },
-  { label: "Workspace", value: "Repository", icon: "i-lucide-folder-tree" },
-  { label: "Capability", value: "Blob", icon: "i-lucide-blocks" },
-  { label: "Instructions", value: "AGENTS.md", icon: "i-lucide-file-text" },
+const files = [
+  { label: "instructions.md", icon: "i-lucide-file-text", kind: "Markdown" },
+  { label: "skills/", icon: "i-lucide-folder", kind: "Markdown" },
+  { label: "tools.ts", icon: "i-lucide-file-code-2", kind: "TypeScript" },
 ] as const;
 </script>
 
@@ -11,69 +10,64 @@ const boundaries = [
   <figure
     class="agent-diagram overflow-hidden border border-default bg-default"
     role="img"
-    aria-label="A GitHub pull request flows into an Agent Definition composed from a Driver, Workspace, Capability, and instructions, then leaves as an Agent Invocation."
+    aria-label="An Agent Definition combines Markdown instructions and skills with TypeScript tools, then handles an invocation."
   >
     <figcaption
       class="flex min-h-11 items-center justify-between gap-4 border-b border-default bg-muted/40 px-4 font-mono text-xs text-muted"
     >
-      <span>server/agents/review.ts</span>
+      <span>server/agents/review/</span>
       <span class="hidden sm:inline">Agent Definition</span>
     </figcaption>
 
-    <div class="relative px-4 py-10 sm:px-7 sm:py-12 lg:px-9 lg:py-14">
-      <div
-        class="agent-flow grid grid-cols-[minmax(4.5rem,1fr)_minmax(1.5rem,0.5fr)_minmax(6.5rem,0.9fr)_minmax(1.5rem,0.5fr)_minmax(4.5rem,1fr)] items-center"
-      >
-        <div class="agent-endpoint justify-self-start">
-          <UIcon name="i-lucide-git-pull-request" class="size-4" aria-hidden="true" />
-          <span>GitHub PR</span>
+    <div class="relative p-4 sm:p-7 lg:p-9">
+      <div class="grid items-center gap-4 sm:grid-cols-[minmax(0,1fr)_3.5rem_minmax(8rem,.72fr)]">
+        <div class="agent-files border border-default bg-default p-3 sm:p-4">
+          <div
+            class="flex items-center gap-2 border-b border-default pb-3 font-mono text-xs font-medium text-highlighted"
+          >
+            <UIcon name="i-lucide-folder-open" class="size-4" aria-hidden="true" />
+            review/
+          </div>
+          <ul class="mt-2" role="list">
+            <li
+              v-for="(file, index) in files"
+              :key="file.label"
+              class="agent-file flex items-center gap-2.5 py-2"
+              :style="{ '--file-delay': `${index * 900}ms` }"
+            >
+              <UIcon :name="file.icon" class="size-4 shrink-0 text-muted" aria-hidden="true" />
+              <span class="font-mono text-xs text-highlighted sm:text-sm">{{ file.label }}</span>
+              <span
+                class="ml-auto hidden text-[0.625rem] uppercase tracking-[0.12em] text-dimmed sm:block"
+                >{{ file.kind }}</span
+              >
+            </li>
+          </ul>
         </div>
 
-        <span class="agent-rail" aria-hidden="true"><span /></span>
+        <div class="agent-connector hidden sm:block" aria-hidden="true"><span /></div>
 
-        <div class="agent-core">
-          <svg viewBox="0 0 80 72" class="size-20 sm:size-24" aria-hidden="true">
-            <polygon points="20,4 60,4 78,36 60,68 20,68 2,36" fill="currentColor" />
-            <polygon
-              class="agent-core-ring"
-              points="23,10 57,10 71,36 57,62 23,62 9,36"
-              fill="none"
-              stroke="var(--ui-bg)"
-              stroke-width="1.5"
-            />
-          </svg>
-          <span class="font-mono text-[0.6875rem] font-medium text-inverted sm:text-xs">Agent</span>
-        </div>
-
-        <span class="agent-rail agent-rail-delay" aria-hidden="true"><span /></span>
-
-        <div class="agent-endpoint justify-self-end">
-          <UIcon name="i-lucide-activity" class="size-4" aria-hidden="true" />
-          <span>Invocation</span>
-        </div>
-      </div>
-
-      <div class="agent-trunk" aria-hidden="true">
-        <span v-for="index in 4" :key="index" />
-      </div>
-
-      <div class="mt-14 grid grid-cols-2 gap-px bg-default sm:mt-16 sm:grid-cols-4">
         <div
-          v-for="(boundary, index) in boundaries"
-          :key="boundary.label"
-          class="agent-boundary min-w-0 border border-default bg-default p-3 sm:p-4"
-          :style="{ '--agent-delay': `${index * 1.1}s` }"
+          class="agent-invocation flex min-h-28 flex-col justify-between border border-default bg-default p-4"
         >
           <div class="flex items-center gap-2 text-muted">
-            <UIcon :name="boundary.icon" class="size-3.5 shrink-0" aria-hidden="true" />
-            <span class="font-mono text-[0.6875rem] uppercase tracking-[0.12em]">{{
-              boundary.label
-            }}</span>
+            <UIcon name="i-lucide-message-square-code" class="size-4" aria-hidden="true" />
+            <span class="font-mono text-[0.6875rem] uppercase tracking-[0.12em]">Invocation</span>
           </div>
-          <p class="mt-2 truncate text-sm font-medium text-highlighted">
-            {{ boundary.value }}
-          </p>
+          <div>
+            <p class="text-sm font-medium text-highlighted">Review this pull request</p>
+            <p class="mt-1 font-mono text-xs text-muted">→ review.ts</p>
+          </div>
         </div>
+      </div>
+
+      <div
+        class="mt-6 flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-default pt-4 font-mono text-[0.6875rem] text-muted sm:mt-8"
+      >
+        <span class="uppercase tracking-[0.12em] text-dimmed">Choose a driver</span>
+        <span>Model</span>
+        <span>Harness</span>
+        <span>Custom</span>
       </div>
     </div>
   </figure>
@@ -84,186 +78,93 @@ const boundaries = [
   background-image:
     linear-gradient(
       90deg,
-      color-mix(in srgb, var(--ui-border) 46%, transparent) 1px,
+      color-mix(in srgb, var(--ui-border) 42%, transparent) 1px,
       transparent 1px
     ),
     linear-gradient(
       180deg,
-      color-mix(in srgb, var(--ui-border) 38%, transparent) 1px,
+      color-mix(in srgb, var(--ui-border) 34%, transparent) 1px,
       transparent 1px
     );
   background-position: center;
   background-size: 4rem 4rem;
 }
 
-.agent-endpoint {
-  display: inline-flex;
-  min-height: 2.5rem;
-  align-items: center;
-  gap: 0.5rem;
-  border: 1px solid var(--ui-border);
-  background: var(--ui-bg);
-  padding: 0.625rem 0.75rem;
-  color: var(--ui-text-muted);
-  font-family: var(--font-mono), ui-monospace, monospace;
-  font-size: 0.75rem;
-  white-space: nowrap;
+.agent-file::before {
+  width: 0.25rem;
+  height: 0.25rem;
+  border-radius: 999px;
+  background: var(--ui-text-highlighted);
+  content: "";
+  opacity: 0.18;
+  animation: agent-file-read 4.8s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+  animation-delay: var(--file-delay);
 }
 
-.agent-rail {
+.agent-connector {
   position: relative;
   height: 1px;
   overflow: hidden;
   background: var(--ui-border-accented);
 }
-
-.agent-rail span {
+.agent-connector span {
   position: absolute;
-  top: -1px;
+  inset-block: -1px;
   left: 0;
-  width: 30%;
-  height: 3px;
+  width: 35%;
   background: var(--ui-text-highlighted);
-  animation: agent-flow 2.8s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+  animation: agent-connect 3.6s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+}
+.agent-invocation {
+  animation: agent-invoke 3.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
 }
 
-.agent-rail-delay span {
-  animation-delay: 1.4s;
+@keyframes agent-file-read {
+  0%,
+  14%,
+  100% {
+    opacity: 0.18;
+    transform: scale(0.8);
+  }
+  5%,
+  9% {
+    opacity: 0.9;
+    transform: scale(1.15);
+  }
 }
-
-.agent-core {
-  position: relative;
-  display: grid;
-  place-items: center;
-  justify-self: center;
-  color: var(--ui-text-highlighted);
-}
-
-.agent-core > * {
-  grid-area: 1 / 1;
-}
-
-.agent-core-ring {
-  animation: agent-core-pulse 2.8s cubic-bezier(0.65, 0, 0.35, 1) infinite;
-  transform-origin: center;
-}
-
-.agent-trunk {
-  position: relative;
-  width: calc(75% + 1px);
-  height: 2.75rem;
-  margin: 0 auto -3.5rem;
-  border-top: 1px solid var(--ui-border-accented);
-}
-
-.agent-trunk::before {
-  position: absolute;
-  bottom: 100%;
-  left: 50%;
-  width: 1px;
-  height: 2.25rem;
-  background: var(--ui-border-accented);
-  content: "";
-}
-
-.agent-trunk span {
-  position: absolute;
-  top: -0.25rem;
-  width: 0.5rem;
-  height: 0.5rem;
-  border: 1px solid var(--ui-border-accented);
-  border-radius: 999px;
-  background: var(--ui-bg);
-}
-
-.agent-trunk span:nth-child(1) {
-  left: 0;
-}
-.agent-trunk span:nth-child(2) {
-  left: 33.333%;
-}
-.agent-trunk span:nth-child(3) {
-  left: 66.666%;
-}
-.agent-trunk span:nth-child(4) {
-  right: 0;
-}
-
-.agent-boundary {
-  animation: agent-boundary 4.4s cubic-bezier(0.65, 0, 0.35, 1) infinite;
-  animation-delay: var(--agent-delay);
-}
-
-@keyframes agent-flow {
+@keyframes agent-connect {
   0% {
     opacity: 0;
-    transform: translateX(-120%);
+    transform: translateX(-110%);
   }
-  20% {
-    opacity: 1;
-  }
-  75% {
+  22%,
+  72% {
     opacity: 1;
   }
   100% {
     opacity: 0;
-    transform: translateX(440%);
+    transform: translateX(390%);
   }
 }
-
-@keyframes agent-core-pulse {
+@keyframes agent-invoke {
   0%,
+  42%,
   100% {
-    opacity: 0.28;
-    transform: scale(0.92);
+    background: var(--ui-bg);
   }
-  50% {
-    opacity: 0.72;
-    transform: scale(1);
-  }
-}
-
-@keyframes agent-boundary {
-  0%,
-  100% {
-    opacity: 0.58;
-    transform: translateY(0);
-  }
-  18%,
-  38% {
-    opacity: 1;
-    transform: translateY(-2px);
-  }
-  56% {
-    opacity: 0.58;
-    transform: translateY(0);
+  55%,
+  74% {
+    background: color-mix(in srgb, var(--ui-text-highlighted) 5%, var(--ui-bg));
   }
 }
-
-@media (max-width: 39.999rem) {
-  .agent-endpoint {
-    flex-direction: column;
-    justify-content: center;
-    gap: 0.25rem;
-    padding: 0.5rem;
-    font-size: 0.625rem;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .agent-rail span,
-  .agent-core-ring,
-  .agent-boundary {
+  .agent-file::before,
+  .agent-connector span,
+  .agent-invocation {
     animation: none;
   }
-
-  .agent-rail span {
+  .agent-connector span {
     display: none;
-  }
-
-  .agent-boundary,
-  .agent-core-ring {
-    opacity: 1;
   }
 }
 </style>

--- a/docs/app/components/landing/AgentDiagram.vue
+++ b/docs/app/components/landing/AgentDiagram.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 const stages = [
   {
-    label: "Build any Agent",
-    icon: "i-lucide-bot",
-    items: ["Review", "Support", "Research"],
+    label: "Model or harness",
+    icon: "i-lucide-cpu",
+    items: ["AI SDK", "Codex", "Claude Code"],
   },
   {
-    label: "Use any Capability",
+    label: "Compose your Agent",
     icon: "i-lucide-blocks",
-    items: ["browser()", "workspaceShell()", "db()"],
+    items: ["yourCapability()", "Workspace", "instructions.md"],
   },
   {
     label: "Deploy anywhere",
@@ -22,7 +22,7 @@ const stages = [
   <figure
     class="overflow-hidden border border-default bg-default p-5 sm:p-7 lg:p-9"
     role="img"
-    aria-label="ViteHub lets developers build any Agent, compose it with any Capability, and deploy it to any host. Examples include Review, Support, and Research Agents; browser, workspace shell, and database Capabilities; and Cloudflare, Vercel, and Node hosts."
+    aria-label="ViteHub lets developers bring any model or harness, compose an Agent with their own Capabilities and a Workspace, and deploy it to any host. Examples include AI SDK models, Codex and Claude Code harnesses, custom Capabilities, and Cloudflare, Vercel, and Node hosts."
   >
     <div class="power-flow">
       <template v-for="(stage, index) in stages" :key="stage.label">

--- a/docs/app/components/landing/AgentDiagram.vue
+++ b/docs/app/components/landing/AgentDiagram.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
 const files = [
-  { label: "instructions.md", icon: "i-lucide-file-text", kind: "Markdown" },
-  { label: "skills/", icon: "i-lucide-folder", kind: "Markdown" },
-  { label: "tools.ts", icon: "i-lucide-file-code-2", kind: "TypeScript" },
+  { label: "config.ts", icon: "i-lucide-file-code-2", kind: "Definition" },
+  { label: "instructions.md", icon: "i-lucide-file-text", kind: "Instructions" },
+  { label: "skills/review/", icon: "i-lucide-folder", kind: "Skill" },
+] as const;
+
+const attachments = [
+  { label: "Pull request checkout", icon: "i-lucide-folder-git-2", kind: "Workspace" },
+  { label: "workspaceShell()", icon: "i-lucide-square-terminal", kind: "Capability" },
 ] as const;
 </script>
 
@@ -10,7 +15,7 @@ const files = [
   <figure
     class="agent-diagram overflow-hidden border border-default bg-default"
     role="img"
-    aria-label="An Agent Definition combines Markdown instructions and skills with TypeScript tools, then handles an invocation."
+    aria-label="A review Agent Definition combines instructions and a review Skill with a pull request Workspace and workspace shell Capability, then handles a pull request invocation."
   >
     <figcaption
       class="flex min-h-11 items-center justify-between gap-4 border-b border-default bg-muted/40 px-4 font-mono text-xs text-muted"
@@ -43,6 +48,33 @@ const files = [
               >
             </li>
           </ul>
+
+          <div class="mt-2 border-t border-default pt-2">
+            <p class="px-1 font-mono text-[0.625rem] uppercase tracking-[0.12em] text-dimmed">
+              Attached
+            </p>
+            <ul class="mt-1" role="list">
+              <li
+                v-for="(attachment, index) in attachments"
+                :key="attachment.label"
+                class="agent-file flex items-center gap-2.5 py-2"
+                :style="{ '--file-delay': `${(files.length + index) * 900}ms` }"
+              >
+                <UIcon
+                  :name="attachment.icon"
+                  class="size-4 shrink-0 text-muted"
+                  aria-hidden="true"
+                />
+                <span class="font-mono text-xs text-highlighted sm:text-sm">{{
+                  attachment.label
+                }}</span>
+                <span
+                  class="ml-auto hidden text-[0.625rem] uppercase tracking-[0.12em] text-dimmed sm:block"
+                  >{{ attachment.kind }}</span
+                >
+              </li>
+            </ul>
+          </div>
         </div>
 
         <div class="agent-connector hidden sm:block" aria-hidden="true"><span /></div>
@@ -52,11 +84,13 @@ const files = [
         >
           <div class="flex items-center gap-2 text-muted">
             <UIcon name="i-lucide-message-square-code" class="size-4" aria-hidden="true" />
-            <span class="font-mono text-[0.6875rem] uppercase tracking-[0.12em]">Invocation</span>
+            <span class="font-mono text-[0.6875rem] uppercase tracking-[0.12em]"
+              >Agent Invocation</span
+            >
           </div>
           <div>
-            <p class="text-sm font-medium text-highlighted">Review this pull request</p>
-            <p class="mt-1 font-mono text-xs text-muted">→ review.ts</p>
+            <p class="text-sm font-medium text-highlighted">Review pull request #574</p>
+            <p class="mt-1 font-mono text-xs text-muted">→ review Agent</p>
           </div>
         </div>
       </div>

--- a/docs/app/components/landing/AgentDiagram.vue
+++ b/docs/app/components/landing/AgentDiagram.vue
@@ -1,19 +1,19 @@
 <script setup lang="ts">
 const stages = [
   {
-    label: "Model or harness",
+    label: "Agent Driver",
     icon: "i-lucide-cpu",
-    items: ["AI SDK", "Codex", "Claude Code"],
+    items: ["driver.model", "driver.harness", "driver.run"],
   },
   {
-    label: "Compose your Agent",
+    label: "Agent Definition",
     icon: "i-lucide-blocks",
-    items: ["yourCapability()", "Workspace", "instructions.md"],
+    items: ["instructions.md", "workspace.sources", "capabilities[]"],
   },
   {
-    label: "Deploy anywhere",
+    label: "Agent Invocation",
     icon: "i-lucide-cloud",
-    items: ["Cloudflare", "Vercel", "Node"],
+    items: ["runAgent()", "invoker", "runtime"],
   },
 ] as const;
 </script>
@@ -22,7 +22,7 @@ const stages = [
   <figure
     class="overflow-hidden border border-default bg-default p-5 sm:p-7 lg:p-9"
     role="img"
-    aria-label="ViteHub lets developers bring any model or harness, compose an Agent with their own Capabilities and a Workspace, and deploy it to any host. Examples include AI SDK models, Codex and Claude Code harnesses, custom Capabilities, and Cloudflare, Vercel, and Node hosts."
+    aria-label="A ViteHub Agent Definition is configured from an Agent Driver, instructions, Workspace Sources, Capabilities, and explicit Agent Invocation context."
   >
     <div class="power-flow">
       <template v-for="(stage, index) in stages" :key="stage.label">

--- a/docs/app/components/landing/AgentDiagram.vue
+++ b/docs/app/components/landing/AgentDiagram.vue
@@ -1,104 +1,85 @@
 <script setup lang="ts">
-const parts = [
-  { label: "Instructions", value: "instructions.md", icon: "i-lucide-file-text" },
-  { label: "Skill", value: "review", icon: "i-lucide-folder" },
-  { label: "Workspace", value: "PR checkout", icon: "i-lucide-folder-git-2" },
-  { label: "Capability", value: "workspaceShell()", icon: "i-lucide-square-terminal" },
+const stages = [
+  {
+    label: "Build any Agent",
+    icon: "i-lucide-bot",
+    items: ["Review", "Support", "Research"],
+  },
+  {
+    label: "Use any Capability",
+    icon: "i-lucide-blocks",
+    items: ["browser()", "workspaceShell()", "db()"],
+  },
+  {
+    label: "Deploy anywhere",
+    icon: "i-lucide-cloud",
+    items: ["Cloudflare", "Vercel", "Node"],
+  },
 ] as const;
 </script>
 
 <template>
   <figure
-    class="agent-diagram overflow-hidden border border-default bg-default p-5 sm:p-7 lg:p-9"
+    class="overflow-hidden border border-default bg-default p-5 sm:p-7 lg:p-9"
     role="img"
-    aria-label="Pull request 574 enters a Review Agent composed of instructions, a review Skill, a pull request Workspace, and a workspace shell Capability. The Agent returns three findings."
+    aria-label="ViteHub lets developers build any Agent, compose it with any Capability, and deploy it to any host. Examples include Review, Support, and Research Agents; browser, workspace shell, and database Capabilities; and Cloudflare, Vercel, and Node hosts."
   >
-    <div class="agent-flow">
-      <div class="agent-endpoint agent-input">
-        <UIcon name="i-lucide-git-pull-request" class="size-5 text-muted" aria-hidden="true" />
-        <div>
-          <p class="font-mono text-sm font-medium text-highlighted">PR #574</p>
-          <p class="mt-0.5 text-xs text-muted">GitHub</p>
+    <div class="power-flow">
+      <template v-for="(stage, index) in stages" :key="stage.label">
+        <div class="power-stage" :style="{ '--stage-index': index }">
+          <div class="flex items-center gap-2.5 border-b border-default px-4 py-3.5">
+            <UIcon :name="stage.icon" class="size-4 text-muted" aria-hidden="true" />
+            <span class="text-sm font-medium text-highlighted">{{ stage.label }}</span>
+          </div>
+          <ul class="space-y-1 p-2" role="list">
+            <li
+              v-for="item in stage.items"
+              :key="item"
+              class="px-2 py-2 font-mono text-xs text-muted"
+            >
+              {{ item }}
+            </li>
+          </ul>
         </div>
-      </div>
 
-      <div class="agent-rail agent-rail-in" aria-hidden="true"><span /></div>
-
-      <div class="agent-definition">
-        <div class="flex items-center gap-2.5 border-b border-default px-4 py-3.5">
-          <UIcon name="i-lucide-bot" class="size-4 text-muted" aria-hidden="true" />
-          <span class="font-mono text-sm font-medium text-highlighted">Review Agent</span>
+        <div
+          v-if="index < stages.length - 1"
+          class="power-rail"
+          :style="{ '--rail-index': index }"
+          aria-hidden="true"
+        >
+          <span />
         </div>
-
-        <ul class="p-2" role="list">
-          <li
-            v-for="(part, index) in parts"
-            :key="part.label"
-            class="agent-part grid grid-cols-1 items-center gap-1 px-2 py-2.5 sm:grid-cols-[1fr_auto] sm:gap-3"
-            :style="{ '--part-index': index }"
-          >
-            <span class="flex min-w-0 items-center gap-2 text-xs text-muted">
-              <UIcon :name="part.icon" class="size-3.5 shrink-0" aria-hidden="true" />
-              {{ part.label }}
-            </span>
-            <span class="pl-[1.375rem] font-mono text-xs text-highlighted sm:pl-0">{{
-              part.value
-            }}</span>
-          </li>
-        </ul>
-      </div>
-
-      <div class="agent-rail agent-rail-out" aria-hidden="true"><span /></div>
-
-      <div class="agent-endpoint agent-output">
-        <UIcon name="i-lucide-circle-check" class="size-5 text-muted" aria-hidden="true" />
-        <div>
-          <p class="font-mono text-sm font-medium text-highlighted">3 findings</p>
-          <p class="mt-0.5 text-xs text-muted">Review posted</p>
-        </div>
-      </div>
+      </template>
     </div>
   </figure>
 </template>
 
 <style scoped>
-.agent-flow {
+.power-flow {
   display: grid;
-  align-items: center;
+  align-items: stretch;
 }
 
-.agent-endpoint {
-  display: flex;
-  min-height: 5rem;
-  align-items: center;
-  gap: 0.75rem;
-  border: 1px solid var(--ui-border);
-  background: var(--ui-bg);
-  padding: 1rem;
-}
-
-.agent-definition {
-  border: 1px solid var(--ui-border);
-  background: var(--ui-bg);
-}
-
-.agent-part {
+.power-stage {
   position: relative;
   isolation: isolate;
+  border: 1px solid var(--ui-border);
+  background: var(--ui-bg);
 }
 
-.agent-part::before {
+.power-stage::before {
   position: absolute;
   z-index: -1;
   inset: 0;
-  background: color-mix(in srgb, var(--ui-text-highlighted) 6%, transparent);
+  background: color-mix(in srgb, var(--ui-text-highlighted) 5%, transparent);
   content: "";
   opacity: 0;
-  animation: agent-read 7.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
-  animation-delay: calc(var(--part-index) * 320ms);
+  animation: power-stage 7.2s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+  animation-delay: calc(var(--stage-index) * 900ms);
 }
 
-.agent-rail {
+.power-rail {
   --flow-from: translateY(-130%);
   --flow-to: translateY(390%);
 
@@ -110,44 +91,35 @@ const parts = [
   background: var(--ui-border-accented);
 }
 
-.agent-rail span {
+.power-rail span {
   position: absolute;
   top: 0;
   left: -1px;
   width: 3px;
   height: 35%;
   background: var(--ui-text-highlighted);
-}
-
-.agent-rail-in span {
-  animation: agent-flow-in 7.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
-}
-
-.agent-rail-out span {
-  animation: agent-flow-out 7.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
-}
-
-.agent-output {
-  animation: agent-output 7.6s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+  animation: power-flow 7.2s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+  animation-delay: calc(450ms + var(--rail-index) * 900ms);
 }
 
 @media (min-width: 40rem) {
-  .agent-flow {
+  .power-flow {
     grid-template-columns:
-      minmax(7rem, 0.72fr) minmax(1.5rem, 0.22fr) minmax(14rem, 1.5fr)
-      minmax(1.5rem, 0.22fr) minmax(7rem, 0.72fr);
+      minmax(9rem, 1fr) minmax(1.5rem, 0.18fr) minmax(11rem, 1.16fr)
+      minmax(1.5rem, 0.18fr) minmax(9rem, 1fr);
   }
 
-  .agent-rail {
+  .power-rail {
     --flow-from: translateX(-130%);
     --flow-to: translateX(390%);
 
     width: auto;
     height: 1px;
+    align-self: center;
     justify-self: stretch;
   }
 
-  .agent-rail span {
+  .power-rail span {
     top: -1px;
     left: 0;
     width: 35%;
@@ -155,59 +127,29 @@ const parts = [
   }
 }
 
-@keyframes agent-read {
+@keyframes power-stage {
   0%,
-  20%,
-  32%,
+  16%,
   100% {
     opacity: 0;
   }
-  24%,
-  29% {
+  5%,
+  11% {
     opacity: 1;
   }
 }
 
-@keyframes agent-output {
+@keyframes power-flow {
   0%,
-  61%,
-  100% {
-    background: var(--ui-bg);
-  }
-  69%,
-  88% {
-    background: color-mix(in srgb, var(--ui-text-highlighted) 6%, var(--ui-bg));
-  }
-}
-
-@keyframes agent-flow-in {
-  0%,
-  8% {
+  4% {
     opacity: 0;
     transform: var(--flow-from);
   }
-  12%,
-  20% {
+  8%,
+  14% {
     opacity: 1;
   }
-  24%,
-  100% {
-    opacity: 0;
-    transform: var(--flow-to);
-  }
-}
-
-@keyframes agent-flow-out {
-  0%,
-  56% {
-    opacity: 0;
-    transform: var(--flow-from);
-  }
-  61%,
-  69% {
-    opacity: 1;
-  }
-  74%,
+  18%,
   100% {
     opacity: 0;
     transform: var(--flow-to);
@@ -215,13 +157,12 @@ const parts = [
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .agent-part::before,
-  .agent-rail span,
-  .agent-output {
+  .power-stage::before,
+  .power-rail span {
     animation: none;
   }
 
-  .agent-rail span {
+  .power-rail span {
     display: none;
   }
 }

--- a/docs/app/components/landing/Hero.vue
+++ b/docs/app/components/landing/Hero.vue
@@ -8,8 +8,8 @@
           Any agent, anywhere.
         </h1>
         <p class="mt-7 max-w-[44ch] text-lg/8 text-muted text-pretty sm:text-xl/8">
-          Build any Agent in Vite, compose it with any Capability, and deploy the same application
-          to any host.
+          Bring any model or harness, compose your own Capabilities around a persistent Workspace,
+          and deploy the same Agent to any host.
         </p>
 
         <LandingInstallCommand class="mt-9" />

--- a/docs/app/components/landing/Hero.vue
+++ b/docs/app/components/landing/Hero.vue
@@ -22,7 +22,7 @@
             Start building
             <UIcon
               name="i-lucide-arrow-right"
-              class="size-4 shrink-0 transition-transform duration-200 group-hover:translate-x-1 motion-reduce:transition-none"
+              class="landing-cta-arrow size-4 shrink-0 transition-transform duration-200 motion-reduce:transition-none"
               aria-hidden="true"
             />
           </NuxtLink>
@@ -45,5 +45,11 @@
   font-size: clamp(3.75rem, 5.8vw, 6.25rem);
   letter-spacing: -0.06em;
   line-height: 0.92;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .group:hover .landing-cta-arrow {
+    transform: translateX(0.25rem);
+  }
 }
 </style>

--- a/docs/app/components/landing/Hero.vue
+++ b/docs/app/components/landing/Hero.vue
@@ -5,11 +5,11 @@
     >
       <div class="vh-landing-reveal min-w-0">
         <h1 class="vh-hero-title max-w-[9ch] font-semibold text-highlighted text-balance">
-          The server layer for Vite.
+          Agents, built like applications.
         </h1>
         <p class="mt-7 max-w-[44ch] text-lg/8 text-muted text-pretty sm:text-xl/8">
-          Define inspectable Agents with explicit drivers, Capabilities, Workspaces, and
-          instructions—then run them on any host, backed by portable Server Primitives.
+          If Nuxt makes web apps obvious, ViteHub does the same for agents. Write instructions and
+          skills in Markdown, tools in TypeScript, and run them on any Vite host.
         </p>
 
         <LandingInstallCommand class="mt-9" />

--- a/docs/app/components/landing/Hero.vue
+++ b/docs/app/components/landing/Hero.vue
@@ -5,11 +5,11 @@
     >
       <div class="vh-landing-reveal min-w-0">
         <h1 class="vh-hero-title max-w-[9ch] font-semibold text-highlighted text-balance">
-          Agents for any host.
+          Any agent, anywhere.
         </h1>
         <p class="mt-7 max-w-[44ch] text-lg/8 text-muted text-pretty sm:text-xl/8">
-          Build Agents in Vite with any model, harness, or custom Agent Driver. Add portable Server
-          Primitives when you need them, without rewriting your application for each provider.
+          Build any Agent in Vite, compose it with any Capability, and deploy the same application
+          to any host.
         </p>
 
         <LandingInstallCommand class="mt-9" />

--- a/docs/app/components/landing/Hero.vue
+++ b/docs/app/components/landing/Hero.vue
@@ -5,11 +5,11 @@
     >
       <div class="vh-landing-reveal min-w-0">
         <h1 class="vh-hero-title max-w-[9ch] font-semibold text-highlighted text-balance">
-          Agents, built like applications.
+          Agents for any host.
         </h1>
         <p class="mt-7 max-w-[44ch] text-lg/8 text-muted text-pretty sm:text-xl/8">
-          If Nuxt makes web apps obvious, ViteHub does the same for agents. Write instructions and
-          skills in Markdown, tools in TypeScript, and run them on any Vite host.
+          Build Agents in Vite with any model, harness, or custom Agent Driver. Add portable Server
+          Primitives when you need them, without rewriting your application for each provider.
         </p>
 
         <LandingInstallCommand class="mt-9" />

--- a/docs/app/components/landing/InstallCommand.vue
+++ b/docs/app/components/landing/InstallCommand.vue
@@ -102,7 +102,8 @@ onBeforeUnmount(() => {
       </div>
 
       <div
-        class="relative h-10 w-[17.25rem] shrink-0"
+        class="relative h-10 shrink-0"
+        :class="activeTab === 'package' ? 'w-[17.25rem]' : 'w-0'"
         role="group"
         aria-label="Package manager"
         :aria-hidden="activeTab !== 'package'"

--- a/docs/app/components/landing/InstallCommand.vue
+++ b/docs/app/components/landing/InstallCommand.vue
@@ -267,7 +267,7 @@ onBeforeUnmount(() => {
   .command-swap-leave-active,
   .copy-icon-enter-active,
   .copy-icon-leave-active {
-    transition: opacity 200ms cubic-bezier(0.23, 1, 0.32, 1);
+    transition: none;
   }
 
   .command-swap-enter-from,

--- a/docs/app/components/landing/InstallCommand.vue
+++ b/docs/app/components/landing/InstallCommand.vue
@@ -80,7 +80,7 @@ onBeforeUnmount(() => {
         aria-label="Install ViteHub"
       >
         <span
-          class="pointer-events-none absolute top-1 bottom-1 left-1 w-[calc((100%_-_0.75rem)/2)] rounded-full bg-default ring-1 ring-accented transition-transform duration-[400ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none"
+          class="pointer-events-none absolute top-1 bottom-1 left-1 w-[calc((100%_-_0.75rem)/2)] rounded-full bg-default ring-1 ring-accented transition-transform duration-[220ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none"
           :style="{
             transform:
               activeTab === 'package' ? 'translateX(calc(100% + 0.25rem))' : 'translateX(0)',
@@ -102,19 +102,14 @@ onBeforeUnmount(() => {
       </div>
 
       <div
-        class="relative h-10 shrink-0 transition-[width] duration-[260ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none"
-        :class="activeTab === 'package' ? 'w-48' : 'w-0'"
+        class="relative h-10 w-[17.25rem] shrink-0"
         role="group"
         aria-label="Package manager"
         :aria-hidden="activeTab !== 'package'"
       >
         <div
-          class="absolute top-0 right-0 flex items-center gap-1 rounded-full bg-muted/80 p-1 text-sm ring-1 ring-default transition-[opacity,transform,filter] duration-[260ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none"
-          :class="
-            activeTab === 'package'
-              ? 'translate-y-0 opacity-100'
-              : 'pointer-events-none translate-y-1 opacity-0 blur-[1px]'
-          "
+          class="package-managers absolute top-0 right-0 flex items-center gap-1 rounded-full bg-muted/80 p-1 text-sm ring-1 ring-default"
+          :class="activeTab === 'package' ? 'package-managers-visible' : 'package-managers-hidden'"
           :aria-hidden="activeTab !== 'package'"
         >
           <button
@@ -124,22 +119,24 @@ onBeforeUnmount(() => {
             :tabindex="activeTab === 'package' ? 0 : -1"
             :aria-pressed="activePackageManager === option.value"
             :aria-label="option.label"
-            class="inline-flex h-8 min-w-8 items-center justify-center overflow-hidden rounded-full font-medium transition-[width,color,transform,background-color,box-shadow] duration-[220ms] ease-out active:translate-y-px focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary motion-reduce:transition-none"
+            class="relative inline-flex h-8 w-16 items-center overflow-hidden rounded-full font-medium focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
             :class="
               activePackageManager === option.value
-                ? 'w-22 bg-default px-2.5 text-highlighted ring-1 ring-accented'
-                : 'w-8 px-0 text-muted grayscale hover:text-default'
+                ? 'bg-default text-highlighted ring-1 ring-accented'
+                : 'text-muted grayscale hover:text-default'
             "
             @click="activePackageManager = option.value"
           >
-            <UIcon :name="option.icon" class="size-3.5 shrink-0" aria-hidden="true" />
+            <UIcon
+              :name="option.icon"
+              class="package-manager-icon absolute left-1/2 size-3.5 shrink-0"
+              :class="activePackageManager === option.value ? 'package-manager-icon-selected' : ''"
+              aria-hidden="true"
+            />
             <span
-              class="overflow-hidden whitespace-nowrap transition-[max-width,opacity,margin-left] duration-[180ms] ease-out motion-reduce:transition-none"
-              :class="
-                activePackageManager === option.value
-                  ? 'ml-1.5 max-w-12 opacity-100'
-                  : 'ml-0 max-w-0 opacity-0'
-              "
+              class="package-manager-label absolute left-[1.875rem] whitespace-nowrap text-xs"
+              :class="activePackageManager === option.value ? 'opacity-100' : 'opacity-0'"
+              aria-hidden="true"
             >
               {{ option.label }}
             </span>
@@ -185,18 +182,50 @@ onBeforeUnmount(() => {
 </template>
 
 <style scoped>
+.package-managers {
+  transition:
+    opacity 220ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 220ms cubic-bezier(0.23, 1, 0.32, 1),
+    visibility 0s linear 220ms;
+}
+
+.package-managers-visible {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: 0s;
+}
+
+.package-managers-hidden {
+  visibility: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(0.25rem);
+}
+
+.package-manager-icon {
+  transform: translateX(-50%);
+  transition: transform 220ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.package-manager-icon-selected {
+  transform: translateX(calc(-50% - 1rem));
+}
+
+.package-manager-label {
+  transition: opacity 220ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
 .command-swap-enter-active,
 .command-swap-leave-active {
   transition:
     opacity 180ms cubic-bezier(0.23, 1, 0.32, 1),
-    filter 180ms cubic-bezier(0.23, 1, 0.32, 1),
     transform 180ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .command-swap-enter-from,
 .command-swap-leave-to {
   opacity: 0;
-  filter: blur(1px);
   transform: translateY(2px);
 }
 
@@ -204,23 +233,47 @@ onBeforeUnmount(() => {
 .copy-icon-leave-active {
   transition:
     opacity 200ms cubic-bezier(0.23, 1, 0.32, 1),
-    filter 200ms cubic-bezier(0.23, 1, 0.32, 1),
     transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .copy-icon-enter-from,
 .copy-icon-leave-to {
   opacity: 0;
-  filter: blur(1px);
-  transform: scale(0.5);
+  transform: scale(0.95);
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .package-managers {
+    transform: none;
+    transition:
+      opacity 200ms cubic-bezier(0.23, 1, 0.32, 1),
+      visibility 0s linear 200ms;
+  }
+
+  .package-managers-visible {
+    transition-delay: 0s;
+  }
+
+  .package-manager-icon {
+    transition: none;
+  }
+
+  .package-manager-label {
+    transition: opacity 200ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
   .command-swap-enter-active,
   .command-swap-leave-active,
   .copy-icon-enter-active,
   .copy-icon-leave-active {
-    transition-duration: 0ms;
+    transition: opacity 200ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
+  .command-swap-enter-from,
+  .command-swap-leave-to,
+  .copy-icon-enter-from,
+  .copy-icon-leave-to {
+    transform: none;
   }
 }
 </style>

--- a/docs/app/components/landing/Paths.vue
+++ b/docs/app/components/landing/Paths.vue
@@ -42,7 +42,7 @@ import { landingPaths } from "./content";
               {{ path.action }}
               <UIcon
                 name="i-lucide-arrow-right"
-                class="size-4 shrink-0 transition-transform duration-200 group-hover:translate-x-1 motion-reduce:transition-none"
+                class="landing-cta-arrow size-4 shrink-0 transition-transform duration-200 motion-reduce:transition-none"
                 aria-hidden="true"
               />
             </NuxtLink>
@@ -64,3 +64,11 @@ import { landingPaths } from "./content";
     </div>
   </section>
 </template>
+
+<style scoped>
+@media (hover: hover) and (pointer: fine) {
+  .group:hover .landing-cta-arrow {
+    transform: translateX(0.25rem);
+  }
+}
+</style>

--- a/docs/app/components/landing/PrimitiveMotion.vue
+++ b/docs/app/components/landing/PrimitiveMotion.vue
@@ -499,7 +499,8 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
   .workspace-cursor,
   .source-scan,
   .target {
-    animation: reduced-confirm 4.8s linear var(--scene-delay) infinite both;
+    animation: none;
+    opacity: 0.7;
     transform: none;
   }
   .write {
@@ -514,16 +515,6 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
   .db-scan,
   .source-scan {
     transform: translateY(17px);
-  }
-  @keyframes reduced-confirm {
-    0%,
-    4% {
-      opacity: 0.45;
-    }
-    8%,
-    100% {
-      opacity: 0.7;
-    }
   }
 }
 </style>

--- a/docs/app/components/landing/PrimitiveMotion.vue
+++ b/docs/app/components/landing/PrimitiveMotion.vue
@@ -1,335 +1,430 @@
 <script setup lang="ts">
-defineProps<{ name: string }>();
+const props = defineProps<{ name: string }>();
+
+const primitives = [
+  "workspace",
+  "kv",
+  "queue",
+  "workflow",
+  "schedule",
+  "sandbox",
+  "database",
+  "blob",
+  "auth",
+  "env",
+  "source",
+  "shell",
+];
+const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
 </script>
 
 <template>
-  <svg v-if="name === 'workspace'" viewBox="0 0 96 56" class="size-full" aria-hidden="true">
-    <path d="M12 12h18l5 5h22" fill="none" stroke="currentColor" stroke-width="1.5" opacity=".42" />
-    <rect
-      x="12"
-      y="9"
-      width="72"
-      height="38"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.5"
-      opacity=".22"
-    />
-    <rect x="24" y="22" width="31" height="3" fill="currentColor" opacity=".34" />
-    <rect x="24" y="29" width="22" height="3" fill="currentColor" opacity=".24" />
-    <path
-      d="M24 38l4 3-4 3"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      opacity=".62"
-    />
-    <rect x="32" y="39.5" width="18" height="3" fill="currentColor" opacity=".4" />
-    <rect x="52" y="38.5" width="2" height="5" fill="currentColor" class="pm-blink" />
-  </svg>
-
-  <svg v-else-if="name === 'kv'" viewBox="0 0 96 56" class="size-full" aria-hidden="true">
-    <circle
-      cx="20"
-      cy="28"
-      r="9"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.75"
-      opacity=".42"
-    />
-    <line x1="29" y1="28" x2="57" y2="28" stroke="currentColor" stroke-width="1.5" opacity=".28" />
-    <rect x="62" y="18" width="22" height="20" fill="currentColor" class="pm-kv-value" />
-    <circle cx="38" cy="28" r="3" fill="currentColor" class="pm-kv-dot" />
-  </svg>
-
-  <svg v-else-if="name === 'queue'" viewBox="0 0 96 56" class="size-full" aria-hidden="true">
-    <line
-      x1="10"
-      y1="28"
-      x2="86"
-      y2="28"
-      stroke="currentColor"
-      stroke-width="1.25"
-      stroke-dasharray="3 4"
-      opacity=".25"
-    />
-    <circle
-      v-for="index in 4"
-      :key="index"
-      cx="12"
-      cy="28"
-      r="6"
-      fill="currentColor"
-      class="pm-queue-dot"
-      :style="{ animationDelay: `${(index - 1) * -1.15}s` }"
-    />
-  </svg>
-
-  <svg v-else-if="name === 'workflow'" viewBox="0 0 96 56" class="size-full" aria-hidden="true">
-    <line
-      x1="20"
-      y1="24"
-      x2="76"
-      y2="24"
-      stroke="currentColor"
-      stroke-width="1.5"
-      stroke-dasharray="3 3"
-      opacity=".28"
-    />
-    <path
-      d="M76 31c-18 20-38 20-56 0"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.25"
-      stroke-dasharray="3 3"
-      opacity=".18"
-    />
-    <circle
-      v-for="x in [20, 48, 76]"
-      :key="x"
-      :cx="x"
-      cy="24"
-      r="7"
-      fill="var(--ui-bg)"
-      stroke="currentColor"
-      stroke-width="1.5"
-      opacity=".5"
-    />
-    <circle cx="20" cy="24" r="3" fill="currentColor" class="pm-workflow-token" />
-  </svg>
-
-  <svg v-else-if="name === 'schedule'" viewBox="0 0 96 56" class="size-full" aria-hidden="true">
-    <circle
-      cx="48"
-      cy="28"
-      r="19"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.5"
-      opacity=".26"
-    />
-    <circle
-      cx="48"
-      cy="28"
-      r="19"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.5"
-      class="pm-radar"
-    />
-    <circle cx="48" cy="28" r="2.5" fill="currentColor" opacity=".65" />
-    <line
-      x1="48"
-      y1="28"
-      x2="48"
-      y2="14"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      class="pm-hand"
-    />
-  </svg>
-
-  <svg v-else viewBox="0 0 96 56" class="size-full" aria-hidden="true">
-    <path
-      d="M48 8l26 12v25L48 50 22 45V20z"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.5"
-      opacity=".34"
-    />
-    <path
-      d="M22 20l26 12 26-12M48 32v18"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.25"
-      opacity=".22"
-    />
-    <path d="M31 17l26 12v14L31 38z" fill="currentColor" opacity=".12" class="pm-sandbox-scan" />
-    <circle cx="48" cy="30" r="4" fill="currentColor" class="pm-sandbox-core" />
+  <svg
+    viewBox="0 0 96 56"
+    class="primitive-motion size-full"
+    :style="{ '--scene-delay': delay }"
+    aria-hidden="true"
+  >
+    <template v-if="name === 'kv'">
+      <circle cx="19" cy="28" r="7" class="outline" />
+      <path d="M26 28h38" class="line" />
+      <rect x="66" y="20" width="18" height="16" rx="2" class="fill target" />
+      <circle cx="31" cy="28" r="2.5" class="accent write" />
+    </template>
+    <template v-else-if="name === 'database'">
+      <rect x="20" y="8" width="56" height="40" rx="3" class="outline" />
+      <path d="M20 17h56" class="line" />
+      <rect x="24" y="21" width="48" height="5" rx="1" class="fill db-scan" />
+      <path d="M25 23h33M25 31h43M25 39h37" class="line" />
+    </template>
+    <template v-else-if="name === 'queue'">
+      <path d="M10 28h76" class="line dashed" />
+      <circle cx="24" cy="28" r="5" class="fill" />
+      <circle cx="42" cy="28" r="5" class="fill" />
+      <circle cx="60" cy="28" r="5" class="accent queue-item" />
+      <path d="m78 24 5 4-5 4" class="outline" />
+    </template>
+    <template v-else-if="name === 'schedule'">
+      <circle cx="48" cy="28" r="20" class="outline" />
+      <path d="M48 28V14M48 28l9 6" class="accent clock-hand" />
+      <circle cx="48" cy="28" r="2.5" class="fill" />
+      <circle cx="48" cy="28" r="20" class="accent trigger" />
+    </template>
+    <template v-else-if="name === 'workflow'">
+      <path d="M20 23h56M76 30Q48 49 20 30" class="line dashed" />
+      <circle v-for="x in [20, 48, 76]" :key="x" :cx="x" cy="23" r="6" class="outline" />
+      <circle cx="20" cy="23" r="3" class="accent workflow-token" />
+    </template>
+    <template v-else-if="name === 'sandbox'">
+      <rect x="26" y="8" width="44" height="40" rx="5" class="outline boundary" />
+      <rect x="43" y="23" width="10" height="10" rx="2" class="fill" />
+      <path d="M48 23V13M53 28h11M48 33v10M43 28H32" class="accent rejected" />
+    </template>
+    <template v-else-if="name === 'shell'">
+      <rect x="18" y="8" width="60" height="40" rx="4" class="outline" />
+      <path d="M18 17h60M25 23l5 4-5 4M34 31h16" class="line" />
+      <g class="shell-output"><path d="M25 37h38M25 42h27" class="accent" /></g>
+    </template>
+    <template v-else-if="name === 'blob'">
+      <g class="stored-card back">
+        <rect x="31" y="13" width="30" height="32" rx="2" class="outline" />
+      </g>
+      <g class="stored-card front">
+        <rect x="35" y="10" width="30" height="32" rx="2" class="fill" />
+        <path d="m39 35 7-8 6 5 7-10" class="accent" />
+        <circle cx="57" cy="17" r="3" class="accent" />
+      </g>
+    </template>
+    <template v-else-if="name === 'auth'">
+      <rect x="32" y="26" width="32" height="23" rx="3" class="outline" />
+      <path d="M39 26v-6a9 9 0 0 1 18 0v6" class="accent shackle" />
+      <path d="M48 34v7" class="line" />
+      <circle cx="48" cy="34" r="2.5" class="fill" />
+    </template>
+    <template v-else-if="name === 'env'">
+      <path d="M56 10v36" class="line dashed" />
+      <path d="m64 18 4 4 8-9" class="accent env-check" />
+      <path d="M19 19h22M19 28h18M19 37h25" class="accent env-values" />
+    </template>
+    <template v-else-if="name === 'workspace'">
+      <path d="M17 10h19l5 5h16v16H17zM24 20h24M24 26h17" class="outline" />
+      <path d="M17 35h62v15H17zM24 40l5 3-5 3M34 46h17" class="line" />
+      <rect x="54" y="42" width="3" height="5" class="fill workspace-cursor" />
+    </template>
+    <template v-else-if="name === 'source'">
+      <path d="M32 5h24l9 9v37H32zM56 5v9h9" class="outline" />
+      <path d="M39 21h19M39 29h15M39 37h19" class="line" />
+      <rect x="36" y="18" width="25" height="7" rx="1" class="fill source-scan" />
+    </template>
   </svg>
 </template>
 
 <style scoped>
-.pm-blink {
-  animation: pm-blink 1.1s step-end infinite;
+.primitive-motion {
+  --cycle: 4.8s;
+  --motion-out: cubic-bezier(0.23, 1, 0.32, 1);
+  --motion-move: cubic-bezier(0.77, 0, 0.175, 1);
+  overflow: visible;
 }
-
-.pm-kv-dot {
-  animation: pm-kv-dot 2.4s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+.outline,
+.line,
+.accent {
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
-
-.pm-kv-value {
-  animation: pm-kv-value 2.4s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+.outline {
+  stroke-width: 1.5;
+  opacity: 0.34;
 }
-
-.pm-queue-dot {
-  opacity: 0;
-  animation: pm-queue 4.6s linear infinite;
+.line {
+  stroke-width: 1.5;
+  opacity: 0.22;
 }
-
-.pm-workflow-token {
-  animation: pm-workflow 3s steps(2, jump-none) infinite;
+.accent {
+  stroke-width: 1.8;
+  opacity: 0.72;
 }
-
-.pm-hand {
-  animation: pm-hand 4s linear infinite;
+.fill {
+  fill: currentColor;
+  opacity: 0.22;
+}
+.dashed {
+  stroke-dasharray: 3 4;
+}
+.write,
+.queue-item,
+.workflow-token,
+.db-scan,
+.clock-hand,
+.trigger,
+.rejected,
+.boundary,
+.shell-output,
+.stored-card,
+.shackle,
+.env-values,
+.env-check,
+.workspace-cursor,
+.source-scan,
+.target {
+  animation-duration: var(--cycle);
+  animation-delay: var(--scene-delay);
+  animation-iteration-count: infinite;
+  animation-fill-mode: both;
+}
+.write {
+  animation-name: arrive-right;
+  animation-timing-function: var(--motion-out);
+}
+.target {
+  animation-name: confirm;
+  animation-timing-function: var(--motion-out);
+}
+.db-scan,
+.source-scan {
+  animation-name: scan-down;
+  animation-timing-function: var(--motion-move);
+}
+.queue-item {
+  animation-name: queue-forward;
+  animation-timing-function: var(--motion-move);
+}
+.workflow-token {
+  animation-name: workflow-handoff;
+  animation-timing-function: var(--motion-move);
+}
+.clock-hand {
   transform-origin: 48px 28px;
+  transform-box: view-box;
+  animation-name: clock-trigger;
+  animation-timing-function: var(--motion-move);
+}
+.trigger {
+  transform-origin: center;
+  transform-box: fill-box;
+  animation-name: confirm-ring;
+  animation-timing-function: var(--motion-out);
+}
+.rejected {
+  transform-origin: center;
+  transform-box: fill-box;
+  animation-name: reject;
+  animation-timing-function: var(--motion-out);
+}
+.boundary,
+.env-check {
+  animation-name: confirm;
+  animation-timing-function: var(--motion-out);
+}
+.shell-output {
+  animation-name: output-arrive;
+  animation-timing-function: var(--motion-out);
+}
+.stored-card {
+  transform-origin: center;
+  transform-box: fill-box;
+  animation-name: store-card;
+  animation-timing-function: var(--motion-out);
+}
+.stored-card.back {
+  animation-delay: calc(var(--scene-delay) - 80ms);
+}
+.shackle {
+  transform-origin: 57px 26px;
+  transform-box: view-box;
+  animation-name: unlock;
+  animation-timing-function: var(--motion-move);
+}
+.env-values {
+  animation-name: validate;
+  animation-timing-function: var(--motion-move);
+}
+.workspace-cursor {
+  animation-name: cursor-result;
+  animation-timing-function: var(--motion-out);
 }
 
-.pm-radar {
-  animation: pm-radar 3s cubic-bezier(0.22, 1, 0.36, 1) infinite;
-  transform-origin: 48px 28px;
-}
-
-.pm-sandbox-scan {
-  animation: pm-sandbox-scan 3.2s cubic-bezier(0.65, 0, 0.35, 1) infinite;
-}
-
-.pm-sandbox-core {
-  animation: pm-sandbox-core 3.2s cubic-bezier(0.65, 0, 0.35, 1) infinite;
-  transform-origin: 48px 30px;
-}
-
-@keyframes pm-blink {
+@keyframes arrive-right {
   0%,
-  49% {
+  3% {
+    opacity: 0;
+    transform: translateX(-12px);
+  }
+  15%,
+  100% {
+    opacity: 0.75;
+    transform: translateX(32px);
+  }
+}
+@keyframes confirm {
+  0%,
+  12% {
+    opacity: 0.15;
+  }
+  18%,
+  100% {
+    opacity: 0.55;
+  }
+}
+@keyframes scan-down {
+  0%,
+  3% {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  17%,
+  100% {
+    opacity: 0.5;
+    transform: translateY(17px);
+  }
+}
+@keyframes queue-forward {
+  0%,
+  3% {
+    transform: translateX(0);
     opacity: 0.72;
   }
-  50%,
+  17%,
   100% {
-    opacity: 0;
+    transform: translateX(18px);
+    opacity: 0.72;
   }
 }
-
-@keyframes pm-kv-dot {
-  0% {
-    opacity: 0;
+@keyframes workflow-handoff {
+  0%,
+  3% {
     transform: translateX(0);
   }
-  20% {
-    opacity: 0.72;
+  10% {
+    transform: translateX(28px);
   }
-  78% {
-    opacity: 0.72;
-  }
+  17%,
   100% {
-    opacity: 0;
-    transform: translateX(24px);
-  }
-}
-
-@keyframes pm-kv-value {
-  0%,
-  58%,
-  100% {
-    opacity: 0.16;
-  }
-  78% {
-    opacity: 0.58;
-  }
-}
-
-@keyframes pm-queue {
-  0% {
-    opacity: 0;
-    transform: translateX(-8px);
-  }
-  16% {
-    opacity: 0.54;
-  }
-  84% {
-    opacity: 0.54;
-  }
-  100% {
-    opacity: 0;
-    transform: translateX(80px);
-  }
-}
-
-@keyframes pm-workflow {
-  from {
-    transform: translateX(0);
-  }
-  to {
     transform: translateX(56px);
   }
 }
-
-@keyframes pm-hand {
-  to {
-    transform: rotate(360deg);
+@keyframes clock-trigger {
+  0%,
+  3% {
+    transform: rotate(0);
+  }
+  17%,
+  100% {
+    transform: rotate(90deg);
   }
 }
-
-@keyframes pm-radar {
-  0% {
-    opacity: 0.38;
-    transform: scale(0.8);
+@keyframes confirm-ring {
+  0%,
+  12% {
+    opacity: 0;
+    transform: scale(0.85);
   }
-  45%,
+  18% {
+    opacity: 0.55;
+  }
+  24%,
   100% {
     opacity: 0;
-    transform: scale(1.35);
+    transform: scale(1.18);
   }
 }
-
-@keyframes pm-sandbox-scan {
+@keyframes reject {
   0%,
-  100% {
-    opacity: 0.08;
-    transform: translateY(-7px);
+  3% {
+    opacity: 0;
+    transform: scale(0.3);
   }
-  50% {
-    opacity: 0.3;
-    transform: translateY(7px);
-  }
-}
-
-@keyframes pm-sandbox-core {
-  0%,
-  100% {
-    opacity: 0.3;
-    transform: scale(0.8);
-  }
-  50% {
-    opacity: 0.7;
+  13% {
+    opacity: 0.75;
     transform: scale(1);
+  }
+  20%,
+  100% {
+    opacity: 0;
+    transform: scale(1);
+  }
+}
+@keyframes output-arrive {
+  0%,
+  3% {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  17%,
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes store-card {
+  0%,
+  3% {
+    opacity: 0;
+    transform: translateX(18px) rotate(8deg);
+  }
+  17%,
+  100% {
+    opacity: 1;
+    transform: translateX(0) rotate(0);
+  }
+}
+@keyframes unlock {
+  0%,
+  3% {
+    transform: rotate(0);
+  }
+  17%,
+  100% {
+    transform: rotate(-28deg);
+  }
+}
+@keyframes validate {
+  0%,
+  3% {
+    opacity: 0.35;
+    transform: translateX(0);
+  }
+  17%,
+  100% {
+    opacity: 0.72;
+    transform: translateX(18px);
+  }
+}
+@keyframes cursor-result {
+  0%,
+  9% {
+    opacity: 0;
+  }
+  14%,
+  100% {
+    opacity: 0.7;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .pm-blink,
-  .pm-kv-dot,
-  .pm-kv-value,
-  .pm-queue-dot,
-  .pm-workflow-token,
-  .pm-hand,
-  .pm-radar,
-  .pm-sandbox-scan,
-  .pm-sandbox-core {
-    animation: none;
+  .write,
+  .queue-item,
+  .workflow-token,
+  .db-scan,
+  .clock-hand,
+  .trigger,
+  .rejected,
+  .boundary,
+  .shell-output,
+  .stored-card,
+  .shackle,
+  .env-values,
+  .env-check,
+  .workspace-cursor,
+  .source-scan,
+  .target {
+    animation: reduced-confirm 4.8s linear var(--scene-delay) infinite both;
+    transform: none;
   }
-
-  .pm-queue-dot,
-  .pm-kv-dot,
-  .pm-radar {
-    opacity: 0.5;
+  .write {
+    transform: translateX(32px);
   }
-
-  .pm-queue-dot:nth-of-type(2) {
-    transform: translateX(20px);
+  .queue-item {
+    transform: translateX(18px);
   }
-
-  .pm-queue-dot:nth-of-type(3) {
-    transform: translateX(40px);
+  .workflow-token {
+    transform: translateX(56px);
   }
-
-  .pm-queue-dot:nth-of-type(4) {
-    transform: translateX(60px);
+  .db-scan,
+  .source-scan {
+    transform: translateY(17px);
+  }
+  @keyframes reduced-confirm {
+    0%,
+    4% {
+      opacity: 0.45;
+    }
+    8%,
+    100% {
+      opacity: 0.7;
+    }
   }
 }
 </style>

--- a/docs/app/components/landing/PrimitiveMotion.vue
+++ b/docs/app/components/landing/PrimitiveMotion.vue
@@ -66,7 +66,7 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
       <g class="shell-output"><path d="M25 37h38M25 42h27" class="accent" /></g>
     </template>
     <template v-else-if="name === 'blob'">
-      <g class="stored-card back">
+      <g class="back">
         <rect x="31" y="13" width="30" height="32" rx="2" class="outline" />
       </g>
       <g class="stored-card front">
@@ -129,6 +129,12 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
 .fill {
   fill: currentColor;
   opacity: 0.22;
+}
+.write,
+.queue-item,
+.workflow-token {
+  fill: currentColor;
+  stroke: none;
 }
 .dashed {
   stroke-dasharray: 3 4;
@@ -208,9 +214,6 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
   animation-name: store-card;
   animation-timing-function: var(--motion-out);
 }
-.stored-card.back {
-  animation-delay: calc(var(--scene-delay) - 80ms);
-}
 .shackle {
   transform-origin: 57px 26px;
   transform-box: view-box;
@@ -233,9 +236,18 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
     transform: translateX(-12px);
   }
   15%,
-  100% {
+  88% {
     opacity: 0.75;
     transform: translateX(32px);
+  }
+  92% {
+    opacity: 0;
+    transform: translateX(32px);
+  }
+  96%,
+  100% {
+    opacity: 0;
+    transform: translateX(-12px);
   }
 }
 @keyframes confirm {
@@ -244,8 +256,12 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
     opacity: 0.15;
   }
   18%,
-  100% {
+  88% {
     opacity: 0.55;
+  }
+  92%,
+  100% {
+    opacity: 0.15;
   }
 }
 @keyframes scan-down {
@@ -255,44 +271,85 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
     transform: translateY(-5px);
   }
   17%,
-  100% {
+  88% {
     opacity: 0.5;
     transform: translateY(17px);
+  }
+  92% {
+    opacity: 0;
+    transform: translateY(17px);
+  }
+  96%,
+  100% {
+    opacity: 0;
+    transform: translateY(-5px);
   }
 }
 @keyframes queue-forward {
   0%,
   3% {
-    transform: translateX(0);
-    opacity: 0.72;
+    opacity: 0;
+    transform: translateX(-18px);
   }
   17%,
-  100% {
-    transform: translateX(18px);
+  88% {
     opacity: 0.72;
+    transform: translateX(0);
+  }
+  92% {
+    opacity: 0;
+    transform: translateX(0);
+  }
+  96%,
+  100% {
+    opacity: 0;
+    transform: translateX(-18px);
   }
 }
 @keyframes workflow-handoff {
   0%,
   3% {
+    opacity: 0;
     transform: translateX(0);
   }
   10% {
+    opacity: 0.72;
     transform: translateX(28px);
   }
   17%,
-  100% {
+  88% {
+    opacity: 0.72;
     transform: translateX(56px);
+  }
+  92% {
+    opacity: 0;
+    transform: translateX(56px);
+  }
+  96%,
+  100% {
+    opacity: 0;
+    transform: translateX(0);
   }
 }
 @keyframes clock-trigger {
   0%,
   3% {
+    opacity: 0;
     transform: rotate(0);
   }
   17%,
-  100% {
+  88% {
+    opacity: 0.72;
     transform: rotate(90deg);
+  }
+  92% {
+    opacity: 0;
+    transform: rotate(90deg);
+  }
+  96%,
+  100% {
+    opacity: 0;
+    transform: rotate(0);
   }
 }
 @keyframes confirm-ring {
@@ -333,9 +390,18 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
     transform: translateY(8px);
   }
   17%,
-  100% {
+  88% {
     opacity: 1;
     transform: translateY(0);
+  }
+  92% {
+    opacity: 0;
+    transform: translateY(0);
+  }
+  96%,
+  100% {
+    opacity: 0;
+    transform: translateY(8px);
   }
 }
 @keyframes store-card {
@@ -345,31 +411,60 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
     transform: translateX(18px) rotate(8deg);
   }
   17%,
-  100% {
+  88% {
     opacity: 1;
     transform: translateX(0) rotate(0);
+  }
+  92% {
+    opacity: 0;
+    transform: translateX(0) rotate(0);
+  }
+  96%,
+  100% {
+    opacity: 0;
+    transform: translateX(18px) rotate(8deg);
   }
 }
 @keyframes unlock {
   0%,
   3% {
+    opacity: 0;
     transform: rotate(0);
   }
   17%,
-  100% {
+  88% {
+    opacity: 0.72;
     transform: rotate(-28deg);
+  }
+  92% {
+    opacity: 0;
+    transform: rotate(-28deg);
+  }
+  96%,
+  100% {
+    opacity: 0;
+    transform: rotate(0);
   }
 }
 @keyframes validate {
   0%,
   3% {
-    opacity: 0.35;
+    opacity: 0;
     transform: translateX(0);
   }
   17%,
-  100% {
+  88% {
     opacity: 0.72;
     transform: translateX(18px);
+  }
+  92% {
+    opacity: 0;
+    transform: translateX(18px);
+  }
+  96%,
+  100% {
+    opacity: 0;
+    transform: translateX(0);
   }
 }
 @keyframes cursor-result {
@@ -378,8 +473,12 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
     opacity: 0;
   }
   14%,
-  100% {
+  88% {
     opacity: 0.7;
+  }
+  92%,
+  100% {
+    opacity: 0;
   }
 }
 
@@ -407,7 +506,7 @@ const delay = `${Math.max(0, primitives.indexOf(props.name)) * 60}ms`;
     transform: translateX(32px);
   }
   .queue-item {
-    transform: translateX(18px);
+    transform: none;
   }
   .workflow-token {
     transform: translateX(56px);

--- a/docs/app/components/landing/Primitives.vue
+++ b/docs/app/components/landing/Primitives.vue
@@ -24,7 +24,7 @@ import { landingPrimitives } from "./content";
             Explore Server Primitives
             <UIcon
               name="i-lucide-arrow-right"
-              class="size-4 shrink-0 transition-transform duration-200 group-hover:translate-x-1 motion-reduce:transition-none"
+              class="landing-cta-arrow size-4 shrink-0 transition-transform duration-200 motion-reduce:transition-none"
               aria-hidden="true"
             />
           </NuxtLink>
@@ -59,3 +59,11 @@ import { landingPrimitives } from "./content";
     </div>
   </section>
 </template>
+
+<style scoped>
+@media (hover: hover) and (pointer: fine) {
+  .group:hover .landing-cta-arrow {
+    transform: translateX(0.25rem);
+  }
+}
+</style>

--- a/docs/app/components/landing/Primitives.vue
+++ b/docs/app/components/landing/Primitives.vue
@@ -32,7 +32,7 @@ import { landingPrimitives } from "./content";
       </div>
 
       <ul
-        class="mt-12 grid gap-px border border-default bg-[var(--ui-border)] sm:grid-cols-2 lg:mt-16 lg:grid-cols-3"
+        class="mt-12 grid gap-px border border-default bg-[var(--ui-border)] sm:grid-cols-2 lg:mt-16 lg:grid-cols-4"
         role="list"
       >
         <li v-for="primitive in landingPrimitives" :key="primitive.id" class="min-w-0 bg-default">

--- a/docs/app/components/landing/content.ts
+++ b/docs/app/components/landing/content.ts
@@ -107,4 +107,40 @@ export const landingPrimitives = [
     description: "Isolated execution",
     to: "/docs/server-primitives/sandbox",
   },
+  {
+    id: "database",
+    name: "Database",
+    description: "Relational data",
+    to: "/docs/server-primitives/database",
+  },
+  {
+    id: "blob",
+    name: "Blob",
+    description: "Files and uploads",
+    to: "/docs/server-primitives/blob",
+  },
+  {
+    id: "auth",
+    name: "Auth",
+    description: "Users and sessions",
+    to: "/docs/server-primitives/auth",
+  },
+  {
+    id: "env",
+    name: "Env",
+    description: "Typed configuration",
+    to: "/docs/server-primitives/env",
+  },
+  {
+    id: "source",
+    name: "Source",
+    description: "Read-only content",
+    to: "/docs/server-primitives/source",
+  },
+  {
+    id: "shell",
+    name: "Shell",
+    description: "Command execution",
+    to: "/docs/server-primitives/shell",
+  },
 ] as const;

--- a/docs/test/landing.test.ts
+++ b/docs/test/landing.test.ts
@@ -99,6 +99,26 @@ describe("landing page", () => {
     ]);
   });
 
+  it("keeps reduced-motion and hidden install controls static", async () => {
+    const primitiveMotion = await readFile(
+      new URL("../app/components/landing/PrimitiveMotion.vue", import.meta.url),
+      "utf8",
+    );
+    const reducedMotion = primitiveMotion.slice(
+      primitiveMotion.indexOf("@media (prefers-reduced-motion: reduce)"),
+    );
+    const installCommand = await readFile(
+      new URL("../app/components/landing/InstallCommand.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(reducedMotion).toContain("animation: none;");
+    expect(reducedMotion).not.toMatch(/animation:[^;]*infinite/);
+    expect(installCommand).toContain(
+      `:class="activeTab === 'package' ? 'w-[17.25rem]' : 'w-0'"`,
+    );
+  });
+
   it("wires landing-page metadata through Docus", async () => {
     const source = await readFile(new URL("../app/pages/index.vue", import.meta.url), "utf8");
 

--- a/docs/test/landing.test.ts
+++ b/docs/test/landing.test.ts
@@ -52,10 +52,23 @@ describe("landing page", () => {
     ).join("\n");
     const normalizedSource = source.replace(/\s+/g, " ");
 
-    expect(source).toContain("The server layer for Vite.");
+    expect(source).toContain("Any agent, anywhere.");
     expect(normalizedSource).toContain(
-      "Define inspectable Agents with explicit drivers, Capabilities, Workspaces, and instructions",
+      "Bring any model or harness, compose your own Capabilities around a persistent Workspace",
     );
+    for (const term of [
+      "driver.model",
+      "driver.harness",
+      "driver.run",
+      "instructions.md",
+      "workspace.sources",
+      "capabilities[]",
+      "runAgent()",
+      "invoker",
+      "runtime",
+    ]) {
+      expect(source).toContain(term);
+    }
     expect(source).toContain("Build your first Agent");
     expect(source).toContain("prefers-reduced-motion");
     expect(source).toMatch(/<pre|<code/);
@@ -69,7 +82,7 @@ describe("landing page", () => {
     expect(source).not.toMatch(/role="(?:tab|tablist|radio|radiogroup)"/);
   });
 
-  it("ends with a compact set of animated primitives", () => {
+  it("ends with the full set of animated primitives", () => {
     expect(landingPrimitives.map((primitive) => primitive.id)).toEqual([
       "workspace",
       "kv",
@@ -77,6 +90,12 @@ describe("landing page", () => {
       "workflow",
       "schedule",
       "sandbox",
+      "database",
+      "blob",
+      "auth",
+      "env",
+      "source",
+      "shell",
     ]);
   });
 

--- a/docs/test/landing.test.ts
+++ b/docs/test/landing.test.ts
@@ -117,6 +117,7 @@ describe("landing page", () => {
     expect(installCommand).toContain(
       `:class="activeTab === 'package' ? 'w-[17.25rem]' : 'w-0'"`,
     );
+    expect(installCommand).toContain("transition: none;");
   });
 
   it("wires landing-page metadata through Docus", async () => {


### PR DESCRIPTION
Reframes the hero around what a ViteHub Agent is: instructions and skills in Markdown, tools in TypeScript, an explicit Agent Driver, and Agent Invocations on any Vite host. Server Primitives remain a separate layer below the hero so readers can understand the Agent model before meeting the broader server surface.

Restores all twelve Server Primitive illustrations as semantic microanimations based on the earlier landing work, with a shared cadence, deliberate easing, long resting states, and meaningful reduced-motion fallbacks.

<!-- babysitter:direction-validation:v1 -->
## Babysitter direction validation

Verdict: proceed

Good: Hero copy and diagram clarify the Agent Definition, Agent Driver, Capabilities, Workspace, and Agent Invocation story before introducing Server Primitives.

Missing: No direction-level gap found inside the existing PR intent.

Corrections applied: None.
<!-- /babysitter:direction-validation:v1 -->