### PR TITLE
feat(blob): add signed R2 requests

### DIFF
--- a/docs/content/docs/server-primitives/blob.md
+++ b/docs/content/docs/server-primitives/blob.md
@@ -179,6 +179,7 @@ Objects from the served store include a URL. With `serve.publicBaseUrl`, the URL
 | `blob.head(pathname)` | Reads object metadata. |
 | `blob.list(options?)` | Lists objects with optional `prefix`, `limit`, `cursor`, and folded folders. |
 | `blob.del(pathnames)` | Deletes one or more objects. |
+| `blob.sign(pathname, options)` | Signs a short-lived `GET` or `PUT` request for one object. |
 | `blob.serve(event, pathname)` | Serves an object stream through an H3 event. |
 | `blob.store(name)` | Selects a named Blob Store. |
 
@@ -192,6 +193,30 @@ Objects from the served store include a URL. With `serve.publicBaseUrl`, the URL
 | `access` | `BlobPutOptions['access']` | Object access policy when the driver supports it. Values: `private`, `public`. |
 | `addRandomSuffix` | `boolean` | Adds a random suffix when supported by the driver. |
 | `prefix` | `string` | Provider path prefix when supported by the driver. |
+
+## Signed requests
+
+Use `blob.sign()` when a client or provider needs short-lived direct access to one private object. The result contains the URL, HTTP method, and every header that must be sent with the request.
+
+```ts [server/api/uploads/presign.post.ts]
+import { blob } from '@vite-hub/blob'
+
+const source = await blob.sign('users/user/jobs/job/source.mp3', {
+  method: 'GET',
+  expiresIn: 6 * 60 * 60,
+})
+
+const upload = await blob.sign('users/user/jobs/job/source.mp3', {
+  method: 'PUT',
+  expiresIn: 15 * 60,
+  contentType: 'audio/mpeg',
+  createOnly: true,
+})
+```
+
+Send `upload.headers` unchanged with the `PUT` body. `contentType` binds the upload MIME type into the signed request. `createOnly` binds a provider condition that rejects the upload when the object already exists; drivers that cannot enforce it throw instead of silently allowing an overwrite.
+
+Cloudflare R2 signs through its S3-compatible HTTP credentials, including when normal reads and writes use a Workers binding. A binding alone cannot mint a presigned URL, so configure `accountId`, `accessKeyId`, `secretAccessKey`, and `bucketName` through runtime environment values. [R2 presigned URLs](https://developers.cloudflare.com/r2/api/s3/presigned-urls/) accept expiries from 1 second through 7 days, and the [S3 compatibility contract](https://developers.cloudflare.com/r2/api/s3/api/) supports `If-None-Match` on `PutObject`.
 
 ## `ensureBlob(blob, options)`
 

--- a/packages/blob/README.md
+++ b/packages/blob/README.md
@@ -70,6 +70,32 @@ export default defineConfig({
 
 Blob stores binary objects and small object metadata. Keep catalogs, indexes, permissions, search records, domain records, and richer metadata queries in KV, Database, or another NoSQL/catalog store next to Blob.
 
+## Signed requests
+
+Use `blob.sign()` to grant short-lived access to one private object without routing its body through your server.
+
+```ts
+const download = await blob.sign("private/audio.mp3", {
+  method: "GET",
+  expiresIn: 60 * 60,
+})
+
+const upload = await blob.sign("private/audio.mp3", {
+  method: "PUT",
+  expiresIn: 15 * 60,
+  contentType: "audio/mpeg",
+  createOnly: true,
+})
+
+await fetch(upload.url, {
+  method: upload.method,
+  headers: upload.headers,
+  body: file,
+})
+```
+
+The returned headers are part of the request contract and must be sent unchanged. `createOnly` prevents overwriting an existing object when the driver can enforce a conditional upload. Drivers that cannot sign the requested operation or enforce `createOnly` throw explicitly.
+
 ## S3-compatible storage
 
 Use `driver: "s3"` for production S3-compatible object storage. Use `driver: "minio"` for local or Docker Compose object storage, and use `driver: "cloudflare-r2"` for Cloudflare R2.

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -74,8 +74,6 @@
     "pathe": "catalog:unjs"
   },
   "devDependencies": {
-    "@aws-sdk/client-s3": "^3.700.0",
-    "@aws-sdk/s3-request-presigner": "^3.700.0",
     "@types/node": "catalog:tooling",
     "@vite-hub/internal": "workspace:*",
     "files-sdk": "catalog:storage",

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -74,6 +74,8 @@
     "pathe": "catalog:unjs"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.700.0",
+    "@aws-sdk/s3-request-presigner": "^3.700.0",
     "@types/node": "catalog:tooling",
     "@vite-hub/internal": "workspace:*",
     "files-sdk": "catalog:storage",
@@ -85,10 +87,18 @@
     "vitest": "catalog:tooling"
   },
   "peerDependencies": {
+    "@aws-sdk/client-s3": "^3.700.0",
+    "@aws-sdk/s3-request-presigner": "^3.700.0",
     "files-sdk": "catalog:storage",
     "vite": "catalog:vite-compat"
   },
   "peerDependenciesMeta": {
+    "@aws-sdk/client-s3": {
+      "optional": true
+    },
+    "@aws-sdk/s3-request-presigner": {
+      "optional": true
+    },
     "files-sdk": {
       "optional": true
     },

--- a/packages/blob/src/drivers/cloudflare.ts
+++ b/packages/blob/src/drivers/cloudflare.ts
@@ -5,7 +5,7 @@ import { importOptionalPeer } from "../internal/optional-peer.ts"
 import { getActiveCloudflareBinding, getActiveCloudflareEnv } from "../runtime/state.ts"
 import { createFilesSdkDriver } from "./files-sdk.ts"
 
-import type { BlobDriverAdapter, BlobListOptions, BlobListResult, BlobObject, BlobPutBody, BlobPutOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
+import type { BlobDriverAdapter, BlobListOptions, BlobListResult, BlobObject, BlobPutBody, BlobPutOptions, BlobSignedRequest, BlobSignOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
 
 const s3PeerInstall = "files-sdk @aws-sdk/client-s3 @aws-sdk/lib-storage @aws-sdk/s3-presigned-post @aws-sdk/s3-request-presigner"
 
@@ -65,6 +65,49 @@ function createHttpDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDri
     ...resolved,
     bucket: resolved.bucketName,
   }))
+}
+
+async function signRequest(options: ResolvedCloudflareR2BlobStoreConfig, pathname: string, signOptions: BlobSignOptions): Promise<BlobSignedRequest> {
+  const accountId = runtimeValue(options.accountId, "R2_ACCOUNT_ID", "CLOUDFLARE_R2_ACCOUNT_ID", "CLOUDFLARE_ACCOUNT_ID")
+  const accessKeyId = runtimeValue(options.accessKeyId, "R2_ACCESS_KEY_ID", "CLOUDFLARE_R2_ACCESS_KEY_ID")
+  const secretAccessKey = runtimeValue(options.secretAccessKey, "R2_SECRET_ACCESS_KEY", "CLOUDFLARE_R2_SECRET_ACCESS_KEY")
+  const bucket = runtimeValue(options.bucketName, "BLOB_BUCKET_NAME", "CLOUDFLARE_R2_BUCKET_NAME", "R2_BUCKET_NAME")
+  if (!accountId || !accessKeyId || !secretAccessKey || !bucket) {
+    throw new Error("Cloudflare R2 signed requests require `accountId`, `accessKeyId`, `secretAccessKey`, and `bucketName` HTTP credentials.")
+  }
+
+  const [{ GetObjectCommand, PutObjectCommand, S3Client }, { getSignedUrl }] = await Promise.all([
+    importOptionalPeer<typeof import("@aws-sdk/client-s3")>("@aws-sdk/client-s3", options.driver, s3PeerInstall),
+    importOptionalPeer<typeof import("@aws-sdk/s3-request-presigner")>("@aws-sdk/s3-request-presigner", options.driver, s3PeerInstall),
+  ])
+  const client = new S3Client({
+    credentials: { accessKeyId, secretAccessKey },
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    region: "auto",
+  })
+  const headers: Record<string, string> = {}
+  const command = signOptions.method === "GET"
+    ? new GetObjectCommand({ Bucket: bucket, Key: pathname })
+    : new PutObjectCommand({
+        Bucket: bucket,
+        ContentType: signOptions.contentType,
+        IfNoneMatch: signOptions.createOnly ? "*" : undefined,
+        Key: pathname,
+      })
+  if (signOptions.method === "PUT") {
+    if (signOptions.contentType) headers["Content-Type"] = signOptions.contentType
+    if (signOptions.createOnly) headers["If-None-Match"] = "*"
+  }
+  return {
+    headers,
+    method: signOptions.method,
+    url: await getSignedUrl(client, command, {
+      expiresIn: signOptions.expiresIn,
+      signableHeaders: signOptions.method === "PUT" && signOptions.contentType
+        ? new Set(["content-type"])
+        : undefined,
+    }),
+  }
 }
 
 function mapObject(object: R2ObjectLike): BlobObject {
@@ -151,5 +194,6 @@ export function createDriver(options: ResolvedCloudflareR2BlobStoreConfig): Blob
     head: pathname => activeDriver().head(pathname),
     list: options => activeDriver().list(options),
     put: (pathname, body, options) => activeDriver().put(pathname, body, options),
+    sign: (pathname, signOptions) => signRequest(options, pathname, signOptions),
   }
 }

