### PR TITLE
fix(schedule): log process runtime errors

### DIFF
--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -217,8 +217,10 @@ function renderNitroSchedulePlugin(options: RenderNitroSchedulePluginOptions): s
     ...(processRuntime
       ? [
           "  function captureRuntimeError(error: unknown) {",
+          "    const runtimeError = error instanceof Error ? error : new Error(String(error))",
+          "    console.error('[vitehub:schedule]', runtimeError)",
           "    try {",
-          "      nitroApp.captureError?.(error instanceof Error ? error : new Error(String(error)), { tags: ['vitehub-schedule'] })",
+          "      nitroApp.captureError?.(runtimeError, { tags: ['vitehub-schedule'] })",
           "    }",
           "    catch {}",
           "  }",

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -217,9 +217,9 @@ function renderNitroSchedulePlugin(options: RenderNitroSchedulePluginOptions): s
     ...(processRuntime
       ? [
           "  function captureRuntimeError(error: unknown) {",
-          "    const runtimeError = error instanceof Error ? error : new Error(String(error))",
-          "    console.error('[vitehub:schedule]', runtimeError)",
           "    try {",
+          "      const runtimeError = error instanceof Error ? error : new Error(String(error))",
+          "      console.error('[vitehub:schedule]', runtimeError)",
           "      nitroApp.captureError?.(runtimeError, { tags: ['vitehub-schedule'] })",
           "    }",
           "    catch {}",

--- a/packages/schedule/test/nitro-process-plugin.test.ts
+++ b/packages/schedule/test/nitro-process-plugin.test.ts
@@ -164,6 +164,20 @@ describe("generated Nitro Process Runtime plugin", () => {
     expect(app.captureError).toHaveBeenCalledWith(installationError, { tags: ["vitehub-schedule"] })
   })
 
+  it("does not replace installation failures when runtime error coercion fails", async () => {
+    const thrownValue = {
+      toString() {
+        throw new Error("runtime error coercion failed")
+      },
+    }
+    const plugin = await loadProcessPlugin(() => Promise.reject(thrownValue))
+    const { app, hooks } = createNitroApp()
+
+    expect(() => plugin(app)).not.toThrow()
+    await expect(hooks.get("request")!()).rejects.toBe(thrownValue)
+    expect(app.captureError).not.toHaveBeenCalled()
+  })
+
   it("does not replace Nitro's local fetch entrypoint", async () => {
     const plugin = await loadProcessPlugin(async () => ({ close: vi.fn() }))
     const localFetch = vi.fn()

--- a/packages/schedule/test/nitro-process-plugin.test.ts
+++ b/packages/schedule/test/nitro-process-plugin.test.ts
@@ -12,12 +12,16 @@ interface RuntimeController {
   close: () => Promise<void> | void
 }
 
+interface RuntimeInstallOptions {
+  onError: (error: unknown) => void
+}
+
 interface PluginHarness {
   createKVRuntimeScheduleStore: () => object
   createKVScheduleRunStore: () => object
   createProcessScheduleWakeDriver: () => () => void
   definePlugin: <T>(plugin: T) => T
-  installScheduleRuntime: () => Promise<RuntimeController>
+  installScheduleRuntime: (options: RuntimeInstallOptions) => Promise<RuntimeController>
 }
 
 interface NitroAppHarness {
@@ -95,6 +99,31 @@ function createNitroApp(localFetch = vi.fn()) {
 }
 
 describe("generated Nitro Process Runtime plugin", () => {
+  it("logs reported runtime failures while preserving Nitro error capture", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const plugin = await loadProcessPlugin(async ({ onError }) => {
+      onError("scheduled handler failed")
+      return { close: vi.fn() }
+    })
+    const { app } = createNitroApp()
+    app.captureError.mockImplementation(() => {
+      throw new Error("Nitro capture failed")
+    })
+
+    try {
+      expect(() => plugin(app)).not.toThrow()
+
+      const runtimeError = consoleError.mock.calls[0]?.[1]
+      expect(runtimeError).toBeInstanceOf(Error)
+      expect(runtimeError).toMatchObject({ message: "scheduled handler failed" })
+      expect(consoleError).toHaveBeenCalledWith("[vitehub:schedule]", runtimeError)
+      expect(app.captureError).toHaveBeenCalledWith(runtimeError, { tags: ["vitehub-schedule"] })
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("installs without a fetch method on the Nitro app", async () => {
     const plugin = await loadProcessPlugin(async () => ({ close: vi.fn() }))
     const { app } = createNitroApp()


### PR DESCRIPTION
Logs Process Runtime failures to stderr before forwarding the same normalized `Error` to Nitro's capture hook. A failing capture hook remains isolated, so systemd and other long-running hosts retain actionable failures in their ordinary service logs.

This closes the visibility gap found in Babysitter, where failed Schedule runs were durable but absent from journald.

<!-- babysitter:direction-validation:v1 -->
## Babysitter direction validation

Verdict: proceed

What is good: keeps the fix scoped to generated Nitro Process Runtime error visibility; logs the same normalized Error that is forwarded to Nitro capture; leaves capture-hook failures isolated.

What is missing: no broader runtime inspection surface, but that is outside this pull request intent.

Corrections applied: none.
<!-- /babysitter:direction-validation:v1 -->
