### PR TITLE
feat(agent): add email capability

### DIFF
--- a/docs/content/docs/capabilities/email.md
+++ b/docs/content/docs/capabilities/email.md
@@ -1,0 +1,191 @@
+---
+title: Email
+description: Let an Agent send authorized plain-text email through the configured Email primitive.
+navigation.title: Email
+navigation.order: 95
+navigation.group: Runtime primitives
+icon: i-lucide-mail
+---
+
+`email()` grants an Agent one external side effect: `email_send` sends a plain-text message from an application-owned sender through the configured ViteHub Email primitive.
+Attach it only when the Agent should contact external recipients, scope exact addresses with `recipients`, then use policy when delivery requires approval or contextual authorization.
+
+::warning
+An approved call can contact real people and incur provider charges.
+Start with a short `recipients` allowlist, `policy: 'require-approval'`, a provider test account, and an approved test recipient.
+::
+
+## Configure the Email primitive first
+
+Enable Email Definition discovery in the ViteHub preset and add one `server/email.ts` or `server.email.ts`.
+The Definition owns the delivery driver, provider credentials, and sender authorization.
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import { vitehub } from 'vite-hub'
+
+export default defineConfig({
+  plugins: [
+    vitehub({ email: true }),
+  ],
+})
+```
+
+Follow [Configure SMTP](/docs/server-primitives/email#configure-smtp) for the bundled adapter, or [implement another provider](/docs/server-primitives/email#implement-another-provider) behind the same `EmailDriver` contract.
+Keep credentials in Server Env or the deployment platform's secret store; the Capability never exposes them to the model.
+
+## Requirements
+
+- The application must run on Node.js 24 or later.
+- Email Definition discovery requires Vite 8 or later and exactly one supported Email Definition below the detected project root.
+- The configured provider must authorize the `from` address.
+- Generated Agent routes receive the Email runtime handle only while the Email Vite integration is active.
+
+## Grant the Agent permission to send
+
+Import `email()` from the official Capability catalog.
+Set `from` to a sender that the configured provider authorizes.
+
+```ts [server/agents/support.ts]
+import { defineAgent } from 'vite-hub/agent'
+import { email } from 'vite-hub/agent/capabilities'
+
+export default defineAgent({
+  driver: { model },
+  capabilities: [
+    email({
+      from: 'support@example.com',
+      recipients: [
+        'customer@example.net',
+        'owner@example.com',
+      ],
+      policy: 'require-approval',
+    }),
+  ],
+})
+```
+
+This configuration exposes one tool:
+
+| Tool | Side effect | Result |
+| --- | --- | --- |
+| `email_send` | Sends one plain-text message from the configured sender. | The Email primitive's `{ id, driver }` acceptance result. |
+
+A successful result means the active provider accepted the message and returned an ID.
+It does not prove inbox delivery, display, or reading.
+
+## Send a message
+
+`email_send` accepts exactly three fields.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `to` | `string \| readonly string[]` | Yes | One recipient address or a non-empty list. Every address must be non-empty. |
+| `subject` | `string` | Yes | A non-empty subject. |
+| `text` | `string` | Yes | A non-empty plain-text body. Do not include credentials or other secrets. |
+
+The Capability fixes `from` from application configuration.
+The model cannot set HTML, headers, attachments, carbon-copy recipients, blind-carbon-copy recipients, or reply routing through this tool.
+The Capability checks that recipient strings are non-empty; the Email driver and provider still own mailbox syntax, sender authorization, and delivery rules.
+ViteHub does not add recipient-count, text-length, payload-size, or send-rate limits beyond non-whitespace validation.
+Your delivery provider owns those limits and may charge for every accepted recipient or message.
+
+## Authorize recipients
+
+Use `recipients` as the hard boundary for exact addresses the Agent may contact.
+Every address in `email_send.to` must match the configured list; one address outside the list denies the entire call before the Email primitive runs, so ViteHub never partially sends a multi-recipient message.
+
+```ts [server/agents/support.ts]
+email({
+  from: 'support@example.com',
+  recipients: [
+    'customer@example.net',
+    'owner@example.com',
+  ],
+})
+```
+
+ViteHub includes this list in Capability metadata and the `email_send` tool description, so the Agent can select a valid address without guessing.
+The list becomes part of the Agent's model context; include only addresses that the model is allowed to see.
+
+Matching trims surrounding whitespace and ignores letter case, but the Capability forwards the original address values to the Email provider.
+Aliases, display-name forms, and other address variations remain different strings unless they appear explicitly in `recipients`.
+Set `recipients: []` to deny all sends, or omit `recipients` when static recipient restriction belongs elsewhere.
+
+The optional `policy` is an additional gate after this allowlist.
+It cannot widen `recipients`: a configured `policy: 'allow'` still denies an address outside the list, while `policy: 'require-approval'` prompts only for an address that passed the list.
+Without `policy`, allowed recipients send immediately; a policy callback can apply contextual authorization by returning `allow`, `deny`, `require-approval`, or `retryable-failure`.
+
+Read [Runtime policy, approvals, and traces](/docs/concepts/runtime-policy-approvals-and-traces) before enabling unattended delivery.
+
+## Handle failures without duplicate delivery
+
+The Capability forwards the Email primitive result and error unchanged.
+It does not retry.
+
+Capability-owned validation and runtime failures happen before the Email driver runs, so these failures cannot have delivered a message:
+
+| Failure | When it occurs |
+| --- | --- |
+| Invalid or missing `from` | `email()` rejects the Agent Definition during construction. |
+| Non-array `recipients`, or a blank, non-string, or sparse entry | `email()` rejects the Agent Definition during construction. |
+| Missing Email primitive | Capability resolution rejects before the Agent Driver receives `email_send`. |
+| Runtime handle without `send()` | Capability resolution rejects before the Agent Driver receives `email_send`. |
+| Empty `to`, `subject`, or `text` | Tool execution rejects before calling the Email primitive. |
+| Recipient outside `recipients` | Policy denies the entire tool call before calling the Email primitive. |
+
+After the Capability calls the Email primitive, handle `EmailError.code` according to the delivery state:
+
+| Failure | What to do |
+| --- | --- |
+| `invalid-message` | Fix the message before retrying. The driver was not called. |
+| `not-configured` | Enable the Email integration and confirm exactly one Email Definition is discoverable. |
+| `authentication` | Fix provider credentials or sender authorization before retrying. |
+| `rate-limit` | Apply an application-owned backoff or queue policy. |
+| `network` or `timeout` | Treat delivery as uncertain. Check provider delivery logs before retrying, because the provider may already have accepted the message. |
+| `provider` | Inspect protected server logs and provider delivery records. Never expose `cause` to the model. |
+
+ViteHub-produced `EmailError.message` values are safe for the public runtime boundary.
+ViteHub-wrapped provider failures remain in `cause` for protected server-side diagnostics and may contain addresses, credentials, or response content; custom drivers must preserve the same rule.
+
+## Keep Dynamic Markdown application-owned
+
+`email_send` is plain-text-only by design.
+It does not render model-authored Markdown into HTML because [`renderEmailMarkdown()`](/docs/server-primitives/email#compose-dynamic-markdown) accepts trusted templates and does not sanitize authored HTML or trusted fragments.
+
+When a product needs branded HTML, compose a trusted template in application code and call the Email primitive directly, or expose a [Custom Capability](/docs/capabilities/custom-capabilities) with a narrow set of escaped template values.
+Do not pass unrestricted model output into a trusted HTML fragment.
+
+## Driver support
+
+| Agent Driver | Support |
+| --- | --- |
+| Model-backed | Receives `email_send` after the Email primitive resolves. |
+| Harness-backed | Runtime requirements apply; model-facing Email tools are not passed by default. |
+| Custom-run-backed | Receives the resolved tool set; `driver.run` decides whether and when to call `email_send`. |
+
+## Inspect and verify
+
+Open the Agent in DevTools and confirm its tool list contains only `email_send` for this Capability.
+The Capability should report write mode and an `email` primitive requirement.
+
+For the first delivery, use an approved test recipient and a test or sandbox provider account.
+Approve the call, confirm the tool returns a non-empty `id`, then verify the same message in provider delivery logs or the recipient mailbox.
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `from` | `string` | Required | Non-empty application-owned sender passed to every message. The provider still validates and authorizes it. |
+| `recipients` | `readonly string[]` | `undefined` (no static allowlist) | Exact recipient allowlist. Every `to` address must match; an empty list denies all sends. |
+| `policy` | `AgentToolPolicyDecision \| function` | `"allow"` | Optional approval or authorization policy for `email_send`. |
+
+`email()` has no `mode` option because Email exposes no read operation.
+The Capability always reports `mode: 'write'` so inspection and policy tooling can identify the side effect.
+
+## Reference
+
+- [Email primitive](/docs/server-primitives/email)
+- [Official capabilities](/docs/capabilities/official-capabilities)
+- [Runtime policy, approvals, and traces](/docs/concepts/runtime-policy-approvals-and-traces)
+- Source: `packages/agent/src/capabilities/email.ts`

--- a/docs/content/docs/capabilities/official-capabilities.md
+++ b/docs/content/docs/capabilities/official-capabilities.md
@@ -19,6 +19,7 @@ import {
   chatSummary,
   chatTitle,
   db,
+  email,
   fetch,
   git,
   inputCommands,
@@ -59,6 +60,7 @@ import {
 | KV storage | [`kv()`](/docs/capabilities/kv) | The Agent needs scoped key-value read or edit tools. |
 | Blob storage | [`blob()`](/docs/capabilities/blob) | The Agent needs scoped object read or edit tools. |
 | Database | [`db()`](/docs/capabilities/db) | The Agent needs guarded SQL query, schema, or mutation tools. |
+| Email | [`email()`](/docs/capabilities/email) | The Agent should send authorized plain-text messages through the configured Email primitive. |
 | Sandbox execution | [`sandbox()`](/docs/capabilities/sandbox) | The Agent may run an allowlisted executable in an isolated runtime. |
 | Schedules | [`schedule()`](/docs/capabilities/schedule) | The Agent declares scheduled invocations or manages Runtime Schedules through tools. |
 | MCP servers | [`mcp()`](/docs/capabilities/mcp) | External MCP server tools should become model-facing Agent tools. |

--- a/docs/content/docs/server-primitives/email.md
+++ b/docs/content/docs/server-primitives/email.md
@@ -378,6 +378,14 @@ Inspect the final message after template composition and confirm that either `ht
 
 This release owns outbound transactional delivery, in-memory attachments, dynamic Markdown composition, and test capture. It does not own queues, retries, scheduling, provider templates, inbound email, webhooks, suppression lists, tracking, HTML sanitization, or CSS inlining.
 
