### PR TITLE
feat(agent): accept scheduled invocation input

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -735,9 +735,12 @@ async function runAgentAsWorkflow<
 
   const handle = await getAgentWorkflowHandle<TRuntimeConfig, CALL_OPTIONS, TOutput>(agent, resolveAgentWorkflowName(agent, binding, context), Boolean(context.agentIdentity))
   const resolvedContext = createResolvedRuntimeContext(context)
+  const workflowInput = { ...input }
+  // ponytail: AbortSignal is live process state and cannot cross a durable Workflow payload.
+  delete workflowInput.abortSignal
   const payload: AgentWorkflowInvocationPayload<CALL_OPTIONS> = {
     ...(context.agentIdentity ? { agentIdentity: context.agentIdentity } : {}),
-    input,
+    input: workflowInput,
     runtime: context.runtime,
     runtimeConfig: resolvedContext.runtimeConfig,
     ...(context.run ? { run: context.run } : {}),
@@ -2534,16 +2537,23 @@ export async function runAgent<
   return await runAgentInline(agent, invocationContext, input)
 }
 
-export async function runScheduledAgent(
+export async function runScheduledAgent<CALL_OPTIONS = unknown>(
   agent: AgentInput<AgentRuntimeContext>,
   context: ScheduleRunContextLike,
   runtimeContext: Partial<ResolvedAgentRuntimeContext> = {},
+  input: AgentRunInput<CALL_OPTIONS> = {},
 ): Promise<unknown> {
   const memoValues = new Map<string, unknown>()
   const runId = context.runId || context.id
   const turn = context.input && typeof context.input === "object" && (context.input as { kind?: unknown }).kind === "agent-turn"
     ? parseScheduledAgentTurnInput(context.input)
     : undefined
+  const forwardedInput = { ...input }
+  if (turn) {
+    delete forwardedInput.message
+    delete forwardedInput.messages
+    delete forwardedInput.prompt
+  }
 
   return await runAgent(agent, {
     ...runtimeContext,
@@ -2555,7 +2565,9 @@ export async function runScheduledAgent(
     runtime: runtimeContext.runtime ?? "unknown",
     waitUntil: runtimeContext.waitUntil ?? context.waitUntil ?? (() => {}),
   }, {
+    ...forwardedInput,
     context: {
+      ...input.context,
       ...(turn
         ? {
             invoker: turn.invoker,

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2578,6 +2578,91 @@ describe("agent message protocol", () => {
     }])
   })
 
+  it("passes invocation input through scheduled Agent runs", async () => {
+    const { defineAgent, runScheduledAgent } = await import("../src/index.ts")
+    const abortController = new AbortController()
+    const seen: unknown[] = []
+    const agent = defineAgent<any, { worktreePath: string }>({
+      driver: { run: context => {
+          seen.push({
+            abortSignal: context.input.abortSignal,
+            owner: context.context.get("owner"),
+            options: context.input.options,
+            prompt: context.prompt,
+            schedule: context.context.get("schedule"),
+          })
+          return "ok"
+        } },
+    })
+    const scheduledAt = new Date("2026-05-23T09:00:00.000Z")
+
+    await expect(runScheduledAgent(agent, {
+      id: "srun-scheduled-review",
+      runId: "review-pr-646",
+      scheduleId: "scheduled-review",
+      scheduledAt,
+      target: "agent/reviewer",
+    }, {}, {
+      abortSignal: abortController.signal,
+      context: { owner: "vite-hub/vitehub" },
+      options: { worktreePath: "/tmp/vitehub-pr-646" },
+      prompt: "Review pull request 646.",
+    })).resolves.toBe("ok")
+
+    expect(seen).toEqual([{
+      abortSignal: abortController.signal,
+      owner: "vite-hub/vitehub",
+      options: { worktreePath: "/tmp/vitehub-pr-646" },
+      prompt: "Review pull request 646.",
+      schedule: {
+        id: "srun-scheduled-review",
+        kind: "schedule",
+        runId: "review-pr-646",
+        scheduleId: "scheduled-review",
+        scheduledAt,
+        target: "agent/reviewer",
+      },
+    }])
+  })
+
+  it("keeps durable scheduled Agent turn prompts authoritative", async () => {
+    const { defineAgent, runScheduledAgent } = await import("../src/index.ts")
+    const seen: unknown[] = []
+    const agent = defineAgent({
+      driver: { run: context => {
+          seen.push({
+            input: context.input,
+            messages: context.messages,
+            prompt: context.prompt,
+          })
+          return "ok"
+        } },
+    })
+
+    await expect(runScheduledAgent(agent, {
+      id: "srun-durable",
+      input: {
+        invoker: { id: "discord:user-1", kind: "chat" },
+        kind: "agent-turn",
+        prompt: "Persisted turn prompt.",
+      },
+      scheduledAt: new Date("2026-05-23T09:00:00.000Z"),
+    }, {}, {
+      message: "Caller message.",
+      messages: [createMessage({ role: "user", text: "Caller messages." })],
+      prompt: [createMessage({ role: "user", text: "Caller prompt messages." })],
+    })).resolves.toBe("ok")
+
+    expect(seen).toEqual([{
+      input: expect.not.objectContaining({
+        message: expect.anything(),
+        messages: expect.anything(),
+      }),
+      messages: [],
+      prompt: "Persisted turn prompt.",
+    }])
+  })
+
   it("uses the schedule id as run id when scheduled context omits provider run id", async () => {
     const { defineAgent, runScheduledAgent } = await import("../src/index.ts")
     const seen: unknown[] = []
@@ -8582,6 +8667,33 @@ describe("agent message protocol", () => {
       await Promise.all(waitUntilTasks)
       await expect(getWorkflowRun("support-agent", run.id)).resolves.toMatchObject({
         result: "received hello",
+        status: "completed",
+      })
+    })
+
+    it("does not serialize abort signals into Agent Workflow payloads", async () => {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = defineAgent({
+        driver: { run: context => Boolean(context.input.abortSignal) },
+      })
+      const run = await runAgent(agent, {
+        agentIdentity: { name: "support-agent-abort-signal" },
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, {
+        abortSignal: new AbortController().signal,
+        prompt: "hello",
+      }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("support-agent-abort-signal", run.id)).resolves.toMatchObject({
+        result: false,
         status: "completed",
       })
     })


### PR DESCRIPTION
Lets scheduled Agent Invocations accept the same input fields as ordinary runs through an optional fourth argument to `runScheduledAgent`. Existing callers remain source-compatible, while scheduled consumers can pass prompt, context, Agent-specific options, and inline cancellation without rebuilding ViteHubs memo, run metadata, runtime, or waitUntil context.

Schedule metadata remains authoritative in invocation context, and durable Agent turns still own their invoker, delivery metadata, and prompt/message fields. Live AbortSignals remain process-local and are not serialized into durable Workflow payloads. The characterization covers prompt, custom context, options.worktreePath, a caller-selected scheduled run ID, durable prompt authority, and the Workflow serialization boundary.

Validated with focused scheduled-input and Workflow-boundary characterizations, Agent typecheck, package build, and diff check. Required CI still exposes four unrelated global-Skill workspace test failures on the base branch.