### PR TITLE
refactor(workspace): scope sandbox sessions with Effect

### DIFF
--- a/fallow.toml
+++ b/fallow.toml
@@ -146,6 +146,10 @@ files = [
 rules = { "unused-class-members" = "off" }
 
 [[overrides]]
+files = ["packages/workspace/src/core/errors.ts"]
+rules = { "unused-class-members" = "off" }
+
+[[overrides]]
 files = ["packages/workspace/src/storage/memory-fs.ts"]
 rules = { "unused-class-members" = "off" }
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -147,6 +147,7 @@
     "@vitejs/devtools-kit": "catalog:vite",
     "chat": "catalog:chat",
     "comark": "catalog:ui",
+    "effect": "catalog:effect",
     "esbuild": "catalog:esbuild-v27"
   },
   "devDependencies": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -147,8 +147,7 @@
     "@vitejs/devtools-kit": "catalog:vite",
     "chat": "catalog:chat",
     "comark": "catalog:ui",
-    "esbuild": "catalog:esbuild-v27",
-    "effect": "catalog:effect"
+    "esbuild": "catalog:esbuild-v27"
   },
   "devDependencies": {
     "@ai-sdk/harness": "catalog:ai",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -147,8 +147,8 @@
     "@vitejs/devtools-kit": "catalog:vite",
     "chat": "catalog:chat",
     "comark": "catalog:ui",
-    "effect": "catalog:effect",
-    "esbuild": "catalog:esbuild-v27"
+    "esbuild": "catalog:esbuild-v27",
+    "effect": "catalog:effect"
   },
   "devDependencies": {
     "@ai-sdk/harness": "catalog:ai",

--- a/packages/agent/src/capabilities/workspace-command.ts
+++ b/packages/agent/src/capabilities/workspace-command.ts
@@ -177,14 +177,22 @@ export function workspaceCommandTools(
         const commandTimeout = normalizeWorkspaceCommandTimeout(value.timeout, `${toolName} timeout`) ?? timeout ?? defaultWorkspaceCommandTimeout
         assertWorkspace(workspace, options.missingWorkspaceMessage || "[vitehub] workspaceShell({ commands }) requires an executable Workspace Session. Trusted workspace/session execution requires a writable workspace.")
         const session = await workspace.startSession()
+        let result
         try {
-          const result = await session.exec(value.command, args, { cwd, env, timeout: commandTimeout })
+          result = await session.exec(value.command, args, { cwd, env, timeout: commandTimeout })
           if (mode === "write" && result.exitCode === 0) await session.commit({ message: options.commitMessage || "workspace shell command" })
-          return result
         }
-        finally {
-          await session.close()
+        catch (error) {
+          try {
+            await session.close()
+          }
+          catch (closeError) {
+            throw new AggregateError([error, closeError], "[vitehub] Workspace command failed and session cleanup also failed.")
+          }
+          throw error
         }
+        await session.close()
+        return result
       },
     }),
   }

--- a/packages/agent/test/workspace-shell-capability.test.ts
+++ b/packages/agent/test/workspace-shell-capability.test.ts
@@ -162,4 +162,19 @@ describe("workspaceShell capability", () => {
     expect(session.commit).not.toHaveBeenCalled()
     expect(session.close).toHaveBeenCalledOnce()
   })
+
+  it("preserves execution and session cleanup failures", async () => {
+    const executionError = new Error("agent-browser failed")
+    const closeError = new Error("sandbox stop failed")
+    const session = workspaceSession()
+    session.exec.mockRejectedValueOnce(executionError)
+    session.close.mockRejectedValueOnce(closeError)
+    const { tools } = await capabilityTools(workspaceShell({ commands: ["agent-browser"] }), session)
+
+    const failure = await tools.workspace_exec!.execute?.({ command: "agent-browser" }).catch(error => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([executionError, closeError])
+    expect(session.close).toHaveBeenCalledOnce()
+  })
 })

