### PR TITLE
docs(concepts): explain agent invocations

### DIFF
--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -9,7 +9,7 @@ An Agent Definition is the code declaration that names one Agent and configures 
 
 ViteHub discovers Agent Definitions from `server/agents`. The Agent File Name or folder name provides the discovered identity, so `server/agents/support.ts` and `server/agents/support/agent.ts` both create a `support` Agent.
 
-Discovered Agent Definitions run as Workflows by default, and ViteHub selects the Workflow provider from the active host integration. Direct `runAgent()` calls without a discovered host identity remain inline. Use `runtime: false` when a hosted Agent must also complete inline, or `runtime: workflow('name')` when it needs a Workflow identity that differs from its discovered Agent identity.
+Discovered Agent Definitions run as Workflows by default, and ViteHub selects the Workflow provider from the active host integration. Direct `runAgent()` calls using that discovery-default binding remain inline without a discovered host identity. Use `runtime: false` when a hosted Agent must also complete inline, or `runtime: workflow('name')` when direct and hosted calls should use that named Workflow identity.
 
 ## Define the Agent
 

--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -9,6 +9,8 @@ An Agent Invocation is one runtime request to an Agent. It receives input, resol
 
 Invoke Agents from server code, Agent Triggers, schedules, DevTools, or framework-owned routes. The invocation input carries prompt or message content plus trusted context values.
 
+Read [Agent Invocations](/docs/concepts/agent-invocations) for the request boundary and its relationship to Agent Definitions, Channels, Chat Sessions, and Workflow Runs.
+
 ## Run an Agent
 
 Use `runAgent` when the caller expects a final result. Pass [Runtime Context](/docs/concepts/runtime-context) separately from invocation input so host resources and task data keep distinct boundaries.

--- a/docs/content/docs/concepts/agent-invocations.md
+++ b/docs/content/docs/concepts/agent-invocations.md
@@ -1,0 +1,66 @@
+---
+title: Agent Invocations
+description: Understand the request boundary that resolves identity, abilities, context, execution, and output for an Agent.
+navigation.order: 5
+icon: i-lucide-play-circle
+---
+
+An Agent Invocation is one runtime request to an Agent. It resolves the reusable Agent Definition into the identity, Capabilities, Workspace context, Agent Driver execution, lifecycle state, and output for that request.
+
+The invocation is the composition boundary. An Agent Definition describes what can run, while an Agent Invocation records what actually ran for one input.
+
+## Why it exists
+
+Agents can be reached from server routes, Agent Triggers, schedules, Channels, DevTools, or other Agents. Each entry surface can supply different input, trusted caller identity, run metadata, and context without creating a different Agent Definition.
+
+Keeping that variation inside an invocation makes runtime behavior inspectable. ViteHub can show which Agent Actor, Capabilities, Workspace Scope, Agent Driver, and output belonged to one request instead of treating them as ambient Agent state.
+
+## Invocation lifecycle
+
+| Phase | What resolves |
+| --- | --- |
+| Entry | A trusted server helper or Agent Trigger prepares prompt, message, or structured input with run metadata. |
+| Identity | ViteHub resolves the Agent Actor from trusted invocation input, a configured profile or resolver, or the fallback identity. |
+| Composition | The Agent Definition and active Channel select the Capabilities that apply to this invocation. |
+| Context | Capabilities can prepare context values, policy, tools, and the visible Workspace Scope before execution. |
+| Execution | The selected Agent Driver processes the prepared input through model-backed, harness-backed, or custom-run-backed execution. |
+| Completion | ViteHub normalizes output and usage, runs finish behavior, records trace state, and returns or streams the result. |
+
+Capability selection happens once for the invocation. A Capability omitted by an invocation-time resolver contributes no tools, requirements, policy, hooks, or cleanup work to that request.
+
+## Keep neighboring concepts separate
+
+| Concept | Responsibility |
+| --- | --- |
+| Agent Definition | Declares the reusable Agent composition and its possible runtime behavior. |
+| Agent Invocation | Resolves and runs that composition once for one input. |
+| Agent Trigger | Maps a product event into Agent Invocation input and run metadata. |
+| Channel | Names reachability, origin, message facts, and delivery behavior around an invocation. |
+| Chat Session | Selects which conversational messages are eligible for one invocation's Chat History Window. |
+| Workflow Run | Provides a durable execution boundary when the Agent Invocation runs through a Workflow. |
+
+A Channel can start many Agent Invocations, and a Chat Session can supply history to many Agent Invocations. Neither becomes the invocation itself. A Workflow Run can carry one hosted Agent Invocation across a durable boundary, but Workflow remains responsible for durability and orchestration.
+
+## Inline and Workflow-backed invocations
+
+Direct calls using the discovery-default Workflow binding run inline without a discovered Agent host identity. An explicit `runtime: workflow('name')` binding still routes direct calls through the named Workflow. Discovered Agent Definitions run through Workflows by default unless the Definition opts out or selects another Workflow binding.
+
+Both paths still create one Agent Invocation. Workflow-backed execution adds a durable serialization boundary, so process-local objects such as an in-memory Trace Event Log do not cross into the Workflow Run.
+
+## Invocation state is not Agent memory
+
+Invocation context, run metadata, tools, and trace state belong to one request. Chat History, Agent Memory, Workspace files, and application stores persist only through the boundaries that own them.
+
+Do not use an Agent Invocation as an implicit conversation or persistence layer. Configure Chat History for prior messages, Memory for durable learned context, and Workspace for file-tree state.
+
+## Inspect an invocation
+
+Inspect the prepared input, Agent Actor, active Channel, resolved Capabilities, visible Workspace Scope, Agent Driver, trace, usage, and final output together. These values explain the runtime request without requiring you to infer behavior from the Agent Definition alone.
+
+Agent DevTools exposes the resolved invocation state. Server code can use invocation hooks, traces, and run events when the application needs programmatic inspection or progress reporting.
+
+## Next steps
+
+- Read [Invocations](/docs/agents/invocations) for `runAgent()`, `streamAgent()`, Agent Triggers, hooks, and run events.
+- Read [Capabilities API](/docs/concepts/capabilities-api) for invocation-resolved abilities.
+- Read [Runtime policy, approvals, and traces](/docs/concepts/runtime-policy-approvals-and-traces) for inspectable runtime decisions.

