### PR TITLE
fix(agent): infer automatic state from host

### DIFF
--- a/docs/content/docs/agents/chat-history-sessions.md
+++ b/docs/content/docs/agents/chat-history-sessions.md
@@ -114,7 +114,7 @@ The default resolver returns `null` for bot authors, so Chat SDK does not associ
 
 ## Persist state deliberately
 
-Chat History and the Concurrent Invocation Guard need an Agent State Provider when they should survive process restarts. Development state providers are useful locally, but hosted runtimes should configure durable state.
+Chat History and the Concurrent Invocation Guard need an Agent State Provider when they should survive process restarts. The default `provider: 'auto'` wires Cloudflare state only when the Agent host or runtime resolves to Cloudflare; Vercel, Netlify, and unknown hosted Node deployments use memory state. Configure a durable provider explicitly when that state must survive process restarts.
 
 ```ts [vite.config.ts]
 import { hubAgent } from '@vite-hub/agent/vite'

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -182,7 +182,7 @@ Capability `cli` can be a static command tree or an invocation resolver that ret
 
 ## Chat state
 
-Chat History and the Concurrent Invocation Guard need an Agent State Provider when they should survive a process restart. Hosted Node deployments use memory state by default outside Cloudflare, so they should configure a durable provider explicitly.
+Chat History and the Concurrent Invocation Guard need an Agent State Provider when they should survive a process restart. The default `provider: "auto"` wires Cloudflare state only when the Agent host or runtime resolves to Cloudflare; Vercel, Netlify, and unknown hosted Node deployments use memory state, so they should configure a durable provider explicitly.
 
 ```ts
 // vite.config.ts

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -5,6 +5,7 @@ import { dirname, join, relative, resolve } from "node:path"
 import { writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored } from "@vite-hub/internal/build/vite"
+import { getHostingProvider } from "@vite-hub/internal/feature-bridge/hosting"
 
 import { chatDevTools } from "./chat/devtools.ts"
 import { registerChatDevtoolsBridge } from "./chat/vite/devtools-bridge.ts"
