### PR TITLE
feat(workspace): adopt public error contract

### DIFF
--- a/fallow.toml
+++ b/fallow.toml
@@ -146,6 +146,10 @@ files = [
 rules = { "unused-class-members" = "off" }
 
 [[overrides]]
+files = ["packages/workspace/src/core/errors.ts"]
+rules = { "unused-class-members" = "off" }
+
+[[overrides]]
 files = ["packages/workspace/src/storage/memory-fs.ts"]
 rules = { "unused-class-members" = "off" }
 

--- a/packages/workspace/fixtures/published-types/consumer.ts
+++ b/packages/workspace/fixtures/published-types/consumer.ts
@@ -1,0 +1,13 @@
+import { ViteHubError, type ViteHubErrorShape } from "@vite-hub/runtime"
+import { WorkspaceNotFoundError, WorkspacePathError } from "@vite-hub/workspace"
+
+const missing = new WorkspaceNotFoundError("documents")
+missing.code satisfies "WORKSPACE_NOT_FOUND"
+missing.details satisfies { name: string } | undefined
+missing.toJSON() satisfies ViteHubErrorShape<"WORKSPACE_NOT_FOUND", { name: string }>
+missing satisfies ViteHubError<"WORKSPACE_NOT_FOUND", { name: string }>
+
+const invalidPath = new WorkspacePathError("../secrets")
+invalidPath.code satisfies "WORKSPACE_PATH_INVALID"
+invalidPath.details satisfies { path: string } | undefined
+invalidPath.toJSON() satisfies ViteHubErrorShape<"WORKSPACE_PATH_INVALID", { path: string }>

--- a/packages/workspace/fixtures/published-types/package.json
+++ b/packages/workspace/fixtures/published-types/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/workspace/fixtures/published-types/tsconfig.json
+++ b/packages/workspace/fixtures/published-types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "types": []
+  },
+  "files": [
+    "consumer.ts"
+  ]
+}

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -135,6 +135,7 @@
   "dependencies": {
     "@vercel/nft": "catalog:vercel",
     "@vite-hub/markdown-template": "workspace:*",
+    "@vite-hub/runtime": "workspace:*",
     "@vite-hub/source": "workspace:*",
     "defu": "catalog:unjs",
     "exsolve": "catalog:unjs",

--- a/packages/workspace/src/core/errors.ts
+++ b/packages/workspace/src/core/errors.ts
@@ -1,3 +1,5 @@
+import { ViteHubError, type ViteHubErrorShape } from "@vite-hub/runtime"
+
 export class WorkspaceError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options)
@@ -6,15 +8,27 @@ export class WorkspaceError extends Error {
 }
 
 export class WorkspaceNotFoundError extends WorkspaceError {
+  readonly code = "WORKSPACE_NOT_FOUND" as const
+  readonly details: { name: string }
+  readonly retryable: false = false
+  readonly toJSON: () => ViteHubErrorShape<"WORKSPACE_NOT_FOUND", { name: string }> = ViteHubError.prototype.toJSON
+
   constructor(name: string) {
     super(`[vitehub] Workspace "${name}" is not registered.`)
     this.name = "WorkspaceNotFoundError"
+    this.details = { name }
   }
 }
 
 export class WorkspacePathError extends WorkspaceError {
+  readonly code = "WORKSPACE_PATH_INVALID" as const
+  readonly details: { path: string }
+  readonly retryable: false = false
+  readonly toJSON: () => ViteHubErrorShape<"WORKSPACE_PATH_INVALID", { path: string }> = ViteHubError.prototype.toJSON
+
   constructor(path: string) {
     super(`[vitehub] Workspace path escapes the workspace root: ${JSON.stringify(path)}.`)
     this.name = "WorkspacePathError"
+    this.details = { path }
   }
 }

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -39,6 +39,7 @@ export type {
 } from "./session/harness.ts"
 export type * from "./ai.ts"
 export { resolveWorkspaceAutoCommit } from "./core/rules.ts"
+export { WorkspaceNotFoundError, WorkspacePathError } from "./core/errors.ts"
 export { resolveRegisteredWorkspaceDefinition } from "./core/registry.ts"
 export { useWorkspace } from "./core/use.ts"
 export type * from "./core/use.ts"

