### PR TITLE
fix(provider-output): preserve Nitro Vercel functions

### DIFF
--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -45,6 +45,7 @@ interface GenerateProviderOutputsOptions {
   clientOutDir: string
   providerOutput?: ComposedProviderOutput
   rootDir: string
+  serverFunctionName?: string
 }
 
 interface GeneratedBlobArtifacts {
@@ -331,7 +332,11 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
   }
 }
 
-function createVercelOutput(artifacts: GeneratedBlobArtifacts, providerOutput: ComposedProviderOutput | undefined): VercelProviderDeploymentOutput {
+function createVercelOutput(
+  artifacts: GeneratedBlobArtifacts,
+  providerOutput: ComposedProviderOutput | undefined,
+  serverFunctionName?: string,
+): VercelProviderDeploymentOutput {
   const databaseRuntime = getProviderRuntimeModule(providerOutput, "database", "vercel")
 
   return {
@@ -366,6 +371,7 @@ function createVercelOutput(artifacts: GeneratedBlobArtifacts, providerOutput: C
       format: "esm",
       platform: "node",
     },
+    ...(serverFunctionName ? { config: {}, serverFunctionName } : {}),
   }
 }
 
@@ -396,7 +402,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     clientOutDir: options.clientOutDir,
     cloudflare: localOnly ? undefined : createCloudflareOutput(options.blob, artifacts, options.providerOutput),
     rootDir: options.rootDir,
-    vercel: localOnly ? undefined : createVercelOutput(artifacts, options.providerOutput),
+    vercel: localOnly ? undefined : createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName),
   })
   return artifacts
 }

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -123,7 +123,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
   let providerOutput: ComposedProviderOutput | undefined
   let rootDir = process.cwd()
   let runtimeConfig: BlobViteRuntimeConfig | undefined
-  let serverFunctionName: string | undefined
+  let vitePlugins: readonly { name: string }[] | undefined
   const getConfig = () => runtimeConfig ??= resolveBlobViteConfig(options)
 
   return {
@@ -154,7 +154,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       blob = config.blob ?? blob
       providerOutput = useComposedProviderOutput(config)
       runtimeConfig = resolveBlobViteConfig(blob)
-      serverFunctionName = resolveNitroVercelFunctionName(config.plugins, "blob")
+      vitePlugins = config.plugins
       await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, importBase)
     },
     configEnvironment(name, config) {
@@ -193,7 +193,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
         artifacts: providerArtifacts,
         providerOutput,
         rootDir,
-        serverFunctionName,
+        serverFunctionName: resolveNitroVercelFunctionName(vitePlugins, "blob", rootDir),
       })
     },
     load(id) {

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -123,6 +123,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
   let providerOutput: ComposedProviderOutput | undefined
   let rootDir = process.cwd()
   let runtimeConfig: BlobViteRuntimeConfig | undefined
+  let nitroPreset: string | undefined
   let vitePlugins: readonly { name: string }[] | undefined
   const getConfig = () => runtimeConfig ??= resolveBlobViteConfig(options)
 
@@ -154,6 +155,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       blob = config.blob ?? blob
       providerOutput = useComposedProviderOutput(config)
       runtimeConfig = resolveBlobViteConfig(blob)
+      nitroPreset = (config as { nitro?: { preset?: string } }).nitro?.preset
       vitePlugins = config.plugins
       await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, importBase)
     },
@@ -193,7 +195,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
         artifacts: providerArtifacts,
         providerOutput,
         rootDir,
