### PR TITLE
feat(agent): support global harness skills

### DIFF
--- a/docs/content/docs/capabilities/skills.md
+++ b/docs/content/docs/capabilities/skills.md
@@ -1,14 +1,13 @@
 ---
 title: Skills
-description: Require a Workspace skill file for an Agent Invocation.
+description: Mount skill files into an Agent Workspace or harness profile.
 navigation.title: Skills
 navigation.order: 60
 navigation.group: Workspace
 icon: i-lucide-scroll-text
 ---
 
-`skills()` makes a Workspace Skill file available to an Agent Invocation.
-Use it when an Agent must have a `SKILL.md` file, and any files beside it, before it runs.
+`skills()` makes a Skill file available to an Agent Invocation. Workspace scope is the default; global scope mounts a source into the harness profile so Codex can discover it as an installed Skill.
 
 ## Installation
 
@@ -20,6 +19,7 @@ Use the configuration example below as the starting point, then tighten modes, p
 The Capability records the configured Skill path in metadata and requires the Workspace path to exist.
 When `shellExecution` is set, model-backed Agents receive the normal Workspace Shell tools in the requested mode.
 When `source` is set, ViteHub adds that source to the Agent Workspace at definition time and mounts it at the skill path.
+With `scope: 'global'`, ViteHub mounts the source into the harness's global Skill directory instead. Global scope requires a source and does not require an Agent Workspace.
 
 Model-facing guidance for a Skill belongs in Agent Driver Instructions or deterministic imported instruction Markdown. Agent DevTools metadata warns when `skills()` makes a Skill available but no explicit instruction coverage names it.
 
