### PR TITLE
feat(agent)!: rename chatTitle to title

### DIFF
--- a/docs/content/docs/capabilities/chat.md
+++ b/docs/content/docs/capabilities/chat.md
@@ -90,6 +90,6 @@ For adapter-backed delivery, inspect the Channel-generated webhook registrations
 
 - [Agent triggers](/docs/agents/triggers)
 - [Chat History and sessions](/docs/agents/chat-history-sessions)
-- [chatTitle()](/docs/capabilities/chat-title)
+- [title()](/docs/capabilities/title)
 - [chatSummary()](/docs/capabilities/chat-summary)
 - Source: `packages/agent/src/chat-trigger.ts`

--- a/docs/content/docs/capabilities/official-capabilities.md
+++ b/docs/content/docs/capabilities/official-capabilities.md
@@ -17,7 +17,7 @@ import {
   browser,
   chat,
   chatSummary,
-  chatTitle,
+  title,
   db,
   email,
   fetch,
@@ -94,7 +94,7 @@ import {
 | LLM routing | [`llmRoute()`](/docs/capabilities/llm-route) | A pre-invocation model decision should choose one developer-defined route. |
 | LLM gate | [`llmGate()`](/docs/capabilities/llm-gate) | A pre-invocation model decision should allow or reject the request. |
 | Rate limit | [`rateLimit()`](/docs/capabilities/rate-limit) | A trusted invocation budget should be checked or consumed before the Agent runs. |
-| Chat title | [`chatTitle()`](/docs/capabilities/chat-title) | Chat streams and finish extensions should include a generated conversation title. |
+| Title | [`title()`](/docs/capabilities/title) | Agent output, finish extensions, or compatible Channel threads should include a generated title. |
 | Chat summary | [`chatSummary()`](/docs/capabilities/chat-summary) | A summary command should replace explicit input with a conversation summary. |
 | Papercut reports | [`papercuts()`](/docs/capabilities/papercuts) | An Agent should report small runtime or developer-experience friction to an application-owned sink. |
 

--- a/docs/content/docs/capabilities/title.md
+++ b/docs/content/docs/capabilities/title.md
@@ -1,14 +1,14 @@
 ---
-title: Chat title
-description: Generate a short chat title and attach it to Agent output.
-navigation.title: Chat title
+title: Title
+description: Generate a short title and attach it to Agent output.
+navigation.title: Title
 navigation.order: 200
 navigation.group: Decisions and output
 icon: i-lucide-heading
 ---
 
-`chatTitle()` adds title generation for chat-style Agent output.
-It can use a model, a custom executor, or a local heuristic, then streams or returns the title as output metadata.
+`title()` generates a short title for an Agent Invocation.
+It can use a model, a custom executor, or a local heuristic, then streams or returns the title as output metadata and optionally delivers it to a Channel thread.
 
 ## Installation
 
@@ -18,38 +18,38 @@ Use the configuration example below as the starting point, then tighten modes, p
 ## What it adds
 
 The Capability reads the first user message, generates a short title, provides it as a finish extension, and injects title data into compatible streams.
+Applications can use the finish extension to name a job, run, artifact, or other durable record without depending on a chat surface.
 It can filter by Agent Trigger id when title generation should run only for selected triggers.
 
 ## Configuration
 
-Attach `chatTitle()` beside `chat()` for chat surfaces.
+Attach `title()` to any Agent Definition that needs a generated title.
 When no model is available to the Capability, ViteHub falls back to a short heuristic title.
 
 ```ts [server/agents/support.ts]
 import { defineAgent } from '@vite-hub/agent'
-import { chat, chatTitle } from '@vite-hub/agent/capabilities'
+import { title } from '@vite-hub/agent/capabilities'
 
 export default defineAgent({
   driver: { model },
   capabilities: [
-    chat(),
-    chatTitle(),
+    title(),
   ],
 })
 ```
 
 ## Runtime behavior
 
-`chatTitle()` runs in the output phase.
+`title()` runs in the output phase.
 It wraps compatible async streams or UI message streams so the title can arrive alongside the response, and it provides `{ title }` in the finish extension.
 
-For framework-managed Chat SDK message Channels, ViteHub generates and delivers the title once per thread by default, even when each webhook contains only the current message or the handler is recreated. Follow-up Channel invocations skip title generation after successful delivery. Set `channelDelivery: "always"` when the platform title should be refreshed on every invocation. Plain `runAgent()` and UI invocations without framework-managed Chat SDK delivery still receive stream data and finish extensions per invocation.
+For framework-managed Chat SDK message Channels, ViteHub also delivers the title once per thread by default, even when each webhook contains only the current message or the handler is recreated. Follow-up Channel invocations skip title generation after successful delivery. Set `channelDelivery: "always"` when the platform title should be refreshed on every invocation. Plain `runAgent()` and UI invocations without framework-managed Chat SDK delivery still receive stream data and finish extensions per invocation.
 
 The Capability avoids wrapping the same result twice.
 
 ## Requirements
 
-`chatTitle()` needs message-shaped input with at least one user message.
+`title()` needs message-shaped input with at least one user message.
 A model, custom executor, or heuristic path must be available.
 
 Use a custom template, variables, or executor when the title must include product-specific context.
@@ -64,7 +64,7 @@ Use a custom template, variables, or executor when the title must include produc
 
 ## Inspect and verify
 
-Send one chat message and inspect the stream for chat title data.
+Run one Agent Invocation and inspect the stream for title data.
 The finish extension should include `{ title }` when title generation succeeds.
 
 Test a vague first message and confirm the fallback title is used instead of an empty string.
@@ -76,8 +76,8 @@ Test a vague first message and confirm the fallback title is used instead of an 
 | `channelDelivery` | `"once-per-thread" \| "always"` | `"once-per-thread"` | Deliver framework-managed Chat SDK Channel titles once per thread, or on every invocation. |
 | `driver` | `AgentDriver` | none | Agent Driver used only for title generation. |
 | `execute` | `(input) => string \| { title?: string }` | none | Custom title generator. |
-| `fallback` | `string` | `"New Conversation"` | Title used when generation returns no usable text. |
-| `id` | `string` | `"chat-title"` | Capability id. |
+| `fallback` | `string` | `"Untitled"` | Title used when generation returns no usable text. |
+| `id` | `string` | `"title"` | Capability id. |
 | `instructions` | `string` | none | System instructions for model-backed title generation. |
 | `maxLength` | `number` | `80` | Maximum title length. |
 | `model` | `AgentModelResolver` | Agent model, then heuristic fallback | Model used for title generation. |
@@ -90,4 +90,4 @@ Test a vague first message and confirm the fallback title is used instead of an 
 
 - [chat()](/docs/capabilities/chat)
 - [chatSummary()](/docs/capabilities/chat-summary)
-- Source: `packages/agent/src/capabilities/chat-title.ts`
+- Source: `packages/agent/src/capabilities/title.ts`

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -20,7 +20,7 @@ Keep the three pieces separate:
 pnpm add @vite-hub/agent @vite-hub/workspace ai
 ```
 
-`ai` is required for model-backed drivers and AI SDK-powered capabilities such as model-backed `chatTitle()`, `chatSummary()`, `llmGate()`, and `transcribe()`. Agents with `driver.run` can bundle without installing `ai`.
+`ai` is required for model-backed drivers and AI SDK-powered capabilities such as model-backed `title()`, `chatSummary()`, `llmGate()`, and `transcribe()`. Agents with `driver.run` can bundle without installing `ai`.
 
 Add the AI SDK model provider you pass to `model`.
 

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -16,8 +16,8 @@ export {
   chatSummary,
 } from "./chat-summary.ts"
 export {
-  chatTitle,
-} from "./chat-title.ts"
+  title,
+} from "./title.ts"
 export {
   fetch,
 } from "./fetch.ts"
@@ -164,13 +164,13 @@ export type {
   ChatSummaryOptions,
 } from "./chat-summary.ts"
 export type {
-  ChatTitleExecuteInput,
-  ChatTitleExecuteResult,
-  ChatTitleOptions,
-  ChatTitleTemplate,
-  ChatTitleTemplateInput,
-  ChatTitleTemplateVariable,
-} from "./chat-title.ts"
+  TitleExecuteInput,
+  TitleExecuteResult,
+  TitleOptions,
+  TitleTemplate,
+  TitleTemplateInput,
+  TitleTemplateVariable,
+} from "./title.ts"
 export type {
   FetchCapabilityMethod,
   FetchCapabilityOptions,

--- a/packages/agent/src/capabilities/title.ts
+++ b/packages/agent/src/capabilities/title.ts
@@ -2,9 +2,9 @@ import { capabilityInvocationStartSymbol, defineCapability } from "../capability
 import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
 import { messageChannelTitleSupportContextKey } from "../channels.ts"
 import {
-  claimMessageChannelChatTitleDelivery,
-  createMessageChannelChatTitleEffectIntent,
-  finishMessageChannelChatTitleDelivery,
+  claimMessageChannelTitleDelivery,
+  createMessageChannelTitleEffectIntent,
+  finishMessageChannelTitleDelivery,
   messageChannelStateContextKey,
   messageChannelTitleDeliveredContextKey,
 } from "../internal/channels.ts"
@@ -29,53 +29,53 @@ import type {
   Message,
   StreamEvent,
 } from "../messages.ts"
-import type { MessageChannelChatTitleDeliveryAttempt, MessageChannelStateBinding } from "../internal/channels.ts"
+import type { MessageChannelTitleDeliveryAttempt, MessageChannelStateBinding } from "../internal/channels.ts"
 
 type ToUIMessageStream = (...args: unknown[]) => ReadableStream<unknown>
-const chatTitleApplied = Symbol("vitehub.chat-title.applied")
-type ChatTitleApplied = { [chatTitleApplied]?: true }
+const titleApplied = Symbol("vitehub.title.applied")
+type TitleApplied = { [titleApplied]?: true }
 
-export interface ChatTitleExecuteInput {
+export interface TitleExecuteInput {
   input: AgentRunInput
   message: Message
   messages: Message[]
   text: string
 }
 
-export type ChatTitleExecuteResult = string | { title?: string }
+export type TitleExecuteResult = string | { title?: string }
 
-export interface ChatTitleTemplateInput extends ChatTitleExecuteInput {
+export interface TitleTemplateInput extends TitleExecuteInput {
   fallback: string
   maxLength: number
   trigger?: string
 }
 
-export type ChatTitleTemplate = string | ((input: ChatTitleTemplateInput) => MaybePromise<string>)
-export type ChatTitleTemplateVariable =
+export type TitleTemplate = string | ((input: TitleTemplateInput) => MaybePromise<string>)
+export type TitleTemplateVariable =
   | boolean
   | null
   | number
   | string
   | undefined
-  | ((input: ChatTitleTemplateInput) => MaybePromise<boolean | null | number | string | undefined>)
+  | ((input: TitleTemplateInput) => MaybePromise<boolean | null | number | string | undefined>)
 
-export interface ChatTitleOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+export interface TitleOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   channelDelivery?: "always" | "once-per-thread"
   driver?: AgentDriver<TRuntimeConfig>
-  execute?: (input: ChatTitleExecuteInput) => MaybePromise<ChatTitleExecuteResult>
+  execute?: (input: TitleExecuteInput) => MaybePromise<TitleExecuteResult>
   fallback?: string
   id?: string
   instructions?: string
   maxLength?: number
   model?: AgentModelResolver<TRuntimeConfig>
-  template?: ChatTitleTemplate
+  template?: TitleTemplate
   trigger?: string | string[]
-  variables?: Record<string, ChatTitleTemplateVariable>
-  when?: (input: ChatTitleTemplateInput) => MaybePromise<boolean>
+  variables?: Record<string, TitleTemplateVariable>
+  when?: (input: TitleTemplateInput) => MaybePromise<boolean>
 }
 
-const defaultChatTitleTemplate = [
-  "Summarize the user's request as a short chat title.",
+const defaultTitleTemplate = [
+  "Summarize the user's request as a short title.",
   "Return only the title.",
   "Use 4-8 words when possible.",
   `Keep it under {{ maxLength }} characters.`,
@@ -93,13 +93,13 @@ function isObjectLike(value: unknown): value is object {
   return (typeof value === "object" && value !== null) || typeof value === "function"
 }
 
-function hasChatTitleApplied(value: unknown): boolean {
-  return isObjectLike(value) && (value as ChatTitleApplied)[chatTitleApplied] === true
+function hasTitleApplied(value: unknown): boolean {
+  return isObjectLike(value) && (value as TitleApplied)[titleApplied] === true
 }
 
-function markChatTitleApplied<T>(value: T): T {
+function markTitleApplied<T>(value: T): T {
   if (isObjectLike(value)) {
-    Object.defineProperty(value, chatTitleApplied, {
+    Object.defineProperty(value, titleApplied, {
       configurable: true,
       value: true,
     })
@@ -139,11 +139,11 @@ function stripChatEntityMarkup(text: string): string {
   return clean || text
 }
 
-function chatTitleData(title: string) {
-  return { title, type: "chat-title" }
+function titleData(title: string) {
+  return { title, type: "title" }
 }
 
-function shouldRunForTrigger(filter: ChatTitleOptions["trigger"], trigger: string | undefined): boolean {
+function shouldRunForTrigger(filter: TitleOptions["trigger"], trigger: string | undefined): boolean {
   if (!filter) return true
   const allowed = Array.isArray(filter) ? filter : [filter]
   return trigger !== undefined && allowed.includes(trigger)
@@ -154,19 +154,19 @@ function agentTriggerId(context: AgentCapabilityRuntimeContext): string | undefi
   return typeof trigger?.id === "string" ? trigger.id : undefined
 }
 
-function supportsChatTitleDelivery(context: AgentCapabilityRuntimeContext): boolean {
+function supportsTitleDelivery(context: AgentCapabilityRuntimeContext): boolean {
   return context.context.get<boolean>(messageChannelTitleSupportContextKey) === true
 }
 
-function shouldProvideChatTitleFinishExtension(context: AgentCapabilityRuntimeContext): boolean {
-  return supportsChatTitleDelivery(context) || context.context.get<boolean>("agent.finishHook") === true
+function shouldProvideTitleFinishExtension(context: AgentCapabilityRuntimeContext): boolean {
+  return supportsTitleDelivery(context) || context.context.get<boolean>("agent.finishHook") === true
 }
 
-async function resolveTemplateVariables(options: ChatTitleOptions, input: ChatTitleTemplateInput): Promise<Record<string, unknown>> {
+async function resolveTemplateVariables(options: TitleOptions, input: TitleTemplateInput): Promise<Record<string, unknown>> {
   const variables: Record<string, unknown> = {}
   for (const [name, value] of Object.entries(options.variables || {})) {
     variables[name] = typeof value === "function"
-      ? await (value as (input: ChatTitleTemplateInput) => MaybePromise<unknown>)(input)
+      ? await (value as (input: TitleTemplateInput) => MaybePromise<unknown>)(input)
       : value
   }
   return {
@@ -178,8 +178,8 @@ async function resolveTemplateVariables(options: ChatTitleOptions, input: ChatTi
   }
 }
 
-async function renderChatTitleTemplate(options: ChatTitleOptions, input: ChatTitleTemplateInput): Promise<string> {
-  const template = options.template ?? defaultChatTitleTemplate
+async function renderTitleTemplate(options: TitleOptions, input: TitleTemplateInput): Promise<string> {
+  const template = options.template ?? defaultTitleTemplate
   if (typeof template === "function") {
     return await template(input)
   }
@@ -191,7 +191,7 @@ async function renderChatTitleTemplate(options: ChatTitleOptions, input: ChatTit
   })
 }
 
-async function resolveChatTitleModel(context: AgentCapabilityRuntimeContext, options: ChatTitleOptions): Promise<unknown | undefined> {
+async function resolveTitleModel(context: AgentCapabilityRuntimeContext, options: TitleOptions): Promise<unknown | undefined> {
   if (options.model) return await context.model.resolve(options.model)
   try {
     return await context.model.resolve()
@@ -204,24 +204,24 @@ async function resolveChatTitleModel(context: AgentCapabilityRuntimeContext, opt
   }
 }
 
-function chatTitleDriverInput(input: ChatTitleExecuteInput, prompt: string): AgentRunInput {
+function titleDriverInput(input: TitleExecuteInput, prompt: string): AgentRunInput {
   const { message: _message, messages: _messages, prompt: _prompt, ...base } = input.input
   return { ...base, prompt }
 }
 
-function chatTitleAdapterRunContext(
+function titleAdapterRunContext(
   context: AgentCapabilityRuntimeContext,
-  input: ChatTitleExecuteInput,
+  input: TitleExecuteInput,
   prompt: string,
 ): AgentAdapterRunContext {
   if (!context.runtimeContext) {
-    throw new Error("[vitehub] chatTitle({ driver }) requires an agent runtime context.")
+    throw new Error("[vitehub] title({ driver }) requires an agent runtime context.")
   }
   return {
     actor: context.actor,
     context: context.context,
     devtools: context.runtimeContext.devtools,
-    input: chatTitleDriverInput(input, prompt),
+    input: titleDriverInput(input, prompt),
     invoker: context.invoker,
     messages: [],
     prompt,
@@ -229,27 +229,27 @@ function chatTitleAdapterRunContext(
   }
 }
 
-function chatTitleRunContext(
+function titleRunContext(
   context: AgentCapabilityRuntimeContext,
-  input: ChatTitleExecuteInput,
+  input: TitleExecuteInput,
   prompt: string,
 ): AgentRunContext {
   if (!context.runtimeContext) {
-    throw new Error("[vitehub] chatTitle({ driver }) requires an agent runtime context.")
+    throw new Error("[vitehub] title({ driver }) requires an agent runtime context.")
   }
   const { runtimeConfig: _runtimeConfig, ...runtime } = context.runtimeContext
   return {
     ...runtime,
     actor: context.actor,
     context: context.context,
-    input: chatTitleDriverInput(input, prompt),
+    input: titleDriverInput(input, prompt),
     invoker: context.invoker,
     messages: [],
     prompt,
   }
 }
 
-async function chatTitleResultText(result: unknown): Promise<string | undefined> {
+async function titleResultText(result: unknown): Promise<string | undefined> {
   let text = ""
   for await (const event of streamAgentOutputToEvents(result)) {
     if (event.type === "text-delta") text += event.text
@@ -258,32 +258,32 @@ async function chatTitleResultText(result: unknown): Promise<string | undefined>
   return toAgentRunResult(result).text
 }
 
-async function generateChatTitleWithDriver(
+async function generateTitleWithDriver(
   context: AgentCapabilityRuntimeContext,
-  options: ChatTitleOptions,
-  input: ChatTitleExecuteInput,
+  options: TitleOptions,
+  input: TitleExecuteInput,
   prompt: string,
 ): Promise<string | undefined> {
   if (!options.driver) return
   const driver = normalizeAgentDriver({ driver: options.driver } as never)
   if (driver.kind === "run") {
-    return await chatTitleResultText(await driver.run(chatTitleRunContext(context, input, prompt) as never))
+    return await titleResultText(await driver.run(titleRunContext(context, input, prompt) as never))
   }
-  const runContext = chatTitleAdapterRunContext(context, input, prompt)
+  const runContext = titleAdapterRunContext(context, input, prompt)
   if (driver.kind === "harness") {
     const { createHarnessAgentAdapter } = await import("../harness-agent.ts")
-    return await chatTitleResultText(await createHarnessAgentAdapter(driver as never).generate(runContext as never))
+    return await titleResultText(await createHarnessAgentAdapter(driver as never).generate(runContext as never))
   }
   const { createAiSdkAdapter } = await import("../ai-sdk.ts")
-  return await chatTitleResultText(await createAiSdkAdapter({
+  return await titleResultText(await createAiSdkAdapter({
     execution: driver.execution,
     instructions: options.instructions ?? driver.instructions,
     model: driver.model,
   } as never).generate(runContext as never))
 }
 
-async function generateChatTitle(context: AgentCapabilityRuntimeContext, options: ChatTitleOptions, input: ChatTitleExecuteInput): Promise<string | undefined> {
-  const fallback = options.fallback ?? "New Conversation"
+async function generateTitle(context: AgentCapabilityRuntimeContext, options: TitleOptions, input: TitleExecuteInput): Promise<string | undefined> {
+  const fallback = options.fallback ?? "Untitled"
   const maxLength = options.maxLength ?? 80
   const templateInput = {
     ...input,
@@ -302,13 +302,13 @@ async function generateChatTitle(context: AgentCapabilityRuntimeContext, options
   }
 
   if (options.driver) {
-    const prompt = await renderChatTitleTemplate(options, templateInput)
-    return cleanGeneratedTitle(await generateChatTitleWithDriver(context, options, input, prompt), maxLength, fallback)
+    const prompt = await renderTitleTemplate(options, templateInput)
+    return cleanGeneratedTitle(await generateTitleWithDriver(context, options, input, prompt), maxLength, fallback)
   }
 
-  const model = await resolveChatTitleModel(context, options)
+  const model = await resolveTitleModel(context, options)
   if (model) {
-    const prompt = await renderChatTitleTemplate(options, templateInput)
+    const prompt = await renderTitleTemplate(options, templateInput)
     const { generateText } = await loadAiSdk()
     const result = await generateText(options.instructions
       ? { instructions: options.instructions, model: model as never, prompt }
@@ -319,13 +319,13 @@ async function generateChatTitle(context: AgentCapabilityRuntimeContext, options
   return heuristicTitle(templateInput.text, maxLength, fallback)
 }
 
-function withChatTitleParallel<T>(
+function withTitleParallel<T>(
   result: AsyncIterable<T>,
   title: Promise<string | undefined>,
   renderTitle: (title: string) => T,
 ): AsyncIterable<T> {
   if (typeof (result as ReadableStream<T>).pipeThrough === "function") {
-    return withChatTitleReadableStreamParallel(result as ReadableStream<T>, title, renderTitle)
+    return withTitleReadableStreamParallel(result as ReadableStream<T>, title, renderTitle)
   }
   const iterable = (async function* () {
     const iterator = result[Symbol.asyncIterator]()
@@ -370,10 +370,10 @@ function withChatTitleParallel<T>(
       await iterator.return?.()
     }
   })()
-  return markChatTitleApplied(iterable)
+  return markTitleApplied(iterable)
 }
 
-function withChatTitleReadableStreamParallel<T>(
+function withTitleReadableStreamParallel<T>(
   result: ReadableStream<T>,
   title: Promise<string | undefined>,
   renderTitle: (title: string) => T,
@@ -392,7 +392,7 @@ function withChatTitleReadableStreamParallel<T>(
     reader?.releaseLock()
   }
 
-  return markChatTitleApplied(withAsyncIterator(new ReadableStream<T>({
+  return markTitleApplied(withAsyncIterator(new ReadableStream<T>({
     async cancel(reason) {
       cancelled = true
       try {
@@ -456,31 +456,31 @@ function withChatTitleReadableStreamParallel<T>(
   }, { highWaterMark: 0 })))
 }
 
-function withChatTitleEvent(result: AsyncIterable<StreamEvent>, title: Promise<string | undefined>): AsyncIterable<StreamEvent> {
-  return withChatTitleParallel(result, title, resolvedTitle => ({ data: chatTitleData(resolvedTitle), type: "data" }))
+function withTitleEvent(result: AsyncIterable<StreamEvent>, title: Promise<string | undefined>): AsyncIterable<StreamEvent> {
+  return withTitleParallel(result, title, resolvedTitle => ({ data: titleData(resolvedTitle), type: "data" }))
 }
 
-function withChatTitleFullStream(result: AsyncIterable<unknown>, title: Promise<string | undefined>): AsyncIterable<unknown> {
-  return withChatTitleParallel(result, title, resolvedTitle => ({ data: chatTitleData(resolvedTitle), type: "data" }))
+function withTitleFullStream(result: AsyncIterable<unknown>, title: Promise<string | undefined>): AsyncIterable<unknown> {
+  return withTitleParallel(result, title, resolvedTitle => ({ data: titleData(resolvedTitle), type: "data" }))
 }
 
-function withChatTitleTextStream(result: AsyncIterable<string>, title: Promise<string | undefined>): AsyncIterable<StreamEvent> {
-  return withChatTitleParallel<StreamEvent>(
+function withTitleTextStream(result: AsyncIterable<string>, title: Promise<string | undefined>): AsyncIterable<StreamEvent> {
+  return withTitleParallel<StreamEvent>(
     (async function* () {
       for await (const text of result) {
         yield { text, type: "text-delta" } satisfies StreamEvent
       }
     })(),
     title,
-    resolvedTitle => ({ data: chatTitleData(resolvedTitle), type: "data" }),
+    resolvedTitle => ({ data: titleData(resolvedTitle), type: "data" }),
   )
 }
 
-function withChatTitleUiMessageStream(result: ReadableStream<unknown>, title: Promise<string | undefined>): ReadableStream<unknown> {
-  return withChatTitleReadableStreamParallel(
+function withTitleUiMessageStream(result: ReadableStream<unknown>, title: Promise<string | undefined>): ReadableStream<unknown> {
+  return withTitleReadableStreamParallel(
     result,
     title,
-    resolvedTitle => ({ data: chatTitleData(resolvedTitle), type: "data-chat-title" }),
+    resolvedTitle => ({ data: titleData(resolvedTitle), type: "data-title" }),
   )
 }
 
@@ -539,36 +539,36 @@ function cloneStreamTextResult<T extends { fullStream?: AsyncIterable<unknown>, 
       writable: true,
     })
   }
-  return markChatTitleApplied(clone)
+  return markTitleApplied(clone)
 }
 
-function chatTitleUiMessageStreamOverride(toUIMessageStream: ToUIMessageStream | undefined, title: Promise<string | undefined>) {
+function titleUiMessageStreamOverride(toUIMessageStream: ToUIMessageStream | undefined, title: Promise<string | undefined>) {
   return toUIMessageStream
     ? {
-        toUIMessageStream: (...args: unknown[]) => withChatTitleUiMessageStream(toUIMessageStream(...args), title),
+        toUIMessageStream: (...args: unknown[]) => withTitleUiMessageStream(toUIMessageStream(...args), title),
       }
     : {}
 }
 
-export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
-  options: ChatTitleOptions<TRuntimeConfig> = {},
+export function title<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
+  options: TitleOptions<TRuntimeConfig> = {},
 ): AgentCapabilityDefinition<TRuntimeConfig> {
-  const capabilityId = options.id || "chat-title"
+  const capabilityId = options.id || "title"
   const invocationStarts = new WeakMap<object, () => Promise<void>>()
   return Object.assign(defineCapability({
     id: capabilityId,
     output(context) {
-      let channelDeliveryAttempt: MessageChannelChatTitleDeliveryAttempt | Promise<MessageChannelChatTitleDeliveryAttempt> | undefined
+      let channelDeliveryAttempt: MessageChannelTitleDeliveryAttempt | Promise<MessageChannelTitleDeliveryAttempt> | undefined
       const getChannelDeliveryAttempt = () => {
         const state = context.context.get<MessageChannelStateBinding>(messageChannelStateContextKey)
-        channelDeliveryAttempt ??= options.channelDelivery === "always" || !supportsChatTitleDelivery(context) || !state || !context.run?.threadId
+        channelDeliveryAttempt ??= options.channelDelivery === "always" || !supportsTitleDelivery(context) || !state || !context.run?.threadId
           ? { deliver: true }
-          : claimMessageChannelChatTitleDelivery(context.context, context.run)
+          : claimMessageChannelTitleDelivery(context.context, context.run)
               .catch(error => ({ deliver: true, error }))
         return channelDeliveryAttempt
       }
       const releaseChannelDeliveryAttempt = async () => {
-        await finishMessageChannelChatTitleDelivery(await getChannelDeliveryAttempt(), false).catch(() => undefined)
+        await finishMessageChannelTitleDelivery(await getChannelDeliveryAttempt(), false).catch(() => undefined)
       }
       let title: Promise<string | undefined> | undefined
       const getTitle = () => {
@@ -580,19 +580,19 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
           const attempt = pendingAttempt instanceof Promise ? await pendingAttempt : pendingAttempt
           if (!attempt.deliver) return
           try {
-            const resolvedTitle = await generateChatTitle(context, options as ChatTitleOptions, {
+            const resolvedTitle = await generateTitle(context, options as TitleOptions, {
               input: context.input.get(),
               message,
               messages,
               text: getMessageText(message),
             })
             if (!resolvedTitle) {
-              await finishMessageChannelChatTitleDelivery(attempt, false).catch(() => undefined)
+              await finishMessageChannelTitleDelivery(attempt, false).catch(() => undefined)
             }
             return resolvedTitle
           }
           catch {
-            await finishMessageChannelChatTitleDelivery(attempt, false).catch(() => undefined)
+            await finishMessageChannelTitleDelivery(attempt, false).catch(() => undefined)
             return undefined
           }
         })()
@@ -601,10 +601,10 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
 
       invocationStarts.set(context.context, async () => {
         if (!firstUserMessage(context.input.messages())) return
-        if (!shouldProvideChatTitleFinishExtension(context)) return
+        if (!shouldProvideTitleFinishExtension(context)) return
         if (context.context.get<boolean>(messageChannelTitleDeliveredContextKey) === true) return
         const resolvedTitle = await getTitle()
-        if (!resolvedTitle || !supportsChatTitleDelivery(context)) {
+        if (!resolvedTitle || !supportsTitleDelivery(context)) {
           await releaseChannelDeliveryAttempt()
           return
         }
@@ -612,21 +612,21 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
           await releaseChannelDeliveryAttempt()
           return
         }
-        context.delivery.effect(createMessageChannelChatTitleEffectIntent(
+        context.delivery.effect(createMessageChannelTitleEffectIntent(
           resolvedTitle.trim(),
           options.channelDelivery,
           await getChannelDeliveryAttempt(),
         ))
       })
       context.finish.provide(async () => {
-        if (!shouldProvideChatTitleFinishExtension(context)) return
+        if (!shouldProvideTitleFinishExtension(context)) return
         const resolvedTitle = await getTitle()
         return resolvedTitle ? { title: resolvedTitle } : undefined
       })
       const titleDeliveryEffect: AgentChannelDeliveryFinishEffectCallback = async (finish) => {
         const resolvedTitle = finish.extensions.get(capabilityId, "title")
         return typeof resolvedTitle === "string" && resolvedTitle.trim()
-          ? createMessageChannelChatTitleEffectIntent(
+          ? createMessageChannelTitleEffectIntent(
               resolvedTitle.trim(),
               options.channelDelivery,
               await getChannelDeliveryAttempt(),
@@ -641,7 +641,7 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
       titleDeliveryEffect.kind = "title"
       context.delivery.finishEffect(titleDeliveryEffect)
       context.output.render((result) => {
-        if (hasChatTitleApplied(result)) return result
+        if (hasTitleApplied(result)) return result
         if (!firstUserMessage(context.input.messages())) return result
         if (isStreamTextResult(result)) {
           const toUIMessageStream = result.toUIMessageStream?.bind(result)
@@ -649,30 +649,30 @@ export function chatTitle<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
             const stream = result.stream
             const fullStream = result.fullStream
             const title = getTitle()
-            const titleStream = stream ? withChatTitleFullStream(stream, title) : undefined
+            const titleStream = stream ? withTitleFullStream(stream, title) : undefined
             return cloneStreamTextResult(result, {
               ...(titleStream ? { stream: titleStream } : {}),
               ...(fullStream
-                ? { fullStream: fullStream === stream && titleStream ? titleStream : withChatTitleFullStream(fullStream, title) }
+                ? { fullStream: fullStream === stream && titleStream ? titleStream : withTitleFullStream(fullStream, title) }
                 : {}),
-              ...chatTitleUiMessageStreamOverride(toUIMessageStream, title),
+              ...titleUiMessageStreamOverride(toUIMessageStream, title),
             })
           }
           if (result.textStream) {
             const title = getTitle()
             return cloneStreamTextResult(result, {
-              stream: withChatTitleTextStream(result.textStream, title),
-              ...chatTitleUiMessageStreamOverride(toUIMessageStream, title),
+              stream: withTitleTextStream(result.textStream, title),
+              ...titleUiMessageStreamOverride(toUIMessageStream, title),
             })
           }
           if (toUIMessageStream) {
             return cloneStreamTextResult(result, {
-              ...chatTitleUiMessageStreamOverride(toUIMessageStream, getTitle()),
+              ...titleUiMessageStreamOverride(toUIMessageStream, getTitle()),
             })
           }
         }
         if (!isAsyncIterable(result)) return result
-        return withChatTitleEvent(result, getTitle())
+        return withTitleEvent(result, getTitle())
       })
     },
   }), {

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -435,10 +435,10 @@ function titleFromUIMessage(message: UIMessage): string | undefined {
   for (const part of message.parts || []) {
     const data = (part as { data?: unknown }).data
     if (
-      (part as { type?: unknown }).type === "data-chat-title"
+      (part as { type?: unknown }).type === "data-title"
       && data
       && typeof data === "object"
-      && (data as { type?: unknown }).type === "chat-title"
+      && (data as { type?: unknown }).type === "title"
       && typeof (data as { title?: unknown }).title === "string"
     ) {
       const title = (data as { title: string }).title.trim()

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -14,13 +14,13 @@ import { createTraceEventLog, resolveRuntimeContext } from "@vite-hub/runtime"
 import { agentResultKind, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent } from "./agent-output.ts"
 import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
 import {
-  finishMessageChannelChatTitleDelivery,
-  isMessageChannelChatTitleEffectIntent,
+  finishMessageChannelTitleDelivery,
+  isMessageChannelTitleEffectIntent,
   messageChannelTitleDeliveredContextKey,
-  prepareMessageChannelChatTitleDelivery,
+  prepareMessageChannelTitleDelivery,
   resolveAgentChannelChatOptions,
 } from "./internal/channels.ts"
-import type { MessageChannelChatTitleDeliveryAttempt } from "./internal/channels.ts"
+import type { MessageChannelTitleDeliveryAttempt } from "./internal/channels.ts"
 import {
   channelHasCustomTitleEffect,
   messageChannelSupportsTitleEffect,
@@ -872,13 +872,13 @@ async function applyChannelDeliveryEffectIntents<
       continue
     }
 
-    const titleDelivery = isMessageChannelChatTitleEffectIntent(intent)
-      ? await prepareMessageChannelChatTitleDelivery(context.context, context.run, intent).catch(async (error) => {
+    const titleDelivery = isMessageChannelTitleEffectIntent(intent)
+      ? await prepareMessageChannelTitleDelivery(context.context, context.run, intent).catch(async (error) => {
           await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, {
             ...metadata,
             "error.message": agentErrorMessage(error),
           })
-          return { deliver: true } as MessageChannelChatTitleDeliveryAttempt
+          return { deliver: true } as MessageChannelTitleDeliveryAttempt
         })
       : undefined
     if (titleDelivery?.error) {
@@ -934,7 +934,7 @@ async function applyChannelDeliveryEffectIntents<
     }
     if (titleDelivery) {
       try {
-        await finishMessageChannelChatTitleDelivery(titleDelivery, delivered, Boolean(finish))
+        await finishMessageChannelTitleDelivery(titleDelivery, delivered, Boolean(finish))
       }
       catch (error) {
         await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, {

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -14,62 +14,62 @@ import type { Lock, StateAdapter } from "chat"
 export const messageChannelTitleDeliveredContextKey = "channel.delivery.titleDelivered"
 export const messageChannelStateContextKey = "chat.channelState"
 const messageChannelTitleClaimTtlMs = 5 * 60 * 1000
-const messageChannelChatTitleEffectIntents = new WeakSet<AgentChannelDeliveryEffectIntent>()
-const messageChannelChatTitleDeliveryPolicies = new WeakMap<AgentChannelDeliveryEffectIntent, "always" | "once-per-thread">()
-const messageChannelChatTitleDeliveryAttempts = new WeakMap<AgentChannelDeliveryEffectIntent, MessageChannelChatTitleDeliveryAttempt>()
+const messageChannelTitleEffectIntents = new WeakSet<AgentChannelDeliveryEffectIntent>()
+const messageChannelTitleDeliveryPolicies = new WeakMap<AgentChannelDeliveryEffectIntent, "always" | "once-per-thread">()
+const messageChannelTitleDeliveryAttempts = new WeakMap<AgentChannelDeliveryEffectIntent, MessageChannelTitleDeliveryAttempt>()
 
 export interface MessageChannelStateBinding {
   keyPrefix: string
   state: StateAdapter
 }
 
-interface MessageChannelChatTitleDeliveryClaim {
+interface MessageChannelTitleDeliveryClaim {
   lock: Lock
   markerKey: string
   settled?: boolean
   state: StateAdapter
 }
 
-export interface MessageChannelChatTitleDeliveryAttempt {
-  claim?: MessageChannelChatTitleDeliveryClaim
+export interface MessageChannelTitleDeliveryAttempt {
+  claim?: MessageChannelTitleDeliveryClaim
   deliver: boolean
   error?: unknown
   reason?: "already-delivered" | "pending"
 }
 
-export function createMessageChannelChatTitleEffectIntent(
+export function createMessageChannelTitleEffectIntent(
   title: string,
   channelDelivery: "always" | "once-per-thread" = "once-per-thread",
-  attempt?: MessageChannelChatTitleDeliveryAttempt,
+  attempt?: MessageChannelTitleDeliveryAttempt,
 ): AgentChannelDeliveryEffectIntent {
   const intent = { kind: "title", payload: { title } }
-  messageChannelChatTitleEffectIntents.add(intent)
-  messageChannelChatTitleDeliveryPolicies.set(intent, channelDelivery)
-  if (attempt) messageChannelChatTitleDeliveryAttempts.set(intent, attempt)
+  messageChannelTitleEffectIntents.add(intent)
+  messageChannelTitleDeliveryPolicies.set(intent, channelDelivery)
+  if (attempt) messageChannelTitleDeliveryAttempts.set(intent, attempt)
   return intent
 }
 
-export function isMessageChannelChatTitleEffectIntent(intent: AgentChannelDeliveryEffectIntent): boolean {
-  return messageChannelChatTitleEffectIntents.has(intent)
+export function isMessageChannelTitleEffectIntent(intent: AgentChannelDeliveryEffectIntent): boolean {
+  return messageChannelTitleEffectIntents.has(intent)
 }
 
-export async function prepareMessageChannelChatTitleDelivery(
+export async function prepareMessageChannelTitleDelivery(
   context: AgentInvocationContextStore,
   run: AgentRunMetadata | undefined,
   intent: AgentChannelDeliveryEffectIntent,
-): Promise<MessageChannelChatTitleDeliveryAttempt> {
-  const prepared = messageChannelChatTitleDeliveryAttempts.get(intent)
+): Promise<MessageChannelTitleDeliveryAttempt> {
+  const prepared = messageChannelTitleDeliveryAttempts.get(intent)
   if (prepared) return prepared
-  if (messageChannelChatTitleDeliveryPolicies.get(intent) === "always") {
+  if (messageChannelTitleDeliveryPolicies.get(intent) === "always") {
     return { deliver: true }
   }
-  return await claimMessageChannelChatTitleDelivery(context, run)
+  return await claimMessageChannelTitleDelivery(context, run)
 }
 
-export async function claimMessageChannelChatTitleDelivery(
+export async function claimMessageChannelTitleDelivery(
   context: AgentInvocationContextStore,
   run: AgentRunMetadata | undefined,
-): Promise<MessageChannelChatTitleDeliveryAttempt> {
+): Promise<MessageChannelTitleDeliveryAttempt> {
   const binding = context.get<MessageChannelStateBinding>(messageChannelStateContextKey)
   if (!binding || !run?.threadId) return { deliver: true }
 
@@ -92,7 +92,7 @@ export async function claimMessageChannelChatTitleDelivery(
     catch (releaseError) {
       return {
         deliver: true,
-        error: new AggregateError([error, releaseError], "Chat title delivery state check and lock release failed."),
+        error: new AggregateError([error, releaseError], "Title delivery state check and lock release failed."),
       }
     }
   }
@@ -111,8 +111,8 @@ export async function claimMessageChannelChatTitleDelivery(
   }
 }
 
-export async function finishMessageChannelChatTitleDelivery(
-  attempt: MessageChannelChatTitleDeliveryAttempt,
+export async function finishMessageChannelTitleDelivery(
+  attempt: MessageChannelTitleDeliveryAttempt,
   delivered: boolean,
   final = true,
 ): Promise<void> {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1983,10 +1983,10 @@ function titleFromUIMessage(message: UIMessage): string | undefined {
   for (const part of message.parts || []) {
     const data = (part as { data?: unknown }).data
     if (
-      (part as { type?: unknown }).type === "data-chat-title"
+      (part as { type?: unknown }).type === "data-title"
       && data
       && typeof data === "object"
-      && (data as { type?: unknown }).type === "chat-title"
+      && (data as { type?: unknown }).type === "title"
       && typeof (data as { title?: unknown }).title === "string"
     ) {
       const title = (data as { title: string }).title.trim()

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -222,7 +222,7 @@ describe("agent output helpers", () => {
 
   it("preserves data-prefixed stream events before text and finish", async () => {
     const output = (async function* () {
-      yield { data: { title: "Chat title", type: "chat-title" }, transient: true, type: "data-chat-title" }
+      yield { data: { title: "Title", type: "title" }, transient: true, type: "data-title" }
       yield { text: "ok", type: "text-delta" }
       yield { finishReason: "stop", type: "finish" }
     })()
@@ -233,7 +233,7 @@ describe("agent output helpers", () => {
     }
 
     expect(events).toEqual([
-      { data: { title: "Chat title", type: "chat-title" }, id: undefined, transient: true, type: "data-chat-title" },
+      { data: { title: "Title", type: "title" }, id: undefined, transient: true, type: "data-title" },
       { text: "ok", type: "text-delta" },
       { reason: "stop", type: "finish" },
     ])
@@ -241,13 +241,13 @@ describe("agent output helpers", () => {
 
   it("folds data-prefixed stream events into messages", () => {
     const messages = applyStreamEvent([], {
-      data: { title: "Chat title", type: "chat-title" },
-      type: "data-chat-title",
+      data: { title: "Title", type: "title" },
+      type: "data-title",
     })
 
     expect(messages).toEqual([{
       id: expect.any(String),
-      parts: [{ data: { title: "Chat title", type: "chat-title" }, type: "data-chat-title" }],
+      parts: [{ data: { title: "Title", type: "title" }, type: "data-title" }],
       role: "assistant",
     }])
   })

--- a/packages/agent/test/chat-summary.test.ts
+++ b/packages/agent/test/chat-summary.test.ts
@@ -38,7 +38,7 @@ describe("chatSummary", () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const execute = vi.fn(() => "User wants a sidebar title and a future summary command.")
 
-    const first = createMessage({ role: "user", text: "We need chat titles in the sidebar." })
+    const first = createMessage({ role: "user", text: "We need titles in the sidebar." })
     const assistant = createMessage({ role: "assistant", text: "Use metadata events." })
     const latest = createMessage({ id: "latest", role: "user", text: "/summary focus on decisions" })
     const resolved = await resolveAgentCapabilities({
@@ -49,7 +49,7 @@ describe("chatSummary", () => {
       args: "focus on decisions",
       messages: [first, assistant],
       text: [
-        "user: We need chat titles in the sidebar.",
+        "user: We need titles in the sidebar.",
         "assistant: Use metadata events.",
       ].join("\n"),
     }))

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -4426,18 +4426,18 @@ describe("server helpers", () => {
 
   it("delivers state-backed Chat SDK titles once per thread across handler recreation", async () => {
     const { defineAgent } = await import("../src/index.ts")
-    const { chatTitle } = await import("../src/capabilities.ts")
+    const { title } = await import("../src/capabilities.ts")
     const { http } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
-    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-once-"))
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-title-once-"))
     const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
     const setThreadTitle = vi.fn(async () => undefined)
     const execute = vi.fn(({ text }: { text: string }) => `Title: ${text}`)
     const run = vi.fn(() => "ok")
     const finish = vi.fn()
     const createHandler = () => createChannelWebhookRouteHandler(defineAgent({
-      capabilities: [chatTitle({ execute })],
+      capabilities: [title({ execute })],
       channels: {
         channel: http({ adapter: () => createTitleChatAdapter(setThreadTitle) as never }),
       },
@@ -4453,8 +4453,8 @@ describe("server helpers", () => {
       expect(run).toHaveBeenCalledTimes(2)
       expect(execute).toHaveBeenCalledOnce()
       expect(setThreadTitle).toHaveBeenCalledOnce()
-      expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Title: first" })
-      expect(finish.mock.calls[1]![0].extensions.get("chat-title")).toBeUndefined()
+      expect(finish.mock.calls[0]![0].extensions.get("title")).toEqual({ title: "Title: first" })
+      expect(finish.mock.calls[1]![0].extensions.get("title")).toBeUndefined()
 
       const recreated = createHandler()
       await expect(recreated(chatWebhookRequest(103, 456, "third"), "channel", { agentName: "mini" })).resolves.toMatchObject({ status: 200 })
@@ -4473,9 +4473,9 @@ describe("server helpers", () => {
     }
   })
 
-  it("releases a Chat title claim when the post-lock marker read fails", async () => {
+  it("releases a Title claim when the post-lock marker read fails", async () => {
     const {
-      claimMessageChannelChatTitleDelivery,
+      claimMessageChannelTitleDelivery,
       messageChannelStateContextKey,
     } = await import("../src/internal/channels.ts")
     const { createAgentInvocationContextStore } = await import("../src/invocation-context.ts")
@@ -4491,16 +4491,16 @@ describe("server helpers", () => {
     const context = createAgentInvocationContextStore()
     context.set(messageChannelStateContextKey, { keyPrefix: "chat:mini:discord:", state })
 
-    await expect(claimMessageChannelChatTitleDelivery(context, { threadId: "discord:123" } as never)).resolves.toEqual({
+    await expect(claimMessageChannelTitleDelivery(context, { threadId: "discord:123" } as never)).resolves.toEqual({
       deliver: true,
       error: readError,
     })
     expect(state.releaseLock).toHaveBeenCalledWith(lock)
   })
 
-  it("does not redeliver a Chat title when marker observation succeeds but lock release fails", async () => {
+  it("does not redeliver a Title when marker observation succeeds but lock release fails", async () => {
     const {
-      claimMessageChannelChatTitleDelivery,
+      claimMessageChannelTitleDelivery,
       messageChannelStateContextKey,
     } = await import("../src/internal/channels.ts")
     const { createAgentInvocationContextStore } = await import("../src/invocation-context.ts")
@@ -4516,7 +4516,7 @@ describe("server helpers", () => {
     const context = createAgentInvocationContextStore()
     context.set(messageChannelStateContextKey, { keyPrefix: "chat:mini:discord:", state })
 
-    await expect(claimMessageChannelChatTitleDelivery(context, { threadId: "discord:123" } as never)).resolves.toEqual({
+    await expect(claimMessageChannelTitleDelivery(context, { threadId: "discord:123" } as never)).resolves.toEqual({
       deliver: false,
       error: releaseError,
       reason: "already-delivered",
@@ -4525,18 +4525,18 @@ describe("server helpers", () => {
 
   it("releases failed title delivery claims for finish and later webhook retries", async () => {
     const { defineAgent } = await import("../src/index.ts")
-    const { chatTitle } = await import("../src/capabilities.ts")
+    const { title } = await import("../src/capabilities.ts")
     const { http } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
-    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-retry-"))
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-title-retry-"))
     const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
     const setThreadTitle = vi.fn()
       .mockRejectedValueOnce(new Error("early delivery failed"))
       .mockRejectedValueOnce(new Error("finish delivery failed"))
       .mockResolvedValue(undefined)
     const handler = createChannelWebhookRouteHandler(defineAgent({
-      capabilities: [chatTitle({ execute: ({ text }) => `Title: ${text}` })],
+      capabilities: [title({ execute: ({ text }) => `Title: ${text}` })],
       channels: {
         channel: http({ adapter: () => createTitleChatAdapter(setThreadTitle) as never }),
       },
@@ -4561,11 +4561,11 @@ describe("server helpers", () => {
 
   it("claims concurrent Chat SDK title delivery atomically", async () => {
     const { defineAgent } = await import("../src/index.ts")
-    const { chatTitle } = await import("../src/capabilities.ts")
+    const { title } = await import("../src/capabilities.ts")
     const { http } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
-    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-concurrent-"))
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-title-concurrent-"))
     const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
     let releaseDelivery: () => void = () => {}
     const deliveryPending = new Promise<void>((resolve) => {
@@ -4591,7 +4591,7 @@ describe("server helpers", () => {
       },
     })
     const createHandler = (prefix: string, adapter: ReturnType<typeof createTitleChatAdapter>) => createChannelWebhookRouteHandler(defineAgent({
-      capabilities: [chatTitle({ execute })],
+      capabilities: [title({ execute })],
       channels: {
         channel: http({ adapter: () => adapter as never }),
       },
@@ -4626,15 +4626,15 @@ describe("server helpers", () => {
 
   it("isolates title delivery by agent and channel on shared explicit state", async () => {
     const { defineAgent } = await import("../src/index.ts")
-    const { chatTitle } = await import("../src/capabilities.ts")
+    const { title } = await import("../src/capabilities.ts")
     const { http } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
-    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-scope-"))
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-title-scope-"))
     const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
     const setThreadTitle = vi.fn(async () => undefined)
     const handler = (channel: string) => createChannelWebhookRouteHandler(defineAgent({
-      capabilities: [chatTitle({ execute: () => `${channel} title` })],
+      capabilities: [title({ execute: () => `${channel} title` })],
       channels: {
         [channel]: http({ adapter: () => createTitleChatAdapter(setThreadTitle) as never }),
       },
@@ -4660,15 +4660,15 @@ describe("server helpers", () => {
 
   it("can deliver state-backed Chat SDK titles on every invocation", async () => {
     const { defineAgent } = await import("../src/index.ts")
-    const { chatTitle } = await import("../src/capabilities.ts")
+    const { title } = await import("../src/capabilities.ts")
     const { http } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
-    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-always-"))
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-title-always-"))
     const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
     const setThreadTitle = vi.fn(async () => undefined)
     const handler = createChannelWebhookRouteHandler(defineAgent({
-      capabilities: [chatTitle({ channelDelivery: "always", execute: ({ text }) => `Title: ${text}` })],
+      capabilities: [title({ channelDelivery: "always", execute: ({ text }) => `Title: ${text}` })],
       channels: {
         channel: http({ adapter: () => createTitleChatAdapter(setThreadTitle) as never }),
       },
@@ -4692,11 +4692,11 @@ describe("server helpers", () => {
 
   it("keeps Chat SDK output and best-effort title delivery when title state coordination fails", async () => {
     const { defineAgent } = await import("../src/index.ts")
-    const { chatTitle } = await import("../src/capabilities.ts")
+    const { title } = await import("../src/capabilities.ts")
     const { http } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
-    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-title-state-failure-"))
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-title-state-failure-"))
     const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
     const failingState = new Proxy(state, {
       get(target, property) {
@@ -4713,7 +4713,7 @@ describe("server helpers", () => {
     const setThreadTitle = vi.fn(async () => undefined)
     const adapter = createTitleChatAdapter(setThreadTitle)
     const handler = createChannelWebhookRouteHandler(defineAgent({
-      capabilities: [chatTitle({ execute: () => "Best effort title" })],
+      capabilities: [title({ execute: () => "Best effort title" })],
       channels: {
         channel: http({ adapter: () => adapter as never }),
       },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createMessage, getMessageText } from "@vite-hub/agent"
 import { createTraceEventLog, deriveTraceRuns, emitTraceEvent } from "@vite-hub/runtime"
-import { chat, chatTitle, schedule, subagents } from "../src/capabilities.ts"
+import { chat, title, schedule, subagents } from "../src/capabilities.ts"
 import { toJsonCompatibleValue } from "../src/tool-runtime.ts"
 
 import type { AgentChannelDeliveryFinishEffectCallback, AgentFinishEvent } from "../src/index.ts"
@@ -3472,12 +3472,12 @@ describe("agent message protocol", () => {
     expect(delivered).toHaveBeenCalledWith("deliver me")
   })
 
-  it("delivers chat titles through message Channels", async () => {
+  it("delivers titles through message Channels", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     const setAssistantTitle = vi.fn()
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => "Prepared title", id: "thread-title" })],
+      capabilities: [title({ execute: () => "Prepared title", id: "thread-title" })],
       channels: {
         portal: defineChannel("portal", {
           adapter: {
@@ -3502,7 +3502,7 @@ describe("agent message protocol", () => {
     expect(setAssistantTitle).toHaveBeenCalledWith("thread-1", "thread-1", "Prepared title")
   })
 
-  it("starts and replaces provisional chat titles while the main driver is pending", async () => {
+  it("starts and replaces provisional titles while the main driver is pending", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     let releaseDriver: () => void = () => {}
@@ -3525,7 +3525,7 @@ describe("agent message protocol", () => {
     const waitUntilTasks: Promise<unknown>[] = []
     const agent = defineAgent({
       capabilities: [
-        chatTitle({ execute }),
+        title({ execute }),
         defineCapability({
           id: "transcribed-input",
           input(context) {
@@ -3595,7 +3595,7 @@ describe("agent message protocol", () => {
     expect(titleEffect).toHaveBeenCalledTimes(2)
   })
 
-  it("retries chat title delivery at finish when any early delivery handler fails", async () => {
+  it("retries title delivery at finish when any early delivery handler fails", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     let releaseDriver: () => void = () => {}
@@ -3609,7 +3609,7 @@ describe("agent message protocol", () => {
     const execute = vi.fn(() => "Prepared title")
     const waitUntilTasks: Promise<unknown>[] = []
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute })],
+      capabilities: [title({ execute })],
       channels: {
         portal: defineChannel("portal", {
           effects: {
@@ -3652,12 +3652,12 @@ describe("agent message protocol", () => {
     expect(retryingTitleEffect).toHaveBeenCalledTimes(2)
   })
 
-  it("delivers chat titles through Slack Assistant message Channels", async () => {
+  it("delivers titles through Slack Assistant message Channels", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     const setAssistantTitle = vi.fn()
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => "Prepared title", id: "thread-title" })],
+      capabilities: [title({ execute: () => "Prepared title", id: "thread-title" })],
       channels: {
         slack: defineChannel("slack", {
           adapter: {
@@ -3718,7 +3718,7 @@ describe("agent message protocol", () => {
     const execute = vi.fn(() => "Unused title")
     const agent = defineAgent({
       capabilities: [
-        chatTitle({ execute }),
+        title({ execute }),
         defineCapability({
           id: "remove-user-message",
           input(context) {
@@ -3785,12 +3785,12 @@ describe("agent message protocol", () => {
     expect(adapter).not.toHaveBeenCalled()
   })
 
-  it("ignores chat title delivery when message Channel adapters cannot set titles", async () => {
+  it("ignores title delivery when message Channel adapters cannot set titles", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     const execute = vi.fn(() => "Prepared title")
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute })],
+      capabilities: [title({ execute })],
       channels: {
         portal: defineChannel("portal", {
           adapter: {
@@ -3814,13 +3814,13 @@ describe("agent message protocol", () => {
     expect(execute).not.toHaveBeenCalled()
   })
 
-  it("preserves chat title finish extensions when message Channel title delivery is unsupported", async () => {
+  it("preserves title finish extensions when message Channel title delivery is unsupported", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     const execute = vi.fn(() => "Prepared title")
     const finish = vi.fn()
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute })],
+      capabilities: [title({ execute })],
       channels: {
         portal: defineChannel("portal", {
           adapter: {
@@ -3845,16 +3845,16 @@ describe("agent message protocol", () => {
 
     await expect(runAgentTrigger(agent, { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }, "portal.message", {})).resolves.toBe("ok")
     expect(execute).toHaveBeenCalledOnce()
-    expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Prepared title" })
+    expect(finish.mock.calls[0]![0].extensions.get("title")).toEqual({ title: "Prepared title" })
   })
 
-  it("delivers chat titles through custom message Channel title effects", async () => {
+  it("delivers titles through custom message Channel title effects", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     const execute = vi.fn(() => "Prepared title")
     const titleEffect = vi.fn()
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute })],
+      capabilities: [title({ execute })],
       channels: {
         portal: defineChannel("portal", {
           adapter: {
@@ -3884,12 +3884,12 @@ describe("agent message protocol", () => {
     }))
   })
 
-  it("delivers chat titles through raw custom Channel title effects", async () => {
+  it("delivers titles through raw custom Channel title effects", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const execute = vi.fn(() => "Prepared title")
     const titleEffect = vi.fn()
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute })],
+      capabilities: [title({ execute })],
       channels: {
         portal: {
           effects: {
@@ -5322,13 +5322,13 @@ describe("agent message protocol", () => {
     expect(extension).not.toHaveBeenCalled()
   })
 
-  it("does not generate chat titles for plain agent runs without title delivery", async () => {
+  it("does not generate titles for plain agent runs without title delivery", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const execute = vi.fn(() => {
       throw new Error("title should not run")
     })
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute })],
+      capabilities: [title({ execute })],
       driver: { run: () => ({ text: "ok" }) },
     })
 
@@ -6363,11 +6363,11 @@ describe("agent message protocol", () => {
     }))
   })
 
-  it("emits chat title data for the first user message in streams", async () => {
+  it("emits title data for the first user message in streams", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const execute = vi.fn(({ text }) => `Title: ${text}`)
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute })],
+      capabilities: [title({ execute })],
       driver: { run: () => (async function* () {
           yield { text: "hello", type: "text-delta" }
           yield { type: "finish" }
@@ -6391,7 +6391,7 @@ describe("agent message protocol", () => {
       text: "First user request",
     }))
     expect(events).toContainEqual({
-      data: { title: "Title: First user request", type: "chat-title" },
+      data: { title: "Title: First user request", type: "title" },
       type: "data",
     })
     expect(events).toContainEqual({ text: "hello", type: "text-delta" })
@@ -6403,7 +6403,7 @@ describe("agent message protocol", () => {
     const execute = vi.fn(({ text }) => `Title: ${text}`)
     const finish = vi.fn()
     const agent = defineAgent({
-      capabilities: [chatTitle({ channelDelivery: "once-per-thread", execute })],
+      capabilities: [title({ channelDelivery: "once-per-thread", execute })],
       driver: { run: () => (async function* () {
           yield { text: "hello", type: "text-delta" }
           yield { type: "finish" }
@@ -6423,25 +6423,25 @@ describe("agent message protocol", () => {
       const events = []
       for await (const event of stream as AsyncIterable<unknown>) events.push(event)
       expect(events).toContainEqual({
-        data: { title: `Title: ${id}`, type: "chat-title" },
+        data: { title: `Title: ${id}`, type: "title" },
         type: "data",
       })
     }
     expect(execute).toHaveBeenCalledTimes(2)
-    expect(finish.mock.calls.map(([event]) => event.extensions.get("chat-title"))).toEqual([
+    expect(finish.mock.calls.map(([event]) => event.extensions.get("title"))).toEqual([
       { title: "Title: user-1" },
       { title: "Title: user-2" },
     ])
   })
 
-  it("streams agent output while chat title generation is pending", async () => {
+  it("streams agent output while title generation is pending", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     let resolveTitle: (title: string) => void = () => {}
     const delayedTitle = new Promise<string>((resolve) => {
       resolveTitle = resolve
     })
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => delayedTitle })],
+      capabilities: [title({ execute: () => delayedTitle })],
       driver: { run: () => (async function* () {
           yield { text: "hello", type: "text-delta" }
           yield { type: "finish" }
@@ -6466,15 +6466,15 @@ describe("agent message protocol", () => {
 
     expect(rest).toContainEqual({ type: "finish" })
     expect(rest).toContainEqual({
-      data: { title: "Delayed title", type: "chat-title" },
+      data: { title: "Delayed title", type: "title" },
       type: "data",
     })
   })
 
-  it("keeps streaming when chat title generation fails", async () => {
+  it("keeps streaming when title generation fails", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => { throw new Error("title failed") } })],
+      capabilities: [title({ execute: () => { throw new Error("title failed") } })],
       driver: { run: () => (async function* () {
           yield { text: "hello", type: "text-delta" }
           yield { type: "finish" }
@@ -6495,14 +6495,14 @@ describe("agent message protocol", () => {
     ])
   })
 
-  it("does not render chat title templates for heuristic fallback titles", async () => {
+  it("does not render title templates for heuristic fallback titles", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const template = vi.fn(() => "Rendered template")
     const variable = vi.fn(() => "Rendered variable")
     const finish = vi.fn()
     const agent = defineAgent({
       capabilities: [
-        chatTitle({
+        title({
           template,
           variables: {
             area: variable,
@@ -6521,10 +6521,10 @@ describe("agent message protocol", () => {
 
     expect(template).not.toHaveBeenCalled()
     expect(variable).not.toHaveBeenCalled()
-    expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Need help with invoices today" })
+    expect(finish.mock.calls[0]![0].extensions.get("title")).toEqual({ title: "Need help with invoices today" })
   })
 
-  it("generates chat titles with the default template and agent model", async () => {
+  it("generates titles with the default template and agent model", async () => {
     const generateText = vi.fn(async () => ({ text: '"Generated invoice title"' }))
     const aiSdk = {
       generateText,
@@ -6542,7 +6542,7 @@ describe("agent message protocol", () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const finish = vi.fn()
       const agent = defineAgent({
-        capabilities: [chatTitle()],
+        capabilities: [title()],
         hooks: {
           "agent:finish": finish,
         },
@@ -6556,7 +6556,7 @@ describe("agent message protocol", () => {
       expect(generateText).toHaveBeenCalledWith({
         model: "agent-title-model",
         prompt: [
-          "Summarize the user's request as a short chat title.",
+          "Summarize the user's request as a short title.",
           "Return only the title.",
           "Use 4-8 words when possible.",
           "Keep it under 80 characters.",
@@ -6564,20 +6564,20 @@ describe("agent message protocol", () => {
           "Use the user's language.",
           "Do not use emoji.",
           "Ignore chat platform mention/channel markup, bot names, and user IDs.",
-          `Use "New Conversation" when the message is too vague.`,
+          `Use "Untitled" when the message is too vague.`,
           "",
           "User message:",
           "Need help with invoices",
         ].join("\n"),
       })
-      expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Generated invoice title" })
+      expect(finish.mock.calls[0]![0].extensions.get("title")).toEqual({ title: "Generated invoice title" })
     }
     finally {
       vi.doUnmock("ai")
     }
   })
 
-  it("cleans generated chat titles without cutting words", async () => {
+  it("cleans generated titles without cutting words", async () => {
     const generateText = vi.fn(async () => ({ text: "Compare Quiet Rainy Morning Cafe Museum Plans" }))
     const aiSdk = {
       generateText,
@@ -6596,7 +6596,7 @@ describe("agent message protocol", () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const finish = vi.fn()
       const agent = defineAgent({
-        capabilities: [chatTitle({ maxLength: 35 })],
+        capabilities: [title({ maxLength: 35 })],
         driver: { model: "agent-title-model" as never },
         hooks: {
           "agent:finish": finish,
@@ -6607,14 +6607,14 @@ describe("agent message protocol", () => {
         messages: [createMessage({ role: "user", text: "Compare a cafe morning and museum morning" })],
       })
 
-      expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Compare Quiet Rainy Morning Cafe" })
+      expect(finish.mock.calls[0]![0].extensions.get("title")).toEqual({ title: "Compare Quiet Rainy Morning Cafe" })
     }
     finally {
       vi.doUnmock("ai")
     }
   })
 
-  it("generates chat titles with a harness title driver", async () => {
+  it("generates titles with a harness title driver", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finish = vi.fn()
     const session = { destroy: vi.fn() }
@@ -6624,7 +6624,7 @@ describe("agent message protocol", () => {
 
     const agent = defineAgent({
       capabilities: [
-        chatTitle({
+        title({
           driver: {
             harness: { provider: "codex" },
             sandbox,
@@ -6650,15 +6650,15 @@ describe("agent message protocol", () => {
       harness: { provider: "codex" },
       sandbox,
     })
-    expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Como Estas" })
+    expect(finish.mock.calls[0]![0].extensions.get("title")).toEqual({ title: "Como Estas" })
   })
 
-  it("generates chat titles from stream-result title drivers", async () => {
+  it("generates titles from stream-result title drivers", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finish = vi.fn()
     const agent = defineAgent({
       capabilities: [
-        chatTitle({
+        title({
           driver: {
             run: () => ({
               stream: (async function* () {
@@ -6680,10 +6680,10 @@ describe("agent message protocol", () => {
       messages: [createMessage({ role: "user", text: "Need a sidebar title" })],
     })
 
-    expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toEqual({ title: "Streamed title" })
+    expect(finish.mock.calls[0]![0].extensions.get("title")).toEqual({ title: "Streamed title" })
   })
 
-  it("renders custom chat title templates and skips unmatched triggers", async () => {
+  it("renders custom title templates and skips unmatched triggers", async () => {
     const generateText = vi.fn(async () => ({ text: "Portal Forecast Help" }))
     vi.doMock("ai", () => ({ generateText, jsonSchema: vi.fn(schema => schema) }))
 
@@ -6692,7 +6692,7 @@ describe("agent message protocol", () => {
       const finish = vi.fn()
       const agent = defineAgent({
         capabilities: [
-          chatTitle({
+          title({
             model: "title-model" as never,
             template: "{{ trigger }} {{ area }}: {{ message }}",
             trigger: "portal.message",
@@ -6730,7 +6730,7 @@ describe("agent message protocol", () => {
 
       await runAgentTrigger(agent, runtime, "teams.message", { text: "Need help with forecast" })
       expect(generateText).not.toHaveBeenCalled()
-      expect(finish.mock.calls[0]![0].extensions.get("chat-title")).toBeUndefined()
+      expect(finish.mock.calls[0]![0].extensions.get("title")).toBeUndefined()
 
       await runAgentTrigger(agent, runtime, "portal.message", { text: "Need help with forecast" })
 
@@ -6738,14 +6738,14 @@ describe("agent message protocol", () => {
         model: "title-model",
         prompt: "portal.message support: Need help with forecast",
       })
-      expect(finish.mock.calls[1]![0].extensions.get("chat-title")).toEqual({ title: "Portal Forecast Help" })
+      expect(finish.mock.calls[1]![0].extensions.get("title")).toEqual({ title: "Portal Forecast Help" })
     }
     finally {
       vi.doUnmock("ai")
     }
   })
 
-  it("emits chat title data for adapter text streams", async () => {
+  it("emits title data for adapter text streams", async () => {
     vi.doMock("ai", () => ({
       jsonSchema: vi.fn(schema => schema),
       ToolLoopAgent: class {
@@ -6766,7 +6766,7 @@ describe("agent message protocol", () => {
     try {
       const { defineAgent, streamAgent } = await import("../src/index.ts")
       const agent = defineAgent({
-        capabilities: [chatTitle({ execute: () => "Adapter title" })],
+        capabilities: [title({ execute: () => "Adapter title" })],
         driver: { model: {} as never },
       })
 
@@ -6778,7 +6778,7 @@ describe("agent message protocol", () => {
         events.push(event)
       }
 
-      expect(events).toContainEqual({ data: { title: "Adapter title", type: "chat-title" }, type: "data" })
+      expect(events).toContainEqual({ data: { title: "Adapter title", type: "title" }, type: "data" })
       expect(events).toContainEqual({ text: "hello", type: "text-delta" })
     }
     finally {
@@ -6786,7 +6786,7 @@ describe("agent message protocol", () => {
     }
   })
 
-  it("preserves stream result methods when adding chat title data to full streams", async () => {
+  it("preserves stream result methods when adding title data to full streams", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finish = vi.fn()
     class StreamResult {
@@ -6800,7 +6800,7 @@ describe("agent message protocol", () => {
       }
     }
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => "Preserved title" })],
+      capabilities: [title({ execute: () => "Preserved title" })],
       hooks: {
         "agent:finish": finish,
       },
@@ -6815,7 +6815,7 @@ describe("agent message protocol", () => {
       events.push(event)
     }
 
-    expect(events).toContainEqual({ data: { title: "Preserved title", type: "chat-title" }, type: "data" })
+    expect(events).toContainEqual({ data: { title: "Preserved title", type: "title" }, type: "data" })
     expect(events).toContainEqual({ text: "hello", type: "text-delta" })
     expect(result).toBeInstanceOf(StreamResult)
     expect(result.metadata).toEqual({ id: "stream-result-1" })
@@ -6824,7 +6824,7 @@ describe("agent message protocol", () => {
     expect(finish.mock.calls[0]![0].result).toBe(result)
   })
 
-  it("preserves readable stream results when adding chat title data", async () => {
+  it("preserves readable stream results when adding title data", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     class StreamResult {
       stream = new ReadableStream<unknown>({
@@ -6839,7 +6839,7 @@ describe("agent message protocol", () => {
       }
     }
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => "Readable title" })],
+      capabilities: [title({ execute: () => "Readable title" })],
       driver: { run: () => new StreamResult() },
     })
 
@@ -6855,7 +6855,7 @@ describe("agent message protocol", () => {
     expect(result).toBeInstanceOf(StreamResult)
     expect(result.stream).toBeInstanceOf(ReadableStream)
     expect(stream).toBeInstanceOf(ReadableStream)
-    expect(events).toContainEqual({ data: { title: "Readable title", type: "chat-title" }, type: "data" })
+    expect(events).toContainEqual({ data: { title: "Readable title", type: "title" }, type: "data" })
     expect(events).toContainEqual({ text: "hello", type: "text-delta" })
   })
 
@@ -6864,7 +6864,7 @@ describe("agent message protocol", () => {
     const pull = vi.fn()
     const source = new ReadableStream<unknown>({ pull }, { highWaterMark: 0 })
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => "Lazy title" })],
+      capabilities: [title({ execute: () => "Lazy title" })],
       driver: { run: () => ({ stream: source }) },
     })
 
@@ -6877,7 +6877,7 @@ describe("agent message protocol", () => {
     await result.stream.cancel("unused")
   })
 
-  it("keeps native UI message stream conversion available after chat title decoration", async () => {
+  it("keeps native UI message stream conversion available after title decoration", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     class StreamResult {
       stream = new ReadableStream<unknown>({
@@ -6896,7 +6896,7 @@ describe("agent message protocol", () => {
       }
     }
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => "Native UI title" })],
+      capabilities: [title({ execute: () => "Native UI title" })],
       driver: { run: () => new StreamResult() },
     })
 
@@ -6908,7 +6908,7 @@ describe("agent message protocol", () => {
       events.push(event)
     }
 
-    expect(events).toContainEqual({ data: { title: "Native UI title", type: "chat-title" }, type: "data-chat-title" })
+    expect(events).toContainEqual({ data: { title: "Native UI title", type: "title" }, type: "data-title" })
     expect(events).toContainEqual({ delta: "hello", id: "text-1", type: "text-delta" })
   })
 
@@ -6930,7 +6930,7 @@ describe("agent message protocol", () => {
       }, { highWaterMark: 0 })
     }
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => new Promise<string>(() => {}) })],
+      capabilities: [title({ execute: () => new Promise<string>(() => {}) })],
       driver: { run: () => new StreamResult() },
     })
 
@@ -6947,7 +6947,7 @@ describe("agent message protocol", () => {
     expect(cancel).toHaveBeenCalledWith("client disconnected")
   })
 
-  it("preserves text stream result metadata when adding chat title data", async () => {
+  it("preserves text stream result metadata when adding title data", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finish = vi.fn()
     class TextStreamResult {
@@ -6961,7 +6961,7 @@ describe("agent message protocol", () => {
       }
     }
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => "Metadata title" })],
+      capabilities: [title({ execute: () => "Metadata title" })],
       hooks: {
         "agent:finish": finish,
       },
@@ -6976,7 +6976,7 @@ describe("agent message protocol", () => {
       events.push(event)
     }
 
-    expect(events).toContainEqual({ data: { title: "Metadata title", type: "chat-title" }, type: "data" })
+    expect(events).toContainEqual({ data: { title: "Metadata title", type: "title" }, type: "data" })
     expect(events).toContainEqual({ text: "hello", type: "text-delta" })
     expect(result).toBeInstanceOf(TextStreamResult)
     expect(result.metadata).toEqual({ usage: "kept" })
@@ -6998,7 +6998,7 @@ describe("agent message protocol", () => {
     const nativeResult = new TextStreamResult()
     const agent = defineAgent({
       capabilities: [
-        chatTitle({ execute }),
+        title({ execute }),
         defineCapability({
           id: "remove-user-message",
           input(context) {
@@ -7019,11 +7019,11 @@ describe("agent message protocol", () => {
     expect(execute).not.toHaveBeenCalled()
   })
 
-  it("emits chat title data for UI message streams", async () => {
+  it("emits title data for UI message streams", async () => {
     const { createUIMessageStream, readUIMessageStream } = await import("ai")
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => "Sidebar title" })],
+      capabilities: [title({ execute: () => "Sidebar title" })],
       driver: { run: () => ({
           toUIMessageStream() {
             return createUIMessageStream({
@@ -7048,7 +7048,7 @@ describe("agent message protocol", () => {
     }
 
     expect(messages.at(-1)?.parts).toEqual([
-      { data: { title: "Sidebar title", type: "chat-title" }, type: "data-chat-title" },
+      { data: { title: "Sidebar title", type: "title" }, type: "data-title" },
       { providerMetadata: undefined, state: "done", text: "answer", type: "text" },
     ])
   })
@@ -7433,11 +7433,11 @@ describe("agent message protocol", () => {
     expect(deriveTraceRuns(traceLog!.entries())).toMatchObject([{ status: "failed" }])
   })
 
-  it("emits one chat title data part when async event streams become UI message streams", async () => {
+  it("emits one title data part when async event streams become UI message streams", async () => {
     const { readUIMessageStream } = await import("ai")
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => "Async title" })],
+      capabilities: [title({ execute: () => "Async title" })],
       driver: { run: () => (async function* () {
           yield { text: "answer", type: "text-delta" }
           yield { type: "finish" }
@@ -7452,10 +7452,10 @@ describe("agent message protocol", () => {
       messages.push(message)
     }
 
-    expect(messages.at(-1)?.parts.filter(part => part.type === "data-chat-title")).toEqual([
-      { data: { title: "Async title", type: "chat-title" }, type: "data-chat-title" },
+    expect(messages.at(-1)?.parts.filter(part => part.type === "data-title")).toEqual([
+      { data: { title: "Async title", type: "title" }, type: "data-title" },
     ])
-    expect(messages.at(-1)?.parts.map(part => part.type).sort()).toEqual(["data-chat-title", "text"])
+    expect(messages.at(-1)?.parts.map(part => part.type).sort()).toEqual(["data-title", "text"])
   })
 
   it("preserves data part ids when async event streams become UI message streams", async () => {
@@ -7510,7 +7510,7 @@ describe("agent message protocol", () => {
     let traceLog: ReturnType<typeof createTraceEventLog> | undefined
     const finish = vi.fn()
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: () => "Run title" })],
+      capabilities: [title({ execute: () => "Run title" })],
       hooks: { "agent:finish": finish },
       driver: { run: (context) => {
         traceLog = context.traceLog
@@ -7529,17 +7529,17 @@ describe("agent message protocol", () => {
       events.push(event)
     }
 
-    expect(events).toContainEqual({ data: { title: "Run title", type: "chat-title" }, type: "data" })
+    expect(events).toContainEqual({ data: { title: "Run title", type: "title" }, type: "data" })
     expect(events).toContainEqual({ text: "answer", type: "text-delta" })
     expect(finish.mock.calls[0]![0].invocation.resultKind).toBe("stream")
     expect(deriveTraceRuns(traceLog!.entries())).toMatchObject([{ status: "completed" }])
   })
 
-  it("exposes chat title finish extension without registering command metadata", async () => {
+  it("exposes title finish extension without registering command metadata", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finish = vi.fn()
     const agent = defineAgent({
-      capabilities: [chatTitle({ execute: ({ text }) => ({ title: `Title: ${text}` }) })],
+      capabilities: [title({ execute: ({ text }) => ({ title: `Title: ${text}` }) })],
       hooks: {
         "agent:finish": finish,
       },
@@ -7551,7 +7551,7 @@ describe("agent message protocol", () => {
     })
 
     const event = finish.mock.calls[0]![0]
-    expect(event.extensions.get("chat-title")).toEqual({ title: "Title: Explain invoices" })
+    expect(event.extensions.get("title")).toEqual({ title: "Title: Explain invoices" })
     expect(agent.capabilities?.[0]?.metadata).toBeUndefined()
   })
 
@@ -8079,7 +8079,7 @@ describe("agent message protocol", () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const agent = defineAgent({
       driver: { run: () => (async function* () {
-          yield { data: { title: "Async title" }, type: "data-chat-title" }
+          yield { data: { title: "Async title" }, type: "data-title" }
           yield { text: "hello", type: "text-delta" }
           yield { id: "tool-1", input: { query: "users" }, name: "search", type: "tool-call" }
           yield { id: "tool-1", name: "search", output: "42", type: "tool-result" }
@@ -8095,10 +8095,10 @@ describe("agent message protocol", () => {
       messages.push(message)
     }
 
-    expect(messages.at(-1)?.parts.map(part => part.type)).toEqual(["data-chat-title", "text", "tool-search"])
+    expect(messages.at(-1)?.parts.map(part => part.type)).toEqual(["data-title", "text", "tool-search"])
     expect(messages.at(-1)?.parts[0]).toEqual({
       data: { title: "Async title" },
-      type: "data-chat-title",
+      type: "data-title",
     })
   })
 

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
-import { access, blob, browser, chat, chatTitle, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -418,7 +418,7 @@ describe("agent public types", () => {
             return "transcript"
           },
         }),
-        chatTitle({
+        title({
           channelDelivery: "once-per-thread",
           model: () => ({}),
           template({ fallback, maxLength, text, trigger }) {


### PR DESCRIPTION
Renames `chatTitle()` to `title()` and generalizes its public types, capability id, stream data parts, documentation, and Channel delivery internals. The Capability can now describe its full boundary: applications can use the finish extension to name durable jobs or runs, while compatible message Channels can still deliver the same title to a thread.

This is intentionally breaking while the Agent API is in active development. Consumers now import `title`, read the `title` extension, and handle `data-title` / `type: "title"` stream metadata. The fallback becomes `Untitled`, with existing model, heuristic, harness-driver, stream, and once-per-thread delivery coverage preserved.