### PR TITLE
fix(docs): prevent desktop table of contents overflow

### DIFF
--- a/docs/app/app.config.ts
+++ b/docs/app/app.config.ts
@@ -131,7 +131,7 @@ export default defineAppConfig({
         highlightVariant: "circuit",
       },
       slots: {
-        root: "sticky top-(--ui-header-height) z-10 bg-default overflow-y-auto max-h-[calc(100vh-var(--ui-header-height))]",
+        root: "sticky top-(--ui-header-height) z-10 bg-default overflow-y-auto max-h-[calc(100vh-var(--ui-header-height))] lg:mx-0",
         container: "flex flex-col pt-14 pb-4",
         title: "text-sm font-medium text-muted",
       },


### PR DESCRIPTION
Resets the responsive table-of-contents margin at the desktop breakpoint so its fixed-width column ends at the viewport edge. This removes the 24px horizontal scroll range visible on 1920px displays while preserving the full-width mobile index.

<!-- babysitter:blocker:v1 -->

> [!WARNING]
> **Babysitter is blocked:** the exact-head Vercel preview deployment is failed because the project exceeded Vercel's daily deployment quota; all repository-owned checks pass.
>
> Reset or increase the Vercel deployment quota, then retry the Vercel preview deployment for `3aab05314b74e6cf722fbd32d856dfe9876d0da6` so the visible status can pass.

<!-- /babysitter:blocker:v1 -->