### PR TITLE
refactor(agent)!: remove stream channel

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -13,21 +13,20 @@ Channel Kind helpers are imported from `@vite-hub/agent/channels`, not the root 
 
 ```ts [server/agents/support.ts]
 import { defineAgent } from '@vite-hub/agent'
-import { github, stream, webChat } from '@vite-hub/agent/channels'
+import { github, webChat } from '@vite-hub/agent/channels'
 
 export default defineAgent({
   channels: {
     github: github({ pullRequest: true }),
-    portal: stream,
-    web: webChat(),
+    portal: webChat,
   },
   run: () => 'ok',
 })
 ```
 
-Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`, `telegram()`, `stream()`, and `webChat()`. A synchronous Channel factory that needs no options can be registered directly, so `channels: { stream }` is equivalent to `channels: { stream: stream() }` and resolves once when `defineAgent()` runs. Call the helper when passing options, such as `stream({ messages: { sessions: false } })`. Use `defineChannel(kind, options)` for an app-owned Channel Kind.
+Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`, `telegram()`, and `webChat()`. A synchronous Channel factory that needs no options can be registered directly, so `channels: { portal: webChat }` is equivalent to `channels: { portal: webChat() }` and resolves once when `defineAgent()` runs. Call the helper when passing options, such as `webChat({ messages: { sessions: false } })`. Use `defineChannel(kind, options)` for an app-owned Channel Kind.
 
-Adapter-backed Channels deliver only the completed response by default. Set top-level `defineAgent({ messages: { stream: true } })` to opt into draft and edit updates, or use the same `messages` option on the Channel when it is the Agent's only message-shaped Channel. Route-backed Stream and Web Chat Channels continue to return streaming responses.
+Adapter-backed Channels deliver only the completed response by default. Set top-level `defineAgent({ messages: { stream: true } })` to opt every adapter Channel into draft and edit updates, or set `messages.stream` on an individual Channel to control progressive delivery for that destination. Web Chat routes return streaming HTTP responses independently of adapter delivery settings.
 
 ## Scope capabilities to a Channel
 
@@ -126,7 +125,7 @@ The legacy `chat` context value remains available through `context.get('chat')` 
 
 ## Admit web chat requests
 