--- a/packages/agent/test/workspace-shell-capability.test.ts
+++ b/packages/agent/test/workspace-shell-capability.test.ts
@@ -171,7 +171,13 @@ describe("workspaceShell capability", () => {
     session.close.mockRejectedValueOnce(closeError)
     const { tools } = await capabilityTools(workspaceShell({ commands: ["agent-browser"] }), session)
 
-    const failure = await tools.workspace_exec!.execute?.({ command: "agent-browser" }).catch(error => error)
+    let failure: unknown
+    try {
+      await tools.workspace_exec!.execute?.({ command: "agent-browser" })
+    }
+    catch (error) {
+      failure = error
+    }
 
     expect(failure).toBeInstanceOf(AggregateError)
     expect((failure as AggregateError).errors).toEqual([executionError, closeError])

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -45,6 +45,7 @@
     "@vite-hub/kv": "workspace:*",
     "@vite-hub/runtime": "workspace:*",
     "cron-schedule": "catalog:workflow",
+    "effect": "catalog:effect",
     "esbuild": "catalog:tooling"
   },
   "devDependencies": {

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -45,7 +45,6 @@
     "@vite-hub/kv": "workspace:*",
     "@vite-hub/runtime": "workspace:*",
     "cron-schedule": "catalog:workflow",
-    "effect": "catalog:effect",
     "esbuild": "catalog:tooling"
   },
   "devDependencies": {

--- a/packages/workspace/fixtures/published-types/consumer.ts
+++ b/packages/workspace/fixtures/published-types/consumer.ts
@@ -1,0 +1,13 @@
+import { ViteHubError, type ViteHubErrorShape } from "@vite-hub/runtime"
+import { WorkspaceNotFoundError, WorkspacePathError } from "@vite-hub/workspace"
+
+const missing = new WorkspaceNotFoundError("documents")
+missing.code satisfies "WORKSPACE_NOT_FOUND"
+missing.details satisfies { name: string } | undefined
+missing.toJSON() satisfies ViteHubErrorShape<"WORKSPACE_NOT_FOUND", { name: string }>
+missing satisfies ViteHubError<"WORKSPACE_NOT_FOUND", { name: string }>
+
+const invalidPath = new WorkspacePathError("../secrets")
+invalidPath.code satisfies "WORKSPACE_PATH_INVALID"
+invalidPath.details satisfies { path: string } | undefined
+invalidPath.toJSON() satisfies ViteHubErrorShape<"WORKSPACE_PATH_INVALID", { path: string }>

--- a/packages/workspace/fixtures/published-types/package.json
+++ b/packages/workspace/fixtures/published-types/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/workspace/fixtures/published-types/tsconfig.json
+++ b/packages/workspace/fixtures/published-types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "types": []
+  },
+  "files": [
+    "consumer.ts"
+  ]
+}

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -138,6 +138,7 @@
     "@vite-hub/runtime": "workspace:*",
     "@vite-hub/source": "workspace:*",
     "defu": "catalog:unjs",
+    "effect": "catalog:effect",
     "exsolve": "catalog:unjs",
     "h3": "catalog:unjs",
     "isomorphic-git": "catalog:workspace",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -135,6 +135,7 @@
   "dependencies": {
     "@vercel/nft": "catalog:vercel",
     "@vite-hub/markdown-template": "workspace:*",
+    "@vite-hub/runtime": "workspace:*",
     "@vite-hub/source": "workspace:*",
     "defu": "catalog:unjs",
     "exsolve": "catalog:unjs",

--- a/packages/workspace/src/ai.ts
+++ b/packages/workspace/src/ai.ts
@@ -240,6 +240,7 @@ function createWorkspaceSessionShellProvider(starter: WorkspaceSessionStarter): 
     },
     async exec(command: string, execOptions: ShellRuntimeExecOptions = {}) {
       const session = await starter.startSession({ paths: execOptions.workspacePaths })
+      let observation: ShellObservation
       try {
         const result = await session.exec("sh", ["-lc", command], {
           cwd: execOptions.cwd || workspaceMountPoint,
@@ -249,7 +250,7 @@ function createWorkspaceSessionShellProvider(starter: WorkspaceSessionStarter): 
         execOptions.onStdout?.(result.stdout)
         execOptions.onStderr?.(result.stderr)
         const timedOut = result.exitCode === 124 && /timed out/i.test(result.stderr)
-        return {
+        observation = {
           command,
           cwd: execOptions.cwd,
           event: timedOut ? "command_timed_out" : "command_finished",
@@ -259,9 +260,17 @@ function createWorkspaceSessionShellProvider(starter: WorkspaceSessionStarter): 
           timedOut,
         } satisfies ShellObservation
       }
-      finally {
-        await session.close()
+      catch (error) {
+        try {
+          await session.close()
+        }
+        catch (closeError) {
+          throw new AggregateError([error, closeError], "[vitehub] Workspace shell execution failed and session cleanup also failed.")
+        }
+        throw error
       }
+      await session.close()
+      return observation
     },
   }
 }

--- a/packages/workspace/src/core/errors.ts
+++ b/packages/workspace/src/core/errors.ts
@@ -1,3 +1,5 @@
+import { ViteHubError, type ViteHubErrorShape } from "@vite-hub/runtime"
+
 export class WorkspaceError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options)
@@ -6,15 +8,27 @@ export class WorkspaceError extends Error {
 }
 
 export class WorkspaceNotFoundError extends WorkspaceError {
+  readonly code = "WORKSPACE_NOT_FOUND" as const
+  readonly details: { name: string }
+  readonly retryable: false = false
+  readonly toJSON: () => ViteHubErrorShape<"WORKSPACE_NOT_FOUND", { name: string }> = ViteHubError.prototype.toJSON
+
   constructor(name: string) {
     super(`[vitehub] Workspace "${name}" is not registered.`)
     this.name = "WorkspaceNotFoundError"
+    this.details = { name }
   }
 }
 
 export class WorkspacePathError extends WorkspaceError {
+  readonly code = "WORKSPACE_PATH_INVALID" as const
+  readonly details: { path: string }
+  readonly retryable: false = false
+  readonly toJSON: () => ViteHubErrorShape<"WORKSPACE_PATH_INVALID", { path: string }> = ViteHubError.prototype.toJSON
+
   constructor(path: string) {
     super(`[vitehub] Workspace path escapes the workspace root: ${JSON.stringify(path)}.`)
     this.name = "WorkspacePathError"
+    this.details = { path }
   }
 }

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -39,6 +39,7 @@ export type {
 } from "./session/harness.ts"
 export type * from "./ai.ts"
 export { resolveWorkspaceAutoCommit } from "./core/rules.ts"
+export { WorkspaceNotFoundError, WorkspacePathError } from "./core/errors.ts"
 export { resolveRegisteredWorkspaceDefinition } from "./core/registry.ts"
 export { useWorkspace } from "./core/use.ts"
 export type * from "./core/use.ts"

--- a/packages/workspace/src/internal/effect-runtime.ts
+++ b/packages/workspace/src/internal/effect-runtime.ts
@@ -1,0 +1,47 @@
+import { Cause, Data, Effect, Exit } from "effect"
+
+export class WorkspaceEffectFailure extends Data.TaggedError("WorkspaceEffectFailure")<{
+  readonly cause: unknown
+  readonly operation: string
+}> {}
+
+function interruptionError(signal?: AbortSignal): unknown {
+  if (signal?.aborted && signal.reason !== undefined) return signal.reason
+  const error = new Error("[vitehub] Workspace operation was interrupted.")
+  error.name = "AbortError"
+  return error
+}
+
+export function workspaceEffectCauseValues(
+  cause: Cause.Cause<unknown>,
+  signal?: AbortSignal,
+): unknown[] {
+  return cause.reasons.map(reason => {
+    if (Cause.isFailReason(reason)) {
+      return reason.error instanceof WorkspaceEffectFailure ? reason.error.cause : reason.error
+    }
+    if (Cause.isDieReason(reason)) return reason.defect
+    return interruptionError(signal)
+  })
+}
+
+export function tryWorkspacePromise<A>(
+  operation: string,
+  evaluate: (signal: AbortSignal) => PromiseLike<A> | A,
+): Effect.Effect<A, WorkspaceEffectFailure> {
+  return Effect.tryPromise({
+    catch: cause => new WorkspaceEffectFailure({ cause, operation }),
+    try: signal => Promise.resolve(evaluate(signal)),
+  })
+}
+
+export async function runWorkspaceEffect<A, E>(
+  effect: Effect.Effect<A, E>,
+  options: { signal?: AbortSignal } = {},
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(effect, options.signal ? { signal: options.signal } : undefined)
+  if (Exit.isSuccess(exit)) return exit.value
+  const causes = workspaceEffectCauseValues(exit.cause, options.signal)
+  if (causes.length === 1) throw causes[0]
+  throw new AggregateError(causes, "[vitehub] Workspace operation failed for multiple reasons.")
+}

--- a/packages/workspace/src/server.ts
+++ b/packages/workspace/src/server.ts
@@ -315,8 +315,9 @@ export async function runWorkspaceDevCommand<Name extends WorkspaceName>(
     label: "Starting workspace session",
   }, async () => await startSession(input.paths ? { paths: input.paths } : undefined))
   const execOptions = { abortSignal: input.abortSignal, timeout: input.timeout }
