### PR TITLE
feat(database): support D1 HTTP on Vercel

### DIFF
--- a/docs/content/docs/frameworks-hosts/vercel.md
+++ b/docs/content/docs/frameworks-hosts/vercel.md
@@ -17,7 +17,7 @@ ViteHub keeps Definitions portable and moves Vercel-specific behavior into packa
 | Vercel Queues | Queue provider configuration and generated callback output. |
 | Vercel Workflow | Workflow provider configuration and generated runtime output. |
 | Vercel Sandbox | Sandbox Provider configuration, with Sandbox Identity passed only when the run needs reuse. |
-| External Database | Database integration `connection`, backed by a hosted libSQL service such as Turso. |
+| External Database | A Database Definition backed by Cloudflare D1 over authenticated HTTP, or Database integration `connection` backed by hosted libSQL. |
 | Credentials | `VERCEL_TOKEN` and `VERCEL_PROJECT_ID` for Blob Provision, with an optional team id; Server Env for app runtime secrets. |
 
 ## Provider-owned configuration
@@ -49,6 +49,25 @@ Vercel-hosted state needs hosted stores. Use `driver: 'vercel-blob'` with `BLOB_
 ::
 
 Database Definitions own tables and identity, while the Database Integration selects the hosted connection used by Vercel output. Use Runtime Env declarations for Marketplace-provisioned credentials so generated output reads them at runtime.
+
+A Definition uses Cloudflare D1 from Vercel only when it declares `cloudflare.http`. Set it to `true` for Cloudflare's D1 raw API, then configure `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` as Vercel Server Env. Cloudflare deployments still prefer the D1 binding.
+
+```ts [server/databases/config.ts]
+import { defineDatabase } from '@vite-hub/database'
+
+import { notes } from './schema'
+
+export default defineDatabase({
+  cloudflare: {
+    databaseId: process.env.CLOUDFLARE_D1_DATABASE_ID,
+    databaseName: process.env.CLOUDFLARE_D1_DATABASE_NAME,
+    http: true,
+  },
+  tables: { notes },
+})
+```
+
+For sustained application traffic, Cloudflare recommends a proxy Worker because its built-in D1 REST API is intended primarily for administrative use and shares the global Cloudflare API rate limit. Set `cloudflare.http` to `{ url, authToken }` for an authenticated raw-compatible HTTP(S) proxy. Omitting `cloudflare.http` preserves the hosted libSQL selection even when the Definition includes a D1 database id.
 
 ```ts [vite.config.ts]
 import { hubDb } from '@vite-hub/database/vite'

--- a/docs/content/docs/server-primitives/database.md
+++ b/docs/content/docs/server-primitives/database.md
@@ -119,6 +119,7 @@ A project uses either one Default Database or a set of Named Databases. Do not m
 | `connection.authToken` | `DatabaseConfigValue` | No | Hosted database auth token. |
 | `cloudflare.binding` | `string` | No | D1 binding. Defaults to `DB` for Default Database and `DB_<NAME>` for Named Databases. |
 | `cloudflare.databaseId` | `DatabaseConfigValue` | No | D1 database id. |
+| `cloudflare.http` | `true \| { url, authToken }` | No | Explicitly selects authenticated D1 raw HTTP access for hosted runtimes. `true` uses Cloudflare's API; an object selects a compatible proxy. |
 | `cloudflare.previewDatabaseId` | `DatabaseConfigValue` | No | D1 preview database id. |
 | `cloudflare.databaseName` | `DatabaseConfigValue` | No | D1 database name. |
 | `cloudflare.migrationsTable` | `string` | No | D1 migrations table. |
