### PR TITLE
feat(markdown-template): add deterministic Markdown templates

### DIFF
--- a/fallow.toml
+++ b/fallow.toml
@@ -62,6 +62,7 @@ dynamicallyLoaded = [
   "packages/agent/test/**/*.test-d.ts",
   "packages/sandbox/test/**/*.test-d.ts",
   "packages/source/test/**/*.test-d.ts",
+  "packages/markdown-template/test/**/*.test-d.ts",
   "packages/sandbox/examples/**/server/**",
   "packages/sandbox/examples/**/src/server.ts",
   "packages/sandbox/examples/**/src/**/*.sandbox.ts",
@@ -120,6 +121,7 @@ ignoreDependencies = [
 
 publicPackages = [
   "@vite-hub/agent",
+  "@vite-hub/markdown-template",
   "@vite-hub/sandbox",
   "@vite-hub/schedule",
   "@vite-hub/shell",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@vite-hub/env": "workspace:*",
     "@vite-hub/internal": "workspace:*",
     "@vite-hub/kv": "workspace:*",
+    "@vite-hub/markdown-template": "workspace:*",
     "@vite-hub/queue": "workspace:*",
     "@vite-hub/sandbox": "workspace:*",
     "@vite-hub/schedule": "workspace:*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -141,6 +141,7 @@
     "@vercel/nft": "catalog:vercel",
     "@vite-hub/box": "workspace:*",
     "@vite-hub/devtools": "workspace:*",
+    "@vite-hub/markdown-template": "workspace:*",
     "@vite-hub/runtime": "workspace:*",
     "@vite-hub/workspace": "workspace:*",
     "@vitejs/devtools-kit": "catalog:vite",

--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -1,6 +1,9 @@
 import { parse } from "comark"
 import binding, { Binding } from "comark/plugins/binding"
 import { renderMarkdown } from "comark/render"
+import { renderMarkdownTemplate } from "@vite-hub/markdown-template"
+
+import type { NodeHandler } from "comark/render"
 
 export interface InstructionImportResolution {
   content: string
@@ -25,6 +28,14 @@ export interface InstructionCoverage {
   sources: Set<string>
 }
 
+interface InstructionCoverageMarker {
+  entries: Array<{
+    attributes: Record<string, unknown>
+    kind: "capability" | "skill" | "source"
+  }>
+  prefix: string
+}
+
 type ConditionOperator = "!" | "!=" | "!==" | "&&" | "(" | ")" | "==" | "===" | "||"
 type ConditionToken =
   | { type: "literal", value: unknown }
@@ -34,51 +45,65 @@ type ComarkElementAttributes = Record<string, unknown>
 type ComarkElement = [string, ComarkElementAttributes, ...ComarkNode[]]
 type ComarkComment = [null, ComarkElementAttributes, string]
 type ComarkNode = ComarkComment | ComarkElement | string
-interface ComposeInstructionState {
-  context: Record<string, unknown>
-  coverage?: InstructionCoverage
-  workspace: Record<string, unknown>
-  tripleBindings: string[]
+interface InstructionMarkdownRuntime {
+  components: Record<string, NodeHandler>
+  rawTag: string
+}
+
+interface InstructionTemplateTags {
+  prefix: string
+  values: string[]
+}
+
+interface InstructionProtectedTokens {
+  prefix: string
+  values: string[]
 }
 
 const defaultImportDepth = 4
 const contextPathPattern = /context(?:\.[A-Za-z_$][\w$-]*)+/
-const compositionPathPattern = /^(?:context|workspace)(?:\.[A-Za-z_$][\w$-]*)+$/
-const compositionBindingPattern = /\{\{(?!\{)\s*((?:context|workspace)(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}/g
 const tripleBindingPattern = /\{\{\{\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}\}/g
-const tripleBindingPlaceholderPattern = /%%VITEHUB_TRIPLE_BINDING_(\d+)%%/g
 const scalarBindingPattern = /\{\{(?!\{)\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}/g
-const legacyCapabilityBindingPattern = /\{\{\s*capabilities(?:\.[A-Za-z_$][\w$-]*)?\s*\}\}/
-const comarkComponents = {
-  Binding,
-  VitehubRaw: (node: ComarkElement) => typeof node[1].value === "string" ? node[1].value : "",
-}
 
 export async function resolveInstructionImports(content: string, options: ResolveInstructionImportsOptions): Promise<string> {
-  return await expandInstructionImports(normalizeConditionShorthand(content), {
+  const runtime = createInstructionMarkdownRuntime()
+  const protectedTokens = createInstructionProtectedTokens()
+  const expanded = await expandInstructionImports(await normalizeDynamicConditionShorthand(content, protectedTokens), {
     ...options,
     maxDepth: options.maxDepth ?? defaultImportDepth,
+    protectedTokens,
+    runtime,
     seen: new Set([options.file]),
   })
+  return restoreInstructionProtectedTokens(expanded, protectedTokens)
 }
 
 export async function composeInstructionDocument(content: string, options: ComposeInstructionDocumentOptions = {}): Promise<string> {
   const state = { context: options.context || {}, workspace: options.workspace || {} }
-  const shorthand = normalizeConditionShorthand(content)
-  validateConditionalDirectives(shorthand)
-  const imported = await expandWorkspaceInstructionImports(shorthand, state.workspace)
-  validateConditionalDirectives(imported)
-  const normalized = await normalizeTripleBindings(imported)
-  const tree = await parseInstructionMarkdown(normalized.content, true)
-  const nodes = await composeNodes(tree.nodes, { ...state, coverage: options.coverage, tripleBindings: normalized.tripleBindings })
-  return cleanMarkdown(await renderMarkdown({ ...tree, nodes }, { components: comarkComponents }))
+  const protectedTokens = createInstructionProtectedTokens()
+  const shorthand = await normalizeDynamicConditionShorthand(content, protectedTokens)
+  validateConditionalDirectives(await instructionDirectiveValidationSource(shorthand))
+  const imported = await expandWorkspaceInstructionImports(shorthand, state.workspace, 0, new Set(), protectedTokens)
+  validateConditionalDirectives(await instructionDirectiveValidationSource(imported))
+  await validateLegacyInstructionBindings(imported)
+  await validateInstructionConditions(imported, state.context)
+  const coverageMarker = createInstructionCoverageMarker()
+  const marked = await markInstructionCoverage(imported, coverageMarker)
+
+  try {
+    const rendered = await renderMarkdownTemplate(restoreInstructionProtectedTokens(marked, protectedTokens), { data: state })
+    return await stripMarkedInstructionCoverage(rendered, coverageMarker, options.coverage)
+  }
+  catch (error) {
+    rethrowInstructionCompositionError(error)
+  }
 }
 
 export function composeStaticInstructionDocument(content: string, options: ComposeInstructionDocumentOptions = {}): string {
   const context = options.context || {}
-  const normalized = normalizeConditionShorthand(content)
+  const normalized = normalizeStaticConditionShorthand(content)
   validateConditionalDirectives(normalized)
-  return stripInstructionCoverageDirectives(renderStaticContextBindings(renderStaticConditionals(normalized, context), context)).trim().replace(/\n{3,}/g, "\n\n")
+  return stripStaticInstructionCoverageDirectives(renderStaticContextBindings(renderStaticConditionals(normalized, context), context)).trim().replace(/\n{3,}/g, "\n\n")
 }
 
 export function createInstructionCoverage(): InstructionCoverage {
@@ -87,6 +112,151 @@ export function createInstructionCoverage(): InstructionCoverage {
     skills: new Set(),
     sources: new Set(),
   }
+}
+
+function createInstructionCoverageMarker(): InstructionCoverageMarker {
+  return {
+    entries: [],
+    prefix: `vitehub-instruction-coverage-${crypto.randomUUID()}`,
+  }
+}
+
+async function validateLegacyInstructionBindings(content: string): Promise<void> {
+  const { tree } = await parseInstructionTemplate(content, true)
+  validateLegacyInstructionBindingNodes(tree.nodes)
+}
+
+function validateLegacyInstructionBindingNodes(nodes: ComarkNode[]): void {
+  for (const node of nodes) {
+    if (!isElement(node)) continue
+    const [tag, attrs, ...children] = node
+    if (tag === "code") continue
+    if (tag === "binding") {
+      const path = attrs[":value"]
+      if (typeof path === "string" && (path === "capabilities" || path.startsWith("capabilities."))) {
+        throw new Error(`[vitehub] Instruction binding "{{ ${path} }}" is no longer supported. Cover Capabilities with ::capability blocks in Agent Driver Instructions.`)
+      }
+      if (path === "workspace.sources") {
+        throw new Error("[vitehub] Instruction binding \"{{ workspace.sources }}\" is no longer supported. Cover Sources with ::source blocks in Agent Driver Instructions.")
+      }
+    }
+    validateLegacyInstructionBindingNodes(children)
+  }
+}
+
+async function validateInstructionConditions(
+  content: string,
+  context: Record<string, unknown>,
+): Promise<void> {
+  const { tree } = await parseInstructionTemplate(content)
+  validateInstructionConditionNodes(tree.nodes, context)
+}
+
+function validateInstructionConditionNodes(
+  nodes: ComarkNode[],
+  context: Record<string, unknown>,
+): void {
+  for (const node of nodes) {
+    if (!isElement(node)) continue
+    const [tag, , ...children] = node
+    if (tag === "code") continue
+    if (tag === "if") {
+      const { after, branches } = conditionalBranches(node)
+      const selected = branches.find(branch =>
+        branch.expression === undefined || evaluateCondition(branch.expression, context))
+      if (selected) validateInstructionConditionNodes(selected.nodes, context)
+      validateInstructionConditionNodes(after, context)
+    }
+    else {
+      validateInstructionConditionNodes(children, context)
+    }
+  }
+}
+
+async function markInstructionCoverage(
+  content: string,
+  marker: InstructionCoverageMarker,
+): Promise<string> {
+  const stack: Array<{ coverage?: number }> = []
+  const lines: string[] = []
+  for (const line of content.split(/\r?\n/)) {
+    if (/^\s*:{2,}\s*$/.test(line)) {
+      const current = stack.pop()
+      lines.push(current?.coverage === undefined
+        ? line
+        : `<!--${coverageMarkerValue(marker, current.coverage, "end")}-->`)
+      continue
+    }
+
+    const directive = line.match(/^\s*(:{2,})([A-Za-z][\w-]*)(?:\{.*\})?\s*$/)
+    if (!directive || directive[2] === "else" || directive[2] === "else-if") {
+      lines.push(line)
+      continue
+    }
+    const tag = directive[2]!
+    if (!isInstructionCoverageTag(tag)) {
+      stack.push({})
+      lines.push(line)
+      continue
+    }
+
+    const attributes = await instructionDirectiveAttributes(line, directive[1]!, tag)
+    const index = marker.entries.push({ attributes, kind: tag }) - 1
+    stack.push({ coverage: index })
+    lines.push(`<!--${coverageMarkerValue(marker, index, "start")}-->`)
+  }
+  return lines.join("\n")
+}
+
+async function instructionDirectiveAttributes(
+  line: string,
+  fence: string,
+  tag: "capability" | "skill" | "source",
+): Promise<Record<string, unknown>> {
+  const tree = await parseInstructionMarkdown(`${line}\nvalue\n${fence}`)
+  const node = tree.nodes.find(node => isElement(node) && node[0] === tag)
+  return node && isElement(node) ? node[1] : {}
+}
+
+async function stripMarkedInstructionCoverage(
+  content: string,
+  marker: InstructionCoverageMarker,
+  coverage: InstructionCoverage | undefined,
+): Promise<string> {
+  let stripped = content
+  for (const [index, entry] of marker.entries.entries()) {
+    const start = `<!--${coverageMarkerValue(marker, index, "start")}-->`
+    const end = `<!--${coverageMarkerValue(marker, index, "end")}-->`
+    if (stripped.includes(start)) recordInstructionCoverage(entry.kind, entry.attributes, coverage)
+    stripped = stripped
+      .replace(new RegExp(`${escapeRegExp(start)}(?:\\r?\\n){0,2}`), "")
+      .replace(new RegExp(`(?:\\r?\\n){0,2}${escapeRegExp(end)}`), "")
+  }
+  return cleanMarkdown(stripped)
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function coverageMarkerValue(
+  marker: InstructionCoverageMarker,
+  index: number,
+  boundary: "end" | "start",
+): string {
+  return `${marker.prefix}-${index}-${boundary}`
+}
+
+function rethrowInstructionCompositionError(error: unknown): never {
+  if (!(error instanceof Error)) throw error
+  const message = error.message
+    .replaceAll("Markdown template fragment", "Instruction markdown binding")
+    .replaceAll("Markdown template binding", "Instruction binding")
+    .replaceAll("Markdown template", "Instruction")
+    .replaceAll("Unsafe Instruction condition", "Unsafe instruction condition")
+    .replaceAll("Invalid Instruction condition", "Invalid instruction condition")
+    .replaceAll("read data paths", "read context.* paths")
+  throw error instanceof TypeError ? new TypeError(message) : new Error(message)
 }
 
 async function parseInstructionMarkdown(content: string, bindings = false) {
@@ -99,24 +269,90 @@ async function parseInstructionMarkdown(content: string, bindings = false) {
   })
 }
 
+function createInstructionMarkdownRuntime(): InstructionMarkdownRuntime {
+  const rawTag = `vitehub-instruction-raw-${crypto.randomUUID().replaceAll("-", "")}`
+  return {
+    components: {
+      Binding,
+      [rawTag]: (node: ComarkElement) => typeof node[1].value === "string" ? node[1].value : "",
+    },
+    rawTag,
+  }
+}
+
+function createInstructionProtectedTokens(): InstructionProtectedTokens {
+  return {
+    prefix: `VITEHUBINSTRUCTIONPROTECTED${crypto.randomUUID().replaceAll("-", "")}`,
+    values: [],
+  }
+}
+
+function restoreInstructionProtectedTokens(
+  content: string,
+  protectedTokens: InstructionProtectedTokens,
+): string {
+  return content.replace(
+    new RegExp(`${protectedTokens.prefix}(\\d+)END`, "g"),
+    (_match, index: string) => protectedTokens.values[Number(index)] ?? _match,
+  )
+}
+
 function cleanMarkdown(content: string): string {
-  return content.trim().replace(/\n{3,}/g, "\n\n")
+  return content.trim()
+}
+
+async function parseInstructionTemplate(content: string, bindings = false) {
+  const tags: InstructionTemplateTags = {
+    prefix: `VITEHUBINSTRUCTIONTAG${crypto.randomUUID().replaceAll("-", "")}`,
+    values: [],
+  }
+  const tree = await parseInstructionMarkdown(maskInstructionTags(content, tags), bindings)
+  return { tags, tree }
+}
+
+async function renderInstructionTemplate(
+  tree: Awaited<ReturnType<typeof parseInstructionMarkdown>>,
+  nodes: ComarkNode[],
+  tags: InstructionTemplateTags,
+  components: Record<string, NodeHandler>,
+): Promise<string> {
+  const rendered = cleanMarkdown(await renderMarkdown({ ...tree, nodes }, { components }))
+  return restoreInstructionTags(rendered, tags)
+}
+
+function maskInstructionTags(content: string, tags: InstructionTemplateTags): string {
+  return content.replace(/<\/?[A-Za-z][^<>]*>/g, (tag) => {
+    const index = tags.values.push(tag) - 1
+    return `${tags.prefix}${index}END`
+  })
+}
+
+function restoreInstructionTags(content: string, tags: InstructionTemplateTags): string {
+  return content.replace(
+    new RegExp(`${tags.prefix}(\\d+)END`, "g"),
+    (_match, index: string) => tags.values[Number(index)] ?? _match,
+  )
 }
 
 async function expandInstructionImports(
   content: string,
-  options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
+  options: ResolveInstructionImportsOptions & {
+    maxDepth: number
+    protectedTokens: InstructionProtectedTokens
+    runtime: InstructionMarkdownRuntime
+    seen: Set<string>
+  },
   depth = 0,
 ): Promise<string> {
-  const tree = await parseInstructionMarkdown(content)
+  const { tags, tree } = await parseInstructionTemplate(content)
   const nodes = await expandImportNodes(tree.nodes, options, depth)
-  const rendered = cleanMarkdown(await renderMarkdown({ ...tree, nodes }, { components: comarkComponents }))
+  const rendered = await renderInstructionTemplate(tree, nodes, tags, options.runtime.components)
   return content.endsWith("\n") ? `${rendered}\n` : rendered
 }
 
 async function expandImportNodes(
   nodes: ComarkNode[],
-  options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
+  options: ResolveInstructionImportsOptions & { maxDepth: number, protectedTokens: InstructionProtectedTokens, runtime: InstructionMarkdownRuntime, seen: Set<string> },
   depth: number,
 ): Promise<ComarkNode[]> {
   const expanded: ComarkNode[] = []
@@ -126,7 +362,7 @@ async function expandImportNodes(
 
 async function expandImportNode(
   node: ComarkNode,
-  options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
+  options: ResolveInstructionImportsOptions & { maxDepth: number, protectedTokens: InstructionProtectedTokens, runtime: InstructionMarkdownRuntime, seen: Set<string> },
   depth: number,
 ): Promise<ComarkNode[]> {
   if (typeof node === "string") return await replaceImportsInText(node, options, depth)
@@ -139,13 +375,13 @@ async function expandImportNode(
 
 async function replaceImportsInText(
   text: string,
-  options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
+  options: ResolveInstructionImportsOptions & { maxDepth: number, protectedTokens: InstructionProtectedTokens, runtime: InstructionMarkdownRuntime, seen: Set<string> },
   depth: number,
 ): Promise<ComarkNode[]> {
   const nodes: ComarkNode[] = []
   let textNode = ""
   let index = 0
-  for (const match of text.matchAll(/@[^\s<>{}\[\]]+/g)) {
+  for (const match of text.matchAll(/@[^\s<>{}[\]]+/g)) {
     textNode += text.slice(index, match.index)
     const token = match[0]
     const replacement = await importReplacement(token, options, depth)
@@ -154,7 +390,7 @@ async function replaceImportsInText(
     }
     else {
       if (textNode) nodes.push(textNode)
-      nodes.push(rawMarkdownNode(replacement))
+      nodes.push(rawMarkdownNode(replacement, options.runtime))
       textNode = ""
     }
     index = match.index + token.length
@@ -169,60 +405,20 @@ async function expandWorkspaceInstructionImports(
   workspace: Record<string, unknown>,
   depth = 0,
   seen: Set<string> = new Set(),
+  protectedTokens: InstructionProtectedTokens = createInstructionProtectedTokens(),
 ): Promise<string> {
-  const tree = await parseInstructionMarkdown(content)
-  const nodes = await expandWorkspaceImportNodes(tree.nodes, workspace, depth, seen)
-  const rendered = cleanMarkdown(await renderMarkdown({ ...tree, nodes }, { components: comarkComponents }))
-  return content.endsWith("\n") ? `${rendered}\n` : rendered
-}
-
-async function expandWorkspaceImportNodes(
-  nodes: ComarkNode[],
-  workspace: Record<string, unknown>,
-  depth: number,
-  seen: Set<string>,
-): Promise<ComarkNode[]> {
-  const expanded: ComarkNode[] = []
-  for (const node of nodes) expanded.push(...await expandWorkspaceImportNode(node, workspace, depth, seen))
-  return expanded
-}
-
-async function expandWorkspaceImportNode(
-  node: ComarkNode,
-  workspace: Record<string, unknown>,
-  depth: number,
-  seen: Set<string>,
-): Promise<ComarkNode[]> {
-  if (typeof node === "string") return await replaceWorkspaceImportsInText(node, workspace, depth, seen)
-  if (!isElement(node)) return [node]
-
-  const [tag, attrs, ...children] = node
-  if (tag === "code") return [node]
-  return [[tag, attrs, ...(await expandWorkspaceImportNodes(children, workspace, depth, seen))] as ComarkElement]
-}
-
-async function replaceWorkspaceImportsInText(
-  text: string,
-  workspace: Record<string, unknown>,
-  depth: number,
-  seen: Set<string>,
-): Promise<ComarkNode[]> {
-  const nodes: ComarkNode[] = []
-  let index = 0
-  for (const match of text.matchAll(/@workspace(?:\.[A-Za-z_$][\w$-]*)+/g)) {
-    const before = text.slice(index, match.index)
-    if (before) nodes.push(before)
-    const token = match[0]
-    nodes.push(rawMarkdownNode(await workspaceImportReplacement(token, workspace, depth, seen)))
-    index = match.index + token.length
+  let expanded = ""
+  let offset = 0
+  for (const match of content.matchAll(/@workspace(?:\.[A-Za-z_$][\w$-]*)+/g)) {
+    expanded += content.slice(offset, match.index)
+    expanded += await workspaceImportReplacement(match[0], workspace, depth, seen, protectedTokens)
+    offset = match.index + match[0].length
   }
-  const after = text.slice(index)
-  if (after) nodes.push(after)
-  return nodes
+  return expanded + content.slice(offset)
 }
 
-function rawMarkdownNode(value: string): ComarkElement {
-  return ["vitehub-raw", { value }]
+function rawMarkdownNode(value: string, runtime: InstructionMarkdownRuntime): ComarkElement {
+  return [runtime.rawTag, { value }]
 }
 
 async function workspaceImportReplacement(
@@ -230,6 +426,7 @@ async function workspaceImportReplacement(
   workspace: Record<string, unknown>,
   depth: number,
   seen: Set<string>,
+  protectedTokens: InstructionProtectedTokens,
 ): Promise<string> {
   if (depth >= defaultImportDepth) {
     throw new Error(`[vitehub] Instruction workspace import depth exceeded ${defaultImportDepth}.`)
@@ -247,7 +444,13 @@ async function workspaceImportReplacement(
   }
   seen.add(path)
   try {
-    return await expandWorkspaceInstructionImports(normalizeConditionShorthand(value), workspace, depth + 1, seen)
+    return await expandWorkspaceInstructionImports(
+      await normalizeDynamicConditionShorthand(value, protectedTokens),
+      workspace,
+      depth + 1,
+      seen,
+      protectedTokens,
+    )
   }
   finally {
     seen.delete(path)
@@ -256,7 +459,7 @@ async function workspaceImportReplacement(
 
 async function importReplacement(
   token: string,
-  options: ResolveInstructionImportsOptions & { maxDepth: number, seen: Set<string> },
+  options: ResolveInstructionImportsOptions & { maxDepth: number, protectedTokens: InstructionProtectedTokens, runtime: InstructionMarkdownRuntime, seen: Set<string> },
   depth: number,
 ): Promise<string | undefined> {
   if (/^@(?:https?:)?\/\//.test(token) || token.startsWith("@/")) {
@@ -279,14 +482,94 @@ async function importReplacement(
   }
   options.seen.add(resolved.file)
   try {
-    return `${await expandInstructionImports(normalizeConditionShorthand(resolved.content), { ...options, file: resolved.file }, depth + 1)}${trailing}`
+    return `${await expandInstructionImports(await normalizeDynamicConditionShorthand(resolved.content, options.protectedTokens), { ...options, file: resolved.file }, depth + 1)}${trailing}`
   }
   finally {
     options.seen.delete(resolved.file)
   }
 }
 
-function normalizeConditionShorthand(content: string): string {
+async function normalizeDynamicConditionShorthand(
+  content: string,
+  protectedTokens: InstructionProtectedTokens,
+): Promise<string> {
+  const nonce = crypto.randomUUID().replaceAll("-", "")
+  const prefix = `VITEHUBINSTRUCTIONCANDIDATE${nonce}`
+  const candidates: Array<{ kind: "directive" | "syntax", value: string }> = []
+  let masked = content.replace(/^(\s*)(::[^\r\n]*)$/gm, (_match, indentation: string, directive: string) => {
+    const index = candidates.push({ kind: "directive", value: directive }) - 1
+    return `${indentation}${prefix}${index}END`
+  })
+  masked = masked.replace(/\{\{\{[^{}\r\n]*\}\}\}|\{\{[^{}\r\n]*\}\}/g, (binding) => {
+    const index = candidates.push({ kind: "syntax", value: binding }) - 1
+    return `${prefix}${index}END`
+  })
+  masked = masked.replace(/@[^\s<>{}[\]]+/g, (specifier) => {
+    const index = candidates.push({ kind: "syntax", value: specifier }) - 1
+    return `${prefix}${index}END`
+  })
+  if (!candidates.length) return content
+
+  const { tree } = await parseInstructionTemplate(masked)
+  const inCode = instructionDirectiveTokensInCode(tree.nodes, prefix)
+  return masked.replace(new RegExp(`${prefix}(\\d+)END`, "g"), (_match, index: string) => {
+    const candidate = candidates[Number(index)]
+    if (!candidate) return _match
+    if (!inCode.has(Number(index))) {
+      return candidate.kind === "directive" ? normalizeConditionDirective(candidate.value) : candidate.value
+    }
+    const protectedIndex = protectedTokens.values.push(candidate.value) - 1
+    return `${protectedTokens.prefix}${protectedIndex}END`
+  })
+}
+
+function normalizeConditionDirective(directive: string): string {
+  return directive.replace(/^(::(?:if|else-if))\{([\s\S]+)\}(\s*)$/, (match, start: string, expression: string, end: string) =>
+    /^(?:if|condition)\s*=/.test(expression.trim())
+      ? match
+      : `${start}{condition=${JSON.stringify(expression.trim())}}${end}`)
+}
+
+async function instructionDirectiveValidationSource(content: string): Promise<string> {
+  const prefix = `VITEHUBINSTRUCTIONVALIDATION${crypto.randomUUID().replaceAll("-", "")}`
+  const directives: string[] = []
+  const masked = content.replace(/^(\s*)(::[^\r\n]*)$/gm, (_match, indentation: string, directive: string) => {
+    const index = directives.push(directive) - 1
+    return `${indentation}${prefix}${index}END`
+  })
+  if (!directives.length) return content
+
+  const { tree } = await parseInstructionTemplate(masked)
+  const inCode = instructionDirectiveTokensInCode(tree.nodes, prefix)
+  return masked.replace(new RegExp(`${prefix}(\\d+)END`, "g"), (_match, index: string) =>
+    inCode.has(Number(index)) ? "code" : directives[Number(index)] ?? _match)
+}
+
+function instructionDirectiveTokensInCode(
+  nodes: ComarkNode[],
+  prefix: string,
+  inCode = false,
+): Set<number> {
+  const found = new Set<number>()
+  for (const node of nodes) {
+    if (typeof node === "string") {
+      if (inCode) {
+        for (const match of node.matchAll(new RegExp(`${prefix}(\\d+)END`, "g"))) found.add(Number(match[1]))
+      }
+      continue
+    }
+    if (!isElement(node)) continue
+    const nested = instructionDirectiveTokensInCode(
+      node.slice(2) as ComarkNode[],
+      prefix,
+      inCode || node[0] === "code",
+    )
+    for (const index of nested) found.add(index)
+  }
+  return found
+}
+
+function normalizeStaticConditionShorthand(content: string): string {
   let fenced: string | undefined
   return content.split(/\r?\n/).map((line) => {
     const fence = line.match(/^\s*(```|~~~)/)?.[1]
@@ -300,143 +583,6 @@ function normalizeConditionShorthand(content: string): string {
         ? match
         : `${start}{condition=${JSON.stringify(expression.trim())}}${end}`)
   }).join("\n")
-}
-
-async function normalizeTripleBindings(content: string): Promise<{ content: string, tripleBindings: string[] }> {
-  const tripleBindings: string[] = []
-  const tree = await parseInstructionMarkdown(content)
-  const nodes = replaceTextOutsideCode(tree.nodes, value =>
-    value.replace(tripleBindingPattern, (_match, path: string) => {
-      const index = tripleBindings.push(path) - 1
-      return `%%VITEHUB_TRIPLE_BINDING_${index}%%`
-    }))
-  return {
-    content: await renderMarkdown({ ...tree, nodes }, { components: comarkComponents }),
-    tripleBindings,
-  }
-}
-
-function replaceTextOutsideCode(nodes: ComarkNode[], replace: (value: string) => string): ComarkNode[] {
-  return nodes.map((node) => {
-    if (typeof node === "string") return replace(node)
-    if (!isElement(node)) return node
-    const [tag, attrs, ...children] = node
-    if (tag === "code") return node
-    return [tag, attrs, ...replaceTextOutsideCode(children, replace)] as ComarkElement
-  })
-}
-
-async function composeNodes(
-  nodes: ComarkNode[],
-  state: ComposeInstructionState,
-  parent?: string,
-): Promise<ComarkNode[]> {
-  return (await Promise.all(nodes.map(node => composeNode(node, state, parent)))).flat()
-}
-
-async function composeNode(
-  node: ComarkNode,
-  state: ComposeInstructionState,
-  parent?: string,
-): Promise<ComarkNode[]> {
-  if (typeof node === "string") return await composeTextNode(node, state, parent)
-  if (!isElement(node)) return [node]
-  const [tag, attrs, ...children] = node
-
-  if (tag === "code") return [node]
-  if (isHtmlElementAttributes(attrs)) {
-    return [[tag, composeHtmlAttributes(attrs, state), ...(await composeNodes(children, state, tag))] as ComarkElement]
-  }
-  if (tag === "if") return await composeIfNode(node, state)
-  if (tag === "else" || tag === "else-if") {
-    throw new Error(`[vitehub] Instruction ${tag} block must follow an if block.`)
-  }
-  if (tag === "binding") return [renderBinding(attrs, state)]
-  if (isInstructionCoverageTag(tag)) {
-    recordInstructionCoverage(tag, attrs, state.coverage)
-    return await composeNodes(children, state, parent)
-  }
-  if (tag === "vitehubTriple" || tag === "vitehub-triple") {
-    return await renderTripleBinding(attrs, state.context, parent)
-  }
-  if (tag === "p") {
-    const path = soleTripleBindingPath(children, state.tripleBindings)
-    // ponytail: Parse standalone bindings as Markdown once without recursively composing their template syntax.
-    if (path) return await renderTripleBindingPath(path, state.context)
-  }
-  return [[tag, composeHtmlAttributes(attrs, state), ...(await composeNodes(children, state, tag))] as ComarkElement]
-}
-
-async function composeTextNode(
-  value: string,
-  state: ComposeInstructionState,
-  parent?: string,
-): Promise<ComarkNode[]> {
-  rejectLegacyCapabilityBinding(value)
-  const nodes: ComarkNode[] = []
-  let index = 0
-  for (const match of value.matchAll(tripleBindingPlaceholderPattern)) {
-    nodes.push(value.slice(index, match.index))
-    const path = state.tripleBindings[Number(match[1])]
-    nodes.push(...(path ? await renderTripleBindingPath(path, state.context, parent) : [match[0]]))
-    index = match.index + match[0].length
-  }
-  nodes.push(value.slice(index))
-  return nodes.filter(node => node !== "")
-}
-
-function renderBinding(
-  attrs: Record<string, unknown>,
-  scopes: { context: Record<string, unknown>, workspace: Record<string, unknown> },
-): ComarkNode {
-  const path = attrs[":value"]
-  if (typeof path === "string" && (path === "capabilities" || path.startsWith("capabilities."))) {
-    throw new Error(`[vitehub] Instruction binding "{{ ${path} }}" is no longer supported. Cover Capabilities with ::capability blocks in Agent Driver Instructions.`)
-  }
-  if (typeof path !== "string" || !compositionPathPattern.test(path)) return ["binding", attrs]
-  if (path === "workspace.sources") {
-    throw new Error("[vitehub] Instruction binding \"{{ workspace.sources }}\" is no longer supported. Cover Sources with ::source blocks in Agent Driver Instructions.")
-  }
-  return renderScalarBinding(path, scopes)
-}
-
-function renderScalarBinding(
-  path: string,
-  scopes: { context: Record<string, unknown>, workspace: Record<string, unknown> },
-): string {
-  const value = namespacePathValue(path.startsWith("workspace.") ? scopes.workspace : scopes.context, path)
-  if (value === null || value === undefined) {
-    throw new Error(`[vitehub] Instruction binding "{{ ${path} }}" is not defined.`)
-  }
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value)
-  throw new TypeError(`[vitehub] Instruction binding "{{ ${path} }}" must resolve to a scalar value.`)
-}
-
-function composeHtmlAttributes(
-  attrs: Record<string, unknown>,
-  state: Pick<ComposeInstructionState, "context" | "workspace">,
-): Record<string, unknown> {
-  if (!isHtmlElementAttributes(attrs)) return attrs
-  return Object.fromEntries(Object.entries(attrs).map(([name, value]) => [
-    name,
-    typeof value === "string"
-      ? value.replace(compositionBindingPattern, (_match, path: string) => escapeHtmlAttribute(renderScalarBinding(path, state)))
-      : value,
-  ]))
-}
-
-function isHtmlElementAttributes(attrs: Record<string, unknown>): boolean {
-  return (attrs.$ as { html?: unknown } | undefined)?.html === 1
-}
-
-function escapeHtmlAttribute(value: string): string {
-  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
-}
-
-function rejectLegacyCapabilityBinding(value: string): void {
-  const match = value.match(legacyCapabilityBindingPattern)
-  if (!match) return
-  throw new Error(`[vitehub] Instruction binding "${match[0]}" is no longer supported. Cover Capabilities with ::capability blocks in Agent Driver Instructions.`)
 }
 
 function isInstructionCoverageTag(tag: string): tag is "capability" | "skill" | "source" {
@@ -464,7 +610,7 @@ function recordInstructionCoverage(
   if (tag === "source") coverage.sources.add(value)
 }
 
-function stripInstructionCoverageDirectives(content: string): string {
+function stripStaticInstructionCoverageDirectives(content: string): string {
   let depth = 0
   const lines: string[] = []
   for (const line of content.split(/\r?\n/)) {
@@ -479,49 +625,6 @@ function stripInstructionCoverageDirectives(content: string): string {
     lines.push(line)
   }
   return lines.join("\n")
-}
-
-async function renderTripleBinding(
-  attrs: Record<string, unknown>,
-  context: Record<string, unknown>,
-  parent?: string,
-): Promise<ComarkNode[]> {
-  const path = attrs.path
-  if (typeof path !== "string" || !path.startsWith("context.")) return []
-  return await renderTripleBindingPath(path, context, parent)
-}
-
-async function renderTripleBindingPath(
-  path: string,
-  context: Record<string, unknown>,
-  parent?: string,
-): Promise<ComarkNode[]> {
-  const value = namespacePathValue(context, path)
-  if (value === null || value === undefined) {
-    throw new Error(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" is not defined.`)
-  }
-  if (typeof value !== "string") {
-    throw new TypeError(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" must resolve to a string.`)
-  }
-  if (parent === "p") return [rawMarkdownNode(value)]
-  const nodes = (await parseInstructionMarkdown(value)).nodes
-  return nodes
-}
-
-function soleTripleBindingPath(children: ComarkNode[], bindings: string[]): string | undefined {
-  if (children.length !== 1 || typeof children[0] !== "string") return
-  const match = children[0].match(/^%%VITEHUB_TRIPLE_BINDING_(\d+)%%$/)
-  return match ? bindings[Number(match[1])] : undefined
-}
-
-async function composeIfNode(node: ComarkElement, state: ComposeInstructionState): Promise<ComarkNode[]> {
-  const { after, branches } = conditionalBranches(node)
-  const selected = branches.find(branch =>
-    branch.expression === undefined || evaluateCondition(branch.expression, state.context))
-  return [
-    ...(selected ? await composeNodes(selected.nodes, state) : []),
-    ...await composeNodes(after, state),
-  ]
 }
 
 function conditionalBranches(node: ComarkElement): { after: ComarkNode[], branches: Array<{ expression?: string, nodes: ComarkNode[] }> } {
@@ -561,7 +664,7 @@ function conditionExpressionFromAttrs(attrs: Record<string, unknown>, kind: stri
 }
 
 function validateConditionalDirectives(content: string): void {
-  const stack: Array<{ sawElse: boolean }> = []
+  const stack: Array<{ kind: "if", sawElse: boolean } | { kind: "other" }> = []
   let fenced: string | undefined
 
   for (const line of content.split(/\r?\n/)) {
@@ -577,14 +680,17 @@ function validateConditionalDirectives(content: string): void {
     }
 
     const directive = directiveLine(line)
-    if (!directive) continue
+    if (!directive) {
+      if (/^\s*::[A-Za-z][\w-]*(?:\{.*\})?\s*$/.test(line)) stack.push({ kind: "other" })
+      continue
+    }
     if (directive.kind === "if") {
-      stack.push({ sawElse: false })
+      stack.push({ kind: "if", sawElse: false })
       continue
     }
 
     const current = stack.at(-1)
-    if (!current) {
+    if (!current || current.kind !== "if") {
       throw new Error(`[vitehub] Instruction ${directive.kind} block must follow an if block.`)
     }
     if (directive.kind === "else-if") {
@@ -598,7 +704,9 @@ function validateConditionalDirectives(content: string): void {
     current.sawElse = true
   }
 
-  if (stack.length) throw new Error("[vitehub] Instruction if block is missing a closing :: line.")
+  if (stack.some(entry => entry.kind === "if")) {
+    throw new Error("[vitehub] Instruction if block is missing a closing :: line.")
+  }
 }
 
 function renderStaticConditionals(content: string, context: Record<string, unknown>): string {
@@ -773,7 +881,7 @@ function createConditionParser(tokens: ConditionToken[], expression: string, con
     const token = peek()
     if (token?.type === "op" && token.value === "!") {
       take("!")
-      return !Boolean(parseUnary())
+      return !parseUnary()
     }
     return parsePrimary()
   }

--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -63,6 +63,7 @@ interface InstructionProtectedTokens {
 const defaultImportDepth = 4
 const contextPathPattern = /context(?:\.[A-Za-z_$][\w$-]*)+/
 const tripleBindingPattern = /\{\{\{\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}\}/g
+const instructionTripleBindingPattern = /\{\{\{\s*([A-Za-z_$][\w$-]*(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}\}/g
 const scalarBindingPattern = /\{\{(?!\{)\s*(context(?:\.[A-Za-z_$][\w$-]*)+)\s*\}\}/g
 
 export async function resolveInstructionImports(content: string, options: ResolveInstructionImportsOptions): Promise<string> {
@@ -85,6 +86,7 @@ export async function composeInstructionDocument(content: string, options: Compo
   validateConditionalDirectives(await instructionDirectiveValidationSource(shorthand))
   const imported = await expandWorkspaceInstructionImports(shorthand, state.workspace, 0, new Set(), protectedTokens)
   validateConditionalDirectives(await instructionDirectiveValidationSource(imported))
+  validateInstructionMarkdownBindings(imported)
   await validateLegacyInstructionBindings(imported)
   await validateInstructionConditions(imported, state.context)
   const coverageMarker = createInstructionCoverageMarker()
@@ -96,6 +98,15 @@ export async function composeInstructionDocument(content: string, options: Compo
   }
   catch (error) {
     rethrowInstructionCompositionError(error)
+  }
+}
+
+function validateInstructionMarkdownBindings(content: string): void {
+  for (const match of content.matchAll(instructionTripleBindingPattern)) {
+    const path = match[1]!
+    if (!path.startsWith("context.")) {
+      throw new Error(`[vitehub] Instruction markdown binding "{{{ ${path} }}}" must use a context.* path. Import Workspace Markdown with @${path}.`)
+    }
   }
 }
 

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -158,7 +158,9 @@ describe("instruction composition", () => {
       },
     })).toBe([
       "Hello Acme.",
+      "",
       "## Policy",
+      "",
       "Use trusted policy.",
       "",
       "Use technical detail.",
@@ -216,6 +218,35 @@ describe("instruction composition", () => {
       .rejects.toThrow("Instruction binding \"{{ context.audience }}\" is not defined")
     await expect(composeInstructionDocument("<policy tone=\"{{ workspace.tone }}\">Use it.</policy>"))
       .rejects.toThrow("Instruction binding \"{{ workspace.tone }}\" is not defined")
+  })
+
+  it("composes multiline XML blocks while enforcing context-only conditions", async () => {
+    expect(await composeInstructionDocument([
+      "<policy>",
+      "Use {{ context.name }}.",
+      "::if{context.enabled}",
+      "{{{ context.section }}}",
+      "::",
+      "</policy>",
+    ].join("\n"), {
+      context: { enabled: true, name: "Acme", section: "**Trusted** guidance." },
+    })).toBe([
+      "<policy>",
+      "Use Acme.",
+      "",
+      "**Trusted** guidance.",
+      "",
+      "</policy>",
+    ].join("\n"))
+
+    await expect(composeInstructionDocument([
+      "<policy>",
+      "::if{workspace.enabled}",
+      "Forbidden",
+      "::",
+      "</policy>",
+    ].join("\n"), { workspace: { enabled: true } }))
+      .rejects.toThrow("Unsafe instruction condition")
   })
 
   it("parses boolean chains without skipping the right side", async () => {
@@ -328,6 +359,38 @@ describe("instruction composition", () => {
     ].join("\n"))
   })
 
+  it("keeps the full template language literal in fenced, indented, and multiline code", async () => {
+    const syntax = [
+      "{{ context.name }}",
+      "{{{ context.section }}}",
+      "::if{context.enabled}",
+      "@workspace.policy",
+      "::",
+    ]
+    const output = await composeInstructionDocument([
+      "```md",
+      ...syntax,
+      "```",
+      "",
+      ...syntax.map(line => `    ${line}`),
+      "",
+      `\`\`${syntax[0]}`,
+      ...syntax.slice(1),
+      "``",
+    ].join("\n"), {
+      context: { enabled: true, name: "Acme", section: "Rendered" },
+      workspace: { policy: "Imported" },
+    })
+
+    expect(output).not.toContain("Acme")
+    expect(output).not.toContain("Rendered")
+    expect(output).not.toContain("Imported")
+    expect(output.match(/@workspace\.policy/g)).toHaveLength(3)
+    expect(output.match(/\{\{ context\.name \}\}/g)).toHaveLength(3)
+    expect(output.match(/\{\{\{ context\.section \}\}\}/g)).toHaveLength(3)
+    expect(output.match(/::if\{context\.enabled\}/g)).toHaveLength(3)
+  })
+
   it("strips explicit instruction coverage wrappers and records covered primitives", async () => {
     const coverage = createInstructionCoverage()
     const document = [
@@ -354,6 +417,66 @@ describe("instruction composition", () => {
     expect([...coverage.skills]).toEqual(["skills/review-browser-evidence"])
   })
 
+  it("records coverage only from selected authored and workspace-imported branches", async () => {
+    const coverage = createInstructionCoverage()
+    const document = [
+      "::if{context.enabled}",
+      "::source{key=\"selected-source\"}",
+      "Use the selected Source.",
+      "::",
+      "::else",
+      "::capability",
+      "Do not validate or cover this branch.",
+      "::",
+      "::",
+      "@workspace.policy",
+    ].join("\n")
+
+    expect(await composeInstructionDocument(document, {
+      context: { enabled: true },
+      coverage,
+      workspace: {
+        policy: [
+          "::if{context.enabled}",
+          "::skill{path=\"skills/selected\"}",
+          "Use the selected Skill.",
+          "::",
+          "::else",
+          "::source{key=\"unselected-source\"}",
+          "Do not use this Source.",
+          "::",
+          "::",
+        ].join("\n"),
+      },
+    })).toBe([
+      "Use the selected Source.",
+      "",
+      "Use the selected Skill.",
+    ].join("\n"))
+    expect([...coverage.sources]).toEqual(["selected-source"])
+    expect([...coverage.capabilities]).toEqual([])
+    expect([...coverage.skills]).toEqual(["skills/selected"])
+  })
+
+  it("does not treat Markdown-fragment coverage directives as authored coverage", async () => {
+    const coverage = createInstructionCoverage()
+    const injected = [
+      "::source{key=\"injected-source\"}",
+      "Injected content.",
+      "::",
+    ].join("\n")
+
+    expect(await composeInstructionDocument([
+      "::source{key=\"authored-source\"}",
+      "{{{ context.section }}}",
+      "::",
+    ].join("\n"), {
+      context: { section: injected },
+      coverage,
+    })).toBe(injected)
+    expect([...coverage.sources]).toEqual(["authored-source"])
+  })
+
   it("rejects legacy ambient instruction slots", async () => {
     await expect(composeInstructionDocument("{{ workspace.sources }}"))
       .rejects.toThrow("{{ workspace.sources }}\" is no longer supported")
@@ -366,6 +489,9 @@ describe("instruction composition", () => {
   it("rejects unsafe expressions and non-scalar double bindings", async () => {
     await expect(composeInstructionDocument("::if{process.exit()}\nNo\n::"))
       .rejects.toThrow("Unsafe instruction condition")
+    await expect(composeInstructionDocument("::if{workspace.enabled}\nNo\n::", {
+      workspace: { enabled: true },
+    })).rejects.toThrow("Unsafe instruction condition")
     await expect(composeInstructionDocument("{{ context.customer }}", { context: { customer: { name: "Acme" } } }))
       .rejects.toThrow("must resolve to a scalar")
     await expect(composeInstructionDocument("::if{context.enabled}\nEnabled\n::else{condition=\"context.admin\"}\nFallback\n::"))

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -332,6 +332,12 @@ describe("instruction composition", () => {
     ].join("\n\n"))
   })
 
+  it("requires workspace Markdown to use recursive imports", async () => {
+    await expect(composeInstructionDocument("{{{ workspace.policy }}}", {
+      workspace: { policy: "Use {{ context.name }}." },
+    })).rejects.toThrow("must use a context.* path. Import Workspace Markdown with @workspace.policy")
+  })
+
   it("does not render bindings or directives inside code spans and fences", async () => {
     expect(await composeInstructionDocument([
       "Hello {{ context.name }}.",

--- a/packages/internal/test/workspace-inventory.test.ts
+++ b/packages/internal/test/workspace-inventory.test.ts
@@ -17,6 +17,7 @@ describe("workspace inventory", () => {
       "devtools",
       "env",
       "kv",
+      "markdown-template",
       "queue",
       "runtime",
       "sandbox",

--- a/packages/markdown-template/README.md
+++ b/packages/markdown-template/README.md
@@ -1,0 +1,45 @@
+# `@vite-hub/markdown-template`
+
+`@vite-hub/markdown-template` renders deterministic Markdown from explicit data. It combines scalar values, Markdown fragments, bounded conditional sections, and caller-resolved relative imports without evaluating JavaScript or performing implicit I/O.
+
+```ts
+import { renderMarkdownTemplate } from "@vite-hub/markdown-template"
+
+const markdown = await renderMarkdownTemplate(template, {
+  data: {
+    pullRequest,
+    sections: {
+      files: filesMarkdown,
+    },
+  },
+})
+```
+
+Use `{{ pullRequest.title }}` for a string, number, or boolean. Scalar values are serialized as Markdown text, so Markdown syntax in the value stays literal. Use `{{{ sections.files }}}` for an intentional Markdown fragment. Fragments are never evaluated again, so bindings, branches, and imports inside their content stay literal.
+
+Scalar bindings also work inside quoted XML-style attributes. Attribute values are HTML-escaped, while template syntax inside code spans and code blocks stays literal.
+
+Conditional sections support own-property data paths, literals, `!`, strict equality and inequality, `&&`, `||`, and parentheses:
+
+```md
+::if{pullRequest.available && !pullRequest.draft}
+Review {{ pullRequest.title }}.
+::else
+No review context is available.
+::
+```
+
+Imports only run when you provide `resolveImport`. The resolver receives a relative specifier and the current canonical source ID, and it returns the imported template with its canonical ID for cycle detection:
+
+```ts
+await renderMarkdownTemplate(template, {
+  sourceId: "/templates/review.md",
+  resolveImport: async (specifier, importer) => {
+    return { id: resolvedId, template: importedMarkdown }
+  },
+})
+```
+
+The package does not provide loops, helpers, macros, a compile phase, filesystem or URL access, HTML rendering, or public syntax-tree hooks. Markdown fragments preserve document structure, but they do not make untrusted content safe for a model; instruction and data boundaries remain the caller's responsibility.
+
+Comark provides the Markdown parser, component syntax, syntax tree, and serializer. ViteHub owns the constrained composition policy exposed by this package.

--- a/packages/markdown-template/package.json
+++ b/packages/markdown-template/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@vite-hub/markdown-template",
+  "version": "0.0.1",
+  "description": "Deterministic Markdown templates with explicit data, conditions, fragments, and caller-resolved imports.",
+  "keywords": [
+    "agent",
+    "markdown",
+    "template",
+    "vitehub"
+  ],
+  "homepage": "https://github.com/vite-hub/vitehub#readme",
+  "bugs": "https://github.com/vite-hub/vitehub/issues",
+  "license": "Apache-2.0",
+  "author": "onmax <maximogarciamtnez@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vite-hub/vitehub.git",
+    "directory": "packages/markdown-template"
+  },
+  "files": [
+    "dist",
+    "package.json"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "vp pack",
+    "dev": "vp pack --watch",
+    "typecheck": "tsc --noEmit -p ./tsconfig.json",
+    "test": "vp run -t @vite-hub/markdown-template#build && vp test"
+  },
+  "dependencies": {
+    "comark": "catalog:ui"
+  },
+  "devDependencies": {
+    "publint": "catalog:tooling",
+    "typescript": "catalog:tooling",
+    "vite-plus": "catalog:tooling",
+    "vitest": "catalog:tooling"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/packages/markdown-template/src/ast.ts
+++ b/packages/markdown-template/src/ast.ts
@@ -1,0 +1,5 @@
+type ComarkElementAttributes = Record<string, unknown>
+type ComarkComment = [null, ComarkElementAttributes, string]
+
+export type ComarkElement = [string, ComarkElementAttributes, ...ComarkNode[]]
+export type ComarkNode = ComarkComment | ComarkElement | string

--- a/packages/markdown-template/src/condition.ts
+++ b/packages/markdown-template/src/condition.ts
@@ -1,0 +1,157 @@
+type ConditionOperator = "!" | "!=" | "!==" | "&&" | "(" | ")" | "==" | "===" | "||"
+type ConditionToken =
+  | { type: "literal", value: unknown }
+  | { type: "op", value: ConditionOperator }
+  | { path: string, type: "path" }
+
+const templatePathSource = String.raw`[A-Za-z_$][\w$-]*(?:\.[A-Za-z_$][\w$-]*)*`
+
+export function evaluateCondition(
+  expression: string,
+  data: Record<string, unknown>,
+): boolean {
+  const parser = createConditionParser(tokenizeCondition(expression), expression, data)
+  const value = parser.parseOr()
+  parser.done()
+  return Boolean(value)
+}
+
+function tokenizeCondition(expression: string): ConditionToken[] {
+  const tokens: ConditionToken[] = []
+  for (let index = 0; index < expression.length;) {
+    const rest = expression.slice(index)
+    if (/^\s/.test(rest)) {
+      index += 1
+      continue
+    }
+    const op = rest.match(/^(===|!==|==|!=|&&|\|\||[!()])/)
+    if (op) {
+      tokens.push({ type: "op", value: op[1] as ConditionOperator })
+      index += op[1]!.length
+      continue
+    }
+    const string = rest.match(/^(['"])((?:\\.|(?!\1)[^\\])*)\1/)
+    if (string) {
+      tokens.push({ type: "literal", value: string[2]!.replace(/\\(['"\\])/g, "$1") })
+      index += string[0].length
+      continue
+    }
+    const number = rest.match(/^-?\d+(?:\.\d+)?/)
+    if (number) {
+      tokens.push({ type: "literal", value: Number(number[0]) })
+      index += number[0].length
+      continue
+    }
+    const literal = rest.match(/^(true|false|null)\b/)
+    if (literal) {
+      tokens.push({ type: "literal", value: literal[1] === "true" ? true : literal[1] === "false" ? false : null })
+      index += literal[0].length
+      continue
+    }
+    const path = rest.match(new RegExp(`^${templatePathSource}`))
+    if (path) {
+      if (/^\s*\(/.test(rest.slice(path[0].length))) throw unsafeConditionError(expression)
+      tokens.push({ path: path[0], type: "path" })
+      index += path[0].length
+      continue
+    }
+    throw unsafeConditionError(expression)
+  }
+  return tokens
+}
+
+function createConditionParser(
+  tokens: ConditionToken[],
+  expression: string,
+  data: Record<string, unknown>,
+) {
+  let index = 0
+  const error = () => new Error(`[vitehub] Invalid Markdown template condition "${expression}".`)
+  const peek = () => tokens[index]
+  const take = (value?: string) => {
+    const token = tokens[index]
+    if (value && (token?.type !== "op" || token.value !== value)) throw error()
+    index += 1
+    return token
+  }
+
+  function parsePrimary(): unknown {
+    const token = take()
+    if (!token) throw error()
+    if (token.type === "literal") return token.value
+    if (token.type === "path") return templatePathValue(data, token.path)
+    if (token.type === "op" && token.value === "(") {
+      const value = parseOr()
+      take(")")
+      return value
+    }
+    throw error()
+  }
+
+  function parseUnary(): unknown {
+    const token = peek()
+    if (token?.type === "op" && token.value === "!") {
+      take("!")
+      return !parseUnary()
+    }
+    return parsePrimary()
+  }
+
+  function parseEquality(): unknown {
+    let value = parseUnary()
+    const token = peek()
+    if (token?.type === "op" && ["==", "===", "!=", "!=="].includes(token.value)) {
+      take()
+      const right = parseUnary()
+      value = token.value === "!=" || token.value === "!==" ? value !== right : value === right
+    }
+    return value
+  }
+
+  function parseAnd(): unknown {
+    let value = parseEquality()
+    while (peek()?.type === "op" && (peek() as { value: string }).value === "&&") {
+      take("&&")
+      const right = parseEquality()
+      value = Boolean(value) && Boolean(right)
+    }
+    return value
+  }
+
+  function parseOr(): unknown {
+    let value = parseAnd()
+    while (peek()?.type === "op" && (peek() as { value: string }).value === "||") {
+      take("||")
+      const right = parseAnd()
+      value = Boolean(value) || Boolean(right)
+    }
+    return value
+  }
+
+  return {
+    done() {
+      if (index !== tokens.length) throw error()
+    },
+    parseOr,
+  }
+}
+
+export function templatePathValue(data: Record<string, unknown>, path: string): unknown {
+  return nestedPathValue(data, path.split("."))
+}
+
+function nestedPathValue(value: unknown, segments: string[]): unknown {
+  if (!segments.length) return value
+  if (!value || typeof value !== "object") return
+
+  for (let count = segments.length; count > 0; count -= 1) {
+    const key = segments.slice(0, count).join(".")
+    if (Object.hasOwn(value, key)) {
+      return nestedPathValue((value as Record<string, unknown>)[key], segments.slice(count))
+    }
+  }
+}
+
+function unsafeConditionError(expression: string): Error {
+  return new Error(`[vitehub] Unsafe Markdown template condition "${expression}". Conditions can only read data paths and use literals, ===, !==, &&, ||, !, and parentheses.`)
+}

--- a/packages/markdown-template/src/imports.ts
+++ b/packages/markdown-template/src/imports.ts
@@ -1,0 +1,151 @@
+import { renderMarkdown } from "comark/render"
+
+import {
+  cleanMarkdown,
+  parseTemplateMarkdown,
+  rawMarkdownNode,
+} from "./markdown.ts"
+
+import type { ComarkElement, ComarkNode } from "./ast.ts"
+import type { MarkdownTemplateRuntime } from "./markdown.ts"
+import type {
+  MarkdownTemplateImport,
+  ResolveMarkdownTemplateImport,
+} from "./types.ts"
+
+interface ExpandMarkdownTemplateImportsOptions {
+  maxImportDepth: number
+  prepare: (template: string) => Promise<string>
+  resolveImport: ResolveMarkdownTemplateImport
+  runtime: MarkdownTemplateRuntime
+  sourceId: string
+}
+
+interface ImportState extends ExpandMarkdownTemplateImportsOptions {
+  seen: Set<string>
+}
+
+export async function expandMarkdownTemplateImports(
+  template: string,
+  options: ExpandMarkdownTemplateImportsOptions,
+): Promise<string> {
+  validateMaxImportDepth(options.maxImportDepth)
+  return await expandImports(template, {
+    ...options,
+    seen: new Set([options.sourceId]),
+  }, 0)
+}
+
+async function expandImports(template: string, state: ImportState, depth: number): Promise<string> {
+  const tree = await parseTemplateMarkdown(template)
+  const nodes = await expandImportNodes(tree.nodes, state, depth)
+  const rendered = cleanMarkdown(await renderMarkdown({ ...tree, nodes }, { components: state.runtime.components }))
+  return template.endsWith("\n") ? `${rendered}\n` : rendered
+}
+
+async function expandImportNodes(
+  nodes: ComarkNode[],
+  state: ImportState,
+  depth: number,
+): Promise<ComarkNode[]> {
+  const expanded: ComarkNode[] = []
+  for (const node of nodes) expanded.push(...await expandImportNode(node, state, depth))
+  return expanded
+}
+
+async function expandImportNode(
+  node: ComarkNode,
+  state: ImportState,
+  depth: number,
+): Promise<ComarkNode[]> {
+  if (typeof node === "string") return await replaceImports(node, state, depth)
+  if (!isElement(node)) return [node]
+
+  const [tag, attrs, ...children] = node
+  if (tag === "code") return [node]
+  return [[tag, attrs, ...(await expandImportNodes(children, state, depth))] as ComarkElement]
+}
+
+async function replaceImports(segment: string, state: ImportState, depth: number): Promise<ComarkNode[]> {
+  const nodes: ComarkNode[] = []
+  let textNode = ""
+  let offset = 0
+
+  for (const match of segment.matchAll(/@[^\s<>{}[\]]+/g)) {
+    textNode += segment.slice(offset, match.index)
+    const token = match[0]
+    const replacement = await importReplacement(token, state, depth)
+    if (replacement === undefined) {
+      textNode += token
+    }
+    else {
+      if (textNode) nodes.push(textNode)
+      nodes.push(rawMarkdownNode(replacement, state.runtime))
+      textNode = ""
+    }
+    offset = match.index + token.length
+  }
+
+  textNode += segment.slice(offset)
+  if (textNode) nodes.push(textNode)
+  return nodes
+}
+
+async function importReplacement(token: string, state: ImportState, depth: number): Promise<string | undefined> {
+  if (/^@(?:https?:)?\/\//.test(token) || token.startsWith("@/")) {
+    throw new Error(`[vitehub] Markdown template import "${token}" must be a relative path.`)
+  }
+  if (!token.startsWith("@./") && !token.startsWith("@../")) return
+
+  const trailing = token.match(/[.,;:!?)]*$/)?.[0] || ""
+  const specifier = token.slice(1, token.length - trailing.length)
+  if (/[*?]/.test(specifier)) {
+    throw new Error(`[vitehub] Markdown template import "${specifier}" cannot use globs.`)
+  }
+  if (depth >= state.maxImportDepth) {
+    throw new Error(`[vitehub] Markdown template import depth exceeded ${state.maxImportDepth}.`)
+  }
+
+  const resolved = await state.resolveImport(specifier, state.sourceId)
+  assertImportResolution(resolved, specifier)
+  if (state.seen.has(resolved.id)) {
+    throw new Error(`[vitehub] Circular Markdown template import: ${specifier}.`)
+  }
+
+  state.seen.add(resolved.id)
+  try {
+    const imported = await expandImports(await state.prepare(resolved.template), {
+      ...state,
+      sourceId: resolved.id,
+    }, depth + 1)
+    return `${imported}${trailing}`
+  }
+  finally {
+    state.seen.delete(resolved.id)
+  }
+}
+
+function isElement(node: ComarkNode): node is ComarkElement {
+  return Array.isArray(node) && typeof node[0] === "string"
+}
+
+function assertImportResolution(
+  resolution: MarkdownTemplateImport | undefined,
+  specifier: string,
+): asserts resolution is MarkdownTemplateImport {
+  if (!resolution) {
+    throw new Error(`[vitehub] Markdown template import "${specifier}" could not be resolved.`)
+  }
+  if (!resolution.id || typeof resolution.id !== "string") {
+    throw new TypeError(`[vitehub] Markdown template import "${specifier}" must resolve with a non-empty id.`)
+  }
+  if (typeof resolution.template !== "string") {
+    throw new TypeError(`[vitehub] Markdown template import "${specifier}" must resolve with a template string.`)
+  }
+}
+
+function validateMaxImportDepth(value: number): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new TypeError("[vitehub] Markdown template maxImportDepth must be a non-negative integer.")
+  }
+}

--- a/packages/markdown-template/src/index.ts
+++ b/packages/markdown-template/src/index.ts
@@ -1,0 +1,7 @@
+export { renderMarkdownTemplate } from "./render.ts"
+
+export type {
+  MarkdownTemplateImport,
+  RenderMarkdownTemplateOptions,
+  ResolveMarkdownTemplateImport,
+} from "./types.ts"

--- a/packages/markdown-template/src/markdown.ts
+++ b/packages/markdown-template/src/markdown.ts
@@ -1,0 +1,39 @@
+import { parse } from "comark"
+import binding, { Binding } from "comark/plugins/binding"
+
+import type { ComarkElement } from "./ast.ts"
+import type { NodeHandler } from "comark/render"
+
+export interface MarkdownTemplateRuntime {
+  components: Record<string, NodeHandler>
+  rawTag: string
+}
+
+export function createMarkdownTemplateRuntime(nonce: string): MarkdownTemplateRuntime {
+  const rawTag = `markdown-template-raw-${nonce}`
+  return {
+    components: {
+      Binding,
+      [rawTag]: (node: ComarkElement) => typeof node[1].value === "string" ? node[1].value : "",
+    },
+    rawTag,
+  }
+}
+
+export async function parseTemplateMarkdown(template: string, bindings = false) {
+  return await parse(template, {
+    autoClose: false,
+    autoUnwrap: false,
+    html: true,
+    linkify: false,
+    plugins: bindings ? [binding()] : [],
+  })
+}
+
+export function cleanMarkdown(markdown: string): string {
+  return markdown.trim()
+}
+
+export function rawMarkdownNode(value: string, runtime: MarkdownTemplateRuntime): ComarkElement {
+  return [runtime.rawTag, { value }]
+}

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -51,7 +51,6 @@ export async function renderMarkdownTemplate(
   const prepare = async (value: string) => maskTemplateTags(
     await protectCodeTemplateSyntax(value, protectedTokens, nonce),
     tagTokens,
-    data,
   )
   const shorthand = await prepare(template)
   const imported = options.resolveImport
@@ -73,18 +72,31 @@ export async function renderMarkdownTemplate(
     fragments: normalized.fragments,
   })
   const rendered = cleanMarkdown(await renderMarkdown({ ...tree, nodes }, { components: runtime.components }))
-  return restoreTemplateTokens(restoreTemplateTokens(rendered, tagTokens), protectedTokens)
+  return restoreTemplateTokens(restoreTemplateTags(rendered, tagTokens, data), protectedTokens)
 }
 
 function maskTemplateTags(
   template: string,
   state: TemplateTokenState,
-  data: Record<string, unknown>,
 ): string {
   return template.replace(/<\/?[A-Za-z][^<>]*>/g, (tag) => {
-    const index = state.values.push(renderTagBindings(tag, data)) - 1
+    const index = state.values.push(tag) - 1
     return `${state.prefix}${index}END`
   })
+}
+
+function restoreTemplateTags(
+  template: string,
+  state: TemplateTokenState,
+  data: Record<string, unknown>,
+): string {
+  return template.replace(
+    new RegExp(`${state.prefix}(\\d+)END`, "g"),
+    (_match, index: string) => {
+      const tag = state.values[Number(index)]
+      return tag === undefined ? _match : renderTagBindings(tag, data)
+    },
+  )
 }
 
 function renderTagBindings(tag: string, data: Record<string, unknown>): string {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -1,0 +1,534 @@
+import { renderMarkdown } from "comark/render"
+
+import { evaluateCondition, templatePathValue } from "./condition.ts"
+import { expandMarkdownTemplateImports } from "./imports.ts"
+import {
+  cleanMarkdown,
+  createMarkdownTemplateRuntime,
+  parseTemplateMarkdown,
+} from "./markdown.ts"
+
+import type { ComarkElement, ComarkNode } from "./ast.ts"
+import type { MarkdownTemplateRuntime } from "./markdown.ts"
+import type { RenderMarkdownTemplateOptions } from "./types.ts"
+
+interface RenderState {
+  data: Record<string, unknown>
+  fragmentToken: string
+  fragments: Array<{ path: string }>
+}
+
+interface TemplateTokenState {
+  prefix: string
+  values: string[]
+}
+
+const defaultImportDepth = 4
+const templatePathSource = String.raw`[A-Za-z_$][\w$-]*(?:\.[A-Za-z_$][\w$-]*)*`
+const templatePathPattern = new RegExp(`^${templatePathSource}$`)
+const tripleBindingPattern = new RegExp(String.raw`\{\{\{\s*(${templatePathSource})\s*\}\}\}`, "g")
+const tagBindingPattern = new RegExp(String.raw`(?<!\{)\{\{(?!\{)\s*(${templatePathSource})\s*\}\}(?!\})`, "g")
+
+export async function renderMarkdownTemplate(
+  template: string,
+  options: RenderMarkdownTemplateOptions = {},
+): Promise<string> {
+  if (typeof template !== "string") {
+    throw new TypeError("[vitehub] Markdown template must be a string.")
+  }
+
+  const data = options.data ?? {}
+  const nonce = crypto.randomUUID().replaceAll("-", "")
+  const runtime = createMarkdownTemplateRuntime(nonce)
+  const protectedTokens: TemplateTokenState = {
+    prefix: `VITEHUBMARKDOWNTEMPLATEPROTECTED${nonce}`,
+    values: [],
+  }
+  const tagTokens: TemplateTokenState = {
+    prefix: `VITEHUBMARKDOWNTEMPLATETAG${nonce}`,
+    values: [],
+  }
+  const prepare = async (value: string) => maskTemplateTags(
+    await protectCodeTemplateSyntax(value, protectedTokens, nonce),
+    tagTokens,
+    data,
+  )
+  const shorthand = await prepare(template)
+  const imported = options.resolveImport
+    ? await expandMarkdownTemplateImports(shorthand, {
+        maxImportDepth: options.maxImportDepth ?? defaultImportDepth,
+        prepare,
+        resolveImport: options.resolveImport,
+        runtime,
+        sourceId: options.sourceId ?? "<template>",
+      })
+    : shorthand
+  validateConditionalDirectives(await directiveValidationSource(imported))
+  const fragmentToken = `VITEHUBMARKDOWNTEMPLATEFRAGMENT${nonce}`
+  const normalized = await normalizeTripleBindings(imported, fragmentToken, runtime)
+  const tree = await parseTemplateMarkdown(normalized.template, true)
+  const nodes = await composeNodes(tree.nodes, {
+    data,
+    fragmentToken,
+    fragments: normalized.fragments,
+  })
+  const rendered = cleanMarkdown(await renderMarkdown({ ...tree, nodes }, { components: runtime.components }))
+  return restoreTemplateTokens(restoreTemplateTokens(rendered, tagTokens), protectedTokens)
+}
+
+function maskTemplateTags(
+  template: string,
+  state: TemplateTokenState,
+  data: Record<string, unknown>,
+): string {
+  return template.replace(/<\/?[A-Za-z][^<>]*>/g, (tag) => {
+    const index = state.values.push(renderTagBindings(tag, data)) - 1
+    return `${state.prefix}${index}END`
+  })
+}
+
+function renderTagBindings(tag: string, data: Record<string, unknown>): string {
+  return tag.replace(/(\s[^\s"'=<>`]+\s*=\s*)(["'])([\s\S]*?)\2/g, (_match, prefix: string, quote: string, value: string) => {
+    const rendered = value.replace(tagBindingPattern, (_binding, path: string) =>
+      escapeHtmlAttribute(scalarValue(path, data)))
+    return `${prefix}${quote}${rendered}${quote}`
+  })
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}
+
+function restoreTemplateTokens(template: string, state: TemplateTokenState): string {
+  return template.replace(
+    new RegExp(`${state.prefix}(\\d+)END`, "g"),
+    (_match, index: string) => state.values[Number(index)] ?? _match,
+  )
+}
+
+async function protectCodeTemplateSyntax(
+  template: string,
+  protectedTokens: TemplateTokenState,
+  nonce: string,
+): Promise<string> {
+  const candidates: Array<{ kind: "directive" | "syntax", value: string }> = []
+  const prefix = `VITEHUBMARKDOWNTEMPLATECANDIDATE${nonce}`
+  let masked = template.replace(/^(\s*)(::[^\r\n]*)$/gm, (_match, indentation: string, directive: string) => {
+    const index = candidates.push({ kind: "directive", value: directive }) - 1
+    return `${indentation}${prefix}${index}END`
+  })
+  masked = masked.replace(/\{\{\{[^{}\r\n]*\}\}\}|\{\{[^{}\r\n]*\}\}/g, (binding) => {
+    const index = candidates.push({ kind: "syntax", value: binding }) - 1
+    return `${prefix}${index}END`
+  })
+  masked = masked.replace(/@[^\s<>{}[\]]+/g, (specifier) => {
+    const index = candidates.push({ kind: "syntax", value: specifier }) - 1
+    return `${prefix}${index}END`
+  })
+  if (!candidates.length) return template
+
+  const tree = await parseTemplateMarkdown(masked)
+  const inCode = directiveTokensInCode(tree.nodes, prefix)
+  return masked.replace(new RegExp(`${prefix}(\\d+)END`, "g"), (_match, index: string) => {
+    const candidate = candidates[Number(index)]
+    if (!candidate) return _match
+    if (!inCode.has(Number(index))) {
+      return candidate.kind === "directive" ? normalizeConditionDirective(candidate.value) : candidate.value
+    }
+    const protectedIndex = protectedTokens.values.push(candidate.value) - 1
+    return `${protectedTokens.prefix}${protectedIndex}END`
+  })
+}
+
+function normalizeConditionDirective(directive: string): string {
+  return directive.replace(/^(::(?:if|else-if))\{([\s\S]+)\}(\s*)$/, (match, start: string, expression: string, end: string) =>
+    /^(?:if|condition)\s*=/.test(expression.trim())
+      ? match
+      : `${start}{condition=${JSON.stringify(expression.trim())}}${end}`)
+}
+
+async function normalizeTripleBindings(
+  template: string,
+  fragmentToken: string,
+  runtime: MarkdownTemplateRuntime,
+): Promise<{
+  fragments: RenderState["fragments"]
+  template: string
+}> {
+  const fragments: RenderState["fragments"] = []
+  const tree = await parseTemplateMarkdown(template)
+  const nodes = replaceTextOutsideCode(tree.nodes, value =>
+    value.replace(tripleBindingPattern, (_match, path: string) => {
+      const index = fragments.push({ path }) - 1
+      return `${fragmentToken}${index}END`
+    }))
+  return {
+    fragments,
+    template: await renderMarkdown({ ...tree, nodes }, { components: runtime.components }),
+  }
+}
+
+async function directiveValidationSource(
+  template: string,
+): Promise<string> {
+  const nonce = crypto.randomUUID().replaceAll("-", "")
+  const prefix = `VITEHUBMARKDOWNTEMPLATEVALIDATION${nonce}`
+  const directives: string[] = []
+  const masked = template.replace(/^(\s*)(::[^\r\n]*)$/gm, (_match, indentation: string, directive: string) => {
+    const index = directives.push(directive) - 1
+    return `${indentation}${prefix}${index}END`
+  })
+  if (!directives.length) return template
+
+  const tree = await parseTemplateMarkdown(masked)
+  const inCode = directiveTokensInCode(tree.nodes, prefix)
+  return masked.replace(new RegExp(`${prefix}(\\d+)END`, "g"), (_match, index: string) =>
+    inCode.has(Number(index)) ? "code" : directives[Number(index)] ?? _match)
+}
+
+function directiveTokensInCode(nodes: ComarkNode[], prefix: string, inCode = false): Set<number> {
+  const found = new Set<number>()
+  for (const node of nodes) {
+    if (typeof node === "string") {
+      if (inCode) {
+        for (const match of node.matchAll(new RegExp(`${prefix}(\\d+)END`, "g"))) found.add(Number(match[1]))
+      }
+      continue
+    }
+    if (!isElement(node)) continue
+    const nested = directiveTokensInCode(node.slice(2) as ComarkNode[], prefix, inCode || node[0] === "code")
+    for (const index of nested) found.add(index)
+  }
+  return found
+}
+
+function replaceTextOutsideCode(nodes: ComarkNode[], replace: (value: string) => string): ComarkNode[] {
+  return nodes.map((node) => {
+    if (typeof node === "string") return replace(node)
+    if (!isElement(node)) return node
+    const [tag, attrs, ...children] = node
+    if (tag === "code") return node
+    return [tag, attrs, ...replaceTextOutsideCode(children, replace)] as ComarkElement
+  })
+}
+
+async function composeNodes(
+  nodes: ComarkNode[],
+  state: RenderState,
+  parent?: string,
+  inlineFragments?: Set<number>,
+): Promise<ComarkNode[]> {
+  const composed: ComarkNode[] = []
+  for (const node of nodes) composed.push(...await composeNode(node, state, parent, inlineFragments))
+  return composed
+}
+
+async function composeNode(
+  node: ComarkNode,
+  state: RenderState,
+  parent?: string,
+  inlineFragments?: Set<number>,
+): Promise<ComarkNode[]> {
+  if (typeof node === "string") return await composeTextNode(node, state, parent, inlineFragments)
+  if (!isElement(node)) return [node]
+  const [tag, attrs, ...children] = node
+
+  if (tag === "if") return await composeIfNode(node, state)
+  if (tag === "else" || tag === "else-if") {
+    throw new Error(`[vitehub] Markdown template ${tag} block must follow an if block.`)
+  }
+  if (tag === "binding") return [renderBinding(attrs, state.data)]
+  if (tag === "code") return [node]
+  if (tag === "p") return await composeParagraph(attrs, children, state)
+  return [[tag, attrs, ...(await composeNodes(
+    children,
+    state,
+    tag,
+    inlineFragments,
+  ))] as ComarkElement]
+}
+
+async function composeParagraph(
+  attrs: Record<string, unknown>,
+  children: ComarkNode[],
+  state: RenderState,
+): Promise<ComarkNode[]> {
+  const inlineFragments = paragraphInlineFragments(children, state)
+  const pattern = fragmentPlaceholderPattern(state)
+  const composed: ComarkNode[] = []
+  let segment: ComarkNode[] = []
+  let hasBlockFragment = false
+  let trimLeadingBoundary = false
+
+  const flushSegment = async () => {
+    const nodes = await composeNodes(segment, state, "p", inlineFragments)
+    if (hasMeaningfulContent(nodes)) composed.push(["p", attrs, ...nodes] as ComarkElement)
+    segment = []
+  }
+
+  for (const child of children) {
+    if (typeof child !== "string") {
+      segment.push(child)
+      continue
+    }
+
+    let offset = 0
+    for (const match of child.matchAll(pattern)) {
+      const index = Number(match[1])
+      if (inlineFragments.has(index)) continue
+
+      hasBlockFragment = true
+      let before = child.slice(offset, match.index)
+      if (trimLeadingBoundary) {
+        before = before.replace(/^\r?\n/, "")
+        trimLeadingBoundary = false
+      }
+      before = before.replace(/\r?\n$/, "")
+      if (before) segment.push(before)
+      await flushSegment()
+      composed.push(...await fragmentNodes(index, state, false))
+      trimLeadingBoundary = true
+      offset = match.index + match[0].length
+    }
+
+    let after = child.slice(offset)
+    if (trimLeadingBoundary) {
+      after = after.replace(/^\r?\n/, "")
+      trimLeadingBoundary = false
+    }
+    if (after) segment.push(after)
+  }
+
+  if (!hasBlockFragment) {
+    return [["p", attrs, ...await composeNodes(children, state, "p", inlineFragments)] as ComarkElement]
+  }
+  await flushSegment()
+  return composed
+}
+
+async function composeTextNode(
+  value: string,
+  state: RenderState,
+  parent?: string,
+  inlineFragments?: Set<number>,
+): Promise<ComarkNode[]> {
+  const nodes: ComarkNode[] = []
+  let offset = 0
+
+  for (const match of value.matchAll(fragmentPlaceholderPattern(state))) {
+    nodes.push(value.slice(offset, match.index))
+    const index = Number(match[1])
+    nodes.push(...(state.fragments[index]
+      ? await fragmentNodes(index, state, parent !== undefined || inlineFragments?.has(index) === true)
+      : [match[0]]))
+    offset = match.index + match[0].length
+  }
+
+  nodes.push(value.slice(offset))
+  return nodes.filter(node => node !== "")
+}
+
+function paragraphInlineFragments(children: ComarkNode[], state: RenderState): Set<number> {
+  const inline = new Set<number>()
+  const placement = fragmentPlacementText(children)
+  for (const match of placement.matchAll(fragmentPlaceholderPattern(state))) {
+    const before = placement.slice(0, match.index).split("\n").at(-1) ?? ""
+    const after = placement.slice(match.index + match[0].length).split("\n")[0] ?? ""
+    if (before.trim() || after.trim()) inline.add(Number(match[1]))
+  }
+  return inline
+}
+
+function fragmentPlacementText(nodes: ComarkNode[]): string {
+  return nodes.map((node) => {
+    if (typeof node === "string") return node
+    if (!isElement(node)) return ""
+    if (node[0] === "code") return "x"
+    return `x${fragmentPlacementText(node.slice(2) as ComarkNode[])}x`
+  }).join("")
+}
+
+function renderBinding(attrs: Record<string, unknown>, data: Record<string, unknown>): ComarkNode {
+  const path = attrs[":value"]
+  if (typeof path !== "string" || !templatePathPattern.test(path)) {
+    throw new Error("[vitehub] Markdown template bindings must contain a data path.")
+  }
+
+  return scalarValue(path, data)
+}
+
+function scalarValue(path: string, data: Record<string, unknown>): string {
+  const value = templatePathValue(data, path)
+  if (value === null || value === undefined) {
+    throw new Error(`[vitehub] Markdown template binding "{{ ${path} }}" is not defined.`)
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value)
+  }
+  throw new TypeError(`[vitehub] Markdown template binding "{{ ${path} }}" must resolve to a scalar value.`)
+}
+
+async function fragmentNodes(
+  index: number,
+  state: RenderState,
+  inline: boolean,
+): Promise<ComarkNode[]> {
+  const { path } = state.fragments[index]!
+  const value = templatePathValue(state.data, path)
+  if (value === null || value === undefined) {
+    throw new Error(`[vitehub] Markdown template fragment "{{{ ${path} }}}" is not defined.`)
+  }
+  if (typeof value !== "string") {
+    throw new TypeError(`[vitehub] Markdown template fragment "{{{ ${path} }}}" must resolve to a string.`)
+  }
+
+  const tree = await parseTemplateMarkdown(value)
+  if (inline) {
+    if (!tree.nodes.length) return []
+    if (tree.nodes.length !== 1 || !isElement(tree.nodes[0]) || tree.nodes[0][0] !== "p") {
+      throw new Error(`[vitehub] Markdown template fragment "{{{ ${path} }}}" cannot contain block Markdown when used inline.`)
+    }
+    return tree.nodes[0].slice(2) as ComarkNode[]
+  }
+  return tree.nodes
+}
+
+function fragmentPlaceholderPattern(state: RenderState): RegExp {
+  return new RegExp(`${state.fragmentToken}(\\d+)END`, "g")
+}
+
+function hasMeaningfulContent(nodes: ComarkNode[]): boolean {
+  return nodes.some(node => typeof node === "string" ? node.trim() : true)
+}
+
+async function composeIfNode(node: ComarkElement, state: RenderState): Promise<ComarkNode[]> {
+  const { after, branches } = conditionalBranches(node)
+  const selected = branches.find(branch =>
+    branch.expression === undefined || evaluateCondition(branch.expression, state.data))
+  return [
+    ...(selected ? await composeNodes(selected.nodes, state) : []),
+    ...await composeNodes(after, state),
+  ]
+}
+
+function conditionalBranches(node: ComarkElement): {
+  after: ComarkNode[]
+  branches: Array<{ expression?: string, nodes: ComarkNode[] }>
+} {
+  const branches: Array<{ expression?: string, nodes: ComarkNode[] }> = []
+  let current: ComarkElement | undefined = node
+  const after: ComarkNode[] = []
+
+  while (current) {
+    const [tag, attrs, ...children] = current
+    if (tag === "else" && Object.keys(attrs).length) {
+      throw new Error("[vitehub] Markdown template else block does not accept a condition.")
+    }
+    const expression = tag === "else" ? undefined : conditionExpressionFromAttrs(attrs, tag)
+    const nextIndex = children.findIndex(child => isElement(child) && (child[0] === "else-if" || child[0] === "else"))
+    if (tag === "else" && nextIndex !== -1) {
+      throw new Error("[vitehub] Markdown template else block cannot be followed by another branch.")
+    }
+    branches.push({
+      expression,
+      nodes: nextIndex === -1 ? children : children.slice(0, nextIndex),
+    })
+    if (nextIndex !== -1) after.push(...children.slice(nextIndex + 1))
+    current = nextIndex === -1 ? undefined : children[nextIndex] as ComarkElement
+  }
+
+  return { after, branches }
+}
+
+function conditionExpressionFromAttrs(attrs: Record<string, unknown>, kind: string): string {
+  const expression = attrs.condition ?? attrs.if
+  if (typeof expression !== "string" || !expression.trim()) {
+    throw new Error(`[vitehub] Markdown template ${kind} block requires a condition.`)
+  }
+  return expression.trim()
+}
+
+function validateConditionalDirectives(template: string): void {
+  const stack: Array<{ kind: "if", sawElse: boolean } | { kind: "other" }> = []
+  let fenced: string | undefined
+
+  for (const line of template.split(/\r?\n/)) {
+    const fence = line.match(/^\s*(```|~~~)/)?.[1]
+    if (fence) {
+      fenced = fenced === fence ? undefined : fence
+      continue
+    }
+    if (fenced) continue
+    if (/^\s*::\s*$/.test(line)) {
+      stack.pop()
+      continue
+    }
+
+    const directive = directiveLine(line)
+    if (!directive) {
+      if (/^\s*::[A-Za-z][\w-]*(?:\{.*\})?\s*$/.test(line)) stack.push({ kind: "other" })
+      continue
+    }
+    if (directive.kind === "if") {
+      stack.push({ kind: "if", sawElse: false })
+      continue
+    }
+
+    const current = stack.at(-1)
+    if (!current || current.kind !== "if") {
+      throw new Error(`[vitehub] Markdown template ${directive.kind} block must follow an if block.`)
+    }
+    if (directive.kind === "else-if") {
+      if (current.sawElse) throw new Error("[vitehub] Markdown template else-if block cannot follow else.")
+      continue
+    }
+    if (directive.raw?.trim()) {
+      throw new Error("[vitehub] Markdown template else block does not accept a condition.")
+    }
+    if (current.sawElse) {
+      throw new Error("[vitehub] Markdown template if chain cannot contain more than one else block.")
+    }
+    current.sawElse = true
+  }
+
+  if (stack.some(entry => entry.kind === "if")) {
+    throw new Error("[vitehub] Markdown template if block is missing a closing :: line.")
+  }
+}
+
+function directiveLine(line: string): {
+  expression?: string
+  kind: "else" | "else-if" | "if"
+  raw?: string
+} | undefined {
+  const match = line.match(/^\s*::(if|else-if|else)(?:\{(.+)\})?\s*$/)
+  if (!match) return
+  const kind = match[1] as "else" | "else-if" | "if"
+  if (kind === "else") {
+    if (match[2]?.trim()) {
+      throw new Error("[vitehub] Markdown template else block does not accept a condition.")
+    }
+    return { kind, raw: match[2] }
+  }
+  const expression = conditionExpression(match[2])
+  if (!expression) {
+    throw new Error(`[vitehub] Markdown template ${kind} block requires a condition.`)
+  }
+  return { expression, kind, raw: match[2] }
+}
+
+function conditionExpression(raw: string | undefined): string | undefined {
+  const value = raw?.trim()
+  if (!value) return
+  const attr = value.match(/^(?:if|condition)\s*=\s*(["'])([\s\S]*)\1$/)
+  return (attr ? attr[2] : value).trim()
+}
+
+function isElement(node: ComarkNode): node is ComarkElement {
+  return Array.isArray(node) && typeof node[0] === "string"
+}

--- a/packages/markdown-template/src/types.ts
+++ b/packages/markdown-template/src/types.ts
@@ -1,0 +1,16 @@
+export interface MarkdownTemplateImport {
+  id: string
+  template: string
+}
+
+export type ResolveMarkdownTemplateImport = (
+  specifier: string,
+  importer: string,
+) => MarkdownTemplateImport | undefined | Promise<MarkdownTemplateImport | undefined>
+
+export interface RenderMarkdownTemplateOptions {
+  data?: Record<string, unknown>
+  maxImportDepth?: number
+  resolveImport?: ResolveMarkdownTemplateImport
+  sourceId?: string
+}

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { renderMarkdownTemplate } from "../src/index.ts"
+
+describe("renderMarkdownTemplate", () => {
+  it("renders scalar data as Markdown text", async () => {
+    expect(await renderMarkdownTemplate([
+      "Hello {{ pullRequest.title }}.",
+      "Attempt {{ count }} is {{ active }}.",
+      "{{ routes.llm-route.choice }}",
+      "{{ support.customer.name }}",
+    ].join("\n"), {
+      data: {
+        active: true,
+        count: 2,
+        pullRequest: { title: "*untrusted* <policy>text</policy>" },
+        routes: { "llm-route": { choice: "fast" } },
+        "support.customer": { name: "Acme" },
+      },
+    })).toBe([
+      "Hello \\*untrusted\\* \\<policy>text\\</policy>.",
+      "Attempt 2 is true.",
+      "fast",
+      "Acme",
+    ].join("\n"))
+  })
+
+  it("renders Markdown fragments without recursively evaluating template syntax", async () => {
+    const template = [
+      "# Review",
+      "{{{ sections.body }}}",
+      "",
+      "Use ({{{ sections.inline }}}).",
+    ].join("\n")
+
+    expect(await renderMarkdownTemplate(template, {
+      data: {
+        pullRequest: { available: true, repository: "vite-hub/vitehub" },
+        sections: {
+          body: [
+            "## Body",
+            "Use **bold** [guidance](https://example.com).",
+            "{{ pullRequest.repository }}",
+            "::if{pullRequest.available}",
+            "Keep this branch literal.",
+            "::",
+            "@./literal.md",
+          ].join("\n"),
+          inline: "**raw Markdown**",
+        },
+      },
+      resolveImport: async () => {
+        throw new Error("fragment imports must not resolve")
+      },
+    })).toBe([
+      "# Review",
+      "",
+      "## Body",
+      "",
+      "Use **bold** [guidance](https://example.com).",
+      "{{ pullRequest.repository }}",
+      "",
+      "::if{pullRequest.available}",
+      "Keep this branch literal.",
+      "::",
+      "",
+      "@./literal.md",
+      "",
+      "Use (**raw Markdown**).",
+    ].join("\n"))
+  })
+
+  it("rejects block Markdown in an inline fragment slot", async () => {
+    await expect(renderMarkdownTemplate("Use ({{{ section }}}).", {
+      data: { section: "## Block heading" },
+    })).rejects.toThrow("cannot contain block Markdown when used inline")
+    await expect(renderMarkdownTemplate("**Prefix** {{{ section }}}", {
+      data: { section: "## Block heading" },
+    })).rejects.toThrow("cannot contain block Markdown when used inline")
+    await expect(renderMarkdownTemplate("{{{ section }}} [suffix](https://example.com)", {
+      data: { section: "## Block heading" },
+    })).rejects.toThrow("cannot contain block Markdown when used inline")
+  })
+
+  it("separates consecutive standalone fragments selected by branches", async () => {
+    expect(await renderMarkdownTemplate([
+      "::if{sections.title}",
+      "{{{ sections.title }}}",
+      "::",
+      "::if{sections.body}",
+      "{{{ sections.body }}}",
+      "::",
+    ].join("\n"), {
+      data: {
+        sections: {
+          body: "## Body\nBody",
+          title: "## Title\nTitle",
+        },
+      },
+    })).toBe([
+      "## Title",
+      "",
+      "Title",
+      "",
+      "## Body",
+      "",
+      "Body",
+    ].join("\n"))
+  })
+
+  it("selects bounded if, else-if, and else branches", async () => {
+    const template = [
+      "::if{pullRequest.available && pullRequest.draft}",
+      "Draft",
+      "::else-if{pullRequest.available && (pullRequest.kind === 'review' || pullRequest.kind === 'issue')}",
+      "Review",
+      "::else",
+      "Missing",
+      "::",
+    ].join("\n")
+
+    await expect(renderMarkdownTemplate(template, {
+      data: { pullRequest: { available: true, draft: false, kind: "review" } },
+    })).resolves.toBe("Review")
+  })
+
+  it("consumes both sides of boolean expressions", async () => {
+    const andTemplate = "::if{enabled && name}\nEnabled\n::else\nDisabled\n::"
+    const orTemplate = "::if{enabled || name}\nEnabled\n::else\nDisabled\n::"
+
+    await expect(renderMarkdownTemplate(andTemplate, {
+      data: { enabled: false, name: "Acme" },
+    })).resolves.toBe("Disabled")
+    await expect(renderMarkdownTemplate(orTemplate, {
+      data: { enabled: true, name: "Acme" },
+    })).resolves.toBe("Enabled")
+  })
+
+  it("preserves authored XML-style tags", async () => {
+    expect(await renderMarkdownTemplate("<policy>Use {{ customer.name }}.</policy>", {
+      data: { customer: { name: "Acme" } },
+    })).toBe("<policy>Use Acme.</policy>")
+  })
+
+  it("renders scalar bindings in quoted XML attributes", async () => {
+    expect(await renderMarkdownTemplate("<policy audience=\"{{ audience }}\" tone='{{ tone }}'>Use it.</policy>", {
+      data: {
+        audience: "A \"technical\" & safe audience",
+        tone: "reviewer's <direct> tone",
+      },
+    })).toBe("<policy audience=\"A &quot;technical&quot; &amp; safe audience\" tone='reviewer&#39;s &lt;direct&gt; tone'>Use it.</policy>")
+
+    await expect(renderMarkdownTemplate("<policy audience=\"{{ audience }}\">Use it.</policy>"))
+      .rejects.toThrow("binding \"{{ audience }}\" is not defined")
+  })
+
+  it("composes the full template language inside multiline XML blocks", async () => {
+    expect(await renderMarkdownTemplate([
+      "<policy>",
+      "Use {{ customer.name }}.",
+      "::if{enabled}",
+      "{{{ section }}}",
+      "@./detail.md",
+      "::",
+      "</policy>",
+    ].join("\n"), {
+      data: {
+        customer: { name: "Acme" },
+        enabled: true,
+        section: "**Trusted** guidance.",
+      },
+      resolveImport: async () => ({ id: "/detail.md", template: "Imported detail." }),
+      sourceId: "/instructions.md",
+    })).toBe([
+      "<policy>",
+      "Use Acme.",
+      "",
+      "**Trusted** guidance.",
+      "",
+      "Imported detail.",
+      "",
+      "</policy>",
+    ].join("\n"))
+  })
+
+  it("keeps bindings, fragments, branches, and imports literal in code", async () => {
+    const resolveImport = vi.fn(() => ({ id: "/used.md", template: "Used" }))
+    const template = [
+      "`{{ name }}`",
+      "``{{{ section }}}``",
+      "```md",
+      "{{ name }}",
+      "{{{ section }}}",
+      "::if{enabled}",
+      "@./ignored.md",
+      "::",
+      "<policy audience=\"{{ name }}\">literal</policy>",
+      "```",
+      "",
+      "    {{ name }}",
+      "    {{{ section }}}",
+      "    ::if{enabled}",
+      "    @./ignored.md",
+      "    ::",
+      "",
+      "``{{ name }}",
+      "{{{ section }}}",
+      "::if{enabled}",
+      "@./ignored.md",
+      "::",
+      "``",
+      "",
+      "@./used.md",
+    ].join("\n")
+
+    expect(await renderMarkdownTemplate(template, {
+      data: { enabled: true, name: "Acme", section: "Rendered" },
+      resolveImport,
+      sourceId: "/instructions.md",
+    })).toBe([
+      "`{{ name }}`",
+      "`{{{ section }}}`",
+      "",
+      "```md",
+      "{{ name }}",
+      "{{{ section }}}",
+      "::if{enabled}",
+      "@./ignored.md",
+      "::",
+      "<policy audience=\"{{ name }}\">literal</policy>",
+      "```",
+      "",
+      "```",
+      "{{ name }}",
+      "{{{ section }}}",
+      "::if{enabled}",
+      "@./ignored.md",
+      "::",
+      "```",
+      "",
+      "`{{ name }} {{{ section }}} ::if{enabled} @./ignored.md :: `",
+      "",
+      "Used",
+    ].join("\n"))
+    expect(resolveImport).toHaveBeenCalledOnce()
+    expect(resolveImport).toHaveBeenCalledWith("./used.md", "/instructions.md")
+  })
+
+  it("preserves blank lines inside fenced code", async () => {
+    await expect(renderMarkdownTemplate("```md\nfirst\n\n\nlast\n```"))
+      .resolves.toBe("```md\nfirst\n\n\nlast\n```")
+  })
+
+  it("does not expose internal placeholders or render handlers", async () => {
+    const authored = [
+      ":markdown-template-raw{value=\"Injected\"}",
+      "%%VITEHUB_MARKDOWN_TEMPLATE_FRAGMENT_0%%",
+      "{{{ section }}}",
+    ].join("\n")
+    const rendered = await renderMarkdownTemplate(authored, { data: { section: "Rendered" } })
+
+    expect(rendered).toContain("markdown-template-raw")
+    expect(rendered).toContain("%%VITEHUB_MARKDOWN_TEMPLATE_FRAGMENT_0%%")
+    expect(rendered).toContain("Rendered")
+    expect(rendered).not.toBe("Injected")
+  })
+
+  it("resolves nested relative imports by canonical id", async () => {
+    const files = new Map([
+      ["/nested.md", "## Nested\n@./policy.md"],
+      ["/policy.md", "::if{enabled}\nPolicy for {{ customer.name }}\n::"],
+    ])
+    const resolveImport = vi.fn(async (specifier: string, importer: string) => {
+      const id = new URL(specifier, `file://${importer}`).pathname
+      const imported = files.get(id)
+      return imported === undefined ? undefined : { id, template: imported }
+    })
+
+    expect(await renderMarkdownTemplate("# Base\n@./nested.md", {
+      data: { customer: { name: "Acme" }, enabled: true },
+      resolveImport,
+      sourceId: "/instructions.md",
+    })).toBe([
+      "# Base",
+      "",
+      "## Nested",
+      "",
+      "Policy for Acme",
+    ].join("\n"))
+    expect(resolveImport).toHaveBeenNthCalledWith(1, "./nested.md", "/instructions.md")
+    expect(resolveImport).toHaveBeenNthCalledWith(2, "./policy.md", "/nested.md")
+  })
+
+  it("leaves relative-looking text literal when no resolver is provided", async () => {
+    await expect(renderMarkdownTemplate("Read @./policy.md")).resolves.toBe("Read @./policy.md")
+  })
+
+  it("rejects invalid imports, cycles, and depth overflow", async () => {
+    const resolveImport = async (specifier: string) => ({ id: specifier, template: `@${specifier}` })
+
+    await expect(renderMarkdownTemplate("@https://example.com/policy.md", {
+      resolveImport,
+    })).rejects.toThrow("must be a relative path")
+    await expect(renderMarkdownTemplate("@./*.md", {
+      resolveImport,
+    })).rejects.toThrow("cannot use globs")
+    await expect(renderMarkdownTemplate("@./missing.md", {
+      resolveImport: async () => undefined,
+    })).rejects.toThrow("could not be resolved")
+    await expect(renderMarkdownTemplate("@./a.md", {
+      resolveImport: async () => ({ id: "/root.md", template: "Again" }),
+      sourceId: "/root.md",
+    })).rejects.toThrow("Circular Markdown template import")
+    await expect(renderMarkdownTemplate("@./a.md", {
+      maxImportDepth: 1,
+      resolveImport,
+    })).rejects.toThrow("import depth exceeded 1")
+  })
+
+  it("rejects missing, null, and non-scalar values", async () => {
+    await expect(renderMarkdownTemplate("{{ missing }}")).rejects.toThrow("is not defined")
+    await expect(renderMarkdownTemplate("{{ value }}", { data: { value: null } })).rejects.toThrow("is not defined")
+    await expect(renderMarkdownTemplate("{{ value }}", { data: { value: {} } })).rejects.toThrow("scalar value")
+    await expect(renderMarkdownTemplate("{{{ missing }}}")).rejects.toThrow("is not defined")
+    await expect(renderMarkdownTemplate("{{{ value }}}", { data: { value: false } })).rejects.toThrow("string")
+  })
+
+  it("rejects unsafe expressions and malformed branch chains", async () => {
+    await expect(renderMarkdownTemplate("::if{name === 'call()'}\nYes\n::", {
+      data: { name: "call()" },
+    })).resolves.toBe("Yes")
+    await expect(renderMarkdownTemplate("::if{process.exit()}\nNo\n::"))
+      .rejects.toThrow("Unsafe Markdown template condition")
+    await expect(renderMarkdownTemplate("::if{enabled}\nYes"))
+      .rejects.toThrow("missing a closing")
+    await expect(renderMarkdownTemplate("::if{enabled}\nYes\n::else{condition=\"admin\"}\nNo\n::"))
+      .rejects.toThrow("else block does not accept a condition")
+    await expect(renderMarkdownTemplate("::if{enabled}\nYes\n::else\nNo\n::else-if{admin}\nAdmin\n::"))
+      .rejects.toThrow("else-if block cannot follow else")
+  })
+
+  it("only traverses own properties", async () => {
+    const inherited = Object.create({ secret: "leak" }) as Record<string, unknown>
+    inherited.visible = "shown"
+
+    await expect(renderMarkdownTemplate("{{ secret }}", { data: inherited })).rejects.toThrow("is not defined")
+    await expect(renderMarkdownTemplate("{{ visible }}", { data: inherited })).resolves.toBe("shown")
+  })
+})

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -154,6 +154,18 @@ describe("renderMarkdownTemplate", () => {
       .rejects.toThrow("binding \"{{ audience }}\" is not defined")
   })
 
+  it("only renders tag attribute bindings in the selected branch", async () => {
+    await expect(renderMarkdownTemplate([
+      "::if{enabled}",
+      "<policy audience=\"{{ missing }}\">Hidden</policy>",
+      "::else",
+      "Visible",
+      "::",
+    ].join("\n"), {
+      data: { enabled: false },
+    })).resolves.toBe("Visible")
+  })
+
   it("composes the full template language inside multiline XML blocks", async () => {
     expect(await renderMarkdownTemplate([
       "<policy>",

--- a/packages/markdown-template/test/types.test-d.ts
+++ b/packages/markdown-template/test/types.test-d.ts
@@ -1,0 +1,19 @@
+import { expectTypeOf, it } from "vitest"
+
+import {
+  renderMarkdownTemplate,
+  type MarkdownTemplateImport,
+  type RenderMarkdownTemplateOptions,
+  type ResolveMarkdownTemplateImport,
+} from "../src/index.ts"
+
+it("exports the Markdown template contract", () => {
+  expectTypeOf(renderMarkdownTemplate).parameters.toEqualTypeOf<[
+    template: string,
+    options?: RenderMarkdownTemplateOptions,
+  ]>()
+  expectTypeOf(renderMarkdownTemplate).returns.toEqualTypeOf<Promise<string>>()
+  expectTypeOf<ResolveMarkdownTemplateImport>().returns.toEqualTypeOf<
+    MarkdownTemplateImport | undefined | Promise<MarkdownTemplateImport | undefined>
+  >()
+})

--- a/packages/markdown-template/tsconfig.build.json
+++ b/packages/markdown-template/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "isolatedDeclarations": true,
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "test"
+  ]
+}

--- a/packages/markdown-template/tsconfig.json
+++ b/packages/markdown-template/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "test/**/*.test-d.ts"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/markdown-template/vite.config.ts
+++ b/packages/markdown-template/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vite-plus"
+
+export default defineConfig({
+  pack: {
+    tsconfig: "tsconfig.build.json",
+    deps: {
+      neverBundle: ["comark"],
+      onlyBundle: false,
+    },
+    entry: ["src/index.ts"],
+    exports: {
+      inlinedDependencies: false,
+    },
+    outExtensions: () => ({
+      dts: ".d.ts",
+      js: ".js",
+    }),
+    publint: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,7 +163,7 @@ catalogs:
       specifier: ^14.3.0
       version: 14.3.0
     comark:
-      specifier: ^0.5.1
+      specifier: 0.5.1
       version: 0.5.1
     tailwindcss:
       specifier: ^4.1.18
@@ -299,6 +299,9 @@ importers:
       '@vite-hub/kv':
         specifier: workspace:*
         version: link:packages/kv
+      '@vite-hub/markdown-template':
+        specifier: workspace:*
+        version: link:packages/markdown-template
       '@vite-hub/queue':
         specifier: workspace:*
         version: link:packages/queue
@@ -426,6 +429,9 @@ importers:
       '@vite-hub/devtools':
         specifier: workspace:*
         version: link:../devtools
+      '@vite-hub/markdown-template':
+        specifier: workspace:*
+        version: link:../markdown-template
       '@vite-hub/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -798,6 +804,25 @@ importers:
       vite-plus:
         specifier: catalog:tooling
         version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'
+
+  packages/markdown-template:
+    dependencies:
+      comark:
+        specifier: catalog:ui
+        version: 0.5.1
+    devDependencies:
+      publint:
+        specifier: catalog:tooling
+        version: 0.3.21
+      typescript:
+        specifier: catalog:tooling
+        version: 6.0.2
+      vite-plus:
+        specifier: catalog:tooling
+        version: 0.1.24(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
         version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(vite@8.0.16)(yaml@2.9.0)'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,7 +71,7 @@ catalogs:
     vue-tsc: ^3.2.6
   ui:
     "@comark/vue": ^0.5.1
-    comark: ^0.5.1
+    comark: 0.5.1
     "@iconify-json/lucide": ^1.2.111
     "@iconify-json/ph": ^1.2.2
     "@iconify-json/simple-icons": ^1.2.84


### PR DESCRIPTION
Adds `@vite-hub/markdown-template` with one async rendering API for escaped scalar data, HTML-escaped XML attributes, non-recursive Markdown fragments, bounded conditions, and caller-resolved relative imports.

Agent instruction composition now delegates the generic Markdown template language to the package while retaining Agent-specific workspace imports, coverage tracking, static rendering, and compatibility errors.

## Verification

- `pnpm --filter @vite-hub/markdown-template test` (19 tests)
- `pnpm --filter @vite-hub/markdown-template typecheck`
- `pnpm --filter @vite-hub/agent test` (46 files, 1160 tests)
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --filter @vite-hub/internal test -- workspace-inventory.test.ts`
- `vp run fallow:dead-code`
- scoped Oxlint (0 warnings)
- frozen lockfile install