+  let result
   try {
-    const result = input.args
+    result = input.args
       ? await session.exec(command, input.args, execOptions)
       : await session.exec("sh", ["-lc", command], execOptions)
     const diff = result.exitCode === 0 ? await session.diff() : undefined
@@ -324,9 +325,16 @@ export async function runWorkspaceDevCommand<Name extends WorkspaceName>(
       const commit = definition ? resolveWorkspaceAutoCommit(definition, diff) : undefined
       if (!definition || !hasWorkspaceCommitRules(definition) || commit) await session.commit({ message: commit?.message || "workspace dev command" })
     }
-    return result
   }
-  finally {
-    await session.close()
+  catch (error) {
+    try {
+      await session.close()
+    }
+    catch (closeError) {
+      throw new AggregateError([error, closeError], "[vitehub] Workspace Dev command failed and session cleanup also failed.")
+    }
+    throw error
   }
+  await session.close()
+  return result
 }

--- a/packages/workspace/src/session/sandbox-scope.ts
+++ b/packages/workspace/src/session/sandbox-scope.ts
@@ -55,6 +55,8 @@ const closeSandboxScope = Effect.fn("Workspace.Sandbox.Scope.close")(function* (
 })
 
 export class SandboxWorkspaceScope<Resource extends SandboxResource, Setup> {
+  private closed = false
+
   constructor(
     readonly resource: Resource,
     readonly setup: Setup,
@@ -63,10 +65,11 @@ export class SandboxWorkspaceScope<Resource extends SandboxResource, Setup> {
   ) {}
 
   isClosed(): boolean {
-    return this.scope.state._tag === "Closed"
+    return this.closed
   }
 
   close(): Promise<void> {
+    this.closed = true
     return runWorkspaceEffect(closeSandboxScope(this.scope, this.failures, Exit.void))
   }
 }

--- a/packages/workspace/src/session/sandbox-scope.ts
+++ b/packages/workspace/src/session/sandbox-scope.ts
@@ -1,0 +1,111 @@
+import { Effect, Exit, Ref, Scope } from "effect"
+
+import {
+  WorkspaceEffectFailure,
+  runWorkspaceEffect,
+  tryWorkspacePromise,
+  workspaceEffectCauseValues,
+} from "../internal/effect-runtime.ts"
+
+interface SandboxResource {
+  readonly provider: string
+  stop(): Promise<void>
+}
+
+function failureValue(exit: Exit.Failure<unknown, unknown>): unknown {
+  const causes = workspaceEffectCauseValues(exit.cause)
+  return causes.length === 1
+    ? causes[0]
+    : new AggregateError(causes, "[vitehub] Workspace sandbox operation failed for multiple reasons.")
+}
+
+const releaseSandbox = Effect.fn("Workspace.Sandbox.release")(function* (
+  sandbox: SandboxResource,
+  failures: Ref.Ref<readonly unknown[]>,
+) {
+  if (sandbox.provider !== "vercel") return
+  const exit = yield* Effect.exit(
+    tryWorkspacePromise("Workspace.Sandbox.release", () => sandbox.stop()),
+  )
+  if (Exit.isFailure(exit)) {
+    const causes = workspaceEffectCauseValues(exit.cause)
+    yield* Ref.update(failures, current => [...current, ...causes])
+  }
+})
+
+const closeSandboxScope = Effect.fn("Workspace.Sandbox.Scope.close")(function* (
+  scope: Scope.Closeable,
+  failures: Ref.Ref<readonly unknown[]>,
+  exit: Exit.Exit<unknown, unknown>,
+) {
+  yield* Scope.close(scope, exit)
+  const causes = yield* Ref.get(failures)
+  if (causes.length === 1) {
+    return yield* Effect.fail(new WorkspaceEffectFailure({
+      cause: causes[0],
+      operation: "Workspace.Sandbox.Scope.close",
+    }))
+  }
+  if (causes.length > 1) {
+    return yield* Effect.fail(new WorkspaceEffectFailure({
+      cause: new AggregateError(causes, "[vitehub] Workspace sandbox cleanup failed for multiple reasons."),
+      operation: "Workspace.Sandbox.Scope.close",
+    }))
+  }
+})
+
+export class SandboxWorkspaceScope<Resource extends SandboxResource, Setup> {
+  constructor(
+    readonly resource: Resource,
+    readonly setup: Setup,
+    private readonly scope: Scope.Closeable,
+    private readonly failures: Ref.Ref<readonly unknown[]>,
+  ) {}
+
+  isClosed(): boolean {
+    return this.scope.state._tag === "Closed"
+  }
+
+  close(): Promise<void> {
+    return runWorkspaceEffect(closeSandboxScope(this.scope, this.failures, Exit.void))
+  }
+}
+
+export function openSandboxWorkspaceScope<Resource extends SandboxResource, Setup>(
+  acquire: () => Promise<Resource>,
+  setup: (resource: Resource) => Promise<Setup>,
+): Promise<SandboxWorkspaceScope<Resource, Setup>> {
+  return runWorkspaceEffect(Effect.gen(function* () {
+    const scope = yield* Scope.make("sequential")
+    const failures = yield* Ref.make<readonly unknown[]>([])
+    const resource = yield* Scope.provide(
+      Effect.acquireRelease(
+        tryWorkspacePromise("Workspace.Sandbox.acquire", acquire),
+        sandbox => releaseSandbox(sandbox, failures),
+      ),
+      scope,
+    )
+
+    const setupExit = yield* Effect.exit(
+      tryWorkspacePromise("Workspace.Sandbox.setup", () => setup(resource)),
+    )
+    if (Exit.isSuccess(setupExit))
+      return new SandboxWorkspaceScope(resource, setupExit.value, scope, failures)
+
+    const setupError = failureValue(setupExit)
+    const closeExit = yield* Effect.exit(closeSandboxScope(scope, failures, setupExit))
+    if (Exit.isFailure(closeExit)) {
+      return yield* Effect.fail(new WorkspaceEffectFailure({
+        cause: new AggregateError(
+          [setupError, failureValue(closeExit)],
+          "[vitehub] Workspace sandbox setup failed and cleanup also failed.",
+        ),
+        operation: "Workspace.Sandbox.setup",
+      }))
+    }
+    return yield* Effect.fail(new WorkspaceEffectFailure({
+      cause: setupError,
+      operation: "Workspace.Sandbox.setup",
+    }))
+  }))
+}

--- a/packages/workspace/src/session/sandbox.ts
+++ b/packages/workspace/src/session/sandbox.ts
@@ -1,9 +1,12 @@
 import { posix } from "node:path"
+import { Effect } from "effect"
 
 import { WorkspaceError } from "../core/errors.ts"
 import { contentToBytes, decodeFile, normalizeSafeWorkspacePath, normalizeWorkspacePath, sha256 } from "../core/path.ts"
+import { runWorkspaceEffect, tryWorkspacePromise } from "../internal/effect-runtime.ts"
 import { loadWorkspaceSandboxModule, loadWorkspaceSandboxRuntimeStateModule } from "../runtime/dependency-loaders.ts"
 import { createSnapshotFromEntries, diffSnapshots } from "../storage/utils.ts"
+import { openSandboxWorkspaceScope } from "./sandbox-scope.ts"
 import { assertDiffInsideSessionPaths, assertPathInSessionScope, filterSessionDiff, filterSessionEntries, isMissingWorkspacePathError, scopedSearchQuery } from "./scope.ts"
 
 import type {
@@ -100,17 +103,19 @@ async function listSandboxEntries(sandbox: SandboxClient, path = "", recursive =
 
 async function snapshotSandbox(sandbox: SandboxClient, name?: string) {
   const entries = await listSandboxEntries(sandbox, "", true)
-  const files = await Promise.all(entries.map(async (entry) => {
-    if (entry.type !== "file") return entry
-    const content = isGitSymlinkEntry(entry)
-      ? await readSandboxSymlinkTarget(sandbox, toSandboxPath(entry.path))
-      : await sandbox.readFile(toSandboxPath(entry.path), { encoding: "binary" })
-    return {
-      ...entry,
-      digest: await sha256(content),
-      size: contentToBytes(content).byteLength,
-    }
-  }))
+  const files = await runWorkspaceEffect(Effect.forEach(entries, entry => {
+    if (entry.type !== "file") return Effect.succeed(entry)
+    return tryWorkspacePromise("Workspace.Sandbox.snapshot.read", async () => {
+      const content = isGitSymlinkEntry(entry)
+        ? await readSandboxSymlinkTarget(sandbox, toSandboxPath(entry.path))
+        : await sandbox.readFile(toSandboxPath(entry.path), { encoding: "binary" })
+      return {
+        ...entry,
+        digest: await sha256(content),
+        size: contentToBytes(content).byteLength,
+      }
+    })
+  }, { concurrency: 16 }))
   return await createSnapshotFromEntries(files, name)
 }
 
@@ -217,14 +222,17 @@ export async function createSandboxWorkspaceSession(
     throw new WorkspaceError("[vitehub] Workspace runtime `sandbox` requires app-level `sandbox` config.")
   }
 
-  const sandbox = await sandboxPackage.createSandboxWithConfig(sandboxConfig)
   const sessionPaths = normalizeSessionPaths(options)
-  let baseline = await materializeWorkspace(workspace, sandbox, options)
+  const sandboxScope = await openSandboxWorkspaceScope(
+    () => sandboxPackage.createSandboxWithConfig(sandboxConfig),
+    sandbox => materializeWorkspace(workspace, sandbox, options),
+  )
+  const sandbox = sandboxScope.resource
+  let baseline = sandboxScope.setup
   const mediaTypes = new Map<string, string>()
-  let closed = false
 
   function assertOpen() {
-    if (closed)
+    if (sandboxScope.isClosed())
       throw new WorkspaceError("[vitehub] Workspace sandbox session is already closed.")
   }
 
@@ -319,10 +327,7 @@ export async function createSandboxWorkspaceSession(
       }
     },
     async close() {
-      if (closed) return
-      closed = true
-      if (sandbox.provider === "vercel")
-        await sandbox.stop().catch(() => {})
+      await sandboxScope.close()
     },
   }
 }