--- a/packages/blob/src/drivers/cloudflare.ts
+++ b/packages/blob/src/drivers/cloudflare.ts
@@ -84,6 +84,7 @@ async function signRequest(options: ResolvedCloudflareR2BlobStoreConfig, pathnam
     credentials: { accessKeyId, secretAccessKey },
     endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
     region: "auto",
+    requestChecksumCalculation: "WHEN_REQUIRED",
   })
   const headers: Record<string, string> = {}
   const command = signOptions.method === "GET"

--- a/packages/blob/src/index.ts
+++ b/packages/blob/src/index.ts
@@ -8,6 +8,8 @@ export type {
   BlobModuleOptions,
   BlobObject,
   BlobPutOptions,
+  BlobSignedRequest,
+  BlobSignOptions,
   BlobSize,
   BlobStorage,
   BlobStoreConfig,

--- a/packages/blob/src/runtime/storage.ts
+++ b/packages/blob/src/runtime/storage.ts
@@ -108,6 +108,7 @@ function createRuntimeBlobStorage(name = "default"): BlobStorage {
       return { ...result, blobs: await Promise.all(result.blobs.map(object => withServedBlobUrl(name, object))) }
     },
     async put(pathname, body, options) { return withServedBlobUrl(name, await (await resolveStorage(name)).put(pathname, body, options)) },
+    async sign(pathname, options) { return (await resolveStorage(name)).sign(pathname, options) },
     async serve(event, pathname) { return (await resolveStorage(name)).serve(event, pathname) },
     store(storeName: BlobStoreName) { return createRuntimeBlobStorage(storeName) },
   }

