### PR TITLE
refactor(agent): finalize invocations with Effect

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,5 +1,6 @@
 import agentRegistry from "#vitehub/agent/registry"
 import { normalizeAgentDriver } from "./internal/agent-driver.ts"
+import { openAgentInvocationLifecycle, type AgentInvocationLifecycle } from "./internal/invocation-lifecycle.ts"
 import { cloneWithPropertyDescriptors } from "./internal/stream-result.ts"
 import { AgentOutputValidationError, validateAgentOutput } from "./internal/agent-structured-output.ts"
 import { loadAgentWorkflowModule, loadAgentWorkflowRuntimeStateModule } from "./internal/workflow-runtime-loaders.ts"
@@ -952,15 +953,6 @@ async function applyChannelDeliveryEffectIntents<
   }
 }
 
-function once<TArgs extends unknown[]>(callback: (...args: TArgs) => Promise<void>): (...args: TArgs) => Promise<void> {
-  let called = false
-  return async (...args) => {
-    if (called) return
-    called = true
-    await callback(...args)
-  }
-}
-
 export { applyAgentToolPolicies, withAgentToolStepReporting } from "./tool-runtime.ts"
 export { defineCapability } from "./capability-runtime.ts"
 export { defineFinishEffect } from "./delivery-effects.ts"
@@ -1848,13 +1840,14 @@ async function finishStreamAgentInvocation<
   CALL_OPTIONS,
 >(
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+  lifecycle: AgentInvocationLifecycle<AgentInvocationFinishOutcome>,
   result: unknown,
   outcome: AgentInvocationFinishOutcome,
   failureMessage: string,
   outputExtensions = new Map<string, unknown>(),
 ): Promise<void> {
   if (outcome.status === "error") {
-    await finishAgentInvocation(context, outcome)
+    await lifecycle.finish(outcome)
     return
   }
   let finishResult: unknown
@@ -1868,9 +1861,9 @@ async function finishStreamAgentInvocation<
       : resultWithUsageRecord(finishResult, usageRecord)
   }
   catch (finishError) {
-    await finishFailedAgentInvocation(context, finishError, failureMessage)
+    await lifecycle.fail({ error: finishError, status: "error" }, finishError, failureMessage)
   }
-  await finishAgentInvocation(context, { result: finishResult, status: "success", usage: finishUsage })
+  await lifecycle.finish({ result: finishResult, status: "success", usage: finishUsage })
 }
 
 function traceUiMessageStream<
@@ -2260,29 +2253,13 @@ async function finishAgentInvocation<
   }
 }
 