-        serverFunctionName: resolveNitroVercelFunctionName(vitePlugins, "blob", rootDir),
+        serverFunctionName: resolveNitroVercelFunctionName(vitePlugins, "blob", nitroPreset),
       })
     },
     load(id) {

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -1,7 +1,7 @@
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
 import { resolve } from "pathe"
 
 import { generateProviderOutputs, prepareProviderOutputs, blobPackageName } from "./internal/vite-build.ts"
@@ -123,6 +123,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
   let providerOutput: ComposedProviderOutput | undefined
   let rootDir = process.cwd()
   let runtimeConfig: BlobViteRuntimeConfig | undefined
+  let serverFunctionName: string | undefined
   const getConfig = () => runtimeConfig ??= resolveBlobViteConfig(options)
 
   return {
@@ -153,6 +154,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       blob = config.blob ?? blob
       providerOutput = useComposedProviderOutput(config)
       runtimeConfig = resolveBlobViteConfig(blob)
+      serverFunctionName = resolveNitroVercelFunctionName(config.plugins, "blob")
       await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, importBase)
     },
     configEnvironment(name, config) {
@@ -191,6 +193,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
         artifacts: providerArtifacts,
         providerOutput,
         rootDir,
+        serverFunctionName,
       })
     },
     load(id) {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs"
 import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { execFile } from "node:child_process"
-import { join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 
@@ -216,6 +216,32 @@ describe("Vite provider outputs", () => {
     })
 
     expect(await readFile(join(rootDir, ".vercel", "output", "static", "index.html"), "utf8")).toContain("<title>vitehub</title>")
+  })
+
+  it("preserves Nitro output when emitting a composed Vercel function", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-nitro-output-")
+    const outputRoot = join(rootDir, ".vercel", "output")
+    const nitroFunction = join(outputRoot, "functions", "__server.func", "index.mjs")
+    const nitroConfig = {
+      routes: [{ src: "/(.*)", dest: "/__server" }],
+      version: 3,
+    }
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(dirname(nitroFunction), { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+    await writeFile(nitroFunction, "export default 'nitro'\n", "utf8")
+    await writeFile(join(outputRoot, "config.json"), `${JSON.stringify(nitroConfig, null, 2)}\n`, "utf8")
+
+    await generateProviderOutputs({
+      blob: {},
+      clientOutDir: "dist",
+      rootDir,
+      serverFunctionName: "__blob.func",
+    })
+
+    await expect(readFile(nitroFunction, "utf8")).resolves.toBe("export default 'nitro'\n")
+    await expect(readFile(join(outputRoot, "config.json"), "utf8").then(JSON.parse)).resolves.toEqual(nitroConfig)
+    expect(existsSync(join(outputRoot, "functions", "__blob.func", "index.mjs"))).toBe(true)
   })
 
   it("omits Cloudflare bucket bindings when none are configured", async () => {

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -39,6 +39,7 @@ interface GenerateProviderOutputsOptions {
   providerOutput?: ComposedProviderOutput
   rootDir: string
   runtimeConfig: ResolvedDBViteConfig
+  serverFunctionName?: string
 }
 
 interface GeneratedDBArtifacts {
@@ -208,6 +209,7 @@ interface ProviderWriteOptions {
   provisionState: ProvisionState
   rootDir: string
   runtimeConfig: ResolvedDBViteConfig
+  serverFunctionName?: string
 }
 
 function createCloudflareOutput({ artifacts, providerOutput, provisionState, runtimeConfig }: ProviderWriteOptions): CloudflareProviderDeploymentOutput {
@@ -249,7 +251,7 @@ function createCloudflareOutput({ artifacts, providerOutput, provisionState, run
   }
 }
 
-function createVercelOutput({ artifacts, providerOutput, runtimeConfig }: ProviderWriteOptions): VercelProviderDeploymentOutput {
+function createVercelOutput({ artifacts, providerOutput, runtimeConfig, serverFunctionName }: ProviderWriteOptions): VercelProviderDeploymentOutput {
   const unsupportedDatabases = getVercelUnsupportedDatabases(runtimeConfig)
   if (unsupportedDatabases.length) {
     throw new Error(`[vitehub] Vercel output requires a remote libSQL \`db.connection.url\` for databases: ${unsupportedDatabases.join(", ")}.`)
@@ -266,6 +268,7 @@ function createVercelOutput({ artifacts, providerOutput, runtimeConfig }: Provid
       format: "esm",
       platform: "node",
     },
+    ...(serverFunctionName ? { config: {}, serverFunctionName } : {}),
   }
 }
 

--- a/packages/database/src/vite.ts
+++ b/packages/database/src/vite.ts
@@ -218,7 +218,11 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
         providerOutput,
         rootDir: resolved.root,
         runtimeConfig,
-        serverFunctionName: resolveNitroVercelFunctionName(resolved.plugins, "database", resolved.root),
+        serverFunctionName: resolveNitroVercelFunctionName(
+          resolved.plugins,
+          "database",
+          (resolved as typeof resolved & { nitro?: { preset?: string } }).nitro?.preset,
+        ),
       })
     },
   }

--- a/packages/database/src/vite.ts
+++ b/packages/database/src/vite.ts
@@ -124,7 +124,6 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
   let providerOutput: ComposedProviderOutput | undefined
   let resolved: ResolvedConfig | undefined
   let runtimeConfig: ResolvedDBViteConfig | undefined
-  let serverFunctionName: string | undefined
 
   function resolvedOptions() {
     return resolved?.database ?? options
@@ -157,7 +156,6 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
     async configResolved(config) {
       resolved = config
       providerOutput = useComposedProviderOutput(config)
-      serverFunctionName = resolveNitroVercelFunctionName(config.plugins, "database")
       await refreshRuntimeConfig()
     },
     configEnvironment(name, config) {
@@ -220,7 +218,7 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
         providerOutput,
         rootDir: resolved.root,
         runtimeConfig,
-        serverFunctionName,
+        serverFunctionName: resolveNitroVercelFunctionName(resolved.plugins, "database", resolved.root),
       })
     },
   }

