### PR TITLE
fix(agent): emit only rolldown build options

### DIFF
--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -404,12 +404,9 @@ function generatedAgentWorkspaceDependencyRuntime(options: AgentGeneratedImportO
 type NitroConfig = Record<string, unknown> & CloudflareAgentStateRollupTarget & CloudflareAgentStateTarget
 type RollupExternalFunction = (source: string, importer?: string, isResolved?: boolean) => boolean | null | undefined | void
 type RollupExternalOption = string | RegExp | (string | RegExp)[] | RollupExternalFunction
-type BuildWithRollupOptions = {
+type BuildWithRolldownOptions = {
   build?: {
     rolldownOptions?: {
-      external?: RollupExternalOption
-    }
-    rollupOptions?: {
       external?: RollupExternalOption
     }
   }
@@ -512,17 +509,17 @@ function mergeCloudflareWorkersExternal(external: RollupExternalOption | undefin
   return mergeRollupExternals(external, ["cloudflare:workers", ...optionalMessageAdapterRuntimeExternals])
 }
 
-function mergeBuildExternal(config: BuildWithRollupOptions, additions: readonly string[]): BuildWithRollupOptions["build"] {
+function mergeBuildExternal(config: BuildWithRolldownOptions, additions: readonly string[]): BuildWithRolldownOptions["build"] {
+  const build = (config.build ?? {}) as NonNullable<BuildWithRolldownOptions["build"]> & { rollupOptions?: unknown }
+  const rollupOptions = isRecord(build.rollupOptions) ? build.rollupOptions : {}
+  delete build.rollupOptions
+  build.rolldownOptions = {
+    ...rollupOptions,
+    ...build.rolldownOptions,
+    external: mergeRollupExternals(build.rolldownOptions?.external ?? rollupOptions.external as RollupExternalOption | undefined, additions),
+  }
   return {
-    ...config.build,
-    rolldownOptions: {
-      ...config.build?.rolldownOptions,
-      external: mergeRollupExternals(config.build?.rolldownOptions?.external, additions),
-    },
-    rollupOptions: {
-      ...config.build?.rollupOptions,
-      external: mergeRollupExternals(config.build?.rollupOptions?.external, additions),
-    },
+    ...build,
   }
 }
 
@@ -1591,7 +1588,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         ...(typeof agent !== "undefined" ? { agent } : {}),
         ...(nitroHandlers.length
           ? {
-              build: mergeBuildExternal(config as BuildWithRollupOptions, optionalMessageAdapterRuntimeExternals),
+              build: mergeBuildExternal(config as BuildWithRolldownOptions, optionalMessageAdapterRuntimeExternals),
             }
           : {}),
         ...(nitroHandlers.length || installCloudflareState

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -857,26 +857,31 @@ describe("agent Vite plugin", () => {
   it("installs automatic Cloudflare chat state for Cloudflare hosting", async () => {
     const { hubAgent } = await import("../src/vite.ts")
     const plugin = hubAgent()
+    const config = {
+      build: {
+        rolldownOptions: {
+          external: ["existing"],
+        },
+        rollupOptions: {
+          external: ["legacy"],
+          input: "legacy-entry",
+        },
+      },
+      nitro: {
+        cloudflare: {
+          wrangler: {
+            migrations: [{
+              deleted_classes: ["ViteHubAgentStateDO"],
+              tag: "delete-vitehub-agent-state-do-2026-06-11",
+            }],
+          },
+        },
+      },
+      preset: "cloudflare",
+      root: hostedAgentRoot,
+    }
     const result = typeof plugin.config === "function"
-      ? await plugin.config.call({} as never, {
-          build: {
-            rolldownOptions: {
-              external: ["existing"],
-            },
-          },
-          nitro: {
-            cloudflare: {
-              wrangler: {
-                migrations: [{
-                  deleted_classes: ["ViteHubAgentStateDO"],
-                  tag: "delete-vitehub-agent-state-do-2026-06-11",
-                }],
-              },
-            },
-          },
-          preset: "cloudflare",
-          root: hostedAgentRoot,
-        } as never, { command: "build", mode: "production" })
+      ? await plugin.config.call({} as never, config as never, { command: "build", mode: "production" })
       : undefined
     const output = result as {
       build?: unknown
@@ -908,9 +913,12 @@ describe("agent Vite plugin", () => {
     expect(output.nitro?.rollupConfig?.external).toEqual(["cloudflare:workers", ...optionalMessageAdapterRuntimeExternals])
     expect(output.nitro?.rollupConfig?.plugins?.some(plugin => plugin.name === "vitehub-agent-cloudflare-state-exports:ViteHubAgentStateDO")).toBe(true)
     expect(output.build).toEqual({
-      rolldownOptions: { external: ["existing", ...optionalMessageAdapterRuntimeExternals] },
-      rollupOptions: { external: optionalMessageAdapterRuntimeExternals },
+      rolldownOptions: {
+        external: ["existing", ...optionalMessageAdapterRuntimeExternals],
+        input: "legacy-entry",
+      },
     })
+    expect(config.build.rollupOptions).toBeUndefined()
   })
 
   it("uses a configured import in the Cloudflare Agent state Rollup entry", async () => {
@@ -1053,7 +1061,6 @@ describe("agent Vite plugin", () => {
     expect(output.nitro?.rollupConfig).toBeUndefined()
     expect(output.build).toEqual({
       rolldownOptions: { external: optionalMessageAdapterRuntimeExternals },
-      rollupOptions: { external: optionalMessageAdapterRuntimeExternals },
     })
   })
 


### PR DESCRIPTION
Vite 8 warns when a plugin returns both `rollupOptions` and `rolldownOptions`, then ignores the legacy Rollup field. The Agent Vite plugin was emitting both solely to externalize optional message-adapter peers.

This keeps that externalization in `rolldownOptions`, removes the unsupported duplicate config, and preserves Nitro's separate `rollupConfig` path. Consumer builds no longer report the conflicting-options warning.