### PR TITLE
feat(agent)!: rename folder entry to agent.ts

### DIFF
--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -7,7 +7,7 @@ icon: i-lucide-file-user
 
 An Agent Definition is the code declaration that names one Agent and configures how it runs. It owns the Agent Driver, optional Box, attached Capabilities, Workspace context, Agent Invoker options, and lifecycle hooks.
 
-ViteHub discovers Agent Definitions from `server/agents`. The Agent File Name or folder name provides the discovered identity, so `server/agents/support.ts` and `server/agents/support/config.ts` both create a `support` Agent.
+ViteHub discovers Agent Definitions from `server/agents`. The Agent File Name or folder name provides the discovered identity, so `server/agents/support.ts` and `server/agents/support/agent.ts` both create a `support` Agent.
 
 ## Define the Agent
 
@@ -57,7 +57,7 @@ Tools are contributed by Capabilities. They are not top-level Agent Definition f
 
 Workspace context gives the Agent a file tree and Sources. The Workspace owns file visibility, while Capabilities decide whether the active Agent Driver receives model-facing tools or other driver-compatible inputs.
 
-```ts [server/agents/docs/config.ts]
+```ts [server/agents/docs/agent.ts]
 import { gateway } from '@ai-sdk/gateway'
 import { defineAgent } from '@vite-hub/agent'
 import { workspaceShell } from '@vite-hub/agent/capabilities'

--- a/docs/content/docs/agents/agent-drivers.md
+++ b/docs/content/docs/agents/agent-drivers.md
@@ -54,7 +54,7 @@ Install the Agent Package with the harness adapter package you use.
 pnpm add @vite-hub/agent @ai-sdk/harness @ai-sdk/harness-codex @ai-sdk/sandbox-vercel
 ```
 
-```ts [server/agents/codex/config.ts]
+```ts [server/agents/codex/agent.ts]
 import { createCodex } from '@ai-sdk/harness-codex'
 import { defineAgent } from '@vite-hub/agent'
 

--- a/docs/content/docs/agents/boxes.md
+++ b/docs/content/docs/agents/boxes.md
@@ -19,7 +19,7 @@ pnpm add @vite-hub/agent @vite-hub/box @ai-sdk/harness @ai-sdk/harness-codex
 
 Declare the Box inline. You do not need a separate `defineBox()` call.
 
-```ts [server/agents/babysitter/config.ts]
+```ts [server/agents/babysitter/agent.ts]
 import { defineAgent } from '@vite-hub/agent'
 import { codexDriver } from '@vite-hub/agent/harness/codex'
 import { trustedHost } from '@vite-hub/box'

--- a/docs/content/docs/agents/evals.md
+++ b/docs/content/docs/agents/evals.md
@@ -13,7 +13,7 @@ Keep the harness adapter, credentials, session key, harness sandbox provider, an
 
 ## Define an eval
 
-Create eval files beside the Agent they protect. A sibling `support.eval.ts` can import `./support`, and a folder-level `eval.ts` can infer `./config`.
+Create eval files beside the Agent they protect. A sibling `support.eval.ts` can import `./support`, and a folder-level `eval.ts` can infer `./agent`.
 
 ```ts [server/agents/support.eval.ts]
 import { defineEval } from '@vite-hub/agent/eval'

--- a/docs/content/docs/agents/index.md
+++ b/docs/content/docs/agents/index.md
@@ -33,7 +33,7 @@ An Agent Definition keeps the execution boundary visible in one file. The Agent 
 
 Define the driver first, then attach the abilities and context the Agent needs.
 
-```ts [server/agents/support/config.ts]
+```ts [server/agents/support/agent.ts]
 import { gateway } from '@ai-sdk/gateway'
 import { defineAgent } from '@vite-hub/agent'
 import { workspaceShell } from '@vite-hub/agent/capabilities'
@@ -61,7 +61,7 @@ export default defineAgent({
 })
 ```
 
-The discovered Agent identity comes from the file or folder name under `server/agents`. `server/agents/support/config.ts` creates the `support` Agent.
+The discovered Agent identity comes from the file or folder name under `server/agents`. `server/agents/support/agent.ts` creates the `support` Agent.
 
 ## Reach product surfaces
 

--- a/docs/content/docs/agents/instructions.md
+++ b/docs/content/docs/agents/instructions.md
@@ -27,7 +27,7 @@ Answer from inspected workspace evidence before using outside knowledge.
 When sources do not answer the question, say that directly.
 ```
 
-```ts [server/agents/support/config.ts]
+```ts [server/agents/support/agent.ts]
 import { gateway } from '@ai-sdk/gateway'
 import { defineAgent } from '@vite-hub/agent'
 
@@ -93,7 +93,7 @@ The value must already exist in invocation context. Missing `context.*` bindings
 
 Use Workspace bindings when instruction text should read explicit Workspace-owned values. Bind scalar values with `{{ workspace.<name> }}`.
 
-```ts [server/agents/support/config.ts]
+```ts [server/agents/support/agent.ts]
 import { gateway } from '@ai-sdk/gateway'
 import { defineAgent } from '@vite-hub/agent'
 
@@ -185,7 +185,7 @@ Coverage warnings clear only when Agent Driver Instructions, or a deterministic 
 
 Harness-backed drivers have two instruction surfaces with different lifetimes. A colocated `instructions.md` is durable repository guidance that ViteHub renders into the Harness Workspace Session as `AGENTS.md` and `CLAUDE.md`. `driver.instructions` is resolved for each invocation and passed to the AI SDK `HarnessAgent` constructor, which fits runtime policy derived from call options or invocation context.
 
-```ts [server/agents/review/config.ts]
+```ts [server/agents/review/agent.ts]
 import { defineAgent } from '@vite-hub/agent'
 import { codexDriver } from '@vite-hub/agent/harness/codex'
 

--- a/docs/content/docs/agents/workspace-context.md
+++ b/docs/content/docs/agents/workspace-context.md
@@ -42,7 +42,7 @@ export default defineConfig({
 })
 ```
 
-```ts [server/agents/docs/config.ts]
+```ts [server/agents/docs/agent.ts]
 import { gateway } from '@ai-sdk/gateway'
 import { defineAgent } from '@vite-hub/agent'
 import { workspaceShell } from '@vite-hub/agent/capabilities'
@@ -76,7 +76,7 @@ The Workspace supplies files. The Workspace Shell Capability exposes read or wri
 
 Use a string when another Agent should read an existing Workspace. Use `{ name, mode: 'write' }` when it should write artifacts into that same Workspace File Tree.
 
-```ts [server/agents/summary/config.ts]
+```ts [server/agents/summary/agent.ts]
 export default defineAgent({
   workspace: { name: 'review', mode: 'write' },
   capabilities: [
@@ -105,7 +105,7 @@ Use `workspace.bindings` when an instruction document needs an explicit Workspac
 
 Use read mode when the Agent only needs to inspect files. Use write mode only when the product expects the Agent to mutate Workspace files and Workspace Rules allow the target paths.
 
-```ts [server/agents/docs/config.ts]
+```ts [server/agents/docs/agent.ts]
 import { workspaceShell } from '@vite-hub/agent/capabilities'
 
 export const workspaceAccess = [
@@ -119,7 +119,7 @@ Workspace access is not process access by default. Use execution Capabilities de
 
 Harness-backed Agent Drivers receive Workspace state through a Harness Workspace Session instead of model-facing Workspace Tools by default.
 
-```ts [server/agents/review/config.ts]
+```ts [server/agents/review/agent.ts]
 import { createCodex } from '@ai-sdk/harness-codex'
 import { defineAgent } from '@vite-hub/agent'
 import { skills } from '@vite-hub/agent/capabilities'
@@ -145,7 +145,7 @@ Read mode materializes the selected Workspace into the harness sandbox and disca
 
 Use the Access Capability when the Agent Invoker should narrow the visible Workspace Scope for one Agent Invocation.
 
-```ts [server/agents/support/config.ts]
+```ts [server/agents/support/agent.ts]
 import { access, workspaceShell } from '@vite-hub/agent/capabilities'
 
 export const supportCapabilities = [
@@ -178,7 +178,7 @@ When the Agent needs scope-specific model guidance, write it in Agent Driver Ins
 
 Source Resolution can narrow a Source from trusted invocation context, such as a Selected Workspace Scope or an Agent Invocation Context Value. Source Resolution is source shaping, not authorization.
 
-```ts [server/agents/support/config.ts]
+```ts [server/agents/support/agent.ts]
 import { github } from '@vite-hub/workspace'
 
 export const supportSources = {

--- a/docs/content/docs/concepts/definitions-and-discovery.md
+++ b/docs/content/docs/concepts/definitions-and-discovery.md
@@ -21,7 +21,7 @@ Generated Agent hosts carry that discovery identity as `context.agentIdentity`, 
 
 ```txt [Definition paths]
 server/agents/support.ts          -> support