--- a/packages/blob/src/storage.ts
+++ b/packages/blob/src/storage.ts
@@ -95,6 +95,15 @@ export function createBlobStorage(driver: BlobDriverAdapter<any>): BlobStorage {
         contentType,
       })
     },
+    async sign(pathname, options) {
+      if (!Number.isInteger(options.expiresIn) || options.expiresIn <= 0) {
+        throw new TypeError("`expiresIn` must be a positive integer.")
+      }
+      if (!driver.sign) {
+        throw new Error(`Blob driver "${driver.name}" does not support signed requests.`)
+      }
+      return driver.sign(normalizePathname(pathname), options)
+    },
     async serve(event, pathname: string) {
       const normalizedPath = normalizePathname(pathname)
       const arrayBuffer = await driver.getArrayBuffer(normalizedPath)

--- a/packages/blob/src/types.ts
+++ b/packages/blob/src/types.ts
@@ -60,6 +60,16 @@ export interface BlobPutOptions {
 
 export type BlobPutBody = string | ReadableStream<unknown> | ArrayBuffer | ArrayBufferView | Blob
 
+export type BlobSignOptions =
+  | { expiresIn: number, method: "GET" }
+  | { contentType?: string, createOnly?: boolean, expiresIn: number, method: "PUT" }
+
+export interface BlobSignedRequest {
+  headers: Record<string, string>
+  method: "GET" | "PUT"
+  url: string
+}
+
 export interface BlobDriverAdapter<TOptions> {
   name: string
   options: TOptions
@@ -69,6 +79,7 @@ export interface BlobDriverAdapter<TOptions> {
   head(pathname: string): Promise<BlobObject | null>
   list(options?: BlobListOptions): Promise<BlobListResult>
   put(pathname: string, body: BlobPutBody, options?: BlobPutOptions): Promise<BlobObject>
+  sign?(pathname: string, options: BlobSignOptions): Promise<BlobSignedRequest>
 }
 
 export interface BlobEnsureOptions {
@@ -82,6 +93,7 @@ export interface BlobStorage {
   head(pathname: string): Promise<BlobObject>
   list(options?: BlobListOptions): Promise<BlobListResult>
   put(pathname: string, body: BlobPutBody, options?: BlobPutOptions): Promise<BlobObject>
+  sign(pathname: string, options: BlobSignOptions): Promise<BlobSignedRequest>
   serve(event: H3Event, pathname: string): Promise<ReadableStream>
   store(name: BlobStoreName): BlobStorage
 }

--- a/packages/blob/test/sign.test.ts
+++ b/packages/blob/test/sign.test.ts
@@ -114,6 +114,10 @@ describe("signed Blob requests", () => {
       expiresIn: 900,
       signableHeaders: new Set(["content-type"]),
     })
+    const client = awsMock.getSignedUrl.mock.calls.at(-1)?.[0] as {
+      config: Record<string, unknown>
+    }
+    expect(client.config.requestChecksumCalculation).toBe("WHEN_REQUIRED")
   })
 
   it("requires R2 HTTP credentials even when CRUD uses a binding", async () => {

--- a/packages/blob/test/sign.test.ts
+++ b/packages/blob/test/sign.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createDriver as createCloudflareDriver } from "../src/drivers/cloudflare.ts"
+import { createBlobStorage } from "../src/storage.ts"
+
+const awsMock = vi.hoisted(() => ({
+  getSignedUrl: vi.fn(async (_client: unknown, command: unknown, options: { expiresIn: number }) => {
+    const operation = command?.constructor?.name || "Unknown"
+    return `https://signed.example/${operation}?expires=${options.expiresIn}`
+  }),
+}))
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  GetObjectCommand: class GetObjectCommand {
+    constructor(public input: Record<string, unknown>) {}
+  },
+  PutObjectCommand: class PutObjectCommand {
+    constructor(public input: Record<string, unknown>) {}
+  },
+  S3Client: class S3Client {
+    constructor(public config: Record<string, unknown>) {}
+  },
+}))
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: awsMock.getSignedUrl,
+}))
+
+function createUnsignedDriver() {
+  return {
+    name: "fs",
+    options: { driver: "fs" as const },
+    async delete() {},
+    async get() {
+      return null
+    },
+    async getArrayBuffer() {
+      return null
+    },
+    async head() {
+      return null
+    },
+    async list() {
+      return { blobs: [], hasMore: false }
+    },
+    async put() {
+      throw new Error("unused")
+    },
+  }
+}
+
+function createR2Storage() {
+  return createBlobStorage(createCloudflareDriver({
+    accountId: "account",
+    accessKeyId: "access-key",
+    binding: "BLOB",
+    bucketName: "private-audio",
+    driver: "cloudflare-r2",
+    secretAccessKey: "secret-key",
+  }))
+}
+
+describe("signed Blob requests", () => {
+  it("signs the Summary source read with the requested lifetime", async () => {
+    const storage = createR2Storage()
+
+    const signed = await storage.sign("/users/user/jobs/job/source.mp3", {
+      expiresIn: 6 * 60 * 60,
+      method: "GET",
+    })
+
+    expect(signed).toEqual({
+      headers: {},
+      method: "GET",
+      url: "https://signed.example/GetObjectCommand?expires=21600",
+    })
+    const command = awsMock.getSignedUrl.mock.calls.at(-1)?.[1] as {
+      input: Record<string, unknown>
+    }
+    expect(command.input).toEqual({
+      Bucket: "private-audio",
+      Key: "users/user/jobs/job/source.mp3",
+    })
+  })
+
+  it("signs the Summary direct upload as create-only with its content type", async () => {
+    const storage = createR2Storage()
+
+    const signed = await storage.sign("users/user/jobs/job/source.mp3", {
+      contentType: "audio/mpeg",
+      createOnly: true,
+      expiresIn: 15 * 60,
+      method: "PUT",
+    })
+
+    expect(signed).toEqual({
+      headers: {
+        "Content-Type": "audio/mpeg",
+        "If-None-Match": "*",
+      },
+      method: "PUT",
+      url: "https://signed.example/PutObjectCommand?expires=900",
+    })
+    const command = awsMock.getSignedUrl.mock.calls.at(-1)?.[1] as {
+      input: Record<string, unknown>
+    }
+    expect(command.input).toEqual({
+      Bucket: "private-audio",
+      ContentType: "audio/mpeg",
+      IfNoneMatch: "*",
+      Key: "users/user/jobs/job/source.mp3",
+    })
+    expect(awsMock.getSignedUrl.mock.calls.at(-1)?.[2]).toEqual({
+      expiresIn: 900,
+      signableHeaders: new Set(["content-type"]),
+    })
+  })
+
+  it("requires R2 HTTP credentials even when CRUD uses a binding", async () => {
+    const storage = createBlobStorage(
+      createCloudflareDriver({
+        binding: "BLOB",
+        bucketName: "private-audio",
+        driver: "cloudflare-r2",
+      }),
+    )
+
+    await expect(storage.sign("source.mp3", { expiresIn: 60, method: "GET" })).rejects.toThrow(
+      "Cloudflare R2 signed requests require `accountId`, `accessKeyId`, `secretAccessKey`, and `bucketName` HTTP credentials.",
+    )
+  })
+
+  it("fails explicitly when a driver cannot sign requests", async () => {
+    const storage = createBlobStorage(createUnsignedDriver())
+
+    await expect(storage.sign("source.mp3", { expiresIn: 60, method: "GET" })).rejects.toThrow('Blob driver "fs" does not support signed requests.')
+  })
+
+  it("rejects invalid expiry before reaching the driver", async () => {
+    const driver = { ...createUnsignedDriver(), sign: vi.fn() }
+    const storage = createBlobStorage(driver)
+
+    await expect(storage.sign("source.mp3", { expiresIn: 0, method: "GET" })).rejects.toThrow("`expiresIn` must be a positive integer.")
+    expect(driver.sign).not.toHaveBeenCalled()
+  })
+})