--- a/packages/database/src/vite.ts
+++ b/packages/database/src/vite.ts
@@ -1,6 +1,6 @@
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
 import { normalize } from "pathe"
 
 import { createDbCliContributor } from "./cli.ts"
@@ -124,6 +124,7 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
   let providerOutput: ComposedProviderOutput | undefined
   let resolved: ResolvedConfig | undefined
   let runtimeConfig: ResolvedDBViteConfig | undefined
+  let serverFunctionName: string | undefined
 
   function resolvedOptions() {
     return resolved?.database ?? options
@@ -156,6 +157,7 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
     async configResolved(config) {
       resolved = config
       providerOutput = useComposedProviderOutput(config)
+      serverFunctionName = resolveNitroVercelFunctionName(config.plugins, "database")
       await refreshRuntimeConfig()
     },
     configEnvironment(name, config) {
@@ -218,6 +220,7 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
         providerOutput,
         rootDir: resolved.root,
         runtimeConfig,
+        serverFunctionName,
       })
     },
   }

--- a/packages/internal/src/build/esbuild.ts
+++ b/packages/internal/src/build/esbuild.ts
@@ -21,6 +21,11 @@ const viteMarkdownTemplateNamespace = "vitehub-markdown-template"
 const markdownTemplateQuery = "markdown-template"
 const markdownTemplateRuntimeSpecifier = "@vite-hub/markdown-template"
 
