### PR TITLE
fix: preserve Vite raw imports in provider builds

### DIFF
--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -236,7 +236,7 @@ async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutp
 
   if (options.bundleEntry && workerOutfile) {
     await rm(workerOutfile, { force: true, recursive: true })
-    writes.push(bundleEsmEntry(options.bundleEntry, workerOutfile, options.bundleOptions))
+    writes.push(bundleEsmEntry(options.bundleEntry, workerOutfile, { ...options.bundleOptions, rootDir: options.rootDir }))
   }
 
   await Promise.all(writes)
@@ -253,7 +253,7 @@ async function writeVercelDeploymentOutput(options: VercelDeploymentOutputOption
   await mkdir(serverDir, { recursive: true })
 
   await Promise.all([
-    bundleEsmEntry(options.bundleEntry, serverEntry, options.bundleOptions),
+    bundleEsmEntry(options.bundleEntry, serverEntry, { ...options.bundleOptions, rootDir: options.rootDir }),
     writeFile(resolve(serverDir, ".vc-config.json"), `${JSON.stringify(options.functionConfig ?? createNodeFunctionConfig(), null, 2)}\n`, "utf8"),
     writeMergedJsonObject(resolve(outputRoot, "config.json"), options.config ?? createVercelConfigJson(), options.configKeys),
     staticIndex
@@ -272,6 +272,7 @@ async function writeNetlifyDeploymentOutput(options: NetlifyDeploymentOutputOpti
     await bundleEsmEntry(func.bundleEntry, outfile, {
       ...func.bundleOptions,
       minifyIdentifiers: func.config ? true : func.bundleOptions.minifyIdentifiers,
+      rootDir: options.rootDir,
     })
     await appendNetlifyFunctionConfig(outfile, func.config)
   })

--- a/packages/internal/src/build/esbuild.ts
+++ b/packages/internal/src/build/esbuild.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
 
 import { build as bundle, type Plugin } from "esbuild"
 
@@ -11,6 +12,7 @@ interface BundleEsmEntryOptions {
   minifyIdentifiers?: boolean
   platform?: "browser" | "node" | "neutral"
   plugins?: Plugin[]
+  rootDir?: string
 }
 
 const viteRawNamespace = "vitehub-vite-raw"
@@ -20,14 +22,15 @@ function hasViteRawQuery(path: string): boolean {
   return queryIndex !== -1 && /(?:^|&)raw(?:&|$)/.test(path.slice(queryIndex + 1))
 }
 
-function createViteRawPlugin(): Plugin {
+function createViteRawPlugin(rootDir: string | undefined): Plugin {
   return {
     name: "vitehub-vite-raw",
     setup(build) {
       build.onResolve({ filter: /\?/ }, async (args) => {
         if (!hasViteRawQuery(args.path)) return
         const path = args.path.slice(0, args.path.indexOf("?"))
-        const resolved = await build.resolve(path, {
+        const specifier = rootDir && path.startsWith("/") ? resolve(rootDir, path.slice(1)) : path
+        const resolved = await build.resolve(specifier, {
           importer: args.importer,
           kind: args.kind,
           namespace: args.namespace,
@@ -102,7 +105,7 @@ export async function bundleEsmEntry(
     minifyIdentifiers: options.minifyIdentifiers,
     outfile,
     platform,
-    plugins: [...(options.plugins ?? []), createViteRawPlugin()],
+    plugins: [...(options.plugins ?? []), createViteRawPlugin(options.rootDir)],
     sourcemap: false,
     target: "es2022",
     write: true,

--- a/packages/internal/src/build/esbuild.ts
+++ b/packages/internal/src/build/esbuild.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises"
+import { readFile, stat } from "node:fs/promises"
 import { resolve } from "node:path"
 
 import { build as bundle, type Plugin } from "esbuild"
@@ -22,6 +22,22 @@ function hasViteRawQuery(path: string): boolean {
   return queryIndex !== -1 && /(?:^|&)raw(?:&|$)/.test(path.slice(queryIndex + 1))
 }
 
+async function resolveViteRawSpecifier(path: string, rootDir: string | undefined): Promise<string> {
+  if (path.startsWith("/@fs/")) return path.slice("/@fs/".length)
+  if (!rootDir || !path.startsWith("/")) return path
+
+  const rootRelativePath = path.slice(1)
+  const publicPath = resolve(rootDir, "public", rootRelativePath)
+  try {
+    await stat(publicPath)
+    return publicPath
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    return resolve(rootDir, rootRelativePath)
+  }
+}
+
 function createViteRawPlugin(rootDir: string | undefined): Plugin {
   return {
     name: "vitehub-vite-raw",
@@ -29,7 +45,7 @@ function createViteRawPlugin(rootDir: string | undefined): Plugin {
       build.onResolve({ filter: /\?/ }, async (args) => {
         if (!hasViteRawQuery(args.path)) return
         const path = args.path.slice(0, args.path.indexOf("?"))
-        const specifier = rootDir && path.startsWith("/") ? resolve(rootDir, path.slice(1)) : path
+        const specifier = await resolveViteRawSpecifier(path, rootDir)
         const resolved = await build.resolve(specifier, {
           importer: args.importer,
           kind: args.kind,

--- a/packages/internal/src/build/esbuild.ts
+++ b/packages/internal/src/build/esbuild.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises"
+
 import { build as bundle, type Plugin } from "esbuild"
 
 interface BundleEsmEntryOptions {
@@ -9,6 +11,63 @@ interface BundleEsmEntryOptions {
   minifyIdentifiers?: boolean
   platform?: "browser" | "node" | "neutral"
   plugins?: Plugin[]
+}
+
+const viteRawNamespace = "vitehub-vite-raw"
+
+function hasViteRawQuery(path: string): boolean {
+  const queryIndex = path.indexOf("?")
+  return queryIndex !== -1 && /(?:^|&)raw(?:&|$)/.test(path.slice(queryIndex + 1))
+}
+
+function createViteRawPlugin(): Plugin {
+  return {
+    name: "vitehub-vite-raw",
+    setup(build) {
+      build.onResolve({ filter: /\?/ }, async (args) => {
+        if (!hasViteRawQuery(args.path)) return
+        const path = args.path.slice(0, args.path.indexOf("?"))
+        const resolved = await build.resolve(path, {
+          importer: args.importer,
+          kind: args.kind,
+          namespace: args.namespace,
+          pluginData: args.pluginData,
+          resolveDir: args.resolveDir,
+          with: args.with,
+        })
+        if (resolved.errors.length) return { errors: resolved.errors, warnings: resolved.warnings }
+        if (resolved.external) {
+          return {
+            external: true,
+            namespace: resolved.namespace,
+            path: resolved.path,
+            pluginData: resolved.pluginData,
+            sideEffects: resolved.sideEffects,
+            suffix: resolved.suffix,
+            warnings: resolved.warnings,
+          }
+        }
+        if (resolved.namespace !== "file") {
+          return {
+            errors: [{ text: `[vitehub] Vite raw fallback cannot load ${JSON.stringify(args.path)} from the ${JSON.stringify(resolved.namespace)} namespace. Handle this raw import in a caller plugin.` }],
+            warnings: resolved.warnings,
+          }
+        }
+        return {
+          namespace: viteRawNamespace,
+          path: resolved.path,
+          pluginData: resolved.pluginData,
+          sideEffects: resolved.sideEffects,
+          suffix: resolved.suffix,
+          warnings: resolved.warnings,
+        }
+      })
+      build.onLoad({ filter: /.*/, namespace: viteRawNamespace }, async args => ({
+        contents: await readFile(args.path),
+        loader: "text",
+      }))
+    },
+  }
 }
 
 export async function bundleEsmEntry(
@@ -43,7 +102,7 @@ export async function bundleEsmEntry(
     minifyIdentifiers: options.minifyIdentifiers,
     outfile,
     platform,
-    plugins: options.plugins,
+    plugins: [...(options.plugins ?? []), createViteRawPlugin()],
     sourcemap: false,
     target: "es2022",
     write: true,

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -349,7 +349,7 @@ describe("provider deployment outputs", () => {
     expect(vi.mocked(bundleEsmEntry)).toHaveBeenCalledWith(
       join(rootDir, "agent.mjs"),
       functionFile,
-      { format: "esm", minifyIdentifiers: true, platform: "node" },
+      { format: "esm", minifyIdentifiers: true, platform: "node", rootDir },
     )
     await expect(readFile(join(netlifyDir, "config.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       edge_functions: [{ function: "vitehub-edge", path: "/edge" }],

--- a/packages/internal/test/esbuild.test.ts
+++ b/packages/internal/test/esbuild.test.ts
@@ -39,6 +39,22 @@ describe("bundleEsmEntry", () => {
       .rejects.toThrow('No loader is configured for ".md" files')
   })
 
+  it("resolves root-absolute raw imports from the Vite root", async () => {
+    const rootDir = await createTempDir()
+    const sourceDir = join(rootDir, "src")
+    const entry = join(rootDir, "entry.mjs")
+    const outfile = join(rootDir, "bundle.mjs")
+    await mkdir(sourceDir, { recursive: true })
+    await writeFile(join(sourceDir, "context.md"), "# Root context\n", "utf8")
+    await writeFile(entry, 'import context from "/src/context.md?raw"\nexport default context\n', "utf8")
+
+    const { bundleEsmEntry } = await import("../src/build/esbuild.ts")
+    await bundleEsmEntry(entry, outfile, { format: "esm", platform: "node", rootDir })
+
+    const loaded = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: string }
+    expect(loaded.default).toBe("# Root context\n")
+  })
+
   it("lets caller plugins handle raw queries before the fallback", async () => {
     const rootDir = await createTempDir()
     const entry = join(rootDir, "entry.mjs")

--- a/packages/internal/test/esbuild.test.ts
+++ b/packages/internal/test/esbuild.test.ts
@@ -5,6 +5,8 @@ import { pathToFileURL } from "node:url"
 
 import { afterEach, describe, expect, it } from "vitest"
 
+import type { Plugin } from "esbuild"
+
 const tempDirs: string[] = []
 
 async function createTempDir() {
@@ -18,6 +20,107 @@ afterEach(async () => {
 })
 
 describe("bundleEsmEntry", () => {
+  it("loads files as text only when imported with Vite's raw query", async () => {
+    const rootDir = await createTempDir()
+    const rawEntry = join(rootDir, "raw-entry.mjs")
+    const plainEntry = join(rootDir, "plain-entry.mjs")
+    const markdown = join(rootDir, "context.md")
+    const outfile = join(rootDir, "bundle.mjs")
+    await writeFile(markdown, "# Repository context\n\nUse **trusted** Markdown.\n", "utf8")
+    await writeFile(rawEntry, 'import context from "./context.md?raw"\nexport default context\n', "utf8")
+    await writeFile(plainEntry, 'import context from "./context.md"\nexport default context\n', "utf8")
+
+    const { bundleEsmEntry } = await import("../src/build/esbuild.ts")
+    await bundleEsmEntry(rawEntry, outfile, { format: "esm", platform: "node" })
+
+    const loaded = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: string }
+    expect(loaded.default).toBe("# Repository context\n\nUse **trusted** Markdown.\n")
+    await expect(bundleEsmEntry(plainEntry, outfile, { format: "esm", platform: "node" }))
+      .rejects.toThrow('No loader is configured for ".md" files')
+  })
+
+  it("lets caller plugins handle raw queries before the fallback", async () => {
+    const rootDir = await createTempDir()
+    const entry = join(rootDir, "entry.mjs")
+    const outfile = join(rootDir, "bundle.mjs")
+    await writeFile(entry, 'import context from "virtual:context?raw"\nexport default context\n', "utf8")
+    const callerPlugin: Plugin = {
+      name: "caller-raw",
+      setup(build) {
+        build.onResolve({ filter: /^virtual:context\?raw$/ }, () => ({
+          namespace: "caller-raw",
+          path: "context",
+        }))
+        build.onLoad({ filter: /.*/, namespace: "caller-raw" }, () => ({
+          contents: 'export default "caller handled raw"',
+          loader: "js",
+        }))
+      },
+    }
+
+    const { bundleEsmEntry } = await import("../src/build/esbuild.ts")
+    await bundleEsmEntry(entry, outfile, { format: "esm", platform: "node", plugins: [callerPlugin] })
+
+    const loaded = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: string }
+    expect(loaded.default).toBe("caller handled raw")
+  })
+
+  it("preserves external results from raw fallback resolution", async () => {
+    const rootDir = await createTempDir()
+    const entry = join(rootDir, "entry.mjs")
+    const outfile = join(rootDir, "bundle.mjs")
+    const importerData = { owner: "caller-plugin" }
+    let resolverContext: { pluginData: unknown, with: Record<string, string> } | undefined
+    await writeFile(entry, 'import context from "external-context?raw" with { type: "text" }\nexport default context\n', "utf8")
+    const externalPlugin: Plugin = {
+      name: "external-context",
+      setup(build) {
+        build.onLoad({ filter: /entry\.mjs$/, namespace: "file" }, async args => ({
+          contents: await readFile(args.path),
+          loader: "js",
+          pluginData: importerData,
+        }))
+        build.onResolve({ filter: /^external-context$/ }, (args) => {
+          resolverContext = { pluginData: args.pluginData, with: args.with }
+          return {
+            external: true,
+            path: "external-context",
+          }
+        })
+      },
+    }
+
+    const { bundleEsmEntry } = await import("../src/build/esbuild.ts")
+    await bundleEsmEntry(entry, outfile, { format: "esm", platform: "node", plugins: [externalPlugin] })
+
+    await expect(readFile(outfile, "utf8")).resolves.toContain('from "external-context"')
+    expect(resolverContext).toEqual({ pluginData: importerData, with: { type: "text" } })
+  })
+
+  it("rejects non-file raw fallback results with a targeted error", async () => {
+    const rootDir = await createTempDir()
+    const entry = join(rootDir, "entry.mjs")
+    const outfile = join(rootDir, "bundle.mjs")
+    await writeFile(entry, 'import context from "virtual:context?raw"\nexport default context\n', "utf8")
+    const virtualPlugin: Plugin = {
+      name: "virtual-context",
+      setup(build) {
+        build.onResolve({ filter: /^virtual:context$/ }, () => ({
+          namespace: "virtual-context",
+          path: "context",
+        }))
+        build.onLoad({ filter: /.*/, namespace: "virtual-context" }, () => ({
+          contents: "virtual contents",
+          loader: "text",
+        }))
+      },
+    }
+
+    const { bundleEsmEntry } = await import("../src/build/esbuild.ts")
+    await expect(bundleEsmEntry(entry, outfile, { format: "esm", platform: "node", plugins: [virtualPlugin] }))
+      .rejects.toThrow('Vite raw fallback cannot load "virtual:context?raw" from the "virtual-context" namespace')
+  })
+
   it("keeps CommonJS globals available in Node ESM bundles", async () => {
     const rootDir = await createTempDir()
     const entry = join(rootDir, "entry.mjs")

--- a/packages/internal/test/esbuild.test.ts
+++ b/packages/internal/test/esbuild.test.ts
@@ -55,6 +55,30 @@ describe("bundleEsmEntry", () => {
     expect(loaded.default).toBe("# Root context\n")
   })
 
+  it("resolves public and /@fs/ raw imports with Vite semantics", async () => {
+    const rootDir = await createTempDir()
+    const publicDir = join(rootDir, "public")
+    const entry = join(rootDir, "entry.mjs")
+    const outsideRoot = join(await createTempDir(), "outside.md")
+    const outfile = join(rootDir, "bundle.mjs")
+    await mkdir(publicDir, { recursive: true })
+    await writeFile(join(rootDir, "robots.txt"), "root robots\n", "utf8")
+    await writeFile(join(publicDir, "robots.txt"), "public robots\n", "utf8")
+    await writeFile(outsideRoot, "outside context\n", "utf8")
+    await writeFile(entry, [
+      `import robots from "/robots.txt?raw"`,
+      `import outside from ${JSON.stringify(`/@fs/${outsideRoot}?raw`)}`,
+      `export default { outside, robots }`,
+      ``,
+    ].join("\n"), "utf8")
+
+    const { bundleEsmEntry } = await import("../src/build/esbuild.ts")
+    await bundleEsmEntry(entry, outfile, { format: "esm", platform: "node", rootDir })
+
+    const loaded = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: { outside: string, robots: string } }
+    expect(loaded.default).toEqual({ outside: "outside context\n", robots: "public robots\n" })
+  })
+
   it("lets caller plugins handle raw queries before the fallback", async () => {
     const rootDir = await createTempDir()
     const entry = join(rootDir, "entry.mjs")

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -295,6 +295,7 @@ async function writeVercelQueueFunctions(rootDir: string, queue: QueueModuleOpti
     await bundleEsmEntry(wrapperFile, functionFile, {
       format: "esm",
       platform: "node",
+      rootDir,
     })
     await rm(wrapperFile, { force: true })
     await writeFile(resolve(functionDir, ".vc-config.json"), `${JSON.stringify(createNodeFunctionConfig({

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -661,6 +661,7 @@ export async function writeVercelScheduleFunctions(options: {
       format: "esm",
       platform: "node",
       plugins: [createScheduleDefinitionAliasPlugin()],
+      rootDir: options.rootDir,
     })
     await rm(wrapperFile, { force: true })
     await writeFile(resolve(functionDir, ".vc-config.json"), `${JSON.stringify(createNodeFunctionConfig(), null, 2)}\n`, "utf8")
@@ -819,6 +820,7 @@ async function writeCloudflareScheduleOutput(options: {
       format: "esm",
       platform: "neutral",
       plugins: [createScheduleDefinitionAliasPlugin()],
+      rootDir: options.rootDir,
     }),
     writeFile(configFile, `${JSON.stringify(wranglerConfig, null, 2)}\n`, "utf8"),
     writeFile(options.stateFile, `${JSON.stringify({ crons: ownedCrons, main }, null, 2)}\n`, "utf8"),

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -89,12 +89,14 @@ describe("Vite workflow provider outputs", () => {
     await mkdir(join(rootDir, "server", "agents", "skills", "shared"), { recursive: true })
     await mkdir(join(rootDir, "server", "agents", "workspace"), { recursive: true })
     await mkdir(inlineAgentDir, { recursive: true })
+    await writeFile(join(agentDir, "repository-host-context.md"), "Repository host context loaded through Vite raw semantics.\n")
     await writeFile(join(agentDir, "agent.ts"), [
       `import { defineAgent } from "@vite-hub/agent"`,
+      `import repositoryHostContext from "./repository-host-context.md?raw"`,
       "",
       "export default defineAgent({",
       "  workspace: {},",
-      `  run: () => "nuxt agent",`,
+      `  run: () => repositoryHostContext,`,
       "})",
       "",
     ].join("\n"))
@@ -162,7 +164,9 @@ describe("Vite workflow provider outputs", () => {
     expect(cloudflareWorkerContents).toContain('runViteHubWorkflowDefinition("welcome"')
     expect(cloudflareWorkerContents).toContain('runViteHubWorkflowDefinition("nuxt"')
     expect(cloudflareWorkerContents).not.toContain('runViteHubWorkflowDefinition("inline"')
-    expect(await readFile(cloudflareWorkerBundle, "utf8")).toContain("runViteHubWorkflowDefinition")
+    const cloudflareWorkerBundleContents = await readFile(cloudflareWorkerBundle, "utf8")
+    expect(cloudflareWorkerBundleContents).toContain("runViteHubWorkflowDefinition")
+    expect(cloudflareWorkerBundleContents).toContain("Repository host context loaded through Vite raw semantics.")
     const registry = await readFile(join(rootDir, ".vitehub", "workflow", "registry.mjs"), "utf8")
     expect(registry).toContain("runAgentWorkflowDefinition")
     expect(registry).toContain('agentIdentity: context.payload?.agentIdentity || { name: "nuxt" }')
@@ -181,6 +185,7 @@ describe("Vite workflow provider outputs", () => {
     expect(registry).not.toContain("Shared directory must not leak")
     expect(await readFile(vercelConfig, "utf8")).toContain("\"/__server\"")
     expect(existsSync(vercelServer)).toBe(true)
+    expect(await readFile(vercelServer, "utf8")).toContain("Repository host context loaded through Vite raw semantics.")
   }, buildOutputTestTimeout)
 
   it("does not emit Cloudflare workflow artifacts for Vercel provider overrides", async () => {

--- a/packages/workspace/src/build/assets.ts
+++ b/packages/workspace/src/build/assets.ts
@@ -99,6 +99,15 @@ function createWorkspaceDefinitionTransform() {
   })
 }
 
+function resolveWorkspaceRawSpecifier(path: string, rootDir: string): string {
+  if (path.startsWith("/@fs/")) return path.slice("/@fs/".length)
+  if (!path.startsWith("/")) return path
+
+  const rootRelativePath = path.slice(1)
+  const publicPath = join(rootDir, "public", rootRelativePath)
+  return existsSync(publicPath) ? publicPath : join(rootDir, rootRelativePath)
+}
+
 export function createWorkspaceDefinitionLoader(rootDir: string, alias: Record<string, string> = {}) {
   let loader: ReturnType<typeof createJiti>
   const virtualModules = new Proxy<Record<string, unknown>>(Object.create(null), {
@@ -106,7 +115,7 @@ export function createWorkspaceDefinitionLoader(rootDir: string, alias: Record<s
       if (typeof id !== "string" || !id.startsWith(rawImportVirtualModulePrefix)) return
       const reference = id.slice(rawImportVirtualModulePrefix.length)
       const [importer, path] = JSON.parse(Buffer.from(reference, "base64url").toString("utf8")) as [string, string]
-      const specifier = path.startsWith("/") ? join(rootDir, path.slice(1)) : path
+      const specifier = resolveWorkspaceRawSpecifier(path, rootDir)
       const resolved = loader.esmResolve(specifier, pathToFileURL(importer).href)
       return { __esModule: true, default: readFileSync(fileURLToPath(resolved), "utf8") }
     },

--- a/packages/workspace/src/build/assets.ts
+++ b/packages/workspace/src/build/assets.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto"
-import { existsSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { mkdir, rm, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
-import { pathToFileURL } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 import { createViteHubEnvImportAliases } from "@vite-hub/internal/build/vite"
 import { createImportPath } from "@vite-hub/internal/build/paths"
@@ -15,6 +15,7 @@ import { createMemoryWorkspaceStore } from "../storage/memory.ts"
 
 import type { DiscoveredWorkspaceDefinition } from "./discovery.ts"
 import type { ResolvedWorkspaceModuleOptions, WorkspaceContent, WorkspaceDefinitionInput, WorkspaceStore } from "../core/types.ts"
+import type { TransformOptions } from "jiti"
 
 export interface WorkspaceAssetFile {
   content: WorkspaceContent
@@ -50,11 +51,74 @@ function generatedViteHubImportAliases(rootDir: string) {
   return aliases
 }
 
-export function createWorkspaceDefinitionLoader(rootDir: string, alias: Record<string, string> = {}) {
-  return createJiti(import.meta.url, {
-    alias: { ...alias, ...generatedViteHubImportAliases(rootDir) },
-    moduleCache: false,
+const rawImportVirtualModulePrefix = "vitehub:workspace-raw:"
+
+interface BabelImportDeclarationPath {
+  node: { source: { type?: string, value?: unknown } }
+}
+
+function rawImportPath(specifier: string) {
+  const queryIndex = specifier.indexOf("?")
+  if (queryIndex === -1 || !/(?:^|&)raw(?:&|$)/.test(specifier.slice(queryIndex + 1))) return
+
+  return specifier.slice(0, queryIndex)
+}
+
+function createRawImportTransformPlugin(importer: string | undefined) {
+  return () => ({
+    visitor: {
+      ImportDeclaration(path: BabelImportDeclarationPath) {
+        if (!importer || path.node.source.type !== "StringLiteral" || typeof path.node.source.value !== "string") return
+        const rawPath = rawImportPath(path.node.source.value)
+        if (rawPath === undefined) return
+
+        const reference = Buffer.from(JSON.stringify([importer, rawPath])).toString("base64url")
+        path.node.source.value = `${rawImportVirtualModulePrefix}${reference}`
+      },
+    },
   })
+}
+
+function createWorkspaceDefinitionTransform() {
+  const transformer = createJiti(import.meta.url, { fsCache: false })
+  return (options: TransformOptions) => ({
+    code: transformer.transform({
+      ...options,
+      babel: {
+        ...options.babel,
+        plugins: [
+          ...(Array.isArray(options.babel?.plugins) ? options.babel.plugins : []),
+          createRawImportTransformPlugin(options.filename),
+        ],
+      },
+    }),
+  })
+}
+
+export function createWorkspaceDefinitionLoader(rootDir: string, alias: Record<string, string> = {}) {
+  let loader: ReturnType<typeof createJiti>
+  const virtualModules = new Proxy<Record<string, unknown>>(Object.create(null), {
+    get(_target, id) {
+      if (typeof id !== "string" || !id.startsWith(rawImportVirtualModulePrefix)) return
+      const reference = id.slice(rawImportVirtualModulePrefix.length)
+      const [importer, path] = JSON.parse(Buffer.from(reference, "base64url").toString("utf8")) as [string, string]
+      const specifier = path.startsWith("/") ? join(rootDir, path.slice(1)) : path
+      const resolved = loader.esmResolve(specifier, pathToFileURL(importer).href)
+      return { __esModule: true, default: readFileSync(fileURLToPath(resolved), "utf8") }
+    },
+    has(_target, id) {
+      return typeof id === "string" && id.startsWith(rawImportVirtualModulePrefix)
+    },
+  })
+
+  loader = createJiti(import.meta.url, {
+    alias: { ...alias, ...generatedViteHubImportAliases(rootDir) },
+    fsCache: false,
+    moduleCache: false,
+    transform: createWorkspaceDefinitionTransform(),
+    virtualModules,
+  })
+  return loader
 }
 
 export async function loadDiscoveredWorkspaceDefinition(

--- a/packages/workspace/src/build/assets.ts
+++ b/packages/workspace/src/build/assets.ts
@@ -53,8 +53,8 @@ function generatedViteHubImportAliases(rootDir: string) {
 
 const rawImportVirtualModulePrefix = "vitehub:workspace-raw:"
 
-interface BabelImportDeclarationPath {
-  node: { source: { type?: string, value?: unknown } }
+interface BabelSourceDeclarationPath {
+  node: { source?: { type?: string, value?: unknown } | null }
 }
 
 function rawImportPath(specifier: string) {
@@ -65,16 +65,20 @@ function rawImportPath(specifier: string) {
 }
 
 function createRawImportTransformPlugin(importer: string | undefined) {
+  function rewriteRawSpecifier(path: BabelSourceDeclarationPath) {
+    if (!importer || path.node.source?.type !== "StringLiteral" || typeof path.node.source.value !== "string") return
+    const rawPath = rawImportPath(path.node.source.value)
+    if (rawPath === undefined) return
+
+    const reference = Buffer.from(JSON.stringify([importer, rawPath])).toString("base64url")
+    path.node.source.value = `${rawImportVirtualModulePrefix}${reference}`
+  }
+
   return () => ({
     visitor: {
-      ImportDeclaration(path: BabelImportDeclarationPath) {
-        if (!importer || path.node.source.type !== "StringLiteral" || typeof path.node.source.value !== "string") return
-        const rawPath = rawImportPath(path.node.source.value)
-        if (rawPath === undefined) return
-
-        const reference = Buffer.from(JSON.stringify([importer, rawPath])).toString("base64url")
-        path.node.source.value = `${rawImportVirtualModulePrefix}${reference}`
-      },
+      ExportAllDeclaration: rewriteRawSpecifier,
+      ExportNamedDeclaration: rewriteRawSpecifier,
+      ImportDeclaration: rewriteRawSpecifier,
     },
   })
 }

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -659,6 +659,37 @@ describe("sources, loaders, and publishers", () => {
     })
   })
 
+  it("loads public and /@fs/ raw paths with Vite semantics", async () => {
+    const root = await createRoot()
+    const outsideRoot = await createRoot()
+    const directory = join(root, "server", "agents", "review")
+    const outsidePath = join(outsideRoot, "outside.md")
+    await mkdir(join(root, "public"), { recursive: true })
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(root, "robots.txt"), "root robots\n")
+    await writeFile(join(root, "public", "robots.txt"), "public robots\n")
+    await writeFile(outsidePath, "outside context\n")
+    await writeFile(join(directory, "config.ts"), [
+      `import robots from "/robots.txt?raw"`,
+      `import outside from ${JSON.stringify(`/@fs/${outsidePath}?raw`)}`,
+      `export default { rootDir: [robots.trim(), outside.trim()].join("|") }`,
+      ``,
+    ].join("\n"))
+
+    const definition = {
+      handler: join(directory, "config.ts"),
+      name: "review",
+      path: join(directory, "config.ts"),
+      source: "test",
+      sourceRootDir: directory,
+    }
+    const loader = createWorkspaceDefinitionLoader(root)
+
+    await expect(loadDiscoveredWorkspaceDefinition(loader, definition)).resolves.toMatchObject({
+      rootDir: "public robots|outside context",
+    })
+  })
+
   it("ignores stale default Jiti transforms when loading raw imports", async () => {
     const root = await createRoot()
     const directory = join(root, "server", "agents", "review")

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -632,6 +632,33 @@ describe("sources, loaders, and publishers", () => {
     }])
   })
 
+  it("loads raw text re-exports from nested Workspace Definition modules", async () => {
+    const root = await createRoot()
+    const directory = join(root, "server", "agents", "review")
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, "repository-host-context.md"), "# Re-exported context\n")
+    await writeFile(join(directory, "context.ts"),
+      `export { default as repositoryHostContext } from "./repository-host-context.md?raw"\n`)
+    await writeFile(join(directory, "config.ts"), [
+      `import { repositoryHostContext } from "./context.ts"`,
+      `export default { rootDir: repositoryHostContext.trim() }`,
+      ``,
+    ].join("\n"))
+
+    const definition = {
+      handler: join(directory, "config.ts"),
+      name: "review",
+      path: join(directory, "config.ts"),
+      source: "test",
+      sourceRootDir: directory,
+    }
+    const loader = createWorkspaceDefinitionLoader(root)
+
+    await expect(loadDiscoveredWorkspaceDefinition(loader, definition)).resolves.toMatchObject({
+      rootDir: "# Re-exported context",
+    })
+  })
+
   it("ignores stale default Jiti transforms when loading raw imports", async () => {
     const root = await createRoot()
     const directory = join(root, "server", "agents", "review")

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -5,10 +5,11 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 import { gzipSync } from "node:zlib"
 
+import { createJiti } from "jiti"
 import { createMemoryStorage, setStorage } from "ocache"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { collectWorkspaceStoreAssetBundle, syncDiscoveredWorkspaceAssetBundles, writeWorkspaceAssetsRegistry } from "../src/build/assets.ts"
+import { collectWorkspaceStoreAssetBundle, createWorkspaceDefinitionLoader, loadDiscoveredWorkspaceDefinition, syncDiscoveredWorkspaceAssetBundles, writeWorkspaceAssetsRegistry } from "../src/build/assets.ts"
 import { initializeWorkspaceAssetRegistry, syncWorkspaceBuildAssets } from "../src/build/integration.ts"
 import { resetWorkspaceAssetsRegistry } from "../src/asset-registry.ts"
 import { custom, defineWorkspace, file, github, glob, markdown, useWorkspace } from "../src/index.ts"
@@ -590,6 +591,81 @@ describe("sources, loaders, and publishers", () => {
     const contents = await readFile(registryFile, "utf8")
     expect(contents.match(/"docs": createWorkspaceAssets/g)).toHaveLength(1)
     expect(contents.match(/"instructions\/AGENTS.md"/g)).toHaveLength(1)
+  })
+
+  it("loads raw text imports while syncing discovered Workspace Definitions", async () => {
+    const root = await createRoot()
+    const directory = join(root, "server", "agents", "review")
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, "repository-host-context.md"), "# Repository host context\n")
+    await writeFile(join(directory, "config.ts"), [
+      `import repositoryHostContext from "./repository-host-context.md?raw"`,
+      `export default {`,
+      `  sources: {`,
+      `    context: {`,
+      `      async getKeys() { return ["repository-host-context.md"] },`,
+      `      async getItem(key) { return { key, path: key, content: repositoryHostContext } },`,
+      `    },`,
+      `  },`,
+      `}`,
+      ``,
+    ].join("\n"))
+
+    const bundles = await syncDiscoveredWorkspaceAssetBundles([{
+      handler: join(directory, "config.ts"),
+      name: "review",
+      path: join(directory, "config.ts"),
+      source: "test",
+      sourceRootDir: directory,
+    }], root, {
+      root: join(root, ".vitehub", "workspaces"),
+      store: { provider: "memory" },
+      assets: true,
+    })
+
+    expect(bundles).toMatchObject([{
+      files: [{
+        content: "# Repository host context\n",
+        path: "context/repository-host-context.md",
+      }],
+      name: "review",
+    }])
+  })
+
+  it("ignores stale default Jiti transforms when loading raw imports", async () => {
+    const root = await createRoot()
+    const directory = join(root, "server", "agents", "review")
+    const definitionPath = join(directory, "config.ts")
+    const definitionSource = [
+      `import repositoryHostContext from "./repository-host-context.md?raw"`,
+      `export default { rootDir: repositoryHostContext.trim() }`,
+      ``,
+    ].join("\n")
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, "repository-host-context.md"), "# Repository host context\n")
+    await writeFile(definitionPath, definitionSource)
+
+    const defaultLoader = createJiti(new URL("../src/build/assets.ts", import.meta.url).href, { moduleCache: false })
+    defaultLoader.transform({
+      async: true,
+      filename: definitionPath,
+      interopDefault: true,
+      source: definitionSource,
+      ts: true,
+    })
+    await expect(defaultLoader.import(definitionPath)).rejects.toMatchObject({ code: "ERR_UNKNOWN_FILE_EXTENSION" })
+
+    const definition = {
+      handler: definitionPath,
+      name: "review",
+      path: definitionPath,
+      source: "test",
+      sourceRootDir: directory,
+    }
+    const loader = createWorkspaceDefinitionLoader(root)
+    await expect(loadDiscoveredWorkspaceDefinition(loader, definition)).resolves.toMatchObject({
+      rootDir: "# Repository host context",
+    })
   })
 
   it("preserves empty source root overrides while syncing build assets", async () => {

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -1088,6 +1088,36 @@ describe("hubWorkspace", () => {
     ])
   })
 
+  it("resolves definition-level Cloudflare Artifacts bindings through raw text imports", async () => {
+    const root = await createViteRoot()
+    await writeFile(join(root, "src", "repository-host-context.md"), "definition-workspaces\n")
+    await writeFile(join(root, "src", "repository-host-context.ts"), [
+      `import repositoryHostContext from "./repository-host-context.md?raw"`,
+      `export const namespace = repositoryHostContext.trim()`,
+      ``,
+    ].join("\n"))
+    await writeFile(join(root, "src", "docs.workspace.ts"), [
+      `import { namespace } from "./repository-host-context.ts"`,
+      `export default {`,
+      `  store: { binding: "DEFINITION_FILES", namespace, provider: "cloudflare-artifacts" },`,
+      `}`,
+      ``,
+    ].join("\n"))
+    const { createDefaultCloudflareOutputRoot } = await import("@vite-hub/internal/build/cloudflare")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace()
+    const configResolved = plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>
+    const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
+
+    await configResolved({ command: "build", root })
+    await closeBundle.handler()
+
+    const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
+    expect(wrangler.artifacts).toEqual([
+      { binding: "DEFINITION_FILES", namespace: "definition-workspaces" },
+    ])
+  })
+
   it("does not import Workspace Definitions when build-time assets are disabled", async () => {
     const root = await createViteRoot()
     await writeFile(join(root, "src", "docs.workspace.ts"), [


### PR DESCRIPTION
Quiver's `@vite-hub/markdown-template` preview verification exposed two build paths that bypass Vite's `?raw` handling.

Workflow provider bundles now load query-bearing raw imports through a query-aware esbuild fallback while preserving caller plugin precedence, external resolution, resolver metadata, and Vite root, default-public, and `/@fs/` paths. Workspace Definition evaluation now applies the same static raw-import contract through its Jiti loader, including nested imports, static re-exports, root/alias resolution, and the same Vite asset paths, without treating plain Markdown imports as raw.

The Workspace evaluator disables Jiti's filesystem cache because its cache key does not include the custom transform; a regression covers upgrading from a stale pre-fix transform.

## Verification

- `@vite-hub/internal`: 81 tests, typecheck, build
- `@vite-hub/workflow`: provider-output regression, typecheck, build and publint
- `@vite-hub/workspace`: 406 tests, typecheck, build and publint
- `@vite-hub/queue` and `@vite-hub/schedule`: typecheck
- scoped lint and `git diff --check`