@@ -37,6 +37,26 @@ export default defineAgent({
   workspace,
   capabilities: [
     skills(),
+  ],
+})
+```
+
+Install a Skill into the isolated Codex profile when Codex should discover it globally without adding it to the project Workspace:
+
+```ts [server/agents/review.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { skills } from '@vite-hub/agent/capabilities'
+import { codexDriver } from '@vite-hub/agent/harness/codex'
+import { github } from '@vite-hub/workspace'
+
+export default defineAgent({
+  driver: codexDriver(),
+  capabilities: [
+    skills({
+      path: 'skills/ponytail',
+      scope: 'global',
+      source: github({ repo: 'onmax/ponytail', root: 'skills/ponytail' }),
+    }),
   ],
 })
 ```
@@ -74,19 +94,21 @@ Model-facing Skill guidance belongs in Agent Driver Instructions or deterministi
 For harness-backed drivers, `skills()` contributes the skill directory to the Harness Workspace Session instead of adding model-facing instructions or tools.
 With `shellExecution: 'write'`, model-backed Workspace Shell writes commit Workspace Session changes back into the Workspace.
 With `source`, ViteHub still uses normal Workspace Source materialization, visibility, and DevTools metadata. `skills()` does not fetch source files at invocation time.
+Global sources are materialized into an ephemeral harness profile for the session. Codex receives an isolated `CODEX_HOME` containing those Skills, an empty `config.toml`, and only the available authentication file from the configured Box or host profile.
 
 ## Requirements
 
 `skills()` requires an explicit Workspace with read access to the configured skill file.
 The path can point to a directory or directly to a `SKILL.md` file.
 When `source` is configured, `path` is the canonical mount. ViteHub mounts the source at the configured skill directory even when the source helper has its own default mount.
+With `scope: 'global'`, `source` is required, `shellExecution` is unsupported, and the selected Harness Agent Driver must expose a global Skill directory.
 
 ## Driver support
 
 | Agent Driver | Support |
 | --- | --- |
 | Model-backed | Validates the skill file requirement and can read the mounted Skill through Workspace tools when tools are available. |
-| Harness-backed | Validates the skill file requirement and mounts the skill directory into the Harness Workspace Session. It does not receive generated skill instructions or Workspace Shell tools from `skills()`. |
+| Harness-backed | Mounts workspace-scoped Skills into the Harness Workspace Session and global-scoped Skills into the harness profile when the driver supports it. Codex supports both scopes. |
 | Custom-run-backed | Validates the skill file requirement before `driver.run`. |
 
 ## Inspect and verify
@@ -103,6 +125,7 @@ The warning clears when Agent Driver Instructions or a deterministic imported in
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `path` | `string` | `"skills"` | Directory or `SKILL.md` path required in the Workspace. |
+| `scope` | `"global" \| "workspace"` | `"workspace"` | Mount the Skill into the Agent Workspace or the harness's isolated global profile. |
 | `shellExecution` | `"read" \| "write"` | none | Optional Workspace Shell mode for model-backed Agents. Harness-backed Agents still receive the skill files, not Workspace Shell tools. |
 | `source` | `WorkspaceSourceInput` | none | Workspace Source to mount at the skill directory. |
 | `sourceKey` | `string` | derived from `path` | Workspace source key used when `source` is configured. |

--- a/docs/content/docs/capabilities/skills.md
+++ b/docs/content/docs/capabilities/skills.md
@@ -98,10 +98,10 @@ Global sources are materialized into an ephemeral harness profile for the sessio
 
 ## Requirements
 
-`skills()` requires an explicit Workspace with read access to the configured skill file.
+Workspace-scoped `skills()` requires an explicit Workspace with read access to the configured skill file.
 The path can point to a directory or directly to a `SKILL.md` file.
 When `source` is configured, `path` is the canonical mount. ViteHub mounts the source at the configured skill directory even when the source helper has its own default mount.
-With `scope: 'global'`, `source` is required, `shellExecution` is unsupported, and the selected Harness Agent Driver must expose a global Skill directory.
+With `scope: 'global'`, `path` and `source` are required, `shellExecution` is unsupported, and the selected Harness Agent Driver must expose a global Skill directory.
 
 ## Driver support
 
@@ -124,7 +124,7 @@ The warning clears when Agent Driver Instructions or a deterministic imported in
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `path` | `string` | `"skills"` | Directory or `SKILL.md` path required in the Workspace. |
+| `path` | `string` | `"skills"` | Directory or `SKILL.md` path required in the Workspace. Required with global scope. |
 | `scope` | `"global" \| "workspace"` | `"workspace"` | Mount the Skill into the Agent Workspace or the harness's isolated global profile. |
 | `shellExecution` | `"read" \| "write"` | none | Optional Workspace Shell mode for model-backed Agents. Harness-backed Agents still receive the skill files, not Workspace Shell tools. |
 | `source` | `WorkspaceSourceInput` | none | Workspace Source to mount at the skill directory. |

--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -47,6 +47,11 @@ function skillSourceKey(path: string): string {
   return `skill.${suffix}`
 }
 
+function skillCapabilityId(sourceKey: string): string {
+  const suffix = sourceKey.replace(/[^A-Za-z0-9_.-]+/g, ".").replace(/^\.+|\.+$/g, "") || "global"
+  return `skills.${suffix}`
+}
+
 function rebaseMountedFileSource(source: WorkspaceSourceInput, mountPath: string): WorkspaceSourceInput {
   const normalizedMount = normalizeSkillPath(mountPath)
   if (!normalizedMount) return source
@@ -120,7 +125,7 @@ export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDe
     : undefined
 
   const capability = defineCapability({
-    id: scope === "global" ? `skills.${sourceKey}` : "skills",
+    id: scope === "global" ? skillCapabilityId(sourceKey) : "skills",
     metadata: {
       path: normalizedPath,
       scope,

--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -76,9 +76,9 @@ function workspacePathInsideMount(path: string, mountPath: string) {
   return normalized.startsWith(`${mountPath}/`) ? normalized.slice(mountPath.length + 1) : undefined
 }
 
-function sourceBinding(source: WorkspaceSourceInput, mountPath: string): WorkspaceSourceInput {
+function sourceBinding(source: WorkspaceSourceInput, mountPath: string, sourceMountPath = mountPath): WorkspaceSourceInput {
   return {
-    source: rebaseMountedFileSource(source, mountPath),
+    source: rebaseMountedFileSource(source, sourceMountPath),
     mount: mountPath,
   }
 }
@@ -153,7 +153,7 @@ export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDe
     return Object.assign(capability, {
       [globalSkillsSymbol]: {
         path,
-        source: sourceBinding(options.source!, path),
+        source: sourceBinding(options.source!, path, directoryPath),
         sourceKey,
       },
     })

--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -1,14 +1,15 @@
-import { defineCapability, workspaceMaterializationPathsSymbol } from "../capability-runtime.ts"
+import { defineCapability, globalSkillsSymbol, workspaceMaterializationPathsSymbol } from "../capability-runtime.ts"
 
 import type {
   AgentCapabilityDefinition,
   AgentCapabilityMode,
   AgentToolSet,
 } from "../types.ts"
-import type { WorkspaceName, WorkspaceSourceInput } from "@vite-hub/workspace"
+import type { WorkspaceSourceInput } from "@vite-hub/workspace"
 
 export interface SkillsCapabilityOptions {
   path?: string
+  scope?: "global" | "workspace"
   shellExecution?: AgentCapabilityMode
   source?: WorkspaceSourceInput
   sourceKey?: string
@@ -20,6 +21,12 @@ function normalizeShellExecution(value: unknown): AgentCapabilityMode | undefine
   if (value === undefined) return undefined
   if (value === "read" || value === "write") return value
   throw new TypeError("[vitehub] skills({ shellExecution }) must be \"read\" or \"write\".")
+}
+
+function normalizeSkillScope(value: unknown): "global" | "workspace" {
+  if (value === undefined || value === "workspace") return "workspace"
+  if (value === "global") return value
+  throw new TypeError("[vitehub] skills({ scope }) must be \"workspace\" or \"global\".")
 }
 
 function normalizeSkillPath(path: string): string {
@@ -87,8 +94,14 @@ function workspaceShellTools(
 }
 
 export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDefinition {
-  const path = options.path || "skills"
-  const normalizedPath = normalizeSkillPath(path)
+  const normalizedPath = normalizeSkillPath(options.path || "skills")
+  const scope = normalizeSkillScope(options.scope)
+  if (scope === "global" && !options.source) {
+    throw new TypeError("[vitehub] skills({ scope: \"global\" }) requires source.")
+  }
+  if (scope === "global" && options.shellExecution !== undefined) {
+    throw new TypeError("[vitehub] skills({ scope: \"global\" }) does not support shellExecution.")
+  }
   const shellExecution = normalizeShellExecution(options.shellExecution)
   const workspaceRequirementMode = shellExecution ?? "read"
   const skillPath = normalizedPath === skillFilename || normalizedPath.endsWith("/SKILL.md")
@@ -96,28 +109,54 @@ export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDe
     : `${normalizedPath}/SKILL.md`
   const directoryPath = skillDirectory(skillPath)
   const harnessWorkspacePath = directoryPath || skillPath
+  const sourceKey = options.sourceKey || skillSourceKey(directoryPath)
   const workspaceSources = options.source
     ? {
-        [options.sourceKey || skillSourceKey(directoryPath)]: sourceBinding(options.source, directoryPath),
+        [sourceKey]: sourceBinding(options.source, directoryPath),
       }
     : undefined
 
-  return Object.assign(defineCapability({
-    id: "skills",
+  const capability = defineCapability({
+    id: scope === "global" ? `skills.${sourceKey}` : "skills",
     metadata: {
       path: normalizedPath,
+      scope,
       skillPath,
       ...(shellExecution ? { shellExecution } : {}),
       ...(workspaceSources ? { sourceKey: Object.keys(workspaceSources)[0] } : {}),
     },
-    requires: [{ primitive: "workspace", workspace: { mode: workspaceRequirementMode, paths: [skillPath], required: true } }],
-    ...(workspaceSources ? { workspaceSources } : {}),
+    ...(scope === "workspace"
+      ? { requires: [{ primitive: "workspace" as const, workspace: { mode: workspaceRequirementMode, paths: [skillPath], required: true } }] }
+      : {}),
+    ...(scope === "workspace" && workspaceSources ? { workspaceSources } : {}),
+    ...(scope === "global"
+      ? {
+          prepare: (context) => {
+            if (context.driver?.kind !== "harness") {
+              throw new Error("[vitehub] skills({ scope: \"global\" }) requires a Harness Agent Driver.")
+            }
+          },
+        }
+      : {}),
     ...(shellExecution
       ? {
           tools: context => context.driver?.kind === "harness" ? undefined : workspaceShellTools(shellExecution, context.workspace as never),
         }
       : {}),
-  }), {
+  })
+
+  if (scope === "global") {
+    const path = directoryPath.replace(/^skills(?:\/|$)/, "")
+    return Object.assign(capability, {
+      [globalSkillsSymbol]: {
+        path,
+        source: sourceBinding(options.source!, path),
+        sourceKey,
+      },
+    })
+  }
+
+  return Object.assign(capability, {
     [workspaceMaterializationPathsSymbol]: [harnessWorkspacePath],
   })
 }

--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -94,14 +94,17 @@ function workspaceShellTools(
 }
 
 export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDefinition {
-  const normalizedPath = normalizeSkillPath(options.path || "skills")
   const scope = normalizeSkillScope(options.scope)
+  if (scope === "global" && !options.path) {
+    throw new TypeError("[vitehub] skills({ scope: \"global\" }) requires path.")
+  }
   if (scope === "global" && !options.source) {
     throw new TypeError("[vitehub] skills({ scope: \"global\" }) requires source.")
   }
   if (scope === "global" && options.shellExecution !== undefined) {
     throw new TypeError("[vitehub] skills({ scope: \"global\" }) does not support shellExecution.")
   }
+  const normalizedPath = normalizeSkillPath(options.path || "skills")
   const shellExecution = normalizeShellExecution(options.shellExecution)
   const workspaceRequirementMode = shellExecution ?? "read"
   const skillPath = normalizedPath === skillFilename || normalizedPath.endsWith("/SKILL.md")

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -36,6 +36,7 @@ import type {
   AgentFinishEvent,
   AgentFinishExtensionValues,
   AgentFinishExtensionProvider,
+  AgentGlobalSkill,
   AgentHookObserverHooks,
   AgentInvocationExtensions,
   AgentOutputExtensionValues,
@@ -64,12 +65,14 @@ type ResolvedAgentOutputRenderer = ((result: unknown, extensions?: AgentOutputEx
   providerCount: number
 }
 export const workspaceMaterializationPathsSymbol: unique symbol = Symbol("vitehub.agent.workspaceMaterializationPaths")
+export const globalSkillsSymbol: unique symbol = Symbol.for("vitehub.agent.globalSkills")
 export const capabilityInvocationStartSymbol: unique symbol = Symbol("vitehub.agent.capabilityInvocationStart")
 type InternalAgentCapabilityDefinition<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > = AgentCapabilityDefinition<TRuntimeConfig, Name> & {
   [capabilityInvocationStartSymbol]?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
+  [globalSkillsSymbol]?: AgentGlobalSkill
   [workspaceMaterializationPathsSymbol]?: readonly string[]
 }
 type AgentCapabilityBashEntry = Extract<AgentCapabilityBashCommand, { command: string }>
@@ -134,6 +137,7 @@ export interface AgentCapabilityInvocationOptions<
 export interface ResolvedAgentCapabilities {
   close: () => Promise<void>
   driverContributions: AgentDriverContribution[]
+  globalSkills: readonly AgentGlobalSkill[]
   hasCloseCallbacks: boolean
   input: AgentRunInput
   messages: Message[]
@@ -764,6 +768,10 @@ export async function resolveAgentCapabilities<
         ],
       ))
     : []
+  const globalSkills = capabilities.flatMap((capability) => {
+    const skill = (capability as InternalAgentCapabilityDefinition)[globalSkillsSymbol]
+    return skill ? [skill] : []
+  })
   let currentInput = normalizeRunInput(input)
   let currentWorkspace = workspace as ReadonlyWorkspaceFacade<Name> | undefined
   let currentWorkspaceDefinition = invocationOptions.workspaceDefinition
@@ -1063,6 +1071,7 @@ export async function resolveAgentCapabilities<
           return {
             close: closeRegisteredCallbacks,
             driverContributions,
+            globalSkills,
             hasCloseCallbacks: hasCloseWork,
             input: currentInput,
             messages,
@@ -1128,6 +1137,7 @@ export async function resolveAgentCapabilities<
   return {
     close: closeRegisteredCallbacks,
     driverContributions,
+    globalSkills,
     hasCloseCallbacks: hasCloseWork,
     input: currentInput,
     messages,

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -529,6 +529,10 @@ async function createHarnessAgent<
   assertSupportedHarnessDriverContributions(context)
   const { HarnessAgent } = await import("@ai-sdk/harness/agent") as unknown as { HarnessAgent: HarnessAgentConstructor }
   const harness = await resolveHarness(options.harness, context)
+  const globalSkillsDirectory = (harness as Record<PropertyKey, unknown>)[harnessGlobalSkillsDirectory]
+  if (context.globalSkills?.length && (typeof globalSkillsDirectory !== "string" || !globalSkillsDirectory)) {
+    throw new Error("[vitehub] This Harness Agent Driver does not support skills({ scope: \"global\" }).")
+  }
   const driverSandbox = context.harnessSandboxProvider === undefined
     ? await resolveHarnessSandboxProvider(options.sandbox, context)
     : undefined
@@ -548,7 +552,7 @@ async function createHarnessAgent<
       ...(workDir !== undefined ? { workDir } : {}),
       onSession: async ({ abortSignal, session, sessionWorkDir }: { abortSignal?: AbortSignal, session: unknown, sessionWorkDir: string }) => {
         setActiveHarnessWorkspaceFiles(context.context, activeHarnessWorkspaceFiles(session as HarnessFileSandbox, sessionWorkDir, abortSignal))
-        await prepareWorkspaceSession(session, sessionWorkDir, abortSignal, (harness as Record<PropertyKey, unknown>)[harnessGlobalSkillsDirectory])
+        await prepareWorkspaceSession(session, sessionWorkDir, abortSignal, globalSkillsDirectory)
       },
     },
     permissionMode: defaultHarnessPermissionMode(harness),

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -524,6 +524,7 @@ async function createHarnessAgent<
     sessionWorkDir: string,
     abortSignal: AbortSignal | undefined,
     globalSkillsDirectory: unknown,
+    globalSkillsWorkspace: Awaited<ReturnType<typeof resolveHarnessGlobalSkills>>,
   ) => Promise<void>,
 ): Promise<{ agent: HarnessAgentLike, instructions?: string, workDir?: string }> {
   assertSupportedHarnessDriverContributions(context)
@@ -533,6 +534,7 @@ async function createHarnessAgent<
   if (context.globalSkills?.length && (typeof globalSkillsDirectory !== "string" || !globalSkillsDirectory)) {
     throw new Error("[vitehub] This Harness Agent Driver does not support skills({ scope: \"global\" }).")
   }
+  const globalSkillsWorkspace = await resolveHarnessGlobalSkills(context)
   const driverSandbox = context.harnessSandboxProvider === undefined
     ? await resolveHarnessSandboxProvider(options.sandbox, context)
     : undefined
@@ -552,7 +554,7 @@ async function createHarnessAgent<
       ...(workDir !== undefined ? { workDir } : {}),
       onSession: async ({ abortSignal, session, sessionWorkDir }: { abortSignal?: AbortSignal, session: unknown, sessionWorkDir: string }) => {
         setActiveHarnessWorkspaceFiles(context.context, activeHarnessWorkspaceFiles(session as HarnessFileSandbox, sessionWorkDir, abortSignal))
-        await prepareWorkspaceSession(session, sessionWorkDir, abortSignal, globalSkillsDirectory)
+        await prepareWorkspaceSession(session, sessionWorkDir, abortSignal, globalSkillsDirectory, globalSkillsWorkspace)
       },
     },
     permissionMode: defaultHarnessPermissionMode(harness),
@@ -562,18 +564,12 @@ async function createHarnessAgent<
   return { agent, instructions, workDir }
 }
 
-async function prepareHarnessGlobalSkills(
+async function resolveHarnessGlobalSkills(
   context: AgentAdapterRunContext,
-  session: unknown,
-  directory: unknown,
-  abortSignal?: AbortSignal,
-): Promise<{ close: (error?: unknown) => MaybePromise<void> } | undefined> {
+) {
   const skills = context.globalSkills || []
   if (!skills.length) return
-  if (typeof directory !== "string" || !directory) {
-    throw new Error("[vitehub] This Harness Agent Driver does not support skills({ scope: \"global\" }).")
-  }
-  const { prepareHarnessWorkspaceSession, useWorkspace } = await import("@vite-hub/workspace")
+  const { useWorkspace } = await import("@vite-hub/workspace")
   const { resolveWorkspaceSources } = await import("@vite-hub/workspace/runtime")
   const definition = await resolveWorkspaceSources({
     name: "__vitehub_global_skills",
@@ -591,9 +587,28 @@ async function prepareHarnessGlobalSkills(
     mode: "write" as const,
   }
   const workspace = useWorkspace("__vitehub_global_skills", workspaceOptions)
-  return await prepareHarnessWorkspaceSession(workspace, {
+  for (const skill of skills) {
+    if (!await workspace.fs.exists(`${skill.path}/SKILL.md`)) {
+      throw new Error(`[vitehub] Global Skill source must contain ${skill.path}/SKILL.md.`)
+    }
+  }
+  return { paths: skills.map(skill => skill.path), workspace }
+}
+
+async function prepareHarnessGlobalSkills(
+  resolved: Awaited<ReturnType<typeof resolveHarnessGlobalSkills>>,
+  session: unknown,
+  directory: unknown,
+  abortSignal?: AbortSignal,
+): Promise<{ close: (error?: unknown) => MaybePromise<void> } | undefined> {
+  if (!resolved) return
+  if (typeof directory !== "string" || !directory) {
+    throw new Error("[vitehub] This Harness Agent Driver does not support skills({ scope: \"global\" }).")
+  }
+  const { prepareHarnessWorkspaceSession } = await import("@vite-hub/workspace")
+  return await prepareHarnessWorkspaceSession(resolved.workspace, {
     abortSignal,
-    paths: skills.map(skill => skill.path),
+    paths: resolved.paths,
     session: session as never,
     sessionWorkDir: directory,
   })
@@ -874,7 +889,7 @@ export function createHarnessAgentAdapter<
   async function createAgentAndSession(context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>) {
     let workspaceSession: { close: (error?: unknown) => MaybePromise<void>, refreshGitBaseline?: () => MaybePromise<void> } | undefined
     let globalSkillsSession: { close: (error?: unknown) => MaybePromise<void> } | undefined
-    const resolved = await createHarnessAgent(options, context, async (session, sessionWorkDir, abortSignal, globalSkillsDirectory) => {
+    const resolved = await createHarnessAgent(options, context, async (session, sessionWorkDir, abortSignal, globalSkillsDirectory, globalSkillsWorkspace) => {
       const harnessInstructions = context.workspace ? await resolveHarnessInstructions(context) : undefined
       try {
         if (context.workspace) {
@@ -894,7 +909,7 @@ export function createHarnessAgentAdapter<
           await writeHarnessInstructionFiles(session as HarnessInstructionSandbox, sessionWorkDir, abortSignal, harnessInstructions)
           if (harnessInstructions) await workspaceSession.refreshGitBaseline?.()
         }
-        globalSkillsSession = await prepareHarnessGlobalSkills(context, session, globalSkillsDirectory, abortSignal)
+        globalSkillsSession = await prepareHarnessGlobalSkills(globalSkillsWorkspace, session, globalSkillsDirectory, abortSignal)
       }
       catch (error) {
         try {

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -76,6 +76,7 @@ const harnessGeneratedFiles = ["harness-tool.mjs"] as const
 const harnessInstructionFiles = ["AGENTS.md", "CLAUDE.md"] as const
 const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
 const harnessGlobalSkillsDirectory = Symbol.for("vitehub.harnessGlobalSkillsDirectory")
+const harnessSessionPrepare = Symbol.for("vitehub.harnessSessionPrepare")
 
 function isHarnessRelativeDirectory(value: unknown): value is string {
   return typeof value === "string"
@@ -567,6 +568,10 @@ async function createHarnessAgent<
       onSession: async ({ abortSignal, session, sessionWorkDir }: { abortSignal?: AbortSignal, session: unknown, sessionWorkDir: string }) => {
         setActiveHarnessWorkspaceFiles(context.context, activeHarnessWorkspaceFiles(session as HarnessFileSandbox, sessionWorkDir, abortSignal))
         await prepareWorkspaceSession(session, sessionWorkDir, abortSignal, globalSkillsDirectory, globalSkillsWorkspace)
+        const prepareSession = (harness as Record<PropertyKey, unknown>)[harnessSessionPrepare]
+        if (typeof prepareSession === "function") {
+          await (prepareSession as (session: unknown) => MaybePromise<void>)(session)
+        }
       },
     },
     permissionMode: defaultHarnessPermissionMode(harness),

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -538,6 +538,7 @@ async function createHarnessAgent<
     abortSignal: AbortSignal | undefined,
     globalSkillsDirectory: unknown,
     globalSkillsWorkspace: Awaited<ReturnType<typeof resolveHarnessGlobalSkills>>,
+    sessionPrepare: unknown,
   ) => Promise<void>,
 ): Promise<{ agent: HarnessAgentLike, instructions?: string, workDir?: string }> {
   assertSupportedHarnessDriverContributions(context)
@@ -567,11 +568,14 @@ async function createHarnessAgent<
       ...(workDir !== undefined ? { workDir } : {}),
       onSession: async ({ abortSignal, session, sessionWorkDir }: { abortSignal?: AbortSignal, session: unknown, sessionWorkDir: string }) => {
         setActiveHarnessWorkspaceFiles(context.context, activeHarnessWorkspaceFiles(session as HarnessFileSandbox, sessionWorkDir, abortSignal))
-        await prepareWorkspaceSession(session, sessionWorkDir, abortSignal, globalSkillsDirectory, globalSkillsWorkspace)
-        const prepareSession = (harness as Record<PropertyKey, unknown>)[harnessSessionPrepare]
-        if (typeof prepareSession === "function") {
-          await (prepareSession as (session: unknown) => MaybePromise<void>)(session)
-        }
+        await prepareWorkspaceSession(
+          session,
+          sessionWorkDir,
+          abortSignal,
+          globalSkillsDirectory,
+          globalSkillsWorkspace,
+          (harness as Record<PropertyKey, unknown>)[harnessSessionPrepare],
+        )
       },
     },
     permissionMode: defaultHarnessPermissionMode(harness),
@@ -915,7 +919,7 @@ export function createHarnessAgentAdapter<
   async function createAgentAndSession(context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>) {
     let workspaceSession: { close: (error?: unknown) => MaybePromise<void>, refreshGitBaseline?: () => MaybePromise<void> } | undefined
     let globalSkillsSession: { close: (error?: unknown) => MaybePromise<void> } | undefined
-    const resolved = await createHarnessAgent(options, context, async (session, sessionWorkDir, abortSignal, globalSkillsDirectory, globalSkillsWorkspace) => {
+    const resolved = await createHarnessAgent(options, context, async (session, sessionWorkDir, abortSignal, globalSkillsDirectory, globalSkillsWorkspace, sessionPrepare) => {
       const harnessInstructions = context.workspace ? await resolveHarnessInstructions(context) : undefined
       try {
         if (context.workspace) {
@@ -936,6 +940,9 @@ export function createHarnessAgentAdapter<
           if (harnessInstructions) await workspaceSession.refreshGitBaseline?.()
         }
         globalSkillsSession = await prepareHarnessGlobalSkills(globalSkillsWorkspace, session, globalSkillsDirectory, abortSignal)
+        if (typeof sessionPrepare === "function") {
+          await (sessionPrepare as (session: unknown) => MaybePromise<void>)(session)
+        }
       }
       catch (error) {
         try {

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -70,6 +70,7 @@ const harnessResumeStates = new WeakMap<object, Map<string, unknown>>()
 const harnessGeneratedFiles = ["harness-tool.mjs"] as const
 const harnessInstructionFiles = ["AGENTS.md", "CLAUDE.md"] as const
 const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
+const harnessGlobalSkillsDirectory = Symbol.for("vitehub.harnessGlobalSkillsDirectory")
 
 interface HarnessAgentAdapterOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -517,7 +518,12 @@ async function createHarnessAgent<
 >(
   options: HarnessAgentAdapterOptions<TRuntimeConfig, CALL_OPTIONS>,
   context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>,
-  prepareWorkspaceSession: (session: unknown, sessionWorkDir: string, abortSignal: AbortSignal | undefined) => Promise<void>,
+  prepareWorkspaceSession: (
+    session: unknown,
+    sessionWorkDir: string,
+    abortSignal: AbortSignal | undefined,
+    globalSkillsDirectory: unknown,
+  ) => Promise<void>,
 ): Promise<{ agent: HarnessAgentLike, instructions?: string, workDir?: string }> {
   assertSupportedHarnessDriverContributions(context)
   const { HarnessAgent } = await import("@ai-sdk/harness/agent") as unknown as { HarnessAgent: HarnessAgentConstructor }
@@ -541,7 +547,7 @@ async function createHarnessAgent<
       ...(workDir !== undefined ? { workDir } : {}),
       onSession: async ({ abortSignal, session, sessionWorkDir }: { abortSignal?: AbortSignal, session: unknown, sessionWorkDir: string }) => {
         setActiveHarnessWorkspaceFiles(context.context, activeHarnessWorkspaceFiles(session as HarnessFileSandbox, sessionWorkDir, abortSignal))
-        await prepareWorkspaceSession(session, sessionWorkDir, abortSignal)
+        await prepareWorkspaceSession(session, sessionWorkDir, abortSignal, (harness as Record<PropertyKey, unknown>)[harnessGlobalSkillsDirectory])
       },
     },
     permissionMode: defaultHarnessPermissionMode(harness),
@@ -549,6 +555,36 @@ async function createHarnessAgent<
     ...(tools ? { tools } : {}),
   })
   return { agent, instructions, workDir }
+}
+
+async function prepareHarnessGlobalSkills(
+  context: AgentAdapterRunContext,
+  session: unknown,
+  directory: unknown,
+  abortSignal?: AbortSignal,
+): Promise<{ close: (error?: unknown) => MaybePromise<void> } | undefined> {
+  const skills = context.globalSkills || []
+  if (!skills.length) return
+  if (typeof directory !== "string" || !directory) {
+    throw new Error("[vitehub] This Harness Agent Driver does not support skills({ scope: \"global\" }).")
+  }
+  const { prepareHarnessWorkspaceSession, useWorkspace } = await import("@vite-hub/workspace")
+  const workspaceOptions = {
+    definition: {
+      name: "__vitehub_global_skills",
+      runtime: "trusted-host",
+      sources: Object.fromEntries(skills.map(skill => [skill.sourceKey, skill.source])),
+      store: { provider: "memory" },
+    },
+    mode: "write" as const,
+  }
+  const workspace = useWorkspace("__vitehub_global_skills", workspaceOptions)
+  return await prepareHarnessWorkspaceSession(workspace, {
+    abortSignal,
+    paths: skills.map(skill => skill.path),
+    session: session as never,
+    sessionWorkDir: directory,
+  })
 }
 
 function hasDetach(session: HarnessAgentSessionLike): session is HarnessAgentSessionLike & { detach: () => MaybePromise<unknown> } {
@@ -825,35 +861,54 @@ export function createHarnessAgentAdapter<
 
   async function createAgentAndSession(context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>) {
     let workspaceSession: { close: (error?: unknown) => MaybePromise<void>, refreshGitBaseline?: () => MaybePromise<void> } | undefined
-    const resolved = await createHarnessAgent(options, context, async (session, sessionWorkDir, abortSignal) => {
-      if (!context.workspace) return
-      const harnessInstructions = await resolveHarnessInstructions(context)
-      const { prepareHarnessWorkspaceSession } = await import("@vite-hub/workspace")
-      const commitDefinition = context.workspaceDefinition && context.workspaceAutoCommit !== undefined
-        ? workspaceDefinitionWithAutoCommitRules(context.workspaceDefinition, context.workspaceAutoCommit)
-        : context.workspaceDefinition
-      workspaceSession = await prepareHarnessWorkspaceSession(context.workspace, {
-        abortSignal,
-        ...(hasWorkspaceCommitRules(commitDefinition) ? { definition: commitDefinition } : {}),
-        ignoreWriteBackPaths: harnessWriteBackIgnorePaths(context, harnessInstructions),
-        onWriteBack: diff => setHarnessWorkspaceDiff(context.context, diff),
-        paths: selectedWorkspaceScopePaths(context, commitDefinition),
-        session: session as never,
-        sessionWorkDir,
-      })
+    let globalSkillsSession: { close: (error?: unknown) => MaybePromise<void> } | undefined
+    const resolved = await createHarnessAgent(options, context, async (session, sessionWorkDir, abortSignal, globalSkillsDirectory) => {
+      const harnessInstructions = context.workspace ? await resolveHarnessInstructions(context) : undefined
       try {
-        await writeHarnessInstructionFiles(session as HarnessInstructionSandbox, sessionWorkDir, abortSignal, harnessInstructions)
-        if (harnessInstructions) await workspaceSession.refreshGitBaseline?.()
+        if (context.workspace) {
+          const { prepareHarnessWorkspaceSession } = await import("@vite-hub/workspace")
+          const commitDefinition = context.workspaceDefinition && context.workspaceAutoCommit !== undefined
+            ? workspaceDefinitionWithAutoCommitRules(context.workspaceDefinition, context.workspaceAutoCommit)
+            : context.workspaceDefinition
+          workspaceSession = await prepareHarnessWorkspaceSession(context.workspace, {
+            abortSignal,
+            ...(hasWorkspaceCommitRules(commitDefinition) ? { definition: commitDefinition } : {}),
+            ignoreWriteBackPaths: harnessWriteBackIgnorePaths(context, harnessInstructions),
+            onWriteBack: diff => setHarnessWorkspaceDiff(context.context, diff),
+            paths: selectedWorkspaceScopePaths(context, commitDefinition),
+            session: session as never,
+            sessionWorkDir,
+          })
+          await writeHarnessInstructionFiles(session as HarnessInstructionSandbox, sessionWorkDir, abortSignal, harnessInstructions)
+          if (harnessInstructions) await workspaceSession.refreshGitBaseline?.()
+        }
+        globalSkillsSession = await prepareHarnessGlobalSkills(context, session, globalSkillsDirectory, abortSignal)
       }
       catch (error) {
-        await workspaceSession.close(error)
+        try {
+          await globalSkillsSession?.close(error)
+        }
+        finally {
+          await workspaceSession?.close(error)
+        }
         workspaceSession = undefined
+        globalSkillsSession = undefined
         throw error
       }
     })
+    const preparationSession = {
+      async close(error?: unknown) {
+        try {
+          await globalSkillsSession?.close(error)
+        }
+        finally {
+          await workspaceSession?.close(error)
+        }
+      },
+    }
     return {
       agent: resolved.agent,
-      ...await createSession(resolved.agent, context, () => workspaceSession, resolved),
+      ...await createSession(resolved.agent, context, () => preparationSession, resolved),
     }
   }
 

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -66,6 +66,10 @@ type HarnessFileSandbox = {
   readBinaryFile?(options: { abortSignal?: AbortSignal, path: string }): MaybePromise<Uint8Array | null>
 }
 
+type HarnessGlobalSkillsSandbox = {
+  run(options: { abortSignal?: AbortSignal, command: string }): PromiseLike<{ exitCode: number, stderr?: string }>
+}
+
 type HarnessAgentConstructor = new (settings: Record<string, unknown>) => HarnessAgentLike
 const harnessResumeStates = new WeakMap<object, Map<string, unknown>>()
 const harnessGeneratedFiles = ["harness-tool.mjs"] as const
@@ -601,10 +605,19 @@ async function prepareHarnessGlobalSkills(
   directory: unknown,
   abortSignal?: AbortSignal,
 ): Promise<{ close: (error?: unknown) => MaybePromise<void> } | undefined> {
-  if (!resolved) return
   if (typeof directory !== "string" || !directory) {
+    if (!resolved) return
     throw new Error("[vitehub] This Harness Agent Driver does not support skills({ scope: \"global\" }).")
   }
+  const quotedDirectory = `'${directory.replace(/'/g, "'\\''")}'`
+  const reset = await (session as HarnessGlobalSkillsSandbox).run({
+    abortSignal,
+    command: `rm -rf -- ${quotedDirectory} && mkdir -p -- ${quotedDirectory}`,
+  })
+  if (reset.exitCode !== 0) {
+    throw new Error(`[vitehub] Failed to reset global Skill directory: ${reset.stderr || "sandbox command failed"}`)
+  }
+  if (!resolved) return
   const { prepareHarnessWorkspaceSession } = await import("@vite-hub/workspace")
   return await prepareHarnessWorkspaceSession(resolved.workspace, {
     abortSignal,

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -9,6 +9,7 @@ import {
   setHarnessWorkspaceDiff,
 } from "./harness-runtime.ts"
 import { composeInstructionDocument } from "./instruction-composition.ts"
+import { agentInvocationSourceContext } from "./invocation-context.ts"
 import {
   colocatedAgentInstructionsSourceKey,
   resolveColocatedAgentInstructionDocument,
@@ -569,13 +570,20 @@ async function prepareHarnessGlobalSkills(
     throw new Error("[vitehub] This Harness Agent Driver does not support skills({ scope: \"global\" }).")
   }
   const { prepareHarnessWorkspaceSession, useWorkspace } = await import("@vite-hub/workspace")
-  const workspaceOptions = {
-    definition: {
-      name: "__vitehub_global_skills",
-      runtime: { allowProduction: true, type: "trusted-host" },
-      sources: Object.fromEntries(skills.map(skill => [skill.sourceKey, skill.source])),
-      store: { provider: "memory" },
+  const { resolveWorkspaceSources } = await import("@vite-hub/workspace/runtime")
+  const definition = await resolveWorkspaceSources({
+    name: "__vitehub_global_skills",
+    runtime: { allowProduction: true, type: "trusted-host" },
+    sources: Object.fromEntries(skills.map(skill => [skill.sourceKey, skill.source])),
+    store: { provider: "memory" },
+  }, {
+    invocation: {
+      context: agentInvocationSourceContext(context.context),
+      run: context.runtime.run,
     },
+  })
+  const workspaceOptions = {
+    definition,
     mode: "write" as const,
   }
   const workspace = useWorkspace("__vitehub_global_skills", workspaceOptions)

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -77,6 +77,14 @@ const harnessInstructionFiles = ["AGENTS.md", "CLAUDE.md"] as const
 const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
 const harnessGlobalSkillsDirectory = Symbol.for("vitehub.harnessGlobalSkillsDirectory")
 
+function isHarnessRelativeDirectory(value: unknown): value is string {
+  return typeof value === "string"
+    && value !== "."
+    && posix.normalize(value) === value
+    && !posix.isAbsolute(value)
+    && !value.split("/").includes("..")
+}
+
 interface HarnessAgentAdapterOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -535,7 +543,7 @@ async function createHarnessAgent<
   const { HarnessAgent } = await import("@ai-sdk/harness/agent") as unknown as { HarnessAgent: HarnessAgentConstructor }
   const harness = await resolveHarness(options.harness, context)
   const globalSkillsDirectory = (harness as Record<PropertyKey, unknown>)[harnessGlobalSkillsDirectory]
-  if (context.globalSkills?.length && (typeof globalSkillsDirectory !== "string" || !globalSkillsDirectory)) {
+  if (context.globalSkills?.length && !isHarnessRelativeDirectory(globalSkillsDirectory)) {
     throw new Error("[vitehub] This Harness Agent Driver does not support skills({ scope: \"global\" }).")
   }
   const globalSkillsWorkspace = await resolveHarnessGlobalSkills(context)
@@ -605,7 +613,7 @@ async function prepareHarnessGlobalSkills(
   directory: unknown,
   abortSignal?: AbortSignal,
 ): Promise<{ close: (error?: unknown) => MaybePromise<void> } | undefined> {
-  if (typeof directory !== "string" || !directory) {
+  if (!isHarnessRelativeDirectory(directory)) {
     if (!resolved) return
     throw new Error("[vitehub] This Harness Agent Driver does not support skills({ scope: \"global\" }).")
   }
@@ -985,3 +993,4 @@ export function createHarnessAgentAdapter<
     },
   }
 }
+import { posix } from "node:path"

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -588,7 +588,7 @@ async function resolveHarnessGlobalSkills(
   })
   const workspaceOptions = {
     definition,
-    mode: "write" as const,
+    mode: "read" as const,
   }
   const workspace = useWorkspace("__vitehub_global_skills", workspaceOptions)
   for (const skill of skills) {

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -572,7 +572,7 @@ async function prepareHarnessGlobalSkills(
   const workspaceOptions = {
     definition: {
       name: "__vitehub_global_skills",
-      runtime: "trusted-host",
+      runtime: { allowProduction: true, type: "trusted-host" },
       sources: Object.fromEntries(skills.map(skill => [skill.sourceKey, skill.source])),
       store: { provider: "memory" },
     },

--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -25,6 +25,7 @@ type CodexDriverSandboxOptions<CALL_OPTIONS = unknown> =
 
 const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
 const harnessGlobalSkillsDirectory = Symbol.for("vitehub.harnessGlobalSkillsDirectory")
+const harnessSessionPrepare = Symbol.for("vitehub.harnessSessionPrepare")
 const codexSandboxAdapterApplied = Symbol("vitehub.codexSandboxAdapterApplied")
 
 export interface CodexDriverOptions<CALL_OPTIONS = unknown> extends CodexHarnessSettings {
@@ -95,6 +96,12 @@ function createViteHubCodex(settings: CodexHarnessSettings, preferOpenAI: boolea
   return {
     ...harness,
     [harnessGlobalSkillsDirectory]: "tmp/harness/codex-home/skills",
+    [harnessSessionPrepare]: async (session: object) => {
+      const authHome = "env" in session && session.env && typeof session.env === "object"
+        ? (session.env as Record<string, string | undefined>).CODEX_HOME
+        : undefined
+      await prepareCodexHome(session, authHome)
+    },
     [harnessSandboxAdapter]: (provider: AgentHarnessSandboxProviderInput, options?: { defaultSandbox?: boolean }) => (provider as Record<PropertyKey, unknown>)[codexSandboxAdapterApplied]
       ? provider
       : relativeCodexSandboxProvider(provider, { preferOpenAI, stripGitHubSecrets: options?.defaultSandbox }),
@@ -232,14 +239,13 @@ function relativeCodexSandboxProvider(
       const onFirstCreate = createOptions?.onFirstCreate
       const session = await (provider as { createSession(options: object): Promise<object> }).createSession({
         ...createOptions,
-        onFirstCreate: async (session: object, context: { abortSignal?: AbortSignal }) => {
-          const authHome = "env" in session && session.env && typeof session.env === "object"
-            ? (session.env as Record<string, string | undefined>).CODEX_HOME
-            : undefined
-          const adapted = adaptSession(session)
-          await prepareCodexHome(adapted, authHome)
-          await onFirstCreate?.(adapted, context)
-        },
+        ...(onFirstCreate
+          ? {
+              onFirstCreate: async (session: object, context: { abortSignal?: AbortSignal }) => {
+                await onFirstCreate(adaptSession(session), context)
+              },
+            }
+          : {}),
       })
       return adaptSession(session)
     },

--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -24,6 +24,7 @@ type CodexDriverSandboxOptions<CALL_OPTIONS = unknown> =
   | AgentHarnessSandboxProviderInput<AgentRuntimeConfig, CALL_OPTIONS>
 
 const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
+const harnessGlobalSkillsDirectory = Symbol.for("vitehub.harnessGlobalSkillsDirectory")
 const codexSandboxAdapterApplied = Symbol("vitehub.codexSandboxAdapterApplied")
 
 export interface CodexDriverOptions<CALL_OPTIONS = unknown> extends CodexHarnessSettings {
@@ -93,6 +94,7 @@ function createViteHubCodex(settings: CodexHarnessSettings, preferOpenAI: boolea
   const harness = createCodex(settings)
   return {
     ...harness,
+    [harnessGlobalSkillsDirectory]: "tmp/harness/codex-home/skills",
     [harnessSandboxAdapter]: (provider: AgentHarnessSandboxProviderInput, options?: { defaultSandbox?: boolean }) => (provider as Record<PropertyKey, unknown>)[codexSandboxAdapterApplied]
       ? provider
       : relativeCodexSandboxProvider(provider, { preferOpenAI, stripGitHubSecrets: options?.defaultSandbox }),
@@ -148,22 +150,38 @@ function patchCodexBridge(bridge: string): string {
 }
 
 function relativeCodexSandboxSession<T extends object>(session: T, bootstrapDir?: string): T {
-  const anchoredBootstrapDir = bootstrapDir ?? `${(session as T & { defaultWorkingDirectory: string }).defaultWorkingDirectory.replace(/\/+$/, "")}/${localCodexBootstrapDir}`
+  const defaultWorkingDirectory = (session as T & { defaultWorkingDirectory: string }).defaultWorkingDirectory.replace(/\/+$/, "")
+  const anchoredBootstrapDir = bootstrapDir ?? `${defaultWorkingDirectory}/${localCodexBootstrapDir}`
+  const codexHome = `${defaultWorkingDirectory}/tmp/harness/codex-home`
   return new Proxy(session, {
     get(target, property, receiver) {
       if (property === "restricted") {
         return () => relativeCodexSandboxSession((target as T & { restricted(): object }).restricted(), anchoredBootstrapDir)
       }
       if (property === "run" || property === "spawn") {
-        return (options: { command: string }) => (target as T & Record<"run" | "spawn", (options: never) => unknown>)[property]({
+        return (options: { command: string, env?: Record<string, string | undefined> }) => (target as T & Record<"run" | "spawn", (options: never) => unknown>)[property]({
           ...options,
           command: options.command.replaceAll("/tmp/harness/codex", anchoredBootstrapDir),
+          env: {
+            ...options.env,
+            CODEX_HOME: codexHome,
+          },
         } as never)
       }
       const value = Reflect.get(target, property, receiver)
       return typeof value === "function" ? value.bind(target) : value
     },
   })
+}
+
+async function prepareCodexHome(session: object, authHome?: string): Promise<void> {
+  const result = await (session as { run(options: { command: string, env?: Record<string, string | undefined> }): Promise<{ exitCode: number, stderr?: string }> }).run({
+    command: 'mkdir -p "$CODEX_HOME" && chmod 700 "$CODEX_HOME" && : > "$CODEX_HOME/config.toml" && chmod 600 "$CODEX_HOME/config.toml" && if [ -n "$VITEHUB_CODEX_AUTH_HOME" ] && [ -f "$VITEHUB_CODEX_AUTH_HOME/auth.json" ]; then ln -sfn "$VITEHUB_CODEX_AUTH_HOME/auth.json" "$CODEX_HOME/auth.json"; elif [ -f "$HOME/.codex/auth.json" ]; then ln -sfn "$HOME/.codex/auth.json" "$CODEX_HOME/auth.json"; fi',
+    ...(authHome ? { env: { VITEHUB_CODEX_AUTH_HOME: authHome } } : {}),
+  })
+  if (result.exitCode !== 0) {
+    throw new Error(`[vitehub] Failed to prepare isolated Codex home: ${result.stderr || "sandbox command failed"}`)
+  }
 }
 
 function codexSandboxProvider(options: {
@@ -212,13 +230,14 @@ function relativeCodexSandboxProvider(
       const onFirstCreate = createOptions?.onFirstCreate
       const session = await (provider as { createSession(options: object): Promise<object> }).createSession({
         ...createOptions,
-        ...(onFirstCreate
-          ? {
-              onFirstCreate: async (session: object, context: { abortSignal?: AbortSignal }) => {
-                await onFirstCreate(adaptSession(session), context)
-              },
-            }
-          : {}),
+        onFirstCreate: async (session: object, context: { abortSignal?: AbortSignal }) => {
+          const authHome = "env" in session && session.env && typeof session.env === "object"
+            ? (session.env as Record<string, string | undefined>).CODEX_HOME
+            : undefined
+          const adapted = adaptSession(session)
+          await prepareCodexHome(adapted, authHome)
+          await onFirstCreate?.(adapted, context)
+        },
       })
       return adaptSession(session)
     },

--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -178,7 +178,7 @@ function relativeCodexSandboxSession<T extends object>(session: T, bootstrapDir?
 
 async function prepareCodexHome(session: object, authHome?: string): Promise<void> {
   const result = await (session as { run(options: { command: string, env?: Record<string, string | undefined> }): Promise<{ exitCode: number, stderr?: string }> }).run({
-    command: 'mkdir -p "$CODEX_HOME" && chmod 700 "$CODEX_HOME" && : > "$CODEX_HOME/config.toml" && chmod 600 "$CODEX_HOME/config.toml" && if [ -n "$VITEHUB_CODEX_AUTH_HOME" ] && [ -f "$VITEHUB_CODEX_AUTH_HOME/auth.json" ]; then ln -sfn "$VITEHUB_CODEX_AUTH_HOME/auth.json" "$CODEX_HOME/auth.json"; elif [ -f "$HOME/.codex/auth.json" ]; then ln -sfn "$HOME/.codex/auth.json" "$CODEX_HOME/auth.json"; fi',
+    command: 'mkdir -p "$CODEX_HOME" && chmod 700 "$CODEX_HOME" && : > "$CODEX_HOME/config.toml" && chmod 600 "$CODEX_HOME/config.toml" && rm -f "$CODEX_HOME/auth.json" && if [ -n "$VITEHUB_CODEX_AUTH_HOME" ] && [ -f "$VITEHUB_CODEX_AUTH_HOME/auth.json" ]; then ln -sfn "$VITEHUB_CODEX_AUTH_HOME/auth.json" "$CODEX_HOME/auth.json"; elif [ -f "$HOME/.codex/auth.json" ]; then ln -sfn "$HOME/.codex/auth.json" "$CODEX_HOME/auth.json"; fi',
     ...(authHome ? { env: { VITEHUB_CODEX_AUTH_HOME: authHome } } : {}),
   })
   if (result.exitCode !== 0) {

--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -149,14 +149,16 @@ function patchCodexBridge(bridge: string): string {
   return patched
 }
 
-function relativeCodexSandboxSession<T extends object>(session: T, bootstrapDir?: string): T {
-  const defaultWorkingDirectory = (session as T & { defaultWorkingDirectory: string }).defaultWorkingDirectory.replace(/\/+$/, "")
+function relativeCodexSandboxSession<T extends object>(session: T, bootstrapDir?: string, codexHome?: string): T {
+  const defaultWorkingDirectory = bootstrapDir && codexHome
+    ? undefined
+    : (session as T & { defaultWorkingDirectory: string }).defaultWorkingDirectory.replace(/\/+$/, "")
   const anchoredBootstrapDir = bootstrapDir ?? `${defaultWorkingDirectory}/${localCodexBootstrapDir}`
-  const codexHome = `${defaultWorkingDirectory}/tmp/harness/codex-home`
+  const anchoredCodexHome = codexHome ?? `${defaultWorkingDirectory}/tmp/harness/codex-home`
   return new Proxy(session, {
     get(target, property, receiver) {
       if (property === "restricted") {
-        return () => relativeCodexSandboxSession((target as T & { restricted(): object }).restricted(), anchoredBootstrapDir)
+        return () => relativeCodexSandboxSession((target as T & { restricted(): object }).restricted(), anchoredBootstrapDir, anchoredCodexHome)
       }
       if (property === "run" || property === "spawn") {
         return (options: { command: string, env?: Record<string, string | undefined> }) => (target as T & Record<"run" | "spawn", (options: never) => unknown>)[property]({
@@ -164,7 +166,7 @@ function relativeCodexSandboxSession<T extends object>(session: T, bootstrapDir?
           command: options.command.replaceAll("/tmp/harness/codex", anchoredBootstrapDir),
           env: {
             ...options.env,
-            CODEX_HOME: codexHome,
+            CODEX_HOME: anchoredCodexHome,
           },
         } as never)
       }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1586,6 +1586,7 @@ async function createAgentInvocationContext<
       finishDeliveryEffectProviders: capabilities.registries.finishDeliveryEffectProviders,
       finishExtensionProviders: capabilities.registries.finishExtensionProviders,
       finishHook: definition?.hooks?.["agent:finish"] as never,
+      globalSkills: capabilities.globalSkills,
       hasCapabilityCleanup: capabilities.hasCloseCallbacks,
       handledResponse: capabilities.response,
       harnessSandboxProvider,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1532,6 +1532,12 @@ export interface AgentAdapterMetadataContext<
   workspace: ReadonlyWorkspaceFacade<Name>
 }
 
+export interface AgentGlobalSkill {
+  path: string
+  source: WorkspaceSourceInput
+  sourceKey: string
+}
+
 export interface AgentAdapterRunContext<
   TOptions = unknown,
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -1543,6 +1549,7 @@ export interface AgentAdapterRunContext<
   context: AgentInvocationContextStore
   devtools?: AgentRuntimeContext<TRuntimeConfig>["devtools"]
   driverContributions?: AgentDriverContribution[]
+  globalSkills?: readonly AgentGlobalSkill[]
   hasCapabilityCleanup?: boolean
   harnessSandboxProvider?: object
   harnessWorkDir?: string

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1035,7 +1035,7 @@ async function resolveWorkspaceMetadataInstructions<
   const composed = await composeInstructions(baseInstructions.join("\n\n"), compositionContext, workspaceBindings, coverage)
   return {
     instructions: composed ? [composed] : [],
-    warnings: instructionCoverageWarnings(coverage, sourceDefinition, options.capabilities),
+    warnings: instructionCoverageWarnings(coverage, sourceDefinition, options.capabilities, workspaceAgentDriverKind(options)),
   }
 }
 
@@ -1043,11 +1043,12 @@ function instructionCoverageWarnings(
   coverage: ReturnType<typeof createInstructionCoverage>,
   definition: WorkspaceDefinition | undefined,
   capabilities: readonly AgentCapabilityDefinition[] | undefined,
+  driverKind: AgentDriverKind,
 ): AgentDevtoolsWarning[] {
   return [
     ...sourceCoverageWarnings(coverage, definition),
     ...capabilityCoverageWarnings(coverage, capabilities),
-    ...skillCoverageWarnings(coverage, capabilities),
+    ...(driverKind === "model" ? skillCoverageWarnings(coverage, capabilities) : []),
   ]
 }
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1048,7 +1048,7 @@ function instructionCoverageWarnings(
   return [
     ...sourceCoverageWarnings(coverage, definition),
     ...capabilityCoverageWarnings(coverage, capabilities),
-    ...(driverKind === "model" ? skillCoverageWarnings(coverage, capabilities) : []),
+    ...(driverKind === "harness" ? [] : skillCoverageWarnings(coverage, capabilities)),
   ]
 }
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1078,7 +1078,7 @@ function capabilityCoverageWarnings(
   capabilities: readonly AgentCapabilityDefinition[] | undefined,
 ): AgentDevtoolsWarning[] {
   return normalizeCapabilities(capabilities as AgentCapabilityDefinition[] | undefined)
-    .filter(capability => capability.id !== "skills")
+    .filter(capability => capability.id !== "skills" && !capability.id.startsWith("skills."))
     .filter(capability => !capabilityCoverageKeys(capability.id).some(key => coverage.capabilities.has(key)))
     .map(capability => warning(
       `instruction-coverage:capability:${capability.id}`,
@@ -1097,7 +1097,7 @@ function skillCoverageWarnings(
   capabilities: readonly AgentCapabilityDefinition[] | undefined,
 ): AgentDevtoolsWarning[] {
   return normalizeCapabilities(capabilities as AgentCapabilityDefinition[] | undefined)
-    .filter(capability => capability.id === "skills")
+    .filter(capability => capability.id === "skills" || capability.id.startsWith("skills."))
     .flatMap((capability) => {
       const metadata = capability.metadata || {}
       const path = skillCoveragePath(metadata.path) || skillCoveragePath(metadata.skillPath)

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -33,7 +33,7 @@ vi.mock("@ai-sdk/harness/agent", () => ({
 
     async generate({ session }: Record<string, any>) {
       const result = await session.host.run({
-        command: "pwd; printf '%s\\n' \"$HOME\" \"$CODEX_HOME\"; test -f AGENTS.md; test -f \"$HOME/.agents/skills/global/SKILL.md\"; printf changed > changed.txt",
+        command: "pwd; printf '%s\\n' \"$HOME\" \"$CODEX_HOME\"; test -f AGENTS.md; test -f \"$HOME/.agents/skills/global/SKILL.md\"; test -f \"$CODEX_HOME/config.toml\"; test ! -s \"$CODEX_HOME/config.toml\"; test \"$(readlink \"$CODEX_HOME/auth.json\")\" = \"$HOME/.codex/auth.json\"; printf changed > changed.txt",
         workingDirectory: session.sessionWorkDir,
       })
       if (result.exitCode) throw new Error(result.stderr)
@@ -64,6 +64,7 @@ describe("Agent Box", () => {
     await Promise.all([
       writeFile(join(worktree, "AGENTS.md"), "Repository instructions.\n"),
       writeFile(join(home, ".agents", "skills", "global", "SKILL.md"), "Global skill.\n"),
+      writeFile(join(home, ".codex", "auth.json"), "{\"token\":\"box\"}\n"),
       writeFile(join(home, ".codex", "config.toml"), "model = \"configured-model\"\n"),
       executable(bin, "codex", "exit 0"),
       executable(bin, "gh", "exit 0"),
@@ -71,7 +72,7 @@ describe("Agent Box", () => {
     ])
 
     const originalPath = process.env.PATH
-    process.env.PATH = bin
+    process.env.PATH = [bin, originalPath].filter(Boolean).join(":")
     try {
       const { trustedHost } = await import("@vite-hub/box")
       const { defineAgent, runAgent } = await import("../src/index.ts")
@@ -86,16 +87,19 @@ describe("Agent Box", () => {
         driver: codexDriver(),
       })
 
-      await expect(runAgent(agent, {
+      const result = await runAgent(agent, {
         memo: vi.fn((_key, create) => create()),
         runtime: "vite",
         waitUntil: vi.fn(),
       }, {
         options: { worktreePath: worktree },
         prompt: "Repair the project.",
-      })).resolves.toMatchObject({
-        text: `${await realpath(worktree)}\n${home}\n${join(home, ".codex")}\n`,
-      })
+      }) as { text: string }
+      const [reportedWorktree, reportedHome, codexHome] = result.text.trim().split("\n")
+
+      expect(reportedWorktree).toBe(await realpath(worktree))
+      expect(reportedHome).toBe(home)
+      expect(codexHome).toMatch(/\/tmp\/harness\/codex-home$/)
 
       await expect(readFile(join(worktree, "changed.txt"), "utf8")).resolves.toBe("changed")
       expect(harnessSettings.at(-1)?.sandbox).toMatchObject({ providerId: "local" })

--- a/packages/agent/test/codex-harness.test.ts
+++ b/packages/agent/test/codex-harness.test.ts
@@ -225,6 +225,9 @@ describe("codexDriver", () => {
     const adaptSandbox = (driver.harness as Record<PropertyKey, unknown>)[Symbol.for("vitehub.harnessSandboxAdapter")] as (provider: object, options: { defaultSandbox: boolean }) => { createSession: () => Promise<typeof rawSession> }
     const session = await adaptSandbox(provider, { defaultSandbox: false }).createSession()
 
+    const prepareSession = (driver.harness as Record<PropertyKey, unknown>)[Symbol.for("vitehub.harnessSessionPrepare")] as (session: object) => Promise<void>
+    await prepareSession(session)
+
     expect(run).toHaveBeenCalledWith(expect.objectContaining({
       command: expect.stringContaining('rm -f "$CODEX_HOME/auth.json"'),
       env: {

--- a/packages/agent/test/codex-harness.test.ts
+++ b/packages/agent/test/codex-harness.test.ts
@@ -195,6 +195,48 @@ describe("codexDriver", () => {
     expect(adaptSandbox(driver.sandbox! as object)).toBe(driver.sandbox)
   })
 
+  it("exposes an isolated global skill directory", async () => {
+    const { codexDriver } = await import("../src/harness/codex.ts")
+    const driver = codexDriver({ sandbox: false })
+
+    expect((driver.harness as Record<PropertyKey, unknown>)[Symbol.for("vitehub.harnessGlobalSkillsDirectory")])
+      .toBe("tmp/harness/codex-home/skills")
+  })
+
+  it("isolates Codex config while preserving sandbox authentication", async () => {
+    const { codexDriver } = await import("../src/harness/codex.ts")
+    const run = vi.fn(async (_options: { command: string, env?: Record<string, string | undefined> }) => ({ exitCode: 0, stderr: "" }))
+    const rawSession = {
+      defaultWorkingDirectory: "/sandbox/run-1",
+      env: { CODEX_HOME: "/box/.codex", HOME: "/box" },
+      run,
+      spawn: vi.fn(),
+    }
+    const provider = {
+      specificationVersion: "harness-sandbox-v1",
+      async createSession(options: { onFirstCreate?: (session: object, context: object) => Promise<void> }) {
+        await options.onFirstCreate?.(rawSession, {})
+        return rawSession
+      },
+    }
+    const driver = codexDriver({ sandbox: provider })
+    const adaptSandbox = (driver.harness as Record<PropertyKey, unknown>)[Symbol.for("vitehub.harnessSandboxAdapter")] as (provider: object, options: { defaultSandbox: boolean }) => { createSession: () => Promise<typeof rawSession> }
+    const session = await adaptSandbox(provider, { defaultSandbox: false }).createSession()
+
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({
+      command: expect.stringContaining('chmod 600 "$CODEX_HOME/config.toml"'),
+      env: {
+        CODEX_HOME: "/sandbox/run-1/tmp/harness/codex-home",
+        VITEHUB_CODEX_AUTH_HOME: "/box/.codex",
+      },
+    }))
+    await session.run({ command: "codex exec" })
+    expect(run).toHaveBeenLastCalledWith({
+      command: "codex exec",
+      env: { CODEX_HOME: "/sandbox/run-1/tmp/harness/codex-home" },
+    })
+  })
+
   it("forwards invocation-scoped harness configuration without treating it as Codex settings", async () => {
     const { codexDriver } = await import("../src/harness/codex.ts")
     const instructions = vi.fn(() => "Repair the pull request.")

--- a/packages/agent/test/codex-harness.test.ts
+++ b/packages/agent/test/codex-harness.test.ts
@@ -226,7 +226,7 @@ describe("codexDriver", () => {
     const session = await adaptSandbox(provider, { defaultSandbox: false }).createSession()
 
     expect(run).toHaveBeenCalledWith(expect.objectContaining({
-      command: expect.stringContaining('chmod 600 "$CODEX_HOME/config.toml"'),
+      command: expect.stringContaining('rm -f "$CODEX_HOME/auth.json"'),
       env: {
         CODEX_HOME: "/sandbox/run-1/tmp/harness/codex-home",
         VITEHUB_CODEX_AUTH_HOME: "/box/.codex",

--- a/packages/agent/test/codex-harness.test.ts
+++ b/packages/agent/test/codex-harness.test.ts
@@ -206,9 +206,11 @@ describe("codexDriver", () => {
   it("isolates Codex config while preserving sandbox authentication", async () => {
     const { codexDriver } = await import("../src/harness/codex.ts")
     const run = vi.fn(async (_options: { command: string, env?: Record<string, string | undefined> }) => ({ exitCode: 0, stderr: "" }))
+    const restrictedRun = vi.fn(async (_options: { command: string, env?: Record<string, string | undefined> }) => ({ exitCode: 0, stderr: "" }))
     const rawSession = {
       defaultWorkingDirectory: "/sandbox/run-1",
       env: { CODEX_HOME: "/box/.codex", HOME: "/box" },
+      restricted: () => ({ run: restrictedRun, spawn: vi.fn() }),
       run,
       spawn: vi.fn(),
     }
@@ -232,6 +234,11 @@ describe("codexDriver", () => {
     }))
     await session.run({ command: "codex exec" })
     expect(run).toHaveBeenLastCalledWith({
+      command: "codex exec",
+      env: { CODEX_HOME: "/sandbox/run-1/tmp/harness/codex-home" },
+    })
+    await session.restricted().run({ command: "codex exec" })
+    expect(restrictedRun).toHaveBeenCalledWith({
       command: "codex exec",
       env: { CODEX_HOME: "/sandbox/run-1/tmp/harness/codex-home" },
     })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -286,6 +286,7 @@ describe("agent public types", () => {
         }),
         skills(),
         skills({ path: "skills/agent-browser", source: githubSource({ repo: "vercel/vercel-plugin", root: "skills/agent-browser" }) }),
+        skills({ path: "skills/agent-browser", scope: "global", source: githubSource({ repo: "vercel/vercel-plugin", root: "skills/agent-browser" }) }),
         skills({ path: "skills/agent-browser", shellExecution: "write", source: githubSource({ repo: "vercel/vercel-plugin", root: "skills/agent-browser" }) }),
         skills({ shellExecution: "read" }),
         skills({ shellExecution: "write" }),
@@ -378,6 +379,9 @@ describe("agent public types", () => {
 
     // @ts-expect-error skills shell execution mode must be read or write
     skills({ shellExecution: "allow" })
+
+    // @ts-expect-error skills scope must be global or workspace
+    skills({ scope: "profile" })
 
     // @ts-expect-error skills delegates shell options to Workspace Shell tools
     skills({ shellExecution: "read", timeout: 1000 })

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -727,6 +727,17 @@ describe("defineAgent workspace option", () => {
     })
     expect(capability.requires).toBeUndefined()
     expect(capability.workspaceSources).toBeUndefined()
+    expect((skills({
+      path: "skills/ponytail/SKILL.md",
+      scope: "global",
+      source: { path: "skills/ponytail/SKILL.md" },
+    }) as unknown as Record<PropertyKey, unknown>)[Symbol.for("vitehub.agent.globalSkills")]).toMatchObject({
+      path: "ponytail",
+      source: {
+        mount: "ponytail",
+        source: { path: "skills/ponytail/SKILL.md", workspacePath: "SKILL.md" },
+      },
+    })
     expect(() => skills({ scope: "global", source: { path: "/opt/skills/ponytail" } })).toThrow("requires path")
     expect(() => skills({ path: "skills/ponytail", scope: "global" })).toThrow("requires source")
     expect(() => skills({ path: "skills/ponytail", scope: "global", shellExecution: "read", source: { path: "/opt/skills/ponytail" } })).toThrow("does not support shellExecution")
@@ -754,6 +765,7 @@ describe("defineAgent workspace option", () => {
     await expect(runAgent(agent, context(), { prompt: "review" })).resolves.toMatchObject({ text: "ok" })
     expect(useWorkspace).toHaveBeenCalledWith("__vitehub_global_skills", expect.objectContaining({
       definition: expect.objectContaining({
+        runtime: { allowProduction: true, type: "trusted-host" },
         sources: {
           "skill.code-review": { mount: "code-review", source: { path: "/opt/skills/code-review" } },
           "skill.ponytail": { mount: "ponytail", source: { path: "/opt/skills/ponytail" } },

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -4425,6 +4425,7 @@ describe("defineAgent workspace option", () => {
   it("warns run drivers when configured skills lack explicit instruction coverage", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
+    exists.mockResolvedValue(true)
     const agent = withExplicitWorkspaceName(defineAgent({
       workspace: {},
       driver: { run: () => "done" },

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -727,8 +727,9 @@ describe("defineAgent workspace option", () => {
     })
     expect(capability.requires).toBeUndefined()
     expect(capability.workspaceSources).toBeUndefined()
-    expect(() => skills({ scope: "global" })).toThrow("requires source")
-    expect(() => skills({ scope: "global", shellExecution: "read", source: { path: "/opt/skills/ponytail" } })).toThrow("does not support shellExecution")
+    expect(() => skills({ scope: "global", source: { path: "/opt/skills/ponytail" } })).toThrow("requires path")
+    expect(() => skills({ path: "skills/ponytail", scope: "global" })).toThrow("requires source")
+    expect(() => skills({ path: "skills/ponytail", scope: "global", shellExecution: "read", source: { path: "/opt/skills/ponytail" } })).toThrow("does not support shellExecution")
     expect(() => skills({ scope: "profile" as never })).toThrow("skills({ scope })")
   })
 
@@ -771,7 +772,7 @@ describe("defineAgent workspace option", () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
     const agent = defineAgent({
-      capabilities: [skills({ scope: "global", source: { path: "/opt/skills/review" } })],
+      capabilities: [skills({ path: "skills/review", scope: "global", source: { path: "/opt/skills/review" } })],
       driver: { harness: { provider: "custom" } },
     })
 
@@ -782,7 +783,7 @@ describe("defineAgent workspace option", () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
     const agent = defineAgent({
-      capabilities: [skills({ scope: "global", source: { path: "/opt/skills/review" } })],
+      capabilities: [skills({ path: "skills/review", scope: "global", source: { path: "/opt/skills/review" } })],
       driver: { model: {} as never },
     })
 

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -728,6 +728,15 @@ describe("defineAgent workspace option", () => {
     })
     expect(capability.requires).toBeUndefined()
     expect(capability.workspaceSources).toBeUndefined()
+    expect(skills({
+      path: "skills/browser",
+      scope: "global",
+      source: { path: "/opt/skills/browser" },
+      sourceKey: "review/browser",
+    })).toMatchObject({
+      id: "skills.review.browser",
+      metadata: { sourceKey: "review/browser" },
+    })
     expect((skills({
       path: "skills/ponytail/SKILL.md",
       scope: "global",

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -851,6 +851,29 @@ describe("defineAgent workspace option", () => {
     }))
   })
 
+  it("closes global Skill preparation when harness session setup fails", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    const close = vi.fn()
+    exists.mockResolvedValue(true)
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce({ close })
+    const agent = defineAgent({
+      capabilities: [skills({ path: "skills/review", scope: "global", source: { path: "/opt/skills/review" } })],
+      driver: {
+        harness: {
+          provider: "codex",
+          [Symbol.for("vitehub.harnessGlobalSkillsDirectory")]: "tmp/harness/codex-home/skills",
+          [Symbol.for("vitehub.harnessSessionPrepare")]: () => {
+            throw new Error("profile setup failed")
+          },
+        },
+      },
+    })
+
+    await expect(runAgent(agent, context(), { prompt: "review" })).rejects.toThrow("profile setup failed")
+    expect(close).toHaveBeenCalledWith(expect.any(Error))
+  })
+
   it("rejects global skills for non-harness Agent Drivers", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -774,7 +774,7 @@ describe("defineAgent workspace option", () => {
           "skill.ponytail": expect.objectContaining({ mount: "ponytail", path: "/opt/skills/ponytail" }),
         },
       }),
-      mode: "write",
+      mode: "read",
     }))
     expect(resolvePonytail).toHaveBeenCalledOnce()
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -4422,6 +4422,20 @@ describe("defineAgent workspace option", () => {
     expect(await resolveAgentDevtoolsMetadata(agent)).not.toHaveProperty("warnings")
   })
 
+  it("warns run drivers when configured skills lack explicit instruction coverage", async () => {
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    const agent = withExplicitWorkspaceName(defineAgent({
+      workspace: {},
+      driver: { run: () => "done" },
+      capabilities: [skills({ path: "skills/review-browser-evidence" })],
+    }), { workspace: "support" })
+
+    expect(await resolveAgentDevtoolsMetadata(agent)).toMatchObject({
+      warnings: [expect.objectContaining({ id: "instruction-coverage:skill:skills/review-browser-evidence", primitive: "skill" })],
+    })
+  })
+
   it("clears instruction coverage warnings with explicit coverage blocks", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const { skills, workspaceShell } = await import("../src/capabilities.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -4354,7 +4354,7 @@ describe("defineAgent workspace option", () => {
     expect(readInstructions).toHaveBeenCalledOnce()
   })
 
-  it("warns when configured primitives lack explicit instruction coverage", async () => {
+  it("warns model drivers when configured primitives lack explicit instruction coverage", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const { skills, workspaceShell } = await import("../src/capabilities.ts")
     exists.mockResolvedValue(true)
@@ -4379,6 +4379,24 @@ describe("defineAgent workspace option", () => {
       expect.objectContaining({ id: "instruction-coverage:capability:workspace-shell", primitive: "capability" }),
       expect.objectContaining({ id: "instruction-coverage:skill:skills/review-browser-evidence", primitive: "skill" }),
     ]))
+  })
+
+  it("does not require explicit instruction coverage for harness-native skills", async () => {
+    const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    const agent = withExplicitWorkspaceName(defineAgent({
+      workspace: {},
+      driver: {
+        harness: { provider: "codex" },
+      },
+      capabilities: [skills({
+        path: "skills/review-browser-evidence",
+        scope: "global",
+        source: { path: "/opt/skills/review-browser-evidence" },
+      })],
+    }), { workspace: "support" })
+
+    expect(await resolveAgentDevtoolsMetadata(agent)).not.toHaveProperty("warnings")
   })
 
   it("clears instruction coverage warnings with explicit coverage blocks", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -754,6 +754,7 @@ describe("defineAgent workspace option", () => {
     const resolvePonytail = vi.fn(() => ({ path: "/opt/skills/ponytail" }))
     prepareHarnessWorkspaceSession.mockResolvedValueOnce({ close: vi.fn() })
     useWorkspace.mockClear()
+    exists.mockResolvedValue(true)
 
     const agent = defineAgent({
       capabilities: [
@@ -791,6 +792,23 @@ describe("defineAgent workspace option", () => {
     })
 
     await expect(runAgent(agent, context(), { prompt: "review" })).rejects.toThrow("does not support skills({ scope: \"global\" })")
+    expect(harnessCreateSession).not.toHaveBeenCalled()
+  })
+
+  it("rejects global sources without a Skill file before opening a harness session", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    const agent = defineAgent({
+      capabilities: [skills({ path: "skills/review", scope: "global", source: { path: "/opt/skills/review" } })],
+      driver: {
+        harness: {
+          provider: "codex",
+          [Symbol.for("vitehub.harnessGlobalSkillsDirectory")]: "tmp/harness/codex-home/skills",
+        },
+      },
+    })
+
+    await expect(runAgent(agent, context(), { prompt: "review" })).rejects.toThrow("review/SKILL.md")
     expect(harnessCreateSession).not.toHaveBeenCalled()
   })
 

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -707,6 +707,88 @@ describe("defineAgent workspace option", () => {
     expect(() => skills({ shellExecution: "execute" as never })).toThrow("skills({ shellExecution })")
   })
 
+  it("defines harness-global skill sources without requiring a Workspace", async () => {
+    const { skills } = await import("../src/capabilities.ts")
+
+    const capability = skills({
+      path: "skills/ponytail",
+      scope: "global",
+      source: { path: "/opt/skills/ponytail" },
+    })
+
+    expect(capability).toMatchObject({
+      id: "skills.skill.ponytail",
+      metadata: {
+        path: "skills/ponytail",
+        scope: "global",
+        skillPath: "skills/ponytail/SKILL.md",
+        sourceKey: "skill.ponytail",
+      },
+    })
+    expect(capability.requires).toBeUndefined()
+    expect(capability.workspaceSources).toBeUndefined()
+    expect(() => skills({ scope: "global" })).toThrow("requires source")
+    expect(() => skills({ scope: "global", shellExecution: "read", source: { path: "/opt/skills/ponytail" } })).toThrow("does not support shellExecution")
+    expect(() => skills({ scope: "profile" as never })).toThrow("skills({ scope })")
+  })
+
+  it("materializes multiple global skills into a supported harness profile", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    const harness = {
+      provider: "codex",
+      [Symbol.for("vitehub.harnessGlobalSkillsDirectory")]: "tmp/harness/codex-home/skills",
+    }
+    prepareHarnessWorkspaceSession.mockResolvedValueOnce({ close: vi.fn() })
+    useWorkspace.mockClear()
+
+    const agent = defineAgent({
+      capabilities: [
+        skills({ path: "skills/ponytail", scope: "global", source: { path: "/opt/skills/ponytail" } }),
+        skills({ path: "skills/code-review", scope: "global", source: { path: "/opt/skills/code-review" } }),
+      ],
+      driver: { harness },
+    })
+
+    await expect(runAgent(agent, context(), { prompt: "review" })).resolves.toMatchObject({ text: "ok" })
+    expect(useWorkspace).toHaveBeenCalledWith("__vitehub_global_skills", expect.objectContaining({
+      definition: expect.objectContaining({
+        sources: {
+          "skill.code-review": { mount: "code-review", source: { path: "/opt/skills/code-review" } },
+          "skill.ponytail": { mount: "ponytail", source: { path: "/opt/skills/ponytail" } },
+        },
+      }),
+      mode: "write",
+    }))
+    expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      paths: ["ponytail", "code-review"],
+      session: harnessFileSession,
+      sessionWorkDir: "tmp/harness/codex-home/skills",
+    }))
+  })
+
+  it("rejects global skills for harnesses without a global skill directory", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    const agent = defineAgent({
+      capabilities: [skills({ scope: "global", source: { path: "/opt/skills/review" } })],
+      driver: { harness: { provider: "custom" } },
+    })
+
+    await expect(runAgent(agent, context(), { prompt: "review" })).rejects.toThrow("does not support skills({ scope: \"global\" })")
+  })
+
+  it("rejects global skills for non-harness Agent Drivers", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { skills } = await import("../src/capabilities.ts")
+    const agent = defineAgent({
+      capabilities: [skills({ scope: "global", source: { path: "/opt/skills/review" } })],
+      driver: { model: {} as never },
+    })
+
+    await expect(runAgent(agent, context(), { prompt: "review" })).rejects.toThrow("requires a Harness Agent Driver")
+  })
+
   it("lets skills() contribute a mounted workspace source", async () => {
     const { skills } = await import("../src/capabilities.ts")
     const { workspaceDefinitionFromOptions } = await import("../src/workspace-agent.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -794,6 +794,18 @@ describe("defineAgent workspace option", () => {
 
     await expect(runAgent(agent, context(), { prompt: "review" })).rejects.toThrow("does not support skills({ scope: \"global\" })")
     expect(harnessCreateSession).not.toHaveBeenCalled()
+
+    const unsafeAgent = defineAgent({
+      capabilities: [skills({ path: "skills/review", scope: "global", source: { path: "/opt/skills/review" } })],
+      driver: {
+        harness: {
+          provider: "custom",
+          [Symbol.for("vitehub.harnessGlobalSkillsDirectory")]: "/home/agent/.codex/skills",
+        },
+      },
+    })
+    await expect(runAgent(unsafeAgent, context(), { prompt: "review" })).rejects.toThrow("does not support skills({ scope: \"global\" })")
+    expect(harnessCreateSession).not.toHaveBeenCalled()
   })
 
   it("rejects global sources without a Skill file before opening a harness session", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -183,6 +183,7 @@ describe("defineAgent workspace option", () => {
     })
     harnessFileSession.readBinaryFile.mockReset()
     harnessFileSession.run.mockReset()
+    harnessFileSession.run.mockResolvedValue({ exitCode: 0, stderr: "", stdout: "" })
     harnessFileSession.writeBinaryFile.mockReset()
     prepareHarnessWorkspaceSession.mockReset()
     agentGenerate.mockReset()
@@ -810,6 +811,23 @@ describe("defineAgent workspace option", () => {
 
     await expect(runAgent(agent, context(), { prompt: "review" })).rejects.toThrow("review/SKILL.md")
     expect(harnessCreateSession).not.toHaveBeenCalled()
+  })
+
+  it("clears a reused harness profile when no global Skills are configured", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      driver: {
+        harness: {
+          provider: "codex",
+          [Symbol.for("vitehub.harnessGlobalSkillsDirectory")]: "tmp/harness/codex-home/skills",
+        },
+      },
+    })
+
+    await expect(runAgent(agent, context(), { prompt: "review" })).resolves.toMatchObject({ text: "ok" })
+    expect(harnessFileSession.run).toHaveBeenCalledWith(expect.objectContaining({
+      command: expect.stringContaining("rm -rf -- 'tmp/harness/codex-home/skills'"),
+    }))
   })
 
   it("rejects global skills for non-harness Agent Drivers", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -751,12 +751,13 @@ describe("defineAgent workspace option", () => {
       provider: "codex",
       [Symbol.for("vitehub.harnessGlobalSkillsDirectory")]: "tmp/harness/codex-home/skills",
     }
+    const resolvePonytail = vi.fn(() => ({ path: "/opt/skills/ponytail" }))
     prepareHarnessWorkspaceSession.mockResolvedValueOnce({ close: vi.fn() })
     useWorkspace.mockClear()
 
     const agent = defineAgent({
       capabilities: [
-        skills({ path: "skills/ponytail", scope: "global", source: { path: "/opt/skills/ponytail" } }),
+        skills({ path: "skills/ponytail", scope: "global", source: { resolve: resolvePonytail } as never }),
         skills({ path: "skills/code-review", scope: "global", source: { path: "/opt/skills/code-review" } }),
       ],
       driver: { harness },
@@ -768,11 +769,12 @@ describe("defineAgent workspace option", () => {
         runtime: { allowProduction: true, type: "trusted-host" },
         sources: {
           "skill.code-review": { mount: "code-review", source: { path: "/opt/skills/code-review" } },
-          "skill.ponytail": { mount: "ponytail", source: { path: "/opt/skills/ponytail" } },
+          "skill.ponytail": expect.objectContaining({ mount: "ponytail", path: "/opt/skills/ponytail" }),
         },
       }),
       mode: "write",
     }))
+    expect(resolvePonytail).toHaveBeenCalledOnce()
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       paths: ["ponytail", "code-review"],
       session: harnessFileSession,

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -791,6 +791,7 @@ describe("defineAgent workspace option", () => {
     })
 
     await expect(runAgent(agent, context(), { prompt: "review" })).rejects.toThrow("does not support skills({ scope: \"global\" })")
+    expect(harnessCreateSession).not.toHaveBeenCalled()
   })
 
   it("rejects global skills for non-harness Agent Drivers", async () => {


### PR DESCRIPTION
Adds `scope: "global"` to `skills()` while keeping Workspace scope as the default. Global scope requires an explicit Skill path and source. Global sources reuse Workspace materialization to install multiple Skills into a harness-advertised profile directory, and unsupported or non-harness drivers fail before execution instead of silently ignoring the Capability.

Codex sessions now use a sandbox-local `CODEX_HOME` with an empty config and only the configured Box or host authentication file linked in. This keeps the agent profile independent from the machine profile while allowing Capability sources such as Ponytail and code review to be installed for that session.

Harness-backed agents rely on native Skill discovery, so DevTools no longer asks them for no-op `::skill` coverage blocks. Model-backed agents retain the existing explicit Skill instruction coverage warning.

This is the source version of the patch currently running in Babysitter on a trusted host: the active run mounted and read three Capability-supplied Skills, then repaired and pushed the head of PR #578. Agent build, publint, typecheck, and package tests pass.
