### PR TITLE
fix(agent): align chat packages with AI SDK 7

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,11 +39,11 @@ catalogs:
       version: 1.6.18
   chat:
     '@chat-adapter/discord':
-      specifier: ^4.32.0
-      version: 4.32.0
+      specifier: ^4.34.0
+      version: 4.34.0
     chat:
-      specifier: ^4.32.0
-      version: 4.32.0
+      specifier: ^4.34.0
+      version: 4.34.0
     chat-state-cloudflare-do:
       specifier: ^0.2.0
       version: 0.2.0
@@ -340,10 +340,10 @@ importers:
         version: 0.2.0(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@netlify/blobs@10.7.5)(@pnpm/logger@1001.0.1)(@upstash/redis@1.37.0)(@vercel/blob@2.4.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.38))(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.10.1)(typescript@6.0.2)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.25)(tailwindcss@4.3.2))
       chat:
         specifier: catalog:chat
-        version: 4.32.0(ai@6.0.226(zod@4.4.3))(zod@4.4.3)
+        version: 4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
       chat-state-cloudflare-do:
         specifier: catalog:chat
-        version: 0.2.0(chat@4.32.0(ai@6.0.226(zod@4.4.3))(zod@4.4.3))
+        version: 0.2.0(chat@4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3))
       drizzle-orm:
         specifier: catalog:database
         version: 0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@upstash/redis@1.37.0)(better-sqlite3@12.9.0)(kysely@0.29.2)(postgres@3.4.9)(sql.js@1.14.1)
@@ -467,7 +467,7 @@ importers:
         version: 0.2.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@voidzero-dev/vite-plus-core@0.1.24)(crossws@0.4.5(srvx@0.11.22))(typescript@6.0.2)
       chat:
         specifier: catalog:chat
-        version: 4.32.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
+        version: 4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
       comark:
         specifier: catalog:ui
         version: 0.5.1
@@ -495,7 +495,7 @@ importers:
         version: 2.0.0(zod@4.4.3)
       '@chat-adapter/discord':
         specifier: catalog:chat
-        version: 4.32.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
+        version: 4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
       '@types/node':
         specifier: catalog:tooling
         version: 24.13.2
@@ -2035,12 +2035,12 @@ packages:
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
-  '@chat-adapter/discord@4.32.0':
-    resolution: {integrity: sha512-npJGIv0jjhhupKdLSF6Di+64mJXFkwEDfx/DOlDn41x66KnJjx2QcqvkuPBpx557kSwWXLgwIq5KWx/rQ+tEPg==}
+  '@chat-adapter/discord@4.34.0':
+    resolution: {integrity: sha512-W++GMZXOAVvFTkih59iy9qUbik9x5t0NAjMjJ8sXypX9X+hYyr57QM6QY6pFxKreM4yyC3pM7P1SW0U4VwYcdA==}
     engines: {node: '>=20'}
 
-  '@chat-adapter/shared@4.32.0':
-    resolution: {integrity: sha512-ANXYe2dbSmr9A+yUAnV8TfFht4GM6f3zR5LnAYtQdNnRI9CJfXIUXuhRaVBe5RD8IEgGXyGi4BKj5qdjBtUumA==}
+  '@chat-adapter/shared@4.34.0':
+    resolution: {integrity: sha512-3j1LIWNLp91du8y78FEUNATOEnXyVGrY3JcTNmO5/KARwHTAa17LMVMuWusj0WQj2KsKW4w/K9wytaOj7ToppA==}
     engines: {node: '>=20'}
 
   '@clack/core@1.4.0':
@@ -8216,11 +8216,11 @@ packages:
     peerDependencies:
       chat: ^4.26.0
 
-  chat@4.32.0:
-    resolution: {integrity: sha512-0NlJcCLycTy8kytRsZEnW4Gzomm+SNh1Yg7y9GVYB5fTjyhOxCcnzqrythgXNn2dvv7VeihDIISpNU0WZdOKKg==}
+  chat@4.34.0:
+    resolution: {integrity: sha512-g3c9ANavtCX7BwHcB5c3lWKIUm+8Oo7qlbgQ7/ni1rmVLLeCQa7FiMfeIyEyTAd/4HlRQu5jcS4EPdb0VyhUDQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      ai: ^6.0.182
+      ai: ^6.0.182 || ^7.0.0
       zod: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       ai:
@@ -14621,10 +14621,10 @@ snapshots:
   '@cfworker/json-schema@4.1.1':
     optional: true
 
-  '@chat-adapter/discord@4.32.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)':
+  '@chat-adapter/discord@4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.32.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
-      chat: 4.32.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
+      '@chat-adapter/shared': 4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
+      chat: 4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
       discord-api-types: 0.37.120
       discord-interactions: 4.4.0
       discord.js: 14.26.4
@@ -14635,9 +14635,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@chat-adapter/shared@4.32.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)':
+  '@chat-adapter/shared@4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      chat: 4.32.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
+      chat: 4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
@@ -21854,26 +21854,11 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  chat-state-cloudflare-do@0.2.0(chat@4.32.0(ai@6.0.226(zod@4.4.3))(zod@4.4.3)):
+  chat-state-cloudflare-do@0.2.0(chat@4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)):
     dependencies:
-      chat: 4.32.0(ai@6.0.226(zod@4.4.3))(zod@4.4.3)
+      chat: 4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3)
 
-  chat@4.32.0(ai@6.0.226(zod@4.4.3))(zod@4.4.3):
-    dependencies:
-      '@workflow/serde': 4.1.0-beta.2
-      mdast-util-to-string: 4.0.0
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
-      remark-stringify: 11.0.0
-      remend: 1.3.0
-      unified: 11.0.5
-    optionalDependencies:
-      ai: 6.0.226(zod@4.4.3)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  chat@4.32.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3):
+  chat@4.34.0(ai@7.0.19(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,8 +21,8 @@ catalogs:
   auth:
     better-auth: ^1.6.18
   chat:
-    "@chat-adapter/discord": ^4.32.0
-    chat: ^4.32.0
+    "@chat-adapter/discord": ^4.34.0
+    chat: ^4.34.0
     chat-state-cloudflare-do: ^0.2.0
   database:
     "@libsql/client": ^0.15.15


### PR DESCRIPTION
Raises the Chat SDK and Discord adapter catalog floor together to 4.34.0, the first matching release pair whose Chat peer contract accepts AI SDK 7.

This removes the invalid `@chat-adapter/discord@4.32.0 -> chat@4.32.0 -> ai@7` workspace resolution while keeping the package catalog and generated lockfile aligned.