### PR TITLE
fix(workflow): clean stale Cloudflare output

### DIFF
--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -74,14 +74,12 @@ interface NetlifyProviderDeploymentCleanup {
   outputRoot?: string
 }
 
-type ProviderDeploymentCleanup<T extends object> = T | (() => T | Promise<T>)
-
 interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
   cloudflare?: CloudflareProviderDeploymentOutput
   cleanup?: {
-    cloudflare?: ProviderDeploymentCleanup<CloudflareProviderDeploymentCleanup>
-    netlify?: ProviderDeploymentCleanup<NetlifyProviderDeploymentCleanup>
-    vercel?: ProviderDeploymentCleanup<VercelProviderDeploymentCleanup>
+    cloudflare?: CloudflareProviderDeploymentCleanup | (() => CloudflareProviderDeploymentCleanup | Promise<CloudflareProviderDeploymentCleanup>)
+    netlify?: NetlifyProviderDeploymentCleanup
+    vercel?: VercelProviderDeploymentCleanup
   }
   netlify?: NetlifyProviderDeploymentOutput
   vercel?: VercelProviderDeploymentOutput
@@ -285,12 +283,8 @@ async function writeNetlifyDeploymentOutput(options: NetlifyDeploymentOutputOpti
   ])
 }
 
-async function resolveProviderDeploymentCleanup<T extends object>(cleanup: ProviderDeploymentCleanup<T>): Promise<T> {
-  return typeof cleanup === "function" ? await cleanup() : cleanup
-}
-
-async function cleanupCloudflareDeploymentOutput(rootDir: string, cleanupInput: ProviderDeploymentCleanup<CloudflareProviderDeploymentCleanup>): Promise<void> {
-  const cleanup = await resolveProviderDeploymentCleanup(cleanupInput)
+async function cleanupCloudflareDeploymentOutput(rootDir: string, cleanupInput: CloudflareProviderDeploymentCleanup | (() => CloudflareProviderDeploymentCleanup | Promise<CloudflareProviderDeploymentCleanup>)): Promise<void> {
+  const cleanup = typeof cleanupInput === "function" ? await cleanupInput() : cleanupInput
   const outputRoot = cleanup.outputRoot ?? createDefaultCloudflareOutputRoot(rootDir)
   const writes = (cleanup.fileNames ?? []).map(fileName => rm(resolve(outputRoot, fileName), { force: true, recursive: true }))
   writes.push(writeCloudflareWranglerConfig({
@@ -308,8 +302,7 @@ async function cleanupCloudflareDeploymentOutput(rootDir: string, cleanupInput: 
   }
 }
 
-async function cleanupVercelDeploymentOutput(rootDir: string, cleanupInput: ProviderDeploymentCleanup<VercelProviderDeploymentCleanup>): Promise<void> {
-  const cleanup = await resolveProviderDeploymentCleanup(cleanupInput)
+async function cleanupVercelDeploymentOutput(rootDir: string, cleanup: VercelProviderDeploymentCleanup): Promise<void> {
   const outputRoot = cleanup.outputRoot ?? createDefaultVercelOutputRoot(rootDir)
   const writes: Array<Promise<void>> = []
   if (cleanup.serverFunctionName) {
@@ -319,8 +312,7 @@ async function cleanupVercelDeploymentOutput(rootDir: string, cleanupInput: Prov
   await Promise.all(writes)
 }
 
-async function cleanupNetlifyDeploymentOutput(rootDir: string, cleanupInput: ProviderDeploymentCleanup<NetlifyProviderDeploymentCleanup>): Promise<void> {
-  const cleanup = await resolveProviderDeploymentCleanup(cleanupInput)
+async function cleanupNetlifyDeploymentOutput(rootDir: string, cleanup: NetlifyProviderDeploymentCleanup): Promise<void> {
   const outputRoot = cleanup.outputRoot ?? createDefaultNetlifyOutputRoot(rootDir)
   const functionsRoot = resolve(outputRoot, "functions")
   const writes = (cleanup.functionNames ?? []).map(functionName =>

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -212,6 +212,13 @@ async function appendNetlifyFunctionConfig(outfile: string, config: object | und
 async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutputOptions): Promise<void> {
   const { clientDir, staticIndex } = resolveClientOutput(options.rootDir, options.clientOutDir)
   const outputRoot = options.outputRoot ?? createDefaultCloudflareOutputRoot(options.rootDir)
+  const files = Object.entries(options.files ?? {})
+  const workerOutfile = options.bundleEntry
+    ? resolve(outputRoot, options.bundleOutfileName ?? "index.js")
+    : undefined
+  if (workerOutfile && files.some(([fileName]) => resolve(outputRoot, fileName) === workerOutfile)) {
+    throw new Error(`Cloudflare output file conflicts with bundle outfile: ${workerOutfile}`)
+  }
 
   await mkdir(outputRoot, { recursive: true })
 
@@ -225,12 +232,11 @@ async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutp
     options.bundleEntry && staticIndex
       ? copyClientOutput(clientDir, options.staticOutputDir ?? createDefaultCloudflareStaticOutputDir(options.rootDir))
       : Promise.resolve(),
-    ...Object.entries(options.files ?? {}).map(([fileName, contents]) =>
+    ...files.map(([fileName, contents]) =>
       writeFile(resolve(outputRoot, fileName), contents, "utf8")),
   ]
 
-  if (options.bundleEntry) {
-    const workerOutfile = resolve(outputRoot, options.bundleOutfileName ?? "index.js")
+  if (options.bundleEntry && workerOutfile) {
     await rm(workerOutfile, { force: true, recursive: true })
     writes.push(bundleEsmEntry(options.bundleEntry, workerOutfile, options.bundleOptions))
   }

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -73,12 +73,14 @@ interface NetlifyProviderDeploymentCleanup {
   outputRoot?: string
 }
 
+type ProviderDeploymentCleanup<T extends object> = T | (() => T | Promise<T>)
+
 interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
   cloudflare?: CloudflareProviderDeploymentOutput
   cleanup?: {
-    cloudflare?: CloudflareProviderDeploymentCleanup
-    netlify?: NetlifyProviderDeploymentCleanup
-    vercel?: VercelProviderDeploymentCleanup
+    cloudflare?: ProviderDeploymentCleanup<CloudflareProviderDeploymentCleanup>
+    netlify?: ProviderDeploymentCleanup<NetlifyProviderDeploymentCleanup>
+    vercel?: ProviderDeploymentCleanup<VercelProviderDeploymentCleanup>
   }
   netlify?: NetlifyProviderDeploymentOutput
   vercel?: VercelProviderDeploymentOutput
@@ -274,7 +276,12 @@ async function writeNetlifyDeploymentOutput(options: NetlifyDeploymentOutputOpti
   ])
 }
 
-async function cleanupCloudflareDeploymentOutput(rootDir: string, cleanup: CloudflareProviderDeploymentCleanup): Promise<void> {
+async function resolveProviderDeploymentCleanup<T extends object>(cleanup: ProviderDeploymentCleanup<T>): Promise<T> {
+  return typeof cleanup === "function" ? await cleanup() : cleanup
+}
+
+async function cleanupCloudflareDeploymentOutput(rootDir: string, cleanupInput: ProviderDeploymentCleanup<CloudflareProviderDeploymentCleanup>): Promise<void> {
+  const cleanup = await resolveProviderDeploymentCleanup(cleanupInput)
   const outputRoot = cleanup.outputRoot ?? createDefaultCloudflareOutputRoot(rootDir)
   const writes = (cleanup.fileNames ?? []).map(fileName => rm(resolve(outputRoot, fileName), { force: true, recursive: true }))
   writes.push(writeCloudflareWranglerConfig({
@@ -292,7 +299,8 @@ async function cleanupCloudflareDeploymentOutput(rootDir: string, cleanup: Cloud
   }
 }
 
-async function cleanupVercelDeploymentOutput(rootDir: string, cleanup: VercelProviderDeploymentCleanup): Promise<void> {
+async function cleanupVercelDeploymentOutput(rootDir: string, cleanupInput: ProviderDeploymentCleanup<VercelProviderDeploymentCleanup>): Promise<void> {
+  const cleanup = await resolveProviderDeploymentCleanup(cleanupInput)
   const outputRoot = cleanup.outputRoot ?? createDefaultVercelOutputRoot(rootDir)
   const writes: Array<Promise<void>> = []
   if (cleanup.serverFunctionName) {
@@ -302,7 +310,8 @@ async function cleanupVercelDeploymentOutput(rootDir: string, cleanup: VercelPro
   await Promise.all(writes)
 }
 
-async function cleanupNetlifyDeploymentOutput(rootDir: string, cleanup: NetlifyProviderDeploymentCleanup): Promise<void> {
+async function cleanupNetlifyDeploymentOutput(rootDir: string, cleanupInput: ProviderDeploymentCleanup<NetlifyProviderDeploymentCleanup>): Promise<void> {
+  const cleanup = await resolveProviderDeploymentCleanup(cleanupInput)
   const outputRoot = cleanup.outputRoot ?? createDefaultNetlifyOutputRoot(rootDir)
   const functionsRoot = resolve(outputRoot, "functions")
   const writes = (cleanup.functionNames ?? []).map(functionName =>

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -20,6 +20,7 @@ interface CloudflareDeploymentOutputOptions extends SharedDeploymentOptions {
   bundleEntry?: string
   bundleOptions?: BundleOptions
   bundleOutfileName?: string
+  files?: Record<string, string>
   outputRoot?: string
   staticOutputDir?: string
   wranglerConfigKeys?: string[]
@@ -224,6 +225,8 @@ async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutp
     options.bundleEntry && staticIndex
       ? copyClientOutput(clientDir, options.staticOutputDir ?? createDefaultCloudflareStaticOutputDir(options.rootDir))
       : Promise.resolve(),
+    ...Object.entries(options.files ?? {}).map(([fileName, contents]) =>
+      writeFile(resolve(outputRoot, fileName), contents, "utf8")),
   ]
 
   if (options.bundleEntry) {

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, readFile, rm, rmdir, writeFile } from "node:fs/promises"
 import { dirname, resolve } from "node:path"
 
 import { copyClientOutput, hasStaticIndex } from "./client-output.ts"
@@ -56,7 +56,7 @@ type NetlifyProviderDeploymentOutput = Omit<NetlifyDeploymentOutputOptions, keyo
 export type VercelProviderDeploymentOutput = Omit<VercelDeploymentOutputOptions, keyof SharedDeploymentOptions>
 
 interface CloudflareProviderDeploymentCleanup {
-  bundleOutfileName?: string
+  fileNames?: string[]
   outputRoot?: string
   wranglerConfigKeys?: string[]
 }
@@ -276,16 +276,20 @@ async function writeNetlifyDeploymentOutput(options: NetlifyDeploymentOutputOpti
 
 async function cleanupCloudflareDeploymentOutput(rootDir: string, cleanup: CloudflareProviderDeploymentCleanup): Promise<void> {
   const outputRoot = cleanup.outputRoot ?? createDefaultCloudflareOutputRoot(rootDir)
-  const writes: Array<Promise<void>> = []
-  if (cleanup.bundleOutfileName) {
-    writes.push(rm(resolve(outputRoot, cleanup.bundleOutfileName), { force: true, recursive: true }))
-  }
+  const writes = (cleanup.fileNames ?? []).map(fileName => rm(resolve(outputRoot, fileName), { force: true, recursive: true }))
   writes.push(writeCloudflareWranglerConfig({
     outputRoot,
     rootDir,
     wranglerConfigKeys: cleanup.wranglerConfigKeys,
   }))
   await Promise.all(writes)
+  try {
+    await rmdir(outputRoot)
+  }
+  catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code !== "ENOENT" && code !== "ENOTEMPTY") throw error
+  }
 }
 
 async function cleanupVercelDeploymentOutput(rootDir: string, cleanup: VercelProviderDeploymentCleanup): Promise<void> {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -515,6 +515,22 @@ describe("provider deployment outputs", () => {
     expect(existsSync(cloudflareDir)).toBe(false)
   })
 
+  it("rejects Cloudflare companion files that conflict with the bundle outfile", async () => {
+    const rootDir = await createTempProject()
+    const { writeProviderDeploymentOutputs } = await import("../src/build/deployment-output.ts")
+
+    await expect(writeProviderDeploymentOutputs({
+      cloudflare: {
+        bundleEntry: join(rootDir, "worker.ts"),
+        bundleOptions: {},
+        files: { "index.js": "export default {}\n" },
+        wranglerConfig: {},
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+    })).rejects.toThrow("Cloudflare output file conflicts with bundle outfile")
+  })
+
   it("copies Vercel function runtime package dependency closures", async () => {
     const rootDir = await createTempProject()
     const {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -488,17 +488,20 @@ describe("provider deployment outputs", () => {
     const cloudflareDir = createDefaultCloudflareOutputRoot(rootDir)
     const providerWrite = writeProviderDeploymentOutputs({
       cloudflare: {
+        files: { "index.js": "export default {}\n" },
         wranglerConfig: { main: "index.js" },
       },
       clientOutDir: "dist/client",
       rootDir,
     })
     let observedConfig: string | undefined
+    let observedWrapper: string | undefined
     const cleanup = writeProviderDeploymentOutputs({
       cleanup: {
         cloudflare: async () => {
           observedConfig = await readFile(join(cloudflareDir, "wrangler.json"), "utf8")
-          return { wranglerConfigKeys: ["main"] }
+          observedWrapper = await readFile(join(cloudflareDir, "index.js"), "utf8")
+          return { fileNames: ["index.js"], wranglerConfigKeys: ["main"] }
         },
       },
       clientOutDir: "dist/client",
@@ -508,6 +511,7 @@ describe("provider deployment outputs", () => {
     await Promise.all([providerWrite, cleanup])
 
     expect(observedConfig && JSON.parse(observedConfig)).toEqual({ main: "index.js" })
+    expect(observedWrapper).toBe("export default {}\n")
     expect(existsSync(cloudflareDir)).toBe(false)
   })
 

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -479,6 +479,38 @@ describe("provider deployment outputs", () => {
     expect(existsSync(cloudflareDir)).toBe(false)
   })
 
+  it("resolves cleanup ownership after preceding provider writes", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultCloudflareOutputRoot,
+      writeProviderDeploymentOutputs,
+    } = await import("../src/build/deployment-output.ts")
+    const cloudflareDir = createDefaultCloudflareOutputRoot(rootDir)
+    const providerWrite = writeProviderDeploymentOutputs({
+      cloudflare: {
+        wranglerConfig: { main: "index.js" },
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+    let observedConfig: string | undefined
+    const cleanup = writeProviderDeploymentOutputs({
+      cleanup: {
+        cloudflare: async () => {
+          observedConfig = await readFile(join(cloudflareDir, "wrangler.json"), "utf8")
+          return { wranglerConfigKeys: ["main"] }
+        },
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    await Promise.all([providerWrite, cleanup])
+
+    expect(observedConfig && JSON.parse(observedConfig)).toEqual({ main: "index.js" })
+    expect(existsSync(cloudflareDir)).toBe(false)
+  })
+
   it("copies Vercel function runtime package dependency closures", async () => {
     const rootDir = await createTempProject()
     const {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -440,7 +440,7 @@ describe("provider deployment outputs", () => {
     await writeProviderDeploymentOutputs({
       cleanup: {
         cloudflare: {
-          bundleOutfileName: "worker.mjs",
+          fileNames: ["worker.mjs"],
           wranglerConfigKeys: ["workflows"],
         },
       },
@@ -452,6 +452,31 @@ describe("provider deployment outputs", () => {
     await expect(readFile(join(cloudflareDir, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       triggers: { crons: ["0 0 * * *"] },
     })
+  })
+
+  it("removes empty Cloudflare output roots after cleanup", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultCloudflareOutputRoot,
+      writeProviderDeploymentOutputs,
+    } = await import("../src/build/deployment-output.ts")
+    const cloudflareDir = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(cloudflareDir, { recursive: true })
+    await writeFile(join(cloudflareDir, "index.js"), "export default {}")
+    await writeFile(join(cloudflareDir, "wrangler.json"), "{\"main\":\"index.js\"}\n")
+
+    await writeProviderDeploymentOutputs({
+      cleanup: {
+        cloudflare: {
+          fileNames: ["index.js"],
+          wranglerConfigKeys: ["main"],
+        },
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    expect(existsSync(cloudflareDir)).toBe(false)
   })
 
   it("copies Vercel function runtime package dependency closures", async () => {

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -411,7 +411,7 @@ async function createCloudflareWorkflowCleanup(rootDir: string) {
   return {
     fileNames: ownsWrapper ? ["index.js", "worker.mjs"] : ["worker.mjs"],
     outputRoot,
-    wranglerConfigKeys: ownsWrapper ? cloudflareWorkflowWranglerConfigKeys : ["workflows"],
+    wranglerConfigKeys: ["workflows"],
   }
 }
 

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { builtinModules } from "node:module"
 import { basename, dirname, join, relative, resolve } from "node:path"
 
@@ -20,6 +20,8 @@ export const workflowPackageName = "@vite-hub/workflow"
 const productName = "workflow"
 
 const generatedRegistryFileName = "registry.mjs"
+const cloudflareWorkflowWranglerConfigKeys = ["compatibility_date", "compatibility_flags", "main", "observability", "workflows"]
+const cloudflareWorkflowWrapperImport = `import worker, { runViteHubWorkflowDefinition } from "./worker.mjs"`
 const packageDir = computePackageDir(import.meta.url)
 const resolveRuntimeModule = (modulePath: string) => resolveRuntimeFromPkg(packageDir, modulePath)
 const nodeBuiltinExternals = [...new Set(["node:*", ...builtinModules, ...builtinModules.map(module => `node:${module}`)])]
@@ -246,7 +248,7 @@ function createWorkflowRegistryContents(registryFile: string, definitions: Disco
 function renderCloudflareWorkerWrapper(definitions: DiscoveredWorkflowDefinition[]) {
   return [
     definitions.length ? `import { WorkflowEntrypoint, waitUntil as viteHubWaitUntil } from "cloudflare:workers"` : `import { waitUntil as viteHubWaitUntil } from "cloudflare:workers"`,
-    `import worker, { runViteHubWorkflowDefinition } from "./worker.mjs"`,
+    cloudflareWorkflowWrapperImport,
     "",
     ...definitions.map((definition) => {
       const className = getCloudflareWorkflowClassName(definition.name)
@@ -383,7 +385,7 @@ function createCloudflareOutput(rootDir: string, artifacts: GeneratedWorkflowArt
     },
     bundleOutfileName: "worker.mjs",
     outputRoot: createDefaultCloudflareOutputRoot(rootDir),
-    wranglerConfigKeys: ["workflows"],
+    wranglerConfigKeys: cloudflareWorkflowWranglerConfigKeys,
     wranglerConfig,
   }
 }
@@ -395,6 +397,22 @@ async function writeCloudflareWorkflowWrapper(rootDir: string, artifacts: Genera
     : false
   const workflowDefinitions = workflowConfig ? artifacts.providerDefinitions : []
   await writeFile(resolve(outputRoot, "index.js"), renderCloudflareWorkerWrapper(workflowDefinitions), "utf8")
+}
+
+async function createCloudflareWorkflowCleanup(rootDir: string) {
+  const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+  let ownsWrapper = false
+  try {
+    ownsWrapper = (await readFile(resolve(outputRoot, "index.js"), "utf8")).includes(cloudflareWorkflowWrapperImport)
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+  return {
+    fileNames: ownsWrapper ? ["index.js", "worker.mjs"] : ["worker.mjs"],
+    outputRoot,
+    wranglerConfigKeys: ownsWrapper ? cloudflareWorkflowWranglerConfigKeys : ["workflows"],
+  }
 }
 
 function createVercelOutput(artifacts: GeneratedWorkflowArtifacts): VercelProviderDeploymentOutput {
@@ -412,24 +430,21 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const artifacts = await writeProviderEntries(options.rootDir, options.workflow)
   const cloudflareWorkflowConfig = resolveWorkflowConfig(options.workflow, "cloudflare")
   const vercelWorkflowConfig = resolveWorkflowConfig(options.workflow, "vercel")
+  const cloudflareOutput = cloudflareWorkflowConfig && cloudflareWorkflowConfig.provider === "cloudflare"
+    ? createCloudflareOutput(options.rootDir, artifacts)
+    : undefined
   await writeProviderDeploymentOutputs({
     clientOutDir: options.clientOutDir,
-    ...(cloudflareWorkflowConfig && cloudflareWorkflowConfig.provider === "cloudflare"
-      ? { cloudflare: createCloudflareOutput(options.rootDir, artifacts) }
-      : {}),
+    cloudflare: cloudflareOutput,
     cleanup: {
-      cloudflare: {
-        bundleOutfileName: "worker.mjs",
-        outputRoot: createDefaultCloudflareOutputRoot(options.rootDir),
-        wranglerConfigKeys: ["workflows"],
-      },
+      cloudflare: cloudflareOutput ? undefined : await createCloudflareWorkflowCleanup(options.rootDir),
     },
     rootDir: options.rootDir,
     ...(vercelWorkflowConfig && vercelWorkflowConfig.provider === "vercel"
       ? { vercel: createVercelOutput(artifacts) }
       : {}),
   })
-  if (cloudflareWorkflowConfig && cloudflareWorkflowConfig.provider === "cloudflare") {
+  if (cloudflareOutput) {
     await writeCloudflareWorkflowWrapper(options.rootDir, artifacts)
   }
   return artifacts

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -384,19 +384,19 @@ function createCloudflareOutput(rootDir: string, artifacts: GeneratedWorkflowArt
       platform: "neutral",
     },
     bundleOutfileName: "worker.mjs",
+    files: { "index.js": createCloudflareWorkflowWrapper(artifacts) },
     outputRoot: createDefaultCloudflareOutputRoot(rootDir),
     wranglerConfigKeys: cloudflareWorkflowWranglerConfigKeys,
     wranglerConfig,
   }
 }
 
-async function writeCloudflareWorkflowWrapper(rootDir: string, artifacts: GeneratedWorkflowArtifacts) {
-  const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+function createCloudflareWorkflowWrapper(artifacts: GeneratedWorkflowArtifacts): string {
   const workflowConfig = artifacts.cloudflareWorkflowConfig && artifacts.cloudflareWorkflowConfig.provider === "cloudflare"
     ? artifacts.cloudflareWorkflowConfig
     : false
   const workflowDefinitions = workflowConfig ? artifacts.providerDefinitions : []
-  await writeFile(resolve(outputRoot, "index.js"), renderCloudflareWorkerWrapper(workflowDefinitions), "utf8")
+  return renderCloudflareWorkerWrapper(workflowDefinitions)
 }
 
 async function createCloudflareWorkflowCleanup(rootDir: string) {
@@ -444,8 +444,5 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
       ? { vercel: createVercelOutput(artifacts) }
       : {}),
   })
-  if (cloudflareOutput) {
-    await writeCloudflareWorkflowWrapper(options.rootDir, artifacts)
-  }
   return artifacts
 }

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -411,7 +411,7 @@ async function createCloudflareWorkflowCleanup(rootDir: string) {
   return {
     fileNames: ownsWrapper ? ["index.js", "worker.mjs"] : ["worker.mjs"],
     outputRoot,
-    wranglerConfigKeys: ["workflows"],
+    wranglerConfigKeys: ownsWrapper ? cloudflareWorkflowWranglerConfigKeys : ["workflows"],
   }
 }
 

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -437,7 +437,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     clientOutDir: options.clientOutDir,
     cloudflare: cloudflareOutput,
     cleanup: {
-      cloudflare: cloudflareOutput ? undefined : await createCloudflareWorkflowCleanup(options.rootDir),
+      cloudflare: cloudflareOutput ? undefined : () => createCloudflareWorkflowCleanup(options.rootDir),
     },
     rootDir: options.rootDir,
     ...(vercelWorkflowConfig && vercelWorkflowConfig.provider === "vercel"

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -251,10 +251,6 @@ describe("Vite workflow provider outputs", () => {
     await expect(readFile(join(cloudflareDir, "sibling-output.mjs"), "utf8")).resolves.toBe("export default {}\n")
     await expect(readFile(nitroOutput, "utf8")).resolves.toBe("{\"preset\":\"vercel\"}\n")
     await expect(readFile(wranglerConfig, "utf8").then(JSON.parse)).resolves.toEqual({
-      compatibility_date: "2026-04-20",
-      compatibility_flags: ["nodejs_compat"],
-      main: "index.js",
-      observability: { enabled: true },
       vars: { USER_OWNED: "true" },
     })
   }, buildOutputTestTimeout)
@@ -294,44 +290,6 @@ describe("Vite workflow provider outputs", () => {
       main: "index.js",
       observability: { enabled: true },
       r2_buckets: [{ binding: "ASSETS", bucket_name: "assets" }],
-    })
-  }, buildOutputTestTimeout)
-
-  it("preserves shared Cloudflare config for sibling ViteHub bindings", async () => {
-    const rootDir = await createPlaygroundCopy("vitehub-workflow-cloudflare-binding-")
-    const viteConfig = join(rootDir, "vite.config.ts")
-
-    await execFileAsync("vp", ["build"], {
-      cwd: rootDir,
-      env: { ...process.env, VITEHUB_VITE_MODE: "workflow" },
-    })
-
-    const cloudflareDir = join(rootDir, "dist", "vite")
-    const wranglerConfig = join(cloudflareDir, "wrangler.json")
-    const wrangler = JSON.parse(await readFile(wranglerConfig, "utf8"))
-    await writeFile(wranglerConfig, `${JSON.stringify({
-      ...wrangler,
-      kv_namespaces: [{ binding: "CACHE", id: "cache" }],
-    }, null, 2)}\n`)
-    await writeFile(
-      viteConfig,
-      (await readFile(viteConfig, "utf8")).replaceAll(
-        "workflow: {},",
-        "workflow: { provider: \"openworkflow\", postgres: { url: \"postgres://example\" } },",
-      ),
-    )
-
-    await execFileAsync("vp", ["build"], {
-      cwd: rootDir,
-      env: { ...process.env, VITEHUB_VITE_MODE: "workflow" },
-    })
-
-    await expect(readFile(wranglerConfig, "utf8").then(JSON.parse)).resolves.toEqual({
-      compatibility_date: "2026-04-20",
-      compatibility_flags: ["nodejs_compat"],
-      main: "index.js",
-      observability: { enabled: true },
-      kv_namespaces: [{ binding: "CACHE", id: "cache" }],
     })
   }, buildOutputTestTimeout)
 

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -217,4 +217,80 @@ describe("Vite workflow provider outputs", () => {
     expect(existsSync(join(rootDir, "dist", "vite"))).toBe(false)
   }, buildOutputTestTimeout)
 
+  it("cleans Cloudflare workflow output when switching to OpenWorkflow", async () => {
+    const rootDir = await createPlaygroundCopy("vitehub-workflow-cloudflare-to-openworkflow-")
+    const viteConfig = join(rootDir, "vite.config.ts")
+
+    await execFileAsync("vp", ["build"], {
+      cwd: rootDir,
+      env: { ...process.env, VITEHUB_VITE_MODE: "workflow" },
+    })
+
+    const cloudflareDir = join(rootDir, "dist", "vite")
+    const nitroOutput = join(rootDir, ".vercel", "output", "nitro.json")
+    const wranglerConfig = join(cloudflareDir, "wrangler.json")
+    const wrangler = JSON.parse(await readFile(wranglerConfig, "utf8"))
+    await writeFile(nitroOutput, "{\"preset\":\"vercel\"}\n")
+    await writeFile(join(cloudflareDir, "sibling-output.mjs"), "export default {}\n")
+    await writeFile(wranglerConfig, `${JSON.stringify({ ...wrangler, vars: { USER_OWNED: "true" } }, null, 2)}\n`)
+    await writeFile(
+      viteConfig,
+      (await readFile(viteConfig, "utf8")).replaceAll(
+        "workflow: {},",
+        "workflow: { provider: \"openworkflow\", postgres: { url: \"postgres://example\" } },",
+      ),
+    )
+
+    await execFileAsync("vp", ["build"], {
+      cwd: rootDir,
+      env: { ...process.env, VITEHUB_VITE_MODE: "workflow" },
+    })
+
+    expect(existsSync(join(cloudflareDir, "index.js"))).toBe(false)
+    expect(existsSync(join(cloudflareDir, "worker.mjs"))).toBe(false)
+    await expect(readFile(join(cloudflareDir, "sibling-output.mjs"), "utf8")).resolves.toBe("export default {}\n")
+    await expect(readFile(nitroOutput, "utf8")).resolves.toBe("{\"preset\":\"vercel\"}\n")
+    await expect(readFile(wranglerConfig, "utf8").then(JSON.parse)).resolves.toEqual({
+      vars: { USER_OWNED: "true" },
+    })
+  }, buildOutputTestTimeout)
+
+  it("preserves sibling Cloudflare output when switching to OpenWorkflow", async () => {
+    const rootDir = await createPlaygroundCopy("vitehub-workflow-cloudflare-sibling-")
+    const viteConfig = join(rootDir, "vite.config.ts")
+
+    await execFileAsync("vp", ["build"], {
+      cwd: rootDir,
+      env: { ...process.env, VITEHUB_VITE_MODE: "workflow" },
+    })
+
+    const cloudflareDir = join(rootDir, "dist", "vite")
+    const wranglerConfig = join(cloudflareDir, "wrangler.json")
+    const wrangler = JSON.parse(await readFile(wranglerConfig, "utf8"))
+    await writeFile(join(cloudflareDir, "index.js"), "export default { fetch() {} }\n")
+    await writeFile(wranglerConfig, `${JSON.stringify({ ...wrangler, r2_buckets: [{ binding: "ASSETS", bucket_name: "assets" }] }, null, 2)}\n`)
+    await writeFile(
+      viteConfig,
+      (await readFile(viteConfig, "utf8")).replaceAll(
+        "workflow: {},",
+        "workflow: { provider: \"openworkflow\", postgres: { url: \"postgres://example\" } },",
+      ),
+    )
+
+    await execFileAsync("vp", ["build"], {
+      cwd: rootDir,
+      env: { ...process.env, VITEHUB_VITE_MODE: "workflow" },
+    })
+
+    expect(existsSync(join(cloudflareDir, "worker.mjs"))).toBe(false)
+    await expect(readFile(join(cloudflareDir, "index.js"), "utf8")).resolves.toBe("export default { fetch() {} }\n")
+    await expect(readFile(wranglerConfig, "utf8").then(JSON.parse)).resolves.toEqual({
+      compatibility_date: "2026-04-20",
+      compatibility_flags: ["nodejs_compat"],
+      main: "index.js",
+      observability: { enabled: true },
+      r2_buckets: [{ binding: "ASSETS", bucket_name: "assets" }],
+    })
+  }, buildOutputTestTimeout)
+
 })

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -251,6 +251,10 @@ describe("Vite workflow provider outputs", () => {
     await expect(readFile(join(cloudflareDir, "sibling-output.mjs"), "utf8")).resolves.toBe("export default {}\n")
     await expect(readFile(nitroOutput, "utf8")).resolves.toBe("{\"preset\":\"vercel\"}\n")
     await expect(readFile(wranglerConfig, "utf8").then(JSON.parse)).resolves.toEqual({
+      compatibility_date: "2026-04-20",
+      compatibility_flags: ["nodejs_compat"],
+      main: "index.js",
+      observability: { enabled: true },
       vars: { USER_OWNED: "true" },
     })
   }, buildOutputTestTimeout)
@@ -290,6 +294,44 @@ describe("Vite workflow provider outputs", () => {
       main: "index.js",
       observability: { enabled: true },
       r2_buckets: [{ binding: "ASSETS", bucket_name: "assets" }],
+    })
+  }, buildOutputTestTimeout)
+
+  it("preserves shared Cloudflare config for sibling ViteHub bindings", async () => {
+    const rootDir = await createPlaygroundCopy("vitehub-workflow-cloudflare-binding-")
+    const viteConfig = join(rootDir, "vite.config.ts")
+
+    await execFileAsync("vp", ["build"], {
+      cwd: rootDir,
+      env: { ...process.env, VITEHUB_VITE_MODE: "workflow" },
+    })
+
+    const cloudflareDir = join(rootDir, "dist", "vite")
+    const wranglerConfig = join(cloudflareDir, "wrangler.json")
+    const wrangler = JSON.parse(await readFile(wranglerConfig, "utf8"))
+    await writeFile(wranglerConfig, `${JSON.stringify({
+      ...wrangler,
+      kv_namespaces: [{ binding: "CACHE", id: "cache" }],
+    }, null, 2)}\n`)
+    await writeFile(
+      viteConfig,
+      (await readFile(viteConfig, "utf8")).replaceAll(
+        "workflow: {},",
+        "workflow: { provider: \"openworkflow\", postgres: { url: \"postgres://example\" } },",
+      ),
+    )
+
+    await execFileAsync("vp", ["build"], {
+      cwd: rootDir,
+      env: { ...process.env, VITEHUB_VITE_MODE: "workflow" },
+    })
+
+    await expect(readFile(wranglerConfig, "utf8").then(JSON.parse)).resolves.toEqual({
+      compatibility_date: "2026-04-20",
+      compatibility_flags: ["nodejs_compat"],
+      main: "index.js",
+      observability: { enabled: true },
+      kv_namespaces: [{ binding: "CACHE", id: "cache" }],
     })
   }, buildOutputTestTimeout)
 


### PR DESCRIPTION
Cloudflare Workflow output wrote `index.js`, `worker.mjs`, and Wrangler config, but cleanup only owned `worker.mjs` and `workflows`, so switching providers left deployable-looking `dist/**` output behind. This declares the complete Workflow-owned file surface, serializes wrapper ownership with provider output, and removes the output root when cleanup leaves it empty.

Cleanup checks whether the Workflow wrapper still owns `index.js`; if another ViteHub primitive has replaced it, shared Cloudflare files and base config are retained. When Workflow still owns the wrapper, its now-stale `main` and base fields are removed with it; sibling binding fragments remain intact.

Regression coverage switches Cloudflare to OpenWorkflow and proves user Wrangler fields, sibling Cloudflare output, and Nitro's `.vercel/output` survive. Internal coverage proves cleanup ownership observes preceding queued writes and rejects companion files that collide with the bundle outfile.