+## Expose Email to an Agent
+
+Use the official [`email()` Capability](/docs/capabilities/email) when a model should send through the discovered Email Definition.
+The Capability fixes the sender in application code and exposes one plain-text `email_send` tool with optional policy; provider configuration and credentials stay in this primitive.
+
+Dynamic Markdown remains an application composition boundary.
+The official Capability does not render model-authored Markdown or expose HTML, headers, and attachments, so richer messages should use a trusted application template or a narrowly scoped Custom Capability.
+
 ## Next steps
 
 - Use [Queue](/docs/server-primitives/queue) when a request should return before email delivery completes.

--- a/docs/content/docs/server-primitives/index.md
+++ b/docs/content/docs/server-primitives/index.md
@@ -116,6 +116,7 @@ Do not expose a primitive to a model just because the app uses it. Attach the re
 | Expose KV with scoped storage tools | [KV capability](/docs/capabilities/kv) |
 | Expose Blob storage with scoped file tools | [Blob capability](/docs/capabilities/blob) |
 | Expose relational data intentionally | [Database capability](/docs/capabilities/db) |
+| Let an Agent send authorized plain-text email | [Email capability](/docs/capabilities/email) |
 | Let an Agent manage allowed Runtime Schedules | [Schedule capability](/docs/capabilities/schedule) |
 | Expose Workspace-backed inspection or mutation | [Workspace shell](/docs/capabilities/workspace-shell) |
 | Run isolated execution from an Agent boundary | [Sandbox capability](/docs/capabilities/sandbox) |

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -139,7 +139,7 @@ Pass `--json` for the structured inspection contract.
 - `papercuts()` lets an Agent report small runtime and developer-experience friction to an application-owned sink, with an optional Capability CLI command.
 - `transcribe()` uses the [AI SDK transcription API](https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/transcribe).
 - `mcp()` connects tools from [Model Context Protocol](https://modelcontextprotocol.io/) servers through `@ai-sdk/mcp`.
-- `kv()`, `blob()`, and `db()` expose [`@vite-hub/kv`](../kv/README.md), [`@vite-hub/blob`](../blob/README.md), and [`@vite-hub/database`](../database/README.md).
+- `kv()`, `blob()`, `db()`, and `email()` expose [`@vite-hub/kv`](../kv/README.md), [`@vite-hub/blob`](../blob/README.md), [`@vite-hub/database`](../database/README.md), and [`@vite-hub/email`](../email/README.md).
 - `sandbox()` and `schedule()` expose [`@vite-hub/sandbox`](../sandbox/README.md) and [`@vite-hub/schedule`](../schedule/README.md).
 - `skills()`, `access()`, `memory()`, `fetch()`, `llmRoute()`, and `llmGate()` cover prompt skills, workspace scope, durable notes, HTTP reads, and pre-run decisions.
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -177,6 +177,7 @@
     "@chat-adapter/discord": "catalog:chat",
     "@vercel/functions": "catalog:vercel",
     "@vite-hub/blob": "workspace:*",
+    "@vite-hub/email": "workspace:*",
     "@vite-hub/schedule": "workspace:*",
     "@vite-hub/workflow": "workspace:*",
     "ai": "catalog:ai-compat",
@@ -205,6 +206,9 @@
       "optional": true
     },
     "@vite-hub/blob": {
+      "optional": true
+    },
+    "@vite-hub/email": {
       "optional": true
     },
     "@vite-hub/schedule": {

--- a/packages/agent/src/capabilities/email.ts
+++ b/packages/agent/src/capabilities/email.ts
@@ -1,0 +1,156 @@
+import { defineCapability } from "../capability-runtime.ts"
+import { defineInternalTool, requirePrimitive } from "./internal.ts"
+
+import type {
+  AgentCapabilityContext,
+  AgentCapabilityDefinition,
+  AgentToolPolicyContext,
+  AgentToolPolicyDecision,
+  AgentToolSchema,
+  MaybePromise,
+} from "../types.ts"
+
+export type EmailCapabilityToolPolicy = AgentToolPolicyDecision | ((context: AgentToolPolicyContext) => MaybePromise<AgentToolPolicyDecision>)
+
+export interface EmailCapabilityOptions {
+  from: string
+  recipients?: readonly string[]
+  policy?: EmailCapabilityToolPolicy
+}
+
+interface EmailSendInput {
+  subject: string
+  text: string
+  to: string | readonly string[]
+}
+
+interface EmailRuntimeClient {
+  send: (message: EmailSendInput & { from: string }) => MaybePromise<unknown>
+}
+
+const emailSendInputSchema: AgentToolSchema<EmailSendInput> = {
+  additionalProperties: false,
+  properties: {
+    subject: { minLength: 1, type: "string" },
+    text: { minLength: 1, type: "string" },
+    to: {
+      anyOf: [
+        { minLength: 1, type: "string" },
+        { items: { minLength: 1, type: "string" }, minItems: 1, type: "array" },
+      ],
+    },
+  },
+  required: ["to", "subject", "text"],
+  type: "object",
+}
+
+function nonEmptyString(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new TypeError(`[vitehub] ${label} must be a non-empty string.`)
+  }
+  return value
+}
+
+function validateRecipients(value: unknown): string | readonly string[] {
+  if (typeof value === "string") return nonEmptyString(value, "email_send to")
+  if (!Array.isArray(value)) {
+    throw new TypeError("[vitehub] email_send to must be a non-empty email address or array of email addresses.")
+  }
+  const recipients = Array.from(value)
+  if (recipients.length === 0 || recipients.some(address => typeof address !== "string" || !address.trim())) {
+    throw new TypeError("[vitehub] email_send to must be a non-empty email address or array of email addresses.")
+  }
+  return recipients as string[]
+}
+
+function recipientKey(address: string): string {
+  return address.trim().toLowerCase()
+}
+
+function normalizeRecipients(value: unknown): readonly string[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) {
+    throw new TypeError("[vitehub] email({ recipients }) must be an array of non-empty email addresses.")
+  }
+  const recipients = Array.from(value)
+  if (recipients.some(address => typeof address !== "string" || !address.trim())) {
+    throw new TypeError("[vitehub] email({ recipients }) must be an array of non-empty email addresses.")
+  }
+  return recipients as string[]
+}
+
+function recipientList(value: string | readonly string[]): readonly string[] {
+  return typeof value === "string" ? [value] : value
+}
+
+function recipientsAllowed(value: string | readonly string[], allowlist: ReadonlySet<string> | undefined): boolean {
+  return allowlist === undefined || recipientList(value).every(address => allowlist.has(recipientKey(address)))
+}
+
+function assertAllowedRecipients(value: string | readonly string[], allowlist: ReadonlySet<string> | undefined): string | readonly string[] {
+  if (!recipientsAllowed(value, allowlist)) {
+    throw new Error("[vitehub] email_send recipient is outside the configured allowlist.")
+  }
+  return value
+}
+
+function emailSendPolicy(allowlist: ReadonlySet<string> | undefined, policy: EmailCapabilityToolPolicy | undefined): EmailCapabilityToolPolicy | undefined {
+  if (allowlist === undefined) return policy
+  return async (context) => {
+    let recipients: string | readonly string[]
+    try {
+      recipients = validateRecipients((context.input as { to?: unknown } | undefined)?.to)
+    }
+    catch {
+      return "deny"
+    }
+    if (!recipientsAllowed(recipients, allowlist)) return "deny"
+    return typeof policy === "function" ? await policy(context) : policy ?? "allow"
+  }
+}
+
+function emailSendDescription(recipients: readonly string[] | undefined): string {
+  const scope = recipients === undefined
+    ? "Recipients are selected in the tool input."
+    : recipients.length === 0
+      ? "Sending is disabled because the configured recipient allowlist is empty."
+      : `Allowed recipients: ${JSON.stringify(recipients)}.`
+  return `Send one plain-text email from the configured sender. ${scope} This external side effect reports provider acceptance, not inbox delivery; do not include secrets.`
+}
+
+function requireEmailClient(context: AgentCapabilityContext): EmailRuntimeClient {
+  const client = requirePrimitive(context, "email")
+  if (!client || typeof client !== "object" || typeof (client as { send?: unknown }).send !== "function") {
+    throw new Error("[vitehub] email primitive must expose send().")
+  }
+  return client as EmailRuntimeClient
+}
+
+export function email(options: EmailCapabilityOptions): AgentCapabilityDefinition {
+  const from = nonEmptyString(options?.from, "email({ from })")
+  const recipients = normalizeRecipients(options.recipients)
+  const recipientAllowlist = recipients === undefined ? undefined : new Set(recipients.map(recipientKey))
+  return defineCapability({
+    id: "email",
+    metadata: recipients === undefined ? undefined : { recipients },
+    mode: "write",
+    requires: [{ primitive: "email" }],
+    tools: (context) => {
+      const client = requireEmailClient(context)
+      return {
+        email_send: defineInternalTool<EmailSendInput>({
+          description: emailSendDescription(recipients),
+          execute: async ({ subject, text, to }) => await client.send({
+            from,
+            subject: nonEmptyString(subject, "email_send subject"),
+            text: nonEmptyString(text, "email_send text"),
+            to: assertAllowedRecipients(validateRecipients(to), recipientAllowlist),
+          }),
+          inputSchema: emailSendInputSchema,
+          name: "email_send",
+          policy: emailSendPolicy(recipientAllowlist, options.policy),
+        }),
+      }
+    },
+  })
+}

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -22,6 +22,9 @@ export {
   fetch,
 } from "./fetch.ts"
 export {
+  email,
+} from "./email.ts"
+export {
   git,
 } from "./git.ts"
 export {
@@ -171,6 +174,10 @@ export type {
   FetchCapabilityToolOptions,
   FetchCapabilityToolRequest,
 } from "./fetch.ts"
+export type {
+  EmailCapabilityOptions,
+  EmailCapabilityToolPolicy,
+} from "./email.ts"
 export type {
   GitCapabilityOptions,
   GitCapabilityToolPolicy,

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from "node:fs"
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, rm, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 
 import { writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
@@ -39,6 +39,7 @@ const generatedAgentDenoServer = ".vitehub/agent/deno-server.ts"
 const generatedAgentDiscordGatewayRouteHandler = ".vitehub/agent/discord-gateway-route.ts"
 const generatedAgentWebhookRouteHandler = ".vitehub/agent/chat-webhook-route.ts"
 const generatedAgentNetlifyFunction = ".vitehub/agent/netlify-function.mjs"
+const generatedAgentEmailRuntime = ".vitehub/agent/email-runtime.js"
 const generatedAgentScheduleRegistry = ".vitehub/agent/schedule-registry.js"
 const netlifyAgentFunctionName = "vitehub-agent"
 const generatedScheduleRuntimeRegistrySuffix = "/.vitehub/nitro/schedule/runtime-registry.js"
@@ -125,6 +126,7 @@ interface GeneratedAgentRuntimeCapability {
 
 const generatedAgentRuntimeCapabilityDefinitions: GeneratedAgentRuntimeCapability[] = [
   { importName: "blob", name: "blob", packageName: "@vite-hub/blob", pluginName: "@vite-hub/blob/vite" },
+  { importName: "email", name: "email", packageName: "@vite-hub/email/server", pluginName: "@vite-hub/email/vite" },
   { importName: "kv", name: "kv", packageName: "@vite-hub/kv", pluginName: "@vite-hub/kv/vite" },
 ]
 
@@ -163,6 +165,36 @@ function generatedAgentRuntimeCapabilities(capabilities: GeneratedAgentRuntimeCa
   const entries = capabilities.map(capability => `${capability.name}: ${generatedAgentRuntimeCapabilityAlias(capability)}`)
   if (schedule) entries.push("schedule: { schedules: vitehubSchedules }")
   return `{ ${entries.join(", ")} }`
+}
+
+async function writeStandaloneAgentRuntimeCapabilities(
+  config: Pick<ResolvedConfig, "plugins" | "root">,
+  capabilities: GeneratedAgentRuntimeCapability[],
+): Promise<GeneratedAgentRuntimeCapability[]> {
+  const emailCapability = capabilities.find(capability => capability.name === "email")
+  const emailPlugin = config.plugins?.find(plugin => plugin.name === "@vite-hub/email/vite") as Plugin & {
+    api?: { getDefinition?: () => { handler: string } | undefined }
+  }
+  const definition = emailPlugin?.api?.getDefinition?.()
+  const runtimePath = join(config.root, generatedAgentEmailRuntime)
+  if (!emailCapability || !definition) {
+    await rm(runtimePath, { force: true })
+    return capabilities
+  }
+
+  const emailImport = emailCapability.packageName.endsWith("/server")
+    ? emailCapability.packageName.slice(0, -"/server".length)
+    : "@vite-hub/email"
+  await mkdir(dirname(runtimePath), { recursive: true })
+  await writeFile(runtimePath, [
+    `import { createEmail } from ${JSON.stringify(emailImport)}`,
+    `import definition from ${JSON.stringify(moduleImportSpecifier(runtimePath, definition.handler))}`,
+    "export const email = createEmail(definition)",
+    "",
+  ].join("\n"), "utf8")
+  return capabilities.map(capability => capability === emailCapability
+    ? { ...capability, packageName: "./email-runtime.js" }
+    : capability)
 }
 
 function getInternalAgentOptions(options: AgentModuleOptions | false | undefined): InternalAgentModuleOptions | undefined {
@@ -1382,6 +1414,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
   const frameworkOptions = getInternalAgentOptions(options)
   let agent: AgentModuleOptions | false | undefined = options
   let runtimeCapabilities: GeneratedAgentRuntimeCapability[] = []
+  let standaloneRuntimeCapabilities: GeneratedAgentRuntimeCapability[] = []
   let resolved: ResolvedConfig | undefined
 
   async function writeGeneratedAgentOutputs(config: ResolvedConfig) {
@@ -1393,7 +1426,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         await writeAgentDenoServer(config.root, {
           agentImportBase: getAgentImportBase(agent, frameworkOptions),
           chatRoute: normalized.routes.chat,
-          runtimeCapabilities,
+          runtimeCapabilities: standaloneRuntimeCapabilities,
           schedule,
           scheduleRuntimeImport: getScheduleRuntimeImport(agent, frameworkOptions),
           workflowImportBase: getWorkflowImportBase(agent, frameworkOptions),
@@ -1437,7 +1470,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
             libsqlState: resolveLibsqlAgentState(normalized),
             providerImportAliases: getProviderImportAliases(agent, frameworkOptions),
             runtime: "vite",
-            runtimeCapabilities,
+            runtimeCapabilities: standaloneRuntimeCapabilities,
             schedule,
             scheduleRuntimeImport: getScheduleRuntimeImport(agent, frameworkOptions),
             workflowImportBase: getWorkflowImportBase(agent, frameworkOptions),
@@ -1580,6 +1613,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         config,
         getInternalAgentOptions(agent)?.runtimeCapabilityImports ?? frameworkOptions?.runtimeCapabilityImports,
       )
+      standaloneRuntimeCapabilities = await writeStandaloneAgentRuntimeCapabilities(config, runtimeCapabilities)
       await writeGeneratedAgentOutputs(config)
       if (agent === false || agent?.eval === false) {
         return
@@ -1613,7 +1647,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
             agentImportBase: getAgentImportBase(agent, frameworkOptions),
             libsqlState: resolveLibsqlAgentState(normalized),
             providerImportAliases: getProviderImportAliases(agent, frameworkOptions),
-            runtimeCapabilities,
+            runtimeCapabilities: standaloneRuntimeCapabilities,
             schedule: hasScheduleVitePlugin(resolved),
             scheduleRuntimeImport: getScheduleRuntimeImport(agent, frameworkOptions),
             workflowImportBase: getWorkflowImportBase(agent, frameworkOptions),

--- a/packages/agent/test/email-capability.test.ts
+++ b/packages/agent/test/email-capability.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { resolveAgentCapabilities } from "../src/capability-runtime.ts"
+import { email } from "../src/capabilities.ts"
+import { applyAgentToolPolicies } from "../src/tool-runtime.ts"
+
+function runtime(capabilities: Record<string, unknown> = {}) {
+  return {
+    capabilities,
+    memo: vi.fn(),
+    runtime: "unknown" as const,
+    runtimeConfig: {},
+    waitUntil: vi.fn(),
+  }
+}
+
+async function resolveEmailTool(capabilities: Record<string, unknown>) {
+  const resolved = await resolveAgentCapabilities({
+    capabilities: [email({ from: "agent@example.com" })],
+  }, runtime(capabilities), {})
+  return resolved.tools!.email_send!
+}
+
+describe("email capability", () => {
+  it("defines one write tool backed by the Email primitive", () => {
+    const capability = email({
+      from: "agent@example.com",
+      policy: "require-approval",
+      recipients: ["owner@example.com"],
+    })
+
+    expect(capability).toMatchObject({
+      id: "email",
+      metadata: { recipients: ["owner@example.com"] },
+      mode: "write",
+      requires: [{ primitive: "email" }],
+    })
+    expect(() => email({ from: " " })).toThrow("email({ from }) must be a non-empty string")
+    expect(() => email({ from: "agent@example.com", recipients: "owner@example.com" as unknown as string[] })).toThrow("email({ recipients }) must be an array of non-empty email addresses")
+    expect(() => email({ from: "agent@example.com", recipients: [123] as unknown as string[] })).toThrow("email({ recipients }) must be an array of non-empty email addresses")
+    expect(() => email({ from: "agent@example.com", recipients: [" "] })).toThrow("email({ recipients }) must be an array of non-empty email addresses")
+    expect(() => email({ from: "agent@example.com", recipients: Array(1) as string[] })).toThrow("email({ recipients }) must be an array of non-empty email addresses")
+  })
+
+  it("sends a validated plain-text message and preserves the primitive result", async () => {
+    const send = vi.fn(async () => ({ driver: "memory", id: "memory-1" }))
+    const tool = await resolveEmailTool({ email: { kind: "email", value: { send } } })
+
+    expect(tool.name).toBe("email_send")
+    expect(tool.policy).toBeUndefined()
+    expect(tool.inputSchema).toMatchObject({
+      additionalProperties: false,
+      required: ["to", "subject", "text"],
+      type: "object",
+    })
+    await expect(tool.execute?.({
+      subject: "Weekly report",
+      text: "The report is ready.",
+      to: ["owner@example.com", "ops@example.com"],
+    })).resolves.toEqual({ driver: "memory", id: "memory-1" })
+    expect(send).toHaveBeenCalledWith({
+      from: "agent@example.com",
+      subject: "Weekly report",
+      text: "The report is ready.",
+      to: ["owner@example.com", "ops@example.com"],
+    })
+  })
+
+  it("accepts a plain runtime handle and forwards policy", async () => {
+    const send = vi.fn(async () => ({ driver: "memory", id: "memory-1" }))
+    const policy = vi.fn(() => "allow" as const)
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [email({ from: "agent@example.com", policy })],
+    }, runtime({ email: { send } }), {})
+
+    expect(resolved.tools!.email_send!.policy).toBe(policy)
+    await resolved.tools!.email_send!.execute?.({ subject: "Hello", text: "Hi", to: "you@example.com" })
+    expect(send).toHaveBeenCalledOnce()
+  })
+
+  it("enforces the recipient allowlist before user policy", async () => {
+    const send = vi.fn(async () => ({ driver: "memory", id: "memory-1" }))
+    const policy = vi.fn(() => "allow" as const)
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [email({
+        from: "agent@example.com",
+        policy,
+        recipients: ["owner@example.com", "ops@example.com"],
+      })],
+    }, runtime({ email: { send } }), {})
+    const tool = applyAgentToolPolicies({ email_send: resolved.tools!.email_send! })!.email_send!
+
+    expect(tool.description).toContain('Allowed recipients: ["owner@example.com","ops@example.com"].')
+
+    await expect(tool.execute?.({
+      subject: "Hello",
+      text: "Hi",
+      to: [" OWNER@example.com ", "ops@example.com"],
+    })).resolves.toEqual({ driver: "memory", id: "memory-1" })
+    expect(send).toHaveBeenLastCalledWith({
+      from: "agent@example.com",
+      subject: "Hello",
+      text: "Hi",
+      to: [" OWNER@example.com ", "ops@example.com"],
+    })
+    expect(policy).toHaveBeenCalledOnce()
+
+    await expect(tool.execute?.({
+      subject: "Hello",
+      text: "Hi",
+      to: ["owner@example.com", "other@example.com"],
+    })).rejects.toMatchObject({ name: "CapabilityDeniedError" })
+    await expect(tool.execute?.({
+      subject: "Hello",
+      text: "Hi",
+      to: Array(1) as string[],
+    })).rejects.toMatchObject({ name: "CapabilityDeniedError" })
+    expect(send).toHaveBeenCalledOnce()
+    expect(policy).toHaveBeenCalledOnce()
+  })
+
+  it("treats an empty recipient allowlist as deny-all", async () => {
+    const send = vi.fn()
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [email({ from: "agent@example.com", policy: "allow", recipients: [] })],
+    }, runtime({ email: { send } }), {})
+    const tool = applyAgentToolPolicies({ email_send: resolved.tools!.email_send! })!.email_send!
+
+    expect(tool.description).toContain("Sending is disabled because the configured recipient allowlist is empty.")
+    await expect(tool.execute?.({ subject: "Hello", text: "Hi", to: "owner@example.com" })).rejects.toMatchObject({ name: "CapabilityDeniedError" })
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it("preserves approval policy after the recipient allowlist", async () => {
+    const send = vi.fn()
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [email({
+        from: "agent@example.com",
+        policy: "require-approval",
+        recipients: ["owner@example.com"],
+      })],
+    }, runtime({ email: { send } }), {})
+    const tool = applyAgentToolPolicies({ email_send: resolved.tools!.email_send! })!.email_send!
+
+    await expect(tool.execute?.({ subject: "Hello", text: "Hi", to: "owner@example.com" })).rejects.toMatchObject({ name: "ApprovalRequiredError" })
+    await expect(tool.execute?.({ subject: "Hello", text: "Hi", to: "other@example.com" })).rejects.toMatchObject({ name: "CapabilityDeniedError" })
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it("rejects invalid tool input before delivery", async () => {
+    const send = vi.fn()
+    const tool = await resolveEmailTool({ email: { send } })
+
+    await expect(tool.execute?.({ subject: "Hello", text: "Hi", to: [] })).rejects.toThrow("email_send to")
+    await expect(tool.execute?.({ subject: "Hello", text: "Hi", to: ["you@example.com", " "] })).rejects.toThrow("email_send to")
+    await expect(tool.execute?.({ subject: "Hello", text: "Hi", to: Array(1) as string[] })).rejects.toThrow("email_send to")
+    await expect(tool.execute?.({ subject: " ", text: "Hi", to: "you@example.com" })).rejects.toThrow("email_send subject")
+    await expect(tool.execute?.({ subject: "Hello", text: " ", to: "you@example.com" })).rejects.toThrow("email_send text")
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it("keeps the allowlist boundary when tools are called without runtime policy wrapping", async () => {
+    const send = vi.fn()
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [email({ from: "agent@example.com", recipients: ["owner@example.com"] })],
+    }, runtime({ email: { send } }), {})
+
+    await expect(resolved.tools!.email_send!.execute?.({
+      subject: "Hello",
+      text: "Hi",
+      to: "owner+tag@example.com",
+    })).rejects.toThrow("recipient is outside the configured allowlist")
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it("treats display-name forms as distinct recipient strings", async () => {
+    const send = vi.fn(async () => ({ id: "message-1" }))
+    const bare = await resolveAgentCapabilities({
+      capabilities: [email({ from: "agent@example.com", recipients: ["owner@example.com"] })],
+    }, runtime({ email: { send } }), {})
+
+    await expect(bare.tools!.email_send!.execute?.({
+      subject: "Hello",
+      text: "Hi",
+      to: "Owner <owner@example.com>",
+    })).rejects.toThrow("recipient is outside the configured allowlist")
+
+    const display = await resolveAgentCapabilities({
+      capabilities: [email({ from: "agent@example.com", recipients: ["Owner <owner@example.com>"] })],
+    }, runtime({ email: { send } }), {})
+    await expect(display.tools!.email_send!.execute?.({
+      subject: "Hello",
+      text: "Hi",
+      to: "owner <OWNER@example.com>",
+    })).resolves.toEqual({ id: "message-1" })
+    expect(send).toHaveBeenCalledOnce()
+  })
+
+  it("requires an Email client and preserves delivery errors", async () => {
+    await expect(resolveEmailTool({})).rejects.toThrow('Capability "email" requires the email primitive to be configured.')
+    await expect(resolveEmailTool({ email: {} })).rejects.toThrow("email primitive must expose send()")
+
+    const error = new Error("safe delivery failure")
+    const tool = await resolveEmailTool({ email: { send: vi.fn(async () => { throw error }) } })
+    await expect(tool.execute?.({ subject: "Hello", text: "Hi", to: "you@example.com" })).rejects.toBe(error)
+  })
+})

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -242,7 +242,7 @@ describe("agent Vite plugin", () => {
       await configResolved({
         command: "serve",
         createResolver: () => async id => `/app/node_modules/${id}`,
-        plugins: [{ name: "@vite-hub/blob/vite" }, { name: "@vite-hub/kv/vite" }],
+        plugins: [{ name: "@vite-hub/blob/vite" }, { name: "@vite-hub/email/vite" }, { name: "@vite-hub/kv/vite" }],
         root,
       })
 
@@ -251,9 +251,10 @@ describe("agent Vite plugin", () => {
 
       expect(registry).toContain("defineScheduledAgentTarget")
       expect(registry).toContain('import { blob as vitehubBlob } from "@vite-hub/blob"')
+      expect(registry).toContain('import { email as vitehubEmail } from "@vite-hub/email/server"')
       expect(registry).toContain('import { kv as vitehubKv } from "@vite-hub/kv"')
       expect(registry).toContain('import { schedules as vitehubSchedules } from "@vite-hub/schedule/runtime"')
-      expect(registry).toContain('{ agentIdentity: {"name":"digest"}, capabilities: { blob: vitehubBlob, kv: vitehubKv, schedule: { schedules: vitehubSchedules } } }')
+      expect(registry).toContain('{ agentIdentity: {"name":"digest"}, capabilities: { blob: vitehubBlob, email: vitehubEmail, kv: vitehubKv, schedule: { schedules: vitehubSchedules } } }')
       expect(registry).toContain('registry["agent/digest"]')
       expect(registry).not.toContain("withAgentDefaults")
       expect(registry).toContain('registry["agent/support"]')
@@ -272,6 +273,7 @@ describe("agent Vite plugin", () => {
         importBase: "vite-hub/_internal/agent",
         runtimeCapabilityImports: {
           blob: "vite-hub/_internal/blob",
+          email: "vite-hub/email/server",
           kv: "vite-hub/_internal/kv",
         },
         workflowImportBase: "vite-hub/_internal/workflow",
@@ -286,14 +288,15 @@ describe("agent Vite plugin", () => {
       const filteredTransform = filteredPlugin.transform as typeof transform
       await filteredConfigResolved({
         command: "serve",
-        createResolver: () => async id => id === "vite-hub/_internal/kv" ? `/app/node_modules/${id}` : undefined,
-        plugins: [{ name: "@vite-hub/blob/vite" }, { name: "@vite-hub/kv/vite" }],
+        createResolver: () => async id => id === "vite-hub/email/server" || id === "vite-hub/_internal/kv" ? `/app/node_modules/${id}` : undefined,
+        plugins: [{ name: "@vite-hub/blob/vite" }, { name: "@vite-hub/email/vite" }, { name: "@vite-hub/kv/vite" }],
         root,
       })
       const filteredRegistry = await filteredTransform("const registry = {}\nexport default registry\n", "\0#vitehub/schedule/registry")
       expect(filteredRegistry).not.toContain('vite-hub/_internal/blob')
+      expect(filteredRegistry).toContain('import { email as vitehubEmail } from "vite-hub/email/server"')
       expect(filteredRegistry).toContain('import { kv as vitehubKv } from "vite-hub/_internal/kv"')
-      expect(filteredRegistry).toContain('{ agentIdentity: {"name":"digest"}, capabilities: { kv: vitehubKv, schedule: { schedules: vitehubSchedules } } }')
+      expect(filteredRegistry).toContain('{ agentIdentity: {"name":"digest"}, capabilities: { email: vitehubEmail, kv: vitehubKv, schedule: { schedules: vitehubSchedules } } }')
       expect(filteredRegistry).toContain('import { setAgentWorkflowRuntimeLoaders as vitehubSetAgentWorkflowRuntimeLoaders } from "vite-hub/_internal/agent/server/internal"')
       expect(filteredRegistry).toContain('workflow: () => import("vite-hub/_internal/workflow")')
       expect(filteredRegistry).toContain('import { setWorkspaceDependencyRuntimeLoaders as vitehubSetWorkspaceDependencyRuntimeLoaders } from "vite-hub/_internal/workspace/runtime"')
@@ -755,6 +758,59 @@ describe("agent Vite plugin", () => {
       expect(netlifyFunction).toContain('import vitehubAgentScheduleRegistry from "./schedule-registry.js"')
       expect(netlifyFunction).toContain("vitehubSetScheduleRuntimeRegistry(vitehubAgentScheduleRegistry)")
       expect(netlifyFunction).toContain("capabilities: vitehubAgentRouteCapabilities")
+    }
+    finally {
+      if (typeof previousHosting === "string") process.env.VITEHUB_HOSTING = previousHosting
+      else delete process.env.VITEHUB_HOSTING
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("embeds the discovered Email definition in standalone Agent provider outputs", async () => {
+    const { hubEmail } = await import("../../email/src/vite.ts")
+    const { hubAgent } = await import("../src/vite.ts")
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-email-provider-routes-"))
+    const previousHosting = process.env.VITEHUB_HOSTING
+    try {
+      await mkdir(join(root, "server", "agents"), { recursive: true })
+      await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+      await writeFile(join(root, "server", "email.ts"), "export default { driver: {} }", "utf8")
+      const emailPlugin = hubEmail()
+      if (typeof emailPlugin.configResolved === "function") {
+        await emailPlugin.configResolved.call({} as never, { root } as never)
+      }
+
+      const denoPlugin = hubAgent({ runtime: "deno" })
+      if (typeof denoPlugin.configResolved === "function") {
+        await denoPlugin.configResolved.call({} as never, {
+          command: "build",
+          plugins: [emailPlugin],
+          root,
+        } as never)
+      }
+      const emailRuntime = await readFile(join(root, ".vitehub/agent/email-runtime.js"), "utf8")
+      const denoServer = await readFile(join(root, ".vitehub/agent/deno-server.ts"), "utf8")
+      expect(emailRuntime).toContain('import { createEmail } from "@vite-hub/email"')
+      expect(emailRuntime).toContain('import definition from "../../server/email.ts"')
+      expect(emailRuntime).toContain("export const email = createEmail(definition)")
+      expect(denoServer).toContain('import { email as vitehubEmail } from "./email-runtime.js"')
+
+      process.env.VITEHUB_HOSTING = "netlify"
+      const netlifyPlugin = hubAgent()
+      if (typeof netlifyPlugin.configResolved === "function") {
+        await netlifyPlugin.configResolved.call({} as never, {
+          build: { outDir: "dist/client" },
+          command: "build",
+          plugins: [emailPlugin],
+          resolve: { alias: [] },
+          root,
+        } as never)
+      }
+      if (typeof netlifyPlugin.closeBundle === "object" && netlifyPlugin.closeBundle?.handler) {
+        await netlifyPlugin.closeBundle.handler.call({} as never)
+      }
+      const netlifyFunction = await readFile(join(root, ".vitehub/agent/netlify-function.mjs"), "utf8")
+      expect(netlifyFunction).toContain('import { email as vitehubEmail } from "./email-runtime.js"')
     }
     finally {
       if (typeof previousHosting === "string") process.env.VITEHUB_HOSTING = previousHosting

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
-import { access, blob, browser, chat, chatTitle, db, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, browser, chat, chatTitle, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -26,6 +26,21 @@ declare global {
 }
 
 describe("agent public types", () => {
+  it("types the Email capability as one explicit send grant", () => {
+    const policy: EmailCapabilityToolPolicy = "require-approval"
+    const options = { from: "agent@example.com", policy, recipients: ["owner@example.com"] as const } satisfies EmailCapabilityOptions
+
+    expectTypeOf(email(options)).toMatchTypeOf<AgentCapabilityDefinition>()
+    // @ts-expect-error Email requires an application-owned sender.
+    email({})
+    // @ts-expect-error Email has no read mode.
+    email({ from: "agent@example.com", mode: "read" })
+    // @ts-expect-error Email recipients must be an array.
+    email({ from: "agent@example.com", recipients: "owner@example.com" })
+    // @ts-expect-error Email recipient entries must be strings.
+    email({ from: "agent@example.com", recipients: [123] })
+  })
+
   it("accepts literal false as the inline runtime opt-out", () => {
     const agent = defineAgent({
       driver: { run: () => "ok" },

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -64,6 +64,10 @@ const result = await email.send({
 
 A successful send returns `{ id, driver: "smtp" }`; the provider supplies `id`. Invalid messages and delivery failures throw `EmailError` with a stable `code`. SMTP and core-wrapped provider failures keep the raw failure in `cause` while exposing a safe message. Custom drivers must follow the same rule when they throw `EmailError` directly.
 
+## Grant an Agent permission to send
+
+The official [`email()` Agent Capability](https://vitehub.dev/docs/capabilities/email) exposes one policy-controlled plain-text send tool through the discovered Email Definition. The application fixes the sender and keeps provider credentials below the Capability boundary; richer messages remain application-owned compositions.
+
 ## Compose dynamic Markdown
 
 `renderEmailMarkdown()` resolves `@vite-hub/markdown-template` data, conditions, fragments, and caller-provided imports before Comark renders the HTML body.

--- a/packages/vite-hub/README.md
+++ b/packages/vite-hub/README.md
@@ -20,11 +20,12 @@ export default defineConfig({
 })
 ```
 
-The default preset composes Agent, Blob, Database, DevTools, Env, Workflow, and Workspace. KV, Queue, Sandbox, Schedule, and Auth stay opt-in:
+The default preset composes Agent, Blob, Database, DevTools, Env, Workflow, and Workspace. Email, KV, Queue, Sandbox, Schedule, and Auth stay opt-in:
 
 ```ts
 vitehub({
   auth: true,
+  email: true,
   kv: true,
   queue: true,
   sandbox: true,

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -193,6 +193,7 @@ export function vitehub(options: ViteHubPresetOptions = {}): PluginOption[] {
       providerImportAliases,
       runtimeCapabilityImports: {
         blob: `${generatedImportBase}/blob`,
+        email: "vite-hub/email/server",
         kv: `${generatedImportBase}/kv`,
       },
       scheduleRuntimeImport: `${generatedImportBase}/schedule/runtime`,

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -24,6 +24,7 @@ describe("framework package contract", () => {
 
   it("forwards feature APIs from their owner packages", () => {
     expect(frameworkAgent.defineAgent).toBe(ownerAgent.defineAgent)
+    expect(frameworkCapabilities.email).toBe(ownerCapabilities.email)
     expect(frameworkCapabilities.workspaceShell).toBe(ownerCapabilities.workspaceShell)
     expect(frameworkAuthHandler).toBe(ownerAuthHandler)
   })

--- a/packages/vite-hub/test/types.test-d.ts
+++ b/packages/vite-hub/test/types.test-d.ts
@@ -2,12 +2,14 @@ import { expectTypeOf } from "vitest"
 
 import { vitehub } from "vite-hub"
 import { defineAgent } from "vite-hub/agent"
+import { email } from "vite-hub/agent/capabilities"
 import { env } from "vite-hub/env"
 import { defineWorkflow } from "vite-hub/workflow"
 import { defineWorkspace } from "vite-hub/workspace"
 
 expectTypeOf(vitehub).toBeFunction()
 expectTypeOf(defineAgent).toBeFunction()
+expectTypeOf(email).toBeFunction()
 expectTypeOf(env).toBeFunction()
 expectTypeOf(defineWorkspace).toBeFunction()
 expectTypeOf(defineWorkflow).toBeFunction()

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -99,6 +99,7 @@ describe("vitehub", () => {
       },
       runtimeCapabilityImports: {
         blob: "vite-hub/_internal/blob",
+        email: "vite-hub/email/server",
         kv: "vite-hub/_internal/kv",
       },
       scheduleRuntimeImport: "vite-hub/_internal/schedule/runtime",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       '@vite-hub/devtools':
         specifier: workspace:*
         version: link:../devtools
+      '@vite-hub/email':
+        specifier: workspace:*
+        version: link:../email
       '@vite-hub/markdown-template':
         specifier: workspace:*
         version: link:../markdown-template


### PR DESCRIPTION
Adds the official `email()` Agent Capability with one policy-aware `email_send` tool for plain-text delivery through the discovered Email primitive. The application fixes the sender and can scope exact recipients with a hard `recipients` allowlist before applying approval policy; the model supplies only recipients, subject, and text, and provider configuration stays behind `@vite-hub/email`. The Capability forwards the existing acceptance result and delivery errors without automatic retries.

Generated Agent routes receive the Email runtime handle when the opt-in Email integration is active, including through the `vite-hub` distribution. Focused runtime, allowlist, generated-route, export, and type coverage lock the public contract, while the guide documents safe setup, recipient authorization and visibility, provider-owned limits and costs, delivery uncertainty, inspection, and the Dynamic Markdown trust boundary.