-async function finishFailedAgentInvocation<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  CALL_OPTIONS,
->(
-  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
-  error: unknown,
-  message: string,
-): Promise<never> {
-  try {
-    await finishAgentInvocation(context, { error, status: "error" })
-  }
-  catch (finishError) {
-    throw new AggregateError([error, finishError], message)
-  }
-  throw error
-}
-
 async function finalizeAgentInvocationResult<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
   TResult,
 >(
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS> & { hasCapabilityCleanup: boolean },
+  lifecycle: AgentInvocationLifecycle<AgentInvocationFinishOutcome>,
   result: unknown,
   finalizeObject: (result: unknown) => MaybePromise<{ deferFinish?: boolean, finishResult: unknown, finishUsage?: AgentUsageRecord, value: TResult }>,
   failureMessage: string,
@@ -2293,15 +2270,12 @@ async function finalizeAgentInvocationResult<
   } = {},
 ): Promise<Response | AsyncIterable<unknown> | TResult> {
   const shouldWrapOutput = shouldWrapInvocationOutput(context)
-  let finishLifecycleStarted = false
   try {
     if (result instanceof Response) {
-      const response = shouldWrapOutput ? await withResponseCleanup(result, outcome => finishAgentInvocation(context, finishOutcomeFromCleanup(outcome, result))) : result
-      finishLifecycleStarted = shouldWrapOutput
+      const response = shouldWrapOutput ? await withResponseCleanup(result, outcome => lifecycle.finish(finishOutcomeFromCleanup(outcome, result))) : result
       return response
     }
     if (isAsyncIterable(result) && !hasTraceableStreamResult(result) && !options.finalizeRawStreams) {
-      finishLifecycleStarted = shouldWrapOutput
       const stream = options.wrapStream?.(result) || result
       if (shouldWrapOutput) {
         const streamed = withStreamedResult(stream, result)
@@ -2309,25 +2283,23 @@ async function finalizeAgentInvocationResult<
           return withCapabilityCleanup(streamed.stream, async (outcome) => {
             const finishOutcome = finishOutcomeFromCleanup(outcome, result)
             const usage = streamed.finishUsage()
-            return finishAgentInvocation(context, finishOutcome.status === "success"
+            return lifecycle.finish(finishOutcome.status === "success"
               ? { ...finishOutcome, usage: usage ? await resolveAgentUsageRecord({ usageRecord: usage }, context.run) : undefined }
               : finishOutcome)
           }, { abortSignal: context.input.abortSignal })
         }
-        return withCapabilityCleanup(streamed.stream, outcome => finishStreamAgentInvocation(context, streamed.finishResult(), finishOutcomeFromCleanup(outcome), failureMessage, options.outputExtensions), { abortSignal: context.input.abortSignal })
+        return withCapabilityCleanup(streamed.stream, outcome => finishStreamAgentInvocation(context, lifecycle, streamed.finishResult(), finishOutcomeFromCleanup(outcome), failureMessage, options.outputExtensions), { abortSignal: context.input.abortSignal })
       }
       return stream
     }
     const finalized = await finalizeObject(result)
-    finishLifecycleStarted = true
     if (!finalized.deferFinish) {
-      await finishAgentInvocation(context, { result: finalized.finishResult, status: "success", usage: finalized.finishUsage })
+      await lifecycle.finish({ result: finalized.finishResult, status: "success", usage: finalized.finishUsage })
     }
     return finalized.value
   }
   catch (error) {
-    if (finishLifecycleStarted) throw error
-    return await finishFailedAgentInvocation(context, error, failureMessage)
+    return await lifecycle.fail({ error, status: "error" }, error, failureMessage)
   }
 }
 
@@ -2365,13 +2337,15 @@ async function executeAgentInvocation<
     ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput>
     : undefined
   const invocation = await createAgentInvocationContext(definition, context, input)
-  invocation.close = once(invocation.close)
+  const lifecycle = await openAgentInvocationLifecycle<AgentInvocationFinishOutcome>(
+    outcome => finishAgentInvocation(invocation, outcome),
+  )
 
   const runFailureMessage = "[vitehub] Agent run failed and finish lifecycle also failed."
   const streamFailureMessage = "[vitehub] Agent stream failed and finish lifecycle also failed."
   const handledFailureMessage = options.kind === "run" ? runFailureMessage : streamFailureMessage
   if (invocation.handledResponse) {
-    return await finalizeAgentInvocationResult(invocation, invocation.handledResponse, async result => ({ finishResult: result, value: result }), handledFailureMessage)
+    return await finalizeAgentInvocationResult(invocation, lifecycle, invocation.handledResponse, async result => ({ finishResult: result, value: result }), handledFailureMessage)
   }
 
   const executionFailureMessage = options.kind === "run" || customRun ? runFailureMessage : streamFailureMessage
@@ -2388,7 +2362,7 @@ async function executeAgentInvocation<
     }
   }
   catch (error) {
-    return await finishFailedAgentInvocation(invocation, error, executionFailureMessage)
+    return await lifecycle.fail({ error, status: "error" }, error, executionFailureMessage)
   }
 
   const outputExtensions = new Map<string, unknown>()