--- a/docs/content/docs/concepts/how-vitehub-fits-together.md
+++ b/docs/content/docs/concepts/how-vitehub-fits-together.md
@@ -27,7 +27,7 @@ For example, Workspace owns the Workspace File Tree and Sources. The Agent Packa
 
 ## Agent composition
 
-An Agent Definition selects one Agent Driver. It may attach Capabilities, define an Agent Invoker resolver, use Workspace context, and run through Agent Invocations.
+An Agent Definition selects one Agent Driver. It may attach Capabilities, define an Agent Invoker resolver, use Workspace context, and run through [Agent Invocations](/docs/concepts/agent-invocations).
 
 Capabilities sit above the Agent Driver. An Agent Definition can attach a static ordered list or resolve its list once from trusted invocation context before Capability setup; the selected list does not change while the invocation runs.
 

--- a/docs/content/docs/concepts/index.md
+++ b/docs/content/docs/concepts/index.md
@@ -17,6 +17,7 @@ The concepts in this section explain those boundaries before the package pages a
 | [Server primitives for any host](/docs/concepts/server-primitives-for-any-host) | Why ViteHub starts from host-independent server behavior. |
 | [How ViteHub fits together](/docs/concepts/how-vitehub-fits-together) | How Vite Integrations, Definitions, Provider Output, Runtime Helpers, and Capabilities connect. |
 | [Definitions and discovery](/docs/concepts/definitions-and-discovery) | How package-owned files become named runtime behavior. |
+| [Agent Invocations](/docs/concepts/agent-invocations) | How one request resolves caller identity, abilities, context, execution, and output. |
 | [Vite Integrations and Provider Output](/docs/concepts/vite-integrations-and-provider-output) | What build and dev integrations own. |
 | [Runtime Helpers and stable imports](/docs/concepts/runtime-helpers-and-stable-imports) | Why application code imports stable ViteHub APIs instead of generated internals. |
 | [Runtime Context](/docs/concepts/runtime-context) | How hosts pass execution facts and resources without framework globals. |


### PR DESCRIPTION
Adds an Agent Invocations concept page that defines the per-request composition boundary and separates it from Agent Definitions, Agent Triggers, Channels, Chat Sessions, and Workflow Runs.

Links that mental model from the Concepts map, the shared Agent composition explanation, and the existing invocation API page so runtime helper details stay in their current owner.