### PR TITLE
fix(vite-hub): publish Env config types

### DIFF
--- a/packages/vite-hub/fixtures/published-types/consumer.ts
+++ b/packages/vite-hub/fixtures/published-types/consumer.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite"
+import { vitehub } from "vite-hub"
+import { env } from "vite-hub/env"
+
+export default defineConfig({
+  env: {
+    server: {
+      GH_TOKEN: env(),
+    },
+  },
+  plugins: [vitehub()],
+})

--- a/packages/vite-hub/fixtures/published-types/package.json
+++ b/packages/vite-hub/fixtures/published-types/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/vite-hub/fixtures/published-types/tsconfig.json
+++ b/packages/vite-hub/fixtures/published-types/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "paths": {
+      "vite": ["../../node_modules/vite"],
+      "vite-hub": ["../../dist/index.d.ts"],
+      "vite-hub/*": ["../../dist/*"]
+    },
+    "skipLibCheck": true,
+    "strict": true,
+    "types": []
+  },
+  "files": [
+    "consumer.ts"
+  ]
+}

--- a/packages/vite-hub/test/published-types.test.ts
+++ b/packages/vite-hub/test/published-types.test.ts
@@ -1,0 +1,14 @@
+import { execFile } from "node:child_process"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { it } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = fileURLToPath(new URL("..", import.meta.url))
+const tsc = resolve(packageRoot, "../../node_modules/typescript/bin/tsc")
+
+it("publishes Env's Vite config augmentation from the framework root", async () => {
+  await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", resolve(packageRoot, "fixtures/published-types")])
+})

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -7,6 +7,13 @@ export default defineConfig({
       neverBundle: ["vite", /^@vite-hub\//],
       onlyBundle: false,
     },
+    plugins: [{
+      name: "vite-hub-env-config-declarations",
+      generateBundle(_options, bundle) {
+        const chunk = bundle["index.d.ts"]
+        if (chunk?.type === "chunk") chunk.code = `import "@vite-hub/env/vite";\n${chunk.code}`
+      },
+    }],
     entry: [
       "src/_internal/agent.ts",
       "src/_internal/agent/cloudflare.ts",


### PR DESCRIPTION
Publishes the Env Vite module augmentation from the `vite-hub` root declaration, so applications that import `vitehub()` from `vite-hub` can use the top-level Vite `env` config without a downstream pnpm patch.

The declaration bundler dropped the runtime-only `@vite-hub/env/vite` import. The package build now preserves that declaration dependency, with a built-package consumer fixture covering `vite-hub` together with `vite-hub/env`.