### PR TITLE
refactor(agent): migrate Deno to deployment catalog

### DIFF
--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1145,45 +1145,19 @@ async function generateAgentDenoServer(
   const routeCapabilities = generatedAgentRouteCapabilities(options)
   const workflowRuntime = generatedAgentWorkflowRuntime(options, agentImportBase)
   const workspaceDependencyRuntime = generatedAgentWorkspaceDependencyRuntime(options, workspaceImportBase)
-  const imports = definitions
-    .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
-    .join("\n")
-  const workspaceEntries = (await Promise.all(definitions
-    .map(async (definition, index) => {
-      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      return definition.workspace
-        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))})`
-        : undefined
-    })))
-    .filter(Boolean)
-    .join(",\n  ")
-  const agentEntries = (await Promise.all(definitions
-    .map(async (definition, index) => {
-      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      const agentExpression = `withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))})`
-      return `${JSON.stringify(definition.name)}: ${agentExpression}`
-    })))
-    .join(",\n  ")
-  const agentModuleEntries = definitions
-    .map((definition, index) => `${JSON.stringify(definition.name)}: agent${index}`)
-    .join(",\n  ")
-  const agentIdentityEntries = generatedAgentIdentityEntries(definitions)
-  const hostedWorkspaceRuntime = generatedHostedWorkspaceRuntimeSetup(definitions, workspaceImportBase)
-  const workspaceRuntimeImports = workspaceEntries
-    ? [`import { setWorkspaceRuntimeRegistry } from ${JSON.stringify(subpath(workspaceImportBase, "runtime"))}`, ...hostedWorkspaceRuntime.imports]
-    : []
-  const workspaceRuntimeSetup = workspaceEntries
-    ? [...hostedWorkspaceRuntime.setup, `setWorkspaceRuntimeRegistry(Object.fromEntries([\n  ${workspaceEntries}\n].filter(Boolean)))`, ""]
-    : []
+  const deploymentCatalog = await generateAgentDeploymentCatalog(definitions, handlerPath, {
+    agentImportBase,
+    workspaceImportBase,
+    workspaceRuntimeImport: definitions.some(definition => definition.workspace)
+      ? subpath(workspaceImportBase, "runtime")
+      : undefined,
+  })
 
   return [
-    `import { workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
-    `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler, hasChannelChatRoute } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
+    ...deploymentCatalog.imports,
     ...workflowRuntime.imports,
     ...workspaceDependencyRuntime.imports,
     ...routeCapabilities.imports,
-    ...workspaceRuntimeImports,
-    imports,
     "",
     ...workflowRuntime.setup,
     ...workspaceDependencyRuntime.setup,
@@ -1192,24 +1166,7 @@ async function generateAgentDenoServer(
     "  throw error",
     "})",
     "",
-    "function resolveAgentModule(module) {",
-    "  return module && typeof module === 'object' && 'default' in module ? module.default : module",
-    "}",
-    "",
-    "function resolveChatRouteOptions(module) {",
-    "  const chatRoute = module && typeof module === 'object' ? module.chatRoute : undefined",
-    "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
-    "}",
-    "",
-    ...generatedWorkspaceSourceRootHelper("withWorkspaceSourceRoot", "workspaceDefinitionFromOptions"),
-    "",
-    "function workspaceRegistryEntry(name, module, sourceRootDir, colocatedInstructions, colocatedSkills) {",
-    "  const agent = withWorkspaceSourceRoot(resolveAgentModule(module), sourceRootDir, colocatedInstructions, colocatedSkills)",
-    "  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return",
-    "  return [name, async () => ({ ...module, default: agent })]",
-    "}",
-    "",
-    ...workspaceRuntimeSetup,
+    ...deploymentCatalog.setup,
     ...routeCapabilities.setup,
     "function jsonError(status, message) {",
     "  return Response.json({ error: true, status, statusText: message, message }, { status })",
@@ -1241,12 +1198,6 @@ async function generateAgentDenoServer(
     "  return Object.keys(options).length ? options : undefined",
     "}",
     "",
-    `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
-    `const agentIdentities = {${agentIdentityEntries ? `\n  ${agentIdentityEntries}\n` : ""}}`,
-    `const agentModules = {${agentModuleEntries ? `\n  ${agentModuleEntries}\n` : ""}}`,
-    "const chatHandlers = Object.fromEntries(Object.entries(agents).filter(([, agent]) => hasChannelChatRoute(agent)).map(([name, agent]) => [name, createChannelChatRouteHandler(agent, resolveChatRouteOptions(agentModules[name]))]))",
-    "const webhookHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, createChannelWebhookRouteHandler(agent)]))",
-    "const agentNames = Object.keys(agents)",
     `const chatRoutePattern = new RegExp(${JSON.stringify(routeRegexSource(options.chatRoute, ["agent"]))})`,
     `const webhookRoutePattern = new RegExp(${JSON.stringify(routeRegexSource(options.webhookRoute, ["agent", "webhook"]))})`,
     "",

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -782,6 +782,84 @@ function generatedAgentIdentityEntries(definitions: DiscoveredAgentDefinition[])
     .join(",\n  ")
 }
 