--- a/packages/workspace/test/errors.test.ts
+++ b/packages/workspace/test/errors.test.ts
@@ -1,0 +1,49 @@
+import type { ViteHubError } from "@vite-hub/runtime"
+import { describe, expect, it } from "vitest"
+
+import { WorkspaceNotFoundError, WorkspacePathError } from "../src/index.ts"
+import { WorkspaceError } from "../src/core/errors.ts"
+
+describe("Workspace public errors", () => {
+  it("serializes missing Workspace failures through the shared contract", () => {
+    const cause = new Error("private provider response")
+    const error = new WorkspaceNotFoundError("documents")
+    Object.defineProperty(error, "cause", { value: cause })
+    Object.assign(error, { providerToken: "secret" })
+
+    const contract: ViteHubError<"WORKSPACE_NOT_FOUND", { name: string }> = error
+
+    expect(contract).toBe(error)
+    expect(error).toBeInstanceOf(WorkspaceError)
+    expect(error).toBeInstanceOf(WorkspaceNotFoundError)
+    expect(error.name).toBe("WorkspaceNotFoundError")
+    expect(error.message).toBe('[vitehub] Workspace "documents" is not registered.')
+    expect(error.toJSON()).toEqual({
+      code: "WORKSPACE_NOT_FOUND",
+      details: { name: "documents" },
+      message: '[vitehub] Workspace "documents" is not registered.',
+      retryable: false,
+    })
+    expect(JSON.stringify(error)).not.toContain("providerToken")
+    expect(JSON.stringify(error)).not.toContain("private provider response")
+    expect(JSON.stringify(error)).not.toContain("stack")
+  })
+
+  it("serializes invalid Workspace paths with allowlisted details", () => {
+    const error = new WorkspacePathError("../secrets")
+
+    const contract: ViteHubError<"WORKSPACE_PATH_INVALID", { path: string }> = error
+
+    expect(contract).toBe(error)
+    expect(error).toBeInstanceOf(WorkspaceError)
+    expect(error).toBeInstanceOf(WorkspacePathError)
+    expect(error.name).toBe("WorkspacePathError")
+    expect(error.message).toBe('[vitehub] Workspace path escapes the workspace root: "../secrets".')
+    expect(error.toJSON()).toEqual({
+      code: "WORKSPACE_PATH_INVALID",
+      details: { path: "../secrets" },
+      message: '[vitehub] Workspace path escapes the workspace root: "../secrets".',
+      retryable: false,
+    })
+  })
+})

