### PR TITLE
feat(agent): add typed structured output

### DIFF
--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -45,11 +45,35 @@ The driver object accepts exactly one concrete variant: `model`, `harness`, or `
 | `invoker` | `AgentInvokerOptions` | None | Configures Agent Actor profiles and resolution through the current `invoker`-named API. |
 | `messages` | `AgentMessageChannelSettings` | Channel defaults | Applies shared message delivery, concurrency, session, state, and transcript settings across adapter-backed Channels. |
 | `name` | `string` | Discovered identity | Supplies an explicit Definition name for direct metadata and Workspace naming. Discovered host identity still comes from the file or folder path. |
+| `output` | `AgentOutputDefinition` | None | Decodes and validates structured Agent output with a Standard Schema. |
 | `runtime` | `false \| workflow(name?)` | Discovered Workflow | Disables hosted Workflow execution or selects an explicit Workflow binding. Direct calls without discovered Agent identity remain inline. |
+| `runEvents` | `AgentRunEvents` | None | Publishes and reads durable events scoped to the current Agent Invocation run. |
 | `version` | `string` | None | Adds a Definition version to generated and DevTools metadata. |
 | `workspace` | `WorkspaceAgentWorkspaceConfig` | None | References a named Workspace or declares an Agent-owned Workspace and access mode. |
 
 The resolved `AgentDefinition` also exposes runtime-owned `resolve()` and, when applicable, `run()`. Those are outputs of `defineAgent()`, not additional authoring fields.
+
+## Declare structured output
+
+Set `output.schema` when server code needs a typed value instead of provider result plumbing. The schema uses [Standard Schema](https://standardschema.dev/), so the Agent Invocation decodes the final JSON, validates it once, and returns the inferred output value.
+
+```ts [server/agents/summary.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { codexDriver } from '@vite-hub/agent/harness/codex'
+import { object, string } from 'valibot'
+
+const summaryOutput = object({
+  summary: string(),
+  title: string(),
+})
+
+export default defineAgent({
+  driver: codexDriver(),
+  output: { schema: summaryOutput },
+})
+```
+
+Harness Agent Drivers receive a JSON-only output instruction. When the validator also implements Standard JSON Schema, ViteHub includes that JSON Schema as model guidance; Standard Schema validation remains the runtime authority either way. Invalid JSON and schema failures throw `AgentOutputValidationError` with distinct `invalid-json` and `schema-validation` codes.
 
 ## Attach Capabilities
 

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -17,6 +17,7 @@ import {
 } from "./workspace-agent.ts"
 import { normalizeAgentWorkspaceSources } from "./workspace-source-metadata.ts"
 import { nextWithAbort } from "./internal/abortable-stream.ts"
+import { agentOutputInstructions } from "./internal/agent-structured-output.ts"
 import {
   colocatedAgentSkillsContextKey,
   type ColocatedAgentSkills,
@@ -426,7 +427,8 @@ async function resolveHarnessDriverInstructions<
   if (resolved !== undefined && typeof resolved !== "string") {
     throw new TypeError("[vitehub] defineAgent({ driver.instructions }) must resolve to a string.")
   }
-  return resolved ? await composeHarnessInstructions(resolved, context) : undefined
+  const configured = resolved ? await composeHarnessInstructions(resolved, context) : undefined
+  return [configured, agentOutputInstructions(context.output)].filter(Boolean).join("\n\n") || undefined
 }
 
 async function resolveHarnessWorkDir<

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1858,7 +1858,7 @@ async function finishStreamAgentInvocation<
   let finishUsage: AgentUsageRecord | undefined
   try {
     const usageRecord = await resolveFinishUsageRecord(context, result)
-    finishUsage = usageRecord ? await resolveAgentUsageRecord({ usageRecord }, context.run) : undefined
+    finishUsage = usageRecord
     finishResult = await applyFinalOutputRenderers(result, context, outputExtensions)
     finishResult = context.output
       ? await validateAgentOutput(context.output, await materializeAgentStructuredOutput(finishResult), { allowMaterializedObject: finishResult !== result })
@@ -2302,7 +2302,7 @@ async function finalizeAgentInvocationResult<
       const stream = options.wrapStream?.(result) || result
       if (shouldWrapOutput) {
         const streamed = withStreamedResult(stream, result)
-        if (!context.finalOutputRenderers.length && !context.output) {
+        if (!context.finalOutputRenderers.length && (!context.output || !options.finalizeRawStreams)) {
           return withCapabilityCleanup(streamed.stream, async (outcome) => {
             const finishOutcome = finishOutcomeFromCleanup(outcome, result)
             const usage = streamed.finishUsage()
@@ -2555,7 +2555,11 @@ export async function streamAgentInline<
         const value = runContext.output
           ? await validateAgentOutput(runContext.output, final, { allowMaterializedObject: true })
           : final
-        return { finishResult: value, value }
+        return {
+          finishResult: value,
+          finishUsage: driverUsageRecord,
+          value,
+        }
       }
       const stream = isStreamResult
         ? streamAgentOutputToEvents(rendered)
@@ -2575,7 +2579,7 @@ export async function streamAgentInline<
           : rendered,
       }
     }, "[vitehub] Agent run failed and finish lifecycle also failed.", {
-      finalizeRawStreams: output === "ui-message-stream" || Boolean(runContext.finalOutputRenderers.length),
+      finalizeRawStreams: output === "ui-message-stream" || Boolean(runContext.finalOutputRenderers.length) || Boolean(runContext.output),
       outputExtensions,
       wrapStream: stream => maybeTraceAgentStream(stream as AsyncIterable<StreamEvent>, runContext),
     })

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1855,8 +1855,10 @@ async function finishStreamAgentInvocation<
     return
   }
   let finishResult: unknown
+  let finishUsage: AgentUsageRecord | undefined
   try {
     const usageRecord = await resolveFinishUsageRecord(context, result)
+    finishUsage = usageRecord
     finishResult = await applyFinalOutputRenderers(result, context, outputExtensions)
     finishResult = context.output
       ? await validateAgentOutput(context.output, await materializeAgentStructuredOutput(finishResult), { allowMaterializedObject: finishResult !== result })
@@ -1865,7 +1867,7 @@ async function finishStreamAgentInvocation<
   catch (finishError) {
     await finishFailedAgentInvocation(context, finishError, failureMessage)
   }
-  await finishAgentInvocation(context, { result: finishResult, status: "success" })
+  await finishAgentInvocation(context, { result: finishResult, status: "success", usage: finishUsage })
 }
 
 function traceUiMessageStream<

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2404,7 +2404,9 @@ export async function runAgentInline<
         : result
       const final = renderOutput ? await applyFinalOutputRenderers(rendered, runContext, outputExtensions) : rendered
       const structuredFinal = renderOutput && runContext.output ? await materializeAgentStructuredOutput(final) : final
-      const structuredUsageRecord = renderOutput && runContext.output ? await resolveFinishUsageRecord(runContext, structuredFinal) : driverUsageRecord
+      const structuredUsageRecord = renderOutput && runContext.output
+        ? await resolveFinishUsageRecord(runContext, structuredFinal) ?? driverUsageRecord
+        : driverUsageRecord
       const value = renderOutput && runContext.output
         ? await validateAgentOutput(runContext.output, structuredFinal, { allowMaterializedObject: structuredFinal === final })
         : final
@@ -2440,7 +2442,9 @@ export async function runAgentInline<
     const rendered = renderOutput ? await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders, outputExtensions) : result
     const final = renderOutput ? await applyFinalOutputRenderers(rendered, adapterContext, outputExtensions) : rendered
     const structuredFinal = renderOutput && adapterContext.output ? await materializeAgentStructuredOutput(final) : final
-    const structuredUsageRecord = renderOutput && adapterContext.output ? await resolveFinishUsageRecord(adapterContext, structuredFinal) : driverUsageRecord
+    const structuredUsageRecord = renderOutput && adapterContext.output
+      ? await resolveFinishUsageRecord(adapterContext, structuredFinal) ?? driverUsageRecord
+      : driverUsageRecord
     const runResult = renderOutput && adapterContext.output
       ? await validateAgentOutput(adapterContext.output, structuredFinal, { allowMaterializedObject: structuredFinal === final && final !== result })
       : renderOutput ? toAgentRunResult(final) : final

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2323,6 +2323,16 @@ async function finalizeAgentInvocationResult<
   }
 }
 
+async function materializeAgentStructuredOutput(result: unknown): Promise<unknown> {
+  if (!isAsyncIterable(result)) return result
+  let text = ""
+  for await (const event of streamAgentOutputToEvents(result)) {
+    if (event.type === "error") throw new Error(event.error)
+    if (event.type === "text-delta") text += event.text
+  }
+  return text
+}
+
 export async function runAgentInline<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -2365,8 +2375,9 @@ export async function runAgentInline<
         ? renderedResult ? result : await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders, outputExtensions)
         : result
       const final = renderOutput ? await applyFinalOutputRenderers(rendered, runContext, outputExtensions) : rendered
+      const structuredFinal = runContext.output ? await materializeAgentStructuredOutput(final) : final
       const value = renderOutput && runContext.output
-        ? await validateAgentOutput(runContext.output, final, { allowMaterializedObject: true })
+        ? await validateAgentOutput(runContext.output, structuredFinal, { allowMaterializedObject: true })
         : final
       return {
         finishResult: runContext.output ? value : hasFinishWork(runContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
@@ -2374,6 +2385,7 @@ export async function runAgentInline<
         value,
       }
     }, "[vitehub] Agent run failed and finish lifecycle also failed.", {
+      finalizeRawStreams: renderOutput && Boolean(runContext.output),
       outputExtensions,
       wrapStream: stream => maybeTraceAgentStream(stream as AsyncIterable<StreamEvent>, runContext),
     }) as TOutput
@@ -2398,15 +2410,18 @@ export async function runAgentInline<
     const driverUsageRecord = await resolveFinishUsageRecord(adapterContext, result)
     const rendered = renderOutput ? await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders, outputExtensions) : result
     const final = renderOutput ? await applyFinalOutputRenderers(rendered, adapterContext, outputExtensions) : rendered
+    const structuredFinal = adapterContext.output ? await materializeAgentStructuredOutput(final) : final
     const runResult = renderOutput && adapterContext.output
-      ? await validateAgentOutput(adapterContext.output, final, { allowMaterializedObject: final !== result })
+      ? await validateAgentOutput(adapterContext.output, structuredFinal, { allowMaterializedObject: final !== result })
       : renderOutput ? toAgentRunResult(final) : final
     return {
       finishResult: adapterContext.output ? runResult : hasFinishWork(adapterContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
       finishUsage: driverUsageRecord,
       value: runResult,
     }
-  }, "[vitehub] Agent run failed and finish lifecycle also failed.") as TOutput
+  }, "[vitehub] Agent run failed and finish lifecycle also failed.", {
+    finalizeRawStreams: renderOutput && Boolean(adapterContext.output),
+  }) as TOutput
 }
 
 export async function runAgent<

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,6 +1,7 @@
 import agentRegistry from "#vitehub/agent/registry"
 import { normalizeAgentDriver } from "./internal/agent-driver.ts"
 import { cloneWithPropertyDescriptors } from "./internal/stream-result.ts"
+import { AgentOutputValidationError, validateAgentOutput } from "./internal/agent-structured-output.ts"
 import { loadAgentWorkflowModule, loadAgentWorkflowRuntimeStateModule } from "./internal/workflow-runtime-loaders.ts"
 import { agentErrorDetails, agentErrorMessage } from "./agent-error.ts"
 import {
@@ -146,6 +147,7 @@ import type {
   AgentMessageChannelSettings,
   AgentMessageConcurrency,
   AgentMessageLockScope,
+  AgentOutputDefinition,
   AgentModelResolver,
   AgentRegistry,
   AgentRegistryModule,
@@ -182,7 +184,7 @@ import type {
   WorkspaceDefinition,
   WorkspaceName,
 } from "@vite-hub/workspace"
-import type { WorkflowHandle } from "@vite-hub/workflow"
+import type { WorkflowHandle, WorkflowRun } from "@vite-hub/workflow"
 import type { BoxRequirement, ResolvedBox } from "@vite-hub/box"
 
 export type {
@@ -316,6 +318,7 @@ export type {
   AgentMessageChannelSettings,
   AgentMessageConcurrency,
   AgentMessageLockScope,
+  AgentOutputDefinition,
   AgentModelInput,
   AgentModelDriver,
   AgentModelExecutionInstrumentation,
@@ -381,6 +384,8 @@ export type {
   WorkspaceAgentWorkspaceOptions,
   WorkspaceAgentWorkspaceConfig,
 } from "./types.ts"
+
+export { AgentOutputValidationError }
 
 export {
   createAgentDevtoolsMetadata,
@@ -566,7 +571,8 @@ type BaseAgentResolver<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
 type AgentDefinitionWithBaseResolve<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
-> = AgentDefinition<TRuntimeConfig, CALL_OPTIONS> & {
+  TOutput = unknown,
+> = AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput> & {
   [baseAgentBoxRequirements]?: readonly BoxRequirement[]
   [baseAgentCapabilitiesResolver]?: AgentCapabilitiesResolver<TRuntimeConfig, WorkspaceName, CALL_OPTIONS>
   [baseAgentDriverKind]?: AgentDriverKind
@@ -671,23 +677,24 @@ function resolveAgentWorkflowName<TRuntimeConfig extends AgentRuntimeConfig>(
 async function getAgentWorkflowHandle<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
+  TOutput,
 >(
-  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
   name: string,
   reuseRegistry: boolean,
-): Promise<WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>> {
+): Promise<WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>> {
   const handles = agentWorkflowHandles.get(agent as object) || new Map<string, WorkflowHandle<AgentWorkflowInvocationPayload, unknown>>()
   const cacheKey = `${reuseRegistry ? "registry" : "inline"}:${name}`
   const existing = handles.get(cacheKey)
-  if (existing) return existing as WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>
+  if (existing) return existing as WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>
 
   const { createWorkflow } = await loadAgentWorkflowModule()
   const { getInlineWorkflowDefinitions, getWorkflowRuntimeRegistry } = await loadAgentWorkflowRuntimeStateModule()
   const handle = (reuseRegistry && getWorkflowRuntimeRegistry()?.[name]) || (agentWorkflowNames.has(name) && getInlineWorkflowDefinitions().has(name))
-    ? createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>(name)
-    : createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, unknown>(name, async (workflowContext) => {
+    ? createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>(name)
+    : createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>(name, async (workflowContext) => {
         const { runAgentWorkflowDefinition } = await import("./runtime/workflow.ts")
-        return await runAgentWorkflowDefinition(agent as never, workflowContext as never, runAgentInline as never)
+        return await runAgentWorkflowDefinition(agent as never, workflowContext as never, runAgentInline as never) as TOutput
       })
   agentWorkflowNames.add(name)
   handles.set(cacheKey, handle as WorkflowHandle<AgentWorkflowInvocationPayload, unknown>)
@@ -698,8 +705,9 @@ async function getAgentWorkflowHandle<
 async function runAgentAsWorkflow<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
+  TOutput,
 >(
-  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
 ) {
@@ -717,7 +725,7 @@ async function runAgentAsWorkflow<
   // ponytail: Host capability handles and registries cannot cross a Workflow payload without losing identity.
   if ("discoveryDefault" in binding && capabilityNames.length) return undefined
 
-  const handle = await getAgentWorkflowHandle<TRuntimeConfig, CALL_OPTIONS>(agent, resolveAgentWorkflowName(agent, binding, context), Boolean(context.agentIdentity))
+  const handle = await getAgentWorkflowHandle<TRuntimeConfig, CALL_OPTIONS, TOutput>(agent, resolveAgentWorkflowName(agent, binding, context), Boolean(context.agentIdentity))
   const resolvedContext = createResolvedRuntimeContext(context)
   const payload: AgentWorkflowInvocationPayload<CALL_OPTIONS> = {
     ...(context.agentIdentity ? { agentIdentity: context.agentIdentity } : {}),
@@ -991,11 +999,12 @@ function defineBaseAgent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
+  TOutput = unknown,
 >(
-  options: AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile>,
-): AgentDefinition<TRuntimeConfig, CALL_OPTIONS> {
+  options: AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined, TOutput>,
+): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, TOutput> {
   const driver = normalizeAgentDriver(options)
-  const { box, capabilities, cli, description, hooks, messages, name, runtime = defaultAgentWorkflowRuntime(), runEvents, version, workspace } = options
+  const { box, capabilities, cli, description, hooks, messages, name, output, runtime = defaultAgentWorkflowRuntime(), runEvents, version, workspace } = options
   const channels = normalizeAgentChannels(options.channels)
   if (box && driver.kind !== "harness") {
     throw new Error("[vitehub] defineAgent({ box }) currently requires a harness Agent Driver.")
@@ -1054,6 +1063,7 @@ function defineBaseAgent<
     invoker,
     messages,
     name,
+    output,
     runtime,
     runEvents,
     run,
@@ -1074,7 +1084,7 @@ function defineBaseAgent<
         ? { ...adapterInstance, tools: capabilityTools }
         : adapterInstance
     },
-  } as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS>
+  } as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS, TOutput>
   Object.defineProperty(definition, "__vitehubAgentSettings", {
     value: channels === options.channels ? options : { ...options, channels },
   })
@@ -1095,8 +1105,9 @@ function defaultAgentWorkflowRuntime(): DefaultAgentWorkflowRuntimeBinding {
 function createSyntheticWorkspaceRun<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
+  TOutput,
 >(
-  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS>,
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput>,
 ): NonNullable<AgentDefinition<TRuntimeConfig, CALL_OPTIONS>["run"]> {
   const run: NonNullable<AgentDefinition<TRuntimeConfig, CALL_OPTIONS>["run"]> = async (context) => {
     const adapter = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(definition as never, context)
@@ -1130,6 +1141,7 @@ export interface DefineAgent {
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
     const TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig, Name>[] | undefined = readonly AgentCapabilityDefinition<TRuntimeConfig, Name>[] | undefined,
+    TOutput = unknown,
     const TOptions extends WorkspaceAgentOptions<
       TRuntimeConfig,
       Name,
@@ -1146,22 +1158,24 @@ export interface DefineAgent {
       AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>
     >,
   >(
-    options: TOptions & { capabilities?: AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities> } & ValidateWorkspaceAgentOptions<TOptions>,
-  ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>, AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>>
+    options: TOptions & { capabilities?: AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>, output?: AgentOutputDefinition<TOutput> } & ValidateWorkspaceAgentOptions<TOptions>,
+  ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>, AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>, TOutput>
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
     const TCapabilities extends readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined = readonly AgentCapabilityDefinition<TRuntimeConfig>[] | undefined,
+    TOutput = unknown,
   >(
     options: AgentSettings<
       TRuntimeConfig,
       CALL_OPTIONS,
       TInvokerProfile,
       AgentCapabilitiesInvocationContextValues<TCapabilities>,
-      AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>
+      AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>,
+      TOutput
     > & { capabilities?: AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, workspace?: never },
-  ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>>
+  ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>, TOutput>
 }
 
 function createWorkspaceAgentDefinition<
@@ -1169,9 +1183,10 @@ function createWorkspaceAgentDefinition<
   Name extends WorkspaceName = WorkspaceName,
   CALL_OPTIONS = unknown,
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
+  TOutput = unknown,
 >(
-  options: WorkspaceAgentOptions<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile>,
-): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS> {
+  options: WorkspaceAgentOptions<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, AgentCapabilitiesInput<TRuntimeConfig, Name, CALL_OPTIONS> | undefined, TOutput>,
+): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, AgentCapabilitiesInput<TRuntimeConfig, Name, CALL_OPTIONS> | undefined, TOutput> {
   const workspaceDefinition = workspaceDefinitionFromOptions(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>)
   if (Array.isArray(options.capabilities)) {
     validateAgentCapabilityComposition(options.capabilities, {
@@ -1179,14 +1194,14 @@ function createWorkspaceAgentDefinition<
       workspaceMode: workspaceModeFromOptions(options as unknown as WorkspaceAgentOptions<AgentRuntimeConfig, Name>),
     })
   }
-  const definition = defineBaseAgent<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile>({
+  const definition = defineBaseAgent<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TOutput>({
     ...options,
     description: options.description,
     hooks: options.hooks,
     runtime: options.runtime,
     version: options.version,
     workspace: workspaceDefinition,
-  } as never) as WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS>
+  } as never) as WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, AgentCapabilitiesInput<TRuntimeConfig, Name, CALL_OPTIONS> | undefined, TOutput>
 
   if (!definition.run) {
     definition.run = createSyntheticWorkspaceRun(definition)
@@ -1341,6 +1356,7 @@ type AgentInvocationContext<
   hooks?: AgentHookObserverHooks
   modelExecutionInstrumentation: AgentCapabilityRegistries["modelExecutionInstrumentation"]
   outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
+  output?: AgentOutputDefinition
   outputRenderers: AgentCapabilityRegistries["outputRenderers"]
   runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
   startTask?: Promise<void>
@@ -1637,6 +1653,7 @@ async function createAgentInvocationContext<
       messages: capabilities.messages,
       modelExecutionInstrumentation: capabilities.registries.modelExecutionInstrumentation,
       outputExtensionProviders: capabilities.registries.outputExtensionProviders,
+      output: definition?.output,
       outputRenderers: capabilities.registries.outputRenderers,
       prompt: typeof capabilities.input.prompt === "string" ? capabilities.input.prompt : undefined,
       providerTools: capabilities.registries.providerTools,
@@ -2301,19 +2318,20 @@ async function finalizeAgentInvocationResult<
 export async function runAgentInline<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
+  TOutput = unknown,
 >(
-  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
   options: RunAgentInlineOptions = {},
-): Promise<Response | AgentRunResult | unknown> {
+): Promise<TOutput | Response> {
   context = withAgentIdentityOwner(agent, context)
   const renderOutput = options.output !== "raw"
   if (hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)) {
     const runContext = await createAgentInvocationContext(agent, context, input)
     runContext.close = once(runContext.close)
     if (runContext.handledResponse) {
-      return await finalizeAgentInvocationResult(runContext, runContext.handledResponse, async result => ({ finishResult: result, value: result }), "[vitehub] Agent run failed and finish lifecycle also failed.")
+      return await finalizeAgentInvocationResult(runContext, runContext.handledResponse, async result => ({ finishResult: result, value: result }), "[vitehub] Agent run failed and finish lifecycle also failed.") as Response
     }
     let result: unknown
     try {
@@ -2339,23 +2357,24 @@ export async function runAgentInline<
         ? renderedResult ? result : await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders, outputExtensions)
         : result
       const final = renderOutput ? await applyFinalOutputRenderers(rendered, runContext, outputExtensions) : rendered
+      const value = runContext.output ? await validateAgentOutput(runContext.output, final) : final
       return {
-        finishResult: hasFinishWork(runContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
+        finishResult: runContext.output ? value : hasFinishWork(runContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
         finishUsage: driverUsageRecord,
-        value: final,
+        value,
       }
     }, "[vitehub] Agent run failed and finish lifecycle also failed.", {
       outputExtensions,
       wrapStream: stream => maybeTraceAgentStream(stream as AsyncIterable<StreamEvent>, runContext),
-    })
+    }) as TOutput
   }
 
   const resolved = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
-  const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> : undefined
+  const definition = hasAgentDefinition(agent) ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput> : undefined
   const adapterContext = await createAgentInvocationContext(definition, context, input)
   adapterContext.close = once(adapterContext.close)
   if (adapterContext.handledResponse) {
-    return await finalizeAgentInvocationResult(adapterContext, adapterContext.handledResponse, async result => ({ finishResult: result, value: result }), "[vitehub] Agent run failed and finish lifecycle also failed.")
+    return await finalizeAgentInvocationResult(adapterContext, adapterContext.handledResponse, async result => ({ finishResult: result, value: result }), "[vitehub] Agent run failed and finish lifecycle also failed.") as Response
   }
   let result: unknown
   try {
@@ -2369,25 +2388,28 @@ export async function runAgentInline<
     const driverUsageRecord = await resolveFinishUsageRecord(adapterContext, result)
     const rendered = renderOutput ? await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders, outputExtensions) : result
     const final = renderOutput ? await applyFinalOutputRenderers(rendered, adapterContext, outputExtensions) : rendered
-    const runResult = renderOutput ? toAgentRunResult(final) : final
+    const runResult = adapterContext.output
+      ? await validateAgentOutput(adapterContext.output, final)
+      : renderOutput ? toAgentRunResult(final) : final
     return {
-      finishResult: hasFinishWork(adapterContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
+      finishResult: adapterContext.output ? runResult : hasFinishWork(adapterContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
       finishUsage: driverUsageRecord,
       value: runResult,
     }
-  }, "[vitehub] Agent run failed and finish lifecycle also failed.")
+  }, "[vitehub] Agent run failed and finish lifecycle also failed.") as TOutput
 }
 
 export async function runAgent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
+  TOutput = unknown,
 >(
-  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
-): Promise<Response | AgentRunResult | unknown> {
+): Promise<TOutput | Response | WorkflowRun<unknown, TOutput>> {
   const invocationContext = withAgentIdentityOwner(agent, context)
-  const workflowRun = await runAgentAsWorkflow(agent, invocationContext, input)
+  const workflowRun = await runAgentAsWorkflow<TRuntimeConfig, CALL_OPTIONS, TOutput>(agent, invocationContext, input)
   if (workflowRun) return workflowRun
   return await runAgentInline(agent, invocationContext, input)
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1861,7 +1861,7 @@ async function finishStreamAgentInvocation<
     finishUsage = usageRecord
     finishResult = await applyFinalOutputRenderers(result, context, outputExtensions)
     finishResult = context.output
-      ? await validateAgentOutput(context.output, await materializeAgentStructuredOutput(finishResult), { allowMaterializedObject: finishResult !== result })
+      ? await validateAgentOutput(context.output, await materializeAgentStructuredOutput(finishResult, context.input.abortSignal), { allowMaterializedObject: finishResult !== result })
       : resultWithUsageRecord(finishResult, usageRecord)
   }
   catch (finishError) {
@@ -2328,12 +2328,13 @@ async function finalizeAgentInvocationResult<
   }
 }
 
-async function materializeAgentStructuredOutput(result: unknown): Promise<unknown> {
+async function materializeAgentStructuredOutput(result: unknown, abortSignal?: AbortSignal): Promise<unknown> {
   if (!isAsyncIterable(result) && !hasTraceableStreamResult(result)) return result
   if (toAgentRunResult(result).text !== undefined) return result
   let text = ""
   let usageRecord: Extract<StreamEvent, { type: "usage" }>["usageRecord"] | undefined
-  for await (const event of streamAgentOutputToEvents(result)) {
+  const events = withCapabilityCleanup(streamAgentOutputToEvents(result), async () => {}, { abortSignal }) as AsyncIterable<StreamEvent>
+  for await (const event of events) {
     if (event.type === "error") throw new Error(event.error)
     if (event.type === "text-delta") text += event.text
     if (event.type === "usage") usageRecord = event.usageRecord
@@ -2403,7 +2404,7 @@ export async function runAgentInline<
         ? renderedResult ? result : await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders, outputExtensions)
         : result
       const final = renderOutput ? await applyFinalOutputRenderers(rendered, runContext, outputExtensions) : rendered
-      const structuredFinal = renderOutput && runContext.output ? await materializeAgentStructuredOutput(final) : final
+      const structuredFinal = renderOutput && runContext.output ? await materializeAgentStructuredOutput(final, runContext.input.abortSignal) : final
       const structuredUsageRecord = renderOutput && runContext.output
         ? await resolveFinishUsageRecord(runContext, structuredFinal) ?? driverUsageRecord
         : driverUsageRecord
@@ -2441,7 +2442,7 @@ export async function runAgentInline<
     const driverUsageRecord = await resolveFinishUsageRecord(adapterContext, result)
     const rendered = renderOutput ? await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders, outputExtensions) : result
     const final = renderOutput ? await applyFinalOutputRenderers(rendered, adapterContext, outputExtensions) : rendered
-    const structuredFinal = renderOutput && adapterContext.output ? await materializeAgentStructuredOutput(final) : final
+    const structuredFinal = renderOutput && adapterContext.output ? await materializeAgentStructuredOutput(final, adapterContext.input.abortSignal) : final
     const structuredUsageRecord = renderOutput && adapterContext.output
       ? await resolveFinishUsageRecord(adapterContext, structuredFinal) ?? driverUsageRecord
       : driverUsageRecord

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2365,7 +2365,9 @@ export async function runAgentInline<
         ? renderedResult ? result : await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders, outputExtensions)
         : result
       const final = renderOutput ? await applyFinalOutputRenderers(rendered, runContext, outputExtensions) : rendered
-      const value = runContext.output ? await validateAgentOutput(runContext.output, final) : final
+      const value = renderOutput && runContext.output
+        ? await validateAgentOutput(runContext.output, final, { allowMaterializedObject: true })
+        : final
       return {
         finishResult: runContext.output ? value : hasFinishWork(runContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
         finishUsage: driverUsageRecord,
@@ -2396,8 +2398,8 @@ export async function runAgentInline<
     const driverUsageRecord = await resolveFinishUsageRecord(adapterContext, result)
     const rendered = renderOutput ? await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders, outputExtensions) : result
     const final = renderOutput ? await applyFinalOutputRenderers(rendered, adapterContext, outputExtensions) : rendered
-    const runResult = adapterContext.output
-      ? await validateAgentOutput(adapterContext.output, final)
+    const runResult = renderOutput && adapterContext.output
+      ? await validateAgentOutput(adapterContext.output, final, { allowMaterializedObject: final !== result })
       : renderOutput ? toAgentRunResult(final) : final
     return {
       finishResult: adapterContext.output ? runResult : hasFinishWork(adapterContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -184,7 +184,7 @@ import type {
   WorkspaceDefinition,
   WorkspaceName,
 } from "@vite-hub/workspace"
-import type { WorkflowHandle, WorkflowRun } from "@vite-hub/workflow"
+import type { WorkflowHandle } from "@vite-hub/workflow"
 import type { BoxRequirement, ResolvedBox } from "@vite-hub/box"
 
 export type {
@@ -585,6 +585,14 @@ interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
   run?: AgentRunMetadata
   runtime?: AgentRuntimeContext["runtime"]
   runtimeConfig?: AgentRuntimeConfig
+}
+interface AgentWorkflowRun<TOutput = unknown> {
+  id: string
+  metadata?: unknown
+  payload?: unknown
+  provider: string
+  result?: TOutput
+  status: "completed" | "failed" | "queued" | "running" | "unknown"
 }
 interface ScheduleRunContextLike {
   attemptId?: string
@@ -2407,7 +2415,7 @@ export async function runAgent<
   agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
-): Promise<TOutput | Response | WorkflowRun<unknown, TOutput>> {
+): Promise<TOutput | Response | AgentWorkflowRun<TOutput>> {
   const invocationContext = withAgentIdentityOwner(agent, context)
   const workflowRun = await runAgentAsWorkflow<TRuntimeConfig, CALL_OPTIONS, TOutput>(agent, invocationContext, input)
   if (workflowRun) return workflowRun

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2329,14 +2329,16 @@ async function finalizeAgentInvocationResult<
 }
 
 async function materializeAgentStructuredOutput(result: unknown): Promise<unknown> {
-  if (!isAsyncIterable(result)) return result
+  if (!isAsyncIterable(result) && !hasTraceableStreamResult(result)) return result
   if (toAgentRunResult(result).text !== undefined) return result
   let text = ""
+  let usageRecord: Extract<StreamEvent, { type: "usage" }>["usageRecord"] | undefined
   for await (const event of streamAgentOutputToEvents(result)) {
     if (event.type === "error") throw new Error(event.error)
     if (event.type === "text-delta") text += event.text
+    if (event.type === "usage") usageRecord = event.usageRecord
   }
-  return text
+  return resultWithUsageRecord(text, usageRecord)
 }
 
 export function runAgentInline<
@@ -2402,12 +2404,13 @@ export async function runAgentInline<
         : result
       const final = renderOutput ? await applyFinalOutputRenderers(rendered, runContext, outputExtensions) : rendered
       const structuredFinal = runContext.output ? await materializeAgentStructuredOutput(final) : final
+      const structuredUsageRecord = runContext.output ? await resolveFinishUsageRecord(runContext, structuredFinal) : driverUsageRecord
       const value = renderOutput && runContext.output
         ? await validateAgentOutput(runContext.output, structuredFinal, { allowMaterializedObject: true })
         : final
       return {
         finishResult: runContext.output ? value : hasFinishWork(runContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
-        finishUsage: driverUsageRecord,
+        finishUsage: structuredUsageRecord,
         value,
       }
     }, "[vitehub] Agent run failed and finish lifecycle also failed.", {
@@ -2437,12 +2440,13 @@ export async function runAgentInline<
     const rendered = renderOutput ? await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders, outputExtensions) : result
     const final = renderOutput ? await applyFinalOutputRenderers(rendered, adapterContext, outputExtensions) : rendered
     const structuredFinal = adapterContext.output ? await materializeAgentStructuredOutput(final) : final
+    const structuredUsageRecord = adapterContext.output ? await resolveFinishUsageRecord(adapterContext, structuredFinal) : driverUsageRecord
     const runResult = renderOutput && adapterContext.output
       ? await validateAgentOutput(adapterContext.output, structuredFinal, { allowMaterializedObject: final !== result })
       : renderOutput ? toAgentRunResult(final) : final
     return {
       finishResult: adapterContext.output ? runResult : hasFinishWork(adapterContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
-      finishUsage: driverUsageRecord,
+      finishUsage: structuredUsageRecord,
       value: runResult,
     }
   }, "[vitehub] Agent run failed and finish lifecycle also failed.", {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2632,7 +2632,7 @@ export async function streamAgentInline<
       }, { abortSignal: adapterContext.input.abortSignal }) : tracedEvents,
     }
   }, "[vitehub] Agent stream failed and finish lifecycle also failed.", {
-    finalizeRawStreams: output === "ui-message-stream" || Boolean(adapterContext.finalOutputRenderers.length),
+    finalizeRawStreams: output === "ui-message-stream" || Boolean(adapterContext.finalOutputRenderers.length) || Boolean(adapterContext.output),
     outputExtensions,
   })
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2333,6 +2333,26 @@ async function materializeAgentStructuredOutput(result: unknown): Promise<unknow
   return text
 }
 
+export function runAgentInline<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+  TOutput = unknown,
+>(
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
+  context: AgentRuntimeContext<TRuntimeConfig>,
+  input: AgentRunInput<CALL_OPTIONS>,
+  options: { output: "raw" },
+): Promise<unknown>
+export function runAgentInline<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+  TOutput = unknown,
+>(
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
+  context: AgentRuntimeContext<TRuntimeConfig>,
+  input: AgentRunInput<CALL_OPTIONS>,
+  options?: RunAgentInlineOptions,
+): Promise<TOutput | Response>
 export async function runAgentInline<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1858,7 +1858,7 @@ async function finishStreamAgentInvocation<
   let finishUsage: AgentUsageRecord | undefined
   try {
     const usageRecord = await resolveFinishUsageRecord(context, result)
-    finishUsage = usageRecord
+    finishUsage = usageRecord ? await resolveAgentUsageRecord({ usageRecord }, context.run) : undefined
     finishResult = await applyFinalOutputRenderers(result, context, outputExtensions)
     finishResult = context.output
       ? await validateAgentOutput(context.output, await materializeAgentStructuredOutput(finishResult), { allowMaterializedObject: finishResult !== result })

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2403,10 +2403,10 @@ export async function runAgentInline<
         ? renderedResult ? result : await applyOutputRenderers(result, runContext.outputRenderers, runContext.outputExtensionProviders, outputExtensions)
         : result
       const final = renderOutput ? await applyFinalOutputRenderers(rendered, runContext, outputExtensions) : rendered
-      const structuredFinal = runContext.output ? await materializeAgentStructuredOutput(final) : final
-      const structuredUsageRecord = runContext.output ? await resolveFinishUsageRecord(runContext, structuredFinal) : driverUsageRecord
+      const structuredFinal = renderOutput && runContext.output ? await materializeAgentStructuredOutput(final) : final
+      const structuredUsageRecord = renderOutput && runContext.output ? await resolveFinishUsageRecord(runContext, structuredFinal) : driverUsageRecord
       const value = renderOutput && runContext.output
-        ? await validateAgentOutput(runContext.output, structuredFinal, { allowMaterializedObject: true })
+        ? await validateAgentOutput(runContext.output, structuredFinal, { allowMaterializedObject: structuredFinal === final })
         : final
       return {
         finishResult: runContext.output ? value : hasFinishWork(runContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,
@@ -2439,10 +2439,10 @@ export async function runAgentInline<
     const driverUsageRecord = await resolveFinishUsageRecord(adapterContext, result)
     const rendered = renderOutput ? await applyOutputRenderers(result, adapterContext.outputRenderers, adapterContext.outputExtensionProviders, outputExtensions) : result
     const final = renderOutput ? await applyFinalOutputRenderers(rendered, adapterContext, outputExtensions) : rendered
-    const structuredFinal = adapterContext.output ? await materializeAgentStructuredOutput(final) : final
-    const structuredUsageRecord = adapterContext.output ? await resolveFinishUsageRecord(adapterContext, structuredFinal) : driverUsageRecord
+    const structuredFinal = renderOutput && adapterContext.output ? await materializeAgentStructuredOutput(final) : final
+    const structuredUsageRecord = renderOutput && adapterContext.output ? await resolveFinishUsageRecord(adapterContext, structuredFinal) : driverUsageRecord
     const runResult = renderOutput && adapterContext.output
-      ? await validateAgentOutput(adapterContext.output, structuredFinal, { allowMaterializedObject: final !== result })
+      ? await validateAgentOutput(adapterContext.output, structuredFinal, { allowMaterializedObject: structuredFinal === final && final !== result })
       : renderOutput ? toAgentRunResult(final) : final
     return {
       finishResult: adapterContext.output ? runResult : hasFinishWork(adapterContext) ? resultWithUsageRecord(final, driverUsageRecord) : final,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1723,6 +1723,7 @@ type InvocationRunContext<
   finishHook?: (event: AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
   hooks?: AgentHookObserverHooks
   input: AgentRunInput<CALL_OPTIONS>
+  output?: AgentOutputDefinition
   outputExtensionProviders: ResolvedAgentOutputExtensionProvider[]
   startTask?: Promise<void>
   actor: AgentInvoker
@@ -1857,7 +1858,9 @@ async function finishStreamAgentInvocation<
   try {
     const usageRecord = await resolveFinishUsageRecord(context, result)
     finishResult = await applyFinalOutputRenderers(result, context, outputExtensions)
-    finishResult = resultWithUsageRecord(finishResult, usageRecord)
+    finishResult = context.output
+      ? await validateAgentOutput(context.output, await materializeAgentStructuredOutput(finishResult), { allowMaterializedObject: finishResult !== result })
+      : resultWithUsageRecord(finishResult, usageRecord)
   }
   catch (finishError) {
     await finishFailedAgentInvocation(context, finishError, failureMessage)
@@ -1987,7 +1990,7 @@ function shouldDeferFinish<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS> & { hasCapabilityCleanup: boolean }): boolean {
-  return context.hasCapabilityCleanup || hasFinishWork(context) || Boolean(context.finalOutputRenderers.length) || hasWorkspaceAutoCommit(context)
+  return context.hasCapabilityCleanup || hasFinishWork(context) || Boolean(context.finalOutputRenderers.length) || Boolean(context.output) || hasWorkspaceAutoCommit(context)
 }
 
 function shouldWrapInvocationOutput<
@@ -2297,7 +2300,7 @@ async function finalizeAgentInvocationResult<
       const stream = options.wrapStream?.(result) || result
       if (shouldWrapOutput) {
         const streamed = withStreamedResult(stream, result)
-        if (!context.finalOutputRenderers.length) {
+        if (!context.finalOutputRenderers.length && !context.output) {
           return withCapabilityCleanup(streamed.stream, async (outcome) => {
             const finishOutcome = finishOutcomeFromCleanup(outcome, result)
             const usage = streamed.finishUsage()
@@ -2325,6 +2328,7 @@ async function finalizeAgentInvocationResult<
 
 async function materializeAgentStructuredOutput(result: unknown): Promise<unknown> {
   if (!isAsyncIterable(result)) return result
+  if (toAgentRunResult(result).text !== undefined) return result
   let text = ""
   for await (const event of streamAgentOutputToEvents(result)) {
     if (event.type === "error") throw new Error(event.error)
@@ -2546,7 +2550,10 @@ export async function streamAgentInline<
       const isStream = isAsyncIterable(rendered) || isStreamResult
       if (!isStream) {
         const final = await applyFinalOutputRenderers(rendered, runContext, outputExtensions)
-        return { finishResult: final, value: final }
+        const value = runContext.output
+          ? await validateAgentOutput(runContext.output, final, { allowMaterializedObject: true })
+          : final
+        return { finishResult: value, value }
       }
       const stream = isStreamResult
         ? streamAgentOutputToEvents(rendered)

--- a/packages/agent/src/internal/agent-structured-output.ts
+++ b/packages/agent/src/internal/agent-structured-output.ts
@@ -80,7 +80,7 @@ export async function validateAgentOutput<TOutput>(
 
 function supportsJsonSchema(schema: StandardSchemaV1): schema is StandardSchemaV1 & StandardJSONSchemaV1 {
   return typeof (schema["~standard"] as { jsonSchema?: unknown }).jsonSchema === "object"
-    && typeof (schema["~standard"] as { jsonSchema?: { output?: unknown } }).jsonSchema?.output === "function"
+    && typeof (schema["~standard"] as { jsonSchema?: { input?: unknown } }).jsonSchema?.input === "function"
 }
 
 export function agentOutputInstructions(output: AgentOutputDefinition | undefined): string | undefined {
@@ -88,7 +88,7 @@ export function agentOutputInstructions(output: AgentOutputDefinition | undefine
   let jsonSchema: Record<string, unknown> | undefined
   if (supportsJsonSchema(output.schema)) {
     try {
-      jsonSchema = output.schema["~standard"].jsonSchema.output({ target: "draft-07" })
+      jsonSchema = output.schema["~standard"].jsonSchema.input({ target: "draft-07" })
     }
     catch {}
   }

--- a/packages/agent/src/internal/agent-structured-output.ts
+++ b/packages/agent/src/internal/agent-structured-output.ts
@@ -18,12 +18,7 @@ function stripJsonFence(value: string): string {
   return match?.[1]?.trim() || value.trim()
 }
 
-function jsonValueFromResult(result: unknown, allowMaterializedObject: boolean): unknown {
-  let materializedObject = false
-  if (allowMaterializedObject && result !== null && typeof result === "object") {
-    const prototype = Object.getPrototypeOf(result)
-    materializedObject = prototype === Object.prototype || prototype === null
-  }
+function jsonValueFromResult(result: unknown): unknown {
   const directText = result && typeof result === "object" && "text" in result
     ? (result as { text?: unknown }).text
     : undefined
@@ -34,7 +29,6 @@ function jsonValueFromResult(result: unknown, allowMaterializedObject: boolean):
     return JSON.parse(stripJsonFence(text))
   }
   catch (cause) {
-    if (materializedObject) return result
     throw new AgentOutputValidationError(
       "invalid-json",
       "[vitehub] Agent output is not valid JSON.",
@@ -60,7 +54,14 @@ export async function validateAgentOutput<TOutput>(
   result: unknown,
   options: { allowMaterializedObject?: boolean } = {},
 ): Promise<TOutput> {
-  const value = jsonValueFromResult(result, options.allowMaterializedObject === true)
+  if (options.allowMaterializedObject && result !== null && typeof result === "object") {
+    const prototype = Object.getPrototypeOf(result)
+    if (prototype === Object.prototype || prototype === null) {
+      const directValidation = await output.schema["~standard"].validate(result)
+      if (!directValidation.issues?.length && "value" in directValidation) return directValidation.value
+    }
+  }
+  const value = jsonValueFromResult(result)
   const validation = await output.schema["~standard"].validate(value)
   if (validation.issues?.length) {
     throw new AgentOutputValidationError(

--- a/packages/agent/src/internal/agent-structured-output.ts
+++ b/packages/agent/src/internal/agent-structured-output.ts
@@ -19,9 +19,10 @@ function stripJsonFence(value: string): string {
 }
 
 function jsonValueFromResult(result: unknown, allowMaterializedObject: boolean): unknown {
+  let materializedObject = false
   if (allowMaterializedObject && result !== null && typeof result === "object") {
     const prototype = Object.getPrototypeOf(result)
-    if (prototype === Object.prototype || prototype === null) return result
+    materializedObject = prototype === Object.prototype || prototype === null
   }
   const directText = result && typeof result === "object" && "text" in result
     ? (result as { text?: unknown }).text
@@ -33,6 +34,7 @@ function jsonValueFromResult(result: unknown, allowMaterializedObject: boolean):
     return JSON.parse(stripJsonFence(text))
   }
   catch (cause) {
+    if (materializedObject) return result
     throw new AgentOutputValidationError(
       "invalid-json",
       "[vitehub] Agent output is not valid JSON.",

--- a/packages/agent/src/internal/agent-structured-output.ts
+++ b/packages/agent/src/internal/agent-structured-output.ts
@@ -18,7 +18,11 @@ function stripJsonFence(value: string): string {
   return match?.[1]?.trim() || value.trim()
 }
 
-function jsonValueFromResult(result: unknown): unknown {
+function jsonValueFromResult(result: unknown, allowMaterializedObject: boolean): unknown {
+  if (allowMaterializedObject && result !== null && typeof result === "object") {
+    const prototype = Object.getPrototypeOf(result)
+    if (prototype === Object.prototype || prototype === null) return result
+  }
   const directText = result && typeof result === "object" && "text" in result
     ? (result as { text?: unknown }).text
     : undefined
@@ -29,7 +33,6 @@ function jsonValueFromResult(result: unknown): unknown {
     return JSON.parse(stripJsonFence(text))
   }
   catch (cause) {
-    if (result !== null && typeof result === "object") return result
     throw new AgentOutputValidationError(
       "invalid-json",
       "[vitehub] Agent output is not valid JSON.",
@@ -53,8 +56,9 @@ function formatIssues(issues: readonly StandardSchemaV1.Issue[]): string {
 export async function validateAgentOutput<TOutput>(
   output: AgentOutputDefinition<TOutput>,
   result: unknown,
+  options: { allowMaterializedObject?: boolean } = {},
 ): Promise<TOutput> {
-  const value = jsonValueFromResult(result)
+  const value = jsonValueFromResult(result, options.allowMaterializedObject === true)
   const validation = await output.schema["~standard"].validate(value)
   if (validation.issues?.length) {
     throw new AgentOutputValidationError(

--- a/packages/agent/src/internal/agent-structured-output.ts
+++ b/packages/agent/src/internal/agent-structured-output.ts
@@ -22,7 +22,7 @@ function jsonValueFromResult(result: unknown): unknown {
   const directText = result && typeof result === "object" && "text" in result
     ? (result as { text?: unknown }).text
     : undefined
-  const text = typeof directText === "string" ? directText : toAgentRunResult(result).text
+  const text = typeof directText === "string" && directText ? directText : toAgentRunResult(result).text
   if (text === undefined) return result
 
   try {

--- a/packages/agent/src/internal/agent-structured-output.ts
+++ b/packages/agent/src/internal/agent-structured-output.ts
@@ -1,0 +1,91 @@
+import { toAgentRunResult } from "../agent-output.ts"
+
+import type { AgentOutputDefinition } from "../types.ts"
+import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
+
+export class AgentOutputValidationError extends Error {
+  readonly code: "invalid-json" | "schema-validation"
+
+  constructor(code: AgentOutputValidationError["code"], message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = "AgentOutputValidationError"
+    this.code = code
+  }
+}
+
+function stripJsonFence(value: string): string {
+  const match = value.trim().match(/^```(?:json)?\s*\n([\s\S]*?)\n```$/i)
+  return match?.[1]?.trim() || value.trim()
+}
+
+function jsonValueFromResult(result: unknown): unknown {
+  const directText = result && typeof result === "object" && "text" in result
+    ? (result as { text?: unknown }).text
+    : undefined
+  const text = typeof directText === "string" ? directText : toAgentRunResult(result).text
+  if (text === undefined) return result
+
+  try {
+    return JSON.parse(stripJsonFence(text))
+  }
+  catch (cause) {
+    throw new AgentOutputValidationError(
+      "invalid-json",
+      "[vitehub] Agent output is not valid JSON.",
+      { cause },
+    )
+  }
+}
+
+function issuePath(issue: StandardSchemaV1.Issue): string | undefined {
+  if (!issue.path?.length) return
+  return issue.path.map(segment => typeof segment === "object" ? String(segment.key) : String(segment)).join(".")
+}
+
+function formatIssues(issues: readonly StandardSchemaV1.Issue[]): string {
+  return issues.map((issue) => {
+    const path = issuePath(issue)
+    return path ? `${path}: ${issue.message}` : issue.message
+  }).join("; ")
+}
+
+export async function validateAgentOutput<TOutput>(
+  output: AgentOutputDefinition<TOutput>,
+  result: unknown,
+): Promise<TOutput> {
+  const value = jsonValueFromResult(result)
+  const validation = await output.schema["~standard"].validate(value)
+  if (validation.issues?.length) {
+    throw new AgentOutputValidationError(
+      "schema-validation",
+      `[vitehub] Agent output failed schema validation: ${formatIssues(validation.issues)}.`,
+    )
+  }
+  if (!("value" in validation)) {
+    throw new AgentOutputValidationError(
+      "schema-validation",
+      "[vitehub] Agent output failed schema validation.",
+    )
+  }
+  return validation.value
+}
+
+function supportsJsonSchema(schema: StandardSchemaV1): schema is StandardSchemaV1 & StandardJSONSchemaV1 {
+  return typeof (schema["~standard"] as { jsonSchema?: unknown }).jsonSchema === "object"
+    && typeof (schema["~standard"] as { jsonSchema?: { output?: unknown } }).jsonSchema?.output === "function"
+}
+
+export function agentOutputInstructions(output: AgentOutputDefinition | undefined): string | undefined {
+  if (!output) return
+  let jsonSchema: Record<string, unknown> | undefined
+  if (supportsJsonSchema(output.schema)) {
+    try {
+      jsonSchema = output.schema["~standard"].jsonSchema.output({ target: "draft-07" })
+    }
+    catch {}
+  }
+  return [
+    "Return only one valid JSON value for the configured Agent output. Do not wrap it in Markdown or add commentary.",
+    ...(jsonSchema ? ["The JSON value must match this schema:", "```json", JSON.stringify(jsonSchema, null, 2), "```"] : []),
+  ].join("\n")
+}

--- a/packages/agent/src/internal/agent-structured-output.ts
+++ b/packages/agent/src/internal/agent-structured-output.ts
@@ -29,6 +29,7 @@ function jsonValueFromResult(result: unknown): unknown {
     return JSON.parse(stripJsonFence(text))
   }
   catch (cause) {
+    if (result !== null && typeof result === "object") return result
     throw new AgentOutputValidationError(
       "invalid-json",
       "[vitehub] Agent output is not valid JSON.",

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1047,12 +1047,17 @@ export interface AgentDefinitionCliOptions {
   capabilities?: boolean
 }
 
+export interface AgentOutputDefinition<TOutput = unknown> {
+  schema: StandardSchemaV1<unknown, TOutput>
+}
+
 type AgentSharedSettings<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
   TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined,
+  TOutput = unknown,
 > = {
   box?: BoxDefinition<AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>>
   capabilities?: TCapabilities
@@ -1063,6 +1068,7 @@ type AgentSharedSettings<
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   name?: string
+  output?: AgentOutputDefinition<TOutput>
   runtime?: AgentRuntimeBinding
   runEvents?: AgentRunEvents
   version?: string
@@ -1075,7 +1081,8 @@ export type AgentSettings<
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
   TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined,
-> = AgentSharedSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities> & {
+  TOutput = unknown,
+> = AgentSharedSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities, TOutput> & {
   driver: AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
 }
 
@@ -1084,6 +1091,7 @@ export interface AgentDefinition<
   CALL_OPTIONS = unknown,
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
+  TOutput = unknown,
 > {
   box?: BoxDefinition<AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>>
   capabilities?: AgentCapabilityDefinition<TRuntimeConfig>[]
@@ -1095,6 +1103,7 @@ export interface AgentDefinition<
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   name?: string
+  output?: AgentOutputDefinition<TOutput>
   runtime?: AgentRuntimeBinding
   runEvents?: AgentRunEvents
   resolve(context: AgentRuntimeContext<TRuntimeConfig>): Promise<AgentAdapter<CALL_OPTIONS>>
@@ -1103,8 +1112,8 @@ export interface AgentDefinition<
   workspace?: WorkspaceAgentWorkspaceConfig
 }
 
-export type AgentInput<TContext extends AgentRuntimeContext<any> = AgentRuntimeContext> =
-  AgentDefinition<TContext extends AgentRuntimeContext<infer TRuntimeConfig> ? TRuntimeConfig : AgentRuntimeConfig, any, any, any>
+export type AgentInput<TContext extends AgentRuntimeContext<any> = AgentRuntimeContext, TOutput = unknown> =
+  AgentDefinition<TContext extends AgentRuntimeContext<infer TRuntimeConfig> ? TRuntimeConfig : AgentRuntimeConfig, any, any, any, TOutput>
 
 export type AgentRegistryModule<TContext extends AgentRuntimeContext<any> = AgentRuntimeContext> =
   | { default?: AgentInput<TContext> }
@@ -1584,6 +1593,7 @@ export interface AgentAdapterRunContext<
   invoker: AgentInvoker
   messages: Message[]
   modelExecutionInstrumentation?: AgentModelExecutionInstrumentation[]
+  output?: AgentOutputDefinition
   outputRenderers?: Array<(result: unknown) => MaybePromise<unknown>>
   prompt?: string
   providerTools?: AgentProviderToolContribution[]

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -105,7 +105,8 @@ export type WorkspaceAgentOptions<
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
   TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, _Name, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, _Name, CALL_OPTIONS> | undefined,
-> = AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities> & {
+  TOutput = unknown,
+> = AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities, TOutput> & {
   name?: string
   workspace: WorkspaceAgentWorkspaceConfig<_Name>
 }
@@ -117,9 +118,10 @@ export type WorkspaceAgentDefinition<
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
   TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, Name, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, Name, CALL_OPTIONS> | undefined,
-> = AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues> & WorkspaceAgentWorkspaceOptions & {
+  TOutput = unknown,
+> = AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput> & WorkspaceAgentWorkspaceOptions & {
   __vitehubWorkspaceAgent: true
-  __vitehubWorkspaceAgentOptions: WorkspaceAgentOptions<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities>
+  __vitehubWorkspaceAgentOptions: WorkspaceAgentOptions<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities, TOutput>
 }
 
 export interface WorkspaceAgentDefaults<Name extends WorkspaceName = WorkspaceName> {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1378,6 +1378,33 @@ describe("agent message protocol", () => {
     expect(session.destroy).toHaveBeenCalledTimes(1)
   })
 
+  it("guides harnesses with optional Standard JSON Schema and validates their final output", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessGenerate.mockResolvedValueOnce({ text: "{\"title\":\"Weekly sync\"}" })
+    const schema = {
+      "~standard": {
+        jsonSchema: {
+          input: () => ({ type: "object" }),
+          output: () => ({ properties: { title: { type: "string" } }, required: ["title"], type: "object" }),
+        },
+        validate: (value: unknown) => ({ value: value as { title: string } }),
+        vendor: "vitehub-test",
+        version: 1 as const,
+      },
+    }
+    const agent = defineAgent({
+      driver: { harness: { provider: "codex" } },
+      output: { schema },
+      runtime: false,
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "summarize" })).resolves.toEqual({ title: "Weekly sync" })
+    expect(harnessAgentSettings.at(-1)?.instructions).toContain("Return only one valid JSON value")
+    expect(harnessAgentSettings.at(-1)?.instructions).toContain('"title"')
+  })
+
   it("requires explicit harness sandboxes on runtimes without local processes", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const agent = defineAgent({ driver: { harness: { provider: "codex" } } })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1405,6 +1405,27 @@ describe("agent message protocol", () => {
     expect(harnessAgentSettings.at(-1)?.instructions).toContain('"title"')
   })
 
+  it("rejects malformed JSON from structured harness results", async () => {
+    const { defineAgent, runAgent, AgentOutputValidationError } = await import("../src/index.ts")
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    harnessGenerate.mockResolvedValueOnce({ text: "hello" })
+    const agent = defineAgent({
+      driver: { harness: { provider: "codex" } },
+      output: {
+        schema: {
+          "~standard": {
+            validate: (value: unknown) => ({ value: value as { text: string } }),
+            vendor: "vitehub-test",
+            version: 1,
+          },
+        },
+      },
+      runtime: false,
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).rejects.toBeInstanceOf(AgentOutputValidationError)
+  })
+
   it("requires explicit harness sandboxes on runtimes without local processes", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const agent = defineAgent({ driver: { harness: { provider: "codex" } } })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1386,8 +1386,8 @@ describe("agent message protocol", () => {
     const schema = {
       "~standard": {
         jsonSchema: {
-          input: () => ({ type: "object" }),
-          output: () => ({ properties: { title: { type: "string" } }, required: ["title"], type: "object" }),
+          input: () => ({ properties: { title: { type: "string" } }, required: ["title"], type: "object" }),
+          output: () => ({ type: "number" }),
         },
         validate: (value: unknown) => ({ value: value as { title: string } }),
         vendor: "vitehub-test",

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -149,6 +149,45 @@ describe("Agent structured output", () => {
     })
   })
 
+  it("materializes structured stream-result wrappers", async () => {
+    const agent = defineAgent({
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { text: "{\"summary\":\"Decisions\",\"title\":\"Weekly sync\"}", type: "text-delta" as const }
+          })(),
+        }),
+      },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+
+    await expect(runAgentInline(agent, runtime(), {})).resolves.toEqual({
+      summary: "Decisions",
+      title: "Weekly sync",
+    })
+  })
+
+  it("preserves usage while materializing structured run streams", async () => {
+    const finish = vi.fn()
+    const agent = defineAgent({
+      driver: {
+        run: async function* () {
+          yield { text: "{\"summary\":\"Decisions\",\"title\":\"Weekly sync\"}", type: "text-delta" as const }
+          yield { type: "usage" as const, usageRecord: { usage: { totalTokens: 3 } } }
+        },
+      },
+      hooks: { "agent:finish": finish },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+
+    await runAgentInline(agent, runtime(), {})
+    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+      invocation: expect.objectContaining({ usage: { usage: { totalTokens: 3 } } }),
+    }))
+  })
+
   it("preserves raw custom driver streams", async () => {
     const agent = defineAgent({
       driver: {

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -97,6 +97,27 @@ describe("Agent structured output", () => {
     await expect(runAgentInline(agent, runtime(), {})).resolves.toEqual({ text: "hello" })
   })
 
+  it("preserves materialized text fields containing valid JSON", async () => {
+    const schema: StandardSchemaV1<unknown, { text: string }> = {
+      "~standard": {
+        validate(value) {
+          return value && typeof value === "object" && typeof (value as { text?: unknown }).text === "string"
+            ? { value: value as { text: string } }
+            : { issues: [{ message: "Expected text" }] }
+        },
+        vendor: "vitehub-test",
+        version: 1,
+      },
+    }
+    const agent = defineAgent({
+      driver: { run: () => ({ text: "42" }) },
+      output: { schema },
+      runtime: false,
+    })
+
+    await expect(runAgentInline(agent, runtime(), {})).resolves.toEqual({ text: "42" })
+  })
+
   it("decodes AgentRunResult text from custom drivers", async () => {
     const agent = defineAgent({
       driver: { run: () => ({ text: "{\"summary\":\"Decisions\",\"title\":\"Weekly sync\"}" }) },

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -156,6 +156,7 @@ describe("Agent structured output", () => {
         run: async function* () {
           yield { text: "{\"summary\":\"Decisions\",", type: "text-delta" as const }
           yield { text: "\"title\":\"Weekly sync\"}", type: "text-delta" as const }
+          yield { type: "usage" as const, usageRecord: { usage: { totalTokens: 3 } } }
         },
       },
       hooks: { "agent:finish": finish },
@@ -167,6 +168,7 @@ describe("Agent structured output", () => {
     expect(typeof (result as AsyncIterable<unknown>)[Symbol.asyncIterator]).toBe("function")
     for await (const _event of result as AsyncIterable<unknown>) {}
     expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+      invocation: expect.objectContaining({ usage: { totalTokens: 3 } }),
       result: { summary: "Decisions", title: "Weekly sync" },
     }))
   })

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -149,6 +149,43 @@ describe("Agent structured output", () => {
     })
   })
 
+  it("preserves raw custom driver streams", async () => {
+    const agent = defineAgent({
+      driver: {
+        run: async function* () {
+          yield { text: "not json", type: "text-delta" as const }
+        },
+      },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+
+    const result = await runAgentInline(agent, runtime(), {}, { output: "raw" })
+    await expect(Array.fromAsync(result as AsyncIterable<unknown>)).resolves.toEqual([
+      { text: "not json", type: "text-delta" },
+    ])
+  })
+
+  it("preserves usage for non-stream structured stream results", async () => {
+    const finish = vi.fn()
+    const agent = defineAgent({
+      driver: {
+        run: () => ({
+          text: "{\"summary\":\"Decisions\",\"title\":\"Weekly sync\"}",
+          usageRecord: { usage: { totalTokens: 3 } },
+        }),
+      },
+      hooks: { "agent:finish": finish },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+
+    await streamAgentInline(agent, runtime(), {})
+    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+      invocation: expect.objectContaining({ usage: { usage: { totalTokens: 3 } } }),
+    }))
+  })
+
   it("validates structured streams before running the finish lifecycle", async () => {
     const finish = vi.fn()
     const agent = defineAgent({
@@ -168,7 +205,7 @@ describe("Agent structured output", () => {
     expect(typeof (result as AsyncIterable<unknown>)[Symbol.asyncIterator]).toBe("function")
     for await (const _event of result as AsyncIterable<unknown>) {}
     expect(finish).toHaveBeenCalledWith(expect.objectContaining({
-      invocation: expect.objectContaining({ usage: { totalTokens: 3 } }),
+      invocation: expect.objectContaining({ usage: { usage: { totalTokens: 3 } } }),
       result: { summary: "Decisions", title: "Weekly sync" },
     }))
   })

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -149,6 +149,26 @@ describe("Agent structured output", () => {
     })
   })
 
+  it("aborts while materializing structured output streams", async () => {
+    const controller = new AbortController()
+    const pending = new Promise<IteratorResult<never>>(() => {})
+    const stream: AsyncIterable<never> = {
+      [Symbol.asyncIterator]() {
+        return { next: () => pending, return: async () => ({ done: true, value: undefined }) }
+      },
+    }
+    const agent = defineAgent({
+      driver: { run: () => stream },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+    const result = runAgentInline(agent, runtime(), { abortSignal: controller.signal })
+
+    controller.abort(new Error("stopped"))
+
+    await expect(result).rejects.toThrow("stopped")
+  })
+
   it("materializes structured stream-result wrappers", async () => {
     const agent = defineAgent({
       driver: {

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -97,6 +97,19 @@ describe("Agent structured output", () => {
     await expect(runAgentInline(agent, runtime(), {})).resolves.toEqual({ text: "hello" })
   })
 
+  it("decodes AgentRunResult text from custom drivers", async () => {
+    const agent = defineAgent({
+      driver: { run: () => ({ text: "{\"summary\":\"Decisions\",\"title\":\"Weekly sync\"}" }) },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+
+    await expect(runAgentInline(agent, runtime(), {})).resolves.toEqual({
+      summary: "Decisions",
+      title: "Weekly sync",
+    })
+  })
+
   it("reports Standard Schema failures separately from JSON decoding", async () => {
     const agent = defineAgent({
       driver: { run: () => "{\"title\":42}" },

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -76,6 +76,27 @@ describe("Agent structured output", () => {
     } satisfies Partial<AgentOutputValidationError>)
   })
 
+  it("validates materialized objects whose schema includes a text field", async () => {
+    const schema: StandardSchemaV1<unknown, { text: string }> = {
+      "~standard": {
+        validate(value) {
+          return value && typeof value === "object" && typeof (value as { text?: unknown }).text === "string"
+            ? { value: value as { text: string } }
+            : { issues: [{ message: "Expected text" }] }
+        },
+        vendor: "vitehub-test",
+        version: 1,
+      },
+    }
+    const agent = defineAgent({
+      driver: { run: () => ({ text: "hello" }) },
+      output: { schema },
+      runtime: false,
+    })
+
+    await expect(runAgentInline(agent, runtime(), {})).resolves.toEqual({ text: "hello" })
+  })
+
   it("reports Standard Schema failures separately from JSON decoding", async () => {
     const agent = defineAgent({
       driver: { run: () => "{\"title\":42}" },

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { AgentOutputValidationError, defineAgent, runAgentInline } from "../src/index.ts"
+import { AgentOutputValidationError, defineAgent, runAgentInline, streamAgentInline } from "../src/index.ts"
 
 import type { AgentRuntimeContext } from "../src/index.ts"
 import type { StandardSchemaV1 } from "@standard-schema/spec"
@@ -147,6 +147,28 @@ describe("Agent structured output", () => {
       summary: "Decisions",
       title: "Weekly sync",
     })
+  })
+
+  it("validates structured streams before running the finish lifecycle", async () => {
+    const finish = vi.fn()
+    const agent = defineAgent({
+      driver: {
+        run: async function* () {
+          yield { text: "{\"summary\":\"Decisions\",", type: "text-delta" as const }
+          yield { text: "\"title\":\"Weekly sync\"}", type: "text-delta" as const }
+        },
+      },
+      hooks: { "agent:finish": finish },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+
+    const result = await streamAgentInline(agent, runtime(), {})
+    expect(typeof (result as AsyncIterable<unknown>)[Symbol.asyncIterator]).toBe("function")
+    for await (const _event of result as AsyncIterable<unknown>) {}
+    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+      result: { summary: "Decisions", title: "Weekly sync" },
+    }))
   })
 
   it("reports Standard Schema failures separately from JSON decoding", async () => {

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -207,6 +207,23 @@ describe("Agent structured output", () => {
     ])
   })
 
+  it("preserves raw stream-result wrappers without consuming them", async () => {
+    const stream = (async function* () {
+      yield { text: "not json", type: "text-delta" as const }
+    })()
+    const wrapper = { stream }
+    const agent = defineAgent({
+      driver: { run: () => wrapper },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+
+    await expect(runAgentInline(agent, runtime(), {}, { output: "raw" })).resolves.toBe(wrapper)
+    const events: unknown[] = []
+    for await (const event of stream) events.push(event)
+    expect(events).toEqual([{ text: "not json", type: "text-delta" }])
+  })
+
   it("preserves usage for non-stream structured stream results", async () => {
     const finish = vi.fn()
     const agent = defineAgent({

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -110,6 +110,24 @@ describe("Agent structured output", () => {
     })
   })
 
+  it("materializes and validates structured custom driver streams", async () => {
+    const agent = defineAgent({
+      driver: {
+        run: async function* () {
+          yield { text: "{\"summary\":\"Dec", type: "text-delta" as const }
+          yield { text: "isions\",\"title\":\"Weekly sync\"}", type: "text-delta" as const }
+        },
+      },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+
+    await expect(runAgentInline(agent, runtime(), {})).resolves.toEqual({
+      summary: "Decisions",
+      title: "Weekly sync",
+    })
+  })
+
   it("reports Standard Schema failures separately from JSON decoding", async () => {
     const agent = defineAgent({
       driver: { run: () => "{\"title\":42}" },

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -161,7 +161,9 @@ describe("Agent structured output", () => {
     })
 
     const result = await runAgentInline(agent, runtime(), {}, { output: "raw" })
-    await expect(Array.fromAsync(result as AsyncIterable<unknown>)).resolves.toEqual([
+    const events: unknown[] = []
+    for await (const event of result as AsyncIterable<unknown>) events.push(event)
+    expect(events).toEqual([
       { text: "not json", type: "text-delta" },
     ])
   })

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { AgentOutputValidationError, defineAgent, runAgentInline } from "../src/index.ts"
+
+import type { AgentRuntimeContext } from "../src/index.ts"
+import type { StandardSchemaV1 } from "@standard-schema/spec"
+
+interface SummaryOutput {
+  summary: string
+  title: string
+}
+
+function summarySchema(): StandardSchemaV1<unknown, SummaryOutput> {
+  return {
+    "~standard": {
+      validate(value) {
+        if (
+          value
+          && typeof value === "object"
+          && typeof (value as { summary?: unknown }).summary === "string"
+          && typeof (value as { title?: unknown }).title === "string"
+        ) {
+          return { value: value as SummaryOutput }
+        }
+        return { issues: [{ message: "Expected summary and title strings", path: ["title"] }] }
+      },
+      vendor: "vitehub-test",
+      version: 1,
+    },
+  }
+}
+
+function runtime(): AgentRuntimeContext {
+  return {
+    memo: (_key, create) => create(),
+    runtime: "unknown",
+    waitUntil: () => {},
+  }
+}
+
+describe("Agent structured output", () => {
+  it("returns the validated Standard Schema value and passes it to finish lifecycle", async () => {
+    const finish = vi.fn()
+    class HarnessResult {
+      get text() {
+        return "{\"summary\":\"Decisions\",\"title\":\"Weekly sync\"}"
+      }
+    }
+    const agent = defineAgent({
+      driver: { run: () => new HarnessResult() },
+      hooks: { "agent:finish": finish },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+
+    await expect(runAgentInline(agent, runtime(), {})).resolves.toEqual({
+      summary: "Decisions",
+      title: "Weekly sync",
+    })
+    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+      result: { summary: "Decisions", title: "Weekly sync" },
+    }))
+  })
+
+  it("reports malformed JSON with a stable ViteHub-owned error", async () => {
+    const agent = defineAgent({
+      driver: { run: () => "not json" },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+
+    await expect(runAgentInline(agent, runtime(), {})).rejects.toMatchObject({
+      code: "invalid-json",
+      message: "[vitehub] Agent output is not valid JSON.",
+      name: "AgentOutputValidationError",
+    } satisfies Partial<AgentOutputValidationError>)
+  })
+
+  it("reports Standard Schema failures separately from JSON decoding", async () => {
+    const agent = defineAgent({
+      driver: { run: () => "{\"title\":42}" },
+      output: { schema: summarySchema() },
+      runtime: false,
+    })
+
+    await expect(runAgentInline(agent, runtime(), {})).rejects.toMatchObject({
+      code: "schema-validation",
+      message: "[vitehub] Agent output failed schema validation: title: Expected summary and title strings.",
+      name: "AgentOutputValidationError",
+    } satisfies Partial<AgentOutputValidationError>)
+  })
+
+  it("preserves untyped Agent results", async () => {
+    const agent = defineAgent({
+      driver: { run: () => "plain text" },
+      runtime: false,
+    })
+
+    await expect(runAgentInline(agent, runtime(), {})).resolves.toBe("plain text")
+  })
+})

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -97,9 +97,11 @@ describe("agent public types", () => {
       runtime: false,
     })
     const result = runAgentInline(agent, {} as AgentRuntimeContext, {})
+    const rawResult = runAgentInline(agent, {} as AgentRuntimeContext, {}, { output: "raw" })
     const workflowResult = runAgent(agent, {} as AgentRuntimeContext, {})
 
     expectTypeOf(result).toEqualTypeOf<Promise<Response | { summary: string, title: string }>>()
+    expectTypeOf(rawResult).toEqualTypeOf<Promise<unknown>>()
     expectTypeOf<Extract<Awaited<typeof workflowResult>, { id: string }>["result"]>().toEqualTypeOf<{ summary: string, title: string } | undefined>()
   })
 

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgentInline, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, chatTitle, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -81,6 +81,24 @@ describe("agent public types", () => {
       // @ts-expect-error Agent Run Events must be created by defineAgentRunEvents().
       runEvents: handWritten,
     })
+  })
+
+  it("infers structured Agent output from its Standard Schema", () => {
+    const schema = {
+      "~standard": {
+        validate: (input: unknown) => ({ value: input as { summary: string, title: string } }),
+        vendor: "test",
+        version: 1 as const,
+      },
+    } satisfies StandardSchemaV1<unknown, { summary: string, title: string }>
+    const agent = defineAgent({
+      driver: { run: () => "{}" },
+      output: { schema },
+      runtime: false,
+    })
+    const result = runAgentInline(agent, {} as AgentRuntimeContext, {})
+
+    expectTypeOf(result).toEqualTypeOf<Promise<Response | { summary: string, title: string }>>()
   })
 
   it("accepts literal false as the inline runtime opt-out", () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgentInline, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, chatTitle, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -97,8 +97,10 @@ describe("agent public types", () => {
       runtime: false,
     })
     const result = runAgentInline(agent, {} as AgentRuntimeContext, {})
+    const workflowResult = runAgent(agent, {} as AgentRuntimeContext, {})
 
     expectTypeOf(result).toEqualTypeOf<Promise<Response | { summary: string, title: string }>>()
+    expectTypeOf<Extract<Awaited<typeof workflowResult>, { id: string }>["result"]>().toEqualTypeOf<{ summary: string, title: string } | undefined>()
   })
 
   it("accepts literal false as the inline runtime opt-out", () => {


### PR DESCRIPTION
Adds a Standard Schema-backed `output.schema` contract to Agent Definitions. Harness Drivers receive JSON-only guidance, and Agent Invocations decode and validate the final output before returning the inferred value or running the finish lifecycle.

This removes provider-result parsing from callers while preserving untyped Agent result behavior. Standard JSON Schema enrichment remains optional; Standard Schema validation is authoritative.