+function resolveEsbuildAliases(aliases: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!aliases) return
+  return Object.fromEntries(Object.entries(aliases).filter(([specifier]) => !specifier.endsWith("/")))
+}
+
 function stripMarkdownCode(template: string): string {
   let fence: { marker: string, length: number, listIndented: boolean } | undefined
   let inList = false
@@ -204,10 +209,11 @@ export async function bundleEsmEntry(
 ): Promise<void> {
   const format = options.format || "esm"
   const platform = options.platform || "neutral"
-  const frameworkRuntime = Object.keys(options.alias || {}).some(specifier => specifier === "vite-hub" || specifier.startsWith("vite-hub/"))
+  const aliases = resolveEsbuildAliases(options.alias)
+  const frameworkRuntime = Object.keys(aliases || {}).some(specifier => specifier === "vite-hub" || specifier.startsWith("vite-hub/"))
 
   await bundle({
-    alias: options.alias,
+    alias: aliases,
     banner: format === "esm" && platform === "node"
       ? {
           js: [
@@ -221,7 +227,7 @@ export async function bundleEsmEntry(
         }
       : undefined,
     bundle: true,
-    conditions: options.conditions,
+    conditions: options.conditions ?? (platform === "node" ? ["node", "import", "default"] : undefined),
     entryPoints: [entryFile],
     external: options.external,
     format,

--- a/packages/internal/src/build/esbuild.ts
+++ b/packages/internal/src/build/esbuild.ts
@@ -227,7 +227,7 @@ export async function bundleEsmEntry(
         }
       : undefined,
     bundle: true,
-    conditions: options.conditions ?? (platform === "node" ? ["node", "import", "default"] : undefined),
+    conditions: options.conditions ?? (platform === "node" ? ["node"] : undefined),
     entryPoints: [entryFile],
     external: options.external,
     format,

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -1,4 +1,4 @@
-import { statSync } from "node:fs"
+import { existsSync, statSync } from "node:fs"
 import { basename, dirname, resolve } from "node:path"
 
 type NoExternalValue = string | true | RegExp | (string | RegExp)[] | undefined
@@ -39,8 +39,11 @@ export function isServerEnvironment(name: string, config: { consumer?: string })
   return name === "ssr" || config.consumer === "server"
 }
 
-export function resolveNitroVercelFunctionName(plugins: readonly { name: string }[] | undefined, product: string): string | undefined {
-  return plugins?.some(plugin => plugin.name === "nitro:main") ? `__${product}.func` : undefined
+export function resolveNitroVercelFunctionName(plugins: readonly { name: string }[] | undefined, product: string, rootDir: string): string | undefined {
+  return plugins?.some(plugin => plugin.name === "nitro:main")
+    && existsSync(resolve(rootDir, ".vercel", "output", "config.json"))
+    ? `__${product}.func`
+    : undefined
 }
 
 export function shouldSkipViteProviderBuild(command: "build" | "serve" | undefined, mode?: string): boolean {

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from "node:fs"
+import { statSync } from "node:fs"
 import { basename, dirname, resolve } from "node:path"
 
 type NoExternalValue = string | true | RegExp | (string | RegExp)[] | undefined
@@ -39,9 +39,15 @@ export function isServerEnvironment(name: string, config: { consumer?: string })
   return name === "ssr" || config.consumer === "server"
 }
 
-export function resolveNitroVercelFunctionName(plugins: readonly { name: string }[] | undefined, product: string, rootDir: string): string | undefined {
-  return plugins?.some(plugin => plugin.name === "nitro:main")
-    && existsSync(resolve(rootDir, ".vercel", "output", "config.json"))
+export function resolveNitroVercelFunctionName(
+  plugins: readonly { name: string }[] | undefined,
+  product: string,
+  nitroPreset?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const preset = nitroPreset || env.NITRO_PRESET || env.SERVER_PRESET
+  const vercel = preset?.startsWith("vercel") || env.VITEHUB_HOSTING === "vercel" || Boolean(env.VERCEL)
+  return plugins?.some(plugin => plugin.name === "nitro:main") && vercel
     ? `__${product}.func`
     : undefined
 }

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -39,8 +39,8 @@ export function isServerEnvironment(name: string, config: { consumer?: string })
   return name === "ssr" || config.consumer === "server"
 }
 
-export function resolveNitroVercelFunctionName(plugins: readonly { name: string }[], product: string): string | undefined {
-  return plugins.some(plugin => plugin.name === "nitro:main") ? `__${product}.func` : undefined
+export function resolveNitroVercelFunctionName(plugins: readonly { name: string }[] | undefined, product: string): string | undefined {
+  return plugins?.some(plugin => plugin.name === "nitro:main") ? `__${product}.func` : undefined
 }
 
 export function shouldSkipViteProviderBuild(command: "build" | "serve" | undefined, mode?: string): boolean {

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -46,7 +46,9 @@ export function resolveNitroVercelFunctionName(
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
   const preset = nitroPreset || env.NITRO_PRESET || env.SERVER_PRESET
-  const vercel = preset?.startsWith("vercel") || env.VITEHUB_HOSTING === "vercel" || Boolean(env.VERCEL)
+  const vercel = preset
+    ? preset.startsWith("vercel")
+    : env.VITEHUB_HOSTING === "vercel" || Boolean(env.VERCEL)
   return plugins?.some(plugin => plugin.name === "nitro:main") && vercel
     ? `__${product}.func`
     : undefined

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -39,6 +39,10 @@ export function isServerEnvironment(name: string, config: { consumer?: string })
   return name === "ssr" || config.consumer === "server"
 }
 
+export function resolveNitroVercelFunctionName(plugins: readonly { name: string }[], product: string): string | undefined {
+  return plugins.some(plugin => plugin.name === "nitro:main") ? `__${product}.func` : undefined
+}
+
 export function shouldSkipViteProviderBuild(command: "build" | "serve" | undefined, mode?: string): boolean {
   return command === "serve" || mode === "e2e"
 }

--- a/packages/internal/test/esbuild.test.ts
+++ b/packages/internal/test/esbuild.test.ts
@@ -282,11 +282,14 @@ describe("bundleEsmEntry", () => {
     const packageDir = join(rootDir, "node_modules", "conditional-package")
     const entry = join(rootDir, "entry.mjs")
     const outfile = join(rootDir, "bundle.mjs")
+    const requireEntry = join(rootDir, "require-entry.cjs")
+    const requireOutfile = join(rootDir, "require-bundle.mjs")
     await mkdir(packageDir, { recursive: true })
     await writeFile(join(packageDir, "package.json"), JSON.stringify({
       exports: {
         ".": {
           module: "./module.mjs",
+          require: "./require.cjs",
           node: "./node.mjs",
           default: "./default.mjs",
         },
@@ -296,13 +299,19 @@ describe("bundleEsmEntry", () => {
     }), "utf8")
     await writeFile(join(packageDir, "module.mjs"), 'export default "module"\n', "utf8")
     await writeFile(join(packageDir, "node.mjs"), 'export default "node"\n', "utf8")
+    await writeFile(join(packageDir, "require.cjs"), 'module.exports = "require"\n', "utf8")
     await writeFile(join(packageDir, "default.mjs"), 'export default "default"\n', "utf8")
     await writeFile(entry, 'import value from "conditional-package"\nexport default value\n', "utf8")
+    await writeFile(requireEntry, 'module.exports = require("conditional-package")\n', "utf8")
 
     const { bundleEsmEntry } = await import("../src/build/esbuild.ts")
     await bundleEsmEntry(entry, outfile, { format: "esm", platform: "node" })
 
     const loaded = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: string }
     expect(loaded.default).toBe("node")
+
+    await bundleEsmEntry(requireEntry, requireOutfile, { format: "esm", platform: "node" })
+    const requireLoaded = await import(`${pathToFileURL(requireOutfile).href}?t=${Date.now()}`) as { default: string }
+    expect(requireLoaded.default).toBe("require")
   })
 })

--- a/packages/internal/test/esbuild.test.ts
+++ b/packages/internal/test/esbuild.test.ts
@@ -254,4 +254,55 @@ describe("bundleEsmEntry", () => {
     const loaded = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: string }
     expect(loaded.default).toBe("neutral-main")
   })
+
+  it("omits Vite prefix aliases that esbuild cannot represent", async () => {
+    const rootDir = await createTempDir()
+    const entry = join(rootDir, "entry.mjs")
+    const target = join(rootDir, "target.mjs")
+    const outfile = join(rootDir, "bundle.mjs")
+    await writeFile(entry, 'import value from "exact-alias"\nexport default value\n', "utf8")
+    await writeFile(target, 'export default "aliased"\n', "utf8")
+
+    const { bundleEsmEntry } = await import("../src/build/esbuild.ts")
+    await bundleEsmEntry(entry, outfile, {
+      alias: {
+        "@/": `${rootDir}/`,
+        "exact-alias": target,
+      },
+      format: "esm",
+      platform: "node",
+    })
+
+    const loaded = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: string }
+    expect(loaded.default).toBe("aliased")
+  })
+
+  it("prefers Node exports over module exports in Node bundles", async () => {
+    const rootDir = await createTempDir()
+    const packageDir = join(rootDir, "node_modules", "conditional-package")
+    const entry = join(rootDir, "entry.mjs")
+    const outfile = join(rootDir, "bundle.mjs")
+    await mkdir(packageDir, { recursive: true })
+    await writeFile(join(packageDir, "package.json"), JSON.stringify({
+      exports: {
+        ".": {
+          module: "./module.mjs",
+          node: "./node.mjs",
+          default: "./default.mjs",
+        },
+      },
+      name: "conditional-package",
+      type: "module",
+    }), "utf8")
+    await writeFile(join(packageDir, "module.mjs"), 'export default "module"\n', "utf8")
+    await writeFile(join(packageDir, "node.mjs"), 'export default "node"\n', "utf8")
+    await writeFile(join(packageDir, "default.mjs"), 'export default "default"\n', "utf8")
+    await writeFile(entry, 'import value from "conditional-package"\nexport default value\n', "utf8")
+
+    const { bundleEsmEntry } = await import("../src/build/esbuild.ts")
+    await bundleEsmEntry(entry, outfile, { format: "esm", platform: "node" })
+
+    const loaded = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: string }
+    expect(loaded.default).toBe("node")
+  })
 })

--- a/packages/internal/test/vite-build.test.ts
+++ b/packages/internal/test/vite-build.test.ts
@@ -1,16 +1,29 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
 import { describe, expect, it } from "vitest"
 
 import { resolveNitroVercelFunctionName } from "../src/build/vite.ts"
 
 describe("Vite provider builds", () => {
-  it("isolates provider functions when Nitro owns the server output", () => {
+  it("isolates provider functions when Nitro owns the Vercel output", async () => {
     const plugins = [{ name: "vitehub" }, { name: "nitro:main" }]
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-nitro-vercel-output-"))
+    await mkdir(join(rootDir, ".vercel", "output"), { recursive: true })
+    await writeFile(join(rootDir, ".vercel", "output", "config.json"), "{}\n", "utf8")
 
-    expect(resolveNitroVercelFunctionName(plugins, "blob")).toBe("__blob.func")
-    expect(resolveNitroVercelFunctionName(plugins, "database")).toBe("__database.func")
-    expect(resolveNitroVercelFunctionName(plugins, "queue")).toBe("__queue.func")
-    expect(resolveNitroVercelFunctionName(plugins, "workflow")).toBe("__workflow.func")
-    expect(resolveNitroVercelFunctionName([{ name: "vitehub" }], "blob")).toBeUndefined()
-    expect(resolveNitroVercelFunctionName(undefined, "blob")).toBeUndefined()
+    try {
+      expect(resolveNitroVercelFunctionName(plugins, "blob", rootDir)).toBe("__blob.func")
+      expect(resolveNitroVercelFunctionName(plugins, "database", rootDir)).toBe("__database.func")
+      expect(resolveNitroVercelFunctionName(plugins, "queue", rootDir)).toBe("__queue.func")
+      expect(resolveNitroVercelFunctionName(plugins, "workflow", rootDir)).toBe("__workflow.func")
+      expect(resolveNitroVercelFunctionName([{ name: "vitehub" }], "blob", rootDir)).toBeUndefined()
+      expect(resolveNitroVercelFunctionName(undefined, "blob", rootDir)).toBeUndefined()
+      expect(resolveNitroVercelFunctionName(plugins, "blob", join(rootDir, "missing"))).toBeUndefined()
+    }
+    finally {
+      await rm(rootDir, { force: true, recursive: true })
+    }
   })
 })

--- a/packages/internal/test/vite-build.test.ts
+++ b/packages/internal/test/vite-build.test.ts
@@ -11,5 +11,6 @@ describe("Vite provider builds", () => {
     expect(resolveNitroVercelFunctionName(plugins, "queue")).toBe("__queue.func")
     expect(resolveNitroVercelFunctionName(plugins, "workflow")).toBe("__workflow.func")
     expect(resolveNitroVercelFunctionName([{ name: "vitehub" }], "blob")).toBeUndefined()
+    expect(resolveNitroVercelFunctionName(undefined, "blob")).toBeUndefined()
   })
 })

--- a/packages/internal/test/vite-build.test.ts
+++ b/packages/internal/test/vite-build.test.ts
@@ -1,29 +1,17 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-
 import { describe, expect, it } from "vitest"
 
 import { resolveNitroVercelFunctionName } from "../src/build/vite.ts"
 
 describe("Vite provider builds", () => {
-  it("isolates provider functions when Nitro owns the Vercel output", async () => {
+  it("isolates provider functions when Nitro owns the Vercel output", () => {
     const plugins = [{ name: "vitehub" }, { name: "nitro:main" }]
-    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-nitro-vercel-output-"))
-    await mkdir(join(rootDir, ".vercel", "output"), { recursive: true })
-    await writeFile(join(rootDir, ".vercel", "output", "config.json"), "{}\n", "utf8")
 
-    try {
-      expect(resolveNitroVercelFunctionName(plugins, "blob", rootDir)).toBe("__blob.func")
-      expect(resolveNitroVercelFunctionName(plugins, "database", rootDir)).toBe("__database.func")
-      expect(resolveNitroVercelFunctionName(plugins, "queue", rootDir)).toBe("__queue.func")
-      expect(resolveNitroVercelFunctionName(plugins, "workflow", rootDir)).toBe("__workflow.func")
-      expect(resolveNitroVercelFunctionName([{ name: "vitehub" }], "blob", rootDir)).toBeUndefined()
-      expect(resolveNitroVercelFunctionName(undefined, "blob", rootDir)).toBeUndefined()
-      expect(resolveNitroVercelFunctionName(plugins, "blob", join(rootDir, "missing"))).toBeUndefined()
-    }
-    finally {
-      await rm(rootDir, { force: true, recursive: true })
-    }
+    expect(resolveNitroVercelFunctionName(plugins, "blob", "vercel", {})).toBe("__blob.func")
+    expect(resolveNitroVercelFunctionName(plugins, "database", "vercel-edge", {})).toBe("__database.func")
+    expect(resolveNitroVercelFunctionName(plugins, "queue", undefined, { VERCEL: "1" })).toBe("__queue.func")
+    expect(resolveNitroVercelFunctionName(plugins, "workflow", undefined, { VITEHUB_HOSTING: "vercel" })).toBe("__workflow.func")
+    expect(resolveNitroVercelFunctionName([{ name: "vitehub" }], "blob", "vercel", {})).toBeUndefined()
+    expect(resolveNitroVercelFunctionName(undefined, "blob", "vercel", {})).toBeUndefined()
+    expect(resolveNitroVercelFunctionName(plugins, "blob", "node-server", {})).toBeUndefined()
   })
 })

--- a/packages/internal/test/vite-build.test.ts
+++ b/packages/internal/test/vite-build.test.ts
@@ -13,5 +13,7 @@ describe("Vite provider builds", () => {
     expect(resolveNitroVercelFunctionName([{ name: "vitehub" }], "blob", "vercel", {})).toBeUndefined()
     expect(resolveNitroVercelFunctionName(undefined, "blob", "vercel", {})).toBeUndefined()
     expect(resolveNitroVercelFunctionName(plugins, "blob", "node-server", {})).toBeUndefined()
+    expect(resolveNitroVercelFunctionName(plugins, "blob", "node-server", { VERCEL: "1" })).toBeUndefined()
+    expect(resolveNitroVercelFunctionName(plugins, "blob", "cloudflare", { VITEHUB_HOSTING: "vercel" })).toBeUndefined()
   })
 })

--- a/packages/internal/test/vite-build.test.ts
+++ b/packages/internal/test/vite-build.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveNitroVercelFunctionName } from "../src/build/vite.ts"
+
+describe("Vite provider builds", () => {
+  it("isolates provider functions when Nitro owns the server output", () => {
+    const plugins = [{ name: "vitehub" }, { name: "nitro:main" }]
+
+    expect(resolveNitroVercelFunctionName(plugins, "blob")).toBe("__blob.func")
+    expect(resolveNitroVercelFunctionName(plugins, "database")).toBe("__database.func")
+    expect(resolveNitroVercelFunctionName(plugins, "queue")).toBe("__queue.func")
+    expect(resolveNitroVercelFunctionName(plugins, "workflow")).toBe("__workflow.func")
+    expect(resolveNitroVercelFunctionName([{ name: "vitehub" }], "blob")).toBeUndefined()
+  })
+})

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -76,6 +76,7 @@ interface GenerateProviderOutputsOptions {
   clientOutDir: string
   queue: QueueModuleOptions | undefined
   rootDir: string
+  serverFunctionName?: string
 }
 
 export interface CloudflareQueueConfigOptions {
@@ -255,13 +256,14 @@ function createVercelQueueWrapperContents(file: string, registryFile: string, na
   ].join("\n")
 }
 
-function createVercelOutput(artifacts: GeneratedQueueArtifacts): VercelProviderDeploymentOutput {
+function createVercelOutput(artifacts: GeneratedQueueArtifacts, serverFunctionName?: string): VercelProviderDeploymentOutput {
   return {
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
       format: "esm",
       platform: "node",
     },
+    ...(serverFunctionName ? { config: {}, serverFunctionName } : {}),
   }
 }
 
@@ -325,10 +327,10 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     clientOutDir: options.clientOutDir,
     cloudflare: createCloudflare ? createCloudflareOutput(artifacts) : undefined,
     cleanup: {
-      vercel: { serverFunctionName: "__server.func" },
+      vercel: { serverFunctionName: options.serverFunctionName ?? "__server.func" },
     },
     rootDir: options.rootDir,
-    vercel: createVercel ? createVercelOutput(artifacts) : undefined,
+    vercel: createVercel ? createVercelOutput(artifacts, options.serverFunctionName) : undefined,
   })
   await writeVercelQueueFunctions(options.rootDir, options.queue, artifacts)
   return artifacts

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -53,7 +53,11 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
         clientOutDir: resolved.build.outDir,
         queue,
         rootDir: resolved.root,
