### PR TITLE
feat(agent): add contextual capabilities and papercuts

### DIFF
--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -55,6 +55,20 @@ export default defineAgent({
 
 Tools are contributed by Capabilities. They are not top-level Agent Definition fields.
 
+When trusted invocation context decides which Agent Definition abilities apply, make `capabilities` a callback. ViteHub resolves the Agent Invoker first and uses the returned list for that invocation; Capabilities contributed by the active Channel still compose normally.
+
+```ts [server/agents/support.ts]
+export default defineAgent({
+  driver: { model },
+  capabilities: ({ actor }) => [
+    customerRecords,
+    ...(actor.meta?.support === true ? [internalDiagnostics] : []),
+  ],
+})
+```
+
+The callback also receives the invocation input and runtime handles. Capabilities that contribute Agent Triggers, chat admission or attachments, or static Workspace Sources must stay in a static array because ViteHub registers those contributions before an invocation starts.
+
 ## Add Workspace context
 
 Workspace context gives the Agent a file tree and Sources. The Workspace owns file visibility, while Capabilities decide whether the active Agent Driver receives model-facing tools or other driver-compatible inputs.

--- a/docs/content/docs/capabilities/custom-capabilities.md
+++ b/docs/content/docs/capabilities/custom-capabilities.md
@@ -198,6 +198,8 @@ ViteHub exposes command metadata through the generated CLI-named tool. Keep `ins
 
 Return `undefined` from a resolver when the CLI should not be available for the current invocation. The Capability remains attached and inspectable.
 
+When the entire Capability should be absent, resolve the Agent Definition's `capabilities` list instead. This keeps selection at the composition boundary, before the Capability can contribute tools, CLI commands, requirements, hooks, or cleanup work.
+
 ```ts [server/agents/capabilities/inventory-runtime.ts]
 export const inventoryRuntime = defineCapability({
   id: 'inventory-runtime',

--- a/docs/content/docs/capabilities/index.md
+++ b/docs/content/docs/capabilities/index.md
@@ -16,7 +16,7 @@ Capabilities decide which parts of that authority become available to an Agent I
 
 ## Capability lifecycle
 
-ViteHub applies Capabilities in the order listed on the Agent Definition.
+ViteHub applies Capabilities in the order listed or returned by the Agent Definition.
 It validates duplicate ids, checks runtime requirements, applies Capability Trigger Contributions, and then runs configure, prepare, bind, input, resolve, and output phases for each invocation.
 
 `access()` is the only official Capability with a fixed position rule.
@@ -41,6 +41,20 @@ export default defineAgent({
 ```
 
 Attaching a Capability opts the Agent into that ability. Model-facing tool policy defaults to `allow`; set `policy: 'require-approval'` or `policy: 'deny'` when the product needs an additional runtime gate. Capability modes, scopes, allowlists, requirements, and input validation still bound the operation before policy applies.
+
+Use a callback when invocation context decides the Agent Definition's Capability list. ViteHub calls it once after resolving the Agent Invoker and before Capability setup; Capabilities contributed by the active Channel still compose normally.
+
+```ts [server/agents/support.ts]
+export default defineAgent({
+  driver: { model },
+  capabilities: ({ actor }) => [
+    workspaceShell({ mode: 'read' }),
+    ...(actor.meta?.support === true ? [internalDiagnostics] : []),
+  ],
+})
+```
+
+Return only invocation-scoped behavior from the callback. Capabilities that contribute Agent Triggers, chat admission or attachments, or static Workspace Sources must stay in a static list because ViteHub registers those contributions before an invocation exists.
 
 ## What Capabilities can contribute
 

--- a/docs/content/docs/capabilities/official-capabilities.md
+++ b/docs/content/docs/capabilities/official-capabilities.md
@@ -28,6 +28,7 @@ import {
   mcp,
   memory,
   openapi,
+  papercuts,
   rateLimit,
   repositoryHost,
   repositoryHostContext,
@@ -71,6 +72,7 @@ import {
 | Rate limit | [`rateLimit()`](/docs/capabilities/rate-limit) | A trusted invocation budget should be checked or consumed before the Agent runs. |
 | Chat title | [`chatTitle()`](/docs/capabilities/chat-title) | Chat streams and finish extensions should include a generated conversation title. |
 | Chat summary | [`chatSummary()`](/docs/capabilities/chat-summary) | A summary command should replace explicit input with a conversation summary. |
+| Papercut reports | [`papercuts()`](/docs/capabilities/papercuts) | An Agent should report small runtime or developer-experience friction to an application-owned sink. |
 
 ## Read capability pages first
 

--- a/docs/content/docs/capabilities/papercuts.md
+++ b/docs/content/docs/capabilities/papercuts.md
@@ -1,0 +1,126 @@
+---
+title: Papercuts
+description: Let an Agent report small runtime and developer-experience friction to an application-owned sink.
+navigation.title: Papercuts
+navigation.order: 220
+navigation.group: Decisions and output
+icon: i-lucide-message-square-warning
+---
+
+`papercuts()` adds the `report_papercut` tool to an Agent.
+Use it to capture small, non-blocking friction while the details are still available to the current Agent Invocation.
+
+The Capability owns the reporting contract and provenance.
+Your application owns persistence, redaction, retention, deduplication, and triage.
+
+## Installation
+
+Import the Capability factory from `@vite-hub/agent/capabilities` and add it to `defineAgent({ capabilities })`.
+Provide a `report` callback that accepts each papercut before the tool reports success.
+
+## What it adds
+
+The Capability always adds `report_papercut`.
+The tool accepts one trimmed message between 1 and 1000 characters and asks the Agent to describe what it was doing and what got in the way.
+
+Each report includes an id, creation time, source, and available Agent, run, and trace provenance.
+The callback also receives the current Capability runtime context for application-specific routing.
+
+## Configuration
+
+Persist the normalized `papercut` record and use `context` only when the sink needs invocation-specific information.
+
+```ts [server/agents/support.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { papercuts } from '@vite-hub/agent/capabilities'
+
+export default defineAgent({
+  driver: { model },
+  capabilities: [
+    papercuts({
+      async report({ papercut, context }) {
+        await savePapercut({
+          ...papercut,
+          actorId: context.actor.id,
+        })
+      },
+    }),
+  ],
+})
+```
+
+Do not serialize the runtime `context` wholesale.
+It is invocation-scoped and may contain request, actor, Workspace, or application values that do not belong in a papercut record; `workspace` and `fs` are absent on Agents without a Workspace.
+
+## Add the Capability CLI
+
+Set `cli: true` when agents and developers should also have a command-shaped reporting surface.
+This adds the fixed `papercuts report` command without replacing `report_papercut`.
+
+```ts [server/agents/support.ts]
+papercuts({
+  cli: true,
+  report: ({ papercut }) => savePapercut(papercut),
+})
+```
+
+Run the command through the Agent Dev Loop.
+
+```bash [Terminal]
+pnpm vitehub agent dev --agent support --cli papercuts -- report "The retry hid the original error."
+```
+
+Successful command output is `Papercut reported.`
+
+## Runtime behavior
+
+ViteHub trims and validates the message, generates the record, and awaits `report`.
+The tool returns `{ reported: true, id }` only after the sink accepts the report; callback errors fail the tool call instead of returning a false success.
+
+The normalized record contains:
+
+| Field | Description |
+| --- | --- |
+| `id` | Generated `papercut_` identifier. |
+| `createdAt` | ISO timestamp created when the report is submitted. |
+| `message` | Trimmed report text. |
+| `source` | `"tool"` or `"cli"`. |
+| `agent` | Agent identity when the host provides one. |
+| `run` | Agent Run metadata, including `runId`, when available. |
+| `trace` | Runtime Trace Context when available. |
+
+Attaching the Capability grants access to the developer-provided reporting sink, so `papercuts()` does not add an approval policy.
+It does not provide a `when` option; attach the Capability only to Agent Definitions that should report papercuts.
+
+## Requirements
+
+`papercuts({ report })` requires a report callback.
+The callback should complete only after its destination accepts the record.
+
+The tool description tells the Agent not to include secrets or customer data, but the sink still owns redaction and data handling appropriate to the application.
+
+## Driver support
+
+| Agent Driver | Support |
+| --- | --- |
+| Model-backed | Receives `report_papercut` and the optional `papercuts` Capability CLI tool. |
+| Harness-backed | Receives the same Capability tools through the Harness Agent tool bridge. |
+| Custom-run-backed | Receives resolved tools in the run context; `driver.run` decides whether to call them. |
+
+## Inspect and verify
+
+Run one Agent Invocation that encounters obvious friction and inspect the `report_papercut` call and normalized sink record.
+When `cli` is enabled, run `papercuts report` through the Agent Dev Loop and confirm the same sink receives a report with `source: "cli"`.
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `report` | `(event: PapercutReportEvent) => void \| Promise<void>` | required | Application-owned sink for the normalized papercut and current Capability runtime context. |
+| `cli` | `boolean` | `false` | Adds the fixed `papercuts report` Capability CLI while keeping `report_papercut`. |
+
+## Reference
+
+- [Agent Evals](/docs/agents/evals)
+- [Custom capabilities](/docs/capabilities/custom-capabilities)
+- Source: `packages/agent/src/capabilities/papercuts.ts`

--- a/docs/content/docs/concepts/capabilities-api.md
+++ b/docs/content/docs/concepts/capabilities-api.md
@@ -55,11 +55,30 @@ The Agent Package root stays focused on Agent Definition, invocation, message, a
 | Invocation context values | Typed data that later Agent and Capability callbacks can read. |
 | Metadata | Inspectable configuration for runtime and DevTools surfaces. |
 
-## Static attachment
+## Invocation-resolved composition
 
-Capabilities are attached before the Agent Invocation runs. Pre-Invocation Decisions can record context values, reject, or influence conditional contributions, but they do not dynamically attach new Capabilities.
+Pass an ordered array when every Agent Invocation uses the same Capabilities. Pass a callback when trusted invocation context decides which Capabilities belong to the invocation.
 
-Capabilities run in array order. A Capability can include nested default Capabilities, but an explicitly listed Capability keeps its top-level position.
+```ts [server/agents/support.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { customerRecords, internalDiagnostics } from './capabilities'
+
+export default defineAgent({
+  driver: { model },
+  capabilities: ({ actor }) => [
+    customerRecords,
+    ...(actor.meta?.support === true ? [internalDiagnostics] : []),
+  ],
+})
+```
+
+ViteHub resolves the Agent Invoker first, then calls the callback once before it sets up any Capability. The returned array is the actual composition boundary, so an omitted Capability contributes no tools, CLI commands, requirements, hooks, or cleanup work.
+
+The callback can inspect the Agent Actor, Agent Invoker, input, run metadata, Agent Invocation Context, runtime handles, and `driver.kind`. It cannot select behavior that ViteHub must register before an invocation exists. Capabilities that contribute Agent Triggers, chat admission or attachments, or static Workspace Sources must stay in a static array. Use the invocation-scoped `workspace` contribution when a selected Capability needs to add Workspace context.
+
+Async DevTools metadata resolution evaluates the callback with its inspection input. Synchronous definition metadata reports only definition-stable configuration because it has no invocation context.
+
+Capabilities run in resolved array order. A Capability can include nested default Capabilities, but an explicitly returned Capability keeps its top-level position. Capability selection does not change after the invocation starts.
 
 Free-form Capability guidance belongs in Agent Driver Instructions or deterministic imported instruction Markdown. Tool descriptions and schemas stay with the tool because they are structured tool contracts, not arbitrary system instructions.
 

--- a/docs/content/docs/concepts/how-vitehub-fits-together.md
+++ b/docs/content/docs/concepts/how-vitehub-fits-together.md
@@ -29,7 +29,7 @@ For example, Workspace owns the Workspace File Tree and Sources. The Agent Packa
 
 An Agent Definition selects one Agent Driver. It may attach Capabilities, define an Agent Invoker resolver, use Workspace context, and run through Agent Invocations.
 
-Capabilities sit above the Agent Driver. They can contribute tools, trigger behavior, metadata, policy, requirements, and invocation context values, but they do not dynamically grant new Capabilities at runtime.
+Capabilities sit above the Agent Driver. An Agent Definition can attach a static ordered list or resolve its list once from trusted invocation context before Capability setup; the selected list does not change while the invocation runs.
 
 ## Inspect it
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -136,6 +136,7 @@ Pass `--json` for the structured inspection contract.
 - `workspaceShell()` runs scoped shell/file work through [`@vite-hub/shell`](../shell/README.md).
 - `webSearch()` searches and reads the web with [Brave](https://brave.com/search/api/), [Exa](https://docs.exa.ai/), [Jina](https://jina.ai/en-US/reader/), [SearXNG](https://docs.searxng.org/dev/search_api.html), [SerpApi](https://serpapi.com/search-api), [SerpBase](https://serpbase.dev/docs), or [Tavily](https://docs.tavily.com/).
 - `openapi()` turns an allowed OpenAPI `operationId` subset into bounded HTTP tools, or into a generated Capability CLI when `cli` is set.
+- `papercuts()` lets an Agent report small runtime and developer-experience friction to an application-owned sink, with an optional Capability CLI command.
 - `transcribe()` uses the [AI SDK transcription API](https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/transcribe).
 - `mcp()` connects tools from [Model Context Protocol](https://modelcontextprotocol.io/) servers through `@ai-sdk/mcp`.
 - `kv()`, `blob()`, and `db()` expose [`@vite-hub/kv`](../kv/README.md), [`@vite-hub/blob`](../blob/README.md), and [`@vite-hub/database`](../database/README.md).

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -40,6 +40,9 @@ export {
   openapi,
 } from "./openapi.ts"
 export {
+  papercuts,
+} from "./papercuts.ts"
+export {
   repositoryHost,
 } from "./repository-host.ts"
 export {
@@ -218,6 +221,13 @@ export type {
   OpenAPIRequestPatch,
   OpenAPIResponseContext,
 } from "./openapi.ts"
+export type {
+  Papercut,
+  PapercutReportContext,
+  PapercutReportEvent,
+  PapercutSource,
+  PapercutsOptions,
+} from "./papercuts.ts"
 export type {
   RepositoryHostClient,
   RepositoryHostOptions,

--- a/packages/agent/src/capabilities/papercuts.ts
+++ b/packages/agent/src/capabilities/papercuts.ts
@@ -1,0 +1,190 @@
+import { defineCapability } from "../capability-runtime.ts"
+import { defineInternalTool } from "./internal.ts"
+
+import type {
+  AgentCapabilityCliContribution,
+  AgentCapabilityDefinition,
+  AgentCapabilityRuntimeContext,
+  AgentHostIdentity,
+  AgentRunMetadata,
+  AgentRuntimeConfig,
+  AgentToolSchema,
+  MaybePromise,
+} from "../types.ts"
+import type { TraceContext } from "@vite-hub/runtime"
+import type { WorkspaceName } from "@vite-hub/workspace"
+
+export type PapercutSource = "cli" | "tool"
+
+export interface Papercut {
+  agent?: AgentHostIdentity
+  createdAt: string
+  id: string
+  message: string
+  run?: AgentRunMetadata
+  source: PapercutSource
+  trace?: TraceContext
+}
+
+export type PapercutReportContext<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> = Omit<AgentCapabilityRuntimeContext<TRuntimeConfig, Name>, "fs" | "workspace"> & {
+  fs?: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>["fs"]
+  workspace?: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>["workspace"]
+}
+
+export interface PapercutReportEvent<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> {
+  context: PapercutReportContext<TRuntimeConfig, Name>
+  papercut: Papercut
+}
+
+export interface PapercutsOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> {
+  cli?: boolean
+  report: (event: PapercutReportEvent<TRuntimeConfig, Name>) => MaybePromise<void>
+}
+
+interface PapercutInput {
+  message: string
+}
+
+interface PapercutResult {
+  id: string
+  reported: true
+}
+
+const maxMessageLength = 1000
+const reportDescription = "Proactively report small friction as soon as it happens, even when non-blocking: a missed or retried tool call, confusing or undocumented setup, flaky command, stale cache, misleading error, or non-obvious gotcha. In one or two sentences, say what you were doing and what got in the way; a likely cause or fix is a bonus. Never include secrets or customer data."
+const papercutInputSchema: AgentToolSchema<PapercutInput> = {
+  additionalProperties: false,
+  properties: {
+    message: {
+      description: "One or two sentences describing what you were doing and what got in the way.",
+      maxLength: maxMessageLength,
+      minLength: 1,
+      type: "string",
+    },
+  },
+  required: ["message"],
+  type: "object",
+}
+
+function createPapercutId(): string {
+  const random = globalThis.crypto?.randomUUID?.().replace(/-/g, "") || Math.random().toString(36).slice(2)
+  return `papercut_${random}`
+}
+
+function normalizePapercutMessage(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new TypeError("[vitehub] report_papercut requires a non-empty message.")
+  }
+  const message = value.trim()
+  if (message.length > maxMessageLength) {
+    throw new TypeError(`[vitehub] report_papercut message must be at most ${maxMessageLength} characters.`)
+  }
+  return message
+}
+
+function createPapercut(
+  context: AgentCapabilityRuntimeContext,
+  message: string,
+  source: PapercutSource,
+): Papercut {
+  return {
+    ...(context.agentIdentity ? { agent: { ...context.agentIdentity } } : {}),
+    createdAt: new Date().toISOString(),
+    id: createPapercutId(),
+    message,
+    ...(context.run ? { run: { ...context.run } } : {}),
+    source,
+    ...(context.trace ? { trace: { ...context.trace } } : {}),
+  }
+}
+
+async function submitPapercut<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: PapercutsOptions<TRuntimeConfig, Name>,
+  context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
+  value: unknown,
+  source: PapercutSource,
+): Promise<Papercut> {
+  const papercut = createPapercut(context, normalizePapercutMessage(value), source)
+  await options.report({ context, papercut })
+  return papercut
+}
+
+function papercutCliMessage(input: unknown): unknown {
+  if (!input || typeof input !== "object") return undefined
+  const argv = (input as { argv?: unknown }).argv
+  if (!Array.isArray(argv) || argv.some(value => typeof value !== "string")) return undefined
+  return argv.join(" ")
+}
+
+function createPapercutsCli<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: PapercutsOptions<TRuntimeConfig, Name>,
+  context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
+): AgentCapabilityCliContribution<TRuntimeConfig, Name> {
+  return {
+    commands: {
+      report: {
+        description: "Report one papercut from the current Agent Invocation.",
+        effects: ["write"],
+        examples: ["papercuts report \"Describe the friction.\""],
+        output: { format: "text" },
+        rest: true,
+        async run({ input }) {
+          await submitPapercut(options, context, papercutCliMessage(input), "cli")
+          return "Papercut reported."
+        },
+      },
+    },
+    description: "Report small friction from the current Agent Invocation.",
+    name: "papercuts",
+  }
+}
+
+export function papercuts<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+>(options: PapercutsOptions<TRuntimeConfig, Name>): AgentCapabilityDefinition<TRuntimeConfig, Name> {
+  if (!options || typeof options.report !== "function") {
+    throw new TypeError("[vitehub] papercuts() requires a report callback.")
+  }
+  if (options.cli !== undefined && typeof options.cli !== "boolean") {
+    throw new TypeError("[vitehub] papercuts({ cli }) must be a boolean.")
+  }
+
+  return defineCapability({
+    id: "papercuts",
+    cli: options.cli ? context => createPapercutsCli(options, context) : undefined,
+    metadata: {
+      ...(options.cli ? { cli: "papercuts" } : {}),
+      tool: "report_papercut",
+    },
+    tools: (capabilityContext) => {
+      const context = capabilityContext as AgentCapabilityRuntimeContext<TRuntimeConfig, Name>
+      return {
+        report_papercut: defineInternalTool<PapercutInput, PapercutResult>({
+          description: reportDescription,
+          inputSchema: papercutInputSchema,
+          name: "report_papercut",
+          async execute(input) {
+            const papercut = await submitPapercut(options, context, input?.message, "tool")
+            return { id: papercut.id, reported: true }
+          },
+        }),
+      }
+    },
+  })
+}

--- a/packages/agent/src/capabilities/subagents.ts
+++ b/packages/agent/src/capabilities/subagents.ts
@@ -97,11 +97,16 @@ function subagentWorkspaceSources(
   const sources: NonNullable<WorkspaceDefinition["sources"]> = {}
   for (const { definition, name } of agents) {
     const workspaceAgent = definition.agent as Partial<{
-      __vitehubWorkspaceAgentOptions: { capabilities?: AgentCapabilityDefinition[] }
-      capabilities: AgentCapabilityDefinition[]
+      __vitehubWorkspaceAgentOptions: { capabilities?: unknown }
+      capabilities: unknown
     }>
+    const capabilities = Array.isArray(workspaceAgent.capabilities)
+      ? workspaceAgent.capabilities
+      : Array.isArray(workspaceAgent.__vitehubWorkspaceAgentOptions?.capabilities)
+        ? workspaceAgent.__vitehubWorkspaceAgentOptions.capabilities
+        : undefined
     const contributed = capabilityWorkspaceSources(
-      workspaceAgent.__vitehubWorkspaceAgentOptions?.capabilities || workspaceAgent.capabilities,
+      capabilities,
     )
     for (const [key, source] of Object.entries(contributed || {})) {
       if (key in sources) {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -17,6 +17,8 @@ import {
 import { runObservedAgentHook } from "./hooks.ts"
 import { nextWithAbort } from "./internal/abortable-stream.ts"
 import type {
+  AgentCapabilitiesInput,
+  AgentCapabilitiesResolverContext,
   AgentCallbackContext,
   AgentCapabilityCliContribution,
   AgentCapabilityContext,
@@ -222,7 +224,7 @@ export function normalizeMode(value: unknown, label: string): AgentCapabilityMod
 }
 
 export function normalizeCapabilities(
-  capabilities: AgentCapabilityDefinition[] | undefined,
+  capabilities: readonly AgentCapabilityDefinition[] | undefined,
 ): AgentCapabilityDefinition[] {
   if (capabilities === undefined) return []
   if (!Array.isArray(capabilities)) {
@@ -254,8 +256,103 @@ export function normalizeCapabilities(
   return normalized
 }
 
+export async function resolveAgentCapabilityDefinitions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  CALL_OPTIONS = unknown,
+>(
+  capabilities: AgentCapabilitiesInput<TRuntimeConfig, Name, CALL_OPTIONS> | undefined,
+  context: AgentCapabilitiesResolverContext<TRuntimeConfig, CALL_OPTIONS>,
+): Promise<AgentCapabilityDefinition<TRuntimeConfig, Name>[]> {
+  const resolved = normalizeCapabilities(
+    typeof capabilities === "function" ? await capabilities(context) : capabilities,
+  ) as AgentCapabilityDefinition<TRuntimeConfig, Name>[]
+
+  if (typeof capabilities !== "function") return resolved
+
+  for (const capability of resolved) {
+    const accessMetadata = capability.id === "access"
+      ? capability.metadata as { chat?: unknown } | undefined
+      : undefined
+    const unsupported = [
+      capability.triggers ? "triggers" : undefined,
+      capability.workspaceSources ? "workspaceSources" : undefined,
+      capability.chatAttachments ? "chatAttachments" : undefined,
+      accessMetadata?.chat === true ? "chat access" : undefined,
+    ].filter((value): value is string => Boolean(value))
+    if (unsupported.length) {
+      throw new Error(`[vitehub] Invocation-resolved Capability "${capability.id}" cannot contribute ${unsupported.join(", ")}. Attach definition-time behavior in a static capabilities array.`)
+    }
+  }
+
+  return resolved
+}
+
+function validateSandboxCommands(commands: unknown): void {
+  if (commands === undefined) return
+  if (!Array.isArray(commands) || !commands.length) {
+    throw new TypeError("[vitehub] sandbox({ commands }) requires at least one executable name.")
+  }
+  for (const command of commands) {
+    if (typeof command !== "string" || !/^[A-Za-z0-9_.-]+$/.test(command)) {
+      throw new TypeError("[vitehub] sandbox({ commands }) accepts executable names only, not shell command strings.")
+    }
+  }
+}
+
+function capabilityRequiresWorkspace(capability: AgentCapabilityDefinition): boolean {
+  const metadata = capability.metadata
+  const optionalWorkspace = typeof metadata === "object"
+    && metadata !== null
+    && (metadata as { [optionalWorkspaceCapabilitySymbol]?: unknown })[optionalWorkspaceCapabilitySymbol] === true
+  const accessWorkspace = capability.id === "access"
+    && typeof metadata === "object"
+    && metadata !== null
+    && (metadata as { workspace?: unknown }).workspace === true
+  const sandboxCommands = capability.id === "sandbox"
+    && Array.isArray((metadata as { commands?: unknown } | undefined)?.commands)
+  return capability.workspace && !optionalWorkspace
+    || capability.id === "workspace-shell"
+    || sandboxCommands
+    || accessWorkspace
+    || Boolean(capability.bash?.length)
+}
+
+export function validateAgentCapabilityComposition(
+  capabilities: readonly AgentCapabilityDefinition[],
+  options: { hasWorkspace: boolean, workspaceMode?: AgentCapabilityMode },
+): void {
+  for (const capability of normalizeCapabilities(capabilities)) {
+    if (capability.id === "sandbox") {
+      validateSandboxCommands((capability.metadata as { commands?: unknown } | undefined)?.commands)
+    }
+    if (!options.hasWorkspace) {
+      if (capabilityRequiresWorkspace(capability)) {
+        const name = capability.id === "workspace-shell" ? "workspaceShell" : capability.id
+        throw new Error(`[vitehub] ${name}() requires an explicit workspace.`)
+      }
+      continue
+    }
+
+    const workspaceMode = options.workspaceMode || "read"
+    if (capability.id === "workspace-shell") {
+      const metadata = capability.metadata as { commands?: unknown } | undefined
+      const requiresWritableSession = metadata?.commands !== undefined
+      if (requiresWritableSession && workspaceMode !== "write") {
+        throw new Error("[vitehub] workspaceShell({ commands }) requires workspace.mode: \"write\".")
+      }
+      if (!requiresWritableSession && normalizeMode(capability.mode, "Workspace Shell") === "write" && workspaceMode !== "write") {
+        throw new Error("[vitehub] workspaceShell({ mode: \"write\" }) requires workspace.mode: \"write\".")
+      }
+    }
+    if (capability.bash?.length && workspaceMode !== "write") {
+      throw new Error(`[vitehub] ${capability.id}() bash requires workspace.mode: "write".`)
+    }
+  }
+}
+
 export function capabilityWorkspaceSources(
-  capabilities: AgentCapabilityDefinition[] | undefined,
+  capabilities: readonly AgentCapabilityDefinition[] | undefined,
 ): WorkspaceDefinition["sources"] | undefined {
   const normalized = normalizeCapabilities(capabilities)
   const sources: NonNullable<WorkspaceDefinition["sources"]> = {}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -24,7 +24,7 @@ import {
   messageChannelSupportsTitleEffect,
   messageChannelTitleSupportContextKey,
 } from "./channels.ts"
-import { createAgentInvocationContextStore } from "./invocation-context.ts"
+import { agentInvocationCallbackContextValues, createAgentInvocationContextStore } from "./invocation-context.ts"
 import {
   createFallbackAgentInvoker,
   normalizeAgentInvokerOptions,
@@ -48,10 +48,10 @@ import {
   createAgentInvocationExtensions,
   defineCapability,
   normalizeCapabilities,
-  normalizeMode,
-  optionalWorkspaceCapabilitySymbol,
   resolveAgentCapabilities,
+  resolveAgentCapabilityDefinitions,
   resolveStaticCapabilityTools,
+  validateAgentCapabilityComposition,
   withCapabilityCleanup,
   withResponseCleanup,
 } from "./capability-runtime.ts"
@@ -96,6 +96,9 @@ import type {
   AgentAdapterRunContext,
   AgentAdapterResult,
   AgentCapabilitiesList,
+  AgentCapabilitiesInput,
+  AgentCapabilitiesResolver,
+  AgentCapabilitiesResolverContext,
   AgentChannelDefinition,
   AgentChannelInputs,
   AgentChannelTriggerContext,
@@ -193,7 +196,10 @@ export type {
   AgentAdapterRunContext,
   AgentActor,
   AgentCapabilities,
+  AgentCapabilitiesInput,
   AgentCapabilitiesList,
+  AgentCapabilitiesResolver,
+  AgentCapabilitiesResolverContext,
   AgentCallSettingsInstrumentation,
   AgentCallSettingsInstrumentationContext,
   AgentCapabilityHandle,
@@ -420,10 +426,10 @@ const baseAgentResolve = Symbol.for("vitehub.baseAgentResolve")
 const baseAgentModel = Symbol.for("vitehub.baseAgentModel")
 const baseAgentDriverKind = Symbol.for("vitehub.baseAgentDriverKind")
 const baseAgentBoxRequirements = Symbol.for("vitehub.baseAgentBoxRequirements")
+const baseAgentCapabilitiesResolver = Symbol.for("vitehub.baseAgentCapabilitiesResolver")
 const workflowSpecifier = "@vite-hub/workflow"
 const workflowRuntimeStateSpecifier = "@vite-hub/workflow/runtime/state"
 
-type NormalizedCapability = AgentCapabilityDefinition & { mode?: AgentCapabilityMode }
 type WorkspaceSourceNames<TWorkspace> =
   TWorkspace extends { sources: infer TSources }
     ? Extract<keyof NonNullable<TSources>, string>
@@ -446,8 +452,12 @@ type CapabilityWorkspaceSourceNames<TCapability> =
   | (TCapability extends { capabilities: infer TCapabilities }
     ? AgentCapabilitiesWorkspaceSourceNames<TCapabilities>
     : never)
+type ResolvedAgentCapabilitiesInput<TCapabilities> =
+  TCapabilities extends (...args: any[]) => infer TResult
+    ? Awaited<TResult>
+    : TCapabilities
 type AgentCapabilitiesWorkspaceSourceNames<TCapabilities> =
-  TCapabilities extends readonly (infer TCapability)[]
+  ResolvedAgentCapabilitiesInput<TCapabilities> extends readonly (infer TCapability)[]
     ? CapabilityWorkspaceSourceNames<TCapability>
     : never
 type WorkspaceSourceHasRemovedScopes<TSource, TDepth extends readonly unknown[] = []> =
@@ -482,7 +492,7 @@ type CapabilityWorkspaceSourcesWithRemovedScopes<TCapability> =
     ? AgentCapabilitiesWorkspaceSourcesWithRemovedScopes<TCapabilities>
     : never)
 type AgentCapabilitiesWorkspaceSourcesWithRemovedScopes<TCapabilities> =
-  TCapabilities extends readonly (infer TCapability)[]
+  ResolvedAgentCapabilitiesInput<TCapabilities> extends readonly (infer TCapability)[]
     ? CapabilityWorkspaceSourcesWithRemovedScopes<TCapability>
     : never
 type InvalidWorkspaceSourceGrant<TSourceName> = {
@@ -512,12 +522,18 @@ type ValidateAgentCapability<TCapability, TWorkspace, TCapabilities> =
       ? ValidateCapabilityWorkspaceSources<TSourceName, TWorkspace, TCapabilities, TCapability>
       : TCapability
     : TCapability
-type ValidateAgentCapabilities<TCapabilities, TWorkspace> =
+type ValidateAgentCapabilitiesList<TCapabilities, TWorkspace> =
   TCapabilities extends readonly [unknown, ...unknown[]] | readonly []
     ? { [Index in keyof TCapabilities]: ValidateAgentCapability<TCapabilities[Index], TWorkspace, TCapabilities> }
     : TCapabilities extends readonly (infer TCapability)[]
-      ? ValidateAgentCapability<TCapability, TWorkspace, TCapabilities>[]
+      ? readonly ValidateAgentCapability<TCapability, TWorkspace, TCapabilities>[]
       : TCapabilities
+type ValidateAgentCapabilities<TCapabilities, TWorkspace> =
+  TCapabilities extends (...args: infer TArgs) => infer TResult
+    ? (...args: TArgs) => TResult extends PromiseLike<infer TResolved>
+      ? Promise<ValidateAgentCapabilitiesList<TResolved, TWorkspace>>
+      : ValidateAgentCapabilitiesList<TResult, TWorkspace>
+    : ValidateAgentCapabilitiesList<TCapabilities, TWorkspace>
 type UnionToIntersection<T> =
   (T extends unknown ? (value: T) => void : never) extends (value: infer TIntersection) => void
     ? TIntersection
@@ -532,9 +548,9 @@ type CapabilityInvocationContextValues<TCapability> =
     : unknown
 type AgentCapabilitiesInvocationContextValues<TCapabilities> =
   AgentInvocationContextValues & UnionToIntersection<
-    TCapabilities extends readonly [unknown, ...unknown[]] | readonly []
-      ? CapabilityInvocationContextValues<TCapabilities[number]>
-      : TCapabilities extends readonly (infer TCapability)[]
+    ResolvedAgentCapabilitiesInput<TCapabilities> extends readonly [unknown, ...unknown[]] | readonly []
+      ? CapabilityInvocationContextValues<ResolvedAgentCapabilitiesInput<TCapabilities>[number]>
+      : ResolvedAgentCapabilitiesInput<TCapabilities> extends readonly (infer TCapability)[]
         ? CapabilityInvocationContextValues<TCapability>
         : unknown
   >
@@ -552,6 +568,7 @@ type AgentDefinitionWithBaseResolve<
   CALL_OPTIONS = unknown,
 > = AgentDefinition<TRuntimeConfig, CALL_OPTIONS> & {
   [baseAgentBoxRequirements]?: readonly BoxRequirement[]
+  [baseAgentCapabilitiesResolver]?: AgentCapabilitiesResolver<TRuntimeConfig, WorkspaceName, CALL_OPTIONS>
   [baseAgentDriverKind]?: AgentDriverKind
   [baseAgentResolve]?: BaseAgentResolver<TRuntimeConfig, CALL_OPTIONS>
   [baseAgentModel]?: AgentModelResolver<TRuntimeConfig>
@@ -938,80 +955,9 @@ export {
 } from "./invocation-stream.ts"
 export type { AgentInvocationStreamEvent } from "./invocation-stream.ts"
 
-function validateSandboxCommands(commands: unknown): string[] | undefined {
-  if (commands === undefined) return undefined
-  if (!Array.isArray(commands) || !commands.length) {
-    throw new TypeError("[vitehub] sandbox({ commands }) requires at least one executable name.")
-  }
-  for (const command of commands) {
-    if (typeof command !== "string" || !/^[A-Za-z0-9_.-]+$/.test(command)) {
-      throw new TypeError("[vitehub] sandbox({ commands }) accepts executable names only, not shell command strings.")
-    }
-  }
-  return commands
-}
-
-function validateWorkspaceCapabilities<Name extends WorkspaceName>(options: WorkspaceAgentOptions<AgentRuntimeConfig, Name>): void {
-  const capabilities = normalizeCapabilities(options.capabilities)
-  const workspaceMode = workspaceModeFromOptions(options)
-  for (const capability of capabilities) {
-    if (capability.id === "workspace-shell") {
-      const metadata = capability.metadata as { commands?: unknown } | undefined
-      const requiresWritableSession = metadata?.commands !== undefined
-      if (requiresWritableSession && workspaceMode !== "write") {
-        throw new Error("[vitehub] workspaceShell({ commands }) requires workspace.mode: \"write\".")
-      }
-      if (!requiresWritableSession && normalizeMode(capability.mode, "Workspace Shell") === "write" && workspaceMode !== "write") {
-        throw new Error("[vitehub] workspaceShell({ mode: \"write\" }) requires workspace.mode: \"write\".")
-      }
-    }
-    if (capabilityRequiresBashWorkspace(capability) && workspaceMode !== "write") {
-      throw new Error(`[vitehub] ${capability.id}() bash requires workspace.mode: "write".`)
-    }
-    if (capability.id === "sandbox") {
-      validateSandboxCommands((capability.metadata as { commands?: unknown } | undefined)?.commands)
-    }
-  }
-}
-
-function accessCapabilityRequiresWorkspace(capability: NormalizedCapability): boolean {
-  if (capability.id !== "access") return false
-  const metadata = capability.metadata
-  return typeof metadata === "object"
-    && metadata !== null
-    && (metadata as { workspace?: unknown }).workspace === true
-}
-
-function capabilityWorkspaceIsOptional(capability: NormalizedCapability): boolean {
-  const metadata = capability.metadata
-  return typeof metadata === "object"
-    && metadata !== null
-    && (metadata as { [optionalWorkspaceCapabilitySymbol]?: unknown })[optionalWorkspaceCapabilitySymbol] === true
-}
-
 function resolveCapabilityCliRunSurface(definition: Pick<AgentDefinition, "cli"> | undefined): boolean {
   if (definition?.cli?.capabilities !== undefined) return definition.cli.capabilities !== false
   return true
-}
-
-function sandboxCapabilityRequiresWorkspace(capability: NormalizedCapability): boolean {
-  if (capability.id !== "sandbox") return false
-  const metadata = capability.metadata as { commands?: unknown } | undefined
-  return Array.isArray(metadata?.commands)
-}
-
-function capabilityRequiresBashWorkspace(capability: NormalizedCapability): boolean {
-  return Boolean(capability.bash?.length)
-}
-
-function validateNonWorkspaceCapabilities(capabilities: NormalizedCapability[], hasWorkspace: boolean): void {
-  if (hasWorkspace) return
-  for (const capability of capabilities) {
-    if (capability.workspace && !capabilityWorkspaceIsOptional(capability) || capability.id === "workspace-shell" || sandboxCapabilityRequiresWorkspace(capability) || accessCapabilityRequiresWorkspace(capability) || capabilityRequiresBashWorkspace(capability)) {
-      const name = capability.id === "workspace-shell" ? "workspaceShell" : capability.id
-      throw new Error(`[vitehub] ${name}() requires an explicit workspace.`)
-    }
-  }
 }
 
 function normalizeAgentChannels<TRuntimeConfig extends AgentRuntimeConfig>(
@@ -1048,7 +994,10 @@ function defineBaseAgent<
     throw new Error("[vitehub] defineAgent({ box }) owns harness execution. Move driver.sandbox and driver.workDir to the Box.")
   }
   const run = driver.kind === "run" ? driver.run : undefined
-  const baseCapabilities = normalizeCapabilities(capabilities as AgentCapabilitiesList | undefined)
+  const capabilitiesResolver = typeof capabilities === "function"
+    ? capabilities as AgentCapabilitiesResolver<TRuntimeConfig, WorkspaceName, CALL_OPTIONS>
+    : undefined
+  const baseCapabilities = normalizeCapabilities(Array.isArray(capabilities) ? capabilities : undefined)
   const invoker = normalizeAgentInvokerOptions(options.invoker) as AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS> | undefined
   const harnessDriver = driver.kind === "harness" ? driver : undefined
   const channelChat = resolveAgentChannelChatOptions<TRuntimeConfig>(channels, messages)
@@ -1060,7 +1009,7 @@ function defineBaseAgent<
   const normalizedCapabilities = channelChat
     ? [...baseCapabilities, defineChatCapability(channelChat) as AgentCapabilityDefinition<TRuntimeConfig>]
     : baseCapabilities
-  validateNonWorkspaceCapabilities(normalizedCapabilities, !!workspace)
+  if (!workspace) validateAgentCapabilityComposition(normalizedCapabilities, { hasWorkspace: false })
   const resolveBaseAgent: BaseAgentResolver<TRuntimeConfig, CALL_OPTIONS> = async (context) => {
     const resolvedAdapter = driver.kind === "model"
       ? (await import("./ai-sdk.ts")).createAiSdkAdapter({
@@ -1084,6 +1033,7 @@ function defineBaseAgent<
     ...(driver.kind === "harness" && driver.requires?.length ? { [baseAgentBoxRequirements]: driver.requires } : {}),
     ...(driver.kind === "model" ? { [baseAgentModel]: driver.model } : {}),
     [baseAgentDriverKind]: driver.kind,
+    ...(capabilitiesResolver ? { [baseAgentCapabilitiesResolver]: capabilitiesResolver } : {}),
     [baseAgentResolve]: resolveBaseAgent,
     box,
     channels,
@@ -1148,44 +1098,58 @@ function createSyntheticWorkspaceRun<
   return Object.assign(run, { [syntheticWorkspaceRun]: true })
 }
 
+type AgentCapabilitiesOption<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+  CALL_OPTIONS,
+  TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig, Name>[] | undefined,
+> = TCapabilities | AgentCapabilitiesResolver<
+  TRuntimeConfig,
+  Name,
+  CALL_OPTIONS,
+  TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig, Name>[]
+    ? TCapabilities
+    : readonly AgentCapabilityDefinition<TRuntimeConfig, Name>[]
+>
+
 export interface DefineAgent {
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     Name extends WorkspaceName = WorkspaceName,
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
-    const TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig, Name>[] | undefined = AgentCapabilityDefinition<TRuntimeConfig, Name>[] | undefined,
+    const TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig, Name>[] | undefined = readonly AgentCapabilityDefinition<TRuntimeConfig, Name>[] | undefined,
     const TOptions extends WorkspaceAgentOptions<
       TRuntimeConfig,
       Name,
       CALL_OPTIONS,
       TInvokerProfile,
       AgentCapabilitiesInvocationContextValues<TCapabilities>,
-      TCapabilities
+      AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>
     > = WorkspaceAgentOptions<
       TRuntimeConfig,
       Name,
       CALL_OPTIONS,
       TInvokerProfile,
       AgentCapabilitiesInvocationContextValues<TCapabilities>,
-      TCapabilities
+      AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>
     >,
   >(
-    options: TOptions & { capabilities?: TCapabilities } & ValidateWorkspaceAgentOptions<TOptions>,
-  ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>, TCapabilities>
+    options: TOptions & { capabilities?: AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities> } & ValidateWorkspaceAgentOptions<TOptions>,
+  ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>, AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>>
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
-    const TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined = AgentCapabilityDefinition<TRuntimeConfig>[] | undefined,
+    const TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined = readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined,
   >(
     options: AgentSettings<
       TRuntimeConfig,
       CALL_OPTIONS,
       TInvokerProfile,
       AgentCapabilitiesInvocationContextValues<TCapabilities>,
-      TCapabilities
-    > & { capabilities?: TCapabilities, workspace?: never },
+      AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>
+    > & { capabilities?: AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, workspace?: never },
   ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>>
 }
 
@@ -1198,7 +1162,12 @@ function createWorkspaceAgentDefinition<
   options: WorkspaceAgentOptions<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile>,
 ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS> {
   const workspaceDefinition = workspaceDefinitionFromOptions(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>)
-  validateWorkspaceCapabilities(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>)
+  if (Array.isArray(options.capabilities)) {
+    validateAgentCapabilityComposition(options.capabilities, {
+      hasWorkspace: true,
+      workspaceMode: workspaceModeFromOptions(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>),
+    })
+  }
   const definition = defineBaseAgent<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile>({
     ...options,
     description: options.description,
@@ -1486,6 +1455,34 @@ async function createAgentInvocationContext<
       context.run,
       invocationContext.get<boolean>(scheduledAgentTurnContextKey) === true,
     )
+    const internalDefinition = definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined
+    const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig>> | undefined
+    const workspaceOptions = workspaceDefinition?.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<AgentRuntimeConfig> | undefined
+    const driverKind = internalDefinition?.[baseAgentDriverKind] || "model"
+    const capabilitiesResolver = internalDefinition?.[baseAgentCapabilitiesResolver]
+    const invocationResolvedCapabilities = capabilitiesResolver
+      ? await resolveAgentCapabilityDefinitions(capabilitiesResolver, {
+          ...agentInvocationCallbackContextValues(invocationContext),
+          ...callbackContext,
+          actor: invoker,
+          context: invocationContext,
+          driver: { kind: driverKind },
+          input,
+          invoker,
+          run: context.run,
+        })
+      : []
+    const channelCapabilities = activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel.capabilities || []
+    const resolvedCapabilityDefinitions = normalizeCapabilities([
+      ...invocationResolvedCapabilities,
+      ...(definition?.capabilities || []),
+      ...channelCapabilities,
+    ]) as AgentCapabilityDefinition<TRuntimeConfig>[]
+    const workspaceMode = workspaceOptions ? workspaceModeFromOptions(workspaceOptions) : "read"
+    validateAgentCapabilityComposition(resolvedCapabilityDefinitions, {
+      hasWorkspace: Boolean(workspaceOptions),
+      ...(workspaceOptions ? { workspaceMode } : {}),
+    })
     const boxDefinition = definition?.box
     const box = boxDefinition
       ? await (await import("@vite-hub/box")).resolveBox(boxDefinition, {
@@ -1499,8 +1496,6 @@ async function createAgentInvocationContext<
           requires: (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentBoxRequirements],
         })
       : undefined
-    const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig>> | undefined
-    const workspaceOptions = workspaceDefinition?.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<AgentRuntimeConfig> | undefined
     if (box?.workspace.path && workspaceOptions) {
       throw new Error("[vitehub] defineAgent({ box.cwd, workspace }) is not supported because an authoritative Box workspace must not be reset by Workspace materialization.")
     }
@@ -1513,7 +1508,6 @@ async function createAgentInvocationContext<
     const workspaceName = workspaceOptions
       ? workspaceNameFromOptions(workspaceOptions, {}, context.agentIdentity)
       : undefined
-    const workspaceMode = workspaceOptions ? workspaceModeFromOptions(workspaceOptions) : "read"
     const configuredWorkspaceDefinition = workspaceOptions && workspaceName
       ? { ...workspaceDefinitionFromOptions(workspaceOptions), name: workspaceName }
       : undefined
@@ -1545,20 +1539,10 @@ async function createAgentInvocationContext<
         ? workspaceModule.useWorkspace(workspaceName, workspaceUseOptions ? { ...workspaceUseOptions, mode: "write" } : { mode: "write" })
         : workspaceUseOptions ? workspaceModule.useWorkspace(workspaceName, { ...workspaceUseOptions, mode: "read" }) : workspaceModule.useWorkspace(workspaceName)
       : undefined
-    const baseCapabilityOptions = definition?.capabilities?.length
-      ? { capabilities: definition.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: definition.hooks as never }
-      : workspaceOptions && workspace
-        ? { capabilities: workspaceOptions.capabilities as AgentCapabilityDefinition<TRuntimeConfig>[], hooks: workspaceOptions.hooks as never }
-        : undefined
-    const channelCapabilities = activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel.capabilities
-    const capabilityOptions = channelCapabilities?.length
-      ? {
-          capabilities: [...(baseCapabilityOptions?.capabilities || []), ...channelCapabilities],
-          hooks: baseCapabilityOptions?.hooks || definition?.hooks,
-        }
-      : baseCapabilityOptions
-    const agentModel = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentModel] as AgentModelResolver<TRuntimeConfig> | undefined
-    const driverKind = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentDriverKind]
+    const capabilityOptions = resolvedCapabilityDefinitions.length
+      ? { capabilities: resolvedCapabilityDefinitions, hooks: definition?.hooks as never }
+      : undefined
+    const agentModel = internalDefinition?.[baseAgentModel] as AgentModelResolver<TRuntimeConfig> | undefined
     const resolveCapabilityCli = resolveCapabilityCliRunSurface(definition)
     const capabilities = await resolveAgentCapabilities(capabilityOptions, runtimeContext, input, workspace as never, workspaceMode, {
       context: invocationContext,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -369,7 +369,8 @@ async function resolveMaybe<T, TContext extends AgentRuntimeContext>(
 function getAgentCapabilities(agent: unknown): AgentCapabilityDefinition[] {
   if (!isRecord(agent)) return []
   const definition = agent as AgentDefinitionWithCapabilities
-  return normalizeCapabilities(definition.__vitehubWorkspaceAgentOptions?.capabilities || definition.capabilities)
+  const capabilities = definition.capabilities || definition.__vitehubWorkspaceAgentOptions?.capabilities
+  return normalizeCapabilities(Array.isArray(capabilities) ? capabilities : undefined)
 }
 
 function getAgentChatOptions(agent: unknown): AgentChatOptions | undefined {

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -64,7 +64,8 @@ function agentCapabilityOptions<TRuntimeConfig extends AgentRuntimeConfig>(
   if (!hasAgentDefinition(agent)) return []
   const workspaceDefinition = agent as Partial<WorkspaceAgentDefinition<TRuntimeConfig>>
   const workspaceOptions = workspaceDefinition.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<TRuntimeConfig> | undefined
-  return (agent.capabilities || workspaceOptions?.capabilities || []) as AgentCapabilityDefinition<TRuntimeConfig>[]
+  const capabilities = agent.capabilities || workspaceOptions?.capabilities
+  return (Array.isArray(capabilities) ? capabilities : []) as AgentCapabilityDefinition<TRuntimeConfig>[]
 }
 
 function agentChannelOptions<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -829,7 +829,31 @@ export type AgentCapabilityInput<
 export type AgentCapabilitiesList<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
-> = Array<AgentCapabilityInput<TRuntimeConfig, Name>>
+> = readonly AgentCapabilityInput<TRuntimeConfig, Name>[]
+
+export interface AgentCapabilitiesResolverContext<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> extends AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>, AgentInvocationCallbackContextValues {
+  driver: {
+    kind: AgentDriverKind
+  }
+}
+
+export type AgentCapabilitiesResolver<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  CALL_OPTIONS = unknown,
+  TCapabilities extends AgentCapabilitiesList<TRuntimeConfig, Name> = AgentCapabilitiesList<TRuntimeConfig, Name>,
+> = (
+  context: AgentCapabilitiesResolverContext<TRuntimeConfig, CALL_OPTIONS>,
+) => MaybePromise<TCapabilities>
+
+export type AgentCapabilitiesInput<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+  CALL_OPTIONS = unknown,
+> = AgentCapabilitiesList<TRuntimeConfig, Name> | AgentCapabilitiesResolver<TRuntimeConfig, Name, CALL_OPTIONS>
 
 export type AgentAdapterInstructionsValue = string | string[]
 
@@ -1025,7 +1049,7 @@ type AgentSharedSettings<
   CALL_OPTIONS = unknown,
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
-  TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined = AgentCapabilitiesList<TRuntimeConfig> | undefined,
+  TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined,
 > = {
   box?: BoxDefinition<AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>>
   capabilities?: TCapabilities
@@ -1046,7 +1070,7 @@ export type AgentSettings<
   CALL_OPTIONS = unknown,
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
-  TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined = AgentCapabilitiesList<TRuntimeConfig> | undefined,
+  TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined,
 > = AgentSharedSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities> & {
   driver: AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
 }

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -3,6 +3,8 @@ import {
   normalizeCapabilities,
   normalizeMode,
   resolveAgentCapabilities,
+  resolveAgentCapabilityDefinitions,
+  validateAgentCapabilityComposition,
 } from "./capability-runtime.ts"
 import { agentInvocationCallbackContextValues, agentInvocationSourceContext, createAgentInvocationContextStore } from "./invocation-context.ts"
 import {
@@ -21,6 +23,7 @@ import { normalizeAgentWorkspaceSources } from "./workspace-source-metadata.ts"
 import type {
   AgentAdapterMetadataContext,
   AgentAdapterInstructions,
+  AgentCapabilitiesInput,
   AgentCapabilityDefinition,
   AgentCapabilityMode,
   AgentDefinition,
@@ -38,6 +41,7 @@ import type {
   AgentInvocationContextStore,
   AgentInvocationContextValues,
   AgentHostIdentity,
+  AgentInvoker,
   AgentInvokerProfile,
   AgentInput,
   AgentModelInput,
@@ -57,7 +61,6 @@ import type {
   WorkspaceMaterializeSourcesOptions,
   WorkspaceName,
   WorkspaceRules,
-  WorkspaceSourceResolutionContextValueReader,
 } from "@vite-hub/workspace"
 
 const defaultWorkspaceName = "workspace"
@@ -86,13 +89,22 @@ const workspaceReferenceKeys = new Set(["mode", "name"])
 type NormalizedWorkspaceOptions = WorkspaceAgentWorkspaceOptions & { mode: AgentCapabilityMode }
 type NormalizedCapability = AgentCapabilityDefinition & { mode?: AgentCapabilityMode }
 
+function staticAgentCapabilities<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(capabilities: AgentCapabilitiesInput<TRuntimeConfig, Name> | undefined): AgentCapabilityDefinition<TRuntimeConfig, Name>[] {
+  return Array.isArray(capabilities)
+    ? normalizeCapabilities(capabilities) as AgentCapabilityDefinition<TRuntimeConfig, Name>[]
+    : []
+}
+
 export type WorkspaceAgentOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   _Name extends WorkspaceName = WorkspaceName,
   CALL_OPTIONS = unknown,
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
-  TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined = AgentCapabilityDefinition<TRuntimeConfig>[] | undefined,
+  TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, _Name, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, _Name, CALL_OPTIONS> | undefined,
 > = AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities> & {
   name?: string
   workspace: WorkspaceAgentWorkspaceConfig<_Name>
@@ -104,7 +116,7 @@ export type WorkspaceAgentDefinition<
   CALL_OPTIONS = unknown,
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
-  TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined = AgentCapabilityDefinition<TRuntimeConfig>[] | undefined,
+  TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, Name, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, Name, CALL_OPTIONS> | undefined,
 > = AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues> & WorkspaceAgentWorkspaceOptions & {
   __vitehubWorkspaceAgent: true
   __vitehubWorkspaceAgentOptions: WorkspaceAgentOptions<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities>
@@ -130,6 +142,18 @@ export interface AgentDevtoolsSourceMaterializationOptions<
   path?: string
   source?: string
   sources?: string[]
+}
+
+interface MetadataCapabilitySelection<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+> {
+  capabilities: AgentCapabilityDefinition<TRuntimeConfig, Name>[]
+  driverKind: AgentDriverKind
+  input: AgentRunInput
+  invocationContext: AgentInvocationContextStore
+  invoker: AgentInvoker
+  runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>
 }
 
 export function normalizeWorkspaceOptions(workspace: WorkspaceAgentWorkspaceConfig): NormalizedWorkspaceOptions {
@@ -221,13 +245,13 @@ export function workspaceDefinitionFromOptions<
   options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
 ): WorkspaceAgentWorkspaceOptions {
   if (typeof options.workspace === "string") {
-    return withCapabilityWorkspaceSources({ mode: "read" }, options.capabilities as AgentCapabilityDefinition[] | undefined)
+    return withCapabilityWorkspaceSources({ mode: "read" }, staticAgentCapabilities(options.capabilities))
   }
   if (isWorkspaceReference(options.workspace)) {
     assertWorkspaceReference(options.workspace)
     return withCapabilityWorkspaceSources(
       normalizeWorkspaceOptions(options.workspace),
-      options.capabilities as AgentCapabilityDefinition[] | undefined,
+      staticAgentCapabilities(options.capabilities),
     )
   }
   const { commit: _commit, ...workspace } = normalizeWorkspaceOptions(options.workspace)
@@ -235,7 +259,7 @@ export function workspaceDefinitionFromOptions<
   assertWorkspaceDefinition(definition)
   return withColocatedAgentInstructions(withCapabilityWorkspaceSources(
     workspace,
-    options.capabilities as AgentCapabilityDefinition[] | undefined,
+    staticAgentCapabilities(options.capabilities),
   ))
 }
 
@@ -427,6 +451,16 @@ function capabilityMetadataTool(capability: NormalizedCapability, options: { dri
         status: "available",
       }
     : undefined
+}
+
+function capabilityMetadataTools(
+  capabilities: readonly AgentCapabilityDefinition[],
+  options: { driverKind?: AgentDriverKind, sourceRequests?: boolean } = {},
+): AgentDevtoolsToolDefinition[] {
+  return normalizeCapabilities(capabilities)
+    .map(capability => capabilityMetadataTool(capability, options))
+    .filter((tool): tool is AgentDevtoolsToolDefinition => Boolean(tool))
+    .sort((left, right) => left.name.localeCompare(right.name))
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -879,10 +913,7 @@ function workspaceMetadataTools<
   toolOptions: { sourceRequests?: boolean } = {},
 ): AgentDevtoolsToolDefinition[] {
   const driverKind = workspaceAgentDriverKind(options)
-  return normalizeCapabilities(options.capabilities)
-    .map(capability => capabilityMetadataTool(capability, { ...toolOptions, driverKind }))
-    .filter((tool): tool is AgentDevtoolsToolDefinition => Boolean(tool))
-    .sort((left, right) => left.name.localeCompare(right.name))
+  return capabilityMetadataTools(staticAgentCapabilities(options.capabilities), { ...toolOptions, driverKind })
 }
 
 async function workspaceHasSourceRequestDescriptors<Name extends WorkspaceName>(
@@ -1039,7 +1070,7 @@ async function resolveWorkspaceMetadataInstructions<
   const composed = await composeInstructions(baseInstructions.join("\n\n"), compositionContext, workspaceBindings, coverage)
   return {
     instructions: composed ? [composed] : [],
-    warnings: instructionCoverageWarnings(coverage, sourceDefinition, options.capabilities, workspaceAgentDriverKind(options)),
+    warnings: instructionCoverageWarnings(coverage, sourceDefinition, staticAgentCapabilities(options.capabilities), workspaceAgentDriverKind(options)),
   }
 }
 
@@ -1119,10 +1150,6 @@ function skillCoverageWarnings(
     })
 }
 
-function createDevtoolsSourceResolutionContext(input: AgentRunInput | undefined): WorkspaceSourceResolutionContextValueReader<object> {
-  return agentInvocationSourceContext(createAgentInvocationContextStore(input?.context))
-}
-
 function workspaceOptionsFromDefinition<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
@@ -1140,13 +1167,8 @@ function workspaceOptionsFromDefinition<
   }
 }
 
-function hasAccessCapability<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  Name extends WorkspaceName,
->(
-  options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
-): boolean {
-  return normalizeCapabilities(options.capabilities as AgentCapabilityDefinition[] | undefined)
+function hasAccessCapability(capabilities: readonly AgentCapabilityDefinition[]): boolean {
+  return normalizeCapabilities(capabilities)
     .some(capability => capability.id === "access")
 }
 
@@ -1156,6 +1178,10 @@ async function createDevtoolsMetadataWorkspace<
 >(
   definition: Partial<WorkspaceAgentDefinition<TRuntimeConfig, Name>>,
   defaultsOverride: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name> = {},
+  selection: {
+    capabilities: readonly AgentCapabilityDefinition[]
+    invocationContext: AgentInvocationContextStore
+  },
 ) {
   const defaults = {
     ...(typeof definition.name === "string" ? { name: definition.name } : {}),
@@ -1169,7 +1195,7 @@ async function createDevtoolsMetadataWorkspace<
   const workspace = useWorkspace(workspaceName)
   const workspaceDefinition = workspaceDefinitionWithNameFromOptions(options, defaults, defaultsOverride.runtime?.agentIdentity)
 
-  if (hasAccessCapability(options)) {
+  if (hasAccessCapability(selection.capabilities)) {
     return { options, workspace }
   }
 
@@ -1179,7 +1205,7 @@ async function createDevtoolsMetadataWorkspace<
 
   const resolved = await createWorkspaceSourceResolutionFacade(workspace, workspaceDefinition, {
     invocation: {
-      context: createDevtoolsSourceResolutionContext(defaults.input),
+      context: agentInvocationSourceContext(selection.invocationContext),
     },
   })
 
@@ -1214,29 +1240,59 @@ function agentCallbackContext<
   return context
 }
 
-async function resolveWorkspaceMetadataCapabilityContext<
+async function resolveMetadataCapabilitySelection<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
 >(
-  definition: Partial<WorkspaceAgentDefinition<TRuntimeConfig, Name>>,
-  options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
-  workspace: ReadonlyWorkspaceFacade<Name>,
+  settings: Pick<WorkspaceAgentOptions<TRuntimeConfig, Name>, "capabilities" | "driver" | "invoker">,
   resolution: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name>,
-) {
+): Promise<MetadataCapabilitySelection<TRuntimeConfig, Name>> {
   const runtime = createDevtoolsMetadataRuntime(resolution)
   const input = resolution.input || { messages: [] }
   const invocationContext: AgentInvocationContextStore = createAgentInvocationContextStore(input.context)
+  const callbackContext = agentCallbackContext(runtime)
   const invoker = await resolveAgentInvoker(
-    (definition as AgentDefinition<TRuntimeConfig>).invoker as never,
-    agentCallbackContext(runtime),
+    settings.invoker as never,
+    callbackContext,
     invocationContext,
     input as never,
     runtime.run,
   )
+  const driverKind = normalizeAgentDriver(settings as AgentSettings<TRuntimeConfig>).kind
+  const capabilities = await resolveAgentCapabilityDefinitions(settings.capabilities, {
+    ...agentInvocationCallbackContextValues(invocationContext),
+    ...callbackContext,
+    actor: invoker,
+    context: invocationContext,
+    driver: { kind: driverKind },
+    input,
+    invoker,
+    run: runtime.run,
+  })
+
+  return {
+    capabilities,
+    driverKind,
+    input,
+    invocationContext,
+    invoker,
+    runtime,
+  }
+}
+
+async function resolveWorkspaceMetadataCapabilityContext<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  options: WorkspaceAgentOptions<TRuntimeConfig, Name>,
+  workspace: ReadonlyWorkspaceFacade<Name>,
+  resolution: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name>,
+  selection: MetadataCapabilitySelection<TRuntimeConfig, Name>,
+) {
+  const { capabilities: capabilityDefinitions, driverKind, input, invocationContext, invoker, runtime } = selection
   const workspaceDefinition = workspaceDefinitionWithNameFromOptions(options, resolution, resolution.runtime?.agentIdentity)
-  const driverKind = workspaceAgentDriverKind(options)
   const capabilities = await resolveAgentCapabilities({
-    capabilities: options.capabilities as AgentCapabilityDefinition<TRuntimeConfig, Name>[],
+    capabilities: capabilityDefinitions,
     hooks: options.hooks as never,
   }, runtime, input, workspace, workspaceModeFromOptions(options), {
     context: invocationContext,
@@ -1248,9 +1304,11 @@ async function resolveWorkspaceMetadataCapabilityContext<
   })
   const sourceResolvedDefinition = invocationContext.get<WorkspaceDefinition>("workspace.sourceResolution.definition")
   const metadataWorkspace = capabilities.workspace || workspace
+  const resolvedDefinition = capabilities.workspaceDefinition || sourceResolvedDefinition || workspaceDefinition
 
   return {
-    definition: capabilities.workspaceDefinition || sourceResolvedDefinition || workspaceDefinition,
+    close: capabilities.close,
+    definition: resolvedDefinition,
     metadataContext: {
       ...agentInvocationCallbackContextValues(invocationContext),
       ...agentCallbackContext(runtime),
@@ -1261,8 +1319,62 @@ async function resolveWorkspaceMetadataCapabilityContext<
       invoker,
       workspace: metadataWorkspace,
     } satisfies AgentAdapterMetadataContext<TRuntimeConfig, Name>,
+    options: {
+      ...workspaceOptionsFromDefinition(options, resolvedDefinition),
+      capabilities: capabilityDefinitions,
+    },
     workspace: metadataWorkspace,
   }
+}
+
+async function withMetadataCapabilityCleanup<T>(
+  context: { close: () => Promise<void> },
+  resolve: () => Promise<T>,
+): Promise<T> {
+  let value: T
+  try {
+    value = await resolve()
+  }
+  catch (error) {
+    try {
+      await context.close()
+    }
+    catch (closeError) {
+      throw new AggregateError([error, closeError], "[vitehub] Agent DevTools metadata resolution failed and Capability cleanup also failed.")
+    }
+    throw error
+  }
+  await context.close()
+  return value
+}
+
+async function resolveNonWorkspaceAgentDevtoolsMetadata<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  definition: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  resolution: AgentDevtoolsMetadataResolutionOptions<TRuntimeConfig, Name>,
+): Promise<AgentDevtoolsMetadata> {
+  const settings = agentSettings(definition)
+  if (!settings) return { files: [], ...agentDevtoolsMetadata(definition as never), tools: [] }
+
+  const selection = await resolveMetadataCapabilitySelection(settings as never, resolution)
+  validateAgentCapabilityComposition(selection.capabilities, { hasWorkspace: false })
+  const capabilities = await resolveAgentCapabilities({
+    capabilities: selection.capabilities,
+    hooks: settings.hooks as never,
+  }, selection.runtime, selection.input, undefined, "read", {
+    context: selection.invocationContext,
+    driverKind: selection.driverKind,
+    invoker: selection.invoker,
+    phases: ["prepare"],
+    resolveTools: false,
+  })
+  return await withMetadataCapabilityCleanup(capabilities, async () => ({
+    files: [],
+    ...agentDevtoolsMetadata(definition as never),
+    tools: capabilityMetadataTools(selection.capabilities, { driverKind: selection.driverKind }),
+  }))
 }
 
 export function createAgentDevtoolsMetadata<
@@ -1294,43 +1406,47 @@ export async function resolveAgentDevtoolsMetadata<
 ): Promise<AgentDevtoolsMetadata> {
   const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig, Name>>
   if (!workspaceDefinition.__vitehubWorkspaceAgent || !workspaceDefinition.__vitehubWorkspaceAgentOptions) {
-    return { files: [], ...agentDevtoolsMetadata(definition), tools: [] }
+    return await resolveNonWorkspaceAgentDevtoolsMetadata(definition, defaultsOverride)
   }
 
-  const metadataWorkspace = await createDevtoolsMetadataWorkspace(workspaceDefinition, defaultsOverride)
+  const workspaceOptions = workspaceDefinition.__vitehubWorkspaceAgentOptions as unknown as WorkspaceAgentOptions<TRuntimeConfig, Name>
+  const selection = await resolveMetadataCapabilitySelection(workspaceOptions, defaultsOverride)
+  validateAgentCapabilityComposition(selection.capabilities, {
+    hasWorkspace: true,
+    workspaceMode: workspaceModeFromOptions(workspaceOptions),
+  })
+  const metadataWorkspace = await createDevtoolsMetadataWorkspace(workspaceDefinition, defaultsOverride, selection)
   if (!metadataWorkspace) {
     return createAgentDevtoolsMetadata(definition)
   }
   const capabilityContext = await resolveWorkspaceMetadataCapabilityContext(
-    workspaceDefinition as never,
     metadataWorkspace.options as never,
     metadataWorkspace.workspace as never,
     defaultsOverride,
+    selection as never,
   )
-  const metadataOptions = workspaceOptionsFromDefinition(
-    metadataWorkspace.options as never,
-    capabilityContext.definition as never,
-  )
-  const config = await resolvedConfigMetadata(
-    workspaceDefinition as AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
-    capabilityContext.metadataContext,
-  )
-  const instructionMetadata = await resolveWorkspaceMetadataInstructions(
-    metadataOptions as never,
-    capabilityContext.workspace as never,
-    defaultsOverride,
-    capabilityContext.definition,
-    capabilityContext.metadataContext.context,
-  )
+  return await withMetadataCapabilityCleanup(capabilityContext, async () => {
+    const config = await resolvedConfigMetadata(
+      workspaceDefinition as AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+      capabilityContext.metadataContext,
+    )
+    const instructionMetadata = await resolveWorkspaceMetadataInstructions(
+      capabilityContext.options as never,
+      capabilityContext.workspace as never,
+      defaultsOverride,
+      capabilityContext.definition,
+      capabilityContext.metadataContext.context,
+    )
 
-  return {
-    files: await resolveWorkspaceMetadataFiles(metadataOptions as never, capabilityContext.workspace as never),
-    instructions: instructionMetadata.instructions,
-    ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
-    ...(config ? { config } : {}),
-    tools: await resolveWorkspaceMetadataTools(metadataWorkspace.options as never, capabilityContext.workspace as never),
-    ...(instructionMetadata.warnings.length ? { warnings: instructionMetadata.warnings } : {}),
-  }
+    return {
+      files: await resolveWorkspaceMetadataFiles(capabilityContext.options as never, capabilityContext.workspace as never),
+      instructions: instructionMetadata.instructions,
+      ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
+      ...(config ? { config } : {}),
+      tools: await resolveWorkspaceMetadataTools(capabilityContext.options as never, capabilityContext.workspace as never),
+      ...(instructionMetadata.warnings.length ? { warnings: instructionMetadata.warnings } : {}),
+    }
+  })
 }
 
 export async function materializeAgentDevtoolsSourceMetadata<
@@ -1342,60 +1458,63 @@ export async function materializeAgentDevtoolsSourceMetadata<
 ): Promise<AgentDevtoolsMetadata> {
   const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig, Name>>
   if (!workspaceDefinition.__vitehubWorkspaceAgent || !workspaceDefinition.__vitehubWorkspaceAgentOptions) {
-    return { files: [], ...agentDevtoolsMetadata(definition), tools: [] }
+    return await resolveNonWorkspaceAgentDevtoolsMetadata(definition, options)
   }
 
-  const metadataWorkspace = await createDevtoolsMetadataWorkspace(workspaceDefinition, options)
+  const workspaceOptions = workspaceDefinition.__vitehubWorkspaceAgentOptions as unknown as WorkspaceAgentOptions<TRuntimeConfig, Name>
+  const selection = await resolveMetadataCapabilitySelection(workspaceOptions, options)
+  validateAgentCapabilityComposition(selection.capabilities, {
+    hasWorkspace: true,
+    workspaceMode: workspaceModeFromOptions(workspaceOptions),
+  })
+  const metadataWorkspace = await createDevtoolsMetadataWorkspace(workspaceDefinition, options, selection)
   if (!metadataWorkspace) {
     return createAgentDevtoolsMetadata(definition)
   }
   const capabilityContext = await resolveWorkspaceMetadataCapabilityContext(
-    workspaceDefinition as never,
     metadataWorkspace.options as never,
     metadataWorkspace.workspace as never,
     options,
+    selection as never,
   )
+  return await withMetadataCapabilityCleanup(capabilityContext, async () => {
+    const sources = [...new Set([
+      ...(options.sources || []),
+      ...(options.source ? [options.source] : []),
+    ])]
+    const preservedSources = options.source
+      ? sources.filter(source => source !== options.source)
+      : []
+    if (preservedSources.length) {
+      await capabilityContext.workspace.fs.materializeSources?.({ sources: preservedSources })
+    }
 
-  const sources = [...new Set([
-    ...(options.sources || []),
-    ...(options.source ? [options.source] : []),
-  ])]
-  const preservedSources = options.source
-    ? sources.filter(source => source !== options.source)
-    : []
-  if (preservedSources.length) {
-    await capabilityContext.workspace.fs.materializeSources?.({ sources: preservedSources })
-  }
+    const materializeOptions: WorkspaceMaterializeSourcesOptions = {
+      ...(options.path ? { path: options.path } : {}),
+      ...(options.source ? { sources: [options.source] } : !preservedSources.length && sources.length ? { sources } : {}),
+    }
+    if (materializeOptions.path || materializeOptions.sources?.length) {
+      await capabilityContext.workspace.fs.materializeSources?.(materializeOptions)
+    }
+    const config = await resolvedConfigMetadata(
+      workspaceDefinition as AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+      capabilityContext.metadataContext,
+    )
+    const instructionMetadata = await resolveWorkspaceMetadataInstructions(
+      capabilityContext.options as never,
+      capabilityContext.workspace as never,
+      options,
+      capabilityContext.definition,
+      capabilityContext.metadataContext.context,
+    )
 
-  const materializeOptions: WorkspaceMaterializeSourcesOptions = {
-    ...(options.path ? { path: options.path } : {}),
-    ...(options.source ? { sources: [options.source] } : !preservedSources.length && sources.length ? { sources } : {}),
-  }
-  if (materializeOptions.path || materializeOptions.sources?.length) {
-    await capabilityContext.workspace.fs.materializeSources?.(materializeOptions)
-  }
-  const metadataOptions = workspaceOptionsFromDefinition(
-    metadataWorkspace.options as never,
-    capabilityContext.definition as never,
-  )
-  const config = await resolvedConfigMetadata(
-    workspaceDefinition as AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
-    capabilityContext.metadataContext,
-  )
-  const instructionMetadata = await resolveWorkspaceMetadataInstructions(
-    metadataOptions as never,
-    capabilityContext.workspace as never,
-    options,
-    capabilityContext.definition,
-    capabilityContext.metadataContext.context,
-  )
-
-  return {
-    files: await resolveWorkspaceMetadataFiles(metadataOptions as never, capabilityContext.workspace as never),
-    instructions: instructionMetadata.instructions,
-    ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
-    ...(config ? { config } : {}),
-    tools: await resolveWorkspaceMetadataTools(metadataWorkspace.options as never, capabilityContext.workspace as never),
-    ...(instructionMetadata.warnings.length ? { warnings: instructionMetadata.warnings } : {}),
-  }
+    return {
+      files: await resolveWorkspaceMetadataFiles(capabilityContext.options as never, capabilityContext.workspace as never),
+      instructions: instructionMetadata.instructions,
+      ...agentDevtoolsMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
+      ...(config ? { config } : {}),
+      tools: await resolveWorkspaceMetadataTools(capabilityContext.options as never, capabilityContext.workspace as never),
+      ...(instructionMetadata.warnings.length ? { warnings: instructionMetadata.warnings } : {}),
+    }
+  })
 }

--- a/packages/agent/test/papercuts-capability.test.ts
+++ b/packages/agent/test/papercuts-capability.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { PapercutReportEvent } from "../src/capabilities/papercuts.ts"
+import type { AgentRunMetadata, AgentRuntimeName } from "../src/index.ts"
+import type { TraceContext } from "@vite-hub/runtime"
+
+const runtime = (options: {
+  agentIdentity?: { name: string, workspace?: string }
+  run?: AgentRunMetadata
+  runtime?: AgentRuntimeName
+  trace?: TraceContext
+} = {}) => ({
+  ...(options.agentIdentity ? { agentIdentity: options.agentIdentity } : {}),
+  memo: vi.fn(),
+  ...(options.run ? { run: options.run } : {}),
+  runtime: options.runtime || "unknown" as const,
+  runtimeConfig: {},
+  ...(options.trace ? { trace: options.trace } : {}),
+  waitUntil: vi.fn(),
+})
+
+describe("papercuts capability", () => {
+  it("requires a report sink", async () => {
+    const { papercuts } = await import("../src/capabilities/papercuts.ts")
+
+    expect(() => papercuts(undefined as never)).toThrow("papercuts() requires a report callback")
+    expect(() => papercuts({ report: undefined as never })).toThrow("papercuts() requires a report callback")
+  })
+
+  it("reports a normalized papercut with invocation provenance", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { papercuts } = await import("../src/capabilities/papercuts.ts")
+    const report = vi.fn(async (_event: PapercutReportEvent) => {})
+    const run = {
+      channelId: "github",
+      origin: "github",
+      runId: "run-123",
+      threadId: "thread-456",
+    }
+    const trace = { id: "trace-789", sampled: true }
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [papercuts({ report })],
+    }, runtime({
+      agentIdentity: { name: "review", workspace: "review" },
+      run,
+      runtime: "vite",
+      trace,
+    }), { prompt: "Review the pull request." })
+
+    expect(Object.keys(resolved.tools || {})).toEqual(["report_papercut"])
+    expect(resolved.tools?.report_papercut).not.toHaveProperty("policy")
+
+    const result = await resolved.tools?.report_papercut?.execute?.({
+      message: "  The retry hid the original error.  ",
+    })
+
+    expect(report).toHaveBeenCalledOnce()
+    const event = report.mock.calls[0]![0]
+    expect(event.context).toMatchObject({
+      agentIdentity: { name: "review", workspace: "review" },
+      run,
+      runtime: "vite",
+      trace,
+    })
+    expect(event.context.workspace).toBeUndefined()
+    expect(event.papercut).toMatchObject({
+      agent: { name: "review", workspace: "review" },
+      createdAt: expect.any(String),
+      id: expect.stringMatching(/^papercut_[a-z0-9]+$/),
+      message: "The retry hid the original error.",
+      run,
+      source: "tool",
+      trace,
+    })
+    expect(Number.isNaN(Date.parse(event.papercut.createdAt))).toBe(false)
+    expect(result).toEqual({
+      id: event.papercut.id,
+      reported: true,
+    })
+  })
+
+  it("validates the normalized message and propagates sink failures", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { papercuts } = await import("../src/capabilities/papercuts.ts")
+    const report = vi.fn(async (_event: PapercutReportEvent) => {})
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [papercuts({ report })],
+    }, runtime(), {})
+    const execute = resolved.tools?.report_papercut?.execute
+
+    await expect(execute?.({ message: "   " })).rejects.toThrow("requires a non-empty message")
+    await expect(execute?.({ message: "x".repeat(1001) })).rejects.toThrow("at most 1000 characters")
+    expect(report).not.toHaveBeenCalled()
+
+    const failure = new Error("Papercut sink unavailable")
+    const failed = await resolveAgentCapabilities({
+      capabilities: [papercuts({ report: async () => { throw failure } })],
+    }, runtime(), {})
+    await expect(failed.tools?.report_papercut?.execute?.({ message: "A flaky command." })).rejects.toBe(failure)
+  })
+
+  it("adds the fixed Capability CLI without replacing the direct tool", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { papercuts } = await import("../src/capabilities/papercuts.ts")
+    const report = vi.fn(async (_event: PapercutReportEvent) => {})
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [papercuts({ cli: true, report })],
+    }, runtime(), {})
+
+    expect(Object.keys(resolved.tools || {})).toEqual(["papercuts", "report_papercut"])
+    expect(resolved.tools?.papercuts).not.toHaveProperty("policy")
+    expect(resolved.tools?.papercuts?.description).toContain("`report \"Describe the friction.\"`")
+
+    const result = await resolved.tools?.papercuts?.execute?.({
+      argv: ["report", "The", "cache", "was", "stale."],
+    })
+
+    expect(report).toHaveBeenCalledOnce()
+    expect(report.mock.calls[0]![0].papercut).toMatchObject({
+      message: "The cache was stale.",
+      source: "cli",
+    })
+    expect(result).toMatchObject({
+      capability: "papercuts",
+      cli: "papercuts",
+      command: "papercuts report The cache was stale.",
+      exitCode: 0,
+      stdout: "Papercut reported.\n",
+    })
+    await expect(resolved.tools?.papercuts?.execute?.({ argv: ["report"] })).rejects.toThrow("requires a non-empty message")
+  })
+})

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -67,6 +67,164 @@ describe("agent message protocol", () => {
     }))
   })
 
