### PR TITLE
fix(agent): default delivery channels to final-only

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -27,6 +27,8 @@ export default defineAgent({
 
 Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`, `telegram()`, `stream()`, and `webChat()`. A synchronous Channel factory that needs no options can be registered directly, so `channels: { stream }` is equivalent to `channels: { stream: stream() }` and resolves once when `defineAgent()` runs. Call the helper when passing options, such as `stream({ messages: { sessions: false } })`. Use `defineChannel(kind, options)` for an app-owned Channel Kind.
 
+Adapter-backed Channels deliver only the completed response by default. Set `messages: { stream: true }` on the Channel to opt into draft and edit updates. Route-backed Stream and Web Chat Channels continue to return streaming responses.
+
 ## Scope capabilities to a Channel
 
 Put a Capability on a Channel when only invocations from that Channel should receive the ability. Agent-level Capabilities remain active for every invocation; ViteHub appends the active Channel's Capabilities when `run.channelId` or the Agent Trigger identifies that Channel.

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -27,7 +27,7 @@ export default defineAgent({
 
 Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`, `telegram()`, `stream()`, and `webChat()`. A synchronous Channel factory that needs no options can be registered directly, so `channels: { stream }` is equivalent to `channels: { stream: stream() }` and resolves once when `defineAgent()` runs. Call the helper when passing options, such as `stream({ messages: { sessions: false } })`. Use `defineChannel(kind, options)` for an app-owned Channel Kind.
 
-Adapter-backed Channels deliver only the completed response by default. Set `messages: { stream: true }` on the Channel to opt into draft and edit updates. Route-backed Stream and Web Chat Channels continue to return streaming responses.
+Adapter-backed Channels deliver only the completed response by default. Set top-level `defineAgent({ messages: { stream: true } })` to opt into draft and edit updates, or use the same `messages` option on the Channel when it is the Agent's only message-shaped Channel. Route-backed Stream and Web Chat Channels continue to return streaming responses.
 
 ## Scope capabilities to a Channel
 

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -207,7 +207,10 @@ export function resolveAgentChannelChatOptions<TRuntimeConfig extends AgentRunti
     }
     Object.assign(options, channelMessageOverrides[0])
   }
-  if (Object.keys(platforms).length) options.platforms = platforms
+  if (Object.keys(platforms).length) {
+    options.platforms = platforms
+    options.stream ??= false
+  }
   if (Object.keys(webhooks).length) options.webhooks = webhooks
   return options
 }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -382,7 +382,9 @@ function hasExplicitNonStreamingMessages(agent: unknown): boolean {
   if (!isRecord(agent)) return false
   if (isRecord(agent.messages) && agent.messages.stream === false) return true
   if (!isRecord(agent.channels)) return true
-  return Object.values(agent.channels).some(
+  const channels = Object.values(agent.channels)
+  if (!channels.some(channel => isRecord(channel) && channel.adapter && channel.messages !== false)) return true
+  return channels.some(
     channel => isRecord(channel) && isRecord(channel.messages) && channel.messages.stream === false,
   )
 }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -378,6 +378,15 @@ function getAgentChatOptions(agent: unknown): AgentChatOptions | undefined {
   return getChatCapabilityOptions(getAgentCapabilities(agent)) || definition.chat
 }
 
+function hasExplicitNonStreamingMessages(agent: unknown): boolean {
+  if (!isRecord(agent)) return false
+  if (isRecord(agent.messages) && agent.messages.stream === false) return true
+  if (!isRecord(agent.channels)) return true
+  return Object.values(agent.channels).some(
+    channel => isRecord(channel) && isRecord(channel.messages) && channel.messages.stream === false,
+  )
+}
+
 interface AgentWebhookRegistrationMatch {
   registration: AgentWebhookRegistrationDefinition
   trigger: ResolvedAgentTriggerDefinition<ViteAgentRouteRuntimeConfig>
@@ -2718,7 +2727,7 @@ export function createChannelWebhookRouteHandler(
       try {
         const handler = await createChatWebhookHandler(agent, context, registration, adapterName!, adapter, chatOptions, handlerOptions)
         const response = await handler(request, { waitUntil: context.waitUntil })
-        if (chatOptions?.stream === false) {
+        if (chatOptions?.stream === false && hasExplicitNonStreamingMessages(agent)) {
           await context.flushWaitUntil?.()
         }
         return response

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2531,6 +2531,7 @@ describe("server helpers", () => {
       driver: { run: () => ({ text: "final answer" }) },
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
+    const waitUntilTasks: Promise<unknown>[] = []
 
     const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
       body: JSON.stringify({
@@ -2544,10 +2545,11 @@ describe("server helpers", () => {
         },
       }),
       method: "POST",
-    }), "telegram")
+    }), "telegram", { waitUntil: task => waitUntilTasks.push(task) })
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ ok: true })
+    await Promise.all(waitUntilTasks)
     expect(agent.chat).toMatchObject({ stream: false })
     expect(adapter.startTyping).not.toHaveBeenCalled()
     expect(adapter.postMessage).toHaveBeenCalledOnce()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2518,6 +2518,43 @@ describe("server helpers", () => {
     }))
   })
 
