### PR TITLE
docs: expand the ViteHub project skill

### DIFF
--- a/docs/content/docs/ai-resources/agent-instructions-skills.md
+++ b/docs/content/docs/ai-resources/agent-instructions-skills.md
@@ -5,8 +5,8 @@ navigation.order: 62
 icon: i-lucide-scroll-text
 ---
 
-The public ViteHub skill helps coding agents build applications with current documentation and the application's installed package contract.
-It covers both Server Primitives and Agents without loading the complete documentation set into every task.
+The public ViteHub skill helps coding agents build complete applications from current documentation and the application's installed package contract.
+It keeps one compact proof loop in `SKILL.md`, then loads only the project-shape, feature, authority, host, migration, or recovery references that match the task.
 
 ## Install the skill
 
@@ -19,6 +19,14 @@ npx skills add https://vitehub.dev
 The CLI discovers the published `vitehub` skill and installs it for the supported coding agents you select.
 Run `npx skills list` to inspect installed project skills.
 
+## Follow one proof loop
+
+The skill orients in the current project, routes the smallest matching reference set, validates every planned import and option against installed exports and types, builds a coherent file set, and proves every requested behavior through its real runtime path.
+
+The bundled references teach reusable composition rather than copying the API reference. They cover project shapes, preview contracts, Server Primitives, framework composition, Agent Definitions and Drivers, Workspaces and Sources, Channels and Triggers, Capabilities, orchestration, Boxes and hosts, proof and recovery, public project patterns, and migration from older package generations.
+
+Links inside a reference are selection menus. The agent opens the smallest live raw page for the current behavior instead of loading the full reference library or documentation set.
+
 ## Ask for an outcome
 
 The skill activates from normal ViteHub requests.
@@ -30,7 +38,7 @@ State the result you want and include any host or runtime constraint.
 | Agent | `Create a harness-backed review Agent with repository context and invoke it locally.` |
 | Host boundary | `Build this ViteHub application for Cloudflare and inspect its Provider Output.` |
 
-The skill selects one product lane, reads the smallest live docs page, checks installed exports and types, and reports the proof.
+The skill selects one primary product lane, reads only matching references and the smallest live docs pages, checks installed exports and types, and reports the proof for each requested behavior.
 When documentation and an installed version differ, the installed contract controls the implementation and the agent reports the mismatch.
 
 ## Keep the instruction surfaces distinct
@@ -40,7 +48,7 @@ Keeping them separate prevents repository guidance from leaking into runtime Age
 
 | Surface | Audience | Purpose |
 | --- | --- | --- |
-| Public ViteHub skill | Coding agents building a ViteHub application | Routes implementation through live docs, installed contracts, and proof. |
+| Public ViteHub skill | Coding agents building a ViteHub application | Routes project patterns through live docs, installed contracts, explicit authority, and runtime proof. |
 | Repository `AGENTS.md` | Coding agents contributing to a repository | Defines local development rules and project boundaries. |
 | [Agent Driver Instructions](/docs/agents/instructions) | Agents that run inside an application | Defines model-facing runtime behavior. |
 | Agent-local `skills/` | Harness-backed Agent Invocations | Automatically installs Skills owned by a folder Agent Definition. |

--- a/docs/skills/vitehub/SKILL.md
+++ b/docs/skills/vitehub/SKILL.md
@@ -1,74 +1,67 @@
 ---
 name: vitehub
-description: Build and debug ViteHub apps from the live docs and installed contract. Use for server primitives and Runtime Helpers; Agent Definitions, Drivers, Capabilities, Workspaces, and Sources; or Vite Integrations, Provider Output, and host deployment.
+description: Build and debug complete ViteHub apps from live docs and installed contracts. Use for server primitives and Runtime Helpers; Agent Definitions, Drivers, Capabilities, Workspaces, Sources, Channels, Triggers, or orchestration; Vite/Nuxt integration, Provider Output, previews, hosts, and deployment.
 ---
 
 # ViteHub
 
-Use one proof loop: orient, choose one lane, inspect the installed contract, act, recover, and prove.
+Use one proof loop: orient, route, inspect the contract, build, and prove. Exact package exports, installed types, and current raw docs outrank remembered or project-example syntax.
 
 ## 1. Orient
 
-- Inspect the package manifest, lockfile, Vite config, and server entry before proposing code.
-- Identify the installed ViteHub packages and versions, framework, host target, and requested outcome.
-- Open `https://vitehub.dev/llms.txt`, then read the single smallest raw Markdown page that covers the task. Add a second page only when the first one explicitly requires it.
+- Inspect the package manifest, lockfile, Vite or Nuxt config, server entry, and nearby project instructions.
+- Identify installed ViteHub packages and versions, package manager, framework, host target, and requested outcome.
+- Open `https://vitehub.dev/llms.txt`, then select the smallest raw Markdown page covering the primary behavior. Links inside references are selection menus; do not open every linked page.
 
-Orientation is complete when you can state the current setup, target outcome, and chosen docs URL.
+Orientation is complete when the current setup, target outcome, host boundary, and first docs URL are named.
 
-## 2. Choose One Lane
+## 2. Route before code
 
