### PR TITLE
fix(blob): infer filesystem base from environment

### DIFF
--- a/docs/content/docs/server-primitives/blob.md
+++ b/docs/content/docs/server-primitives/blob.md
@@ -73,7 +73,7 @@ export default defineConfig({
 | Shape | Description |
 | --- | --- |
 | `blob: false` | Disables Blob runtime configuration. |
-| `blob: { driver: 'fs', base?: string }` | Uses local filesystem storage. Default `base`: `.data/blob`. |
+| `blob: { driver: 'fs', base?: string }` | Uses local filesystem storage. At config time, `base` falls back to `BLOB_FS_BASE`, then `.data/blob`. |
 | `blob: { driver: 'cloudflare-r2', binding?: string, bucketName?: string }` | Uses Cloudflare R2. Default `binding`: `BLOB`. HTTP credentials can provide fallback access when no runtime binding exists. |
 | `blob: { driver: 'vercel-blob', token?, access? }` | Uses Vercel Blob. Runtime token can come from `BLOB_READ_WRITE_TOKEN`; access can be `private` or `public`. |
 | `blob: { driver: 's3', bucket, endpoint?, region? }` | Uses production S3-compatible object storage. |

--- a/packages/blob/README.md
+++ b/packages/blob/README.md
@@ -52,6 +52,7 @@ export default defineConfig({
 Use `hubBlob()` in Vite to resolve blob config and expose the `blob` runtime helper to server code.
 
 Core drivers include local `fs`, [Vercel Blob](https://vercel.com/docs/vercel-blob), [Cloudflare R2](https://developers.cloudflare.com/r2/), S3-compatible stores, and [files-sdk](https://files-sdk.dev/).
+At config time, the `fs` driver uses `BLOB_FS_BASE` when `blob.base` is omitted, then defaults to `.data/blob`.
 
 Set `blob.serve` to generate a Nitro route for serving Blob-backed assets. `serve: true` uses `/api/_vitehub/blob` as a safe namespaced API route. Use `serve.route` for product-facing paths such as `/assets`.
 Objects from the served store receive an absolute URL when `serve.publicBaseUrl` is configured, or a route-relative URL otherwise.

--- a/packages/blob/src/config.ts
+++ b/packages/blob/src/config.ts
@@ -37,8 +37,9 @@ const MINIO_SECRET_KEY_ENV = ["MINIO_SECRET_ACCESS_KEY", "MINIO_SECRET_KEY", "MI
 
 function resolveFsStore(
   config: Partial<FsBlobStoreConfig> = {},
+  env: Record<string, string | undefined> = process.env,
 ): ResolvedFsBlobStoreConfig {
-  return defu({ base: trimmed(config.base) }, { base: ".data/blob", driver: "fs" as const })
+  return defu({ base: trimmed(config.base) ?? readEnv(env, "BLOB_FS_BASE") }, { base: ".data/blob", driver: "fs" as const })
 }
 
 function resolveCloudflareStore(
@@ -112,7 +113,7 @@ function resolveExplicitStore(
     case "cloudflare-r2":
       return resolveCloudflareStore(store, env)
     case "fs":
-      return resolveFsStore(store)
+      return resolveFsStore(store, env)
     case "minio":
       return resolveMinioStore(store, env)
     case "netlify-blobs":
@@ -225,7 +226,7 @@ export function normalizeBlobOptions(
     return createResolvedConfig(resolveVercelStore(), undefined, serve)
   }
 
-  return createResolvedConfig(resolveFsStore(), undefined, serve)
+  return createResolvedConfig(resolveFsStore({}, env), undefined, serve)
 }
 
 export function warnVercelBlobFallback(

--- a/packages/blob/test/config.test.ts
+++ b/packages/blob/test/config.test.ts
@@ -18,6 +18,42 @@ describe("blob config", () => {
     })
   })
 
+  it("defaults the fs base from BLOB_FS_BASE", () => {
+    expect(normalizeBlobOptions(undefined, {
+      env: { BLOB_FS_BASE: "/data/blob" },
+    })).toEqual({
+      store: {
+        base: "/data/blob",
+        driver: "fs",
+      },
+    })
+  })
+
+  it("resolves an explicit fs store base from BLOB_FS_BASE", () => {
+    expect(normalizeBlobOptions({ driver: "fs" }, {
+      env: { BLOB_FS_BASE: "/data/blob" },
+    })).toEqual({
+      store: {
+        base: "/data/blob",
+        driver: "fs",
+      },
+    })
+  })
+
+  it("keeps an explicit fs base over BLOB_FS_BASE", () => {
+    expect(normalizeBlobOptions({
+      base: ".data/assets",
+      driver: "fs",
+    }, {
+      env: { BLOB_FS_BASE: "/data/blob" },
+    })).toEqual({
+      store: {
+        base: ".data/assets",
+        driver: "fs",
+      },
+    })
+  })
+
   it("defaults Cloudflare hosting to an R2 binding", () => {
     expect(normalizeBlobOptions({}, {
       env: { BLOB_BUCKET_NAME: "assets" },


### PR DESCRIPTION
Allows filesystem Blob stores to resolve their base from `BLOB_FS_BASE` when `blob.base` is omitted, while keeping explicit config precedence and the `.data/blob` fallback. This makes deployment-owned mount paths configurable without app-local Vite config or package patches.

Documents the config-time precedence and covers implicit resolution, explicit filesystem stores, and explicit override behavior.