### PR TITLE
fix(agent): show fallback for native chat streams

### DIFF
--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -804,6 +804,35 @@ async function postChatStream(
     return
   }
 
+  if (thread.adapter.stream) {
+    const placeholder = fallback === null
+      ? undefined
+      : await thread.adapter.postMessage(thread.id, fallback).catch(() => undefined)
+    let cleared = false
+    const clearPlaceholder = async () => {
+      if (cleared || !placeholder?.id) return
+      cleared = true
+      await thread.adapter.deleteMessage(placeholder.threadId || thread.id, placeholder.id).catch(() => undefined)
+    }
+    const nativeResponse: ChatTextStream = {
+      getText: response.getText,
+      async *[Symbol.asyncIterator]() {
+        for await (const chunk of response) {
+          await clearPlaceholder()
+          yield chunk
+        }
+      },
+    }
+    try {
+      sent = await thread.post(chatStreamPostable(thread, nativeResponse) as never)
+      await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent))
+    }
+    finally {
+      await clearPlaceholder()
+    }
+    return
+  }
+
   // ponytail: Chat SDK has no per-stream fallback option; replace this when it exposes one.
   const chatThread = thread as Thread & { _fallbackStreamingPlaceholderText?: string | null }
   const previous = chatThread._fallbackStreamingPlaceholderText

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -796,6 +796,7 @@ async function postChatStream(
   thread: Thread,
   response: ChatTextStream,
   fallback: string | null | undefined,
+  waitUntil: AgentWaitUntil,
 ): Promise<void> {
   let sent: unknown
   if (fallback === undefined) {
@@ -825,7 +826,7 @@ async function postChatStream(
       return clearing
     }
     const finishPlaceholder = () => {
-      void clearPlaceholder().then(() => cleared ? undefined : clearPlaceholder())
+      waitUntil(clearPlaceholder().then(() => cleared ? undefined : clearPlaceholder()))
     }
     const nativeResponse: ChatTextStream = {
       getText: response.getText,
@@ -1742,6 +1743,7 @@ async function handleChatSdkMessage(
           thread,
           response,
           typeof thinkingFallback === "string" || thinkingFallback === null ? thinkingFallback : undefined,
+          context.waitUntil,
         )
       }
       finally {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -805,14 +805,17 @@ async function postChatStream(
   }
 
   if (thread.adapter.stream) {
+    const adapter = thread.adapter
+    const nativeStream = adapter.stream!.bind(adapter)
     const placeholder = fallback === null
       ? undefined
-      : await thread.adapter.postMessage(thread.id, fallback).catch(() => undefined)
+      : await adapter.postMessage(thread.id, fallback).catch(() => undefined)
     let cleared = false
     const clearPlaceholder = async () => {
       if (cleared || !placeholder?.id) return
-      cleared = true
-      await thread.adapter.deleteMessage(placeholder.threadId || thread.id, placeholder.id).catch(() => undefined)
+      await adapter.deleteMessage(placeholder.threadId || thread.id, placeholder.id)
+        .then(() => { cleared = true })
+        .catch(() => undefined)
     }
     const nativeResponse: ChatTextStream = {
       getText: response.getText,
@@ -823,11 +826,31 @@ async function postChatStream(
         }
       },
     }
+    const chatThread = thread as Thread & { _adapter?: Adapter, _fallbackStreamingPlaceholderText?: string | null }
+    const previousAdapter = chatThread._adapter
+    const previousFallback = chatThread._fallbackStreamingPlaceholderText
+    // ponytail: Chat SDK does not expose whether native streaming was accepted.
+    chatThread._adapter = new Proxy(adapter, {
+      get(target, property, receiver) {
+        if (property === "stream") {
+          return async (...args: Parameters<typeof nativeStream>) => {
+            const raw = await nativeStream(...args)
+            if (!raw) await clearPlaceholder()
+            return raw
+          }
+        }
+        const value = Reflect.get(target, property, receiver)
+        return typeof value === "function" ? value.bind(target) : value
+      },
+    })
+    chatThread._fallbackStreamingPlaceholderText = fallback
     try {
       sent = await thread.post(chatStreamPostable(thread, nativeResponse) as never)
       await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent))
     }
     finally {
+      chatThread._adapter = previousAdapter
+      chatThread._fallbackStreamingPlaceholderText = previousFallback
       await clearPlaceholder()
     }
     return

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -851,8 +851,19 @@ async function postChatStream(
         if (property === "stream") {
           return async (...args: Parameters<typeof nativeStream>) => {
             const raw = await nativeStream(...args)
-            if (!raw) finishPlaceholder()
             return raw
+          }
+        }
+        if (property === "postMessage" && fallback !== null) {
+          return async (...args: Parameters<Adapter["postMessage"]>) => {
+            if (args[0] === thread.id && args[1] === fallback) {
+              const message = await placeholder
+              if (message) {
+                cleared = true
+                return message
+              }
+            }
+            return adapter.postMessage(...args)
           }
         }
         const value = Reflect.get(target, property, target)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -808,20 +808,30 @@ async function postChatStream(
     const adapter = thread.adapter
     const nativeStream = adapter.stream!.bind(adapter)
     const placeholder = fallback === null
-      ? undefined
-      : await adapter.postMessage(thread.id, fallback).catch(() => undefined)
+      ? Promise.resolve(undefined)
+      : adapter.postMessage(thread.id, fallback).catch(() => undefined)
     let cleared = false
+    let clearing: Promise<void> | undefined
     const clearPlaceholder = async () => {
-      if (cleared || !placeholder?.id) return
-      await adapter.deleteMessage(placeholder.threadId || thread.id, placeholder.id)
-        .then(() => { cleared = true })
-        .catch(() => undefined)
+      if (cleared) return
+      if (clearing) return clearing
+      clearing = placeholder.then(async (message) => {
+        if (!message?.id) return
+        await adapter.deleteMessage(message.threadId || thread.id, message.id)
+        cleared = true
+      }).catch(() => undefined).finally(() => {
+        clearing = undefined
+      })
+      return clearing
+    }
+    const finishPlaceholder = () => {
+      void clearPlaceholder().then(() => cleared ? undefined : clearPlaceholder())
     }
     const nativeResponse: ChatTextStream = {
       getText: response.getText,
       async *[Symbol.asyncIterator]() {
         for await (const chunk of response) {
-          await clearPlaceholder()
+          void clearPlaceholder()
           yield chunk
         }
       },
@@ -831,15 +841,15 @@ async function postChatStream(
     const previousFallback = chatThread._fallbackStreamingPlaceholderText
     // ponytail: Chat SDK does not expose whether native streaming was accepted.
     chatThread._adapter = new Proxy(adapter, {
-      get(target, property, receiver) {
+      get(target, property) {
         if (property === "stream") {
           return async (...args: Parameters<typeof nativeStream>) => {
             const raw = await nativeStream(...args)
-            if (!raw) await clearPlaceholder()
+            if (!raw) finishPlaceholder()
             return raw
           }
         }
-        const value = Reflect.get(target, property, receiver)
+        const value = Reflect.get(target, property, target)
         return typeof value === "function" ? value.bind(target) : value
       },
     })
@@ -851,7 +861,7 @@ async function postChatStream(
     finally {
       chatThread._adapter = previousAdapter
       chatThread._fallbackStreamingPlaceholderText = previousFallback
-      await clearPlaceholder()
+      finishPlaceholder()
     }
     return
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -813,6 +813,7 @@ async function postChatStream(
       : adapter.postMessage(thread.id, fallback).catch(() => undefined)
     let cleared = false
     let clearing: Promise<void> | undefined
+    let clearRequested = false
     const clearPlaceholder = async () => {
       if (cleared) return
       if (clearing) return clearing
@@ -832,7 +833,11 @@ async function postChatStream(
       getText: response.getText,
       async *[Symbol.asyncIterator]() {
         for await (const chunk of response) {
-          void clearPlaceholder()
+          // Consuming a native stream chunk means the adapter has visible output to replace the fallback.
+          if (!clearRequested) {
+            clearRequested = true
+            void clearPlaceholder()
+          }
           yield chunk
         }
       },

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5206,9 +5206,9 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Working on it...")
-    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", "Working on it...")
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-2", { markdown: "done" })
+    expect(adapter.deleteMessage).not.toHaveBeenCalled()
+    expect(adapter.postMessage).toHaveBeenCalledOnce()
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "done" })
   })
 
   it("does not block native output on slow fallback delivery or cleanup", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5127,6 +5127,7 @@ describe("server helpers", () => {
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
+    adapter.deleteMessage.mockRejectedValueOnce(new Error("try again"))
     let runStarted!: () => void
     let finishRun!: () => void
     const runStartedPromise = new Promise<void>(resolve => {
@@ -5174,8 +5175,40 @@ describe("server helpers", () => {
     const response = await responsePromise
 
     expect(response.status).toBe(200)
-    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.deleteMessage).toHaveBeenNthCalledWith(1, "telegram:456", "sent-1")
+    expect(adapter.deleteMessage).toHaveBeenNthCalledWith(2, "telegram:456", "sent-1")
     expect(adapter.stream).toHaveBeenCalledOnce()
+  })
+
+  it("hands the configured fallback back to Chat SDK when native streaming declines", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.stream = vi.fn(async () => null)
+    const agent = defineAgent({
+      capabilities: [
+        defineChatCapability({
+          fallbackStreamingPlaceholderText: "Working on it...",
+          platforms: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      driver: { run: async () => "done" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(21047), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Working on it...")
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", "Working on it...")
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-2", { markdown: "done" })
   })
 
   it("posts a random chat fallback option while streamed webhook work is still running", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5216,6 +5216,7 @@ describe("server helpers", () => {
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
+    const backgroundTasks: Promise<unknown>[] = []
     let postPlaceholder!: (message: { id: string, raw: unknown, threadId: string }) => void
     let deletePlaceholder!: () => void
     adapter.postMessage.mockImplementationOnce(async () => await new Promise(resolve => {
@@ -5244,15 +5245,19 @@ describe("server helpers", () => {
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
 
-    const response = await handler(chatWebhookRequest(21048), "telegram")
+    const response = await handler(chatWebhookRequest(21048), "telegram", {
+      waitUntil: task => backgroundTasks.push(task),
+    })
 
     expect(response.status).toBe(200)
+    expect(backgroundTasks.length).toBeGreaterThan(1)
     expect(adapter.deleteMessage).not.toHaveBeenCalled()
     postPlaceholder({ id: "placeholder-1", raw: {}, threadId: "telegram:456" })
     await vi.waitFor(() => {
       expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "placeholder-1")
     })
     deletePlaceholder()
+    await Promise.all(backgroundTasks)
   })
 
   it("posts a random chat fallback option while streamed webhook work is still running", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5211,6 +5211,50 @@ describe("server helpers", () => {
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-2", { markdown: "done" })
   })
 
+  it("does not block native output on slow fallback delivery or cleanup", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    let postPlaceholder!: (message: { id: string, raw: unknown, threadId: string }) => void
+    let deletePlaceholder!: () => void
+    adapter.postMessage.mockImplementationOnce(async () => await new Promise(resolve => {
+      postPlaceholder = resolve
+    }))
+    adapter.deleteMessage.mockImplementationOnce(async () => await new Promise<void>(resolve => {
+      deletePlaceholder = resolve
+    }))
+    adapter.stream = vi.fn(async (threadId: string, textStream: AsyncIterable<string | StreamChunk>) => {
+      for await (const _chunk of textStream) {}
+      return { id: "stream-1", raw: {}, threadId }
+    })
+    const agent = defineAgent({
+      capabilities: [
+        defineChatCapability({
+          fallbackStreamingPlaceholderText: "Working on it...",
+          platforms: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      driver: { run: async () => "done" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(21048), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.deleteMessage).not.toHaveBeenCalled()
+    postPlaceholder({ id: "placeholder-1", raw: {}, threadId: "telegram:456" })
+    await vi.waitFor(() => {
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "placeholder-1")
+    })
+    deletePlaceholder()
+  })
+
   it("posts a random chat fallback option while streamed webhook work is still running", async () => {
     const random = vi.spyOn(Math, "random").mockReturnValue(0.75)
     try {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -124,6 +124,7 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
       }
       return Response.json({ ok: true })
     }),
+    deleteMessage: vi.fn(async () => {}),
     initialize: vi.fn(async (chat: ChatInstance) => {
       chatInstance = chat
     }),
@@ -161,6 +162,7 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
   }
   return adapter as unknown as Adapter & {
     _chatInstance: () => ChatInstance | undefined
+    deleteMessage: ReturnType<typeof vi.fn>
     handleWebhook: ReturnType<typeof vi.fn>
     editMessage: ReturnType<typeof vi.fn>
     fetchMessages: ReturnType<typeof vi.fn>
@@ -5118,6 +5120,62 @@ describe("server helpers", () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ ok: true })
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "done" })
+  })
+
+  it("shows configured chat fallback while native adapter streams are pending", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    let runStarted!: () => void
+    let finishRun!: () => void
+    const runStartedPromise = new Promise<void>(resolve => {
+      runStarted = resolve
+    })
+    const finishRunPromise = new Promise<void>(resolve => {
+      finishRun = resolve
+    })
+    adapter.stream = vi.fn(async (threadId: string, textStream: AsyncIterable<string | StreamChunk>) => {
+      let text = ""
+      for await (const chunk of textStream) {
+        if (typeof chunk === "string") text += chunk
+        else if (chunk.type === "markdown_text") text += chunk.text
+      }
+      return { id: "stream-1", raw: { text }, threadId }
+    })
+    const agent = defineAgent({
+      capabilities: [
+        defineChatCapability({
+          fallbackStreamingPlaceholderText: "Working on it...",
+          platforms: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      driver: { run: async () => {
+        runStarted()
+        await finishRunPromise
+        return "done"
+      } },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const responsePromise = handler(chatWebhookRequest(21046), "telegram")
+
+    await runStartedPromise
+    await Promise.resolve()
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Working on it...")
+    expect(adapter.deleteMessage).not.toHaveBeenCalled()
+
+    finishRun()
+    const response = await responsePromise
+
+    expect(response.status).toBe(200)
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.stream).toHaveBeenCalledOnce()
   })
 
   it("posts a random chat fallback option while streamed webhook work is still running", async () => {


### PR DESCRIPTION
Shows the resolved `fallbackStreamingPlaceholderText` immediately for adapters with native streaming by posting a temporary adapter-level message, then removing it on the first output chunk or when the stream finishes. Non-native adapters keep using Chat SDK's existing post-and-edit fallback path, and progress delivery remains best-effort so it cannot block the final answer.\n\nAdds provider regression coverage that holds an Agent Invocation open and proves the native fallback is visible while work is pending, then removed before the streamed response is committed.