-server/agents/docs/config.ts      -> docs
+server/agents/docs/agent.ts      -> docs
 src/triager.agent.ts              -> triager
 server/auth.ts                    -> Primary Auth Definition
 server.auth.ts                    -> Primary Auth Definition alias

--- a/docs/content/docs/reference/file-conventions.md
+++ b/docs/content/docs/reference/file-conventions.md
@@ -11,14 +11,14 @@ File conventions produce Discovered Definitions. Discovery Identity comes from t
 
 | Definition | Directory convention | Suffix convention | Discovery Identity |
 | --- | --- | --- | --- |
-| Agent | `server/agents/<name>.ts` or `server/agents/<name>/config.ts` | `<path>.agent.ts` outside `server/` | Relative file or directory path. A leading `src/` is removed from suffix identities. |
+| Agent | `server/agents/<name>.ts` or `server/agents/<name>/agent.ts` | `<path>.agent.ts` outside `server/` | Relative file or directory path. A leading `src/` is removed from suffix identities. |
 | Auth | `server/auth.ts` | `server.auth.ts` | `default`. Only one Auth Definition is allowed. |
 | Database | `server/databases/config.ts` for one default database, or `server/databases/<name>/config.ts` for named databases | `src/database.ts` for the default database, or `<path>.database.ts` for a named database | `default` or the normalized relative path. Default and named modes cannot be mixed. |
 | Queue | `server/queues/<path>.ts` | `<path>.queue.ts` | Normalized relative path. A leading `src/` is removed from suffix identities. |
 | Workflow | `server/workflows/<path>.ts` or a folder containing `index.ts` or numbered step files | `<path>.workflow.ts` | Normalized relative file or folder path. Agent Definitions using `runtime: workflow(...)` also contribute their selected workflow identity. |
 | Schedule | `server/schedules/<path>.ts` | `<path>.schedule.ts` | Normalized relative path. A leading `src/` is removed from suffix identities. |
 | Sandbox | `server/sandboxes/<path>.ts` | `<path>.sandbox.ts` outside `server/sandboxes/` | Normalized relative path, without a trailing `.sandbox` segment. |
-| Workspace | `server/workspaces/<path>.ts`, `server/workspaces/<name>/config.ts`, or `server/agents/<name>/config.ts` when the Agent declares a Workspace | `<path>.workspace.ts` | Normalized relative path or the colocated Agent name. |
+| Workspace | `server/workspaces/<path>.ts`, `server/workspaces/<name>/config.ts`, or `server/agents/<name>/agent.ts` when the Agent declares a Workspace | `<path>.workspace.ts` | Normalized relative path or the colocated Agent name. |
 
 The table uses `.ts` for brevity. Directory and suffix patterns accept JavaScript and TypeScript module variants where the owning package permits them. `src/database.ts` is the exact default Database suffix-mode file.
 

--- a/docs/content/docs/server-primitives/kv.md
+++ b/docs/content/docs/server-primitives/kv.md
@@ -146,7 +146,7 @@ Application code should keep importing `kv` from `@vite-hub/kv` when switching b
 
 Direct KV access is for app and server code. To let a model inspect or edit scoped key-value data, attach the KV Capability from the agent capability catalog.
 
-```ts [server/agents/support/config.ts]
+```ts [server/agents/support/agent.ts]
 import { kv } from '@vite-hub/agent/capabilities'
 ```
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -6,7 +6,7 @@
   <img alt="AI SDK" src="https://img.shields.io/badge/AI%20SDK-v7-111827?style=flat-square">
 </p>
 
-`@vite-hub/agent` defines model-backed agents from files such as `server/agents/support/config.ts`.
+`@vite-hub/agent` defines model-backed agents from files such as `server/agents/support/agent.ts`.
 
 Keep the three pieces separate:
 
@@ -37,7 +37,7 @@ For non-local omitted sandbox fallback, also add `@ai-sdk/sandbox-vercel`.
 ## Minimal API
 
 ```ts
-// server/agents/support/config.ts
+// server/agents/support/agent.ts
 import { gateway } from "@ai-sdk/gateway"
 import { defineAgent } from "@vite-hub/agent"
 import { chat, workspaceShell } from "@vite-hub/agent/capabilities"