+  it("defaults adapter-backed Channels to final-only delivery", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { stream, telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        stream,
+        telegram: telegram({ adapter: () => adapter as never }),
+      },
+      driver: { run: () => ({ text: "final answer" }) },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 2043,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 2008,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(agent.chat).toMatchObject({ stream: false })
+    expect(adapter.startTyping).not.toHaveBeenCalled()
+    expect(adapter.postMessage).toHaveBeenCalledOnce()
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "final answer" })
+    expect(adapter.editMessage).not.toHaveBeenCalled()
+  })
+
   it("splits long Discord chat output after stream finalization", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { discord } = await import("../src/channels.ts")
@@ -2539,7 +2576,10 @@ describe("server helpers", () => {
     let replyText = "short reply"
     const agent = defineAgent({
       channels: {
-        discord: discord({ adapter: () => adapter as never }),
+        discord: discord({
+          adapter: () => adapter as never,
+          messages: { stream: true },
+        }),
       },
       driver: {
         run: () => ({ text: replyText }),
@@ -3009,8 +3049,8 @@ describe("server helpers", () => {
         ]),
       })],
     }))
-    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "...")
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "ok: reenviado\naudio transcript" })
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "ok: reenviado\naudio transcript" })
+    expect(adapter.editMessage).not.toHaveBeenCalled()
   })
 
   it("routes channel webhook custom ids through the channel adapter", async () => {
@@ -3057,8 +3097,8 @@ describe("server helpers", () => {
         runId: "support:7",
       }),
     }))
-    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "...")
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "echo: hello" })
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "echo: hello" })
+    expect(adapter.editMessage).not.toHaveBeenCalled()
   })
 
   it("forwards Discord Gateway events to the registered webhook id", async () => {
@@ -5732,9 +5772,9 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ ok: true })
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:988", "...")
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:988", { markdown: "Preparing assets." })
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:988", "sent-1", { markdown: "agent answer" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:988", { markdown: "Preparing assets." })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:988", { markdown: "agent answer" })
+    expect(adapter.editMessage).not.toHaveBeenCalled()
   })
 
   it("posts finish channel delivery replies after input replacement and appends link artifacts", async () => {
@@ -5786,8 +5826,8 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ ok: true })
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:987", "...")
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:987", "sent-1", { markdown: "agent answer" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:987", { markdown: "agent answer" })
+    expect(adapter.editMessage).not.toHaveBeenCalled()
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:987", {
       markdown: "See the report.\n\n[Result report](<https://assets.example/reports/result.md>)",
     })
@@ -5852,8 +5892,8 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ ok: true })
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:989", "...")
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:989", "sent-1", { markdown: "agent answer" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:989", { markdown: "agent answer" })
+    expect(adapter.editMessage).not.toHaveBeenCalled()
     const deliveryMessage = adapter.postMessage.mock.calls[1]?.[1] as {
       attachments?: Array<{ mimeType?: string, name?: string, type?: string, url?: string }>
       files?: Array<{ data: ArrayBuffer, filename: string, mimeType?: string }>

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2521,7 +2521,7 @@ describe("server helpers", () => {
   it("defaults adapter-backed Channels to final-only delivery", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { stream, telegram } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createChannelChatRouteHandler, createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const agent = defineAgent({
       channels: {
@@ -2553,6 +2553,17 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenCalledOnce()
     expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "final answer" })
     expect(adapter.editMessage).not.toHaveBeenCalled()
+
+    const streamResponse = await createChannelChatRouteHandler(agent as never)(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        id: "portal-thread",
+        messages: [{ id: "user-1", parts: [{ text: "hello", type: "text" }], role: "user" }],
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }))
+    expect(streamResponse.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
+    await expect(streamResponse.text()).resolves.toContain("final answer")
   })
 
   it("splits long Discord chat output after stream finalization", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -6101,6 +6101,7 @@ describe("server helpers", () => {
   it("flushes deferred non-streaming chat webhook work before returning", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { usageTelemetry } = await import("../src/capabilities.ts")
+    const { github } = await import("../src/channels.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter({ deferMessageProcessing: true })
@@ -6144,6 +6145,7 @@ describe("server helpers", () => {
           },
         }),
       ],
+      channels: { github: github() },
       hooks: {
         "agent:finish": finish,
       },


### PR DESCRIPTION
Defaults adapter-backed Channels to final-only message delivery. Telegram, Discord, Slack, Teams, and custom Chat SDK adapters now run non-streaming generation and post one completed response unless `messages.stream: true` is explicitly configured; route-backed Stream and Web Chat Channels keep streaming.

Streaming delivery previously created a draft/edit message and forwarded every intermediate text delta, so pre-tool progress could appear in the answer and Telegram Web could reject the draft-style message. Regression coverage keeps a Stream Channel alongside Telegram, proves Telegram posts only the final response, and preserves explicit Discord streaming.
