### PR TITLE
fix(schedule): clean unused provider output

### DIFF
--- a/packages/internal/src/build/cloudflare.ts
+++ b/packages/internal/src/build/cloudflare.ts
@@ -128,7 +128,6 @@ export async function writeCloudflareWranglerConfig(options: CloudflareWranglerC
   const configFile = resolve(outputRoot, "wrangler.json")
   if (!options.wranglerConfig) {
     if (options.wranglerArrayOwnedValues && options.wranglerArrayMergeKeys) {
-      await mkdir(outputRoot, { recursive: true })
       await writeMergedJsonObject(configFile, {}, options.wranglerConfigKeys, options.wranglerArrayMergeKeys, options.wranglerArrayOwnedValues)
       return
     }

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -136,6 +136,22 @@ describe("provider deployment outputs", () => {
     })
   })
 
+  it("does not create Cloudflare output while cleaning absent owned config", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultCloudflareOutputRoot,
+      writeCloudflareWranglerConfig,
+    } = await import("../src/build/cloudflare.ts")
+
+    await writeCloudflareWranglerConfig({
+      rootDir,
+      wranglerArrayMergeKeys: { kv_namespaces: "binding" },
+      wranglerArrayOwnedValues: { kv_namespaces: ["SETTINGS"] },
+    })
+
+    expect(existsSync(createDefaultCloudflareOutputRoot(rootDir))).toBe(false)
+  })
+
   it("merges keyed Cloudflare config arrays without dropping unrelated entries", async () => {
     const rootDir = await createTempProject()
     const {

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs"
-import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises"
-import { dirname, resolve } from "node:path"
+import { mkdir, readFile, readdir, rm, rmdir, writeFile } from "node:fs/promises"
+import { dirname, isAbsolute, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
+import { isDeepStrictEqual } from "node:util"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
 import { createDefaultCloudflareOutputRoot, createDefaultNetlifyOutputRoot, createDefaultVercelOutputRoot } from "@vite-hub/internal/build/deployment-output"
@@ -74,6 +75,29 @@ interface GenerateProviderOutputsOptions {
   rootDir: string
   runtimeImport?: string
   source?: DiscoveredScheduleDefinition["source"]
+}
+
+async function removeEmptyDirectories(directory: string, rootDir: string): Promise<void> {
+  const root = resolve(rootDir)
+  let current = resolve(directory)
+  const pathFromRoot = relative(root, current)
+  if (!pathFromRoot || pathFromRoot.startsWith("..") || isAbsolute(pathFromRoot)) return
+
+  while (current !== root) {
+    try {
+      await rmdir(current)
+    }
+    catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code === "ENOENT") {
+        current = dirname(current)
+        continue
+      }
+      if (code === "ENOTEMPTY" || code === "EEXIST") return
+      throw error
+    }
+    current = dirname(current)
+  }
 }
 
 export interface NetlifyScheduleFunctionOutput {
@@ -643,20 +667,44 @@ export async function writeVercelScheduleFunctions(options: {
   }
 
   const configFile = resolve(outputRoot, "config.json")
-  await mkdir(outputRoot, { recursive: true })
-  let vercelConfig = createVercelConfigJson() as ReturnType<typeof createVercelConfigJson> & { crons?: Array<{ path: string, schedule: string }> }
+  let vercelConfig: ReturnType<typeof createVercelConfigJson> & { crons?: Array<{ path: string, schedule: string }> }
   try {
     vercelConfig = JSON.parse(await readFile(configFile, "utf8"))
   }
   catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    if (!definitions.length) {
+      await removeEmptyDirectories(functionRoot, options.rootDir)
+      return
+    }
+    vercelConfig = createVercelConfigJson()
   }
   const schedulePathPrefix = "/api/vitehub/schedules/vercel/"
-  const existingCrons = vercelConfig.crons?.filter(cron => !cron.path.startsWith(schedulePathPrefix)) ?? []
-  vercelConfig.crons = [...existingCrons, ...definitions.map(definition => ({
+  const previousCrons = vercelConfig.crons ?? []
+  const existingCrons = previousCrons.filter(cron => !cron.path.startsWith(schedulePathPrefix))
+  if (!definitions.length && existingCrons.length === previousCrons.length) {
+    await removeEmptyDirectories(functionRoot, options.rootDir)
+    return
+  }
+  const nextCrons = [...existingCrons, ...definitions.map(definition => ({
     path: getVercelSchedulePath(definition.name),
     schedule: crons.get(definition.name)!,
   }))]
+  if (nextCrons.length) {
+    vercelConfig.crons = nextCrons
+  }
+  else {
+    delete vercelConfig.crons
+  }
+  if (!definitions.length) {
+    await removeEmptyDirectories(functionRoot, options.rootDir)
+    const outputFiles = await readdir(outputRoot)
+    if (outputFiles.length === 1 && outputFiles[0] === "config.json" && isDeepStrictEqual(vercelConfig, createVercelConfigJson())) {
+      await rm(configFile, { force: true })
+      await removeEmptyDirectories(outputRoot, options.rootDir)
+      return
+    }
+  }
   await writeFile(configFile, `${JSON.stringify(vercelConfig, null, 2)}\n`, "utf8")
 }
 
@@ -689,6 +737,7 @@ async function writeNetlifyScheduleFunctions(options: {
   definitions: DiscoveredScheduleDefinition[]
   outputRoot: string
   registryFile: string
+  rootDir: string
 }) {
   const functionRoot = resolve(options.outputRoot, "functions")
   const existingFiles = await readdir(functionRoot).catch((error: NodeJS.ErrnoException) => {
@@ -704,7 +753,10 @@ async function writeNetlifyScheduleFunctions(options: {
     functionRoot,
     registryFile: options.registryFile,
   })
-  if (outputs.length === 0) return
+  if (outputs.length === 0) {
+    await removeEmptyDirectories(functionRoot, options.rootDir)
+    return
+  }
 
   await mkdir(functionRoot, { recursive: true })
   await Promise.all(outputs.map(async output => writeFile(output.file, output.source, "utf8")))
@@ -838,6 +890,8 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     await Promise.all([
       rm(artifacts.cloudflareWorkerFile, { force: true }),
       rm(artifacts.denoCronFile, { force: true }),
+      rm(artifacts.registryFile, { force: true }),
+      rm(artifacts.vercelServerFile, { force: true }),
       cleanCloudflareScheduleOutput(options.rootDir, cloudflareStateFile),
     ])
   }
@@ -852,6 +906,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     definitions: artifacts.definitions,
     outputRoot: createDefaultNetlifyOutputRoot(options.rootDir),
     registryFile: artifacts.registryFile,
+    rootDir: options.rootDir,
   })
   return artifacts
 }

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -684,7 +684,7 @@ export async function writeVercelScheduleFunctions(options: {
   const existingCrons = previousCrons.filter(cron => !cron.path.startsWith(schedulePathPrefix))
   if (!definitions.length && existingCrons.length === previousCrons.length) {
     await removeEmptyDirectories(functionRoot, options.rootDir)
-    if (previousCrons.length === 0 && "crons" in vercelConfig) {
+    if (previousCrons.length === 0) {
       delete vercelConfig.crons
       if (isDeepStrictEqual(vercelConfig, createVercelConfigJson())) {
         await rm(configFile, { force: true })

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -691,7 +691,6 @@ async function writeNetlifyScheduleFunctions(options: {
   registryFile: string
 }) {
   const functionRoot = resolve(options.outputRoot, "functions")
-  await mkdir(functionRoot, { recursive: true })
   const existingFiles = await readdir(functionRoot).catch((error: NodeJS.ErrnoException) => {
     if (error.code === "ENOENT") return []
     throw error
@@ -705,6 +704,9 @@ async function writeNetlifyScheduleFunctions(options: {
     functionRoot,
     registryFile: options.registryFile,
   })
+  if (outputs.length === 0) return
+
+  await mkdir(functionRoot, { recursive: true })
   await Promise.all(outputs.map(async output => writeFile(output.file, output.source, "utf8")))
 }
 

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -684,6 +684,13 @@ export async function writeVercelScheduleFunctions(options: {
   const existingCrons = previousCrons.filter(cron => !cron.path.startsWith(schedulePathPrefix))
   if (!definitions.length && existingCrons.length === previousCrons.length) {
     await removeEmptyDirectories(functionRoot, options.rootDir)
+    if (previousCrons.length === 0 && "crons" in vercelConfig) {
+      delete vercelConfig.crons
+      if (isDeepStrictEqual(vercelConfig, createVercelConfigJson())) {
+        await rm(configFile, { force: true })
+        await removeEmptyDirectories(outputRoot, options.rootDir)
+      }
+    }
     return
   }
   const nextCrons = [...existingCrons, ...definitions.map(definition => ({

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -687,8 +687,11 @@ export async function writeVercelScheduleFunctions(options: {
     if (previousCrons.length === 0) {
       delete vercelConfig.crons
       if (isDeepStrictEqual(vercelConfig, createVercelConfigJson())) {
-        await rm(configFile, { force: true })
-        await removeEmptyDirectories(outputRoot, options.rootDir)
+        const outputFiles = await readdir(outputRoot)
+        if (outputFiles.length === 1 && outputFiles[0] === "config.json") {
+          await rm(configFile, { force: true })
+          await removeEmptyDirectories(outputRoot, options.rootDir)
+        }
       }
     }
     return

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -184,11 +184,12 @@ describe("schedule provider output", () => {
 
   it("avoids empty Netlify output and cleans stale files without static schedules", async () => {
     const rootDir = await createTempProject("vitehub-schedule-output-empty-netlify-")
-    const functionRoot = join(createDefaultNetlifyOutputRoot(rootDir), "functions")
+    const outputRoot = createDefaultNetlifyOutputRoot(rootDir)
+    const functionRoot = join(outputRoot, "functions")
 
     await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
 
-    expect(existsSync(createDefaultNetlifyOutputRoot(rootDir))).toBe(false)
+    expect(existsSync(outputRoot)).toBe(false)
 
     await mkdir(functionRoot, { recursive: true })
     await writeFile(join(functionRoot, "other.mjs"), "keep\n", "utf8")
@@ -197,6 +198,64 @@ describe("schedule provider output", () => {
 
     await expect(readFile(join(functionRoot, "other.mjs"), "utf8")).resolves.toBe("keep\n")
     await expect(readFile(join(functionRoot, "vitehub-schedule-stale.mjs"), "utf8")).rejects.toThrow()
+
+    await rm(join(functionRoot, "other.mjs"))
+    await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
+
+    expect(existsSync(join(rootDir, ".netlify"))).toBe(false)
+  })
+
+  it("avoids empty Vercel output and cleans stale files without static schedules", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-output-empty-vercel-")
+    const outputRoot = join(rootDir, ".vercel", "output")
+    const functionRoot = join(outputRoot, "functions", "api", "vitehub", "schedules", "vercel")
+
+    await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
+
+    expect(existsSync(join(rootDir, ".vercel"))).toBe(false)
+
+    await generateProviderOutputs({ clientOutDir: "dist/client", rootDir })
+    expect(existsSync(join(outputRoot, "config.json"))).toBe(true)
+    await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
+
+    expect(existsSync(join(rootDir, ".vercel"))).toBe(false)
+
+    await mkdir(join(functionRoot, "stale.func"), { recursive: true })
+    await writeFile(join(functionRoot, "stale.func", "index.mjs"), "stale\n", "utf8")
+    await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
+
+    expect(existsSync(join(rootDir, ".vercel"))).toBe(false)
+
+    await mkdir(join(functionRoot, "stale.func"), { recursive: true })
+    await writeFile(join(functionRoot, "stale.func", "index.mjs"), "stale\n", "utf8")
+    const userFunction = join(outputRoot, "functions", "api", "user.func", "index.mjs")
+    await mkdir(dirname(userFunction), { recursive: true })
+    await writeFile(userFunction, "keep\n", "utf8")
+    await writeFile(join(outputRoot, "existing.txt"), "keep\n", "utf8")
+    await writeFile(join(outputRoot, "config.json"), JSON.stringify({
+      crons: [
+        { path: "/api/user-cron", schedule: "0 1 * * *" },
+        { path: "/api/vitehub/schedules/vercel/stale", schedule: "0 2 * * *" },
+      ],
+      routes: [{ handle: "filesystem" }],
+      version: 3,
+    }), "utf8")
+    await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
+
+    expect(existsSync(functionRoot)).toBe(false)
+    await expect(readFile(userFunction, "utf8")).resolves.toBe("keep\n")
+    await expect(readFile(join(outputRoot, "existing.txt"), "utf8")).resolves.toBe("keep\n")
+    await expect(readFile(join(outputRoot, "config.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      crons: [{ path: "/api/user-cron", schedule: "0 1 * * *" }],
+      routes: [{ handle: "filesystem" }],
+      version: 3,
+    })
+
+    const unrelatedConfig = "{\n  \"version\": 3,\n  \"custom\": \"keep exact bytes\"\n}\n"
+    await writeFile(join(outputRoot, "config.json"), unrelatedConfig, "utf8")
+    await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
+
+    await expect(readFile(join(outputRoot, "config.json"), "utf8")).resolves.toBe(unrelatedConfig)
   })
 
   it("removes stale Deno and Cloudflare output when no static schedules remain", async () => {
@@ -215,6 +274,8 @@ describe("schedule provider output", () => {
 
     expect(existsSync(join(rootDir, ".vitehub", "schedule", "deno-cron.mjs"))).toBe(false)
     expect(existsSync(join(rootDir, ".vitehub", "schedule", "cloudflare-worker.mjs"))).toBe(false)
+    expect(existsSync(join(rootDir, ".vitehub", "schedule", "registry.mjs"))).toBe(false)
+    expect(existsSync(join(rootDir, ".vitehub", "schedule", "vercel-server.mjs"))).toBe(false)
     expect(existsSync(join(cloudflareRoot, "index.js"))).toBe(false)
     await expect(readFile(configFile, "utf8")).resolves.toContain('"custom": "keep"')
     expect(JSON.parse(await readFile(configFile, "utf8")).triggers.crons).toEqual(["0 1 * * *"])

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -239,6 +239,16 @@ describe("schedule provider output", () => {
 
     expect(existsSync(join(rootDir, ".vercel"))).toBe(false)
 
+    await mkdir(outputRoot, { recursive: true })
+    const siblingFunction = join(outputRoot, "functions", "__server.func", "index.mjs")
+    await mkdir(dirname(siblingFunction), { recursive: true })
+    await writeFile(siblingFunction, "keep\n", "utf8")
+    await writeFile(join(outputRoot, "config.json"), JSON.stringify(createVercelConfigJson()), "utf8")
+    await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
+
+    await expect(readFile(siblingFunction, "utf8")).resolves.toBe("keep\n")
+    await expect(readFile(join(outputRoot, "config.json"), "utf8").then(JSON.parse)).resolves.toEqual(createVercelConfigJson())
+
     await mkdir(join(functionRoot, "stale.func"), { recursive: true })
     await writeFile(join(functionRoot, "stale.func", "index.mjs"), "stale\n", "utf8")
     const userFunction = join(outputRoot, "functions", "api", "user.func", "index.mjs")

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -227,6 +227,12 @@ describe("schedule provider output", () => {
 
     expect(existsSync(join(rootDir, ".vercel"))).toBe(false)
 
+    await mkdir(outputRoot, { recursive: true })
+    await writeFile(join(outputRoot, "config.json"), JSON.stringify(createVercelConfigJson()), "utf8")
+    await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
+
+    expect(existsSync(join(rootDir, ".vercel"))).toBe(false)
+
     await mkdir(join(functionRoot, "stale.func"), { recursive: true })
     await writeFile(join(functionRoot, "stale.func", "index.mjs"), "stale\n", "utf8")
     await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -182,6 +182,23 @@ describe("schedule provider output", () => {
     expect(JSON.parse(await readFile(join(cloudflareRoot, "wrangler.json"), "utf8")).triggers.crons).toEqual(["0 1 * * *", "0 0 * * *"])
   })
 
+  it("avoids empty Netlify output and cleans stale files without static schedules", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-output-empty-netlify-")
+    const functionRoot = join(createDefaultNetlifyOutputRoot(rootDir), "functions")
+
+    await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
+
+    expect(existsSync(createDefaultNetlifyOutputRoot(rootDir))).toBe(false)
+
+    await mkdir(functionRoot, { recursive: true })
+    await writeFile(join(functionRoot, "other.mjs"), "keep\n", "utf8")
+    await writeFile(join(functionRoot, "vitehub-schedule-stale.mjs"), "stale\n", "utf8")
+    await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
+
+    await expect(readFile(join(functionRoot, "other.mjs"), "utf8")).resolves.toBe("keep\n")
+    await expect(readFile(join(functionRoot, "vitehub-schedule-stale.mjs"), "utf8")).rejects.toThrow()
+  })
+
   it("removes stale Deno and Cloudflare output when no static schedules remain", async () => {
     const rootDir = await createTempProject("vitehub-schedule-output-empty-cleanup-")
     const cloudflareRoot = createDefaultCloudflareOutputRoot(rootDir)

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url"
 
 import { afterAll, describe, expect, it } from "vitest"
 import { createDefaultCloudflareOutputRoot, createDefaultNetlifyOutputRoot } from "@vite-hub/internal/build/deployment-output"
+import { createVercelConfigJson } from "@vite-hub/internal/build/vercel-config"
 
 import { createNetlifyScheduleFunctionOutputs, generateProviderOutputs, resolveScheduleDefinitionEntry, resolveScheduleRuntimeEntry, validateProviderCron, writeVercelScheduleFunctions } from "../src/internal/provider-output.ts"
 import { discoverScheduleDefinitions } from "../src/discovery.ts"
@@ -216,6 +217,12 @@ describe("schedule provider output", () => {
 
     await generateProviderOutputs({ clientOutDir: "dist/client", rootDir })
     expect(existsSync(join(outputRoot, "config.json"))).toBe(true)
+    await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
+
+    expect(existsSync(join(rootDir, ".vercel"))).toBe(false)
+
+    await mkdir(outputRoot, { recursive: true })
+    await writeFile(join(outputRoot, "config.json"), JSON.stringify({ ...createVercelConfigJson(), crons: [] }), "utf8")
     await generateProviderOutputs({ clientOutDir: "dist/client", definitions: [], rootDir })
 
     expect(existsSync(join(rootDir, ".vercel"))).toBe(false)


### PR DESCRIPTION
Avoids creating empty provider output when no static Schedule definitions are emitted, and removes stale ViteHub-owned Netlify and Vercel functions plus generated schedule artifacts when static schedules are disabled.

Vercel cleanup only removes schedule-owned cron paths and deletes the default config/output when no sibling provider content remains. Unrelated provider files, functions, config fields, routes, and crons are preserved. Cloudflare array-owned cleanup also stops creating an absent output root.