### PR TITLE
refactor(agent): centralize stream lifetimes with Effect

### DIFF
--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -14,8 +14,12 @@ import {
   resolveInputAgentInvoker,
 } from "./invoker.ts"
 import { runObservedAgentHook } from "./hooks.ts"
-import { nextWithAbort } from "./internal/abortable-stream.ts"
 import { openAgentCapabilityScope } from "./internal/capability-scope.ts"
+import {
+  withAgentReadableStreamCleanup,
+  withAgentStreamCleanup,
+} from "./internal/stream-lifetime.ts"
+import type { AgentStreamCleanupOutcome } from "./internal/stream-lifetime.ts"
 import type {
   AgentCapabilitiesInput,
   AgentCapabilitiesResolverContext,
@@ -1368,115 +1372,22 @@ export async function createAgentInvocationExtensions(
   return extensions
 }
 
-type CapabilityCleanupOutcome =
-  | { failed: false }
-  | { error: unknown, failed: true }
-
-async function closeCapabilityStreamIterator(
-  iterator: AsyncIterator<unknown>,
-  completed: boolean,
-  outcome: CapabilityCleanupOutcome,
-  close: (outcome: CapabilityCleanupOutcome) => Promise<void>,
-): Promise<void> {
-  if (!completed) {
-    let returnTask: Promise<IteratorResult<unknown>> | undefined
-    try {
-      returnTask = iterator.return?.()
-    }
-    catch (returnError) {
-      returnTask = Promise.reject(returnError)
-    }
-    if (outcome.failed) void returnTask?.catch(() => {})
-    else {
-      try {
-        await returnTask
-      }
-      catch (returnError) {
-        try {
-          await close({ error: returnError, failed: true })
-        }
-        catch (closeError) {
-          throw new AggregateError([returnError, closeError], "[vitehub] Agent stream return failed and finish lifecycle also failed.")
-        }
-        throw returnError
-      }
-    }
-  }
-  await close(outcome)
-}
-
 export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(
   stream: T,
-  close: (outcome: CapabilityCleanupOutcome) => Promise<void>,
+  close: (outcome: AgentStreamCleanupOutcome) => Promise<void>,
   options: { abortSignal?: AbortSignal } = {},
 ): AsyncIterable<unknown> {
-  return (async function* () {
-    const iterator = stream[Symbol.asyncIterator]()
-    let completed = false
-    let error: unknown
-    let failed = false
-    try {
-      for (;;) {
-        const result = await nextWithAbort(iterator.next(), options.abortSignal, "[vitehub] Agent Invocation stream aborted.")
-        if (result.done) {
-          completed = true
-          break
-        }
-        yield result.value
-      }
-    }
-    catch (caught) {
-      failed = true
-      error = caught
-      throw caught
-    }
-    finally {
-      await closeCapabilityStreamIterator(iterator, completed, failed ? { error, failed: true } : { failed: false }, close)
-    }
-  })()
+  return withAgentStreamCleanup(stream, close, {
+    ...options,
+    returnFailureMessage: "[vitehub] Agent stream return failed and finish lifecycle also failed.",
+  })
 }
 
-export function withResponseCleanup(response: Response, close: (outcome: CapabilityCleanupOutcome) => Promise<void>): Response | Promise<Response> {
+export function withResponseCleanup(response: Response, close: (outcome: AgentStreamCleanupOutcome) => Promise<void>): Response | Promise<Response> {
   if (!response.body) {
     return close({ failed: false }).then(() => response)
   }
-  const reader = response.body.getReader()
-  let closed = false
-  async function closeOnce(outcome: CapabilityCleanupOutcome = { failed: false }) {
-    if (closed) return
-    closed = true
-    await close(outcome)
-  }
-  const wrapped = new Response(new ReadableStream({
-    async cancel(reason) {
-      let cancelOutcome: CapabilityCleanupOutcome = reason === undefined ? { failed: false } : { error: reason, failed: true }
-      try {
-        await reader.cancel(reason)
-      }
-      catch (error) {
-        cancelOutcome = { error, failed: true }
-        throw error
-      }
-      finally {
-        await closeOnce(cancelOutcome)
-      }
-    },
-    async pull(controller) {
-      try {
-        const result = await reader.read()
-        if (result.done) {
-          await closeOnce()
-          controller.close()
-          return
-        }
-        controller.enqueue(result.value)
-      }
-      catch (error) {
-        await closeOnce({ error, failed: true })
-        throw error
-      }
-    },
-  }), response)
+  const wrapped = new Response(withAgentReadableStreamCleanup(response.body, close), response)
   Object.defineProperties(wrapped, {
     redirected: { configurable: true, enumerable: true, value: response.redirected },
     type: { configurable: true, enumerable: true, value: response.type },

--- a/packages/agent/src/internal/stream-lifetime.ts
+++ b/packages/agent/src/internal/stream-lifetime.ts
@@ -1,0 +1,174 @@
+import { Deferred, Effect, Stream } from "effect"
+
+import { nextWithAbort } from "./abortable-stream.ts"
+import { runAgentEffect, tryAgentPromise } from "./effect-runtime.ts"
+
+export type AgentStreamCleanupOutcome =
+  | { failed: false }
+  | { error: unknown, failed: true }
+
+interface AgentStreamIterator<T> extends AsyncIterator<T> {
+  cancel(reason?: unknown): Promise<void>
+}
+
+const cleanupFailureMessage = "[vitehub] Agent stream failed and finish lifecycle also failed."
+
+async function openAgentStream<T>(
+  source: AsyncIterable<T>,
+  cleanup: (outcome: AgentStreamCleanupOutcome) => Promise<void>,
+  options: {
+    abortSignal?: AbortSignal
+    onCancel?: (reason: unknown) => void
+    returnFailureMessage: string
+  },
+) {
+  const sourceIterator = source[Symbol.asyncIterator]()
+  let completed = false
+  let returned = false
+  let returnError: unknown
+  let suppressReturnFailure = false
+  const returnSource = async () => {
+    if (completed || returned || !sourceIterator.return) return
+    returned = true
+    try {
+      await sourceIterator.return()
+    }
+    catch (error) {
+      if (!suppressReturnFailure) returnError = error
+    }
+  }
+  const managed: AsyncIterable<T> = { [Symbol.asyncIterator]: () => ({
+    async next() {
+      const result = await sourceIterator.next()
+      if (result.done) completed = true
+      return result
+    },
+    async return() {
+      await returnSource()
+      return { done: true, value: undefined }
+    },
+  }) }
+  const iterator = Stream.toAsyncIterable(
+    Stream.fromAsyncIterable(managed, error => error),
+  )[Symbol.asyncIterator]()
+  const completion = await runAgentEffect(Effect.gen(function* () {
+    const outcome = yield* Deferred.make<AgentStreamCleanupOutcome>()
+    const complete = yield* Effect.cached(Deferred.await(outcome).pipe(
+      Effect.flatMap(value => tryAgentPromise("Agent.Stream.cleanup", () => cleanup(value))),
+    ))
+    return { complete, outcome }
+  }))
+  let finished = false
+
+  const finish = async (outcome: AgentStreamCleanupOutcome, throwOutcome: boolean, message: string) => {
+    try {
+      await runAgentEffect(Deferred.succeed(completion.outcome, outcome).pipe(Effect.andThen(completion.complete)))
+    }
+    catch (cleanupError) {
+      if (throwOutcome && outcome.failed) throw new AggregateError([outcome.error, cleanupError], message)
+      throw cleanupError
+    }
+    if (throwOutcome && outcome.failed) throw outcome.error
+  }
+  const close = async () => {
+    await iterator.return?.()
+    await returnSource()
+    if (returnError !== undefined) throw returnError
+  }
+
+  return {
+    async cancel(reason?: unknown) {
+      if (finished) return
+      finished = true
+      options.onCancel?.(reason)
+      try {
+        await close()
+      }
+      catch (error) {
+        await finish({ error, failed: true }, true, options.returnFailureMessage)
+      }
+      await finish(reason === undefined ? { failed: false } : { error: reason, failed: true }, false, cleanupFailureMessage)
+    },
+    async next(): Promise<IteratorResult<T>> {
+      if (finished) return { done: true, value: undefined }
+      let result: IteratorResult<T>
+      try {
+        result = await nextWithAbort(iterator.next(), options.abortSignal, "[vitehub] Agent Invocation stream aborted.")
+      }
+      catch (error) {
+        finished = true
+        suppressReturnFailure = true
+        await close().catch(() => {})
+        await finish({ error, failed: true }, true, cleanupFailureMessage)
+        throw error
+      }
+      if (!result.done) return result
+      finished = true
+      await close()
+      await finish({ failed: false }, false, cleanupFailureMessage)
+      return result
+    },
+  }
+}
+
+export function withAgentStreamCleanup<T>(
+  source: AsyncIterable<T>,
+  cleanup: (outcome: AgentStreamCleanupOutcome) => Promise<void>,
+  options: {
+    abortSignal?: AbortSignal
+    onCancel?: (reason: unknown) => void
+    returnFailureMessage?: string
+  } = {},
+): AsyncIterable<T> {
+  let session: ReturnType<typeof openAgentStream<T>> | undefined
+  const open = () => session ??= openAgentStream(source, cleanup, {
+    returnFailureMessage: options.returnFailureMessage ?? cleanupFailureMessage,
+    ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+    ...(options.onCancel ? { onCancel: options.onCancel } : {}),
+  })
+  const iterator: AgentStreamIterator<T> = {
+    cancel: reason => open().then(value => value.cancel(reason)),
+    next: () => open().then(value => value.next()),
+    async return() {
+      await iterator.cancel()
+      return { done: true, value: undefined }
+    },
+  }
+  return { [Symbol.asyncIterator]: () => iterator }
+}
+
+export function withAgentReadableStreamCleanup<T>(
+  stream: ReadableStream<T>,
+  cleanup: (outcome: AgentStreamCleanupOutcome) => Promise<void>,
+  onChunk?: (chunk: T) => void,
+): ReadableStream<T> {
+  const reader = stream.getReader()
+  let cancelReason: unknown
+  const source: AsyncIterable<T> = { [Symbol.asyncIterator]: () => ({
+    async next() {
+      const result = await reader.read()
+      if (!result.done) onChunk?.(result.value)
+      return result
+    },
+    async return() {
+      await reader.cancel(cancelReason)
+      return { done: true, value: undefined }
+    },
+  }) }
+  const iterator = withAgentStreamCleanup(source, cleanup, {
+    onCancel: reason => { cancelReason = reason },
+  })[Symbol.asyncIterator]() as AgentStreamIterator<T>
+  return new ReadableStream<T>({
+    cancel: reason => iterator.cancel(reason),
+    async pull(controller) {
+      try {
+        const result = await iterator.next()
+        if (result.done) controller.close()
+        else controller.enqueue(result.value)
+      }
+      catch (error) {
+        controller.error(error)
+      }
+    },
+  }, { highWaterMark: 0 })
+}

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -1,4 +1,7 @@
 import { isAsyncIterable } from "./internal/stream-result.ts"
+import {
+  withAgentReadableStreamCleanup,
+} from "./internal/stream-lifetime.ts"
 import { usageRecordFromStreamChunk } from "./agent-output.ts"
 
 import type { AgentUsageRecord, MaybePromise } from "./types.ts"
@@ -13,9 +16,7 @@ interface AgentUIMessageStreamWriter {
   write(event: unknown): void
 }
 
-type StreamCleanupOutcome =
-  | { failed: false }
-  | { error: unknown, failed: true }
+import type { AgentStreamCleanupOutcome as StreamCleanupOutcome } from "./internal/stream-lifetime.ts"
 
 const uiMessageStreamHeaders = {
   "cache-control": "no-cache",
@@ -97,44 +98,7 @@ export function withReadableStreamCleanup<T>(
   cleanup: (outcome: StreamCleanupOutcome) => Promise<void>,
   options: { onChunk?: (chunk: T) => void } = {},
 ): ReadableStream<T> {
-  const reader = stream.getReader()
-  let cleaned = false
-  const runCleanup = async (outcome: StreamCleanupOutcome = { failed: false }) => {
-    if (cleaned) return
-    cleaned = true
-    await cleanup(outcome)
-  }
-  return new ReadableStream<T>({
-    async pull(controller) {
-      try {
-        const result = await reader.read()
-        if (result.done) {
-          await runCleanup()
-          controller.close()
-          return
-        }
-        options.onChunk?.(result.value)
-        controller.enqueue(result.value)
-      }
-      catch (error) {
-        await runCleanup({ error, failed: true })
-        controller.error(error)
-      }
-    },
-    async cancel(reason) {
-      let outcome: StreamCleanupOutcome = reason === undefined ? { failed: false } : { error: reason, failed: true }
-      try {
-        await reader.cancel(reason)
-      }
-      catch (error) {
-        outcome = { error, failed: true }
-        throw error
-      }
-      finally {
-        await runCleanup(outcome)
-      }
-    },
-  })
+  return withAgentReadableStreamCleanup(stream, cleanup, options.onChunk)
 }
 
 function textFromRenderedOutput(rendered: unknown): string | undefined {

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -1807,7 +1807,8 @@ describe("agent capability runtime", () => {
   it("closes streamed output as failed when source iterator return rejects", async () => {
     const { withCapabilityCleanup } = await import("../src/capability-runtime.ts")
     const returnError = new Error("return failed")
-    const close = vi.fn(async () => {})
+    const closeError = new Error("close failed")
+    const close = vi.fn(async () => { throw closeError })
     const iterator = {
       next: vi.fn(async () => ({ done: false as const, value: "hello" })),
       return: vi.fn(async () => { throw returnError }),
@@ -1820,7 +1821,9 @@ describe("agent capability runtime", () => {
       for await (const _chunk of withCapabilityCleanup(stream, close)) break
     }
 
-    await expect(consume()).rejects.toThrow("return failed")
+    const failure = await consume().catch(error => error) as AggregateError
+    expect(failure.message).toBe("[vitehub] Agent stream return failed and finish lifecycle also failed.")
+    expect(failure.errors).toEqual([returnError, closeError])
     expect(close).toHaveBeenCalledWith({ error: returnError, failed: true })
   })
 
@@ -1842,6 +1845,25 @@ describe("agent capability runtime", () => {
 
     await expect(consume()).rejects.toThrow("return failed")
     expect(close).toHaveBeenCalledWith({ error: returnError, failed: true })
+  })
+
+  it("preserves AbortSignal reasons while returning the source iterator", async () => {
+    const { withCapabilityCleanup } = await import("../src/capability-runtime.ts")
+    const abort = new AbortController()
+    const abortReason = new Error("client disconnected")
+    const close = vi.fn(async () => {})
+    const iterator = {
+      next: vi.fn(() => new Promise<IteratorResult<unknown>>(() => {})),
+      return: vi.fn(async () => ({ done: true as const, value: undefined })),
+    }
+    const stream = withCapabilityCleanup({ [Symbol.asyncIterator]: () => iterator }, close, { abortSignal: abort.signal })
+    const next = stream[Symbol.asyncIterator]().next()
+
+    abort.abort(abortReason)
+
+    await expect(next).rejects.toBe(abortReason)
+    expect(iterator.return).toHaveBeenCalledTimes(1)
+    expect(close).toHaveBeenCalledWith({ error: abortReason, failed: true })
   })
 
   it("preserves read-only Response metadata while wrapping body cleanup", async () => {


### PR DESCRIPTION
Replaces the three duplicated Agent stream, Response body, and UI stream cleanup wrappers with one scoped Effect Stream boundary. The probe preserves lazy pull/backpressure, Response metadata, consumer cancellation reasons, AbortSignal reason identity, source `return()` exactly once, and ordered primary-plus-cleanup aggregation without exposing Effect or FiberFailure through the public API.

EFFECT ADOPTION STATUS

BLOCKED. Effect v4’s Web Stream adapters cannot preserve this contract directly: `Stream.toReadableStream` drops `cancel(reason)`, `Stream.fromReadableStream` cancels without the caller reason, and the async-iterable adapter does not initialize its source until the first pull. Preserving never-pulled cancellation and raw return/cancel error identity therefore requires a 174-line ViteHub bridge; the complete diff is 215 additions and 144 deletions, including 24 lines of new contract tests. That does not pass the migration report’s pay-rent gate, so this draft should not merge unless Effect gains the missing interop or the boundary can be reduced materially.

The focused capability-runtime and runtime suites pass, Agent typecheck passes, the Agent build and publint pass, and generated declarations contain no `effect` import or `FiberFailure`. Remote [CI run 29632376915](https://github.com/vite-hub/vitehub/actions/runs/29632376915) passed lint, typecheck, contracts, the tutorial fixture, provider verification for Vercel/Cloudflare/Netlify, consumer tests, and docs. Its sole failure was the unrelated `local-sandbox.test.ts` case “preserves roots owned by live processes”: 1,267 tests passed and that test lost `/tmp/vitehub-harness/owner-4243-…/keep.txt`. This branch changes only capability cleanup, the new stream-lifetime helper, stream-output cleanup, and their focused test, so no sandbox fix belongs here; the failing test uses a fixed fake PID under a temp directory shared by parallel workers and is susceptible to cross-worker reclamation.

DEPENDENCY STATUS

#677: open; this draft is stacked on `refactor/effect-agent-invocation-lifecycle` at `e20dcba`.

#670: open; inherited through #677.