--- a/packages/blob/test/types.test-d.ts
+++ b/packages/blob/test/types.test-d.ts
@@ -51,6 +51,17 @@ describe("types", () => {
     expectTypeOf(blob.get).returns.toEqualTypeOf<Promise<Blob | null>>()
     expectTypeOf(blob.list).toBeFunction()
     expectTypeOf(blob.put).toBeFunction()
+    expectTypeOf(blob.sign("private/audio.mp3", { expiresIn: 900, method: "GET" })).toMatchTypeOf<Promise<{
+      headers: Record<string, string>
+      method: "GET" | "PUT"
+      url: string
+    }>>()
+    expectTypeOf(blob.sign("private/audio.mp3", {
+      contentType: "audio/mpeg",
+      createOnly: true,
+      expiresIn: 900,
+      method: "PUT",
+    })).toMatchTypeOf<Promise<{ url: string }>>()
   })
 
   it("returns a vite plugin with runtime config access", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,6 +557,12 @@ importers:
 
   packages/blob:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.700.0
+        version: 3.1045.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.700.0
+        version: 3.1045.0
       defu:
         specifier: catalog:unjs
         version: 6.1.7
@@ -576,12 +582,6 @@ importers:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
         version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.8(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.4.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.25)(tailwindcss@4.3.2)))(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
     devDependencies:
-      '@aws-sdk/client-s3':
-        specifier: ^3.700.0
-        version: 3.1045.0
-      '@aws-sdk/s3-request-presigner':
-        specifier: ^3.700.0
-        version: 3.1045.0
       '@types/node':
         specifier: catalog:tooling
         version: 24.13.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,12 @@ importers:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
         version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@nuxt/kit@4.4.8(magicast@0.5.3))(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.4.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.25)(tailwindcss@4.3.2)))(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
     devDependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.700.0
+        version: 3.1045.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.700.0
+        version: 3.1045.0
       '@types/node':
         specifier: catalog:tooling
         version: 24.13.2
@@ -13632,14 +13638,12 @@ snapshots:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
-    optional: true
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
-    optional: true
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
@@ -13649,7 +13653,6 @@ snapshots:
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
-    optional: true
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
@@ -13736,7 +13739,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-    optional: true
 
   '@aws-sdk/core@3.974.8':
     dependencies:
@@ -13759,7 +13761,6 @@ snapshots:
     dependencies:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/credential-provider-env@3.972.34':
     dependencies:
@@ -13768,7 +13769,6 @@ snapshots:
       '@smithy/property-provider': 4.2.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/credential-provider-http@3.972.36':
     dependencies:
@@ -13782,7 +13782,6 @@ snapshots:
       '@smithy/types': 4.14.1
       '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/credential-provider-ini@3.972.38':
     dependencies:
@@ -13802,7 +13801,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-    optional: true
 
   '@aws-sdk/credential-provider-login@3.972.38':
     dependencies:
@@ -13816,7 +13814,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-    optional: true
 
   '@aws-sdk/credential-provider-node@3.972.39':
     dependencies:
@@ -13834,7 +13831,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-    optional: true
 
   '@aws-sdk/credential-provider-process@3.972.34':
     dependencies:
@@ -13844,7 +13840,6 @@ snapshots:
       '@smithy/shared-ini-file-loader': 4.4.9
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/credential-provider-sso@3.972.38':
     dependencies:
@@ -13858,7 +13853,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-    optional: true
 
   '@aws-sdk/credential-provider-web-identity@3.972.13':
     dependencies:
@@ -13883,7 +13877,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-    optional: true
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
     dependencies:
@@ -13894,7 +13887,6 @@ snapshots:
       '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/middleware-expect-continue@3.972.10':
     dependencies:
@@ -13902,7 +13894,6 @@ snapshots:
       '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/middleware-flexible-checksums@3.974.16':
     dependencies:
@@ -13920,7 +13911,6 @@ snapshots:
       '@smithy/util-stream': 4.5.25
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/middleware-host-header@3.972.10':
     dependencies:
@@ -13934,7 +13924,6 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/middleware-logger@3.972.10':
     dependencies:
@@ -13972,7 +13961,6 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/middleware-user-agent@3.972.38':
     dependencies:
@@ -14062,7 +14050,6 @@ snapshots:
       '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/signature-v4-multi-region@3.996.25':
     dependencies:
@@ -14084,7 +14071,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-    optional: true
 
   '@aws-sdk/types@3.973.8':
     dependencies:
@@ -14109,7 +14095,6 @@ snapshots:
       '@smithy/querystring-builder': 4.2.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/util-locate-window@3.965.5':
     dependencies:
@@ -18503,12 +18488,10 @@ snapshots:
     dependencies:
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
-    optional: true
 
   '@smithy/chunked-blob-reader@5.2.2':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@smithy/config-resolver@4.4.17':
     dependencies:
@@ -18546,34 +18529,29 @@ snapshots:
       '@smithy/types': 4.14.1
       '@smithy/util-hex-encoding': 4.2.2
       tslib: 2.8.1
-    optional: true
 
   '@smithy/eventstream-serde-browser@4.2.14':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.2.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@smithy/eventstream-serde-config-resolver@4.3.14':
     dependencies:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@smithy/eventstream-serde-node@4.2.14':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.2.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@smithy/eventstream-serde-universal@4.2.14':
     dependencies:
       '@smithy/eventstream-codec': 4.2.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@smithy/fetch-http-handler@5.3.17':
     dependencies:
@@ -18589,7 +18567,6 @@ snapshots:
       '@smithy/chunked-blob-reader-native': 4.2.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@smithy/hash-node@4.2.14':
     dependencies:
@@ -18603,7 +18580,6 @@ snapshots:
       '@smithy/types': 4.14.1
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
-    optional: true
 
   '@smithy/invalid-dependency@4.2.14':
     dependencies:
@@ -18623,7 +18599,6 @@ snapshots:
       '@smithy/types': 4.14.1
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
-    optional: true
 
   '@smithy/middleware-content-length@4.2.14':
     dependencies:
@@ -18837,7 +18812,6 @@ snapshots:
     dependencies:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    optional: true
 
   '@smithy/uuid@1.1.2':
     dependencies:


### PR DESCRIPTION
Adds `blob.sign(pathname, options)` as the provider-neutral contract for short-lived private object access. Signed requests return the method, URL, and required headers; Cloudflare R2 supports signed `GET` and `PUT`, binds `Content-Type`, and maps `createOnly` to `If-None-Match: *`, while unsupported drivers fail explicitly.

R2 signing uses its S3-compatible HTTP credentials even when normal Blob reads and writes use a Workers binding. This lets downstream applications delete their AWS SDK signing adapter while keeping direct uploads conditional and source downloads short-lived, with matching runtime, public-type, package, and documentation coverage.