@@ -67,7 +67,7 @@ export default defineAgent({
 Harness-backed agents use AI SDK `HarnessAgent` behind the ViteHub Agent Driver boundary.
 
 ```ts
-// server/agents/codex/config.ts
+// server/agents/codex/agent.ts
 import { defineAgent } from "@vite-hub/agent"
 import { codexDriver } from "@vite-hub/agent/harness/codex"
 import { file } from "@vite-hub/workspace"

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -11,7 +11,8 @@ import {
 import type { DiscoveredAgentDefinition } from "./types.ts"
 
 const agentSuffixPattern = /\.agent\.(?:c|m)?[jt]s$/i
-const configPattern = /^config\.(?:c|m)?[jt]s$/i
+const folderAgentPattern = /^agent\.(?:c|m)?[jt]s$/i
+const legacyFolderAgentPattern = /^config\.(?:c|m)?[jt]s$/i
 const evalDefinitionPattern = /^(?:.+\.)?eval\.(?:c|m)?[jt]s$/i
 const indexDefinitionPattern = /^index\.(?:c|m)?[jt]s$/i
 
@@ -30,7 +31,7 @@ function stripComments(source: string) {
     .replace(/(^|[^:])\/\/.*$/gm, "$1")
 }
 
-function isWorkspaceAgentConfig(source: string): boolean {
+function isWorkspaceAgentDefinition(source: string): boolean {
   return /\bdefineAgent\s*\(\s*\{[\s\S]*?\bworkspace\s*:/.test(stripComments(source))
 }
 
@@ -41,20 +42,20 @@ function isAgentDefinitionSource(source: string): boolean {
     || /\bexport\s+default\s+\w*Agent\b/.test(stripped)
 }
 
-function isInsideConfiguredAgent(file: string, configuredAgentDirs: Set<string>): boolean {
+function isInsideFolderAgent(file: string, folderAgentDirs: Set<string>): boolean {
   const directory = dirname(file)
-  if (configuredAgentDirs.has(directory) && indexDefinitionPattern.test(basename(file))) return false
+  if (folderAgentDirs.has(directory) && indexDefinitionPattern.test(basename(file))) return false
   if (isAgentDefinitionSource(readFileSync(file, "utf8"))) return false
-  for (const agentDir of configuredAgentDirs) {
+  for (const agentDir of folderAgentDirs) {
     const path = relative(agentDir, directory)
     if (path === "" || (!path.startsWith("..") && path !== "..")) return true
   }
   return false
 }
 
-function isWorkspaceSourceConfig(file: string, configuredAgentDirs: Set<string>): boolean {
+function isWorkspaceSourceConfig(file: string, folderAgentDirs: Set<string>): boolean {
   const directory = dirname(file)
-  for (const agentDir of configuredAgentDirs) {
+  for (const agentDir of folderAgentDirs) {
     const path = relative(agentDir, directory).replace(/\\/g, "/")
     if (!path || path.startsWith("../") || path === "..") continue
     if (path.split("/")[0] === "workspace") return true
@@ -62,7 +63,7 @@ function isWorkspaceSourceConfig(file: string, configuredAgentDirs: Set<string>)
   return false
 }
 
-function discoverDirectoryAgentConfigs(scanDirs: string[]): DiscoveredAgentDefinition[] {
+function discoverFolderAgentDefinitions(scanDirs: string[]): DiscoveredAgentDefinition[] {
   const candidates: DiscoveredAgentDefinition[] = []
 
   const walk = (agentsRoot: string, current: string) => {
@@ -82,11 +83,11 @@ function discoverDirectoryAgentConfigs(scanDirs: string[]): DiscoveredAgentDefin
         continue
       }
 
-      if (!entry.isFile() || (!configPattern.test(basename(file)) && !indexDefinitionPattern.test(basename(file)))) continue
+      if (!entry.isFile() || (!folderAgentPattern.test(basename(file)) && !indexDefinitionPattern.test(basename(file)))) continue
       const source = readFileSync(file, "utf8")
       const agent = relative(agentsRoot, dirname(file)).replace(/\\/g, "/")
       if (!agent || agent === ".") continue
-      const workspace = isWorkspaceAgentConfig(source)
+      const workspace = isWorkspaceAgentDefinition(source)
       candidates.push({
         handler: file,
         name: agent,
@@ -100,7 +101,7 @@ function discoverDirectoryAgentConfigs(scanDirs: string[]): DiscoveredAgentDefin
     walk(resolve(scanDir, "agents"), resolve(scanDir, "agents"))
   }
 
-  const ownedSkillConfigs = new Set(candidates.flatMap(definition => candidates.some(parent => {
+  const ownedSkillEntries = new Set(candidates.flatMap(definition => candidates.some(parent => {
     if (parent === definition) return false
     const path = relative(dirname(parent.handler), dirname(definition.handler)).replace(/\\/g, "/")
     return path === "skills" || path.startsWith("skills/")
@@ -114,11 +115,11 @@ function discoverDirectoryAgentConfigs(scanDirs: string[]): DiscoveredAgentDefin
     })
     ? [definition.handler]
     : []))
-  const discoveredCandidates = candidates.filter(definition => !ownedSkillConfigs.has(definition.handler) && !nestedHelperIndexes.has(definition.handler))
-  const configuredAgentDirs = new Set(discoveredCandidates
+  const discoveredCandidates = candidates.filter(definition => !ownedSkillEntries.has(definition.handler) && !nestedHelperIndexes.has(definition.handler))
+  const folderAgentDirs = new Set(discoveredCandidates
     .filter(definition => definition.source === "server-agent-workspace")
     .map(definition => dirname(definition.handler)))
-  return discoveredCandidates.filter(definition => !isWorkspaceSourceConfig(definition.handler, configuredAgentDirs))
+  return discoveredCandidates.filter(definition => !isWorkspaceSourceConfig(definition.handler, folderAgentDirs))
 }
 
 export function discoverAgentDefinitions(options:
@@ -126,17 +127,19 @@ export function discoverAgentDefinitions(options:
   | { mode: "server-agents", scanDirs: string[] }
 ): DiscoveredAgentDefinition[] {
   if (options.mode === "server-agents") {
-    const configDefinitions = discoverDirectoryAgentConfigs(options.scanDirs)
-    const configuredAgentDirs = new Set(configDefinitions.map(definition => dirname(definition.handler)))
+    const folderDefinitions = discoverFolderAgentDefinitions(options.scanDirs)
+    const folderAgentDirs = new Set(folderDefinitions.map(definition => dirname(definition.handler)))
     const directoryDefinitions = discoverDefinitions("agent", [
       createDirectoryDefinitionSource<DiscoveredAgentDefinition>("server-agents", options.scanDirs, "agents", {
         normalizeName(directory, file) {
-          if (configPattern.test(basename(file)) || indexDefinitionPattern.test(basename(file)) || isEvalDefinitionFile(file)) return
-          for (const agentDir of configuredAgentDirs) {
+          const fileName = basename(file)
+          if (folderAgentPattern.test(fileName) && dirname(file) !== directory) return
+          if (legacyFolderAgentPattern.test(fileName) || indexDefinitionPattern.test(fileName) || isEvalDefinitionFile(file)) return
+          for (const agentDir of folderAgentDirs) {
             const path = relative(agentDir, file).replace(/\\/g, "/")
             if (path === "skills" || path.startsWith("skills/")) return
           }
-          if (isInsideConfiguredAgent(file, configuredAgentDirs)) return
+          if (isInsideFolderAgent(file, folderAgentDirs)) return
           return relative(directory, file).replace(/\.(?:c|m)?[jt]s$/i, "").replace(/\/index$/i, "")
         },
         createDefinition({ file, name }) {
@@ -149,7 +152,7 @@ export function discoverAgentDefinitions(options:
       }),
     ])
 
-    return mergeDefinitions("agent", directoryDefinitions, configDefinitions)
+    return mergeDefinitions("agent", directoryDefinitions, folderDefinitions)
   }
 
   const roots = new Set([options.rootDir, ...(options.scanDirs || [])].filter(Boolean))

--- a/packages/agent/src/eval.ts
+++ b/packages/agent/src/eval.ts
@@ -225,7 +225,7 @@ async function resolveSiblingAgent<TRuntimeConfig extends AgentRuntimeConfig>(
   const extension = extname(caller)
   const base = basename(caller, extension)
   const sibling = base === "eval"
-    ? join(dirname(caller), `config${extension}`)
+    ? join(dirname(caller), `agent${extension}`)
     : caller.slice(0, -extension.length).replace(/\.eval$/, "") + extension
   const module = await import(pathToFileURL(sibling).href) as { default?: AgentEvalAgent<TRuntimeConfig> }
   if (!module.default) {

--- a/packages/agent/src/vite/colocated-agent-skills.ts
+++ b/packages/agent/src/vite/colocated-agent-skills.ts
@@ -10,7 +10,7 @@ export interface EncodedColocatedAgentSkillSource {
 }
 
 export function readColocatedAgentSkills(handler: string): Record<string, EncodedColocatedAgentSkillSource> | undefined {
-  if (!/^(?:config|index)\.(?:c|m)?[jt]s$/i.test(basename(handler))) return
+  if (!/^(?:agent|index)\.(?:c|m)?[jt]s$/i.test(basename(handler))) return
   const sourceRoot = dirname(handler)
   const skillsRoot = join(sourceRoot, "skills")
   if (!existsSync(skillsRoot) || !statSync(skillsRoot).isDirectory()) return

--- a/packages/agent/src/vite/colocated-agent-skills.ts
+++ b/packages/agent/src/vite/colocated-agent-skills.ts
@@ -12,6 +12,9 @@ export interface EncodedColocatedAgentSkillSource {
 export function readColocatedAgentSkills(handler: string): Record<string, EncodedColocatedAgentSkillSource> | undefined {
   if (!/^(?:agent|index)\.(?:c|m)?[jt]s$/i.test(basename(handler))) return
   const sourceRoot = dirname(handler)
+  if (/^agent\.(?:c|m)?[jt]s$/i.test(basename(handler))
+    && basename(sourceRoot) === "agents"
+    && basename(dirname(sourceRoot)) === "server") return
   const skillsRoot = join(sourceRoot, "skills")
   if (!existsSync(skillsRoot) || !statSync(skillsRoot).isDirectory()) return
 

--- a/packages/agent/test/colocated-agent-skills.test.ts
+++ b/packages/agent/test/colocated-agent-skills.test.ts
@@ -17,7 +17,7 @@ describe("colocated Agent Skills", () => {
   it("recursively embeds files as binary-safe build sources", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-skills-"))
     roots.push(root)
-    const handler = join(root, "config.ts")
+    const handler = join(root, "agent.ts")
     const binary = Uint8Array.from([0, 255, 128, 13, 10, 42])
     await mkdir(join(root, "skills", "review", "assets"), { recursive: true })
     await writeFile(handler, "export default {}\n", "utf8")

--- a/packages/agent/test/colocated-agent-skills.test.ts
+++ b/packages/agent/test/colocated-agent-skills.test.ts
@@ -68,4 +68,17 @@ describe("colocated Agent Skills", () => {
     await writeFile(join(root, "review", "index.ts"), "export default {}\n", "utf8")
     expect(readColocatedAgentSkills(join(root, "review", "index.ts"))).toBeDefined()
   })
+
+  it("does not treat a sibling Agent named skills as Skills owned by a flat Agent named agent", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-skills-"))
+    roots.push(root)
+    const agentsRoot = join(root, "server", "agents")
+    await mkdir(join(agentsRoot, "skills", "skills", "review"), { recursive: true })
+    await writeFile(join(agentsRoot, "agent.ts"), "export default {}\n", "utf8")
+    await writeFile(join(agentsRoot, "skills", "agent.ts"), "export default {}\n", "utf8")
+    await writeFile(join(agentsRoot, "skills", "skills", "review", "SKILL.md"), "# Review\n", "utf8")
+
+    expect(readColocatedAgentSkills(join(agentsRoot, "agent.ts"))).toBeUndefined()
+    expect(readColocatedAgentSkills(join(agentsRoot, "skills", "agent.ts"))).toBeDefined()
+  })
 })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -160,7 +160,7 @@ describe("agent discovery", () => {
     await mkdir(join(root, "server", "agents"), { recursive: true })
     await mkdir(join(root, "server", "agents", "docs"), { recursive: true })
     await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
-    await writeFile(join(root, "server", "agents", "docs", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "docs", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
 
     expect(discoverAgentDefinitions({
       mode: "server-agents",
@@ -171,11 +171,35 @@ describe("agent discovery", () => {
     ])
   })
 
+  it("discovers a flat Agent named agent", async () => {
+    const root = await createTempRoot("vitehub-agent-flat-agent-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "agent.ts"), "export default defineAgent({ driver: { model } })", "utf8")
+
+    expect(discoverAgentDefinitions({
+      mode: "server-agents",
+      scanDirs: [join(root, "server")],
+    })).toEqual([
+      expect.objectContaining({ name: "agent", source: "server-agents" }),
+    ])
+  })
+
+  it("does not discover legacy folder config files", async () => {
+    const root = await createTempRoot("vitehub-agent-legacy-config-")
+    await mkdir(join(root, "server", "agents", "support"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default defineAgent({ driver: { model } })", "utf8")
+
+    expect(discoverAgentDefinitions({
+      mode: "server-agents",
+      scanDirs: [join(root, "server")],
+    })).toEqual([])
+  })
+
   it("does not discover TypeScript files inside Agent Skill trees", async () => {
     const root = await createTempRoot("vitehub-agent-server-skills-")
     await mkdir(join(root, "server", "agents", "review", "skills", "helper", "scripts"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "review", "config.ts"), "export default {}", "utf8")
-    await writeFile(join(root, "server", "agents", "review", "skills", "helper", "config.ts"), "export default {}", "utf8")
+    await writeFile(join(root, "server", "agents", "review", "agent.ts"), "export default {}", "utf8")
+    await writeFile(join(root, "server", "agents", "review", "skills", "helper", "agent.ts"), "export default {}", "utf8")
     await writeFile(join(root, "server", "agents", "review", "skills", "helper", "scripts", "run.ts"), "export {}", "utf8")
 
     expect(discoverAgentDefinitions({
@@ -189,7 +213,7 @@ describe("agent discovery", () => {
   it("allows a top-level folder Agent named skills", async () => {
     const root = await createTempRoot("vitehub-agent-server-skills-name-")
     await mkdir(join(root, "server", "agents", "skills"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "skills", "config.ts"), "export default {}", "utf8")
+    await writeFile(join(root, "server", "agents", "skills", "agent.ts"), "export default {}", "utf8")
 
     expect(discoverAgentDefinitions({
       mode: "server-agents",
@@ -202,8 +226,8 @@ describe("agent discovery", () => {
   it("ignores eval definitions during server agent discovery", async () => {
     const root = await createTempRoot("vitehub-agent-server-eval-")
     await mkdir(join(root, "server", "agents", "support"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
-    await writeFile(join(root, "server", "agents", "support", "config.eval.ts"), "export default defineEval({})", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "agent.eval.ts"), "export default defineEval({})", "utf8")
     await writeFile(join(root, "server", "agents", "support", "eval.ts"), "export default defineEval({})", "utf8")
     await writeFile(join(root, "server", "agents", "support.eval.ts"), "export default defineEval({})", "utf8")
 
@@ -215,16 +239,16 @@ describe("agent discovery", () => {
     ])
   })
 
-  it("ignores helper files inside configured server agents", async () => {
+  it("ignores helper files inside folder Agents", async () => {
     const root = await createTempRoot("vitehub-agent-server-helpers-")
     await mkdir(join(root, "server", "agents", "chat", "workspace"), { recursive: true })
     await mkdir(join(root, "server", "agents", "review"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "chat", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "chat", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
     await writeFile(join(root, "server", "agents", "chat", "access.ts"), "export const access = {}", "utf8")
     await writeFile(join(root, "server", "agents", "chat", "audience.test.ts"), "export const test = {}", "utf8")
     await writeFile(join(root, "server", "agents", "chat", "prompts.ts"), "export default { system: 'help' }", "utf8")
     await writeFile(join(root, "server", "agents", "chat", "workspace", "config.ts"), "export const sources = {}", "utf8")
-    await writeFile(join(root, "server", "agents", "review", "config.ts"), "export default defineAgent({ driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "review", "agent.ts"), "export default defineAgent({ driver: { model } })", "utf8")
 
     expect(discoverAgentDefinitions({
       mode: "server-agents",
@@ -238,7 +262,7 @@ describe("agent discovery", () => {
   it("uses folder identity for colocated workspace agents", async () => {
     const root = await createTempRoot("vitehub-agent-workspace-name-")
     await mkdir(join(root, "server", "agents", "docs"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "docs", "config.ts"), "export default defineAgent({ workspace: {}, name: 'context', driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "docs", "agent.ts"), "export default defineAgent({ workspace: {}, name: 'context', driver: { model } })", "utf8")
 
     expect(discoverAgentDefinitions({
       mode: "server-agents",
@@ -251,7 +275,7 @@ describe("agent discovery", () => {
   it("discovers nested agents named workspace when no parent agent owns the source root", async () => {
     const root = await createTempRoot("vitehub-agent-nested-workspace-")
     await mkdir(join(root, "server", "agents", "team", "workspace"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "team", "workspace", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "workspace", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
 
     expect(discoverAgentDefinitions({
       mode: "server-agents",
@@ -261,11 +285,11 @@ describe("agent discovery", () => {
     ])
   })
 
-  it("discovers nested agents named workspace below plain config agents", async () => {
+  it("discovers nested agents named workspace below plain folder Agents", async () => {
     const root = await createTempRoot("vitehub-agent-plain-parent-workspace-")
     await mkdir(join(root, "server", "agents", "team", "workspace"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "team", "config.ts"), "export default defineAgent({ driver: { run: () => 'ok' } })", "utf8")
-    await writeFile(join(root, "server", "agents", "team", "workspace", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "agent.ts"), "export default defineAgent({ driver: { run: () => 'ok' } })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "workspace", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
 
     expect(discoverAgentDefinitions({
       mode: "server-agents",
@@ -276,10 +300,10 @@ describe("agent discovery", () => {
     ])
   })
 
-  it("discovers nested file agents below configured agents", async () => {
+  it("discovers nested file Agents below folder Agents", async () => {
     const root = await createTempRoot("vitehub-agent-nested-file-agent-")
     await mkdir(join(root, "server", "agents", "team"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "team", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
     await writeFile(join(root, "server", "agents", "team", "access.ts"), "export const access = {}", "utf8")
     await writeFile(join(root, "server", "agents", "team", "review.ts"), "export default defineAgent({ driver: { model } })", "utf8")
 
@@ -295,10 +319,10 @@ describe("agent discovery", () => {
     ]))
   })
 
-  it("discovers nested re-exported file agents below configured agents", async () => {
+  it("discovers nested re-exported file Agents below folder Agents", async () => {
     const root = await createTempRoot("vitehub-agent-nested-reexport-agent-")
     await mkdir(join(root, "server", "agents", "team"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "team", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
     await writeFile(join(root, "server", "agents", "team", "prompts.ts"), "export default { system: 'help' }", "utf8")
     await writeFile(join(root, "server", "agents", "team", "review.ts"), "export { default } from './review-agent'", "utf8")
 
@@ -326,10 +350,10 @@ describe("agent discovery", () => {
     })).toThrow("Duplicate agent name")
   })
 
-  it("throws when a configured server agent also has an index definition", async () => {
-    const root = await createTempRoot("vitehub-agent-config-index-duplicate-")
+  it("throws when a folder Agent also has an index definition", async () => {
+    const root = await createTempRoot("vitehub-agent-folder-index-duplicate-")
     await mkdir(join(root, "server", "agents", "support"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
     await writeFile(join(root, "server", "agents", "support", "index.ts"), "export default defineAgent({ driver: { model } })", "utf8")
 
     expect(() => discoverAgentDefinitions({
@@ -352,10 +376,10 @@ describe("agent discovery", () => {
     ])
   })
 
-  it("keeps helper indexes out of configured Agent discovery", async () => {
+  it("keeps helper indexes out of folder Agent discovery", async () => {
     const root = await createTempRoot("vitehub-agent-helper-index-")
     await mkdir(join(root, "server", "agents", "support", "lib"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default defineAgent({ driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "agent.ts"), "export default defineAgent({ driver: { model } })", "utf8")
     await writeFile(join(root, "server", "agents", "support", "lib", "index.ts"), "export * from './helper'", "utf8")
 
     expect(discoverAgentDefinitions({
@@ -366,11 +390,11 @@ describe("agent discovery", () => {
     ])
   })
 
-  it("throws when a nested configured server agent also has an index definition", async () => {
-    const root = await createTempRoot("vitehub-agent-nested-config-index-duplicate-")
+  it("throws when a nested folder Agent also has an index definition", async () => {
+    const root = await createTempRoot("vitehub-agent-nested-folder-index-duplicate-")
     await mkdir(join(root, "server", "agents", "team", "review"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "team", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
-    await writeFile(join(root, "server", "agents", "team", "review", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "team", "review", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
     await writeFile(join(root, "server", "agents", "team", "review", "index.ts"), "export default defineAgent({ driver: { model } })", "utf8")
 
     expect(() => discoverAgentDefinitions({
@@ -392,7 +416,7 @@ describe("agent chat capability discovery", () => {
       "  capabilities: [chat({ concurrency: 'queue', events: ['directMessage'] })],",
       "})",
     ].join("\n"), "utf8")
-    await writeFile(join(root, "server", "agents", "docs", "config.ts"), [
+    await writeFile(join(root, "server", "agents", "docs", "agent.ts"), [
       "import { defineAgent } from '@vite-hub/agent'",
       "import { chat } from '@vite-hub/agent/capabilities'",
       "export default defineAgent({",
@@ -1622,7 +1646,7 @@ describe("agent chat capability discovery", () => {
   it("accepts declared workspace agent names as dev loop aliases", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-alias-")
     await mkdir(join(root, "server", "agents", "review"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "review", "config.ts"), "export default {}", "utf8")
+    await writeFile(join(root, "server", "agents", "review", "agent.ts"), "export default {}", "utf8")
 
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
@@ -1678,7 +1702,7 @@ describe("agent chat capability discovery", () => {
   it("prefers exact dev loop agent names over aliases", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-exact-name-")
     await mkdir(join(root, "server", "agents", "review"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "review", "config.ts"), "export default {}", "utf8")
+    await writeFile(join(root, "server", "agents", "review", "agent.ts"), "export default {}", "utf8")
     await writeFile(join(root, "server", "agents", "summary.ts"), "export default {}", "utf8")
 
     const { defineAgent } = await import("../src/index.ts")
@@ -2004,7 +2028,7 @@ describe("agent chat capability discovery", () => {
   it("refreshes chat devtools workspace metadata after source materialization", async () => {
     const root = await createTempRoot("vitehub-agent-devtools-materialized-source-")
     await mkdir(join(root, "server", "agents", "support"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
 
     const { chat } = await import("../src/capabilities.ts")
     const { defineAgent } = await import("../src/index.ts")
@@ -2092,7 +2116,7 @@ describe("agent chat capability discovery", () => {
   it("materializes resolver-backed lazy sources from the chat devtools file tree", async () => {
     const root = await createTempRoot("vitehub-agent-devtools-click-source-")
     await mkdir(join(root, "server", "agents", "support"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "agent.ts"), "export default defineAgent({ workspace: {}, driver: { model } })", "utf8")
 
     const { chat } = await import("../src/capabilities.ts")
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -93,7 +93,7 @@ describe("agent eval", () => {
     expect(evaliteCalls[0]?.variants).toBeUndefined()
   })
 
-  it("infers config.ts and the folder name from folder-level eval.ts files", async () => {
+  it("infers agent.ts and the folder name from folder-level eval.ts files", async () => {
     await import("./fixtures/folder-eval/eval.ts")
 
     expect(evaliteCalls[0]?.name).toBe("folder-eval")
@@ -101,7 +101,7 @@ describe("agent eval", () => {
     const output = await evaliteCalls[0]!.opts.task(evaliteCalls[0]!.opts.data[0].input)
     const score = await evaliteCalls[0]!.opts.scorers[0].scorer({ output })
 
-    expect(output.text).toBe("folder config")
+    expect(output.text).toBe("folder agent")
     expect(score.score).toBe(1)
   })
 

--- a/packages/agent/test/fixtures/folder-eval/agent.ts
+++ b/packages/agent/test/fixtures/folder-eval/agent.ts
@@ -1,5 +1,5 @@
 export default {
-  generate: async () => ({ text: "folder config" }),
+  generate: async () => ({ text: "folder agent" }),
   stream: async () => {
     throw new Error("stream is not used by this eval fixture.")
   },

--- a/packages/agent/test/fixtures/folder-eval/eval.ts
+++ b/packages/agent/test/fixtures/folder-eval/eval.ts
@@ -4,6 +4,6 @@ export default defineEval({
   scenarios: [{
     input: { prompt: "hello" },
     name: "hello",
-    scorers: [textContains("folder config")],
+    scorers: [textContains("folder agent")],
   }],
 })

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -380,7 +380,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
   it("installs GitHub workspace stores before Agent Workspace commands", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-workspace-command-github-store-"))
     await mkdir(join(root, "server", "agents", "support"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default {}", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "agent.ts"), "export default {}", "utf8")
 
     const { readWorkspaceDevToken, workspaceDevTokenHeader, workspaceDevTokenServerId } = await import("@vite-hub/workspace/server")
     const { defineAgent } = await import("../src/index.ts")
@@ -582,7 +582,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
 
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-workspace-command-env-string-hosted-"))
     await mkdir(join(root, "server", "agents", "support"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default {}", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "agent.ts"), "export default {}", "utf8")
 
     const { readWorkspaceDevToken, workspaceDevTokenHeader, workspaceDevTokenServerId } = await import("@vite-hub/workspace/server")
     const { defineAgent } = await import("../src/index.ts")
@@ -765,7 +765,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
   it("keeps harness driver metadata when wrapping channel streams for delivery previews", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-invocation-stream-harness-preview-metadata-"))
     await mkdir(join(root, "server", "agents", "review", "skills", "code-review"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "review", "config.ts"), "export default {}", "utf8")
+    await writeFile(join(root, "server", "agents", "review", "agent.ts"), "export default {}", "utf8")
     await writeFile(join(root, "server", "agents", "review", "skills", "code-review", "SKILL.md"), "# Code review\n", "utf8")
 
     harnessStreamResult.mockReturnValueOnce({

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -234,7 +234,7 @@ describe("agent Vite plugin", () => {
     try {
       await mkdir(join(root, "server", "agents", "support", "workspace"), { recursive: true })
       await writeFile(join(root, "server", "agents", "digest.ts"), "export default {}", "utf8")
-      await writeFile(join(root, "server", "agents", "support", "config.ts"), "export default defineAgent({ workspace: {} })", "utf8")
+      await writeFile(join(root, "server", "agents", "support", "agent.ts"), "export default defineAgent({ workspace: {} })", "utf8")
       await writeFile(join(root, "server", "agents", "support", "instructions.md"), "Use support instructions.\n", "utf8")
       const plugin = hubAgent()
       const configResolved = plugin.configResolved as unknown as (config: { agent?: unknown, command: "serve", createResolver: () => (id: string) => Promise<string | undefined>, plugins: Array<{ name: string }>, root: string }) => Promise<void>
@@ -722,7 +722,7 @@ describe("agent Vite plugin", () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-github-workspace-route-"))
     try {
       await mkdir(join(root, "server", "agents", "support"), { recursive: true })
-      await writeFile(join(root, "server", "agents", "support", "config.ts"), [
+      await writeFile(join(root, "server", "agents", "support", "agent.ts"), [
         "import { defineAgent } from '@vite-hub/agent'",
         "export default defineAgent({",
         "  driver: { async run() { return 'ok' } },",
@@ -989,7 +989,7 @@ describe("agent Vite plugin", () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-hosted-workspace-route-"))
     try {
       await mkdir(join(root, "server", "agents", "audio-bitacora"), { recursive: true })
-      await writeFile(join(root, "server", "agents", "audio-bitacora", "config.ts"), [
+      await writeFile(join(root, "server", "agents", "audio-bitacora", "agent.ts"), [
         "import { defineAgent } from '@vite-hub/agent'",
         "export default defineAgent({",
         "  workspace: {",
@@ -1034,7 +1034,7 @@ describe("agent Vite plugin", () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-implicit-vercel-blob-workspace-route-"))
     try {
       await mkdir(join(root, "server", "agents", "audio-bitacora"), { recursive: true })
-      await writeFile(join(root, "server", "agents", "audio-bitacora", "config.ts"), [
+      await writeFile(join(root, "server", "agents", "audio-bitacora", "agent.ts"), [
         "import { defineAgent } from '@vite-hub/agent'",
         "export default defineAgent({",
         "  workspace: {",
@@ -1103,7 +1103,7 @@ describe("agent Vite plugin", () => {
     try {
       await mkdir(join(root, "server", "agents", "support", "workspace"), { recursive: true })
       await mkdir(join(root, "server", "agents", "support", "skills", "review", "scripts"), { recursive: true })
-      await writeFile(join(root, "server", "agents", "support", "config.ts"), [
+      await writeFile(join(root, "server", "agents", "support", "agent.ts"), [
         "import { defineAgent } from '@vite-hub/agent'",
         "export default defineAgent({",
         "  workspace: {},",

--- a/packages/workflow/src/discovery.ts
+++ b/packages/workflow/src/discovery.ts
@@ -132,7 +132,9 @@ function discoverFlatServerAgentWorkflowDefinitions(scanDirs: string[]): Discove
         if ((folderAgentFilePattern.test(fileName) && parent !== normalize(directory)) || agentEvalFilePattern.test(fileName)) {
           return undefined
         }
-        if (parent !== normalize(directory) && hasFolderAgentDefinition(parent)) {
+        if (parent !== normalize(directory)
+          && hasFolderAgentDefinition(parent)
+          && extractAgentWorkflowName(file, "__vitehub_agent_workflow__") === undefined) {
           return undefined
         }
         return normalizePathDefinitionName(directory, file)

--- a/packages/workflow/src/discovery.ts
+++ b/packages/workflow/src/discovery.ts
@@ -23,6 +23,7 @@ const sourceFilePattern = /\.(?:c|m)?[jt]s$/i
 const declarationFilePattern = /\.d\.(?:c|m)?[jt]s$/i
 const stepFilePattern = /^\d+[.-].*\.(?:c|m)?[jt]s$/i
 const folderAgentFilePattern = /^agent\.(?:c|m)?[jt]s$/i
+const legacyFolderAgentFilePattern = /^config\.(?:c|m)?[jt]s$/i
 const agentEvalFilePattern = /\.eval\.(?:c|m)?[jt]s$/i
 
 function normalizeSuffixWorkflowName(rootDir: string, file: string) {
@@ -129,7 +130,9 @@ function discoverFlatServerAgentWorkflowDefinitions(scanDirs: string[]): Discove
       normalizeName(directory, file) {
         const fileName = normalize(file).split("/").pop()!
         const parent = normalize(resolve(file, ".."))
-        if ((folderAgentFilePattern.test(fileName) && parent !== normalize(directory)) || agentEvalFilePattern.test(fileName)) {
+        if ((folderAgentFilePattern.test(fileName) && parent !== normalize(directory))
+          || legacyFolderAgentFilePattern.test(fileName)
+          || agentEvalFilePattern.test(fileName)) {
           return undefined
         }
         if (parent !== normalize(directory)

--- a/packages/workflow/src/discovery.ts
+++ b/packages/workflow/src/discovery.ts
@@ -22,7 +22,7 @@ const agentSuffixPattern = /\.agent\.(?:c|m)?[jt]s$/i
 const sourceFilePattern = /\.(?:c|m)?[jt]s$/i
 const declarationFilePattern = /\.d\.(?:c|m)?[jt]s$/i
 const stepFilePattern = /^\d+[.-].*\.(?:c|m)?[jt]s$/i
-const agentConfigFilePattern = /^config\.(?:c|m)?[jt]s$/i
+const folderAgentFilePattern = /^agent\.(?:c|m)?[jt]s$/i
 const agentEvalFilePattern = /\.eval\.(?:c|m)?[jt]s$/i
 
 function normalizeSuffixWorkflowName(rootDir: string, file: string) {
@@ -90,11 +90,11 @@ function findWorkflowFolders(workflowsDir: string): string[] {
   return folders.sort()
 }
 
-function hasConfigAgentDefinition(directory: string): boolean {
-  return readDirEntries(directory).some(entry => entry.isFile() && agentConfigFilePattern.test(entry.name) && isSourceFile(entry.name))
+function hasFolderAgentDefinition(directory: string): boolean {
+  return readDirEntries(directory).some(entry => entry.isFile() && folderAgentFilePattern.test(entry.name) && isSourceFile(entry.name))
 }
 
-function findAgentConfigFiles(agentsDir: string): string[] {
+function findFolderAgentFiles(agentsDir: string): string[] {
   const files: string[] = []
   for (const entry of readDirEntries(agentsDir)) {
     if (entry.name.startsWith(".")) {
@@ -102,10 +102,10 @@ function findAgentConfigFiles(agentsDir: string): string[] {
     }
     const absolute = resolve(agentsDir, entry.name)
     if (entry.isDirectory() && !entry.isSymbolicLink()) {
-      files.push(...findAgentConfigFiles(absolute))
+      files.push(...findFolderAgentFiles(absolute))
       continue
     }
-    if (entry.isFile() && agentConfigFilePattern.test(entry.name) && isSourceFile(entry.name)) {
+    if (entry.isFile() && folderAgentFilePattern.test(entry.name) && isSourceFile(entry.name)) {
       files.push(absolute)
     }
   }
@@ -128,11 +128,11 @@ function discoverFlatServerAgentWorkflowDefinitions(scanDirs: string[]): Discove
     createDirectoryDefinitionSource<DiscoveredWorkflowDefinition>("agent-workflow", scanDirs, "agents", {
       normalizeName(directory, file) {
         const fileName = normalize(file).split("/").pop()!
-        if (agentConfigFilePattern.test(fileName) || agentEvalFilePattern.test(fileName)) {
+        const parent = normalize(resolve(file, ".."))
+        if ((folderAgentFilePattern.test(fileName) && parent !== normalize(directory)) || agentEvalFilePattern.test(fileName)) {
           return undefined
         }
-        const parent = normalize(resolve(file, ".."))
-        if (parent !== normalize(directory) && hasConfigAgentDefinition(parent)) {
+        if (parent !== normalize(directory) && hasFolderAgentDefinition(parent)) {
           return undefined
         }
         return normalizePathDefinitionName(directory, file)
@@ -150,7 +150,7 @@ function discoverConfiguredServerAgentWorkflowDefinitions(scanDirs: string[]): D
 
   for (const scanDir of scanDirs) {
     const agentsDir = resolve(scanDir, "agents")
-    for (const file of findAgentConfigFiles(agentsDir)) {
+    for (const file of findFolderAgentFiles(agentsDir)) {
       const name = normalize(relative(agentsDir, resolve(file, "..")))
       if (!name || name === ".") {
         continue

--- a/packages/workflow/test/definition.test.ts
+++ b/packages/workflow/test/definition.test.ts
@@ -84,6 +84,7 @@ describe("workflow definitions", () => {
     await mkdir(agentDir, { recursive: true })
     await writeFile(join(agentDir, "agent.ts"), "export default defineAgent({ runtime: workflow() })\n", "utf8")
     await writeFile(join(agentDir, "review.ts"), "export default defineAgent({ runtime: workflow() })\n", "utf8")
+    await writeFile(join(agentDir, "config.ts"), "export default defineAgent({ runtime: workflow() })\n", "utf8")
     await writeFile(join(agentDir, "helper.ts"), "export const helper = true\n", "utf8")
 
     expect(discoverWorkflowDefinitions({ rootDir })).toEqual([

--- a/packages/workflow/test/definition.test.ts
+++ b/packages/workflow/test/definition.test.ts
@@ -77,6 +77,21 @@ describe("workflow definitions", () => {
     expect(discoverWorkflowDefinitions({ rootDir })).toEqual([])
   })
 
+  it("discovers nested file Agent workflows inside folder Agents without discovering helpers", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-workflow-nested-file-"))
+    tempDirs.push(rootDir)
+    const agentDir = join(rootDir, "server", "agents", "team")
+    await mkdir(agentDir, { recursive: true })
+    await writeFile(join(agentDir, "agent.ts"), "export default defineAgent({ runtime: workflow() })\n", "utf8")
+    await writeFile(join(agentDir, "review.ts"), "export default defineAgent({ runtime: workflow() })\n", "utf8")
+    await writeFile(join(agentDir, "helper.ts"), "export const helper = true\n", "utf8")
+
+    expect(discoverWorkflowDefinitions({ rootDir })).toEqual([
+      expect.objectContaining({ name: "team", source: "agent-workflow" }),
+      expect.objectContaining({ name: "team/review", source: "agent-workflow" }),
+    ])
+  })
+
   it("keeps root workflow files when the workflows directory has folder markers", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vitehub-workflow-root-flat-"))
     tempDirs.push(rootDir)

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -82,7 +82,7 @@ describe("Vite workflow provider outputs", () => {
     const rootDir = await createPlaygroundCopy("vitehub-workflow-vite-playground-")
     const agentDir = join(rootDir, "server", "agents", "nuxt")
     await mkdir(agentDir, { recursive: true })
-    await writeFile(join(agentDir, "config.ts"), [
+    await writeFile(join(agentDir, "agent.ts"), [
       `import { defineAgent, workflow } from "@vite-hub/agent"`,
       "",
       "export default defineAgent({",

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -86,7 +86,7 @@ describe("Vite workflow provider outputs", () => {
       `import { defineAgent, workflow } from "@vite-hub/agent"`,
       "",
       "export default defineAgent({",
-      `  runtime: workflow("nuxt-agent"),`,
+      "  runtime: workflow(),",
       `  run: () => "nuxt agent",`,
       "})",
       "",
@@ -104,7 +104,7 @@ describe("Vite workflow provider outputs", () => {
     const vercelServer = join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs")
     const wrangler = JSON.parse(await readFile(cloudflareConfig, "utf8"))
     const className = getCloudflareWorkflowClassName("welcome")
-    const agentClassName = getCloudflareWorkflowClassName("nuxt-agent")
+    const agentClassName = getCloudflareWorkflowClassName("nuxt")
 
     expect(existsSync(cloudflareWorker)).toBe(true)
     expect(existsSync(cloudflareWorkerBundle)).toBe(true)
@@ -114,9 +114,9 @@ describe("Vite workflow provider outputs", () => {
       name: "workflow--77656c636f6d65",
     })
     expect(wrangler.workflows).toContainEqual({
-      binding: getCloudflareWorkflowBindingName("nuxt-agent"),
+      binding: getCloudflareWorkflowBindingName("nuxt"),
       class_name: agentClassName,
-      name: getCloudflareWorkflowName("nuxt-agent"),
+      name: getCloudflareWorkflowName("nuxt"),
     })
     expect(wrangler.workflows).toHaveLength(2)
     const cloudflareWorkerContents = await readFile(cloudflareWorker, "utf8")
@@ -124,7 +124,7 @@ describe("Vite workflow provider outputs", () => {
     expect(cloudflareWorkerContents).toContain(`export class ${className} extends WorkflowEntrypoint`)
     expect(cloudflareWorkerContents).toContain(`export class ${agentClassName} extends WorkflowEntrypoint`)
     expect(cloudflareWorkerContents).toContain('runViteHubWorkflowDefinition("welcome"')
-    expect(cloudflareWorkerContents).toContain('runViteHubWorkflowDefinition("nuxt-agent"')
+    expect(cloudflareWorkerContents).toContain('runViteHubWorkflowDefinition("nuxt"')
     expect(await readFile(cloudflareWorkerBundle, "utf8")).toContain("runViteHubWorkflowDefinition")
     expect(await readFile(join(rootDir, ".vitehub", "workflow", "registry.mjs"), "utf8")).toContain("runAgentWorkflowDefinition")
     expect(await readFile(vercelConfig, "utf8")).toContain("\"/__server\"")

--- a/packages/workspace/src/build/discovery.ts
+++ b/packages/workspace/src/build/discovery.ts
@@ -11,7 +11,7 @@ import {
   normalizeSuffixDefinitionName,
 } from "@vite-hub/internal/definition-catalog"
 
-import { workspaceConfigFileNames, workspaceConfigPattern, workspaceSuffixPattern } from "./workspace-config.ts"
+import { workspaceAgentPattern, workspaceConfigFileNames, workspaceConfigPattern, workspaceSuffixPattern } from "./workspace-config.ts"
 
 import type { DefinitionCatalogSource } from "@vite-hub/internal/definition-catalog"
 
@@ -37,7 +37,7 @@ function isAgentConfig(file: string) {
   return /\bdefineAgent\s*\(/.test(stripComments(readFileSync(file, "utf8")))
 }
 
-function isWorkspaceAgentConfig(file: string) {
+function isWorkspaceAgentDefinition(file: string) {
   return /\bdefineAgent\s*\(\s*\{[\s\S]*?\bworkspace\s*:/.test(stripComments(readFileSync(file, "utf8")))
 }
 
@@ -115,7 +115,7 @@ function serverWorkspaceSource(rootDir: string): WorkspaceDefinitionCatalogSourc
       normalizeName: normalizeDirectoryName,
       createDefinition: ({ file, name }) => {
         if (isAgentConfig(file)) {
-          throw new Error(`[vitehub] Workspace config "${file}" must use defineWorkspace(); defineAgent() belongs in server/agents/<name>/config.ts.`)
+          throw new Error(`[vitehub] Workspace config "${file}" must use defineWorkspace(); defineAgent() belongs in server/agents/<name>/agent.ts.`)
         }
         return createWorkspaceDefinition("server-workspaces-directory-config", file, name)
       },
@@ -123,8 +123,8 @@ function serverWorkspaceSource(rootDir: string): WorkspaceDefinitionCatalogSourc
     createDirectoryDefinitionSource("server-agent-workspaces", [resolve(rootDir, "server")], "agents", {
       includeHidden: true,
       normalizeName(_agentsRoot, file) {
-        if (!workspaceConfigPattern.test(basename(file))) return
-        if (!isWorkspaceAgentConfig(file)) return
+        if (!workspaceAgentPattern.test(basename(file))) return
+        if (!isWorkspaceAgentDefinition(file)) return
         const name = relative(agentsDir, dirname(file)).replace(/\\/g, "/")
         return name && name !== "." ? name : undefined
       },

--- a/packages/workspace/test/discovery.test.ts
+++ b/packages/workspace/test/discovery.test.ts
@@ -87,11 +87,11 @@ describe("discoverServerWorkspaceDefinitions", () => {
   it("discovers workspace definitions colocated with directory agents", async () => {
     const root = await createRoot()
     await mkdir(join(root, "server", "agents", "docs", "workspace"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "docs", "config.ts"), "export default defineAgent({ workspace: {}, model })\n", "utf8")
+    await writeFile(join(root, "server", "agents", "docs", "agent.ts"), "export default defineAgent({ workspace: {}, model })\n", "utf8")
 
     expect(discoverServerWorkspaceDefinitions(root)).toEqual([
       expect.objectContaining({
-        handler: join(root, "server", "agents", "docs", "config.ts"),
+        handler: join(root, "server", "agents", "docs", "agent.ts"),
         name: "docs",
         source: "server-agent-workspaces",
         sourceRootDir: join(root, "server", "agents", "docs", "workspace"),
@@ -104,6 +104,6 @@ describe("discoverServerWorkspaceDefinitions", () => {
     await mkdir(join(root, "server", "workspaces", "docs"), { recursive: true })
     await writeFile(join(root, "server", "workspaces", "docs", "config.ts"), "export default defineAgent({ workspace: {}, model })\n", "utf8")
 
-    expect(() => discoverServerWorkspaceDefinitions(root)).toThrow("defineAgent() belongs in server/agents/<name>/config.ts")
+    expect(() => discoverServerWorkspaceDefinitions(root)).toThrow("defineAgent() belongs in server/agents/<name>/agent.ts")
   })
 })


### PR DESCRIPTION
Renames the folder Agent Definition entry from `server/agents/<name>/config.ts` to `server/agents/<name>/agent.ts` as a clean breaking change. Agent discovery, folder Evals, colocated Skills, Workspace discovery, generated-provider fixtures, and public docs now use the primitive-specific filename with no compatibility alias.

Folder-derived identity and sibling `instructions.md`, `skills/`, and `workspace/` behavior stay unchanged. Flat `server/agents/agent.ts` remains a valid Agent named `agent`, while genuine Workspace `config.ts` and the separate folder `index.ts` behavior remain intact.

Agent, Workspace, Workflow, and docs test suites pass, along with the affected package typechecks.