@@ -2403,11 +2377,11 @@ async function executeAgentInvocation<
     }
   }
   catch (error) {
-    return await finishFailedAgentInvocation(invocation, error, executionFailureMessage)
+    return await lifecycle.fail({ error, status: "error" }, error, executionFailureMessage)
   }
 
   if (options.kind === "run") {
-    return await finalizeAgentInvocationResult(invocation, result, async (result) => {
+    return await finalizeAgentInvocationResult(invocation, lifecycle, result, async (result) => {
       const driverUsageRecord = await resolveFinishUsageRecord(invocation, result)
       const rendered = options.renderOutput
         ? renderedResult ? result : await applyOutputRenderers(result, invocation.outputRenderers, invocation.outputExtensionProviders, outputExtensions)
@@ -2438,12 +2412,12 @@ async function executeAgentInvocation<
     })
   }
 
-  return await finalizeAgentInvocationResult(invocation, result, async (result) => {
+  return await finalizeAgentInvocationResult(invocation, lifecycle, result, async (result) => {
     const driverUsageRecord = await resolveFinishUsageRecord(invocation, result)
     const rendered = renderedResult ? result : await applyOutputRenderers(result, invocation.outputRenderers, invocation.outputExtensionProviders, outputExtensions)
     if (options.output === "ui-message-stream") {
       return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, invocation), shouldWrapInvocationOutput(invocation), async (outcome, streamedText, streamedUsageRecord) => {
-        await finishStreamAgentInvocation(invocation, resultWithStreamedTextAndUsage(rendered, streamedText || "", streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
+        await finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(rendered, streamedText || "", streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
       })
     }
 
@@ -2468,7 +2442,7 @@ async function executeAgentInvocation<
     const shouldWrapOutput = shouldWrapInvocationOutput(invocation)
     const value = shouldWrapOutput
       ? withCapabilityCleanup(tracedStream, async (outcome) => {
-          await finishStreamAgentInvocation(invocation, streamed.finishResult(), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
+          await finishStreamAgentInvocation(invocation, lifecycle, streamed.finishResult(), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
         }, { abortSignal: invocation.input.abortSignal }) as AsyncIterable<StreamEvent>
       : tracedStream
     return {

--- a/packages/agent/src/internal/invocation-lifecycle.ts
+++ b/packages/agent/src/internal/invocation-lifecycle.ts
@@ -1,0 +1,63 @@
+import { Deferred, Effect, Exit } from "effect"
+
+import {
+  AgentEffectFailure,
+  agentEffectCauseValues,
+  runAgentEffect,
+  tryAgentPromise,
+} from "./effect-runtime.ts"
+
+const makeInvocationLifecycle = Effect.fn("Agent.InvocationLifecycle.open")(function* <Outcome>(
+  finish: (outcome: Outcome) => Promise<void>,
+) {
+  const outcome = yield* Deferred.make<Outcome>()
+  const complete = yield* Effect.cached(
+    Deferred.await(outcome).pipe(
+      Effect.flatMap(value => tryAgentPromise("Agent.InvocationLifecycle.finish", () => finish(value))),
+    ),
+  )
+  return new AgentInvocationLifecycle(outcome, complete)
+})
+
+export class AgentInvocationLifecycle<Outcome> {
+  constructor(
+    private readonly outcome: Deferred.Deferred<Outcome>,
+    private readonly complete: Effect.Effect<void, AgentEffectFailure>,
+  ) {}
+
+  finish(outcome: Outcome): Promise<void> {
+    return runAgentEffect(
+      Deferred.succeed(this.outcome, outcome).pipe(
+        Effect.andThen(this.complete),
+      ),
+    )
+  }
+
+  fail(outcome: Outcome, error: unknown, message: string): Promise<never> {
+    const { complete, outcome: lifecycleOutcome } = this
+    return runAgentEffect(Effect.gen(function* () {
+      const started = yield* Deferred.succeed(lifecycleOutcome, outcome)
+      const exit = yield* Effect.exit(complete)
+      if (Exit.isFailure(exit) && started) {
+        const causes = agentEffectCauseValues(exit.cause)
+        const finishError = causes.length === 1
+          ? causes[0]
+          : new AggregateError(causes, "[vitehub] Agent finish lifecycle failed for multiple reasons.")
+        return yield* Effect.fail(new AgentEffectFailure({
+          cause: new AggregateError([error, finishError], message),
+          operation: "Agent.InvocationLifecycle.fail",
+        }))
+      }
+      return yield* Effect.fail(new AgentEffectFailure({
+        cause: error,
+        operation: "Agent.InvocationLifecycle.fail",
+      }))
+    }))
+  }
+}
+
+export function openAgentInvocationLifecycle<Outcome>(
+  finish: (outcome: Outcome) => Promise<void>,
+): Promise<AgentInvocationLifecycle<Outcome>> {
+  return runAgentEffect(makeInvocationLifecycle(finish))
+}

--- a/packages/agent/src/internal/invocation-lifecycle.ts
+++ b/packages/agent/src/internal/invocation-lifecycle.ts
@@ -7,54 +7,56 @@ import {
   tryAgentPromise,
 } from "./effect-runtime.ts"
 
+export interface AgentInvocationLifecycle<Outcome> {
+  fail: (outcome: Outcome, error: unknown, message: string) => Promise<never>
+  finish: (outcome: Outcome) => Promise<void>
+}
+
+const failInvocation = Effect.fn("Agent.InvocationLifecycle.fail")(function* <Outcome>(
+  deferred: Deferred.Deferred<Outcome>,
+  complete: Effect.Effect<void, AgentEffectFailure>,
+  outcome: Outcome,
+  error: unknown,
+  message: string,
+) {
+  const started = yield* Deferred.succeed(deferred, outcome)
+  const exit = yield* Effect.exit(complete)
+  if (Exit.isFailure(exit) && started) {
+    const causes = agentEffectCauseValues(exit.cause)
+    const finishError = causes.length === 1
+      ? causes[0]
+      : new AggregateError(causes, "[vitehub] Agent finish lifecycle failed for multiple reasons.")
+    return yield* Effect.fail(new AgentEffectFailure({
+      cause: new AggregateError([error, finishError], message),
+      operation: "Agent.InvocationLifecycle.fail",
+    }))
+  }
+  return yield* Effect.fail(new AgentEffectFailure({
+    cause: error,
+    operation: "Agent.InvocationLifecycle.fail",
+  }))
+})
+
 const makeInvocationLifecycle = Effect.fn("Agent.InvocationLifecycle.open")(function* <Outcome>(
   finish: (outcome: Outcome) => Promise<void>,
 ) {
-  const outcome = yield* Deferred.make<Outcome>()
+  const deferred = yield* Deferred.make<Outcome>()
   const complete = yield* Effect.cached(
-    Deferred.await(outcome).pipe(
+    Deferred.await(deferred).pipe(
       Effect.flatMap(value => tryAgentPromise("Agent.InvocationLifecycle.finish", () => finish(value))),
     ),
   )
-  return new AgentInvocationLifecycle(outcome, complete)
-})
-
-export class AgentInvocationLifecycle<Outcome> {
-  constructor(
-    private readonly outcome: Deferred.Deferred<Outcome>,
-    private readonly complete: Effect.Effect<void, AgentEffectFailure>,
-  ) {}
-
-  finish(outcome: Outcome): Promise<void> {
-    return runAgentEffect(
-      Deferred.succeed(this.outcome, outcome).pipe(
-        Effect.andThen(this.complete),
+  return {
+    fail: (outcome: Outcome, error: unknown, message: string) => runAgentEffect(
+      failInvocation(deferred, complete, outcome, error, message),
+    ),
+    finish: (outcome: Outcome) => runAgentEffect(
+      Deferred.succeed(deferred, outcome).pipe(
+        Effect.andThen(complete),
       ),
-    )
-  }
-
-  fail(outcome: Outcome, error: unknown, message: string): Promise<never> {
-    const { complete, outcome: lifecycleOutcome } = this
-    return runAgentEffect(Effect.gen(function* () {
-      const started = yield* Deferred.succeed(lifecycleOutcome, outcome)
-      const exit = yield* Effect.exit(complete)
-      if (Exit.isFailure(exit) && started) {
-        const causes = agentEffectCauseValues(exit.cause)
-        const finishError = causes.length === 1
-          ? causes[0]
-          : new AggregateError(causes, "[vitehub] Agent finish lifecycle failed for multiple reasons.")
-        return yield* Effect.fail(new AgentEffectFailure({
-          cause: new AggregateError([error, finishError], message),
-          operation: "Agent.InvocationLifecycle.fail",
-        }))
-      }
-      return yield* Effect.fail(new AgentEffectFailure({
-        cause: error,
-        operation: "Agent.InvocationLifecycle.fail",
-      }))
-    }))
-  }
-}
+    ),
+  } satisfies AgentInvocationLifecycle<Outcome>
+})
 
 export function openAgentInvocationLifecycle<Outcome>(
   finish: (outcome: Outcome) => Promise<void>,

--- a/packages/agent/test/invocation-lifecycle.test.ts
+++ b/packages/agent/test/invocation-lifecycle.test.ts
@@ -41,7 +41,9 @@ vi.mock("@ai-sdk/harness/agent", () => ({
 type DriverKind = "harness" | "model" | "run"
 type InvocationForm = "run" | "stream"
 type LifecycleScenario = {
+  close?: () => void | Promise<void>
   execute?: (events: string[]) => unknown
+  finish?: () => void | Promise<void>
   input?: (events: string[]) => Response
 }
 
@@ -86,11 +88,13 @@ async function createLifecycleProbe(
   const driver = createInvocationDriverFixture(kind, form)
   const close = vi.fn(() => {
     events.push("close")
+    return scenario.close?.()
   })
   let finishError: unknown
   const finish = vi.fn((event) => {
     finishError = event.error
     events.push("finish")
+    return scenario.finish?.()
   })
   driver.execute.mockImplementation(() => scenario.execute?.(events))
   const agent = defineAgent({
@@ -108,6 +112,11 @@ async function createLifecycleProbe(
     execute: driver.execute,
     get finishError() {
       return finishError
+    },
+    expectCloseFailed(expectedEvents: string[]) {
+      expect(events).toEqual(expectedEvents)
+      expect(close).toHaveBeenCalledOnce()
+      expect(finish).not.toHaveBeenCalled()
     },
     expectFinished(expectedEvents: string[]) {
       expect(events).toEqual(expectedEvents)
@@ -157,6 +166,62 @@ describe("Agent Invocation Interface lifecycle", () => {
     await expect(runAgent(probe.agent, createInvocationRuntime(), { prompt: "hello" })).rejects.toBe(failure)
     probe.expectFinished(["driver", "close", "finish"])
     expect(probe.finishError).toBe(failure)
+  })
+
+  it.each(driverKinds)("preserves the %s finish failure identity after successful execution", async (kind) => {
+    const { runAgent } = await import("../src/index.ts")
+    const finishFailure = new Error(`${kind} finish failed`)
+    const probe = await createLifecycleProbe(kind, "run", {
+      execute(events) {
+        events.push("driver")
+        return { finishReason: "stop", text: "ok" }
+      },
+      finish() {
+        throw finishFailure
+      },
+    })
+
+    await expect(runAgent(probe.agent, createInvocationRuntime(), { prompt: "hello" })).rejects.toBe(finishFailure)
+    probe.expectFinished(["driver", "close", "finish"])
+  })
+
+  it.each(driverKinds)("orders the %s execution and finish failures without losing identity", async (kind) => {
+    const { runAgent } = await import("../src/index.ts")
+    const executionFailure = new Error(`${kind} execution failed`)
+    const finishFailure = new Error(`${kind} finish failed`)
+    const probe = await createLifecycleProbe(kind, "run", {
+      execute(events) {
+        events.push("driver")
+        throw executionFailure
+      },
+      finish() {
+        throw finishFailure
+      },
+    })
+
+    const error = await runAgent(probe.agent, createInvocationRuntime(), { prompt: "hello" }).catch(error => error) as AggregateError
+    expect(error).toBeInstanceOf(AggregateError)
+    expect(error.message).toBe("[vitehub] Agent run failed and finish lifecycle also failed.")
+    expect(error.errors).toEqual([executionFailure, finishFailure])
+    probe.expectFinished(["driver", "close", "finish"])
+    expect(probe.finishError).toBe(executionFailure)
+  })
+
+  it("preserves a close failure instead of aggregating it with itself", async () => {
+    const { runAgent } = await import("../src/index.ts")
+    const closeFailure = new Error("close failed")
+    const probe = await createLifecycleProbe("run", "run", {
+      close() {
+        throw closeFailure
+      },
+      execute(events) {
+        events.push("driver")
+        return "ok"
+      },
+    })
+
+    await expect(runAgent(probe.agent, createInvocationRuntime(), { prompt: "hello" })).rejects.toBe(closeFailure)
+    probe.expectCloseFailed(["driver", "close"])
   })
 
   it.each(driverKinds)("defers %s stream cleanup and finish until early termination", async (kind) => {
@@ -221,5 +286,23 @@ describe("Agent Invocation Interface lifecycle", () => {
 
     await expect(response.text()).resolves.toBe("handled")
     probe.expectFinished(["input", "close", "finish"])
+  })
+})
+
+describe("Agent Invocation lifecycle completion", () => {
+  it("runs the first concurrent finish exactly once", async () => {
+    const { openAgentInvocationLifecycle } = await import("../src/internal/invocation-lifecycle.ts")
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const finish = vi.fn(async () => { await gate })
+    const lifecycle = await openAgentInvocationLifecycle(finish)
+
+    const first = lifecycle.finish("first")
+    const second = lifecycle.finish("second")
+    await vi.waitFor(() => expect(finish).toHaveBeenCalledOnce())
+    release()
+
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined])
+    expect(finish).toHaveBeenCalledWith("first")
   })
 })

--- a/packages/agent/test/public-api.test.ts
+++ b/packages/agent/test/public-api.test.ts
@@ -2,6 +2,31 @@ import { readFile, readdir } from "node:fs/promises"
 
 import { expect, it } from "vitest"
 
+const effectImportPattern = /(?:from\s*|import\()\s*["']effect(?:\/[^"']+)?["']/
+
+async function readBundleGraph(entry: URL): Promise<string> {
+  const sources: string[] = []
+  const visited = new Set<string>()
+
+  async function visit(file: URL): Promise<void> {
+    if (visited.has(file.href)) return
+    visited.add(file.href)
+    const source = await readFile(file, "utf8").catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined
+      throw error
+    })
+    if (source === undefined) return
+    sources.push(source)
+    for (const match of source.matchAll(/(?:from\s*|import\()\s*["']([^"']+)["']/g)) {
+      const specifier = match[1]
+      if (specifier?.startsWith(".")) await visit(new URL(specifier, file))
+    }
+  }
+
+  await visit(entry)
+  return sources.join("\n")
+}
+
 it("keeps Effect out of published Agent declarations", async () => {
   const dist = new URL("../dist/", import.meta.url)
   const declarations = await Promise.all(
@@ -10,5 +35,12 @@ it("keeps Effect out of published Agent declarations", async () => {
       .map(path => readFile(new URL(path, dist), "utf8")),
   )
 
-  expect(declarations.join("\n")).not.toMatch(/(?:from\s*|import\()\s*["']effect["']/)
+  expect(declarations.join("\n")).not.toMatch(effectImportPattern)
+})
+
+it("keeps Effect out of provider and browser bundle graphs", async () => {
+  for (const entry of ["cloudflare.js", "cloudflare/state.js", "messages.js", "output.js"]) {
+    const bundle = await readBundleGraph(new URL(`../dist/${entry}`, import.meta.url))
+    expect(bundle, `${entry} must remain Effect-free`).not.toMatch(effectImportPattern)
+  }
 })


### PR DESCRIPTION
Agent Invocation finalization now has one Effect-cached completion that owns the first finish outcome and shares its result with every later caller. The public Promise, `Response`, and async-iterable APIs remain unchanged; close still precedes finish hooks, Workspace commits still occur only after successful finalization, and original failures retain identity unless a separately failing finish lifecycle requires the existing ordered `AggregateError`.

The public artifact guard rejects both `effect` and `effect/*` imports from every emitted Agent declaration. It also walks the built Cloudflare provider and browser-safe messages/output bundle graphs, so a future shared-chunk edge that pulls Effect into those artifacts fails the package suite.

Validation: the Agent build, publint, and typecheck pass. The restricted run passed 1,266 of 1,268 tests; its only failures were the two localhost listeners blocked by `listen EPERM`, and both affected files then passed 21/21 with localhost permission (1,287 passing test executions across the two runs).

EFFECT ADOPTION STATUS
  seam: Agent Invocation finalization
  decision: adopted
  public API: unchanged Promise, Response, and async-iterable contracts
  boundary: packages/agent/src/internal/effect-runtime.ts
  typed failures: AgentEffectFailure wraps original finish causes; Exit/Cause triage restores exact public identities and contains defects/interruption without FiberFailure
  resources/fibers: Deferred first outcome plus cached completion; no long-lived fibers
  deleted: manual close-once wrapper, finishFailedAgentInvocation ladder, finishLifecycleStarted boolean, and hand-written finish-failure aggregation
  artifacts: declarations and provider/browser bundle graphs remain Effect-free
  todos: 0
  confidence: high

DEPENDENCY STATUS
  #673: merged into the foundation branch
  #670: open at accepted final head 9331ce1c421ea0240c4c835e2b97332f43396c7e; this draft remains stacked on refactor/effect-error-contract from historical ancestor 4898061
