### PR TITLE
refactor(workspace): own canonical Source metadata

### DIFF
--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -27,8 +27,12 @@ export {
 export {
   getWorkspaceSourceRequestDescriptor,
   isWorkspaceSourceRequestOnly,
+  normalizeWorkspaceSourceMetadata,
+  normalizeWorkspaceSourcesMetadata,
+  workspaceSourceGrantPaths,
   workspaceSourceRequestDescriptorPath,
 } from "./sources/config.ts"
+export type { WorkspaceSourceMetadata } from "./sources/config.ts"
 export { markLiveWorkspaceSource } from "./sources/live.ts"
 export {
   attachWorkspaceSourceRequestExecution,

--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -9,6 +9,7 @@ import {
   assertWorkspaceSourceRequestDescriptorKey,
   getWorkspaceSourceRequestDescriptor,
   isWorkspaceSourceRequestOnly,
+  workspaceSourceRequestDescriptorPath,
 } from "./request-metadata.ts"
 
 import type {
@@ -44,6 +45,11 @@ export interface ResolvedWorkspaceSource {
   requestDescriptor?: WorkspaceSourceRequestDescriptor
   requestOnly?: boolean
 }
+
+export type WorkspaceSourceMetadata = Pick<
+  ResolvedWorkspaceSource,
+  "cache" | "key" | "materialize" | "mountPath" | "probeKeys" | "requestOnly" | "source" | "sync"
+>
 
 export {
   getWorkspaceSourceRequestDescriptor,
@@ -135,6 +141,58 @@ export function normalizeWorkspaceSource(key: string, input: WorkspaceSourceInpu
     requestDescriptor,
     requestOnly: isWorkspaceSourceRequestOnly(source),
   }
+}
+
+export function normalizeWorkspaceSourcesMetadata(sources: WorkspaceDefinition["sources"]): WorkspaceSourceMetadata[] {
+  return normalizeWorkspaceSources(sources).map(toWorkspaceSourceMetadata)
+}
+
+export function normalizeWorkspaceSourceMetadata(key: string, input: WorkspaceSourceInput): WorkspaceSourceMetadata {
+  return toWorkspaceSourceMetadata(normalizeWorkspaceSource(key, input))
+}
+
+export function workspaceSourceGrantPaths(key: string, input: WorkspaceSourceInput): string[] {
+  const source = normalizeWorkspaceSourceMetadata(key, input)
+  const descriptorPath = safeWorkspaceSourceRequestDescriptorPath(key)
+  if (source.requestOnly) {
+    if (!descriptorPath) {
+      throw new Error(`[vitehub] Workspace Scope source grant "${key}" is request-only without a Source Request descriptor.`)
+    }
+    return [descriptorPath]
+  }
+
+  const probePaths = source.probeKeys?.map(sourcePath => joinSourcePath(source.mountPath, sourcePath)).filter(Boolean) || []
+  const paths = probePaths.length ? probePaths : source.mountPath ? [source.mountPath] : []
+  if (!paths.length) {
+    throw new Error(`[vitehub] Workspace Scope source grant "${key}" is root-mounted; grant explicit paths instead.`)
+  }
+  return descriptorPath ? [...paths, descriptorPath] : paths
+}
+
+function toWorkspaceSourceMetadata(source: ResolvedWorkspaceSource): WorkspaceSourceMetadata {
+  return {
+    cache: source.cache,
+    key: source.key,
+    materialize: source.materialize,
+    mountPath: source.mountPath,
+    ...(source.probeKeys?.length ? { probeKeys: source.probeKeys } : {}),
+    requestOnly: source.requestOnly,
+    source: source.source,
+    sync: source.sync,
+  }
+}
+
+function safeWorkspaceSourceRequestDescriptorPath(key: string): string | undefined {
+  try {
+    return workspaceSourceRequestDescriptorPath(key)
+  }
+  catch {
+    return undefined
+  }
+}
+
+function joinSourcePath(mountPath: string, sourcePath: string): string {
+  return [mountPath, sourcePath].filter(Boolean).join("/")
 }
 
 export function sourceMountContainsPath(source: Pick<ResolvedWorkspaceSource, "mountPath">, workspacePath: string): boolean {

--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -335,14 +335,17 @@ async function loadInferredWorkspaceSource(family: WorkspaceSourceFamily, input:
 
 function inferredSourceDefaults(family: WorkspaceSourceFamily, input: WorkspaceSourceInput): Partial<WorkspaceSource> {
   if (!isPlainRecord(input)) {
-    return family === "file" ? { mount: "" } : {}
+    return family === "file" ? { mount: "", probeKeys: [inferredFileSourceKey(input)] } : {}
   }
 
   if (family === "file") {
     const mount = typeof input.mount === "object" && input.mount && !("path" in input.mount)
       ? { ...input.mount, path: "" }
       : input.mount ?? ""
-    return copySourceRuntimeOptions(input, { mount })
+    return copySourceRuntimeOptions(input, {
+      mount,
+      probeKeys: [inferredFileSourceKey(input)],
+    })
   }
 
   if (family === "fetch") {
@@ -374,9 +377,18 @@ function copySourceRuntimeOptions(input: Record<string, unknown>, defaults: Part
     cache: input.cache as WorkspaceSource["cache"] ?? defaults.cache,
     materialize: input.materialize as WorkspaceSource["materialize"] ?? defaults.materialize,
     mount: input.mount as WorkspaceSource["mount"] ?? defaults.mount,
+    probeKeys: input.probeKeys as WorkspaceSource["probeKeys"] ?? defaults.probeKeys,
     sync: input.sync as WorkspaceSource["sync"] ?? defaults.sync,
     validate: input.validate as WorkspaceSource["validate"] ?? defaults.validate,
   }
+}
+
+function inferredFileSourceKey(input: WorkspaceSourceInput): string {
+  if (typeof input === "string") return normalizeSafeWorkspacePath(input)
+  const options = input as unknown as Record<string, unknown>
+  if (typeof options.workspacePath === "string") return normalizeSafeWorkspacePath(options.workspacePath)
+  if (typeof options.path === "string") return normalizeSafeWorkspacePath(options.path)
+  throw new TypeError("[vitehub] file requires a path or workspacePath.")
 }
 
 function inferredLivePaths(family: WorkspaceSourceFamily, input: WorkspaceSourceInput): Record<string, string> | undefined {

--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -458,12 +458,13 @@ function applyWorkspaceBinding(source: WorkspaceSource, input: WorkspaceSourceIn
   copyDefinedWorkspaceBindingOption(next, input, "cache")
   copyDefinedWorkspaceBindingOption(next, input, "materialize")
   copyDefinedWorkspaceBindingOption(next, input, "mount")
+  copyDefinedWorkspaceBindingOption(next, input, "probeKeys")
   copyDefinedWorkspaceBindingOption(next, input, "sync")
   copyDefinedWorkspaceBindingOption(next, input, "validate")
   return next
 }
 
-function copyDefinedWorkspaceBindingOption<TKey extends "cache" | "materialize" | "mount" | "sync" | "validate">(
+function copyDefinedWorkspaceBindingOption<TKey extends "cache" | "materialize" | "mount" | "probeKeys" | "sync" | "validate">(
   target: WorkspaceSource,
   input: Record<string, unknown>,
   key: TKey,

--- a/packages/workspace/test/source-metadata.test.ts
+++ b/packages/workspace/test/source-metadata.test.ts
@@ -182,6 +182,21 @@ describe("Workspace Source metadata", () => {
     expect(workspaceSourceGrantPaths("customers/acme", {} as never)).toEqual([
       "customers/acme",
     ])
+    expect(workspaceSourceGrantPaths("instructions", {
+      probeKeys: ["AGENTS.md"],
+      source: custom({
+        mount: "",
+        async getKeys() {
+          return []
+        },
+        async getItem(key) {
+          return { content: "", key }
+        },
+      }),
+    })).toEqual([
+      "AGENTS.md",
+      ".vitehub/sources/instructions.json",
+    ])
     expect(() => workspaceSourceGrantPaths("root", custom({
       mount: "",
       async getKeys() {

--- a/packages/workspace/test/source-metadata.test.ts
+++ b/packages/workspace/test/source-metadata.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { custom, fetch, file, github, mcpResources } from "../src/index.ts"
+import {
+  normalizeWorkspaceSourceMetadata,
+  normalizeWorkspaceSourcesMetadata,
+  resolveWorkspaceSources,
+  useWorkspace,
+  workspaceSourceGrantPaths,
+} from "../src/runtime.ts"
+import { resetWorkspaceRegistry } from "../src/core/registry.ts"
+import { registerWorkspace } from "../src/test.ts"
+
+import type { McpResourcesClient } from "../src/index.ts"
+
+const invocation = {
+  context: {
+    entries: () => new Map<string, unknown>().entries(),
+    get: () => undefined,
+    has: () => false,
+    toJSON: () => ({}),
+  },
+}
+
+const mcpClient: McpResourcesClient = {
+  async listResources() {
+    return {
+      resources: [{
+        name: "documentation-pages",
+        uri: "resource://nuxt-com/documentation-pages",
+      }],
+    }
+  },
+  async readResource({ uri }) {
+    return {
+      contents: [{
+        mimeType: "application/json",
+        text: JSON.stringify([{ path: "/docs/getting-started" }]),
+        uri,
+      }],
+    }
+  },
+}
+
+afterEach(() => {
+  resetWorkspaceRegistry()
+  vi.unstubAllGlobals()
+})
+
+describe("Workspace Source metadata", () => {
+  it("projects canonical metadata for every Source form", () => {
+    const sources = Object.fromEntries(normalizeWorkspaceSourcesMetadata({
+      customDocs: custom({
+        materialize: "lazy",
+        mount: "docs",
+        probeKeys: ["guide.md"],
+        async getKeys() {
+          return ["guide.md"]
+        },
+        async getItem(key) {
+          return { content: "guide", key }
+        },
+      }),
+      nuxt: mcpResources({
+        server: mcpClient,
+        sync: true,
+      }),
+      repository: github({
+        cache: { maxAge: 60 },
+        repo: "vite-hub/vitehub",
+      }),
+      request: fetch({
+        method: "POST",
+        url: "https://status.example.com/query",
+      }),
+      rootFile: file("AGENTS.md"),
+      status: fetch({
+        url: "https://status.example.com/health",
+        workspacePath: "external/status.json",
+      }),
+    }).map(source => [source.key, source]))
+
+    expect(sources.rootFile).toMatchObject({
+      cache: false,
+      materialize: "build",
+      mountPath: "",
+      probeKeys: ["AGENTS.md"],
+      requestOnly: false,
+      sync: false,
+    })
+    expect(sources.status).toMatchObject({
+      cache: false,
+      materialize: "lazy",
+      mountPath: "external",
+      probeKeys: ["status.json"],
+      requestOnly: false,
+      sync: false,
+    })
+    expect(sources.repository).toMatchObject({
+      cache: { maxAge: 60 },
+      materialize: "lazy",
+      mountPath: "repository",
+      requestOnly: false,
+      sync: false,
+    })
+    expect(sources.nuxt).toMatchObject({
+      cache: false,
+      materialize: "none",
+      mountPath: "nuxt",
+      requestOnly: false,
+      sync: { stale: "keep" },
+    })
+    expect(sources.customDocs).toMatchObject({
+      cache: false,
+      materialize: "lazy",
+      mountPath: "docs",
+      probeKeys: ["guide.md"],
+      requestOnly: false,
+      sync: false,
+    })
+    expect(sources.request).toMatchObject({
+      cache: false,
+      materialize: "lazy",
+      mountPath: "",
+      requestOnly: true,
+      sync: false,
+    })
+  })
+
+  it("uses canonical custom Source detection and sync normalization", () => {
+    const incompleteCustom = normalizeWorkspaceSourceMetadata("repository", {
+      async getKeys() {
+        return []
+      },
+      repo: "vite-hub/vitehub",
+    } as never)
+    const synced = normalizeWorkspaceSourceMetadata("synced", custom({
+      async getKeys() {
+        return []
+      },
+      async getItem(key) {
+        return { content: "", key }
+      },
+      sync: true,
+    }))
+
+    expect(incompleteCustom.source.getItem).toBeTypeOf("function")
+    expect(synced.sync).toEqual({ stale: "keep" })
+  })
+
+  it("derives Access grant candidates from canonical Source placement", () => {
+    expect(workspaceSourceGrantPaths("docs", file({ path: "README.md", mount: "docs" }))).toEqual([
+      "docs/README.md",
+      ".vitehub/sources/docs.json",
+    ])
+    expect(workspaceSourceGrantPaths("status", fetch({
+      url: "https://status.example.com/health",
+      workspacePath: "external/status/health.json",
+    }))).toEqual([
+      "external/status/health.json",
+      ".vitehub/sources/status.json",
+    ])
+    expect(workspaceSourceGrantPaths("request", fetch({
+      method: "POST",
+      url: "https://status.example.com/query",
+    }))).toEqual([
+      ".vitehub/sources/request.json",
+    ])
+    expect(workspaceSourceGrantPaths("customers/acme", {} as never)).toEqual([
+      "customers/acme",
+    ])
+    expect(() => workspaceSourceGrantPaths("root", custom({
+      mount: "",
+      async getKeys() {
+        return []
+      },
+      async getItem(key) {
+        return { content: "", key }
+      },
+    }))).toThrow("root-mounted; grant explicit paths instead")
+  })
+
+  it("keeps dynamic Source metadata aligned with the Source that is read", async () => {
+    const resolved = await resolveWorkspaceSources({
+      name: "customer-status",
+      sources: {
+        status: fetch(({ selectedWorkspaceScope }) => ({
+          responseType: "text",
+          url: "https://status.example.com/health",
+          workspacePath: `customers/${selectedWorkspaceScope?.name}/status.txt`,
+        })),
+      },
+      store: { provider: "memory" },
+    }, {
+      invocation,
+      selectedWorkspaceScope: {
+        all: false,
+        name: "acme",
+        paths: ["customers/acme/status.txt"],
+        role: "viewer",
+      },
+    })
+    const status = normalizeWorkspaceSourceMetadata("status", resolved.sources!.status!)
+    const request = vi.fn(async () => new Response("healthy", {
+      headers: { "content-type": "text/plain" },
+      status: 200,
+    }))
+    vi.stubGlobal("fetch", request)
+    registerWorkspace("customer-status", {
+      sources: resolved.sources,
+      store: { provider: "memory" },
+    })
+
+    expect(status).toMatchObject({
+      materialize: "lazy",
+      mountPath: "customers/acme",
+      probeKeys: ["status.txt"],
+      requestOnly: false,
+    })
+    await expect(useWorkspace("customer-status").fs.readFile("customers/acme/status.txt")).resolves.toBe("healthy")
+    expect(request).toHaveBeenCalledOnce()
+  })
+
+  it("reads File, MCP, and Custom Sources through the Workspace runtime", async () => {
+    registerWorkspace("source-forms", {
+      sources: {
+        guide: custom({
+          files: [{ content: "guide", path: "guide.md" }],
+          mount: "docs",
+        }),
+        instructions: file({
+          content: "instructions",
+          workspacePath: "AGENTS.md",
+        }),
+        nuxt: mcpResources({
+          mount: "mcp",
+          server: mcpClient,
+        }),
+      },
+      store: { provider: "memory" },
+    })
+    const workspace = useWorkspace("source-forms")
+
+    await expect(workspace.fs.readFile("AGENTS.md")).resolves.toBe("instructions")
+    await expect(workspace.fs.readFile("docs/guide.md")).resolves.toBe("guide")
+    await expect(workspace.fs.readFile("mcp/nuxt-com/documentation-pages.json")).resolves.toBe(
+      JSON.stringify([{ path: "/docs/getting-started" }]),
+    )
+  })
+})

--- a/packages/workspace/test/source-metadata.test.ts
+++ b/packages/workspace/test/source-metadata.test.ts
@@ -148,6 +148,19 @@ describe("Workspace Source metadata", () => {
     expect(synced.sync).toEqual({ stale: "keep" })
   })
 
+  it("retains probe keys for inferred File Sources before loading them", () => {
+    expect(normalizeWorkspaceSourceMetadata("instructions", "AGENTS.md")).toMatchObject({
+      mountPath: "",
+      probeKeys: ["AGENTS.md"],
+    })
+    expect(normalizeWorkspaceSourceMetadata("summaryInstructions", {
+      path: ".agents/summary/AGENTS.md",
+    } as never)).toMatchObject({
+      mountPath: "",
+      probeKeys: [".agents/summary/AGENTS.md"],
+    })
+  })
+
   it("derives Access grant candidates from canonical Source placement", () => {
     expect(workspaceSourceGrantPaths("docs", file({ path: "README.md", mount: "docs" }))).toEqual([
       "docs/README.md",


### PR DESCRIPTION
Exposes one Workspace-owned Source metadata interface, backed directly by the existing Workspace normalizer, so runtime consumers share mount, materialization, cache and sync, probe, request-only, and grant-path semantics.

Adds an executable Source-form matrix for File, Fetch, GitHub, MCP, Custom, root-mounted, request-only, cached, synced, and dynamic Sources, including real Workspace reads and regressions for custom detection and sync normalization. Access authorization stays unchanged; a stacked follow-up migrates Agent callers and deletes its mirrored interpreter.