### PR TITLE
feat(agent): add async transcription client

### DIFF
--- a/docs/content/docs/capabilities/transcribe.md
+++ b/docs/content/docs/capabilities/transcribe.md
@@ -59,10 +59,49 @@ transcribe({
 })
 ```
 
+## Asynchronous remote transcription
+
+Use `createTranscription()` when a durable workflow should submit a private remote object and resume after the provider completes it.
+The client returns the provider operation ID used for acknowledgement and idempotency, then normalizes an authenticated completion payload into a provider-neutral transcript or failure.
+
+```ts
+import {
+  createTranscription,
+  elevenLabsScribe,
+} from '@vite-hub/agent/capabilities'
+
+const transcription = createTranscription({
+  driver: elevenLabsScribe({
+    apiKey: () => env.ELEVENLABS_API_KEY,
+    diarize: true,
+    tagAudioEvents: true,
+    timestampsGranularity: 'word',
+    webhookId: env.ELEVENLABS_WEBHOOK_ID,
+  }),
+})
+
+const submission = await transcription.submit({
+  metadata: { attemptId, jobId },
+  source: { url: signedAudioUrl },
+})
+
+const completion = await transcription.receive(authenticatedProviderPayload)
+```
+
+`submit()` never downloads the remote object into the application process.
+Use a signed HTTPS URL for private Blob objects, with an expiry long enough for the provider to fetch it.
+
+The caller still owns callback authentication before `receive()`, durable operation state, duplicate-delivery handling, timeouts, and workflow resumption.
+Compose those concerns with the Workflow primitive; correlation metadata is untrusted until it matches the stored workflow attempt.
+Provider callback payloads and SDK types do not cross the transcription client interface.
+
 ## Requirements
 
 Basic transcription requires a model or custom executor.
 Artifact persistence requires an explicit writable Workspace.
+
+Asynchronous remote transcription requires a `TranscriptionDriver`.
+The built-in ElevenLabs Scribe driver requires an API key and an explicitly configured speech-to-text webhook ID.
 
 Audio data must stay within `maxBytes`.
 Artifact paths must stay inside the Workspace and cannot target reserved `.git` or `.vitehub` paths.
@@ -74,6 +113,8 @@ Artifact paths must stay inside the Workspace and cannot target reserved `.git` 
 | Model-backed | Receives text-enriched messages after transcription. |
 | Harness-backed | Receives text-enriched Agent Run Input before harness execution. |
 | Custom-run-backed | Receives text-enriched Agent Run Input and can read transcription results from context. |
+
+Asynchronous transcription is independent of the Agent Driver because the caller composes its submitted operation and completion result into a durable Workflow.
 
 ## Inspect and verify
 
@@ -98,6 +139,15 @@ When artifacts are enabled, inspect the Workspace for transcript files and the f
 | `artifacts.audio` | `boolean \| object` | disabled | Persist source audio artifacts to Workspace. |
 | `artifacts.audio.path` | `string \| function` | generated | Audio artifact path. |
 | `artifacts.audio.mediaType` | `string \| function` | audio media type | Audio artifact media type. |
+
+### Asynchronous client
+
+| Interface | Result | Description |
+| --- | --- | --- |
+| `createTranscription({ driver })` | `TranscriptionClient` | Creates a provider-neutral asynchronous client. |
+| `client.submit({ source, metadata, abortSignal })` | `submitted` operation | Submits a remote HTTP(S) source and returns the provider operation ID. |
+| `client.receive(payload)` | `completed \| failed` completion | Normalizes an already-authenticated provider completion payload. |
+| `elevenLabsScribe(options)` | `TranscriptionDriver` | Maps remote Scribe v2 submission and callback payloads without exposing provider types. |
 
 ## Reference
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -138,6 +138,7 @@ Pass `--json` for the structured inspection contract.
 - `openapi()` turns an allowed OpenAPI `operationId` subset into bounded HTTP tools, or into a generated Capability CLI when `cli` is set.
 - `papercuts()` lets an Agent report small runtime and developer-experience friction to an application-owned sink, with an optional Capability CLI command.
 - `transcribe()` uses the [AI SDK transcription API](https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/transcribe).
+- `createTranscription()` composes remote asynchronous submission and completion through a provider-neutral driver; `elevenLabsScribe()` is the built-in Scribe v2 adapter.
 - `mcp()` connects tools from [Model Context Protocol](https://modelcontextprotocol.io/) servers through `@ai-sdk/mcp`.
 - `kv()`, `blob()`, and `db()` expose [`@vite-hub/kv`](../kv/README.md), [`@vite-hub/blob`](../blob/README.md), and [`@vite-hub/database`](../database/README.md).
 - `sandbox()` and `schedule()` expose [`@vite-hub/sandbox`](../sandbox/README.md) and [`@vite-hub/schedule`](../schedule/README.md).

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -74,6 +74,13 @@ export {
   transcribe,
 } from "./transcribe.ts"
 export {
+  createTranscription,
+  TranscriptionError,
+} from "./transcription.ts"
+export {
+  elevenLabsScribe,
+} from "./transcription-elevenlabs.ts"
+export {
   workspaceShell,
 } from "./workspace-shell.ts"
 export type {
@@ -292,6 +299,25 @@ export type {
   TranscribeTranscriptArtifactOptions,
   TranscriptionResult,
 } from "./transcribe.ts"
+export type {
+  CreateTranscriptionOptions,
+  TranscriptionClient,
+  TranscriptionCompletion,
+  TranscriptionDriver,
+  TranscriptionDriverCompletion,
+  TranscriptionDriverSubmission,
+  TranscriptionErrorCode,
+  TranscriptionErrorOptions,
+  TranscriptionMetadata,
+  TranscriptionSource,
+  TranscriptionSubmission,
+  TranscriptionSubmitInput,
+  TranscriptionTranscript,
+  TranscriptionWord,
+} from "./transcription.ts"
+export type {
+  ElevenLabsScribeOptions,
+} from "./transcription-elevenlabs.ts"
 export type {
   BlobCapabilityOptions,
 } from "./storage/blob.ts"

--- a/packages/agent/src/capabilities/transcription-elevenlabs.ts
+++ b/packages/agent/src/capabilities/transcription-elevenlabs.ts
@@ -68,7 +68,7 @@ function assertOptions(options: ElevenLabsScribeOptions): void {
 }
 
 function mapWord(value: ElevenLabsWord): TranscriptionWord | undefined {
-  if (!nonEmptyString(value.text) || !nonEmptyString(value.type)) return
+  if (typeof value.text !== "string" || !nonEmptyString(value.type)) return
   return {
     ...(typeof value.channel_index === "number" && Number.isFinite(value.channel_index) ? { channel: value.channel_index } : {}),
     ...(typeof value.end === "number" && Number.isFinite(value.end) ? { end: value.end } : {}),

--- a/packages/agent/src/capabilities/transcription-elevenlabs.ts
+++ b/packages/agent/src/capabilities/transcription-elevenlabs.ts
@@ -1,0 +1,201 @@
+import { TranscriptionError } from "./transcription.ts"
+
+import type {
+  TranscriptionDriver,
+  TranscriptionDriverCompletion,
+  TranscriptionMetadata,
+  TranscriptionSubmitInput,
+  TranscriptionTranscript,
+  TranscriptionWord,
+} from "./transcription.ts"
+import type { MaybePromise } from "../types.ts"
+
+type Fetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+type ElevenLabsModel = "scribe_v1" | "scribe_v2"
+type TimestampGranularity = "character" | "none" | "word"
+
+export interface ElevenLabsScribeOptions {
+  apiKey: string | (() => MaybePromise<string>)
+  diarize?: boolean
+  fetch?: Fetch
+  model?: ElevenLabsModel
+  noVerbatim?: boolean
+  tagAudioEvents?: boolean
+  timestampsGranularity?: TimestampGranularity
+  webhookId: string
+}
+
+interface ElevenLabsWord {
+  channel_index?: unknown
+  end?: unknown
+  speaker_id?: unknown
+  start?: unknown
+  text?: unknown
+  type?: unknown
+}
+
+interface ElevenLabsTranscript {
+  language_code?: unknown
+  language_probability?: unknown
+  text?: unknown
+  words?: unknown
+}
+
+interface ElevenLabsWebhookEvent {
+  data?: {
+    error?: unknown
+    request_id?: unknown
+    transcription?: unknown
+    webhook_metadata?: unknown
+  }
+  type?: unknown
+}
+
+const endpoint = "https://api.elevenlabs.io/v1/speech-to-text"
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0
+}
+
+function assertOptions(options: ElevenLabsScribeOptions): void {
+  if (!options || typeof options !== "object") throw new TypeError("[vitehub] elevenLabsScribe() requires options.")
+  if (typeof options.apiKey !== "string" && typeof options.apiKey !== "function") {
+    throw new TypeError("[vitehub] elevenLabsScribe({ apiKey }) requires a string or resolver.")
+  }
+  if (!nonEmptyString(options.webhookId)) {
+    throw new TypeError("[vitehub] elevenLabsScribe({ webhookId }) requires a non-empty webhook id.")
+  }
+}
+
+function mapWord(value: ElevenLabsWord): TranscriptionWord | undefined {
+  if (!nonEmptyString(value.text) || !nonEmptyString(value.type)) return
+  return {
+    ...(typeof value.channel_index === "number" && Number.isFinite(value.channel_index) ? { channel: value.channel_index } : {}),
+    ...(typeof value.end === "number" && Number.isFinite(value.end) ? { end: value.end } : {}),
+    ...(nonEmptyString(value.speaker_id) ? { speaker: value.speaker_id } : {}),
+    ...(typeof value.start === "number" && Number.isFinite(value.start) ? { start: value.start } : {}),
+    text: value.text,
+    type: value.type,
+  }
+}
+
+function mapTranscript(value: unknown): TranscriptionTranscript {
+  if (!value || typeof value !== "object") {
+    throw new TranscriptionError("invalid-payload", "[vitehub] ElevenLabs returned an invalid transcript.", { provider: "elevenlabs" })
+  }
+  const transcript = value as ElevenLabsTranscript
+  if (typeof transcript.text !== "string") {
+    throw new TranscriptionError("invalid-payload", "[vitehub] ElevenLabs returned a transcript without text.", { provider: "elevenlabs" })
+  }
+  const words = Array.isArray(transcript.words)
+    ? transcript.words.map(word => mapWord(word as ElevenLabsWord)).filter((word): word is TranscriptionWord => Boolean(word))
+    : undefined
+  return {
+    ...(nonEmptyString(transcript.language_code) ? { language: transcript.language_code } : {}),
+    ...(typeof transcript.language_probability === "number" && Number.isFinite(transcript.language_probability)
+      ? { languageConfidence: transcript.language_probability }
+      : {}),
+    text: transcript.text,
+    ...(words ? { words } : {}),
+  }
+}
+
+function mapMetadata(value: unknown): TranscriptionMetadata | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as TranscriptionMetadata
+    : undefined
+}
+
+function receive(payload: unknown): TranscriptionDriverCompletion {
+  if (!payload || typeof payload !== "object") {
+    throw new TranscriptionError("invalid-payload", "[vitehub] ElevenLabs completion must be an object.", { provider: "elevenlabs" })
+  }
+  const event = payload as ElevenLabsWebhookEvent
+  if (event.type !== "speech_to_text_transcription" || !nonEmptyString(event.data?.request_id)) {
+    throw new TranscriptionError("invalid-payload", "[vitehub] ElevenLabs completion is missing its type or request id.", { provider: "elevenlabs" })
+  }
+  const metadata = mapMetadata(event.data.webhook_metadata)
+  if (event.data.transcription) {
+    return {
+      id: event.data.request_id,
+      ...(metadata ? { metadata } : {}),
+      status: "completed",
+      transcript: mapTranscript(event.data.transcription),
+    }
+  }
+  return {
+    error: nonEmptyString(event.data.error) ? event.data.error : "ElevenLabs returned no transcription.",
+    id: event.data.request_id,
+    ...(metadata ? { metadata } : {}),
+    status: "failed",
+  }
+}
+
+function errorDetail(value: { detail?: unknown } | undefined, statusText: string): string {
+  if (typeof value?.detail === "string") return value.detail
+  if (value?.detail) return JSON.stringify(value.detail)
+  return statusText || "unknown provider error"
+}
+
+function errorCode(status: number): "authentication" | "invalid-request" | "provider" | "rate-limit" {
+  if (status === 401 || status === 403) return "authentication"
+  if (status === 429) return "rate-limit"
+  if (status >= 400 && status < 500) return "invalid-request"
+  return "provider"
+}
+
+async function resolveApiKey(value: ElevenLabsScribeOptions["apiKey"]): Promise<string> {
+  const apiKey = typeof value === "function" ? await value() : value
+  if (!nonEmptyString(apiKey)) {
+    throw new TranscriptionError("authentication", "[vitehub] ElevenLabs API key resolver returned an empty value.", { provider: "elevenlabs" })
+  }
+  return apiKey
+}
+
+export function elevenLabsScribe(options: ElevenLabsScribeOptions): TranscriptionDriver {
+  assertOptions(options)
+  const request = options.fetch || globalThis.fetch
+  return {
+    name: "elevenlabs",
+    receive,
+    async submit(input: TranscriptionSubmitInput) {
+      const form = new FormData()
+      form.set("model_id", options.model || "scribe_v2")
+      form.set("source_url", input.source.url)
+      form.set("webhook", "true")
+      form.set("webhook_id", options.webhookId)
+      if (input.metadata) form.set("webhook_metadata", JSON.stringify(input.metadata))
+      if (options.diarize !== undefined) form.set("diarize", String(options.diarize))
+      if (options.noVerbatim !== undefined) form.set("no_verbatim", String(options.noVerbatim))
+      if (options.tagAudioEvents !== undefined) form.set("tag_audio_events", String(options.tagAudioEvents))
+      if (options.timestampsGranularity) form.set("timestamps_granularity", options.timestampsGranularity)
+
+      let response: Response
+      try {
+        response = await request(endpoint, {
+          body: form,
+          headers: { "xi-api-key": await resolveApiKey(options.apiKey) },
+          method: "POST",
+          signal: input.abortSignal,
+        })
+      }
+      catch (cause) {
+        if (cause instanceof TranscriptionError) throw cause
+        throw new TranscriptionError("network", "[vitehub] ElevenLabs transcription request failed.", {
+          cause,
+          provider: "elevenlabs",
+        })
+      }
+      const body = await response.json().catch(() => undefined) as { detail?: unknown, request_id?: unknown } | undefined
+      if (!response.ok) {
+        throw new TranscriptionError(errorCode(response.status), `[vitehub] ElevenLabs rejected the transcription request (${response.status}): ${errorDetail(body, response.statusText)}`, {
+          provider: "elevenlabs",
+        })
+      }
+      if (!nonEmptyString(body?.request_id)) {
+        throw new TranscriptionError("provider", "[vitehub] ElevenLabs returned no transcription request id.", { provider: "elevenlabs" })
+      }
+      return { id: body.request_id }
+    },
+  }
+}

--- a/packages/agent/src/capabilities/transcription.ts
+++ b/packages/agent/src/capabilities/transcription.ts
@@ -1,0 +1,204 @@
+import type { MaybePromise } from "../types.ts"
+
+export type TranscriptionErrorCode = "authentication" | "invalid-payload" | "invalid-request" | "network" | "provider" | "rate-limit"
+export type TranscriptionMetadata = Readonly<Record<string, unknown>>
+
+export interface TranscriptionSource {
+  mediaType?: string
+  name?: string
+  url: string
+}
+
+export interface TranscriptionWord {
+  channel?: number
+  end?: number
+  speaker?: string
+  start?: number
+  text: string
+  type: string
+}
+
+export interface TranscriptionTranscript {
+  language?: string
+  languageConfidence?: number
+  text: string
+  words?: readonly TranscriptionWord[]
+}
+
+export interface TranscriptionSubmitInput {
+  abortSignal?: AbortSignal
+  metadata?: TranscriptionMetadata
+  source: TranscriptionSource
+}
+
+export interface TranscriptionDriverSubmission {
+  id: string
+}
+
+export type TranscriptionDriverCompletion =
+  | {
+    error: string
+    id: string
+    metadata?: TranscriptionMetadata
+    status: "failed"
+  }
+  | {
+    id: string
+    metadata?: TranscriptionMetadata
+    status: "completed"
+    transcript: TranscriptionTranscript
+  }
+
+export interface TranscriptionDriver {
+  name: string
+  receive: (payload: unknown) => MaybePromise<TranscriptionDriverCompletion>
+  submit: (input: TranscriptionSubmitInput) => MaybePromise<TranscriptionDriverSubmission>
+}
+
+export interface TranscriptionSubmission extends TranscriptionDriverSubmission {
+  provider: string
+  status: "submitted"
+}
+
+export type TranscriptionCompletion =
+  | (Extract<TranscriptionDriverCompletion, { status: "failed" }> & { provider: string })
+  | (Extract<TranscriptionDriverCompletion, { status: "completed" }> & { provider: string })
+
+export interface TranscriptionClient {
+  receive: (payload: unknown) => Promise<TranscriptionCompletion>
+  submit: (input: TranscriptionSubmitInput) => Promise<TranscriptionSubmission>
+}
+
+export interface CreateTranscriptionOptions {
+  driver: TranscriptionDriver
+}
+
+export interface TranscriptionErrorOptions {
+  cause?: unknown
+  provider?: string
+}
+
+export class TranscriptionError extends Error {
+  readonly code: TranscriptionErrorCode
+  readonly provider?: string
+
+  constructor(code: TranscriptionErrorCode, message: string, options: TranscriptionErrorOptions = {}) {
+    super(message, { cause: options.cause })
+    this.name = "TranscriptionError"
+    this.code = code
+    this.provider = options.provider
+  }
+}
+
+function assertDriver(driver: unknown): asserts driver is TranscriptionDriver {
+  if (!driver || typeof driver !== "object") throw new TypeError("[vitehub] Transcription driver must be an object.")
+  const value = driver as Partial<TranscriptionDriver>
+  if (typeof value.name !== "string" || !value.name.trim()) {
+    throw new TypeError("[vitehub] Transcription driver name must be a non-empty string.")
+  }
+  if (typeof value.submit !== "function") throw new TypeError("[vitehub] Transcription driver submit must be a function.")
+  if (typeof value.receive !== "function") throw new TypeError("[vitehub] Transcription driver receive must be a function.")
+}
+
+function assertMetadata(metadata: unknown, field: string): asserts metadata is TranscriptionMetadata | undefined {
+  if (metadata === undefined) return
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new TranscriptionError("invalid-payload", `[vitehub] ${field} must be an object.`)
+  }
+}
+
+function normalizeSource(source: TranscriptionSource | undefined): TranscriptionSource {
+  if (!source || typeof source !== "object") {
+    throw new TranscriptionError("invalid-request", "[vitehub] Transcription source must be an object.")
+  }
+  if (typeof source.url !== "string" || !source.url.trim()) {
+    throw new TranscriptionError("invalid-request", "[vitehub] Transcription source.url must be a non-empty URL.")
+  }
+  let url: URL
+  try {
+    url = new URL(source.url)
+  }
+  catch (cause) {
+    throw new TranscriptionError("invalid-request", "[vitehub] Transcription source.url must be an absolute URL.", { cause })
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new TranscriptionError("invalid-request", "[vitehub] Transcription source.url must use HTTP or HTTPS.")
+  }
+  if (source.mediaType !== undefined && (typeof source.mediaType !== "string" || !source.mediaType.trim())) {
+    throw new TranscriptionError("invalid-request", "[vitehub] Transcription source.mediaType must be a non-empty string.")
+  }
+  if (source.name !== undefined && (typeof source.name !== "string" || !source.name.trim())) {
+    throw new TranscriptionError("invalid-request", "[vitehub] Transcription source.name must be a non-empty string.")
+  }
+  return { ...source, url: url.href }
+}
+
+function assertId(id: unknown, provider: string, phase: string): asserts id is string {
+  if (typeof id !== "string" || !id.trim()) {
+    throw new TranscriptionError("provider", `[vitehub] Transcription driver ${provider} returned an invalid ${phase} id.`, { provider })
+  }
+}
+
+function assertTranscript(transcript: unknown, provider: string): asserts transcript is TranscriptionTranscript {
+  if (!transcript || typeof transcript !== "object" || typeof (transcript as { text?: unknown }).text !== "string") {
+    throw new TranscriptionError("invalid-payload", `[vitehub] Transcription driver ${provider} returned an invalid transcript.`, { provider })
+  }
+  const words = (transcript as TranscriptionTranscript).words
+  if (words !== undefined && (!Array.isArray(words) || words.some(word => !word || typeof word !== "object" || typeof word.text !== "string" || typeof word.type !== "string"))) {
+    throw new TranscriptionError("invalid-payload", `[vitehub] Transcription driver ${provider} returned invalid transcript words.`, { provider })
+  }
+}
+
+function normalizeCompletion(completion: TranscriptionDriverCompletion, provider: string): TranscriptionCompletion {
+  if (!completion || typeof completion !== "object") {
+    throw new TranscriptionError("invalid-payload", `[vitehub] Transcription driver ${provider} returned an invalid completion.`, { provider })
+  }
+  assertId(completion.id, provider, "completion")
+  assertMetadata(completion.metadata, "Transcription completion metadata")
+  if (completion.status === "failed") {
+    if (typeof completion.error !== "string" || !completion.error.trim()) {
+      throw new TranscriptionError("invalid-payload", `[vitehub] Transcription driver ${provider} returned an invalid failure.`, { provider })
+    }
+    return { ...completion, provider }
+  }
+  if (completion.status === "completed") {
+    assertTranscript(completion.transcript, provider)
+    return { ...completion, provider }
+  }
+  throw new TranscriptionError("invalid-payload", `[vitehub] Transcription driver ${provider} returned an unsupported completion status.`, { provider })
+}
+
+export function createTranscription(options: CreateTranscriptionOptions): TranscriptionClient {
+  assertDriver(options?.driver)
+  const driver = options.driver
+  return {
+    async submit(input): Promise<TranscriptionSubmission> {
+      assertMetadata(input?.metadata, "Transcription metadata")
+      const normalized = { ...input, source: normalizeSource(input?.source) }
+      try {
+        const submission = await driver.submit(normalized)
+        assertId(submission?.id, driver.name, "submission")
+        return { id: submission.id, provider: driver.name, status: "submitted" }
+      }
+      catch (error) {
+        if (error instanceof TranscriptionError) throw error
+        throw new TranscriptionError("provider", `[vitehub] Transcription submission failed through ${driver.name}.`, {
+          cause: error,
+          provider: driver.name,
+        })
+      }
+    },
+    async receive(payload): Promise<TranscriptionCompletion> {
+      try {
+        return normalizeCompletion(await driver.receive(payload), driver.name)
+      }
+      catch (error) {
+        if (error instanceof TranscriptionError) throw error
+        throw new TranscriptionError("invalid-payload", `[vitehub] Transcription completion from ${driver.name} was invalid.`, {
+          cause: error,
+          provider: driver.name,
+        })
+      }
+    },
+  }
+}

--- a/packages/agent/test/async-transcription.test-d.ts
+++ b/packages/agent/test/async-transcription.test-d.ts
@@ -1,0 +1,32 @@
+import { expectTypeOf, it } from "vitest"
+
+import {
+  createTranscription,
+  elevenLabsScribe,
+  type TranscriptionClient,
+  type TranscriptionCompletion,
+  type TranscriptionDriver,
+  type TranscriptionSubmission,
+  type TranscriptionSubmitInput,
+} from "../src/capabilities.ts"
+
+declare const driver: TranscriptionDriver
+declare const payload: unknown
+declare const submitInput: TranscriptionSubmitInput
+
+it("exports the asynchronous transcription contract", () => {
+  expectTypeOf(createTranscription({ driver })).toEqualTypeOf<TranscriptionClient>()
+  expectTypeOf(createTranscription({ driver }).submit(submitInput)).toEqualTypeOf<Promise<TranscriptionSubmission>>()
+  expectTypeOf(createTranscription({ driver }).receive(payload)).toEqualTypeOf<Promise<TranscriptionCompletion>>()
+  expectTypeOf(elevenLabsScribe({ apiKey: "secret", webhookId: "webhook-1" })).toEqualTypeOf<TranscriptionDriver>()
+})
+
+it("keeps provider completion handling exhaustive", async () => {
+  const completion = await createTranscription({ driver }).receive(payload)
+  if (completion.status === "completed") {
+    expectTypeOf(completion.transcript.text).toEqualTypeOf<string>()
+  }
+  else {
+    expectTypeOf(completion.error).toEqualTypeOf<string>()
+  }
+})

--- a/packages/agent/test/async-transcription.test.ts
+++ b/packages/agent/test/async-transcription.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createTranscription,
+  elevenLabsScribe,
+} from "../src/capabilities.ts"
+
+import type {
+  TranscriptionDriver,
+  TranscriptionSubmitInput,
+} from "../src/capabilities.ts"
+
+function fixtureDriver(overrides: Partial<TranscriptionDriver> = {}): TranscriptionDriver {
+  return {
+    name: "fixture",
+    receive: vi.fn(async () => ({
+      id: "operation-1",
+      status: "completed" as const,
+      transcript: { text: "Hello" },
+    })),
+    submit: vi.fn(async () => ({ id: "operation-1" })),
+    ...overrides,
+  }
+}
+
+describe("createTranscription", () => {
+  it("normalizes remote submissions and provider completions", async () => {
+    const driver = fixtureDriver()
+    const client = createTranscription({ driver })
+
+    await expect(client.submit({
+      metadata: { attemptNonce: "attempt-1", jobId: "job-1" },
+      source: { mediaType: "audio/mpeg", name: "meeting.mp3", url: "https://private.example/audio.mp3?signature=1" },
+    })).resolves.toEqual({ id: "operation-1", provider: "fixture", status: "submitted" })
+    expect(driver.submit).toHaveBeenCalledWith({
+      metadata: { attemptNonce: "attempt-1", jobId: "job-1" },
+      source: { mediaType: "audio/mpeg", name: "meeting.mp3", url: "https://private.example/audio.mp3?signature=1" },
+    })
+
+    await expect(client.receive({ provider: "payload" })).resolves.toEqual({
+      id: "operation-1",
+      provider: "fixture",
+      status: "completed",
+      transcript: { text: "Hello" },
+    })
+  })
+
+  it.each([
+    [{ source: undefined }, "source must be an object"],
+    [{ source: { url: "audio.mp3" } }, "absolute URL"],
+    [{ source: { url: "file:///audio.mp3" } }, "HTTP or HTTPS"],
+    [{ metadata: [], source: { url: "https://example.com/audio.mp3" } }, "metadata must be an object"],
+  ])("rejects an invalid submission before calling the driver", async (input, message) => {
+    const driver = fixtureDriver()
+    const client = createTranscription({ driver })
+
+    await expect(client.submit(input as TranscriptionSubmitInput)).rejects.toThrow(message)
+    expect(driver.submit).not.toHaveBeenCalled()
+  })
+
+  it("normalizes unknown driver failures without exposing provider details", async () => {
+    const cause = new Error("secret provider response")
+    const client = createTranscription({ driver: fixtureDriver({ submit: vi.fn(async () => { throw cause }) }) })
+
+    await expect(client.submit({ source: { url: "https://example.com/audio.mp3" } })).rejects.toMatchObject({
+      cause,
+      code: "provider",
+      message: "[vitehub] Transcription submission failed through fixture.",
+      provider: "fixture",
+    })
+  })
+
+  it("rejects invalid driver results", async () => {
+    const invalidSubmission = createTranscription({ driver: fixtureDriver({ submit: vi.fn(async () => ({ id: "" })) }) })
+    const invalidCompletion = createTranscription({ driver: fixtureDriver({ receive: vi.fn(async () => ({ id: "operation-1", status: "queued" } as never)) }) })
+
+    await expect(invalidSubmission.submit({ source: { url: "https://example.com/audio.mp3" } })).rejects.toThrow("invalid submission id")
+    await expect(invalidCompletion.receive({})).rejects.toThrow("unsupported completion status")
+  })
+})
+
+describe("elevenLabsScribe", () => {
+  it("submits a Summary-shaped private URL and normalizes its correlated callback", async () => {
+    const request = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const form = init?.body as FormData
+      expect(form.get("model_id")).toBe("scribe_v2")
+      expect(form.get("source_url")).toBe("https://private.example/jobs/job-1/audio.mp3?signature=1")
+      expect(form.get("webhook")).toBe("true")
+      expect(form.get("webhook_id")).toBe("webhook-1")
+      expect(form.get("webhook_metadata")).toBe(JSON.stringify({
+        attempt_nonce: "attempt-1",
+        hook_token: "hook-1",
+        job_id: "job-1",
+      }))
+      expect(form.get("diarize")).toBe("true")
+      expect(form.get("timestamps_granularity")).toBe("word")
+      expect(form.get("tag_audio_events")).toBe("true")
+      return Response.json({ request_id: "request-1" })
+    })
+    const client = createTranscription({
+      driver: elevenLabsScribe({
+        apiKey: () => "secret",
+        diarize: true,
+        fetch: request,
+        tagAudioEvents: true,
+        timestampsGranularity: "word",
+        webhookId: "webhook-1",
+      }),
+    })
+
+    await expect(client.submit({
+      metadata: { attempt_nonce: "attempt-1", hook_token: "hook-1", job_id: "job-1" },
+      source: { url: "https://private.example/jobs/job-1/audio.mp3?signature=1" },
+    })).resolves.toEqual({ id: "request-1", provider: "elevenlabs", status: "submitted" })
+    expect(request).toHaveBeenCalledWith("https://api.elevenlabs.io/v1/speech-to-text", expect.objectContaining({
+      headers: { "xi-api-key": "secret" },
+      method: "POST",
+    }))
+
+    await expect(client.receive({
+      data: {
+        request_id: "request-1",
+        transcription: {
+          language_code: "th",
+          language_probability: 0.98,
+          text: "สวัสดี",
+          words: [{ channel_index: 0, end: 0.5, speaker_id: "speaker_0", start: 0, text: "สวัสดี", type: "word" }],
+        },
+        webhook_metadata: { attempt_nonce: "attempt-1", hook_token: "hook-1", job_id: "job-1" },
+      },
+      type: "speech_to_text_transcription",
+    })).resolves.toEqual({
+      id: "request-1",
+      metadata: { attempt_nonce: "attempt-1", hook_token: "hook-1", job_id: "job-1" },
+      provider: "elevenlabs",
+      status: "completed",
+      transcript: {
+        language: "th",
+        languageConfidence: 0.98,
+        text: "สวัสดี",
+        words: [{ channel: 0, end: 0.5, speaker: "speaker_0", start: 0, text: "สวัสดี", type: "word" }],
+      },
+    })
+  })
+
+  it("normalizes provider completion failures for workflow handling", async () => {
+    const client = createTranscription({
+      driver: elevenLabsScribe({ apiKey: "secret", fetch: vi.fn(), webhookId: "webhook-1" }),
+    })
+
+    await expect(client.receive({
+      data: { error: "Unsupported audio", request_id: "request-2", webhook_metadata: { job_id: "job-1" } },
+      type: "speech_to_text_transcription",
+    })).resolves.toEqual({
+      error: "Unsupported audio",
+      id: "request-2",
+      metadata: { job_id: "job-1" },
+      provider: "elevenlabs",
+      status: "failed",
+    })
+  })
+
+  it.each([
+    [401, "authentication"],
+    [422, "invalid-request"],
+    [429, "rate-limit"],
+    [503, "provider"],
+  ])("maps HTTP %s to a stable %s error", async (status, code) => {
+    const client = createTranscription({
+      driver: elevenLabsScribe({
+        apiKey: "secret",
+        fetch: vi.fn(async () => Response.json({ detail: "rejected" }, { status })),
+        webhookId: "webhook-1",
+      }),
+    })
+
+    await expect(client.submit({ source: { url: "https://example.com/audio.mp3" } })).rejects.toMatchObject({
+      code: code as never,
+      provider: "elevenlabs",
+    })
+  })
+
+  it("rejects malformed callback payloads at the adapter seam", async () => {
+    const client = createTranscription({
+      driver: elevenLabsScribe({ apiKey: "secret", fetch: vi.fn(), webhookId: "webhook-1" }),
+    })
+
+    await expect(client.receive({ data: { request_id: "request-1" }, type: "other" })).rejects.toMatchObject({
+      code: "invalid-payload",
+      provider: "elevenlabs",
+    })
+  })
+})

--- a/packages/agent/test/async-transcription.test.ts
+++ b/packages/agent/test/async-transcription.test.ts
@@ -124,7 +124,10 @@ describe("elevenLabsScribe", () => {
           language_code: "th",
           language_probability: 0.98,
           text: "สวัสดี",
-          words: [{ channel_index: 0, end: 0.5, speaker_id: "speaker_0", start: 0, text: "สวัสดี", type: "word" }],
+          words: [
+            { channel_index: 0, end: 0.5, speaker_id: "speaker_0", start: 0, text: "สวัสดี", type: "word" },
+            { end: 0.6, start: 0.5, text: " ", type: "spacing" },
+          ],
         },
         webhook_metadata: { attempt_nonce: "attempt-1", hook_token: "hook-1", job_id: "job-1" },
       },
@@ -138,7 +141,10 @@ describe("elevenLabsScribe", () => {
         language: "th",
         languageConfidence: 0.98,
         text: "สวัสดี",
-        words: [{ channel: 0, end: 0.5, speaker: "speaker_0", start: 0, text: "สวัสดี", type: "word" }],
+        words: [
+          { channel: 0, end: 0.5, speaker: "speaker_0", start: 0, text: "สวัสดี", type: "word" },
+          { end: 0.6, start: 0.5, text: " ", type: "spacing" },
+        ],
       },
     })
   })


### PR DESCRIPTION
Adds a provider-neutral asynchronous transcription client beside the existing synchronous `transcribe()` Capability. Remote submissions return a stable provider operation ID for acknowledgement and idempotency, while authenticated completion payloads normalize into `completed` or `failed` results with correlation metadata and transcript words, speakers, channels, timestamps, and language details.

Includes an ElevenLabs Scribe adapter for signed remote URLs and webhook delivery without leaking provider request or response types. Callback authentication, durable waiting, duplicate handling, timeouts, and workflow resumption stay with the caller and the Workflow primitive, so this slice remains independently mergeable.