### PR TITLE
feat(box): restore disposable Git checkouts

### DIFF
--- a/docs/content/docs/agents/boxes.md
+++ b/docs/content/docs/agents/boxes.md
@@ -9,7 +9,7 @@ A Box is the execution environment for a harness Agent. The project declares wha
 
 Use `trustedHost()` when the Agent may use the current host's filesystem, processes, and installed executables. Use `crabbox()` to run the same Box declaration through Crabbox Static SSH. Neither runtime reads credentials or configuration from the machine's normal Home.
 
-## Run Codex in an existing checkout
+## Run Codex in an exact disposable checkout
 
 Install the Agent and Box packages with the Codex harness adapter:
 
@@ -26,13 +26,19 @@ import { trustedHost } from "@vite-hub/box";
 import { useServerEnv } from "#vitehub/env/server";
 
 interface BabysitterRunOptions {
-  worktreePath: string;
+  ref: string;
+  remote: string;
+  sha: string;
 }
 
 export default defineAgent<any, BabysitterRunOptions>({
   box: {
     runtime: trustedHost({ stateRoot: "/var/lib/vitehub/boxes" }),
-    cwd: ({ input }) => input.options?.worktreePath,
+    checkout: {
+      ref: ({ input }) => input.options?.ref,
+      remote: ({ input }) => input.options?.remote,
+      sha: ({ input }) => input.options?.sha,
+    },
     env: {
       GH_TOKEN: () => useServerEnv().githubToken.unseal(),
       GIT_CONFIG_NOSYSTEM: "1",
@@ -59,6 +65,10 @@ export default defineAgent<any, BabysitterRunOptions>({
   driver: codexDriver(),
 });
 ```
+
+For every invocation, `checkout` fetches `ref` from `remote`, verifies the fetched commit against the full `sha`, and starts Codex in a detached real Git repository. The checkout supports ordinary commits and explicit pushes such as `git push origin HEAD:<branch>`, then the Box deletes it on completion or boot failure. For a fork pull request, use the fork repository as `remote`; keep credentials in Box env or Home instead of embedding them in the remote URL.
+
+Use `cwd` instead when the caller already owns an authoritative directory. `checkout` and `cwd` are mutually exclusive. Git is an implicit checkout requirement and appears in resolved Box metadata.
 
 The runtime creates an owner-only Home outside the checkout, sets the XDG directories beneath it, and exposes the same environment to Codex, Git, `gh`, MCP servers, and ordinary Box commands. `codexDriver()` uses `$HOME/.codex` directly and contributes `codex login status` automatically, so Codex refreshes remain in Box state.
 
@@ -108,8 +118,9 @@ Box boot follows one order:
 3. The runtime inspects existing state and resolves seeds only for missing state.
 4. The runtime resolves env and files; if any required input fails, no new state becomes authoritative.
 5. The runtime attaches state, writes files with private permissions, and builds a sanitized environment.
-6. The runtime runs requirements inside that environment.
-7. Only a successful Box is exposed to harness bootstrap and commands.
+6. When declared, the runtime creates the disposable Git checkout and verifies its exact SHA.
+7. The runtime runs requirements inside that environment.
+8. Only a successful Box is exposed to harness bootstrap and commands.
 
 `HOME`, the XDG paths, and working-directory variables are runtime-owned and cannot be declared or overridden by a command. The runtime inherits a small operational allowlist such as `PATH`, shell, locale, and temporary-directory variables; it does not spread the launcher process environment. An absent declaration cannot be masked by a host token or dotfile.
 
@@ -144,7 +155,11 @@ box: {
     profile: 'babysitter',
     stateRoot: '/var/lib/vitehub/boxes',
   }),
-  cwd: ({ input }) => input.options?.worktreePath,
+  checkout: {
+    ref: ({ input }) => input.options?.ref,
+    remote: ({ input }) => input.options?.remote,
+    sha: ({ input }) => input.options?.sha,
+  },
   env: {
     GH_TOKEN: () => useServerEnv().githubToken.unseal(),
   },
@@ -156,9 +171,9 @@ box: {
 }
 ```
 
-Crabbox creates the private Home on the target and sends resolved material through its protected stdin channel. Its `stateRoot` is an absolute target-host path and remains outside Workspace synchronization. The runtime creates private children without changing permissions on an existing caller-owned root. Only the authoritative `cwd` is synchronized back.
+Crabbox creates the private Home on the target and sends resolved material through its protected stdin channel. Its `stateRoot` is an absolute target-host path and remains outside Workspace synchronization. The runtime creates private children without changing permissions on an existing caller-owned root. An authoritative `cwd` is synchronized back; a disposable `checkout` remains target-local and is deleted with the Box session.
 
-Crabbox requires `cwd` and targets Linux/POSIX Static SSH hosts. Static SSH does not provide port publishing; set `network: 'direct'` only when the target shares the ViteHub process loopback namespace.
+Crabbox requires either `cwd` or `checkout` and targets Linux/POSIX Static SSH hosts. Static SSH does not provide port publishing; set `network: 'direct'` only when the target shares the ViteHub process loopback namespace.
 
 Commands must remain owned by their Box session. Daemonizing or escaping the session's process supervision is outside the v1 concurrency guarantee.
 
@@ -184,11 +199,11 @@ Do not copy a general user Home into Box state. It mixes unrelated credentials a
 | Workspace | Model-visible file context, Sources, rules, snapshots, and writeback.                                       |
 | Sandbox   | Provider isolation for untrusted code.                                                                      |
 
-An explicit Box `cwd` cannot be combined with Agent Workspace materialization because both would own the working tree. Omit `cwd` when an Agent Workspace should be materialized into a disposable Box session.
+Box `cwd` and `checkout` cannot be combined with Agent Workspace materialization because each owns the working tree. Omit both when an Agent Workspace should be materialized into a disposable Box session.
 
 Home and environment isolation do not isolate the filesystem, network, installed executables, or trusted project code. Use `trustedHost()` only when the Agent may act with the host user's authority.
 
-V1 deliberately stops at env values, Home files, writable directory state, and direct boot checks. Secret-manager registries, a ViteHub encryption format, live rotation, per-command credential narrowing, keychain forwarding, and provider-specific auth helpers can be added outside core or later when a concrete runtime needs them.
+V1 deliberately stops at env values, Home files, writable directory state, generic Git checkout, and direct boot checks. Secret-manager registries, a ViteHub encryption format, live rotation, per-command credential narrowing, keychain forwarding, and provider-specific auth helpers can be added outside core or later when a concrete runtime needs them.
 
 ## Related pages
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -106,10 +106,14 @@ import { codexDriver } from "@vite-hub/agent/harness/codex";
 import { trustedHost } from "@vite-hub/box";
 import { useServerEnv } from "#vitehub/env/server";
 
-export default defineAgent<any, { worktreePath: string }>({
+export default defineAgent<any, { ref: string; remote: string; sha: string }>({
   box: {
     runtime: trustedHost({ stateRoot: "/var/lib/vitehub/boxes" }),
-    cwd: ({ input }) => input.options?.worktreePath,
+    checkout: {
+      ref: ({ input }) => input.options?.ref,
+      remote: ({ input }) => input.options?.remote,
+      sha: ({ input }) => input.options?.sha,
+    },
     env: {
       GH_TOKEN: () => useServerEnv().githubToken.unseal(),
     },
@@ -133,7 +137,9 @@ export default defineAgent<any, { worktreePath: string }>({
 });
 ```
 
-`env` and `home.files` are immutable boot inputs. `home.state` is writable, persists CLI refreshes under an exclusive session lease, and resolves its seed only when state does not exist. Every Box gets a private Home; missing declarations fail instead of falling back to the machine's normal Home. `codexDriver()` contributes a generic `codex login status` check, and other CLIs use string or direct-argv `requires` entries without provider-specific Box APIs. Do not combine an explicit `box.cwd` with Agent Workspace materialization.
+`checkout` fetches one invocation-resolved Git ref, verifies its full SHA, and runs the harness in an isolated detached checkout with normal commit and explicit-push behavior. The Box deletes it on completion or boot failure. Use `cwd` instead for a caller-owned authoritative directory; the two modes are mutually exclusive.
+
+`env` and `home.files` are immutable boot inputs. `home.state` is writable, persists CLI refreshes under an exclusive session lease, and resolves its seed only when state does not exist. Every Box gets a private Home; missing declarations fail instead of falling back to the machine's normal Home. `codexDriver()` contributes a generic `codex login status` check, and other CLIs use string or direct-argv `requires` entries without provider-specific Box APIs. Do not combine `box.cwd` or `box.checkout` with Agent Workspace materialization.
 
 For model-backed drivers, put free-form guidance for configured Sources, Capabilities, and Skills in `driver.instructions` or a deterministic imported instruction file. Tool descriptions and schemas stay with the tools as structured contracts.
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1538,8 +1538,8 @@ async function createAgentInvocationContext<
           requires: (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentBoxRequirements],
         })
       : undefined
-    if (box?.workspace.path && workspaceOptions) {
-      throw new Error("[vitehub] defineAgent({ box.cwd, workspace }) is not supported because an authoritative Box workspace must not be reset by Workspace materialization.")
+    if (box?.workspace.workDir && workspaceOptions) {
+      throw new Error("[vitehub] defineAgent({ box.cwd or box.checkout, workspace }) is not supported because a Box-owned working tree must not be reset by Workspace materialization.")
     }
     const harnessSandboxProvider = box?.sandbox || (box
       ? (await import("./harness/local-sandbox.ts")).createTrustedHostHarnessSandbox({
@@ -1656,7 +1656,7 @@ async function createAgentInvocationContext<
       hasCapabilityCleanup: capabilities.hasCloseCallbacks,
       handledResponse: capabilities.response,
       harnessSandboxProvider,
-      harnessWorkDir: box?.workspace.path ? "workspace" : undefined,
+      harnessWorkDir: box?.workspace.workDir,
       hooks: definition?.hooks as AgentHookObserverHooks | undefined,
       input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
       instructions,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1538,7 +1538,7 @@ async function createAgentInvocationContext<
           requires: (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentBoxRequirements],
         })
       : undefined
-    if (box?.workspace.workDir && workspaceOptions) {
+    if ((box?.workspace.path || box?.workspace.workDir) && workspaceOptions) {
       throw new Error("[vitehub] defineAgent({ box.cwd or box.checkout, workspace }) is not supported because a Box-owned working tree must not be reset by Workspace materialization.")
     }
     const harnessSandboxProvider = box?.sandbox || (box

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1656,7 +1656,7 @@ async function createAgentInvocationContext<
       hasCapabilityCleanup: capabilities.hasCloseCallbacks,
       handledResponse: capabilities.response,
       harnessSandboxProvider,
-      harnessWorkDir: box?.workspace.workDir,
+      harnessWorkDir: box?.workspace.workDir ?? (box?.workspace.path ? "workspace" : undefined),
       hooks: definition?.hooks as AgentHookObserverHooks | undefined,
       input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
       instructions,

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -222,6 +222,45 @@ describe("Agent Box", () => {
     })).toThrow("defineAgent({ box }) owns harness execution")
   })
 
+  it("preserves the harness work directory for custom runtimes with an authoritative path", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { codexDriver } = await import("../src/harness/codex.ts")
+    const agent = defineAgent({
+      box: {
+        cwd: "/workspace",
+        runtime: {
+          name: "path-only",
+          async resolve({ identity }: { identity: string }) {
+            return {
+              cache: { state: "disposable" as const },
+              environment: { env: {} },
+              identity,
+              isolation: "none" as const,
+              requirements: [],
+              runtime: "path-only",
+              sandbox: {
+                providerId: "path-only",
+                specificationVersion: "harness-sandbox-v1" as const,
+                async createSession() {
+                  throw new Error("stop after harness configuration")
+                },
+              },
+              workspace: { path: "/workspace", state: "authoritative" as const },
+            }
+          },
+        },
+      },
+      driver: codexDriver(),
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "Repair the project." })).rejects.toThrow("stop after harness configuration")
+    expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "workspace" })
+  })
+
   it("rejects Box checkout with Agent Workspace materialization", async () => {
     const { trustedHost } = await import("@vite-hub/box")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -1,6 +1,8 @@
-import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises"
+import { execFile } from "node:child_process"
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { promisify } from "node:util"
 
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -44,6 +46,7 @@ vi.mock("@ai-sdk/harness/agent", () => ({
 }))
 
 const roots: string[] = []
+const exec = promisify(execFile)
 
 afterEach(async () => {
   harnessSettings.length = 0
@@ -129,6 +132,82 @@ describe("Agent Box", () => {
     }
   })
 
+  it("runs Codex in a Box-owned disposable Git checkout", async () => {
+    const root = await temporaryRoot()
+    const repository = join(root, "repository")
+    const stateRoot = join(root, "state")
+    const bin = join(root, "bin")
+    await Promise.all([mkdir(repository), mkdir(bin)])
+    await exec("git", ["init", "--quiet", "--initial-branch=main", repository])
+    await writeFile(join(repository, "AGENTS.md"), "Repository instructions.\n")
+    await exec("git", ["-C", repository, "add", "AGENTS.md"])
+    await exec("git", [
+      "-C", repository,
+      "-c", "user.name=Fixture",
+      "-c", "user.email=fixture@example.com",
+      "commit", "--quiet", "-m", "initial",
+    ])
+    const sha = (await exec("git", ["-C", repository, "rev-parse", "HEAD"])).stdout.trim()
+    await Promise.all([
+      executable(bin, "codex", "exit 0"),
+      executable(bin, "gh", "exit 0"),
+      executable(bin, "pnpm", "exit 0"),
+    ])
+
+    const originalPath = process.env.PATH
+    process.env.PATH = [bin, originalPath].filter(Boolean).join(":")
+    try {
+      const { trustedHost } = await import("@vite-hub/box")
+      const { custom } = await import("@vite-hub/workspace")
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { skills } = await import("../src/capabilities.ts")
+      const { codexDriver } = await import("../src/harness/codex.ts")
+      const agent = defineAgent({
+        box: {
+          checkout: { ref: "refs/heads/main", remote: repository, sha },
+          home: {
+            files: {
+              ".codex/config.toml": {
+                contents: 'model = "configured-model"\ncli_auth_credentials_store = "file"\n',
+              },
+            },
+            state: {
+              ".codex": {
+                key: "agent-box-test/checkout-codex",
+                seed: { "auth.json": { contents: '{"token":"box"}\n' } },
+              },
+            },
+          },
+          requires: [{ command: "gh", args: ["auth", "status"] }, "pnpm"],
+          runtime: trustedHost({ stateRoot }),
+        },
+        capabilities: [
+          skills({
+            path: "skills/global",
+            scope: "global",
+            source: custom({ files: [{ content: "Global skill.\n", path: "SKILL.md" }] }),
+          }),
+        ],
+        driver: codexDriver(),
+      })
+
+      const result = await runAgent(agent, {
+        memo: vi.fn((_key, create) => create()),
+        runtime: "vite",
+        waitUntil: vi.fn(),
+      }, { prompt: "Repair the project." }) as { text: string }
+      const [reportedCheckout] = result.text.trim().split("\n")
+
+      expect(reportedCheckout).toMatch(/\/vitehub-box-[^/]+\/workspace$/)
+      await expect(stat(join(reportedCheckout, ".."))).rejects.toMatchObject({ code: "ENOENT" })
+      expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "workspace" })
+    }
+    finally {
+      if (originalPath === undefined) delete process.env.PATH
+      else process.env.PATH = originalPath
+    }
+  })
+
   it("rejects overlapping Box and harness execution configuration", async () => {
     const { trustedHost } = await import("@vite-hub/box")
     const { defineAgent } = await import("../src/index.ts")
@@ -141,6 +220,30 @@ describe("Agent Box", () => {
       box: { runtime: trustedHost() },
       driver: { harness: {}, workDir: "repository" },
     })).toThrow("defineAgent({ box }) owns harness execution")
+  })
+
+  it("rejects Box checkout with Agent Workspace materialization", async () => {
+    const { trustedHost } = await import("@vite-hub/box")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { codexDriver } = await import("../src/harness/codex.ts")
+    const agent = defineAgent({
+      box: {
+        checkout: {
+          ref: "refs/heads/main",
+          remote: "https://example.com/repository.git",
+          sha: "0".repeat(40),
+        },
+        runtime: trustedHost(),
+      },
+      driver: codexDriver(),
+      workspace: { mode: "write", store: { provider: "memory" } },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "Repair the project." })).rejects.toThrow("Box-owned working tree")
   })
 })
 

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -245,6 +245,38 @@ describe("Agent Box", () => {
       waitUntil: vi.fn(),
     }, { prompt: "Repair the project." })).rejects.toThrow("Box-owned working tree")
   })
+
+  it("rejects an authoritative Box path with Agent Workspace materialization", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { codexDriver } = await import("../src/harness/codex.ts")
+    const agent = defineAgent({
+      box: {
+        cwd: "/workspace",
+        runtime: {
+          name: "path-only",
+          async resolve({ cwd, identity }: { cwd?: string, identity: string }) {
+            return {
+              cache: { state: "disposable" as const },
+              environment: { env: {} },
+              identity,
+              isolation: "none" as const,
+              requirements: [],
+              runtime: "path-only",
+              workspace: { path: cwd, state: "authoritative" as const },
+            }
+          },
+        },
+      },
+      driver: codexDriver(),
+      workspace: { mode: "write", store: { provider: "memory" } },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "Repair the project." })).rejects.toThrow("Box-owned working tree")
+  })
 })
 
 async function temporaryRoot() {

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -200,7 +200,7 @@ describe("Agent Box", () => {
 
       expect(reportedCheckout).toMatch(/\/vitehub-box-[^/]+\/workspace$/)
       await expect(stat(join(reportedCheckout, ".."))).rejects.toMatchObject({ code: "ENOENT" })
-      expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "workspace" })
+      expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "." })
     }
     finally {
       if (originalPath === undefined) delete process.env.PATH

--- a/packages/box/README.md
+++ b/packages/box/README.md
@@ -16,10 +16,14 @@ import { codexDriver } from "@vite-hub/agent/harness/codex";
 import { trustedHost } from "@vite-hub/box";
 import { useServerEnv } from "#vitehub/env/server";
 
-export default defineAgent<any, { worktreePath: string }>({
+export default defineAgent<any, { ref: string; remote: string; sha: string }>({
   box: {
     runtime: trustedHost({ stateRoot: "/var/lib/vitehub/boxes" }),
-    cwd: ({ input }) => input.options?.worktreePath,
+    checkout: {
+      ref: ({ input }) => input.options?.ref,
+      remote: ({ input }) => input.options?.remote,
+      sha: ({ input }) => input.options?.sha,
+    },
     env: {
       GH_TOKEN: () => useServerEnv().githubToken.unseal(),
       GIT_CONFIG_NOSYSTEM: "1",
@@ -46,6 +50,10 @@ export default defineAgent<any, { worktreePath: string }>({
   driver: codexDriver(),
 });
 ```
+
+`checkout` gives each invocation a disposable real Git repository at the exact requested commit. The runtime fetches `ref` from `remote`, verifies the resulting commit against the full `sha`, and starts the harness in a detached checkout. Normal Git commits work, and callers can push explicitly with `git push origin HEAD:<branch>`. Use the source repository as `remote` for fork pull requests, and keep credentials in Box `env` or Home rather than embedding them in the remote URL.
+
+`checkout` and `cwd` are mutually exclusive. Use `cwd` for a caller-owned authoritative directory; use `checkout` when the Box should create, isolate, and delete the working tree. Git is an implicit checkout requirement and is included in resolved Box metadata.
 
 Every Box session receives a new private `HOME` plus `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, and `XDG_STATE_HOME`. The runtime starts from a small operational environment allowlist, applies the declared `env`, attaches writable state, materializes files, and runs requirements before the harness starts. Missing declarations fail boot; the host Home and undeclared credential variables cannot satisfy them.
 
@@ -89,7 +97,11 @@ box: {
     profile: "babysitter",
     stateRoot: "/var/lib/vitehub/boxes",
   }),
-  cwd: ({ input }) => input.options?.worktreePath,
+  checkout: {
+    ref: ({ input }) => input.options?.ref,
+    remote: ({ input }) => input.options?.remote,
+    sha: ({ input }) => input.options?.sha,
+  },
   env: {
     GH_TOKEN: () => useServerEnv().githubToken.unseal(),
   },
@@ -101,9 +113,9 @@ box: {
 }
 ```
 
-Crabbox materializes the same declaration on the target before requirement checks. Resolved material travels through Crabbox's protected stdin channel rather than command arguments. The private Home and writable state stay outside Workspace synchronization; only `cwd` is synchronized back.
+Crabbox materializes the same declaration on the target before requirement checks. Resolved material travels through Crabbox's protected stdin channel rather than command arguments. The private Home and writable state stay outside Workspace synchronization. An authoritative `cwd` is synchronized back; a disposable `checkout` remains target-local and is deleted with the Box session.
 
-Crabbox requires `cwd` and targets Linux/POSIX Static SSH hosts. `stateRoot` is an absolute path on the target. Static SSH does not support Crabbox port publishing; use `network: "direct"` only when the target shares the ViteHub process loopback namespace.
+Crabbox requires either `cwd` or `checkout` and targets Linux/POSIX Static SSH hosts. `stateRoot` is an absolute path on the target. Static SSH does not support Crabbox port publishing; use `network: "direct"` only when the target shares the ViteHub process loopback namespace.
 
 Commands must remain owned by their Box session. Daemonizing or escaping the session's process supervision is outside the v1 concurrency guarantee.
 
@@ -113,4 +125,4 @@ A Box isolates Home, configuration, and declared process environment from ambien
 
 Resolved environment values, file contents, state, physical Home paths, and sandbox handles are excluded from serialized Box metadata. Requirement failures discard command output, while every process inside the Box remains trusted and can still read or log its credentials. Stable session identity uses declaration targets and state keys, never secret values or temporary paths.
 
-An explicit Box `cwd` cannot be combined with Agent Workspace materialization because both would own the working tree. Omit `cwd` when the Agent should use a disposable Workspace session.
+Box `cwd` and `checkout` cannot be combined with Agent Workspace materialization because each owns the working tree. Omit both when the Agent should use a disposable Workspace session.

--- a/packages/box/src/index.ts
+++ b/packages/box/src/index.ts
@@ -110,7 +110,7 @@ export interface ResolvedBox {
   readonly workspace: {
     readonly path?: string;
     readonly state: "authoritative" | "disposable";
-    readonly workDir?: "workspace";
+    readonly workDir?: "." | "workspace";
   };
 }
 

--- a/packages/box/src/index.ts
+++ b/packages/box/src/index.ts
@@ -31,7 +31,14 @@ export interface BoxHome<Context> {
   >;
 }
 
+export interface BoxCheckout<Context> {
+  ref: BoxValue<string, Context>;
+  remote: BoxValue<string, Context>;
+  sha: BoxValue<string, Context>;
+}
+
 export interface BoxDefinition<Context = unknown> {
+  checkout?: BoxCheckout<Context>;
   cwd?: BoxValue<string, Context>;
   env?: Readonly<Record<string, BoxValue<string, Context>>>;
   home?: BoxHome<Context>;
@@ -68,10 +75,17 @@ export interface ResolvedBoxRequirementInput {
 }
 
 export interface ResolvedBoxInput {
+  checkout?: ResolvedBoxCheckout;
   cwd?: string;
   identity: string;
   plan: ResolvedBoxPlan;
   requirements: readonly ResolvedBoxRequirementInput[];
+}
+
+export interface ResolvedBoxCheckout {
+  readonly ref: string;
+  readonly remote: string;
+  readonly sha: string;
 }
 
 export interface ResolvedBoxEnvironment {
@@ -96,6 +110,7 @@ export interface ResolvedBox {
   readonly workspace: {
     readonly path?: string;
     readonly state: "authoritative" | "disposable";
+    readonly workDir?: "workspace";
   };
 }
 
@@ -127,23 +142,43 @@ export async function resolveBox<Context>(
   ) {
     throw new TypeError("[vitehub] Box requires a runtime.");
   }
+  if (definition.cwd !== undefined && definition.checkout !== undefined) {
+    throw new TypeError("[vitehub] Box checkout cannot be combined with cwd.");
+  }
   const cwdValue = await resolveValue(definition.cwd, context);
   const cwd = cwdValue === undefined ? undefined : resolve(resolveString(cwdValue, "cwd"));
+  const checkout = definition.checkout
+    ? {
+        ref: resolveString(await resolveValue(definition.checkout.ref, context), "checkout ref"),
+        remote: resolveString(
+          await resolveValue(definition.checkout.remote, context),
+          "checkout remote",
+        ),
+        sha: resolveSha(await resolveValue(definition.checkout.sha, context)),
+      }
+    : undefined;
   const plan = resolvePlan(definition, context, cwd || process.cwd());
   const requirements = normalizeRequirements([
+    ...(checkout ? ["git"] : []),
     ...(definition.requires || []),
     ...(options.requires || []),
   ]);
   return await definition.runtime.resolve({
+    ...(checkout ? { checkout } : {}),
     ...(cwd ? { cwd } : {}),
-    identity: planIdentity(plan, requirements),
+    identity: planIdentity(plan, requirements, checkout),
     plan,
     requirements,
   });
 }
 
-function planIdentity(plan: ResolvedBoxPlan, requirements: readonly ResolvedBoxRequirementInput[]) {
+function planIdentity(
+  plan: ResolvedBoxPlan,
+  requirements: readonly ResolvedBoxRequirementInput[],
+  checkout: ResolvedBoxCheckout | undefined,
+) {
   const value = JSON.stringify({
+    checkout,
     env: Object.keys(plan.env).toSorted(),
     files: Object.keys(plan.files).toSorted(),
     requirements,
@@ -393,6 +428,14 @@ function resolveString(value: unknown, label: string) {
     throw new TypeError(`[vitehub] Box ${label} must resolve to a non-empty string.`);
   if (value.includes("\0")) throw new TypeError(`[vitehub] Box ${label} cannot contain NUL.`);
   return value;
+}
+
+function resolveSha(value: unknown) {
+  const sha = resolveString(value, "checkout sha").toLowerCase();
+  if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(sha)) {
+    throw new TypeError("[vitehub] Box checkout sha must be a full Git object id.");
+  }
+  return sha;
 }
 
 async function resolveValue<T, Context>(

--- a/packages/box/src/internal/crabbox.ts
+++ b/packages/box/src/internal/crabbox.ts
@@ -9,11 +9,13 @@ import type { HarnessV1NetworkSandboxSession, HarnessV1SandboxProvider } from "@
 
 import type {
   BoxRuntime,
+  ResolvedBoxCheckout,
   ResolvedBoxFile,
   ResolvedBoxInput,
   ResolvedBoxPlan,
   ResolvedBoxRequirementInput,
 } from "../index.ts"
+import { materializeGitCheckout } from "./git-checkout.ts"
 
 export interface CrabboxOptions {
   /** Enables loopback port URLs when the target shares the ViteHub process network namespace. */
@@ -26,9 +28,10 @@ export interface CrabboxOptions {
 }
 
 interface CrabboxSandboxOptions extends CrabboxOptions {
+  checkout?: ResolvedBoxCheckout
   plan: ResolvedBoxPlan;
   requirements: readonly ResolvedBoxRequirementInput[]
-  workspace: string
+  workspace?: string
 }
 
 interface CrabboxSessionOptions extends CrabboxSandboxOptions {
@@ -79,7 +82,7 @@ export function crabbox(options: CrabboxOptions = {}): BoxRuntime {
     name: "crabbox",
     async resolve(input: ResolvedBoxInput) {
       const cwd = input.cwd
-      if (!cwd) throw new Error("[vitehub] crabbox() requires box.cwd.")
+      if (!cwd && !input.checkout) throw new Error("[vitehub] crabbox() requires box.cwd or box.checkout.")
       if (input.plan.state.length && (!options.stateRoot || !posix.isAbsolute(options.stateRoot))) {
         throw new Error(
           "[vitehub] crabbox({ stateRoot }) requires an absolute target path when box.home.state is declared.",
@@ -94,10 +97,12 @@ export function crabbox(options: CrabboxOptions = {}): BoxRuntime {
           "[vitehub] Box stateRoot must be a dedicated directory, not the filesystem root.",
         );
       }
-      const requestedWorkspace = resolve(cwd)
-      const workspace = await realpath(requestedWorkspace).catch(() => requestedWorkspace)
-      const item = await stat(workspace).catch(() => undefined)
-      if (!item?.isDirectory()) throw new Error(`[vitehub] Box workspace directory does not exist: ${workspace}`)
+      const requestedWorkspace = cwd ? resolve(cwd) : undefined
+      const workspace = requestedWorkspace
+        ? await realpath(requestedWorkspace).catch(() => requestedWorkspace)
+        : undefined
+      const item = workspace ? await stat(workspace).catch(() => undefined) : undefined
+      if (workspace && !item?.isDirectory()) throw new Error(`[vitehub] Box workspace directory does not exist: ${workspace}`)
       const requirements = input.requirements;
       const environment = {} as { env: Readonly<Record<string, string | undefined>> }
       Object.defineProperty(environment, "env", { enumerable: false, value: Object.freeze({}) })
@@ -110,11 +115,14 @@ export function crabbox(options: CrabboxOptions = {}): BoxRuntime {
         runtime: "crabbox",
         sandbox: createCrabboxSandbox({
           ...options,
+          ...(input.checkout ? { checkout: input.checkout } : {}),
           plan: input.plan,
           requirements,
-          workspace,
+          ...(workspace ? { workspace } : {}),
         }),
-        workspace: { path: workspace, state: "authoritative" as const },
+        workspace: workspace
+          ? { path: workspace, state: "authoritative" as const, workDir: "workspace" as const }
+          : { state: "disposable" as const, workDir: "workspace" as const },
       } as const
       Object.defineProperty(box, "sandbox", { enumerable: false, value: box.sandbox })
       return box
@@ -141,14 +149,14 @@ function createCrabboxSandbox(options: CrabboxSandboxOptions): HarnessV1SandboxP
       let remoteRoot: string | undefined;
       let initializedState: string[] = [];
       try {
-        releaseWorkspace = await acquireWorkspace(options.workspace, createOptions.abortSignal);
+        if (options.workspace) releaseWorkspace = await acquireWorkspace(options.workspace, createOptions.abortSignal);
         leaseId = await warmup(sessionOptions, createOptions.abortSignal)
         const hasState = options.plan.state.length > 0;
         const setup = await runCrabbox(sessionOptions, leaseId, {
           abortSignal: createOptions.abortSignal,
-          command: sessionSetupCommand(hasState ? options.stateRoot : undefined),
-          localWorkingDirectory: options.workspace,
-          sync: true,
+          command: sessionSetupCommand(hasState ? options.stateRoot : undefined, Boolean(options.workspace)),
+          ...(options.workspace ? { localWorkingDirectory: options.workspace } : {}),
+          sync: Boolean(options.workspace),
         })
         if (setup.exitCode !== 0) throw crabboxError("create disposable Box cache", setup)
         const [root, remoteWorkspace, remotePath, remoteUser, remoteStateRoot] = lastLines(setup.stdout,
@@ -181,9 +189,22 @@ function createCrabboxSandbox(options: CrabboxSandboxOptions): HarnessV1SandboxP
           bootstrapSignal,
         );
         initializedState = materialized.initializedState;
-        const syncedWorkspacePaths = await listRemoteWorkspacePaths(sessionOptions, leaseId, remoteWorkspace,
-          bootstrapSignal,
-        );
+        if (options.checkout) {
+          await materializeGitCheckout(options.checkout, remoteWorkspace, {
+            abortSignal: bootstrapSignal,
+            async run(args) {
+              const result = await runCrabbox(sessionOptions, leaseId!, {
+                abortSignal: bootstrapSignal,
+                command: `${shellQuote(materialized.environmentFile)} git ${args.map(shellQuote).join(" ")}`,
+              })
+              if (result.exitCode !== 0) throw new Error("Git command failed.")
+              return { stdout: result.stdout }
+            },
+          })
+        }
+        const syncedWorkspacePaths = options.workspace
+          ? await listRemoteWorkspacePaths(sessionOptions, leaseId, remoteWorkspace, bootstrapSignal)
+          : [];
         const session = createCrabboxSession({
             environmentFile: materialized.environmentFile,
             leaseId,
@@ -234,14 +255,17 @@ function createCrabboxSandbox(options: CrabboxSandboxOptions): HarnessV1SandboxP
   }
 }
 
-function sessionSetupCommand(stateRoot: string | undefined) {
+function sessionSetupCommand(stateRoot: string | undefined, authoritativeWorkspace: boolean) {
   const state = stateRoot
     ? ` && mkdir -p -- ${shellQuote(stateRoot)} && state_root=$(realpath -- ${shellQuote(stateRoot)})`
     : "";
   const output = stateRoot
     ? `printf '%s\\n%s\\n%s\\n%s\\n%s\\n' "$root" "$workspace" "$PATH" "$(id -un)" "$state_root"`
     : `printf '%s\\n%s\\n%s\\n%s\\n' "$root" "$workspace" "$PATH" "$(id -un)"`;
-  return `root=$(mktemp -d /tmp/vitehub-box.XXXXXX) && trap 'rm -rf -- "$root"' EXIT && umask 077 && workspace=$(pwd -P) && home="$root/home" && mkdir -m 700 "$home" && ln -s "$workspace" "$root/workspace"${state} && trap - EXIT && ${output}`;
+  const workspace = authoritativeWorkspace
+    ? `workspace=$(pwd -P) && ln -s "$workspace" "$root/workspace"`
+    : `workspace="$root/workspace" && mkdir -m 700 "$workspace"`;
+  return `root=$(mktemp -d /tmp/vitehub-box.XXXXXX) && trap 'rm -rf -- "$root"' EXIT && umask 077 && ${workspace} && home="$root/home" && mkdir -m 700 "$home"${state} && trap - EXIT && ${output}`;
 }
 
 async function materializePlan(
@@ -604,7 +628,7 @@ function createCrabboxSession(state: CrabboxSessionState, sessionId: string | un
       try {
         await this.stop();
         state.stateLease.assertActive();
-        await syncWorkspaceBack(state)
+        if (state.options.workspace) await syncWorkspaceBack(state)
       }
       catch (error) {
         failure = error
@@ -941,6 +965,8 @@ async function acquireWorkspace(workspace: string, abortSignal?: AbortSignal) {
 }
 
 async function syncWorkspaceBack(state: CrabboxSessionState) {
+  const workspace = state.options.workspace
+  if (!workspace) return
   const abortSignal = stateAbortSignal(state);
   const initialManifest = Buffer.from(state.syncedWorkspacePaths.map(path => `${path}\0`).join("")).toString("base64")
   const result = await runCrabboxScript(state.options, state.leaseId, {
@@ -948,23 +974,23 @@ async function syncWorkspaceBack(state: CrabboxSessionState) {
     script: `temporary=$(mktemp -d /tmp/vitehub-workspace.XXXXXX) && archive="$temporary/workspace.tar" && manifest="$temporary/manifest" && existing_manifest="$temporary/existing-manifest" && ignore_failed_read=$(tar --ignore-failed-read -cf /dev/null -T /dev/null >/dev/null 2>&1 && printf %s --ignore-failed-read || true) && trap 'rm -rf -- "$temporary"' EXIT && if git -C ${shellQuote(state.remoteWorkspace)} rev-parse --is-inside-work-tree >/dev/null 2>&1; then printf %s ${shellQuote(initialManifest)} | base64 -d > "$manifest" && git -C ${shellQuote(state.remoteWorkspace)} ls-files -z --cached --others --exclude-standard >> "$manifest" && (cd ${shellQuote(state.remoteWorkspace)} && xargs -0 sh -c 'for path do if test -e "$path" || test -L "$path"; then printf "%s\\0" "$path"; fi; done' sh < "$manifest") > "$existing_manifest" && tar $ignore_failed_read --no-recursion --null -C ${shellQuote(state.remoteWorkspace)} -cf "$archive" -T "$existing_manifest"; else tar -C ${shellQuote(state.remoteWorkspace)} --exclude ./.git --exclude .git -cf "$archive" .; fi && base64 < "$archive"`,
   })
   const archive = Buffer.from(result.stdout.replace(/\s+/g, ""), "base64")
-  const transactionRoot = await mkdtemp(join(dirname(state.options.workspace), ".vitehub-workspace-"))
+  const transactionRoot = await mkdtemp(join(dirname(workspace), ".vitehub-workspace-"))
   const stagedWorkspace = join(transactionRoot, "workspace")
   const backupWorkspace = join(transactionRoot, "backup")
   await withTemporaryFile(async (localPath) => {
     try {
       await writeFile(localPath, archive)
-      await cp(state.options.workspace, stagedWorkspace, { recursive: true })
+      await cp(workspace, stagedWorkspace, { recursive: true })
       await rejectSymlinkedArchiveParents(stagedWorkspace, localPath)
       await pruneWorkspaceForArchive(stagedWorkspace, localPath, state.syncedWorkspacePaths)
       const extract = await runProcess(spawnChildProcess("tar", ["--no-same-owner", "--no-same-permissions", "-xf", localPath, "-C", stagedWorkspace]))
       if (extract.exitCode !== 0) throw crabboxError("extract Crabbox workspace", extract)
-      await rename(state.options.workspace, backupWorkspace)
+      await rename(workspace, backupWorkspace)
       try {
-        await rename(stagedWorkspace, state.options.workspace)
+        await rename(stagedWorkspace, workspace)
       }
       catch (error) {
-        await rename(backupWorkspace, state.options.workspace)
+        await rename(backupWorkspace, workspace)
         throw error
       }
     }

--- a/packages/box/src/internal/git-checkout.ts
+++ b/packages/box/src/internal/git-checkout.ts
@@ -14,7 +14,12 @@ export async function materializeGitCheckout(
   workspace: string,
   runner: GitCheckoutCommandRunner,
 ) {
-  await run("initialize", ["init", "--quiet", workspace]);
+  await run("initialize", [
+    "init",
+    "--quiet",
+    ...(checkout.sha.length === 64 ? ["--object-format=sha256"] : []),
+    workspace,
+  ]);
   await run("configure remote", ["-C", workspace, "remote", "add", "--", "origin", checkout.remote]);
   await run("fetch ref", [
     "-C",

--- a/packages/box/src/internal/git-checkout.ts
+++ b/packages/box/src/internal/git-checkout.ts
@@ -1,0 +1,60 @@
+import type { ResolvedBoxCheckout } from "../index.ts";
+
+export interface GitCheckoutCommandResult {
+  readonly stdout: string;
+}
+
+export interface GitCheckoutCommandRunner {
+  readonly abortSignal?: AbortSignal;
+  run(args: readonly string[]): Promise<GitCheckoutCommandResult>;
+}
+
+export async function materializeGitCheckout(
+  checkout: ResolvedBoxCheckout,
+  workspace: string,
+  runner: GitCheckoutCommandRunner,
+) {
+  await run("initialize", ["init", "--quiet", workspace]);
+  await run("configure remote", ["-C", workspace, "remote", "add", "--", "origin", checkout.remote]);
+  await run("fetch ref", [
+    "-C",
+    workspace,
+    "fetch",
+    "--quiet",
+    "--no-tags",
+    "--depth=100",
+    "origin",
+    "--",
+    checkout.ref,
+  ]);
+  const revision = (
+    await run("resolve revision", ["-C", workspace, "rev-parse", "--verify", "FETCH_HEAD^{commit}"])
+  ).stdout
+    .trim()
+    .toLowerCase();
+  if (revision !== checkout.sha) {
+    throw new Error(
+      `[vitehub] Box checkout revision mismatch: expected ${checkout.sha}, received ${revision || "<empty>"}.`,
+    );
+  }
+  await run("check out revision", [
+    "-C",
+    workspace,
+    "checkout",
+    "--quiet",
+    "--detach",
+    checkout.sha,
+  ]);
+
+  async function run(operation: string, args: readonly string[]) {
+    runner.abortSignal?.throwIfAborted();
+    try {
+      const result = await runner.run(args);
+      runner.abortSignal?.throwIfAborted();
+      return result;
+    } catch {
+      runner.abortSignal?.throwIfAborted();
+      throw new Error(`[vitehub] Box checkout failed to ${operation}.`);
+    }
+  }
+}

--- a/packages/box/src/internal/git-checkout.ts
+++ b/packages/box/src/internal/git-checkout.ts
@@ -1,10 +1,10 @@
 import type { ResolvedBoxCheckout } from "../index.ts";
 
-export interface GitCheckoutCommandResult {
+interface GitCheckoutCommandResult {
   readonly stdout: string;
 }
 
-export interface GitCheckoutCommandRunner {
+interface GitCheckoutCommandRunner {
   readonly abortSignal?: AbortSignal;
   run(args: readonly string[]): Promise<GitCheckoutCommandResult>;
 }

--- a/packages/box/src/internal/trusted-host.ts
+++ b/packages/box/src/internal/trusted-host.ts
@@ -33,6 +33,7 @@ import type {
   ResolvedBoxRequirementInput,
   ResolvedBoxState,
 } from "../index.ts";
+import { materializeGitCheckout } from "./git-checkout.ts";
 
 export interface TrustedHostOptions {
   stateRoot?: string;
@@ -123,8 +124,10 @@ export function trustedHost(options: TrustedHostOptions = {}): BoxRuntime {
         runtime: "trusted-host",
         sandbox,
         workspace: cwd
-          ? { path: cwd, state: "authoritative" as const }
-          : { state: "disposable" as const },
+          ? { path: cwd, state: "authoritative" as const, workDir: "workspace" as const }
+          : input.checkout
+            ? { state: "disposable" as const, workDir: "workspace" as const }
+            : { state: "disposable" as const },
       } as const;
       Object.defineProperty(box, "sandbox", { enumerable: false, value: sandbox });
       return box;
@@ -177,6 +180,19 @@ async function createSession(
     const env = await resolveEnvironment(home, input.plan.env);
     await materializeState(home, states, initializedState);
     await materializeFiles(home, files);
+    const checkout = input.checkout ? join(root, "workspace") : undefined;
+    if (input.checkout && checkout) {
+      await materializeGitCheckout(input.checkout, checkout, {
+        abortSignal: createOptions.abortSignal,
+        async run(args) {
+          const result = await promisify(execFile)("git", [...args], {
+            env,
+            signal: createOptions.abortSignal,
+          });
+          return { stdout: result.stdout };
+        },
+      });
+    }
     session = await createTrustedHostSession({
       env,
       home,
@@ -185,7 +201,7 @@ async function createSession(
       sessionId: createOptions.sessionId,
       workspace: input.cwd,
     });
-    await validateRequirements(input.requirements, env, input.cwd ?? root);
+    await validateRequirements(input.requirements, env, checkout ?? input.cwd ?? root);
     await createOptions.onFirstCreate?.(session, { abortSignal: createOptions.abortSignal });
     return session;
   } catch (error) {

--- a/packages/box/src/internal/trusted-host.ts
+++ b/packages/box/src/internal/trusted-host.ts
@@ -126,7 +126,7 @@ export function trustedHost(options: TrustedHostOptions = {}): BoxRuntime {
         workspace: cwd
           ? { path: cwd, state: "authoritative" as const, workDir: "workspace" as const }
           : input.checkout
-            ? { state: "disposable" as const, workDir: "workspace" as const }
+            ? { state: "disposable" as const, workDir: "." as const }
             : { state: "disposable" as const },
       } as const;
       Object.defineProperty(box, "sandbox", { enumerable: false, value: sandbox });

--- a/packages/box/test/crabbox.test.ts
+++ b/packages/box/test/crabbox.test.ts
@@ -51,6 +51,47 @@ describe("crabbox", () => {
     expect(JSON.stringify(box)).not.toContain("sandbox")
   })
 
+  it("materializes a disposable exact Git checkout without workspace synchronization", async () => {
+    const root = await temporaryRoot()
+    const repository = join(root, "repository")
+    const bin = join(root, "bin")
+    const log = join(root, "crabbox.log")
+    await Promise.all([mkdir(repository), mkdir(bin)])
+    await fakeCrabbox(bin)
+    await runGit(repository, ["init", "--initial-branch=main"])
+    await writeFile(join(repository, "README.md"), "checkout\n")
+    await runGit(repository, ["add", "README.md"])
+    await runGit(repository, [
+      "-c", "user.name=Fixture",
+      "-c", "user.email=fixture@example.com",
+      "commit", "-m", "initial",
+    ])
+    const sha = (await execFileAsync("git", ["-C", repository, "rev-parse", "HEAD"])).stdout.trim()
+
+    await withEnvironment(
+      { CRABBOX_TEST_LOG: log, PATH: `${bin}:${process.env.PATH || ""}` },
+      async () => {
+        const box = await resolveBox({
+          checkout: { ref: "refs/heads/main", remote: repository, sha },
+          runtime: crabbox({ profile: "babysitter" }),
+        }, {})
+        expect(box.workspace).toEqual({ state: "disposable", workDir: "workspace" })
+        const session = await (box.sandbox as HarnessV1SandboxProvider).createSession()
+        const sessionRoot = session.defaultWorkingDirectory
+        await expect(session.run({
+          command: "git rev-parse HEAD",
+          workingDirectory: join(sessionRoot, "workspace"),
+        })).resolves.toMatchObject({ exitCode: 0, stdout: `${sha}\n` })
+        await session.destroy?.()
+        await expect(stat(sessionRoot)).rejects.toMatchObject({ code: "ENOENT" })
+
+        const invocations = await readFile(log, "utf8")
+        expect(invocations).toContain("--no-sync")
+        expect(invocations).not.toContain("|cp|")
+      },
+    )
+  }, 30_000)
+
   it("rejects invalid Box requirement names", async () => {
     const root = await temporaryRoot()
     const workspace = join(root, "workspace")

--- a/packages/box/test/crabbox.test.ts
+++ b/packages/box/test/crabbox.test.ts
@@ -82,12 +82,74 @@ describe("crabbox", () => {
           command: "git rev-parse HEAD",
           workingDirectory: join(sessionRoot, "workspace"),
         })).resolves.toMatchObject({ exitCode: 0, stdout: `${sha}\n` })
+        await expect(session.run({
+          command: [
+            "git config user.name Fixture",
+            "git config user.email fixture@example.com",
+            "printf 'pushed from Crabbox\\n' > CHANGELOG.md",
+            "git add CHANGELOG.md",
+            "git commit -m update",
+            "git push origin HEAD:refs/heads/crabbox-test",
+          ].join(" && "),
+          workingDirectory: join(sessionRoot, "workspace"),
+        })).resolves.toMatchObject({ exitCode: 0 })
         await session.destroy?.()
         await expect(stat(sessionRoot)).rejects.toMatchObject({ code: "ENOENT" })
+
+        const pushed = (await execFileAsync(
+          "git",
+          ["-C", repository, "rev-parse", "refs/heads/crabbox-test"],
+        )).stdout.trim()
+        expect(pushed).not.toBe(sha)
 
         const invocations = await readFile(log, "utf8")
         expect(invocations).toContain("--no-sync")
         expect(invocations).not.toContain("|cp|")
+      },
+    )
+  }, 30_000)
+
+  it("removes a partial disposable checkout when revision verification fails", async () => {
+    const root = await temporaryRoot()
+    const repository = join(root, "repository")
+    const bin = join(root, "bin")
+    const log = join(root, "crabbox.log")
+    await Promise.all([mkdir(repository), mkdir(bin)])
+    await fakeCrabbox(bin)
+    await runGit(repository, ["init", "--initial-branch=main"])
+    await writeFile(join(repository, "README.md"), "checkout\n")
+    await runGit(repository, ["add", "README.md"])
+    await runGit(repository, [
+      "-c", "user.name=Fixture",
+      "-c", "user.email=fixture@example.com",
+      "commit", "-m", "initial",
+    ])
+
+    await withEnvironment(
+      { CRABBOX_TEST_LOG: log, PATH: `${bin}:${process.env.PATH || ""}` },
+      async () => {
+        const box = await resolveBox({
+          checkout: {
+            ref: "refs/heads/main",
+            remote: repository,
+            sha: "0".repeat(40),
+          },
+          runtime: crabbox({ profile: "babysitter" }),
+        }, {})
+
+        await expect(
+          (box.sandbox as HarnessV1SandboxProvider).createSession(),
+        ).rejects.toThrow("checkout revision mismatch")
+        const cleanup = (await readFile(log, "utf8"))
+          .trim()
+          .split("\n")
+          .findLast(invocation => (
+            invocation.includes("rm -rf --") && invocation.includes("/tmp/vitehub-box.")
+          ))
+        expect(cleanup).toBeDefined()
+        const sessionRoot = cleanup?.match(/\/tmp\/vitehub-box\.[A-Za-z0-9]+/)?.[0]
+        expect(sessionRoot).toBeDefined()
+        await expect(stat(sessionRoot!)).rejects.toMatchObject({ code: "ENOENT" })
       },
     )
   }, 30_000)

--- a/packages/box/test/git-checkout.test.ts
+++ b/packages/box/test/git-checkout.test.ts
@@ -42,12 +42,12 @@ describe("Box checkout", () => {
     );
 
     expect(resolutions).toBe(3);
-    expect(box.workspace).toEqual({ state: "disposable", workDir: "workspace" });
+    expect(box.workspace).toEqual({ state: "disposable", workDir: "." });
     expect(JSON.stringify(box)).not.toContain(repository.remote);
     const sandbox = box.sandbox as HarnessV1SandboxProvider;
     const [first, second] = await Promise.all([sandbox.createSession(), sandbox.createSession()]);
-    const firstWorkspace = join(first.defaultWorkingDirectory, "workspace");
-    const secondWorkspace = join(second.defaultWorkingDirectory, "workspace");
+    const firstWorkspace = first.defaultWorkingDirectory;
+    const secondWorkspace = second.defaultWorkingDirectory;
 
     expect(firstWorkspace).not.toBe(secondWorkspace);
     expect(resolutions).toBe(3);

--- a/packages/box/test/git-checkout.test.ts
+++ b/packages/box/test/git-checkout.test.ts
@@ -1,0 +1,268 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import type { HarnessV1SandboxProvider } from "@ai-sdk/harness";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveBox, trustedHost } from "../src/index.ts";
+import { materializeGitCheckout } from "../src/internal/git-checkout.ts";
+
+const exec = promisify(execFile);
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+describe("Box checkout", () => {
+  it("materializes isolated exact Git revisions with private Home commit and push support", async () => {
+    const root = await temporaryRoot();
+    const repository = await createRepository(root);
+    let resolutions = 0;
+    const box = await resolveBox(
+      {
+        checkout: {
+          ref: (context: typeof repository & { ref: string }) => (++resolutions, context.ref),
+          remote: (context: typeof repository & { ref: string }) => (++resolutions, context.remote),
+          sha: (context: typeof repository & { ref: string }) => (++resolutions, context.sha),
+        },
+        home: {
+          files: {
+            ".gitconfig": {
+              contents: "[user]\n\tname = Box Agent\n\temail = box@example.com\n",
+            },
+          },
+        },
+        runtime: trustedHost(),
+      },
+      { ...repository, ref: "refs/heads/main" },
+    );
+
+    expect(resolutions).toBe(3);
+    expect(box.workspace).toEqual({ state: "disposable", workDir: "workspace" });
+    expect(JSON.stringify(box)).not.toContain(repository.remote);
+    const sandbox = box.sandbox as HarnessV1SandboxProvider;
+    const [first, second] = await Promise.all([sandbox.createSession(), sandbox.createSession()]);
+    const firstWorkspace = join(first.defaultWorkingDirectory, "workspace");
+    const secondWorkspace = join(second.defaultWorkingDirectory, "workspace");
+
+    expect(firstWorkspace).not.toBe(secondWorkspace);
+    expect(resolutions).toBe(3);
+    for (const [session, workspace] of [
+      [first, firstWorkspace],
+      [second, secondWorkspace],
+    ] as const) {
+      await expect(
+        session.run({ command: "git rev-parse HEAD", workingDirectory: workspace }),
+      ).resolves.toMatchObject({ exitCode: 0, stdout: `${repository.sha}\n` });
+      await expect(stat(join(workspace, ".git"))).resolves.toMatchObject({});
+    }
+
+    const change = await first.run({
+      command:
+        "printf changed > changed.txt && git add changed.txt && git commit --quiet -m change && git push --quiet origin HEAD:refs/heads/box-change",
+      workingDirectory: firstWorkspace,
+    });
+    expect(change.exitCode).toBe(0);
+    await expect(
+      exec("git", ["--git-dir", repository.remote, "rev-parse", "box-change"]),
+    ).resolves.toMatchObject({ stdout: expect.stringMatching(/^[0-9a-f]{40}\n$/) });
+
+    const sessionRoots = [first.defaultWorkingDirectory, second.defaultWorkingDirectory];
+    await Promise.all([first.destroy?.(), second.destroy?.()]);
+    for (const sessionRoot of sessionRoots) {
+      await expect(stat(sessionRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  });
+
+  it("fails closed on revision mismatch and removes the partial checkout", async () => {
+    const root = await temporaryRoot();
+    const repository = await createRepository(root);
+    const sessionTmp = join(root, "sessions");
+    await mkdir(sessionTmp);
+    const box = await resolveBox(
+      {
+        checkout: {
+          ref: "refs/heads/main",
+          remote: repository.remote,
+          sha: "0".repeat(40),
+        },
+        runtime: trustedHost(),
+      },
+      {},
+    );
+
+    await withEnvironment({ TMPDIR: sessionTmp }, async () => {
+      await expect((box.sandbox as HarnessV1SandboxProvider).createSession()).rejects.toThrow(
+        `expected ${"0".repeat(40)}, received ${repository.sha}`,
+      );
+    });
+    await expect(readdir(sessionTmp)).resolves.toEqual([]);
+  });
+
+  it("honors cancellation and removes the partial checkout", async () => {
+    const root = await temporaryRoot();
+    const bin = join(root, "bin");
+    const sessionTmp = join(root, "sessions");
+    await Promise.all([mkdir(bin), mkdir(sessionTmp)]);
+    await executable(bin, "git", "trap 'exit 130' TERM INT\nwhile :; do sleep 0.05; done");
+    const box = await resolveBox(
+      {
+        checkout: {
+          ref: "refs/heads/main",
+          remote: "https://example.com/repository.git",
+          sha: "0".repeat(40),
+        },
+        runtime: trustedHost(),
+      },
+      {},
+    );
+    const abort = new AbortController();
+
+    await withEnvironment({ PATH: bin, TMPDIR: sessionTmp }, async () => {
+      const creating = (box.sandbox as HarnessV1SandboxProvider).createSession({
+        abortSignal: abort.signal,
+      });
+      setTimeout(() => abort.abort(new Error("cancelled")), 25);
+      await expect(creating).rejects.toThrow("cancelled");
+    });
+    await expect(readdir(sessionTmp)).resolves.toEqual([]);
+  });
+
+  it("treats invocation-controlled remotes and refs as positional Git arguments", async () => {
+    const root = await temporaryRoot();
+    const repository = await createRepository(root);
+    const marker = join(root, "option-injection");
+    const box = await resolveBox(
+      {
+        checkout: {
+          ref: `--upload-pack=sh -c 'touch ${marker}'`,
+          remote: repository.remote,
+          sha: repository.sha,
+        },
+        runtime: trustedHost(),
+      },
+      {},
+    );
+
+    await expect((box.sandbox as HarnessV1SandboxProvider).createSession()).rejects.toThrow(
+      "checkout failed to fetch ref",
+    );
+    await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const commands: string[][] = [];
+    await materializeGitCheckout(
+      { ref: "--upload-pack=payload", remote: "--mirror=fetch", sha: "0".repeat(40) },
+      "/workspace",
+      {
+        async run(args) {
+          commands.push([...args]);
+          return { stdout: args.includes("rev-parse") ? `${"0".repeat(40)}\n` : "" };
+        },
+      },
+    );
+    expect(commands[1]).toEqual([
+      "-C",
+      "/workspace",
+      "remote",
+      "add",
+      "--",
+      "origin",
+      "--mirror=fetch",
+    ]);
+    expect(commands[2].slice(-3)).toEqual(["origin", "--", "--upload-pack=payload"]);
+  });
+
+  it("rejects cwd composition before resolving invocation values", async () => {
+    let resolutions = 0;
+
+    await expect(
+      resolveBox(
+        {
+          checkout: {
+            ref: () => (++resolutions, "refs/heads/main"),
+            remote: () => (++resolutions, "https://example.com/repository.git"),
+            sha: () => (++resolutions, "0".repeat(40)),
+          },
+          cwd: () => (++resolutions, process.cwd()),
+          runtime: trustedHost(),
+        },
+        {},
+      ),
+    ).rejects.toThrow("checkout cannot be combined with cwd");
+    expect(resolutions).toBe(0);
+  });
+
+  it("includes the resolved checkout in Box identity", async () => {
+    const definition = (sha: string) => ({
+      checkout: {
+        ref: "refs/heads/main",
+        remote: "https://example.com/repository.git",
+        sha,
+      },
+      runtime: trustedHost(),
+    });
+
+    const first = await resolveBox(definition("0".repeat(40)), {});
+    const same = await resolveBox(definition("0".repeat(40)), {});
+    const changed = await resolveBox(definition("1".repeat(40)), {});
+
+    expect(first.identity).toBe(same.identity);
+    expect(first.identity).not.toBe(changed.identity);
+  });
+});
+
+async function createRepository(root: string) {
+  const remote = join(root, "remote.git");
+  const seed = join(root, "seed");
+  await exec("git", ["init", "--quiet", "--bare", remote]);
+  await exec("git", ["init", "--quiet", "--initial-branch=main", seed]);
+  await writeFile(join(seed, "README.md"), "initial\n");
+  await exec("git", ["-C", seed, "add", "README.md"]);
+  await exec("git", [
+    "-C",
+    seed,
+    "-c",
+    "user.name=Fixture",
+    "-c",
+    "user.email=fixture@example.com",
+    "commit",
+    "--quiet",
+    "-m",
+    "initial",
+  ]);
+  await exec("git", ["-C", seed, "remote", "add", "origin", remote]);
+  await exec("git", ["-C", seed, "push", "--quiet", "origin", "main"]);
+  const sha = (await exec("git", ["-C", seed, "rev-parse", "HEAD"])).stdout.trim();
+  return { remote, sha };
+}
+
+async function temporaryRoot() {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-box-checkout-test-"));
+  roots.push(root);
+  return root;
+}
+
+async function executable(bin: string, name: string, body: string) {
+  const path = join(bin, name);
+  await writeFile(path, `#!/bin/sh\n${body}\n`);
+  await chmod(path, 0o755);
+}
+
+async function withEnvironment<T>(environment: Record<string, string>, run: () => Promise<T>) {
+  const original = Object.fromEntries(
+    Object.keys(environment).map((name) => [name, process.env[name]]),
+  );
+  Object.assign(process.env, environment);
+  try {
+    return await run();
+  } finally {
+    for (const [name, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}

--- a/packages/box/test/git-checkout.test.ts
+++ b/packages/box/test/git-checkout.test.ts
@@ -176,6 +176,27 @@ describe("Box checkout", () => {
     expect(commands[2].slice(-3)).toEqual(["origin", "--", "--upload-pack=payload"]);
   });
 
+  it("initializes SHA-256 repositories for SHA-256 revisions", async () => {
+    const commands: string[][] = [];
+    await materializeGitCheckout(
+      { ref: "refs/heads/main", remote: "https://example.com/repository.git", sha: "a".repeat(64) },
+      "/workspace",
+      {
+        async run(args) {
+          commands.push([...args]);
+          return { stdout: args.includes("rev-parse") ? `${"a".repeat(64)}\n` : "" };
+        },
+      },
+    );
+
+    expect(commands[0]).toEqual([
+      "init",
+      "--quiet",
+      "--object-format=sha256",
+      "/workspace",
+    ]);
+  });
+
   it("rejects cwd composition before resolving invocation values", async () => {
     let resolutions = 0;
 


### PR DESCRIPTION
Restores the disposable Git checkout support from #618 onto `main` after the stacked branch was squash-merged without the child changes. A Box can resolve a remote, ref, and full SHA; materialize and verify an isolated real repository; expose it as the harness working directory; and remove it after the invocation while still supporting ordinary commits and explicit pushes.

Carries the same contract across `trustedHost()` and `crabbox()`, keeps checkout ownership exclusive with `cwd` and Agent Workspace materialization, and uses the portable Box Home for Git, GitHub, and Codex configuration instead of embedding credentials in repository URLs.

Updates the public documentation and regression coverage, including the current runtime-specific harness working-directory semantics.