### PR TITLE
docs: add Drop example

### DIFF
--- a/docs/app/data/examples.ts
+++ b/docs/app/data/examples.ts
@@ -41,6 +41,19 @@ export type Example = PendingProject | PublishedProject | Template;
 
 export const examples: readonly Example[] = [
   {
+    slug: "drop",
+    name: "Drop",
+    description: "Temporary image uploads for agents, backed by ViteHub server primitives.",
+    builtWith: ["Blob", "Queue", "Rate Limit"],
+    kind: "project",
+    status: "pending",
+    action: {
+      kind: "source",
+      label: "Source unavailable",
+    },
+    publicationNote: "Pending an explicit license.",
+  },
+  {
     slug: "babysitter",
     name: "Babysitter",
     description: "A ViteHub Agent and Schedule that owns pull requests from trusted-host worktrees.",

--- a/docs/test/examples.test.ts
+++ b/docs/test/examples.test.ts
@@ -16,8 +16,16 @@ describe("examples catalog", () => {
     expect(sitemap).toContain('{ path: "/examples" }');
   });
 
-  it("keeps Babysitter pending until its source is publishable", () => {
+  it("keeps projects pending until their source is publishable", () => {
     expect(examples).toEqual([
+      expect.objectContaining({
+        name: "Drop",
+        kind: "project",
+        status: "pending",
+        action: { kind: "source", label: "Source unavailable" },
+        builtWith: ["Blob", "Queue", "Rate Limit"],
+        publicationNote: "Pending an explicit license.",
+      }),
       expect.objectContaining({
         name: "Babysitter",
         kind: "project",


### PR DESCRIPTION
Adds Drop to the examples catalog as a project candidate built with Blob, Queue, and Rate Limit.

The source repository is being made public separately, while catalog publication remains gated on an explicit license.