### PR TITLE
feat(agent): add info CLI command

### DIFF
--- a/docs/content/docs/agents/devtools.md
+++ b/docs/content/docs/agents/devtools.md
@@ -38,14 +38,17 @@ Use the Agent DevTools Feature to answer the basic discovery questions before de
 
 If discovery is wrong, fix the Agent Definition before inspecting model output.
 
-## Inspect from chat
+## Inspect from the CLI
 
-Type `//inspect` in the Agent DevTools chat composer to add a local inspection summary to the transcript.
-It is a Host Command, so DevTools handles it before Agent Invocation and does not send it to the Agent.
-The summary points at the resolved Agent Definition surface: driver metadata, tool count, visible Workspace files and Sources, instruction documents, Agent Invoker Profiles, warnings, and metadata status.
-Use the side panel for the full config, files, tools, instructions, and metadata.
+Start the app's Vite Development Server, then inspect one chat-capable Agent Definition without invoking its Agent Driver.
 
-Other `//...` Host Commands are handled locally and are not forwarded to the Agent.
+```bash [Terminal]
+pnpm vitehub agent info --agent support
+```
+
+The command reads the same resolved metadata as the Agent DevTools side panel: Driver metadata, tools, visible Workspace files and Sources, instruction documents, Agent Invoker Profiles, warnings, and metadata status.
+Pass `--json` when another agent or script needs the structured inspection contract, and use `--url` when Vite is not listening on `http://localhost:5173`.
+Agent DevTools must be enabled because the command inspects resolved runtime metadata from its running Vite bridge.
 
 ## Inspect an invocation
 

--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -34,6 +34,7 @@ Available namespaces:
 | Command | Status | Owner | Use it for |
 | --- | --- | --- | --- |
 | `vitehub agent eval` | Available | Agent Package | Run discovered Agent Evals through ViteHub defaults. |
+| `vitehub agent info` | Available | Agent Package | Inspect resolved Agent metadata through a running Vite Development Server. |
 | `vitehub agent dev` | Available | Agent Package | Talk to a discovered Agent through a running Vite Development Server. |
 | `vitehub workspace dev` | Available | Workspace Package | Run commands through a Workspace Session exposed by a Compatible Vite Development Server. |
 | `vitehub provision run` | Available | ViteHub CLI plus package Provision Steps | Create missing provider resources idempotently. |