+  it("resolves Agent Capabilities from invocation context before composition", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const close = vi.fn()
+    const prepare = vi.fn()
+    const selected = defineCapability({
+      close,
+      id: "selected",
+      prepare,
+      tools: {
+        selected: {
+          execute: () => "selected",
+          name: "selected",
+        },
+      },
+    })
+    const resolveCapabilities = vi.fn(async (context) => {
+      expect(context.actor).toBe(context.invoker)
+      expect(context.driver.kind).toBe("run")
+      expect(context.input.prompt).toBe("hello")
+      expect(context.run?.channelId).toBe("portal")
+      return context.context.get("enableSelected") ? [selected] : []
+    })
+    const agent = defineAgent({
+      capabilities: resolveCapabilities,
+      driver: {
+        run: context => Object.keys(context.tools || {}),
+      },
+    })
+    const runtime = {
+      memo: vi.fn(),
+      run: { channelId: "portal", runId: "run-1" },
+      runtime: "unknown" as const,
+      waitUntil: vi.fn(),
+    }
+
+    expect(resolveCapabilities).not.toHaveBeenCalled()
+    await expect(runAgent(agent, runtime, {
+      context: { enableSelected: true },
+      prompt: "hello",
+    })).resolves.toEqual(["selected"])
+    expect(prepare).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
+    await expect(runAgent(agent, runtime, {
+      context: { enableSelected: false },
+      prompt: "hello",
+    })).resolves.toEqual([])
+    expect(resolveCapabilities).toHaveBeenCalledTimes(2)
+    expect(prepare).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it("resolves callback-selected tools for Workspace and Harness Agent Drivers", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const { defineWorkspace } = await import("@vite-hub/workspace")
+    const { registerWorkspace } = await import("@vite-hub/workspace/test")
+    const selected = defineCapability({
+      id: "selected",
+      tools: {
+        selected: {
+          execute: () => "selected",
+          name: "selected",
+        },
+      },
+    })
+    const workspaceName = `dynamic-capabilities-${Math.random().toString(36).slice(2)}`
+    registerWorkspace(workspaceName, defineWorkspace({ store: { provider: "memory" } }))
+    const workspaceAgent = defineAgent({
+      capabilities: () => [selected],
+      driver: { run: context => Object.keys(context.tools || {}) },
+      workspace: workspaceName,
+    })
+
+    await expect(runAgent(workspaceAgent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })).resolves.toEqual(["selected"])
+
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    harnessGenerate.mockResolvedValueOnce({ text: "ok" })
+    const harnessAgent = defineAgent({
+      capabilities: context => context.driver.kind === "harness" ? [selected] : [],
+      driver: { harness: { provider: "codex" } },
+    })
+    await expect(runAgent(harnessAgent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })).resolves.toMatchObject({ text: "ok" })
+    expect(harnessAgentSettings.at(-1)?.tools).toMatchObject({ selected: expect.any(Object) })
+  })
+
+  it("allows invocation-selected Workspace Access and rejects dynamic Chat Access", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { access } = await import("../src/capabilities.ts")
+    const { defineWorkspace } = await import("@vite-hub/workspace")
+    const { registerWorkspace } = await import("@vite-hub/workspace/test")
+    const workspaceName = `dynamic-access-${Math.random().toString(36).slice(2)}`
+    registerWorkspace(workspaceName, defineWorkspace({ store: { provider: "memory" } }))
+    const workspaceAgent = defineAgent({
+      capabilities: () => [
+        access({
+          workspace: {
+            resolve: { role: "admin", scope: "all" },
+            scopes: { all: { all: true } },
+          },
+        }),
+      ],
+      driver: { run: ({ context }) => context.get("access") },
+      workspace: workspaceName,
+    })
+
+    await expect(runAgent(workspaceAgent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })).resolves.toMatchObject({
+      workspaceScope: { all: true, scope: "all" },
+    })
+
+    const chatAgent = defineAgent({
+      capabilities: () => [access({ chat: { resolve: () => true } })],
+      driver: { run: () => "ok" },
+    })
+    await expect(runAgent(chatAgent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })).rejects.toThrow(
+      'Invocation-resolved Capability "access" cannot contribute chat access',
+    )
+  })
+
+  it("rejects definition-time contributions from invocation-resolved Capabilities", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: () => [
+        defineCapability({
+          id: "dynamic-trigger",
+          triggers: {
+            manual: {
+              invoke: () => ({ input: { prompt: "hello" } }),
+            },
+          },
+        }),
+      ],
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })).rejects.toThrow(
+      'Invocation-resolved Capability "dynamic-trigger" cannot contribute triggers',
+    )
+  })
+
   it("rejects the legacy top-level harnessSandbox option", async () => {
     const { defineAgent } = await import("../src/index.ts")
 

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
-import { access, blob, browser, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type SubagentToolInput } from "../src/capabilities.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { access, blob, browser, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -751,6 +751,62 @@ describe("agent public types", () => {
     type _PublicTranscriptionContextKey = CapabilityExports["TRANSCRIPTION_RESULTS_CONTEXT_KEY"]
   })
 
