### PR TITLE
fix(agent): allow opted-in capability tools by default

### DIFF
--- a/docs/content/docs/capabilities/blob.md
+++ b/docs/content/docs/capabilities/blob.md
@@ -43,7 +43,7 @@ export default defineAgent({
 
 ViteHub selects the configured Blob store and exposes a small Storage Capability Tool Surface.
 Read mode supports one object read, metadata read, or prefix list operation per tool call.
-Write mode adds put/delete operations with approval required by default.
+Write mode adds put/delete operations and allows them by default.
 Put operations accept either `body` or `workspacePath`, not both.
 Delete operations return `{ pathname, deleted: true }`.
 
@@ -52,7 +52,8 @@ Delete operations return `{ pathname, deleted: true }`.
 `blob()` requires a configured `blob` primitive.
 Named store selection requires the Blob primitive to expose store selection.
 
-Writes require write mode and should keep approval enabled unless the product explicitly accepts autonomous storage writes.
+Writes require explicit write mode.
+Set `policy: 'require-approval'` or `policy: 'deny'` when the product needs an additional gate.
 
 ## Driver support
 
@@ -77,7 +78,7 @@ The Capability should fail before exposing tools.
 | `mode` | `"read" \| "write"` | `"read"` | Adds `blob_edit` when set to `"write"`. |
 | `assetPaths` | `boolean \| string \| string[]` | `false` | Materializes Harness asset paths and publishes current-run files explicitly referenced by final Markdown. `true` uses `screenshots`. |
 | `store` | `string` | default store | Selects a named Blob store when the Blob primitive supports `store()`. |
-| `policy` | `AgentToolPolicyDecision \| function` | `"require-approval"` | Policy for `blob_edit`. |
+| `policy` | `AgentToolPolicyDecision \| function` | `"allow"` | Policy for `blob_edit`. |
 
 ## Harness artifacts
 

--- a/docs/content/docs/capabilities/custom-capabilities.md
+++ b/docs/content/docs/capabilities/custom-capabilities.md
@@ -74,8 +74,8 @@ If the product needs provisioning, keep that in the primitive or framework integ
 
 ## Add policy
 
-Policy belongs with the model-facing action.
-Use it to require approval for writes, limit shell or sandbox commands, restrict prefixes, reject unsafe SQL, or prevent broad Workspace access.
+Tool policy defaults to `allow` when omitted.
+Use `require-approval` or `deny` when a model-facing action needs an additional runtime gate after the Capability has established its modes, scopes, allowlists, and input validation.
 
 Custom policy should be narrow and visible.
 A reviewer should be able to understand the Capability's authority by reading the Capability Definition.

--- a/docs/content/docs/capabilities/db.md
+++ b/docs/content/docs/capabilities/db.md
@@ -50,7 +50,8 @@ The primitive must expose raw string `query()` for reads and `exec()` for mutati
 
 Mutation tools require write mode.
 DDL requires schema write mode.
-Writes require approval by default.
+Enabled mutations are allowed by default, while the single-statement, rationale, and SQL-kind checks still apply.
+Set `policy: 'require-approval'` or `policy: 'deny'` when the product needs an additional gate.
 
 ## Driver support
 
@@ -75,7 +76,7 @@ The Capability should reject it before it reaches the database primitive.
 | `database` | `string` | `"default"` | Selects a named database when the DB primitive supports `database()`. |
 | `mode` | `"read" \| "write"` | `"read"` | Allows data mutation through `db_exec` when set to `"write"`. |
 | `schemaMode` | `"read" \| "write"` | `"read"` | Allows DDL through `db_exec` when set to `"write"`. |
-| `policy` | `AgentToolPolicyDecision \| function` | `"require-approval"` | Policy for `db_exec`. |
+| `policy` | `AgentToolPolicyDecision \| function` | `"allow"` | Policy for `db_exec`. |
 
 ## Reference
 

--- a/docs/content/docs/capabilities/git.md
+++ b/docs/content/docs/capabilities/git.md
@@ -42,6 +42,7 @@ Read mode allows source-history commands such as `status`, `diff`, `log`, `show`
 
 Write mode supports only `fetch`, `checkout`, and `switch` on a clean working tree.
 It blocks commit, push, reset, rebase, tag, arbitrary remote URLs, shell composition, and path escapes outside the Workspace.
+Supported write commands are allowed by default after the developer enables write mode. An explicit policy can require approval or deny them, but it cannot enable blocked commands.
 
 ## Requirements
 
@@ -62,7 +63,7 @@ The Workspace requirement is write-mode because ViteHub may need session-local G
 | --- | --- | --- | --- |
 | `mode` | `"read" \| "write"` | `"read"` | Allows local `fetch`, `checkout`, and `switch` commands through `shell` when set to `"write"`. |
 | `maxOutputLength` | `number` | `30000` | Maximum stdout/stderr characters returned per command. |
-| `policy` | `AgentToolPolicyDecision \| function` | `"require-approval"` | Policy for write-mode `shell` commands. Read-only Git commands are allowed without approval. |
+| `policy` | `AgentToolPolicyDecision \| function` | `"allow"` | Policy for write-mode `shell` commands. Read-only Git commands remain allowed. |
 | `timeout` | `number` | none | Execution timeout passed to Workspace Session git commands. |
 
 ## Inspect and verify

--- a/docs/content/docs/capabilities/index.md
+++ b/docs/content/docs/capabilities/index.md
@@ -40,6 +40,8 @@ export default defineAgent({
 })
 ```
 
+Attaching a Capability opts the Agent into that ability. Model-facing tool policy defaults to `allow`; set `policy: 'require-approval'` or `policy: 'deny'` when the product needs an additional runtime gate. Capability modes, scopes, allowlists, requirements, and input validation still bound the operation before policy applies.
+
 ## What Capabilities can contribute
 
 | Contribution | What it changes |

--- a/docs/content/docs/capabilities/kv.md
+++ b/docs/content/docs/capabilities/kv.md
@@ -41,14 +41,15 @@ export default defineAgent({
 
 ViteHub selects the configured KV store and exposes a small Storage Capability Tool Surface.
 Read mode supports one exact key or one prefix per tool call.
-Write mode adds a put/delete tool with approval required by default.
+Write mode adds a put/delete tool and allows its normal operations by default.
 
 ## Requirements
 
 `kv()` requires a configured `kv` primitive.
 Named store selection requires the KV primitive to expose store selection.
 
-Writes require write mode and should keep approval enabled unless the product explicitly accepts autonomous storage writes.
+Writes require explicit write mode.
+Set `policy: 'require-approval'` or `policy: 'deny'` when the product needs an additional gate.
 
 ## Driver support
 
@@ -72,7 +73,7 @@ The Capability should fail before exposing tools.
 | --- | --- | --- | --- |
 | `mode` | `"read" \| "write"` | `"read"` | Adds `kv_edit` when set to `"write"`. |
 | `store` | `string` | default store | Selects a named KV store when the KV primitive supports `store()`. |
-| `policy` | `AgentToolPolicyDecision \| function` | `"require-approval"` | Policy for `kv_edit`. |
+| `policy` | `AgentToolPolicyDecision \| function` | `"allow"` | Policy for `kv_edit`. |
 
 ## Reference
 

--- a/docs/content/docs/capabilities/memory.md
+++ b/docs/content/docs/capabilities/memory.md
@@ -50,7 +50,8 @@ export default defineAgent({
 During input, `memory()` can preload records from configured stores for model-backed behavior.
 During resolve, it creates read tools for stores that allow reading and write tools for stores that opt into tool writes.
 
-Write tools add provenance from the current Agent Invocation and require approval by default unless the store policy changes it.
+Write tools add provenance from the current Agent Invocation and allow writes by default after a store opts into `write.mode: 'tool'`.
+Set the store policy to `require-approval` or `deny` when writes need an additional gate.
 
 ## Requirements
 
@@ -87,7 +88,7 @@ For the workspace JSONL store, inspect the configured Workspace file and verify 
 | `stores.*.read.tools.read` | `boolean` | `true` | Expose exact memory read. |
 | `stores.*.read.preload` | `Array` | none | Preload scoped memories into instructions. |
 | `stores.*.write.mode` | `"off" \| "tool"` | `"off"` | Expose remember/delete tools when set to `"tool"`. |
-| `stores.*.write.policy` | `AgentToolPolicyDecision` | `"require-approval"` | Policy for write tools. |
+| `stores.*.write.policy` | `AgentToolPolicyDecision` | `"allow"` | Policy for write tools. |
 | `stores.*.retention.export` | `boolean` | `false` | Allow export operations. |
 | `stores.*.retention.hardDelete` | `boolean` | `false` | Allow hard delete behavior when supported. |
 

--- a/docs/content/docs/capabilities/repository-host.md
+++ b/docs/content/docs/capabilities/repository-host.md
@@ -45,6 +45,7 @@ Operations that target a single Change Request, issue, comment, check, or status
 
 `repository_host_write` requires write mode and a client with `write()`.
 Comment writes require a `body`; all writes require a target id.
+Supported writes are allowed by default after the developer enables write mode. Set an explicit policy when comments or reactions need approval or must be denied at runtime.
 
 ## Requirements
 
@@ -65,13 +66,13 @@ The client must expose `read()`, and write mode also requires `write()` before t
 | --- | --- | --- | --- |
 | `client` | `RepositoryHostClient \| function` | primitive | Provider client with `read()` and optional `write()`. |
 | `mode` | `"read" \| "write"` | `"read"` | Adds `repository_host_write` when set to `"write"`. |
-| `policy` | `AgentToolPolicyDecision \| function` | `"require-approval"` | Policy for `repository_host_write`. |
+| `policy` | `AgentToolPolicyDecision \| function` | `"allow"` | Policy for `repository_host_write`. |
 | `provider` | `"github" \| "gitlab" \| "bitbucket" \| string` | client provider | Provider metadata for inspection. |
 
 ## Inspect and verify
 
 Inspect the Agent tool list in DevTools.
-Read one repository or Change Request through `repository_host_read`, then verify write mode requires approval before posting comments or reactions.
+Read one repository or Change Request through `repository_host_read`, then verify read mode exposes no write tool. When using an explicit approval policy, verify that posting comments or reactions requests approval.
 
 ## Reference
 

--- a/docs/content/docs/capabilities/schedule.md
+++ b/docs/content/docs/capabilities/schedule.md
@@ -70,9 +70,10 @@ Runtime Schedule mode reads visible Runtime Schedules and can create, edit, paus
 Static schedules require at least one five-field UTC cron expression.
 Runtime Schedule mode requires a configured `schedule` primitive.
 
-Runtime Schedule edits require write mode and approval by default.
+Runtime Schedule edits require explicit write mode and are allowed by default.
 Self-targeting requires explicit self-target permission.
 Runtime Schedules still require a provider wake or a long-running Schedule runner to execute when due.
+Set `policy: 'require-approval'` or `policy: 'deny'` when mutations need an additional gate; read operations remain allowed.
 
 ## Driver support
 
@@ -100,7 +101,7 @@ The Capability should reject it before the Agent starts.
 | `allowSelfTarget` | `boolean` | `false` | Lets the Agent create scheduled turns for itself. ViteHub derives the target from the discovered Agent name. |
 | `delivery` | `"origin"` | none | Delivers a scheduled Agent turn to the channel thread where it was created. Requires `allowSelfTarget: true`. |
 | `timeZone` | `string` | none (UTC fallback) | Default IANA time zone for Runtime Schedules created by the tool. New schedules use it before falling back to UTC. |
-| `policy` | `AgentToolPolicyDecision \| function` | `"require-approval"` | Policy for mutating `cronjob` operations. Read operations remain allowed. |
+| `policy` | `AgentToolPolicyDecision \| function` | `"allow"` | Policy for mutating `cronjob` operations. Read operations remain allowed. |
 
 ## Reference
 

--- a/docs/content/docs/concepts/runtime-policy-approvals-and-traces.md
+++ b/docs/content/docs/concepts/runtime-policy-approvals-and-traces.md
@@ -17,7 +17,7 @@ ViteHub treats policy and tracing as inspectable runtime behavior. The model sho
 
 | Surface | Current behavior |
 | --- | --- |
-| Storage Capabilities | Write tools require approval by default unless the developer opts into autonomous storage writes. |
+| Storage Capabilities | Attaching a write-enabled Capability opts into its bounded write tools; developers can add approval or deny policy when the product needs another runtime gate. |
 | Workspace | Workspace Rules enforce path-scoped write policy before writes reach the store. |
 | Workspace Scope | Access can narrow visible files for one Agent Invocation without exposing hidden paths to the model. |
 | Harness-backed Agent Drivers | V1 bypasses adapter-level approval prompts when supported and relies on ViteHub-owned Workspace and runtime boundaries. |

--- a/docs/content/docs/reference/runtime-events.md
+++ b/docs/content/docs/reference/runtime-events.md
@@ -44,6 +44,7 @@ They do not replace package-owned hooks such as Agent Finish Hooks.
 
 Policy Decisions are runtime outcomes, not generic booleans.
 An Approval Request is created only when policy requires external approval.
+An omitted policy resolves to `allow`.
 
 | Value | Meaning |
 | --- | --- |

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -470,7 +470,7 @@ async function cleanWorkingTree(session: WorkspaceSession, cwd: string, timeout:
   if (result.stdout.trim()) throw new Error("[vitehub] git write commands require a clean working tree.")
 }
 
-function gitShellPolicy(policy: GitCapabilityToolPolicy | undefined, defaultCwd: string | undefined): GitCapabilityToolPolicy {
+function gitShellPolicy(policy: GitCapabilityToolPolicy, defaultCwd: string | undefined): GitCapabilityToolPolicy {
   return async (context) => {
     let args: string[] | undefined
     try {
@@ -487,7 +487,7 @@ function gitShellPolicy(policy: GitCapabilityToolPolicy | undefined, defaultCwd:
         input: normalizeGitToolInput(context.input, defaultCwd),
       })
     }
-    return policy || "require-approval"
+    return policy
   }
 }
 
@@ -536,7 +536,7 @@ function gitTools(
         ? "Git shell command, for example `git status --short`, `git diff --stat`, `git log --oneline -n 20`, `git fetch origin pull/123/head`, or `git switch main`. Bare git subcommands are accepted and normalized to start with `git`. Pass one command only; do not use shell composition such as `&&` or `|`."
         : "Read-only git shell command, for example `git status --short`, `git diff --stat`, or `git log --oneline -n 20`. Bare git subcommands are accepted and normalized to start with `git`. Pass one command only; do not use shell composition such as `&&` or `|`."),
       name: "shell",
-      ...(mode === "write" ? { policy: gitShellPolicy(options.policy, defaultCwd) } : {}),
+      policy: mode === "write" && options.policy ? gitShellPolicy(options.policy, defaultCwd) : undefined,
     },
   }
 }

--- a/packages/agent/src/capabilities/memory.ts
+++ b/packages/agent/src/capabilities/memory.ts
@@ -517,8 +517,9 @@ export function memory(options: MemoryCapabilityOptions): AgentCapabilityDefinit
       const writePolicy = ({ input }: { input?: unknown }) => {
         const selected = getStore((input as { store?: string } | undefined)?.store)
         assertWriteAllowed(selected)
-        return selected.options.write?.policy || "require-approval"
+        return selected.options.write?.policy || "allow"
       }
+      const hasWritePolicy = [...resolved.values()].some(store => store.options.write?.policy !== undefined)
       const tools: AgentToolSet = {}
       if ([...resolved.values()].some(store => readSearchAllowed(store.options))) {
         tools.memory_search = createTool({
@@ -573,7 +574,7 @@ export function memory(options: MemoryCapabilityOptions): AgentCapabilityDefinit
           },
           inputSchema: memoryRememberInputSchema,
           name: "memory_remember",
-          policy: writePolicy,
+          policy: hasWritePolicy ? writePolicy : undefined,
         })
         tools.memory_delete = createTool({
           description: "Soft-delete one durable memory record.",
@@ -584,7 +585,7 @@ export function memory(options: MemoryCapabilityOptions): AgentCapabilityDefinit
           },
           inputSchema: memoryDeleteInputSchema,
           name: "memory_delete",
-          policy: writePolicy,
+          policy: hasWritePolicy ? writePolicy : undefined,
         })
       }
       context.tools.add(tools)

--- a/packages/agent/src/capabilities/repository-host.ts
+++ b/packages/agent/src/capabilities/repository-host.ts
@@ -136,7 +136,7 @@ function repositoryHostTools(mode: AgentCapabilityMode, options: RepositoryHostO
         },
         inputSchema: repositoryHostWriteInputSchema,
         name: "repository_host_write",
-        policy: options.policy || "require-approval",
+        policy: options.policy,
       })
     }
     return tools

--- a/packages/agent/src/capabilities/schedule.ts
+++ b/packages/agent/src/capabilities/schedule.ts
@@ -389,7 +389,13 @@ function runtimeScheduleTools(options: NormalizedRuntimeScheduleCapabilityOption
     }
     const client = scheduleClient(context as never, options.mode)
     const writeOperations = new Set(["create", "delete", "edit", "pause", "resume", "run"])
-    const writePolicy = options.policy || "require-approval"
+    const writePolicy = options.policy
+    const policy: ScheduleCapabilityToolPolicy | undefined = writePolicy
+      ? async (policyContext) => {
+          if (!writeOperations.has((policyContext.input as { operation?: unknown } | undefined)?.operation as string)) return "allow"
+          return typeof writePolicy === "function" ? await writePolicy(policyContext) : writePolicy
+        }
+      : undefined
     const tools: AgentToolSet = {
       cronjob: createTool<RuntimeScheduleToolInput>({
         description: "List, inspect, create, edit, pause, resume, run, or delete scoped cron jobs.",
@@ -495,9 +501,7 @@ function runtimeScheduleTools(options: NormalizedRuntimeScheduleCapabilityOption
         },
         inputSchema: runtimeScheduleInputSchema(options.mode, options.allowSelfTarget),
         name: "cronjob",
-        policy: async policyContext => writeOperations.has((policyContext.input as { operation?: unknown } | undefined)?.operation as string)
-          ? typeof writePolicy === "function" ? await writePolicy(policyContext) : writePolicy
-          : "allow",
+        policy,
       }),
     }
 

--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -287,7 +287,7 @@ function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): A
         },
         inputSchema: blobEditInputSchema,
         name: "blob_edit",
-        policy: options.policy || "require-approval",
+        policy: options.policy,
       })
     }
     return tools

--- a/packages/agent/src/capabilities/storage/db.ts
+++ b/packages/agent/src/capabilities/storage/db.ts
@@ -133,7 +133,7 @@ function dbTools(mode: AgentCapabilityMode, schemaMode: AgentCapabilityMode, opt
         },
         inputSchema: dbExecInputSchema,
         name: "db_exec",
-        policy: options.policy || "require-approval",
+        policy: options.policy,
       })
     }
     return tools

--- a/packages/agent/src/capabilities/storage/kv.ts
+++ b/packages/agent/src/capabilities/storage/kv.ts
@@ -75,7 +75,7 @@ function kvTools(mode: AgentCapabilityMode, options: KVCapabilityOptions): Agent
         },
         inputSchema: kvEditInputSchema,
         name: "kv_edit",
-        policy: options.policy || "require-approval",
+        policy: options.policy,
       })
     }
     return tools

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -164,10 +164,10 @@ describe("git capability", () => {
 
   it("runs local write commands only on a clean tree", async () => {
     const session = gitSession()
-    const { startSession, tools } = await capabilityTools(git({ mode: "write", policy: "allow" }), session)
+    const { startSession, tools } = await capabilityTools(git({ mode: "write" }), session)
 
     expect(Object.keys(tools)).toEqual(["shell"])
-    expect(typeof tools.shell!.policy).toBe("function")
+    expect(tools.shell!.policy).toBeUndefined()
     await expect(tools.shell!.execute?.({ command: "git switch feature/pr-1", cwd: "portal" })).resolves.toMatchObject({
       args: ["switch", "feature/pr-1"],
       cwd: "/workspace/portal",
@@ -178,16 +178,10 @@ describe("git capability", () => {
     expect(session.commit).toHaveBeenCalledWith({ message: "git switch" })
   })
 
-  it("defaults write commands to approval and allows read commands without approval", async () => {
+  it("allows supported commands by default", async () => {
     const { tools } = await capabilityTools(git({ mode: "write" }))
-    const policy = tools.shell!.policy
 
-    if (typeof policy !== "function") throw new Error("shell policy must be executable")
-
-    await expect(policy({ name: "shell", input: { command: "git status --short" } })).resolves.toBe("allow")
-    await expect(policy({ name: "shell", input: { command: "git fetch origin pull/123/head" } })).resolves.toBe("require-approval")
-    await expect(policy({ name: "shell", input: { command: "git checkout main" } })).resolves.toBe("require-approval")
-    await expect(policy({ name: "shell", input: { command: "git switch main" } })).resolves.toBe("require-approval")
+    expect(tools.shell!.policy).toBeUndefined()
   })
 
   it("evaluates custom write policies with normalized git inputs", async () => {
@@ -375,7 +369,7 @@ describe("git capability", () => {
       stderr: "",
       stdout: "",
     }))
-    const { tools } = await capabilityTools(git({ mode: "write", policy: "allow" }), session, {
+    const { tools } = await capabilityTools(git({ mode: "write" }), session, {
       pullRequest: {
         pullRequest: {
           base: { ref: "main" },

--- a/packages/agent/test/memory.test.ts
+++ b/packages/agent/test/memory.test.ts
@@ -61,7 +61,7 @@ describe("agent memory capability", () => {
               adapter,
               allowKinds: ["procedural", "semantic"],
               scope: { agent: "support" },
-              write: { mode: "tool", policy: "allow" },
+              write: { mode: "tool" },
             },
           },
         }),
@@ -75,10 +75,10 @@ describe("agent memory capability", () => {
     await expect(capturedTools.memory_read!.execute({ id: "mem_1" })).resolves.toMatchObject({ item: { id: "mem_1" } })
     await expect(capturedTools.memory_remember!.execute({ content: "Prefer workspace JSONL.", kind: "semantic" })).resolves.toMatchObject({ item: { id: "mem_2" } })
     await expect(capturedTools.memory_delete!.execute({ id: "mem_1", reason: "obsolete" })).resolves.toMatchObject({ ok: true })
-    expect(await (capturedTools.memory_remember!.policy as (context: { input?: unknown }) => unknown)({ input: {} })).toBe("allow")
+    expect(capturedTools.memory_remember!.policy).toBeUndefined()
   })
 
-  it("enforces memory write mode and policy for the selected store", async () => {
+  it("enforces memory write mode for the selected store", async () => {
     const writable: MemoryStoreAdapter = {
       append: vi.fn(async request => ({ action: "created" as const, item: memoryRecord({ ...request, id: "mem_1" }) })),
       delete: vi.fn(async request => ({ deletedId: request.id, ok: true as const, tombstoneId: "mem_del_1" })),
@@ -107,7 +107,7 @@ describe("agent memory capability", () => {
             agent: {
               adapter: writable,
               scope: { agent: "support" },
-              write: { mode: "tool", policy: "allow" },
+              write: { mode: "tool" },
             },
             readonly: {
               adapter: readonly,
@@ -119,7 +119,7 @@ describe("agent memory capability", () => {
     })
 
     await runAgent(agent, runtime(), {})
-    expect(await capturedTools.memory_remember!.policy!({ input: { store: "agent" } })).toBe("allow")
+    expect(capturedTools.memory_remember!.policy).toBeUndefined()
     await expect(Promise.resolve().then(() => capturedTools.memory_remember!.execute({ content: "Keep this.", kind: "semantic", store: "readonly" }))).rejects.toThrow("does not allow writes")
     await expect(Promise.resolve().then(() => capturedTools.memory_delete!.execute({ id: "mem_1", store: "readonly" }))).rejects.toThrow("does not allow writes")
     expect(readonly.append).not.toHaveBeenCalled()
@@ -197,7 +197,7 @@ describe("agent memory capability", () => {
             project: {
               adapter,
               scope: { project: "vitehub" },
-              write: { mode: "tool", policy: "allow" },
+              write: { mode: "tool" },
             },
           },
         }),
@@ -263,7 +263,7 @@ describe("agent memory capability", () => {
             agent: {
               adapter,
               scope: { agent: "support" },
-              write: { mode: "tool", policy: "allow" },
+              write: { mode: "tool" },
             },
           },
         }),
@@ -409,7 +409,7 @@ describe("agent memory capability", () => {
             agent: {
               adapter,
               scope: { agent: "support" },
-              write: { mode: "tool", policy: "allow" },
+              write: { mode: "tool" },
             },
           },
         }),
@@ -446,7 +446,7 @@ describe("agent memory capability", () => {
             agent: {
               adapter,
               scope: context => ({ agent: "support", thread: context.run?.threadId }),
-              write: { mode: "tool", policy: "allow" },
+              write: { mode: "tool" },
             },
           },
         }),

--- a/packages/agent/test/memory.test.ts
+++ b/packages/agent/test/memory.test.ts
@@ -109,6 +109,11 @@ describe("agent memory capability", () => {
               scope: { agent: "support" },
               write: { mode: "tool" },
             },
+            guarded: {
+              adapter: writable,
+              scope: { agent: "support" },
+              write: { mode: "tool", policy: "deny" },
+            },
             readonly: {
               adapter: readonly,
               scope: { agent: "support" },
@@ -119,7 +124,8 @@ describe("agent memory capability", () => {
     })
 
     await runAgent(agent, runtime(), {})
-    expect(capturedTools.memory_remember!.policy).toBeUndefined()
+    expect(await capturedTools.memory_remember!.policy!({ input: { store: "agent" } })).toBe("allow")
+    expect(await capturedTools.memory_remember!.policy!({ input: { store: "guarded" } })).toBe("deny")
     await expect(Promise.resolve().then(() => capturedTools.memory_remember!.execute({ content: "Keep this.", kind: "semantic", store: "readonly" }))).rejects.toThrow("does not allow writes")
     await expect(Promise.resolve().then(() => capturedTools.memory_delete!.execute({ id: "mem_1", store: "readonly" }))).rejects.toThrow("does not allow writes")
     expect(readonly.append).not.toHaveBeenCalled()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1754,7 +1754,6 @@ describe("server helpers", () => {
           allowSelfTarget: true,
           delivery: "origin",
           mode: "write",
-          policy: "allow",
           timeZone: "Asia/Bangkok",
         }),
       ],

--- a/packages/agent/test/repository-host-capability.test.ts
+++ b/packages/agent/test/repository-host-capability.test.ts
@@ -85,9 +85,9 @@ describe("repositoryHost capability", () => {
     const readTools = await resolveTools(repositoryHost({ client: readOnly }))
     expect(Object.keys(readTools)).toEqual(["repository_host_read"])
 
-    const writeTools = await resolveTools(repositoryHost({ client: readOnly, mode: "write", policy: "allow" }))
+    const writeTools = await resolveTools(repositoryHost({ client: readOnly, mode: "write" }))
     expect(Object.keys(writeTools).sort()).toEqual(["repository_host_read", "repository_host_write"])
-    expect(writeTools.repository_host_write!.policy).toBe("allow")
+    expect(writeTools.repository_host_write!.policy).toBeUndefined()
     await expect(Promise.resolve().then(() => writeTools.repository_host_write!.execute?.({
       body: "Queued review.",
       operation: "comment",

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8211,6 +8211,28 @@ describe("agent message protocol", () => {
     expect(execute).not.toHaveBeenCalled()
   })
 
+  it("allows tools when policy is omitted", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => "refunded")
+
+    const agent = defineAgent({
+      driver: { model: {} as never },
+      capabilities: [{
+        id: "refund-tools",
+        tools: {
+          refund: {
+            execute,
+            name: "refund",
+          },
+        },
+      }],
+    })
+    const resolved = await agent.resolve({ memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }) as unknown as { tools: Record<string, { execute: (input: unknown) => Promise<unknown> }> }
+
+    await expect(resolved.tools.refund!.execute({ amount: 100 })).resolves.toBe("refunded")
+    expect(execute).toHaveBeenCalledWith({ amount: 100 })
+  })
+
   it("turns approval-required tool policy into an approval error", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const execute = vi.fn()

--- a/packages/agent/test/schedule-process-integration.test.ts
+++ b/packages/agent/test/schedule-process-integration.test.ts
@@ -45,7 +45,7 @@ describe("Agent Process Schedule integration", () => {
       "}",
       "export default defineAgent({",
       "  runtime: false,",
-      "  capabilities: [kv(), schedule({ allowSelfTarget: true, delivery: 'origin', mode: 'write', policy: 'allow', timeZone: 'Asia/Bangkok' })],",
+      "  capabilities: [kv(), schedule({ allowSelfTarget: true, delivery: 'origin', mode: 'write', timeZone: 'Asia/Bangkok' })],",
       "  channels: {",
       "    discord: defineChannel('discord', {",
       "      adapter: {",

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -84,6 +84,12 @@ describe("storage capabilities", () => {
     expect(Object.keys(tools)).toEqual(["cronjob"])
     expect(tools.cronjob!.policy).toBeUndefined()
 
+    const guardedTools = await resolveTools([schedule({ mode: "write", policy: "deny", targets: ["reports"] })], { schedule: { schedules } })
+    const guardedPolicy = guardedTools.cronjob!.policy
+    if (typeof guardedPolicy !== "function") throw new TypeError("Expected Schedule policy to dispatch by operation.")
+    expect(await guardedPolicy({ input: { operation: "list" }, name: "cronjob" })).toBe("allow")
+    expect(await guardedPolicy({ input: { operation: "create" }, name: "cronjob" })).toBe("deny")
+
     await expect(tools.cronjob!.execute?.({ operation: "targets" })).resolves.toEqual({ targets: ["reports"] })
     await expect(tools.cronjob!.execute?.({ operation: "list" })).resolves.toEqual([records[0]])
     await expect(tools.cronjob!.execute?.({ id: "daily", operation: "get" })).resolves.toEqual(records[0])

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -80,9 +80,9 @@ describe("storage capabilities", () => {
 
     await expect(resolveTools([schedule({ mode: "read", targets: ["reports"] })], { schedule: { schedules } }).then(tools => Object.keys(tools).sort())).resolves.toEqual(["cronjob"])
 
-    const tools = await resolveTools([schedule({ mode: "write", policy: "allow", targets: ["reports"] })], { schedule: { schedules } })
+    const tools = await resolveTools([schedule({ mode: "write", targets: ["reports"] })], { schedule: { schedules } })
     expect(Object.keys(tools)).toEqual(["cronjob"])
-    expect(await (tools.cronjob!.policy as (context: { input?: unknown, name: string }) => unknown)({ input: { operation: "list" }, name: "cronjob" })).toBe("allow")
+    expect(tools.cronjob!.policy).toBeUndefined()
 
     await expect(tools.cronjob!.execute?.({ operation: "targets" })).resolves.toEqual({ targets: ["reports"] })
     await expect(tools.cronjob!.execute?.({ operation: "list" })).resolves.toEqual([records[0]])
@@ -449,9 +449,9 @@ describe("storage capabilities", () => {
 
     await expect(resolveTools([kv()], { kv: { kind: "kv", value: store } }).then(tools => Object.keys(tools).sort())).resolves.toEqual(["kv_read"])
 
-    const tools = await resolveTools([kv({ mode: "write", policy: "allow" })], { kv: { kind: "kv", value: store } })
+    const tools = await resolveTools([kv({ mode: "write" })], { kv: { kind: "kv", value: store } })
     expect(Object.keys(tools).sort()).toEqual(["kv_edit", "kv_read"])
-    expect(tools.kv_edit?.policy).toBe("allow")
+    expect(tools.kv_edit?.policy).toBeUndefined()
 
     await expect(tools.kv_read!.execute?.({ key: "app:1" })).resolves.toBe("value")
     await expect(tools.kv_read!.execute?.({ prefix: "app:" })).resolves.toEqual(["app:1"])
@@ -503,7 +503,7 @@ describe("storage capabilities", () => {
 
     const tools = await resolveTools([blob({ mode: "write" })], { blob: store }, workspace)
     expect(Object.keys(tools).sort()).toEqual(["blob_edit", "blob_read"])
-    expect(tools.blob_edit?.policy).toBe("require-approval")
+    expect(tools.blob_edit?.policy).toBeUndefined()
 
     await tools.blob_read!.execute?.({ operation: "get", pathname: "images/a.png" })
     await tools.blob_read!.execute?.({ operation: "head", pathname: "images/a.png" })
@@ -659,7 +659,7 @@ describe("storage capabilities", () => {
       db: { run: vi.fn() },
       schema: { notes: true },
     }
-    const tools = await resolveTools([db({ mode: "write", policy: "allow" })], {
+    const tools = await resolveTools([db({ mode: "write" })], {
       db: database,
     })
 
@@ -704,15 +704,15 @@ describe("storage capabilities", () => {
     await expect(readTools.db_query!.execute?.({ statement: "with [delete] as (select 1) select * from [delete]" })).resolves.toEqual({ ok: true })
     await expect(readTools.db_query!.execute?.({ statement: "with cleaned as (select replace(title, 'a', 'b') from notes) select * from cleaned" })).resolves.toEqual({ ok: true })
 
-    const writeTools = await resolveTools([db({ mode: "write", policy: "allow" })], { db: database })
-    expect(writeTools.db_exec?.policy).toBe("allow")
+    const writeTools = await resolveTools([db({ mode: "write" })], { db: database })
+    expect(writeTools.db_exec?.policy).toBeUndefined()
     await expect(Promise.resolve().then(() => writeTools.db_exec!.execute?.({ rationale: "", statement: "delete from notes where id = 1" }))).rejects.toThrow("rationale")
     await expect(Promise.resolve().then(() => writeTools.db_exec!.execute?.({ rationale: "remove duplicate", statement: "delete from notes where id = 1; delete from notes where id = 2" }))).rejects.toThrow("exactly one")
     await expect(Promise.resolve().then(() => writeTools.db_exec!.execute?.({ rationale: "create table", statement: "create table notes (id integer)" }))).rejects.toThrow("schemaMode")
     await expect(writeTools.db_exec!.execute?.({ rationale: "remove duplicate", statement: "delete from notes where id = 1" })).resolves.toEqual({ ok: true })
     await expect(writeTools.db_exec!.execute?.({ rationale: "remove duplicate", statement: "with stale as (select id from notes) delete from notes where id in (select id from stale)" })).resolves.toEqual({ ok: true })
 
-    const schemaTools = await resolveTools([db({ policy: "allow", schemaMode: "write" })], { db: database })
+    const schemaTools = await resolveTools([db({ schemaMode: "write" })], { db: database })
     await expect(schemaTools.db_exec!.execute?.({ rationale: "create table", statement: "create table notes (id integer)" })).resolves.toEqual({ ok: true })
     await expect(Promise.resolve().then(() => schemaTools.db_exec!.execute?.({ rationale: "read", statement: "select * from notes" }))).rejects.toThrow("use db_query")
   })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -181,8 +181,8 @@ describe("agent public types", () => {
           },
         }),
         workspaceShell(),
-        blob({ mode: "write", policy: () => "allow", store: "assets" }),
-        db({ database: "analytics", mode: "write", policy: "allow", schemaMode: "write" }),
+        blob({ mode: "write", policy: () => "require-approval", store: "assets" }),
+        db({ database: "analytics", mode: "write", schemaMode: "write" }),
         fetch({
           tools: {
             status: {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -375,7 +375,7 @@ describe("defineAgent workspace option", () => {
     })
 
     const agent = withExplicitWorkspaceName(defineAgent({
-      capabilities: [blob({ mode: "write", policy: "allow" })],
+      capabilities: [blob({ mode: "write" })],
       driver: {
         harness: { provider: "codex" },
       },

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -44,6 +44,8 @@ const decision = await resolveCapabilityPolicy("require-approval", {
 })
 ```
 
+An omitted policy resolves to `allow`. Pass `require-approval` or `deny` when an operation needs an explicit gate.
+
 ## Used by
 
 Feature packages use Runtime Capability handles instead of passing every provider client through every API. Agent Capabilities consume these handles when they expose KV, Blob, DB, sandbox, shell, or workspace behavior.

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -81,6 +81,7 @@ describe("@vite-hub/runtime", () => {
   })
 
   it("resolves policy decisions", async () => {
+    await expect(resolveCapabilityPolicy(undefined, { capability: "email" })).resolves.toBe("allow")
     await expect(resolveCapabilityPolicy("deny", { capability: "email" })).resolves.toBe("deny")
     await expect(resolveCapabilityPolicy(ctx => ctx.input ? "require-approval" : "allow", {
       capability: "refund",


### PR DESCRIPTION
Treats attaching or configuring a write-enabled Capability as the developer's explicit opt-in by letting omitted tool policy resolve to `allow` across KV, Blob, DB, Git, Memory, Repository Host, and Schedule. Developers can still set `require-approval` or `deny` when the product needs an additional runtime gate.

Preserves the Capability-owned security boundaries around write modes, store and schema selection, Git command restrictions, memory scopes, and Schedule target allowlists, then aligns the tests, public types, and documentation so official Capabilities no longer require `policy: 'allow'` boilerplate.

The Agent and Runtime suites, docs build, package typechecks, lint, workspace builds, and contract tests pass. The full root verification still reaches five unrelated existing `@vite-hub/box` failures caused by macOS path normalization and BSD tar behavior.