### PR TITLE
fix(agent): reclaim abandoned harness roots

### DIFF
--- a/packages/agent/src/harness/local-sandbox.ts
+++ b/packages/agent/src/harness/local-sandbox.ts
@@ -59,15 +59,17 @@ async function managedRootDir(sessionId: string) {
     if (!entry.isDirectory()) return
     const match = localHarnessOwnerPattern.exec(entry.name)
     if (!match || isProcessAlive(Number(match[1]))) return
-    await rm(join(parent, entry.name), { force: true, recursive: true })
+    await rm(join(parent, entry.name), { force: true, recursive: true }).catch(() => undefined)
   }))
 
   return join(owner, createHash("sha256").update(sessionId).digest("hex"))
 }
 
-async function defaultRootDir(sessionId: string | undefined) {
+async function defaultRootDir(sessionId: string | undefined, cleanup: boolean) {
   if (sessionId) {
-    const root = await managedRootDir(sessionId)
+    const root = cleanup
+      ? await managedRootDir(sessionId)
+      : join(tmpdir(), "vitehub-harness", createHash("sha256").update(sessionId).digest("hex"))
     await mkdir(root, { recursive: true })
     return root
   }
@@ -183,12 +185,13 @@ async function collect(stream: ReadableStream<Uint8Array>) {
 }
 
 async function createSession(options: LocalHarnessSandboxProviderOptions, sessionId: string | undefined): Promise<LocalHarnessSandboxSession> {
-  const rootDir = options.rootDir || await defaultRootDir(sessionId)
+  const cleanup = options.cleanup ?? !options.rootDir
+  const rootDir = options.rootDir || await defaultRootDir(sessionId, cleanup)
   await mkdir(rootDir, { recursive: true })
   if (options.workspaceDir) await bindWorkspace(rootDir, options.workspaceDir)
   const env = { ...stringEnv(options.env || process.env), INIT_CWD: rootDir, OLDPWD: rootDir, PWD: rootDir }
   const session = {
-    cleanup: options.cleanup ?? !options.rootDir,
+    cleanup,
     defaultWorkingDirectory: rootDir,
     description: "Workspace shell.",
     env,

--- a/packages/agent/src/harness/local-sandbox.ts
+++ b/packages/agent/src/harness/local-sandbox.ts
@@ -55,12 +55,12 @@ async function managedRootDir(sessionId: string | undefined) {
   await mkdir(owner, { recursive: true })
 
   const entries = await readdir(parent, { withFileTypes: true })
-  await Promise.all(entries.map(async (entry) => {
-    if (!entry.isDirectory()) return
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
     const match = localHarnessOwnerPattern.exec(entry.name)
-    if (!match || isProcessAlive(Number(match[1]))) return
-    await rm(join(parent, entry.name), { force: true, recursive: true }).catch(() => undefined)
-  }))
+    if (!match || isProcessAlive(Number(match[1]))) continue
+    void rm(join(parent, entry.name), { force: true, recursive: true }).catch(() => undefined)
+  }
 
   if (sessionId) return join(owner, createHash("sha256").update(sessionId).digest("hex"))
   return await mkdtemp(join(owner, "session-"))

--- a/packages/agent/src/harness/local-sandbox.ts
+++ b/packages/agent/src/harness/local-sandbox.ts
@@ -1,6 +1,6 @@
 import { spawn as spawnChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process"
 import { realpathSync } from "node:fs"
-import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, isAbsolute, join, relative, resolve } from "node:path"
 import { Readable } from "node:stream"
@@ -32,13 +32,42 @@ interface LocalHarnessSandboxSession extends HarnessV1NetworkSandboxSession {
   readonly rootDir: string
 }
 
+const localHarnessOwnerName = `owner-${process.pid}-${randomUUID()}`
+const localHarnessOwnerPattern = /^owner-(\d+)-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
 function stringEnv(env: Record<string, string | undefined>): Record<string, string> {
   return Object.fromEntries(Object.entries(env).filter((entry): entry is [string, string] => typeof entry[1] === "string"))
 }
 
+function isProcessAlive(pid: number) {
+  try {
+    process.kill(pid, 0)
+    return true
+  }
+  catch (error) {
+    return !(error instanceof Error && "code" in error && error.code === "ESRCH")
+  }
+}
+
+async function managedRootDir(sessionId: string) {
+  const parent = join(tmpdir(), "vitehub-harness")
+  const owner = join(parent, localHarnessOwnerName)
+  await mkdir(owner, { recursive: true })
+
+  const entries = await readdir(parent, { withFileTypes: true })
+  await Promise.all(entries.map(async (entry) => {
+    if (!entry.isDirectory()) return
+    const match = localHarnessOwnerPattern.exec(entry.name)
+    if (!match || isProcessAlive(Number(match[1]))) return
+    await rm(join(parent, entry.name), { force: true, recursive: true })
+  }))
+
+  return join(owner, createHash("sha256").update(sessionId).digest("hex"))
+}
+
 async function defaultRootDir(sessionId: string | undefined) {
   if (sessionId) {
-    const root = join(tmpdir(), "vitehub-harness", createHash("sha256").update(sessionId).digest("hex"))
+    const root = await managedRootDir(sessionId)
     await mkdir(root, { recursive: true })
     return root
   }

--- a/packages/agent/src/harness/local-sandbox.ts
+++ b/packages/agent/src/harness/local-sandbox.ts
@@ -49,7 +49,7 @@ function isProcessAlive(pid: number) {
   }
 }
 
-async function managedRootDir(sessionId: string) {
+async function managedRootDir(sessionId: string | undefined) {
   const parent = join(tmpdir(), "vitehub-harness")
   const owner = join(parent, localHarnessOwnerName)
   await mkdir(owner, { recursive: true })
@@ -62,14 +62,18 @@ async function managedRootDir(sessionId: string) {
     await rm(join(parent, entry.name), { force: true, recursive: true }).catch(() => undefined)
   }))
 
-  return join(owner, createHash("sha256").update(sessionId).digest("hex"))
+  if (sessionId) return join(owner, createHash("sha256").update(sessionId).digest("hex"))
+  return await mkdtemp(join(owner, "session-"))
 }
 
 async function defaultRootDir(sessionId: string | undefined, cleanup: boolean) {
+  if (cleanup) {
+    const root = await managedRootDir(sessionId)
+    await mkdir(root, { recursive: true })
+    return root
+  }
   if (sessionId) {
-    const root = cleanup
-      ? await managedRootDir(sessionId)
-      : join(tmpdir(), "vitehub-harness", createHash("sha256").update(sessionId).digest("hex"))
+    const root = join(tmpdir(), "vitehub-harness", createHash("sha256").update(sessionId).digest("hex"))
     await mkdir(root, { recursive: true })
     return root
   }

--- a/packages/agent/test/codex-harness.test.ts
+++ b/packages/agent/test/codex-harness.test.ts
@@ -110,8 +110,8 @@ describe("codexDriver", () => {
     const second = await driver.sandbox?.createSession()
 
     try {
-      expect(first?.defaultWorkingDirectory).toContain("vitehub-harness-")
-      expect(second?.defaultWorkingDirectory).toContain("vitehub-harness-")
+      expect(first?.defaultWorkingDirectory).toMatch(/[\\/]vitehub-harness[\\/]owner-\d+-[0-9a-f-]{36}[\\/]session-/)
+      expect(second?.defaultWorkingDirectory).toMatch(/[\\/]vitehub-harness[\\/]owner-\d+-[0-9a-f-]{36}[\\/]session-/)
       expect(first?.defaultWorkingDirectory).not.toBe(second?.defaultWorkingDirectory)
     }
     finally {

--- a/packages/agent/test/local-sandbox.test.ts
+++ b/packages/agent/test/local-sandbox.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises"
+import { randomUUID } from "node:crypto"
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises"
 import { createServer, type Server } from "node:net"
 import { tmpdir } from "node:os"
 import { join, relative } from "node:path"
@@ -22,15 +23,94 @@ function close(server: Server | undefined): Promise<void> {
   return new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
 }
 
+function mockProcessLiveness(deadPids: readonly number[] = []) {
+  return vi.spyOn(process, "kill").mockImplementation((pid) => {
+    if (deadPids.includes(pid)) throw Object.assign(new Error("Process not found"), { code: "ESRCH" })
+    return true
+  })
+}
+
+async function ownerFixture(pid: number) {
+  const root = join(tmpdir(), "vitehub-harness", `owner-${pid}-${randomUUID()}`)
+  await mkdir(root, { recursive: true })
+  await writeFile(join(root, "keep.txt"), "keep")
+  return root
+}
+
 describe("local harness sandbox", () => {
   it("keeps session ids inside the local sandbox root", async () => {
     const session = await createLocalHarnessSandbox().createSession({ sessionId: "../../outside" })
 
     try {
-      expect(relative(join(tmpdir(), "vitehub-harness"), (session as unknown as { rootDir: string }).rootDir)).toMatch(/^[a-f0-9]{64}$/)
+      const [owner, sessionRoot] = relative(join(tmpdir(), "vitehub-harness"), (session as unknown as { rootDir: string }).rootDir).split(/[\\/]/)
+      expect(owner).toMatch(/^owner-\d+-[0-9a-f-]{36}$/)
+      expect(sessionRoot).toMatch(/^[a-f0-9]{64}$/)
     }
     finally {
       await session.destroy?.()
+    }
+  })
+
+  it("removes managed session roots on destroy", async () => {
+    const session = await createLocalHarnessSandbox().createSession({ sessionId: `cleanup-${randomUUID()}` })
+    const root = (session as unknown as { rootDir: string }).rootDir
+
+    await session.destroy?.()
+
+    await expect(stat(root)).rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  it("reclaims roots owned by dead processes", async () => {
+    const deadPid = 4242
+    const abandoned = await ownerFixture(deadPid)
+    const kill = mockProcessLiveness([deadPid])
+    let session: Awaited<ReturnType<HarnessV1SandboxProvider["createSession"]>> | undefined
+
+    try {
+      session = await createLocalHarnessSandbox().createSession({ sessionId: `reclaim-${randomUUID()}` })
+
+      await expect(stat(abandoned)).rejects.toMatchObject({ code: "ENOENT" })
+    }
+    finally {
+      kill.mockRestore()
+      await session?.destroy?.()
+      await rm(abandoned, { force: true, recursive: true })
+    }
+  })
+
+  it("preserves roots owned by live processes", async () => {
+    const live = await ownerFixture(4243)
+    const kill = mockProcessLiveness()
+    let session: Awaited<ReturnType<HarnessV1SandboxProvider["createSession"]>> | undefined
+
+    try {
+      session = await createLocalHarnessSandbox().createSession({ sessionId: `preserve-${randomUUID()}` })
+
+      await expect(readFile(join(live, "keep.txt"), "utf8")).resolves.toBe("keep")
+    }
+    finally {
+      kill.mockRestore()
+      await session?.destroy?.()
+      await rm(live, { force: true, recursive: true })
+    }
+  })
+
+  it("does not delete unrelated directories", async () => {
+    const unrelated = join(tmpdir(), "vitehub-harness", `unrelated-${randomUUID()}`)
+    await mkdir(unrelated, { recursive: true })
+    await writeFile(join(unrelated, "keep.txt"), "keep")
+    const kill = mockProcessLiveness()
+    let session: Awaited<ReturnType<HarnessV1SandboxProvider["createSession"]>> | undefined
+
+    try {
+      session = await createLocalHarnessSandbox().createSession({ sessionId: `unrelated-${randomUUID()}` })
+
+      await expect(readFile(join(unrelated, "keep.txt"), "utf8")).resolves.toBe("keep")
+    }
+    finally {
+      kill.mockRestore()
+      await session?.destroy?.()
+      await rm(unrelated, { force: true, recursive: true })
     }
   })
 

--- a/packages/agent/test/local-sandbox.test.ts
+++ b/packages/agent/test/local-sandbox.test.ts
@@ -60,6 +60,29 @@ describe("local harness sandbox", () => {
     await expect(stat(root)).rejects.toMatchObject({ code: "ENOENT" })
   })
 
+  it("preserves cleanup-disabled session roots across providers", async () => {
+    const sessionId = `persistent-${randomUUID()}`
+    const persistent = await createLocalHarnessSandbox({ cleanup: false }).createSession({ sessionId })
+    const root = (persistent as unknown as { rootDir: string }).rootDir
+    await persistent.writeTextFile({ content: "keep", path: "keep.txt" })
+
+    try {
+      await persistent.destroy?.()
+      const managed = await createLocalHarnessSandbox().createSession({ sessionId: `managed-${randomUUID()}` })
+
+      try {
+        expect(relative(join(tmpdir(), "vitehub-harness"), root)).toMatch(/^[a-f0-9]{64}$/)
+        await expect(readFile(join(root, "keep.txt"), "utf8")).resolves.toBe("keep")
+      }
+      finally {
+        await managed.destroy?.()
+      }
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("reclaims roots owned by dead processes", async () => {
     const deadPid = 4242
     const abandoned = await ownerFixture(deadPid)

--- a/packages/agent/test/local-sandbox.test.ts
+++ b/packages/agent/test/local-sandbox.test.ts
@@ -106,7 +106,7 @@ describe("local harness sandbox", () => {
     try {
       session = await createLocalHarnessSandbox().createSession({ sessionId: `reclaim-${randomUUID()}` })
 
-      await expect(stat(abandoned)).rejects.toMatchObject({ code: "ENOENT" })
+      await vi.waitFor(async () => await expect(stat(abandoned)).rejects.toMatchObject({ code: "ENOENT" }))
     }
     finally {
       kill.mockRestore()

--- a/packages/agent/test/local-sandbox.test.ts
+++ b/packages/agent/test/local-sandbox.test.ts
@@ -60,6 +60,20 @@ describe("local harness sandbox", () => {
     await expect(stat(root)).rejects.toMatchObject({ code: "ENOENT" })
   })
 
+  it("puts anonymous cleanup roots under the process owner", async () => {
+    const session = await createLocalHarnessSandbox().createSession()
+    const root = (session as unknown as { rootDir: string }).rootDir
+
+    try {
+      const [owner, sessionRoot] = relative(join(tmpdir(), "vitehub-harness"), root).split(/[\\/]/)
+      expect(owner).toMatch(/^owner-\d+-[0-9a-f-]{36}$/)
+      expect(sessionRoot).toMatch(/^session-/)
+    }
+    finally {
+      await session.destroy?.()
+    }
+  })
+
   it("preserves cleanup-disabled session roots across providers", async () => {
     const sessionId = `persistent-${randomUUID()}`
     const persistent = await createLocalHarnessSandbox({ cleanup: false }).createSession({ sessionId })


### PR DESCRIPTION
Moves cleanup-enabled session roots under an atomically created process-owned lease directory and reclaims only leases whose owner PID is demonstrably gone. Reclamation is best effort, so a busy or inaccessible abandoned root cannot block new sessions.

`cleanup:false` retains its stable direct-hash root for persistent cross-provider and cross-process resumption, while live, ambiguous, legacy, and unrelated directories remain untouched. Focused coverage exercises normal cleanup, persistent cleanup-disabled roots, dead-owner reclamation, live-owner preservation, and unrelated-directory preservation.