-Use `webChat({ route })` when an app-owned web chat route needs the common AI SDK UI-message request shape but still owns authentication and product context.
+Use `webChat()` when a web destination should expose the generated AI SDK UI-message route. Pass `route` options when the route needs authentication or product context, or set `route: false` when application code invokes the Channel from its own handler.
 
 ```ts [server/agents/support.ts]
 import { defineAgent } from '@vite-hub/agent'

--- a/docs/content/docs/concepts/channels-api.md
+++ b/docs/content/docs/concepts/channels-api.md
@@ -13,7 +13,7 @@ Channel definitions own invocation reachability, route admission, and delivery f
 
 ## Message-shaped invocation
 
-Generated routes should be configured on Channel definitions, such as `webChat({ route })` or `defineChannel(kind, { route })`. Application code should not import generated route handler factories.
+Generated routes should be configured on Channel definitions. `webChat()` enables its route by default, while `webChat({ route })` customizes admission and input mapping; application code should not import generated route handler factories.
 
 Application routes can consume the same trigger directly when the app owns the chat UI.
 

--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -14,7 +14,7 @@ They may resolve to Runtime Registries, generated files, virtual modules, or pac
 | --- | --- | --- |
 | `@vite-hub/agent` | Agent Package | Agent Definition helpers, invocation helpers, trigger helpers, Agent Actor types, and legacy Agent Invoker compatibility types. |
 | `@vite-hub/agent/capabilities` | Agent Package | Official Capability factories such as `access()`, `browser()`, `workspaceShell()`, `inputCommands()`, and `subagents()`. |
-| `@vite-hub/agent/channels` | Agent Package | Official Channel Kind helpers such as `github()`, `stream()`, `teams()`, `telegram()`, `webChat()`, and `defineChannel()`. |
+| `@vite-hub/agent/channels` | Agent Package | Official Channel Kind helpers such as `github()`, `teams()`, `telegram()`, `webChat()`, and `defineChannel()`. |
 | `@vite-hub/agent/eval` | Agent Package | Agent Eval authoring helpers. |
 | `@vite-hub/agent/test` | Agent Package | Agent test runner helpers for local and CI Agent Invocation checks. |
 | `@vite-hub/agent/harness/local-sandbox` | Agent Package | Trusted local harness sandbox helper for development and Agent Evals. |

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -99,21 +99,13 @@ export interface AgentChannelOptions<TRuntimeConfig extends AgentRuntimeConfig =
 type AgentChannelDefinitionOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> =
   Omit<AgentChannelDefinition<TRuntimeConfig>, "kind">
 
-export interface AgentStreamChannelOptions<
-  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody,
-  TAuth = unknown,
->
-  extends AgentChannelOptions<TRuntimeConfig> {
-  route?: true | AgentChannelChatRouteHandlerOptions<TBody, TAuth>
-}
-
 export interface AgentWebChatChannelOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody,
   TAuth = unknown,
->
-  extends AgentStreamChannelOptions<TRuntimeConfig, TBody, TAuth> {}
+> extends AgentChannelOptions<TRuntimeConfig> {
+  route?: boolean | AgentChannelChatRouteHandlerOptions<TBody, TAuth>
+}
 
 type GitHubAppValue<T, TRuntimeConfig extends AgentRuntimeConfig> =
   MaybeResolvable<T, AgentCallbackContext<TRuntimeConfig> | AgentChannelDeliveryEffectContext<TRuntimeConfig>>
@@ -1867,19 +1859,6 @@ export function teams<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCo
   return defineChannel("teams", options)
 }
 
-export function stream<
-  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody,
-  TAuth = unknown,
->(
-  options: AgentStreamChannelOptions<TRuntimeConfig, TBody, TAuth> = {},
-): AgentChannelDefinition<TRuntimeConfig> {
-  return defineChannel("stream", {
-    ...options,
-    route: options.route ?? true,
-  })
-}
-
 export function telegram<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   options: AgentChannelOptions<TRuntimeConfig> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {
@@ -1896,5 +1875,8 @@ export function webChat<
 >(
   options: AgentWebChatChannelOptions<TRuntimeConfig, TBody, TAuth> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {
-  return defineChannel("web-chat", options)
+  return defineChannel("web-chat", {
+    ...options,
+    route: options.route ?? true,
+  })
 }

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -203,9 +203,14 @@ export function resolveAgentChannelChatOptions<TRuntimeConfig extends AgentRunti
   }
   if (channelMessageOverrides.length) {
     if (messageChannelCount > 1) {
-      throw new TypeError("[vitehub] Channel-local messages options are only supported when an Agent defines one message-shaped Channel. Move shared settings to defineAgent({ messages }) until Channel-scoped chat triggers land.")
+      const unsupportedOverrides = channelMessageOverrides.some(({ stream: _stream, ...channelMessages }) => Object.keys(channelMessages).length > 0)
+      if (unsupportedOverrides) {
+        throw new TypeError("[vitehub] Channel-local messages options other than stream are only supported when an Agent defines one message-shaped Channel. Move shared settings to defineAgent({ messages }) until Channel-scoped chat triggers land.")
+      }
     }
-    Object.assign(options, channelMessageOverrides[0])
+    else {
+      Object.assign(options, channelMessageOverrides[0])
+    }
   }
   if (Object.keys(platforms).length) {
     options.platforms = platforms

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -378,10 +378,25 @@ function getAgentChatOptions(agent: unknown): AgentChatOptions | undefined {
   return getChatCapabilityOptions(getAgentCapabilities(agent)) || definition.chat
 }
 
-function hasExplicitNonStreamingMessages(agent: unknown): boolean {
+function getChannelChatOptions(
+  agent: unknown,
+  channelId: string | undefined,
+  options: AgentChatOptions | undefined,
+): AgentChatOptions | undefined {
+  if (!channelId || !isRecord(agent) || !isRecord(agent.channels)) return options
+  const channel = agent.channels[channelId]
+  if (!isRecord(channel) || !isRecord(channel.messages)) return options
+  return { ...options, ...channel.messages }
+}
+
+function hasExplicitNonStreamingMessages(agent: unknown, channelId?: string): boolean {
   if (!isRecord(agent)) return false
   if (isRecord(agent.messages) && agent.messages.stream === false) return true
   if (!isRecord(agent.channels)) return true
+  if (channelId) {
+    const channel = agent.channels[channelId]
+    return isRecord(channel) && isRecord(channel.messages) && channel.messages.stream === false
+  }
   const channels = Object.values(agent.channels)
   if (!channels.some(channel => isRecord(channel) && channel.adapter && channel.messages !== false)) return true
   return channels.some(
@@ -2718,8 +2733,8 @@ export function createChannelWebhookRouteHandler(
         }
       }
 
-      const chatOptions = getAgentChatOptions(agent)
-      const adapters = await resolveChatAdapters(chatOptions, context)
+      const baseChatOptions = getAgentChatOptions(agent)
+      const adapters = await resolveChatAdapters(baseChatOptions, context)
       const adapterName = resolveChatAdapterName(adapters, registration)
       const adapter = adapterName ? adapters[adapterName] : undefined
       if (!adapter) {
@@ -2727,9 +2742,10 @@ export function createChannelWebhookRouteHandler(
       }
 
       try {
+        const chatOptions = getChannelChatOptions(agent, registration.channelId, baseChatOptions)
         const handler = await createChatWebhookHandler(agent, context, registration, adapterName!, adapter, chatOptions, handlerOptions)
         const response = await handler(request, { waitUntil: context.waitUntil })
-        if (chatOptions?.stream === false && hasExplicitNonStreamingMessages(agent)) {
+        if (chatOptions?.stream === false && hasExplicitNonStreamingMessages(agent, registration.channelId)) {
           await context.flushWaitUntil?.()
         }
         return response

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1848,9 +1848,9 @@ describe("server helpers", () => {
     await expect(response.text()).rejects.toThrow("upstream failed")
   })
 
-  it("serves stream Channel chat routes with channel-owned trusted input mapping", async () => {
+  it("serves default webChat routes with channel-owned trusted input mapping", async () => {
     const { defineAgent } = await import("../src/index.ts")
-    const { stream } = await import("../src/channels.ts")
+    const { webChat } = await import("../src/channels.ts")
     const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const run = vi.fn(({ context, invoker, run }) => {
       const chatContext = context.get("chat") as { meta?: { audience?: string }, user?: { email?: string } } | undefined
@@ -1858,7 +1858,7 @@ describe("server helpers", () => {
     })
     const handler = createChannelChatRouteHandler(defineAgent({
       channels: {
-        portal: stream({
+        portal: webChat({
           route: {
             mapInput({ body, request }) {
               if (request.headers.get("x-quiver-chat-token") !== "trusted") {
@@ -2535,12 +2535,12 @@ describe("server helpers", () => {
 
   it("defaults adapter-backed Channels to final-only delivery", async () => {
     const { defineAgent } = await import("../src/index.ts")
-    const { stream, telegram } = await import("../src/channels.ts")
+    const { telegram, webChat } = await import("../src/channels.ts")
     const { createChannelChatRouteHandler, createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const agent = defineAgent({
       channels: {
-        stream,
+        web: webChat,
         telegram: telegram({ adapter: () => adapter as never }),
       },
       driver: { run: () => ({ text: "final answer" }) },
@@ -2581,6 +2581,44 @@ describe("server helpers", () => {
     }))
     expect(streamResponse.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
     await expect(streamResponse.text()).resolves.toContain("final answer")
+  })
+
+  it("scopes progressive delivery to the active Channel", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const progressiveAdapter = createTestChatAdapter()
+    const finalAdapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        final: telegram({ adapter: () => finalAdapter as never, messages: { stream: false } }),
+        progressive: telegram({ adapter: () => progressiveAdapter as never, messages: { stream: true } }),
+      },
+      driver: { run: () => ({ text: "channel reply" }) },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    const request = (messageId: number) => new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: messageId,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: messageId,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    })
+
+    await handler(request(1), "progressive")
+    expect(progressiveAdapter.postMessage).toHaveBeenCalledWith("telegram:456", "...")
+    expect(progressiveAdapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "channel reply" })
+
+    await handler(request(2), "final")
+    expect(finalAdapter.postMessage).toHaveBeenCalledOnce()
+    expect(finalAdapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "channel reply" })
+    expect(finalAdapter.editMessage).not.toHaveBeenCalled()
   })
 
   it("splits long Discord chat output after stream finalization", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4943,8 +4943,8 @@ describe("agent message protocol", () => {
 
   it("resolves zero-argument Channel factories once per Agent definition", async () => {
     const { defineAgent } = await import("../src/index.ts")
-    const { defineChannel, stream } = await import("../src/channels.ts")
-    const factory = vi.fn(() => stream())
+    const { defineChannel, webChat } = await import("../src/channels.ts")
+    const factory = vi.fn(() => webChat())
     const existing = defineChannel("custom")
     const workspace = { sources: {} }
 
@@ -4974,9 +4974,9 @@ describe("agent message protocol", () => {
     })).toThrowError(new TypeError('[vitehub] Channel factory "broken" must return an Agent Channel definition.'))
   })
 
-  it("keeps shorthand and explicit Stream Channels equivalent on generated routes", async () => {
+  it("enables equivalent generated routes for shorthand and explicit Web Chat Channels", async () => {
     const { defineAgent } = await import("../src/index.ts")
-    const { stream, webChat } = await import("../src/channels.ts")
+    const { webChat } = await import("../src/channels.ts")
     const { createChannelChatRouteHandler, hasChannelChatRoute } = await import("../src/server/internal.ts")
     const shorthandRun = vi.fn(({ run }) => `${run.channelId}:${run.origin}`)
     const explicitRun = vi.fn(({ run }) => `${run.channelId}:${run.origin}`)
@@ -4987,23 +4987,36 @@ describe("agent message protocol", () => {
       method: "POST",
     })
 
-    const shorthand = defineAgent({ channels: { portal: stream }, driver: { run: shorthandRun } })
-    const explicit = defineAgent({ channels: { portal: stream() }, driver: { run: explicitRun } })
-    const routeDisabled = defineAgent({ channels: { portal: webChat() }, driver: { run: () => "ok" } })
+    const shorthand = defineAgent({ channels: { portal: webChat }, driver: { run: shorthandRun } })
+    const explicit = defineAgent({ channels: { portal: webChat() }, driver: { run: explicitRun } })
+    const routeDisabled = defineAgent({ channels: { portal: webChat({ route: false }) }, driver: { run: () => "ok" } })
     const shorthandResponse = await createChannelChatRouteHandler(shorthand as never)(request(), { agentName: "support" })
     const explicitResponse = await createChannelChatRouteHandler(explicit as never)(request(), { agentName: "support" })
 
     expect(shorthandResponse.status).toBe(200)
     expect(explicitResponse.status).toBe(200)
-    expect(shorthandRun).toHaveBeenCalledWith(expect.objectContaining({ run: expect.objectContaining({ channelId: "portal", origin: "stream" }) }))
-    expect(explicitRun).toHaveBeenCalledWith(expect.objectContaining({ run: expect.objectContaining({ channelId: "portal", origin: "stream" }) }))
+    expect(shorthandRun).toHaveBeenCalledWith(expect.objectContaining({ run: expect.objectContaining({ channelId: "portal", origin: "web-chat" }) }))
+    expect(explicitRun).toHaveBeenCalledWith(expect.objectContaining({ run: expect.objectContaining({ channelId: "portal", origin: "web-chat" }) }))
     expect(hasChannelChatRoute(explicit as never)).toBe(true)
     expect(hasChannelChatRoute(routeDisabled as never)).toBe(false)
 
     expect(() => createChannelChatRouteHandler(defineAgent({
-      channels: { first: stream, second: stream },
+      channels: { first: webChat, second: webChat },
       driver: { run: () => "ok" },
     }) as never)).toThrow("multiple route-enabled Channels")
+  })
+
+  it("accepts channel-local stream delivery across multiple message-shaped channels", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { teams, telegram } = await import("../src/channels.ts")
+
+    expect(() => defineAgent({
+      channels: {
+        teams: teams({ adapter: () => ({}) as never, messages: { stream: false } }),
+        telegram: telegram({ adapter: () => ({}) as never, messages: { stream: true } }),
+      },
+      driver: { run: () => "ok" },
+    })).not.toThrow()
   })
 
   it("applies channel-local message settings for one message-shaped channel", async () => {
@@ -5038,7 +5051,7 @@ describe("agent message protocol", () => {
         web: webChat({ messages: { triggerHistory: "none" } }),
       },
       driver: { run: () => "ok" },
-    })).toThrow("Channel-local messages options are only supported when an Agent defines one message-shaped Channel")
+    })).toThrow("Channel-local messages options other than stream are only supported when an Agent defines one message-shaped Channel")
   })
 
   it("rejects channel-local identity across multiple message-shaped channels", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, observability, openapi, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, usageTelemetry, webSearch, workspaceShell, type SubagentToolInput, type UsageTelemetryRecord } from "../src/capabilities.ts"
-import { defineChannel, github, http, pullRequest, stream, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
+import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
@@ -30,19 +30,19 @@ describe("agent public types", () => {
     interface RuntimeConfig extends AgentRuntimeConfig {
       token: string
     }
-    const factory: AgentChannelFactory = stream
-    const runtimeFactory: AgentChannelFactory<RuntimeConfig> = stream
+    const factory: AgentChannelFactory = webChat
+    const runtimeFactory: AgentChannelFactory<RuntimeConfig> = webChat
     const input: AgentChannelInput = factory
     const inputs: AgentChannelInputs = { portal: input }
 
     defineAgent({ channels: inputs, driver: { run: () => "ok" } })
-    const runtimeAgent = defineAgent<RuntimeConfig>({ channels: { stream: runtimeFactory }, driver: { run: () => "ok" } })
-    expectTypeOf(runtimeAgent.channels?.stream).toEqualTypeOf<AgentChannelDefinition<RuntimeConfig> | undefined>()
-    defineAgent({ channels: { portal: stream }, driver: { run: () => "ok" } })
-    defineAgent({ channels: { portal: stream() }, driver: { run: () => "ok" } })
-    defineAgent({ channels: { portal: stream({ messages: { sessions: false } }) }, driver: { run: () => "ok" } })
+    const runtimeAgent = defineAgent<RuntimeConfig>({ channels: { web: runtimeFactory }, driver: { run: () => "ok" } })
+    expectTypeOf(runtimeAgent.channels?.web).toEqualTypeOf<AgentChannelDefinition<RuntimeConfig> | undefined>()
+    defineAgent({ channels: { portal: webChat }, driver: { run: () => "ok" } })
+    defineAgent({ channels: { portal: webChat() }, driver: { run: () => "ok" } })
+    defineAgent({ channels: { portal: webChat({ messages: { sessions: false } }) }, driver: { run: () => "ok" } })
 
-    const requiresOptions = (_options: { route: boolean }) => stream()
+    const requiresOptions = (_options: { route: boolean }) => webChat()
     defineAgent({
       channels: {
         // @ts-expect-error Channel factories cannot require arguments.
@@ -62,7 +62,7 @@ describe("agent public types", () => {
     defineAgent({
       channels: {
         // @ts-expect-error Channel factories must resolve synchronously.
-        portal: async () => stream(),
+        portal: async () => webChat(),
       },
       driver: { run: () => "ok" },
     })
@@ -943,7 +943,7 @@ describe("agent public types", () => {
         telegram: telegram({
           adapter: () => ({}) as never,
         }),
-        portalStream: stream({
+        portalWeb: webChat({
           route: {
             mapInput({ body, request }) {
               expectTypeOf(body.messages).toEqualTypeOf<unknown>()
@@ -1022,6 +1022,7 @@ describe("agent public types", () => {
     type ChannelExports = typeof import("../src/channels.ts")
     type _PublicDefineChannel = ChannelExports["defineChannel"]
     type _PublicGithub = ChannelExports["github"]
+    // @ts-expect-error streaming is delivery behavior, not a public Channel Kind.
     type _PublicStream = ChannelExports["stream"]
     type _PublicTelegram = ChannelExports["telegram"]
     type _PublicTeams = ChannelExports["teams"]

--- a/test/local/deno-real-project.mjs
+++ b/test/local/deno-real-project.mjs
@@ -104,10 +104,10 @@ async function writeFixtureFiles(overrides) {
   await mkdir(join(appDir, "server", "agents"), { recursive: true })
   await writeFile(join(appDir, "server", "agents", "support.ts"), [
     "import { defineAgent } from \"@vite-hub/agent\"",
-    "import { stream } from \"@vite-hub/agent/channels\"",
+    "import { webChat } from \"@vite-hub/agent/channels\"",
     "",
     "export default defineAgent({",
-    "  channels: { portal: stream },",
+    "  channels: { portal: webChat },",
     "  driver: {",
     "    run({ messages }) {",
     "      const latest = messages.at(-1)",

--- a/test/local/netlify-real-project.mjs
+++ b/test/local/netlify-real-project.mjs
@@ -90,11 +90,11 @@ async function writeFixtureFiles(overrides) {
   await writeFile(join(appDir, "src", "lib", "reply.ts"), "export const replyMarker = \"netlify-alias-ok\"\n", "utf8")
   await writeFile(join(appDir, "server", "agents", "support.ts"), [
     "import { defineAgent } from \"@vite-hub/agent\"",
-    "import { stream } from \"@vite-hub/agent/channels\"",
+    "import { webChat } from \"@vite-hub/agent/channels\"",
     "import { replyMarker } from \"@/lib/reply\"",
     "",
     "export default defineAgent({",
-    "  channels: { portal: stream },",
+    "  channels: { portal: webChat },",
     "  driver: {",
     "    run({ messages }) {",
     "      const latest = messages.at(-1)",


### PR DESCRIPTION
Removes the public `stream()` Channel factory and `"stream"` kind, and makes `webChat()` the route-enabled default for AI SDK UI-message-stream HTTP chat. This keeps Channels destination-named while runtime and HTTP streaming APIs remain unchanged.

Resolves `messages.stream` from the active adapter-backed Channel so progressive delivery is channel-scoped. Tests, docs, and the Deno and Netlify fixtures now use `webChat()` directly; other channel-local message settings retain their existing single-message-Channel limitation.