### PR TITLE
feat(agent): add channel-scoped capabilities

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -27,6 +27,32 @@ export default defineAgent({
 
 Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`, `telegram()`, `stream()`, and `webChat()`. A synchronous Channel factory that needs no options can be registered directly, so `channels: { stream }` is equivalent to `channels: { stream: stream() }` and resolves once when `defineAgent()` runs. Call the helper when passing options, such as `stream({ messages: { sessions: false } })`. Use `defineChannel(kind, options)` for an app-owned Channel Kind.
 
+## Scope capabilities to a Channel
+
+Put a Capability on a Channel when only invocations from that Channel should receive the ability. Agent-level Capabilities remain active for every invocation; ViteHub appends the active Channel's Capabilities when `run.channelId` or the Agent Trigger identifies that Channel.
+
+```ts [server/agents/support.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { openapi } from '@vite-hub/agent/capabilities'
+import { teams, webChat } from '@vite-hub/agent/channels'
+
+const portalApi = openapi({
+  cli: { name: 'portal-api' },
+  operations: ['purchaseOrders'],
+  spec: 'https://portal.example.com/_openapi.json',
+})
+
+export default defineAgent({
+  channels: {
+    portal: webChat({ capabilities: [portalApi] }),
+    teams: teams(),
+  },
+  run: () => 'ok',
+})
+```
+
+Direct invocations without an active Channel receive only the Agent-level Capabilities. Channel Trigger callbacks can inspect their effective list through `context.agentCapabilities`. Keep authentication and Agent Actor resolution at the route, trigger, or `access()` boundary; Channel-scoped Capabilities select abilities, not trusted identity.
+
 ## Discord
 
 Use `discord({ adapter })` when a Discord bot should receive message events through Chat SDK's Discord adapter. Install `@chat-adapter/discord` in the app when using the built-in adapter options. ViteHub keeps Discord conversation state thread-scoped by default, so separate Discord threads can run independent Agent conversations.
@@ -55,7 +81,7 @@ Set `routes.discordGateway: true` on `hubAgent()` when the deployment needs a ge
 
 | Boundary | Owns | Does not own |
 | --- | --- | --- |
-| Channel | Origin, event, delivery, thread, and message metadata. | Trusted identity, access decisions, command rewriting. |
+| Channel | Origin, event, delivery, thread, message metadata, and origin-scoped abilities. | Trusted identity, access decisions, command rewriting. |
 | Agent Actor | Trusted caller identity for one Agent Invocation. | Transport delivery, webhook shape, UI session state. |
 | Input Command | User-authored command parsing and input rewriting before the Agent Driver runs. | Channel verification, delivery, caller identity. |
 

--- a/docs/content/docs/capabilities/openapi.md
+++ b/docs/content/docs/capabilities/openapi.md
@@ -15,7 +15,7 @@ Channel, customer, or tenant admission belongs in `access()`, Agent Trigger rout
 
 ## Installation
 
-Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Import the Capability factory from `@vite-hub/agent/capabilities`. Add it to `defineAgent({ capabilities })` when every invocation needs it, or to one [Channel's capabilities](/docs/agents/channels#scope-capabilities-to-a-channel) when only that Channel should receive it.
 
 ```ts [server/agents/support.ts]
 import { defineAgent } from '@vite-hub/agent'

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -20,6 +20,7 @@ import type {
   AgentChatFinishExtension,
   AgentChatMessage,
   AgentChannelDefinition,
+  AgentChannelTriggerContext,
   AgentChannelDeliveryEffectContext,
   AgentChannelDeliveryEffectIntent,
   AgentChannelDeliveryEffects,
@@ -87,6 +88,7 @@ export type {
 } from "./types.ts"
 export interface AgentChannelOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   adapter?: AgentChannelDefinition<TRuntimeConfig>["adapter"]
+  capabilities?: AgentChannelDefinition<TRuntimeConfig>["capabilities"]
   effects?: AgentChannelDefinition<TRuntimeConfig>["effects"]
   identity?: AgentChannelDefinition<TRuntimeConfig>["identity"]
   messages?: false | AgentMessageChannelSettings<TRuntimeConfig>
@@ -502,12 +504,6 @@ function parseSlashCommand(body: string): { args: string, command: `/${string}` 
   }
 }
 
-type AgentChannelTriggerContextWithCapabilities<TRuntimeConfig extends AgentRuntimeConfig> =
-  AgentCallbackContext<TRuntimeConfig> & {
-    capabilities?: readonly AgentCapabilityDefinition<TRuntimeConfig>[]
-    trigger?: { channelId?: string }
-  }
-
 type InputCommandsMetadata = {
   commands: Record<string, { channels?: readonly string[] } | unknown>
   trigger: string
@@ -519,12 +515,12 @@ function inputCommandsMetadata(value: unknown): InputCommandsMetadata | undefine
 }
 
 function declaredInputCommand<TRuntimeConfig extends AgentRuntimeConfig>(
-  context: AgentCallbackContext<TRuntimeConfig>,
+  context: AgentChannelTriggerContext<TRuntimeConfig>,
   command: string,
 ): boolean | undefined {
   let sawMatchingTrigger = false
-  const channelId = (context as AgentChannelTriggerContextWithCapabilities<TRuntimeConfig>).trigger?.channelId
-  for (const capability of (context as AgentChannelTriggerContextWithCapabilities<TRuntimeConfig>).capabilities || []) {
+  const channelId = context.trigger.channelId
+  for (const capability of context.agentCapabilities || []) {
     const metadata = inputCommandsMetadata(capability.metadata)
     if (!metadata || !command.startsWith(metadata.trigger)) continue
     const name = command.slice(metadata.trigger.length)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -726,7 +726,7 @@ function channelDeliveryEffectHandlers<TRuntimeConfig extends AgentRuntimeConfig
   return typeof handlers === "function" ? [handlers] : [...handlers]
 }
 
-function activeDeliveryChannel<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+function activeAgentChannel<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
   channels: AgentChannels<TRuntimeConfig> | undefined,
   context: AgentInvocationContextStore,
   run?: AgentRunMetadata,
@@ -744,7 +744,7 @@ async function setChannelDeliverySupportContext<TRuntimeConfig extends AgentRunt
   input: AgentRunInput<CALL_OPTIONS>,
   run?: AgentRunMetadata,
 ): Promise<void> {
-  const active = activeDeliveryChannel(channels, invocationContext, run)
+  const active = activeAgentChannel(channels, invocationContext, run)
   if (!active) return
   if (!channelDeliveryEffectHandlers(active.channel, { kind: "title" }).length) {
     invocationContext.set(messageChannelTitleSupportContextKey, false, { overwrite: true })
@@ -781,7 +781,7 @@ async function applyChannelDeliveryEffectIntents<
   finish?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
 ): Promise<void> {
   if (!intents.length) return
-  const active = activeDeliveryChannel(context.channels, context.context, context.run)
+  const active = activeAgentChannel(context.channels, context.context, context.run)
 
   for (const intent of intents) {
     const handlers = active ? channelDeliveryEffectHandlers(active.channel, intent) : []
@@ -1469,11 +1469,18 @@ async function createAgentInvocationContext<
         ? workspaceModule.useWorkspace(workspaceName, workspaceUseOptions ? { ...workspaceUseOptions, mode: "write" } : { mode: "write" })
         : workspaceUseOptions ? workspaceModule.useWorkspace(workspaceName, { ...workspaceUseOptions, mode: "read" }) : workspaceModule.useWorkspace(workspaceName)
       : undefined
-    const capabilityOptions = definition?.capabilities?.length
+    const baseCapabilityOptions = definition?.capabilities?.length
       ? { capabilities: definition.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: definition.hooks as never }
       : workspaceOptions && workspace
         ? { capabilities: workspaceOptions.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: workspaceOptions.hooks as never }
         : undefined
+    const channelCapabilities = activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel.capabilities
+    const capabilityOptions = channelCapabilities?.length
+      ? {
+          capabilities: [...(baseCapabilityOptions?.capabilities || []), ...channelCapabilities],
+          hooks: baseCapabilityOptions?.hooks || definition?.hooks,
+        }
+      : baseCapabilityOptions
     const agentModel = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentModel] as AgentModelResolver<TRuntimeConfig> | undefined
     const driverKind = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentDriverKind]
     const resolveCapabilityCli = resolveCapabilityCliRunSurface(definition)
@@ -1954,7 +1961,7 @@ function createFinishDeliveryEffectContext<
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
 ): AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS> {
   const result = event.result === undefined ? undefined : toAgentRunResult(event.result)
-  const active = activeDeliveryChannel(context.channels, context.context, context.run)
+  const active = activeAgentChannel(context.channels, context.context, context.run)
   const reply: AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS>["reply"] = (input, options = {}) => {
     const inputArtifacts = typeof input === "object" && input !== null ? input.artifacts : undefined
     return createReplyDeliveryEffectIntent(input, {

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -147,6 +147,7 @@ export async function resolveAgentTriggers<
     }
   }
   for (const [channelId, channel] of Object.entries(agentChannelOptions(agent))) {
+    const channelCapabilities = normalizeCapabilities([...capabilities, ...(channel.capabilities || [])]) as AgentCapabilityDefinition<TRuntimeConfig>[]
     const channelWebhooks = normalizeChannelWebhookRegistrations(channelId, channel.kind, channel.webhooks)
     const capabilityWebhookTrigger = capabilityWebhookTriggerForChannel(triggers, channelId, channel.kind)
     if (capabilityWebhookTrigger && channelWebhooks?.length) {
@@ -169,8 +170,8 @@ export async function resolveAgentTriggers<
         input: trigger.input,
         invoke: input => trigger.invoke({
           ...runtimeContext,
+          agentCapabilities: channelCapabilities,
           channel,
-          capabilities: capabilities as never,
           trigger: {
             channelId,
             id,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -373,6 +373,7 @@ export interface AgentChannelTriggerContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
 > extends AgentCallbackContext<TRuntimeConfig> {
   actor?: AgentActor
+  agentCapabilities: readonly AgentCapabilityDefinition<TRuntimeConfig>[]
   channel: AgentChannelDefinition<TRuntimeConfig>
   trigger: {
     channelId: string
@@ -1296,6 +1297,7 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
 
 export interface AgentChannelDefinition<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   adapter?: AgentChatPlatformResolver<TRuntimeConfig>
+  capabilities?: readonly AgentCapabilityDefinition<TRuntimeConfig>[]
   effects?: AgentChannelDeliveryEffects<TRuntimeConfig>
   identity?: IdentityResolver
   kind: string

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -490,7 +490,7 @@ describe("agent channels", () => {
 
     const blocked = await trigger.invoke({
       ...context,
-      capabilities: [{ metadata: { commands: { review: { channels: ["other"] } }, trigger: "/" } }],
+      agentCapabilities: [{ metadata: { commands: { review: { channels: ["other"] } }, trigger: "/" } }],
     } as never, { pullRequest })
     if (!(blocked instanceof Response)) throw new Error("Expected blocked GitHub context response.")
     await expect(blocked.json()).resolves.toMatchObject({ reason: "not_command" })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2836,6 +2836,77 @@ describe("agent message protocol", () => {
     await expect(runAgentTrigger(agent, runtime, "portal.message", { text: "hello" })).resolves.toBe("channel:portal:hello")
   })
 
+  it("adds only the active Channel Capabilities", async () => {
+    const { defineAgent, defineCapability, runAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { openapi } = await import("../src/capabilities.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const triggerCapabilities: string[][] = []
+    const resolvedTools: string[][] = []
+    const shared = defineCapability({
+      cli: {
+        commands: { ping: { run: () => "ok" } },
+        name: "shared",
+      },
+      id: "shared",
+    })
+    const portalApi = openapi({
+      cli: { name: "portal-api" },
+      operations: ["ping"],
+      spec: {
+        paths: {
+          "/ping": {
+            get: {
+              operationId: "ping",
+              responses: { 200: { description: "OK" } },
+            },
+          },
+        },
+        servers: [{ url: "https://portal.example.com" }],
+      },
+    })
+    const agent = defineAgent({
+      capabilities: [shared],
+      channels: {
+        portal: defineChannel("portal", {
+          capabilities: [portalApi],
+          messages: false,
+          triggers: {
+            message: {
+              invoke(context) {
+                triggerCapabilities.push(context.agentCapabilities.map(capability => capability.id))
+                return { input: {}, run: { channelId: context.trigger.channelId, runId: "portal-run" } }
+              },
+            },
+          },
+        }),
+        teams: defineChannel("teams", {
+          messages: false,
+          triggers: {
+            message: {
+              invoke(context) {
+                triggerCapabilities.push(context.agentCapabilities.map(capability => capability.id))
+                return { input: {}, run: { channelId: context.trigger.channelId, runId: "teams-run" } }
+              },
+            },
+          },
+        }),
+      },
+      driver: {
+        run({ tools }) {
+          resolvedTools.push(Object.keys(tools || {}).sort())
+          return "ok"
+        },
+      },
+    })
+    const runtime = { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }
+
+    await expect(runAgentTrigger(agent, runtime, "teams.message", {})).resolves.toBe("ok")
+    await expect(runAgent(agent, runtime, {})).resolves.toBe("ok")
+    await expect(runAgentTrigger(agent, runtime, "portal.message", {})).resolves.toBe("ok")
+    expect(triggerCapabilities).toEqual([["shared"], ["shared", "openapi"]])
+    expect(resolvedTools).toEqual([["shared"], ["shared"], ["portal-api", "shared"]])
+  })
+
   it("lets Channels execute Capability-contributed delivery effect intents", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -844,6 +844,7 @@ describe("agent public types", () => {
     // @ts-expect-error Development samples belong in CLI payload files, not Channel Definitions.
     defineChannel("portal", { dev: { samples: {} } })
     const custom = defineChannel("portal", {
+      capabilities: [defineCapability({ id: "portal-api" })],
       effects: {
         reaction(context) {
           expectTypeOf(context.effect.kind).toEqualTypeOf<AgentChannelDeliveryEffectKind>()
@@ -858,6 +859,7 @@ describe("agent public types", () => {
       triggers: {
         event: {
           invoke(context, input: { text: string }) {
+            expectTypeOf(context.agentCapabilities).toEqualTypeOf<readonly AgentCapabilityDefinition[]>()
             expectTypeOf(context.channel.kind).toEqualTypeOf<string>()
             expectTypeOf(context.trigger.channelId).toEqualTypeOf<string>()
             expectTypeOf(input.text).toEqualTypeOf<string>()
@@ -880,6 +882,7 @@ describe("agent public types", () => {
         },
       },
     })
+    expectTypeOf(custom.capabilities?.[0]).toEqualTypeOf<AgentCapabilityDefinition | undefined>()
     expectTypeOf(custom.kind).toEqualTypeOf<string>()
     expectTypeOf<AgentDeliveryArtifact>().toMatchTypeOf<{ path: string }>()
 


### PR DESCRIPTION
Adds static Capability lists to Channel definitions and merges the active Channel's capabilities after Agent-level capabilities for trigger and runtime resolution. Multi-channel Agents can expose authenticated tools only on the Channel that owns them without creating separate Agent Definitions or app-local runtime patches.

Channel trigger callbacks receive the effective Agent Definition list as `context.agentCapabilities`, keeping it distinct from runtime primitive handles on `context.capabilities`. Direct invocations continue to receive Agent-level capabilities only, and the Channel/OpenAPI docs describe the boundary.

Replaces the closed #539 on current `main`.