-- **Server primitives** serve direct application and server behavior through Vite Integrations, Definitions when discovery is needed, and Runtime Helpers.
-- **Agents** serve model-backed, harness-backed, or custom-run-backed behavior through Agent Definitions. Agents may compose server primitives; server primitives remain useful without an Agent.
+Choose one primary lane. Server Primitives serve application behavior through Vite Integrations and Runtime Helpers. Agents serve model-backed, harness-backed, or custom-run behavior through Agent Definitions; they may compose Server Primitives without changing the primary lane.
 
-Choose one primary lane. Treat framework and host work as a boundary around that lane, not as a third product model.
+Read only the references whose conditions match, but read them before writing code:
 
-Lane selection is complete when every requested behavior belongs to the chosen lane and any host boundary is named.
+| Task condition | Required reference |
+| --- | --- |
+| New project, uncertain file layout, or cross-feature composition | [Project shapes](references/project-shapes.md) |
+| Released or `pkg.pr.new` installation, upgrade, or package mismatch | [Installed and preview contracts](references/preview-contract.md) |
+| KV, Blob, Database, Env, Email, Queue, Sandbox, Shell, or another Server Primitive | [Server Primitives](references/server-primitives.md) |
+| Modify an existing framework integration; add Nitro or Nuxt; use generated types; configure a provider; or diagnose a framework-specific failure | [Framework composition](references/framework-composition.md) |
+| Agent Definition, Agent Driver, Agent Invocation, instructions, output, hooks, or Evals | [Agent Definitions and Drivers](references/agent-definitions.md) |
+| Workspace, Source, access scope, mounted files, or write-back | [Workspaces, Sources, and access](references/workspaces-sources-access.md) |
+| Channel, Trigger, webhook, messages, admission, concurrency, or delivery | [Channels and Triggers](references/channels-triggers.md) |
+| Capability, tool, secret, rate limit, telemetry, or other granted authority | [Capabilities and authority](references/capabilities-authority.md) |
+| Schedule, Workflow, orchestration retry, idempotency, or terminal state | [Schedules, Workflows, and Invocations](references/schedules-workflows-invocations.md) |
+| Box, trusted host, isolation, required command, or deployment target | [Boxes and hosts](references/boxes-hosts.md) |
+| A proof has failed, generated state disagrees, or a runtime/host failure needs diagnosis | [Proof and recovery](references/proof-recovery.md) |
+| Looking for a complete public application pattern | [Project patterns](references/project-patterns.md) |
+| Existing `@vitehub/*`, `@vite-hub/vite`, or individual `hubX()` composition | [Migration quarantine](references/migration.md) |
 
-## 3. Inspect The Installed Contract
+Routing is complete when every requested behavior has one primary lane and every matching reference has been read. Do not load the whole library.
 
-- Read each installed package's `package.json`, exports, and relevant types before writing imports or options.
-- For a fresh application, follow the installation page, install `vite-hub`, then inspect its root and feature-subpath exports. Use direct owner packages only for a focused library or advanced composition.
-- When live docs, installed types, and exports disagree, implement the installed contract and report the mismatch with both versions or sources. Do not invent a missing API.
+## 3. Inspect the installed contract
 
-Contract inspection is complete when every planned import, option, and runtime entry exists in the installed version.
+- Read each installed package's `package.json`, exports, relevant types, and generated declarations before writing imports or options.
+- For a fresh application, install `vite-hub` and use its root integration plus feature subpaths. Use direct owner packages only for a focused library, an unexported advanced subpath, or an installed older contract.
+- When docs, examples, and installed artifacts disagree, implement the installed artifacts and record the mismatch. Treat project examples as patterns whose imports must be revalidated.
 
-## 4. Act
+Contract inspection is complete when every planned package, import, option, generated path, and runtime entry exists in the installed graph; no syntax is inferred only from memory.
 
-### Server primitive lane
+## 4. Build the coherent file set
 
-1. Install `vite-hub` for an application, or the primitive owner package for a focused library integration.
-2. Register `vitehub()` in the existing Vite config. Use an owner package's `hubX()` integration only when direct package control is intentional.
-3. Add a named Definition only when the primitive relies on discovery.
-4. Call the primitive from application or server code through its Runtime Helper.
-5. Keep primitive authority in application code unless the task explicitly grants it to an Agent through a Capability.
+Before editing, map every requested behavior to:
 
-### Agent lane
+| Behavior | Package owner | Source file | Runtime path | Authority or persistence | Proof |
+| --- | --- | --- | --- | --- | --- |
 
-1. Add one Agent Definition and select one model-backed, harness-backed, or custom Agent Driver.
-2. Satisfy the selected driver's credentials, executable, or callback prerequisites.
-3. Attach only the Workspace, Sources, and Capabilities required by the task.
-4. Put model-facing guidance for configured Sources, Capabilities, and Skills in Agent Driver Instructions or deterministic imported instruction Markdown.
-5. Invoke the Agent through the documented Runtime Helper and keep granted authority visible in the Definition and inspection output.
+Then implement the smallest coherent set: manifest and lockfile, framework integration, discovered Definition where needed, application or orchestration entrypoint, and proof surface. Keep application authority in application code; grant an Agent access only through visible Capabilities, Workspace rules, Sources, Channels, or Box configuration.
 
-### Host boundary
+Building is complete when every requested behavior has an implemented row and no placeholder, unused integration, implicit authority, or unowned persistence remains.
 
-When the task includes deployment, read the target host page, build for that target, and inspect generated Provider Output. State unsupported or partially supported behavior as an explicit limitation.
+## 5. Prove and repair
 