@@ -50,6 +51,21 @@ pnpm vitehub agent eval --output .vitehub/evals/support.json --hide-table
 ```
 
 Set `agent.eval.testTimeout` in `vite.config.ts` for long-running model or harness evals.
+
+## Inspect an Agent Definition
+
+Start the app's Vite Development Server, then inspect the resolved metadata for one chat-capable Agent Definition.
+The command does not invoke the Agent Driver.
+
+```bash [Terminal]
+pnpm vitehub agent info --agent support
+pnpm vitehub agent info --agent support --json
+```
+
+The default output summarizes the selected Driver, tools, visible Workspace files and Sources, instructions, Agent Invoker Profiles, warnings, and metadata status.
+Use `--json` for the structured inspection contract and `--url` when Vite is not listening on `http://localhost:5173`.
+When multiple chat-capable Agents are discovered, `--agent` is required.
+Agent DevTools must be enabled because `agent info` reads resolved runtime metadata from its running Vite bridge.
 
 ## Talk to an Agent during development
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -128,9 +128,9 @@ export default defineConfig({
 
 ## DevTools inspection
 
-With `hubAgent()` and the ViteHub DevTools shell active, open the Agent Chat feature and type `//inspect`.
-DevTools handles this Host Command locally and adds a transcript summary of the resolved Agent Definition surface without sending the command to the Agent.
-Use it to verify the selected driver, tools, Workspace files and Sources, instructions, Agent Invoker Profiles, warnings, and metadata status before debugging model output.
+With `hubAgent()` and Agent DevTools active, start the Vite Development Server and run `vitehub agent info --agent <name>`.
+The command reads the resolved Agent Definition metadata without invoking the Agent Driver, so use it to verify the selected Driver, tools, Workspace files and Sources, instructions, Agent Invoker Profiles, warnings, and metadata status before debugging model output.
+Pass `--json` for the structured inspection contract.
 
 ## Capabilities
 

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -110,11 +110,6 @@ interface ChatDevtoolsBridgeState {
   selected?: string
 }
 
-interface ChatDevtoolsHostCommand {
-  name: string
-  text: string
-}
-
 function normalizeChatDevtoolsAction(action: string): ChatDevtoolsAction | undefined {
   if (action === "get-state" || action === chatDevtoolsGetStateRpc) return "get-state"
   if (action === "send" || action === chatDevtoolsSendRpc) return "send"
@@ -587,10 +582,6 @@ function uiMessageMetadata(message: UIMessage): Record<string, unknown> | undefi
   return isRecord(message.metadata) ? message.metadata : undefined
 }
 
-function isHostCommandUIMessage(message: UIMessage): boolean {
-  return isRecord(uiMessageMetadata(message)?.hostCommand)
-}
-
 function hasCompletedMetadata(message: UIMessage): boolean {
   const completedAt = uiMessageMetadata(message)?.completedAt
   return typeof completedAt === "string" && completedAt.trim().length > 0
@@ -646,106 +637,13 @@ function createChatDevtoolsVisibleHistory(messages: UIMessage[]): UIMessage[] {
 }
 
 export function createChatDevtoolsPromptHistory(messages: UIMessage[]): UIMessage[] {
-  return createChatDevtoolsVisibleHistory(messages).filter(message => !isHostCommandUIMessage(message))
+  return createChatDevtoolsVisibleHistory(messages)
 }
 
 function readableStreamFromResult(value: unknown): ReadableStream<never> {
   if (value instanceof ReadableStream) return value as ReadableStream<never>
   if (value instanceof Response && value.body) return value.body as ReadableStream<never>
   throw new Error("[vitehub] Chat DevTools expected a UI message stream.")
-}
-
-function parseChatDevtoolsHostCommand(text: string): ChatDevtoolsHostCommand | undefined {
-  if (!text.startsWith("//")) return
-  const raw = text.slice(2).trim()
-  const name = raw.split(/\s+/, 1)[0] || ""
-  return {
-    name,
-    text,
-  }
-}
-
-function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
-  return `${count} ${count === 1 ? singular : pluralLabel}`
-}
-
-function countDevtoolsFiles(files: NonNullable<ChatDevtoolsStateResult["files"]>): { directories: number, files: number, sources: number } {
-  const sources = new Set<string>()
-  let fileCount = 0
-  let directoryCount = 0
-  const pending = [...files]
-  while (pending.length) {
-    const file = pending.shift()!
-    if (file.kind === "directory") directoryCount += 1
-    else fileCount += 1
-    if (file.source) sources.add(file.source)
-    pending.push(...(file.children || []))
-  }
-  return { directories: directoryCount, files: fileCount, sources: sources.size }
-}
-
-function driverSummary(config: ChatDevtoolsStateResult["config"]): string {
-  const driver = config?.driver
-  if (!driver) return "unavailable"
-  if (driver.kind === "model") return driver.model?.id ? `Model-backed Agent Driver (${driver.model.id})` : "Model-backed Agent Driver"
-  if (driver.kind === "harness") return driver.harness?.provider ? `Harness-backed Agent Driver (${driver.harness.provider})` : "Harness-backed Agent Driver"
-  return "Custom-run Agent Driver"
-}
-
-function namesSummary(values: Array<{ name: string }>, fallback: string): string {
-  if (!values.length) return fallback
-  const names = values.slice(0, 5).map(value => value.name)
-  return values.length > names.length ? `${names.join(", ")}, +${values.length - names.length} more` : names.join(", ")
-}
-
-function inspectSummary(state: ChatDevtoolsStateResult): string {
-  const files = countDevtoolsFiles(state.files || [])
-  const metadata = state.metadataError
-    ? `${state.metadataStatus || "error"} (${state.metadataError})`
-    : state.metadataStatus || "ready"
-  return [
-    "### Agent inspection",
-    `- Agent: ${state.title || state.selected || "unknown"}`,
-    `- Metadata: ${metadata}`,
-    `- Driver: ${driverSummary(state.config)}`,
-    `- Tools: ${plural(state.tools?.length || 0, "tool")} (${namesSummary(state.tools || [], "none")})`,
-    `- Workspace files: ${plural(files.files, "file")}, ${plural(files.directories, "directory", "directories")}, ${plural(files.sources, "source")}`,
-    `- Instructions: ${plural(state.instructions?.length || 0, "document")}`,
-    `- Invoker profiles: ${plural(state.invokerProfiles?.length || 0, "profile")}`,
-    `- Warnings: ${plural(state.warnings?.length || 0, "warning")}`,
-    "",
-    "Use the side panel for full config, files, tools, instructions, and metadata.",
-  ].join("\n")
-}
-
-async function handleDevtoolsHostCommand(
-  state: ChatDevtoolsBridgeState,
-  selected: string,
-  entry: ChatDevtoolsAgentEntry,
-  session: ChatDevtoolsSession,
-  command: ChatDevtoolsHostCommand,
-  userMessage: UIMessage,
-  requestedSelection: ChatDevtoolsInvokerSelection,
-): Promise<ChatDevtoolsStateResult> {
-  if (command.name === "inspect" && entry.metadataTask) {
-    await entry.metadataTask.catch(() => {})
-  }
-  const now = new Date().toISOString()
-  const status = command.name === "inspect" ? "handled" : "unknown"
-  const assistantText = command.name === "inspect"
-    ? inspectSummary(await serializeState(state, selected, requestedSelection))
-    : `Unknown Host Command: \`${command.text}\`.\n\nAvailable Host Commands: \`//inspect\`.`
-  const metadata = {
-    completedAt: now,
-    createdAt: now,
-    hostCommand: { name: command.name || command.text, status },
-  }
-  session.uiMessages = [
-    ...createChatDevtoolsVisibleHistory(session.uiMessages),
-    { ...userMessage, metadata },
-    createAssistantUIMessage(assistantText, metadata),
-  ]
-  return await serializeState(state, selected, requestedSelection)
 }
 
 async function sendDevtoolsUIMessage(
@@ -794,11 +692,6 @@ async function sendDevtoolsUIMessage(
       : requestedProfileId || selectedEntry.metadata.invokerProfiles?.[0]?.id
   }
   const userMessage = createUserUIMessage(text)
-  const hostCommand = parseChatDevtoolsHostCommand(text)
-  if (hostCommand) {
-    return await handleDevtoolsHostCommand(state, selected, selectedEntry, session, hostCommand, userMessage, requestedSelection)
-  }
-
   const visibleBaseMessages = [...createChatDevtoolsVisibleHistory(session.uiMessages), userMessage]
   const promptMessages = [...createChatDevtoolsPromptHistory(session.uiMessages), userMessage]
   const run = createRunMetadata(session, userMessage.id)

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -106,6 +106,7 @@ interface ChatDevtoolsAgentEntry {
 
 interface ChatDevtoolsBridgeState {
   entries: Map<string, ChatDevtoolsAgentEntry>
+  root: string
   sessions: Map<string, ChatDevtoolsSession>
   selected?: string
 }
@@ -536,6 +537,7 @@ async function serializeState(
     ...(requestedSelection.meta ? { meta: requestedSelection.meta } : {}),
     ...(entry?.metadataError ? { metadataError: entry.metadataError } : {}),
     ...(entry?.metadataStatus ? { metadataStatus: entry.metadataStatus } : {}),
+    root: state.root,
     selected: nextSelected,
     thinkingFallback: selectedSession?.thinkingFallback ?? null,
     ...(title ? { title } : {}),
@@ -932,6 +934,7 @@ function errorResponse(error: unknown): Response {
 export function registerChatDevtoolsBridge(server: ViteDevServer): void {
   const state: ChatDevtoolsBridgeState = {
     entries: new Map(),
+    root: server.config.root,
     sessions: new Map(),
   }
   installChatDevtoolsInvalidation(server, state)

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path"
 import { readWorkspaceDevToken, workspaceDevTokenHeader } from "@vite-hub/workspace/server"
 
 import { formatAgentError } from "./agent-error.ts"
+import { runAgentInfoCli } from "./internal/agent-info-cli.ts"
 import { vercelAiGatewayPricing, type AgentUsagePricing } from "./internal/usage-pricing.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig, type ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, readAgentInvocationStream } from "./invocation-stream.ts"
@@ -1285,6 +1286,12 @@ export function createAgentCliContributor(options?: false | AgentCliContributorO
   const evalOptions = resolveAgentEvalOptions(options?.eval)
   const features: AgentCliContributor["namespaces"][number]["features"] = [
     {
+      description: "Inspect a discovered Agent through a running Vite Development Server.",
+      name: "info",
+      run: async (args, context) => await runAgentInfoCli(args, context),
+      usage: "vitehub agent info [--agent <name>] [--json]",
+    },
+    {
       description: "Talk to a discovered Agent through a running Vite Development Server.",
       name: "dev",
       run: async (args, context) => await runAgentDevCli(args, context),
@@ -1307,3 +1314,5 @@ export function createAgentCliContributor(options?: false | AgentCliContributorO
     }],
   }
 }
+
+export { runAgentInfoCli }

--- a/packages/agent/src/internal/agent-info-cli.ts
+++ b/packages/agent/src/internal/agent-info-cli.ts
@@ -199,7 +199,13 @@ export async function runAgentInfoCli<TContext extends AgentInfoCliContext>(
       context.stderr.write(`Agent inspection is unavailable at ${parsed.url}. Start the Vite Development Server with Agent DevTools enabled.\n`)
       return 1
     }
-    state = await response.json() as ChatDevtoolsStateResult
+    try {
+      state = await response.json() as ChatDevtoolsStateResult
+    }
+    catch {
+      context.stderr.write(`Agent inspection returned an invalid response from ${parsed.url}.\n`)
+      return 1
+    }
 
     const agents = state.chats?.map(chat => chat.name) || []
     if (!agents.length) {

--- a/packages/agent/src/internal/agent-info-cli.ts
+++ b/packages/agent/src/internal/agent-info-cli.ts
@@ -2,6 +2,7 @@ import { chatDevtoolsBridgeRoute, type ChatDevtoolsMetadata, type ChatDevtoolsSt
 
 interface AgentInfoCliContext {
   env: NodeJS.ProcessEnv
+  rootDir: string
   stderr: { write: (chunk: string | Uint8Array) => unknown }
   stdout: { write: (chunk: string | Uint8Array) => unknown }
 }
@@ -204,6 +205,10 @@ export async function runAgentInfoCli<TContext extends AgentInfoCliContext>(
     }
     catch {
       context.stderr.write(`Agent inspection returned an invalid response from ${parsed.url}.\n`)
+      return 1
+    }
+    if (typeof state.root === "string" && state.root !== context.rootDir) {
+      context.stderr.write(`Compatible Vite Development Server root mismatch: ${state.root}\n`)
       return 1
     }
 

--- a/packages/agent/src/internal/agent-info-cli.ts
+++ b/packages/agent/src/internal/agent-info-cli.ts
@@ -1,0 +1,228 @@
+import { chatDevtoolsBridgeRoute, type ChatDevtoolsMetadata, type ChatDevtoolsStateResult } from "../chat/devtools-shared.ts"
+
+interface AgentInfoCliContext {
+  env: NodeJS.ProcessEnv
+  stderr: { write: (chunk: string | Uint8Array) => unknown }
+  stdout: { write: (chunk: string | Uint8Array) => unknown }
+}
+
+interface AgentInfoCliOptions {
+  fetch?: typeof fetch
+}
+
+interface ParsedInfoArgs {
+  agent?: string
+  help: boolean
+  json: boolean
+  url: string
+}
+
+function writeInfoUsage(context: AgentInfoCliContext): void {
+  context.stdout.write([
+    "Usage: vitehub agent info [--agent <name>] [--url <url>] [--json]",
+    "",
+    "Inspect a discovered Agent through a running Vite Development Server.",
+    "",
+    "Options:",
+    "  --agent <name>  Agent to inspect. Required when multiple Agents are available.",
+    "  --url <url>     Compatible Vite Development Server URL. Defaults to http://localhost:5173.",
+    "  --json          Print structured Agent metadata.",
+    "  -h, --help      Show this help.",
+    "",
+  ].join("\n"))
+}
+
+function readOptionValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1]
+  if (!value || value.startsWith("-")) throw new Error(`Missing value for ${flag}.`)
+  return value
+}
+
+function parseInfoArgs(args: string[], env: NodeJS.ProcessEnv): ParsedInfoArgs {
+  const parsed: ParsedInfoArgs = {
+    help: false,
+    json: false,
+    url: env.VITEHUB_DEV_SERVER_URL || "http://localhost:5173",
+  }
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]!
+    if (arg === "-h" || arg === "--help") {
+      parsed.help = true
+      continue
+    }
+    if (arg === "--json") {
+      parsed.json = true
+      continue
+    }
+    if (arg === "--agent") {
+      parsed.agent = readOptionValue(args, index, arg)
+      index++
+      continue
+    }
+    if (arg.startsWith("--agent=")) {
+      parsed.agent = arg.slice("--agent=".length)
+      continue
+    }
+    if (arg === "--url" || arg === "--server") {
+      parsed.url = readOptionValue(args, index, arg)
+      index++
+      continue
+    }
+    if (arg.startsWith("--url=")) {
+      parsed.url = arg.slice("--url=".length)
+      continue
+    }
+    if (arg.startsWith("-")) throw new Error(`Unknown option: ${arg}.`)
+    throw new Error(`Unexpected argument: ${arg}.`)
+  }
+
+  return parsed
+}
+
+function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralLabel}`
+}
+
+function countAgentInfoFiles(files: NonNullable<ChatDevtoolsStateResult["files"]>): { directories: number, files: number, sources: number } {
+  const sources = new Set<string>()
+  let fileCount = 0
+  let directoryCount = 0
+  const pending = [...files]
+  while (pending.length) {
+    const file = pending.shift()!
+    if (file.kind === "directory") directoryCount += 1
+    else fileCount += 1
+    if (file.source) sources.add(file.source)
+    pending.push(...(file.children || []))
+  }
+  return { directories: directoryCount, files: fileCount, sources: sources.size }
+}
+
+function agentInfoDriver(config: ChatDevtoolsStateResult["config"]): string {
+  const driver = config?.driver
+  if (!driver) return "unavailable"
+  if (driver.kind === "model") return driver.model?.id ? `Model-backed Agent Driver (${driver.model.id})` : "Model-backed Agent Driver"
+  if (driver.kind === "harness") return driver.harness?.provider ? `Harness-backed Agent Driver (${driver.harness.provider})` : "Harness-backed Agent Driver"
+  return "Custom-run Agent Driver"
+}
+
+function agentInfoNames(values: Array<{ name: string }>, fallback: string): string {
+  if (!values.length) return fallback
+  const names = values.slice(0, 5).map(value => value.name)
+  return values.length > names.length ? `${names.join(", ")}, +${values.length - names.length} more` : names.join(", ")
+}
+
+function writeAgentInfo(context: AgentInfoCliContext, state: ChatDevtoolsStateResult): void {
+  const files = countAgentInfoFiles(state.files || [])
+  const metadata = state.metadataError
+    ? `${state.metadataStatus || "error"} (${state.metadataError})`
+    : state.metadataStatus || "ready"
+  context.stdout.write([
+    `Agent: ${state.selected || "unknown"}`,
+    `Metadata: ${metadata}`,
+    `Driver: ${agentInfoDriver(state.config)}`,
+    `Tools: ${plural(state.tools?.length || 0, "tool")} (${agentInfoNames(state.tools || [], "none")})`,
+    `Workspace files: ${plural(files.files, "file")}, ${plural(files.directories, "directory", "directories")}, ${plural(files.sources, "source")}`,
+    `Instructions: ${plural(state.instructions?.length || 0, "document")}`,
+    `Invoker profiles: ${plural(state.invokerProfiles?.length || 0, "profile")}`,
+    `Warnings: ${plural(state.warnings?.length || 0, "warning")}`,
+    "",
+  ].join("\n"))
+}
+
+function agentInfoMetadata(state: ChatDevtoolsStateResult): ChatDevtoolsMetadata {
+  return {
+    ...(state.config ? { config: state.config } : {}),
+    files: state.files || [],
+    instructions: state.instructions || [],
+    invokerProfiles: state.invokerProfiles || [],
+    name: state.selected,
+    tools: state.tools || [],
+    ...(state.version ? { version: state.version } : {}),
+    warnings: state.warnings || [],
+  }
+}
+
+async function fetchAgentInfoState(url: string, agent: string | undefined, fetchImpl: typeof fetch): Promise<Response> {
+  return await fetchImpl(url, {
+    body: JSON.stringify({ action: "get-state", ...(agent ? { chat: agent } : {}) }),
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    method: "POST",
+  })
+}
+
+export async function runAgentInfoCli<TContext extends AgentInfoCliContext>(
+  args: string[],
+  context: TContext,
+  options: AgentInfoCliOptions = {},
+): Promise<number> {
+  let parsed: ParsedInfoArgs
+  try {
+    parsed = parseInfoArgs(args, context.env)
+  }
+  catch (error) {
+    context.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    writeInfoUsage(context)
+    return 1
+  }
+  if (parsed.help) {
+    writeInfoUsage(context)
+    return 0
+  }
+
+  let url: string
+  try {
+    url = new URL(chatDevtoolsBridgeRoute, parsed.url.endsWith("/") ? parsed.url : `${parsed.url}/`).href
+  }
+  catch {
+    context.stderr.write(`Invalid Vite Development Server URL: ${parsed.url}\n`)
+    return 1
+  }
+
+  const fetchImpl = options.fetch || globalThis.fetch
+  let state: ChatDevtoolsStateResult
+  const startedAt = Date.now()
+  for (;;) {
+    let response: Response
+    try {
+      response = await fetchAgentInfoState(url, parsed.agent, fetchImpl)
+    }
+    catch {
+      context.stderr.write(`No Compatible Vite Development Server found at ${parsed.url}.\n`)
+      return 1
+    }
+    if (!response.ok) {
+      context.stderr.write(`Agent inspection is unavailable at ${parsed.url}. Start the Vite Development Server with Agent DevTools enabled.\n`)
+      return 1
+    }
+    state = await response.json() as ChatDevtoolsStateResult
+
+    const agents = state.chats?.map(chat => chat.name) || []
+    if (!agents.length) {
+      context.stderr.write("No chat-capable Agents discovered.\n")
+      return 1
+    }
+    if (parsed.agent && !agents.includes(parsed.agent)) {
+      context.stderr.write(`Unknown Agent inspection target: ${parsed.agent}\n`)
+      return 1
+    }
+    if (!parsed.agent && agents.length > 1) {
+      context.stderr.write(`Multiple Agents discovered. Pass --agent ${agents.join("|")}.\n`)
+      return 1
+    }
+    if (state.metadataStatus !== "loading") break
+    if (Date.now() - startedAt >= 30_000) {
+      context.stderr.write(`Agent metadata is still loading for ${state.selected}.\n`)
+      return 1
+    }
+    await new Promise(resolve => setTimeout(resolve, 50))
+  }
+
+  if (parsed.json) context.stdout.write(`${JSON.stringify(agentInfoMetadata(state), null, 2)}\n`)
+  else writeAgentInfo(context, state)
+  return state.metadataError ? 1 : 0
+}

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -162,6 +162,20 @@ describe("agent CLI", () => {
     expect(stderr.output()).toBe("Multiple Agents discovered. Pass --agent review|support.\n")
   })
 
+  it("reports an invalid Agent inspection response", async () => {
+    const stderr = stream()
+    const exitCode = await runAgentInfoCli([], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, { fetch: vi.fn(async () => new Response("not json")) as never })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toBe("Agent inspection returned an invalid response from http://localhost:5173.\n")
+  })
+
   it("streams a one-shot Agent Dev Loop message through the Vite endpoint", async () => {
     const stdout = stream()
     const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { refreshWorkspaceDevToken, workspaceDevTokenHeader } from "@vite-hub/workspace/server"
 import { describe, expect, it, vi } from "vitest"
 
-import { createAgentCliContributor, runAgentDevCli, runAgentEvalCli } from "../src/cli.ts"
+import { createAgentCliContributor, runAgentDevCli, runAgentEvalCli, runAgentInfoCli } from "../src/cli.ts"
 import { createAgentEvaliteConfigPath, writeAgentEvaliteConfig } from "../src/internal/evalite-config.ts"
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue } from "../src/invocation-stream.ts"
 
@@ -33,6 +33,7 @@ describe("agent CLI", () => {
         description: "Agent development workflows.",
         features: [
           expect.objectContaining({ name: "eval" }),
+          expect.objectContaining({ name: "info" }),
           expect.objectContaining({ name: "dev" }),
         ],
         name: "agent",
@@ -44,10 +45,121 @@ describe("agent CLI", () => {
     expect(createAgentCliContributor({ eval: false })).toEqual({
       namespaces: [{
         description: "Agent development workflows.",
-        features: [expect.objectContaining({ name: "dev" })],
+        features: [
+          expect.objectContaining({ name: "info" }),
+          expect.objectContaining({ name: "dev" }),
+        ],
         name: "agent",
       }],
     })
+  })
+
+  it("prints concise resolved Agent information from the running Vite server", async () => {
+    const stdout = stream()
+    const fetchAgentInfo = vi.fn(async () => Response.json({
+      chats: [{ messages: [], name: "support" }],
+      config: { driver: { kind: "model", model: { id: "openai/gpt-5" } } },
+      files: [
+        {
+          children: [{ kind: "file", path: "docs/AGENTS.md", source: "docs" }],
+          kind: "directory",
+          path: "docs",
+          source: "docs",
+        },
+      ],
+      instructions: ["docs/AGENTS.md"],
+      invokerProfiles: [{ id: "technical" }],
+      metadataStatus: "ready",
+      selected: "support",
+      tools: [{ name: "search" }, { name: "shell" }],
+      warnings: [],
+    }))
+
+    const exitCode = await runAgentInfoCli([], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr: stream(),
+      stdout,
+    }, { fetch: fetchAgentInfo as never })
+
+    expect(exitCode).toBe(0)
+    expect(stdout.output()).toBe([
+      "Agent: support",
+      "Metadata: ready",
+      "Driver: Model-backed Agent Driver (openai/gpt-5)",
+      "Tools: 2 tools (search, shell)",
+      "Workspace files: 1 file, 1 directory, 1 source",
+      "Instructions: 1 document",
+      "Invoker profiles: 1 profile",
+      "Warnings: 0 warnings",
+      "",
+    ].join("\n"))
+    expect(fetchAgentInfo).toHaveBeenCalledWith("http://localhost:5173/__vitehub/agent/chat/devtools", expect.objectContaining({
+      body: JSON.stringify({ action: "get-state" }),
+      method: "POST",
+    }))
+  })
+
+  it("prints the existing Agent inspection contract as JSON", async () => {
+    const stdout = stream()
+    const fetchAgentInfo = vi.fn(async () => Response.json({
+      chats: [{ messages: [], name: "support" }],
+      config: { driver: { kind: "run" } },
+      files: [],
+      instructions: [],
+      invokerProfiles: [],
+      metadataStatus: "ready",
+      selected: "support",
+      tools: [{ name: "shell" }],
+      uiMessages: [{ id: "private-history", parts: [], role: "user" }],
+      version: "1",
+      warnings: [],
+    }))
+
+    const exitCode = await runAgentInfoCli(["--agent", "support", "--json"], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr: stream(),
+      stdout,
+    }, { fetch: fetchAgentInfo as never })
+
+    expect(exitCode).toBe(0)
+    expect(JSON.parse(stdout.output())).toEqual({
+      config: { driver: { kind: "run" } },
+      files: [],
+      instructions: [],
+      invokerProfiles: [],
+      name: "support",
+      tools: [{ name: "shell" }],
+      version: "1",
+      warnings: [],
+    })
+    expect(JSON.parse(stdout.output())).not.toHaveProperty("uiMessages")
+  })
+
+  it("requires an Agent target when multiple chat-capable Agents are discovered", async () => {
+    const stderr = stream()
+    const fetchAgentInfo = vi.fn(async () => Response.json({
+      chats: [
+        { messages: [], name: "review" },
+        { messages: [], name: "support" },
+      ],
+      metadataStatus: "ready",
+      selected: "review",
+    }))
+
+    const exitCode = await runAgentInfoCli([], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, { fetch: fetchAgentInfo as never })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toBe("Multiple Agents discovered. Pass --agent review|support.\n")
   })
 
   it("streams a one-shot Agent Dev Loop message through the Vite endpoint", async () => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -70,6 +70,7 @@ describe("agent CLI", () => {
       instructions: ["docs/AGENTS.md"],
       invokerProfiles: [{ id: "technical" }],
       metadataStatus: "ready",
+      root: "/repo",
       selected: "support",
       tools: [{ name: "search" }, { name: "shell" }],
       warnings: [],
@@ -174,6 +175,20 @@ describe("agent CLI", () => {
 
     expect(exitCode).toBe(1)
     expect(stderr.output()).toBe("Agent inspection returned an invalid response from http://localhost:5173.\n")
+  })
+
+  it("rejects an Agent inspection server for a different project root", async () => {
+    const stderr = stream()
+    const exitCode = await runAgentInfoCli([], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, { fetch: vi.fn(async () => Response.json({ root: "/other-repo" })) as never })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toBe("Compatible Vite Development Server root mismatch: /other-repo\n")
   })
 
   it("streams a one-shot Agent Dev Loop message through the Vite endpoint", async () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -592,6 +592,40 @@ describe("agent chat capability discovery", () => {
     expect(textFromUiMessage(fallbackFinalState.uiMessages[1])).toBe("answered as devtools:maximo@quiver.dk with workspace")
   })
 
+  it("forwards double-slash input through the normal Agent input path", async () => {
+    const root = await createTempRoot("vitehub-agent-devtools-double-slash-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+
+    const { chat } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const run = vi.fn(({ messages }) => `received ${getMessageText(messages.at(-1))}`)
+    const agent = defineAgent({
+      capabilities: [chat()],
+      driver: { run },
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent()
+
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      action: "send",
+      chat: "support",
+      stream: true,
+      text: "//inspect",
+    })
+    const events = response.body
+      .trim()
+      .split("\n")
+      .map(line => JSON.parse(line))
+    const finalState = events.filter(event => event.type === "state").at(-1)?.state
+
+    expect(events.at(-1)).toEqual({ type: "done" })
+    expect(run).toHaveBeenCalledOnce()
+    expect(textFromUiMessage(finalState.uiMessages[1])).toBe("received //inspect")
+  })
+
   it("serves Agent Invocation Stream events from the Vite endpoint", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -592,59 +592,6 @@ describe("agent chat capability discovery", () => {
     expect(textFromUiMessage(fallbackFinalState.uiMessages[1])).toBe("answered as devtools:maximo@quiver.dk with workspace")
   })
 
-  it("handles chat devtools Host Commands before agent invocation", async () => {
-    const root = await createTempRoot("vitehub-agent-devtools-host-command-")
-    await mkdir(join(root, "server", "agents"), { recursive: true })
-    await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
-
-    const { chat } = await import("../src/capabilities.ts")
-    const { defineAgent } = await import("../src/index.ts")
-    const run = vi.fn(() => "agent response")
-    const agent = defineAgent({
-      capabilities: [chat()],
-      driver: { run },
-    })
-    const { handlers, server } = createFakeServer(root, { default: agent })
-    const plugin = (await import("../src/vite.ts")).hubAgent()
-
-    await configurePluginServer(plugin, server)
-
-    const inspectResponse = await invokeMiddleware(handlers[0]!, {
-      action: "send",
-      chat: "support",
-      stream: true,
-      text: "//inspect",
-    })
-    const inspectEvents = inspectResponse.body
-      .trim()
-      .split("\n")
-      .map(line => JSON.parse(line))
-    const inspectState = inspectEvents.filter(event => event.type === "state").at(-1)?.state
-
-    expect(inspectEvents.at(-1)).toEqual({ type: "done" })
-    expect(run).not.toHaveBeenCalled()
-    expect(textFromUiMessage(inspectState.uiMessages[0])).toBe("//inspect")
-    expect(textFromUiMessage(inspectState.uiMessages[1])).toContain("Agent inspection")
-    expect(textFromUiMessage(inspectState.uiMessages[1])).toContain("Driver: Custom-run Agent Driver")
-
-    const unknownResponse = await invokeMiddleware(handlers[0]!, {
-      action: "send",
-      chat: "support",
-      stream: true,
-      text: "//wat",
-    })
-    const unknownEvents = unknownResponse.body
-      .trim()
-      .split("\n")
-      .map(line => JSON.parse(line))
-    const unknownState = unknownEvents.filter(event => event.type === "state").at(-1)?.state
-
-    expect(unknownEvents.at(-1)).toEqual({ type: "done" })
-    expect(run).not.toHaveBeenCalled()
-    expect(textFromUiMessage(unknownState.uiMessages.at(-1))).toContain("Unknown Host Command: `//wat`")
-    expect(textFromUiMessage(unknownState.uiMessages.at(-1))).toContain("//inspect")
-  })
-
   it("serves Agent Invocation Stream events from the Vite endpoint", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-")
     await mkdir(join(root, "server", "agents"), { recursive: true })
@@ -2264,12 +2211,6 @@ describe("agent chat capability discovery", () => {
           { text: "done", type: "text" },
         ],
         role: "assistant",
-      },
-      {
-        id: "host-command",
-        metadata: { hostCommand: { name: "inspect", status: "handled" } },
-        parts: [{ text: "//inspect", type: "text" }],
-        role: "user",
       },
     ])
 

--- a/packages/devtools/src/chat-shared.ts
+++ b/packages/devtools/src/chat-shared.ts
@@ -143,6 +143,7 @@ export interface ChatDevtoolsStateResult {
   meta?: Record<string, unknown>
   metadataError?: string
   metadataStatus?: ChatDevtoolsMetadataStatus
+  root?: string
   selected: string
   thinkingFallback?: string | null
   title?: string


### PR DESCRIPTION
Adds `vitehub agent info` as the runtime-backed inspection surface for chat-capable Agent Definitions, with concise human output and `--json` using the existing metadata contract. It reads resolved Agent DevTools metadata without invoking the Agent Driver.

Removes the legacy Chat DevTools `//inspect` Host Command parser and its general `//` namespace, so double-slash input follows the normal Agent input path. Updates the Agent and CLI documentation and adds focused CLI coverage while preserving `vitehub agent dev`.