### PR TITLE
feat(schedule): add waitUntil to run contexts

### DIFF
--- a/docs/content/docs/server-primitives/schedule.md
+++ b/docs/content/docs/server-primitives/schedule.md
@@ -37,8 +37,9 @@ import { defineSchedule } from '@vite-hub/schedule'
 
 export default defineSchedule({
   cron: '0 8 * * *',
-  async handler(context) {
-    await sendDailyReport(context.scheduledAt)
+  async handler({ scheduledAt, waitUntil }) {
+    await sendDailyReport(scheduledAt)
+    waitUntil(recordDelivery())
   },
 })
 ```
@@ -139,7 +140,9 @@ Cron expressions use the Schedule Time Base, currently UTC. The discovered file 
 | `handler` | `ScheduleHandler` | Yes | Function called with Schedule Run Context. |
 | `allowRuntimeSchedules` | `boolean` | No | Allows Runtime Schedules to target this definition. |
 
-`ScheduleRunContext` includes `id`, `scheduledAt`, optional `attemptId`, optional `runId`, optional Runtime Schedule id, optional Runtime Schedule target, and optional Runtime Schedule `input`.
+`ScheduleRunContext` includes `id`, `scheduledAt`, `waitUntil`, optional `attemptId`, optional `runId`, optional Runtime Schedule id, optional Runtime Schedule target, and optional Runtime Schedule `input`.
+
+Use `waitUntil(promise)` for consequential work that can outlive the handler body. Direct and local execution settles registered work before recording the Schedule Run result; a rejection fails the run with the same diagnostics as a handler rejection. An installed wake runtime instead retains registered work after the handler returns, reports rejection through its `onError` hook, and drains outstanding work when the runtime closes.
 
 ## Create recurring Runtime Schedules
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -571,6 +571,7 @@ interface ScheduleRunContextLike {
   scheduleId?: string
   scheduledAt: Date
   target?: string
+  waitUntil?: (promise: PromiseLike<unknown>) => void
 }
 
 const agentWorkflowHandles = new WeakMap<object, Map<string, WorkflowHandle<AgentWorkflowInvocationPayload, unknown>>>()
@@ -2378,7 +2379,7 @@ export async function runScheduledAgent(
     },
     run: { ...runtimeContext.run, ...turn?.delivery, runId },
     runtime: runtimeContext.runtime ?? "unknown",
-    waitUntil: runtimeContext.waitUntil ?? (() => {}),
+    waitUntil: runtimeContext.waitUntil ?? context.waitUntil ?? (() => {}),
   }, {
     context: {
       ...(turn

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2377,8 +2377,10 @@ describe("agent message protocol", () => {
   it("runs scheduled agents with schedule-owned input metadata and no synthetic messages", async () => {
     const { defineAgent, runScheduledAgent } = await import("../src/index.ts")
     const seen: unknown[] = []
+    const waitUntil = vi.fn()
     const agent = defineAgent({
       driver: { run: context => {
+          context.waitUntil(Promise.resolve())
           seen.push({ input: context.input, messages: context.messages })
           return "ok"
         } },
@@ -2391,7 +2393,10 @@ describe("agent message protocol", () => {
       scheduleId: "schedule-0-9",
       scheduledAt: new Date("2026-05-23T09:00:00.000Z"),
       target: "support",
+      waitUntil,
     })).resolves.toBe("ok")
+
+    expect(waitUntil).toHaveBeenCalledOnce()
 
     expect(seen).toEqual([{
       input: {

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -492,7 +492,7 @@ function renderProviderEntry(file: string, registryFile: string, provider: "clou
           "    const tasks = Object.entries(scheduleRegistry).map(async ([name]) => {",
           "      const definition = await loadScheduleDefinition(name)",
           "      if (!definition || definition.cron !== event.cron) return",
-          "      await executeStaticSchedule({ cron: event.cron, definition, name, scheduledAt: new Date(event.scheduledTime), waitUntil: promise => ctx.waitUntil(promise) })",
+          "      await executeStaticSchedule({ cron: event.cron, definition, name, scheduledAt: new Date(event.scheduledTime), waitUntil: (promise) => ctx.waitUntil(promise) })",
           "    })",
           "    await Promise.all(tasks)",
           "  },",

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -492,7 +492,7 @@ function renderProviderEntry(file: string, registryFile: string, provider: "clou
           "    const tasks = Object.entries(scheduleRegistry).map(async ([name]) => {",
           "      const definition = await loadScheduleDefinition(name)",
           "      if (!definition || definition.cron !== event.cron) return",
-          "      await executeStaticSchedule({ cron: event.cron, definition, name, scheduledAt: new Date(event.scheduledTime) })",
+          "      await executeStaticSchedule({ cron: event.cron, definition, name, scheduledAt: new Date(event.scheduledTime), waitUntil: promise => ctx.waitUntil(promise) })",
           "    })",
           "    await Promise.all(tasks)",
           "  },",

--- a/packages/schedule/src/runtime/driver.ts
+++ b/packages/schedule/src/runtime/driver.ts
@@ -375,6 +375,7 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
   let reconciledDriver: RuntimeScheduleWakeDriver | undefined
   let staticSchedules: StaticSchedules = { byId: new Map(), records: [] }
   let aborted = false
+  let closing = false
 
   setScheduleRuntimeRegistry(options.registry)
   setScheduleRunStore(options.scheduleRunStore)
@@ -385,7 +386,7 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
       staticSchedules = createStaticSchedules(await loadStaticDefinitions(options.staticRegistry), runtimeSchedules)
       driver = await options.createDriver({
         reportError,
-        wake: input => serialize.runWake(async () => {
+        wake: input => closing ? Promise.resolve() : serialize.runWake(async () => {
           const staticSchedule = staticSchedules.byId.get(input.scheduleId)
           if (staticSchedule) {
             if (!isRuntimeScheduleDue(staticSchedule.record, input.scheduledAt)) {
@@ -461,7 +462,9 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
   let closePromise: Promise<void> | undefined
   return {
     close() {
-      return closePromise ??= serialize(async () => {}).then(async () => {
+      if (closePromise) return closePromise
+      closing = true
+      return closePromise = serialize(async () => {}).then(async () => {
         await flushWaitUntil()
         await installedDriver.close?.()
       })

--- a/packages/schedule/src/runtime/driver.ts
+++ b/packages/schedule/src/runtime/driver.ts
@@ -353,6 +353,23 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
   const previousRuntimeScheduleStore = getRuntimeScheduleStore()
   const previousScheduleRunStore = getScheduleRunStore()
   const reportError = createErrorReporter(options.onError)
+  const pendingWork = new Set<Promise<unknown>>()
+  function waitUntil(value: PromiseLike<unknown>): void {
+    const promise = Promise.resolve(value)
+    pendingWork.add(promise)
+    void promise.then(
+      () => pendingWork.delete(promise),
+      (error) => {
+        pendingWork.delete(promise)
+        reportError(error)
+      },
+    )
+  }
+  async function flushWaitUntil(): Promise<void> {
+    while (pendingWork.size > 0) {
+      await Promise.allSettled([...pendingWork])
+    }
+  }
   const serialize = createSerializer()
   let driver: RuntimeScheduleWakeDriver | undefined
   let reconciledDriver: RuntimeScheduleWakeDriver | undefined
@@ -383,12 +400,14 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
               definition: staticSchedule.definition,
               name: staticSchedule.name,
               scheduledAt: input.scheduledAt,
+              waitUntil,
             })
             return
           }
           await executeRuntimeScheduleWake(input, {
             runtimeScheduleStore: options.runtimeScheduleStore,
             scheduleRunStore: options.scheduleRunStore,
+            waitUntil,
           })
         }),
       })
@@ -444,6 +463,7 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
     close() {
       return closePromise ??= serialize(async () => {}).then(async () => {
         await installedDriver.close?.()
+        await flushWaitUntil()
       })
     },
   }

--- a/packages/schedule/src/runtime/driver.ts
+++ b/packages/schedule/src/runtime/driver.ts
@@ -462,8 +462,8 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
   return {
     close() {
       return closePromise ??= serialize(async () => {}).then(async () => {
-        await installedDriver.close?.()
         await flushWaitUntil()
+        await installedDriver.close?.()
       })
     },
   }

--- a/packages/schedule/src/runtime/driver.ts
+++ b/packages/schedule/src/runtime/driver.ts
@@ -371,6 +371,7 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
     }
   }
   const serialize = createSerializer()
+  const activeWakes = new Set<Promise<void>>()
   let driver: RuntimeScheduleWakeDriver | undefined
   let reconciledDriver: RuntimeScheduleWakeDriver | undefined
   let staticSchedules: StaticSchedules = { byId: new Map(), records: [] }
@@ -386,31 +387,37 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
       staticSchedules = createStaticSchedules(await loadStaticDefinitions(options.staticRegistry), runtimeSchedules)
       driver = await options.createDriver({
         reportError,
-        wake: input => closing ? Promise.resolve() : serialize.runWake(async () => {
-          const staticSchedule = staticSchedules.byId.get(input.scheduleId)
-          if (staticSchedule) {
-            if (!isRuntimeScheduleDue(staticSchedule.record, input.scheduledAt)) {
-              throw new ScheduleError(`Static Schedule is not due: ${staticSchedule.name}`, {
-                code: "SCHEDULE_NOT_DUE",
-                details: { id: input.scheduleId, scheduledAt: input.scheduledAt },
-                httpStatus: 409,
+        wake(input) {
+          if (closing) return Promise.resolve()
+          const wake = serialize.runWake(async () => {
+            const staticSchedule = staticSchedules.byId.get(input.scheduleId)
+            if (staticSchedule) {
+              if (!isRuntimeScheduleDue(staticSchedule.record, input.scheduledAt)) {
+                throw new ScheduleError(`Static Schedule is not due: ${staticSchedule.name}`, {
+                  code: "SCHEDULE_NOT_DUE",
+                  details: { id: input.scheduleId, scheduledAt: input.scheduledAt },
+                  httpStatus: 409,
+                })
+              }
+              await executeStaticSchedule({
+                cron: staticSchedule.definition.cron,
+                definition: staticSchedule.definition,
+                name: staticSchedule.name,
+                scheduledAt: input.scheduledAt,
+                waitUntil,
               })
+              return
             }
-            await executeStaticSchedule({
-              cron: staticSchedule.definition.cron,
-              definition: staticSchedule.definition,
-              name: staticSchedule.name,
-              scheduledAt: input.scheduledAt,
+            await executeRuntimeScheduleWake(input, {
+              runtimeScheduleStore: options.runtimeScheduleStore,
+              scheduleRunStore: options.scheduleRunStore,
               waitUntil,
             })
-            return
-          }
-          await executeRuntimeScheduleWake(input, {
-            runtimeScheduleStore: options.runtimeScheduleStore,
-            scheduleRunStore: options.scheduleRunStore,
-            waitUntil,
           })
-        }),
+          activeWakes.add(wake)
+          void wake.finally(() => activeWakes.delete(wake)).catch(() => {})
+          return wake
+        },
       })
       const installedDriver = driver
       reconciledDriver = {
@@ -464,10 +471,13 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
     close() {
       if (closePromise) return closePromise
       closing = true
-      return closePromise = serialize(async () => {}).then(async () => {
+      return closePromise = (async () => {
+        while (activeWakes.size > 0) {
+          await Promise.allSettled([...activeWakes])
+        }
         await flushWaitUntil()
         await installedDriver.close?.()
-      })
+      })()
     },
   }
 }

--- a/packages/schedule/src/runtime/driver.ts
+++ b/packages/schedule/src/runtime/driver.ts
@@ -475,6 +475,7 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
         while (activeWakes.size > 0) {
           await Promise.allSettled([...activeWakes])
         }
+        await serialize(async () => {})
         await flushWaitUntil()
         await installedDriver.close?.()
       })()

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -3,6 +3,7 @@ import { randomId } from "@vite-hub/internal/runtime/random"
 import { ScheduleError } from "../errors.ts"
 import { isRuntimeScheduleDue } from "./due.ts"
 import { getRuntimeScheduleStore, getScheduleRunStore, loadScheduleDefinition } from "./state.ts"
+import { createLocalWaitUntil } from "./wait-until.ts"
 
 import type { RuntimeScheduleRecord, RuntimeScheduleStore, RuntimeScheduleWake, ScheduleDefinition, ScheduleRegistryDefinition, ScheduleRunAttemptRecord, ScheduleRunContext, ScheduleRunError, ScheduleRunRecord, ScheduleRunStore, ScheduleTargetName } from "../types.ts"
 
@@ -14,6 +15,7 @@ interface ExecuteScheduleOptions {
   source?: "direct" | "runtime" | "static"
   scheduledAt?: Date
   target: ScheduleTargetName
+  waitUntil?: (promise: PromiseLike<unknown>) => void
 }
 
 interface ExecuteStaticScheduleOptions {
@@ -21,6 +23,7 @@ interface ExecuteStaticScheduleOptions {
   definition: ScheduleDefinition
   name: string
   scheduledAt?: Date
+  waitUntil?: (promise: PromiseLike<unknown>) => void
 }
 
 interface ExecuteRuntimeScheduleOptions {
@@ -29,11 +32,13 @@ interface ExecuteRuntimeScheduleOptions {
   runtimeScheduleStore?: RuntimeScheduleStore
   scheduledAt?: Date
   scheduleRunStore?: ScheduleRunStore
+  waitUntil?: (promise: PromiseLike<unknown>) => void
 }
 
 interface ExecuteRuntimeScheduleWakeOptions {
   runtimeScheduleStore: RuntimeScheduleStore
   scheduleRunStore: ScheduleRunStore
+  waitUntil?: (promise: PromiseLike<unknown>) => void
 }
 
 function assertRuntimeExecuteOptionsObject(options: unknown): asserts options is ExecuteRuntimeScheduleOptions {
@@ -140,7 +145,12 @@ async function startAttempt(run: ScheduleRunRecord, store: ScheduleRunStore = ge
   return attempt
 }
 
-function toHandlerContext(run: ScheduleRunRecord, attempt: ScheduleRunAttemptRecord, input?: unknown): ScheduleRunContext {
+function toHandlerContext(
+  run: ScheduleRunRecord,
+  attempt: ScheduleRunAttemptRecord,
+  input: unknown,
+  waitUntil: (promise: PromiseLike<unknown>) => void,
+): ScheduleRunContext {
   return {
     attemptId: attempt.id,
     id: run.id,
@@ -149,6 +159,7 @@ function toHandlerContext(run: ScheduleRunRecord, attempt: ScheduleRunAttemptRec
     scheduleId: run.scheduleId,
     scheduledAt: run.scheduledAt,
     target: run.target,
+    waitUntil,
   }
 }
 
@@ -183,7 +194,7 @@ async function failRun(run: ScheduleRunRecord, attempt: ScheduleRunAttemptRecord
   }))
 }
 
-export async function createScheduleRun(options: Omit<ExecuteScheduleOptions, "definition">): Promise<ScheduleRunRecord> {
+export async function createScheduleRun(options: Omit<ExecuteScheduleOptions, "definition" | "waitUntil">): Promise<ScheduleRunRecord> {
   const scheduledAt = validateScheduledAt(options.scheduledAt ?? new Date())
   return (await createOrGetRun({ ...options, scheduledAt })).run
 }
@@ -200,8 +211,11 @@ export async function executeSchedule(options: ExecuteScheduleOptions): Promise<
 
   const runStore = options.runStore ?? getScheduleRunStore()
   const attempt = await startAttempt(run, runStore)
+  const localWaitUntil = createLocalWaitUntil()
+  const waitUntil = options.waitUntil ?? localWaitUntil.waitUntil
   try {
-    await options.definition.handler(toHandlerContext(run, attempt, options.input))
+    await options.definition.handler(toHandlerContext(run, attempt, options.input, waitUntil))
+    if (!options.waitUntil) await localWaitUntil.flush()
     return await completeRun(run, attempt, runStore)
   }
   catch (error) {
@@ -217,6 +231,7 @@ export async function executeStaticSchedule(options: ExecuteStaticScheduleOption
     source: "static",
     scheduledAt: options.scheduledAt,
     target: options.name,
+    waitUntil: options.waitUntil,
   })
 }
 
@@ -283,6 +298,7 @@ export async function executeRuntimeSchedule(options: ExecuteRuntimeScheduleOpti
     source: "runtime",
     scheduledAt,
     target: schedule.target,
+    waitUntil: runtimeOptions.waitUntil,
   })
 }
 
@@ -293,5 +309,6 @@ export async function executeRuntimeScheduleWake(input: RuntimeScheduleWake, opt
     runtimeScheduleStore: options.runtimeScheduleStore,
     scheduledAt: input.scheduledAt,
     scheduleRunStore: options.scheduleRunStore,
+    waitUntil: options.waitUntil,
   })
 }

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -219,6 +219,14 @@ export async function executeSchedule(options: ExecuteScheduleOptions): Promise<
     return await completeRun(run, attempt, runStore)
   }
   catch (error) {
+    if (!options.waitUntil) {
+      try {
+        await localWaitUntil.flush()
+      }
+      catch {
+        // Preserve the handler error after all locally owned work settles.
+      }
+    }
     await failRun(run, attempt, error, runStore)
     throw error
   }

--- a/packages/schedule/src/runtime/static.ts
+++ b/packages/schedule/src/runtime/static.ts
@@ -1,10 +1,12 @@
 import type { ScheduleDefinition, ScheduleDefinitionRegistry, ScheduleRegistryDefinition, ScheduleRunContext } from "../types.ts"
+import { createLocalWaitUntil } from "./wait-until.ts"
 
 export interface ExecuteStaticScheduleOptions {
   cron: string
   definition: ScheduleDefinition
   name: string
   scheduledAt?: Date
+  waitUntil?: (promise: PromiseLike<unknown>) => void
 }
 
 export interface ExecuteMatchingStaticSchedulesOptions {
@@ -34,18 +36,27 @@ export interface StaticScheduleRun extends ScheduleRunContext {
   scheduleId: string
 }
 
-export function createStaticScheduleRun(options: Omit<ExecuteStaticScheduleOptions, "definition">): StaticScheduleRun {
+export function createStaticScheduleRun(
+  options: Omit<ExecuteStaticScheduleOptions, "definition" | "waitUntil"> & { waitUntil: NonNullable<ExecuteStaticScheduleOptions["waitUntil"]> },
+): StaticScheduleRun {
   const scheduledAt = options.scheduledAt ?? new Date()
   return {
     cron: options.cron,
     id: `run_${options.name}_${scheduledAt.toISOString()}`,
     scheduleId: options.name,
     scheduledAt,
+    waitUntil: options.waitUntil,
   }
 }
 
 export async function executeStaticSchedule(options: ExecuteStaticScheduleOptions): Promise<unknown> {
-  return await options.definition.handler(createStaticScheduleRun(options))
+  const localWaitUntil = createLocalWaitUntil()
+  const result = await options.definition.handler(createStaticScheduleRun({
+    ...options,
+    waitUntil: options.waitUntil ?? localWaitUntil.waitUntil,
+  }))
+  if (!options.waitUntil) await localWaitUntil.flush()
+  return result
 }
 
 export async function executeMatchingStaticSchedules(options: ExecuteMatchingStaticSchedulesOptions): Promise<unknown[]> {

--- a/packages/schedule/src/runtime/static.ts
+++ b/packages/schedule/src/runtime/static.ts
@@ -90,14 +90,14 @@ export async function executeCloudflareStaticSchedules(
 ): Promise<unknown[]> {
   const scheduled = readCloudflareScheduledEvent(event)
   const hostWaitUntil = readCloudflareWaitUntil(event)
-  return await runWithCloudflareServerEnv(event, async () => {
+  return await runWithCloudflareServerEnv(event, async (waitUntil) => {
     return await executeMatchingStaticSchedules({
       cron: scheduled.cron,
       registry: options.registry,
       scheduledAt: scheduled.scheduledAt,
-      waitUntil: hostWaitUntil ? promise => hostWaitUntil(Promise.resolve(promise)) : undefined,
+      waitUntil,
     })
-  })
+  }, hostWaitUntil)
 }
 
 function readCloudflareScheduledEvent(event: CloudflareScheduledEventLike): { cron: string, scheduledAt: Date } {
@@ -117,24 +117,47 @@ function readCloudflareScheduledEvent(event: CloudflareScheduledEventLike): { cr
   return { cron, scheduledAt }
 }
 
-function runWithCloudflareServerEnv<T>(event: CloudflareScheduledEventLike, callback: () => T): T {
+async function runWithCloudflareServerEnv<T>(
+  event: CloudflareScheduledEventLike,
+  callback: (waitUntil?: (promise: PromiseLike<unknown>) => void) => Promise<T>,
+  hostWaitUntil?: (promise: Promise<unknown>) => void,
+): Promise<T> {
   const globals = globalThis as { __env__?: Record<string, unknown> }
   const hadGlobalEnv = Object.prototype.hasOwnProperty.call(globals, "__env__")
   const previousGlobalEnv = globals.__env__
   const env = readCloudflareEventEnv(event)
   if (env) globals.__env__ = env
+  const pending = new Set<Promise<unknown>>()
+  const waitUntil = hostWaitUntil
+    ? (value: PromiseLike<unknown>) => {
+        const promise = Promise.resolve(value)
+        pending.add(promise)
+        void promise.then(
+          () => pending.delete(promise),
+          () => pending.delete(promise),
+        )
+        hostWaitUntil(promise)
+      }
+    : undefined
 
   try {
-    const result = callback()
-    if (isPromiseLike(result)) {
-      return result.finally(() => restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)) as T
-    }
-    restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)
-    return result
+    return await callback(waitUntil)
   }
-  catch (error) {
-    restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)
-    throw error
+  finally {
+    if (pending.size === 0) {
+      restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)
+    }
+    else {
+      hostWaitUntil!(flushPendingWork(pending).finally(() => {
+        restoreGlobalEnv(globals, hadGlobalEnv, previousGlobalEnv)
+      }))
+    }
+  }
+}
+
+async function flushPendingWork(pending: Set<Promise<unknown>>): Promise<void> {
+  while (pending.size > 0) {
+    await Promise.allSettled([...pending])
   }
 }
 
@@ -145,12 +168,6 @@ function restoreGlobalEnv(
 ): void {
   if (hadGlobalEnv) globals.__env__ = previousGlobalEnv
   else delete globals.__env__
-}
-
-function isPromiseLike(value: unknown): value is Promise<unknown> {
-  return typeof value === "object"
-    && value !== null
-    && typeof (value as { finally?: unknown }).finally === "function"
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/schedule/src/runtime/static.ts
+++ b/packages/schedule/src/runtime/static.ts
@@ -18,6 +18,7 @@ export interface ExecuteMatchingStaticSchedulesOptions {
 
 export interface ExecuteCloudflareStaticSchedulesOptions {
   registry: ScheduleDefinitionRegistry
+  waitUntil?: (promise: PromiseLike<unknown>) => void
 }
 
 interface CloudflareScheduledEventLike {
@@ -89,7 +90,7 @@ export async function executeCloudflareStaticSchedules(
   options: ExecuteCloudflareStaticSchedulesOptions,
 ): Promise<unknown[]> {
   const scheduled = readCloudflareScheduledEvent(event)
-  const hostWaitUntil = readCloudflareWaitUntil(event)
+  const hostWaitUntil = options.waitUntil ?? readCloudflareWaitUntil(event)
   return await runWithCloudflareServerEnv(event, async (waitUntil) => {
     return await executeMatchingStaticSchedules({
       cron: scheduled.cron,

--- a/packages/schedule/src/runtime/static.ts
+++ b/packages/schedule/src/runtime/static.ts
@@ -13,6 +13,7 @@ export interface ExecuteMatchingStaticSchedulesOptions {
   cron: string
   registry: ScheduleDefinitionRegistry
   scheduledAt?: Date
+  waitUntil?: (promise: PromiseLike<unknown>) => void
 }
 
 export interface ExecuteCloudflareStaticSchedulesOptions {
@@ -78,7 +79,7 @@ export async function executeMatchingStaticSchedules(options: ExecuteMatchingSta
   for (const [name, load] of Object.entries(options.registry)) {
     const definition = unwrapScheduleDefinition(await load())
     if (!definition || definition.cron !== options.cron) continue
-    runs.push(executeStaticSchedule({ cron: options.cron, definition, name, scheduledAt }))
+    runs.push(executeStaticSchedule({ cron: options.cron, definition, name, scheduledAt, waitUntil: options.waitUntil }))
   }
   return await Promise.all(runs)
 }
@@ -88,11 +89,13 @@ export async function executeCloudflareStaticSchedules(
   options: ExecuteCloudflareStaticSchedulesOptions,
 ): Promise<unknown[]> {
   const scheduled = readCloudflareScheduledEvent(event)
+  const hostWaitUntil = readCloudflareWaitUntil(event)
   return await runWithCloudflareServerEnv(event, async () => {
     return await executeMatchingStaticSchedules({
       cron: scheduled.cron,
       registry: options.registry,
       scheduledAt: scheduled.scheduledAt,
+      waitUntil: hostWaitUntil ? promise => hostWaitUntil(Promise.resolve(promise)) : undefined,
     })
   })
 }
@@ -152,6 +155,33 @@ function isPromiseLike(value: unknown): value is Promise<unknown> {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+// ponytail: Keep this provider entry free of the Node-backed shared Cloudflare runtime module.
+function readCloudflareWaitUntil(event: CloudflareScheduledEventLike): ((promise: Promise<unknown>) => void) | undefined {
+  const context = isRecord(event.context) ? event.context : undefined
+  const cloudflareContext = isRecord(context?.cloudflare) ? context.cloudflare : undefined
+  const platformContext = isRecord(context?._platform) ? context._platform : undefined
+  const platformCloudflareContext = isRecord(platformContext?.cloudflare) ? platformContext.cloudflare : undefined
+  const request = isRecord(event.req) ? event.req : undefined
+  const runtime = isRecord(request?.runtime) ? request.runtime : undefined
+  const runtimeCloudflare = isRecord(runtime?.cloudflare) ? runtime.cloudflare : undefined
+  const owners = [
+    event,
+    context,
+    cloudflareContext,
+    isRecord(cloudflareContext?.context) ? cloudflareContext.context : undefined,
+    platformCloudflareContext,
+    isRecord(platformCloudflareContext?.context) ? platformCloudflareContext.context : undefined,
+    request,
+    runtimeCloudflare,
+    isRecord(runtimeCloudflare?.context) ? runtimeCloudflare.context : undefined,
+  ]
+  for (const owner of owners) {
+    if (typeof owner?.waitUntil === "function") {
+      return (owner.waitUntil as (promise: Promise<unknown>) => void).bind(owner)
+    }
+  }
 }
 
 function readCloudflareEventEnv(event: CloudflareScheduledEventLike): Record<string, unknown> | undefined {

--- a/packages/schedule/src/runtime/static.ts
+++ b/packages/schedule/src/runtime/static.ts
@@ -51,12 +51,25 @@ export function createStaticScheduleRun(
 
 export async function executeStaticSchedule(options: ExecuteStaticScheduleOptions): Promise<unknown> {
   const localWaitUntil = createLocalWaitUntil()
-  const result = await options.definition.handler(createStaticScheduleRun({
-    ...options,
-    waitUntil: options.waitUntil ?? localWaitUntil.waitUntil,
-  }))
-  if (!options.waitUntil) await localWaitUntil.flush()
-  return result
+  try {
+    const result = await options.definition.handler(createStaticScheduleRun({
+      ...options,
+      waitUntil: options.waitUntil ?? localWaitUntil.waitUntil,
+    }))
+    if (!options.waitUntil) await localWaitUntil.flush()
+    return result
+  }
+  catch (error) {
+    if (!options.waitUntil) {
+      try {
+        await localWaitUntil.flush()
+      }
+      catch {
+        // Preserve the handler error after all locally owned work settles.
+      }
+    }
+    throw error
+  }
 }
 
 export async function executeMatchingStaticSchedules(options: ExecuteMatchingStaticSchedulesOptions): Promise<unknown[]> {

--- a/packages/schedule/src/runtime/wait-until.ts
+++ b/packages/schedule/src/runtime/wait-until.ts
@@ -1,0 +1,31 @@
+interface LocalWaitUntil {
+  flush(): Promise<void>
+  waitUntil(promise: PromiseLike<unknown>): void
+}
+
+export function createLocalWaitUntil(): LocalWaitUntil {
+  const pending = new Set<Promise<unknown>>()
+  let error: unknown
+  let failed = false
+
+  return {
+    async flush() {
+      while (pending.size > 0) {
+        await Promise.allSettled([...pending])
+      }
+      if (failed) throw error
+    },
+    waitUntil(value) {
+      const promise = Promise.resolve(value)
+      pending.add(promise)
+      void promise.then(
+        () => pending.delete(promise),
+        (reason) => {
+          pending.delete(promise)
+          if (!failed) error = reason
+          failed = true
+        },
+      )
+    },
+  }
+}

--- a/packages/schedule/src/types.ts
+++ b/packages/schedule/src/types.ts
@@ -6,6 +6,7 @@ export interface ScheduleRunContext<TInput = unknown> {
   scheduleId?: string
   scheduledAt: Date
   target?: ScheduleTargetName
+  waitUntil(promise: PromiseLike<unknown>): void
 }
 
 export type ScheduleHandler<TResult = unknown, TInput = unknown> = {

--- a/packages/schedule/test/driver.test.ts
+++ b/packages/schedule/test/driver.test.ts
@@ -870,6 +870,35 @@ describe("Runtime Schedule Wake Driver", () => {
     expect(await loadScheduleDefinition("report")).toBeDefined()
   })
 
+  it("waits for queued Runtime Schedule mutations before closing the driver", async () => {
+    let releaseReconcile: (() => void) | undefined
+    let driverClosed = false
+    const controller = await installScheduleRuntime({
+      createDriver: () => ({
+        async close() { driverClosed = true },
+        async reconcile(records) {
+          if (records.some(record => record.id === "daily")) {
+            await new Promise<void>(resolve => { releaseReconcile = resolve })
+          }
+        },
+      }),
+      registry,
+      runtimeScheduleStore: createMemoryRuntimeScheduleStore(),
+      scheduleRunStore: createMemoryScheduleRunStore(),
+    })
+
+    const mutation = schedules.create({ cron: "0 9 * * *", id: "daily", target: "report" })
+    await vi.waitFor(() => expect(releaseReconcile).toBeTypeOf("function"))
+    let closed = false
+    const closing = controller.close().then(() => { closed = true })
+    await Promise.resolve()
+    expect(driverClosed).toBe(false)
+    expect(closed).toBe(false)
+    releaseReconcile!()
+    await Promise.all([mutation, closing])
+    expect(driverClosed).toBe(true)
+  })
+
   it("lets active wake handlers mutate Runtime Schedules while closing", async () => {
     const scheduledAt = new Date("2026-07-11T09:00:00.000Z")
     const runtimeScheduleStore = createMemoryRuntimeScheduleStore()

--- a/packages/schedule/test/driver.test.ts
+++ b/packages/schedule/test/driver.test.ts
@@ -875,8 +875,7 @@ describe("Runtime Schedule Wake Driver", () => {
     const runtimeScheduleStore = createMemoryRuntimeScheduleStore()
     let context: RuntimeScheduleWakeDriverContext | undefined
     let activeWake: Promise<void> | undefined
-    let markCloseStarted: (() => void) | undefined
-    const closeStarted = new Promise<void>(resolve => { markCloseStarted = resolve })
+    let releaseHandler: (() => void) | undefined
     await runtimeScheduleStore.create({
       createdAt: scheduledAt,
       cron: "0 9 * * *",
@@ -889,10 +888,7 @@ describe("Runtime Schedule Wake Driver", () => {
       createDriver(driverContext) {
         context = driverContext
         return {
-          async close() {
-            markCloseStarted?.()
-            await activeWake
-          },
+          async close() {},
           async reconcile() {},
         }
       },
@@ -900,7 +896,7 @@ describe("Runtime Schedule Wake Driver", () => {
         report: async () => ({
           cron: "0 9 * * *",
           handler: async () => {
-            await closeStarted
+            await new Promise<void>(resolve => { releaseHandler = resolve })
             await schedules.create({ cron: "0 10 * * *", id: "follow-up", target: "report" })
           },
           options: { allowRuntimeSchedules: true },
@@ -911,7 +907,9 @@ describe("Runtime Schedule Wake Driver", () => {
     })
 
     activeWake = context!.wake({ scheduleId: "daily", scheduledAt })
+    await vi.waitFor(() => expect(releaseHandler).toBeTypeOf("function"))
     const closing = controller.close()
+    releaseHandler!()
 
     await vi.waitFor(() => expect(runtimeScheduleStore.get("follow-up")).toBeDefined(), {
       interval: 1,

--- a/packages/schedule/test/process-driver.test.ts
+++ b/packages/schedule/test/process-driver.test.ts
@@ -83,27 +83,18 @@ describe("Process Schedule Wake Driver", () => {
     const now = new Date("2026-07-11T09:00:20.000Z")
     const runtimeScheduleStore = createMemoryRuntimeScheduleStore()
     await runtimeScheduleStore.create(record("daily"))
-    let markCloseStarted: (() => void) | undefined
-    const closeStarted = new Promise<void>(resolve => { markCloseStarted = resolve })
+    let releaseHandler: (() => void) | undefined
     const processDriverFactory = createProcessScheduleWakeDriver({ now: () => now })
 
     const controller = await installScheduleRuntime({
       async createDriver(context) {
-        const driver = await processDriverFactory(context)
-        return {
-          async close() {
-            const closing = Promise.resolve(driver.close?.())
-            markCloseStarted?.()
-            await closing
-          },
-          reconcile: records => driver.reconcile(records),
-        }
+        return await processDriverFactory(context)
       },
       registry: {
         report: async () => ({
           cron: "* * * * *",
           handler: async () => {
-            await closeStarted
+            await new Promise<void>(resolve => { releaseHandler = resolve })
             await schedules.create({ cron: "0 10 * * *", id: "follow-up", target: "report" })
           },
           options: { allowRuntimeSchedules: true },
@@ -113,7 +104,10 @@ describe("Process Schedule Wake Driver", () => {
       scheduleRunStore: createMemoryScheduleRunStore(),
     })
 
-    await controller.close()
+    await vi.waitFor(() => expect(releaseHandler).toBeTypeOf("function"))
+    const closing = controller.close()
+    releaseHandler!()
+    await closing
 
     await expect(schedules.get("follow-up")).resolves.toMatchObject({ id: "follow-up" })
   })

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -71,6 +71,7 @@ describe("schedule provider output", () => {
     const netlifyFunction = join(createDefaultNetlifyOutputRoot(rootDir), "functions", "vitehub-schedule-cleanup.mjs")
 
     expect(existsSync(cloudflareWorker)).toBe(true)
+    await expect(readFile(cloudflareWorker, "utf8")).resolves.toContain("waitUntil: (promise) => ctx.waitUntil(promise)")
     expect(JSON.parse(await readFile(cloudflareConfig, "utf8")).triggers.crons).toEqual(["0 0 * * *"])
     expect(JSON.parse(await readFile(vercelConfig, "utf8")).crons).toEqual([{
       path: "/api/vitehub/schedules/vercel/cleanup",

--- a/packages/schedule/test/static-runtime.test.ts
+++ b/packages/schedule/test/static-runtime.test.ts
@@ -45,13 +45,20 @@ describe("Static Schedule runtime", () => {
   it("executes Cloudflare scheduled events with runtime env active", async () => {
     const seen: Array<string | undefined> = []
     const deferred: Promise<unknown>[] = []
+    let deferredEnv: string | undefined
+    let releaseDeferred: (() => void) | undefined
     const registry: ScheduleDefinitionRegistry = {
       sync: async () => ({
         default: {
           cron: "0 4 * * *",
           handler: async ({ waitUntil }) => {
             seen.push((globalThis as { __env__?: Record<string, unknown> }).__env__?.AIRTABLE_TOKEN as string | undefined)
-            waitUntil(Promise.resolve("recorded"))
+            waitUntil(new Promise<string>((resolve) => {
+              releaseDeferred = () => {
+                deferredEnv = (globalThis as { __env__?: Record<string, unknown> }).__env__?.AIRTABLE_TOKEN as string | undefined
+                resolve("recorded")
+              }
+            }))
           },
         },
       }),
@@ -69,7 +76,11 @@ describe("Static Schedule runtime", () => {
     }, { registry })
 
     expect(seen).toEqual(["airtable-secret"])
-    await expect(Promise.all(deferred)).resolves.toEqual(["recorded"])
+    expect(releaseDeferred).toBeTypeOf("function")
+    expect((globalThis as { __env__?: Record<string, unknown> }).__env__?.AIRTABLE_TOKEN).toBe("airtable-secret")
+    releaseDeferred!()
+    await expect(Promise.all(deferred)).resolves.toEqual(["recorded", undefined])
+    expect(deferredEnv).toBe("airtable-secret")
     expect((globalThis as { __env__?: Record<string, unknown> }).__env__).toBeUndefined()
   })
 

--- a/packages/schedule/test/static-runtime.test.ts
+++ b/packages/schedule/test/static-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { executeCloudflareStaticSchedules, executeMatchingStaticSchedules } from "../src/runtime/static.ts"
+import { executeCloudflareStaticSchedules, executeMatchingStaticSchedules, executeStaticSchedule } from "../src/runtime/static.ts"
 
 import type { ScheduleDefinitionRegistry } from "../src/types.ts"
 
@@ -67,5 +67,32 @@ describe("Static Schedule runtime", () => {
 
     expect(seen).toEqual(["airtable-secret"])
     expect((globalThis as { __env__?: Record<string, unknown> }).__env__).toBeUndefined()
+  })
+
+  it("drains deferred work before returning a handler failure", async () => {
+    let releaseDeferred: (() => void) | undefined
+    let deferredCompleted = false
+    const execution = executeStaticSchedule({
+      cron: "0 4 * * *",
+      definition: {
+        cron: "0 4 * * *",
+        handler: async ({ waitUntil }) => {
+          waitUntil(new Promise<void>((resolve) => {
+            releaseDeferred = () => {
+              deferredCompleted = true
+              resolve()
+            }
+          }))
+          throw new Error("handler failed")
+        },
+      },
+      name: "report",
+    })
+
+    await expect.poll(() => releaseDeferred).toBeTypeOf("function")
+    releaseDeferred!()
+
+    await expect(execution).rejects.toThrow("handler failed")
+    expect(deferredCompleted).toBe(true)
   })
 })

--- a/packages/schedule/test/static-runtime.test.ts
+++ b/packages/schedule/test/static-runtime.test.ts
@@ -44,12 +44,14 @@ describe("Static Schedule runtime", () => {
 
   it("executes Cloudflare scheduled events with runtime env active", async () => {
     const seen: Array<string | undefined> = []
+    const deferred: Promise<unknown>[] = []
     const registry: ScheduleDefinitionRegistry = {
       sync: async () => ({
         default: {
           cron: "0 4 * * *",
-          handler: async () => {
+          handler: async ({ waitUntil }) => {
             seen.push((globalThis as { __env__?: Record<string, unknown> }).__env__?.AIRTABLE_TOKEN as string | undefined)
+            waitUntil(Promise.resolve("recorded"))
           },
         },
       }),
@@ -63,9 +65,11 @@ describe("Static Schedule runtime", () => {
       env: {
         AIRTABLE_TOKEN: "airtable-secret",
       },
+      waitUntil: (promise: Promise<unknown>) => deferred.push(promise),
     }, { registry })
 
     expect(seen).toEqual(["airtable-secret"])
+    await expect(Promise.all(deferred)).resolves.toEqual(["recorded"])
     expect((globalThis as { __env__?: Record<string, unknown> }).__env__).toBeUndefined()
   })
 

--- a/packages/schedule/test/static-runtime.test.ts
+++ b/packages/schedule/test/static-runtime.test.ts
@@ -84,6 +84,23 @@ describe("Static Schedule runtime", () => {
     expect((globalThis as { __env__?: Record<string, unknown> }).__env__).toBeUndefined()
   })
 
+  it("accepts Cloudflare waitUntil separately from the scheduled event", async () => {
+    const deferred: Promise<unknown>[] = []
+    await executeCloudflareStaticSchedules({
+      controller: { cron: "0 4 * * *", scheduledTime: "2026-06-12T04:00:00.000Z" },
+    }, {
+      registry: {
+        report: async () => ({
+          cron: "0 4 * * *",
+          handler: async ({ waitUntil }) => waitUntil(Promise.resolve("recorded")),
+        }),
+      },
+      waitUntil: promise => deferred.push(Promise.resolve(promise)),
+    })
+
+    await expect(Promise.all(deferred)).resolves.toEqual(["recorded"])
+  })
+
   it("drains deferred work before returning a handler failure", async () => {
     let releaseDeferred: (() => void) | undefined
     let deferredCompleted = false

--- a/packages/schedule/test/types.test-d.ts
+++ b/packages/schedule/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf, it } from "vitest"
 
-import { defineSchedule, defineScheduleTarget, schedules } from "../src/index.ts"
+import { defineSchedule, defineScheduleTarget, executeRuntimeSchedule, executeStaticSchedule, schedules } from "../src/index.ts"
 import { installScheduleRuntime } from "../src/runtime/driver.ts"
 import { createProcessScheduleWakeDriver } from "../src/runtime/process.ts"
 import { hubSchedule } from "../src/vite.ts"
@@ -25,6 +25,8 @@ it("types the defineSchedule helper signature", () => {
     cron: "0 9 * * *",
     handler: async (context) => {
       expectTypeOf(context.scheduledAt).toEqualTypeOf<Date>()
+      expectTypeOf(context.waitUntil).toEqualTypeOf<(promise: PromiseLike<unknown>) => void>()
+      context.waitUntil(Promise.resolve())
     },
   })
 
@@ -59,6 +61,18 @@ it("types cronless Runtime Schedule targets", () => {
 
   // @ts-expect-error cron belongs to defineSchedule, not defineScheduleTarget.
   defineScheduleTarget({ cron: "0 9 * * *", handler: () => {} })
+})
+
+it("types host waitUntil for Static and Runtime Schedule execution", async () => {
+  const waitUntil = (promise: PromiseLike<unknown>) => { void promise }
+
+  await executeStaticSchedule({
+    cron: "0 9 * * *",
+    definition: defineSchedule({ cron: "0 9 * * *", handler: async () => {} }),
+    name: "daily-report",
+    waitUntil,
+  })
+  await executeRuntimeSchedule({ id: "daily-report", waitUntil })
 })
 
 it("types Runtime Schedule helper inputs", async () => {

--- a/packages/schedule/test/wait-until.test.ts
+++ b/packages/schedule/test/wait-until.test.ts
@@ -127,6 +127,7 @@ describe("Schedule waitUntil", () => {
     const releases: Array<() => void> = []
     const completed: string[] = []
     const onError = vi.fn()
+    let driverClosed = false
     let context: RuntimeScheduleWakeDriverContext | undefined
     let reconciled: RuntimeScheduleRecord[] = []
     await runtimeScheduleStore.create({
@@ -147,6 +148,9 @@ describe("Schedule waitUntil", () => {
       createDriver(driverContext) {
         context = driverContext
         return {
+          async close() {
+            driverClosed = true
+          },
           async reconcile(records) {
             reconciled = [...records]
           },
@@ -184,10 +188,12 @@ describe("Schedule waitUntil", () => {
     const closing = controller.close().then(() => { closed = true })
     await flushAsyncWork()
     expect(closed).toBe(false)
+    expect(driverClosed).toBe(false)
 
     for (const release of releases) release()
     await closing
 
     expect(completed).toEqual(["static", "runtime"])
+    expect(driverClosed).toBe(true)
   })
 })

--- a/packages/schedule/test/wait-until.test.ts
+++ b/packages/schedule/test/wait-until.test.ts
@@ -83,6 +83,44 @@ describe("Schedule waitUntil", () => {
     await controller.close()
   })
 
+  it("drains locally deferred work before recording a handler failure", async () => {
+    let releaseDeferred: (() => void) | undefined
+    let deferredCompleted = false
+    const execution = executeStaticSchedule({
+      cron: "0 10 * * *",
+      definition: {
+        cron: "0 10 * * *",
+        handler: async ({ waitUntil }) => {
+          waitUntil(new Promise<void>((resolve) => {
+            releaseDeferred = () => {
+              deferredCompleted = true
+              resolve()
+            }
+          }))
+          throw new Error("handler failed")
+        },
+      },
+      name: "static-report",
+      scheduledAt: new Date("2026-05-23T10:00:00.000Z"),
+    })
+
+    await vi.waitFor(() => expect(releaseDeferred).toBeTypeOf("function"))
+    expect(await schedules.listRuns()).toEqual([
+      expect.objectContaining({ status: "running" }),
+    ])
+
+    releaseDeferred!()
+
+    await expect(execution).rejects.toThrow("handler failed")
+    expect(deferredCompleted).toBe(true)
+    expect(await schedules.listRuns()).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({ message: "handler failed" }),
+        status: "failed",
+      }),
+    ])
+  })
+
   it("propagates driver-owned work, reports rejections, and drains on close", async () => {
     const scheduledAt = new Date("2026-07-11T09:00:00.000Z")
     const runtimeScheduleStore = createMemoryRuntimeScheduleStore()

--- a/packages/schedule/test/wait-until.test.ts
+++ b/packages/schedule/test/wait-until.test.ts
@@ -198,4 +198,52 @@ describe("Schedule waitUntil", () => {
     expect(completed).toEqual(["static", "runtime"])
     expect(driverClosed).toBe(true)
   })
+
+  it("waits for active wakes to register deferred work before closing", async () => {
+    const scheduledAt = new Date("2026-07-11T09:00:00.000Z")
+    const runtimeScheduleStore = createMemoryRuntimeScheduleStore()
+    let context: RuntimeScheduleWakeDriverContext | undefined
+    let releaseHandler: (() => void) | undefined
+    let releaseDeferred: (() => void) | undefined
+    let driverClosed = false
+    await runtimeScheduleStore.create({
+      createdAt: scheduledAt,
+      cron: "0 9 * * *",
+      enabled: true,
+      id: "report",
+      target: "report",
+      updatedAt: scheduledAt,
+    })
+    const controller = await installScheduleRuntime({
+      createDriver(driverContext) {
+        context = driverContext
+        return {
+          async close() { driverClosed = true },
+          async reconcile() {},
+        }
+      },
+      registry: {
+        report: async () => defineScheduleTarget({
+          handler: async ({ waitUntil }) => {
+            await new Promise<void>(resolve => { releaseHandler = resolve })
+            waitUntil(new Promise<void>(resolve => { releaseDeferred = resolve }))
+          },
+        }),
+      },
+      runtimeScheduleStore,
+      scheduleRunStore: createMemoryScheduleRunStore(),
+    })
+
+    const wake = context!.wake({ scheduleId: "report", scheduledAt })
+    await vi.waitFor(() => expect(releaseHandler).toBeTypeOf("function"))
+    let closed = false
+    const closing = controller.close().then(() => { closed = true })
+    releaseHandler!()
+    await vi.waitFor(() => expect(releaseDeferred).toBeTypeOf("function"))
+    expect(closed).toBe(false)
+    expect(driverClosed).toBe(false)
+    releaseDeferred!()
+    await Promise.all([wake, closing])
+    expect(driverClosed).toBe(true)
+  })
 })

--- a/packages/schedule/test/wait-until.test.ts
+++ b/packages/schedule/test/wait-until.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { defineScheduleTarget, executeStaticSchedule, schedules } from "../src/index.ts"
+import { installScheduleRuntime } from "../src/runtime/driver.ts"
+import { resetScheduleRuntime } from "../src/runtime/state.ts"
+import { createMemoryRuntimeScheduleStore, createMemoryScheduleRunStore } from "../src/runtime/store.ts"
+
+import type { RuntimeScheduleRecord } from "../src/types.ts"
+import type { RuntimeScheduleWakeDriverContext } from "../src/runtime/driver.ts"
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+afterEach(() => {
+  resetScheduleRuntime()
+})
+
+describe("Schedule waitUntil", () => {
+  it("drains locally deferred work before completing a run", async () => {
+    let releaseDeferred: (() => void) | undefined
+    let deferredCompleted = false
+    const execution = executeStaticSchedule({
+      cron: "0 10 * * *",
+      definition: {
+        cron: "0 10 * * *",
+        handler: async ({ waitUntil }) => {
+          waitUntil(new Promise<void>((resolve) => {
+            releaseDeferred = () => {
+              deferredCompleted = true
+              resolve()
+            }
+          }))
+        },
+      },
+      name: "static-report",
+      scheduledAt: new Date("2026-05-23T10:00:00.000Z"),
+    })
+
+    await vi.waitFor(() => expect(releaseDeferred).toBeTypeOf("function"))
+    expect(deferredCompleted).toBe(false)
+    expect(await schedules.listRuns()).toEqual([
+      expect.objectContaining({ status: "running" }),
+    ])
+
+    releaseDeferred!()
+
+    await expect(execution).resolves.toMatchObject({ status: "succeeded" })
+    expect(deferredCompleted).toBe(true)
+  })
+
+  it("fails a run when locally deferred work rejects", async () => {
+    const controller = await installScheduleRuntime({
+      createDriver: () => ({ async reconcile() {} }),
+      registry: {
+        report: async () => defineScheduleTarget({
+          handler: async ({ waitUntil }) => {
+            waitUntil(Promise.reject(new TypeError("deferred failed")))
+          },
+        }),
+      },
+      runtimeScheduleStore: createMemoryRuntimeScheduleStore(),
+      scheduleRunStore: createMemoryScheduleRunStore(),
+    })
+    await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
+
+    await expect(schedules.run("schedule-1", {
+      scheduledAt: new Date("2026-05-23T09:00:00.000Z"),
+    })).rejects.toThrow("deferred failed")
+
+    const [run] = await schedules.listRuns()
+    expect(run).toMatchObject({
+      error: { message: "deferred failed", name: "TypeError" },
+      status: "failed",
+    })
+    const [attempt] = await schedules.listAttempts(run!.id)
+    expect(attempt).toMatchObject({
+      error: { message: "deferred failed", name: "TypeError" },
+      status: "failed",
+    })
+    await controller.close()
+  })
+
+  it("propagates driver-owned work, reports rejections, and drains on close", async () => {
+    const scheduledAt = new Date("2026-07-11T09:00:00.000Z")
+    const runtimeScheduleStore = createMemoryRuntimeScheduleStore()
+    const releases: Array<() => void> = []
+    const completed: string[] = []
+    const onError = vi.fn()
+    let context: RuntimeScheduleWakeDriverContext | undefined
+    let reconciled: RuntimeScheduleRecord[] = []
+    await runtimeScheduleStore.create({
+      createdAt: scheduledAt,
+      cron: "0 9 * * *",
+      enabled: true,
+      id: "runtime-report",
+      target: "report",
+      updatedAt: scheduledAt,
+    })
+    const defer = (name: string) => new Promise<void>((resolve) => {
+      releases.push(() => {
+        completed.push(name)
+        resolve()
+      })
+    })
+    const controller = await installScheduleRuntime({
+      createDriver(driverContext) {
+        context = driverContext
+        return {
+          async reconcile(records) {
+            reconciled = [...records]
+          },
+        }
+      },
+      onError,
+      registry: {
+        report: async () => defineScheduleTarget({
+          handler: async ({ waitUntil }) => {
+            waitUntil(defer("runtime"))
+            waitUntil(Promise.reject(new Error("deferred driver failure")))
+          },
+        }),
+      },
+      runtimeScheduleStore,
+      scheduleRunStore: createMemoryScheduleRunStore(),
+      staticRegistry: {
+        "static-report": async () => ({
+          cron: "0 9 * * *",
+          handler: async ({ waitUntil }) => waitUntil(defer("static")),
+        }),
+      },
+    })
+
+    const staticSchedule = reconciled.find(schedule => schedule.target === "static-report")!
+    await context!.wake({ scheduleId: staticSchedule.id, scheduledAt })
+    await context!.wake({ scheduleId: "runtime-report", scheduledAt })
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+      message: "deferred driver failure",
+    })))
+    expect(releases).toHaveLength(2)
+    expect(completed).toEqual([])
+
+    let closed = false
+    const closing = controller.close().then(() => { closed = true })
+    await flushAsyncWork()
+    expect(closed).toBe(false)
+
+    for (const release of releases) release()
+    await closing
+
+    expect(completed).toEqual(["static", "runtime"])
+  })
+})

--- a/packages/schedule/test/wait-until.test.ts
+++ b/packages/schedule/test/wait-until.test.ts
@@ -189,6 +189,8 @@ describe("Schedule waitUntil", () => {
     await flushAsyncWork()
     expect(closed).toBe(false)
     expect(driverClosed).toBe(false)
+    await context!.wake({ scheduleId: "runtime-report", scheduledAt: new Date("2026-07-12T09:00:00.000Z") })
+    expect(releases).toHaveLength(2)
 
     for (const release of releases) release()
     await closing


### PR DESCRIPTION
Exposes `ScheduleRunContext.waitUntil()` and threads a host callback through Static and Runtime Schedule execution. Local execution drains deferred promises before recording success, while a deferred rejection fails the run and attempt with the same diagnostics as a handler failure.

Installed wake drivers retain handler-deferred work across both Static and Runtime wakes, report rejected work through the existing `onError` hook, and flush pending work when the runtime closes. This upstreams the remaining Babysitter lifecycle patch without duplicating the provider-output cleanup merged in #576.