### PR TITLE
fix(schedule): publish virtual registry types

### DIFF
--- a/packages/schedule/fixtures/published-types/consumer.ts
+++ b/packages/schedule/fixtures/published-types/consumer.ts
@@ -1,0 +1,4 @@
+import type { ScheduleDefinitionRegistry } from "@vite-hub/schedule"
+import registry from "#vitehub/schedule/registry"
+
+registry satisfies ScheduleDefinitionRegistry

--- a/packages/schedule/fixtures/published-types/package.json
+++ b/packages/schedule/fixtures/published-types/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/schedule/fixtures/published-types/tsconfig.json
+++ b/packages/schedule/fixtures/published-types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "files": [
+    "consumer.ts"
+  ]
+}

--- a/packages/schedule/src/index.ts
+++ b/packages/schedule/src/index.ts
@@ -1,6 +1,5 @@
 export { defineSchedule, defineScheduleTarget } from "./definition.ts"
 export { discoverScheduleDefinitions } from "./discovery.ts"
-export type {} from "./registry-module.d.ts"
 export { ScheduleError } from "./errors.ts"
 export { createScheduleRun, executeRuntimeSchedule, executeSchedule, executeStaticSchedule } from "./runtime/execute.ts"
 export { startScheduleRunner } from "./runtime/runner.ts"

--- a/packages/schedule/src/runtime.ts
+++ b/packages/schedule/src/runtime.ts
@@ -1,5 +1,3 @@
-export type {} from "./registry-module.d.ts"
-
 export { ScheduleError } from "./errors.ts"
 export { schedules, validateRuntimeScheduleCron } from "./runtime/client.ts"
 export { createMemoryRuntimeScheduleStore } from "./runtime/store.ts"

--- a/packages/schedule/test/published-types.test.ts
+++ b/packages/schedule/test/published-types.test.ts
@@ -1,0 +1,30 @@
+import { execFile } from "node:child_process"
+import { copyFile, cp, mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { it } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const fixtureRoot = join(packageRoot, "fixtures", "published-types")
+const tsc = resolve(packageRoot, "../../node_modules/typescript/bin/tsc")
+
+it("publishes virtual Schedule registry declarations", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-types-"))
+
+  try {
+    await cp(fixtureRoot, root, { recursive: true })
+    const installedPackageRoot = join(root, "node_modules", "@vite-hub", "schedule")
+    await mkdir(installedPackageRoot, { recursive: true })
+    await copyFile(join(packageRoot, "package.json"), join(installedPackageRoot, "package.json"))
+    await cp(join(packageRoot, "dist"), join(installedPackageRoot, "dist"), { recursive: true })
+
+    await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", root])
+  }
+  finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})

--- a/packages/schedule/vite.config.ts
+++ b/packages/schedule/vite.config.ts
@@ -9,6 +9,17 @@ export default defineConfig({
       neverBundle: ["vite", "esbuild"],
       onlyBundle: false,
     },
+    plugins: [{
+      name: "schedule-registry-declarations",
+      generateBundle(_options, bundle) {
+        for (const fileName of ["index.d.ts", "runtime.d.ts"]) {
+          const chunk = bundle[fileName]
+          if (chunk?.type === "chunk") {
+            chunk.code = `/// <reference path="./registry-module.d.ts" />\n${chunk.code}`
+          }
+        }
+      },
+    }],
     entry: [
       "src/definition.ts",
       "src/index.ts",


### PR DESCRIPTION
Publishes Schedule's generated registry declarations as a standalone ambient script referenced by the packed index.d.ts and runtime.d.ts entrypoints. The previous empty type re-exports were bundled into an external declaration chunk, so installed consumers could not resolve #vitehub/schedule/registry even though source-tree type tests passed.

Adds an isolated post-build consumer fixture that installs only package.json and dist before running tsc, preventing source declarations from masking the published package contract.

<!-- babysitter:direction-validation:v1 -->
## Babysitter direction validation

Verdict: proceed

What is good: publishes the Schedule virtual registry declaration through the packed public entrypoints and proves the installed package contract from dist only.

What is missing: no remaining direction gap; continued readiness still depends on exact-head review evidence and checks.

Corrections applied: none.
<!-- /babysitter:direction-validation:v1 -->