### PR TITLE
refactor(agent): generate one deployment catalog for Nitro

### DIFF
--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -782,6 +782,84 @@ function generatedAgentIdentityEntries(definitions: DiscoveredAgentDefinition[])
     .join(",\n  ")
 }
 
+interface GeneratedAgentDeploymentCatalog {
+  imports: string[]
+  setup: string[]
+}
+
+async function generateAgentDeploymentCatalog(
+  definitions: DiscoveredAgentDefinition[],
+  handlerPath: string,
+  options: {
+    agentImportBase: string
+    workspaceImportBase: string
+    workspaceRuntimeImport?: string
+  },
+): Promise<GeneratedAgentDeploymentCatalog> {
+  const entries = await Promise.all(definitions.map(async (definition, index) => {
+    const moduleName = `agent${index}`
+    const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
+    const colocatedInstructions = await readColocatedAgentInstructions(definition.handler)
+    const colocatedSkills = readColocatedAgentSkills(definition.handler)
+    const agentExpression = `withWorkspaceSourceRoot(resolveAgentModule(${moduleName}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(colocatedInstructions)}, ${JSON.stringify(colocatedSkills)})`
+    return {
+      agentEntry: `${JSON.stringify(definition.name)}: ${agentExpression}`,
+      import: `import * as ${moduleName} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`,
+      moduleEntry: `${JSON.stringify(definition.name)}: ${moduleName}`,
+      workspaceEntry: definition.workspace
+        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, ${moduleName}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(colocatedInstructions)}, ${JSON.stringify(colocatedSkills)})`
+        : undefined,
+    }
+  }))
+  const hostedWorkspaceRuntime = generatedHostedWorkspaceRuntimeSetup(definitions, options.workspaceImportBase)
+  const workspaceEntries = entries.flatMap(entry => entry.workspaceEntry ? [entry.workspaceEntry] : []).join(",\n  ")
+  if (workspaceEntries && !options.workspaceRuntimeImport) {
+    throw new TypeError("[vitehub] Agent deployment catalog requires a Workspace runtime import for Workspace Agents.")
+  }
+  const agentEntries = entries.map(entry => entry.agentEntry).join(",\n  ")
+  const agentModuleEntries = entries.map(entry => entry.moduleEntry).join(",\n  ")
+  const agentIdentityEntries = generatedAgentIdentityEntries(definitions)
+
+  return {
+    imports: [
+      `import { workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(options.agentImportBase)}`,
+      `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler, hasChannelChatRoute } from ${JSON.stringify(subpath(options.agentImportBase, "server/internal"))}`,
+      ...(options.workspaceRuntimeImport ? [`import { setWorkspaceRuntimeRegistry } from ${JSON.stringify(options.workspaceRuntimeImport)}`] : []),
+      ...hostedWorkspaceRuntime.imports,
+      ...entries.map(entry => entry.import),
+    ],
+    setup: [
+      "function resolveAgentModule(module) {",
+      "  return module && typeof module === 'object' && 'default' in module ? module.default : module",
+      "}",
+      "",
+      "function resolveChatRouteOptions(module) {",
+      "  const chatRoute = module && typeof module === 'object' ? module.chatRoute : undefined",
+      "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
+      "}",
+      "",
+      ...generatedWorkspaceSourceRootHelper("withWorkspaceSourceRoot", "workspaceDefinitionFromOptions"),
+      "",
+      "function workspaceRegistryEntry(name, module, sourceRootDir, colocatedInstructions, colocatedSkills) {",
+      "  const agent = withWorkspaceSourceRoot(resolveAgentModule(module), sourceRootDir, colocatedInstructions, colocatedSkills)",
+      "  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return",
+      "  return [name, async () => ({ ...module, default: agent })]",
+      "}",
+      "",
+      ...hostedWorkspaceRuntime.setup,
+      ...(options.workspaceRuntimeImport
+        ? [`setWorkspaceRuntimeRegistry(Object.fromEntries([${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}].filter(Boolean)))`, ""]
+        : []),
+      `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
+      `const agentIdentities = {${agentIdentityEntries ? `\n  ${agentIdentityEntries}\n` : ""}}`,
+      `const agentModules = {${agentModuleEntries ? `\n  ${agentModuleEntries}\n` : ""}}`,
+      "const chatHandlers = Object.fromEntries(Object.entries(agents).filter(([, agent]) => hasChannelChatRoute(agent)).map(([name, agent]) => [name, createChannelChatRouteHandler(agent, resolveChatRouteOptions(agentModules[name]))]))",
+      "const webhookHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, createChannelWebhookRouteHandler(agent)]))",
+      "const agentNames = Object.keys(agents)",
+    ],
+  }
+}
+
 async function generateAgentWebhookRouteHandler(
   definitions: DiscoveredAgentDefinition[],
   handlerPath: string,
@@ -793,31 +871,11 @@ async function generateAgentWebhookRouteHandler(
   const workflowRuntime = generatedAgentWorkflowRuntime(options, agentImportBase)
   const workspaceDependencyRuntime = generatedAgentWorkspaceDependencyRuntime(options, workspaceImportBase)
   const runtimeRouteOption = options.runtime === "vite" ? ", runtime: 'vite'" : ""
-  const imports = definitions
-    .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
-    .join("\n")
-  const workspaceEntries = (await Promise.all(definitions
-    .map(async (definition, index) => {
-      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      return definition.workspace
-        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))})`
-        : undefined
-    })))
-    .filter(Boolean)
-    .join(",\n  ")
-  const agentEntries = definitions
-    .map(async (definition, index) => {
-      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      const agentExpression = `withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))})`
-      return `${JSON.stringify(definition.name)}: ${agentExpression}`
-    })
-  const resolvedAgentEntries = (await Promise.all(agentEntries))
-    .join(",\n  ")
-  const agentModuleEntries = definitions
-    .map((definition, index) => `${JSON.stringify(definition.name)}: agent${index}`)
-    .join(",\n  ")
-  const agentIdentityEntries = generatedAgentIdentityEntries(definitions)
-  const hostedWorkspaceRuntime = generatedHostedWorkspaceRuntimeSetup(definitions, workspaceImportBase)
+  const deploymentCatalog = await generateAgentDeploymentCatalog(definitions, handlerPath, {
+    agentImportBase,
+    workspaceImportBase,
+    workspaceRuntimeImport: subpath(workspaceImportBase, "runtime"),
+  })
   const webhookRoute = typeof options.webhookRoute === "string" ? options.webhookRoute : ""
   const webhookSelector = webhookRoute.includes("[webhook]") ? "getRouterParam(event, 'webhook')" : "''"
   const webhookStateOption = options.cloudflareState
@@ -827,38 +885,17 @@ async function generateAgentWebhookRouteHandler(
       : ""
 
   return [
-    `import { workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
+    ...deploymentCatalog.imports,
     ...(options.cloudflareState ? [`import { createCloudflareAgentState } from ${JSON.stringify(subpath(agentImportBase, "cloudflare"))}`] : []),
     ...(options.libsqlState ? [`import { createLibsqlAgentState } from ${JSON.stringify(subpath(agentImportBase, "state/sqlite"))}`] : []),
-    `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler, hasChannelChatRoute } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
     ...workflowRuntime.imports,
     ...workspaceDependencyRuntime.imports,
     ...routeCapabilities.imports,
-    `import { setWorkspaceRuntimeRegistry } from ${JSON.stringify(subpath(workspaceImportBase, "runtime"))}`,
-    ...hostedWorkspaceRuntime.imports,
     "import { createError, defineEventHandler, getRequestHeaders, getRequestURL, getRouterParam, readRawBody } from 'h3'",
-    imports,
     "",
     ...workflowRuntime.setup,
     ...workspaceDependencyRuntime.setup,
-    "function resolveAgentModule(module) {",
-    "  return module && typeof module === 'object' && 'default' in module ? module.default : module",
-    "}",
-    "",
-    "function resolveChatRouteOptions(module) {",
-    "  const chatRoute = module && typeof module === 'object' ? module.chatRoute : undefined",
-    "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
-    "}",
-    "",
-    ...generatedWorkspaceSourceRootHelper("withWorkspaceSourceRoot", "workspaceDefinitionFromOptions"),
-    "",
-    "function workspaceRegistryEntry(name, module, sourceRootDir, colocatedInstructions, colocatedSkills) {",
-    "  const agent = withWorkspaceSourceRoot(resolveAgentModule(module), sourceRootDir, colocatedInstructions, colocatedSkills)",
-    "  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return",
-    "  return [name, async () => ({ ...module, default: agent })]",
-    "}",
-    "",
-    ...hostedWorkspaceRuntime.setup,
+    ...deploymentCatalog.setup,
     "async function toRequest(event) {",
     "  const body = await readRawBody(event)",
     "  return new Request(getRequestURL(event), {",
@@ -873,14 +910,6 @@ async function generateAgentWebhookRouteHandler(
     ...(options.libsqlState ? generatedLibsqlChatStateHelper(options.libsqlState) : []),
     "",
     ...routeCapabilities.setup,
-    `setWorkspaceRuntimeRegistry(Object.fromEntries([${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}].filter(Boolean)))`,
-    "",
-    `const agents = {${resolvedAgentEntries ? `\n  ${resolvedAgentEntries}\n` : ""}}`,
-    `const agentIdentities = {${agentIdentityEntries ? `\n  ${agentIdentityEntries}\n` : ""}}`,
-    `const agentModules = {${agentModuleEntries ? `\n  ${agentModuleEntries}\n` : ""}}`,
-    "const chatHandlers = Object.fromEntries(Object.entries(agents).filter(([, agent]) => hasChannelChatRoute(agent)).map(([name, agent]) => [name, createChannelChatRouteHandler(agent, resolveChatRouteOptions(agentModules[name]))]))",
-    "const webhookHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, createChannelWebhookRouteHandler(agent)]))",
-    "const agentNames = Object.keys(agents)",
     `const chatRoutePattern = new RegExp(${JSON.stringify(routeRegexSource(options.chatRoute))})`,
     `const webhookRoutePattern = new RegExp(${JSON.stringify(routeRegexSource(options.webhookRoute))})`,
     "",


### PR DESCRIPTION
Introduces one generated Agent deployment catalog for definition imports, identities, Workspace registration, colocated assets, and route handler lookup, then migrates the Nitro Adapter to consume it. Nitro keeps its H3 request conversion, state, wait-until, and route selection local while repeated catalog construction moves behind one interface.

The existing executable deployment fixture proves chat, webhook, unknown-Agent, Workspace, colocated instruction and skill, state, and wait-until behavior through the generated Nitro handler.