@@ -172,7 +173,53 @@ export default defineEventHandler(() => {
 | --- | --- | --- |
 | Local SQLite | `connection.url` or no connection config | Default for local development and generated Drizzle artifacts. |
 | Hosted SQLite/libSQL-style connection | `connection.url` and optional `connection.authToken` | Keep URLs and tokens in Server Env when they are secrets. |
-| Cloudflare D1 | `cloudflare` Definition options or integration-level `database.driver: 'd1'` | Provider binding is wiring; Default/Named Database remains the public identity. |
+| Cloudflare D1 | `cloudflare` Definition options or integration-level `database.driver: 'd1'` | Uses a D1 binding on Cloudflare. Hosted Vercel output uses D1 only when `cloudflare.http` is selected explicitly. |
+
+### Use Cloudflare D1 from Vercel
+
+A Database Definition can use the same D1 database from Cloudflare and Vercel. Cloudflare output prefers the configured binding. Set `cloudflare.http: true` to make Vercel call Cloudflare's D1 raw API with `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` from Server Env.
+
+```ts [server/databases/config.ts]
+import { defineDatabase } from '@vite-hub/database'
+
+import { notes } from './schema'
+
+export default defineDatabase({
+  cloudflare: {
+    databaseId: process.env.CLOUDFLARE_D1_DATABASE_ID,
+    databaseName: process.env.CLOUDFLARE_D1_DATABASE_NAME,
+    http: true,
+  },
+  tables: { notes },
+})
+```
+
+Use `cloudflare.http: { url, authToken }` to send the same raw query wire format to an authenticated HTTP(S) proxy instead. Both values are required at runtime, and proxy authentication never falls back to `CLOUDFLARE_API_TOKEN`.
+
+```ts [server/databases/config.ts]
+import { defineDatabase } from '@vite-hub/database'
+
+import { notes } from './schema'
+
+export default defineDatabase({
+  cloudflare: {
+    databaseId: process.env.CLOUDFLARE_D1_DATABASE_ID,
+    http: {
+      authToken: process.env.D1_HTTP_TOKEN,
+      url: process.env.D1_HTTP_URL,
+    },
+  },
+  tables: { notes },
+})
+```
+
+Selecting D1 HTTP also generates Drizzle Kit's `d1-http` credentials. Migration and inspection commands use Cloudflare's API with `CLOUDFLARE_ACCOUNT_ID`, the database id, and `CLOUDFLARE_API_TOKEN`; those credentials are never embedded in generated output.
+
+::warning
+Cloudflare describes its built-in D1 REST API as best suited to administrative use because the global Cloudflare API rate limit applies. For sustained application traffic, use a narrowly authenticated proxy Worker and validate which queries or tables it may access. See Cloudflare's [D1 proxy Worker guide](https://developers.cloudflare.com/d1/tutorials/build-an-api-to-access-d1/).
+::
+
+Omitting `cloudflare.http` preserves the existing hosted libSQL selection even when `cloudflare.databaseId` is present.
 
 ### Select a hosted database for Vercel
 
@@ -218,7 +265,7 @@ The Database Capability is not a raw Drizzle client proxy. It uses agent-facing 
 
 Database Table Schema is the source schema in code. Live Database Schema can diverge when migrations have not run or when an Agent has explicit schema write permission.
 
-Keep provider credentials in Server Env. Keep migrations, backup behavior, and hosted database lifecycle in deployment workflows instead of hiding them in route code.
+Keep provider credentials in Server Env. Direct D1 HTTP access sends `CLOUDFLARE_API_TOKEN` only as the Cloudflare Bearer credential; proxy access sends only its configured `cloudflare.http.authToken`. Keep migrations, backup behavior, and hosted database lifecycle in deployment workflows instead of hiding them in route code.
 
 ## Next steps
 

--- a/packages/database/src/config.ts
+++ b/packages/database/src/config.ts
@@ -15,6 +15,7 @@ import { createRuntimeEnvConfigValue, resolveConfigValue } from "./config-value.
 
 import type {
   CloudflareD1BindingConfig,
+  CloudflareD1HttpConfig,
   DatabaseConfigValue,
   DatabaseConnectionConfig,
   DBModulePublicOptions,
@@ -113,10 +114,21 @@ function readStringValue(body: string | undefined, property: string): string | u
 function readDefinitionCloudflareConfig(file: string): CloudflareD1BindingConfig | undefined {
   const body = objectLiteralBody(readObjectPropertyValue(readDefinitionObjectBody(file), "cloudflare"))
   if (!body) return
+  const httpExpression = readObjectPropertyValue(body, "http")?.trim()
+  const httpBody = objectLiteralBody(httpExpression)
+  const http = httpExpression === "true"
+    ? true
+    : httpBody
+      ? {
+          authToken: readConfigValue(httpBody, "authToken"),
+          url: readConfigValue(httpBody, "url"),
+        } satisfies Partial<CloudflareD1HttpConfig>
+      : undefined
   const value = {
     binding: readStringValue(body, "binding"),
     databaseId: readConfigValue(body, "databaseId"),
     databaseName: readConfigValue(body, "databaseName"),
+    ...(http && (http === true || http.authToken || http.url) ? { http: http as true | CloudflareD1HttpConfig } : {}),
     migrationsTable: readStringValue(body, "migrationsTable"),
     previewDatabaseId: readConfigValue(body, "previewDatabaseId"),
   } satisfies CloudflareD1BindingConfig
@@ -223,6 +235,7 @@ function normalizeCloudflareConfig(
   return {
     binding: typeof value.binding === "string" && value.binding.trim() ? value.binding.trim() : getDefaultCloudflareBindingName(name),
     ...(typeof value.databaseId !== "undefined" ? { databaseId: value.databaseId } : {}),
+    ...(typeof value.http !== "undefined" ? { http: value.http } : {}),
     ...(typeof value.previewDatabaseId !== "undefined" ? { previewDatabaseId: value.previewDatabaseId } : {}),
     ...(typeof value.databaseName !== "undefined" ? { databaseName: value.databaseName } : {}),
     migrationsDir,

--- a/packages/database/src/config.ts
+++ b/packages/database/src/config.ts
@@ -80,6 +80,8 @@ function readConfigValue(body: string | undefined, property: string): DatabaseCo
   if (!expression) return
   const quoted = readStaticStringLiteral(expression)
   if (typeof quoted !== "undefined") return quoted
+  const declaration = readRuntimeEnvDeclaration(expression)
+  if (declaration) return declaration
   const fallbackParts = expression.split(/\s*(?:\|\||\?\?)\s*/)
   if (fallbackParts.length === 1) {
     const envName = readProcessEnvName(fallbackParts[0]!)
@@ -94,6 +96,25 @@ function readConfigValue(body: string | undefined, property: string): DatabaseCo
     const staticFallback = readStaticStringLiteral(fallback)
     if (typeof staticFallback !== "undefined") return createRuntimeEnvConfigValue([envName], staticFallback)
   }
+}
+
+function readRuntimeEnvDeclaration(expression: string): DatabaseConfigValue | undefined {
+  const match = /^env\s*\((.*)\)$/s.exec(expression.trim())
+  const body = objectLiteralBody(match?.[1])
+  if (!body) return
+  const source = readObjectPropertyValue(body, "source")?.trim()
+  const sourceMatch = /^env\.source\s*\((.*)\)$/s.exec(source || "")
+  if (!sourceMatch) return
+  const sourceValue = sourceMatch[1]!.trim()
+  const singleName = readStaticStringLiteral(sourceValue)
+  const names = typeof singleName !== "undefined"
+    ? [singleName]
+    : /^\[(.*)\]$/s.exec(sourceValue)?.[1]
+        ?.split(",")
+        .map(value => readStaticStringLiteral(value.trim()))
+  if (!names?.length || names.some(name => typeof name === "undefined" || !name.trim())) return
+  const defaultValue = readStaticStringLiteral(readObjectPropertyValue(body, "default")?.trim() || "")
+  return createRuntimeEnvConfigValue(names as string[], defaultValue)
 }
 
 function readStaticStringLiteral(expression: string) {

--- a/packages/database/src/definition.ts
+++ b/packages/database/src/definition.ts
@@ -24,6 +24,9 @@ export function defineDatabase<TTables extends Record<string, unknown>>(
 
   if (typeof options.cloudflare !== "undefined") {
     assertPlainObject(options.cloudflare, "defineDatabase().cloudflare")
+    if (options.cloudflare.http !== true && typeof options.cloudflare.http !== "undefined") {
+      assertPlainObject(options.cloudflare.http, "defineDatabase().cloudflare.http")
+    }
   }
   if (typeof options.connection !== "undefined") {
     assertPlainObject(options.connection, "defineDatabase().connection")

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,6 +1,7 @@
 export { defineDatabase } from "./definition.ts"
 export type {
   CloudflareD1BindingConfig,
+  CloudflareD1HttpConfig,
   DatabaseConfigValue,
   DatabaseConnectionConfig,
   DatabaseDefinition,

--- a/packages/database/src/internal/generated.ts
+++ b/packages/database/src/internal/generated.ts
@@ -24,6 +24,18 @@ function renderGeneratedDrizzleSchema(file: string, definition: DiscoveredDataba
 }
 
 function renderDbCredentials(database: ResolvedDrizzleDatabaseConfig) {
+  const databaseId = renderConfigValueExpression(database.cloudflare?.databaseId)
+  if (database.cloudflare?.http && databaseId) {
+    return [
+      "  driver: \"d1-http\",",
+      "  dbCredentials: {",
+      "    accountId: process.env[\"CLOUDFLARE_ACCOUNT_ID\"],",
+      `    databaseId: ${databaseId},`,
+      "    token: process.env[\"CLOUDFLARE_API_TOKEN\"],",
+      "  },",
+    ]
+  }
+
   const url = renderConfigValueExpression(database.connection?.url)
   const authToken = renderConfigValueExpression(database.connection?.authToken)
   if (!url) return []

--- a/packages/database/src/internal/runtime-config-expression.ts
+++ b/packages/database/src/internal/runtime-config-expression.ts
@@ -1,0 +1,34 @@
+import type { ResolvedDBViteConfig, ResolvedDrizzleDatabaseConfig } from "../types.ts"
+
+function getDefaultCloudflareBindingName(name: string) {
+  if (name === "default") return "DB"
+  const suffix = name
+    .replace(/[^a-z0-9]+/gi, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_")
+    .toUpperCase()
+  return `DB_${suffix || "DATABASE"}`
+}
+
+function renderConfigExpression(value: unknown) {
+  return typeof value === "undefined" ? "undefined" : JSON.stringify(value)
+}
+
+function serializeDatabaseConfig({ cloudflare: _cloudflare, connection: _connection, drizzle: _drizzle, ...database }: ResolvedDrizzleDatabaseConfig) {
+  return JSON.stringify(database, null, 4)
+}
+
+export function renderDatabaseConfigExpression(name: string, config: ResolvedDBViteConfig, definitionVariable: string) {
+  const base = config.databases[name]!
+  const baseHttp = base.cloudflare?.http
+  const baseHttpConfig = baseHttp && baseHttp !== true ? baseHttp : undefined
+  const http = `${definitionVariable}.cloudflare.http === true ? true : ${definitionVariable}.cloudflare.http ? { authToken: ${definitionVariable}.cloudflare.http.authToken ?? ${renderConfigExpression(baseHttpConfig?.authToken)}, url: ${definitionVariable}.cloudflare.http.url ?? ${renderConfigExpression(baseHttpConfig?.url)} } : ${renderConfigExpression(baseHttp)}`
+  return [
+    "{",
+    `      ...${serializeDatabaseConfig(base)},`,
+    `      cloudflare: ${definitionVariable}.cloudflare ? { binding: ${definitionVariable}.cloudflare.binding ?? ${JSON.stringify(base.cloudflare?.binding ?? getDefaultCloudflareBindingName(name))}, databaseId: ${definitionVariable}.cloudflare.databaseId, databaseName: ${definitionVariable}.cloudflare.databaseName, http: ${http}, migrationsDir: ${JSON.stringify(base.migrationsDir)}, migrationsTable: ${definitionVariable}.cloudflare.migrationsTable, previewDatabaseId: ${definitionVariable}.cloudflare.previewDatabaseId } : undefined,`,
+    `      connection: ${definitionVariable}.connection ? { authToken: ${definitionVariable}.connection.authToken ?? ${renderConfigExpression(base.connection?.authToken)}, url: ${definitionVariable}.connection.url ?? ${renderConfigExpression(base.connection?.url)} } : ${renderConfigExpression(base.connection)},`,
+    `      drizzle: ${definitionVariable}.drizzle ?? {},`,
+    "    }",
+  ].join("\n")
+}

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -259,6 +259,7 @@ function shouldCreateVercelOutput(runtimeConfig: ResolvedDBViteConfig) {
 
 function shouldCreateCloudflareOutput(runtimeConfig: ResolvedDBViteConfig, provisionState: ProvisionState) {
   return getCloudflareUnsupportedDatabases(runtimeConfig, provisionState).length === 0
+    && getCloudflareDatabasesMissingNames(runtimeConfig, provisionState).length === 0
 }
 
 function getSupportedProviderRuntimeModules(

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -291,7 +291,14 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     clientOutDir: options.clientOutDir,
     cloudflare: shouldCreateCloudflareOutput(options.runtimeConfig, provisionState) ? createCloudflareOutput(writeOptions) : undefined,
     cleanup: {
-      cloudflare: { fileNames: ["index.js"], wranglerConfigKeys: ["d1_databases"] },
+      cloudflare: () => {
+        const hasOtherCloudflareOutput = Object.entries(options.providerOutput?.runtimeModuleFilesByProduct ?? {})
+          .some(([product, modules]) => product !== productName && Boolean(modules?.cloudflare))
+        return {
+          ...(!hasOtherCloudflareOutput ? { fileNames: ["index.js"] } : {}),
+          wranglerConfigKeys: ["d1_databases"],
+        }
+      },
     },
     rootDir: options.rootDir,
     vercel: shouldCreateVercelOutput(options.runtimeConfig) ? createVercelOutput(writeOptions) : undefined,

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -291,7 +291,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     clientOutDir: options.clientOutDir,
     cloudflare: shouldCreateCloudflareOutput(options.runtimeConfig, provisionState) ? createCloudflareOutput(writeOptions) : undefined,
     cleanup: {
-      cloudflare: { wranglerConfigKeys: ["d1_databases"] },
+      cloudflare: { fileNames: ["index.js"], wranglerConfigKeys: ["d1_databases"] },
     },
     rootDir: options.rootDir,
     vercel: shouldCreateVercelOutput(options.runtimeConfig) ? createVercelOutput(writeOptions) : undefined,

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -9,9 +9,10 @@ import { resolve } from "pathe"
 
 import { resolveConfigValue } from "../config-value.ts"
 import { resolveCloudflareD1Bindings } from "./cloudflare.ts"
+import { renderDatabaseConfigExpression } from "./runtime-config-expression.ts"
 
 import type { ProvisionState } from "@vite-hub/internal/provision"
-import type { DatabaseConfigValue, ResolvedDBViteConfig, ResolvedDrizzleDatabaseConfig } from "../types.ts"
+import type { DatabaseConfigValue, ResolvedDBViteConfig } from "../types.ts"
 import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const dbPackageName = "@vite-hub/database"
@@ -57,36 +58,6 @@ interface CloudflareDBConfig {
   main: string
   name?: string
   observability: { enabled: true }
-}
-
-function serializeDatabaseConfig({ cloudflare: _cloudflare, connection: _connection, drizzle: _drizzle, ...database }: ResolvedDrizzleDatabaseConfig) {
-  return JSON.stringify(database, null, 4)
-}
-
-function renderConfigExpression(value: unknown) {
-  return typeof value === "undefined" ? "undefined" : JSON.stringify(value)
-}
-
-function getDefaultCloudflareBindingName(name: string) {
-  if (name === "default") return "DB"
-  const suffix = name
-    .replace(/[^a-z0-9]+/gi, "_")
-    .replace(/^_+|_+$/g, "")
-    .replace(/_+/g, "_")
-    .toUpperCase()
-  return `DB_${suffix || "DATABASE"}`
-}
-
-function renderDatabaseConfigExpression(name: string, runtimeConfig: ResolvedDBViteConfig, definitionVariable: string) {
-  const base = runtimeConfig.databases[name]!
-  return [
-    "{",
-    `      ...${serializeDatabaseConfig(base)},`,
-    `      cloudflare: ${definitionVariable}.cloudflare ? { binding: ${definitionVariable}.cloudflare.binding ?? ${JSON.stringify(base.cloudflare?.binding ?? getDefaultCloudflareBindingName(name))}, databaseId: ${definitionVariable}.cloudflare.databaseId, databaseName: ${definitionVariable}.cloudflare.databaseName, migrationsDir: ${JSON.stringify(base.migrationsDir)}, migrationsTable: ${definitionVariable}.cloudflare.migrationsTable, previewDatabaseId: ${definitionVariable}.cloudflare.previewDatabaseId } : undefined,`,
-    `      connection: ${definitionVariable}.connection ? { authToken: ${definitionVariable}.connection.authToken ?? ${renderConfigExpression(base.connection?.authToken)}, url: ${definitionVariable}.connection.url ?? ${renderConfigExpression(base.connection?.url)} } : ${renderConfigExpression(base.connection)},`,
-    `      drizzle: ${definitionVariable}.drizzle ?? {},`,
-    "    }",
-  ].join("\n")
 }
 
 function renderRuntimeModule(file: string, runtimeConfig: ResolvedDBViteConfig) {
@@ -180,6 +151,13 @@ function isRemoteLibsqlConnectionUrl(value: DatabaseConfigValue | undefined) {
     : typeof value !== "undefined"
 }
 
+function hasConfigValue(value: DatabaseConfigValue | undefined) {
+  const databaseId = resolveConfigValue(value)
+  return typeof databaseId === "string"
+    ? Boolean(databaseId.trim())
+    : typeof value !== "undefined"
+}
+
 function getCloudflareUnsupportedDatabases(runtimeConfig: ResolvedDBViteConfig, provisionState: ProvisionState) {
   return runtimeConfig.databaseNames.filter((name) => {
     const database = runtimeConfig.databases[name]
@@ -198,7 +176,10 @@ function getCloudflareDatabasesMissingNames(runtimeConfig: ResolvedDBViteConfig,
 function getVercelUnsupportedDatabases(runtimeConfig: ResolvedDBViteConfig) {
   return runtimeConfig.databaseNames.filter((name) => {
     const database = runtimeConfig.databases[name]
-    return !isRemoteLibsqlConnectionUrl(database?.connection?.url)
+    const hasD1Http = Boolean(database?.cloudflare?.http)
+      && hasConfigValue(database.cloudflare?.databaseId)
+    return !hasD1Http
+      && !isRemoteLibsqlConnectionUrl(database?.connection?.url)
   })
 }
 
@@ -254,7 +235,7 @@ function createCloudflareOutput({ artifacts, providerOutput, provisionState, run
 function createVercelOutput({ artifacts, providerOutput, runtimeConfig, serverFunctionName }: ProviderWriteOptions): VercelProviderDeploymentOutput {
   const unsupportedDatabases = getVercelUnsupportedDatabases(runtimeConfig)
   if (unsupportedDatabases.length) {
-    throw new Error(`[vitehub] Vercel output requires a remote libSQL \`db.connection.url\` for databases: ${unsupportedDatabases.join(", ")}.`)
+    throw new Error(`[vitehub] Vercel output requires \`db.cloudflare.http\` with \`db.cloudflare.databaseId\`, or a remote libSQL \`db.connection.url\`, for databases: ${unsupportedDatabases.join(", ")}.`)
   }
   const blobRuntime = getProviderRuntimeModule(providerOutput, "blob", "vercel")
 

--- a/packages/database/src/runtime/drizzle-adapter.ts
+++ b/packages/database/src/runtime/drizzle-adapter.ts
@@ -119,7 +119,7 @@ function createCloudflareD1HttpDb<TSchema extends Record<string, unknown>>(
 ) {
   async function execute(queries: D1HttpQuery[]) {
     const response = await fetch(config.url, {
-      body: JSON.stringify(queries.length === 1 ? queries[0] : { batch: queries }),
+      body: JSON.stringify(queries.length === 1 ? queries[0] : queries),
       headers: {
         Authorization: `Bearer ${config.token}`,
         "Content-Type": "application/json",

--- a/packages/database/src/runtime/drizzle-adapter.ts
+++ b/packages/database/src/runtime/drizzle-adapter.ts
@@ -119,7 +119,7 @@ function createCloudflareD1HttpDb<TSchema extends Record<string, unknown>>(
 ) {
   async function execute(queries: D1HttpQuery[]) {
     const response = await fetch(config.url, {
-      body: JSON.stringify(queries.length === 1 ? queries[0] : queries),
+      body: JSON.stringify(queries.length === 1 ? queries[0] : { batch: queries }),
       headers: {
         Authorization: `Bearer ${config.token}`,
         "Content-Type": "application/json",

--- a/packages/database/src/runtime/drizzle-adapter.ts
+++ b/packages/database/src/runtime/drizzle-adapter.ts
@@ -1,5 +1,6 @@
 import { getActiveCloudflareBinding } from "@vite-hub/internal/runtime/cloudflare-env"
 import { drizzle as drizzleD1 } from "drizzle-orm/d1"
+import { drizzle as drizzleProxy } from "drizzle-orm/sqlite-proxy"
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core"
 
 import { resolveConfigValue } from "../config-value.ts"
@@ -27,10 +28,140 @@ interface LibsqlClientFactory {
 }
 
 interface DrizzleSqliteAdapterOptions {
+  cloudflareD1Http?: boolean
   libsql: LibsqlClientFactory
   requireRemoteUrl: boolean
   resolveLocalUrl?: (url: string) => string
   missingConnectionMessage: (config: ResolvedDrizzleDatabaseConfig) => string
+}
+
+interface D1HttpQuery {
+  params: unknown[]
+  sql: string
+}
+
+interface D1HttpPayload {
+  errors?: D1HttpErrorInfo[]
+  result?: Array<{
+    error?: unknown
+    errors?: D1HttpErrorInfo[]
+    results?: { rows?: unknown[][] }
+    success?: boolean
+  }>
+  success?: boolean
+}
+
+interface D1HttpErrorInfo {
+  message?: unknown
+}
+
+interface D1HttpErrorSource {
+  error?: unknown
+  errors?: D1HttpErrorInfo[]
+}
+
+function getD1HttpErrorDetail(...sources: Array<D1HttpErrorSource | undefined>) {
+  const messages = sources.flatMap(source => [
+    ...(typeof source?.error === "string" ? [source.error] : []),
+    ...(Array.isArray(source?.errors) ? source.errors : []).map(error => error.message),
+  ]).filter((message): message is string => typeof message === "string" && Boolean(message.trim()))
+  return messages.join("; ")
+}
+
+function cloudflareD1HttpError(response: Response, label = "request", ...sources: Array<D1HttpErrorSource | undefined>) {
+  const detail = getD1HttpErrorDetail(...sources)
+  return new Error(`[vitehub] Cloudflare D1 ${label} failed (${response.status})${detail ? `: ${detail}` : "."}`)
+}
+
+function validateD1HttpUrl(value: string, name: string) {
+  try {
+    const url = new URL(value)
+    if (url.protocol === "http:" || url.protocol === "https:") return value
+  }
+  catch {}
+  throw new Error(`[vitehub] Hosted Cloudflare D1 database "${name}" requires cloudflare.http.url to be an HTTP(S) URL.`)
+}
+
+function isD1HttpPayload(value: unknown): value is D1HttpPayload {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  const result = "result" in value ? value.result : undefined
+  return typeof result === "undefined"
+    || (Array.isArray(result) && result.every(item => Boolean(item) && typeof item === "object" && !Array.isArray(item)))
+}
+
+function resolveCloudflareD1HttpConnection(config: ResolvedDrizzleDatabaseConfig, databaseId: string) {
+  const http = config.cloudflare?.http
+  if (!http) return
+
+  if (http === true) {
+    const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim()
+    const token = process.env.CLOUDFLARE_API_TOKEN?.trim()
+    if (!accountId || !token) {
+      throw new Error(`[vitehub] Hosted Cloudflare D1 database "${config.name}" requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN when cloudflare.http is true.`)
+    }
+    return {
+      token,
+      url: `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(accountId)}/d1/database/${encodeURIComponent(databaseId)}/raw`,
+    }
+  }
+
+  const token = resolveConfigValue(http.authToken)?.trim()
+  const url = resolveConfigValue(http.url)?.trim()
+  if (!token || !url) {
+    throw new Error(`[vitehub] Hosted Cloudflare D1 database "${config.name}" requires cloudflare.http.url and cloudflare.http.authToken at runtime.`)
+  }
+  return { token, url: validateD1HttpUrl(url, config.name) }
+}
+
+function createCloudflareD1HttpDb<TSchema extends Record<string, unknown>>(
+  config: { casing?: "snake_case" | "camelCase", token: string, url: string },
+  schema: TSchema,
+) {
+  async function execute(queries: D1HttpQuery[]) {
+    const response = await fetch(config.url, {
+      body: JSON.stringify(queries.length === 1 ? queries[0] : { batch: queries }),
+      headers: {
+        Authorization: `Bearer ${config.token}`,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    })
+
+    let payload: D1HttpPayload
+    try {
+      const value: unknown = await response.json()
+      if (!isD1HttpPayload(value)) throw new TypeError("Invalid D1 response")
+      payload = value
+    }
+    catch {
+      throw cloudflareD1HttpError(response)
+    }
+
+    if (!response.ok || payload.success !== true || !Array.isArray(payload.result)) {
+      throw cloudflareD1HttpError(response, "request", payload)
+    }
+    if (payload.result.length !== queries.length) {
+      throw new Error("[vitehub] Cloudflare D1 returned an unexpected query result count.")
+    }
+
+    return payload.result.map((result, index) => {
+      if (result.success !== true) {
+        throw cloudflareD1HttpError(response, `query ${index + 1}`, result, payload)
+      }
+      return Array.isArray(result.results?.rows) ? result.results.rows : []
+    })
+  }
+
+  function formatResult(rows: unknown[][], method: "run" | "all" | "values" | "get") {
+    return { rows: method === "get" ? rows[0] as unknown[] : rows }
+  }
+
+  return drizzleProxy(
+    async (sql, params, method) => formatResult((await execute([{ params, sql }]))[0]!, method),
+    async queries => (await execute(queries.map(({ params, sql }) => ({ params, sql }))))
+      .map((rows, index) => formatResult(rows, queries[index]!.method)),
+    { casing: config.casing, schema },
+  ) as RuntimeDrizzleDatabase<TSchema>
 }
 
 export function isRemoteSqliteUrl(url: string) {
@@ -43,6 +174,9 @@ export function createDrizzleSqliteAdapter<TSchema extends Record<string, unknow
   options: DrizzleSqliteAdapterOptions,
 ) {
   const d1Instances = new WeakMap<D1DatabaseLike, RuntimeDrizzleDatabase<TSchema>>()
+  let d1HttpInstance: RuntimeDrizzleDatabase<TSchema> | undefined
+  let d1HttpInstanceToken: string | undefined
+  let d1HttpInstanceUrl: string | undefined
   let libsqlInstance: RuntimeDrizzleDatabase<TSchema> | undefined
   let libsqlInstanceUrl: string | undefined
 
@@ -64,6 +198,24 @@ export function createDrizzleSqliteAdapter<TSchema extends Record<string, unknow
       }) as RuntimeDrizzleDatabase<TSchema>
       d1Instances.set(d1Binding, instance)
       return instance
+    }
+
+    const databaseId = options.cloudflareD1Http && config.cloudflare?.http
+      ? resolveConfigValue(config.cloudflare?.databaseId)?.trim()
+      : undefined
+    if (databaseId) {
+      const http = resolveCloudflareD1HttpConnection(config, databaseId)!
+      if (d1HttpInstance && d1HttpInstanceUrl === http.url && d1HttpInstanceToken === http.token) {
+        return d1HttpInstance
+      }
+
+      d1HttpInstance = createCloudflareD1HttpDb({
+        casing: config.drizzle.casing,
+        ...http,
+      }, schema)
+      d1HttpInstanceToken = http.token
+      d1HttpInstanceUrl = http.url
+      return d1HttpInstance
     }
 
     const url = resolveConfigValue(config.connection?.url)

--- a/packages/database/src/runtime/hosted.ts
+++ b/packages/database/src/runtime/hosted.ts
@@ -15,8 +15,9 @@ export function createHostedDrizzleDb<TSchema extends Record<string, unknown>>(
   schema: TSchema,
 ) {
   return createDrizzleSqliteAdapter(dbConfig, schema, {
+    cloudflareD1Http: true,
     libsql: { createClient, drizzle: drizzleLibsql as never },
-    missingConnectionMessage: config => `[vitehub] Hosted DB "${config.name}" requires a Cloudflare D1 binding or a remote libSQL URL. Hosted deployment requires \`db.connection.url\` to be a hosted libSQL endpoint before deploying this database to Cloudflare or Vercel.`,
+    missingConnectionMessage: config => `[vitehub] Hosted DB "${config.name}" requires an active Cloudflare D1 binding, cloudflare.http with databaseId, or a remote libSQL URL.`,
     requireRemoteUrl: true,
   })
 }

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -13,9 +13,15 @@ export interface RuntimeEnvDeclarationLike {
 
 export type DatabaseConfigValue = string | RuntimeEnvDeclarationLike
 
+export interface CloudflareD1HttpConfig {
+  authToken: DatabaseConfigValue
+  url: DatabaseConfigValue
+}
+
 export interface CloudflareD1BindingConfig {
   binding?: string
   databaseId?: DatabaseConfigValue
+  http?: true | CloudflareD1HttpConfig
   previewDatabaseId?: DatabaseConfigValue
   databaseName?: DatabaseConfigValue
   migrationsTable?: string
@@ -81,6 +87,7 @@ export interface DiscoveredDatabaseDefinition {
 export interface ResolvedCloudflareD1BindingConfig {
   binding: string
   databaseId?: DatabaseConfigValue
+  http?: true | CloudflareD1HttpConfig
   previewDatabaseId?: DatabaseConfigValue
   databaseName?: DatabaseConfigValue
   migrationsDir: string

--- a/packages/database/src/vite.ts
+++ b/packages/database/src/vite.ts
@@ -6,13 +6,14 @@ import { normalize } from "pathe"
 import { createDbCliContributor } from "./cli.ts"
 import { resolveDBViteConfig } from "./config.ts"
 import { writeGeneratedDatabaseArtifacts } from "./internal/generated.ts"
+import { renderDatabaseConfigExpression } from "./internal/runtime-config-expression.ts"
 import { dbPackageName, generateProviderOutputs, prepareProviderOutputs } from "./internal/vite-build.ts"
 import { createDatabaseProvisionStep } from "./provision.ts"
 
 import type { ViteHubCliContributor } from "@vite-hub/internal/cli"
 import type { ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import type { Plugin, ResolvedConfig } from "vite"
-import type { DBModulePublicOptions, ResolvedDBViteConfig, ResolvedDrizzleDatabaseConfig } from "./types.ts"
+import type { DBModulePublicOptions, ResolvedDBViteConfig } from "./types.ts"
 
 export const DB_VIRTUAL_SCHEMA_ID = "#vitehub/database/schema"
 export const DB_VIRTUAL_DATABASES_ID = "#vitehub/database/databases"
@@ -59,36 +60,6 @@ function renderSchemaModule(config: ResolvedDBViteConfig | undefined) {
     `export * from ${JSON.stringify(config.generatedSchemaFilesByDatabase[defaultName])}`,
     `export { default, schema } from ${JSON.stringify(config.generatedSchemaFilesByDatabase[defaultName])}`,
     "",
-  ].join("\n")
-}
-
-function getDefaultCloudflareBindingName(name: string) {
-  if (name === "default") return "DB"
-  const suffix = name
-    .replace(/[^a-z0-9]+/gi, "_")
-    .replace(/^_+|_+$/g, "")
-    .replace(/_+/g, "_")
-    .toUpperCase()
-  return `DB_${suffix || "DATABASE"}`
-}
-
-function serializeDatabaseConfig({ cloudflare: _cloudflare, connection: _connection, drizzle: _drizzle, ...database }: ResolvedDrizzleDatabaseConfig) {
-  return JSON.stringify(database, null, 6)
-}
-
-function renderConfigExpression(value: unknown) {
-  return typeof value === "undefined" ? "undefined" : JSON.stringify(value)
-}
-
-function renderDatabaseConfigExpression(name: string, config: ResolvedDBViteConfig, definitionVariable: string) {
-  const base = config.databases[name]!
-  return [
-    "{",
-    `      ...${serializeDatabaseConfig(base)},`,
-    `      cloudflare: ${definitionVariable}.cloudflare ? { binding: ${definitionVariable}.cloudflare.binding ?? ${JSON.stringify(base.cloudflare?.binding ?? getDefaultCloudflareBindingName(name))}, databaseId: ${definitionVariable}.cloudflare.databaseId, databaseName: ${definitionVariable}.cloudflare.databaseName, migrationsDir: ${JSON.stringify(base.migrationsDir)}, migrationsTable: ${definitionVariable}.cloudflare.migrationsTable, previewDatabaseId: ${definitionVariable}.cloudflare.previewDatabaseId } : undefined,`,
-    `      connection: ${definitionVariable}.connection ? { authToken: ${definitionVariable}.connection.authToken ?? ${renderConfigExpression(base.connection?.authToken)}, url: ${definitionVariable}.connection.url ?? ${renderConfigExpression(base.connection?.url)} } : ${renderConfigExpression(base.connection)},`,
-    `      drizzle: ${definitionVariable}.drizzle ?? {},`,
-    "    }",
   ].join("\n")
 }
 

--- a/packages/database/test/config.test.ts
+++ b/packages/database/test/config.test.ts
@@ -309,4 +309,34 @@ describe("resolveDBViteConfig", () => {
       else process.env.D1_HTTP_URL = originalUrl
     }
   })
+
+  it("preserves Runtime Env declarations for D1 HTTP proxy config", async () => {
+    const rootDir = await createTempProject()
+    await writeDefinition(rootDir, "server/databases/config.ts", "notes", {
+      cloudflare: [
+        "    databaseId: env({ source: env.source('CLOUDFLARE_D1_DATABASE_ID') }),",
+        "    http: {",
+        "      authToken: env({ secret: true, source: env.source('D1_HTTP_TOKEN') }),",
+        "      url: env({ source: env.source(['D1_HTTP_URL', 'D1_PROXY_URL']) }),",
+        "    },",
+      ].join("\n"),
+    })
+
+    expect(resolveDBViteConfig(undefined, rootDir)?.databases.default.cloudflare).toMatchObject({
+      databaseId: {
+        kind: "env-variable",
+        source: { kind: "env", name: "CLOUDFLARE_D1_DATABASE_ID" },
+      },
+      http: {
+        authToken: {
+          kind: "env-variable",
+          source: { kind: "env", name: "D1_HTTP_TOKEN" },
+        },
+        url: {
+          kind: "env-variable",
+          source: { kind: "env", name: "D1_HTTP_URL", names: ["D1_HTTP_URL", "D1_PROXY_URL"] },
+        },
+      },
+    })
+  })
 })

--- a/packages/database/test/config.test.ts
+++ b/packages/database/test/config.test.ts
@@ -14,7 +14,7 @@ async function createTempProject() {
   return rootDir
 }
 
-async function writeDefinition(rootDir: string, path: string, tables = "notes", options: { connection?: string } = {}) {
+async function writeDefinition(rootDir: string, path: string, tables = "notes", options: { cloudflare?: string, connection?: string } = {}) {
   const file = join(rootDir, path)
   await mkdir(dirname(file), { recursive: true })
   await writeFile(file, [
@@ -22,6 +22,7 @@ async function writeDefinition(rootDir: string, path: string, tables = "notes", 
     "import { sqliteTable, text } from 'drizzle-orm/sqlite-core'",
     `const ${tables} = sqliteTable('${tables}', { title: text('title') })`,
     "export default defineDatabase({",
+    ...(options.cloudflare ? ["  cloudflare: {", options.cloudflare, "  },"] : []),
     ...(options.connection ? ["  connection: {", options.connection, "  },"] : []),
     `  tables: { ${tables} },`,
     "})",
@@ -267,6 +268,45 @@ describe("resolveDBViteConfig", () => {
       else process.env.TURSO_AUTH_TOKEN = originalAuthToken
       if (typeof originalUrl === "undefined") delete process.env.TURSO_DATABASE_URL
       else process.env.TURSO_DATABASE_URL = originalUrl
+    }
+  })
+
+  it("preserves explicit D1 HTTP proxy declarations without resolving their secrets", async () => {
+    const rootDir = await createTempProject()
+    const originalToken = process.env.D1_HTTP_TOKEN
+    const originalUrl = process.env.D1_HTTP_URL
+    delete process.env.D1_HTTP_TOKEN
+    delete process.env.D1_HTTP_URL
+
+    try {
+      await writeDefinition(rootDir, "server/databases/config.ts", "notes", {
+        cloudflare: [
+          "    databaseId: process.env.CLOUDFLARE_D1_DATABASE_ID,",
+          "    http: {",
+          "      authToken: process.env.D1_HTTP_TOKEN,",
+          "      url: process.env.D1_HTTP_URL,",
+          "    },",
+        ].join("\n"),
+      })
+
+      expect(resolveDBViteConfig(undefined, rootDir)?.databases.default.cloudflare).toMatchObject({
+        http: {
+          authToken: {
+            kind: "env-variable",
+            source: { kind: "env", name: "D1_HTTP_TOKEN" },
+          },
+          url: {
+            kind: "env-variable",
+            source: { kind: "env", name: "D1_HTTP_URL" },
+          },
+        },
+      })
+    }
+    finally {
+      if (typeof originalToken === "undefined") delete process.env.D1_HTTP_TOKEN
+      else process.env.D1_HTTP_TOKEN = originalToken
+      if (typeof originalUrl === "undefined") delete process.env.D1_HTTP_URL
+      else process.env.D1_HTTP_URL = originalUrl
     }
   })
 })

--- a/packages/database/test/runtime.test.ts
+++ b/packages/database/test/runtime.test.ts
@@ -381,10 +381,12 @@ describe("hosted drizzle runtime", () => {
       [{ id: 2, name: "second" }],
     ])
     const [, request] = fetchMock.mock.calls[0]!
-    expect(JSON.parse(String(request?.body))).toMatchObject([
-      { params: [1], sql: expect.stringContaining("analytics_events") },
-      { params: [2], sql: expect.stringContaining("analytics_events") },
-    ])
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      batch: [
+        { params: [1], sql: expect.stringContaining("analytics_events") },
+        { params: [2], sql: expect.stringContaining("analytics_events") },
+      ],
+    })
   })
 
   it("requires Cloudflare API credentials before D1 HTTP access", async () => {

--- a/packages/database/test/runtime.test.ts
+++ b/packages/database/test/runtime.test.ts
@@ -381,12 +381,10 @@ describe("hosted drizzle runtime", () => {
       [{ id: 2, name: "second" }],
     ])
     const [, request] = fetchMock.mock.calls[0]!
-    expect(JSON.parse(String(request?.body))).toMatchObject({
-      batch: [
-        { params: [1], sql: expect.stringContaining("analytics_events") },
-        { params: [2], sql: expect.stringContaining("analytics_events") },
-      ],
-    })
+    expect(JSON.parse(String(request?.body))).toMatchObject([
+      { params: [1], sql: expect.stringContaining("analytics_events") },
+      { params: [2], sql: expect.stringContaining("analytics_events") },
+    ])
   })
 
   it("requires Cloudflare API credentials before D1 HTTP access", async () => {

--- a/packages/database/test/runtime.test.ts
+++ b/packages/database/test/runtime.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os"
 import { promisify } from "node:util"
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { sql } from "drizzle-orm"
+import { eq, sql } from "drizzle-orm"
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core"
 import { setActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 
@@ -45,6 +45,36 @@ function createFakeD1Binding() {
       }
     },
   }
+}
+
+async function createHostedAnalyticsDb(http: true | { authToken: string, url: string } = true) {
+  const { createHostedDrizzleDb } = await import("../src/runtime/hosted.ts")
+  const db = createHostedDrizzleDb({
+    cloudflare: {
+      binding: "DB_ANALYTICS",
+      databaseId: "analytics-d1-id",
+      http,
+      migrationsDir: "server/databases/analytics/migrations",
+    },
+    dialect: "sqlite",
+    drizzle: {},
+    generatedSchemaFile: ".vitehub/database/schema/analytics.ts",
+    migrationsDir: "server/databases/analytics/migrations",
+    mode: "named",
+    name: "analytics",
+    orm: "drizzle",
+  }, analyticsSchema)
+  return { db }
+}
+
+function createD1Response(...rows: unknown[][][]) {
+  return new Response(JSON.stringify({
+    result: rows.map(resultRows => ({ results: { rows: resultRows }, success: true })),
+    success: true,
+  }), {
+    headers: { "Content-Type": "application/json" },
+    status: 200,
+  })
 }
 
 ;(vi.mock as any)("#vitehub/database/schema", () => ({
@@ -109,6 +139,8 @@ afterEach(async () => {
   runtimeState.analyticsDbPath = ""
   runtimeState.dbPath = ""
   setActiveCloudflareEnv(undefined)
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
   vi.resetModules()
   if (tempDir) {
     await rm(tempDir, { force: true, recursive: true })
@@ -209,7 +241,7 @@ describe("hosted drizzle runtime", () => {
       orm: "drizzle",
     }, defaultSchema)
 
-    expect(() => db.run).toThrow("Hosted DB \"default\" requires a Cloudflare D1 binding or a remote libSQL URL")
+    expect(() => db.run).toThrow("Hosted DB \"default\" requires an active Cloudflare D1 binding, cloudflare.http with databaseId, or a remote libSQL URL")
   })
 
   it("rejects non-libsql remote schemes in hosted mode", async () => {
@@ -228,7 +260,7 @@ describe("hosted drizzle runtime", () => {
       orm: "drizzle",
     }, defaultSchema)
 
-    expect(() => db.run).toThrow("Hosted DB \"default\" requires a Cloudflare D1 binding or a remote libSQL URL")
+    expect(() => db.run).toThrow("Hosted DB \"default\" requires an active Cloudflare D1 binding, cloudflare.http with databaseId, or a remote libSQL URL")
   })
 
   it("uses the active Cloudflare binding when hosted outputs run on Cloudflare", async () => {
@@ -240,6 +272,7 @@ describe("hosted drizzle runtime", () => {
       cloudflare: {
         binding: "DB_ANALYTICS",
         databaseId: "analytics-d1-id",
+        http: true,
         migrationsDir: "src/database/analytics/migrations",
       },
       dialect: "sqlite",
@@ -252,5 +285,166 @@ describe("hosted drizzle runtime", () => {
     }, analyticsSchema)
 
     expect((db as { $client?: unknown }).$client).toBe(binding)
+  })
+
+  it("queries configured Cloudflare D1 over authenticated HTTP", async () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "account-id")
+    vi.stubEnv("CLOUDFLARE_API_TOKEN", "api-token")
+    const fetchMock = vi.fn(async (_input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) => createD1Response([[1, "page-view"]]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { db } = await createHostedAnalyticsDb()
+    await expect(db.select().from(analyticsSchema.analyticsEvents)).resolves.toEqual([{ id: 1, name: "page-view" }])
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, request] = fetchMock.mock.calls[0]!
+    expect(url).toBe("https://api.cloudflare.com/client/v4/accounts/account-id/d1/database/analytics-d1-id/raw")
+    expect(request).toMatchObject({
+      headers: {
+        Authorization: "Bearer api-token",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    })
+    expect(JSON.parse(String(request?.body))).toMatchObject({ params: [], sql: expect.stringContaining("analytics_events") })
+  })
+
+  it("maps all, get, and run results through the D1 raw transport", async () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "account-id")
+    vi.stubEnv("CLOUDFLARE_API_TOKEN", "api-token")
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(createD1Response([[1, "page-view"]]))
+      .mockResolvedValueOnce(createD1Response([[2, "download"]]))
+      .mockResolvedValueOnce(createD1Response([]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { db } = await createHostedAnalyticsDb()
+    await expect(db.select().from(analyticsSchema.analyticsEvents)).resolves.toEqual([{ id: 1, name: "page-view" }])
+    await expect(db.select().from(analyticsSchema.analyticsEvents).where(eq(analyticsSchema.analyticsEvents.id, 2)).get()).resolves.toEqual({ id: 2, name: "download" })
+    await expect(db.insert(analyticsSchema.analyticsEvents).values({ name: "signup" }).run()).resolves.toEqual({ rows: [] })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it("uses an explicitly configured authenticated D1 proxy", async () => {
+    vi.stubEnv("CLOUDFLARE_API_TOKEN", "cloudflare-token-must-not-be-used")
+    const fetchMock = vi.fn(async (_input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) => createD1Response([[1, "page-view"]]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { db } = await createHostedAnalyticsDb({
+      authToken: "proxy-token",
+      url: "https://d1.example.com/raw",
+    })
+    await db.select().from(analyticsSchema.analyticsEvents)
+
+    const [url, request] = fetchMock.mock.calls[0]!
+    expect(url).toBe("https://d1.example.com/raw")
+    expect(request?.headers).toMatchObject({ Authorization: "Bearer proxy-token" })
+    expect(JSON.stringify(request)).not.toContain("cloudflare-token-must-not-be-used")
+  })
+
+  it("preserves a configured libSQL fallback when D1 HTTP is not selected", async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+    const { createHostedDrizzleDb } = await import("../src/runtime/hosted.ts")
+    const db = createHostedDrizzleDb({
+      cloudflare: {
+        binding: "DB_ANALYTICS",
+        databaseId: "analytics-d1-id",
+        migrationsDir: "server/databases/analytics/migrations",
+      },
+      connection: { url: "libsql://analytics.example.turso.io" },
+      dialect: "sqlite",
+      drizzle: {},
+      generatedSchemaFile: ".vitehub/database/schema/analytics.ts",
+      migrationsDir: "server/databases/analytics/migrations",
+      mode: "named",
+      name: "analytics",
+      orm: "drizzle",
+    }, analyticsSchema)
+
+    expect((db as { $client?: unknown }).$client).toBeDefined()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("sends Drizzle batches through one Cloudflare D1 request", async () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "account-id")
+    vi.stubEnv("CLOUDFLARE_API_TOKEN", "api-token")
+    const fetchMock = vi.fn(async (_input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) => createD1Response([[1, "first"]], [[2, "second"]]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { db } = await createHostedAnalyticsDb()
+    const batchDb = db as unknown as { batch: (queries: unknown[]) => Promise<unknown[]> }
+    await expect(batchDb.batch([
+      db.select().from(analyticsSchema.analyticsEvents).where(eq(analyticsSchema.analyticsEvents.id, 1)),
+      db.select().from(analyticsSchema.analyticsEvents).where(eq(analyticsSchema.analyticsEvents.id, 2)),
+    ])).resolves.toEqual([
+      [{ id: 1, name: "first" }],
+      [{ id: 2, name: "second" }],
+    ])
+    const [, request] = fetchMock.mock.calls[0]!
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      batch: [
+        { params: [1], sql: expect.stringContaining("analytics_events") },
+        { params: [2], sql: expect.stringContaining("analytics_events") },
+      ],
+    })
+  })
+
+  it("requires Cloudflare API credentials before D1 HTTP access", async () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "")
+    vi.stubEnv("CLOUDFLARE_API_TOKEN", "")
+    const { db } = await createHostedAnalyticsDb()
+    expect(() => db.run).toThrow("Hosted Cloudflare D1 database \"analytics\" requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN when cloudflare.http is true.")
+  })
+
+  it("requires both configured proxy values without falling back to Cloudflare credentials", async () => {
+    vi.stubEnv("CLOUDFLARE_API_TOKEN", "cloudflare-token")
+    const { db } = await createHostedAnalyticsDb({ authToken: "", url: "https://d1.example.com/raw" })
+    expect(() => db.run).toThrow("requires cloudflare.http.url and cloudflare.http.authToken at runtime")
+  })
+
+  it("rejects malformed and failed D1 responses without exposing credentials", async () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "account-id")
+    vi.stubEnv("CLOUDFLARE_API_TOKEN", "secret-api-token")
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response("not json", { status: 502 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        errors: [{ message: "permission denied" }],
+        success: false,
+      }), { headers: { "Content-Type": "application/json" }, status: 403 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { db } = await createHostedAnalyticsDb()
+    const malformedError = await db.select().from(analyticsSchema.analyticsEvents).then(() => undefined, error => error)
+    const deniedError = await db.select().from(analyticsSchema.analyticsEvents).then(() => undefined, error => error)
+    expect(malformedError).toMatchObject({
+      cause: { message: "[vitehub] Cloudflare D1 request failed (502)." },
+    })
+    expect(deniedError).toMatchObject({
+      cause: { message: "[vitehub] Cloudflare D1 request failed (403): permission denied" },
+    })
+    expect(JSON.stringify([malformedError, deniedError])).not.toContain("secret-api-token")
+  })
+
+  it("rejects per-query errors and mismatched D1 batch results", async () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "account-id")
+    vi.stubEnv("CLOUDFLARE_API_TOKEN", "api-token")
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        result: [
+          { results: { rows: [[1, "first"]] }, success: true },
+          { errors: [{ message: "second query failed" }], success: false },
+        ],
+        success: true,
+      }), { headers: { "Content-Type": "application/json" }, status: 200 }))
+      .mockResolvedValueOnce(createD1Response([[1, "only-result"]]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { db } = await createHostedAnalyticsDb()
+    const batch = () => (db as unknown as { batch: (queries: unknown[]) => Promise<unknown[]> }).batch([
+      db.select().from(analyticsSchema.analyticsEvents).where(eq(analyticsSchema.analyticsEvents.id, 1)),
+      db.select().from(analyticsSchema.analyticsEvents).where(eq(analyticsSchema.analyticsEvents.id, 2)),
+    ])
+    await expect(batch()).rejects.toThrow("Cloudflare D1 query 2 failed (200): second query failed")
+    await expect(batch()).rejects.toThrow("Cloudflare D1 returned an unexpected query result count")
   })
 })

--- a/packages/database/test/types.test.ts
+++ b/packages/database/test/types.test.ts
@@ -2,10 +2,11 @@ import type { UserConfig } from "vite"
 
 import { env } from "@vite-hub/env"
 import "../src/virtual.ts"
+import { defineDatabase } from "../src/index.ts"
 
 import { describe, expectTypeOf, it } from "vitest"
 
-import type { DBModulePublicOptions } from "../src/index.ts"
+import type { CloudflareD1HttpConfig, DBModulePublicOptions } from "../src/index.ts"
 
 type DrizzleModule = typeof import("../src/drizzle.ts")
 
@@ -35,6 +36,29 @@ describe("types", () => {
     }
 
     expectTypeOf(config).toMatchTypeOf<DBModulePublicOptions>()
+  })
+
+  it("accepts explicit D1 HTTP transport configuration", () => {
+    const direct = defineDatabase({
+      cloudflare: {
+        databaseId: env({ source: env.source("CLOUDFLARE_D1_DATABASE_ID") }),
+        http: true,
+      },
+      tables: {},
+    })
+    const proxied = defineDatabase({
+      cloudflare: {
+        databaseId: env({ source: env.source("CLOUDFLARE_D1_DATABASE_ID") }),
+        http: {
+          authToken: env({ secret: true, source: env.source("D1_HTTP_TOKEN") }),
+          url: env({ source: env.source("D1_HTTP_URL") }),
+        },
+      },
+      tables: {},
+    })
+
+    expectTypeOf(direct.cloudflare?.http).toEqualTypeOf<true | CloudflareD1HttpConfig | undefined>()
+    expectTypeOf(proxied.cloudflare?.http).toEqualTypeOf<true | CloudflareD1HttpConfig | undefined>()
   })
 
   it("exposes drizzle types when the virtual ambient module entry is loaded", () => {

--- a/packages/database/test/vite-output.test.ts
+++ b/packages/database/test/vite-output.test.ts
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 
 import { afterAll, describe, expect, it } from "vitest"
-import { getProviderRuntimeModule, type ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
+import { createDefaultCloudflareOutputRoot, getProviderRuntimeModule, type ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 
 import { prepareProviderOutputs as prepareDatabaseProviderOutputs } from "../src/internal/vite-build.ts"
 
@@ -593,6 +593,9 @@ describe("Vite db provider outputs", () => {
 
   it("skips Cloudflare output when a Vercel D1 HTTP database has no Cloudflare database name", async () => {
     const rootDir = await createDbBuildProject("vitehub-db-vite-cloudflare-invalid-")
+    const staleCloudflareOutput = join(createDefaultCloudflareOutputRoot(rootDir), "index.js")
+    await mkdir(dirname(staleCloudflareOutput), { recursive: true })
+    await writeFile(staleCloudflareOutput, "export default 'stale'\n")
     await writeDatabaseDefinition(rootDir, "analytics", {
       cloudflare: [
         "    binding: 'DB_ANALYTICS',",
@@ -614,7 +617,7 @@ describe("Vite db provider outputs", () => {
       VITEHUB_D1_DATABASE_ID: "primary-d1-id",
     })
 
-    expect(existsSync(join(rootDir, "dist", "cloudflare"))).toBe(false)
+    expect(existsSync(staleCloudflareOutput)).toBe(false)
     expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"))).toBe(true)
   }, 30_000)
 })

--- a/packages/database/test/vite-output.test.ts
+++ b/packages/database/test/vite-output.test.ts
@@ -1,7 +1,9 @@
 import { existsSync } from "node:fs"
+import { createServer } from "node:http"
 import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises"
 import { execFile } from "node:child_process"
 import { dirname, join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 
 import { afterAll, describe, expect, it } from "vitest"
@@ -53,7 +55,7 @@ async function writeDatabaseDefinition(rootDir: string, name: string, options: {
   ].join("\n"))
 }
 
-async function createDbBuildProject(prefix: string, options: { integrationConnection?: boolean } = {}) {
+async function createDbBuildProject(prefix: string, options: { integrationConnection?: boolean, nitro?: boolean } = {}) {
   const rootDir = await createWorkspaceTempDir(prefix)
   const nodeModules = resolvePlaygroundNodeModules()
   await mkdir(join(rootDir, "src"), { recursive: true })
@@ -79,14 +81,14 @@ async function createDbBuildProject(prefix: string, options: { integrationConnec
     "  },",
     ...(options.integrationConnection
       ? [
-          "  plugins: [hubDb({",
+          `  plugins: [${options.nitro ? "{ name: 'nitro:main' }, " : ""}hubDb({`,
           "    connection: {",
           "      authToken: { kind: 'env-variable', source: { kind: 'env', name: 'TURSO_AUTH_TOKEN' } },",
           "      url: { kind: 'env-variable', source: { kind: 'env', name: 'TURSO_DATABASE_URL' } },",
           "    },",
           "  })],",
         ]
-      : ["  plugins: [hubDb()],"]),
+      : [`  plugins: [${options.nitro ? "{ name: 'nitro:main' }, " : ""}hubDb()],`]),
     "})",
     "",
   ].join("\n"))
@@ -267,12 +269,27 @@ function expectNoRuntimeImport(code: string, specifier: string) {
   expect(code).not.toMatch(new RegExp(`\\b(?:from\\s+|import\\(|require\\()["']${escaped}["']`))
 }
 
+async function listen(server: ReturnType<typeof createServer>) {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("Expected a TCP server address.")
+  return `http://127.0.0.1:${address.port}`
+}
+
+async function close(server: ReturnType<typeof createServer>) {
+  if (!server.listening) return
+  await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+}
+
 afterAll(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
 })
 
 describe("Vite db provider outputs", () => {
-  it("does not register unsupported Vercel database runtimes for composed sibling output", async () => {
+  it("registers D1 HTTP as a supported Vercel database runtime", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-db-vite-vercel-registry-")
     const providerOutput = { runtimeModuleFilesByProduct: {} } satisfies ComposedProviderOutput
 
@@ -284,12 +301,13 @@ describe("Vite db provider outputs", () => {
           binding: "DB_PRIMARY",
           databaseId: "primary-d1-id",
           databaseName: "primary",
+          http: true,
         },
       }),
     })
 
     expect(getProviderRuntimeModule(providerOutput, "database", "cloudflare")).toContain("cloudflare-runtime.mjs")
-    expect(getProviderRuntimeModule(providerOutput, "database", "vercel")).toBeUndefined()
+    expect(getProviderRuntimeModule(providerOutput, "database", "vercel")).toContain("vercel-runtime.mjs")
   })
 
   it("composes direct Blob and Database provider output in either plugin order", async () => {
@@ -428,21 +446,37 @@ describe("Vite db provider outputs", () => {
     expect(code).toContain("TURSO_AUTH_TOKEN")
   }, 30_000)
 
-  it("skips Vercel output when a named database has no remote fallback URL", async () => {
+  it("runs a D1-backed database through generated Vercel output", async () => {
     const rootDir = await createDbBuildProject("vitehub-db-vite-vercel-invalid-")
     await writeDatabaseDefinition(rootDir, "analytics", {
       cloudflare: [
         "    binding: 'DB_ANALYTICS',",
         "    databaseName: 'vitehub-playground-analytics',",
         "    databaseId: process.env.VITEHUB_D1_ANALYTICS_DATABASE_ID,",
+        "    http: {",
+        "      authToken: process.env.VITEHUB_D1_HTTP_TOKEN,",
+        "      url: process.env.VITEHUB_D1_HTTP_URL,",
+        "    },",
       ].join("\n"),
     })
+    await writeFile(join(rootDir, "src/server.ts"), [
+      "import { databases } from '@vite-hub/database/drizzle'",
+      "export default {",
+      "  async fetch() {",
+      "    const { db, schema } = databases.analytics",
+      "    return Response.json(await db.select().from(schema.analyticsItems))",
+      "  },",
+      "}",
+      "",
+    ].join("\n"))
 
     await runDbBuild(rootDir, {
       TURSO_AUTH_TOKEN: "token",
       TURSO_DATABASE_URL: "libsql://database.example.turso.io",
       VITEHUB_D1_ANALYTICS_DATABASE_ID: "analytics-d1-id",
       VITEHUB_D1_DATABASE_ID: "primary-d1-id",
+      VITEHUB_D1_HTTP_TOKEN: "proxy-secret-value",
+      VITEHUB_D1_HTTP_URL: "https://d1.example.com/raw",
     })
 
     const cloudflareConfig = await readCloudflareConfig(rootDir)
@@ -453,7 +487,96 @@ describe("Vite db provider outputs", () => {
         database_name: "vitehub-playground-analytics",
       }),
     ]))
-    expect(existsSync(join(rootDir, ".vercel", "output"))).toBe(false)
+    const vercelServer = join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs")
+    expect(existsSync(vercelServer)).toBe(true)
+    const code = await readFile(vercelServer, "utf8")
+    expect(code).toContain("VITEHUB_D1_HTTP_TOKEN")
+    expect(code).toContain("VITEHUB_D1_HTTP_URL")
+    expect(code).toContain("VITEHUB_D1_ANALYTICS_DATABASE_ID")
+    expect(code).not.toContain("proxy-secret-value")
+    expect(code).not.toContain("https://d1.example.com/raw")
+
+    let proxyRequest: { authorization?: string, body?: unknown } = {}
+    const proxy = createServer(async (request, response) => {
+      let body = ""
+      for await (const chunk of request) body += chunk
+      proxyRequest = {
+        authorization: request.headers.authorization,
+        body: JSON.parse(body),
+      }
+      response.setHeader("Content-Type", "application/json")
+      response.end(JSON.stringify({
+        result: [{ results: { rows: [["page-view"]] }, success: true }],
+        success: true,
+      }))
+    })
+    const app = createServer()
+    const originalDatabaseId = process.env.VITEHUB_D1_ANALYTICS_DATABASE_ID
+    const originalToken = process.env.VITEHUB_D1_HTTP_TOKEN
+    const originalUrl = process.env.VITEHUB_D1_HTTP_URL
+
+    try {
+      process.env.VITEHUB_D1_ANALYTICS_DATABASE_ID = "analytics-d1-id"
+      process.env.VITEHUB_D1_HTTP_TOKEN = "runtime-proxy-token"
+      process.env.VITEHUB_D1_HTTP_URL = await listen(proxy)
+      const handler = (await import(`${pathToFileURL(vercelServer).href}?t=${Date.now()}`)).default
+      app.on("request", (request, response) => void Promise.resolve(handler(request, response)).catch((error) => {
+        response.statusCode = 500
+        response.end(String(error))
+      }))
+      const appUrl = await listen(app)
+
+      const response = await fetch(appUrl)
+      await expect(response.json()).resolves.toEqual([{ title: "page-view" }])
+      expect(proxyRequest).toMatchObject({
+        authorization: "Bearer runtime-proxy-token",
+        body: { params: [], sql: expect.stringContaining("analytics_items") },
+      })
+    }
+    finally {
+      await Promise.all([close(app), close(proxy)])
+      if (typeof originalDatabaseId === "undefined") delete process.env.VITEHUB_D1_ANALYTICS_DATABASE_ID
+      else process.env.VITEHUB_D1_ANALYTICS_DATABASE_ID = originalDatabaseId
+      if (typeof originalToken === "undefined") delete process.env.VITEHUB_D1_HTTP_TOKEN
+      else process.env.VITEHUB_D1_HTTP_TOKEN = originalToken
+      if (typeof originalUrl === "undefined") delete process.env.VITEHUB_D1_HTTP_URL
+      else process.env.VITEHUB_D1_HTTP_URL = originalUrl
+    }
+  }, 30_000)
+
+  it("preserves Nitro Vercel output while emitting an isolated D1 database function", async () => {
+    const rootDir = await createDbBuildProject("vitehub-db-vite-nitro-d1-", { nitro: true })
+    await writeDatabaseDefinition(rootDir, "analytics", {
+      cloudflare: [
+        "    binding: 'DB_ANALYTICS',",
+        "    databaseName: 'vitehub-playground-analytics',",
+        "    databaseId: process.env.VITEHUB_D1_ANALYTICS_DATABASE_ID,",
+        "    http: true,",
+      ].join("\n"),
+    })
+    const outputRoot = join(rootDir, ".vercel", "output")
+    const nitroFunction = join(outputRoot, "functions", "__server.func", "index.mjs")
+    const nitroConfig = {
+      routes: [{ src: "/(.*)", dest: "/__server" }],
+      version: 3,
+    }
+    await mkdir(dirname(nitroFunction), { recursive: true })
+    await writeFile(nitroFunction, "export default 'nitro'\n", "utf8")
+    await writeFile(join(outputRoot, "config.json"), `${JSON.stringify(nitroConfig, null, 2)}\n`, "utf8")
+
+    await runDbBuild(rootDir, {
+      NITRO_PRESET: "vercel",
+      TURSO_AUTH_TOKEN: "token",
+      TURSO_DATABASE_URL: "libsql://database.example.turso.io",
+      VITEHUB_D1_ANALYTICS_DATABASE_ID: "analytics-d1-id",
+      VITEHUB_D1_DATABASE_ID: "primary-d1-id",
+    })
+
+    await expect(readFile(nitroFunction, "utf8")).resolves.toBe("export default 'nitro'\n")
+    await expect(readFile(join(outputRoot, "config.json"), "utf8").then(JSON.parse)).resolves.toEqual(nitroConfig)
+    const databaseFunction = join(outputRoot, "functions", "__database.func", "index.mjs")
+    expect(existsSync(databaseFunction)).toBe(true)
+    await expect(readFile(databaseFunction, "utf8")).resolves.toContain("CLOUDFLARE_ACCOUNT_ID")
   }, 30_000)
 
   it("skips provider output for local-only databases", async () => {

--- a/packages/database/test/vite-output.test.ts
+++ b/packages/database/test/vite-output.test.ts
@@ -591,12 +591,13 @@ describe("Vite db provider outputs", () => {
     expect(existsSync(join(rootDir, ".vercel", "output"))).toBe(false)
   }, 30_000)
 
-  it("fails Cloudflare output when a D1 database ID is missing a database name", async () => {
+  it("skips Cloudflare output when a Vercel D1 HTTP database has no Cloudflare database name", async () => {
     const rootDir = await createDbBuildProject("vitehub-db-vite-cloudflare-invalid-")
     await writeDatabaseDefinition(rootDir, "analytics", {
       cloudflare: [
         "    binding: 'DB_ANALYTICS',",
         "    databaseId: process.env.VITEHUB_D1_ANALYTICS_DATABASE_ID,",
+        "    http: true,",
       ].join("\n"),
       connection: [
         "    authToken: process.env.TURSO_AUTH_TOKEN,",
@@ -604,21 +605,16 @@ describe("Vite db provider outputs", () => {
       ].join("\n"),
     })
 
-    let error: Error | undefined
-    try {
-      await runDbBuild(rootDir, {
-        TURSO_ANALYTICS_DATABASE_URL: "libsql://analytics.example.turso.io",
-        TURSO_AUTH_TOKEN: "token",
-        TURSO_DATABASE_URL: "libsql://database.example.turso.io",
-        VITEHUB_D1_ANALYTICS_DATABASE_ID: "analytics-d1-id",
-        VITEHUB_D1_DATABASE_ID: "primary-d1-id",
-      })
-    }
-    catch (caught) {
-      error = caught as Error
-    }
+    await runDbBuild(rootDir, {
+      CLOUDFLARE_ACCOUNT_ID: "account-id",
+      CLOUDFLARE_API_TOKEN: "api-token",
+      TURSO_AUTH_TOKEN: "token",
+      TURSO_DATABASE_URL: "libsql://database.example.turso.io",
+      VITEHUB_D1_ANALYTICS_DATABASE_ID: "analytics-d1-id",
+      VITEHUB_D1_DATABASE_ID: "primary-d1-id",
+    })
 
-    expect(error).toBeTruthy()
-    expect(errorText(error)).toContain("Cloudflare output requires `db.cloudflare.databaseName` when `db.cloudflare.databaseId` is set for databases: analytics")
+    expect(existsSync(join(rootDir, "dist", "cloudflare"))).toBe(false)
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"))).toBe(true)
   }, 30_000)
 })

--- a/packages/database/test/vite.test.ts
+++ b/packages/database/test/vite.test.ts
@@ -18,7 +18,7 @@ async function createTempProject() {
   return rootDir
 }
 
-async function writeDefinition(rootDir: string, path: string, table = "notes", options: { connection?: string } = {}) {
+async function writeDefinition(rootDir: string, path: string, table = "notes", options: { cloudflare?: string, connection?: string } = {}) {
   const file = join(rootDir, path)
   await mkdir(dirname(file), { recursive: true })
   await writeFile(file, [
@@ -26,6 +26,7 @@ async function writeDefinition(rootDir: string, path: string, table = "notes", o
     "import { sqliteTable, text } from 'drizzle-orm/sqlite-core'",
     `const ${table} = sqliteTable('${table}', { title: text('title') })`,
     "export default defineDatabase({",
+    ...(options.cloudflare ? ["  cloudflare: {", options.cloudflare, "  },"] : []),
     ...(options.connection ? ["  connection: {", options.connection, "  },"] : []),
     `  tables: { ${table} },`,
     "})",
@@ -117,6 +118,56 @@ describe("hubDb", () => {
       if (typeof originalUrl === "undefined") delete process.env.TURSO_DATABASE_URL
       else process.env.TURSO_DATABASE_URL = originalUrl
     }
+  })
+
+  it("writes Cloudflare D1 HTTP credentials for Drizzle Kit", async () => {
+    const rootDir = await createTempProject()
+    const originalDatabaseId = process.env.CLOUDFLARE_D1_DATABASE_ID
+    process.env.CLOUDFLARE_D1_DATABASE_ID = "secret-database-id"
+
+    try {
+      await writeDefinition(rootDir, "server/databases/config.ts", "notes", {
+        cloudflare: [
+          "    databaseId: process.env.CLOUDFLARE_D1_DATABASE_ID,",
+          "    http: true,",
+        ].join("\n"),
+      })
+
+      const plugin = hubDb()
+      const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+      await configResolved({ db: undefined, root: rootDir } as never)
+
+      const drizzleConfig = await readFile(join(rootDir, ".vitehub/database/drizzle.config.ts"), "utf8")
+      expect(drizzleConfig).toContain("driver: \"d1-http\"")
+      expect(drizzleConfig).toContain("accountId: process.env[\"CLOUDFLARE_ACCOUNT_ID\"]")
+      expect(drizzleConfig).toContain("databaseId: process.env[\"CLOUDFLARE_D1_DATABASE_ID\"]")
+      expect(drizzleConfig).toContain("token: process.env[\"CLOUDFLARE_API_TOKEN\"]")
+      expect(drizzleConfig).not.toContain("secret-database-id")
+    }
+    finally {
+      if (typeof originalDatabaseId === "undefined") delete process.env.CLOUDFLARE_D1_DATABASE_ID
+      else process.env.CLOUDFLARE_D1_DATABASE_ID = originalDatabaseId
+    }
+  })
+
+  it("keeps Drizzle Kit on libSQL when D1 HTTP is not selected", async () => {
+    const rootDir = await createTempProject()
+    await writeDefinition(rootDir, "server/databases/config.ts", "notes", {
+      cloudflare: "    databaseId: process.env.CLOUDFLARE_D1_DATABASE_ID,",
+      connection: [
+        "    authToken: 'libsql-token',",
+        "    url: 'libsql://database.example.turso.io',",
+      ].join("\n"),
+    })
+
+    const plugin = hubDb()
+    const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+    await configResolved({ db: undefined, root: rootDir } as never)
+
+    const drizzleConfig = await readFile(join(rootDir, ".vitehub/database/drizzle.config.ts"), "utf8")
+    expect(drizzleConfig).toContain("url: \"libsql://database.example.turso.io\"")
+    expect(drizzleConfig).toContain("authToken: \"libsql-token\"")
+    expect(drizzleConfig).not.toContain("driver: \"d1-http\"")
   })
 
   it("lets top-level config disable the database plugin", async () => {


### PR DESCRIPTION
Adds an explicit `cloudflare.http` transport to Database Definitions, so Vercel-hosted runtimes can query Cloudflare D1 through the authenticated raw API or a compatible proxy without changing the existing D1 binding and hosted libSQL selection rules. Cloudflare bindings remain first priority, and a D1 database id alone continues to use the configured libSQL fallback off Cloudflare.

The hosted Drizzle adapter supports single queries and batches, generated Drizzle Kit config selects `d1-http`, and Vercel Provider Output accepts explicitly selected D1 HTTP databases. The package contracts cover credential isolation, generated-function execution, and Nitro sidecar output, while the docs call out Cloudflare's administrative API rate limit and proxy option.
