### PR TITLE
fix(vite): make optional integrations opt-in

### DIFF
--- a/docs/content/docs/reference/config-options.md
+++ b/docs/content/docs/reference/config-options.md
@@ -12,7 +12,7 @@ Provider Selection belongs in Integration Options when it changes generated outp
 
 | Import | Public type | Placement | Defaults |
 | --- | --- | --- | --- |
-| `@vite-hub/vite` | `ViteHubPresetOptions` | `vitehub(options)` in Vite `plugins` | Composes Agent, Blob, Database, DevTools, Env, KV, Sandbox, Schedule, Workflow, and Workspace unless a key is `false`. Queue is opt-in with `queue: true` or Queue options. Auth is not included. The preset does not re-export package APIs. |
+| `@vite-hub/vite` | `ViteHubPresetOptions` | `vitehub(options)` in Vite `plugins` | Composes Agent, Blob, Database, DevTools, Env, Workflow, and Workspace unless a key is `false`. KV, Queue, Sandbox, and Schedule are enabled with `true` for inferred defaults or with their integration options. Auth is not included. The preset does not re-export package APIs. |
 
 ## Vite Integration options
 

--- a/docs/test/launch-trust.test.ts
+++ b/docs/test/launch-trust.test.ts
@@ -75,8 +75,11 @@ describe("launch documentation trust boundaries", () => {
 
     expect(readme).toMatch(/import \{ vitehub \} from ["']@vite-hub\/vite["']/);
     expect(readme).toMatch(/composition preset/i);
-    expect(readme).toMatch(/Queue is opt-in/i);
+    expect(readme).toMatch(/KV, Queue, Sandbox, and Schedule are opt-in/i);
+    expect(readme).toContain("kv: true");
     expect(readme).toContain("queue: true");
+    expect(readme).toContain("sandbox: true");
+    expect(readme).toContain("schedule: true");
     expect(readme).toMatch(/does not re-export/i);
   });
 
@@ -84,7 +87,7 @@ describe("launch documentation trust boundaries", () => {
     const config = readFileSync(resolve(docsRoot, "reference/config-options.md"), "utf8");
     const conventions = readFileSync(resolve(docsRoot, "reference/file-conventions.md"), "utf8");
 
-    expect(config).toContain("Queue is opt-in");
+    expect(config).toContain("KV, Queue, Sandbox, and Schedule are enabled with `true`");
     expect(config).toContain("Netlify does not infer a provider");
     expect(conventions).toContain("`server/databases/<name>/config.ts`");
     expect(conventions).toContain("`<path>.agent.ts`");

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -33,15 +33,12 @@ The preset composes these integrations by default:
 - Database
 - DevTools
 - Env
-- KV
-- Sandbox
-- Schedule
 - Workflow
 - Workspace
 
 Auth is not part of the preset. Register `hubAuth()` from `@vite-hub/auth/vite` explicitly when the application has an Auth Definition. Runtime, Shell, and Source are libraries rather than preset Vite integrations.
 
-Pass `false` for an integration that the application does not use.
+Pass `false` to disable one of the default integrations.
 
 ```ts
 // vite.config.ts
@@ -52,14 +49,13 @@ export default defineConfig({
   plugins: [
     vitehub({
       agent: false,
-      sandbox: false,
       workflow: false,
     }),
   ],
 })
 ```
 
-Queue is opt-in because enabling it selects hosted Queue Provider Output. Pass `queue: true` to use provider inference, or pass Queue integration options explicitly. Netlify does not infer a Queue provider.
+KV, Queue, Sandbox, and Schedule are opt-in. Pass `true` to enable one with inferred defaults, or pass its integration options explicitly. Netlify does not infer a Queue provider.
 
 ```ts
 // vite.config.ts
@@ -69,7 +65,10 @@ import { defineConfig } from "vite"
 export default defineConfig({
   plugins: [
     vitehub({
+      kv: true,
       queue: true,
+      sandbox: true,
+      schedule: true,
     }),
   ],
 })

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -29,10 +29,10 @@ export interface ViteHubPresetOptions {
   database?: false | DBModulePublicOptions
   devtools?: false | HubDevtoolsOptions
   env?: false | EnvIntegrationOptions
-  kv?: false | KVModuleOptions
+  kv?: boolean | KVModuleOptions
   queue?: boolean | QueueModuleOptions
-  sandbox?: false | SandboxPublicOptions
-  schedule?: false | ScheduleVitePluginOptions
+  sandbox?: boolean | SandboxPublicOptions
+  schedule?: boolean | ScheduleVitePluginOptions
   workflow?: false | WorkflowModuleOptions
   workspace?: false | WorkspaceModuleOptions
 }
@@ -43,10 +43,10 @@ export function vitehub(options: ViteHubPresetOptions = {}): PluginOption[] {
   if (options.agent !== false) plugins.push(hubAgent(options.agent))
   if (options.database !== false) plugins.push(hubDb(options.database))
   if (options.blob !== false) plugins.push(hubBlob(options.blob))
-  if (options.kv !== false) plugins.push(hubKv(options.kv))
+  if (options.kv) plugins.push(hubKv(options.kv === true ? undefined : options.kv))
   if (options.queue) plugins.push(hubQueue(options.queue === true ? {} : options.queue))
-  if (options.sandbox !== false) plugins.push(hubSandbox(options.sandbox))
-  if (options.schedule !== false) plugins.push(hubSchedule(options.schedule))
+  if (options.sandbox) plugins.push(hubSandbox(options.sandbox === true ? undefined : options.sandbox))
+  if (options.schedule) plugins.push(hubSchedule(options.schedule === true ? undefined : options.schedule))
   if (options.workflow !== false) plugins.push(hubWorkflow(options.workflow))
   if (options.workspace !== false) plugins.push(hubWorkspace(options.workspace))
   if (options.devtools !== false) plugins.push(hubDevtools(options.devtools))

--- a/packages/vite/test/vite.test.ts
+++ b/packages/vite/test/vite.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from "vitest"
 
 const integrationMocks = vi.hoisted(() => ({
   hubAgent: vi.fn(() => ({ name: "@vite-hub/agent/vite" })),
+  hubKv: vi.fn(() => ({ name: "@vite-hub/kv/vite" })),
   hubQueue: vi.fn(() => ({ name: "@vite-hub/queue/vite" })),
+  hubSandbox: vi.fn(() => ({ name: "@vite-hub/sandbox/vite" })),
   hubSchedule: vi.fn(() => ({ name: "@vite-hub/schedule/vite" })),
 }))
 
@@ -11,9 +13,9 @@ vi.mock("@vite-hub/blob/vite", () => ({ hubBlob: () => ({ name: "@vite-hub/blob/
 vi.mock("@vite-hub/database/vite", () => ({ hubDb: () => ({ name: "@vite-hub/database/vite" }) }))
 vi.mock("@vite-hub/devtools", () => ({ hubDevtools: () => ({ name: "@vite-hub/devtools" }) }))
 vi.mock("@vite-hub/env/vite", () => ({ hubEnv: () => ({ name: "@vite-hub/env/vite" }) }))
-vi.mock("@vite-hub/kv/vite", () => ({ hubKv: () => ({ name: "@vite-hub/kv/vite" }) }))
+vi.mock("@vite-hub/kv/vite", () => ({ hubKv: integrationMocks.hubKv }))
 vi.mock("@vite-hub/queue/vite", () => ({ hubQueue: integrationMocks.hubQueue }))
-vi.mock("@vite-hub/sandbox/vite", () => ({ hubSandbox: () => ({ name: "@vite-hub/sandbox/vite" }) }))
+vi.mock("@vite-hub/sandbox/vite", () => ({ hubSandbox: integrationMocks.hubSandbox }))
 vi.mock("@vite-hub/schedule/vite", () => ({ hubSchedule: integrationMocks.hubSchedule }))
 vi.mock("@vite-hub/workflow/vite", () => ({ hubWorkflow: () => ({ name: "@vite-hub/workflow/vite" }) }))
 vi.mock("@vite-hub/workspace/vite", () => ({ hubWorkspace: () => ({ name: "@vite-hub/workspace/vite" }) }))
@@ -26,8 +28,18 @@ function pluginNames(plugins: PluginOption[]): string[] {
 }
 
 describe("vitehub", () => {
-  it("composes ViteHub primitive integrations explicitly", () => {
+  it("keeps optional integrations inactive until configured", () => {
     expect(pluginNames(vitehub())).toEqual([
+      "@vite-hub/env/vite",
+      "@vite-hub/agent/vite",
+      "@vite-hub/database/vite",
+      "@vite-hub/blob/vite",
+      "@vite-hub/workflow/vite",
+      "@vite-hub/workspace/vite",
+      "@vite-hub/devtools",
+    ])
+
+    expect(pluginNames(vitehub({ kv: true, sandbox: true, schedule: true }))).toEqual([
       "@vite-hub/env/vite",
       "@vite-hub/agent/vite",
       "@vite-hub/database/vite",
@@ -39,15 +51,11 @@ describe("vitehub", () => {
       "@vite-hub/workspace/vite",
       "@vite-hub/devtools",
     ])
-    expect(pluginNames(vitehub({ database: false, devtools: false, kv: false }))).toEqual([
-      "@vite-hub/env/vite",
-      "@vite-hub/agent/vite",
-      "@vite-hub/blob/vite",
-      "@vite-hub/sandbox/vite",
-      "@vite-hub/schedule/vite",
-      "@vite-hub/workflow/vite",
-      "@vite-hub/workspace/vite",
-    ])
+
+    expect(integrationMocks.hubKv).toHaveBeenLastCalledWith(undefined)
+    expect(integrationMocks.hubSandbox).toHaveBeenLastCalledWith(undefined)
+    expect(integrationMocks.hubSchedule).toHaveBeenLastCalledWith(undefined)
+
     integrationMocks.hubQueue.mockClear()
     expect(pluginNames(vitehub({ queue: true }))).toContain("@vite-hub/queue/vite")
     expect(integrationMocks.hubQueue).toHaveBeenLastCalledWith({})


### PR DESCRIPTION
Stops `vitehub()` from registering KV, Sandbox, and Schedule unless the application requests them, aligning their activation with the existing opt-in Queue integration. Passing `true` uses each package's inferred defaults, explicit options configure the integration, and omission or `false` leaves it inactive.

Previously these integrations were enabled implicitly, so applications had to carry negative `false` configuration for primitives they did not use. The preset tests and package/reference documentation now capture the positive activation contract; package tests, typecheck, build, and documentation tests pass.