+interface GeneratedAgentDeploymentCatalog {
+  imports: string[]
+  setup: string[]
+}
+
+async function generateAgentDeploymentCatalog(
+  definitions: DiscoveredAgentDefinition[],
+  handlerPath: string,
+  options: {
+    agentImportBase: string
+    workspaceImportBase: string
+    workspaceRuntimeImport?: string
+  },
+): Promise<GeneratedAgentDeploymentCatalog> {
+  const entries = await Promise.all(definitions.map(async (definition, index) => {
+    const moduleName = `agent${index}`
+    const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
+    const colocatedInstructions = await readColocatedAgentInstructions(definition.handler)
+    const colocatedSkills = readColocatedAgentSkills(definition.handler)
+    const agentExpression = `withWorkspaceSourceRoot(resolveAgentModule(${moduleName}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(colocatedInstructions)}, ${JSON.stringify(colocatedSkills)})`
+    return {
+      agentEntry: `${JSON.stringify(definition.name)}: ${agentExpression}`,
+      import: `import * as ${moduleName} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`,
+      moduleEntry: `${JSON.stringify(definition.name)}: ${moduleName}`,
+      workspaceEntry: definition.workspace
+        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, ${moduleName}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(colocatedInstructions)}, ${JSON.stringify(colocatedSkills)})`
+        : undefined,
+    }
+  }))
+  const hostedWorkspaceRuntime = generatedHostedWorkspaceRuntimeSetup(definitions, options.workspaceImportBase)
+  const workspaceEntries = entries.flatMap(entry => entry.workspaceEntry ? [entry.workspaceEntry] : []).join(",\n  ")
+  if (workspaceEntries && !options.workspaceRuntimeImport) {
+    throw new TypeError("[vitehub] Agent deployment catalog requires a Workspace runtime import for Workspace Agents.")
+  }
+  const agentEntries = entries.map(entry => entry.agentEntry).join(",\n  ")
+  const agentModuleEntries = entries.map(entry => entry.moduleEntry).join(",\n  ")
+  const agentIdentityEntries = generatedAgentIdentityEntries(definitions)
+
+  return {
+    imports: [
+      `import { workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(options.agentImportBase)}`,
+      `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler, hasChannelChatRoute } from ${JSON.stringify(subpath(options.agentImportBase, "server/internal"))}`,
+      ...(options.workspaceRuntimeImport ? [`import { setWorkspaceRuntimeRegistry } from ${JSON.stringify(options.workspaceRuntimeImport)}`] : []),
+      ...hostedWorkspaceRuntime.imports,
+      ...entries.map(entry => entry.import),
+    ],
+    setup: [
+      "function resolveAgentModule(module) {",
+      "  return module && typeof module === 'object' && 'default' in module ? module.default : module",
+      "}",
+      "",
+      "function resolveChatRouteOptions(module) {",
+      "  const chatRoute = module && typeof module === 'object' ? module.chatRoute : undefined",
+      "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
+      "}",
+      "",
+      ...generatedWorkspaceSourceRootHelper("withWorkspaceSourceRoot", "workspaceDefinitionFromOptions"),
+      "",
+      "function workspaceRegistryEntry(name, module, sourceRootDir, colocatedInstructions, colocatedSkills) {",
+      "  const agent = withWorkspaceSourceRoot(resolveAgentModule(module), sourceRootDir, colocatedInstructions, colocatedSkills)",
+      "  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return",
+      "  return [name, async () => ({ ...module, default: agent })]",
+      "}",
+      "",
+      ...hostedWorkspaceRuntime.setup,
+      ...(options.workspaceRuntimeImport
+        ? [`setWorkspaceRuntimeRegistry(Object.fromEntries([${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}].filter(Boolean)))`, ""]
+        : []),
+      `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
+      `const agentIdentities = {${agentIdentityEntries ? `\n  ${agentIdentityEntries}\n` : ""}}`,
+      `const agentModules = {${agentModuleEntries ? `\n  ${agentModuleEntries}\n` : ""}}`,
+      "const chatHandlers = Object.fromEntries(Object.entries(agents).filter(([, agent]) => hasChannelChatRoute(agent)).map(([name, agent]) => [name, createChannelChatRouteHandler(agent, resolveChatRouteOptions(agentModules[name]))]))",
+      "const webhookHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, createChannelWebhookRouteHandler(agent)]))",
+      "const agentNames = Object.keys(agents)",
+    ],
+  }
+}
+
 async function generateAgentWebhookRouteHandler(
   definitions: DiscoveredAgentDefinition[],
   handlerPath: string,
@@ -793,31 +871,11 @@ async function generateAgentWebhookRouteHandler(
   const workflowRuntime = generatedAgentWorkflowRuntime(options, agentImportBase)
   const workspaceDependencyRuntime = generatedAgentWorkspaceDependencyRuntime(options, workspaceImportBase)
   const runtimeRouteOption = options.runtime === "vite" ? ", runtime: 'vite'" : ""
-  const imports = definitions
-    .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
-    .join("\n")
-  const workspaceEntries = (await Promise.all(definitions
-    .map(async (definition, index) => {
-      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      return definition.workspace
-        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))})`
-        : undefined
-    })))
-    .filter(Boolean)
-    .join(",\n  ")
-  const agentEntries = definitions
-    .map(async (definition, index) => {
-      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      const agentExpression = `withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))})`
-      return `${JSON.stringify(definition.name)}: ${agentExpression}`
-    })
-  const resolvedAgentEntries = (await Promise.all(agentEntries))
-    .join(",\n  ")
-  const agentModuleEntries = definitions
-    .map((definition, index) => `${JSON.stringify(definition.name)}: agent${index}`)
-    .join(",\n  ")
-  const agentIdentityEntries = generatedAgentIdentityEntries(definitions)
-  const hostedWorkspaceRuntime = generatedHostedWorkspaceRuntimeSetup(definitions, workspaceImportBase)
+  const deploymentCatalog = await generateAgentDeploymentCatalog(definitions, handlerPath, {
+    agentImportBase,
+    workspaceImportBase,
+    workspaceRuntimeImport: subpath(workspaceImportBase, "runtime"),
+  })
   const webhookRoute = typeof options.webhookRoute === "string" ? options.webhookRoute : ""
   const webhookSelector = webhookRoute.includes("[webhook]") ? "getRouterParam(event, 'webhook')" : "''"
   const webhookStateOption = options.cloudflareState
@@ -827,38 +885,17 @@ async function generateAgentWebhookRouteHandler(
       : ""
 
   return [
-    `import { workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
+    ...deploymentCatalog.imports,
     ...(options.cloudflareState ? [`import { createCloudflareAgentState } from ${JSON.stringify(subpath(agentImportBase, "cloudflare"))}`] : []),
     ...(options.libsqlState ? [`import { createLibsqlAgentState } from ${JSON.stringify(subpath(agentImportBase, "state/sqlite"))}`] : []),
-    `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler, hasChannelChatRoute } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
     ...workflowRuntime.imports,
     ...workspaceDependencyRuntime.imports,
     ...routeCapabilities.imports,
-    `import { setWorkspaceRuntimeRegistry } from ${JSON.stringify(subpath(workspaceImportBase, "runtime"))}`,
-    ...hostedWorkspaceRuntime.imports,
     "import { createError, defineEventHandler, getRequestHeaders, getRequestURL, getRouterParam, readRawBody } from 'h3'",
-    imports,
     "",
     ...workflowRuntime.setup,
     ...workspaceDependencyRuntime.setup,
-    "function resolveAgentModule(module) {",
-    "  return module && typeof module === 'object' && 'default' in module ? module.default : module",
-    "}",
-    "",
-    "function resolveChatRouteOptions(module) {",
-    "  const chatRoute = module && typeof module === 'object' ? module.chatRoute : undefined",
-    "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
-    "}",
-    "",
-    ...generatedWorkspaceSourceRootHelper("withWorkspaceSourceRoot", "workspaceDefinitionFromOptions"),
-    "",
-    "function workspaceRegistryEntry(name, module, sourceRootDir, colocatedInstructions, colocatedSkills) {",
-    "  const agent = withWorkspaceSourceRoot(resolveAgentModule(module), sourceRootDir, colocatedInstructions, colocatedSkills)",
-    "  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return",
-    "  return [name, async () => ({ ...module, default: agent })]",
-    "}",
-    "",
-    ...hostedWorkspaceRuntime.setup,
+    ...deploymentCatalog.setup,
     "async function toRequest(event) {",
     "  const body = await readRawBody(event)",
     "  return new Request(getRequestURL(event), {",
@@ -873,14 +910,6 @@ async function generateAgentWebhookRouteHandler(
     ...(options.libsqlState ? generatedLibsqlChatStateHelper(options.libsqlState) : []),
     "",
     ...routeCapabilities.setup,
-    `setWorkspaceRuntimeRegistry(Object.fromEntries([${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}].filter(Boolean)))`,
-    "",
-    `const agents = {${resolvedAgentEntries ? `\n  ${resolvedAgentEntries}\n` : ""}}`,
-    `const agentIdentities = {${agentIdentityEntries ? `\n  ${agentIdentityEntries}\n` : ""}}`,
-    `const agentModules = {${agentModuleEntries ? `\n  ${agentModuleEntries}\n` : ""}}`,
-    "const chatHandlers = Object.fromEntries(Object.entries(agents).filter(([, agent]) => hasChannelChatRoute(agent)).map(([name, agent]) => [name, createChannelChatRouteHandler(agent, resolveChatRouteOptions(agentModules[name]))]))",
-    "const webhookHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, createChannelWebhookRouteHandler(agent)]))",
-    "const agentNames = Object.keys(agents)",
     `const chatRoutePattern = new RegExp(${JSON.stringify(routeRegexSource(options.chatRoute))})`,
     `const webhookRoutePattern = new RegExp(${JSON.stringify(routeRegexSource(options.webhookRoute))})`,
     "",

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -940,55 +940,24 @@ async function generateAgentNetlifyFunctionRouteHandler(
   const workflowRuntime = generatedAgentWorkflowRuntime(options, agentImportBase)
   const workspaceDependencyRuntime = generatedAgentWorkspaceDependencyRuntime(options, workspaceImportBase)
   const runtimeRouteOption = options.runtime === "vite" ? ", runtime: 'vite'" : ""
-  const imports = definitions
-    .map((definition, index) => `import * as agent${index} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`)
-    .join("\n")
-  const workspaceEntries = (await Promise.all(definitions
-    .map(async (definition, index) => {
-      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      return definition.workspace
-        ? `workspaceRegistryEntry(${JSON.stringify(definition.workspace)}, agent${index}, ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))})`
-        : undefined
-    })))
-    .filter(Boolean)
-    .join(",\n  ")
-  const agentEntries = (await Promise.all(definitions
-    .map(async (definition, index) => {
-      const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
-      const agentExpression = `withWorkspaceSourceRoot(resolveAgentModule(agent${index}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))})`
-      return `${JSON.stringify(definition.name)}: ${agentExpression}`
-    })))
-    .join(",\n  ")
-  const agentModuleEntries = definitions
-    .map((definition, index) => `${JSON.stringify(definition.name)}: agent${index}`)
-    .join(",\n  ")
-  const agentIdentityEntries = generatedAgentIdentityEntries(definitions)
-  const hostedWorkspaceRuntime = generatedHostedWorkspaceRuntimeSetup(definitions, workspaceImportBase)
+  const deploymentCatalog = await generateAgentDeploymentCatalog(definitions, handlerPath, {
+    agentImportBase,
+    workspaceImportBase,
+    workspaceRuntimeImport: subpath(agentImportBase, "server/workspace"),
+  })
   const webhookSelector = routeUsesParam(options.webhookRoute, "webhook") ? "netlifyParam(context, 'webhook')" : "''"
   const webhookStateOption = options.libsqlState ? "state: chatStateFromLibsql(), " : ""
 
   return [
-    `import { workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
+    ...deploymentCatalog.imports,
     ...(options.libsqlState ? [`import { createLibsqlAgentState } from ${JSON.stringify(subpath(agentImportBase, "state/sqlite"))}`] : []),
-    `import { createChannelChatRouteHandler, createChannelWebhookRouteHandler, createDiscordGatewayRouteHandler, hasChannelChatRoute } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
+    `import { createDiscordGatewayRouteHandler } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
     ...workflowRuntime.imports,
     ...workspaceDependencyRuntime.imports,
     ...routeCapabilities.imports,
-    `import { setWorkspaceRuntimeRegistry } from ${JSON.stringify(subpath(agentImportBase, "server/workspace"))}`,
-    ...hostedWorkspaceRuntime.imports,
-    imports,
     "",
     ...workflowRuntime.setup,
     ...workspaceDependencyRuntime.setup,
-    "function resolveAgentModule(module) {",
-    "  return module && typeof module === 'object' && 'default' in module ? module.default : module",
-    "}",
-    "",
-    "function resolveChatRouteOptions(module) {",
-    "  const chatRoute = module && typeof module === 'object' ? module.chatRoute : undefined",
-    "  return chatRoute && typeof chatRoute === 'object' ? chatRoute : undefined",
-    "}",
-    "",
     "function bearerToken(value) {",
     "  const match = /^Bearer\\s+(.+)$/i.exec(value || '')",
     "  return match?.[1]",
@@ -1000,28 +969,12 @@ async function generateAgentNetlifyFunctionRouteHandler(
     "    .replace(/(^|\\/):([^/]+)/g, (_, prefix, key) => `${prefix}${encodeURIComponent(values[key] || '')}`)",
     "}",
     "",
-    ...generatedWorkspaceSourceRootHelper("withWorkspaceSourceRoot", "workspaceDefinitionFromOptions"),
-    "",
-    "function workspaceRegistryEntry(name, module, sourceRootDir, colocatedInstructions, colocatedSkills) {",
-    "  const agent = withWorkspaceSourceRoot(resolveAgentModule(module), sourceRootDir, colocatedInstructions, colocatedSkills)",
-    "  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return",
-    "  return [name, async () => ({ ...module, default: agent })]",
-    "}",
-    "",
-    ...hostedWorkspaceRuntime.setup,
+    ...deploymentCatalog.setup,
     ...(options.libsqlState ? generatedLibsqlChatStateHelper(options.libsqlState) : []),
     ...generatedNetlifyRuntimeHelpers(),
     "",
     ...routeCapabilities.setup,
-    `setWorkspaceRuntimeRegistry(Object.fromEntries([${workspaceEntries ? `\n  ${workspaceEntries}\n` : ""}].filter(Boolean)))`,
-    "",
-    `const agents = {${agentEntries ? `\n  ${agentEntries}\n` : ""}}`,
-    `const agentIdentities = {${agentIdentityEntries ? `\n  ${agentIdentityEntries}\n` : ""}}`,
-    `const agentModules = {${agentModuleEntries ? `\n  ${agentModuleEntries}\n` : ""}}`,
-    "const chatHandlers = Object.fromEntries(Object.entries(agents).filter(([, agent]) => hasChannelChatRoute(agent)).map(([name, agent]) => [name, createChannelChatRouteHandler(agent, resolveChatRouteOptions(agentModules[name]))]))",
-    "const webhookHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, createChannelWebhookRouteHandler(agent)]))",
     "const discordGatewayHandlers = Object.fromEntries(Object.entries(agents).map(([name, agent]) => [name, createDiscordGatewayRouteHandler(agent)]))",
-    "const agentNames = Object.keys(agents)",
     `const webhookRoute = ${JSON.stringify(generatedWebhookRoute(options.webhookRoute))}`,
     `const defaultDiscordGatewayDurationMs = ${JSON.stringify(9 * 60 * 1000)}`,
     `const chatRoutePattern = new RegExp(${JSON.stringify(routeRegexSource(options.chatRoute))})`,

--- a/packages/agent/test/deployment-catalog.test.ts
+++ b/packages/agent/test/deployment-catalog.test.ts
@@ -52,6 +52,7 @@ function deploymentRuntimeModules(): Map<string, string> {
       "export const hasChannelChatRoute = () => true",
       "export const createChannelChatRouteHandler = agent => async (_request, options) => handle('chat', agent, undefined, options)",
       "export const createChannelWebhookRouteHandler = agent => async (_request, webhook, options) => handle('webhook', agent, webhook, options)",
+      "export const createDiscordGatewayRouteHandler = agent => async (_request, options) => handle('discord', agent, undefined, options)",
     ].join("\n")],
     ["@vite-hub/agent/state/sqlite", [
       `const capture = globalThis.${runtimeCaptureKey}`,
@@ -61,6 +62,10 @@ function deploymentRuntimeModules(): Map<string, string> {
       "}",
     ].join("\n")],
     ["@vite-hub/workspace/runtime", [
+      `const capture = globalThis.${runtimeCaptureKey}`,
+      "export function setWorkspaceRuntimeRegistry(workspaceRegistry) { capture.workspaceRegistry = workspaceRegistry }",
+    ].join("\n")],
+    ["@vite-hub/agent/server/workspace", [
       `const capture = globalThis.${runtimeCaptureKey}`,
       "export function setWorkspaceRuntimeRegistry(workspaceRegistry) { capture.workspaceRegistry = workspaceRegistry }",
     ].join("\n")],
@@ -77,8 +82,10 @@ function deploymentRuntimeModules(): Map<string, string> {
   ])
 }
 