-        serverFunctionName: resolveNitroVercelFunctionName(resolved.plugins, "queue", resolved.root),
+        serverFunctionName: resolveNitroVercelFunctionName(
+          resolved.plugins,
+          "queue",
+          (resolved as typeof resolved & { nitro?: { preset?: string } }).nitro?.preset,
+        ),
       })
     },
   }

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -53,7 +53,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
         clientOutDir: resolved.build.outDir,
         queue,
         rootDir: resolved.root,
-        serverFunctionName: resolveNitroVercelFunctionName(resolved.plugins, "queue"),
+        serverFunctionName: resolveNitroVercelFunctionName(resolved.plugins, "queue", resolved.root),
       })
     },
   }

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -1,6 +1,6 @@
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
 
 import { generateProviderOutputs, queuePackageName } from "./internal/vite-build.ts"
 import { createQueueProvisionStep } from "./provision.ts"
@@ -53,6 +53,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
         clientOutDir: resolved.build.outDir,
         queue,
         rootDir: resolved.root,
+        serverFunctionName: resolveNitroVercelFunctionName(resolved.plugins, "queue"),
       })
     },
   }

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -209,6 +209,7 @@ interface GenerateProviderOutputsOptions {
   importBase?: string
   providerImportAliases?: Record<string, string>
   rootDir: string
+  serverFunctionName?: string
   workflow: WorkflowModuleOptions | undefined
   workspaceDependencyRuntimeImports?: WorkspaceDependencyRuntimeImports
   workspaceImportBase?: string
@@ -621,6 +622,7 @@ function createVercelOutput(
   workflowTransformPlugin: Plugin | undefined,
   frameworkImportBase?: string,
   providerImportAliases?: Record<string, string>,
+  serverFunctionName?: string,
 ): VercelProviderDeploymentOutput {
   return {
     bundleEntry: artifacts.vercelServerFile,
@@ -637,6 +639,7 @@ function createVercelOutput(
       platform: "node",
       plugins: workflowTransformPlugin ? [workflowTransformPlugin] : [],
     },
+    ...(serverFunctionName ? { config: {}, serverFunctionName } : {}),
   }
 }
 
@@ -656,7 +659,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     ? await createVercelWorkflowTransformPlugin(options.rootDir)
     : undefined
   const vercelOutput = vercelWorkflowConfig && vercelWorkflowConfig.provider === "vercel"
-    ? createVercelOutput(artifacts, workflowTransformPlugin, options.importBase, options.providerImportAliases)
+    ? createVercelOutput(artifacts, workflowTransformPlugin, options.importBase, options.providerImportAliases, options.serverFunctionName)
     : undefined
   const writeOutputs = async () => {
     await writeProviderDeploymentOutputs({

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -68,7 +68,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
           ...internalOptions?.providerImportAliases,
         },
         rootDir: resolved.root,
-        serverFunctionName: resolveNitroVercelFunctionName(resolved.plugins, "workflow"),
+        serverFunctionName: resolveNitroVercelFunctionName(resolved.plugins, "workflow", resolved.root),
         workflow,
         workspaceDependencyRuntimeImports: internalOptions?.workspaceDependencyRuntimeImports,
         workspaceImportBase: internalOptions?.workspaceImportBase,

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -1,6 +1,6 @@
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
 
 import { generateProviderOutputs, workflowPackageName } from "./internal/vite-build.ts"
 
@@ -68,6 +68,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
           ...internalOptions?.providerImportAliases,
         },
         rootDir: resolved.root,
+        serverFunctionName: resolveNitroVercelFunctionName(resolved.plugins, "workflow"),
         workflow,
         workspaceDependencyRuntimeImports: internalOptions?.workspaceDependencyRuntimeImports,
         workspaceImportBase: internalOptions?.workspaceImportBase,

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -68,7 +68,11 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
           ...internalOptions?.providerImportAliases,
         },
         rootDir: resolved.root,
-        serverFunctionName: resolveNitroVercelFunctionName(resolved.plugins, "workflow", resolved.root),
+        serverFunctionName: resolveNitroVercelFunctionName(
+          resolved.plugins,
+          "workflow",
+          (resolved as typeof resolved & { nitro?: { preset?: string } }).nitro?.preset,
+        ),
         workflow,
         workspaceDependencyRuntimeImports: internalOptions?.workspaceDependencyRuntimeImports,
         workspaceImportBase: internalOptions?.workspaceImportBase,


### PR DESCRIPTION
Preserves Nitro's Vercel server output when Blob, Database, Queue, and Workflow provider builds run alongside `nitro:main`. Composed builds now emit product-owned sidecar functions without replacing Nitro's function or routes, while standalone package builds retain their existing `__server.func` contract.

Centralizes esbuild filtering for unsupported trailing-slash Vite aliases and Node export-condition selection, so every provider bundle uses the same safe resolution boundary.