### PR TITLE
refactor(internal): centralize provider output preservation

### DIFF
--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -9,7 +9,7 @@ import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
 import { normalizeBlobOptions } from "../config.ts"
 
 import type { BlobModuleOptions, ResolvedBlobModuleOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
-import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, ProviderJsonRecord, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
+import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const blobPackageName = "@vite-hub/blob"
 const productName = "blob"
@@ -55,7 +55,7 @@ interface GeneratedBlobArtifacts {
   vercelServerFile: string
 }
 
-interface CloudflareBlobConfig extends ProviderJsonRecord {
+interface CloudflareBlobConfig {
   assets?: { directory?: string, run_worker_first: string[] }
   compatibility_date: string
   compatibility_flags: string[]

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -9,7 +9,7 @@ import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
 import { normalizeBlobOptions } from "../config.ts"
 
 import type { BlobModuleOptions, ResolvedBlobModuleOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
-import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
+import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, ProviderJsonRecord, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const blobPackageName = "@vite-hub/blob"
 const productName = "blob"
@@ -55,7 +55,7 @@ interface GeneratedBlobArtifacts {
   vercelServerFile: string
 }
 
-interface CloudflareBlobConfig {
+interface CloudflareBlobConfig extends ProviderJsonRecord {
   assets?: { directory?: string, run_worker_first: string[] }
   compatibility_date: string
   compatibility_flags: string[]
@@ -371,7 +371,7 @@ function createVercelOutput(
       format: "esm",
       platform: "node",
     },
-    serverFunctionName,
+    ...(serverFunctionName ? { function: { kind: "isolated" as const, name: serverFunctionName } } : {}),
   }
 }
 

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -371,7 +371,7 @@ function createVercelOutput(
       format: "esm",
       platform: "node",
     },
-    ...(serverFunctionName ? { config: {}, serverFunctionName } : {}),
+    serverFunctionName,
   }
 }
 

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -249,7 +249,7 @@ function createVercelOutput({ artifacts, providerOutput, runtimeConfig, serverFu
       format: "esm",
       platform: "node",
     },
-    ...(serverFunctionName ? { config: {}, serverFunctionName } : {}),
+    serverFunctionName,
   }
 }
 

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -13,7 +13,7 @@ import { renderDatabaseConfigExpression } from "./runtime-config-expression.ts"
 
 import type { ProvisionState } from "@vite-hub/internal/provision"
 import type { DatabaseConfigValue, ResolvedDBViteConfig } from "../types.ts"
-import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, ProviderJsonRecord, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
+import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const dbPackageName = "@vite-hub/database"
 const productName = "database"
@@ -50,7 +50,7 @@ interface GeneratedDBArtifacts {
   vercelServerFile: string
 }
 
-interface CloudflareDBConfig extends ProviderJsonRecord {
+interface CloudflareDBConfig {
   assets?: { directory?: string, run_worker_first: string[] }
   compatibility_date: string
   compatibility_flags: string[]

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -13,7 +13,7 @@ import { renderDatabaseConfigExpression } from "./runtime-config-expression.ts"
 
 import type { ProvisionState } from "@vite-hub/internal/provision"
 import type { DatabaseConfigValue, ResolvedDBViteConfig } from "../types.ts"
-import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
+import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, ProviderJsonRecord, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const dbPackageName = "@vite-hub/database"
 const productName = "database"
@@ -50,7 +50,7 @@ interface GeneratedDBArtifacts {
   vercelServerFile: string
 }
 
-interface CloudflareDBConfig {
+interface CloudflareDBConfig extends ProviderJsonRecord {
   assets?: { directory?: string, run_worker_first: string[] }
   compatibility_date: string
   compatibility_flags: string[]
@@ -249,7 +249,7 @@ function createVercelOutput({ artifacts, providerOutput, runtimeConfig, serverFu
       format: "esm",
       platform: "node",
     },
-    serverFunctionName,
+    ...(serverFunctionName ? { function: { kind: "isolated" as const, name: serverFunctionName } } : {}),
   }
 }
 
@@ -296,7 +296,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
           .some(([product, modules]) => product !== productName && Boolean(modules?.cloudflare))
         return {
           ...(!hasOtherCloudflareOutput ? { fileNames: ["index.js"] } : {}),
-          wranglerConfigKeys: ["d1_databases"],
+          wranglerConfigOwnership: { keys: ["d1_databases"] },
         }
       },
     },

--- a/packages/internal/src/build/cloudflare.ts
+++ b/packages/internal/src/build/cloudflare.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir } from "node:fs/promises"
 import { resolve } from "node:path"
 
+import { cleanProviderOutputConfig, writeProviderOutputConfig } from "./provider-output-config.ts"
 import { toSafeAppName } from "./user-entry.ts"
 
 export const defaultCloudflareCompatibilityDate = "2026-04-20"
@@ -18,129 +19,27 @@ export function createDefaultCloudflareOutputRoot(rootDir: string): string {
   return resolve(rootDir, "dist", toSafeAppName(rootDir))
 }
 
-function isJsonObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-}
-
-async function readJsonObject(file: string): Promise<Record<string, unknown>> {
-  try {
-    const parsed = JSON.parse(await readFile(file, "utf8"))
-    return isJsonObject(parsed) ? parsed : {}
-  }
-  catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {}
-    throw error
-  }
-}
-
-function deleteJsonObjectKeys(value: Record<string, unknown>, keys: string[] | undefined): Record<string, unknown> {
-  if (!keys?.length) return value
-  const next = { ...value }
-  for (const key of keys) {
-    delete next[key]
-  }
-  return next
-}
-
-function mergeJsonObjectArrays(
-  existing: Record<string, unknown>,
-  value: Record<string, unknown>,
-  arrayMergeKeys: Record<string, string> | undefined,
-  arrayOwnedValues: Record<string, unknown[]> | undefined,
-): Record<string, unknown> {
-  if (!arrayMergeKeys) return value
-  const next = { ...value }
-  for (const [field, key] of Object.entries(arrayMergeKeys)) {
-    const current = existing[field]
-    const incoming = value[field]
-    const currentArray = Array.isArray(current) ? current : []
-    const incomingArray = Array.isArray(incoming) ? incoming : []
-    const ownedValues = new Set(arrayOwnedValues?.[field] ?? [])
-    if (!currentArray.length && !incomingArray.length) continue
-
-    const incomingKeys = new Set<unknown>()
-    for (const item of incomingArray) {
-      if (isJsonObject(item) && item[key] !== undefined) incomingKeys.add(item[key])
-    }
-    const removedKeys = new Set([...ownedValues, ...incomingKeys])
-    const merged = [
-      ...currentArray.filter(item => !isJsonObject(item) || !removedKeys.has(item[key])),
-      ...incomingArray,
-    ]
-    if (!merged.length) {
-      delete next[field]
-      continue
-    }
-    next[field] = merged
-  }
-  return next
-}
-
-async function writeMergedJsonObject(
-  file: string,
-  value: object,
-  ownedKeys?: string[],
-  arrayMergeKeys?: Record<string, string>,
-  arrayOwnedValues?: Record<string, unknown[]>,
-): Promise<void> {
-  const existing = await readJsonObject(file)
-  const ownedTopLevelKeys = [...(ownedKeys ?? []), ...Object.keys(arrayMergeKeys ?? {})]
-  const next = {
-    ...deleteJsonObjectKeys(existing, ownedTopLevelKeys),
-    ...mergeJsonObjectArrays(existing, value as Record<string, unknown>, arrayMergeKeys, arrayOwnedValues),
-  }
-  if (!Object.keys(next).length) {
-    await rm(file, { force: true })
-    return
-  }
-  await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
-}
-
-async function deleteJsonObjectKeysFromFile(file: string, keys: string[] | undefined): Promise<void> {
-  if (!keys?.length) return
-  let existing: Record<string, unknown>
-  try {
-    const parsed = JSON.parse(await readFile(file, "utf8"))
-    existing = isJsonObject(parsed) ? parsed : {}
-  }
-  catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
-    throw error
-  }
-  const next = { ...existing }
-  let changed = false
-  for (const key of keys) {
-    if (key in next) {
-      delete next[key]
-      changed = true
-    }
-  }
-  if (!changed) return
-  if (!Object.keys(next).length) {
-    await rm(file, { force: true })
-    return
-  }
-  await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
+function createConfigOwnership(options: CloudflareWranglerConfigOptions) {
+  const arrays = Object.fromEntries(Object.entries(options.wranglerArrayMergeKeys ?? {}).map(([field, key]) => [field, {
+    key,
+    values: options.wranglerArrayOwnedValues?.[field],
+  }]))
+  return { arrays, keys: options.wranglerConfigKeys }
 }
 
 export async function writeCloudflareWranglerConfig(options: CloudflareWranglerConfigOptions): Promise<void> {
   const outputRoot = options.outputRoot ?? createDefaultCloudflareOutputRoot(options.rootDir)
   const configFile = resolve(outputRoot, "wrangler.json")
   if (!options.wranglerConfig) {
-    if (options.wranglerArrayOwnedValues && options.wranglerArrayMergeKeys) {
-      await writeMergedJsonObject(configFile, {}, options.wranglerConfigKeys, options.wranglerArrayMergeKeys, options.wranglerArrayOwnedValues)
-      return
-    }
-    await deleteJsonObjectKeysFromFile(configFile, options.wranglerConfigKeys)
+    await cleanProviderOutputConfig(configFile, createConfigOwnership(options))
     return
   }
 
   await mkdir(outputRoot, { recursive: true })
-  await writeMergedJsonObject(
+  await writeProviderOutputConfig(
     configFile,
     options.wranglerConfig,
-    options.wranglerConfigKeys,
-    options.wranglerArrayMergeKeys,
-    options.wranglerArrayOwnedValues,
+    createConfigOwnership(options),
+    { removeIfEmpty: true },
   )
 }

--- a/packages/internal/src/build/cloudflare.ts
+++ b/packages/internal/src/build/cloudflare.ts
@@ -4,14 +4,14 @@ import { resolve } from "node:path"
 import { cleanProviderOutputConfig, writeProviderOutputConfig } from "./provider-output-config.ts"
 import { toSafeAppName } from "./user-entry.ts"
 
-import type { ProviderJsonRecord, ProviderOutputConfigOwnership } from "./provider-output-config.ts"
+import type { ProviderOutputConfigOwnership } from "./provider-output-config.ts"
 
 export const defaultCloudflareCompatibilityDate = "2026-04-20"
 
 interface CloudflareWranglerConfigOptions {
   outputRoot?: string
   rootDir: string
-  wranglerConfig?: ProviderJsonRecord
+  wranglerConfig?: object
   wranglerConfigOwnership?: ProviderOutputConfigOwnership
 }
 

--- a/packages/internal/src/build/cloudflare.ts
+++ b/packages/internal/src/build/cloudflare.ts
@@ -4,34 +4,26 @@ import { resolve } from "node:path"
 import { cleanProviderOutputConfig, writeProviderOutputConfig } from "./provider-output-config.ts"
 import { toSafeAppName } from "./user-entry.ts"
 
+import type { ProviderJsonRecord, ProviderOutputConfigOwnership } from "./provider-output-config.ts"
+
 export const defaultCloudflareCompatibilityDate = "2026-04-20"
 
 interface CloudflareWranglerConfigOptions {
-  wranglerArrayOwnedValues?: Record<string, unknown[]>
   outputRoot?: string
   rootDir: string
-  wranglerArrayMergeKeys?: Record<string, string>
-  wranglerConfig?: object
-  wranglerConfigKeys?: string[]
+  wranglerConfig?: ProviderJsonRecord
+  wranglerConfigOwnership?: ProviderOutputConfigOwnership
 }
 
 export function createDefaultCloudflareOutputRoot(rootDir: string): string {
   return resolve(rootDir, "dist", toSafeAppName(rootDir))
 }
 
-function createConfigOwnership(options: CloudflareWranglerConfigOptions) {
-  const arrays = Object.fromEntries(Object.entries(options.wranglerArrayMergeKeys ?? {}).map(([field, key]) => [field, {
-    key,
-    values: options.wranglerArrayOwnedValues?.[field],
-  }]))
-  return { arrays, keys: options.wranglerConfigKeys }
-}
-
 export async function writeCloudflareWranglerConfig(options: CloudflareWranglerConfigOptions): Promise<void> {
   const outputRoot = options.outputRoot ?? createDefaultCloudflareOutputRoot(options.rootDir)
   const configFile = resolve(outputRoot, "wrangler.json")
   if (!options.wranglerConfig) {
-    await cleanProviderOutputConfig(configFile, createConfigOwnership(options))
+    await cleanProviderOutputConfig(configFile, options.wranglerConfigOwnership ?? {})
     return
   }
 
@@ -39,7 +31,7 @@ export async function writeCloudflareWranglerConfig(options: CloudflareWranglerC
   await writeProviderOutputConfig(
     configFile,
     options.wranglerConfig,
-    createConfigOwnership(options),
+    options.wranglerConfigOwnership,
     { removeIfEmpty: true },
   )
 }

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -30,7 +30,7 @@ interface CloudflareDeploymentOutputOptions extends SharedDeploymentOptions {
   wranglerConfig: object
 }
 
-export type VercelFunctionOutput =
+type VercelFunctionOutput =
   | { kind: "isolated", name: string }
   | { kind: "root" }
 

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -4,14 +4,13 @@ import { dirname, resolve } from "node:path"
 import { copyClientOutput, hasStaticIndex } from "./client-output.ts"
 import { createDefaultCloudflareOutputRoot, writeCloudflareWranglerConfig } from "./cloudflare.ts"
 import { bundleEsmEntry } from "./esbuild.ts"
-import { cleanProviderOutputConfig, writeProviderOutputConfig } from "./provider-output-config.ts"
+import { cleanProviderOutputConfig, stringifyProviderOutputConfig, writeProviderOutputConfig } from "./provider-output-config.ts"
 import { createNodeFunctionConfig, createVercelConfigJson } from "./vercel-config.ts"
 
-import type { ProviderJsonRecord, ProviderOutputConfigOwnership } from "./provider-output-config.ts"
+import type { ProviderOutputConfigOwnership } from "./provider-output-config.ts"
 
 export { createDefaultCloudflareOutputRoot } from "./cloudflare.ts"
 export { shouldSkipViteProviderBuild } from "./vite.ts"
-export type { ProviderJsonRecord } from "./provider-output-config.ts"
 
 type BundleOptions = NonNullable<Parameters<typeof bundleEsmEntry>[2]>
 
@@ -28,7 +27,7 @@ interface CloudflareDeploymentOutputOptions extends SharedDeploymentOptions {
   outputRoot?: string
   staticOutputDir?: string
   wranglerConfigKeys?: string[]
-  wranglerConfig: ProviderJsonRecord
+  wranglerConfig: object
 }
 
 export type VercelFunctionOutput =
@@ -38,10 +37,10 @@ export type VercelFunctionOutput =
 interface VercelDeploymentOutputOptions extends SharedDeploymentOptions {
   bundleEntry: string
   bundleOptions: BundleOptions
-  config?: ProviderJsonRecord
+  config?: object
   configKeys?: string[]
   function?: VercelFunctionOutput
-  functionConfig?: ProviderJsonRecord
+  functionConfig?: object
   outputRoot?: string
   staticOutputDir?: string
 }
@@ -49,12 +48,12 @@ interface VercelDeploymentOutputOptions extends SharedDeploymentOptions {
 interface NetlifyFunctionDeploymentOutput {
   bundleEntry: string
   bundleOptions: BundleOptions
-  config?: ProviderJsonRecord
+  config?: object
   functionName: string
 }
 
 interface NetlifyDeploymentOutputOptions extends SharedDeploymentOptions {
-  config?: ProviderJsonRecord
+  config?: object
   configKeys?: string[]
   functions?: NetlifyFunctionDeploymentOutput[]
   outputRoot?: string
@@ -153,10 +152,10 @@ function resolveNetlifyFunctionFile(functionsRoot: string, functionName: string)
   return resolve(functionsRoot, `${functionName}.mjs`)
 }
 
-async function appendNetlifyFunctionConfig(outfile: string, config: ProviderJsonRecord | undefined): Promise<void> {
+async function appendNetlifyFunctionConfig(outfile: string, config: object | undefined): Promise<void> {
   if (!config) return
   const bundled = await readFile(outfile, "utf8")
-  await writeFile(outfile, `${bundled.trimEnd()}\n\nexport const config = ${JSON.stringify(config, null, 2)}\n`, "utf8")
+  await writeFile(outfile, `${bundled.trimEnd()}\n\nexport const config = ${stringifyProviderOutputConfig(config)}\n`, "utf8")
 }
 
 async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutputOptions): Promise<void> {
@@ -208,7 +207,7 @@ async function writeVercelDeploymentOutput(options: VercelDeploymentOutputOption
 
   await Promise.all([
     bundleEsmEntry(options.bundleEntry, serverEntry, { ...options.bundleOptions, rootDir: options.rootDir }),
-    writeFile(resolve(serverDir, ".vc-config.json"), `${JSON.stringify(options.functionConfig ?? createNodeFunctionConfig(), null, 2)}\n`, "utf8"),
+    writeProviderOutputConfig(resolve(serverDir, ".vc-config.json"), options.functionConfig ?? createNodeFunctionConfig()),
     writeProviderOutputConfig(resolve(outputRoot, "config.json"), config, { keys: options.configKeys }),
     staticIndex
       ? copyClientOutput(clientDir, options.staticOutputDir ?? resolve(outputRoot, "static"))

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from "node:path"
 import { copyClientOutput, hasStaticIndex } from "./client-output.ts"
 import { createDefaultCloudflareOutputRoot, writeCloudflareWranglerConfig } from "./cloudflare.ts"
 import { bundleEsmEntry } from "./esbuild.ts"
+import { cleanProviderOutputConfig, writeProviderOutputConfig } from "./provider-output-config.ts"
 import { createNodeFunctionConfig, createVercelConfigJson } from "./vercel-config.ts"
 
 export { createDefaultCloudflareOutputRoot } from "./cloudflare.ts"
@@ -122,62 +123,6 @@ function resolveClientOutput(rootDir: string, clientOutDir: string): ResolvedCli
   }
 }
 
-function isJsonObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-}
-
-async function readJsonObject(file: string): Promise<Record<string, unknown>> {
-  try {
-    const parsed = JSON.parse(await readFile(file, "utf8"))
-    return isJsonObject(parsed) ? parsed : {}
-  }
-  catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {}
-    throw error
-  }
-}
-
-function deleteJsonObjectKeys(value: Record<string, unknown>, keys: string[] | undefined): Record<string, unknown> {
-  if (!keys?.length) return value
-  const next = { ...value }
-  for (const key of keys) {
-    delete next[key]
-  }
-  return next
-}
-
-async function writeMergedJsonObject(file: string, value: object, ownedKeys?: string[]): Promise<void> {
-  const existing = await readJsonObject(file)
-  await writeFile(file, `${JSON.stringify({ ...deleteJsonObjectKeys(existing, ownedKeys), ...value }, null, 2)}\n`, "utf8")
-}
-
-async function deleteJsonObjectKeysFromFile(file: string, keys: string[] | undefined): Promise<void> {
-  if (!keys?.length) return
-  let existing: Record<string, unknown>
-  try {
-    const parsed = JSON.parse(await readFile(file, "utf8"))
-    existing = isJsonObject(parsed) ? parsed : {}
-  }
-  catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
-    throw error
-  }
-  const next = { ...existing }
-  let changed = false
-  for (const key of keys) {
-    if (key in next) {
-      delete next[key]
-      changed = true
-    }
-  }
-  if (!changed) return
-  if (!Object.keys(next).length) {
-    await rm(file, { force: true })
-    return
-  }
-  await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
-}
-
 function createDefaultCloudflareStaticOutputDir(rootDir: string): string {
   return resolve(rootDir, "dist", "client")
 }
@@ -246,6 +191,7 @@ async function writeVercelDeploymentOutput(options: VercelDeploymentOutputOption
   const { clientDir, staticIndex } = resolveClientOutput(options.rootDir, options.clientOutDir)
   const outputRoot = options.outputRoot ?? createDefaultVercelOutputRoot(options.rootDir)
   const serverFunctionName = options.serverFunctionName ?? "__server.func"
+  const config = options.config ?? (options.serverFunctionName ? {} : createVercelConfigJson())
   const serverDir = resolve(outputRoot, "functions", serverFunctionName)
   const serverEntry = resolve(serverDir, "index.mjs")
 
@@ -255,7 +201,7 @@ async function writeVercelDeploymentOutput(options: VercelDeploymentOutputOption
   await Promise.all([
     bundleEsmEntry(options.bundleEntry, serverEntry, { ...options.bundleOptions, rootDir: options.rootDir }),
     writeFile(resolve(serverDir, ".vc-config.json"), `${JSON.stringify(options.functionConfig ?? createNodeFunctionConfig(), null, 2)}\n`, "utf8"),
-    writeMergedJsonObject(resolve(outputRoot, "config.json"), options.config ?? createVercelConfigJson(), options.configKeys),
+    writeProviderOutputConfig(resolve(outputRoot, "config.json"), config, { keys: options.configKeys }),
     staticIndex
       ? copyClientOutput(clientDir, options.staticOutputDir ?? resolve(outputRoot, "static"))
       : Promise.resolve(),
@@ -279,7 +225,7 @@ async function writeNetlifyDeploymentOutput(options: NetlifyDeploymentOutputOpti
 
   await mkdir(outputRoot, { recursive: true })
   await Promise.all([
-    writeMergedJsonObject(resolve(outputRoot, "config.json"), options.config ?? {}, options.configKeys),
+    writeProviderOutputConfig(resolve(outputRoot, "config.json"), options.config ?? {}, { keys: options.configKeys }),
     ...functionWrites,
   ])
 }
@@ -309,7 +255,7 @@ async function cleanupVercelDeploymentOutput(rootDir: string, cleanup: VercelPro
   if (cleanup.serverFunctionName) {
     writes.push(rm(resolve(outputRoot, "functions", cleanup.serverFunctionName), { force: true, recursive: true }))
   }
-  writes.push(deleteJsonObjectKeysFromFile(resolve(outputRoot, "config.json"), cleanup.configKeys))
+  writes.push(cleanProviderOutputConfig(resolve(outputRoot, "config.json"), { keys: cleanup.configKeys }))
   await Promise.all(writes)
 }
 
@@ -318,7 +264,7 @@ async function cleanupNetlifyDeploymentOutput(rootDir: string, cleanup: NetlifyP
   const functionsRoot = resolve(outputRoot, "functions")
   const writes = (cleanup.functionNames ?? []).map(functionName =>
     rm(resolveNetlifyFunctionFile(functionsRoot, functionName), { force: true, recursive: true }))
-  writes.push(deleteJsonObjectKeysFromFile(resolve(outputRoot, "config.json"), cleanup.configKeys))
+  writes.push(cleanProviderOutputConfig(resolve(outputRoot, "config.json"), { keys: cleanup.configKeys }))
   await Promise.all(writes)
 }
 

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -7,8 +7,11 @@ import { bundleEsmEntry } from "./esbuild.ts"
 import { cleanProviderOutputConfig, writeProviderOutputConfig } from "./provider-output-config.ts"
 import { createNodeFunctionConfig, createVercelConfigJson } from "./vercel-config.ts"
 
+import type { ProviderJsonRecord, ProviderOutputConfigOwnership } from "./provider-output-config.ts"
+
 export { createDefaultCloudflareOutputRoot } from "./cloudflare.ts"
 export { shouldSkipViteProviderBuild } from "./vite.ts"
+export type { ProviderJsonRecord } from "./provider-output-config.ts"
 
 type BundleOptions = NonNullable<Parameters<typeof bundleEsmEntry>[2]>
 
@@ -25,29 +28,33 @@ interface CloudflareDeploymentOutputOptions extends SharedDeploymentOptions {
   outputRoot?: string
   staticOutputDir?: string
   wranglerConfigKeys?: string[]
-  wranglerConfig: object
+  wranglerConfig: ProviderJsonRecord
 }
+
+export type VercelFunctionOutput =
+  | { kind: "isolated", name: string }
+  | { kind: "root" }
 
 interface VercelDeploymentOutputOptions extends SharedDeploymentOptions {
   bundleEntry: string
   bundleOptions: BundleOptions
-  config?: object
+  config?: ProviderJsonRecord
   configKeys?: string[]
-  functionConfig?: object
+  function?: VercelFunctionOutput
+  functionConfig?: ProviderJsonRecord
   outputRoot?: string
-  serverFunctionName?: string
   staticOutputDir?: string
 }
 
 interface NetlifyFunctionDeploymentOutput {
   bundleEntry: string
   bundleOptions: BundleOptions
-  config?: object
+  config?: ProviderJsonRecord
   functionName: string
 }
 
 interface NetlifyDeploymentOutputOptions extends SharedDeploymentOptions {
-  config?: object
+  config?: ProviderJsonRecord
   configKeys?: string[]
   functions?: NetlifyFunctionDeploymentOutput[]
   outputRoot?: string
@@ -60,7 +67,7 @@ export type VercelProviderDeploymentOutput = Omit<VercelDeploymentOutputOptions,
 interface CloudflareProviderDeploymentCleanup {
   fileNames?: string[]
   outputRoot?: string
-  wranglerConfigKeys?: string[]
+  wranglerConfigOwnership?: ProviderOutputConfigOwnership
 }
 
 interface VercelProviderDeploymentCleanup {
@@ -146,7 +153,7 @@ function resolveNetlifyFunctionFile(functionsRoot: string, functionName: string)
   return resolve(functionsRoot, `${functionName}.mjs`)
 }
 
-async function appendNetlifyFunctionConfig(outfile: string, config: object | undefined): Promise<void> {
+async function appendNetlifyFunctionConfig(outfile: string, config: ProviderJsonRecord | undefined): Promise<void> {
   if (!config) return
   const bundled = await readFile(outfile, "utf8")
   await writeFile(outfile, `${bundled.trimEnd()}\n\nexport const config = ${JSON.stringify(config, null, 2)}\n`, "utf8")
@@ -170,7 +177,7 @@ async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutp
       outputRoot,
       rootDir: options.rootDir,
       wranglerConfig: options.wranglerConfig,
-      wranglerConfigKeys: options.wranglerConfigKeys,
+      wranglerConfigOwnership: { keys: options.wranglerConfigKeys },
     }),
     options.bundleEntry && staticIndex
       ? copyClientOutput(clientDir, options.staticOutputDir ?? createDefaultCloudflareStaticOutputDir(options.rootDir))
@@ -190,8 +197,9 @@ async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutp
 async function writeVercelDeploymentOutput(options: VercelDeploymentOutputOptions): Promise<void> {
   const { clientDir, staticIndex } = resolveClientOutput(options.rootDir, options.clientOutDir)
   const outputRoot = options.outputRoot ?? createDefaultVercelOutputRoot(options.rootDir)
-  const serverFunctionName = options.serverFunctionName ?? "__server.func"
-  const config = options.config ?? (options.serverFunctionName ? {} : createVercelConfigJson())
+  const functionOutput = options.function ?? { kind: "root" }
+  const serverFunctionName = functionOutput.kind === "root" ? "__server.func" : functionOutput.name
+  const config = options.config ?? (functionOutput.kind === "root" ? createVercelConfigJson() : {})
   const serverDir = resolve(outputRoot, "functions", serverFunctionName)
   const serverEntry = resolve(serverDir, "index.mjs")
 
@@ -237,7 +245,7 @@ async function cleanupCloudflareDeploymentOutput(rootDir: string, cleanupInput: 
   writes.push(writeCloudflareWranglerConfig({
     outputRoot,
     rootDir,
-    wranglerConfigKeys: cleanup.wranglerConfigKeys,
+    wranglerConfigOwnership: cleanup.wranglerConfigOwnership,
   }))
   await Promise.all(writes)
   try {

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -207,7 +207,11 @@ async function writeVercelDeploymentOutput(options: VercelDeploymentOutputOption
 
   await Promise.all([
     bundleEsmEntry(options.bundleEntry, serverEntry, { ...options.bundleOptions, rootDir: options.rootDir }),
-    writeProviderOutputConfig(resolve(serverDir, ".vc-config.json"), options.functionConfig ?? createNodeFunctionConfig()),
+    writeFile(
+      resolve(serverDir, ".vc-config.json"),
+      `${stringifyProviderOutputConfig(options.functionConfig ?? createNodeFunctionConfig())}\n`,
+      "utf8",
+    ),
     writeProviderOutputConfig(resolve(outputRoot, "config.json"), config, { keys: options.configKeys }),
     staticIndex
       ? copyClientOutput(clientDir, options.staticOutputDir ?? resolve(outputRoot, "static"))

--- a/packages/internal/src/build/provider-output-config.ts
+++ b/packages/internal/src/build/provider-output-config.ts
@@ -1,18 +1,38 @@
 import { readFile, rm, writeFile } from "node:fs/promises"
 
+export type ProviderJsonPrimitive = boolean | null | number | string
+export type ProviderJsonRecord = Record<string, unknown>
+
 export interface ProviderOutputConfigOwnership {
-  arrays?: Record<string, { key: string, values?: unknown[] }>
+  arrays?: Record<string, { key: string, values?: ProviderJsonPrimitive[] }>
   keys?: string[]
 }
 
-function isJsonObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
+function isProviderJsonRecord(value: unknown): value is ProviderJsonRecord {
+  return typeof value === "object"
+    && value !== null
+    && !Array.isArray(value)
+    && Object.values(value).every(entry => entry === undefined || isProviderJsonValue(entry))
 }
 
-async function readJsonObject(file: string): Promise<Record<string, unknown> | undefined> {
+function isProviderJsonValue(value: unknown): boolean {
+  if (value === null || typeof value === "boolean" || typeof value === "string") return true
+  if (typeof value === "number") return Number.isFinite(value)
+  if (Array.isArray(value)) return value.every(isProviderJsonValue)
+  return isProviderJsonRecord(value)
+}
+
+function assertProviderJsonRecord(value: unknown): asserts value is ProviderJsonRecord {
+  if (!isProviderJsonRecord(value)) {
+    throw new TypeError("[vitehub] Provider output config must be a JSON object.")
+  }
+}
+
+async function readProviderJsonRecord(file: string): Promise<ProviderJsonRecord | undefined> {
   try {
-    const parsed = JSON.parse(await readFile(file, "utf8"))
-    return isJsonObject(parsed) ? parsed : {}
+    const parsed: unknown = JSON.parse(await readFile(file, "utf8"))
+    assertProviderJsonRecord(parsed)
+    return parsed
   }
   catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return
@@ -20,26 +40,48 @@ async function readJsonObject(file: string): Promise<Record<string, unknown> | u
   }
 }
 
-function deleteOwnedKeys(value: Record<string, unknown>, ownership: ProviderOutputConfigOwnership): Record<string, unknown> {
+function deleteOwnedFields(value: ProviderJsonRecord, ownership: ProviderOutputConfigOwnership): ProviderJsonRecord {
   const next = { ...value }
   for (const key of ownership.keys ?? []) delete next[key]
   for (const field of Object.keys(ownership.arrays ?? {})) delete next[field]
   return next
 }
 
+function getKeyedArrayEntryValue(value: unknown, key: string): ProviderJsonPrimitive | undefined {
+  if (!isProviderJsonRecord(value)) return
+  const entryValue = value[key]
+  return entryValue === null || typeof entryValue === "boolean" || typeof entryValue === "number" || typeof entryValue === "string"
+    ? entryValue
+    : undefined
+}
+
+function preserveUnownedKeyedArrayEntries(
+  value: unknown,
+  ownership: NonNullable<ProviderOutputConfigOwnership["arrays"]>[string],
+  replacements: unknown[] = [],
+): unknown[] {
+  const current = Array.isArray(value) ? value : []
+  const replacementKeys = replacements.flatMap((entry) => {
+    const key = getKeyedArrayEntryValue(entry, ownership.key)
+    return key === undefined ? [] : [key]
+  })
+  const ownedKeys = new Set([...(ownership.values ?? []), ...replacementKeys])
+  return current.filter((entry) => {
+    const key = getKeyedArrayEntryValue(entry, ownership.key)
+    return key === undefined || !ownedKeys.has(key)
+  })
+}
+
 function mergeOwnedArrays(
-  existing: Record<string, unknown>,
-  value: Record<string, unknown>,
+  existing: ProviderJsonRecord,
+  value: ProviderJsonRecord,
   arrays: ProviderOutputConfigOwnership["arrays"],
-): Record<string, unknown> {
+): ProviderJsonRecord {
   const next = { ...value }
   for (const [field, ownership] of Object.entries(arrays ?? {})) {
-    const current = Array.isArray(existing[field]) ? existing[field] : []
     const incoming = Array.isArray(value[field]) ? value[field] : []
-    const incomingKeys = new Set(incoming.flatMap(item => isJsonObject(item) && item[ownership.key] !== undefined ? [item[ownership.key]] : []))
-    const ownedKeys = new Set([...(ownership.values ?? []), ...incomingKeys])
     const merged = [
-      ...current.filter(item => !isJsonObject(item) || !ownedKeys.has(item[ownership.key])),
+      ...preserveUnownedKeyedArrayEntries(existing[field], ownership, incoming),
       ...incoming,
     ]
     if (merged.length) next[field] = merged
@@ -48,46 +90,43 @@ function mergeOwnedArrays(
   return next
 }
 
-export async function writeProviderOutputConfig(
-  file: string,
-  value: object,
-  ownership: ProviderOutputConfigOwnership = {},
-  options: { removeIfEmpty?: boolean } = {},
-): Promise<void> {
-  const existing = await readJsonObject(file) ?? {}
-  const next = {
-    ...deleteOwnedKeys(existing, ownership),
-    ...mergeOwnedArrays(existing, value as Record<string, unknown>, ownership.arrays),
-  }
-  if (options.removeIfEmpty && !Object.keys(next).length) {
+async function persistProviderJsonRecord(file: string, value: ProviderJsonRecord, removeIfEmpty: boolean): Promise<void> {
+  if (removeIfEmpty && !Object.keys(value).length) {
     await rm(file, { force: true })
     return
   }
-  await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
+  await writeFile(file, `${JSON.stringify(value, null, 2)}\n`, "utf8")
+}
+
+export async function writeProviderOutputConfig(
+  file: string,
+  value: ProviderJsonRecord,
+  ownership: ProviderOutputConfigOwnership = {},
+  options: { removeIfEmpty?: boolean } = {},
+): Promise<void> {
+  assertProviderJsonRecord(value)
+  const existing = await readProviderJsonRecord(file) ?? {}
+  const next = {
+    ...deleteOwnedFields(existing, ownership),
+    ...mergeOwnedArrays(existing, value, ownership.arrays),
+  }
+  await persistProviderJsonRecord(file, next, options.removeIfEmpty === true)
 }
 
 export async function cleanProviderOutputConfig(file: string, ownership: ProviderOutputConfigOwnership): Promise<void> {
   if (!ownership.keys?.length && !Object.keys(ownership.arrays ?? {}).length) return
-  const existing = await readJsonObject(file)
+  const existing = await readProviderJsonRecord(file)
   if (!existing) return
 
-  const next = deleteOwnedKeys(existing, ownership)
+  const next = deleteOwnedFields(existing, ownership)
   let changed = (ownership.keys ?? []).some(key => key in existing)
   for (const [field, arrayOwnership] of Object.entries(ownership.arrays ?? {})) {
-    const current = Array.isArray(existing[field]) ? existing[field] : []
-    const ownedKeys = new Set(arrayOwnership.values ?? [])
-    const preserved = current.filter(item => !isJsonObject(item) || !ownedKeys.has(item[arrayOwnership.key]))
-    if (preserved.length === current.length) {
-      if (current.length) next[field] = current
-      continue
-    }
-    changed = true
+    if (!(field in existing)) continue
+    const current = existing[field]
+    const preserved = preserveUnownedKeyedArrayEntries(current, arrayOwnership)
+    changed ||= !Array.isArray(current) || preserved.length !== current.length || preserved.length === 0
     if (preserved.length) next[field] = preserved
   }
   if (!changed) return
-  if (!Object.keys(next).length) {
-    await rm(file, { force: true })
-    return
-  }
-  await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
+  await persistProviderJsonRecord(file, next, true)
 }

--- a/packages/internal/src/build/provider-output-config.ts
+++ b/packages/internal/src/build/provider-output-config.ts
@@ -1,31 +1,80 @@
 import { readFile, rm, writeFile } from "node:fs/promises"
 
-export type ProviderJsonPrimitive = boolean | null | number | string
-export type ProviderJsonRecord = Record<string, unknown>
+type ProviderJsonPrimitive = boolean | null | number | string
+type ProviderJsonValue = ProviderJsonPrimitive | ProviderJsonRecord | ProviderJsonValue[]
+
+interface ProviderJsonRecord {
+  [key: string]: ProviderJsonValue
+}
 
 export interface ProviderOutputConfigOwnership {
   arrays?: Record<string, { key: string, values?: ProviderJsonPrimitive[] }>
   keys?: string[]
 }
 
-function isProviderJsonRecord(value: unknown): value is ProviderJsonRecord {
-  return typeof value === "object"
-    && value !== null
-    && !Array.isArray(value)
-    && Object.values(value).every(entry => entry === undefined || isProviderJsonValue(entry))
+function isProviderJsonArray(value: unknown[], ancestors: Set<object>): value is ProviderJsonValue[] {
+  if (Object.getPrototypeOf(value) !== Array.prototype || ancestors.has(value)) return false
+  if (Reflect.ownKeys(value).length !== value.length + 1) return false
+
+  ancestors.add(value)
+  try {
+    for (let index = 0; index < value.length; index++) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index))
+      if (!descriptor?.enumerable || !("value" in descriptor) || !isProviderJsonValue(descriptor.value, ancestors)) return false
+    }
+    return true
+  }
+  finally {
+    ancestors.delete(value)
+  }
 }
 
-function isProviderJsonValue(value: unknown): boolean {
+function isProviderJsonRecordValue(value: object, ancestors: Set<object>): value is ProviderJsonRecord {
+  const prototype = Object.getPrototypeOf(value)
+  if ((prototype !== Object.prototype && prototype !== null) || ancestors.has(value)) return false
+
+  ancestors.add(value)
+  try {
+    return Reflect.ownKeys(value).every((key) => {
+      if (typeof key !== "string") return false
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      return descriptor?.enumerable === true
+        && "value" in descriptor
+        && isProviderJsonValue(descriptor.value, ancestors)
+    })
+  }
+  finally {
+    ancestors.delete(value)
+  }
+}
+
+function isProviderJsonValue(value: unknown, ancestors: Set<object>): value is ProviderJsonValue {
   if (value === null || typeof value === "boolean" || typeof value === "string") return true
   if (typeof value === "number") return Number.isFinite(value)
-  if (Array.isArray(value)) return value.every(isProviderJsonValue)
-  return isProviderJsonRecord(value)
+  if (Array.isArray(value)) return isProviderJsonArray(value, ancestors)
+  return typeof value === "object" && isProviderJsonRecordValue(value, ancestors)
+}
+
+function isProviderJsonRecord(value: unknown): value is ProviderJsonRecord {
+  try {
+    return typeof value === "object"
+      && value !== null
+      && !Array.isArray(value)
+      && isProviderJsonRecordValue(value, new Set())
+  }
+  catch {
+    return false
+  }
 }
 
 function assertProviderJsonRecord(value: unknown): asserts value is ProviderJsonRecord {
   if (!isProviderJsonRecord(value)) {
     throw new TypeError("[vitehub] Provider output config must be a JSON object.")
   }
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT"
 }
 
 async function readProviderJsonRecord(file: string): Promise<ProviderJsonRecord | undefined> {
@@ -35,7 +84,7 @@ async function readProviderJsonRecord(file: string): Promise<ProviderJsonRecord 
     return parsed
   }
   catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    if (isFileNotFoundError(error)) return
     throw error
   }
 }
@@ -56,10 +105,10 @@ function getKeyedArrayEntryValue(value: unknown, key: string): ProviderJsonPrimi
 }
 
 function preserveUnownedKeyedArrayEntries(
-  value: unknown,
+  value: ProviderJsonValue | undefined,
   ownership: NonNullable<ProviderOutputConfigOwnership["arrays"]>[string],
-  replacements: unknown[] = [],
-): unknown[] {
+  replacements: ProviderJsonValue[] = [],
+): ProviderJsonValue[] {
   const current = Array.isArray(value) ? value : []
   const replacementKeys = replacements.flatMap((entry) => {
     const key = getKeyedArrayEntryValue(entry, ownership.key)
@@ -100,17 +149,22 @@ async function persistProviderJsonRecord(file: string, value: ProviderJsonRecord
 
 export async function writeProviderOutputConfig(
   file: string,
-  value: ProviderJsonRecord,
+  value: unknown,
   ownership: ProviderOutputConfigOwnership = {},
   options: { removeIfEmpty?: boolean } = {},
 ): Promise<void> {
-  assertProviderJsonRecord(value)
   const existing = await readProviderJsonRecord(file) ?? {}
+  assertProviderJsonRecord(value)
   const next = {
     ...deleteOwnedFields(existing, ownership),
     ...mergeOwnedArrays(existing, value, ownership.arrays),
   }
   await persistProviderJsonRecord(file, next, options.removeIfEmpty === true)
+}
+
+export function stringifyProviderOutputConfig(value: unknown): string {
+  assertProviderJsonRecord(value)
+  return JSON.stringify(value, null, 2)
 }
 
 export async function cleanProviderOutputConfig(file: string, ownership: ProviderOutputConfigOwnership): Promise<void> {

--- a/packages/internal/src/build/provider-output-config.ts
+++ b/packages/internal/src/build/provider-output-config.ts
@@ -1,0 +1,93 @@
+import { readFile, rm, writeFile } from "node:fs/promises"
+
+export interface ProviderOutputConfigOwnership {
+  arrays?: Record<string, { key: string, values?: unknown[] }>
+  keys?: string[]
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+async function readJsonObject(file: string): Promise<Record<string, unknown> | undefined> {
+  try {
+    const parsed = JSON.parse(await readFile(file, "utf8"))
+    return isJsonObject(parsed) ? parsed : {}
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    throw error
+  }
+}
+
+function deleteOwnedKeys(value: Record<string, unknown>, ownership: ProviderOutputConfigOwnership): Record<string, unknown> {
+  const next = { ...value }
+  for (const key of ownership.keys ?? []) delete next[key]
+  for (const field of Object.keys(ownership.arrays ?? {})) delete next[field]
+  return next
+}
+
+function mergeOwnedArrays(
+  existing: Record<string, unknown>,
+  value: Record<string, unknown>,
+  arrays: ProviderOutputConfigOwnership["arrays"],
+): Record<string, unknown> {
+  const next = { ...value }
+  for (const [field, ownership] of Object.entries(arrays ?? {})) {
+    const current = Array.isArray(existing[field]) ? existing[field] : []
+    const incoming = Array.isArray(value[field]) ? value[field] : []
+    const incomingKeys = new Set(incoming.flatMap(item => isJsonObject(item) && item[ownership.key] !== undefined ? [item[ownership.key]] : []))
+    const ownedKeys = new Set([...(ownership.values ?? []), ...incomingKeys])
+    const merged = [
+      ...current.filter(item => !isJsonObject(item) || !ownedKeys.has(item[ownership.key])),
+      ...incoming,
+    ]
+    if (merged.length) next[field] = merged
+    else delete next[field]
+  }
+  return next
+}
+
+export async function writeProviderOutputConfig(
+  file: string,
+  value: object,
+  ownership: ProviderOutputConfigOwnership = {},
+  options: { removeIfEmpty?: boolean } = {},
+): Promise<void> {
+  const existing = await readJsonObject(file) ?? {}
+  const next = {
+    ...deleteOwnedKeys(existing, ownership),
+    ...mergeOwnedArrays(existing, value as Record<string, unknown>, ownership.arrays),
+  }
+  if (options.removeIfEmpty && !Object.keys(next).length) {
+    await rm(file, { force: true })
+    return
+  }
+  await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
+}
+
+export async function cleanProviderOutputConfig(file: string, ownership: ProviderOutputConfigOwnership): Promise<void> {
+  if (!ownership.keys?.length && !Object.keys(ownership.arrays ?? {}).length) return
+  const existing = await readJsonObject(file)
+  if (!existing) return
+
+  const next = deleteOwnedKeys(existing, ownership)
+  let changed = (ownership.keys ?? []).some(key => key in existing)
+  for (const [field, arrayOwnership] of Object.entries(ownership.arrays ?? {})) {
+    const current = Array.isArray(existing[field]) ? existing[field] : []
+    const ownedKeys = new Set(arrayOwnership.values ?? [])
+    const preserved = current.filter(item => !isJsonObject(item) || !ownedKeys.has(item[arrayOwnership.key]))
+    if (preserved.length === current.length) {
+      if (current.length) next[field] = current
+      continue
+    }
+    changed = true
+    if (preserved.length) next[field] = preserved
+  }
+  if (!changed) return
+  if (!Object.keys(next).length) {
+    await rm(file, { force: true })
+    return
+  }
+  await writeFile(file, `${JSON.stringify(next, null, 2)}\n`, "utf8")
+}

--- a/packages/internal/src/build/vercel-config.ts
+++ b/packages/internal/src/build/vercel-config.ts
@@ -1,4 +1,6 @@
-interface VercelConfigJson {
+import type { ProviderJsonRecord } from "./provider-output-config.ts"
+
+interface VercelConfigJson extends ProviderJsonRecord {
   routes: Array<{ handle: string } | { dest: string, src: string }>
   version: 3
 }
@@ -13,16 +15,15 @@ export function createVercelConfigJson(): VercelConfigJson {
   }
 }
 
-interface NodeFunctionConfig {
+interface NodeFunctionConfig extends ProviderJsonRecord {
   handler: "index.mjs"
   launcherType: "Nodejs"
   runtime: "nodejs22.x"
   shouldAddHelpers: false
   supportsResponseStreaming: true
-  [key: string]: unknown
 }
 
-export function createNodeFunctionConfig(extra: Record<string, unknown> = {}): NodeFunctionConfig {
+export function createNodeFunctionConfig(extra: ProviderJsonRecord = {}): NodeFunctionConfig {
   return {
     handler: "index.mjs",
     launcherType: "Nodejs",

--- a/packages/internal/src/build/vercel-config.ts
+++ b/packages/internal/src/build/vercel-config.ts
@@ -1,6 +1,4 @@
-import type { ProviderJsonRecord } from "./provider-output-config.ts"
-
-interface VercelConfigJson extends ProviderJsonRecord {
+interface VercelConfigJson {
   routes: Array<{ handle: string } | { dest: string, src: string }>
   version: 3
 }
@@ -15,7 +13,7 @@ export function createVercelConfigJson(): VercelConfigJson {
   }
 }
 
-interface NodeFunctionConfig extends ProviderJsonRecord {
+interface NodeFunctionConfig {
   handler: "index.mjs"
   launcherType: "Nodejs"
   runtime: "nodejs22.x"
@@ -23,7 +21,7 @@ interface NodeFunctionConfig extends ProviderJsonRecord {
   supportsResponseStreaming: true
 }
 
-export function createNodeFunctionConfig(extra: ProviderJsonRecord = {}): NodeFunctionConfig {
+export function createNodeFunctionConfig(extra: object = {}): NodeFunctionConfig {
   return {
     handler: "index.mjs",
     launcherType: "Nodejs",

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -229,6 +229,34 @@ describe("provider deployment outputs", () => {
     })
   })
 
+  it("preserves host Vercel config when writing an isolated function", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultVercelOutputRoot,
+      writeProviderDeploymentOutputs,
+    } = await import("../src/build/deployment-output.ts")
+    const outputRoot = createDefaultVercelOutputRoot(rootDir)
+    const config = {
+      routes: [{ dest: "/__server", src: "/(.*)" }],
+      version: 3,
+    }
+    await mkdir(outputRoot, { recursive: true })
+    await writeFile(join(outputRoot, "config.json"), `${JSON.stringify(config, null, 2)}\n`, "utf8")
+
+    await writeProviderDeploymentOutputs({
+      clientOutDir: "dist/client",
+      rootDir,
+      vercel: {
+        bundleEntry: join(rootDir, "entry.mjs"),
+        bundleOptions: {},
+        serverFunctionName: "__blob.func",
+      },
+    })
+
+    await expect(readFile(join(outputRoot, "config.json"), "utf8").then(JSON.parse)).resolves.toEqual(config)
+    expect(existsSync(join(outputRoot, "functions", "__blob.func", ".vc-config.json"))).toBe(true)
+  })
+
   it("serializes concurrent writes to shared provider config files", async () => {
     const rootDir = await createTempProject()
     const {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -136,6 +136,43 @@ describe("provider deployment outputs", () => {
     })
   })
 
+  it.each([
+    ["a top-level undefined value", { main: undefined }],
+    ["a nested undefined value", { assets: { directory: undefined } }],
+    ["a non-finite number", { limit: Number.POSITIVE_INFINITY }],
+    ["a bigint", { limit: 1n }],
+    ["a symbol", { binding: Symbol("binding") }],
+    ["a function", { resolve: () => undefined }],
+    ["a Date", new Date("2026-01-01")],
+    ["a Map", new Map([["binding", "SETTINGS"]])],
+    ["a class instance", new class ProviderConfig { binding = "SETTINGS" }()],
+    ["a nested non-plain object", { binding: new Date("2026-01-01") }],
+  ])("rejects provider config containing %s", async (_label, wranglerConfig) => {
+    const rootDir = await createTempProject()
+    const { writeCloudflareWranglerConfig } = await import("../src/build/cloudflare.ts")
+
+    await expect(writeCloudflareWranglerConfig({ rootDir, wranglerConfig })).rejects.toThrow(
+      "[vitehub] Provider output config must be a JSON object.",
+    )
+  })
+
+  it("accepts provider config with ordinary and null-prototype records", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultCloudflareOutputRoot,
+      writeCloudflareWranglerConfig,
+    } = await import("../src/build/cloudflare.ts")
+    const nested = Object.assign(Object.create(null), { enabled: true })
+    const wranglerConfig = Object.assign(Object.create(null), { nested })
+
+    await writeCloudflareWranglerConfig({ rootDir, wranglerConfig })
+
+    const configFile = join(createDefaultCloudflareOutputRoot(rootDir), "wrangler.json")
+    await expect(readFile(configFile, "utf8").then(JSON.parse)).resolves.toEqual({
+      nested: { enabled: true },
+    })
+  })
+
   it("does not create Cloudflare output while cleaning absent owned config", async () => {
     const rootDir = await createTempProject()
     const {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -357,6 +357,33 @@ describe("provider deployment outputs", () => {
     expect(existsSync(join(outputRoot, "functions", "__blob.func", ".vc-config.json"))).toBe(true)
   })
 
+  it("replaces owned Vercel function config", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultVercelOutputRoot,
+      writeProviderDeploymentOutputs,
+    } = await import("../src/build/deployment-output.ts")
+    const outputRoot = createDefaultVercelOutputRoot(rootDir)
+    const functionDir = join(outputRoot, "functions", "__blob.func")
+    await mkdir(functionDir, { recursive: true })
+    await writeFile(join(functionDir, ".vc-config.json"), '{"stale":true}\n', "utf8")
+
+    await writeProviderDeploymentOutputs({
+      clientOutDir: "dist/client",
+      rootDir,
+      vercel: {
+        bundleEntry: join(rootDir, "entry.mjs"),
+        bundleOptions: {},
+        function: { kind: "isolated", name: "__blob.func" },
+        functionConfig: { runtime: "nodejs22.x" },
+      },
+    })
+
+    await expect(readFile(join(functionDir, ".vc-config.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      runtime: "nodejs22.x",
+    })
+  })
+
   it("serializes concurrent writes to shared provider config files", async () => {
     const rootDir = await createTempProject()
     const {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -145,8 +145,9 @@ describe("provider deployment outputs", () => {
 
     await writeCloudflareWranglerConfig({
       rootDir,
-      wranglerArrayMergeKeys: { kv_namespaces: "binding" },
-      wranglerArrayOwnedValues: { kv_namespaces: ["SETTINGS"] },
+      wranglerConfigOwnership: {
+        arrays: { kv_namespaces: { key: "binding", values: ["SETTINGS"] } },
+      },
     })
 
     expect(existsSync(createDefaultCloudflareOutputRoot(rootDir))).toBe(false)
@@ -170,9 +171,11 @@ describe("provider deployment outputs", () => {
 
     await writeCloudflareWranglerConfig({
       rootDir,
-      wranglerArrayMergeKeys: { kv_namespaces: "binding" },
       wranglerConfig: {
         kv_namespaces: [{ binding: "SETTINGS", id: "new-namespace" }],
+      },
+      wranglerConfigOwnership: {
+        arrays: { kv_namespaces: { key: "binding" } },
       },
     })
 
@@ -186,12 +189,72 @@ describe("provider deployment outputs", () => {
 
     await writeCloudflareWranglerConfig({
       rootDir,
-      wranglerArrayMergeKeys: { kv_namespaces: "binding" },
-      wranglerArrayOwnedValues: { kv_namespaces: ["SETTINGS"] },
+      wranglerConfigOwnership: {
+        arrays: { kv_namespaces: { key: "binding", values: ["SETTINGS"] } },
+      },
     })
 
     await expect(readFile(join(cloudflareDir, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       kv_namespaces: [{ binding: "MANUAL", id: "manual-namespace" }],
+      triggers: { crons: ["0 0 * * *"] },
+    })
+  })
+
+  it("removes empty owned Cloudflare config arrays and output roots", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultCloudflareOutputRoot,
+      writeProviderDeploymentOutputs,
+    } = await import("../src/build/deployment-output.ts")
+    const cloudflareDir = createDefaultCloudflareOutputRoot(rootDir)
+    const configFile = join(cloudflareDir, "wrangler.json")
+    await mkdir(cloudflareDir, { recursive: true })
+    await writeFile(configFile, "{\"kv_namespaces\":[]}\n")
+
+    await writeProviderDeploymentOutputs({
+      cleanup: {
+        cloudflare: {
+          wranglerConfigOwnership: {
+            arrays: { kv_namespaces: { key: "binding", values: ["SETTINGS"] } },
+          },
+        },
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    expect(existsSync(configFile)).toBe(false)
+    expect(existsSync(cloudflareDir)).toBe(false)
+  })
+
+  it("removes empty owned Cloudflare config arrays independently of unrelated keys", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultCloudflareOutputRoot,
+      writeProviderDeploymentOutputs,
+    } = await import("../src/build/deployment-output.ts")
+    const cloudflareDir = createDefaultCloudflareOutputRoot(rootDir)
+    const configFile = join(cloudflareDir, "wrangler.json")
+    await mkdir(cloudflareDir, { recursive: true })
+    await writeFile(configFile, `${JSON.stringify({
+      kv_namespaces: [],
+      triggers: { crons: ["0 0 * * *"] },
+    }, null, 2)}\n`)
+
+    await writeProviderDeploymentOutputs({
+      cleanup: {
+        cloudflare: {
+          wranglerConfigOwnership: {
+            arrays: { kv_namespaces: { key: "binding", values: ["SETTINGS"] } },
+          },
+        },
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    expect(existsSync(cloudflareDir)).toBe(true)
+    await expect(readFile(configFile, "utf8").then(JSON.parse)).resolves.toEqual({
       triggers: { crons: ["0 0 * * *"] },
     })
   })
@@ -249,7 +312,7 @@ describe("provider deployment outputs", () => {
       vercel: {
         bundleEntry: join(rootDir, "entry.mjs"),
         bundleOptions: {},
-        serverFunctionName: "__blob.func",
+        function: { kind: "isolated", name: "__blob.func" },
       },
     })
 
@@ -287,7 +350,7 @@ describe("provider deployment outputs", () => {
             version: 3,
           },
           configKeys: ["routes"],
-          serverFunctionName: "blob.func",
+          function: { kind: "isolated", name: "blob.func" },
         },
       }),
       writeProviderDeploymentOutputs({
@@ -311,7 +374,7 @@ describe("provider deployment outputs", () => {
             version: 3,
           },
           configKeys: ["crons"],
-          serverFunctionName: "database.func",
+          function: { kind: "isolated", name: "database.func" },
         },
       }),
     ])
@@ -469,7 +532,7 @@ describe("provider deployment outputs", () => {
       cleanup: {
         cloudflare: {
           fileNames: ["worker.mjs"],
-          wranglerConfigKeys: ["workflows"],
+          wranglerConfigOwnership: { keys: ["workflows"] },
         },
       },
       clientOutDir: "dist/client",
@@ -497,7 +560,7 @@ describe("provider deployment outputs", () => {
       cleanup: {
         cloudflare: {
           fileNames: ["index.js"],
-          wranglerConfigKeys: ["main"],
+          wranglerConfigOwnership: { keys: ["main"] },
         },
       },
       clientOutDir: "dist/client",
@@ -529,7 +592,7 @@ describe("provider deployment outputs", () => {
         cloudflare: async () => {
           observedConfig = await readFile(join(cloudflareDir, "wrangler.json"), "utf8")
           observedWrapper = await readFile(join(cloudflareDir, "index.js"), "utf8")
-          return { fileNames: ["index.js"], wranglerConfigKeys: ["main"] }
+          return { fileNames: ["index.js"], wranglerConfigOwnership: { keys: ["main"] } }
         },
       },
       clientOutDir: "dist/client",

--- a/packages/kv/src/vite.ts
+++ b/packages/kv/src/vite.ts
@@ -189,8 +189,14 @@ export function hubKv(options?: KVModuleOptions): KVVitePlugin {
 
         await writeCloudflareWranglerConfig({
           rootDir: resolved.root,
-          wranglerArrayOwnedValues: { kv_namespaces: [...previousBindings, ...nextBindings] },
-          wranglerArrayMergeKeys: { kv_namespaces: "binding" },
+          wranglerConfigOwnership: {
+            arrays: {
+              kv_namespaces: {
+                key: "binding",
+                values: [...previousBindings, ...nextBindings],
+              },
+            },
+          },
           ...(wranglerConfig ? { wranglerConfig } : {}),
         })
         await writeOwnedCloudflareKVBindings(resolved.root, nextBindings)

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -15,7 +15,7 @@ import { getCloudflareQueueBindingName, getCloudflareQueueName } from "../integr
 import { getVercelQueueTopicName } from "../integrations/vercel.ts"
 
 import type { DiscoveredQueueDefinition, QueueModuleOptions, QueueProvider } from "../types.ts"
-import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
+import type { CloudflareProviderDeploymentOutput, ProviderJsonRecord, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const queuePackageName = "@vite-hub/queue"
 const productName = "queue"
@@ -84,7 +84,7 @@ export interface CloudflareQueueConfigOptions {
   rootDir?: string
 }
 
-export interface CloudflareQueueConfig {
+export interface CloudflareQueueConfig extends ProviderJsonRecord {
   assets?: { directory?: string, run_worker_first: string[] }
   compatibility_date: string
   compatibility_flags: string[]
@@ -263,7 +263,7 @@ function createVercelOutput(artifacts: GeneratedQueueArtifacts, serverFunctionNa
       format: "esm",
       platform: "node",
     },
-    serverFunctionName,
+    ...(serverFunctionName ? { function: { kind: "isolated" as const, name: serverFunctionName } } : {}),
   }
 }
 
@@ -317,7 +317,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   if (!createCloudflare && createVercel) {
     await writeProviderDeploymentOutputs({
       cleanup: {
-        cloudflare: { wranglerConfigKeys: ["queues"] },
+        cloudflare: { wranglerConfigOwnership: { keys: ["queues"] } },
       },
       clientOutDir: options.clientOutDir,
       rootDir: options.rootDir,

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -263,7 +263,7 @@ function createVercelOutput(artifacts: GeneratedQueueArtifacts, serverFunctionNa
       format: "esm",
       platform: "node",
     },
-    ...(serverFunctionName ? { config: {}, serverFunctionName } : {}),
+    serverFunctionName,
   }
 }
 

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -15,7 +15,7 @@ import { getCloudflareQueueBindingName, getCloudflareQueueName } from "../integr
 import { getVercelQueueTopicName } from "../integrations/vercel.ts"
 
 import type { DiscoveredQueueDefinition, QueueModuleOptions, QueueProvider } from "../types.ts"
-import type { CloudflareProviderDeploymentOutput, ProviderJsonRecord, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
+import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const queuePackageName = "@vite-hub/queue"
 const productName = "queue"
@@ -84,7 +84,7 @@ export interface CloudflareQueueConfigOptions {
   rootDir?: string
 }
 
-export interface CloudflareQueueConfig extends ProviderJsonRecord {
+export interface CloudflareQueueConfig {
   assets?: { directory?: string, run_worker_first: string[] }
   compatibility_date: string
   compatibility_flags: string[]

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -639,7 +639,7 @@ function createVercelOutput(
       platform: "node",
       plugins: workflowTransformPlugin ? [workflowTransformPlugin] : [],
     },
-    ...(serverFunctionName ? { config: {}, serverFunctionName } : {}),
+    serverFunctionName,
   }
 }
 

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -15,7 +15,7 @@ import { discoverWorkflowDefinitions } from "../discovery.ts"
 import { createCloudflareWorkflowBindings, getCloudflareWorkflowClassName } from "../integrations/cloudflare.ts"
 
 import type { DiscoveredWorkflowDefinition, ResolvedWorkflowOptions, WorkflowModuleOptions, WorkflowProvider } from "../types.ts"
-import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
+import type { CloudflareProviderDeploymentOutput, ProviderJsonRecord, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const workflowPackageName = "@vite-hub/workflow"
 const productName = "workflow"
@@ -228,7 +228,7 @@ interface WorkflowImportBases {
   workspaceDependencies?: WorkspaceDependencyRuntimeImports
 }
 
-interface CloudflareWorkflowConfig {
+interface CloudflareWorkflowConfig extends ProviderJsonRecord {
   assets?: { directory?: string, run_worker_first: string[] }
   compatibility_date: string
   compatibility_flags: string[]
@@ -613,7 +613,9 @@ async function createCloudflareWorkflowCleanup(rootDir: string) {
   return {
     fileNames: ownsWrapper ? ["index.js", "worker.mjs"] : ["worker.mjs"],
     outputRoot,
-    wranglerConfigKeys: ownsWrapper ? cloudflareWorkflowWranglerConfigKeys : ["workflows"],
+    wranglerConfigOwnership: {
+      keys: ownsWrapper ? cloudflareWorkflowWranglerConfigKeys : ["workflows"],
+    },
   }
 }
 
@@ -639,7 +641,7 @@ function createVercelOutput(
       platform: "node",
       plugins: workflowTransformPlugin ? [workflowTransformPlugin] : [],
     },
-    serverFunctionName,
+    ...(serverFunctionName ? { function: { kind: "isolated" as const, name: serverFunctionName } } : {}),
   }
 }
 

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -15,7 +15,7 @@ import { discoverWorkflowDefinitions } from "../discovery.ts"
 import { createCloudflareWorkflowBindings, getCloudflareWorkflowClassName } from "../integrations/cloudflare.ts"
 
 import type { DiscoveredWorkflowDefinition, ResolvedWorkflowOptions, WorkflowModuleOptions, WorkflowProvider } from "../types.ts"
-import type { CloudflareProviderDeploymentOutput, ProviderJsonRecord, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
+import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const workflowPackageName = "@vite-hub/workflow"
 const productName = "workflow"
@@ -228,7 +228,7 @@ interface WorkflowImportBases {
   workspaceDependencies?: WorkspaceDependencyRuntimeImports
 }
 
-interface CloudflareWorkflowConfig extends ProviderJsonRecord {
+interface CloudflareWorkflowConfig {
   assets?: { directory?: string, run_worker_first: string[] }
   compatibility_date: string
   compatibility_flags: string[]

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -230,8 +230,14 @@ async function writeCloudflareArtifactsProviderOutput(
 
   await writeCloudflareWranglerConfig({
     rootDir,
-    wranglerArrayOwnedValues: { artifacts: [...previousBindings, ...nextBindings] },
-    wranglerArrayMergeKeys: { artifacts: "binding" },
+    wranglerConfigOwnership: {
+      arrays: {
+        artifacts: {
+          key: "binding",
+          values: [...previousBindings, ...nextBindings],
+        },
+      },
+    },
     ...(wranglerConfig ? { wranglerConfig } : {}),
   })
   await writeOwnedCloudflareArtifactsBindings(rootDir, nextBindings)


### PR DESCRIPTION
Centralizes owned provider-config merge, keyed-array preservation, cleanup, and file/root removal in one Internal module. Named Vercel functions now use an explicit root or isolated output contract, so Blob, Database, Queue, and Workflow no longer pass local empty-config preservation workarounds while feature artifact topology stays with each owner package.

The JSON persistence seam validates exact serializable records, preserves unrelated Cloudflare, Vercel, and Netlify configuration, and removes empty owned output deterministically. No provider Adapter, package, public output, CI, or release surface changes.