### PR TITLE
refactor(vite-hub): derive distribution build catalogs

### DIFF
--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -32,26 +32,8 @@ import type { WorkflowModuleOptions } from "@vite-hub/workflow"
 import type { WorkspaceModuleOptions } from "@vite-hub/workspace"
 import type { Plugin, PluginOption } from "vite"
 
-const frameworkDependencyNames = [
-  "@vite-hub/agent",
-  "@vite-hub/auth",
-  "@vite-hub/blob",
-  "@vite-hub/box",
-  "@vite-hub/database",
-  "@vite-hub/devtools",
-  "@vite-hub/email",
-  "@vite-hub/env",
-  "@vite-hub/kv",
-  "@vite-hub/markdown-template",
-  "@vite-hub/queue",
-  "@vite-hub/runtime",
-  "@vite-hub/sandbox",
-  "@vite-hub/schedule",
-  "@vite-hub/shell",
-  "@vite-hub/source",
-  "@vite-hub/workflow",
-  "@vite-hub/workspace",
-] as const
+const frameworkDependencyNames = Object.keys(frameworkPackageManifest.dependencies)
+  .filter(name => name.startsWith("@vite-hub/") && name !== "@vite-hub/cli")
 
 const frameworkVirtualImporters = new Set([
   "\0#vitehub/auth/server",

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -32,8 +32,33 @@ import type { WorkflowModuleOptions } from "@vite-hub/workflow"
 import type { WorkspaceModuleOptions } from "@vite-hub/workspace"
 import type { Plugin, PluginOption } from "vite"
 
-const frameworkDependencyNames = Object.keys(frameworkPackageManifest.dependencies)
-  .filter(name => name.startsWith("@vite-hub/") && name !== "@vite-hub/cli")
+type FrameworkDependencyName = Extract<keyof typeof frameworkPackageManifest.dependencies, `@vite-hub/${string}`>
+
+const generatedOwnerPackageAccess = {
+  "@vite-hub/agent": true,
+  "@vite-hub/auth": true,
+  "@vite-hub/blob": true,
+  "@vite-hub/box": true,
+  "@vite-hub/cli": false,
+  "@vite-hub/database": true,
+  "@vite-hub/devtools": true,
+  "@vite-hub/email": true,
+  "@vite-hub/env": true,
+  "@vite-hub/kv": true,
+  "@vite-hub/markdown-template": true,
+  "@vite-hub/queue": true,
+  "@vite-hub/runtime": true,
+  "@vite-hub/sandbox": true,
+  "@vite-hub/schedule": true,
+  "@vite-hub/shell": true,
+  "@vite-hub/source": true,
+  "@vite-hub/workflow": true,
+  "@vite-hub/workspace": true,
+} satisfies Record<FrameworkDependencyName, boolean>
+
+const generatedOwnerPackageNames = Object.entries(generatedOwnerPackageAccess)
+  .filter(([, allowed]) => allowed)
+  .map(([name]) => name)
 
 const frameworkVirtualImporters = new Set([
   "\0#vitehub/auth/server",
@@ -114,7 +139,7 @@ function frameworkDependencyResolver(
     resolveId(id, importer) {
       if (!isGeneratedImporter(importer)) return
       const isFrameworkPackageImport = id === frameworkPackageName || id.startsWith(`${frameworkPackageName}/`)
-      const isOwnerPackageImport = frameworkDependencyNames.some(name => id === name || id.startsWith(`${name}/`))
+      const isOwnerPackageImport = generatedOwnerPackageNames.some(name => id === name || id.startsWith(`${name}/`))
       if (!isFrameworkPackageImport && !isOwnerPackageImport) return
       return fileURLToPath(import.meta.resolve(id))
     },

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -10,6 +10,7 @@ import * as framework from "vite-hub"
 import * as frameworkAgent from "vite-hub/agent"
 import * as frameworkCapabilities from "vite-hub/agent/capabilities"
 import frameworkAuthHandler from "vite-hub/auth/server"
+import { distributionBinEntries, distributionEntriesFromManifest } from "../vite.config.ts"
 
 const packageRoot = fileURLToPath(new URL("..", import.meta.url))
 const manifest = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
@@ -43,5 +44,33 @@ describe("framework package contract", () => {
     }
 
     expect(readFileSync(`${packageRoot}/${manifest.bin.vitehub}`, "utf8")).toMatch(/^#!\/usr\/bin\/env node/)
+  })
+
+  it("derives deduplicated binary entries from the package manifest", () => {
+    expect(distributionBinEntries).toEqual({
+      "vite-hub": "src/bin.ts",
+      vitehub: "src/bin.ts",
+    })
+    expect(distributionEntriesFromManifest(manifest.bin)).toEqual(["src/bin.ts"])
+  })
+
+  it("normalizes conditional export leaves into unique runtime entries", () => {
+    expect(distributionEntriesFromManifest({
+      ".": {
+        import: {
+          default: "./dist/index.js",
+          node: "./dist/index.js",
+        },
+        types: "./dist/index.d.ts",
+      },
+      "./feature": [
+        { types: "./dist/feature.d.ts" },
+        { import: "./dist/feature.js" },
+      ],
+      "./package.json": "./package.json",
+    })).toEqual([
+      "src/feature.ts",
+      "src/index.ts",
+    ])
   })
 })

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -217,6 +217,7 @@ describe("vitehub", () => {
     expect(await resolveId.call({} as never, "@vite-hub/agent", "\0virtual:third-party", {} as never)).toBeUndefined()
     expect(await resolveId.call({} as never, "@vite-hub/agent", "/app/.vitehub-other/agent.ts", {} as never)).toBeUndefined()
     expect(await resolveId.call({} as never, "@vite-hub/agent", "\0#vitehub/custom", {} as never)).toBeUndefined()
+    expect(await resolveId.call({} as never, "@vite-hub/cli", "\0#vitehub/templates", {} as never)).toBeUndefined()
     expect(await resolveId.call({} as never, "@vite-hub/workspace/runtime", "\0#vitehub-workspace-registry", {} as never)).toBeUndefined()
     expect(await resolveId.call({} as never, "@chat-adapter/discord", "/app/.vitehub/agent/route.ts", {} as never)).toBeUndefined()
     expect(await resolveId.call({} as never, "@vite-hub/agent/server", "/app/.vitehub/agent/route.ts", {} as never))

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url"
+
 import { describe, expect, it, vi } from "vitest"
 
 const integrationMocks = vi.hoisted(() => ({
@@ -40,7 +42,13 @@ vi.mock("@vite-hub/workspace/vite", () => ({ hubWorkspace: integrationMocks.hubW
 
 import type { KVModuleOptions } from "@vite-hub/kv"
 import type { Plugin, PluginOption } from "vite"
+import frameworkPackageManifest from "../package.json" with { type: "json" }
 import { vitehub } from "../src/index.ts"
+
+const deniedGeneratedOwnerPackageNames = new Set(["@vite-hub/cli"])
+const generatedOwnerPackageCases = Object.keys(frameworkPackageManifest.dependencies)
+  .filter(name => name.startsWith("@vite-hub/"))
+  .map(name => [name, deniedGeneratedOwnerPackageNames.has(name) ? "deny" : "resolve"] as const)
 
 function pluginNames(plugins: PluginOption[]): string[] {
   return plugins.map(plugin => (plugin as Plugin).name)
@@ -217,7 +225,6 @@ describe("vitehub", () => {
     expect(await resolveId.call({} as never, "@vite-hub/agent", "\0virtual:third-party", {} as never)).toBeUndefined()
     expect(await resolveId.call({} as never, "@vite-hub/agent", "/app/.vitehub-other/agent.ts", {} as never)).toBeUndefined()
     expect(await resolveId.call({} as never, "@vite-hub/agent", "\0#vitehub/custom", {} as never)).toBeUndefined()
-    expect(await resolveId.call({} as never, "@vite-hub/cli", "\0#vitehub/templates", {} as never)).toBeUndefined()
     expect(await resolveId.call({} as never, "@vite-hub/workspace/runtime", "\0#vitehub-workspace-registry", {} as never)).toBeUndefined()
     expect(await resolveId.call({} as never, "@chat-adapter/discord", "/app/.vitehub/agent/route.ts", {} as never)).toBeUndefined()
     expect(await resolveId.call({} as never, "@vite-hub/agent/server", "/app/.vitehub/agent/route.ts", {} as never))
@@ -260,6 +267,12 @@ describe("vitehub", () => {
       "/app/.vitehub/nitro/blob/plugin.ts",
       {} as never,
     )).toMatch(/\/vite-hub\/dist\/_internal\/blob\/runtime\/state\.js$/)
+  })
+
+  it.each(generatedOwnerPackageCases)("classifies generated import %s as %s", async (name, access) => {
+    const resolved = await dependencyResolver().call({} as never, name, "\0#vitehub/templates", {} as never)
+    if (access === "deny") expect(resolved).toBeUndefined()
+    else expect(resolved).toBe(fileURLToPath(import.meta.resolve(name)))
   })
 
   it("keeps third-party driver fallbacks out of the global alias map", async () => {

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -2,14 +2,33 @@ import { defineConfig } from "vite-plus"
 
 import frameworkPackageManifest from "./package.json" with { type: "json" }
 
-const distributionEntries = [...new Set(
-  [
-    ...Object.values(frameworkPackageManifest.exports),
-    ...Object.values(frameworkPackageManifest.bin),
-  ]
-    .filter(target => target.startsWith("./dist/"))
-    .map(target => target.replace(/^\.\/dist\//, "src/").replace(/\.js$/, ".ts")),
-)].sort()
+function manifestStringLeaves(value: unknown): string[] {
+  if (typeof value === "string") return [value]
+  if (Array.isArray(value)) return value.flatMap(manifestStringLeaves)
+  if (!value || typeof value !== "object") return []
+  return Object.values(value).flatMap(manifestStringLeaves)
+}
+
+export function distributionEntriesFromManifest(value: unknown): string[] {
+  return [...new Set(
+    manifestStringLeaves(value)
+      .filter(target => target.startsWith("./dist/") && target.endsWith(".js"))
+      .map(target => target.replace(/^\.\/dist\//, "src/").replace(/\.js$/, ".ts")),
+  )].sort()
+}
+
+export const distributionBinEntries = Object.fromEntries(
+  Object.entries(frameworkPackageManifest.bin).map(([name, target]) => {
+    const [entry] = distributionEntriesFromManifest(target)
+    if (!entry) throw new TypeError(`Unsupported ViteHub binary target: ${target}`)
+    return [name, entry]
+  }),
+)
+
+const distributionEntries = distributionEntriesFromManifest([
+  frameworkPackageManifest.exports,
+  frameworkPackageManifest.bin,
+])
 
 export default defineConfig({
   pack: {
@@ -28,10 +47,7 @@ export default defineConfig({
     entry: distributionEntries,
     exports: {
       exclude: ["bin"],
-      bin: {
-        "vite-hub": "src/bin.ts",
-        vitehub: "src/bin.ts",
-      },
+      bin: distributionBinEntries,
       inlinedDependencies: false,
     },
     outExtensions: () => ({

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -1,5 +1,16 @@
 import { defineConfig } from "vite-plus"
 
+import frameworkPackageManifest from "./package.json" with { type: "json" }
+
+const distributionEntries = [...new Set(
+  [
+    ...Object.values(frameworkPackageManifest.exports),
+    ...Object.values(frameworkPackageManifest.bin),
+  ]
+    .filter(target => target.startsWith("./dist/"))
+    .map(target => target.replace(/^\.\/dist\//, "src/").replace(/\.js$/, ".ts")),
+)].sort()
+
 export default defineConfig({
   pack: {
     tsconfig: "tsconfig.build.json",
@@ -14,65 +25,7 @@ export default defineConfig({
         if (chunk?.type === "chunk") chunk.code = `import "@vite-hub/env/vite";\n${chunk.code}`
       },
     }],
-    entry: [
-      "src/_internal/agent.ts",
-      "src/_internal/agent/cloudflare.ts",
-      "src/_internal/agent/cloudflare/state.ts",
-      "src/_internal/agent/runtime/workflow.ts",
-      "src/_internal/agent/server.ts",
-      "src/_internal/agent/server/internal.ts",
-      "src/_internal/agent/server/workspace.ts",
-      "src/_internal/agent/state/sqlite.ts",
-      "src/_internal/blob.ts",
-      "src/_internal/blob/runtime/state.ts",
-      "src/_internal/kv.ts",
-      "src/_internal/kv/runtime/disabled-upstash.ts",
-      "src/_internal/markdown-template.ts",
-      "src/_internal/schedule.ts",
-      "src/_internal/schedule/runtime.ts",
-      "src/_internal/schedule/runtime/driver.ts",
-      "src/_internal/schedule/runtime/process.ts",
-      "src/_internal/schedule/runtime/static.ts",
-      "src/_internal/sandbox/runtime/state.ts",
-      "src/_internal/workflow.ts",
-      "src/_internal/workflow/runtime/execute.ts",
-      "src/_internal/workflow/runtime/state.ts",
-      "src/_internal/workspace.ts",
-      "src/_internal/workspace/internal/runtime/hosted.ts",
-      "src/_internal/workspace/internal/runtime/hosted-vercel-blob.ts",
-      "src/_internal/workspace/runtime.ts",
-      "src/agent.ts",
-      "src/agent/capabilities.ts",
-      "src/agent/channels.ts",
-      "src/auth.ts",
-      "src/auth/server.ts",
-      "src/bin.ts",
-      "src/blob.ts",
-      "src/box.ts",
-      "src/database.ts",
-      "src/database/drizzle.ts",
-      "src/email.ts",
-      "src/email/markdown.ts",
-      "src/email/server.ts",
-      "src/env.ts",
-      "src/env/presets.ts",
-      "src/env/schema.ts",
-      "src/env/secret.ts",
-      "src/env/server.ts",
-      "src/index.ts",
-      "src/kv.ts",
-      "src/queue.ts",
-      "src/runtime.ts",
-      "src/sandbox.ts",
-      "src/schedule.ts",
-      "src/schedule/runtime.ts",
-      "src/shell.ts",
-      "src/shell/workspace.ts",
-      "src/source.ts",
-      "src/workflow.ts",
-      "src/workspace.ts",
-      "src/workspace/runtime.ts",
-    ],
+    entry: distributionEntries,
     exports: {
       exclude: ["bin"],
       bin: {


### PR DESCRIPTION
Derives vite-hub build entries, binary aliases, and generated owner-package authorization from existing package metadata, removing hand-maintained pack and resolver lists while preserving all 57 export keys, 114 emitted artifacts, both CLI names, and 18 allowed owner packages.

The resolver policy is fail-closed: every current @vite-hub dependency is explicitly allowed or denied, with @vite-hub/cli kept unavailable to generated importers. Conditional export objects, arrays, and shared binary targets are handled without changing manifests, forwarders, public subpaths, or @vite-hub/vite compatibility. Forwarder ownership remains a separate follow-up.