--- a/packages/workspace/test/public-api.test.ts
+++ b/packages/workspace/test/public-api.test.ts
@@ -111,7 +111,7 @@ describe("workspace public API", () => {
     const builtServer = await readFile(new URL("../dist/server.d.ts", import.meta.url), "utf8")
     const builtSandboxStore = await readFile(new URL("../dist/providers/vercel/blob-store.d.ts", import.meta.url), "utf8")
     const distDir = new URL("../dist/", import.meta.url)
-    const declarations = (await Promise.all((await readdir(distDir))
+    const declarations = (await Promise.all((await readdir(distDir, { recursive: true }))
       .filter(file => file.endsWith(".d.ts"))
       .map(file => readFile(new URL(file, distDir), "utf8")))).join("\n")
 
@@ -130,6 +130,7 @@ describe("workspace public API", () => {
     expect(declarations).not.toContain("@vercel/blob")
     expect(builtSandboxStore).not.toContain("files-sdk")
     expect(declarations).not.toContain("@vite-hub/sandbox")
+    expect(declarations).not.toMatch(/(?:from\s*|import\s*\(|import\s+)["']effect["']/)
   })
 
   it("keeps hosted runtime setup off the public Workspace surface", async () => {

--- a/packages/workspace/test/public-api.test.ts
+++ b/packages/workspace/test/public-api.test.ts
@@ -111,9 +111,20 @@ describe("workspace public API", () => {
     const builtServer = await readFile(new URL("../dist/server.d.ts", import.meta.url), "utf8")
     const builtSandboxStore = await readFile(new URL("../dist/providers/vercel/blob-store.d.ts", import.meta.url), "utf8")
     const distDir = new URL("../dist/", import.meta.url)
-    const declarations = (await Promise.all((await readdir(distDir, { recursive: true }))
+    const distFiles = await readdir(distDir, { recursive: true })
+    const declarations = (await Promise.all(distFiles
       .filter(file => file.endsWith(".d.ts"))
       .map(file => readFile(new URL(file, distDir), "utf8")))).join("\n")
+    const effectFreeBundles = (await Promise.all([
+      "cloudflare.js",
+      "source-metadata.js",
+      "runtime/empty-assets-registry.js",
+      "runtime/empty-registry.js",
+      "providers/cloudflare/artifacts-store.js",
+      "providers/github/store.js",
+      "providers/vercel/blob-store.js",
+    ].map(file => readFile(new URL(file, distDir), "utf8")))).join("\n")
+    const effectImport = /(?:from\s*|import\s*(?:\(\s*)?)["']effect(?:\/[^"']*)?["']/
 
     expect(packageJson.dependencies?.h3).toBe("catalog:unjs")
     expect(packageJson.dependencies?.["files-sdk"]).toBeUndefined()
@@ -130,7 +141,8 @@ describe("workspace public API", () => {
     expect(declarations).not.toContain("@vercel/blob")
     expect(builtSandboxStore).not.toContain("files-sdk")
     expect(declarations).not.toContain("@vite-hub/sandbox")
-    expect(declarations).not.toMatch(/(?:from\s*|import\s*\(|import\s+)["']effect["']/)
+    expect(declarations).not.toMatch(effectImport)
+    expect(effectFreeBundles).not.toMatch(effectImport)
   })
 
   it("keeps hosted runtime setup off the public Workspace surface", async () => {

--- a/packages/workspace/test/published-types.test.ts
+++ b/packages/workspace/test/published-types.test.ts
@@ -1,0 +1,33 @@
+import { execFile } from "node:child_process"
+import { copyFile, cp, mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { it } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const runtimeRoot = resolve(packageRoot, "../runtime")
+const fixtureRoot = join(packageRoot, "fixtures", "published-types")
+const tsc = resolve(packageRoot, "../../node_modules/typescript/bin/tsc")
+
+it("publishes Workspace errors through the shared contract", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-types-"))
+
+  try {
+    await cp(fixtureRoot, root, { recursive: true })
+    for (const [name, source] of [["workspace", packageRoot], ["runtime", runtimeRoot]] as const) {
+      const installedPackageRoot = join(root, "node_modules", "@vite-hub", name)
+      await mkdir(installedPackageRoot, { recursive: true })
+      await copyFile(join(source, "package.json"), join(installedPackageRoot, "package.json"))
+      await cp(join(source, "dist"), join(installedPackageRoot, "dist"), { recursive: true })
+    }
+
+    await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", root])
+  }
+  finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})

--- a/packages/workspace/test/sandbox-runtime.test.ts
+++ b/packages/workspace/test/sandbox-runtime.test.ts
@@ -9,6 +9,10 @@ import { getWorkspaceDependencyRuntimeLoaders, setWorkspaceDependencyRuntimeLoad
 import { setSandboxRuntimeConfig } from "@vite-hub/sandbox/runtime/state"
 
 type FakeEntry = { content?: string | Uint8Array, target?: string, type: "directory" | "file" | "symlink" }
+type FakeSandboxOptions = {
+  onReadFile?: (path: string) => Promise<void>
+  stopError?: unknown
+}
 
 const tempDirs: string[] = []
 
@@ -18,7 +22,7 @@ async function createTempDir() {
   return dir
 }
 
-function createFakeSandbox(provider: "cloudflare" | "vercel") {
+function createFakeSandbox(provider: "cloudflare" | "vercel", hooks: FakeSandboxOptions = {}) {
   const files = new Map<string, FakeEntry>([
     ["/workspace", { type: "directory" }],
   ])
@@ -63,6 +67,7 @@ function createFakeSandbox(provider: "cloudflare" | "vercel") {
         files.set(path, { content, type: "file" })
       },
       async readFile(path: string, options?: { encoding?: "binary" | "utf8" }): Promise<string | Uint8Array> {
+        await hooks.onReadFile?.(path)
         const entry = files.get(path)
         if (!entry || (entry.type !== "file" && entry.type !== "symlink")) throw new Error(`missing file: ${path}`)
         if (entry.type === "symlink")
@@ -120,6 +125,7 @@ function createFakeSandbox(provider: "cloudflare" | "vercel") {
       },
       async stop() {
         calls.push("stop")
+        if (hooks.stopError !== undefined) throw hooks.stopError
       },
     },
   }
@@ -142,6 +148,135 @@ afterEach(async () => {
 })
 
 describe("sandbox workspace runtime", () => {
+  it("releases a Vercel sandbox when session setup fails", async () => {
+    const setupError = new Error("materialization failed")
+    const fake = createFakeSandbox("vercel")
+    fake.sandbox.writeFile = vi.fn(async () => {
+      throw setupError
+    })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "vercel", runtime: "node24" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    await workspace.writeFile("README.md", "# Docs\n")
+
+    await expect(workspace.startSession()).rejects.toBe(setupError)
+    expect(fake.calls.filter(call => call === "stop")).toHaveLength(1)
+  })
+
+  it("preserves setup and cleanup failures without exposing FiberFailure", async () => {
+    const setupError = new Error("materialization failed")
+    const stopError = new Error("sandbox stop failed")
+    const fake = createFakeSandbox("vercel", { stopError })
+    fake.sandbox.writeFile = vi.fn(async () => {
+      throw setupError
+    })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "vercel", runtime: "node24" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    await workspace.writeFile("README.md", "# Docs\n")
+
+    const failure = await workspace.startSession().catch(error => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([setupError, stopError])
+    expect((failure as Error).name).not.toBe("FiberFailure")
+    expect(fake.calls.filter(call => call === "stop")).toHaveLength(1)
+  })
+
+  it("never stops caller-owned Cloudflare sandboxes", async () => {
+    const setupError = new Error("materialization failed")
+    const fake = createFakeSandbox("cloudflare")
+    fake.sandbox.writeFile = vi.fn(async () => {
+      throw setupError
+    })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "cloudflare", binding: "SANDBOX" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    await workspace.writeFile("README.md", "# Docs\n")
+
+    await expect(workspace.startSession()).rejects.toBe(setupError)
+    expect(fake.calls).not.toContain("stop")
+  })
+
+  it("stops a Vercel sandbox exactly once across concurrent closes", async () => {
+    const fake = createFakeSandbox("vercel")
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "vercel", runtime: "node24" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    const session = await workspace.startSession()
+
+    await Promise.all([session.close(), session.close(), session.close()])
+
+    expect(fake.calls.filter(call => call === "stop")).toHaveLength(1)
+  })
+
+  it("returns Vercel cleanup failures by identity without exposing FiberFailure", async () => {
+    const stopError = new Error("sandbox stop failed")
+    const fake = createFakeSandbox("vercel", { stopError })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "vercel", runtime: "node24" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    const session = await workspace.startSession()
+    const failure = await session.close().catch(error => error)
+
+    expect(failure).toBe(stopError)
+    expect((failure as Error).name).not.toBe("FiberFailure")
+    expect(fake.calls.filter(call => call === "stop")).toHaveLength(1)
+  })
+
+  it("bounds concurrent sandbox snapshot reads at 16", async () => {
+    let activeReads = 0
+    let maximumReads = 0
+    const fake = createFakeSandbox("cloudflare", {
+      async onReadFile() {
+        activeReads += 1
+        maximumReads = Math.max(maximumReads, activeReads)
+        await new Promise(resolve => setTimeout(resolve, 5))
+        activeReads -= 1
+      },
+    })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "cloudflare", binding: "SANDBOX" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    await Promise.all(Array.from({ length: 40 }, (_, index) =>
+      workspace.writeFile(`files/${index}.txt`, String(index))))
+
+    const session = await workspace.startSession()
+
+    expect(maximumReads).toBe(16)
+    await session.close()
+  })
+
   it("uses configured generated-host sandbox loaders", async () => {
     const fake = createFakeSandbox("cloudflare")
     const createSandboxWithConfig = vi.fn(async () => fake.sandbox)

--- a/packages/workspace/test/sandbox-runtime.test.ts
+++ b/packages/workspace/test/sandbox-runtime.test.ts
@@ -11,6 +11,7 @@ import { setSandboxRuntimeConfig } from "@vite-hub/sandbox/runtime/state"
 type FakeEntry = { content?: string | Uint8Array, target?: string, type: "directory" | "file" | "symlink" }
 type FakeSandboxOptions = {
   onReadFile?: (path: string) => Promise<void>
+  onStop?: () => Promise<void>
   stopError?: unknown
 }
 
@@ -125,6 +126,7 @@ function createFakeSandbox(provider: "cloudflare" | "vercel", hooks: FakeSandbox
       },
       async stop() {
         calls.push("stop")
+        await hooks.onStop?.()
         if (hooks.stopError !== undefined) throw hooks.stopError
       },
     },
@@ -228,6 +230,29 @@ describe("sandbox workspace runtime", () => {
     await Promise.all([session.close(), session.close(), session.close()])
 
     expect(fake.calls.filter(call => call === "stop")).toHaveLength(1)
+  })
+
+  it("closes the public session before asynchronous release finishes", async () => {
+    let releaseStop!: () => void
+    const stop = new Promise<void>((resolve) => {
+      releaseStop = resolve
+    })
+    const fake = createFakeSandbox("vercel", { onStop: () => stop })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "vercel", runtime: "node24" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    await workspace.writeFile("README.md", "# Docs\n")
+    const session = await workspace.startSession()
+
+    const closing = session.close()
+    await expect(session.readFile("README.md")).rejects.toThrow("already closed")
+    releaseStop()
+    await closing
   })
 
   it("returns Vercel cleanup failures by identity without exposing FiberFailure", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,6 +484,9 @@ importers:
       comark:
         specifier: catalog:ui
         version: 0.5.1(shiki@4.3.1)
+      effect:
+        specifier: catalog:effect
+        version: 4.0.0-beta.99
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1361,6 +1361,9 @@ importers:
       defu:
         specifier: catalog:unjs
         version: 6.1.7
+      effect:
+        specifier: catalog:effect
+        version: 4.0.0-beta.99
       exsolve:
         specifier: catalog:unjs
         version: 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1076,6 +1076,9 @@ importers:
       cron-schedule:
         specifier: catalog:workflow
         version: 6.0.0
+      effect:
+        specifier: catalog:effect
+        version: 4.0.0-beta.99
       esbuild:
         specifier: catalog:tooling
         version: 0.28.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1352,6 +1352,9 @@ importers:
       '@vite-hub/markdown-template':
         specifier: workspace:*
         version: link:../markdown-template
+      '@vite-hub/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       '@vite-hub/source':
         specifier: workspace:*
         version: link:../source

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,9 +484,6 @@ importers:
       comark:
         specifier: catalog:ui
         version: 0.5.1(shiki@4.3.1)
-      effect:
-        specifier: catalog:effect
-        version: 4.0.0-beta.99
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7
@@ -1076,9 +1073,6 @@ importers:
       cron-schedule:
         specifier: catalog:workflow
         version: 6.0.0
-      effect:
-        specifier: catalog:effect
-        version: 4.0.0-beta.99
       esbuild:
         specifier: catalog:tooling
         version: 0.28.1

--- a/test/effect-ownership.test.ts
+++ b/test/effect-ownership.test.ts
@@ -21,7 +21,7 @@ import { describe, expect, it } from "vitest"
 
 const repoRoot = resolve(import.meta.dirname, "..")
 const effectVersion = "4.0.0-beta.99"
-const expectedEffectOwners = ["agent", "schedule"]
+const expectedEffectOwners = ["agent", "schedule", "workspace"]
 const allowedEffectOwners = new Set(expectedEffectOwners)
 
 type PackageEffectOwnership = {


### PR DESCRIPTION
Moves sandbox session acquisition, setup, bounded snapshot traversal, and cleanup behind one manually owned Effect 4 Scope that outlives the opening interpreter until `WorkspaceSession.close()`. Vercel sandboxes stop exactly once, Cloudflare sandboxes remain caller-owned, setup and cleanup failures preserve both original causes, and Promise callers never receive Effect `FiberFailure` wrappers.

The public session closes synchronously before asynchronous release finishes, using wrapper-owned state instead of reading Effect's non-contract `scope.state` internals. Concurrent closes remain idempotent. Snapshot reads use one bounded Effect traversal with concurrency 16 instead of unbounded `Promise.all`.

Public declarations reject `effect` and `effect/*`, and provider/shared entry bundles are checked independently so the internal interpreter cannot leak across those artifacts. The root ownership contract from #670 also proves Agent and Workspace resolve the exact Effect 4 beta.99 catalog version while the optional UploadThing Effect 3 subtree remains isolated.

This PR includes the focused Workspace public error contract formerly proposed in closed #672: the existing not-found and invalid-path errors now expose stable codes, JSON-safe details, and the shared ViteHub serializer without changing the Promise API. Those typed errors are the prerequisite for the lifecycle boundary in this branch.

Proof: frozen install, Workspace build and publint, typecheck, focused Workspace and Agent tests, exact Effect ownership guard, provider/declaration artifact guards, targeted Oxlint, and diff validation pass.

```text
EFFECT ADOPTION STATUS
  seam: Sandbox WorkspaceSession acquisition, setup, snapshot concurrency, and release
  public API: unchanged Promise/Web contract; concrete Workspace errors are exported; cleanup failures are no longer swallowed
  boundary: packages/workspace/src/internal/effect-runtime.ts
  typed failures: WorkspaceEffectFailure wrapping original sandbox lifecycle causes
  resources/fibers: one manually owned sequential Scope per Sandbox WorkspaceSession; no long-lived fibers
  dependency: #670 owns Effect 4.0.0-beta.99; this PR adds the Workspace owner
  deleted: swallowed Vercel stop failure, unbounded snapshot Promise.all, non-contract Scope state inspection
  retained: one wrapper-owned closed flag required by the synchronous public session guard
  todos: 0
  confidence: high
```