--- a/packages/workspace/test/errors.test.ts
+++ b/packages/workspace/test/errors.test.ts
@@ -1,0 +1,49 @@
+import type { ViteHubError } from "@vite-hub/runtime"
+import { describe, expect, it } from "vitest"
+
+import { WorkspaceNotFoundError, WorkspacePathError } from "../src/index.ts"
+import { WorkspaceError } from "../src/core/errors.ts"
+
+describe("Workspace public errors", () => {
+  it("serializes missing Workspace failures through the shared contract", () => {
+    const cause = new Error("private provider response")
+    const error = new WorkspaceNotFoundError("documents")
+    Object.defineProperty(error, "cause", { value: cause })
+    Object.assign(error, { providerToken: "secret" })
+
+    const contract: ViteHubError<"WORKSPACE_NOT_FOUND", { name: string }> = error
+
+    expect(contract).toBe(error)
+    expect(error).toBeInstanceOf(WorkspaceError)
+    expect(error).toBeInstanceOf(WorkspaceNotFoundError)
+    expect(error.name).toBe("WorkspaceNotFoundError")
+    expect(error.message).toBe('[vitehub] Workspace "documents" is not registered.')
+    expect(error.toJSON()).toEqual({
+      code: "WORKSPACE_NOT_FOUND",
+      details: { name: "documents" },
+      message: '[vitehub] Workspace "documents" is not registered.',
+      retryable: false,
+    })
+    expect(JSON.stringify(error)).not.toContain("providerToken")
+    expect(JSON.stringify(error)).not.toContain("private provider response")
+    expect(JSON.stringify(error)).not.toContain("stack")
+  })
+
+  it("serializes invalid Workspace paths with allowlisted details", () => {
+    const error = new WorkspacePathError("../secrets")
+
+    const contract: ViteHubError<"WORKSPACE_PATH_INVALID", { path: string }> = error
+
+    expect(contract).toBe(error)
+    expect(error).toBeInstanceOf(WorkspaceError)
+    expect(error).toBeInstanceOf(WorkspacePathError)
+    expect(error.name).toBe("WorkspacePathError")
+    expect(error.message).toBe('[vitehub] Workspace path escapes the workspace root: "../secrets".')
+    expect(error.toJSON()).toEqual({
+      code: "WORKSPACE_PATH_INVALID",
+      details: { path: "../secrets" },
+      message: '[vitehub] Workspace path escapes the workspace root: "../secrets".',
+      retryable: false,
+    })
+  })
+})

--- a/packages/workspace/test/published-types.test.ts
+++ b/packages/workspace/test/published-types.test.ts
@@ -1,0 +1,33 @@
+import { execFile } from "node:child_process"
+import { copyFile, cp, mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { it } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const runtimeRoot = resolve(packageRoot, "../runtime")
+const fixtureRoot = join(packageRoot, "fixtures", "published-types")
+const tsc = resolve(packageRoot, "../../node_modules/typescript/bin/tsc")
+
+it("publishes Workspace errors through the shared contract", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-types-"))
+
+  try {
+    await cp(fixtureRoot, root, { recursive: true })
+    for (const [name, source] of [["workspace", packageRoot], ["runtime", runtimeRoot]] as const) {
+      const installedPackageRoot = join(root, "node_modules", "@vite-hub", name)
+      await mkdir(installedPackageRoot, { recursive: true })
+      await copyFile(join(source, "package.json"), join(installedPackageRoot, "package.json"))
+      await cp(join(source, "dist"), join(installedPackageRoot, "dist"), { recursive: true })
+    }
+
+    await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", root])
+  }
+  finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1337,6 +1337,9 @@ importers:
       '@vite-hub/markdown-template':
         specifier: workspace:*
         version: link:../markdown-template
+      '@vite-hub/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       '@vite-hub/source':
         specifier: workspace:*
         version: link:../source


### PR DESCRIPTION
Exports the existing Workspace not-found and invalid-path errors with stable codes, JSON-safe details, and the shared ViteHub error serializer. Both errors keep their names, messages, and `WorkspaceError` identity, while the generic Workspace error and Promise APIs remain unchanged.

The published-consumer fixture verifies that `@vite-hub/workspace` declares its runtime dependency and exposes the concrete error shapes outside the monorepo. The exact Workspace error module is exempted from Fallow's unused-class-member rule because these members are consumed as public API, matching the repository's existing error-module convention.

## Hard dependency

This PR targets `refactor/effect-error-contract` and must not merge before #670. Rebase it onto `main` after #670 lands.

EFFECT ADOPTION STATUS
  seam: Workspace public error foundation
  public API: additive WorkspaceNotFoundError and WorkspacePathError exports
  boundary: packages/workspace/src/core/errors.ts
  typed failures: WORKSPACE_NOT_FOUND | WORKSPACE_PATH_INVALID
  resources/fibers: none; this foundation does not install an Effect runtime
  deleted: none; the shared allowlisted serializer replaces no lifecycle machinery yet
  todos: 0
  confidence: high

<!-- babysitter:blocker:v1 -->

> [!WARNING]
> **Babysitter is blocked:** PR #670 is still open, and this pull request depends on its shared runtime error contract.
>
> Merge PR #670 into `main`; then rebase this branch onto `main` so its exact head can be reviewed and merged.

<!-- /babysitter:blocker:v1 -->