-async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixture> {
-  const root = await mkdtemp(join(tmpdir(), "vitehub-agent-deployment-catalog-"))
+async function createDeploymentRuntimeFixture(adapter: "netlify" | "nitro" = "nitro"): Promise<DeploymentRuntimeFixture> {
+  const root = await mkdtemp(adapter === "netlify"
+    ? join(import.meta.dirname, "fixtures", "deployment-catalog-")
+    : join(tmpdir(), "vitehub-agent-deployment-catalog-"))
   const supportRoot = join(root, "server", "agents", "support")
   const reviewerRoot = join(root, "server", "agents", "reviewer")
   const capture: DeploymentRuntimeCapture = { workspaceRegistry: {} }
@@ -87,7 +94,6 @@ async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixtur
 
   await mkdir(join(supportRoot, "workspace"), { recursive: true })
   await mkdir(join(supportRoot, "skills", "review"), { recursive: true })
-  await mkdir(reviewerRoot, { recursive: true })
   await writeFile(join(supportRoot, "agent.ts"), [
     "import { defineAgent } from '@vite-hub/agent'",
     "export default defineAgent({",
@@ -100,15 +106,18 @@ async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixtur
   ].join("\n"), "utf8")
   await writeFile(join(supportRoot, "instructions.md"), "Support the deployment catalog.\n", "utf8")
   await writeFile(join(supportRoot, "skills", "review", "SKILL.md"), "# Review\n", "utf8")
-  await writeFile(join(reviewerRoot, "agent.ts"), [
-    "import { defineAgent } from '@vite-hub/agent'",
-    "export default defineAgent({",
-    "  description: 'reviewer',",
-    "  driver: { run: async () => ({ text: 'reviewer' }) },",
-    "  runtime: false,",
-    "})",
-    "",
-  ].join("\n"), "utf8")
+  if (adapter === "nitro") {
+    await mkdir(reviewerRoot, { recursive: true })
+    await writeFile(join(reviewerRoot, "agent.ts"), [
+      "import { defineAgent } from '@vite-hub/agent'",
+      "export default defineAgent({",
+      "  description: 'reviewer',",
+      "  driver: { run: async () => ({ text: 'reviewer' }) },",
+      "  runtime: false,",
+      "})",
+      "",
+    ].join("\n"), "utf8")
+  }
 
   const modules = deploymentRuntimeModules()
   const server = await createServer({
@@ -127,6 +136,7 @@ async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixtur
         },
       }),
       {
+        enforce: "pre",
         name: "vitehub-agent-deployment-runtime-fixture",
         resolveId(id) {
           return modules.has(id) ? `\0${id}` : undefined
@@ -146,9 +156,12 @@ async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixtur
     server: { middlewareMode: true },
   })
 
-  const route = await server.ssrLoadModule(join(root, ".vitehub", "agent", "chat-webhook-route.ts")) as {
-    default: (event: Record<string, unknown>) => Promise<Response>
-  }
+  const route = await server.ssrLoadModule(join(
+    root,
+    ".vitehub",
+    "agent",
+    adapter === "netlify" ? "netlify-function.mjs" : "chat-webhook-route.ts",
+  )) as { default: (input: Record<string, unknown> | Request, context?: Record<string, unknown>) => Promise<Response> }
   const waitUntilTasks: Promise<unknown>[] = []
 
   return {
@@ -162,6 +175,21 @@ async function createDeploymentRuntimeFixture(): Promise<DeploymentRuntimeFixtur
     },
     async request(agent, requestedRoute) {
       const webhook = requestedRoute === "webhooks/channel" ? "channel" : undefined
+      if (adapter === "netlify") {
+        return await route.default(
+          new Request(`https://example.com/api/_vitehub/agents/${agent}/${requestedRoute}`, {
+            body: "{}",
+            headers: { "content-type": "application/json" },
+            method: "POST",
+          }),
+          {
+            params: { agent, ...(webhook ? { webhook } : {}) },
+            waitUntil(task: Promise<unknown>) {
+              waitUntilTasks.push(task)
+            },
+          },
+        )
+      }
       return await route.default({
         body: "{}",
         context: {
@@ -248,5 +276,25 @@ describe("generated Agent deployment catalog", () => {
       instructions: "Support the deployment catalog.\n",
       skill: "# Review\n",
     })
+  })
+
+  it("executes the same catalog through the Netlify Adapter", async () => {
+    await runtime!.close()
+    vi.stubEnv("VITEHUB_HOSTING", "netlify")
+    runtime = await createDeploymentRuntimeFixture("netlify")
+
+    await expect((await runtime.request("support", "chat")).json()).resolves.toMatchObject({
+      agent: "support",
+      agentIdentity: { name: "support", workspace: "support" },
+      kind: "chat",
+    })
+    await expect((await runtime.request("support", "webhooks/channel")).json()).resolves.toMatchObject({
+      agent: "support",
+      agentIdentity: { name: "support", workspace: "support" },
+      kind: "webhook",
+      webhook: "channel",
+    })
+    expect(Object.keys(runtime.capture.workspaceRegistry)).toEqual(["support"])
+    expect(runtime.waitUntilTasks).toHaveLength(2)
   })
 })

--- a/packages/agent/test/deployment-catalog.test.ts
+++ b/packages/agent/test/deployment-catalog.test.ts
@@ -13,6 +13,7 @@ interface CapturedStateAdapter {
 }
 
 interface DeploymentRuntimeCapture {
+  denoHandler?: (request: Request) => Promise<Response>
   stateAdapter?: CapturedStateAdapter
   workspaceRegistry: Record<string, () => Promise<{ default?: Record<PropertyKey, unknown> }>>
 }
@@ -82,7 +83,7 @@ function deploymentRuntimeModules(): Map<string, string> {
   ])
 }
 
