### PR TITLE
docs(concepts): explain ViteHub Bash

### DIFF
--- a/docs/content/docs/capabilities/custom-capabilities.md
+++ b/docs/content/docs/capabilities/custom-capabilities.md
@@ -145,10 +145,11 @@ export function browserPreview() {
 ```
 
 ViteHub merges all Capability `bash` entries into one `bash` tool.
-The tool schema only accepts registered executable names, and each call runs inside a trusted Workspace Session.
+The tool schema only accepts registered executable names, and each call runs inside an executable Workspace Session.
 
 `bash` is a runtime tool surface, not a Capability factory.
 Do not create a `bash()` Capability or use `workspaceShell()` as the public owner for product-specific executables.
+Read the [Bash concept](/docs/concepts/bash) for the execution model and its relationship to Workspace Shell, Shell, Workspace Sessions, and Sandbox.
 
 ## Add a Capability CLI
 

--- a/docs/content/docs/capabilities/workspace-shell.md
+++ b/docs/content/docs/capabilities/workspace-shell.md
@@ -62,6 +62,9 @@ Workspace Shell is not Sandbox.
 It exposes Workspace file operations and optional Workspace-session commands, while `sandbox()` runs allowlisted executables in an isolated runtime.
 Use `sandbox()` for untrusted execution and a domain-specific Capability when the executable set is known.
 
+Workspace Shell is also separate from ViteHub's global model-facing `bash` tool.
+Read the [Bash concept](/docs/concepts/bash) when a Capability should contribute its own executable to that shared surface.
+
 For a Linux-hosted Agent that intentionally owns its machine or container, configure both unrestricted trusted-host commands and the trusted-host Workspace runtime:
 
 ```ts [server/agents/operator.ts]
@@ -113,6 +116,7 @@ The scoped Workspace should hide or reject paths outside the selected grants.
 
 ## Reference
 
+- [Bash concept](/docs/concepts/bash)
 - [Workspace context](/docs/agents/workspace-context)
 - [Workspace primitive](/docs/server-primitives/workspace)
 - [sandbox()](/docs/capabilities/sandbox)

--- a/docs/content/docs/concepts/bash.md
+++ b/docs/content/docs/concepts/bash.md
@@ -1,0 +1,68 @@
+---
+title: Bash
+description: Understand how Capability-owned executables become one constrained Agent tool.
+navigation.order: 8.5
+icon: i-lucide-terminal
+---
+
+Bash is ViteHub's single model-facing execution surface for executables owned by Capabilities. Each attached Capability can contribute commands, and ViteHub combines them into one `bash` tool for the Agent Driver.
+
+The name describes the familiar interface presented to the Agent. It does not grant an arbitrary shell: each call selects one registered executable and passes structured arguments through an executable Workspace Session.
+
+## One Agent philosophy, not the only one
+
+Bash supports a **code mode** philosophy: give an Agent a small execution surface and let it write code or compose commands instead of exposing every operation as a separate tool. This approach is explored by [Anthropic](https://www.anthropic.com/engineering/code-execution-with-mcp), [Vercel](https://vercel.com/blog/testing-if-bash-is-all-you-need), and [Cloudflare](https://blog.cloudflare.com/code-mode/).
+
+ViteHub does not require every Agent to follow that philosophy. Agent Definitions can combine Bash contributions with structured tools, Capability CLIs, or other model-facing surfaces. Choose the interface that makes the Agent's work most reliable and inspectable; Bash is one composable option rather than a universal replacement for typed tools.
+
+## One tool, Capability-owned commands
+
+Capabilities own the executables that make their abilities useful. A browser Capability can contribute `agent-browser`, while a deployment Capability can contribute its deployment CLI.
+
+ViteHub merges those contributions instead of exposing one model tool per integration. The Agent sees one stable `bash` tool, while each Capability keeps ownership of its executable contract, requirements, and lifecycle.
+
+Only attached Capabilities contribute commands. Removing a Capability from the resolved Agent Definition also removes its executables from the `bash` tool.
+
+## How a call runs
+
+ViteHub resolves Bash in four steps:
+
+1. The resolved Capabilities contribute their executable metadata.
+2. ViteHub creates one `bash` tool whose command field accepts only those registered executables.
+3. A tool call supplies the command with structured `args`, `cwd`, `env`, and `timeout` values.
+4. ViteHub opens an executable Workspace Session, runs the command, commits successful Workspace changes, and closes the session.
+
+The tool does not parse its input as a shell script. Pipes, redirects, command substitution, and chaining are unavailable unless a registered executable implements that behavior itself.
+
+## The execution boundary
+
+Bash contributions require an explicit writable Workspace because every call executes against a Workspace Session and can commit changes to the Workspace Store. Workspace rules and the selected Workspace Scope still control which file changes ViteHub can commit.
+
+The Workspace runtime defines where the process runs. Use `runtime: 'sandbox'` for a provider-managed isolated session, or opt into `runtime: 'trusted-host'` when the Agent intentionally runs with the host service account's authority.
+
+The executable allowlist limits which process the Agent can start. It does not make that process safe or remove its filesystem, network, credential, or child-process authority, so the Workspace runtime and host configuration remain part of the security boundary.
+
+## How the terms fit together
+
+| Term | Responsibility |
+| --- | --- |
+| `bash` Agent tool | Gives the Agent one structured execution tool containing the commands contributed by its resolved Capabilities. |
+| Capability `bash` contribution | Declares an executable owned by that Capability. It is a contribution field, not a `bash()` Capability factory. |
+| `workspaceShell()` | Adds a Bash-compatible `shell` inspection tool and structured Workspace mutation tools. Its optional `commands` setting creates `workspace_exec` for app-selected executables rather than contributing to the global `bash` tool. |
+| Shell | Provides server-side Unix-like command runtimes, command analysis, policy boundaries, and observations. The Agent Package assembles the global `bash` tool separately and dispatches it through Workspace Sessions. |
+| Workspace Session | Supplies the executable file-tree session used by a `bash` call and commits successful Workspace changes. |
+| Sandbox | Provides optional isolated execution. It can back a Workspace Session, but it does not define or populate the global `bash` tool. |
+
+## Choose the right surface
+
+Contribute to `bash` when a Capability owns a real CLI and the Agent should use it through the shared execution surface. This keeps executable discovery consistent as more Capabilities attach.
+
+Use `workspaceShell()` when the Agent needs general Workspace inspection, structured file mutation, or an app-selected `workspace_exec` allowlist. Use a structured tool or Capability CLI when the operation has a narrow typed contract that should not look like process execution.
+
+Use the Shell primitive from server code when the application owns the command runtime directly. Use Sandbox when provider-managed isolation is the primary requirement.
+
+## Next steps
+
+- Add commands through [Custom capabilities](/docs/capabilities/custom-capabilities#contribute-bash-commands).
+- Inspect Workspace behavior with [Workspace shell](/docs/capabilities/workspace-shell).
+- Configure execution with [Workspace](/docs/server-primitives/workspace), [Shell](/docs/server-primitives/shell), and [Sandbox](/docs/server-primitives/sandbox).

--- a/docs/content/docs/concepts/index.md
+++ b/docs/content/docs/concepts/index.md
@@ -23,6 +23,7 @@ The concepts in this section explain those boundaries before the package pages a
 | [Runtime Context](/docs/concepts/runtime-context) | How hosts pass execution facts and resources without framework globals. |
 | [Workspace and Sources](/docs/concepts/workspace-and-sources) | How persistent file trees consume read-only origins. |
 | [Capabilities API](/docs/concepts/capabilities-api) | How Agents receive selected abilities. |
+| [Bash](/docs/concepts/bash) | How Capability-owned executables become one constrained Agent tool. |
 | [Channels API](/docs/concepts/channels-api) | How message-shaped Agent Invocations, channel metadata, and host commands stay separate. |
 | [Auth Users and Agent Invokers](/docs/concepts/auth-users-and-agent-invokers) | How authenticated app users map into trusted Agent Invocation identity. |
 | [Runtime policy, approvals, and traces](/docs/concepts/runtime-policy-approvals-and-traces) | How ViteHub records runtime decisions without making policy invisible. |

--- a/docs/content/docs/server-primitives/shell.md
+++ b/docs/content/docs/server-primitives/shell.md
@@ -188,6 +188,8 @@ Do not treat analysis as sandbox enforcement. Execution Providers and caller-own
 
 Agents use Shell through Capabilities, usually `workspaceShell()`. That Capability exposes shell-shaped Workspace inspection and optional structured Workspace mutation tools through Workspace Scope, Workspace rules, and Shell policy.
 
+The global Agent `bash` tool is a separate Agent Package surface. Capabilities register executables, and ViteHub dispatches each structured call through an executable Workspace Session. Read the [Bash concept](/docs/concepts/bash) for that model-facing boundary.
+
 Do not expose a raw Shell Runtime to a model. Use [Official capabilities](/docs/capabilities/official-capabilities) so policy, metadata, driver support, and tool surfaces stay attached to the Agent Definition.
 
 ## Production boundaries
@@ -198,6 +200,7 @@ Use Sandbox when the app needs provider-managed isolation. Use Shell when the ap
 
 ## Next steps
 
+- Understand the model-facing [Bash](/docs/concepts/bash) tool.
 - Use [Workspace](/docs/server-primitives/workspace) for file-tree state.
 - Use [Sandbox](/docs/server-primitives/sandbox) for isolated execution providers.
 - Expose command inspection to agents through [Official capabilities](/docs/capabilities/official-capabilities).


### PR DESCRIPTION
Adds a Bash concept page that explains how Capability-owned executable contributions resolve into one model-facing `bash` tool, including its structured command contract and Workspace Session commit flow.

Frames Bash and code mode as one composable Agent philosophy rather than ViteHub's universal model, with further reading from Anthropic, Vercel, and Cloudflare.

Clarifies the boundary between the global `bash` tool, `workspaceShell()`, Shell, Workspace Sessions, and Sandbox, then links the concept from the overview and the nearest capability and primitive pages.