### PR TITLE
refactor(agent): migrate Netlify to deployment catalog

### DIFF
--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -940,55 +940,24 @@ async function generateAgentNetlifyFunctionRouteHandler(
   const workflowRuntime = generatedAgentWorkflowRuntime(options, agentImportBase)
   const workspaceDependencyRuntime = generatedAgentWorkspaceDependencyRuntime(options, workspaceImportBase)
   const runtimeRouteOption = options.runtime === "vite" ? ", runtime: 'vite'" : ""
-  const imports = definitions
-    .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
-    .join("\n")
-  const workspaceEntries = (await Promise.all(definitions
-    .map(async (definition, index) => {
-      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      return definition.workspace
-        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))})`
-        : undefined
-    })))
-    .filter(Boolean)
-    .join(",\n  ")
-  const agentEntries = (await Promise.all(definitions
-    .map(async (definition, index) => {
-      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      const agentExpression = `withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))})`
-      return `${JSON.stringify(definition.name)}: ${agentExpression}`
-    })))
-    .join(",\n  ")
-  const agentModuleEntries = definitions
-    .map((definition, index) => `${JSON.stringify(definition.name)}: agent${index}`)
-    .join(",\n  ")
-  const agentIdentityEntries = generatedAgentIdentityEntries(definitions)
-  const hostedWorkspaceRuntime = generatedHostedWorkspaceRuntimeSetup(definitions, workspaceImportBase)
+  const deploymentCatalog = await generateAgentDeploymentCatalog(definitions, handlerPath, {
+    agentImportBase,
+    workspaceImportBase,
+    workspaceRuntimeImport: subpath(agentImportBase, "server/workspace"),
+  })
   const webhookSelector = routeUsesParam(options.webhookRoute, "webhook") ? "netlifyParam(context, 'webhook')" : "''"
   const webhookStateOption = options.libsqlState ? "state: chatStateFromLibsql(), " : ""
 
   return [
-    `import { workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
+    ...deploymentCatalog.imports,
     ...(options.libsqlState ? [`import { createLibsqlAgentState } from ${JSON.stringify(subpath(agentImportBase, "state/sqlite"))}`] : []),
-    `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler, createDiscordGatewayRouteHandler, hasChannelChatRoute } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
+    `import { createDiscordGatewayRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
     ...workflowRuntime.imports,
     ...workspaceDependencyRuntime.imports,
     ...routeCapabilities.imports,
-    `import { setWorkspaceRuntimeRegistry } from ${JSON.stringify(subpath(agentImportBase, "server/workspace"))}`,
-    ...hostedWorkspaceRuntime.imports,
-    imports,
     "",
     ...workflowRuntime.setup,
     ...workspaceDependencyRuntime.setup,
-    "function resolveAgentModule(module) {",
-    "  return module && typeof module === 'object' && 'default' in module ? module.default : module",
-    "}",
-    "",
-    "function resolveChatRouteOptions(module) {",
-    "  const chatRoute = module && typeof module === 'object' ? module.chatRoute : undefined",
-    "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
-    "}",
-    "",
     "function bearerToken(value) {",
     "  const match = /^Bearer\\s+(.+)$/i.exec(value || '')",
     "  return match?.[1]",
@@ -1000,28 +969,12 @@ async function generateAgentNetlifyFunctionRouteHandler(
     "    .replace(/(^|\\/):([^/]+)/g, (_, prefix, key) => `${prefix}${encodeURIComponent(values[key] || '')}`)",
     "}",
     "",
-    ...generatedWorkspaceSourceRootHelper("withWorkspaceSourceRoot", "workspaceDefinitionFromOptions"),
-    "",
-    "function workspaceRegistryEntry(name, module, sourceRootDir, colocatedInstructions, colocatedSkills) {",
-    "  const agent = withWorkspaceSourceRoot(resolveAgentModule(module), sourceRootDir, colocatedInstructions, colocatedSkills)",
-    "  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return",
-    "  return [name, async () => ({ ...module, default: agent })]",
-    "}",
-    "",
-    ...hostedWorkspaceRuntime.setup,
+    ...deploymentCatalog.setup,
     ...(options.libsqlState ? generatedLibsqlChatStateHelper(options.libsqlState) : []),
     ...generatedNetlifyRuntimeHelpers(),
     "",
     ...routeCapabilities.setup,
-    `setWorkspaceRuntimeRegistry(Object.fromEntries([${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}].filter(Boolean)))`,
-    "",
-    `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
-    `const agentIdentities = {${agentIdentityEntries ? `\n  ${agentIdentityEntries}\n` : ""}}`,
-    `const agentModules = {${agentModuleEntries ? `\n  ${agentModuleEntries}\n` : ""}}`,
-    "const chatHandlers = Object.fromEntries(Object.entries(agents).filter(([, agent]) => hasChannelChatRoute(agent)).map(([name, agent]) => [name, createChannelChatRouteHandler(agent, resolveChatRouteOptions(agentModules[name]))]))",
-    "const webhookHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, createChannelWebhookRouteHandler(agent)]))",
     "const discordGatewayHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, createDiscordGatewayRouteHandler(agent)]))",
-    "const agentNames = Object.keys(agents)",
     `const webhookRoute = ${JSON.stringify(generatedWebhookRoute(options.webhookRoute))}`,
     `const defaultDiscordGatewayDurationMs = ${JSON.stringify(9 * 60 * 1000)}`,
     `const chatRoutePattern = new RegExp(${JSON.stringify(routeRegexSource(options.chatRoute))})`,

--- a/packages/agent/test/deployment-catalog.test.ts
+++ b/packages/agent/test/deployment-catalog.test.ts
@@ -52,6 +52,7 @@ function deploymentRuntimeModules(): Map<string, string> {
       "export const hasChannelChatRoute = () => true",
       "export const createChannelChatRouteHandler = agent => async (_request, options) => handle('chat', agent, undefined, options)",
       "export const createChannelWebhookRouteHandler = agent => async (_request, webhook, options) => handle('webhook', agent, webhook, options)",
+      "export const createDiscordGatewayRouteHandler = agent => async (_request, options) => handle('discord', agent, undefined, options)",
     ].join("\n")],
     ["@vite-hub/agent/state/sqlite", [
       `const capture = globalThis.${runtimeCaptureKey}`,
@@ -61,6 +62,10 @@ function deploymentRuntimeModules(): Map<string, string> {
       "}",
     ].join("\n")],
     ["@vite-hub/workspace/runtime", [
+      `const capture = globalThis.${runtimeCaptureKey}`,
+      "export function setWorkspaceRuntimeRegistry(workspaceRegistry) { capture.workspaceRegistry = workspaceRegistry }",
+    ].join("\n")],
+    ["@vite-hub/agent/server/workspace", [
       `const capture = globalThis.${runtimeCaptureKey}`,
       "export function setWorkspaceRuntimeRegistry(workspaceRegistry) { capture.workspaceRegistry = workspaceRegistry }",
     ].join("\n")],
@@ -77,8 +82,10 @@ function deploymentRuntimeModules(): Map<string, string> {
   ])
 }
 
-async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixture> {
-  const root = await mkdtemp(join(tmpdir(), "vitehub-agent-deployment-catalog-"))
+async function createDeploymentRuntimeFixture(adapter: "netlify" | "nitro" = "nitro"): Promise<DeploymentRuntimeFixture> {
+  const root = await mkdtemp(adapter === "netlify"
+    ? join(import.meta.dirname, "fixtures", "deployment-catalog-")
+    : join(tmpdir(), "vitehub-agent-deployment-catalog-"))
   const supportRoot = join(root, "server", "agents", "support")
   const reviewerRoot = join(root, "server", "agents", "reviewer")
   const capture: DeploymentRuntimeCapture = { workspaceRegistry: {} }
@@ -87,7 +94,6 @@ async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixtur
 
   await mkdir(join(supportRoot, "workspace"), { recursive: true })
   await mkdir(join(supportRoot, "skills", "review"), { recursive: true })
-  await mkdir(reviewerRoot, { recursive: true })
   await writeFile(join(supportRoot, "agent.ts"), [
     "import { defineAgent } from '@vite-hub/agent'",
     "export default defineAgent({",
@@ -100,15 +106,18 @@ async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixtur
   ].join("\n"), "utf8")
   await writeFile(join(supportRoot, "instructions.md"), "Support the deployment catalog.\n", "utf8")
   await writeFile(join(supportRoot, "skills", "review", "SKILL.md"), "# Review\n", "utf8")
-  await writeFile(join(reviewerRoot, "agent.ts"), [
-    "import { defineAgent } from '@vite-hub/agent'",
-    "export default defineAgent({",
-    "  description: 'reviewer',",
-    "  driver: { run: async () => ({ text: 'reviewer' }) },",
-    "  runtime: false,",
-    "})",
-    "",
-  ].join("\n"), "utf8")
+  if (adapter === "nitro") {
+    await mkdir(reviewerRoot, { recursive: true })
+    await writeFile(join(reviewerRoot, "agent.ts"), [
+      "import { defineAgent } from '@vite-hub/agent'",
+      "export default defineAgent({",
+      "  description: 'reviewer',",
+      "  driver: { run: async () => ({ text: 'reviewer' }) },",
+      "  runtime: false,",
+      "})",
+      "",
+    ].join("\n"), "utf8")
+  }
 
   const modules = deploymentRuntimeModules()
   const server = await createServer({
@@ -127,6 +136,7 @@ async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixtur
         },
       }),
       {
+        enforce: "pre",
         name: "vitehub-agent-deployment-runtime-fixture",
         resolveId(id) {
           return modules.has(id) ? `\0${id}` : undefined
@@ -146,9 +156,12 @@ async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixtur
     server: { middlewareMode: true },
   })
 
-  const route = await server.ssrLoadModule(join(root, ".vitehub", "agent", "chat-webhook-route.ts")) as {
-    default: (event: Record<string, unknown>) => Promise<Response>
-  }
+  const route = await server.ssrLoadModule(join(
+    root,
+    ".vitehub",
+    "agent",
+    adapter === "netlify" ? "netlify-function.mjs" : "chat-webhook-route.ts",
+  )) as { default: (input: Record<string, unknown> | Request, context?: Record<string, unknown>) => Promise<Response> }
   const waitUntilTasks: Promise<unknown>[] = []
 
   return {
@@ -162,6 +175,21 @@ async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixtur
     },
     async request(agent, requestedRoute) {
       const webhook = requestedRoute === "webhooks/channel" ? "channel" : undefined
+      if (adapter === "netlify") {
+        return await route.default(
+          new Request(`https://example.com/api/_vitehub/agents/${agent}/${requestedRoute}`, {
+            body: "{}",
+            headers: { "content-type": "application/json" },
+            method: "POST",
+          }),
+          {
+            params: { agent, ...(webhook ? { webhook } : {}) },
+            waitUntil(task: Promise<unknown>) {
+              waitUntilTasks.push(task)
+            },
+          },
+        )
+      }
       return await route.default({
         body: "{}",
         context: {
@@ -248,5 +276,25 @@ describe("generated Agent deployment catalog", () => {
       instructions: "Support the deployment catalog.\n",
       skill: "# Review\n",
     })
+  })
+
+  it("executes the same catalog through the Netlify Adapter", async () => {
+    await runtime!.close()
+    vi.stubEnv("VITEHUB_HOSTING", "netlify")
+    runtime = await createDeploymentRuntimeFixture("netlify")
+
+    await expect((await runtime.request("support", "chat")).json()).resolves.toMatchObject({
+      agent: "support",
+      agentIdentity: { name: "support", workspace: "support" },
+      kind: "chat",
+    })
+    await expect((await runtime.request("support", "webhooks/channel")).json()).resolves.toMatchObject({
+      agent: "support",
+      agentIdentity: { name: "support", workspace: "support" },
+      kind: "webhook",
+      webhook: "channel",
+    })
+    expect(Object.keys(runtime.capture.workspaceRegistry)).toEqual(["support"])
+    expect(runtime.waitUntilTasks).toHaveLength(2)
   })
 })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -429,7 +429,6 @@ describe("agent Vite plugin", () => {
 
       const wrapper = await readFile(join(root, ".vitehub/agent/netlify-function.mjs"), "utf8")
       expect(wrapper).toContain("export default async function viteHubAgentNetlifyFunction(request, context)")
-      expect(wrapper).toContain("import { createChannelChatRouteHandler, createChannelWebhookRouteHandler, createDiscordGatewayRouteHandler, hasChannelChatRoute } from \"@vite-hub/agent/server/internal\"")
       expect(wrapper).toContain("import { setAgentWorkflowRuntimeLoaders as vitehubSetAgentWorkflowRuntimeLoaders } from \"@vite-hub/agent/server/internal\"")
       expect(wrapper).toContain("state: () => import(\"vite-hub/_internal/workflow/runtime/state\")")
       expect(wrapper).toContain("workflow: () => import(\"vite-hub/_internal/workflow\")")


### PR DESCRIPTION
Migrates the Netlify Adapter to the generated Agent deployment catalog introduced in #645, so definition imports, identities, Workspace registration, colocated assets, and common chat/webhook handlers have one owner. Netlify keeps its request conversion, secrets, Discord gateway behavior, state, and wait-until integration local.

The executable deployment fixture now runs the generated Netlify function through chat and webhook requests, checks Agent identity and Workspace registration, and verifies wait-until forwarding. Focused validation passes 144 tests plus Agent typecheck, Oxlint, Fallow, and diff checks.

Depends on #645; merge or rebase the Nitro catalog seam first.