-Acting is complete when the smallest coherent implementation exists in the chosen lane.
+- Run the narrow typecheck or package test nearest the change, then the relevant build.
+- Prove the actual lane: execute the Runtime Helper, perform an Agent Invocation, exercise the webhook or schedule, or inspect generated Provider Output.
+- On failure, return to installed exports/types, `.vitehub` generated state, the selected raw docs page, and [Proof and recovery](references/proof-recovery.md). Repair the cause and rerun the same proof.
 
-## 5. Recover
-
-- For missing imports or type errors, return to installed exports and types.
-- For discovery or runtime failures, inspect generated `.vitehub` state and the diagnostics page selected from `llms.txt`.
-- For docs drift, keep the installed contract in code and report the exact disagreement.
-- For unavailable host behavior, preserve the supported ViteHub boundary and state what remains host-owned.
-
-Recovery is complete when the failure has a source-backed cause, a verified correction, or a precise unsupported boundary.
-
-## 6. Prove
-
-- **Server primitive:** its Vite Integration is registered, its Runtime Helper executes, and the observed output matches the expected output.
-- **Agent:** its Agent Invocation returns or streams the expected result, the Agent Driver prerequisites are satisfied, and granted authority is inspectable.
-- **Host boundary:** the build emits the documented Provider Output and every target limitation is explicit.
-
-Run the narrow package test or typecheck nearest the change, then the relevant application build or invocation proof. Report the commands and observed result, the raw docs URL, installed ViteHub versions, and any contract mismatch or host limitation.
+The task is complete when every behavior row has an observed result, or a precise source-backed unsupported boundary. Report commands and observations, docs URLs, installed ViteHub versions or preview commit, contract mismatches, and host limitations.

--- a/docs/skills/vitehub/agents/openai.yaml
+++ b/docs/skills/vitehub/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "ViteHub"
-  short_description: "Build ViteHub primitives and Agents"
-  default_prompt: "Use $vitehub to choose one ViteHub lane, follow the live docs and installed contract, and prove the result."
+  short_description: "Build complete ViteHub projects"
+  default_prompt: "Use $vitehub to route the smallest relevant reference set, follow live docs and the installed contract, and prove every requested behavior."