-async function createDeploymentRuntimeFixture(adapter: "netlify" | "nitro" = "nitro"): Promise<DeploymentRuntimeFixture> {
+async function createDeploymentRuntimeFixture(adapter: "deno" | "netlify" | "nitro" = "nitro"): Promise<DeploymentRuntimeFixture> {
   const root = await mkdtemp(adapter === "netlify"
     ? join(import.meta.dirname, "fixtures", "deployment-catalog-")
     : join(tmpdir(), "vitehub-agent-deployment-catalog-"))
@@ -90,6 +91,7 @@ async function createDeploymentRuntimeFixture(adapter: "netlify" | "nitro" = "ni
   const reviewerRoot = join(root, "server", "agents", "reviewer")
   const capture: DeploymentRuntimeCapture = { workspaceRegistry: {} }
   const scope = globalThis as typeof globalThis & Record<string, unknown>
+  const previousDeno = scope.Deno
   scope[runtimeCaptureKey] = capture
 
   await mkdir(join(supportRoot, "workspace"), { recursive: true })
@@ -118,6 +120,10 @@ async function createDeploymentRuntimeFixture(adapter: "netlify" | "nitro" = "ni
       "",
     ].join("\n"), "utf8")
   }
+  if (adapter === "deno") {
+    await mkdir(join(root, ".vitehub", "schedule"), { recursive: true })
+    await writeFile(join(root, ".vitehub", "schedule", "deno-cron.mjs"), "", "utf8")
+  }
 
   const modules = deploymentRuntimeModules()
   const server = await createServer({
@@ -134,6 +140,7 @@ async function createDeploymentRuntimeFixture(adapter: "netlify" | "nitro" = "ni
             url: "file:catalog.sqlite",
           },
         },
+        ...(adapter === "deno" ? { runtime: "deno" } : {}),
       }),
       {
         enforce: "pre",
@@ -156,11 +163,20 @@ async function createDeploymentRuntimeFixture(adapter: "netlify" | "nitro" = "ni
     server: { middlewareMode: true },
   })
 
