### PR TITLE
fix(vite-hub): own workflow runtime dependencies

### DIFF
--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -50,9 +50,9 @@ import { defineWorkspace } from "vite-hub/workspace"
 ```
 
 Model providers, chat adapters, and harness adapters remain explicit
-dependencies because the application chooses them. Workflow's existing Vercel
-Functions runtime is a deliberate framework default; other provider SDKs stay
-package-owned and explicit.
+dependencies because the application chooses them. The distribution includes
+the Workflow DevKit runtime and builders because Vercel Workflow is a deliberate
+framework default; other provider SDKs stay package-owned and explicit.
 
 ## Install an owner package directly
 

--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -41,9 +41,9 @@ composition and explicit feature subpaths for application APIs.
 | `vite-hub/workspace` and `vite-hub/workspace/runtime` | Workspace Definitions, Sources, runtime facades, and registry APIs. |
 
 Third-party model providers, chat adapters, and harness packages remain explicit
-dependencies. Workflow retains its Vercel Functions runtime default; other
-provider-specific and host-specific ViteHub subpaths stay on their owner packages
-unless this reference promotes them.
+dependencies. The distribution includes the Workflow DevKit runtime and builders
+for its Vercel Workflow default; other provider-specific and host-specific
+ViteHub subpaths stay on their owner packages unless this reference promotes them.
 
 ## Direct owner-package imports
 

--- a/fallow.toml
+++ b/fallow.toml
@@ -123,6 +123,9 @@ ignoreDependencies = [
   "@vitejs/devtools",
   # Required by declarations re-exported from @vite-hub/devtools.
   "@vitejs/devtools-kit",
+  # Owned by vite-hub for Workflow DevKit's application-root runtime resolution.
+  "@workflow/builders",
+  "workflow",
   "@vueuse/nuxt",
 ]
 

--- a/fixtures/consumer/vite-hub/server/workflows/roundtrip.ts
+++ b/fixtures/consumer/vite-hub/server/workflows/roundtrip.ts
@@ -1,5 +1,15 @@
-import { defineWorkflow } from "vite-hub/workflow"
+import { defineWorkflow, type WorkflowExecutionContext } from "vite-hub/workflow"
 
-export default defineWorkflow<{ marker: string }, { marker: string }>(async ({ payload }) => ({
-  marker: payload.marker,
-}))
+type RoundtripPayload = { marker: string }
+type RoundtripResult = { marker: string }
+
+async function durableRoundtrip({ payload }: WorkflowExecutionContext<RoundtripPayload>): Promise<RoundtripResult> {
+  "use workflow"
+
+  return { marker: payload.marker }
+}
+
+export default defineWorkflow<RoundtripPayload, RoundtripResult>(
+  async ({ payload }) => ({ marker: payload.marker }),
+  { native: durableRoundtrip },
+)

--- a/packages/vite-hub/README.md
+++ b/packages/vite-hub/README.md
@@ -45,6 +45,6 @@ import { defineWorkflow } from "vite-hub/workflow"
 
 The root export intentionally contains only the framework configuration API. Feature code belongs on a feature subpath, which forwards to the package that owns it.
 
-Third-party model providers, chat adapters, and harnesses remain explicit. Workflow keeps its existing Vercel Functions runtime as a deliberate framework default; other host SDKs stay package-owned and explicit. For example, install the Codex harness package and use `@vite-hub/agent/harness/codex` when that integration is part of the application.
+Third-party model providers, chat adapters, and harnesses remain explicit. The distribution includes the Workflow DevKit runtime and builders because Vercel Workflow is a deliberate framework default; other host SDKs stay package-owned and explicit. For example, install the Codex harness package and use `@vite-hub/agent/harness/codex` when that integration is part of the application.
 
 Install an `@vite-hub/*` owner package directly when building a custom composition, another framework integration, or package-level tooling. `@vite-hub/vite` remains a supported compatibility import for `vitehub()`; new applications should use `vite-hub`.

--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -116,8 +116,10 @@
     "@vite-hub/workflow": "workspace:*",
     "@vite-hub/workspace": "workspace:*",
     "@vitejs/devtools-kit": "catalog:vite",
+    "@workflow/builders": "catalog:workflow",
     "drizzle-kit": "catalog:database",
-    "drizzle-orm": "catalog:database"
+    "drizzle-orm": "catalog:database",
+    "workflow": "catalog:workflow"
   },
   "devDependencies": {
     "@types/node": "catalog:tooling",

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
-import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { builtinModules, createRequire } from "node:module"
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path"
 
@@ -60,6 +60,31 @@ async function createVercelWorkflowTransformPlugin(rootDir: string): Promise<Plu
   const builders = await loadVercelWorkflowBuilders()
   if (!builders) return undefined
   return builders.createSwcPlugin({ mode: "workflow", projectRoot: rootDir })
+}
+
+async function withVercelWorkflowPackageLink<T>(rootDir: string, run: () => Promise<T>): Promise<T> {
+  const target = join(rootDir, "node_modules", "workflow")
+  if (existsSync(target)) return await run()
+
+  // Workflow DevKit resolves its builtins from the application root, even when a framework owns the dependency.
+  const require = createRequire(import.meta.url)
+  const source = dirname(dirname(dirname(require.resolve("workflow/internal/builtins"))))
+  await mkdir(dirname(target), { recursive: true })
+  let ownsLink = false
+  try {
+    await symlink(source, target, process.platform === "win32" ? "junction" : "dir")
+    ownsLink = true
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
+  }
+
+  try {
+    return await run()
+  }
+  finally {
+    if (ownsLink) await rm(target, { force: true })
+  }
 }
 
 async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: DiscoveredWorkflowDefinition[], aliases: Record<string, string> = {}): Promise<void> {
@@ -128,7 +153,7 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
     workflowsBundlePath: "./.well-known/workflow/v1/flow.js",
     workingDir: rootDir,
   })
-  await builder.build()
+  await withVercelWorkflowPackageLink(rootDir, async () => await builder.build())
   const workflowConfig = JSON.parse(await readFile(outputConfigFile, "utf8")) as { routes?: unknown[], [key: string]: unknown }
   await writeFile(outputConfigFile, `${JSON.stringify({
     ...workflowConfig,

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -628,9 +628,6 @@ async function createVercelOutput(
         ...(frameworkImportBase ? [] : optionalAgentRuntimeExternals),
         "cloudflare:workers",
         ...nodeBuiltinExternals,
-        "workflow",
-        "workflow/api",
-        "workflow/runtime",
       ],
       format: "esm",
       platform: "node",
@@ -654,15 +651,19 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const vercelOutput = vercelWorkflowConfig && vercelWorkflowConfig.provider === "vercel"
     ? await createVercelOutput(options.rootDir, artifacts, options.importBase, options.providerImportAliases)
     : undefined
-  await writeProviderDeploymentOutputs({
-    clientOutDir: options.clientOutDir,
-    cloudflare: cloudflareOutput,
-    cleanup: {
-      cloudflare: cloudflareOutput ? undefined : () => createCloudflareWorkflowCleanup(options.rootDir),
-    },
-    rootDir: options.rootDir,
-    ...(vercelOutput ? { vercel: vercelOutput } : {}),
-  })
-  if (vercelOutput) await buildVercelNativeWorkflowOutput(options.rootDir, artifacts.providerDefinitions, options.providerImportAliases)
+  const writeOutputs = async () => {
+    await writeProviderDeploymentOutputs({
+      clientOutDir: options.clientOutDir,
+      cloudflare: cloudflareOutput,
+      cleanup: {
+        cloudflare: cloudflareOutput ? undefined : () => createCloudflareWorkflowCleanup(options.rootDir),
+      },
+      rootDir: options.rootDir,
+      ...(vercelOutput ? { vercel: vercelOutput } : {}),
+    })
+    if (vercelOutput) await buildVercelNativeWorkflowOutput(options.rootDir, artifacts.providerDefinitions, options.providerImportAliases)
+  }
+  if (vercelOutput) await withVercelWorkflowPackageLink(options.rootDir, writeOutputs)
+  else await writeOutputs()
   return artifacts
 }

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -612,13 +612,12 @@ async function createCloudflareWorkflowCleanup(rootDir: string) {
   }
 }
 
-async function createVercelOutput(
-  rootDir: string,
+function createVercelOutput(
   artifacts: GeneratedWorkflowArtifacts,
+  workflowTransformPlugin: Plugin | undefined,
   frameworkImportBase?: string,
   providerImportAliases?: Record<string, string>,
-): Promise<VercelProviderDeploymentOutput> {
-  const workflowTransformPlugin = await createVercelWorkflowTransformPlugin(rootDir)
+): VercelProviderDeploymentOutput {
   return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
@@ -628,6 +627,7 @@ async function createVercelOutput(
         ...(frameworkImportBase ? [] : optionalAgentRuntimeExternals),
         "cloudflare:workers",
         ...nodeBuiltinExternals,
+        ...(!workflowTransformPlugin ? ["workflow", "workflow/api", "workflow/runtime"] : []),
       ],
       format: "esm",
       platform: "node",
@@ -648,8 +648,11 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const cloudflareOutput = cloudflareWorkflowConfig && cloudflareWorkflowConfig.provider === "cloudflare"
     ? createCloudflareOutput(options.rootDir, artifacts, options.providerImportAliases)
     : undefined
+  const workflowTransformPlugin = vercelWorkflowConfig && vercelWorkflowConfig.provider === "vercel"
+    ? await createVercelWorkflowTransformPlugin(options.rootDir)
+    : undefined
   const vercelOutput = vercelWorkflowConfig && vercelWorkflowConfig.provider === "vercel"
-    ? await createVercelOutput(options.rootDir, artifacts, options.importBase, options.providerImportAliases)
+    ? createVercelOutput(artifacts, workflowTransformPlugin, options.importBase, options.providerImportAliases)
     : undefined
   const writeOutputs = async () => {
     await writeProviderDeploymentOutputs({
@@ -663,7 +666,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     })
     if (vercelOutput) await buildVercelNativeWorkflowOutput(options.rootDir, artifacts.providerDefinitions, options.providerImportAliases)
   }
-  if (vercelOutput) await withVercelWorkflowPackageLink(options.rootDir, writeOutputs)
+  if (workflowTransformPlugin) await withVercelWorkflowPackageLink(options.rootDir, writeOutputs)
   else await writeOutputs()
   return artifacts
 }

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -467,10 +467,13 @@ function renderProviderEntry(
   entryFile: string,
   userAppEntry: string | undefined,
   serializedWorkflowConfig: string,
+  framework: boolean,
 ) {
+  const installVercelWorkflowRuntime = spec.name === "vercel" && framework
   const imports = [
-    `import { ${spec.factory} } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(spec.runtimeModule)))}`,
+    `import { ${spec.factory}${installVercelWorkflowRuntime ? ", setVercelWorkflowRuntimeModules" : ""} } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(spec.runtimeModule)))}`,
     `import workflowRegistry from ${JSON.stringify(`./${generatedRegistryFileName}`)}`,
+    ...(installVercelWorkflowRuntime ? [`import * as workflowApi from "workflow/api"`, `import * as workflowRuntime from "workflow/runtime"`] : []),
   ]
   if (spec.name === "cloudflare") {
     imports.push(`import { runCloudflareWorkflow } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule("runtime/cloudflare-runner")))}`)
@@ -491,6 +494,7 @@ function renderProviderEntry(
   return [
     ...imports,
     "",
+    installVercelWorkflowRuntime ? "setVercelWorkflowRuntimeModules(workflowApi, workflowRuntime)" : "",
     `const workflowConfig = ${serializedWorkflowConfig}`,
     ...cloudflareDispatcher,
     "",
@@ -526,7 +530,7 @@ async function writeProviderEntries(
       ? cloudflareWorkflowConfig
       : resolveWorkflowConfig(workflow, spec.hosting)
     const serialized = JSON.stringify(workflowConfig, null, 2)
-    await writeFile(entryFile, renderProviderEntry(spec, entryFile, userAppEntry, serialized), "utf8")
+    await writeFile(entryFile, renderProviderEntry(spec, entryFile, userAppEntry, serialized, Boolean(importBases.workflow)), "utf8")
     entryFiles[spec.name] = entryFile
   }))
 
@@ -627,7 +631,7 @@ function createVercelOutput(
         ...(frameworkImportBase ? [] : optionalAgentRuntimeExternals),
         "cloudflare:workers",
         ...nodeBuiltinExternals,
-        ...(!workflowTransformPlugin ? ["workflow", "workflow/api", "workflow/runtime"] : []),
+        ...(!frameworkImportBase ? ["workflow", "workflow/api", "workflow/runtime"] : []),
       ],
       format: "esm",
       platform: "node",
@@ -666,7 +670,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     })
     if (vercelOutput) await buildVercelNativeWorkflowOutput(options.rootDir, artifacts.providerDefinitions, options.providerImportAliases)
   }
-  if (workflowTransformPlugin) await withVercelWorkflowPackageLink(options.rootDir, writeOutputs)
+  if (workflowTransformPlugin && options.importBase) await withVercelWorkflowPackageLink(options.rootDir, writeOutputs)
   else await writeOutputs()
   return artifacts
 }

--- a/packages/workflow/src/runtime/vercel-vite.ts
+++ b/packages/workflow/src/runtime/vercel-vite.ts
@@ -8,6 +8,8 @@ import { runWithWorkflowRuntimeEvent, setWorkflowRuntimeConfig, setWorkflowRunti
 
 import type { ResolvedWorkflowOptions, WorkflowDefinitionRegistry } from "../types.ts"
 
+export { setVercelWorkflowRuntimeModules } from "./vercel.ts"
+
 interface WorkflowVercelServerOptions {
   app?: WorkflowApp
   registry?: WorkflowDefinitionRegistry

--- a/packages/workflow/src/runtime/vercel.ts
+++ b/packages/workflow/src/runtime/vercel.ts
@@ -49,13 +49,10 @@ interface VercelWorkflowRuntimeModule {
   }
 }
 
-type VercelWorkflowImporter = <T>(specifier: string) => Promise<T>
-
 async function loadVercelWorkflowRuntime(): Promise<VercelWorkflowRuntime> {
-  const importVercelWorkflow = new Function("specifier", "return import(specifier)") as VercelWorkflowImporter
   const [api, runtime] = await Promise.all([
-    importVercelWorkflow<VercelWorkflowApiModule>("workflow/api"),
-    importVercelWorkflow<VercelWorkflowRuntimeModule>("workflow/runtime"),
+    import("workflow/api") as Promise<VercelWorkflowApiModule>,
+    import("workflow/runtime") as Promise<VercelWorkflowRuntimeModule>,
   ])
   const { getRun, resumeHook, start } = api
   const { getWorld } = runtime

--- a/packages/workflow/src/runtime/vercel.ts
+++ b/packages/workflow/src/runtime/vercel.ts
@@ -31,13 +31,13 @@ export interface VercelWorkflowRuntime {
   start: (handler: (...args: never[]) => unknown, args: unknown[]) => Promise<VercelRun>
 }
 
-interface VercelWorkflowApiModule {
+export interface VercelWorkflowApiModule {
   getRun: (id: string) => VercelRun
   resumeHook: VercelWorkflowRuntime["resumeHook"]
   start: VercelWorkflowRuntime["start"]
 }
 
-interface VercelWorkflowRuntimeModule {
+export interface VercelWorkflowRuntimeModule {
   getWorld: () => Promise<{
     steps: {
       list: (options: unknown) => Promise<{ cursor?: string, data: unknown[], hasMore: boolean }>
@@ -50,10 +50,15 @@ interface VercelWorkflowRuntimeModule {
 }
 
 async function loadVercelWorkflowRuntime(): Promise<VercelWorkflowRuntime> {
+  const importVercelWorkflow = new Function("specifier", "return import(specifier)") as <T>(specifier: string) => Promise<T>
   const [api, runtime] = await Promise.all([
-    import("workflow/api") as Promise<VercelWorkflowApiModule>,
-    import("workflow/runtime") as Promise<VercelWorkflowRuntimeModule>,
+    importVercelWorkflow<VercelWorkflowApiModule>("workflow/api"),
+    importVercelWorkflow<VercelWorkflowRuntimeModule>("workflow/runtime"),
   ])
+  return createVercelWorkflowRuntime(api, runtime)
+}
+
+function createVercelWorkflowRuntime(api: VercelWorkflowApiModule, runtime: VercelWorkflowRuntimeModule): VercelWorkflowRuntime {
   const { getRun, resumeHook, start } = api
   const { getWorld } = runtime
   return {
@@ -81,6 +86,10 @@ let runtimeLoader: () => Promise<VercelWorkflowRuntime> = loadVercelWorkflowRunt
 
 export function setVercelWorkflowRuntimeLoader(loader?: () => Promise<VercelWorkflowRuntime>): void {
   runtimeLoader = loader || loadVercelWorkflowRuntime
+}
+
+export function setVercelWorkflowRuntimeModules(api: VercelWorkflowApiModule, runtime: VercelWorkflowRuntimeModule): void {
+  runtimeLoader = async () => createVercelWorkflowRuntime(api, runtime)
 }
 
 async function getVercelWorkflowRuntime(): Promise<VercelWorkflowRuntime> {

--- a/packages/workflow/src/runtime/vercel.ts
+++ b/packages/workflow/src/runtime/vercel.ts
@@ -31,13 +31,13 @@ export interface VercelWorkflowRuntime {
   start: (handler: (...args: never[]) => unknown, args: unknown[]) => Promise<VercelRun>
 }
 
-export interface VercelWorkflowApiModule {
+interface VercelWorkflowApiModule {
   getRun: (id: string) => VercelRun
   resumeHook: VercelWorkflowRuntime["resumeHook"]
   start: VercelWorkflowRuntime["start"]
 }
 
-export interface VercelWorkflowRuntimeModule {
+interface VercelWorkflowRuntimeModule {
   getWorld: () => Promise<{
     steps: {
       list: (options: unknown) => Promise<{ cursor?: string, data: unknown[], hasMore: boolean }>

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -189,10 +189,8 @@ describe("Vite workflow provider outputs", () => {
     expect(registry).not.toContain("Shared directory must not leak")
     expect(await readFile(vercelConfig, "utf8")).toContain("\"/__server\"")
     expect(existsSync(vercelServer)).toBe(true)
-    const vercelServerContents = await readFile(vercelServer, "utf8")
-    expect(vercelServerContents).toContain("Repository host context loaded through Vite raw semantics.")
-    expect(vercelServerContents).toContain("bundled Markdown template")
-    expect(vercelServerContents).not.toContain("return import(specifier)")
+    expect(await readFile(vercelServer, "utf8")).toContain("Repository host context loaded through Vite raw semantics.")
+    expect(await readFile(vercelServer, "utf8")).toContain("bundled Markdown template")
   }, buildOutputTestTimeout)
 
   it("does not emit Cloudflare workflow artifacts for Vercel provider overrides", async () => {

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -189,8 +189,10 @@ describe("Vite workflow provider outputs", () => {
     expect(registry).not.toContain("Shared directory must not leak")
     expect(await readFile(vercelConfig, "utf8")).toContain("\"/__server\"")
     expect(existsSync(vercelServer)).toBe(true)
-    expect(await readFile(vercelServer, "utf8")).toContain("Repository host context loaded through Vite raw semantics.")
-    expect(await readFile(vercelServer, "utf8")).toContain("bundled Markdown template")
+    const vercelServerContents = await readFile(vercelServer, "utf8")
+    expect(vercelServerContents).toContain("Repository host context loaded through Vite raw semantics.")
+    expect(vercelServerContents).toContain("bundled Markdown template")
+    expect(vercelServerContents).not.toContain("return import(specifier)")
   }, buildOutputTestTimeout)
 
   it("does not emit Cloudflare workflow artifacts for Vercel provider overrides", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1223,6 +1223,9 @@ importers:
       '@vitejs/devtools-kit':
         specifier: catalog:vite
         version: 0.2.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@voidzero-dev/vite-plus-core@0.1.24)(crossws@0.4.5(srvx@0.11.22))(typescript@6.0.2)
+      '@workflow/builders':
+        specifier: catalog:workflow
+        version: 4.0.5(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       drizzle-kit:
         specifier: catalog:database
         version: 0.31.10
@@ -1232,6 +1235,9 @@ importers:
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
         version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.2)(@vitejs/devtools@0.1.19)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.2)(unrun@0.2.36)(yaml@2.9.0)'
+      workflow:
+        specifier: catalog:workflow
+        version: 4.2.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.2)
     devDependencies:
       '@types/node':
         specifier: catalog:tooling

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -30,7 +30,6 @@ const optionalPackages = [
   "files-sdk",
   "openworkflow",
   "vitest",
-  "workflow",
 ]
 
 interface PackageManifest {
@@ -155,6 +154,11 @@ async function assertPackedPackage(tarball: string, framework: boolean) {
 
   if (!framework) return
 
+  expect(manifest.dependencies).toMatchObject({
+    "@workflow/builders": expect.any(String),
+    workflow: expect.any(String),
+  })
+
   for (const [name, spec] of Object.entries(manifest.dependencies || {})) {
     if (name.startsWith("@vite-hub/")) {
       expect(spec, `${manifest.name} should pin ${name} to its tested release matrix`).toBe(manifest.version)
@@ -249,14 +253,14 @@ async function readGeneratedSources(dir: string, root = dir): Promise<Record<str
   return sources
 }
 
-async function assertOptionalPackagesAbsent(appDir: string) {
-  const virtualStore = join(appDir, "node_modules/.pnpm")
-  const entries = await readdir(virtualStore)
-
-  for (const name of optionalPackages) {
-    const installed = entries.some(entry => existsSync(join(virtualStore, entry, "node_modules", ...name.split("/"))))
-    expect(installed, `${name} should remain opt-in`).toBe(false)
-  }
+async function assertOptionalPackagesUnreachable(appDir: string) {
+  const script = [
+    `const packages = ${JSON.stringify(optionalPackages)}`,
+    "const reachable = packages.filter((name) => { try { import.meta.resolve(name); return true } catch { return false } })",
+    "process.stdout.write(JSON.stringify(reachable))",
+  ].join("\n")
+  const { stdout } = await run("node", ["--input-type=module", "--eval", script], appDir)
+  expect(JSON.parse(stdout), "optional packages must not resolve from the consumer root").toEqual([])
 }
 
 function importSpecifierOccurrences(source: string) {
@@ -363,7 +367,7 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
         "--eval",
         "let resolved = false; try { import.meta.resolve('@vite-hub/agent'); resolved = true } catch {} if (resolved) throw new Error('owner package resolved from the consumer root')",
       ], appDir)
-      await assertOptionalPackagesAbsent(appDir)
+      await assertOptionalPackagesUnreachable(appDir)
 
       await run("pnpm", ["run", "typecheck"], appDir)
       await run("pnpm", ["run", "build"], appDir)

--- a/test/local/netlify-real-project.mjs
+++ b/test/local/netlify-real-project.mjs
@@ -62,6 +62,8 @@ function renderWorkspaceYaml(overrides) {
   return [
     "allowBuilds:",
     "  '@mongodb-js/zstd': true",
+    "  '@swc/core': true",
+    "  cbor-extract: true",
     "  esbuild: true",
     "  node-liblzma: true",
     "catalog:",


### PR DESCRIPTION
Makes the `vite-hub` framework distribution own the Workflow DevKit runtime and builders required by its default Vercel Workflow integration, so applications keep a single direct ViteHub dependency.

The published consumer contract now compiles a native `"use workflow"` entry under pnpm's no-hoist layout. `@vite-hub/workflow` remains provider-agnostic for direct owner-package consumers, while the framework's nested SDK is temporarily exposed to Workflow DevKit's application-root resolver during native output generation.