+  it("accepts invocation-resolved Agent Capabilities", () => {
+    const conditional = defineCapability({
+      id: "conditional",
+      tools: {},
+    })
+
+    defineAgent({
+      capabilities: async (context) => {
+        expectTypeOf(context).toEqualTypeOf<AgentCapabilitiesResolverContext>()
+        expectTypeOf(context.actor.id).toEqualTypeOf<string>()
+        expectTypeOf(context.channel?.meta?.customer).toEqualTypeOf<string | undefined>()
+        expectTypeOf(context.context.get<boolean>("enabled")).toEqualTypeOf<boolean | undefined>()
+        expectTypeOf(context.driver.kind).toEqualTypeOf<"harness" | "model" | "run">()
+        expectTypeOf(context.input.prompt).toEqualTypeOf<AgentRunInput["prompt"]>()
+        expectTypeOf(context.run?.channelId).toEqualTypeOf<string | undefined>()
+        return context.context.get<boolean>("enabled") ? [conditional] : []
+      },
+      driver: { run: () => "ok" },
+    })
+
+    defineAgent({
+      capabilities: async () => [
+        pullRequestContext({
+          context: { number: 42, repository: "acme/app" },
+        }),
+      ] as const,
+      driver: {
+        run({ context }) {
+          const pullRequest: PullRequestContextValue | undefined = context.get("pullRequest")
+          expectTypeOf(pullRequest).toEqualTypeOf<PullRequestContextValue | undefined>()
+          return "ok"
+        },
+      },
+    })
+  })
+
+  it("types Papercut report events from the capabilities entry", () => {
+    const capability = papercuts({
+      async report(event) {
+        expectTypeOf(event).toEqualTypeOf<PapercutReportEvent>()
+        expectTypeOf(event.context.actor.id).toEqualTypeOf<string>()
+        expectTypeOf(event.papercut.createdAt).toEqualTypeOf<string>()
+        expectTypeOf(event.papercut.message).toEqualTypeOf<string>()
+        expectTypeOf(event.papercut.source).toEqualTypeOf<"cli" | "tool">()
+        expectTypeOf(event.context).toEqualTypeOf<PapercutReportContext>()
+        expectTypeOf(event.context.workspace).toEqualTypeOf<ReadonlyWorkspaceFacade | undefined>()
+        expectTypeOf(event.context.fs).toEqualTypeOf<ReadonlyWorkspaceFacade["fs"] | undefined>()
+      },
+    })
+
+    expectTypeOf(capability.id).toEqualTypeOf<string>()
+    type RootAgentExports = typeof import("../src/index.ts")
+    // @ts-expect-error official Capability factories are exported from the capabilities entry.
+    type _RootPapercuts = RootAgentExports["papercuts"]
+  })
+
   it("accepts flat Capability CLI contributions", () => {
     const inputSchema = {
       "~standard": {
@@ -1337,6 +1393,25 @@ describe("agent public types", () => {
           },
         }),
       ],
+      driver: { model: {} as never },
+      workspace: {
+        sources: {
+          docs: file("AGENTS.md"),
+        },
+      },
+    })
+
+    // @ts-expect-error callback access source grants are checked against defineAgent({ workspace.sources })
+    defineAgent({
+      capabilities: () => [
+        access({
+          workspace: {
+            scopes: {
+              customer: { source: "missing" },
+            },
+          },
+        }),
+      ] as const,
       driver: { model: {} as never },
       workspace: {
         sources: {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1154,6 +1154,27 @@ describe("defineAgent workspace option", () => {
     })
   })
 
+  it("leaves invocation-resolved subagent Capabilities out of static source discovery", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { subagents } = await import("../src/capabilities.ts")
+
+    const child = defineAgent({
+      capabilities: () => [],
+      driver: { run: () => "ok" },
+      workspace: {},
+    })
+    const capability = subagents({
+      agents: {
+        child: {
+          agent: child,
+          description: "Handle one delegated task.",
+        },
+      },
+    })
+
+    expect(capability.workspaceSources).toBeUndefined()
+  })
+
   it("adds capability sources to shared named workspace references for one invocation", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
@@ -1406,7 +1427,7 @@ describe("defineAgent workspace option", () => {
   })
 
   it("requires writable workspace for configured workspace shell commands", async () => {
-    const { defineAgent } = await import("../src/index.ts")
+    const { defineAgent, defineCapability } = await import("../src/index.ts")
     const { workspaceShell } = await import("../src/capabilities.ts")
 
     expect(() => defineAgent({
@@ -1417,6 +1438,15 @@ describe("defineAgent workspace option", () => {
 
     expect(() => defineAgent({
       capabilities: [workspaceShell({ commands: "trusted-host" })],
+      driver: { model: {} as never },
+      workspace: { mode: "read" },
+    })).toThrow("workspaceShell({ commands }) requires workspace.mode: \"write\"")
+
+    expect(() => defineAgent({
+      capabilities: [defineCapability({
+        capabilities: [workspaceShell({ commands: ["agent-browser"] })],
+        id: "nested-shell",
+      })],
       driver: { model: {} as never },
       workspace: { mode: "read" },
     })).toThrow("workspaceShell({ commands }) requires workspace.mode: \"write\"")
@@ -4432,6 +4462,134 @@ describe("defineAgent workspace option", () => {
     })
   })
 
+  it("resolves invocation-selected Capabilities for DevTools metadata", async () => {
+    const { defineAgent, resolveAgentDevtoolsMetadata } = await import("../src/index.ts")
+    const { workspaceShell } = await import("../src/capabilities.ts")
+    const resolveCapabilities = vi.fn(({ actor, context, driver }) => {
+      expect(actor.kind).toBe("devtools")
+      expect(driver.kind).toBe("model")
+      return context.get("workspaceShellEnabled") ? [workspaceShell()] : []
+    })
+    const agent = withExplicitWorkspaceName(defineAgent({
+      capabilities: resolveCapabilities,
+      driver: { model: {} as never },
+      workspace: {},
+    }), { workspace: "support" })
+
+    const metadata = await resolveAgentDevtoolsMetadata(agent, {
+      input: {
+        context: {
+          invoker: { id: "devtools", kind: "devtools" },
+          workspaceShellEnabled: true,
+        },
+      },
+    })
+
+    expect(resolveCapabilities).toHaveBeenCalledOnce()
+    expect(metadata.tools).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "workspaceShell" }),
+    ]))
+  })
+
+  it("resolves invocation-selected Capabilities for non-Workspace DevTools metadata", async () => {
+    const { defineAgent, defineCapability, resolveAgentDevtoolsMetadata } = await import("../src/index.ts")
+    const selected = defineCapability({
+      id: "selected",
+      tools: { selected: { name: "selected" } },
+    })
+    const resolveCapabilities = vi.fn(({ actor, context, driver }) => {
+      expect(actor.kind).toBe("devtools")
+      expect(driver.kind).toBe("run")
+      return context.get("selectedEnabled") ? [selected] : []
+    })
+    const agent = defineAgent({
+      capabilities: resolveCapabilities,
+      driver: { run: () => "ok" },
+    })
+
+    const metadata = await resolveAgentDevtoolsMetadata(agent, {
+      input: {
+        context: {
+          invoker: { id: "devtools", kind: "devtools" },
+          selectedEnabled: true,
+        },
+      },
+    })
+
+    expect(resolveCapabilities).toHaveBeenCalledOnce()
+    expect(metadata.tools).toEqual([
+      expect.objectContaining({ name: "selected" }),
+    ])
+  })
+
+  it("rejects impossible invocation-selected Capabilities in non-Workspace DevTools metadata", async () => {
+    const { defineAgent, resolveAgentDevtoolsMetadata } = await import("../src/index.ts")
+    const { workspaceShell } = await import("../src/capabilities.ts")
+    const agent = defineAgent({
+      capabilities: () => [workspaceShell()],
+      driver: { run: () => "ok" },
+    })
+
+    await expect(resolveAgentDevtoolsMetadata(agent)).rejects.toThrow(
+      "workspaceShell() requires an explicit workspace",
+    )
+  })
+
+  it("closes prepared Capabilities after DevTools metadata success and failure", async () => {
+    const { defineAgent, defineCapability, resolveAgentDevtoolsMetadata } = await import("../src/index.ts")
+    const close = vi.fn()
+    const prepare = vi.fn()
+    const capability = defineCapability({ close, id: "metadata-resource", prepare })
+    const createAgent = (model: unknown) => withExplicitWorkspaceName(defineAgent({
+      capabilities: [capability],
+      driver: { model: model as never },
+      workspace: {},
+    }), { workspace: "support" })
+
+    await expect(resolveAgentDevtoolsMetadata(createAgent({}))).resolves.toBeDefined()
+    expect(prepare).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
+
+    const failure = new Error("model metadata failed")
+    await expect(resolveAgentDevtoolsMetadata(createAgent(() => { throw failure }))).rejects.toBe(failure)
+    expect(prepare).toHaveBeenCalledTimes(2)
+    expect(close).toHaveBeenCalledTimes(2)
+  })
+
+  it("resolves invocation-selected Workspace Access before DevTools Source Resolution", async () => {
+    const { defineAgent, resolveAgentDevtoolsMetadata } = await import("../src/index.ts")
+    const { access } = await import("../src/capabilities.ts")
+    useWorkspace.mockReturnValueOnce(readonlyWorkspaceFacade())
+    const resolveCapabilities = vi.fn(() => [
+      access({
+        workspace: {
+          resolve: { role: "admin", scope: "all" },
+          scopes: { all: { all: true } },
+        },
+      }),
+    ])
+    const agent = withExplicitWorkspaceName(defineAgent({
+      capabilities: resolveCapabilities,
+      driver: { model: {} as never },
+      workspace: {
+        sources: {
+          docs: { name: "docs" } as never,
+        },
+      },
+    }), { workspace: "support" })
+
+    await expect(resolveAgentDevtoolsMetadata(agent)).resolves.toBeDefined()
+    expect(resolveCapabilities).toHaveBeenCalledOnce()
+    expect(createWorkspaceSourceResolutionFacade).toHaveBeenCalledOnce()
+    expect(createWorkspaceSourceResolutionFacade).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        selectedWorkspaceScope: expect.objectContaining({ all: true, name: "all", role: "admin" }),
+      }),
+    )
+  })
+
   it("resolves dynamic model metadata for DevTools", async () => {
     const { resolveAgentDevtoolsMetadata, defineAgent } = await import("../src/index.ts")
     const resolveModel = vi.fn((context: { channel?: { meta?: { customer?: string } }, invoker: { kind?: string } }) => ({
@@ -4676,7 +4834,7 @@ describe("defineAgent workspace option", () => {
       ].join("\n\n")],
       tools: [expect.objectContaining({ name: "tracked" })],
     })
-    expect(phase.mock.calls.map(call => call[0])).toEqual(["hook:prepare", "prepare"])
+    expect(phase.mock.calls.map(call => call[0])).toEqual(["hook:prepare", "prepare", "close"])
     expect(toolResolver).not.toHaveBeenCalled()
     expect(invokerResolve).toHaveBeenCalledOnce()
   })


### PR DESCRIPTION
Allows Agent Definitions to resolve their Capability list from invocation context after Agent Invoker resolution and before setup, while keeping definition-time contributions static. Applications can select the abilities that apply to an invocation instead of attaching them and removing them later, and Capabilities contributed by the active Channel still compose normally.

Adds the built-in `papercuts()` Capability with an always-available `report_papercut` tool, optional `papercuts report` CLI surface, normalized provenance, and an application-owned `report({ papercut, context })` sink. The Capability intentionally has no `when` or policy option: attaching it is the opt-in, while persistence, redaction, retention, and triage remain application concerns.

Updates public types, runtime and DevTools resolution, static discovery, subagent source discovery, tests, and documentation for both contracts. The Agent build, publint, typecheck, all 1,170 Agent tests, and docs typecheck pass.