+  if (adapter === "deno") {
+    scope.Deno = {
+      args: [],
+      serve(...args: unknown[]) {
+        capture.denoHandler = args.at(-1) as (request: Request) => Promise<Response>
+      },
+    }
+  }
+
   const route = await server.ssrLoadModule(join(
     root,
     ".vitehub",
     "agent",
-    adapter === "netlify" ? "netlify-function.mjs" : "chat-webhook-route.ts",
+    adapter === "deno" ? "deno-server.ts" : adapter === "netlify" ? "netlify-function.mjs" : "chat-webhook-route.ts",
   )) as { default: (input: Record<string, unknown> | Request, context?: Record<string, unknown>) => Promise<Response> }
   const waitUntilTasks: Promise<unknown>[] = []
 
@@ -171,10 +187,22 @@ async function createDeploymentRuntimeFixture(adapter: "netlify" | "nitro" = "ni
     async close() {
       await server.close()
       delete scope[runtimeCaptureKey]
+      if (adapter === "deno") {
+        if (previousDeno === undefined) delete scope.Deno
+        else scope.Deno = previousDeno
+      }
       await rm(root, { force: true, recursive: true })
     },
     async request(agent, requestedRoute) {
       const webhook = requestedRoute === "webhooks/channel" ? "channel" : undefined
+      if (adapter === "deno") {
+        if (!capture.denoHandler) throw new Error("Deno server handler was not registered.")
+        return await capture.denoHandler(new Request(`https://example.com/api/_vitehub/agents/${agent}/${requestedRoute}`, {
+          body: "{}",
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        }))
+      }
       if (adapter === "netlify") {
         return await route.default(
           new Request(`https://example.com/api/_vitehub/agents/${agent}/${requestedRoute}`, {
@@ -296,5 +324,24 @@ describe("generated Agent deployment catalog", () => {
     })
     expect(Object.keys(runtime.capture.workspaceRegistry)).toEqual(["support"])
     expect(runtime.waitUntilTasks).toHaveLength(2)
+  })
+
+  it("executes the same catalog through the Deno Adapter", async () => {
+    await runtime!.close()
+    runtime = await createDeploymentRuntimeFixture("deno")
+
+    await expect((await runtime.request("support", "chat")).json()).resolves.toMatchObject({
+      agent: "support",
+      agentIdentity: { name: "support", workspace: "support" },
+      kind: "chat",
+    })
+    await expect((await runtime.request("support", "webhooks/channel")).json()).resolves.toMatchObject({
+      agent: "support",
+      agentIdentity: { name: "support", workspace: "support" },
+      kind: "webhook",
+      webhook: "channel",
+    })
+    expect(await runtime.request("missing", "chat")).toMatchObject({ status: 404 })
+    expect(Object.keys(runtime.capture.workspaceRegistry)).toEqual(["support"])
   })
 })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -429,7 +429,6 @@ describe("agent Vite plugin", () => {
 
       const wrapper = await readFile(join(root, ".vitehub/agent/netlify-function.mjs"), "utf8")
       expect(wrapper).toContain("export default async function viteHubAgentNetlifyFunction(request, context)")
-      expect(wrapper).toContain("import { createChannelChatRouteHandler, createChannelWebhookRouteHandler, createDiscordGatewayRouteHandler, hasChannelChatRoute } from \"@vite-hub/agent/server/internal\"")
       expect(wrapper).toContain("import { setAgentWorkflowRuntimeLoaders as vitehubSetAgentWorkflowRuntimeLoaders } from \"@vite-hub/agent/server/internal\"")
       expect(wrapper).toContain("state: () => import(\"vite-hub/_internal/workflow/runtime/state\")")
       expect(wrapper).toContain("workflow: () => import(\"vite-hub/_internal/workflow\")")


### PR DESCRIPTION
Migrates the Deno Adapter to the generated Agent deployment catalog, preserving Deno request routing, serve argument parsing, and optional cron loading while sharing definition imports, identities, Workspace registration, colocated assets, and chat/webhook handler construction.

The prerequisite Nitro catalog and Netlify migration had only landed on deleted stacked bases (#645 and #653), so this branch now carries those two catalog-only commits directly on `main`. Unrelated Workspace and Skill history from the obsolete stack was removed. This makes the Deno migration self-contained without waiting on abandoned branch refs.

Executable deployment fixtures cover Nitro, Netlify, and Deno runtime behavior, including chat, webhook, unknown-Agent, Agent identity, Workspace registration, colocated assets, state, and provider lifecycle integration where applicable.

Validation: 145 focused tests, Agent typecheck, Oxlint, Fallow review, diff checks, and base-relative code review.
