### PR TITLE
fix(agent): harden trusted-host Codex sessions

### DIFF
--- a/docs/content/docs/agents/boxes.md
+++ b/docs/content/docs/agents/boxes.md
@@ -40,7 +40,7 @@ export default defineAgent<any, BabysitterRunOptions>({
 
 The Box boots in `worktreePath`, preserves mutations in that checkout, and inherits the host Home. Codex therefore reads the repository's `AGENTS.md` and skills from the checkout while using the host's existing Codex configuration, selected model, authentication, and global skills. Harness bootstrap packages and resume data live in a disposable temporary root, so they do not dirty the authoritative checkout.
 
-`codexDriver()` contributes its `codex` requirement automatically. The Agent Definition only lists additional requirements used by its own workflow.
+`codexDriver()` contributes its Codex requirement automatically. With ambient authentication it requires `codex login status`; with explicit driver authentication it checks only that the Codex CLI is installed. The Agent Definition only lists additional requirements used by its own workflow.
 
 ## Use a portable Home
 
@@ -64,6 +64,7 @@ Keep the Home outside the project checkout and protect it as a credential bundle
 | Requirement | Boot check |
 | --- | --- |
 | `codex` | Finds `codex` on `PATH` and runs `codex login status`. |
+| `codex-cli` | Finds `codex` on `PATH` without requiring ambient authentication. |
 | `github` | Finds `gh` on `PATH` and runs `gh auth status`. |
 | Any other name | Finds an executable with that name on `PATH`. |
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -113,7 +113,7 @@ export default defineAgent<any, { worktreePath: string }>({
 })
 ```
 
-`codexDriver()` contributes the `codex` requirement automatically. `trustedHost()` checks required tools and named authentication before execution, inherits the ambient Home when `home` is omitted, and provides no filesystem, credential, or process isolation. Set `box.home` to use a managed portable Home. Do not combine an explicit `box.cwd` with Agent Workspace materialization in this first slice.
+`codexDriver()` contributes an authenticated `codex` requirement for ambient auth and an executable-only `codex-cli` requirement for explicit auth. `trustedHost()` checks required tools and named authentication before execution, inherits the ambient Home when `home` is omitted, and provides no filesystem, credential, or process isolation. Set `box.home` to use a managed portable Home. Do not combine an explicit `box.cwd` with Agent Workspace materialization in this first slice.
 
 For model-backed drivers, put free-form guidance for configured Sources, Capabilities, and Skills in `driver.instructions` or a deterministic imported instruction file. Tool descriptions and schemas stay with the tools as structured contracts.
 

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -83,6 +83,16 @@ interface HarnessAgentAdapterOptions<
   workDir?: AgentHarnessWorkDir<TRuntimeConfig, CALL_OPTIONS>
 }
 
+interface HarnessSessionIdentity {
+  box?: {
+    home?: string
+    runtime: string
+    workspace?: string
+  }
+  instructions?: string
+  workDir?: string
+}
+
 function hasEntries(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && Object.keys(value).length > 0
 }
@@ -512,10 +522,14 @@ async function createHarnessAgent<
   assertSupportedHarnessDriverContributions(context)
   const { HarnessAgent } = await import("@ai-sdk/harness/agent") as unknown as { HarnessAgent: HarnessAgentConstructor }
   const harness = await resolveHarness(options.harness, context)
-  const baseSandbox = context.harnessSandboxProvider ?? await resolveHarnessSandboxProvider(options.sandbox, context) ?? await createDefaultHarnessSandbox(context)
+  const driverSandbox = context.harnessSandboxProvider === undefined
+    ? await resolveHarnessSandboxProvider(options.sandbox, context)
+    : undefined
+  const defaultSandbox = context.harnessSandboxProvider === undefined && driverSandbox === undefined
+  const baseSandbox = context.harnessSandboxProvider ?? driverSandbox ?? await createDefaultHarnessSandbox(context)
   const adaptSandbox = (harness as Record<PropertyKey, unknown>)[harnessSandboxAdapter]
   const sandbox = typeof adaptSandbox === "function"
-    ? (adaptSandbox as (provider: object) => object)(baseSandbox)
+    ? (adaptSandbox as (provider: object, options: { defaultSandbox: boolean }) => object)(baseSandbox, { defaultSandbox })
     : baseSandbox
   const instructions = await resolveHarnessDriverInstructions(options.instructions, context)
   const workDir = await resolveHarnessWorkDir(options.workDir, context) ?? context.harnessWorkDir
@@ -724,12 +738,12 @@ function getResumeStates(options: object): Map<string, unknown> {
 async function resolveHarnessProviderSessionId(
   sessionId: string,
   resumeKey: string,
-  identity: { instructions?: string, workDir?: string },
+  identity: HarnessSessionIdentity,
 ): Promise<string> {
-  if (identity.instructions === undefined && identity.workDir === undefined) return sessionId
+  if (identity.box === undefined && identity.instructions === undefined && identity.workDir === undefined) return sessionId
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(resumeKey))
   const fingerprint = Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, "0")).join("")
-  return `vitehub:${fingerprint}`
+  return `vitehub-${fingerprint}`
 }
 
 export function createHarnessAgentAdapter<
@@ -745,10 +759,22 @@ export function createHarnessAgentAdapter<
     agent: HarnessAgentLike,
     context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>,
     getWorkspaceSession: () => { close: (error?: unknown) => MaybePromise<void> } | undefined,
-    identity: { instructions?: string, workDir?: string },
+    agentIdentity: Omit<HarnessSessionIdentity, "box">,
   ) {
+    const identity: HarnessSessionIdentity = {
+      ...agentIdentity,
+      ...(context.box
+        ? {
+            box: {
+              home: context.box.environment.home,
+              runtime: context.box.runtime,
+              workspace: context.box.workspace.path,
+            },
+          }
+        : {}),
+    }
     const sessionId = await resolveHarnessSessionKey(options.sessionKey, context)
-    const resumeKey = sessionId ? JSON.stringify([sessionId, identity.instructions, identity.workDir]) : undefined
+    const resumeKey = sessionId ? JSON.stringify([sessionId, identity.instructions, identity.workDir, identity.box]) : undefined
     const providerSessionId = sessionId && resumeKey
       ? await resolveHarnessProviderSessionId(sessionId, resumeKey, identity)
       : undefined

--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -24,6 +24,7 @@ type CodexDriverSandboxOptions<CALL_OPTIONS = unknown> =
   | AgentHarnessSandboxProviderInput<AgentRuntimeConfig, CALL_OPTIONS>
 
 const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
+const codexSandboxAdapterApplied = Symbol("vitehub.codexSandboxAdapterApplied")
 
 export interface CodexDriverOptions<CALL_OPTIONS = unknown> extends CodexHarnessSettings {
   authJson?: string
@@ -47,6 +48,11 @@ export function codexDriver<CALL_OPTIONS = unknown>(options: CodexDriverOptions<
     ...settings
   } = options
   const defaultOpenAIAuth = settings.auth === undefined
+  const usesAmbientCodexAuth = settings.auth === undefined
+    && authJson === undefined
+    && authJsonPath === undefined
+    && env?.CODEX_AUTH_JSON === undefined
+    && env?.CODEX_AUTH_JSON_PATH === undefined
   const auth = settings.auth ?? { openai: {} }
   // The upstream harness pins a model when this is undefined, which bypasses the operator's Codex profile.
   const model = settings.model ?? ""
@@ -62,7 +68,7 @@ export function codexDriver<CALL_OPTIONS = unknown>(options: CodexDriverOptions<
     credentials: credentials ?? { label: "Codex", source: "ambient" },
     harness: createViteHubCodex({ ...settings, auth, model }, defaultOpenAIAuth),
     ...(instructions !== undefined ? { instructions } : {}),
-    requires: ["codex"],
+    requires: [usesAmbientCodexAuth ? "codex" : "codex-cli"],
     ...(sandboxProvider ? { sandbox: sandboxProvider } : {}),
     ...(workDir !== undefined ? { workDir } : {}),
   }
@@ -87,7 +93,9 @@ function createViteHubCodex(settings: CodexHarnessSettings, preferOpenAI: boolea
   const harness = createCodex(settings)
   return {
     ...harness,
-    [harnessSandboxAdapter]: (provider: AgentHarnessSandboxProviderInput) => relativeCodexSandboxProvider(provider, { preferOpenAI }),
+    [harnessSandboxAdapter]: (provider: AgentHarnessSandboxProviderInput, options?: { defaultSandbox?: boolean }) => (provider as Record<PropertyKey, unknown>)[codexSandboxAdapterApplied]
+      ? provider
+      : relativeCodexSandboxProvider(provider, { preferOpenAI, stripGitHubSecrets: options?.defaultSandbox }),
     async getBootstrap() {
       const [pkg, lock, bridge, hostToolMcp] = await Promise.all([
         readCodexBridgeAsset("package.json"),
@@ -187,16 +195,19 @@ function codexSandboxProvider(options: {
 
 function relativeCodexSandboxProvider(
   provider: AgentHarnessSandboxProviderInput,
-  options: { preferOpenAI?: boolean } = {},
+  options: { preferOpenAI?: boolean, stripGitHubSecrets?: boolean } = {},
 ): AgentHarnessDriver["sandbox"] {
   const adaptSession = (session: object) => {
-    if (options.preferOpenAI && "env" in session && session.env && typeof session.env === "object") {
-      stripGatewaySecrets(session.env as Record<string, string | undefined>)
+    if ("env" in session && session.env && typeof session.env === "object") {
+      const env = session.env as Record<string, string | undefined>
+      if (options.stripGitHubSecrets) stripGitHubSecrets(env)
+      if (options.preferOpenAI) stripGatewaySecrets(env)
     }
     return relativeCodexSandboxSession(session)
   }
   return {
     ...provider,
+    [codexSandboxAdapterApplied]: true,
     async createSession(createOptions: { onFirstCreate?: (session: object, context: { abortSignal?: AbortSignal }) => Promise<void> } = {}) {
       const onFirstCreate = createOptions?.onFirstCreate
       const session = await (provider as { createSession(options: object): Promise<object> }).createSession({

--- a/packages/agent/test/codex-harness.test.ts
+++ b/packages/agent/test/codex-harness.test.ts
@@ -25,6 +25,49 @@ describe("codexDriver", () => {
     expect(driver.sandbox).toBeUndefined()
   })
 
+  it("scrubs GitHub secrets when the default local sandbox is adapted", async () => {
+    const originalGitHubToken = process.env.GITHUB_TOKEN
+    const originalGitHubPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY
+    process.env.GITHUB_TOKEN = "github-token"
+    process.env.GITHUB_APP_PRIVATE_KEY = "github-private-key"
+
+    try {
+      const { codexDriver } = await import("../src/harness/codex.ts")
+      const { createLocalHarnessSandbox } = await import("../src/harness/local-sandbox.ts")
+      const driver = codexDriver()
+      const adaptSandbox = (driver.harness as Record<PropertyKey, unknown>)[Symbol.for("vitehub.harnessSandboxAdapter")] as (provider: object, options: { defaultSandbox: boolean }) => { createSession: () => Promise<{ destroy: () => Promise<void>, env: Record<string, string> }> }
+      const session = await adaptSandbox(createLocalHarnessSandbox(), { defaultSandbox: true }).createSession()
+
+      try {
+        expect(session.env.GITHUB_TOKEN).toBeUndefined()
+        expect(session.env.GITHUB_APP_PRIVATE_KEY).toBeUndefined()
+      }
+      finally {
+        await session.destroy()
+      }
+    }
+    finally {
+      restoreEnv("GITHUB_TOKEN", originalGitHubToken)
+      restoreEnv("GITHUB_APP_PRIVATE_KEY", originalGitHubPrivateKey)
+    }
+  })
+
+  it("preserves GitHub credentials in explicitly supplied sandboxes", async () => {
+    const { codexDriver } = await import("../src/harness/codex.ts")
+    const { createLocalHarnessSandbox } = await import("../src/harness/local-sandbox.ts")
+    const driver = codexDriver()
+    const adaptSandbox = (driver.harness as Record<PropertyKey, unknown>)[Symbol.for("vitehub.harnessSandboxAdapter")] as (provider: object, options: { defaultSandbox: boolean }) => { createSession: () => Promise<{ destroy: () => Promise<void>, env: Record<string, string> }> }
+    const provider = createLocalHarnessSandbox({ env: { GH_TOKEN: "box-token" } })
+    const session = await adaptSandbox(provider, { defaultSandbox: false }).createSession()
+
+    try {
+      expect(session.env.GH_TOKEN).toBe("box-token")
+    }
+    finally {
+      await session.destroy()
+    }
+  })
+
   it("keeps host AI Gateway env out of the default local Codex sandbox", async () => {
     const originalGatewayKey = process.env.AI_GATEWAY_API_KEY
     const originalGatewayBaseUrl = process.env.AI_GATEWAY_BASE_URL
@@ -141,6 +184,15 @@ describe("codexDriver", () => {
 
     expect(createCodex).toHaveBeenLastCalledWith({ auth: { gateway: { apiKey: "gateway-key" } }, model: "" })
     expect(driver.sandbox).toBeUndefined()
+    expect(driver.requires).toEqual(["codex-cli"])
+  })
+
+  it("does not adapt explicit local Codex sandboxes twice", async () => {
+    const { codexDriver } = await import("../src/harness/codex.ts")
+    const driver = codexDriver({ sandbox: {} })
+    const adaptSandbox = (driver.harness as Record<PropertyKey, unknown>)[Symbol.for("vitehub.harnessSandboxAdapter")] as (provider: object) => object
+
+    expect(adaptSandbox(driver.sandbox! as object)).toBe(driver.sandbox)
   })
 
   it("forwards invocation-scoped harness configuration without treating it as Codex settings", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1425,6 +1425,29 @@ describe("agent message protocol", () => {
     expect((harnessAgentSettings.at(-1)?.tools as Record<string, unknown> | undefined)?.sandbox_exec).toBeUndefined()
   })
 
+  it("identifies fallback sandboxes for harness adapters", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const adaptSandbox = vi.fn(provider => provider)
+    const harness = {
+      [Symbol.for("vitehub.harnessSandboxAdapter")]: adaptSandbox,
+      provider: "codex",
+    }
+    const provider = { providerId: "local-test", specificationVersion: "harness-sandbox-v1" }
+    harnessCreateSession
+      .mockResolvedValueOnce({ destroy: vi.fn() })
+      .mockResolvedValueOnce({ destroy: vi.fn() })
+    harnessGenerate.mockResolvedValue({ text: "ok" })
+
+    const defaultAgent = defineAgent({ driver: { harness } })
+    const configuredAgent = defineAgent({ driver: { harness, sandbox: provider } })
+
+    await runAgent(defaultAgent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "default" })
+    await runAgent(configuredAgent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "configured" })
+
+    expect(adaptSandbox).toHaveBeenNthCalledWith(1, expect.any(Object), { defaultSandbox: true })
+    expect(adaptSandbox).toHaveBeenNthCalledWith(2, provider, { defaultSandbox: false })
+  })
+
   it("resolves function-valued driver.sandbox for each invocation", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const session = { destroy: vi.fn() }
@@ -1635,8 +1658,8 @@ describe("agent message protocol", () => {
     expect(harnessGenerate).toHaveBeenCalledWith(expect.not.objectContaining({ instructions: expect.anything() }))
     const firstSessionOptions = harnessCreateSession.mock.calls[0]?.[0] as { resumeFrom?: unknown, sessionId: string }
     const secondSessionOptions = harnessCreateSession.mock.calls[1]?.[0] as { resumeFrom?: unknown, sessionId: string }
-    expect(firstSessionOptions.sessionId).toMatch(/^vitehub:[a-f0-9]{64}$/)
-    expect(secondSessionOptions.sessionId).toMatch(/^vitehub:[a-f0-9]{64}$/)
+    expect(firstSessionOptions.sessionId).toMatch(/^vitehub-[a-f0-9]{64}$/)
+    expect(secondSessionOptions.sessionId).toMatch(/^vitehub-[a-f0-9]{64}$/)
     expect(secondSessionOptions.sessionId).not.toBe(firstSessionOptions.sessionId)
     expect(firstSessionOptions).not.toHaveProperty("resumeFrom")
     expect(secondSessionOptions).not.toHaveProperty("resumeFrom")
@@ -2188,6 +2211,54 @@ describe("agent message protocol", () => {
     }))
     expect(firstSession.detach).toHaveBeenCalledTimes(1)
     expect(secondSession.detach).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not resume harness sessions across different Box identities", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const firstSession = { detach: vi.fn(async () => ({ token: "resume" })), destroy: vi.fn() }
+    const secondSession = { detach: vi.fn(async () => ({ token: "next" })), destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(firstSession).mockResolvedValueOnce(secondSession)
+    harnessGenerate.mockResolvedValue({ text: "ok" })
+
+    const agent = defineAgent<any, { home: string, workspace: string }>({
+      box: {
+        cwd: ({ input }) => input.options?.workspace,
+        home: ({ input }) => input.options?.home,
+        runtime: {
+          name: "test",
+          async resolve({ cwd, home }) {
+            return {
+              cache: { state: "disposable" },
+              environment: { env: {}, home },
+              isolation: "none",
+              requirements: [],
+              runtime: "test",
+              workspace: { path: cwd, state: "authoritative" },
+            }
+          },
+        },
+      },
+      driver: {
+        harness: { provider: "codex" },
+        sessionKey: "pull-request-577",
+      },
+    })
+
+    await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      options: { home: "/home/one", workspace: "/worktrees/one" },
+      prompt: "repair",
+    })
+    await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      options: { home: "/home/two", workspace: "/worktrees/two" },
+      prompt: "repair",
+    })
+
+    const firstOptions = harnessCreateSession.mock.calls[0]?.[0] as { resumeFrom?: unknown, sessionId: string }
+    const secondOptions = harnessCreateSession.mock.calls[1]?.[0] as { resumeFrom?: unknown, sessionId: string }
+    expect(firstOptions.sessionId).toMatch(/^vitehub-[a-f0-9]{64}$/)
+    expect(secondOptions.sessionId).toMatch(/^vitehub-[a-f0-9]{64}$/)
+    expect(secondOptions.sessionId).not.toBe(firstOptions.sessionId)
+    expect(secondOptions).not.toHaveProperty("resumeFrom")
   })
 
   it("treats undefined harness detach state as a resumed session", async () => {

--- a/packages/box/README.md
+++ b/packages/box/README.md
@@ -32,7 +32,7 @@ export default defineAgent<any, { worktreePath: string }>({
 
 The Agent mounts the checkout into a disposable harness root. Project mutations remain in `cwd`, while harness bootstrap packages and resume data are removed with the session.
 
-`codexDriver()` contributes the `codex` requirement automatically. At Box boot, `trustedHost()` checks `codex login status`, checks `gh auth status` for the `github` requirement, and verifies other requirement names on `PATH`.
+`codexDriver()` contributes `codex` for ambient authentication and `codex-cli` for explicit authentication. At Box boot, `trustedHost()` runs `codex login status` for `codex`, checks only the executable for `codex-cli`, checks `gh auth status` for `github`, and verifies other requirement names on `PATH`.
 
 Authentication values remain runtime-owned. A Box stores requirement names and an optional Home path, while its resolved environment is deliberately excluded from JSON serialization.
 

--- a/packages/box/src/index.ts
+++ b/packages/box/src/index.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os"
 import { delimiter, isAbsolute, join, resolve } from "node:path"
 import { promisify } from "node:util"
 
-export type BoxRequirement = "codex" | "github" | (string & {})
+export type BoxRequirement = "codex" | "codex-cli" | "github" | (string & {})
 
 export type BoxValue<T, Context> = T | ((context: Context) => T | undefined | Promise<T | undefined>)
 
@@ -123,6 +123,7 @@ async function assertDirectory(path: string, label: string) {
 
 const requirementCommands: Record<string, { args: string[], command: string }> = {
   codex: { args: ["login", "status"], command: "codex" },
+  "codex-cli": { args: [], command: "codex" },
   github: { args: ["auth", "status"], command: "gh" },
 }
 
@@ -133,12 +134,13 @@ async function resolveRequirement(
 ): Promise<ResolvedBoxRequirement> {
   if (!name.trim()) throw new Error("[vitehub] Box requirements must be non-empty names.")
   const check = requirementCommands[name] || { args: [], command: name }
-  if (!await findExecutable(check.command, env.PATH)) {
+  const executable = await findExecutable(check.command, env.PATH, env.PATHEXT)
+  if (!executable) {
     throw new Error(`[vitehub] Box requirement "${name}" is unavailable: ${check.command} is not on PATH.`)
   }
   if (check.args.length) {
     try {
-      await promisify(execFile)(check.command, check.args, { cwd, env, timeout: 10_000 })
+      await promisify(execFile)(executable, check.args, { cwd, env, shell: isWindowsCommandShim(executable), timeout: 10_000 })
     }
     catch (error) {
       const detail = typeof error === "object" && error && "stderr" in error
@@ -150,11 +152,21 @@ async function resolveRequirement(
   return { command: check.command, name }
 }
 
-async function findExecutable(command: string, path: string | undefined) {
-  const candidates = command.includes("/") || isAbsolute(command)
-    ? [resolve(command)]
-    : (path || "").split(delimiter).filter(Boolean).map(directory => join(directory, command))
+async function findExecutable(command: string, path: string | undefined, pathExt: string | undefined) {
+  const names = [
+    command,
+    ...(pathExt || "").split(";").map(extension => extension.trim()).filter(Boolean).flatMap((extension) => {
+      return command.toLowerCase().endsWith(extension.toLowerCase()) ? [] : [`${command}${extension}`]
+    }),
+  ]
+  const candidates = command.includes("/") || command.includes("\\") || isAbsolute(command)
+    ? names.map(name => resolve(name))
+    : (path || "").split(delimiter).filter(Boolean).flatMap(directory => names.map(name => join(directory, name)))
   for (const candidate of candidates) {
     if (await access(candidate, constants.X_OK).then(() => true, () => false)) return candidate
   }
+}
+
+function isWindowsCommandShim(path: string) {
+  return process.platform === "win32" && /\.(?:bat|cmd)$/i.test(path)
 }

--- a/packages/box/test/trusted-host.test.ts
+++ b/packages/box/test/trusted-host.test.ts
@@ -78,6 +78,34 @@ describe("trustedHost", () => {
         runtime: trustedHost(),
       }, {}))).rejects.toThrow('Box requirement "github" failed: not logged in')
   })
+
+  it("uses PATHEXT when resolving Windows command shims", async () => {
+    const root = await temporaryRoot()
+    const bin = join(root, "bin")
+    await mkdir(bin)
+    await executable(bin, "codex.cmd", "exit 0")
+
+    await expect(withEnv({ PATH: bin, PATHEXT: ".cmd" }, () => resolveBox({
+      requires: ["codex"],
+      runtime: trustedHost(),
+    }, {}))).resolves.toMatchObject({
+      requirements: [{ command: "codex", name: "codex" }],
+    })
+  })
+
+  it("checks only the Codex executable for explicit-auth requirements", async () => {
+    const root = await temporaryRoot()
+    const bin = join(root, "bin")
+    await mkdir(bin)
+    await executable(bin, "codex", "exit 1")
+
+    await expect(withPath(bin, () => resolveBox({
+      requires: ["codex-cli"],
+      runtime: trustedHost(),
+    }, {}))).resolves.toMatchObject({
+      requirements: [{ command: "codex", name: "codex-cli" }],
+    })
+  })
 })
 
 async function temporaryRoot() {
@@ -101,5 +129,19 @@ async function withPath<T>(path: string, run: () => Promise<T>) {
   finally {
     if (original === undefined) delete process.env.PATH
     else process.env.PATH = original
+  }
+}
+
+async function withEnv<T>(env: Record<string, string>, run: () => Promise<T>) {
+  const original = Object.fromEntries(Object.keys(env).map(key => [key, process.env[key]]))
+  Object.assign(process.env, env)
+  try {
+    return await run()
+  }
+  finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
   }
 }


### PR DESCRIPTION
Follows up on the five late Codex findings from #577. Default Codex fallbacks keep GitHub secrets scrubbed without adapting configured sandboxes twice, explicit Codex authentication requires only the executable, and trusted-host requirement discovery honors Windows `PATHEXT`.

Includes resolved Box workspace and Home identity in harness session reuse so a shared `sessionKey` cannot cross checkouts or Homes. Regression coverage and Box documentation now distinguish ambient from explicit Codex authentication.