### PR TITLE
feat(agent): add trusted-host boxes

### DIFF
--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -5,7 +5,7 @@ navigation.order: 21
 icon: i-lucide-file-user
 ---
 
-An Agent Definition is the code declaration that names one Agent and configures how it runs. It owns the Agent Driver, attached Capabilities, Workspace context, Agent Invoker options, and lifecycle hooks.
+An Agent Definition is the code declaration that names one Agent and configures how it runs. It owns the Agent Driver, optional Box, attached Capabilities, Workspace context, Agent Invoker options, and lifecycle hooks.
 
 ViteHub discovers Agent Definitions from `server/agents`. The Agent File Name or folder name provides the discovered identity, so `server/agents/support.ts` and `server/agents/support/config.ts` both create a `support` Agent.
 
@@ -118,5 +118,6 @@ Agent Invokers are not Channels, Auth Users, or Access roles. They carry trusted
 ## Next steps
 
 - Read [Agent Drivers](/docs/agents/agent-drivers) for the driver variants.
+- Read [Boxes](/docs/agents/boxes) when a harness Agent needs an explicit execution environment.
 - Read [Workspace context](/docs/agents/workspace-context) before exposing files.
 - Read [Capabilities](/docs/capabilities) for official and custom ability pages.

--- a/docs/content/docs/agents/agent-drivers.md
+++ b/docs/content/docs/agents/agent-drivers.md
@@ -88,6 +88,8 @@ export default defineAgent({
 
 `sandbox({ commands })` remains the Capability shape for model-facing command execution authority.
 
+Use a [Box](/docs/agents/boxes) instead of `driver.sandbox` and `driver.workDir` when the harness should receive an explicit execution environment, Home, working checkout, and boot requirements. `codexDriver()` contributes its Codex requirement automatically.
+
 `driver.harness`, `driver.instructions`, `driver.sessionKey`, `driver.sandbox`, and `driver.workDir` can also be callbacks. Each callback receives the invocation `input`, `context`, `invoker`, and run metadata. Use callbacks when one Agent Definition needs invocation-scoped harness auth, instructions, sandbox setup, working directory, or session reuse.
 
 ViteHub resolves `driver.instructions` before constructing the AI SDK `HarnessAgent`, so stock harness adapters receive the invocation-specific instructions for generated and streamed turns. Session reuse keeps the harness adapter's normal instruction lifecycle. `driver.workDir` must resolve to a non-empty relative POSIX path inside the sandbox default working directory.
@@ -145,5 +147,6 @@ Workspace-backed harness execution depends on Harness Workspace Session support 
 ## Next steps
 
 - Read [Instructions](/docs/agents/instructions) for model-backed instruction composition.
+- Read [Boxes](/docs/agents/boxes) for trusted-host harness execution.
 - Read [Invocations](/docs/agents/invocations) for `runAgent` and `streamAgent`.
 - Read [DevTools](/docs/agents/devtools) to inspect resolved driver metadata.

--- a/docs/content/docs/agents/boxes.md
+++ b/docs/content/docs/agents/boxes.md
@@ -1,0 +1,88 @@
+---
+title: Boxes
+description: Run a harness Agent with an explicit workspace, Home, host tools, and named authentication requirements.
+navigation.order: 22.5
+icon: i-lucide-package-open
+---
+
+A Box is the execution environment for a harness Agent. It selects where the Agent runs, which Home it sees, and which host tools and authentication must be ready before the Agent starts.
+
+The first Box runtime is `trustedHost()`. It uses the host filesystem, processes, CLI installations, configuration, and authentication without providing isolation.
+
+## Run Codex in an existing checkout
+
+Install the Agent and Box packages with the Codex harness adapter:
+
+```bash [Terminal]
+pnpm add @vite-hub/agent @vite-hub/box @ai-sdk/harness @ai-sdk/harness-codex
+```
+
+Declare the Box inline. You do not need a separate `defineBox()` call.
+
+```ts [server/agents/babysitter/config.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { codexDriver } from '@vite-hub/agent/harness/codex'
+import { trustedHost } from '@vite-hub/box'
+
+interface BabysitterRunOptions {
+  worktreePath: string
+}
+
+export default defineAgent<any, BabysitterRunOptions>({
+  box: {
+    runtime: trustedHost(),
+    cwd: ({ input }) => input.options?.worktreePath,
+    requires: ['github', 'pnpm'],
+  },
+  driver: codexDriver(),
+})
+```
+
+The Box boots in `worktreePath`, preserves mutations in that checkout, and inherits the host Home. Codex therefore reads the repository's `AGENTS.md` and skills from the checkout while using the host's existing Codex configuration, selected model, authentication, and global skills. Harness bootstrap packages and resume data live in a disposable temporary root, so they do not dirty the authoritative checkout.
+
+`codexDriver()` contributes its `codex` requirement automatically. The Agent Definition only lists additional requirements used by its own workflow.
+
+## Use a portable Home
+
+Set `home` when the Agent should use a managed Home instead of the host user's current Home:
+
+```ts
+box: {
+  runtime: trustedHost(),
+  home: '/srv/vitehub/homes/babysitter',
+}
+```
+
+The trusted-host runtime derives `HOME`, `XDG_CONFIG_HOME`, and `CODEX_HOME` from that directory. The directory can contain `.codex`, `.config/gh`, `.agents/skills`, `.gitconfig`, and other files consumed through normal Home and XDG conventions.
+
+Keep the Home outside the project checkout and protect it as a credential bundle. The Box Definition stores only its path; authentication values remain in the runtime environment and are excluded from serialized Box metadata.
+
+## Check requirements at boot
+
+`trustedHost()` validates every requirement before harness execution:
+
+| Requirement | Boot check |
+| --- | --- |
+| `codex` | Finds `codex` on `PATH` and runs `codex login status`. |
+| `github` | Finds `gh` on `PATH` and runs `gh auth status`. |
+| Any other name | Finds an executable with that name on `PATH`. |
+
+A failed check stops the Agent Invocation with the requirement name and command failure. This catches missing CLI installations and expired named authentication before Codex starts working.
+
+## Keep the execution boundaries separate
+
+| Primitive | Owns |
+| --- | --- |
+| Box | Harness execution environment, Home, working checkout, disposable cache, and boot requirements. |
+| Workspace | File-tree context, Sources, rules, snapshots, and writeback. |
+| Sandbox | Isolated provider execution for untrusted code. |
+
+An explicit Box `cwd` is an authoritative checkout, so ViteHub does not combine it with Agent Workspace materialization in this first slice. Omit `cwd` when an Agent Workspace should be materialized into a disposable trusted-host session.
+
+`trustedHost()` does not provide filesystem, credential, network, or process isolation. Use it only when the Agent is trusted to act with the host user's authority.
+
+## Related pages
+
+- [Agent Drivers](/docs/agents/agent-drivers)
+- [Workspace context](/docs/agents/workspace-context)
+- [Sandbox](/docs/server-primitives/sandbox)

--- a/docs/content/docs/reference/index.md
+++ b/docs/content/docs/reference/index.md
@@ -17,6 +17,7 @@ Each package owns the public APIs, Vite Integration, Provider Output, errors, an
 | `@vite-hub/agent` | Agent Definitions, Agent Invocations, Agent Driver boundary, Capability composition, Agent Evals, Agent Trigger API | `@vite-hub/agent`, `@vite-hub/agent/capabilities`, `@vite-hub/agent/channels`, `@vite-hub/agent/eval`, `@vite-hub/agent/vite` |
 | `@vite-hub/auth` | Auth Definitions, Better Auth server wiring, generated Auth route behavior | `@vite-hub/auth`, `@vite-hub/auth/server`, `@vite-hub/auth/vite` |
 | `@vite-hub/blob` | Blob Stores, Default Blob Store behavior, Blob Driver Modules, provider storage output | `@vite-hub/blob`, `@vite-hub/blob/vite`, `@vite-hub/blob/drivers/*` |
+| `@vite-hub/box` | Box Definitions, resolved execution contracts, trusted-host boot validation | `@vite-hub/box` |
 | `@vite-hub/database` | Database Definitions, Drizzle schema generation, D1 and hosted database wiring | `@vite-hub/database`, `@vite-hub/database/drizzle`, `@vite-hub/database/vite` |
 | `@vite-hub/devtools` | ViteHub DevTools Client shell integration and DevTools Feature registration helpers | `@vite-hub/devtools` |
 | `@vite-hub/env` | Env Declarations, Public Env, Server Env, Secret Env, generated env access | `@vite-hub/env`, `@vite-hub/env/vite`, `@vite-hub/env/server`, `@vite-hub/env/secret` |

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -96,6 +96,25 @@ For Claude Code, use `claudeCodeDriver()` from `@vite-hub/agent/harness/claude-c
 
 `driver.harness` is the AI SDK harness adapter instance. Workspace-backed harness drivers in Vite dev use ViteHub's local harness sandbox by default and receive a Harness Workspace Session prepared from the selected Workspace. The local sandbox is a tempdir-backed shell convenience, not OS/process isolation; pass a real harness sandbox provider through `driver.sandbox` when isolation matters. Outside the local workspace path, ViteHub uses the AI SDK Vercel Sandbox default when `@ai-sdk/sandbox-vercel` is installed. Harness sandbox provider setup is Agent Package runtime plumbing; use `driver.sandbox` when an Agent needs a specific harness process or session provider. `driver.workDir` selects a relative directory inside the sandbox default working directory. Add `sandbox({ commands })` only when the model should receive `sandbox_exec`. `driver.harness`, `driver.instructions`, `driver.sessionKey`, `driver.sandbox`, and `driver.workDir` can be callbacks when one Agent Definition needs invocation-scoped harness setup. ViteHub resolves harness instructions before constructing the AI SDK `HarnessAgent`, so stock harness adapters receive the selected instructions for both generated and streamed turns. When `access()` narrows Workspace Scope, ViteHub materializes only that selected scope plus generated source descriptors. Read mode materializes files and discards sandbox changes; write mode syncs additions, updates, and deletions back through Workspace rules. V1 configures built-in harness permissions internally with the no-approval policy and does not expose a public permission option. Skills stay a Capability through `skills()` rather than becoming a root Agent Definition field. For harness drivers, `skills()` relies on mounted Workspace files and does not inject model instructions or Workspace Shell tools. Put repository-wide guidance in Workspace files such as `AGENTS.md`; use `driver.instructions` for invocation-specific harness policy.
 
+## Boxes
+
+Use a Box when a harness Agent should boot in an explicit execution environment. A trusted-host Box can run Codex in an existing checkout with the host's tools and Home:
+
+```ts
+import { trustedHost } from "@vite-hub/box"
+
+export default defineAgent<any, { worktreePath: string }>({
+  box: {
+    runtime: trustedHost(),
+    cwd: ({ input }) => input.options?.worktreePath,
+    requires: ["github", "pnpm"],
+  },
+  driver: codexDriver(),
+})
+```
+
+`codexDriver()` contributes the `codex` requirement automatically. `trustedHost()` checks required tools and named authentication before execution, inherits the ambient Home when `home` is omitted, and provides no filesystem, credential, or process isolation. Set `box.home` to use a managed portable Home. Do not combine an explicit `box.cwd` with Agent Workspace materialization in this first slice.
+
 For model-backed drivers, put free-form guidance for configured Sources, Capabilities, and Skills in `driver.instructions` or a deterministic imported instruction file. Tool descriptions and schemas stay with the tools as structured contracts.
 
 ```ts

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -139,6 +139,7 @@
     "@types/json-schema": "catalog:ai",
     "@vercel/functions": "catalog:vercel",
     "@vercel/nft": "catalog:vercel",
+    "@vite-hub/box": "workspace:*",
     "@vite-hub/devtools": "workspace:*",
     "@vite-hub/runtime": "workspace:*",
     "@vite-hub/workspace": "workspace:*",

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -69,6 +69,7 @@ type HarnessAgentConstructor = new (settings: Record<string, unknown>) => Harnes
 const harnessResumeStates = new WeakMap<object, Map<string, unknown>>()
 const harnessGeneratedFiles = ["harness-tool.mjs"] as const
 const harnessInstructionFiles = ["AGENTS.md", "CLAUDE.md"] as const
+const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
 
 interface HarnessAgentAdapterOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -416,7 +417,7 @@ async function resolveHarnessWorkDir<
   return resolved
 }
 
-async function createDefaultHarnessSandbox(context: AgentAdapterRunContext) {
+async function createDefaultHarnessSandbox(context: AgentAdapterRunContext): Promise<object> {
   if (context.workspace && context.runtime.runtime === "vite") {
     const { createLocalHarnessSandbox } = await import("./harness/local-sandbox.ts")
     return createLocalHarnessSandbox()
@@ -433,7 +434,7 @@ async function createDefaultHarnessSandbox(context: AgentAdapterRunContext) {
   return sandboxModule.createVercelSandbox({
     ports: [4000],
     runtime: "node24",
-  })
+  }) as object
 }
 
 function hasHarnessInstructionDocument(context: AgentAdapterRunContext): boolean {
@@ -510,10 +511,14 @@ async function createHarnessAgent<
 ): Promise<{ agent: HarnessAgentLike, instructions?: string, workDir?: string }> {
   assertSupportedHarnessDriverContributions(context)
   const { HarnessAgent } = await import("@ai-sdk/harness/agent") as unknown as { HarnessAgent: HarnessAgentConstructor }
-  const sandbox = context.harnessSandboxProvider ?? await resolveHarnessSandboxProvider(options.sandbox, context) ?? await createDefaultHarnessSandbox(context)
   const harness = await resolveHarness(options.harness, context)
+  const baseSandbox = context.harnessSandboxProvider ?? await resolveHarnessSandboxProvider(options.sandbox, context) ?? await createDefaultHarnessSandbox(context)
+  const adaptSandbox = (harness as Record<PropertyKey, unknown>)[harnessSandboxAdapter]
+  const sandbox = typeof adaptSandbox === "function"
+    ? (adaptSandbox as (provider: object) => object)(baseSandbox)
+    : baseSandbox
   const instructions = await resolveHarnessDriverInstructions(options.instructions, context)
-  const workDir = await resolveHarnessWorkDir(options.workDir, context)
+  const workDir = await resolveHarnessWorkDir(options.workDir, context) ?? context.harnessWorkDir
   const tools = toHarnessTools(context)
   const agent = new HarnessAgent({
     harness,

--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -23,6 +23,8 @@ type CodexDriverSandboxOptions<CALL_OPTIONS = unknown> =
   | LocalHarnessSandboxOptions
   | AgentHarnessSandboxProviderInput<AgentRuntimeConfig, CALL_OPTIONS>
 
+const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
+
 export interface CodexDriverOptions<CALL_OPTIONS = unknown> extends CodexHarnessSettings {
   authJson?: string
   authJsonPath?: string
@@ -46,6 +48,8 @@ export function codexDriver<CALL_OPTIONS = unknown>(options: CodexDriverOptions<
   } = options
   const defaultOpenAIAuth = settings.auth === undefined
   const auth = settings.auth ?? { openai: {} }
+  // The upstream harness pins a model when this is undefined, which bypasses the operator's Codex profile.
+  const model = settings.model ?? ""
   const sandboxProvider = codexSandboxProvider({
     authJson,
     authJsonPath,
@@ -56,8 +60,9 @@ export function codexDriver<CALL_OPTIONS = unknown>(options: CodexDriverOptions<
 
   return {
     credentials: credentials ?? { label: "Codex", source: "ambient" },
-    harness: createViteHubCodex({ ...settings, auth }),
+    harness: createViteHubCodex({ ...settings, auth, model }, defaultOpenAIAuth),
     ...(instructions !== undefined ? { instructions } : {}),
+    requires: ["codex"],
     ...(sandboxProvider ? { sandbox: sandboxProvider } : {}),
     ...(workDir !== undefined ? { workDir } : {}),
   }
@@ -78,10 +83,11 @@ const codexBridgeLockReplacements = {
   "sha512-FzMznm7fr5/nbjZgOujZ9Y9AbdGm7ji1FOoWiY3U+srqauvZaTgn6o6aCheSL7kuymu7nTLOO/cAyWV6NuesqQ==": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
 } as const
 
-function createViteHubCodex(settings: CodexHarnessSettings) {
+function createViteHubCodex(settings: CodexHarnessSettings, preferOpenAI: boolean) {
   const harness = createCodex(settings)
   return {
     ...harness,
+    [harnessSandboxAdapter]: (provider: AgentHarnessSandboxProviderInput) => relativeCodexSandboxProvider(provider, { preferOpenAI }),
     async getBootstrap() {
       const [pkg, lock, bridge, hostToolMcp] = await Promise.all([
         readCodexBridgeAsset("package.json"),
@@ -100,7 +106,7 @@ function createViteHubCodex(settings: CodexHarnessSettings) {
         files: [
           { content: `${JSON.stringify(packageJson, null, 2)}\n`, path: `${codexBootstrapDir}/package.json` },
           { content: replaceCodexBridgeLock(lock), path: `${codexBootstrapDir}/pnpm-lock.yaml` },
-          { content: bridge, path: `${codexBootstrapDir}/bridge.mjs` },
+          { content: patchCodexBridge(bridge), path: `${codexBootstrapDir}/bridge.mjs` },
           { content: hostToolMcp, path: `${codexBootstrapDir}/host-tool-mcp.mjs` },
         ],
         harnessId: "codex",
@@ -118,6 +124,19 @@ function replaceCodexBridgeLock(lock: string): string {
   let result = lock
   for (const [from, to] of Object.entries(codexBridgeLockReplacements)) result = result.replaceAll(from, to)
   return result
+}
+
+function patchCodexBridge(bridge: string): string {
+  const errorItemHandler = `  if (item.type === "error" && event.type === "item.completed") {
+    ctx.send({
+      type: "error",
+      error: item.message ?? "codex item error"
+    });
+    return;
+  }`
+  const patched = bridge.replace(errorItemHandler, `  if (item.type === "error" && event.type === "item.completed") return;`)
+  if (patched === bridge) throw new Error("[vitehub] The pinned Codex bridge error-item patch no longer applies.")
+  return patched
 }
 
 function relativeCodexSandboxSession<T extends object>(session: T, bootstrapDir?: string): T {
@@ -149,9 +168,10 @@ function codexSandboxProvider(options: {
   const { sandbox } = options
   if (sandbox === false) return
   if (typeof sandbox === "function" || isHarnessSandboxProvider(sandbox)) return sandbox
+  if (sandbox === undefined && options.authJson === undefined && options.authJsonPath === undefined && options.env === undefined) return
 
   const localOptions = sandbox as LocalHarnessSandboxOptions | undefined
-  const provider = createLocalHarnessSandbox({
+  return relativeCodexSandboxProvider(createLocalHarnessSandbox({
     ...localOptions,
     env: codexLocalEnv({
       authJson: options.authJson,
@@ -162,22 +182,34 @@ function codexSandboxProvider(options: {
       },
       preferOpenAI: options.preferOpenAI,
     }),
-  })
+  }))
+}
+
+function relativeCodexSandboxProvider(
+  provider: AgentHarnessSandboxProviderInput,
+  options: { preferOpenAI?: boolean } = {},
+): AgentHarnessDriver["sandbox"] {
+  const adaptSession = (session: object) => {
+    if (options.preferOpenAI && "env" in session && session.env && typeof session.env === "object") {
+      stripGatewaySecrets(session.env as Record<string, string | undefined>)
+    }
+    return relativeCodexSandboxSession(session)
+  }
   return {
     ...provider,
-    async createSession(createOptions: Parameters<typeof provider.createSession>[0]) {
+    async createSession(createOptions: { onFirstCreate?: (session: object, context: { abortSignal?: AbortSignal }) => Promise<void> } = {}) {
       const onFirstCreate = createOptions?.onFirstCreate
-      const session = await provider.createSession({
+      const session = await (provider as { createSession(options: object): Promise<object> }).createSession({
         ...createOptions,
         ...(onFirstCreate
           ? {
-              onFirstCreate: async (session, context) => {
-                await onFirstCreate(relativeCodexSandboxSession(session), context)
+              onFirstCreate: async (session: object, context: { abortSignal?: AbortSignal }) => {
+                await onFirstCreate(adaptSession(session), context)
               },
             }
           : {}),
       })
-      return relativeCodexSandboxSession(session)
+      return adaptSession(session)
     },
   }
 }
@@ -201,8 +233,7 @@ function codexLocalEnv(options: {
   stripGitHubSecrets(env)
 
   if (options.preferOpenAI) {
-    delete env.AI_GATEWAY_API_KEY
-    delete env.AI_GATEWAY_BASE_URL
+    stripGatewaySecrets(env)
   }
 
   const codexHome = codexHomeFromAuth({
@@ -216,6 +247,11 @@ function codexLocalEnv(options: {
     env.PATH,
   ].filter(Boolean).join(":")
   return env
+}
+
+function stripGatewaySecrets(env: Record<string, string | undefined>): void {
+  delete env.AI_GATEWAY_API_KEY
+  delete env.AI_GATEWAY_BASE_URL
 }
 
 function stripGitHubSecrets(env: Record<string, string | undefined>): void {

--- a/packages/agent/src/harness/local-sandbox.ts
+++ b/packages/agent/src/harness/local-sandbox.ts
@@ -1,5 +1,6 @@
 import { spawn as spawnChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { realpathSync } from "node:fs"
+import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, isAbsolute, join, relative, resolve } from "node:path"
 import { Readable } from "node:stream"
@@ -14,9 +15,19 @@ export interface LocalHarnessSandboxOptions {
   rootDir?: string
 }
 
+export interface TrustedHostHarnessSandboxOptions {
+  env: Record<string, string | undefined>
+  workspaceDir?: string
+}
+
+interface LocalHarnessSandboxProviderOptions extends LocalHarnessSandboxOptions {
+  workspaceDir?: string
+}
+
 interface LocalHarnessSandboxSession extends HarnessV1NetworkSandboxSession {
   readonly cleanup: boolean
   readonly env: Record<string, string>
+  readonly physicalWorkingDirectory: boolean
   readonly processes: Set<ChildProcessWithoutNullStreams>
   readonly rootDir: string
 }
@@ -98,9 +109,10 @@ function spawnProcess(session: LocalHarnessSandboxSession, options: {
   workingDirectory?: string
 }) {
   const cwd = resolvePath(session, options.workingDirectory)
+  const physicalCwd = session.physicalWorkingDirectory ? realpathSync(cwd) : cwd
   const child = spawnChildProcess(options.command, {
-    cwd,
-    env: { ...session.env, ...options.env, INIT_CWD: cwd, OLDPWD: cwd, PWD: cwd },
+    cwd: physicalCwd,
+    env: { ...session.env, ...options.env, INIT_CWD: physicalCwd, OLDPWD: physicalCwd, PWD: physicalCwd },
     shell: true,
   })
   session.processes.add(child)
@@ -141,9 +153,10 @@ async function collect(stream: ReadableStream<Uint8Array>) {
   return new TextDecoder().decode(await bytesFromReadableStream(stream))
 }
 
-async function createSession(options: LocalHarnessSandboxOptions, sessionId: string | undefined): Promise<LocalHarnessSandboxSession> {
+async function createSession(options: LocalHarnessSandboxProviderOptions, sessionId: string | undefined): Promise<LocalHarnessSandboxSession> {
   const rootDir = options.rootDir || await defaultRootDir(sessionId)
   await mkdir(rootDir, { recursive: true })
+  if (options.workspaceDir) await bindWorkspace(rootDir, options.workspaceDir)
   const env = { ...stringEnv(options.env || process.env), INIT_CWD: rootDir, OLDPWD: rootDir, PWD: rootDir }
   const session = {
     cleanup: options.cleanup ?? !options.rootDir,
@@ -152,6 +165,7 @@ async function createSession(options: LocalHarnessSandboxOptions, sessionId: str
     env,
     id: sessionId || randomUUID(),
     ports: options.ports || [0],
+    physicalWorkingDirectory: Boolean(options.workspaceDir),
     processes: new Set<ChildProcessWithoutNullStreams>(),
     rootDir,
     async destroy() {
@@ -214,7 +228,30 @@ async function createSession(options: LocalHarnessSandboxOptions, sessionId: str
   return session
 }
 
+async function bindWorkspace(rootDir: string, workspaceDir: string): Promise<void> {
+  const link = join(rootDir, "workspace")
+  try {
+    await symlink(workspaceDir, link, "dir")
+  }
+  catch (error) {
+    if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") throw error
+    if (await realpath(link) !== await realpath(workspaceDir)) throw error
+  }
+}
+
 export function createLocalHarnessSandbox(options: LocalHarnessSandboxOptions = {}): HarnessV1SandboxProvider {
+  return createLocalHarnessSandboxProvider(options)
+}
+
+export function createTrustedHostHarnessSandbox(options: TrustedHostHarnessSandboxOptions): HarnessV1SandboxProvider {
+  return createLocalHarnessSandboxProvider({
+    cleanup: true,
+    env: options.env,
+    workspaceDir: options.workspaceDir,
+  })
+}
+
+function createLocalHarnessSandboxProvider(options: LocalHarnessSandboxProviderOptions): HarnessV1SandboxProvider {
   const firstCreates = new Map<string, Promise<void>>()
 
   return {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -173,6 +173,7 @@ import type {
   WorkspaceName,
 } from "@vite-hub/workspace"
 import type { WorkflowHandle } from "@vite-hub/workflow"
+import type { BoxRequirement, ResolvedBox } from "@vite-hub/box"
 
 export type {
   AgentAccessInvocationContextValue,
@@ -413,6 +414,7 @@ const syntheticWorkspaceRun = Symbol.for("vitehub.syntheticWorkspaceRun")
 const baseAgentResolve = Symbol.for("vitehub.baseAgentResolve")
 const baseAgentModel = Symbol.for("vitehub.baseAgentModel")
 const baseAgentDriverKind = Symbol.for("vitehub.baseAgentDriverKind")
+const baseAgentBoxRequirements = Symbol.for("vitehub.baseAgentBoxRequirements")
 const workflowSpecifier = "@vite-hub/workflow"
 const workflowRuntimeStateSpecifier = "@vite-hub/workflow/runtime/state"
 
@@ -544,6 +546,7 @@ type AgentDefinitionWithBaseResolve<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
 > = AgentDefinition<TRuntimeConfig, CALL_OPTIONS> & {
+  [baseAgentBoxRequirements]?: readonly BoxRequirement[]
   [baseAgentDriverKind]?: AgentDriverKind
   [baseAgentResolve]?: BaseAgentResolver<TRuntimeConfig, CALL_OPTIONS>
   [baseAgentModel]?: AgentModelResolver<TRuntimeConfig>
@@ -1003,8 +1006,14 @@ function defineBaseAgent<
   options: AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile>,
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS> {
   const driver = normalizeAgentDriver(options)
-  const { capabilities, cli, description, hooks, messages, name, runtime, version, workspace } = options
+  const { box, capabilities, cli, description, hooks, messages, name, runtime, version, workspace } = options
   const channels = normalizeAgentChannels(options.channels)
+  if (box && driver.kind !== "harness") {
+    throw new Error("[vitehub] defineAgent({ box }) currently requires a harness Agent Driver.")
+  }
+  if (box && driver.kind === "harness" && (driver.sandbox !== undefined || driver.workDir !== undefined)) {
+    throw new Error("[vitehub] defineAgent({ box }) owns harness execution. Move driver.sandbox and driver.workDir to the Box.")
+  }
   const run = driver.kind === "run" ? driver.run : undefined
   const baseCapabilities = normalizeCapabilities(capabilities as AgentCapabilitiesList | undefined)
   const invoker = normalizeAgentInvokerOptions(options.invoker) as AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS> | undefined
@@ -1039,9 +1048,11 @@ function defineBaseAgent<
   }
 
   const definition = {
+    ...(driver.kind === "harness" && driver.requires?.length ? { [baseAgentBoxRequirements]: driver.requires } : {}),
     ...(driver.kind === "model" ? { [baseAgentModel]: driver.model } : {}),
     [baseAgentDriverKind]: driver.kind,
     [baseAgentResolve]: resolveBaseAgent,
+    box,
     channels,
     chat,
     cli,
@@ -1296,6 +1307,7 @@ type AgentInvocationContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 > = AgentRunContext<TRuntimeConfig, CALL_OPTIONS> & {
+  box?: ResolvedBox
   channels?: AgentChannels<TRuntimeConfig>
   close: () => Promise<void>
   deliveryEffectIntents: AgentChannelDeliveryEffectIntent[]
@@ -1306,7 +1318,8 @@ type AgentInvocationContext<
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
   finishHook?: (event: AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
   hasCapabilityCleanup: boolean
-  harnessSandboxProvider?: unknown
+  harnessSandboxProvider?: object
+  harnessWorkDir?: string
   hooks?: AgentHookObserverHooks
   modelExecutionInstrumentation: AgentCapabilityRegistries["modelExecutionInstrumentation"]
   outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
@@ -1334,6 +1347,7 @@ function toAgentAdapterRunContext<
 ): AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig> {
   return {
     ...context,
+    box: context.box,
     instructions: context.instructions,
     modelExecutionInstrumentation: context.modelExecutionInstrumentation as never,
     runtime: context.runtimeContext,
@@ -1432,8 +1446,30 @@ async function createAgentInvocationContext<
       context.run,
       invocationContext.get<boolean>(scheduledAgentTurnContextKey) === true,
     )
+    const boxDefinition = definition?.box
+    const box = boxDefinition
+      ? await (await import("@vite-hub/box")).resolveBox(boxDefinition, {
+          ...callbackContext,
+          actor: invoker,
+          context: invocationContext,
+          input,
+          invoker,
+          run: context.run,
+        }, {
+          requires: (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentBoxRequirements],
+        })
+      : undefined
     const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig>> | undefined
     const workspaceOptions = workspaceDefinition?.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<AgentRuntimeConfig> | undefined
+    if (box?.workspace.path && workspaceOptions) {
+      throw new Error("[vitehub] defineAgent({ box.cwd, workspace }) is not supported because an authoritative Box workspace must not be reset by Workspace materialization.")
+    }
+    const harnessSandboxProvider = box
+      ? (await import("./harness/local-sandbox.ts")).createTrustedHostHarnessSandbox({
+          env: box.environment.env,
+          ...(box.workspace.path ? { workspaceDir: box.workspace.path } : {}),
+        })
+      : undefined
     const workspaceName = workspaceOptions
       ? workspaceNameFromOptions(workspaceOptions, {}, context.agentIdentity)
       : undefined
@@ -1532,6 +1568,7 @@ async function createAgentInvocationContext<
     const invocation = {
       ...callbackContext,
       actor: invoker,
+      box,
       channels: definition?.channels,
       close: capabilities.close,
       context: invocationContext,
@@ -1544,6 +1581,8 @@ async function createAgentInvocationContext<
       finishHook: definition?.hooks?.["agent:finish"] as never,
       hasCapabilityCleanup: capabilities.hasCloseCallbacks,
       handledResponse: capabilities.response,
+      harnessSandboxProvider,
+      harnessWorkDir: box?.workspace.path ? "workspace" : undefined,
       hooks: definition?.hooks as AgentHookObserverHooks | undefined,
       input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
       instructions,

--- a/packages/agent/src/internal/agent-driver.ts
+++ b/packages/agent/src/internal/agent-driver.ts
@@ -15,6 +15,7 @@ import type {
   AgentRuntimeConfig,
   AgentSettings,
 } from "../types.ts"
+import type { BoxRequirement } from "@vite-hub/box"
 
 type NormalizedAgentDriver<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -31,6 +32,7 @@ type NormalizedAgentDriver<
     harness: AgentHarnessDriverInput<TRuntimeConfig, CALL_OPTIONS>
     instructions?: AgentHarnessInstructions<TRuntimeConfig, CALL_OPTIONS>
     kind: "harness"
+    requires?: readonly BoxRequirement[]
     sandbox?: AgentHarnessSandboxProviderInput<TRuntimeConfig, CALL_OPTIONS>
     sessionKey?: AgentHarnessSessionKey<TRuntimeConfig, CALL_OPTIONS>
     workDir?: AgentHarnessWorkDir<TRuntimeConfig, CALL_OPTIONS>
@@ -86,7 +88,7 @@ function normalizeHarnessCredentialSource(value: unknown): AgentHarnessCredentia
 }
 
 const modelDriverKeys = new Set(["execution", "instructions", "model"])
-const harnessDriverKeys = new Set(["credentials", "harness", "instructions", "sandbox", "sessionKey", "workDir"])
+const harnessDriverKeys = new Set(["credentials", "harness", "instructions", "requires", "sandbox", "sessionKey", "workDir"])
 const runDriverKeys = new Set(["run"])
 
 function validateHarnessSandboxProviderInput(value: unknown): void {
@@ -132,6 +134,7 @@ function normalizeExplicitAgentDriver<
       harness: driver.harness as AgentHarnessDriverInput,
       instructions: driver.instructions as AgentHarnessInstructions<TRuntimeConfig, CALL_OPTIONS> | undefined,
       kind: "harness",
+      requires: driver.requires as readonly BoxRequirement[] | undefined,
       sandbox: driver.sandbox as AgentHarnessSandboxProviderInput<TRuntimeConfig, CALL_OPTIONS> | undefined,
       sessionKey: driver.sessionKey as AgentHarnessSessionKey<TRuntimeConfig, CALL_OPTIONS> | undefined,
       workDir: driver.workDir as AgentHarnessWorkDir<TRuntimeConfig, CALL_OPTIONS> | undefined,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1,4 +1,5 @@
 import type { Message, StreamEvent } from "./messages.ts"
+import type { BoxDefinition, BoxRequirement, ResolvedBox } from "@vite-hub/box"
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
 import type { JSONSchema7 } from "json-schema"
 import type { Adapter, AdapterPostableMessage, IdentityResolver, StateAdapter, TranscriptsConfig } from "chat"
@@ -981,6 +982,7 @@ export interface AgentHarnessDriver<
   model?: never
   permissionMode?: never
   permissions?: never
+  requires?: readonly BoxRequirement[]
   run?: never
   sandbox?: AgentHarnessSandboxProviderInput<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   sessionKey?: AgentHarnessSessionKey<TRuntimeConfig, CALL_OPTIONS, TContextValues>
@@ -1025,6 +1027,7 @@ type AgentSharedSettings<
   TContextValues extends object = AgentInvocationContextValues,
   TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined = AgentCapabilitiesList<TRuntimeConfig> | undefined,
 > = {
+  box?: BoxDefinition<AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>>
   capabilities?: TCapabilities
   channels?: AgentChannelInputs<TRuntimeConfig>
   cli?: AgentDefinitionCliOptions
@@ -1054,6 +1057,7 @@ export interface AgentDefinition<
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
 > {
+  box?: BoxDefinition<AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>>
   capabilities?: AgentCapabilityDefinition<TRuntimeConfig>[]
   channels?: AgentChannels<TRuntimeConfig>
   chat?: AgentChatOptions<TRuntimeConfig>
@@ -1532,12 +1536,14 @@ export interface AgentAdapterRunContext<
   Name extends WorkspaceName = WorkspaceName,
 > {
   actor: AgentActor
+  box?: ResolvedBox
   close?: () => Promise<void>
   context: AgentInvocationContextStore
   devtools?: AgentRuntimeContext<TRuntimeConfig>["devtools"]
   driverContributions?: AgentDriverContribution[]
   hasCapabilityCleanup?: boolean
-  harnessSandboxProvider?: unknown
+  harnessSandboxProvider?: object
+  harnessWorkDir?: string
   input: AgentRunInput<TOptions>
   instructions?: string
   invoker: AgentInvoker

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -1,0 +1,135 @@
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const harnessSettings = vi.hoisted(() => [] as Record<string, any>[])
+
+vi.mock("@ai-sdk/harness/agent", () => ({
+  HarnessAgent: class {
+    settings: Record<string, any>
+
+    constructor(settings: Record<string, any>) {
+      this.settings = settings
+      harnessSettings.push(settings)
+    }
+
+    async createSession() {
+      const session = await this.settings.sandbox.createSession()
+      const sessionWorkDir = this.settings.sandboxConfig.workDir
+        ? join(session.defaultWorkingDirectory, this.settings.sandboxConfig.workDir)
+        : session.defaultWorkingDirectory
+      await this.settings.sandboxConfig.onSession({
+        session,
+        sessionWorkDir,
+      })
+      return {
+        destroy: () => session.destroy(),
+        host: session,
+        sessionWorkDir,
+      }
+    }
+
+    async generate({ session }: Record<string, any>) {
+      const result = await session.host.run({
+        command: "pwd; printf '%s\\n' \"$HOME\" \"$CODEX_HOME\"; test -f AGENTS.md; test -f \"$HOME/.agents/skills/global/SKILL.md\"; printf changed > changed.txt",
+        workingDirectory: session.sessionWorkDir,
+      })
+      if (result.exitCode) throw new Error(result.stderr)
+      return { text: result.stdout }
+    }
+  },
+}))
+
+const roots: string[] = []
+
+afterEach(async () => {
+  harnessSettings.length = 0
+  await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
+})
+
+describe("Agent Box", () => {
+  it("runs Codex in the authoritative trusted-host workspace with the selected Home", async () => {
+    const root = await temporaryRoot()
+    const worktree = join(root, "worktree")
+    const home = join(root, "home")
+    const bin = join(root, "bin")
+    await Promise.all([
+      mkdir(worktree),
+      mkdir(join(home, ".agents", "skills", "global"), { recursive: true }),
+      mkdir(join(home, ".codex"), { recursive: true }),
+      mkdir(bin),
+    ])
+    await Promise.all([
+      writeFile(join(worktree, "AGENTS.md"), "Repository instructions.\n"),
+      writeFile(join(home, ".agents", "skills", "global", "SKILL.md"), "Global skill.\n"),
+      writeFile(join(home, ".codex", "config.toml"), "model = \"configured-model\"\n"),
+      executable(bin, "codex", "exit 0"),
+      executable(bin, "gh", "exit 0"),
+      executable(bin, "pnpm", "exit 0"),
+    ])
+
+    const originalPath = process.env.PATH
+    process.env.PATH = bin
+    try {
+      const { trustedHost } = await import("@vite-hub/box")
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { codexDriver } = await import("../src/harness/codex.ts")
+      const agent = defineAgent<any, { worktreePath: string }>({
+        box: {
+          cwd: ({ input }) => input.options?.worktreePath,
+          home,
+          requires: ["github", "pnpm"],
+          runtime: trustedHost(),
+        },
+        driver: codexDriver(),
+      })
+
+      await expect(runAgent(agent, {
+        memo: vi.fn((_key, create) => create()),
+        runtime: "vite",
+        waitUntil: vi.fn(),
+      }, {
+        options: { worktreePath: worktree },
+        prompt: "Repair the project.",
+      })).resolves.toMatchObject({
+        text: `${await realpath(worktree)}\n${home}\n${join(home, ".codex")}\n`,
+      })
+
+      await expect(readFile(join(worktree, "changed.txt"), "utf8")).resolves.toBe("changed")
+      expect(harnessSettings.at(-1)?.sandbox).toMatchObject({ providerId: "local" })
+      expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "workspace" })
+    }
+    finally {
+      if (originalPath === undefined) delete process.env.PATH
+      else process.env.PATH = originalPath
+    }
+  })
+
+  it("rejects overlapping Box and harness execution configuration", async () => {
+    const { trustedHost } = await import("@vite-hub/box")
+    const { defineAgent } = await import("../src/index.ts")
+
+    expect(() => defineAgent({
+      box: { runtime: trustedHost() },
+      driver: { harness: {}, sandbox: {} },
+    })).toThrow("defineAgent({ box }) owns harness execution")
+    expect(() => defineAgent({
+      box: { runtime: trustedHost() },
+      driver: { harness: {}, workDir: "repository" },
+    })).toThrow("defineAgent({ box }) owns harness execution")
+  })
+})
+
+async function temporaryRoot() {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-agent-box-test-"))
+  roots.push(root)
+  return root
+}
+
+async function executable(bin: string, name: string, body: string) {
+  const path = join(bin, name)
+  await writeFile(path, `#!/bin/sh\n${body}\n`)
+  await chmod(path, 0o755)
+}

--- a/packages/agent/test/codex-harness.test.ts
+++ b/packages/agent/test/codex-harness.test.ts
@@ -11,17 +11,18 @@ vi.mock("@ai-sdk/harness-codex", () => ({
 }))
 
 describe("codexDriver", () => {
-  it("defaults to direct OpenAI auth and local sandbox credentials", async () => {
+  it("defaults to direct OpenAI auth and contributes its Box requirement", async () => {
     const { codexDriver } = await import("../src/harness/codex.ts")
 
     const driver = codexDriver()
 
-    expect(createCodex).toHaveBeenLastCalledWith({ auth: { openai: {} } })
+    expect(createCodex).toHaveBeenLastCalledWith({ auth: { openai: {} }, model: "" })
     expect(driver).toMatchObject({
       credentials: { label: "Codex", source: "ambient" },
       harness: { provider: "codex" },
-      sandbox: { providerId: "local" },
+      requires: ["codex"],
     })
+    expect(driver.sandbox).toBeUndefined()
   })
 
   it("keeps host AI Gateway env out of the default local Codex sandbox", async () => {
@@ -72,7 +73,7 @@ describe("codexDriver", () => {
 
     try {
       const { codexDriver } = await import("../src/harness/codex.ts")
-      const driver = codexDriver() as { sandbox?: { createSession: () => Promise<{ destroy: () => Promise<void>, env: Record<string, string> }> } }
+      const driver = codexDriver({ sandbox: {} }) as { sandbox?: { createSession: () => Promise<{ destroy: () => Promise<void>, env: Record<string, string> }> } }
       const session = await driver.sandbox?.createSession()
 
       try {
@@ -91,7 +92,7 @@ describe("codexDriver", () => {
 
   it("creates isolated default local sandbox sessions", async () => {
     const { codexDriver } = await import("../src/harness/codex.ts")
-    const driver = codexDriver() as { sandbox?: { createSession: () => Promise<{ defaultWorkingDirectory: string, destroy: () => Promise<void> }> } }
+    const driver = codexDriver({ sandbox: {} }) as { sandbox?: { createSession: () => Promise<{ defaultWorkingDirectory: string, destroy: () => Promise<void> }> } }
     const first = await driver.sandbox?.createSession()
     const second = await driver.sandbox?.createSession()
 
@@ -138,7 +139,7 @@ describe("codexDriver", () => {
 
     const driver = codexDriver({ auth: { gateway: { apiKey: "gateway-key" } }, sandbox: false })
 
-    expect(createCodex).toHaveBeenLastCalledWith({ auth: { gateway: { apiKey: "gateway-key" } } })
+    expect(createCodex).toHaveBeenLastCalledWith({ auth: { gateway: { apiKey: "gateway-key" } }, model: "" })
     expect(driver.sandbox).toBeUndefined()
   })
 
@@ -155,7 +156,7 @@ describe("codexDriver", () => {
 
     expect(driver.instructions).toBe(instructions)
     expect(driver.workDir).toBe(workDir)
-    expect(createCodex).toHaveBeenLastCalledWith({ auth: { openai: {} } })
+    expect(createCodex).toHaveBeenLastCalledWith({ auth: { openai: {} }, model: "" })
   })
 
   it("preserves an empty work directory for harness validation", async () => {

--- a/packages/agent/test/harness-codex-patch.test.ts
+++ b/packages/agent/test/harness-codex-patch.test.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util"
 import { describe, expect, it } from "vitest"
 
 import { codexDriver } from "../src/harness/codex.ts"
+import { createLocalHarnessSandbox } from "../src/harness/local-sandbox.ts"
 
 import type { HarnessV1SandboxProvider } from "@ai-sdk/harness"
 
@@ -18,6 +19,7 @@ describe("ViteHub Codex harness", () => {
     const harness = codexDriver({ sandbox: false }).harness as ReturnType<typeof createCodex>
     const bootstrap = await harness.getBootstrap!()
     const bridgePackage = bootstrap.files.find(file => file.path.endsWith("package.json"))
+    const bridge = bootstrap.files.find(file => file.path.endsWith("bridge.mjs"))
 
     expect(bootstrap.bootstrapDir).toBe("/tmp/harness/codex")
     expect(bootstrap.commands).toContainEqual({
@@ -26,6 +28,7 @@ describe("ViteHub Codex harness", () => {
     expect(JSON.parse(bridgePackage!.content)).toMatchObject({
       dependencies: { "@openai/codex-sdk": "0.144.1" },
     })
+    expect(bridge!.content).not.toContain("codex item error")
   })
 
   it("loads bridge assets after the adapter is bundled into another directory", async () => {
@@ -97,6 +100,33 @@ describe("ViteHub Codex harness", () => {
         },
       })
       expect(output).toBe("ready")
+      await session.destroy?.()
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("adapts a Box sandbox for Codex paths and direct OpenAI auth", async () => {
+    const root = await mkdtemp(join(import.meta.dirname, ".codex-box-"))
+    const harness = codexDriver({ sandbox: false }).harness as Record<PropertyKey, unknown>
+    const adapt = harness[Symbol.for("vitehub.harnessSandboxAdapter")] as (provider: HarnessV1SandboxProvider) => HarnessV1SandboxProvider
+    const provider = adapt(createLocalHarnessSandbox({
+      env: {
+        AI_GATEWAY_API_KEY: "host-key",
+        AI_GATEWAY_BASE_URL: "https://gateway.example",
+        PATH: process.env.PATH,
+      },
+      rootDir: root,
+    }))
+
+    try {
+      const session = await provider.createSession()
+      await session.writeTextFile({ content: "ready", path: "/tmp/harness/codex/marker" })
+
+      expect((session as unknown as { env: Record<string, string> }).env.AI_GATEWAY_API_KEY).toBeUndefined()
+      expect((session as unknown as { env: Record<string, string> }).env.AI_GATEWAY_BASE_URL).toBeUndefined()
+      await expect(session.run({ command: "cat /tmp/harness/codex/marker" })).resolves.toMatchObject({ stdout: "ready" })
       await session.destroy?.()
     }
     finally {

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -5,6 +5,9 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "paths": {
+      "@vite-hub/box": [
+        "packages/box/src/index.ts"
+      ],
       "#vitehub/agent/registry": [
         "packages/agent/src/runtime/empty-registry.ts"
       ],

--- a/packages/box/README.md
+++ b/packages/box/README.md
@@ -1,0 +1,43 @@
+# @vite-hub/box
+
+`@vite-hub/box` defines the execution environment used by a ViteHub harness Agent. The first runtime is `trustedHost()`, which runs against tools, configuration, and authentication already available on the host.
+
+## Install
+
+```sh
+pnpm add @vite-hub/box
+```
+
+## Trusted host
+
+Declare the Box inline with the Agent Definition:
+
+```ts
+import { defineAgent } from "@vite-hub/agent"
+import { codexDriver } from "@vite-hub/agent/harness/codex"
+import { trustedHost } from "@vite-hub/box"
+
+export default defineAgent<any, { worktreePath: string }>({
+  box: {
+    runtime: trustedHost(),
+    cwd: ({ input }) => input.options?.worktreePath,
+    home: "/srv/vitehub/home",
+    requires: ["github", "pnpm"],
+  },
+  driver: codexDriver(),
+})
+```
+
+`cwd` is an authoritative mutable checkout. `home` points to a portable Home containing configuration such as `.codex`, `.config/gh`, and `.agents/skills`. When `home` is omitted, the Box inherits the host Home.
+
+The Agent mounts the checkout into a disposable harness root. Project mutations remain in `cwd`, while harness bootstrap packages and resume data are removed with the session.
+
+`codexDriver()` contributes the `codex` requirement automatically. At Box boot, `trustedHost()` checks `codex login status`, checks `gh auth status` for the `github` requirement, and verifies other requirement names on `PATH`.
+
+Authentication values remain runtime-owned. A Box stores requirement names and an optional Home path, while its resolved environment is deliberately excluded from JSON serialization.
+
+## Security boundary
+
+A trusted-host Box provides no filesystem, credential, or process isolation. Use it only when the Agent is trusted to act as the host user. `@vite-hub/sandbox` remains the isolated execution primitive.
+
+An explicit Box `cwd` cannot currently be combined with an Agent Workspace because Workspace materialization resets its target directory. Omit `cwd` when the Agent should use a disposable Workspace session.

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@vite-hub/box",
+  "version": "0.0.1",
+  "description": "Portable execution environments for ViteHub agents.",
+  "keywords": [
+    "agent",
+    "runtime",
+    "vitehub"
+  ],
+  "homepage": "https://github.com/vite-hub/vitehub#readme",
+  "bugs": "https://github.com/vite-hub/vitehub/issues",
+  "license": "Apache-2.0",
+  "author": "onmax <maximogarciamtnez@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vite-hub/vitehub.git",
+    "directory": "packages/box"
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "vp pack",
+    "dev": "vp pack --watch",
+    "typecheck": "tsc --noEmit -p ./tsconfig.json",
+    "test": "vp run -t @vite-hub/box#build && vp test"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:tooling",
+    "publint": "catalog:tooling",
+    "typescript": "catalog:tooling",
+    "vite-plus": "catalog:tooling",
+    "vitest": "catalog:tooling"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/packages/box/src/index.ts
+++ b/packages/box/src/index.ts
@@ -1,0 +1,160 @@
+import { execFile } from "node:child_process"
+import { constants } from "node:fs"
+import { access, stat } from "node:fs/promises"
+import { homedir } from "node:os"
+import { delimiter, isAbsolute, join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+export type BoxRequirement = "codex" | "github" | (string & {})
+
+export type BoxValue<T, Context> = T | ((context: Context) => T | undefined | Promise<T | undefined>)
+
+export interface BoxDefinition<Context = unknown> {
+  cwd?: BoxValue<string, Context>
+  home?: BoxValue<string, Context>
+  requires?: readonly BoxRequirement[]
+  runtime: BoxRuntime
+}
+
+export interface BoxRuntime {
+  readonly name: string
+  resolve(input: ResolvedBoxInput): Promise<ResolvedBox>
+}
+
+export interface ResolvedBoxInput {
+  cwd?: string
+  home?: string
+  requirements: readonly BoxRequirement[]
+}
+
+export interface ResolvedBoxEnvironment {
+  readonly env: Readonly<Record<string, string | undefined>>
+  readonly home?: string
+}
+
+export interface ResolvedBoxRequirement {
+  readonly command: string
+  readonly name: BoxRequirement
+}
+
+export interface ResolvedBox {
+  readonly cache: {
+    readonly state: "disposable"
+  }
+  readonly environment: ResolvedBoxEnvironment
+  readonly isolation: "none"
+  readonly requirements: readonly ResolvedBoxRequirement[]
+  readonly runtime: string
+  readonly workspace: {
+    readonly path?: string
+    readonly state: "authoritative" | "disposable"
+  }
+}
+
+export interface ResolveBoxOptions {
+  requires?: readonly BoxRequirement[]
+}
+
+export async function resolveBox<Context>(
+  definition: BoxDefinition<Context>,
+  context: Context,
+  options: ResolveBoxOptions = {},
+): Promise<ResolvedBox> {
+  if (!definition || typeof definition !== "object" || !definition.runtime || typeof definition.runtime.resolve !== "function") {
+    throw new TypeError("[vitehub] Box requires a runtime.")
+  }
+  const [cwd, home] = await Promise.all([
+    resolveValue(definition.cwd, context),
+    resolveValue(definition.home, context),
+  ])
+  return await definition.runtime.resolve({
+    ...(cwd ? { cwd } : {}),
+    ...(home ? { home } : {}),
+    requirements: [...new Set([...(definition.requires || []), ...(options.requires || [])])],
+  })
+}
+
+export function trustedHost(): BoxRuntime {
+  return {
+    name: "trusted-host",
+    async resolve(input) {
+      const cwd = input.cwd ? resolve(input.cwd) : undefined
+      const home = input.home ? resolve(input.home) : process.env.HOME || homedir()
+      await Promise.all([
+        cwd ? assertDirectory(cwd, "workspace") : undefined,
+        input.home ? assertDirectory(home!, "Home") : undefined,
+      ])
+      const env = {
+        ...process.env,
+        ...(home ? { HOME: home } : {}),
+        ...(input.home
+          ? {
+              CODEX_HOME: join(home!, ".codex"),
+              XDG_CONFIG_HOME: join(home!, ".config"),
+            }
+          : {}),
+      }
+      const requirements = []
+      for (const name of input.requirements) requirements.push(await resolveRequirement(name, env, cwd))
+      const environment = { home } as ResolvedBoxEnvironment
+      Object.defineProperty(environment, "env", { enumerable: false, value: Object.freeze(env) })
+      return {
+        cache: { state: "disposable" },
+        environment,
+        isolation: "none",
+        requirements,
+        runtime: "trusted-host",
+        workspace: cwd ? { path: cwd, state: "authoritative" } : { state: "disposable" },
+      }
+    },
+  }
+}
+
+async function resolveValue<T, Context>(value: BoxValue<T, Context> | undefined, context: Context): Promise<T | undefined> {
+  return typeof value === "function"
+    ? await (value as (context: Context) => T | undefined | Promise<T | undefined>)(context)
+    : value
+}
+
+async function assertDirectory(path: string, label: string) {
+  const item = await stat(path).catch(() => undefined)
+  if (!item?.isDirectory()) throw new Error(`[vitehub] Box ${label} directory does not exist: ${path}`)
+}
+
+const requirementCommands: Record<string, { args: string[], command: string }> = {
+  codex: { args: ["login", "status"], command: "codex" },
+  github: { args: ["auth", "status"], command: "gh" },
+}
+
+async function resolveRequirement(
+  name: BoxRequirement,
+  env: Record<string, string | undefined>,
+  cwd: string | undefined,
+): Promise<ResolvedBoxRequirement> {
+  if (!name.trim()) throw new Error("[vitehub] Box requirements must be non-empty names.")
+  const check = requirementCommands[name] || { args: [], command: name }
+  if (!await findExecutable(check.command, env.PATH)) {
+    throw new Error(`[vitehub] Box requirement "${name}" is unavailable: ${check.command} is not on PATH.`)
+  }
+  if (check.args.length) {
+    try {
+      await promisify(execFile)(check.command, check.args, { cwd, env, timeout: 10_000 })
+    }
+    catch (error) {
+      const detail = typeof error === "object" && error && "stderr" in error
+        ? String(error.stderr).trim()
+        : error instanceof Error ? error.message : String(error)
+      throw new Error(`[vitehub] Box requirement "${name}" failed${detail ? `: ${detail}` : "."}`, { cause: error })
+    }
+  }
+  return { command: check.command, name }
+}
+
+async function findExecutable(command: string, path: string | undefined) {
+  const candidates = command.includes("/") || isAbsolute(command)
+    ? [resolve(command)]
+    : (path || "").split(delimiter).filter(Boolean).map(directory => join(directory, command))
+  for (const candidate of candidates) {
+    if (await access(candidate, constants.X_OK).then(() => true, () => false)) return candidate
+  }
+}

--- a/packages/box/test/trusted-host.test.ts
+++ b/packages/box/test/trusted-host.test.ts
@@ -1,0 +1,105 @@
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import { resolveBox, trustedHost } from "../src/index.ts"
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
+})
+
+describe("trustedHost", () => {
+  it("resolves an authoritative workspace and portable Home without serializing auth", async () => {
+    const root = await temporaryRoot()
+    const workspace = join(root, "workspace")
+    const home = join(root, "home")
+    const bin = join(root, "bin")
+    await Promise.all([mkdir(workspace), mkdir(home), mkdir(bin)])
+    await executable(bin, "codex", "exit 0")
+    await executable(bin, "gh", "exit 0")
+    await executable(bin, "pnpm", "exit 0")
+
+    const box = await withPath(bin, () => resolveBox({
+        cwd: ({ worktree }: { worktree: string }) => worktree,
+        home,
+        requires: ["github", "pnpm"],
+        runtime: trustedHost(),
+      }, { worktree: workspace }, { requires: ["codex"] }))
+
+    expect(box).toMatchObject({
+      cache: { state: "disposable" },
+      environment: {
+        env: {
+          CODEX_HOME: join(home, ".codex"),
+          HOME: home,
+          PATH: bin,
+          XDG_CONFIG_HOME: join(home, ".config"),
+        },
+        home,
+      },
+      isolation: "none",
+      requirements: [
+        { command: "gh", name: "github" },
+        { command: "pnpm", name: "pnpm" },
+        { command: "codex", name: "codex" },
+      ],
+      runtime: "trusted-host",
+      workspace: { path: workspace, state: "authoritative" },
+    })
+    expect(JSON.stringify(box)).not.toContain("token")
+  })
+
+  it("uses a disposable workspace and the ambient Home when paths are omitted", async () => {
+    const box = await resolveBox({ runtime: trustedHost() }, {})
+
+    expect(box.environment.home).toBe(process.env.HOME)
+    expect(box.workspace).toEqual({ state: "disposable" })
+  })
+
+  it("names a missing requirement", async () => {
+    await expect(withPath("", () => resolveBox({
+        requires: ["missing-tool"],
+        runtime: trustedHost(),
+      }, {}))).rejects.toThrow('Box requirement "missing-tool" is unavailable')
+  })
+
+  it("fails when named authentication is not ready", async () => {
+    const root = await temporaryRoot()
+    const bin = join(root, "bin")
+    await mkdir(bin)
+    await executable(bin, "gh", 'echo "not logged in" >&2\nexit 1')
+
+    await expect(withPath(bin, () => resolveBox({
+        requires: ["github"],
+        runtime: trustedHost(),
+      }, {}))).rejects.toThrow('Box requirement "github" failed: not logged in')
+  })
+})
+
+async function temporaryRoot() {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-box-test-"))
+  roots.push(root)
+  return root
+}
+
+async function executable(bin: string, name: string, body: string) {
+  const path = join(bin, name)
+  await writeFile(path, `#!/bin/sh\n${body}\n`)
+  await chmod(path, 0o755)
+}
+
+async function withPath<T>(path: string, run: () => Promise<T>) {
+  const original = process.env.PATH
+  process.env.PATH = path
+  try {
+    return await run()
+  }
+  finally {
+    if (original === undefined) delete process.env.PATH
+    else process.env.PATH = original
+  }
+}

--- a/packages/box/tsconfig.build.json
+++ b/packages/box/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "isolatedDeclarations": true,
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "test"
+  ]
+}

--- a/packages/box/tsconfig.json
+++ b/packages/box/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../..",
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "@vite-hub/box": [
+        "packages/box/src/index.ts"
+      ]
+    },
+    "rootDir": ".."
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/box/vite.config.ts
+++ b/packages/box/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite-plus"
+
+export default defineConfig({
+  pack: {
+    entry: ["src/index.ts"],
+    exports: {
+      inlinedDependencies: false,
+    },
+    outExtensions: () => ({
+      dts: ".d.ts",
+      js: ".js",
+    }),
+    publint: true,
+    tsconfig: "tsconfig.build.json",
+  },
+})

--- a/packages/box/vitest.config.ts
+++ b/packages/box/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    fileParallelism: false,
+    include: ["test/**/*.test.ts"],
+  },
+})

--- a/packages/internal/test/workspace-inventory.test.ts
+++ b/packages/internal/test/workspace-inventory.test.ts
@@ -11,6 +11,7 @@ describe("workspace inventory", () => {
       "agent",
       "auth",
       "blob",
+      "box",
       "cli",
       "database",
       "devtools",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,6 +429,9 @@ importers:
       '@vercel/nft':
         specifier: catalog:vercel
         version: 1.5.0(rollup@4.60.4)
+      '@vite-hub/box':
+        specifier: workspace:*
+        version: link:../box
       '@vite-hub/devtools':
         specifier: workspace:*
         version: link:../devtools
@@ -579,6 +582,24 @@ importers:
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
         version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
+
+  packages/box:
+    devDependencies:
+      '@types/node':
+        specifier: catalog:tooling
+        version: 24.13.2
+      publint:
+        specifier: catalog:tooling
+        version: 0.3.21
+      typescript:
+        specifier: catalog:tooling
+        version: 6.0.2
+      vite-plus:
+        specifier: catalog:tooling
+        version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
 
   packages/cli:
     dependencies:


### PR DESCRIPTION
Adds `@vite-hub/box` as the provider-neutral definition and resolved runtime boundary, with one concrete `trustedHost()` runtime. Agent Definitions can inline a mutable checkout, optional managed Home, and named boot requirements; `codexDriver()` contributes Codex automatically and uses the host profile, authentication, global skills, and CLI configuration while harness cache state stays disposable.

Connects Box resolution directly to harness Agents and rejects conflicting Workspace or driver sandbox wiring. Focused tests cover definition resolution and trusted-host execution, the docs distinguish Box, Workspace, and Sandbox ownership, and the real Babysitter `runAgent()` path completes against the existing ChatGPT, GitHub CLI, Git, and pnpm setup without dirtying the target checkout.