@@ -277,10 +278,39 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
-function shouldInstallCloudflareAgentState(options: false | ResolvedAgentModuleOptions): options is ResolvedAgentModuleOptions {
+function readHostingPreset(value: unknown): string | undefined {
+  return isRecord(value) && typeof value.preset === "string" ? value.preset : undefined
+}
+
+function resolveAgentHosting(config: unknown): "cloudflare" | "netlify" | "vercel" | undefined {
+  const target = isRecord(config) ? config : {}
+  const values = [
+    readHostingPreset(target.vitehub),
+    typeof target.preset === "string" ? target.preset : undefined,
+    readHostingPreset(target.nitro),
+    process.env.VITEHUB_HOSTING,
+  ]
+  for (const value of values) {
+    const provider = getHostingProvider(value)
+    if (provider) return provider
+  }
+
+  if (process.env.CLOUDFLARE_WORKER || process.env.CF_PAGES) return "cloudflare"
+  if (process.env.VERCEL || process.env.VERCEL_ENV) return "vercel"
+  if (process.env.NETLIFY || process.env.NETLIFY_DEV || process.env.NETLIFY_LOCAL) return "netlify"
+}
+
+function shouldInstallCloudflareAgentState(
+  options: false | ResolvedAgentModuleOptions,
+  config: unknown,
+): options is ResolvedAgentModuleOptions {
   if (!options) return false
   const provider = options.providers.state.provider
-  return provider === "auto" || provider === "cloudflare" || provider === "cloudflare-agents"
+  if (provider === "cloudflare" || provider === "cloudflare-agents") return true
+  if (provider !== "auto") return false
+  if (options.runtime === "cloudflare-agents") return true
+  if (options.runtime === "vercel" || options.runtime === "deno") return false
+  return resolveAgentHosting(config) === "cloudflare"
 }
 
 function resolveEnvNameForValue(value: string | undefined): string | undefined {
@@ -435,17 +465,7 @@ function generatedWebhookRoute(route: false | string | undefined): string {
 }
 
 function isNetlifyHosting(config: ResolvedConfig): boolean {
-  const target = config as ResolvedConfig & { preset?: unknown, vitehub?: { preset?: unknown } }
-  const hosting = [
-    target.vitehub?.preset,
-    target.preset,
-    process.env.VITEHUB_HOSTING,
-    process.env.NETLIFY ? "netlify" : undefined,
-    process.env.NETLIFY_DEV ? "netlify" : undefined,
-    process.env.NETLIFY_LOCAL ? "netlify" : undefined,
-  ]
-  return hosting.some(value =>
-    typeof value === "string" && value.trim().toLowerCase().replaceAll("_", "-").includes("netlify"))
+  return resolveAgentHosting(config) === "netlify"
 }
 
 function resolveStringAliases(config: ResolvedConfig): Record<string, string> {
@@ -1228,7 +1248,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         await writeAgentWebhookRouteHandler(config.root, {
           agentImportBase: getAgentImportBase(agent),
           chatRoute: normalized.routes.chat,
-          cloudflareState: shouldInstallCloudflareAgentState(normalized),
+          cloudflareState: shouldInstallCloudflareAgentState(normalized, config),
           libsqlState: resolveLibsqlAgentState(normalized),
           ...(config.command === "serve" ? { runtime: "vite" as const } : {}),
           runtimeCapabilities,
@@ -1326,7 +1346,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       const resolved = normalizeAgentOptions(agent)
       const hasHostedAgents = Boolean(resolved && hasHostedAgentDefinitions(resolve(config.root || process.cwd())))
       const denoOutput = resolved && resolved.runtime === "deno"
-      const installCloudflareState = hasHostedAgents && !denoOutput && shouldInstallCloudflareAgentState(resolved)
+      const installCloudflareState = hasHostedAgents && !denoOutput && shouldInstallCloudflareAgentState(resolved, config)
       const nitroHandlers = [
         ...(resolved && hasHostedAgents && !denoOutput
           ? [{

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -752,7 +752,7 @@ describe("agent Vite plugin", () => {
     }
   })
 
-  it("installs Cloudflare chat state bindings for generated webhook routes", async () => {
+  it("installs automatic Cloudflare chat state for Cloudflare hosting", async () => {
     const { hubAgent } = await import("../src/vite.ts")
     const plugin = hubAgent()
     const result = typeof plugin.config === "function"
@@ -772,6 +772,7 @@ describe("agent Vite plugin", () => {
               },
             },
           },
+          preset: "cloudflare",
           root: hostedAgentRoot,
         } as never, { command: "build", mode: "production" })
       : undefined
@@ -808,6 +809,89 @@ describe("agent Vite plugin", () => {
       rolldownOptions: { external: ["existing", ...optionalMessageAdapterRuntimeExternals] },
       rollupOptions: { external: optionalMessageAdapterRuntimeExternals },
     })
+  })
+
+  it("keeps automatic chat state host-neutral for Vercel hosting", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const plugin = hubAgent({ devtools: false })
+    const result = typeof plugin.config === "function"
+      ? await plugin.config.call({} as never, {
+          preset: "vercel",
+          root: hostedAgentRoot,
+        } as never, { command: "build", mode: "production" })
+      : undefined
+    const output = result as {
+      nitro?: {
+        cloudflare?: unknown
+        handlers?: unknown[]
+        rollupConfig?: unknown
+      }
+    }
+
+    expect(output.nitro?.handlers).toContainEqual({
+      handler: ".vitehub/agent/chat-webhook-route.ts",
+      route: "/api/_vitehub/agents/:agent/chat",
+    })
+    expect(output.nitro?.handlers).toContainEqual({
+      handler: ".vitehub/agent/chat-webhook-route.ts",
+      route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
+    })
+    expect(output.nitro?.cloudflare).toBeUndefined()
+    expect(output.nitro?.rollupConfig).toBeUndefined()
+  })
+
+  it("prefers an explicit Vercel runtime over inferred Cloudflare hosting", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const plugin = hubAgent({ runtime: "vercel" })
+    const result = typeof plugin.config === "function"
+      ? await plugin.config.call({} as never, {
+          preset: "cloudflare",
+          root: hostedAgentRoot,
+        } as never, { command: "build", mode: "production" })
+      : undefined
+
+    expect((result as { nitro?: { cloudflare?: unknown } } | undefined)?.nitro?.cloudflare).toBeUndefined()
+  })
+
+  it("prefers explicit Cloudflare hosting over ambient Vercel CI", async () => {
+    const previousVercel = process.env.VERCEL
+    try {
+      process.env.VERCEL = "1"
+      const { hubAgent } = await import("../src/vite.ts")
+      const plugin = hubAgent()
+      const result = typeof plugin.config === "function"
+        ? await plugin.config.call({} as never, {
+            preset: "cloudflare",
+            root: hostedAgentRoot,
+          } as never, { command: "build", mode: "production" })
+        : undefined
+
+      expect((result as { nitro?: { cloudflare?: unknown } } | undefined)?.nitro?.cloudflare).toBeDefined()
+    }
+    finally {
+      if (previousVercel === undefined) delete process.env.VERCEL
+      else process.env.VERCEL = previousVercel
+    }
+  })
+
+  it("detects automatic Cloudflare hosting from the build environment", async () => {
+    const previousCloudflarePages = process.env.CF_PAGES
+    try {
+      process.env.CF_PAGES = "1"
+      const { hubAgent } = await import("../src/vite.ts")
+      const plugin = hubAgent()
+      const result = typeof plugin.config === "function"
+        ? await plugin.config.call({} as never, {
+            root: hostedAgentRoot,
+          } as never, { command: "build", mode: "production" })
+        : undefined
+
+      expect((result as { nitro?: { cloudflare?: unknown } } | undefined)?.nitro?.cloudflare).toBeDefined()
+    }
+    finally {
+      if (previousCloudflarePages === undefined) delete process.env.CF_PAGES
+      else process.env.CF_PAGES = previousCloudflarePages
+    }
   })
 
   it("keeps Cloudflare chat state opt-out when the state provider is memory", async () => {
@@ -895,15 +979,15 @@ describe("agent Vite plugin", () => {
       expect(webhookRoute).not.toContain("withAgentDefaults")
       expect(webhookRoute).toContain("const agentIdentities")
       expect(webhookRoute).toContain('"support": {"name":"support"}')
-      expect(webhookRoute).toContain("import { createCloudflareAgentState } from \"@vite-hub/agent/cloudflare\"")
+      expect(webhookRoute).not.toContain("import { createCloudflareAgentState } from \"@vite-hub/agent/cloudflare\"")
       expect(webhookRoute).toContain("async function toRequest(event)")
       expect(webhookRoute).toContain("const body = await readRawBody(event)")
       expect(webhookRoute).not.toContain("return event.request")
       expect(webhookRoute).toContain("function waitUntilFromEvent(event)")
-      expect(webhookRoute).toContain("function chatStateFromCloudflare(cloudflare)")
+      expect(webhookRoute).not.toContain("function chatStateFromCloudflare(cloudflare)")
       expect(webhookRoute).toContain("function resolveChatRouteOptions(module)")
       expect(webhookRoute).toContain("waitUntil: waitUntilFromEvent(event)")
-      expect(webhookRoute).toContain("state: chatStateFromCloudflare(cloudflare)")
+      expect(webhookRoute).not.toContain("state: chatStateFromCloudflare(cloudflare)")
       expect(webhookRoute).toContain("runtime: 'vite'")
       expect(webhookRoute).toContain("const agentModules")
       expect(webhookRoute).toContain("const chatHandlers")
@@ -914,6 +998,28 @@ describe("agent Vite plugin", () => {
       expect(webhookRoute).toContain("const agent = getRouterParam(event, 'agent') || (agentNames.length === 1 ? agentNames[0] : undefined)")
       expect(webhookRoute).toContain("return isWebhookRoute ? await handler(await toRequest(event), webhook")
       expect(webhookRoute).not.toContain("@vite-hub/schedule/runtime")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("writes generated Cloudflare state helpers for Cloudflare hosting", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-cloudflare-state-routes-"))
+    try {
+      await mkdir(join(root, "server", "agents"), { recursive: true })
+      await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+      const plugin = hubAgent()
+      if (typeof plugin.configResolved === "function") {
+        await plugin.configResolved.call({} as never, { command: "build", preset: "cloudflare", root } as never)
+      }
+
+      const webhookRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
+
+      expect(webhookRoute).toContain("import { createCloudflareAgentState } from \"@vite-hub/agent/cloudflare\"")
+      expect(webhookRoute).toContain("function chatStateFromCloudflare(cloudflare)")
+      expect(webhookRoute).toContain("state: chatStateFromCloudflare(cloudflare)")
     }
     finally {
       await rm(root, { force: true, recursive: true })
@@ -977,7 +1083,7 @@ describe("agent Vite plugin", () => {
       const webhookRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
 
       expect(webhookRoute).not.toContain("runtime: 'vite'")
-      expect(webhookRoute).toContain("return isWebhookRoute ? await handler(await toRequest(event), webhook, { agentIdentity: agentIdentities[agent], cloudflare, state: chatStateFromCloudflare(cloudflare), waitUntil: waitUntilFromEvent(event) }) : await handler(await toRequest(event), { agentIdentity: agentIdentities[agent], cloudflare, waitUntil: waitUntilFromEvent(event) })")
+      expect(webhookRoute).toContain("return isWebhookRoute ? await handler(await toRequest(event), webhook, { agentIdentity: agentIdentities[agent], cloudflare, waitUntil: waitUntilFromEvent(event) }) : await handler(await toRequest(event), { agentIdentity: agentIdentities[agent], cloudflare, waitUntil: waitUntilFromEvent(event) })")
     }
     finally {
       await rm(root, { force: true, recursive: true })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, observability, openapi, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type AgentObservabilityFinishExtension, type SubagentToolInput, type UsageTelemetryRecord } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -26,6 +26,29 @@ declare global {
 }
 
 describe("agent public types", () => {
+  it("keeps generated Channel routes out of hubAgent options", () => {
+    const options = {
+      devtools: false,
+      routes: { discordGateway: true },
+    } satisfies AgentModuleOptions
+    expectTypeOf(options.devtools).toEqualTypeOf<false>()
+
+    const chatRoute: AgentModuleOptions = {
+      routes: {
+        // @ts-expect-error Chat route ownership belongs to Channels.
+        chat: true,
+      },
+    }
+    const webhookRoute: AgentModuleOptions = {
+      routes: {
+        // @ts-expect-error Webhook route ownership belongs to Channels.
+        webhooks: true,
+      },
+    }
+    void chatRoute
+    void webhookRoute
+  })
+
   it("accepts zero-argument Channel factories and keeps configured Channels explicit", () => {
     interface RuntimeConfig extends AgentRuntimeConfig {
       token: string


### PR DESCRIPTION
Derives automatic Cloudflare Agent State installation from an explicit Agent runtime or a positively detected hosting provider. This prevents `hubAgent()` from adding Cloudflare bindings to Vercel, Netlify, and unknown hosted Node builds while preserving explicit Cloudflare configuration and Channel-owned generated routes.

Keeps `devtools: false` as an intentional application override, adds focused runtime and type coverage for the inferred configuration, and documents when durable state still needs an explicit provider.