### PR TITLE
feat(agent): add run event server utilities

### DIFF
--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -88,6 +88,46 @@ export default defineAgent({
 
 The finish hook runs before the invocation's terminal Trace Event. Agent tests and eval observations expose the finalized `TraceRunView` as `result.trace` or `observation.trace` after completion. Stream and Response traces become terminal when the caller consumes, cancels, or encounters an error from the output.
 
+## Publish application run events
+
+Use Agent Run Events when server code needs to expose application-owned progress across Capability input, Agent Driver, and finish phases. Define the store beside the Agent so Workflow execution imports the resolver instead of serializing it in the Workflow payload.
+
+```ts [server/agents/summary/agent.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { defineAgentRunEvents } from '@vite-hub/agent/server'
+import { summaryRunEventStore } from '../../run-event-store'
+
+export const summaryRunEvents = defineAgentRunEvents({
+  store: context => summaryRunEventStore(context),
+})
+
+export default defineAgent({
+  runEvents: summaryRunEvents,
+  capabilities: [{
+    id: 'transcribe',
+    async input(context) {
+      await context.runEvents?.publish({
+        type: 'stage',
+        data: { stage: 'transcribe' },
+      })
+    },
+  }],
+  driver: {
+    async run(context) {
+      await context.runEvents?.publish({
+        type: 'stage',
+        data: { stage: 'summarize' },
+      })
+      return summarize(context)
+    },
+  },
+})
+```
+
+The publisher exists only when the invocation has a stable `runId`; ViteHub does not invent a second identity for inline calls. Workflow-backed Agents use the Workflow Run id, while Capability input, the Agent Driver, and finish hooks remain phases inside that one run rather than separate Workflow steps.
+
+Server routes can call `summaryRunEvents.read(runId, cursor)` for replay or `summaryRunEvents.subscribe(runId, cursor, { signal })` for replay followed by live events. The configured store owns cursor assignment, ordering, timestamps, persistence, and the replay-to-live handoff, and it must stop subscriptions when the abort signal fires. ViteHub supplies no default persistence or authorization; authenticate the server route and scope every store operation to the application's run owner.
+
 ## Invoke a trigger
 
 Use `runAgentTrigger` or `streamAgentTrigger` when a Capability owns the product event shape. The trigger prepares Agent Invocation input, metadata, and run state before the Agent Driver starts.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -26,6 +26,7 @@ import {
   messageChannelTitleSupportContextKey,
 } from "./channels.ts"
 import { agentInvocationCallbackContextValues, createAgentInvocationContextStore } from "./invocation-context.ts"
+import { bindAgentRunEvents } from "./run-events.ts"
 import {
   createFallbackAgentInvoker,
   normalizeAgentInvokerOptions,
@@ -954,6 +955,16 @@ export {
 } from "./invocation-stream.ts"
 export type { AgentInvocationStreamEvent } from "./invocation-stream.ts"
 
+export type {
+  AgentRunEvent,
+  AgentRunEventInput,
+  AgentRunEventPublisher,
+  AgentRunEvents,
+  AgentRunEventStore,
+  AgentRunEventStoreResolveContext,
+  AgentRunEventStoreResolver,
+} from "./run-events.ts"
+
 function resolveCapabilityCliRunSurface(definition: Pick<AgentDefinition, "cli"> | undefined): boolean {
   if (definition?.cli?.capabilities !== undefined) return definition.cli.capabilities !== false
   return true
@@ -984,7 +995,7 @@ function defineBaseAgent<
   options: AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile>,
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS> {
   const driver = normalizeAgentDriver(options)
-  const { box, capabilities, cli, description, hooks, messages, name, runtime = defaultAgentWorkflowRuntime(), version, workspace } = options
+  const { box, capabilities, cli, description, hooks, messages, name, runtime = defaultAgentWorkflowRuntime(), runEvents, version, workspace } = options
   const channels = normalizeAgentChannels(options.channels)
   if (box && driver.kind !== "harness") {
     throw new Error("[vitehub] defineAgent({ box }) currently requires a harness Agent Driver.")
@@ -1044,6 +1055,7 @@ function defineBaseAgent<
     messages,
     name,
     runtime,
+    runEvents,
     run,
     version,
     workspace,
@@ -1431,13 +1443,17 @@ async function createAgentInvocationContext<
 ): Promise<AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>> {
   const startedAt = Date.now()
   const resolvedContext = createResolvedRuntimeContext(context)
-  const runtimeContext = resolvedContext.trace && resolvedContext.traceLog
+  const tracedRuntimeContext = resolvedContext.trace && resolvedContext.traceLog
     ? resolvedContext
     : {
         ...resolvedContext,
         trace: resolvedContext.trace || { id: createTraceId(context.run) },
         traceLog: resolvedContext.traceLog || createTraceEventLog(),
       }
+  const boundRunEvents = bindAgentRunEvents(definition?.runEvents, tracedRuntimeContext)
+  const runtimeContext = boundRunEvents
+    ? { ...tracedRuntimeContext, runEvents: boundRunEvents }
+    : tracedRuntimeContext
   const callbackContext = createAgentCallbackContext(runtimeContext)
   const invocationContext = createAgentInvocationContextStore(input.context)
   invocationContext.set(scheduledAgentChannelIdsContextKey, Object.keys(definition?.channels || {}), { overwrite: true })

--- a/packages/agent/src/run-events.ts
+++ b/packages/agent/src/run-events.ts
@@ -1,0 +1,135 @@
+import type { MaybePromise, ResolvedAgentRuntimeContext } from "./types.ts"
+
+const bindAgentRunEventsSymbol = Symbol("vitehub.bindAgentRunEvents")
+
+export interface AgentRunEvent<TData = unknown> {
+  cursor: string
+  data?: TData
+  runId: string
+  timestamp: string
+  type: string
+}
+
+export interface AgentRunEventInput<TData = unknown> {
+  data?: TData
+  type: string
+}
+
+export interface AgentRunEventReadOptions {
+  after?: string
+}
+
+export interface AgentRunEventSubscribeOptions extends AgentRunEventReadOptions {
+  signal?: AbortSignal
+}
+
+export interface AgentRunEventStore {
+  append(runId: string, event: AgentRunEventInput): MaybePromise<AgentRunEvent>
+  read(runId: string, options?: AgentRunEventReadOptions): MaybePromise<readonly AgentRunEvent[]>
+  /** Replays events after the cursor before yielding live events for the same run. */
+  subscribe(runId: string, options?: AgentRunEventSubscribeOptions): AsyncIterable<AgentRunEvent>
+}
+
+export interface AgentRunEventStoreResolveContext {
+  operation: "publish" | "read" | "subscribe"
+  runId: string
+  runtime?: ResolvedAgentRuntimeContext
+}
+
+export type AgentRunEventStoreResolver = (
+  context: AgentRunEventStoreResolveContext,
+) => MaybePromise<AgentRunEventStore>
+
+export interface AgentRunEventsOptions {
+  store: AgentRunEventStore | AgentRunEventStoreResolver
+}
+
+export interface AgentRunEventPublisher {
+  publish<TData = unknown>(event: AgentRunEventInput<TData>): Promise<AgentRunEvent<TData>>
+}
+
+export interface AgentRunEvents {
+  publish<TData = unknown>(runId: string, event: AgentRunEventInput<TData>): Promise<AgentRunEvent<TData>>
+  read(runId: string, cursor?: string): Promise<readonly AgentRunEvent[]>
+  subscribe(runId: string, cursor?: string, options?: { signal?: AbortSignal }): AsyncIterable<AgentRunEvent>
+}
+
+interface BoundAgentRunEvents extends AgentRunEvents {
+  [bindAgentRunEventsSymbol](runtime: ResolvedAgentRuntimeContext): AgentRunEventPublisher | undefined
+}
+
+function assertRunId(runId: string): void {
+  if (typeof runId !== "string" || !runId.trim()) {
+    throw new TypeError("[vitehub] Agent Run Events require a non-empty run id.")
+  }
+}
+
+function assertEvent(event: AgentRunEventInput): void {
+  if (!event || typeof event !== "object" || typeof event.type !== "string" || !event.type.trim()) {
+    throw new TypeError("[vitehub] Agent Run Events require an event with a non-empty type.")
+  }
+}
+
+function isStore(value: AgentRunEventStore | AgentRunEventStoreResolver): value is AgentRunEventStore {
+  return typeof value === "object" && value !== null
+}
+
+async function resolveStore(
+  input: AgentRunEventStore | AgentRunEventStoreResolver,
+  context: AgentRunEventStoreResolveContext,
+): Promise<AgentRunEventStore> {
+  const store = isStore(input) ? input : await input(context)
+  if (!store || typeof store.append !== "function" || typeof store.read !== "function" || typeof store.subscribe !== "function") {
+    throw new TypeError("[vitehub] Agent Run Events require a store with append(), read(), and subscribe().")
+  }
+  return store
+}
+
+export function defineAgentRunEvents(options: AgentRunEventsOptions): AgentRunEvents {
+  if (!options || typeof options !== "object" || !("store" in options)) {
+    throw new TypeError("[vitehub] defineAgentRunEvents() requires a store.")
+  }
+
+  const events: BoundAgentRunEvents = {
+    [bindAgentRunEventsSymbol](runtime) {
+      const runId = runtime.run?.runId
+      if (!runId) return
+      return {
+        publish: async <TData = unknown>(event: AgentRunEventInput<TData>) => {
+          assertEvent(event)
+          const store = await resolveStore(options.store, { operation: "publish", runId, runtime })
+          return await store.append(runId, event) as AgentRunEvent<TData>
+        },
+      }
+    },
+    async publish<TData = unknown>(runId: string, event: AgentRunEventInput<TData>): Promise<AgentRunEvent<TData>> {
+      assertRunId(runId)
+      assertEvent(event)
+      const store = await resolveStore(options.store, { operation: "publish", runId })
+      return await store.append(runId, event) as AgentRunEvent<TData>
+    },
+    async read(runId: string, cursor?: string): Promise<readonly AgentRunEvent[]> {
+      assertRunId(runId)
+      const store = await resolveStore(options.store, { operation: "read", runId })
+      return await store.read(runId, cursor === undefined ? undefined : { after: cursor })
+    },
+    async *subscribe(runId: string, cursor?: string, subscribeOptions: { signal?: AbortSignal } = {}): AsyncIterable<AgentRunEvent> {
+      assertRunId(runId)
+      const store = await resolveStore(options.store, { operation: "subscribe", runId })
+      yield* store.subscribe(runId, {
+        ...(cursor === undefined ? {} : { after: cursor }),
+        ...(subscribeOptions.signal ? { signal: subscribeOptions.signal } : {}),
+      })
+    },
+  }
+  return events
+}
+
+export function bindAgentRunEvents(events: AgentRunEvents | undefined, runtime: ResolvedAgentRuntimeContext): AgentRunEventPublisher | undefined {
+  if (!events) return
+  const bind = (events as Partial<BoundAgentRunEvents>)[bindAgentRunEventsSymbol]
+  if (typeof bind !== "function") {
+    throw new TypeError("[vitehub] defineAgent({ runEvents }) requires a definition created by defineAgentRunEvents().")
+  }
+  return bind.call(events, runtime)
+}

--- a/packages/agent/src/run-events.ts
+++ b/packages/agent/src/run-events.ts
@@ -1,6 +1,7 @@
 import type { MaybePromise, ResolvedAgentRuntimeContext } from "./types.ts"
 
 const bindAgentRunEventsSymbol = Symbol("vitehub.bindAgentRunEvents")
+const agentRunEventsBrand: unique symbol = Symbol("vitehub.agentRunEvents")
 
 export interface AgentRunEvent<TData = unknown> {
   cursor: string
@@ -49,6 +50,7 @@ export interface AgentRunEventPublisher {
 }
 
 export interface AgentRunEvents {
+  readonly [agentRunEventsBrand]: true
   publish<TData = unknown>(runId: string, event: AgentRunEventInput<TData>): Promise<AgentRunEvent<TData>>
   read(runId: string, cursor?: string): Promise<readonly AgentRunEvent[]>
   subscribe(runId: string, cursor?: string, options?: { signal?: AbortSignal }): AsyncIterable<AgentRunEvent>
@@ -91,6 +93,7 @@ export function defineAgentRunEvents(options: AgentRunEventsOptions): AgentRunEv
   }
 
   const events: BoundAgentRunEvents = {
+    [agentRunEventsBrand]: true,
     [bindAgentRunEventsSymbol](runtime) {
       const runId = runtime.run?.runId
       if (!runId) return

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -2,6 +2,21 @@ export {
   createDiscordGatewayRouteHandler,
 } from "./server/routes.ts"
 
+export { defineAgentRunEvents } from "./run-events.ts"
+
+export type {
+  AgentRunEvent,
+  AgentRunEventInput,
+  AgentRunEventPublisher,
+  AgentRunEventReadOptions,
+  AgentRunEvents,
+  AgentRunEventsOptions,
+  AgentRunEventStore,
+  AgentRunEventStoreResolveContext,
+  AgentRunEventStoreResolver,
+  AgentRunEventSubscribeOptions,
+} from "./run-events.ts"
+
 export type {
   AgentChannelChatRouteAdmissionContext,
   AgentChannelChatRouteAdmissionOptions,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1,4 +1,5 @@
 import type { Message, StreamEvent } from "./messages.ts"
+import type { AgentRunEventPublisher, AgentRunEvents } from "./run-events.ts"
 import type { BoxDefinition, BoxRequirement, ResolvedBox } from "@vite-hub/box"
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
 import type { JSONSchema7 } from "json-schema"
@@ -64,7 +65,9 @@ export type ResolvedAgentRuntimeContext<TRuntimeConfig extends AgentRuntimeConfi
   AgentRuntimeContext<TRuntimeConfig> & { runtimeConfig: TRuntimeConfig }
 
 export type AgentCallbackContext<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> =
-  Omit<ResolvedAgentRuntimeContext<TRuntimeConfig>, "runtimeConfig">
+  Omit<ResolvedAgentRuntimeContext<TRuntimeConfig>, "runtimeConfig"> & {
+    runEvents?: AgentRunEventPublisher
+  }
 
 export type AgentInvokerMeta = Record<string, unknown>
 
@@ -477,7 +480,7 @@ export interface AgentFinishEvent<
     usage?: AgentUsageRecord
   }
   result?: unknown
-  runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>
+  runtime: ResolvedAgentRuntimeContext<TRuntimeConfig> & { runEvents?: AgentRunEventPublisher }
   text?: string
 }
 
@@ -1061,6 +1064,7 @@ type AgentSharedSettings<
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   name?: string
   runtime?: AgentRuntimeBinding
+  runEvents?: AgentRunEvents
   version?: string
   workspace?: WorkspaceAgentWorkspaceConfig
 }
@@ -1092,6 +1096,7 @@ export interface AgentDefinition<
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   name?: string
   runtime?: AgentRuntimeBinding
+  runEvents?: AgentRunEvents
   resolve(context: AgentRuntimeContext<TRuntimeConfig>): Promise<AgentAdapter<CALL_OPTIONS>>
   run?(context: AgentRunContext<TRuntimeConfig, CALL_OPTIONS, WorkspaceName, TContextValues>): MaybePromise<Response | AgentRunResult | AsyncIterable<StreamEvent> | unknown>
   version?: string

--- a/packages/agent/test/run-events.test.ts
+++ b/packages/agent/test/run-events.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { defineAgent, defineCapability, runAgent } from "../src/index.ts"
+import { defineAgentRunEvents } from "../src/server.ts"
+
+import type {
+  AgentRunEvent,
+  AgentRunEventInput,
+  AgentRunEventStore,
+  AgentRunEventSubscribeOptions,
+} from "../src/server.ts"
+
+function memoryStore() {
+  const events: AgentRunEvent[] = []
+  const subscribe = vi.fn((runId: string, options?: AgentRunEventSubscribeOptions): AsyncIterable<AgentRunEvent> => (async function* () {
+    const cursor = Number(options?.after || 0)
+    for (const event of events) {
+      if (event.runId === runId && Number(event.cursor) > cursor) yield event
+    }
+  })())
+  const store: AgentRunEventStore = {
+    append(runId, event) {
+      const stored = {
+        ...event,
+        cursor: String(events.length + 1),
+        runId,
+        timestamp: new Date(0).toISOString(),
+      }
+      events.push(stored)
+      return stored
+    },
+    read(runId, options) {
+      const cursor = Number(options?.after || 0)
+      return events.filter(event => event.runId === runId && Number(event.cursor) > cursor)
+    },
+    subscribe,
+  }
+  return { events, store, subscribe }
+}
+
+describe("Agent Run Events", () => {
+  it("publishes application-owned events across capability, driver, and finish phases", async () => {
+    const { events, store } = memoryStore()
+    const resolveStore = vi.fn(({ runtime }) => {
+      expect(runtime?.run?.runId).toBe("summary-run")
+      return store
+    })
+    const runEvents = defineAgentRunEvents({ store: resolveStore })
+    const agent = defineAgent({
+      capabilities: [defineCapability({
+        id: "transcribe",
+        async input(context) {
+          await context.runEvents?.publish({ data: { stage: "transcribe" }, type: "stage" })
+        },
+      })],
+      driver: {
+        async run(context) {
+          await context.runEvents?.publish({ data: { stage: "summarize" }, type: "stage" })
+          return "done"
+        },
+      },
+      hooks: {
+        async "agent:finish"(event) {
+          await event.runtime.runEvents?.publish({ data: { stage: "finalize" }, type: "stage" })
+        },
+      },
+      runEvents,
+      runtime: false,
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "summary-run" },
+      runtime: "vercel",
+      runtimeConfig: { region: "iad" },
+      waitUntil: vi.fn(),
+    }, { prompt: "summarize" })).resolves.toBe("done")
+
+    expect(events).toMatchObject([
+      { cursor: "1", data: { stage: "transcribe" }, runId: "summary-run", type: "stage" },
+      { cursor: "2", data: { stage: "summarize" }, runId: "summary-run", type: "stage" },
+      { cursor: "3", data: { stage: "finalize" }, runId: "summary-run", type: "stage" },
+    ])
+    expect(resolveStore).toHaveBeenCalledTimes(3)
+  })
+
+  it("reads and subscribes after an opaque cursor", async () => {
+    const { store, subscribe } = memoryStore()
+    const runEvents = defineAgentRunEvents({ store })
+    await runEvents.publish("run-1", { data: 1, type: "progress" })
+    await runEvents.publish("run-1", { data: 2, type: "progress" })
+
+    await expect(runEvents.read("run-1", "1")).resolves.toMatchObject([
+      { cursor: "2", data: 2 },
+    ])
+    const signal = new AbortController().signal
+    const replay: AgentRunEvent[] = []
+    for await (const event of runEvents.subscribe("run-1", "1", { signal })) replay.push(event)
+
+    expect(replay).toMatchObject([{ cursor: "2", data: 2 }])
+    expect(subscribe).toHaveBeenCalledWith("run-1", { after: "1", signal })
+  })
+
+  it("does not invent a run id for inline invocations", async () => {
+    const { store } = memoryStore()
+    const run = vi.fn(context => context.runEvents)
+    const agent = defineAgent({
+      driver: { run },
+      runEvents: defineAgentRunEvents({ store }),
+      runtime: false,
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).resolves.toBeUndefined()
+    expect(run).toHaveBeenCalledOnce()
+  })
+
+  it("rejects hand-written run event definitions", async () => {
+    const agent = defineAgent({
+      driver: { run: () => "done" },
+      runEvents: {
+        publish: vi.fn(),
+        read: vi.fn(),
+        subscribe: vi.fn(),
+      } as never,
+      runtime: false,
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-1" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).rejects.toThrow("created by defineAgentRunEvents")
+  })
+
+  it.each([
+    ["empty run id", () => defineAgentRunEvents({ store: memoryStore().store }).publish("", { type: "stage" })],
+    ["empty event type", () => defineAgentRunEvents({ store: memoryStore().store }).publish("run-1", { type: "" } as AgentRunEventInput)],
+  ])("rejects %s", async (_case, invoke) => {
+    await expect(invoke()).rejects.toThrow("non-empty")
+  })
+})

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8538,6 +8538,60 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("reconstructs Agent Run Events inside workflow execution", async () => {
+      const { defineAgent, defineCapability, runAgent, workflow } = await import("../src/index.ts")
+      const { defineAgentRunEvents } = await import("../src/server.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      const published: Array<{ runId: string, event: { type: string } }> = []
+      let innerRunId: string | undefined
+      const store = {
+        append(runId: string, event: { type: string }) {
+          published.push({ event, runId })
+          return { ...event, cursor: String(published.length), runId, timestamp: new Date(0).toISOString() }
+        },
+        read: () => [],
+        subscribe: () => (async function* () {})(),
+      }
+      const resolveStore = vi.fn(({ runtime }) => {
+        innerRunId = runtime.run?.runId
+        expect(runtime.runtimeConfig).toEqual({ region: "iad" })
+        return store
+      })
+      const agent = defineAgent({
+        capabilities: [defineCapability({
+          id: "transcribe",
+          async input(context) {
+            await context.runEvents?.publish({ type: "transcribe" })
+          },
+        })],
+        driver: { run: context => context.runEvents?.publish({ type: "summarize" }).then(() => "done") },
+        runEvents: defineAgentRunEvents({ store: resolveStore }),
+        runtime: workflow("summary-run-events"),
+      })
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const run = await runAgent(agent, {
+        memo: vi.fn(),
+        runtime: "vercel",
+        runtimeConfig: { region: "iad" },
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "hello" }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("summary-run-events", run.id)).resolves.toMatchObject({
+        result: "done",
+        status: "completed",
+      })
+      expect(resolveStore).toHaveBeenCalledTimes(2)
+      expect(innerRunId).toBe(run.id)
+      expect(published).toEqual([
+        { event: { type: "transcribe" }, runId: run.id },
+        { event: { type: "summarize" }, runId: run.id },
+      ])
+    })
+
     it("keeps programmatic agent runs inline without a discovered identity", async () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const agent = defineAgent({

--- a/packages/agent/test/test-runner.test.ts
+++ b/packages/agent/test/test-runner.test.ts
@@ -6,7 +6,7 @@ const inspectTools = vi.fn(() => ({}))
 const agentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
 const agentGenerate = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<{ finishReason: string, text: string, usage?: unknown }>>(async () => ({ finishReason: "stop", text: "ok" })))
 const workflowMock = vi.hoisted(() => {
-  const run = vi.fn(() => "workflow")
+  const run = vi.fn((_payload?: unknown, _options?: unknown) => "workflow")
   return { create: vi.fn(() => ({ run })), run }
 })
 
@@ -98,6 +98,35 @@ describe("agent test runner", () => {
       },
       usage: { outputTokens: 2 },
     })
+  })
+
+  it("keeps Agent Run Event store resolvers out of workflow payloads", async () => {
+    const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+    const { defineAgentRunEvents } = await import("../src/server.ts")
+    const resolveStore = vi.fn()
+    const agent = defineAgent({
+      driver: { run: () => "done" },
+      runEvents: defineAgentRunEvents({ store: resolveStore }),
+      runtime: workflow("run-events-payload"),
+    })
+
+    await runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-events-1" },
+      runtime: "vercel",
+      runtimeConfig: { region: "iad" },
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })
+
+    const payload = workflowMock.run.mock.calls.at(-1)?.[0]
+    expect(payload).toEqual({
+      input: { prompt: "hello" },
+      run: { runId: "run-events-1" },
+      runtime: "vercel",
+      runtimeConfig: { region: "iad" },
+    })
+    expect(() => JSON.stringify(payload)).not.toThrow()
+    expect(resolveStore).not.toHaveBeenCalled()
   })
 
   it("captures a terminal trace after reading Response output", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -7,6 +7,7 @@ import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinit
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../src/output.ts"
+import { defineAgentRunEvents, type AgentRunEventPublisher } from "../src/server.ts"
 import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentToolDefinition, AgentToolSchema, StreamEvent } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
 import type { StandardSchemaV1 } from "@standard-schema/spec"
@@ -39,6 +40,36 @@ describe("agent public types", () => {
     email({ from: "agent@example.com", recipients: "owner@example.com" })
     // @ts-expect-error Email recipient entries must be strings.
     email({ from: "agent@example.com", recipients: [123] })
+  })
+
+  it("exposes a run-scoped event publisher across Agent phases", () => {
+    const runEvents = defineAgentRunEvents({
+      store: {
+        append: (_runId, event) => ({ ...event, cursor: "1", runId: "run-1", timestamp: new Date(0).toISOString() }),
+        read: () => [],
+        subscribe: () => (async function* () {})(),
+      },
+    })
+
+    defineAgent({
+      capabilities: [defineCapability({
+        id: "progress",
+        input(context) {
+          expectTypeOf(context.runEvents).toEqualTypeOf<AgentRunEventPublisher | undefined>()
+        },
+      })],
+      driver: {
+        run(context) {
+          expectTypeOf(context.runEvents).toEqualTypeOf<AgentRunEventPublisher | undefined>()
+        },
+      },
+      hooks: {
+        "agent:finish"(event) {
+          expectTypeOf(event.runtime.runEvents).toEqualTypeOf<AgentRunEventPublisher | undefined>()
+        },
+      },
+      runEvents,
+    })
   })
 
   it("accepts literal false as the inline runtime opt-out", () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -70,6 +70,17 @@ describe("agent public types", () => {
       },
       runEvents,
     })
+
+    const handWritten = {
+      publish: runEvents.publish,
+      read: runEvents.read,
+      subscribe: runEvents.subscribe,
+    }
+    defineAgent({
+      driver: { run: () => "ok" },
+      // @ts-expect-error Agent Run Events must be created by defineAgentRunEvents().
+      runEvents: handWritten,
+    })
   })
 
   it("accepts literal false as the inline runtime opt-out", () => {


### PR DESCRIPTION
Adds server-owned Agent Run Events with an application-provided store, opaque cursors, and replay-then-live subscriptions. Agents opt in through defineAgent({ runEvents }), then Capability input, Agent Driver, and finish phases receive one publisher bound to the Agent run id.

Workflow-backed invocations resolve the store from the imported Agent Definition after execution context reconstruction, so provider functions never enter the Workflow payload and generated Workflow run ids remain the event identity. ViteHub supplies no default persistence or authorization; applications retain both boundaries.