### PR TITLE
fix(agent): preserve instruction markdown on Comark 0.5

### DIFF
--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -44,6 +44,7 @@ interface ComposeInstructionState {
 const defaultImportDepth = 4
 const contextPathPattern = /context(?:\.[A-Za-z_$][\w$-]*)+/
 const compositionPathPattern = /^(?:context|workspace)(?:\.[A-Za-z_$][\w$-]*)+$/
+const compositionBindingPattern = /\{\{(?!\{)\s*((?:context|workspace)(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}/g
 const tripleBindingPattern = /\{\{\{\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}\}/g
 const tripleBindingPlaceholderPattern = /%%VITEHUB_TRIPLE_BINDING_(\d+)%%/g
 const scalarBindingPattern = /\{\{(?!\{)\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}/g
@@ -342,6 +343,10 @@ async function composeNode(
   if (!isElement(node)) return [node]
   const [tag, attrs, ...children] = node
 
+  if (tag === "code") return [node]
+  if (isHtmlElementAttributes(attrs)) {
+    return [[tag, composeHtmlAttributes(attrs, state), ...(await composeNodes(children, state, tag))] as ComarkElement]
+  }
   if (tag === "if") return await composeIfNode(node, state)
   if (tag === "else" || tag === "else-if") {
     throw new Error(`[vitehub] Instruction ${tag} block must follow an if block.`)
@@ -354,12 +359,12 @@ async function composeNode(
   if (tag === "vitehubTriple" || tag === "vitehub-triple") {
     return await renderTripleBinding(attrs, state.context, parent)
   }
-  if (tag === "code") return [node]
   if (tag === "p") {
     const path = soleTripleBindingPath(children, state.tripleBindings)
+    // ponytail: Parse standalone bindings as Markdown once without recursively composing their template syntax.
     if (path) return await renderTripleBindingPath(path, state.context)
   }
-  return [[tag, attrs, ...(await composeNodes(children, state, tag))] as ComarkElement]
+  return [[tag, composeHtmlAttributes(attrs, state), ...(await composeNodes(children, state, tag))] as ComarkElement]
 }
 
 async function composeTextNode(
@@ -392,12 +397,40 @@ function renderBinding(
   if (path === "workspace.sources") {
     throw new Error("[vitehub] Instruction binding \"{{ workspace.sources }}\" is no longer supported. Cover Sources with ::source blocks in Agent Driver Instructions.")
   }
+  return renderScalarBinding(path, scopes)
+}
+
+function renderScalarBinding(
+  path: string,
+  scopes: { context: Record<string, unknown>, workspace: Record<string, unknown> },
+): string {
   const value = namespacePathValue(path.startsWith("workspace.") ? scopes.workspace : scopes.context, path)
   if (value === null || value === undefined) {
     throw new Error(`[vitehub] Instruction binding "{{ ${path} }}" is not defined.`)
   }
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value)
   throw new TypeError(`[vitehub] Instruction binding "{{ ${path} }}" must resolve to a scalar value.`)
+}
+
+function composeHtmlAttributes(
+  attrs: Record<string, unknown>,
+  state: Pick<ComposeInstructionState, "context" | "workspace">,
+): Record<string, unknown> {
+  if (!isHtmlElementAttributes(attrs)) return attrs
+  return Object.fromEntries(Object.entries(attrs).map(([name, value]) => [
+    name,
+    typeof value === "string"
+      ? value.replace(compositionBindingPattern, (_match, path: string) => escapeHtmlAttribute(renderScalarBinding(path, state)))
+      : value,
+  ]))
+}
+
+function isHtmlElementAttributes(attrs: Record<string, unknown>): boolean {
+  return (attrs.$ as { html?: unknown } | undefined)?.html === 1
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
 }
 
 function rejectLegacyCapabilityBinding(value: string): void {
@@ -470,7 +503,7 @@ async function renderTripleBindingPath(
   if (typeof value !== "string") {
     throw new TypeError(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" must resolve to a string.`)
   }
-  if (parent === "p") return [["vitehub-raw", { value }] as ComarkElement]
+  if (parent === "p") return [rawMarkdownNode(value)]
   const nodes = (await parseInstructionMarkdown(value)).nodes
   return nodes
 }

--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -48,13 +48,9 @@ const tripleBindingPattern = /\{\{\{\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}\
 const tripleBindingPlaceholderPattern = /%%VITEHUB_TRIPLE_BINDING_(\d+)%%/g
 const scalarBindingPattern = /\{\{(?!\{)\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}/g
 const legacyCapabilityBindingPattern = /\{\{\s*capabilities(?:\.[A-Za-z_$][\w$-]*)?\s*\}\}/
-const comarkComponents = { Binding }
-const noLinkify = {
-  markdownItPlugins: [(md: { disable: (rule: string) => unknown, set: (options: Record<string, unknown>) => unknown }) => {
-    md.disable("linkify")
-    md.set({ linkify: false })
-  }],
-  name: "vitehub-no-linkify",
+const comarkComponents = {
+  Binding,
+  VitehubRaw: (node: ComarkElement) => typeof node[1].value === "string" ? node[1].value : "",
 }
 
 export async function resolveInstructionImports(content: string, options: ResolveInstructionImportsOptions): Promise<string> {
@@ -96,8 +92,9 @@ async function parseInstructionMarkdown(content: string, bindings = false) {
   return await parse(content, {
     autoClose: false,
     autoUnwrap: false,
-    html: false,
-    plugins: bindings ? [noLinkify, binding()] : [noLinkify],
+    html: true,
+    linkify: false,
+    plugins: bindings ? [binding()] : [],
   })
 }
 
@@ -122,9 +119,7 @@ async function expandImportNodes(
   depth: number,
 ): Promise<ComarkNode[]> {
   const expanded: ComarkNode[] = []
-  for (const node of nodes) {
-    expanded.push(...await expandImportNode(node, options, depth))
-  }
+  for (const node of nodes) expanded.push(...await expandImportNode(node, options, depth))
   return expanded
 }
 
@@ -133,9 +128,7 @@ async function expandImportNode(
   options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
   depth: number,
 ): Promise<ComarkNode[]> {
-  if (typeof node === "string") {
-    return [await replaceImportsInText(node, options, depth)]
-  }
+  if (typeof node === "string") return await replaceImportsInText(node, options, depth)
   if (!isElement(node)) return [node]
 
   const [tag, attrs, ...children] = node
@@ -147,17 +140,27 @@ async function replaceImportsInText(
   text: string,
   options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
   depth: number,
-): Promise<string> {
-  let rendered = ""
+): Promise<ComarkNode[]> {
+  const nodes: ComarkNode[] = []
+  let textNode = ""
   let index = 0
   for (const match of text.matchAll(/@[^\s<>{}\[\]]+/g)) {
-    rendered += text.slice(index, match.index)
+    textNode += text.slice(index, match.index)
     const token = match[0]
     const replacement = await importReplacement(token, options, depth)
-    rendered += replacement ?? token
+    if (replacement === undefined) {
+      textNode += token
+    }
+    else {
+      if (textNode) nodes.push(textNode)
+      nodes.push(rawMarkdownNode(replacement))
+      textNode = ""
+    }
     index = match.index + token.length
   }
-  return rendered + text.slice(index)
+  textNode += text.slice(index)
+  if (textNode) nodes.push(textNode)
+  return nodes
 }
 
 async function expandWorkspaceInstructionImports(
@@ -179,9 +182,7 @@ async function expandWorkspaceImportNodes(
   seen: Set<string>,
 ): Promise<ComarkNode[]> {
   const expanded: ComarkNode[] = []
-  for (const node of nodes) {
-    expanded.push(...await expandWorkspaceImportNode(node, workspace, depth, seen))
-  }
+  for (const node of nodes) expanded.push(...await expandWorkspaceImportNode(node, workspace, depth, seen))
   return expanded
 }
 
@@ -191,9 +192,7 @@ async function expandWorkspaceImportNode(
   depth: number,
   seen: Set<string>,
 ): Promise<ComarkNode[]> {
-  if (typeof node === "string") {
-    return [await replaceWorkspaceImportsInText(node, workspace, depth, seen)]
-  }
+  if (typeof node === "string") return await replaceWorkspaceImportsInText(node, workspace, depth, seen)
   if (!isElement(node)) return [node]
 
   const [tag, attrs, ...children] = node
@@ -206,16 +205,23 @@ async function replaceWorkspaceImportsInText(
   workspace: Record<string, unknown>,
   depth: number,
   seen: Set<string>,
-): Promise<string> {
-  let rendered = ""
+): Promise<ComarkNode[]> {
+  const nodes: ComarkNode[] = []
   let index = 0
   for (const match of text.matchAll(/@workspace(?:\.[A-Za-z_$][\w$-]*)+/g)) {
-    rendered += text.slice(index, match.index)
+    const before = text.slice(index, match.index)
+    if (before) nodes.push(before)
     const token = match[0]
-    rendered += await workspaceImportReplacement(token, workspace, depth, seen)
+    nodes.push(rawMarkdownNode(await workspaceImportReplacement(token, workspace, depth, seen)))
     index = match.index + token.length
   }
-  return rendered + text.slice(index)
+  const after = text.slice(index)
+  if (after) nodes.push(after)
+  return nodes
+}
+
+function rawMarkdownNode(value: string): ComarkElement {
+  return ["vitehub-raw", { value }]
 }
 
 async function workspaceImportReplacement(
@@ -349,6 +355,10 @@ async function composeNode(
     return await renderTripleBinding(attrs, state.context, parent)
   }
   if (tag === "code") return [node]
+  if (tag === "p") {
+    const path = soleTripleBindingPath(children, state.tripleBindings)
+    if (path) return await renderTripleBindingPath(path, state.context)
+  }
   return [[tag, attrs, ...(await composeNodes(children, state, tag))] as ComarkElement]
 }
 
@@ -460,8 +470,15 @@ async function renderTripleBindingPath(
   if (typeof value !== "string") {
     throw new TypeError(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" must resolve to a string.`)
   }
-  if (parent === "p") return [value]
-  return (await parseInstructionMarkdown(value)).nodes
+  if (parent === "p") return [["vitehub-raw", { value }] as ComarkElement]
+  const nodes = (await parseInstructionMarkdown(value)).nodes
+  return nodes
+}
+
+function soleTripleBindingPath(children: ComarkNode[], bindings: string[]): string | undefined {
+  if (children.length !== 1 || typeof children[0] !== "string") return
+  const match = children[0].match(/^%%VITEHUB_TRIPLE_BINDING_(\d+)%%$/)
+  return match ? bindings[Number(match[1])] : undefined
 }
 
 async function composeIfNode(node: ComarkElement, state: ComposeInstructionState): Promise<ComarkNode[]> {

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -207,9 +207,15 @@ describe("instruction composition", () => {
   })
 
   it("preserves XML-style prompt tags as authored text", async () => {
-    expect(await composeInstructionDocument("<policy>Use {{ context.name }}.</policy>", {
-      context: { name: "Acme" },
-    })).toBe("<policy>Use Acme.</policy>")
+    expect(await composeInstructionDocument("<capability audience=\"{{ context.audience }}\" tone=\"{{ workspace.tone }}\">Use {{ context.name }}.</capability>", {
+      context: { audience: "A \"technical\" & safe", name: "Acme" },
+      workspace: { tone: "direct" },
+    })).toBe("<capability audience=\"A &quot;technical&quot; &amp; safe\" tone=\"direct\">Use Acme.</capability>")
+
+    await expect(composeInstructionDocument("<policy audience=\"{{ context.audience }}\">Use it.</policy>"))
+      .rejects.toThrow("Instruction binding \"{{ context.audience }}\" is not defined")
+    await expect(composeInstructionDocument("<policy tone=\"{{ workspace.tone }}\">Use it.</policy>"))
+      .rejects.toThrow("Instruction binding \"{{ workspace.tone }}\" is not defined")
   })
 
   it("parses boolean chains without skipping the right side", async () => {

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -61,6 +61,72 @@ describe("instruction composition", () => {
     })).toBe("Shared\n\nShared")
   })
 
+  it("preserves imported markdown structure on Comark 0.5", async () => {
+    const files = new Map([["/agent/policy.md", [
+      "## Policy",
+      "<policy>Use {{ context.name }}.</policy>",
+    ].join("\n")]])
+
+    expect(await resolveInstructionImports("@./policy.md", {
+      file: "/agent/instructions.md",
+      read: importReader(files),
+    })).toBe([
+      "## Policy",
+      "",
+      "<policy>Use {{ context.name }}.</policy>",
+    ].join("\n"))
+  })
+
+  it("keeps template syntax literal in indented code blocks", async () => {
+    const input = [
+      "    @./ignored.md",
+      "    @workspace.policy",
+      "    {{{ context.policy }}}",
+    ].join("\n")
+    const imported = await resolveInstructionImports(input, {
+      file: "/agent/instructions.md",
+      read: importReader(new Map()),
+    })
+    const expected = [
+      "```",
+      "@./ignored.md",
+      "@workspace.policy",
+      "{{{ context.policy }}}",
+      "```",
+    ].join("\n")
+
+    expect(imported).toBe(expected)
+    expect(await composeInstructionDocument(imported, {
+      context: { policy: "must not render" },
+      workspace: { policy: "must not import" },
+    })).toBe(expected)
+  })
+
+  it("keeps template syntax literal in multiline code spans", async () => {
+    const files = new Map([["/agent/used.md", "Used"]])
+    const imported = await resolveInstructionImports([
+      "Before ``code",
+      "@./ignored.md",
+      "@workspace.policy",
+      "{{{ context.policy }}}",
+      "code``",
+      "@./used.md",
+    ].join("\n"), {
+      file: "/agent/instructions.md",
+      read: importReader(files),
+    })
+    const expected = [
+      "Before `code @./ignored.md @workspace.policy {{{ context.policy }}} code`",
+      "Used",
+    ].join("\n")
+
+    expect(imported).toBe(expected)
+    expect(await composeInstructionDocument(imported, {
+      context: { policy: "must not render" },
+      workspace: { policy: "must not import" },
+    })).toBe(expected)
+  })
+
   it("normalizes shorthand conditions from imported documents", async () => {
     const files = new Map([["/agent/policy.md", "::if{context.enabled}\nEnabled\n::"]])
     const imported = await resolveInstructionImports("@./policy.md", {
@@ -103,6 +169,41 @@ describe("instruction composition", () => {
     expect(await composeInstructionDocument("Use ({{{ context.policy }}}).", {
       context: { policy: "trusted policy" },
     })).toBe("Use (trusted policy).")
+  })
+
+  it("renders markdown bindings without recursively evaluating their content", async () => {
+    expect(await composeInstructionDocument("{{{ context.policy }}}", {
+      context: {
+        enabled: true,
+        name: "Acme",
+        policy: [
+          "## Policy",
+          "Use **bold** [guidance](https://example.com).",
+          "{{ context.name }}",
+          "::if{context.enabled}",
+          "Keep this directive literal.",
+          "::",
+          "@workspace.policy",
+        ].join("\n"),
+      },
+    })).toBe([
+      "## Policy",
+      "",
+      "Use **bold** [guidance](https://example.com).",
+      "{{ context.name }}",
+      "",
+      "::if{context.enabled}",
+      "Keep this directive literal.",
+      "::",
+      "",
+      "@workspace.policy",
+    ].join("\n"))
+  })
+
+  it("escapes scalar bindings as markdown text", async () => {
+    expect(await composeInstructionDocument("{{ context.value }}", {
+      context: { value: "# Heading with *emphasis* and <policy>tags</policy>" },
+    })).toBe("\\# Heading with \\*emphasis\\* and \\<policy>tags\\</policy>")
   })
 
   it("preserves XML-style prompt tags as authored text", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2880,7 +2880,7 @@ describe("defineAgent workspace option", () => {
     expect(agentSettings.at(-1)?.instructions).toBe([
       "# Support\n\nImported policy.",
       "Use technical detail for Acme.",
-      "## Runtime policy\nUse trusted runtime context.",
+      "## Runtime policy\n\nUse trusted runtime context.",
       "Use docs for Acme.",
       "Use runtime support context for Acme.",
     ].join("\n\n"))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ catalogs:
       version: 3.2.6
   ui:
     '@comark/vue':
-      specifier: ^0.3.1
-      version: 0.3.1
+      specifier: ^0.5.1
+      version: 0.5.1
     '@iconify-json/lucide':
       specifier: ^1.2.111
       version: 1.2.111
@@ -163,14 +163,8 @@ catalogs:
       specifier: ^14.3.0
       version: 14.3.0
     comark:
-      specifier: ^0.3.2
-      version: 0.3.2
-    motion-v:
-      specifier: ^2.2.1
-      version: 2.2.1
-    shiki:
-      specifier: ^4.0.2
-      version: 4.0.2
+      specifier: ^0.5.1
+      version: 0.5.1
     tailwindcss:
       specifier: ^4.1.18
       version: 4.3.0
@@ -446,7 +440,7 @@ importers:
         version: 4.32.0(ai@7.0.0(zod@4.4.3))(zod@4.4.3)
       comark:
         specifier: catalog:ui
-        version: 0.3.2(shiki@4.0.2)
+        version: 0.5.1
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7
@@ -674,7 +668,7 @@ importers:
     devDependencies:
       '@comark/vue':
         specifier: catalog:ui
-        version: 0.3.1(shiki@4.0.2)(vue@3.5.34(typescript@6.0.2))
+        version: 0.5.1(vue@3.5.34(typescript@6.0.2))
       '@iconify-json/lucide':
         specifier: catalog:ui
         version: 1.2.111
@@ -1894,12 +1888,12 @@ packages:
   '@colordx/core@5.4.3':
     resolution: {integrity: sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==}
 
-  '@comark/vue@0.3.1':
-    resolution: {integrity: sha512-23fueUVe1tVuRV7M5PsGCcaFqL0cEZJfHRqdx5Ha5kW1F1J2O81B6LFibdh24vASqhjsHuoclrUrjeanq+gfqQ==}
+  '@comark/vue@0.5.1':
+    resolution: {integrity: sha512-uz5Oirzg7ruuJJItceWRswAftuMoY17Omge9bsUampmAL/XdI77YrBOozA5DlId+OCX0VXnt1tCCe4c1IrcJ7w==}
     peerDependencies:
       beautiful-mermaid: ^1.1.3
-      katex: ^0.16.45
-      shiki: ^4.0.0
+      katex: ^0.17.0
+      shiki: ^4.3.1
       vue: ^3.5.0
     peerDependenciesMeta:
       beautiful-mermaid:
@@ -7749,12 +7743,12 @@ packages:
   colortranslator@5.0.0:
     resolution: {integrity: sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==}
 
-  comark@0.3.2:
-    resolution: {integrity: sha512-wZ16V3PPItX49EScg6yDswqQ24bsMAhujZUGIf1dBKMmZjqGBa4HmXDe+WZNeqNQSOd8v4AJJT1NKyrvgdf3dA==}
+  comark@0.5.1:
+    resolution: {integrity: sha512-RRRmUaEc6tokYJhgIGHrl8+pUt3kY1BxMnbRrxMxkCk2RcPcrilq9OmmPWIO7zuUIF7qLLRCCQz+wPuMg7Vz9w==}
     peerDependencies:
       beautiful-mermaid: ^1.1.3
-      katex: ^0.16.45
-      shiki: ^4.0.0
+      katex: ^0.17.0
+      shiki: ^4.3.1
     peerDependenciesMeta:
       beautiful-mermaid:
         optional: true
@@ -9635,6 +9629,10 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+    hasBin: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -9832,8 +9830,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
@@ -9951,8 +9949,8 @@ packages:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
     engines: {node: '>=18'}
 
-  markdown-exit@1.0.0-beta.9:
-    resolution: {integrity: sha512-5tzrMKMF367amyBly131vm6eGuWRL2DjBqWaFmPzPbLyuxP0XOmyyyroOAIXuBAMF/3kZbbfqOxvW/SotqKqbQ==}
+  markdown-exit@1.1.0-beta.2:
+    resolution: {integrity: sha512-8CzMGVlFZ4DEfnc8KU+4ycUW2SIOuiXqCHD7z51ecVEi/weyc0f2ylQbCm4KoKuVlTZSuMUMnWT0hTyquZ7anQ==}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -14106,12 +14104,10 @@ snapshots:
 
   '@colordx/core@5.4.3': {}
 
-  '@comark/vue@0.3.1(shiki@4.0.2)(vue@3.5.34(typescript@6.0.2))':
+  '@comark/vue@0.5.1(vue@3.5.34(typescript@6.0.2))':
     dependencies:
-      comark: 0.3.2(shiki@4.0.2)
+      comark: 0.5.1
       vue: 3.5.34(typescript@6.0.2)
-    optionalDependencies:
-      shiki: 4.0.2
 
   '@discordjs/builders@1.14.1':
     dependencies:
@@ -19366,7 +19362,7 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       tinyexec: 1.1.2
-      vite: 8.0.16(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
       vue: 3.5.34(typescript@6.0.2)
       ws: 8.21.0
     transitivePeerDependencies:
@@ -21028,14 +21024,12 @@ snapshots:
 
   colortranslator@5.0.0: {}
 
-  comark@0.3.2(shiki@4.0.2):
+  comark@0.5.1:
     dependencies:
       entities: 8.0.0
       htmlparser2: 12.0.0
-      js-yaml: 4.1.1
-      markdown-exit: 1.0.0-beta.9
-    optionalDependencies:
-      shiki: 4.0.2
+      js-yaml: 5.2.1
+      markdown-exit: 1.1.0-beta.2
 
   combined-stream@1.0.8:
     dependencies:
@@ -23345,6 +23339,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@5.2.1:
+    dependencies:
+      argparse: 2.0.1
+
   jsesc@3.1.0: {}
 
   json-bigint@1.0.0:
@@ -23559,7 +23557,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -23728,12 +23726,12 @@ snapshots:
       type-fest: 4.41.0
       web-worker: 1.5.0
 
-  markdown-exit@1.0.0-beta.9:
+  markdown-exit@1.1.0-beta.2:
     dependencies:
       '@types/linkify-it': 5.0.0
       '@types/mdurl': 2.0.0
       entities: 7.0.1
-      linkify-it: 5.0.0
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,8 +70,8 @@ catalogs:
     vitest: ^4.1.4
     vue-tsc: ^3.2.6
   ui:
-    "@comark/vue": ^0.3.1
-    comark: ^0.3.2
+    "@comark/vue": ^0.5.1
+    comark: ^0.5.1
     "@iconify-json/lucide": ^1.2.111
     "@iconify-json/ph": ^1.2.2
     "@iconify-json/simple-icons": ^1.2.84


### PR DESCRIPTION
Updates Comark and its Vue adapter to 0.5.1 while preserving instruction-document behavior across imports, XML-style prompt tags, Markdown fragments, and code blocks or spans. Scalar bindings now use Comark's current Markdown escaping, while regression coverage prevents recursive template evaluation and expansion inside code.

This is the compatibility base for the follow-up `@vite-hub/markdown-template` extraction.
