### PR TITLE
feat(docs): refine navigation card grids

### DIFF
--- a/docs/app/app.config.ts
+++ b/docs/app/app.config.ts
@@ -85,6 +85,22 @@ export default defineAppConfig({
     pageBody: {
       base: "mt-0 px-4 pb-24 sm:px-8 lg:px-8 xl:px-12",
     },
+    pageGrid: {
+      base: "grid-cols-1 gap-px border border-default bg-[var(--ui-border)] sm:grid-cols-2 lg:grid-cols-2",
+    },
+    pageCard: {
+      defaultVariants: {
+        variant: "ghost",
+      },
+      slots: {
+        root: "group rounded-none bg-default",
+        container: "gap-0 p-4 sm:p-5",
+        leading: "mb-3 size-8 items-center justify-center border border-default bg-muted/30",
+        leadingIcon: "size-4 text-muted transition-colors group-hover:text-highlighted",
+        title: "text-sm font-semibold",
+        description: "mt-1 text-sm/6 text-muted",
+      },
+    },
     contentSearchButton: {
       defaultVariants: {
         collapsed: false,

--- a/docs/app/assets/main.css
+++ b/docs/app/assets/main.css
@@ -143,17 +143,8 @@ body {
   }
 }
 
-.docs-content .u-page-grid {
-  gap: 0.75rem;
-}
-
-.docs-content .u-page-card,
 .docs-content .code-block-wrapper {
   border-radius: 0.125rem;
-}
-
-.docs-content .u-page-card {
-  box-shadow: none;
 }
 
 .docs-content [data-reka-tabs-content] .code-block-wrapper {


### PR DESCRIPTION
## Summary

Documentation card grids now use Nuxt UI's `pageGrid` and `pageCard` app-config slots instead of stale class selectors. The shared treatment keeps Docus and Nuxt Content's existing MDC components, while presenting a compact two-column desktop index, a single-column mobile stack, subtle dividers, and matched dark-mode states.

## Testing

- `pnpm --filter vitehub-docs typecheck`
- `pnpm --filter vitehub-docs test` — 31 tests passed
- `pnpm --filter vitehub-docs build`
- Browser QA on the docs overview, card navigation, mobile navigation, dark mode, and reference-table overflow

The local runtime proof used the Docus 5.12 update from #610 plus a temporary resolution pin for Nuxt Content's current H3 mismatch. Neither dependency workaround is included here, so this PR stays focused on the UI layer.