--- a/docs/skills/vitehub/references/agent-definitions.md
+++ b/docs/skills/vitehub/references/agent-definitions.md
@@ -1,0 +1,33 @@
+# Agent Definitions and Drivers
+
+Use this for Agent Definitions, model or harness Drivers, deterministic custom Drivers, instructions, structured output, hooks, or Evals.
+
+## Select current pages
+
+For a first deterministic custom Driver and direct invocation, open only [First Agent](https://vitehub.dev/raw/docs/getting-started/first-agent.md). Use [Agent Definitions](https://vitehub.dev/raw/docs/agents/agent-definitions.md) for advanced composition or discovery, [Agent Drivers](https://vitehub.dev/raw/docs/agents/agent-drivers.md) for model/harness details, and [Agent Invocations](https://vitehub.dev/raw/docs/agents/invocations.md) for advanced runtime context. Open [Instructions](https://vitehub.dev/raw/docs/agents/instructions.md) or [Evals](https://vitehub.dev/raw/docs/agents/evals.md) only when that behavior is requested. Do not read the whole set.
+
+## Definition shape
+
+Default-export one `defineAgent()` boundary from `server/agents/<name>.ts` or `server/agents/<name>/agent.ts`. Compose only the facets the outcome needs:
+
+```text
+driver        how the Agent runs
+instructions model-facing behavior
+workspace     files and Sources available to the invocation
+capabilities  granted tools and authority
+channels      external conversation adapters
+box           execution environment and requirements
+hooks/output  lifecycle and delivery behavior
+```
+
+Use a deterministic custom `driver.run` for the first offline proof. Add model or harness packages, credentials, executable prerequisites, and sandbox requirements only when the requested outcome needs them.
+
+Keep repository-wide guidance in repository files, Agent behavior in Driver Instructions, and reusable runtime Skills in the documented Agent skill surface.
+
+## Invocation boundary
+
+Pass invocation input separately from trusted runtime context. Keep run identity, memoization, wait-until behavior, actor/admission context, and runtime selection explicit where the chosen invocation helper requires them.
+
+## Proof
+
+Prove Driver prerequisites, run one real Agent Invocation, inspect granted authority, and assert the expected output. A typecheck without an invocation is incomplete.

--- a/docs/skills/vitehub/references/boxes-hosts.md
+++ b/docs/skills/vitehub/references/boxes-hosts.md
@@ -1,0 +1,17 @@
+# Boxes and hosts
+
+Use this for trusted-host commands, isolated execution, credentials projected into Home, required binaries, deployment targets, or Provider Output.
+
+## Select current pages
+
+Open [Boxes](https://vitehub.dev/raw/docs/agents/boxes.md) for execution environments, the selected page under [Frameworks and hosts](https://vitehub.dev/raw/docs/frameworks-hosts.md) for a deployment target, or [Provider Output](https://vitehub.dev/raw/docs/reference/provider-output.md) for artifact ownership. Open only the pages matching the task.
+
+## State the runtime boundary
+
+Name the Box provider or trusted host, isolation guarantee, persistence lifetime, network policy, required commands, projected credentials, cost, and production-readiness. A local tempdir or host process is convenience, not isolation.
+
+Keep host-specific setup behind the Box or provider boundary. Agent Instructions may explain available commands, but configuration must make the commands and credentials actually available.
+
+## Proof
+
+Inspect the resolved Box requirements, execute one required command, prove credential access without exposing the credential, and confirm cleanup or persistence. For deployment, build and inspect the documented Provider Output before a live target check.

--- a/docs/skills/vitehub/references/capabilities-authority.md
+++ b/docs/skills/vitehub/references/capabilities-authority.md
@@ -1,0 +1,25 @@
+# Capabilities and authority
+
+Use this whenever an Agent receives a tool, secret-backed operation, browser, storage, shell, repository, rate-limit, telemetry, or custom action.
+
+## Select current pages
+
+Open [Official Capabilities](https://vitehub.dev/raw/docs/capabilities/official-capabilities.md) plus the chosen Capability page. Use [Capabilities API](https://vitehub.dev/raw/docs/concepts/capabilities-api.md) for lifecycle or authority questions, and [Custom Capabilities](https://vitehub.dev/raw/docs/capabilities/custom-capabilities.md) only when no official Capability fits.
+
+## Authority pass
+
+Every Capability changes what an Agent may observe or do. For each one, name:
+
+- operations exposed to the model;
+- data and secret sources;
+- actor, scope, rate, and policy checks;
+- persistence or external side effects;
+- artifacts or traces available for inspection.
+
+Use official factories before writing a custom Capability. Use `defineCapability()` when the application needs a stable domain-specific boundary, not as a wrapper around an already suitable official tool.
+
+Keep secrets server-side and unseal them only at the documented execution boundary. A Workspace Source does not grant an operation; a Capability should not silently mount unrelated data.
+
+## Proof
+
+Run one allowed operation and one relevant denied or out-of-scope case. Inspect the tool surface, result, trace/artifact, and external effect.

--- a/docs/skills/vitehub/references/channels-triggers.md
+++ b/docs/skills/vitehub/references/channels-triggers.md
@@ -1,0 +1,19 @@
+# Channels and Triggers
+
+Use this for GitHub, Teams, Telegram, Discord, web chat, custom webhooks, message history, admission, concurrency, or delivery effects.
+
+## Select one current page
+
+Open [Channels](https://vitehub.dev/raw/docs/agents/channels.md) for conversation adapters, [Triggers](https://vitehub.dev/raw/docs/agents/triggers.md) for other inbound events, or [Chat history and sessions](https://vitehub.dev/raw/docs/agents/chat-history-sessions.md) for identity and persistence. Open another page only when the first explicitly crosses that boundary.
+
+## Composition
+
+A Channel adapts an external conversation surface; a Trigger admits an external event into an Agent Invocation. Keep webhook verification, actor/admission rules, history/session identity, concurrency, input commands, and delivery behavior explicit.
+
+Use official Channel helpers when the installed contract provides them. Create a custom Trigger only when the external event is not a conversation adapter or the official boundary cannot represent the source.
+
+Treat webhook secrets and installation tokens as server-only Env. Keep generated routes inspectable and document the exact local or deployed URL used for proof.
+
+## Proof
+
+Exercise the generated or custom webhook with a verified event, observe the Agent Invocation, and confirm the expected external delivery or persisted message. A route existing in Provider Output is not proof that admission and delivery work.

--- a/docs/skills/vitehub/references/framework-composition.md
+++ b/docs/skills/vitehub/references/framework-composition.md
@@ -1,0 +1,29 @@
+# Framework composition
+
+Use this for Vite, Nitro, Nuxt, integration ordering, generated types, or deployment configuration.
+
+## Select one current page
+
+Start with [Vite Integrations and Provider Output](https://vitehub.dev/raw/docs/concepts/vite-integrations-and-provider-output.md). Open [Config options](https://vitehub.dev/raw/docs/reference/config-options.md) only for an option mismatch, or the selected page under [Frameworks and hosts](https://vitehub.dev/raw/docs/frameworks-hosts.md) only for a named framework or deployment target.
+
+## Current application contract
+
+Fresh apps install `vite-hub`, register `vitehub()` from the root, and use feature subpaths for runtime APIs. Direct `hubX()` integrations belong to an installed owner-package contract or deliberate advanced composition.
+
+For Vite plus Nitro, keep ordering explicit:
+
+```text
+client/framework plugins
+vitehub(...)
+nitro(...)
+```
+
+For Nuxt, use documented modules or the Vite extension point supported by the installed packages. Do not reproduce app-local aliases or output rewrites from project examples without a source-backed need.
+
+## Generated state
+
+Include `.vitehub/types/**/*.d.ts` when generated names or `#vitehub/*` imports require it. Inspect `.vitehub` during development, but author source Definitions and stable imports rather than generated files.
+
+## Proof
+
+Run prepare/typecheck, build the selected framework, inspect `.vitehub`, and inspect the target's Provider Output. Ordering is proven by generated bindings and a live Runtime Helper or Agent Invocation, not by config shape alone.

--- a/docs/skills/vitehub/references/migration.md
+++ b/docs/skills/vitehub/references/migration.md
@@ -1,0 +1,24 @@
+# Migration quarantine
+
+Use this only when the installed application already uses an older composition generation or the user explicitly asks for migration.
+
+## Identify the generation
+
+| Installed shape | Meaning | Direction |
+| --- | --- | --- |
+| `vite-hub` with feature subpaths | Current application facade | Keep and inspect installed exports |
+| Individual `@vite-hub/*` packages with `hubX()` plugins | Supported owner-package composition | Keep for focused/advanced ownership or migrate application composition to the facade |
+| `@vite-hub/vite` root preset | Former aggregate application preset | Migrate to `vite-hub` when the installed target supports it |
+| `@vitehub/*` | Historical package scope | Do not copy; migrate through current docs and exports |
+
+Read [Migration](https://vitehub.dev/raw/docs/getting-started/migration.md), [Installation](https://vitehub.dev/raw/docs/getting-started/installation.md), and [Import paths](https://vitehub.dev/raw/docs/reference/import-paths.md).
+
+## Migration procedure
+
+1. Record the current package graph, imports, integrations, generated state, and live proof.
+2. Install one coherent target graph and inspect its exports/types.
+3. Replace the composition boundary first, then feature imports one owner at a time.
+4. Remove compatibility aliases and app-local glue whose upstream seam now exists.
+5. Rerun the same live proof after each boundary changes.
+
+Migration is complete when no historical import remains, the lockfile contains one intentional graph, generated state matches the target contract, and the original behavior proof still passes.

--- a/docs/skills/vitehub/references/preview-contract.md
+++ b/docs/skills/vitehub/references/preview-contract.md
@@ -1,0 +1,36 @@
+# Installed and preview contracts
+
+Use this for installation, upgrades, `pkg.pr.new`, missing imports, or dependency graphs that mix package generations.
+
+## Released packages
+
+For a fresh application, read [Installation](https://vitehub.dev/raw/docs/getting-started/installation.md), install `vite-hub`, inspect `node_modules/vite-hub/package.json`, and use the root `vitehub()` integration plus exported feature subpaths. Open [Import paths](https://vitehub.dev/raw/docs/reference/import-paths.md) only when an export is ambiguous or an existing import must migrate.
+
+## Preview packages
+
+Use an immutable full commit SHA. Probe the exact facade tarball before editing:
+
+```bash
+curl -I -L --fail "https://pkg.pr.new/vite-hub/vitehub/vite-hub@<full-sha>"
+```
+
+Install the facade as one coherent graph. Current pnpm versions reject preview tarballs whose dependencies are also tarball URLs unless exotic subdependencies are explicitly allowed:
+
+```bash
+PNPM_CONFIG_BLOCK_EXOTIC_SUBDEPS=false pnpm add "vite-hub@https://pkg.pr.new/vite-hub/vitehub/vite-hub@<full-sha>"
+```
+
+If the application intentionally needs direct owner packages, generate every selected URL from the same full SHA, probe each URL, and install them together. A split-commit graph is a canary-development exception; record why each split is required and prove it separately.
+
+## Contract gate
+
+1. Inspect the installed facade and owner-package `package.json` files, exports, and types.
+2. Confirm every planned import exists in the installed graph.
+3. Search the lockfile for `pkg.pr.new/vite-hub/vitehub` and verify resolved package names and commit keys match the intended graph.
+4. Run the application build before assuming a `200` tarball is compatible.
+
+The gate passes only when tarballs are available, the installed exports support the plan, the lockfile records the intended graph, and the smallest build succeeds.
+
+## Drift rule
+
+Never encode “latest” as a branch alias or copy a preview SHA from another project. Determine the requested commit, use its full SHA, and preserve it in the final report.

--- a/docs/skills/vitehub/references/project-patterns.md
+++ b/docs/skills/vitehub/references/project-patterns.md
@@ -1,0 +1,22 @@
+# Project patterns
+
+Use these as composition evidence after the installed-contract gate. Copy decisions and file relationships, then rederive imports and options from the installed packages and current docs.
+
+| Pattern | Public source | Reusable lesson | Contract warning |
+| --- | --- | --- | --- |
+| Current minimal Server Primitive | [ViteHub tutorial fixture](https://github.com/vite-hub/vitehub/tree/main/fixtures/tutorials/server-primitives) | facade integration, stable Runtime Helper, live persistence proof | Follow the fixture's commit or installed facade exports |
+| Current deterministic Agent | [ViteHub tutorial fixture](https://github.com/vite-hub/vitehub/tree/main/fixtures/tutorials/agents) | smallest offline Driver, Definition, explicit invocation context | Upgrade Driver syntax from installed types |
+| Compact deployed channel Agent | [vite-hub/nuxt-agent](https://github.com/vite-hub/nuxt-agent) | channel, Sources, rate limit, transcription, telemetry, Vercel boundary | Repository may use owner-package plugins rather than the facade |
+| Scheduled coding Agent | [vite-hub/babysitter](https://github.com/vite-hub/babysitter) | schedule ownership, exact-head proof, terminal outcome | Treat GitHub/worktree policy as application-specific |
+| Multi-Agent trusted-host app | [onmax/bitacora-agent](https://github.com/onmax/bitacora-agent) | multiple Definitions, schedules, typed Env, host authority | Owner-package composition and credentials are contract-specific |
+| Server Primitives plus custom Source | [onmax/quiver-airtable](https://github.com/onmax/quiver-airtable) | Nuxt primitives, schedules, custom Workspace Source | Auth aliases and output rewrites are app glue, not ViteHub patterns |
+
+## Card procedure
+
+1. Inspect the source manifest and lockfile commit.
+2. Name the ViteHub package generation: current facade, owner packages, former aggregate preset, or historical scope.
+3. Select one reusable boundary and list the bespoke product policy to exclude.
+4. Rebuild the selected boundary from installed exports/types and current raw docs.
+5. Prove it through the target application's real runtime path.
+
+Do not use historical `@vitehub/*` projects for current syntax.

--- a/docs/skills/vitehub/references/project-patterns.md
+++ b/docs/skills/vitehub/references/project-patterns.md
@@ -7,9 +7,6 @@ Use these as composition evidence after the installed-contract gate. Copy decisi
 | Current minimal Server Primitive | [ViteHub tutorial fixture](https://github.com/vite-hub/vitehub/tree/main/fixtures/tutorials/server-primitives) | facade integration, stable Runtime Helper, live persistence proof | Follow the fixture's commit or installed facade exports |
 | Current deterministic Agent | [ViteHub tutorial fixture](https://github.com/vite-hub/vitehub/tree/main/fixtures/tutorials/agents) | smallest offline Driver, Definition, explicit invocation context | Upgrade Driver syntax from installed types |
 | Compact deployed channel Agent | [vite-hub/nuxt-agent](https://github.com/vite-hub/nuxt-agent) | channel, Sources, rate limit, transcription, telemetry, Vercel boundary | Repository may use owner-package plugins rather than the facade |
-| Scheduled coding Agent | [vite-hub/babysitter](https://github.com/vite-hub/babysitter) | schedule ownership, exact-head proof, terminal outcome | Treat GitHub/worktree policy as application-specific |
-| Multi-Agent trusted-host app | [onmax/bitacora-agent](https://github.com/onmax/bitacora-agent) | multiple Definitions, schedules, typed Env, host authority | Owner-package composition and credentials are contract-specific |
-| Server Primitives plus custom Source | [onmax/quiver-airtable](https://github.com/onmax/quiver-airtable) | Nuxt primitives, schedules, custom Workspace Source | Auth aliases and output rewrites are app glue, not ViteHub patterns |
 
 ## Card procedure
 

--- a/docs/skills/vitehub/references/project-shapes.md
+++ b/docs/skills/vitehub/references/project-shapes.md
@@ -1,0 +1,58 @@
+# Project shapes
+
+Use this when a task creates a project, spans more than one ViteHub feature, or leaves the file layout unclear.
+
+## Inspect first
+
+Read the installed manifest and exports, then open only the guide matching the primary lane. Use File conventions only when discovery layout is unclear:
+
+- [Installation](https://vitehub.dev/raw/docs/getting-started/installation.md)
+- [First Server Primitive](https://vitehub.dev/raw/docs/getting-started/first-server-primitive.md)
+- [First Agent](https://vitehub.dev/raw/docs/getting-started/first-agent.md)
+- [File conventions](https://vitehub.dev/raw/docs/reference/file-conventions.md)
+
+## Coherent shapes
+
+### Server Primitive
+
+```text
+package.json          package, scripts, Node version
+pnpm-lock.yaml        exact resolved contract
+vite.config.ts        ViteHub integration and provider choice
+src/server.ts         application HTTP boundary and Runtime Helper
+```
+
+Add a discovered Definition under `server/` only when the primitive's docs require discovery. The proof must call the Runtime Helper and observe provider-backed behavior.
+
+### Agent application
+
+```text
+package.json
+pnpm-lock.yaml
+vite.config.ts
+server/agents/<name>/agent.ts
+src/server.ts or framework route
+```
+
+Use the folder form when the Agent owns instructions, a Workspace, or Skills. Add Sources, Capabilities, Channels, Boxes, Schedules, and Workflows only when the outcome needs them.
+
+### Scheduled Agent
+
+```text
+server/agents/<name>/agent.ts
+server/schedules/<name>.ts
+```
+
+The Schedule owns wake timing; orchestration invokes the Agent with explicit input, identity, retry/idempotency, and terminal-state behavior.
+
+### Full-stack application
+
+Keep client framework plugins first, ViteHub composition next, and the host integration last. Client code calls an application route; server code owns Runtime Helpers, Agent Invocations, secrets, and provider bindings.
+
+## Boundary pass
+
+For every shape, state whether persistence is ephemeral or durable, which external authority exists, which host runs the code, how failures retry, and what the user can observe. A local demo may answer “ephemeral, local, no external authority,” but it must answer.
+
+## Proof
+
+The shape is complete when every requested behavior has a source file and runtime path, the build succeeds, and one live request or invocation observes the intended state change.

--- a/docs/skills/vitehub/references/proof-recovery.md
+++ b/docs/skills/vitehub/references/proof-recovery.md
@@ -1,0 +1,29 @@
+# Proof and recovery
+
+Use this when code compiles but behavior is unproven, or when imports, discovery, runtime bindings, host output, or deployment fail.
+
+## Select the failing boundary
+
+Use [Verification](https://vitehub.dev/raw/docs/development/verification.md) to choose the proof, [Generated files](https://vitehub.dev/raw/docs/development/generated-files.md) for discovery/binding state, [Errors and diagnostics](https://vitehub.dev/raw/docs/reference/errors-diagnostics.md) for a surfaced ViteHub error, or [Troubleshooting](https://vitehub.dev/raw/docs/development/troubleshooting.md) when the failure does not yet have a boundary. Open one first.
+
+## Recovery loop
+
+1. Reproduce the narrow failing command or request.
+2. Inspect installed exports/types for import or option failures.
+3. Inspect `.vitehub` registries, generated declarations, and diagnostics for discovery or binding failures.
+4. Inspect Provider Output for host failures.
+5. Correct the source boundary and rerun the same proof.
+
+Do not add compatibility glue until the installed contract and current docs prove the missing seam is application-owned. Report upstream gaps with the exact package version, docs URL, generated state, and failing observation.
+
+## Proof matrix
+
+| Lane | Required observation |
+| --- | --- |
+| Server Primitive | Vite Integration registered, Runtime Helper executed, provider effect observed |
+| Agent | Driver prerequisites met, Agent Invocation executed, output and authority inspected |
+| Channel or Trigger | verified event admitted, invocation observed, delivery or persisted message observed |
+| Schedule or Workflow | due/run identity observed, steps executed, retry/terminal state verified |
+| Host | build emitted documented Provider Output and live limitation or behavior was checked |
+
+Completion requires every requested behavior to have an observation or a source-backed unsupported boundary.

--- a/docs/skills/vitehub/references/schedules-workflows-invocations.md
+++ b/docs/skills/vitehub/references/schedules-workflows-invocations.md
@@ -1,0 +1,25 @@
+# Schedules, Workflows, and Agent Invocations
+
+Use this for wake timing, durable orchestration, Agent Invocation context, retries, idempotency, timeouts, or terminal-state persistence.
+
+## Select one current page
+
+Open [Schedule](https://vitehub.dev/raw/docs/server-primitives/schedule.md) for wake timing or [Workflows](https://vitehub.dev/raw/docs/server-primitives/workflows.md) for durable multi-step orchestration. Agent Invocation syntax belongs to [Agent Definitions and Drivers](agent-definitions.md); do not load this reference for a direct invocation alone.
+
+## Ownership
+
+Schedules own when work becomes due. Workflows own durable multi-step orchestration. Agent Definitions own agent behavior. Application routes or orchestration code own the explicit call between them.
+
+Keep discovered files separate:
+
+```text
+server/agents/<name>/agent.ts
+server/schedules/<name>.ts
+server/workflows/<name>/index.ts
+```
+
+Pass stable run identity, actor/context, input, wait-until behavior, timeouts, and persistence explicitly where the installed helper requires them. Design retries around idempotent steps or a durable completion fingerprint; never treat “started” as terminal success.
+
+## Proof
+
+Invoke the Agent directly first. Then exercise the Schedule or Workflow path, observe step/invocation identity, retry behavior, and terminal state. For provider-backed wakeups or workflows, inspect the target Provider Output and one live execution.

--- a/docs/skills/vitehub/references/server-primitives.md
+++ b/docs/skills/vitehub/references/server-primitives.md
@@ -1,0 +1,31 @@
+# Server Primitives
+
+Use this for application-owned storage, scheduling, environment, messaging, execution, or infrastructure behavior that does not need model judgment.
+
+## Choose the primitive
+
+When the primitive is known, open only its raw docs page, such as `https://vitehub.dev/raw/docs/server-primitives/kv.md`. Use the [Server Primitives index](https://vitehub.dev/raw/docs/server-primitives.md) only when choosing between primitives. Confirm the selected primitive's Vite Integration, optional Definition, Runtime Helper, local driver, and host support.
+
+Common composition:
+
+```text
+vite.config.ts           provider and integration
+server/<definitions>/    named discovered configuration when required
+application server code stable Runtime Helper calls
+.vitehub/                generated registry and diagnostics
+provider output          deployment artifact when applicable
+```
+
+With the current facade, register `vitehub()` from `vite-hub` and import application APIs from feature subpaths such as `vite-hub/kv` or `vite-hub/blob`. Validate those paths against installed exports before coding.
+
+## Authority
+
+Runtime Helpers called by application code keep authority in the application. If an Agent needs the same behavior, grant the narrow Capability documented for that feature; do not make every application primitive an Agent tool.
+
+## Provider boundary
+
+Keep provider selection in Vite config or the documented Definition. Application code should remain on stable Runtime Helpers when moving from a local driver to a hosted provider.
+
+## Proof
+
+Register the integration, execute the Runtime Helper, and observe the expected provider effect. For persistence, restart the process and read the value again. For a hosted target, also inspect the documented Provider Output.

--- a/docs/skills/vitehub/references/workspaces-sources-access.md
+++ b/docs/skills/vitehub/references/workspaces-sources-access.md
@@ -1,0 +1,21 @@
+# Workspaces, Sources, and access
+
+Use this when an Agent or application needs files, repository content, external resources, lazy materialization, scoped selection, or write-back.
+
+## Select current pages
+
+Start with [Workspaces and Sources](https://vitehub.dev/raw/docs/concepts/workspace-and-sources.md). Open [Workspace context](https://vitehub.dev/raw/docs/agents/workspace-context.md) for Agent materialization, or [Access Capability](https://vitehub.dev/raw/docs/capabilities/access.md) when an Agent selects or narrows Sources.
+
+## Compose the boundary
+
+Definitions describe the Workspace; Sources resolve content; access rules select what an invocation may receive; Workspace rules and mode decide whether changes can write back. Mounted data is context, not automatically Agent authority.
+
+Prefer colocated Workspace files for static Agent-owned context. Use file, glob, GitHub, fetch, MCP-resource, or custom Sources when content has a different lifecycle. Keep dynamic shaping in Source resolution and authorization in access/Workspace rules.
+
+## Inspectability
+
+Before invoking, name the expected Workspace paths, Source identities, selection scope, read/write mode, and ignored write-back paths. Inspect the resolved Workspace or generated source descriptors rather than assuming a Source mounted correctly.
+
+## Proof
+
+Read a selected file through the actual Workspace path. For write mode, modify one allowed path and verify the configured write-back while proving disallowed paths stay unchanged.

--- a/docs/test/agent-resources.test.ts
+++ b/docs/test/agent-resources.test.ts
@@ -28,6 +28,19 @@ describe("public ViteHub skill", () => {
     expect(listFiles(skillRoot).map(path => relative(skillRoot, path))).toEqual([
       "SKILL.md",
       "agents/openai.yaml",
+      "references/agent-definitions.md",
+      "references/boxes-hosts.md",
+      "references/capabilities-authority.md",
+      "references/channels-triggers.md",
+      "references/framework-composition.md",
+      "references/migration.md",
+      "references/preview-contract.md",
+      "references/project-patterns.md",
+      "references/project-shapes.md",
+      "references/proof-recovery.md",
+      "references/schedules-workflows-invocations.md",
+      "references/server-primitives.md",
+      "references/workspaces-sources-access.md",
     ]);
 
     const skill = readFileSync(resolve(skillRoot, "SKILL.md"), "utf8");
@@ -39,21 +52,36 @@ describe("public ViteHub skill", () => {
 
     const openai = readFileSync(resolve(skillRoot, "agents/openai.yaml"), "utf8");
     expect(openai).toContain("Use $vitehub");
-    expect(openai).toContain("live docs and installed contract");
+    expect(openai).toContain("live docs and the installed contract");
   });
 
-  it("routes through one lane, the installed contract, recovery, and proof", () => {
+  it("routes through references, the installed contract, a coherent build, and proof", () => {
     const skill = readFileSync(resolve(skillRoot, "SKILL.md"), "utf8");
 
     expect(skill).toContain("## 1. Orient");
-    expect(skill).toContain("## 2. Choose One Lane");
-    expect(skill).toContain("## 3. Inspect The Installed Contract");
-    expect(skill).toContain("## 4. Act");
-    expect(skill).toContain("## 5. Recover");
-    expect(skill).toContain("## 6. Prove");
-    expect(skill).toContain("Vite Integration is registered, its Runtime Helper executes, and the observed output matches the expected output");
-    expect(skill).toContain("Agent Invocation returns or streams the expected result, the Agent Driver prerequisites are satisfied, and granted authority is inspectable");
-    expect(skill).toContain("build emits the documented Provider Output and every target limitation is explicit");
+    expect(skill).toContain("## 2. Route before code");
+    expect(skill).toContain("## 3. Inspect the installed contract");
+    expect(skill).toContain("## 4. Build the coherent file set");
+    expect(skill).toContain("## 5. Prove and repair");
+    expect(skill).toContain("Package owner | Source file | Runtime path | Authority or persistence | Proof");
+    expect(skill).toContain("every behavior row has an observed result, or a precise source-backed unsupported boundary");
+  });
+
+  it("publishes every directly routed reference", () => {
+    const skill = readFileSync(resolve(skillRoot, "SKILL.md"), "utf8");
+    const referencesRoot = resolve(skillRoot, "references");
+    const references = listFiles(referencesRoot).map(path => relative(referencesRoot, path));
+
+    expect(references.length).toBeGreaterThan(10);
+    for (const reference of references) {
+      expect(skill).toContain(`references/${reference}`);
+    }
+
+    const localLinks = [...new Set([...skill.matchAll(/\]\((references\/[^)]+)\)/g)].map(match => match[1]))];
+    expect(localLinks).toHaveLength(references.length);
+    for (const localLink of localLinks) {
+      expect(existsSync(resolve(skillRoot, localLink)), localLink).toBe(true);
+    }
   });
 
   it("keeps published agent resources free of private filesystem paths", () => {
@@ -73,7 +101,9 @@ describe("public ViteHub skill", () => {
     expect(urls.length).toBeGreaterThan(0);
     for (const rawPath of urls) {
       expect(rawPath).not.toMatch(/(?:^|\/)index\.md$/);
-      expect(existsSync(resolve(contentRoot, rawPath)), rawPath).toBe(true);
+      const directPath = resolve(contentRoot, rawPath);
+      const sectionIndexPath = resolve(contentRoot, rawPath.replace(/\.md$/, "/index.md"));
+      expect(existsSync(directPath) || existsSync(sectionIndexPath), rawPath).toBe(true);
     }
   });
 });


### PR DESCRIPTION
Turns the public ViteHub skill into one compact project-building proof loop with 13 progressively disclosed references for project shape, package contracts, primitives, Agents, authority, orchestration, hosts, recovery, and migration. The router keeps exact syntax subordinate to installed exports/types and current raw docs, while the preview guide captures the reproducible `pkg.pr.new` gate.

Updates the public installation guidance and locks the artifact with tests requiring every routed reference to ship and every raw docs target to resolve. The controlled subagent benchmark showed better preview setup and narrower routing after refinement, but both build runs stalled during dependency installation, so it does not claim one-shot runtime uplift.