### PR TITLE
refactor(workspace): scope trusted-host sessions with Effect

### DIFF
--- a/fallow.toml
+++ b/fallow.toml
@@ -146,6 +146,10 @@ files = [
 rules = { "unused-class-members" = "off" }
 
 [[overrides]]
+files = ["packages/workspace/src/core/errors.ts"]
+rules = { "unused-class-members" = "off" }
+
+[[overrides]]
 files = ["packages/workspace/src/storage/memory-fs.ts"]
 rules = { "unused-class-members" = "off" }
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -147,6 +147,7 @@
     "@vitejs/devtools-kit": "catalog:vite",
     "chat": "catalog:chat",
     "comark": "catalog:ui",
+    "effect": "catalog:effect",
     "esbuild": "catalog:esbuild-v27"
   },
   "devDependencies": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -147,8 +147,7 @@
     "@vitejs/devtools-kit": "catalog:vite",
     "chat": "catalog:chat",
     "comark": "catalog:ui",
-    "esbuild": "catalog:esbuild-v27",
-    "effect": "catalog:effect"
+    "esbuild": "catalog:esbuild-v27"
   },
   "devDependencies": {
     "@ai-sdk/harness": "catalog:ai",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -147,8 +147,8 @@
     "@vitejs/devtools-kit": "catalog:vite",
     "chat": "catalog:chat",
     "comark": "catalog:ui",
-    "effect": "catalog:effect",
-    "esbuild": "catalog:esbuild-v27"
+    "esbuild": "catalog:esbuild-v27",
+    "effect": "catalog:effect"
   },
   "devDependencies": {
     "@ai-sdk/harness": "catalog:ai",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -147,7 +147,8 @@
     "@vitejs/devtools-kit": "catalog:vite",
     "chat": "catalog:chat",
     "comark": "catalog:ui",
-    "esbuild": "catalog:esbuild-v27"
+    "esbuild": "catalog:esbuild-v27",
+    "effect": "catalog:effect"
   },
   "devDependencies": {
     "@ai-sdk/harness": "catalog:ai",
@@ -229,6 +230,6 @@
     }
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.15.0"
   }
 }

--- a/packages/agent/src/capabilities/workspace-command.ts
+++ b/packages/agent/src/capabilities/workspace-command.ts
@@ -177,14 +177,22 @@ export function workspaceCommandTools(
         const commandTimeout = normalizeWorkspaceCommandTimeout(value.timeout, `${toolName} timeout`) ?? timeout ?? defaultWorkspaceCommandTimeout
         assertWorkspace(workspace, options.missingWorkspaceMessage || "[vitehub] workspaceShell({ commands }) requires an executable Workspace Session. Trusted workspace/session execution requires a writable workspace.")
         const session = await workspace.startSession()
+        let result
         try {
-          const result = await session.exec(value.command, args, { cwd, env, timeout: commandTimeout })
+          result = await session.exec(value.command, args, { cwd, env, timeout: commandTimeout })
           if (mode === "write" && result.exitCode === 0) await session.commit({ message: options.commitMessage || "workspace shell command" })
-          return result
         }
-        finally {
-          await session.close()
+        catch (error) {
+          try {
+            await session.close()
+          }
+          catch (closeError) {
+            throw new AggregateError([error, closeError], "[vitehub] Workspace command failed and session cleanup also failed.")
+          }
+          throw error
         }
+        await session.close()
+        return result
       },
     }),
   }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -15,6 +15,7 @@ import {
 } from "./invoker.ts"
 import { runObservedAgentHook } from "./hooks.ts"
 import { nextWithAbort } from "./internal/abortable-stream.ts"
+import { openAgentCapabilityScope } from "./internal/capability-scope.ts"
 import type {
   AgentCapabilitiesInput,
   AgentCapabilitiesResolverContext,
@@ -870,9 +871,8 @@ export async function resolveAgentCapabilities<
   let currentWorkspaceDefinition = invocationOptions.workspaceDefinition
   let messages = getRunMessages(currentInput)
   let tools: AgentToolSet | undefined
-  const closeCallbacks: Array<() => MaybePromise<void>> = []
   const driverContributions: AgentDriverContribution[] = []
-  let hasCloseWork = false
+  let capabilityScope: Awaited<ReturnType<typeof openAgentCapabilityScope>> | undefined
   const toolTransforms: AgentToolTransform[] = []
   const initialDeliveryEffectIntents = invocationContext.get<AgentChannelDeliveryEffectIntent[]>(channelDeliveryEffectsContextKey) || []
   const initialFinishDeliveryEffectProviders = invocationContext.get<AgentChannelDeliveryFinishEffect[]>(channelDeliveryFinishEffectsContextKey) || []
@@ -912,18 +912,8 @@ export async function resolveAgentCapabilities<
     })
   }
 
-  async function closeRegisteredCallbacks() {
-    const errors: unknown[] = []
-    for (const callback of [...closeCallbacks].reverse()) {
-      try {
-        await callback()
-      }
-      catch (error) {
-        errors.push(error)
-      }
-    }
-    if (errors.length === 1) throw errors[0]
-    if (errors.length > 1) throw new AggregateError(errors, "[vitehub] Multiple capability close callbacks failed.")
+  async function closeCapabilities() {
+    await capabilityScope?.close()
   }
 
   let invocationStarted = false
@@ -1148,8 +1138,8 @@ export async function resolveAgentCapabilities<
       }
 
       if (capability.close || options?.hooks?.["capability:close"] || options?.hooks?.["capability:close:after"]) {
-        hasCloseWork = true
-        closeCallbacks.push(async () => {
+        capabilityScope ??= await openAgentCapabilityScope()
+        await capabilityScope.add(async () => {
           await callHooks("capability:close", capabilityContext, options?.hooks)
           await capability.close?.(capabilityContext)
           await callHooks("capability:close:after", capabilityContext, options?.hooks)
@@ -1162,10 +1152,10 @@ export async function resolveAgentCapabilities<
         await callHooks(`capability:${phase}:after`, capabilityContext, options?.hooks)
         if (result instanceof Response) {
           return {
-            close: closeRegisteredCallbacks,
+            close: closeCapabilities,
             driverContributions,
             globalSkills,
-            hasCloseCallbacks: hasCloseWork,
+            hasCloseCallbacks: Boolean(capabilityScope),
             input: currentInput,
             messages,
             response: result,
@@ -1218,20 +1208,15 @@ export async function resolveAgentCapabilities<
     }
   }
   catch (error) {
-    try {
-      await closeRegisteredCallbacks()
-    }
-    catch (closeError) {
-      throw new AggregateError([error, closeError], "[vitehub] Capability setup failed and cleanup also failed.")
-    }
+    if (capabilityScope) return await capabilityScope.failSetup(error)
     throw error
   }
 
   return {
-    close: closeRegisteredCallbacks,
+    close: closeCapabilities,
     driverContributions,
     globalSkills,
-    hasCloseCallbacks: hasCloseWork,
+    hasCloseCallbacks: Boolean(capabilityScope),
     input: currentInput,
     messages,
     registries,

--- a/packages/agent/src/internal/capability-scope.ts
+++ b/packages/agent/src/internal/capability-scope.ts
@@ -1,0 +1,111 @@
+import { Effect, Exit, Ref, Scope } from "effect"
+
+import type { MaybePromise } from "../types.ts"
+
+import {
+  AgentEffectFailure,
+  agentEffectCauseValues,
+  runAgentEffect,
+  tryAgentPromise,
+} from "./effect-runtime.ts"
+
+const closeCapability = Effect.fn("Capability.close")(function* (
+  close: () => MaybePromise<void>,
+  failures: Ref.Ref<readonly unknown[]>,
+) {
+  const exit = yield* Effect.exit(tryAgentPromise("Capability.close", () => close()))
+  if (Exit.isFailure(exit)) {
+    const causes = agentEffectCauseValues(exit.cause)
+    yield* Ref.update(failures, current => [...current, ...causes])
+  }
+})
+
+const addCapability = Effect.fn("Capability.Scope.add")(function* (
+  scope: Scope.Closeable,
+  failures: Ref.Ref<readonly unknown[]>,
+  close: () => MaybePromise<void>,
+) {
+  yield* Scope.provide(
+    Effect.acquireRelease(
+      Effect.succeed(close),
+      registered => closeCapability(registered, failures),
+    ),
+    scope,
+  )
+})
+
+const closeCapabilityScope = Effect.fn("Capability.Scope.close")(function* (
+  scope: Scope.Closeable,
+  failures: Ref.Ref<readonly unknown[]>,
+) {
+  yield* Scope.close(scope, Exit.void)
+  const causes = yield* Ref.get(failures)
+  if (causes.length === 1) {
+    return yield* Effect.fail(
+      new AgentEffectFailure({ cause: causes[0], operation: "Capability.Scope.close" }),
+    )
+  }
+  if (causes.length > 1) {
+    return yield* Effect.fail(
+      new AgentEffectFailure({
+        cause: new AggregateError(causes, "[vitehub] Multiple capability close callbacks failed."),
+        operation: "Capability.Scope.close",
+      }),
+    )
+  }
+})
+
+const failCapabilitySetup = Effect.fn("Capability.Scope.failSetup")(function* (
+  scope: Scope.Closeable,
+  failures: Ref.Ref<readonly unknown[]>,
+  setupError: unknown,
+) {
+  const closeExit = yield* Effect.exit(closeCapabilityScope(scope, failures))
+  if (Exit.isFailure(closeExit)) {
+    const closeCauses = agentEffectCauseValues(closeExit.cause)
+    const closeError = closeCauses.length === 1
+      ? closeCauses[0]
+      : new AggregateError(closeCauses, "[vitehub] Multiple capability close callbacks failed.")
+    return yield* Effect.fail(
+      new AgentEffectFailure({
+        cause: new AggregateError(
+          [setupError, closeError],
+          "[vitehub] Capability setup failed and cleanup also failed.",
+        ),
+        operation: "Capability.Scope.failSetup",
+      }),
+    )
+  }
+  return yield* Effect.fail(
+    new AgentEffectFailure({ cause: setupError, operation: "Capability.Scope.failSetup" }),
+  )
+})
+
+const makeCapabilityScope = Effect.fn("Capability.Scope.open")(function* () {
+  const scope = yield* Scope.make("sequential")
+  const failures = yield* Ref.make<readonly unknown[]>([])
+  return new AgentCapabilityScope(scope, failures)
+})
+
+export class AgentCapabilityScope {
+  constructor(
+    private readonly scope: Scope.Closeable,
+    private readonly failures: Ref.Ref<readonly unknown[]>,
+  ) {}
+
+  add(close: () => MaybePromise<void>): Promise<void> {
+    return runAgentEffect(addCapability(this.scope, this.failures, close))
+  }
+
+  close(): Promise<void> {
+    return runAgentEffect(closeCapabilityScope(this.scope, this.failures))
+  }
+
+  failSetup(error: unknown): Promise<never> {
+    return runAgentEffect(failCapabilitySetup(this.scope, this.failures, error))
+  }
+}
+
+export function openAgentCapabilityScope(): Promise<AgentCapabilityScope> {
+  return runAgentEffect(makeCapabilityScope())
+}

--- a/packages/agent/src/internal/effect-runtime.ts
+++ b/packages/agent/src/internal/effect-runtime.ts
@@ -1,0 +1,47 @@
+import { Cause, Data, Effect, Exit } from "effect"
+
+export class AgentEffectFailure extends Data.TaggedError("AgentEffectFailure")<{
+  readonly cause: unknown
+  readonly operation: string
+}> {}
+
+function interruptionError(signal?: AbortSignal): unknown {
+  if (signal?.aborted && signal.reason !== undefined) return signal.reason
+  const error = new Error("[vitehub] Agent operation was interrupted.")
+  error.name = "AbortError"
+  return error
+}
+
+export function agentEffectCauseValues(
+  cause: Cause.Cause<unknown>,
+  signal?: AbortSignal,
+): unknown[] {
+  return cause.reasons.map(reason => {
+    if (Cause.isFailReason(reason)) {
+      return reason.error instanceof AgentEffectFailure ? reason.error.cause : reason.error
+    }
+    if (Cause.isDieReason(reason)) return reason.defect
+    return interruptionError(signal)
+  })
+}
+
+export function tryAgentPromise<A>(
+  operation: string,
+  evaluate: (signal: AbortSignal) => PromiseLike<A> | A,
+): Effect.Effect<A, AgentEffectFailure> {
+  return Effect.tryPromise({
+    catch: cause => new AgentEffectFailure({ cause, operation }),
+    try: signal => Promise.resolve(evaluate(signal)),
+  })
+}
+
+export async function runAgentEffect<A, E>(
+  effect: Effect.Effect<A, E>,
+  options: { signal?: AbortSignal } = {},
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(effect, options.signal ? { signal: options.signal } : undefined)
+  if (Exit.isSuccess(exit)) return exit.value
+  const causes = agentEffectCauseValues(exit.cause, options.signal)
+  if (causes.length === 1) throw causes[0]
+  throw new AggregateError(causes, "[vitehub] Agent operation failed for multiple reasons.")
+}

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -181,6 +181,67 @@ describe("agent capability runtime", () => {
     expect(order).toEqual(["resolve:first", "resolve:second", "close:second", "close:first"])
   })
 
+  it("preserves a single capability cleanup failure by identity", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const closeError = new Error("close failed")
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          close: async () => { throw closeError },
+          id: "failing-close",
+        }),
+      ],
+    }, runtime(), {})
+
+    await expect(resolved.close()).rejects.toBe(closeError)
+  })
+
+  it("aggregates capability cleanup failures in reverse acquisition order", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const firstError = new Error("first close failed")
+    const secondError = new Error("second close failed")
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          close: () => { throw firstError },
+          id: "first",
+        }),
+        defineCapability({
+          close: () => { throw secondError },
+          id: "second",
+        }),
+      ],
+    }, runtime(), {})
+
+    const closeError = await resolved.close().catch(error => error)
+    expect(closeError).toBeInstanceOf(AggregateError)
+    expect(closeError.message).toBe("[vitehub] Multiple capability close callbacks failed.")
+    expect(closeError.errors).toEqual([secondError, firstError])
+  })
+
+  it("preserves setup and cleanup failures in the existing aggregate contract", async () => {
+    const { defineCapability, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const setupError = new Error("setup failed")
+    const closeError = new Error("close failed")
+
+    const failure = await resolveAgentCapabilities({
+      capabilities: [
+        defineCapability({
+          close: () => { throw closeError },
+          id: "initialized",
+        }),
+        defineCapability({
+          id: "failing-setup",
+          resolve: () => { throw setupError },
+        }),
+      ],
+    }, runtime(), {}).catch(error => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect(failure.message).toBe("[vitehub] Capability setup failed and cleanup also failed.")
+    expect(failure.errors).toEqual([setupError, closeError])
+  })
+
   it("applies tool transforms, renderers, and input mutation", async () => {
     const {
       applyCapabilityToolTransforms,

--- a/packages/agent/test/public-api.test.ts
+++ b/packages/agent/test/public-api.test.ts
@@ -1,0 +1,14 @@
+import { readFile, readdir } from "node:fs/promises"
+
+import { expect, it } from "vitest"
+
+it("keeps Effect out of published Agent declarations", async () => {
+  const dist = new URL("../dist/", import.meta.url)
+  const declarations = await Promise.all(
+    (await readdir(dist, { recursive: true }))
+      .filter(path => path.endsWith(".d.ts"))
+      .map(path => readFile(new URL(path, dist), "utf8")),
+  )
+
+  expect(declarations.join("\n")).not.toMatch(/(?:from\s*|import\()\s*["']effect["']/)
+})

--- a/packages/agent/test/workspace-shell-capability.test.ts
+++ b/packages/agent/test/workspace-shell-capability.test.ts
@@ -162,4 +162,19 @@ describe("workspaceShell capability", () => {
     expect(session.commit).not.toHaveBeenCalled()
     expect(session.close).toHaveBeenCalledOnce()
   })
+
+  it("preserves execution and session cleanup failures", async () => {
+    const executionError = new Error("agent-browser failed")
+    const closeError = new Error("sandbox stop failed")
+    const session = workspaceSession()
+    session.exec.mockRejectedValueOnce(executionError)
+    session.close.mockRejectedValueOnce(closeError)
+    const { tools } = await capabilityTools(workspaceShell({ commands: ["agent-browser"] }), session)
+
+    const failure = await tools.workspace_exec!.execute?.({ command: "agent-browser" }).catch(error => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([executionError, closeError])
+    expect(session.close).toHaveBeenCalledOnce()
+  })
 })

--- a/packages/agent/test/workspace-shell-capability.test.ts
+++ b/packages/agent/test/workspace-shell-capability.test.ts
@@ -171,7 +171,13 @@ describe("workspaceShell capability", () => {
     session.close.mockRejectedValueOnce(closeError)
     const { tools } = await capabilityTools(workspaceShell({ commands: ["agent-browser"] }), session)
 
-    const failure = await tools.workspace_exec!.execute?.({ command: "agent-browser" }).catch(error => error)
+    let failure: unknown
+    try {
+      await tools.workspace_exec!.execute?.({ command: "agent-browser" })
+    }
+    catch (error) {
+      failure = error
+    }
 
     expect(failure).toBeInstanceOf(AggregateError)
     expect((failure as AggregateError).errors).toEqual([executionError, closeError])

--- a/packages/runtime/fixtures/published-types/consumer.ts
+++ b/packages/runtime/fixtures/published-types/consumer.ts
@@ -1,0 +1,15 @@
+import {
+  ApprovalRequiredError,
+  CapabilityNotFoundError,
+  ViteHubError,
+  type ViteHubErrorShape,
+} from "@vite-hub/runtime"
+
+const error = new ViteHubError("PROVIDER_FAILED", "The provider request failed.", {
+  details: { provider: "fixture" },
+  retryable: true,
+})
+
+error.toJSON() satisfies ViteHubErrorShape<"PROVIDER_FAILED", { provider: string }>
+new CapabilityNotFoundError("kv").code satisfies "CAPABILITY_NOT_FOUND"
+new ApprovalRequiredError({ id: "approval-1", state: "awaiting-approval" }).toJSON() satisfies ViteHubErrorShape<"APPROVAL_REQUIRED">

--- a/packages/runtime/fixtures/published-types/package.json
+++ b/packages/runtime/fixtures/published-types/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/runtime/fixtures/published-types/tsconfig.json
+++ b/packages/runtime/fixtures/published-types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "files": [
+    "consumer.ts"
+  ]
+}

--- a/packages/runtime/src/errors.ts
+++ b/packages/runtime/src/errors.ts
@@ -1,0 +1,55 @@
+export type ViteHubErrorDetail =
+  | boolean
+  | null
+  | number
+  | string
+  | readonly ViteHubErrorDetail[]
+  | { readonly [key: string]: ViteHubErrorDetail | undefined }
+
+export type ViteHubErrorDetails = Readonly<Record<string, ViteHubErrorDetail | undefined>>
+
+export interface ViteHubErrorShape<
+  TCode extends string = string,
+  TDetails extends ViteHubErrorDetails = ViteHubErrorDetails,
+> {
+  code: TCode
+  details?: TDetails
+  message: string
+  requestId?: string
+  retryable?: boolean
+}
+
+export interface ViteHubErrorOptions<TDetails extends ViteHubErrorDetails = ViteHubErrorDetails> extends ErrorOptions {
+  details?: TDetails
+  requestId?: string
+  retryable?: boolean
+}
+
+export class ViteHubError<
+  TCode extends string = string,
+  TDetails extends ViteHubErrorDetails = ViteHubErrorDetails,
+> extends Error {
+  readonly code: TCode
+  readonly details?: TDetails
+  readonly requestId?: string
+  readonly retryable?: boolean
+
+  constructor(code: TCode, message: string, options: ViteHubErrorOptions<TDetails> = {}) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause })
+    this.name = "ViteHubError"
+    this.code = code
+    this.details = options.details
+    this.requestId = options.requestId
+    this.retryable = options.retryable
+  }
+
+  toJSON(): ViteHubErrorShape<TCode, TDetails> {
+    return {
+      code: this.code,
+      ...(this.details === undefined ? {} : { details: this.details }),
+      message: this.message,
+      ...(this.requestId === undefined ? {} : { requestId: this.requestId }),
+      ...(this.retryable === undefined ? {} : { retryable: this.retryable }),
+    }
+  }
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -463,9 +463,15 @@ export class CapabilityNotFoundError extends ViteHubError<"CAPABILITY_NOT_FOUND"
   }
 }
 
+export interface CapabilityDeniedErrorOptions extends ErrorOptions {
+  safeReason?: string
+}
+
 export class CapabilityDeniedError extends ViteHubError<"CAPABILITY_DENIED", { capability: string, reason?: string }> {
-  constructor(name: string, reason?: string) {
+  constructor(name: string, options: CapabilityDeniedErrorOptions = {}) {
+    const reason = options.safeReason
     super("CAPABILITY_DENIED", `[vitehub:runtime] Capability "${name}" was denied${reason ? `: ${reason}` : "."}`, {
+      cause: options.cause,
       details: { capability: name, ...(reason === undefined ? {} : { reason }) },
       retryable: false,
     })

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,3 +1,13 @@
+import { ViteHubError } from "./errors.ts"
+
+export {
+  ViteHubError,
+  type ViteHubErrorDetail,
+  type ViteHubErrorDetails,
+  type ViteHubErrorOptions,
+  type ViteHubErrorShape,
+} from "./errors.ts"
+
 export type MaybePromise<T> = T | Promise<T>
 
 export type RuntimeWaitUntil = (task: Promise<unknown>) => void
@@ -443,25 +453,36 @@ export interface LeaseStore {
   acquire(key: string, options?: { owner?: string, ttl?: number }): MaybePromise<Lease>
 }
 
-export class CapabilityNotFoundError extends Error {
+export class CapabilityNotFoundError extends ViteHubError<"CAPABILITY_NOT_FOUND", { capability: string }> {
   constructor(name: string) {
-    super(`[vitehub:runtime] Capability "${name}" was not found.`)
+    super("CAPABILITY_NOT_FOUND", `[vitehub:runtime] Capability "${name}" was not found.`, {
+      details: { capability: name },
+      retryable: false,
+    })
     this.name = "CapabilityNotFoundError"
   }
 }
 
-export class CapabilityDeniedError extends Error {
+export class CapabilityDeniedError extends ViteHubError<"CAPABILITY_DENIED", { capability: string, reason?: string }> {
   constructor(name: string, reason?: string) {
-    super(`[vitehub:runtime] Capability "${name}" was denied${reason ? `: ${reason}` : "."}`)
+    super("CAPABILITY_DENIED", `[vitehub:runtime] Capability "${name}" was denied${reason ? `: ${reason}` : "."}`, {
+      details: { capability: name, ...(reason === undefined ? {} : { reason }) },
+      retryable: false,
+    })
     this.name = "CapabilityDeniedError"
   }
 }
 
-export class ApprovalRequiredError<TInput = unknown> extends Error {
+export class ApprovalRequiredError<TInput = unknown> extends ViteHubError<"APPROVAL_REQUIRED", { capability: string, requestId: string }> {
   request: ApprovalRequest<TInput>
 
   constructor(request: ApprovalRequest<TInput>) {
-    super(`[vitehub:runtime] Approval is required for "${request.capability || request.id}".`)
+    const capability = request.capability || request.id
+    super("APPROVAL_REQUIRED", `[vitehub:runtime] Approval is required for "${capability}".`, {
+      details: { capability, requestId: request.id },
+      requestId: request.id,
+      retryable: false,
+    })
     this.name = "ApprovalRequiredError"
     this.request = request
   }

--- a/packages/runtime/test/published-types.test.ts
+++ b/packages/runtime/test/published-types.test.ts
@@ -1,0 +1,30 @@
+import { execFile } from "node:child_process"
+import { copyFile, cp, mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { it } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const fixtureRoot = join(packageRoot, "fixtures", "published-types")
+const tsc = resolve(packageRoot, "../../node_modules/typescript/bin/tsc")
+
+it("publishes the ViteHub error contract", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-runtime-types-"))
+
+  try {
+    await cp(fixtureRoot, root, { recursive: true })
+    const installedPackageRoot = join(root, "node_modules", "@vite-hub", "runtime")
+    await mkdir(installedPackageRoot, { recursive: true })
+    await copyFile(join(packageRoot, "package.json"), join(installedPackageRoot, "package.json"))
+    await cp(join(packageRoot, "dist"), join(installedPackageRoot, "dist"), { recursive: true })
+
+    await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", root])
+  }
+  finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   ApprovalRequiredError,
   CapabilityDeniedError,
+  CapabilityNotFoundError,
   createExecutionContext,
   createTraceEventLog,
   deriveTraceRuns,
@@ -17,6 +18,7 @@ import {
   type ApprovalRequest,
   type LeaseStore,
   type RunLifecycleHooks,
+  ViteHubError,
 } from "../src/index.ts"
 
 describe("@vite-hub/runtime", () => {
@@ -66,7 +68,7 @@ describe("@vite-hub/runtime", () => {
     const request: ApprovalRequest = {
       capability: "refund",
       id: "approval-1",
-      input: { amount: 100 },
+      input: { amount: 100, token: "secret" },
       reason: "High-value refund",
       state: "awaiting-approval",
     }
@@ -76,8 +78,59 @@ describe("@vite-hub/runtime", () => {
       state: "approved",
     }
 
-    expect(new ApprovalRequiredError(request).request).toEqual(request)
+    const error = new ApprovalRequiredError(request)
+
+    expect(error.request).toEqual(request)
+    expect(error).toMatchObject({
+      code: "APPROVAL_REQUIRED",
+      details: { capability: "refund", requestId: "approval-1" },
+      requestId: "approval-1",
+      retryable: false,
+    })
+    expect(error.toJSON()).toEqual({
+      code: "APPROVAL_REQUIRED",
+      details: { capability: "refund", requestId: "approval-1" },
+      message: '[vitehub:runtime] Approval is required for "refund".',
+      requestId: "approval-1",
+      retryable: false,
+    })
+    expect(JSON.stringify(error)).not.toContain("secret")
     expect(decision).toMatchObject({ approved: true, state: "approved" })
+  })
+
+  it("serializes only the public ViteHub error contract", () => {
+    const cause = new Error("provider token: secret")
+    const error = Object.assign(new ViteHubError("PROVIDER_FAILED", "The provider request failed.", {
+      cause,
+      details: { provider: "fixture" },
+      requestId: "request-1",
+      retryable: true,
+    }), {
+      providerResponse: { authorization: "secret" },
+    })
+
+    expect(JSON.parse(JSON.stringify(error))).toEqual({
+      code: "PROVIDER_FAILED",
+      details: { provider: "fixture" },
+      message: "The provider request failed.",
+      requestId: "request-1",
+      retryable: true,
+    })
+    expect(JSON.stringify(error)).not.toContain("secret")
+    expect(error.cause).toBe(cause)
+  })
+
+  it("gives runtime capability failures stable codes and allowlisted details", () => {
+    expect(new CapabilityNotFoundError("kv")).toMatchObject({
+      code: "CAPABILITY_NOT_FOUND",
+      details: { capability: "kv" },
+      retryable: false,
+    })
+    expect(new CapabilityDeniedError("email", "Policy rejected this operation.")).toMatchObject({
+      code: "CAPABILITY_DENIED",
+      details: { capability: "email", reason: "Policy rejected this operation." },
+      retryable: false,
+    })
   })
 
   it("resolves policy decisions", async () => {

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -126,11 +126,22 @@ describe("@vite-hub/runtime", () => {
       details: { capability: "kv" },
       retryable: false,
     })
-    expect(new CapabilityDeniedError("email", "Policy rejected this operation.")).toMatchObject({
+    expect(new CapabilityDeniedError("email", { safeReason: "Policy rejected this operation." })).toMatchObject({
       code: "CAPABILITY_DENIED",
       details: { capability: "email", reason: "Policy rejected this operation." },
       retryable: false,
     })
+
+    const cause = new Error("policy secret: allow-internal-only")
+    const denied = new CapabilityDeniedError("email", { cause })
+    expect(denied.cause).toBe(cause)
+    expect(JSON.parse(JSON.stringify(denied))).toEqual({
+      code: "CAPABILITY_DENIED",
+      details: { capability: "email" },
+      message: '[vitehub:runtime] Capability "email" was denied.',
+      retryable: false,
+    })
+    expect(JSON.stringify(denied)).not.toContain("allow-internal-only")
   })
 
   it("resolves policy decisions", async () => {

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@vite-hub/kv": "workspace:*",
     "cron-schedule": "catalog:workflow",
-    "effect": "catalog:effect",
     "esbuild": "catalog:tooling"
   },
   "devDependencies": {

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@vite-hub/kv": "workspace:*",
     "cron-schedule": "catalog:workflow",
+    "effect": "catalog:effect",
     "esbuild": "catalog:tooling"
   },
   "devDependencies": {

--- a/packages/workspace/fixtures/published-types/consumer.ts
+++ b/packages/workspace/fixtures/published-types/consumer.ts
@@ -1,0 +1,13 @@
+import { ViteHubError, type ViteHubErrorShape } from "@vite-hub/runtime"
+import { WorkspaceNotFoundError, WorkspacePathError } from "@vite-hub/workspace"
+
+const missing = new WorkspaceNotFoundError("documents")
+missing.code satisfies "WORKSPACE_NOT_FOUND"
+missing.details satisfies { name: string } | undefined
+missing.toJSON() satisfies ViteHubErrorShape<"WORKSPACE_NOT_FOUND", { name: string }>
+missing satisfies ViteHubError<"WORKSPACE_NOT_FOUND", { name: string }>
+
+const invalidPath = new WorkspacePathError("../secrets")
+invalidPath.code satisfies "WORKSPACE_PATH_INVALID"
+invalidPath.details satisfies { path: string } | undefined
+invalidPath.toJSON() satisfies ViteHubErrorShape<"WORKSPACE_PATH_INVALID", { path: string }>

--- a/packages/workspace/fixtures/published-types/package.json
+++ b/packages/workspace/fixtures/published-types/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/workspace/fixtures/published-types/tsconfig.json
+++ b/packages/workspace/fixtures/published-types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "types": []
+  },
+  "files": [
+    "consumer.ts"
+  ]
+}

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -138,6 +138,7 @@
     "@vite-hub/runtime": "workspace:*",
     "@vite-hub/source": "workspace:*",
     "defu": "catalog:unjs",
+    "effect": "catalog:effect",
     "exsolve": "catalog:unjs",
     "h3": "catalog:unjs",
     "isomorphic-git": "catalog:workspace",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -135,6 +135,7 @@
   "dependencies": {
     "@vercel/nft": "catalog:vercel",
     "@vite-hub/markdown-template": "workspace:*",
+    "@vite-hub/runtime": "workspace:*",
     "@vite-hub/source": "workspace:*",
     "defu": "catalog:unjs",
     "exsolve": "catalog:unjs",

--- a/packages/workspace/src/ai.ts
+++ b/packages/workspace/src/ai.ts
@@ -240,6 +240,7 @@ function createWorkspaceSessionShellProvider(starter: WorkspaceSessionStarter): 
     },
     async exec(command: string, execOptions: ShellRuntimeExecOptions = {}) {
       const session = await starter.startSession({ paths: execOptions.workspacePaths })
+      let observation: ShellObservation
       try {
         const result = await session.exec("sh", ["-lc", command], {
           cwd: execOptions.cwd || workspaceMountPoint,
@@ -249,7 +250,7 @@ function createWorkspaceSessionShellProvider(starter: WorkspaceSessionStarter): 
         execOptions.onStdout?.(result.stdout)
         execOptions.onStderr?.(result.stderr)
         const timedOut = result.exitCode === 124 && /timed out/i.test(result.stderr)
-        return {
+        observation = {
           command,
           cwd: execOptions.cwd,
           event: timedOut ? "command_timed_out" : "command_finished",
@@ -259,9 +260,17 @@ function createWorkspaceSessionShellProvider(starter: WorkspaceSessionStarter): 
           timedOut,
         } satisfies ShellObservation
       }
-      finally {
-        await session.close()
+      catch (error) {
+        try {
+          await session.close()
+        }
+        catch (closeError) {
+          throw new AggregateError([error, closeError], "[vitehub] Workspace shell execution failed and session cleanup also failed.")
+        }
+        throw error
       }
+      await session.close()
+      return observation
     },
   }
 }

--- a/packages/workspace/src/core/errors.ts
+++ b/packages/workspace/src/core/errors.ts
@@ -1,3 +1,5 @@
+import { ViteHubError, type ViteHubErrorShape } from "@vite-hub/runtime"
+
 export class WorkspaceError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options)
@@ -6,15 +8,27 @@ export class WorkspaceError extends Error {
 }
 
 export class WorkspaceNotFoundError extends WorkspaceError {
+  readonly code = "WORKSPACE_NOT_FOUND" as const
+  readonly details: { name: string }
+  readonly retryable: false = false
+  readonly toJSON: () => ViteHubErrorShape<"WORKSPACE_NOT_FOUND", { name: string }> = ViteHubError.prototype.toJSON
+
   constructor(name: string) {
     super(`[vitehub] Workspace "${name}" is not registered.`)
     this.name = "WorkspaceNotFoundError"
+    this.details = { name }
   }
 }
 
 export class WorkspacePathError extends WorkspaceError {
+  readonly code = "WORKSPACE_PATH_INVALID" as const
+  readonly details: { path: string }
+  readonly retryable: false = false
+  readonly toJSON: () => ViteHubErrorShape<"WORKSPACE_PATH_INVALID", { path: string }> = ViteHubError.prototype.toJSON
+
   constructor(path: string) {
     super(`[vitehub] Workspace path escapes the workspace root: ${JSON.stringify(path)}.`)
     this.name = "WorkspacePathError"
+    this.details = { path }
   }
 }

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -39,6 +39,7 @@ export type {
 } from "./session/harness.ts"
 export type * from "./ai.ts"
 export { resolveWorkspaceAutoCommit } from "./core/rules.ts"
+export { WorkspaceNotFoundError, WorkspacePathError } from "./core/errors.ts"
 export { resolveRegisteredWorkspaceDefinition } from "./core/registry.ts"
 export { useWorkspace } from "./core/use.ts"
 export type * from "./core/use.ts"

--- a/packages/workspace/src/internal/effect-runtime.ts
+++ b/packages/workspace/src/internal/effect-runtime.ts
@@ -1,0 +1,47 @@
+import { Cause, Data, Effect, Exit } from "effect"
+
+export class WorkspaceEffectFailure extends Data.TaggedError("WorkspaceEffectFailure")<{
+  readonly cause: unknown
+  readonly operation: string
+}> {}
+
+function interruptionError(signal?: AbortSignal): unknown {
+  if (signal?.aborted && signal.reason !== undefined) return signal.reason
+  const error = new Error("[vitehub] Workspace operation was interrupted.")
+  error.name = "AbortError"
+  return error
+}
+
+export function workspaceEffectCauseValues(
+  cause: Cause.Cause<unknown>,
+  signal?: AbortSignal,
+): unknown[] {
+  return cause.reasons.map(reason => {
+    if (Cause.isFailReason(reason)) {
+      return reason.error instanceof WorkspaceEffectFailure ? reason.error.cause : reason.error
+    }
+    if (Cause.isDieReason(reason)) return reason.defect
+    return interruptionError(signal)
+  })
+}
+
+export function tryWorkspacePromise<A>(
+  operation: string,
+  evaluate: (signal: AbortSignal) => PromiseLike<A> | A,
+): Effect.Effect<A, WorkspaceEffectFailure> {
+  return Effect.tryPromise({
+    catch: cause => new WorkspaceEffectFailure({ cause, operation }),
+    try: signal => Promise.resolve(evaluate(signal)),
+  })
+}
+
+export async function runWorkspaceEffect<A, E>(
+  effect: Effect.Effect<A, E>,
+  options: { signal?: AbortSignal } = {},
+): Promise<A> {
+  const exit = await Effect.runPromiseExit(effect, options.signal ? { signal: options.signal } : undefined)
+  if (Exit.isSuccess(exit)) return exit.value
+  const causes = workspaceEffectCauseValues(exit.cause, options.signal)
+  if (causes.length === 1) throw causes[0]
+  throw new AggregateError(causes, "[vitehub] Workspace operation failed for multiple reasons.")
+}

--- a/packages/workspace/src/internal/effect-runtime.ts
+++ b/packages/workspace/src/internal/effect-runtime.ts
@@ -21,7 +21,7 @@ export function workspaceEffectCauseValues(
       return reason.error instanceof WorkspaceEffectFailure ? reason.error.cause : reason.error
     }
     if (Cause.isDieReason(reason)) {
-      return reason.defect instanceof WorkspaceEffectFailure ? reason.defect.cause : reason.defect
+      return reason.defect
     }
     return interruptionError(signal)
   })

--- a/packages/workspace/src/internal/effect-runtime.ts
+++ b/packages/workspace/src/internal/effect-runtime.ts
@@ -20,7 +20,9 @@ export function workspaceEffectCauseValues(
     if (Cause.isFailReason(reason)) {
       return reason.error instanceof WorkspaceEffectFailure ? reason.error.cause : reason.error
     }
-    if (Cause.isDieReason(reason)) return reason.defect
+    if (Cause.isDieReason(reason)) {
+      return reason.defect instanceof WorkspaceEffectFailure ? reason.defect.cause : reason.defect
+    }
     return interruptionError(signal)
   })
 }

--- a/packages/workspace/src/server.ts
+++ b/packages/workspace/src/server.ts
@@ -315,8 +315,9 @@ export async function runWorkspaceDevCommand<Name extends WorkspaceName>(
     label: "Starting workspace session",
   }, async () => await startSession(input.paths ? { paths: input.paths } : undefined))
   const execOptions = { abortSignal: input.abortSignal, timeout: input.timeout }
+  let result
   try {
-    const result = input.args
+    result = input.args
       ? await session.exec(command, input.args, execOptions)
       : await session.exec("sh", ["-lc", command], execOptions)
     const diff = result.exitCode === 0 ? await session.diff() : undefined
@@ -324,9 +325,16 @@ export async function runWorkspaceDevCommand<Name extends WorkspaceName>(
       const commit = definition ? resolveWorkspaceAutoCommit(definition, diff) : undefined
       if (!definition || !hasWorkspaceCommitRules(definition) || commit) await session.commit({ message: commit?.message || "workspace dev command" })
     }
-    return result
   }
-  finally {
-    await session.close()
+  catch (error) {
+    try {
+      await session.close()
+    }
+    catch (closeError) {
+      throw new AggregateError([error, closeError], "[vitehub] Workspace Dev command failed and session cleanup also failed.")
+    }
+    throw error
   }
+  await session.close()
+  return result
 }

--- a/packages/workspace/src/session/resource-scope.ts
+++ b/packages/workspace/src/session/resource-scope.ts
@@ -69,6 +69,7 @@ function makeWorkspaceResourceScope<Resource, Setup>(
 ): WorkspaceResourceScope<Resource, Setup> {
   let closed = false
   let closePromise: Promise<void> | undefined
+  let pendingRegistrations = Promise.resolve()
 
   return {
     resource,
@@ -76,23 +77,29 @@ function makeWorkspaceResourceScope<Resource, Setup>(
     close() {
       if (!closePromise) {
         closed = true
-        closePromise = runWorkspaceEffect(closeResourceScope(scope, failures, Exit.void, operation))
+        closePromise = pendingRegistrations.then(
+          () => runWorkspaceEffect(closeResourceScope(scope, failures, Exit.void, operation)),
+        )
       }
       return closePromise
     },
     isClosed: () => closed,
     async runChild(use) {
+      if (closed) throw new Error("[vitehub] Workspace resource scope is already closed.")
+      let finishRegistration!: () => void
+      const registration = new Promise<void>((resolve) => {
+        finishRegistration = resolve
+      })
+      pendingRegistrations = Promise.all([pendingRegistrations, registration]).then(() => {})
       const childScope = await runWorkspaceEffect(Scope.fork(scope, "sequential"))
-      if (closed) {
-        await runWorkspaceEffect(Scope.close(childScope, Exit.void))
-        throw new Error("[vitehub] Workspace resource scope is already closed.")
-      }
       try {
-        return await use(finalizer => runWorkspaceEffect(
-          Scope.addFinalizer(childScope, Effect.promise(finalizer)),
-        ))
+        return await use(async (finalizer) => {
+          await runWorkspaceEffect(Scope.addFinalizer(childScope, Effect.promise(finalizer)))
+          finishRegistration()
+        })
       }
       finally {
+        finishRegistration()
         await runWorkspaceEffect(Scope.close(childScope, Exit.void))
       }
     },

--- a/packages/workspace/src/session/resource-scope.ts
+++ b/packages/workspace/src/session/resource-scope.ts
@@ -1,0 +1,130 @@
+import { Effect, Exit, Ref, Scope } from "effect"
+
+import {
+  WorkspaceEffectFailure,
+  runWorkspaceEffect,
+  tryWorkspacePromise,
+  workspaceEffectCauseValues,
+} from "../internal/effect-runtime.ts"
+
+function failureValue(exit: Exit.Failure<unknown, unknown>): unknown {
+  const causes = workspaceEffectCauseValues(exit.cause)
+  return causes.length === 1
+    ? causes[0]
+    : new AggregateError(causes, "[vitehub] Workspace resource operation failed for multiple reasons.")
+}
+
+const releaseResource = Effect.fn("Workspace.ResourceScope.release")(function* <Resource>(
+  resource: Resource,
+  release: (resource: Resource) => Promise<void>,
+  failures: Ref.Ref<readonly unknown[]>,
+  operation: string,
+) {
+  const exit = yield* Effect.exit(tryWorkspacePromise(`${operation}.release`, () => release(resource)))
+  if (Exit.isFailure(exit)) {
+    const causes = workspaceEffectCauseValues(exit.cause)
+    yield* Ref.update(failures, current => [...current, ...causes])
+  }
+})
+
+const closeResourceScope = Effect.fn("Workspace.ResourceScope.close")(function* (
+  scope: Scope.Closeable,
+  failures: Ref.Ref<readonly unknown[]>,
+  exit: Exit.Exit<unknown, unknown>,
+  operation: string,
+) {
+  yield* Scope.close(scope, exit)
+  const causes = yield* Ref.get(failures)
+  if (causes.length) {
+    return yield* Effect.fail(new WorkspaceEffectFailure({
+      cause: causes.length === 1
+        ? causes[0]
+        : new AggregateError(causes, "[vitehub] Workspace resource cleanup failed for multiple reasons."),
+      operation: `${operation}.Scope.close`,
+    }))
+  }
+})
+
+export interface WorkspaceResourceScope<Resource, Setup> {
+  readonly resource: Resource
+  readonly setup: Setup
+  close(): Promise<void>
+  isClosed(): boolean
+  runChild<A>(use: (registerFinalizer: (finalizer: () => Promise<void>) => Promise<void>) => Promise<A>): Promise<A>
+}
+
+interface WorkspaceResourceScopeOptions<Resource, Setup> {
+  readonly acquire: () => Promise<Resource>
+  readonly operation: string
+  readonly release: (resource: Resource) => Promise<void>
+  readonly setup: (resource: Resource) => Promise<Setup>
+}
+
+function makeWorkspaceResourceScope<Resource, Setup>(
+  resource: Resource,
+  setup: Setup,
+  scope: Scope.Closeable,
+  failures: Ref.Ref<readonly unknown[]>,
+  operation: string,
+): WorkspaceResourceScope<Resource, Setup> {
+  let closed = false
+  let closePromise: Promise<void> | undefined
+
+  return {
+    resource,
+    setup,
+    close() {
+      if (!closePromise) {
+        closed = true
+        closePromise = runWorkspaceEffect(closeResourceScope(scope, failures, Exit.void, operation))
+      }
+      return closePromise
+    },
+    isClosed: () => closed,
+    async runChild(use) {
+      const childScope = await runWorkspaceEffect(Scope.fork(scope, "sequential"))
+      try {
+        return await use(finalizer => runWorkspaceEffect(
+          Scope.addFinalizer(childScope, Effect.promise(finalizer)),
+        ))
+      }
+      finally {
+        await runWorkspaceEffect(Scope.close(childScope, Exit.void))
+      }
+    },
+  }
+}
+
+export function openWorkspaceResourceScope<Resource, Setup>(
+  options: WorkspaceResourceScopeOptions<Resource, Setup>,
+): Promise<WorkspaceResourceScope<Resource, Setup>> {
+  const { acquire, operation, release, setup } = options
+  return runWorkspaceEffect(Effect.gen(function* () {
+    const scope = yield* Scope.make("sequential")
+    const failures = yield* Ref.make<readonly unknown[]>([])
+    const resource = yield* Scope.provide(
+      Effect.acquireRelease(
+        tryWorkspacePromise(`${operation}.acquire`, acquire),
+        resource => releaseResource(resource, release, failures, operation),
+      ),
+      scope,
+    )
+
+    const setupExit = yield* Effect.exit(tryWorkspacePromise(`${operation}.setup`, () => setup(resource)))
+    if (Exit.isSuccess(setupExit))
+      return makeWorkspaceResourceScope(resource, setupExit.value, scope, failures, operation)
+
+    const setupError = failureValue(setupExit)
+    const closeExit = yield* Effect.exit(closeResourceScope(scope, failures, setupExit, operation))
+    if (Exit.isFailure(closeExit)) {
+      return yield* Effect.fail(new WorkspaceEffectFailure({
+        cause: new AggregateError(
+          [setupError, failureValue(closeExit)],
+          "[vitehub] Workspace resource setup failed and cleanup also failed.",
+        ),
+        operation: `${operation}.setup`,
+      }))
+    }
+    return yield* Effect.fail(new WorkspaceEffectFailure({ cause: setupError, operation: `${operation}.setup` }))
+  }))
+}

--- a/packages/workspace/src/session/resource-scope.ts
+++ b/packages/workspace/src/session/resource-scope.ts
@@ -103,12 +103,29 @@ function makeWorkspaceResourceScope<Resource, Setup>(
         finishRegistration()
         throw error
       }
+      const childFailures = await runWorkspaceEffect(Ref.make<readonly {
+        cause: unknown
+        parentOwned: boolean
+      }[]>([]))
 
       const useExit = await Promise.resolve().then(() => use(async (finalizer) => {
         try {
           await runWorkspaceEffect(Scope.addFinalizer(
             childScope,
-            Effect.orDie(tryWorkspacePromise(`${operation}.Child.release`, () => finalizer())),
+            Effect.catchTag(
+              tryWorkspacePromise(`${operation}.Child.release`, () => finalizer()),
+              "WorkspaceEffectFailure",
+              failure => Effect.gen(function* () {
+                const parentOwned = closed
+                yield* Ref.update(childFailures, current => [...current, {
+                  cause: failure.cause,
+                  parentOwned,
+                }])
+                if (parentOwned) {
+                  yield* Ref.update(failures, current => [...current, failure.cause])
+                }
+              }),
+            ),
           ))
         }
         finally {
@@ -120,19 +137,29 @@ function makeWorkspaceResourceScope<Resource, Setup>(
       )
       finishRegistration()
 
-      const closeExit = await runWorkspaceEffect(Scope.close(childScope, Exit.void)).then(
-        () => ({ _tag: "Success" }) as const,
-        error => ({ _tag: "Failure", error }) as const,
-      )
+      const closeResult = await runWorkspaceEffect(Effect.gen(function* () {
+        const exit = yield* Effect.exit(Scope.close(childScope, Exit.void))
+        const cleanupCauses = yield* Ref.get(childFailures)
+        return { cleanupCauses, exit }
+      }))
+      const closeCauses = [
+        ...(Exit.isFailure(closeResult.exit) ? workspaceEffectCauseValues(closeResult.exit.cause) : []),
+        ...closeResult.cleanupCauses.filter(failure => !failure.parentOwned).map(failure => failure.cause),
+      ]
+      const closeError = closeCauses.length === 0
+        ? undefined
+        : closeCauses.length === 1
+          ? closeCauses[0]
+          : new AggregateError(closeCauses, "[vitehub] Workspace child cleanup failed for multiple reasons.")
 
-      if (useExit._tag === "Failure" && closeExit._tag === "Failure") {
+      if (useExit._tag === "Failure" && closeError !== undefined) {
         throw new AggregateError(
-          [useExit.error, closeExit.error],
+          [useExit.error, closeError],
           "[vitehub] Workspace child operation failed and cleanup also failed.",
         )
       }
       if (useExit._tag === "Failure") throw useExit.error
-      if (closeExit._tag === "Failure") throw closeExit.error
+      if (closeError !== undefined) throw closeError
       return useExit.value
     },
   }

--- a/packages/workspace/src/session/resource-scope.ts
+++ b/packages/workspace/src/session/resource-scope.ts
@@ -33,8 +33,12 @@ const closeResourceScope = Effect.fn("Workspace.ResourceScope.close")(function* 
   exit: Exit.Exit<unknown, unknown>,
   operation: string,
 ) {
-  yield* Scope.close(scope, exit)
-  const causes = yield* Ref.get(failures)
+  const closeExit = yield* Effect.exit(Scope.close(scope, exit))
+  const scopeCauses = Exit.isFailure(closeExit)
+    ? workspaceEffectCauseValues(closeExit.cause)
+    : []
+  const releaseCauses = yield* Ref.get(failures)
+  const causes = [...scopeCauses, ...releaseCauses]
   if (causes.length) {
     return yield* Effect.fail(new WorkspaceEffectFailure({
       cause: causes.length === 1
@@ -91,17 +95,45 @@ function makeWorkspaceResourceScope<Resource, Setup>(
         finishRegistration = resolve
       })
       pendingRegistrations = Promise.all([pendingRegistrations, registration]).then(() => {})
-      const childScope = await runWorkspaceEffect(Scope.fork(scope, "sequential"))
+      let childScope: Scope.Closeable
       try {
-        return await use(async (finalizer) => {
-          await runWorkspaceEffect(Scope.addFinalizer(childScope, Effect.promise(finalizer)))
-          finishRegistration()
-        })
+        childScope = await runWorkspaceEffect(Scope.fork(scope, "sequential"))
       }
-      finally {
+      catch (error) {
         finishRegistration()
-        await runWorkspaceEffect(Scope.close(childScope, Exit.void))
+        throw error
       }
+
+      const useExit = await Promise.resolve().then(() => use(async (finalizer) => {
+        try {
+          await runWorkspaceEffect(Scope.addFinalizer(
+            childScope,
+            Effect.orDie(tryWorkspacePromise(`${operation}.Child.release`, () => finalizer())),
+          ))
+        }
+        finally {
+          finishRegistration()
+        }
+      })).then(
+        value => ({ _tag: "Success", value }) as const,
+        error => ({ _tag: "Failure", error }) as const,
+      )
+      finishRegistration()
+
+      const closeExit = await runWorkspaceEffect(Scope.close(childScope, Exit.void)).then(
+        () => ({ _tag: "Success" }) as const,
+        error => ({ _tag: "Failure", error }) as const,
+      )
+
+      if (useExit._tag === "Failure" && closeExit._tag === "Failure") {
+        throw new AggregateError(
+          [useExit.error, closeExit.error],
+          "[vitehub] Workspace child operation failed and cleanup also failed.",
+        )
+      }
+      if (useExit._tag === "Failure") throw useExit.error
+      if (closeExit._tag === "Failure") throw closeExit.error
+      return useExit.value
     },
   }
 }

--- a/packages/workspace/src/session/resource-scope.ts
+++ b/packages/workspace/src/session/resource-scope.ts
@@ -83,6 +83,10 @@ function makeWorkspaceResourceScope<Resource, Setup>(
     isClosed: () => closed,
     async runChild(use) {
       const childScope = await runWorkspaceEffect(Scope.fork(scope, "sequential"))
+      if (closed) {
+        await runWorkspaceEffect(Scope.close(childScope, Exit.void))
+        throw new Error("[vitehub] Workspace resource scope is already closed.")
+      }
       try {
         return await use(finalizer => runWorkspaceEffect(
           Scope.addFinalizer(childScope, Effect.promise(finalizer)),

--- a/packages/workspace/src/session/sandbox-scope.ts
+++ b/packages/workspace/src/session/sandbox-scope.ts
@@ -55,6 +55,8 @@ const closeSandboxScope = Effect.fn("Workspace.Sandbox.Scope.close")(function* (
 })
 
 export class SandboxWorkspaceScope<Resource extends SandboxResource, Setup> {
+  private closed = false
+
   constructor(
     readonly resource: Resource,
     readonly setup: Setup,
@@ -63,10 +65,11 @@ export class SandboxWorkspaceScope<Resource extends SandboxResource, Setup> {
   ) {}
 
   isClosed(): boolean {
-    return this.scope.state._tag === "Closed"
+    return this.closed
   }
 
   close(): Promise<void> {
+    this.closed = true
     return runWorkspaceEffect(closeSandboxScope(this.scope, this.failures, Exit.void))
   }
 }

--- a/packages/workspace/src/session/sandbox-scope.ts
+++ b/packages/workspace/src/session/sandbox-scope.ts
@@ -1,0 +1,111 @@
+import { Effect, Exit, Ref, Scope } from "effect"
+
+import {
+  WorkspaceEffectFailure,
+  runWorkspaceEffect,
+  tryWorkspacePromise,
+  workspaceEffectCauseValues,
+} from "../internal/effect-runtime.ts"
+
+interface SandboxResource {
+  readonly provider: string
+  stop(): Promise<void>
+}
+
+function failureValue(exit: Exit.Failure<unknown, unknown>): unknown {
+  const causes = workspaceEffectCauseValues(exit.cause)
+  return causes.length === 1
+    ? causes[0]
+    : new AggregateError(causes, "[vitehub] Workspace sandbox operation failed for multiple reasons.")
+}
+
+const releaseSandbox = Effect.fn("Workspace.Sandbox.release")(function* (
+  sandbox: SandboxResource,
+  failures: Ref.Ref<readonly unknown[]>,
+) {
+  if (sandbox.provider !== "vercel") return
+  const exit = yield* Effect.exit(
+    tryWorkspacePromise("Workspace.Sandbox.release", () => sandbox.stop()),
+  )
+  if (Exit.isFailure(exit)) {
+    const causes = workspaceEffectCauseValues(exit.cause)
+    yield* Ref.update(failures, current => [...current, ...causes])
+  }
+})
+
+const closeSandboxScope = Effect.fn("Workspace.Sandbox.Scope.close")(function* (
+  scope: Scope.Closeable,
+  failures: Ref.Ref<readonly unknown[]>,
+  exit: Exit.Exit<unknown, unknown>,
+) {
+  yield* Scope.close(scope, exit)
+  const causes = yield* Ref.get(failures)
+  if (causes.length === 1) {
+    return yield* Effect.fail(new WorkspaceEffectFailure({
+      cause: causes[0],
+      operation: "Workspace.Sandbox.Scope.close",
+    }))
+  }
+  if (causes.length > 1) {
+    return yield* Effect.fail(new WorkspaceEffectFailure({
+      cause: new AggregateError(causes, "[vitehub] Workspace sandbox cleanup failed for multiple reasons."),
+      operation: "Workspace.Sandbox.Scope.close",
+    }))
+  }
+})
+
+export class SandboxWorkspaceScope<Resource extends SandboxResource, Setup> {
+  constructor(
+    readonly resource: Resource,
+    readonly setup: Setup,
+    private readonly scope: Scope.Closeable,
+    private readonly failures: Ref.Ref<readonly unknown[]>,
+  ) {}
+
+  isClosed(): boolean {
+    return this.scope.state._tag === "Closed"
+  }
+
+  close(): Promise<void> {
+    return runWorkspaceEffect(closeSandboxScope(this.scope, this.failures, Exit.void))
+  }
+}
+
+export function openSandboxWorkspaceScope<Resource extends SandboxResource, Setup>(
+  acquire: () => Promise<Resource>,
+  setup: (resource: Resource) => Promise<Setup>,
+): Promise<SandboxWorkspaceScope<Resource, Setup>> {
+  return runWorkspaceEffect(Effect.gen(function* () {
+    const scope = yield* Scope.make("sequential")
+    const failures = yield* Ref.make<readonly unknown[]>([])
+    const resource = yield* Scope.provide(
+      Effect.acquireRelease(
+        tryWorkspacePromise("Workspace.Sandbox.acquire", acquire),
+        sandbox => releaseSandbox(sandbox, failures),
+      ),
+      scope,
+    )
+
+    const setupExit = yield* Effect.exit(
+      tryWorkspacePromise("Workspace.Sandbox.setup", () => setup(resource)),
+    )
+    if (Exit.isSuccess(setupExit))
+      return new SandboxWorkspaceScope(resource, setupExit.value, scope, failures)
+
+    const setupError = failureValue(setupExit)
+    const closeExit = yield* Effect.exit(closeSandboxScope(scope, failures, setupExit))
+    if (Exit.isFailure(closeExit)) {
+      return yield* Effect.fail(new WorkspaceEffectFailure({
+        cause: new AggregateError(
+          [setupError, failureValue(closeExit)],
+          "[vitehub] Workspace sandbox setup failed and cleanup also failed.",
+        ),
+        operation: "Workspace.Sandbox.setup",
+      }))
+    }
+    return yield* Effect.fail(new WorkspaceEffectFailure({
+      cause: setupError,
+      operation: "Workspace.Sandbox.setup",
+    }))
+  }))
+}

--- a/packages/workspace/src/session/sandbox-scope.ts
+++ b/packages/workspace/src/session/sandbox-scope.ts
@@ -1,114 +1,24 @@
-import { Effect, Exit, Ref, Scope } from "effect"
+import { openWorkspaceResourceScope } from "./resource-scope.ts"
 
-import {
-  WorkspaceEffectFailure,
-  runWorkspaceEffect,
-  tryWorkspacePromise,
-  workspaceEffectCauseValues,
-} from "../internal/effect-runtime.ts"
+import type { WorkspaceResourceScope } from "./resource-scope.ts"
 
 interface SandboxResource {
   readonly provider: string
   stop(): Promise<void>
 }
 
-function failureValue(exit: Exit.Failure<unknown, unknown>): unknown {
-  const causes = workspaceEffectCauseValues(exit.cause)
-  return causes.length === 1
-    ? causes[0]
-    : new AggregateError(causes, "[vitehub] Workspace sandbox operation failed for multiple reasons.")
-}
-
-const releaseSandbox = Effect.fn("Workspace.Sandbox.release")(function* (
-  sandbox: SandboxResource,
-  failures: Ref.Ref<readonly unknown[]>,
-) {
-  if (sandbox.provider !== "vercel") return
-  const exit = yield* Effect.exit(
-    tryWorkspacePromise("Workspace.Sandbox.release", () => sandbox.stop()),
-  )
-  if (Exit.isFailure(exit)) {
-    const causes = workspaceEffectCauseValues(exit.cause)
-    yield* Ref.update(failures, current => [...current, ...causes])
-  }
-})
-
-const closeSandboxScope = Effect.fn("Workspace.Sandbox.Scope.close")(function* (
-  scope: Scope.Closeable,
-  failures: Ref.Ref<readonly unknown[]>,
-  exit: Exit.Exit<unknown, unknown>,
-) {
-  yield* Scope.close(scope, exit)
-  const causes = yield* Ref.get(failures)
-  if (causes.length === 1) {
-    return yield* Effect.fail(new WorkspaceEffectFailure({
-      cause: causes[0],
-      operation: "Workspace.Sandbox.Scope.close",
-    }))
-  }
-  if (causes.length > 1) {
-    return yield* Effect.fail(new WorkspaceEffectFailure({
-      cause: new AggregateError(causes, "[vitehub] Workspace sandbox cleanup failed for multiple reasons."),
-      operation: "Workspace.Sandbox.Scope.close",
-    }))
-  }
-})
-
-export class SandboxWorkspaceScope<Resource extends SandboxResource, Setup> {
-  private closed = false
-
-  constructor(
-    readonly resource: Resource,
-    readonly setup: Setup,
-    private readonly scope: Scope.Closeable,
-    private readonly failures: Ref.Ref<readonly unknown[]>,
-  ) {}
-
-  isClosed(): boolean {
-    return this.closed
-  }
-
-  close(): Promise<void> {
-    this.closed = true
-    return runWorkspaceEffect(closeSandboxScope(this.scope, this.failures, Exit.void))
-  }
-}
+export type SandboxWorkspaceScope<Resource extends SandboxResource, Setup> = WorkspaceResourceScope<Resource, Setup>
 
 export function openSandboxWorkspaceScope<Resource extends SandboxResource, Setup>(
   acquire: () => Promise<Resource>,
   setup: (resource: Resource) => Promise<Setup>,
 ): Promise<SandboxWorkspaceScope<Resource, Setup>> {
-  return runWorkspaceEffect(Effect.gen(function* () {
-    const scope = yield* Scope.make("sequential")
-    const failures = yield* Ref.make<readonly unknown[]>([])
-    const resource = yield* Scope.provide(
-      Effect.acquireRelease(
-        tryWorkspacePromise("Workspace.Sandbox.acquire", acquire),
-        sandbox => releaseSandbox(sandbox, failures),
-      ),
-      scope,
-    )
-
-    const setupExit = yield* Effect.exit(
-      tryWorkspacePromise("Workspace.Sandbox.setup", () => setup(resource)),
-    )
-    if (Exit.isSuccess(setupExit))
-      return new SandboxWorkspaceScope(resource, setupExit.value, scope, failures)
-
-    const setupError = failureValue(setupExit)
-    const closeExit = yield* Effect.exit(closeSandboxScope(scope, failures, setupExit))
-    if (Exit.isFailure(closeExit)) {
-      return yield* Effect.fail(new WorkspaceEffectFailure({
-        cause: new AggregateError(
-          [setupError, failureValue(closeExit)],
-          "[vitehub] Workspace sandbox setup failed and cleanup also failed.",
-        ),
-        operation: "Workspace.Sandbox.setup",
-      }))
-    }
-    return yield* Effect.fail(new WorkspaceEffectFailure({
-      cause: setupError,
-      operation: "Workspace.Sandbox.setup",
-    }))
-  }))
+  return openWorkspaceResourceScope({
+    acquire,
+    operation: "Workspace.Sandbox",
+    release: async (sandbox) => {
+      if (sandbox.provider === "vercel") await sandbox.stop()
+    },
+    setup,
+  })
 }

--- a/packages/workspace/src/session/sandbox.ts
+++ b/packages/workspace/src/session/sandbox.ts
@@ -1,9 +1,12 @@
 import { posix } from "node:path"
+import { Effect } from "effect"
 
 import { WorkspaceError } from "../core/errors.ts"
 import { contentToBytes, decodeFile, normalizeSafeWorkspacePath, normalizeWorkspacePath, sha256 } from "../core/path.ts"
+import { runWorkspaceEffect, tryWorkspacePromise } from "../internal/effect-runtime.ts"
 import { loadWorkspaceSandboxModule, loadWorkspaceSandboxRuntimeStateModule } from "../runtime/dependency-loaders.ts"
 import { createSnapshotFromEntries, diffSnapshots } from "../storage/utils.ts"
+import { openSandboxWorkspaceScope } from "./sandbox-scope.ts"
 import { assertDiffInsideSessionPaths, assertPathInSessionScope, filterSessionDiff, filterSessionEntries, isMissingWorkspacePathError, scopedSearchQuery } from "./scope.ts"
 
 import type {
@@ -100,17 +103,19 @@ async function listSandboxEntries(sandbox: SandboxClient, path = "", recursive =
 
 async function snapshotSandbox(sandbox: SandboxClient, name?: string) {
   const entries = await listSandboxEntries(sandbox, "", true)
-  const files = await Promise.all(entries.map(async (entry) => {
-    if (entry.type !== "file") return entry
-    const content = isGitSymlinkEntry(entry)
-      ? await readSandboxSymlinkTarget(sandbox, toSandboxPath(entry.path))
-      : await sandbox.readFile(toSandboxPath(entry.path), { encoding: "binary" })
-    return {
-      ...entry,
-      digest: await sha256(content),
-      size: contentToBytes(content).byteLength,
-    }
-  }))
+  const files = await runWorkspaceEffect(Effect.forEach(entries, entry => {
+    if (entry.type !== "file") return Effect.succeed(entry)
+    return tryWorkspacePromise("Workspace.Sandbox.snapshot.read", async () => {
+      const content = isGitSymlinkEntry(entry)
+        ? await readSandboxSymlinkTarget(sandbox, toSandboxPath(entry.path))
+        : await sandbox.readFile(toSandboxPath(entry.path), { encoding: "binary" })
+      return {
+        ...entry,
+        digest: await sha256(content),
+        size: contentToBytes(content).byteLength,
+      }
+    })
+  }, { concurrency: 16 }))
   return await createSnapshotFromEntries(files, name)
 }
 
@@ -217,14 +222,17 @@ export async function createSandboxWorkspaceSession(
     throw new WorkspaceError("[vitehub] Workspace runtime `sandbox` requires app-level `sandbox` config.")
   }
 
-  const sandbox = await sandboxPackage.createSandboxWithConfig(sandboxConfig)
   const sessionPaths = normalizeSessionPaths(options)
-  let baseline = await materializeWorkspace(workspace, sandbox, options)
+  const sandboxScope = await openSandboxWorkspaceScope(
+    () => sandboxPackage.createSandboxWithConfig(sandboxConfig),
+    sandbox => materializeWorkspace(workspace, sandbox, options),
+  )
+  const sandbox = sandboxScope.resource
+  let baseline = sandboxScope.setup
   const mediaTypes = new Map<string, string>()
-  let closed = false
 
   function assertOpen() {
-    if (closed)
+    if (sandboxScope.isClosed())
       throw new WorkspaceError("[vitehub] Workspace sandbox session is already closed.")
   }
 
@@ -319,10 +327,7 @@ export async function createSandboxWorkspaceSession(
       }
     },
     async close() {
-      if (closed) return
-      closed = true
-      if (sandbox.provider === "vercel")
-        await sandbox.stop().catch(() => {})
+      await sandboxScope.close()
     },
   }
 }

--- a/packages/workspace/src/session/trusted-host-scope.ts
+++ b/packages/workspace/src/session/trusted-host-scope.ts
@@ -1,0 +1,18 @@
+import { openWorkspaceResourceScope } from "./resource-scope.ts"
+
+import type { WorkspaceResourceScope } from "./resource-scope.ts"
+
+export type TrustedHostWorkspaceScope<Resource, Setup> = WorkspaceResourceScope<Resource, Setup>
+
+export function openTrustedHostWorkspaceScope<Resource, Setup>(
+  acquire: () => Promise<Resource>,
+  setup: (resource: Resource) => Promise<Setup>,
+  release: (resource: Resource) => Promise<void>,
+): Promise<TrustedHostWorkspaceScope<Resource, Setup>> {
+  return openWorkspaceResourceScope({
+    acquire,
+    operation: "Workspace.TrustedHost",
+    release,
+    setup,
+  })
+}

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -241,6 +241,18 @@ async function execLocal(
   const cwd = toLocalPath(root, normalizeSessionCwd(options.cwd), { allowGenerated: true })
   if (options.abortSignal?.aborted) return { args, command, exitCode: 130, stderr: "Command aborted", stdout: "" }
   return await scope.runChild(async (registerFinalizer) => {
+    let closeRequested = false
+    let abort = () => {
+      closeRequested = true
+    }
+    let result: Promise<ExecResult> | undefined
+    await registerFinalizer(async () => {
+      abort()
+      await result
+    })
+    if (closeRequested)
+      return { args, command, exitCode: 130, stderr: "Command aborted", stdout: "" }
+
     const child = spawn(command, args, {
       cwd,
       env: { ...process.env, ...options.env },
@@ -256,7 +268,7 @@ async function execLocal(
       child.kill("SIGTERM")
       killTimer = setTimeout(() => child.kill("SIGKILL"), 100)
     }
-    const abort = () => {
+    abort = () => {
       if (timedOut || aborted || settled) return
       aborted = true
       terminate()
@@ -279,7 +291,7 @@ async function execLocal(
     child.stderr?.setEncoding("utf8")
     child.stdout?.on("data", chunk => stdout += chunk)
     child.stderr?.on("data", chunk => stderr += chunk)
-    const result = new Promise<ExecResult>((resolve) => {
+    result = new Promise<ExecResult>((resolve) => {
       const finish = (value: ExecResult) => {
         settled = true
         clearTimers()
@@ -301,10 +313,6 @@ async function execLocal(
           : timedOut ? `${stderr}${stderr ? "\n" : ""}Command timed out${signal ? ` (${signal})` : ""}` : stderr,
         stdout,
       }))
-    })
-    await registerFinalizer(async () => {
-      abort()
-      await result
     })
     return await result
   })

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -250,7 +250,7 @@ async function execLocal(
       abort()
       await result
     })
-    if (closeRequested)
+    if (closeRequested || options.abortSignal?.aborted)
       return { args, command, exitCode: 130, stderr: "Command aborted", stdout: "" }
 
     const child = spawn(command, args, {

--- a/packages/workspace/src/session/trusted-host.ts
+++ b/packages/workspace/src/session/trusted-host.ts
@@ -7,6 +7,9 @@ import { WorkspaceError } from "../core/errors.ts"
 import { contentToBytes, decodeFile, matchesAny, normalizeSafeWorkspacePath, normalizeWorkspacePath, resolveInside, sha256 } from "../core/path.ts"
 import { createSnapshotFromEntries, diffSnapshots } from "../storage/utils.ts"
 import { assertDiffInsideSessionPaths, assertPathInSessionScope, filterSessionDiff, filterSessionEntries, isMissingWorkspacePathError, scopedSearchQuery } from "./scope.ts"
+import { openTrustedHostWorkspaceScope } from "./trusted-host-scope.ts"
+
+import type { TrustedHostWorkspaceScope } from "./trusted-host-scope.ts"
 
 import type {
   ExecOptions,
@@ -228,10 +231,16 @@ async function commitLocalChanges(
   await workspace.snapshot({ name: "local-commit" })
 }
 
-async function execLocal(root: string, command: string, args: string[] = [], options: ExecOptions = {}): Promise<ExecResult> {
+async function execLocal(
+  scope: TrustedHostWorkspaceScope<string, Awaited<ReturnType<typeof snapshotLocal>>>,
+  root: string,
+  command: string,
+  args: string[] = [],
+  options: ExecOptions = {},
+): Promise<ExecResult> {
   const cwd = toLocalPath(root, normalizeSessionCwd(options.cwd), { allowGenerated: true })
   if (options.abortSignal?.aborted) return { args, command, exitCode: 130, stderr: "Command aborted", stdout: "" }
-  return await new Promise((resolve) => {
+  return await scope.runChild(async (registerFinalizer) => {
     const child = spawn(command, args, {
       cwd,
       env: { ...process.env, ...options.env },
@@ -241,19 +250,20 @@ async function execLocal(root: string, command: string, args: string[] = [], opt
     let stderr = ""
     let timedOut = false
     let aborted = false
+    let settled = false
     let killTimer: NodeJS.Timeout | undefined
     const terminate = () => {
       child.kill("SIGTERM")
       killTimer = setTimeout(() => child.kill("SIGKILL"), 100)
     }
     const abort = () => {
-      if (timedOut || aborted) return
+      if (timedOut || aborted || settled) return
       aborted = true
       terminate()
     }
     const timer = options.timeout
       ? setTimeout(() => {
-          if (timedOut || aborted) return
+          if (timedOut || aborted || settled) return
           timedOut = true
           terminate()
         }, options.timeout)
@@ -269,19 +279,20 @@ async function execLocal(root: string, command: string, args: string[] = [], opt
     child.stderr?.setEncoding("utf8")
     child.stdout?.on("data", chunk => stdout += chunk)
     child.stderr?.on("data", chunk => stderr += chunk)
-    child.on("error", error => {
-      clearTimers()
-      resolve({
+    const result = new Promise<ExecResult>((resolve) => {
+      const finish = (value: ExecResult) => {
+        settled = true
+        clearTimers()
+        resolve(value)
+      }
+      child.on("error", error => finish({
         args,
         command,
         exitCode: aborted ? 130 : 127,
         stderr: aborted ? `${stderr}${stderr ? "\n" : ""}Command aborted` : error instanceof Error ? error.message : String(error),
         stdout,
-      })
-    })
-    child.on("close", (code, signal) => {
-      clearTimers()
-      resolve({
+      }))
+      child.on("close", (code, signal) => finish({
         args,
         command,
         exitCode: aborted ? 130 : timedOut ? 124 : code ?? 1,
@@ -289,8 +300,13 @@ async function execLocal(root: string, command: string, args: string[] = [], opt
           ? `${stderr}${stderr ? "\n" : ""}Command aborted${signal ? ` (${signal})` : ""}`
           : timedOut ? `${stderr}${stderr ? "\n" : ""}Command timed out${signal ? ` (${signal})` : ""}` : stderr,
         stdout,
-      })
+      }))
     })
+    await registerFinalizer(async () => {
+      abort()
+      await result
+    })
+    return await result
   })
 }
 
@@ -300,17 +316,18 @@ export async function createTrustedHostWorkspaceSession(
   options?: WorkspaceSessionOptions,
 ): Promise<WorkspaceSession> {
   assertTrustedHostWorkspaceRuntimeAllowed(definition)
-  const root = await mkdtemp(join(tmpdir(), `vitehub-workspace-${workspace.name.replace(/[^a-zA-Z0-9._-]+/g, "-") || "workspace"}-`))
+  const trustedHostScope = await openTrustedHostWorkspaceScope(
+    () => mkdtemp(join(tmpdir(), `vitehub-workspace-${workspace.name.replace(/[^a-zA-Z0-9._-]+/g, "-") || "workspace"}-`)),
+    root => materializeWorkspace(workspace, root, options),
+    root => rm(root, { force: true, recursive: true }),
+  )
+  const root = trustedHostScope.resource
   const sessionPaths = normalizeSessionPaths(options)
-  let baseline = await materializeWorkspace(workspace, root, options).catch(async (error) => {
-    await rm(root, { force: true, recursive: true })
-    throw error
-  })
+  let baseline = trustedHostScope.setup
   const mediaTypes = new Map<string, string>()
-  let closed = false
 
   function assertOpen() {
-    if (closed)
+    if (trustedHostScope.isClosed())
       throw new WorkspaceError("[vitehub] Workspace trusted-host session is already closed.")
   }
 
@@ -396,12 +413,10 @@ export async function createTrustedHostWorkspaceSession(
     },
     async exec(command, args = [], options = {}) {
       assertOpen()
-      return await execLocal(root, command, args, options)
+      return await execLocal(trustedHostScope, root, command, args, options)
     },
     async close() {
-      if (closed) return
-      closed = true
-      await rm(root, { force: true, recursive: true })
+      await trustedHostScope.close()
     },
   }
 }

--- a/packages/workspace/test/effect-runtime.test.ts
+++ b/packages/workspace/test/effect-runtime.test.ts
@@ -1,0 +1,33 @@
+import { Cause, Effect, Exit } from "effect"
+import { describe, expect, it } from "vitest"
+
+import {
+  runWorkspaceEffect,
+  tryWorkspacePromise,
+  WorkspaceEffectFailure,
+} from "../src/internal/effect-runtime.ts"
+
+describe("workspace Effect runtime", () => {
+  it("preserves defects even when they resemble the typed failure wrapper", async () => {
+    const cause = new Error("provider failed")
+    const defect = new WorkspaceEffectFailure({ cause, operation: "workspace.test" })
+
+    await expect(runWorkspaceEffect(Effect.die(defect))).rejects.toBe(defect)
+  })
+
+  it("keeps expected Promise failures in the typed failure channel", async () => {
+    const cause = new Error("provider failed")
+    const effect = tryWorkspacePromise("workspace.test", () => Promise.reject(cause))
+    const exit = await Effect.runPromiseExit(effect)
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isSuccess(exit)) return
+    expect(exit.cause.reasons).toHaveLength(1)
+    const [reason] = exit.cause.reasons
+    expect(Cause.isFailReason(reason)).toBe(true)
+    if (!Cause.isFailReason(reason)) return
+    expect(reason.error).toBeInstanceOf(WorkspaceEffectFailure)
+    expect(reason.error.cause).toBe(cause)
+    await expect(runWorkspaceEffect(effect)).rejects.toBe(cause)
+  })
+})

--- a/packages/workspace/test/errors.test.ts
+++ b/packages/workspace/test/errors.test.ts
@@ -1,0 +1,49 @@
+import type { ViteHubError } from "@vite-hub/runtime"
+import { describe, expect, it } from "vitest"
+
+import { WorkspaceNotFoundError, WorkspacePathError } from "../src/index.ts"
+import { WorkspaceError } from "../src/core/errors.ts"
+
+describe("Workspace public errors", () => {
+  it("serializes missing Workspace failures through the shared contract", () => {
+    const cause = new Error("private provider response")
+    const error = new WorkspaceNotFoundError("documents")
+    Object.defineProperty(error, "cause", { value: cause })
+    Object.assign(error, { providerToken: "secret" })
+
+    const contract: ViteHubError<"WORKSPACE_NOT_FOUND", { name: string }> = error
+
+    expect(contract).toBe(error)
+    expect(error).toBeInstanceOf(WorkspaceError)
+    expect(error).toBeInstanceOf(WorkspaceNotFoundError)
+    expect(error.name).toBe("WorkspaceNotFoundError")
+    expect(error.message).toBe('[vitehub] Workspace "documents" is not registered.')
+    expect(error.toJSON()).toEqual({
+      code: "WORKSPACE_NOT_FOUND",
+      details: { name: "documents" },
+      message: '[vitehub] Workspace "documents" is not registered.',
+      retryable: false,
+    })
+    expect(JSON.stringify(error)).not.toContain("providerToken")
+    expect(JSON.stringify(error)).not.toContain("private provider response")
+    expect(JSON.stringify(error)).not.toContain("stack")
+  })
+
+  it("serializes invalid Workspace paths with allowlisted details", () => {
+    const error = new WorkspacePathError("../secrets")
+
+    const contract: ViteHubError<"WORKSPACE_PATH_INVALID", { path: string }> = error
+
+    expect(contract).toBe(error)
+    expect(error).toBeInstanceOf(WorkspaceError)
+    expect(error).toBeInstanceOf(WorkspacePathError)
+    expect(error.name).toBe("WorkspacePathError")
+    expect(error.message).toBe('[vitehub] Workspace path escapes the workspace root: "../secrets".')
+    expect(error.toJSON()).toEqual({
+      code: "WORKSPACE_PATH_INVALID",
+      details: { path: "../secrets" },
+      message: '[vitehub] Workspace path escapes the workspace root: "../secrets".',
+      retryable: false,
+    })
+  })
+})

--- a/packages/workspace/test/public-api.test.ts
+++ b/packages/workspace/test/public-api.test.ts
@@ -111,7 +111,7 @@ describe("workspace public API", () => {
     const builtServer = await readFile(new URL("../dist/server.d.ts", import.meta.url), "utf8")
     const builtSandboxStore = await readFile(new URL("../dist/providers/vercel/blob-store.d.ts", import.meta.url), "utf8")
     const distDir = new URL("../dist/", import.meta.url)
-    const declarations = (await Promise.all((await readdir(distDir))
+    const declarations = (await Promise.all((await readdir(distDir, { recursive: true }))
       .filter(file => file.endsWith(".d.ts"))
       .map(file => readFile(new URL(file, distDir), "utf8")))).join("\n")
 
@@ -130,6 +130,7 @@ describe("workspace public API", () => {
     expect(declarations).not.toContain("@vercel/blob")
     expect(builtSandboxStore).not.toContain("files-sdk")
     expect(declarations).not.toContain("@vite-hub/sandbox")
+    expect(declarations).not.toMatch(/(?:from\s*|import\s*\(|import\s+)["']effect["']/)
   })
 
   it("keeps hosted runtime setup off the public Workspace surface", async () => {

--- a/packages/workspace/test/public-api.test.ts
+++ b/packages/workspace/test/public-api.test.ts
@@ -111,9 +111,20 @@ describe("workspace public API", () => {
     const builtServer = await readFile(new URL("../dist/server.d.ts", import.meta.url), "utf8")
     const builtSandboxStore = await readFile(new URL("../dist/providers/vercel/blob-store.d.ts", import.meta.url), "utf8")
     const distDir = new URL("../dist/", import.meta.url)
-    const declarations = (await Promise.all((await readdir(distDir, { recursive: true }))
+    const distFiles = await readdir(distDir, { recursive: true })
+    const declarations = (await Promise.all(distFiles
       .filter(file => file.endsWith(".d.ts"))
       .map(file => readFile(new URL(file, distDir), "utf8")))).join("\n")
+    const effectFreeBundles = (await Promise.all([
+      "cloudflare.js",
+      "source-metadata.js",
+      "runtime/empty-assets-registry.js",
+      "runtime/empty-registry.js",
+      "providers/cloudflare/artifacts-store.js",
+      "providers/github/store.js",
+      "providers/vercel/blob-store.js",
+    ].map(file => readFile(new URL(file, distDir), "utf8")))).join("\n")
+    const effectImport = /(?:from\s*|import\s*(?:\(\s*)?)["']effect(?:\/[^"']*)?["']/
 
     expect(packageJson.dependencies?.h3).toBe("catalog:unjs")
     expect(packageJson.dependencies?.["files-sdk"]).toBeUndefined()
@@ -130,7 +141,8 @@ describe("workspace public API", () => {
     expect(declarations).not.toContain("@vercel/blob")
     expect(builtSandboxStore).not.toContain("files-sdk")
     expect(declarations).not.toContain("@vite-hub/sandbox")
-    expect(declarations).not.toMatch(/(?:from\s*|import\s*\(|import\s+)["']effect["']/)
+    expect(declarations).not.toMatch(effectImport)
+    expect(effectFreeBundles).not.toMatch(effectImport)
   })
 
   it("keeps hosted runtime setup off the public Workspace surface", async () => {

--- a/packages/workspace/test/published-types.test.ts
+++ b/packages/workspace/test/published-types.test.ts
@@ -1,0 +1,33 @@
+import { execFile } from "node:child_process"
+import { copyFile, cp, mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { it } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const runtimeRoot = resolve(packageRoot, "../runtime")
+const fixtureRoot = join(packageRoot, "fixtures", "published-types")
+const tsc = resolve(packageRoot, "../../node_modules/typescript/bin/tsc")
+
+it("publishes Workspace errors through the shared contract", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-types-"))
+
+  try {
+    await cp(fixtureRoot, root, { recursive: true })
+    for (const [name, source] of [["workspace", packageRoot], ["runtime", runtimeRoot]] as const) {
+      const installedPackageRoot = join(root, "node_modules", "@vite-hub", name)
+      await mkdir(installedPackageRoot, { recursive: true })
+      await copyFile(join(source, "package.json"), join(installedPackageRoot, "package.json"))
+      await cp(join(source, "dist"), join(installedPackageRoot, "dist"), { recursive: true })
+    }
+
+    await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", root])
+  }
+  finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})

--- a/packages/workspace/test/sandbox-runtime.test.ts
+++ b/packages/workspace/test/sandbox-runtime.test.ts
@@ -9,6 +9,10 @@ import { getWorkspaceDependencyRuntimeLoaders, setWorkspaceDependencyRuntimeLoad
 import { setSandboxRuntimeConfig } from "@vite-hub/sandbox/runtime/state"
 
 type FakeEntry = { content?: string | Uint8Array, target?: string, type: "directory" | "file" | "symlink" }
+type FakeSandboxOptions = {
+  onReadFile?: (path: string) => Promise<void>
+  stopError?: unknown
+}
 
 const tempDirs: string[] = []
 
@@ -18,7 +22,7 @@ async function createTempDir() {
   return dir
 }
 
-function createFakeSandbox(provider: "cloudflare" | "vercel") {
+function createFakeSandbox(provider: "cloudflare" | "vercel", hooks: FakeSandboxOptions = {}) {
   const files = new Map<string, FakeEntry>([
     ["/workspace", { type: "directory" }],
   ])
@@ -63,6 +67,7 @@ function createFakeSandbox(provider: "cloudflare" | "vercel") {
         files.set(path, { content, type: "file" })
       },
       async readFile(path: string, options?: { encoding?: "binary" | "utf8" }): Promise<string | Uint8Array> {
+        await hooks.onReadFile?.(path)
         const entry = files.get(path)
         if (!entry || (entry.type !== "file" && entry.type !== "symlink")) throw new Error(`missing file: ${path}`)
         if (entry.type === "symlink")
@@ -120,6 +125,7 @@ function createFakeSandbox(provider: "cloudflare" | "vercel") {
       },
       async stop() {
         calls.push("stop")
+        if (hooks.stopError !== undefined) throw hooks.stopError
       },
     },
   }
@@ -142,6 +148,135 @@ afterEach(async () => {
 })
 
 describe("sandbox workspace runtime", () => {
+  it("releases a Vercel sandbox when session setup fails", async () => {
+    const setupError = new Error("materialization failed")
+    const fake = createFakeSandbox("vercel")
+    fake.sandbox.writeFile = vi.fn(async () => {
+      throw setupError
+    })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "vercel", runtime: "node24" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    await workspace.writeFile("README.md", "# Docs\n")
+
+    await expect(workspace.startSession()).rejects.toBe(setupError)
+    expect(fake.calls.filter(call => call === "stop")).toHaveLength(1)
+  })
+
+  it("preserves setup and cleanup failures without exposing FiberFailure", async () => {
+    const setupError = new Error("materialization failed")
+    const stopError = new Error("sandbox stop failed")
+    const fake = createFakeSandbox("vercel", { stopError })
+    fake.sandbox.writeFile = vi.fn(async () => {
+      throw setupError
+    })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "vercel", runtime: "node24" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    await workspace.writeFile("README.md", "# Docs\n")
+
+    const failure = await workspace.startSession().catch(error => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([setupError, stopError])
+    expect((failure as Error).name).not.toBe("FiberFailure")
+    expect(fake.calls.filter(call => call === "stop")).toHaveLength(1)
+  })
+
+  it("never stops caller-owned Cloudflare sandboxes", async () => {
+    const setupError = new Error("materialization failed")
+    const fake = createFakeSandbox("cloudflare")
+    fake.sandbox.writeFile = vi.fn(async () => {
+      throw setupError
+    })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "cloudflare", binding: "SANDBOX" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    await workspace.writeFile("README.md", "# Docs\n")
+
+    await expect(workspace.startSession()).rejects.toBe(setupError)
+    expect(fake.calls).not.toContain("stop")
+  })
+
+  it("stops a Vercel sandbox exactly once across concurrent closes", async () => {
+    const fake = createFakeSandbox("vercel")
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "vercel", runtime: "node24" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    const session = await workspace.startSession()
+
+    await Promise.all([session.close(), session.close(), session.close()])
+
+    expect(fake.calls.filter(call => call === "stop")).toHaveLength(1)
+  })
+
+  it("returns Vercel cleanup failures by identity without exposing FiberFailure", async () => {
+    const stopError = new Error("sandbox stop failed")
+    const fake = createFakeSandbox("vercel", { stopError })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "vercel", runtime: "node24" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    const session = await workspace.startSession()
+    const failure = await session.close().catch(error => error)
+
+    expect(failure).toBe(stopError)
+    expect((failure as Error).name).not.toBe("FiberFailure")
+    expect(fake.calls.filter(call => call === "stop")).toHaveLength(1)
+  })
+
+  it("bounds concurrent sandbox snapshot reads at 16", async () => {
+    let activeReads = 0
+    let maximumReads = 0
+    const fake = createFakeSandbox("cloudflare", {
+      async onReadFile() {
+        activeReads += 1
+        maximumReads = Math.max(maximumReads, activeReads)
+        await new Promise(resolve => setTimeout(resolve, 5))
+        activeReads -= 1
+      },
+    })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "cloudflare", binding: "SANDBOX" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    await Promise.all(Array.from({ length: 40 }, (_, index) =>
+      workspace.writeFile(`files/${index}.txt`, String(index))))
+
+    const session = await workspace.startSession()
+
+    expect(maximumReads).toBe(16)
+    await session.close()
+  })
+
   it("uses configured generated-host sandbox loaders", async () => {
     const fake = createFakeSandbox("cloudflare")
     const createSandboxWithConfig = vi.fn(async () => fake.sandbox)

--- a/packages/workspace/test/sandbox-runtime.test.ts
+++ b/packages/workspace/test/sandbox-runtime.test.ts
@@ -11,6 +11,7 @@ import { setSandboxRuntimeConfig } from "@vite-hub/sandbox/runtime/state"
 type FakeEntry = { content?: string | Uint8Array, target?: string, type: "directory" | "file" | "symlink" }
 type FakeSandboxOptions = {
   onReadFile?: (path: string) => Promise<void>
+  onStop?: () => Promise<void>
   stopError?: unknown
 }
 
@@ -125,6 +126,7 @@ function createFakeSandbox(provider: "cloudflare" | "vercel", hooks: FakeSandbox
       },
       async stop() {
         calls.push("stop")
+        await hooks.onStop?.()
         if (hooks.stopError !== undefined) throw hooks.stopError
       },
     },
@@ -228,6 +230,29 @@ describe("sandbox workspace runtime", () => {
     await Promise.all([session.close(), session.close(), session.close()])
 
     expect(fake.calls.filter(call => call === "stop")).toHaveLength(1)
+  })
+
+  it("closes the public session before asynchronous release finishes", async () => {
+    let releaseStop!: () => void
+    const stop = new Promise<void>((resolve) => {
+      releaseStop = resolve
+    })
+    const fake = createFakeSandbox("vercel", { onStop: () => stop })
+    const sandboxPackage = await import("@vite-hub/sandbox")
+    vi.mocked(sandboxPackage.createSandboxWithConfig).mockResolvedValue(fake.sandbox as never)
+    setSandboxRuntimeConfig({ provider: "vercel", runtime: "node24" })
+
+    const workspace = createWorkspace({
+      ...defineWorkspace({ runtime: "sandbox", store: { provider: "memory" } }),
+      name: "docs",
+    })
+    await workspace.writeFile("README.md", "# Docs\n")
+    const session = await workspace.startSession()
+
+    const closing = session.close()
+    await expect(session.readFile("README.md")).rejects.toThrow("already closed")
+    releaseStop()
+    await closing
   })
 
   it("returns Vercel cleanup failures by identity without exposing FiberFailure", async () => {

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -356,6 +356,20 @@ describe("trusted host workspace runtime", () => {
     expect(release).toHaveBeenCalledTimes(1)
   })
 
+  it("does not start child work after the parent scope closes", async () => {
+    const scope = await openTrustedHostWorkspaceScope(
+      async () => "root",
+      async () => undefined,
+      async () => {},
+    )
+    const use = vi.fn(async () => {})
+
+    await scope.close()
+
+    await expect(scope.runChild(use)).rejects.toThrow("Workspace resource scope is already closed")
+    expect(use).not.toHaveBeenCalled()
+  })
+
   it("returns trusted-host cleanup failures by identity without exposing FiberFailure", async () => {
     const cleanupError = new Error("root cleanup failed")
     const scope = await openTrustedHostWorkspaceScope(

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -343,6 +343,25 @@ describe("trusted host workspace runtime", () => {
     expect(Date.now() - closedAt).toBeLessThan(2000)
   })
 
+  it("aborts commands accepted immediately before close", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    const session = await workspace.startSession()
+
+    const command = session.exec(process.execPath, ["-e", "setInterval(() => {}, 1000)"])
+    await session.close()
+
+    await expect(command).resolves.toMatchObject({
+      exitCode: 130,
+      stderr: expect.stringContaining("Command aborted"),
+    })
+  })
+
   it("releases trusted-host roots exactly once across concurrent closes", async () => {
     const release = vi.fn(async () => {})
     const scope = await openTrustedHostWorkspaceScope(

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -258,6 +258,29 @@ describe("trusted host workspace runtime", () => {
     await session.close()
   })
 
+  it("does not spawn commands aborted while registering cleanup", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    let checks = 0
+    const signal = {
+      get aborted() {
+        checks += 1
+        return checks > 1
+      },
+    } as AbortSignal
+
+    const session = await workspace.startSession()
+    const result = await session.exec("vitehub-command-that-does-not-exist", [], { abortSignal: signal })
+
+    expect(result).toMatchObject({ exitCode: 130, stderr: "Command aborted" })
+    await session.close()
+  })
+
   it("removes AbortSignal listeners when commands finish", async () => {
     const workspace = createWorkspace({
       ...defineWorkspace({

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -317,6 +317,85 @@ describe("trusted host workspace runtime", () => {
     expect(events).toEqual(["child", "root"])
   })
 
+  it("returns child cleanup failures by identity without exposing FiberFailure", async () => {
+    const cleanupError = new Error("child cleanup failed")
+    const scope = await openTrustedHostWorkspaceScope(
+      async () => "root",
+      async () => undefined,
+      async () => {},
+    )
+
+    const failure = await scope.runChild(async (registerFinalizer) => {
+      await registerFinalizer(async () => {
+        throw cleanupError
+      })
+    }).catch(error => error)
+
+    expect(failure).toBe(cleanupError)
+    expect((failure as Error).name).not.toBe("FiberFailure")
+    await scope.close()
+  })
+
+  it("preserves child operation and cleanup failures in order", async () => {
+    const operationError = new Error("child operation failed")
+    const cleanupError = new Error("child cleanup failed")
+    const scope = await openTrustedHostWorkspaceScope(
+      async () => "root",
+      async () => undefined,
+      async () => {},
+    )
+
+    const failure = await scope.runChild(async (registerFinalizer) => {
+      await registerFinalizer(async () => {
+        throw cleanupError
+      })
+      throw operationError
+    }).catch(error => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([operationError, cleanupError])
+    expect((failure as Error).name).not.toBe("FiberFailure")
+    await scope.close()
+  })
+
+  it("preserves child and root cleanup failures in order", async () => {
+    const childCleanupError = new Error("child cleanup failed")
+    const rootCleanupError = new Error("root cleanup failed")
+    let finishChild!: () => void
+    let markChildRegistered!: () => void
+    const childFinished = new Promise<void>((resolve) => {
+      finishChild = resolve
+    })
+    const childRegistered = new Promise<void>((resolve) => {
+      markChildRegistered = resolve
+    })
+    const scope = await openTrustedHostWorkspaceScope(
+      async () => "root",
+      async () => undefined,
+      async () => {
+        throw rootCleanupError
+      },
+    )
+    const child = scope.runChild(async (registerFinalizer) => {
+      await registerFinalizer(async () => {
+        finishChild()
+        throw childCleanupError
+      })
+      markChildRegistered()
+      await childFinished
+    })
+
+    await childRegistered
+    const [closeFailure] = await Promise.all([
+      scope.close().catch(error => error),
+      child,
+    ])
+
+    expect(closeFailure).toBeInstanceOf(AggregateError)
+    expect((closeFailure as AggregateError).errors).toEqual([childCleanupError, rootCleanupError])
+    expect((closeFailure as Error).name).not.toBe("FiberFailure")
+  })
+
   it("waits for every active command before the session closes", async () => {
     const workspace = createWorkspace({
       ...defineWorkspace({

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -1,11 +1,11 @@
 import { readdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
-
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { defineWorkspace, fetch as fetchSource } from "../src/index.ts"
 import { createWorkspace } from "../src/core/workspace.ts"
 import { createTrustedHostWorkspaceSession } from "../src/session/trusted-host.ts"
+import { openTrustedHostWorkspaceScope } from "../src/session/trusted-host-scope.ts"
 
 import type { Workspace } from "../src/core/types.ts"
 
@@ -71,6 +71,31 @@ describe("trusted host workspace runtime", () => {
 
     expect(result.exitCode).toBe(0)
     expect(JSON.parse(result.stdout)).toEqual(serviceEnvironment)
+    await session.close()
+  })
+
+  it("preserves command output and exit codes", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+
+    const session = await workspace.startSession()
+    const result = await session.exec(process.execPath, [
+      "-e",
+      "process.stdout.write('out'); process.stderr.write('err'); process.exit(7)",
+    ])
+
+    expect(result).toEqual({
+      args: ["-e", "process.stdout.write('out'); process.stderr.write('err'); process.exit(7)"],
+      command: process.execPath,
+      exitCode: 7,
+      stderr: "err",
+      stdout: "out",
+    })
     await session.close()
   })
 
@@ -167,11 +192,13 @@ describe("trusted host workspace runtime", () => {
     const startedAt = Date.now()
     const result = await session.exec(process.execPath, [
       "-e",
-      "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)",
-    ], { timeout: 20 })
+      "const fs = require('node:fs'); process.on('SIGTERM', () => fs.appendFileSync('signals', 'SIGTERM\\n')); setInterval(() => {}, 1000)",
+    ], { timeout: 200 })
 
     expect(result.exitCode).toBe(124)
     expect(result.stderr).toContain("Command timed out")
+    await expect(session.readFile("signals")).resolves.toBe("SIGTERM\n")
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(250)
     expect(Date.now() - startedAt).toBeLessThan(2000)
     await session.close()
   })
@@ -187,17 +214,198 @@ describe("trusted host workspace runtime", () => {
 
     const session = await workspace.startSession()
     const controller = new AbortController()
-    const startedAt = Date.now()
-    setTimeout(() => controller.abort(), 20)
-    const result = await session.exec(process.execPath, [
+    const command = session.exec(process.execPath, [
       "-e",
-      "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)",
+      "const fs = require('node:fs'); process.on('SIGTERM', () => fs.appendFileSync('signals', 'SIGTERM\\n')); fs.writeFileSync('ready', ''); setInterval(() => {}, 1000)",
     ], { abortSignal: controller.signal })
+    while (!await session.readFile("ready").then(() => true, () => false))
+      await new Promise(resolve => setTimeout(resolve, 5))
+    const abortedAt = Date.now()
+    controller.abort()
+    const result = await command
 
     expect(result.exitCode).toBe(130)
     expect(result.stderr).toContain("Command aborted")
-    expect(Date.now() - startedAt).toBeLessThan(2000)
+    await expect(session.readFile("signals")).resolves.toBe("SIGTERM\n")
+    expect(Date.now() - abortedAt).toBeGreaterThanOrEqual(80)
+    expect(Date.now() - abortedAt).toBeLessThan(2000)
     await session.close()
+  })
+
+  it("does not spawn commands for already-aborted signals", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    const controller = new AbortController()
+    controller.abort()
+
+    const session = await workspace.startSession()
+    const result = await session.exec("vitehub-command-that-does-not-exist", [], {
+      abortSignal: controller.signal,
+    })
+
+    expect(result).toEqual({
+      args: [],
+      command: "vitehub-command-that-does-not-exist",
+      exitCode: 130,
+      stderr: "Command aborted",
+      stdout: "",
+    })
+    await session.close()
+  })
+
+  it("removes AbortSignal listeners when commands finish", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    const controller = new AbortController()
+    const addEventListener = vi.spyOn(controller.signal, "addEventListener")
+    const removeEventListener = vi.spyOn(controller.signal, "removeEventListener")
+
+    const session = await workspace.startSession()
+    const result = await session.exec(process.execPath, ["-e", "process.stdout.write('done')"], {
+      abortSignal: controller.signal,
+      timeout: 1000,
+    })
+
+    expect(result).toMatchObject({ exitCode: 0, stdout: "done" })
+    expect(addEventListener).toHaveBeenCalledTimes(1)
+    expect(removeEventListener).toHaveBeenCalledWith("abort", addEventListener.mock.calls[0]?.[1])
+    controller.abort()
+    await session.close()
+  })
+
+  it("stops active child processes before releasing the session root", async () => {
+    const events: string[] = []
+    let finishChild: (() => void) | undefined
+    let markChildStarted!: () => void
+    const childStarted = new Promise<void>((resolve) => {
+      markChildStarted = resolve
+    })
+    const scope = await openTrustedHostWorkspaceScope(
+      async () => "root",
+      async () => undefined,
+      async () => {
+        events.push("root")
+      },
+    )
+    const child = scope.runChild(async (registerFinalizer) => {
+      markChildStarted()
+      const finished = new Promise<void>((resolve) => {
+        finishChild = resolve
+      })
+      await registerFinalizer(async () => {
+        events.push("child")
+        finishChild?.()
+        await finished
+      })
+      await finished
+    })
+
+    await childStarted
+    await scope.close()
+    await child
+
+    expect(events).toEqual(["child", "root"])
+  })
+
+  it("waits for every active command before the session closes", async () => {
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        runtime: "trusted-host",
+        store: { provider: "memory" },
+      }),
+      name: "docs",
+    })
+    const session = await workspace.startSession()
+    const commands = ["one", "two"].map(name => session.exec(process.execPath, [
+      "-e",
+      `const fs = require('node:fs'); process.on('SIGTERM', () => {}); fs.writeFileSync('ready-${name}', ''); setInterval(() => {}, 1000)`,
+    ]))
+
+    while (!await Promise.all(["one", "two"].map(name => session.readFile(`ready-${name}`).then(() => true, () => false))).then(states => states.every(Boolean)))
+      await new Promise(resolve => setTimeout(resolve, 5))
+    const closedAt = Date.now()
+    await Promise.all([session.close(), session.close(), session.close()])
+    const results = await Promise.all(commands)
+
+    expect(results.map(result => result.exitCode)).toEqual([130, 130])
+    expect(results.every(result => result.stderr.includes("Command aborted"))).toBe(true)
+    expect(Date.now() - closedAt).toBeGreaterThanOrEqual(80)
+    expect(Date.now() - closedAt).toBeLessThan(2000)
+  })
+
+  it("releases trusted-host roots exactly once across concurrent closes", async () => {
+    const release = vi.fn(async () => {})
+    const scope = await openTrustedHostWorkspaceScope(
+      async () => "root",
+      async () => undefined,
+      release,
+    )
+
+    await Promise.all([scope.close(), scope.close(), scope.close()])
+
+    expect(release).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns trusted-host cleanup failures by identity without exposing FiberFailure", async () => {
+    const cleanupError = new Error("root cleanup failed")
+    const scope = await openTrustedHostWorkspaceScope(
+      async () => "root",
+      async () => undefined,
+      async () => {
+        throw cleanupError
+      },
+    )
+
+    const failure = await scope.close().catch(error => error)
+
+    expect(failure).toBe(cleanupError)
+    expect((failure as Error).name).not.toBe("FiberFailure")
+  })
+
+  it("preserves trusted-host setup and cleanup failures", async () => {
+    const setupError = new Error("materialization failed")
+    const cleanupError = new Error("root cleanup failed")
+
+    const failure = await openTrustedHostWorkspaceScope(
+      async () => "root",
+      async () => {
+        throw setupError
+      },
+      async () => {
+        throw cleanupError
+      },
+    ).catch(error => error)
+
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect((failure as AggregateError).errors).toEqual([setupError, cleanupError])
+    expect((failure as Error).name).not.toBe("FiberFailure")
+  })
+
+  it("returns trusted-host setup failures by identity after successful cleanup", async () => {
+    const setupError = new Error("materialization failed")
+    const release = vi.fn(async () => {})
+
+    const failure = await openTrustedHostWorkspaceScope(
+      async () => "root",
+      async () => {
+        throw setupError
+      },
+      release,
+    ).catch(error => error)
+
+    expect(failure).toBe(setupError)
+    expect((failure as Error).name).not.toBe("FiberFailure")
+    expect(release).toHaveBeenCalledTimes(1)
   })
 
   it("materializes generated source descriptors for shell inspection", async () => {

--- a/packages/workspace/test/trusted-host-runtime.test.ts
+++ b/packages/workspace/test/trusted-host-runtime.test.ts
@@ -358,7 +358,34 @@ describe("trusted host workspace runtime", () => {
     await scope.close()
   })
 
-  it("preserves child and root cleanup failures in order", async () => {
+  it("keeps primary, child, and root failures at their owning boundaries", async () => {
+    const operationError = new Error("child operation failed")
+    const childCleanupError = new Error("child cleanup failed")
+    const rootCleanupError = new Error("root cleanup failed")
+    const scope = await openTrustedHostWorkspaceScope(
+      async () => "root",
+      async () => undefined,
+      async () => {
+        throw rootCleanupError
+      },
+    )
+
+    const childFailure = await scope.runChild(async (registerFinalizer) => {
+      await registerFinalizer(async () => {
+        throw childCleanupError
+      })
+      throw operationError
+    }).catch(error => error)
+    const rootFailure = await scope.close().catch(error => error)
+
+    expect(childFailure).toBeInstanceOf(AggregateError)
+    expect((childFailure as AggregateError).errors).toEqual([operationError, childCleanupError])
+    expect((childFailure as Error).name).not.toBe("FiberFailure")
+    expect(rootFailure).toBe(rootCleanupError)
+    expect((rootFailure as Error).name).not.toBe("FiberFailure")
+  })
+
+  it("preserves child and root cleanup failures across concurrent closes", async () => {
     const childCleanupError = new Error("child cleanup failed")
     const rootCleanupError = new Error("root cleanup failed")
     let finishChild!: () => void
@@ -386,7 +413,9 @@ describe("trusted host workspace runtime", () => {
     })
 
     await childRegistered
-    const [closeFailure] = await Promise.all([
+    const [closeFailure, secondCloseFailure, thirdCloseFailure] = await Promise.all([
+      scope.close().catch(error => error),
+      scope.close().catch(error => error),
       scope.close().catch(error => error),
       child,
     ])
@@ -394,6 +423,8 @@ describe("trusted host workspace runtime", () => {
     expect(closeFailure).toBeInstanceOf(AggregateError)
     expect((closeFailure as AggregateError).errors).toEqual([childCleanupError, rootCleanupError])
     expect((closeFailure as Error).name).not.toBe("FiberFailure")
+    expect(secondCloseFailure).toBe(closeFailure)
+    expect(thirdCloseFailure).toBe(closeFailure)
   })
 
   it("waits for every active command before the session closes", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,6 +484,9 @@ importers:
       comark:
         specifier: catalog:ui
         version: 0.5.1(shiki@4.3.1)
+      effect:
+        specifier: catalog:effect
+        version: 4.0.0-beta.99
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1064,6 +1064,9 @@ importers:
       cron-schedule:
         specifier: catalog:workflow
         version: 6.0.0
+      effect:
+        specifier: catalog:effect
+        version: 4.0.0-beta.99
       esbuild:
         specifier: catalog:tooling
         version: 0.28.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1337,6 +1337,9 @@ importers:
       '@vite-hub/markdown-template':
         specifier: workspace:*
         version: link:../markdown-template
+      '@vite-hub/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       '@vite-hub/source':
         specifier: workspace:*
         version: link:../source

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,10 @@ catalogs:
     drizzle-orm:
       specifier: ^0.45.2
       version: 0.45.2
+  effect:
+    effect:
+      specifier: 4.0.0-beta.99
+      version: 4.0.0-beta.99
   email:
     '@types/nodemailer':
       specifier: ^8.0.1
@@ -480,6 +484,9 @@ importers:
       comark:
         specifier: catalog:ui
         version: 0.5.1(shiki@4.3.1)
+      effect:
+        specifier: catalog:effect
+        version: 4.0.0-beta.99
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7
@@ -8894,6 +8901,9 @@ packages:
   effect@3.17.7:
     resolution: {integrity: sha512-dpt0ONUn3zzAuul6k4nC/coTTw27AL5nhkORXgTi6NfMPzqWYa1M05oKmOMTxpVSTKepqXVcW9vIwkuaaqx9zA==}
 
+  effect@4.0.0-beta.99:
+    resolution: {integrity: sha512-hP1C61uzINfLl/4kKMwcqksxd34s4sQ3VSjsWjhGrkx9CRlXaqnfOK9dpTEKynQ6rA7wU9rb3c+48eDYw7uzxA==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -9225,6 +9235,10 @@ packages:
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
+
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -9988,6 +10002,10 @@ packages:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  ini@7.0.0:
+    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   inspect-with-kind@1.0.5:
     resolution: {integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==}
 
@@ -10310,6 +10328,9 @@ packages:
 
   knitwork@1.3.0:
     resolution: {integrity: sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==}
+
+  kubernetes-types@1.30.0:
+    resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
 
   kysely@0.29.3:
     resolution: {integrity: sha512-VHtBdW6XB/pgoTSqraM3UAa2rYoYdNXqnNPpX+8XXP+cwYbVEFuAp3HyPt1vpNfU9l7Y2kpUrA9QDPsy8uUqOQ==}
@@ -10832,6 +10853,9 @@ packages:
 
   msgpackr@1.12.1:
     resolution: {integrity: sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==}
+
+  msgpackr@2.0.4:
+    resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
@@ -11736,6 +11760,9 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
+
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
@@ -12543,6 +12570,10 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  toml@4.3.0:
+    resolution: {integrity: sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==}
+    engines: {node: '>=20'}
 
   tosource@2.0.0-alpha.3:
     resolution: {integrity: sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug==}
@@ -22551,6 +22582,19 @@ snapshots:
       fast-check: 3.23.2
     optional: true
 
+  effect@4.0.0-beta.99:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 4.9.0
+      find-my-way-ts: 0.1.6
+      ini: 7.0.0
+      kubernetes-types: 1.30.0
+      msgpackr: 2.0.4
+      multipasta: 0.2.8
+      toml: 4.3.0
+      uuid: 11.1.1
+      yaml: 2.9.0
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
@@ -23038,6 +23082,10 @@ snapshots:
       pure-rand: 6.1.0
     optional: true
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
@@ -23225,8 +23273,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-my-way-ts@0.1.6:
-    optional: true
+  find-my-way-ts@0.1.6: {}
 
   find-my-way@9.6.0:
     dependencies:
@@ -23963,6 +24010,8 @@ snapshots:
 
   ini@6.0.0: {}
 
+  ini@7.0.0: {}
+
   inspect-with-kind@1.0.5:
     dependencies:
       kind-of: 6.0.3
@@ -24314,6 +24363,8 @@ snapshots:
       zod: 4.4.3
 
   knitwork@1.3.0: {}
+
+  kubernetes-types@1.30.0: {}
 
   kysely@0.29.3: {}
 
@@ -25078,10 +25129,13 @@ snapshots:
       msgpackr-extract: 3.0.4
     optional: true
 
+  msgpackr@2.0.4:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
+
   muggle-string@0.4.1: {}
 
-  multipasta@0.2.8:
-    optional: true
+  multipasta@0.2.8: {}
 
   nanoid@3.3.16: {}
 
@@ -27250,6 +27304,8 @@ snapshots:
   pure-rand@6.1.0:
     optional: true
 
+  pure-rand@8.4.2: {}
+
   qs@6.15.3:
     dependencies:
       es-define-property: 1.0.1
@@ -28274,6 +28330,8 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  toml@4.3.0: {}
+
   tosource@2.0.0-alpha.3: {}
 
   totalist@3.0.1: {}
@@ -28808,8 +28866,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.1:
-    optional: true
+  uuid@11.1.1: {}
 
   valibot@1.4.2(typescript@6.0.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,9 +484,6 @@ importers:
       comark:
         specifier: catalog:ui
         version: 0.5.1(shiki@4.3.1)
-      effect:
-        specifier: catalog:effect
-        version: 4.0.0-beta.99
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7
@@ -1064,9 +1061,6 @@ importers:
       cron-schedule:
         specifier: catalog:workflow
         version: 6.0.0
-      effect:
-        specifier: catalog:effect
-        version: 4.0.0-beta.99
       esbuild:
         specifier: catalog:tooling
         version: 0.28.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1349,6 +1349,9 @@ importers:
       defu:
         specifier: catalog:unjs
         version: 6.1.7
+      effect:
+        specifier: catalog:effect
+        version: 4.0.0-beta.99
       exsolve:
         specifier: catalog:unjs
         version: 1.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,8 @@ packages:
 catalogMode: prefer
 
 catalogs:
+  effect:
+    effect: 4.0.0-beta.99
   ai:
     "@ai-sdk/harness": 1.0.0
     "@ai-sdk/harness-claude-code": 1.0.0

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -203,7 +203,7 @@ function workspaceConfig(specs: Record<string, string>) {
     "  - .",
     "allowBuilds:",
     "  esbuild: true",
-    "  msgpackr-extract: true",
+    "  msgpackr-extract: false",
     "overrides:",
     ...overrides,
     "",
@@ -262,6 +262,23 @@ async function assertOptionalPackagesUnreachable(appDir: string) {
   ].join("\n")
   const { stdout } = await run("node", ["--input-type=module", "--eval", script], appDir)
   expect(JSON.parse(stdout), "optional packages must not resolve from the consumer root").toEqual([])
+}
+
+async function assertEffectMsgpackFallback(appDir: string) {
+  const script = [
+    "import { createRequire } from \"node:module\"",
+    "const viteHubRequire = createRequire(import.meta.resolve(\"vite-hub/package.json\"))",
+    "const agentRequire = createRequire(viteHubRequire.resolve(\"@vite-hub/agent/package.json\"))",
+    "const effectRequire = createRequire(agentRequire.resolve(\"effect\"))",
+    "const msgpackr = await import(effectRequire.resolve(\"msgpackr\"))",
+    "const input = { fallback: true, value: \"vitehub\" }",
+    "const output = msgpackr.unpack(msgpackr.pack(input))",
+    "if (JSON.stringify(output) !== JSON.stringify(input)) throw new Error(\"msgpackr fallback roundtrip failed\")",
+  ].join("\n")
+  await run("node", ["--input-type=module", "--eval", script], appDir, {
+    ...process.env,
+    MSGPACKR_NATIVE_ACCELERATION_DISABLED: "true",
+  })
 }
 
 function importSpecifierOccurrences(source: string) {
@@ -369,6 +386,7 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
         "let resolved = false; try { import.meta.resolve('@vite-hub/agent'); resolved = true } catch {} if (resolved) throw new Error('owner package resolved from the consumer root')",
       ], appDir)
       await assertOptionalPackagesUnreachable(appDir)
+      await assertEffectMsgpackFallback(appDir)
 
       await run("pnpm", ["run", "typecheck"], appDir)
       await run("pnpm", ["run", "build"], appDir)

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -203,6 +203,7 @@ function workspaceConfig(specs: Record<string, string>) {
     "  - .",
     "allowBuilds:",
     "  esbuild: true",
+    "  msgpackr-extract: true",
     "overrides:",
     ...overrides,
     "",
@@ -451,24 +452,21 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
       const netlifyProviderImports = importSpecifierOccurrences(netlifyFunctionSource)
         .filter(({ specifier }) => specifier === "vite-hub" || specifier.startsWith("vite-hub/") || specifier.startsWith("@vite-hub/"))
       expect(netlifyProviderImports, "Netlify Agent output must bundle canonical and owner-package imports").toEqual([])
-      const netlifyFunction = await import(`${pathToFileURL(netlifyFunctionPath).href}?contract=${Date.now()}`) as {
-        default: (request: Request, context: { waitUntil: (task: Promise<unknown>) => void }) => Promise<Response>
-      }
-      const netlifyTasks: Promise<unknown>[] = []
-      const netlifyResponse = await netlifyFunction.default(new Request("https://example.com/api/_vitehub/agents/echo/chat", {
-        body: JSON.stringify({
-          messages: [{ id: "user-1", parts: [{ text: "netlify", type: "text" }], role: "user" }],
-        }),
-        headers: { "content-type": "application/json" },
-        method: "POST",
-      }), {
-        waitUntil(task) {
-          netlifyTasks.push(task)
-        },
-      })
+      const netlifyInvocation = await run("node", ["--input-type=module", "--eval", `
+        const handler = await import(${JSON.stringify(pathToFileURL(netlifyFunctionPath).href)})
+        const tasks = []
+        const response = await handler.default(new Request("https://example.com/api/_vitehub/agents/echo/chat", {
+          body: JSON.stringify({ messages: [{ id: "user-1", parts: [{ text: "netlify", type: "text" }], role: "user" }] }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        }), { waitUntil: task => tasks.push(task) })
+        const body = await response.text()
+        await Promise.all(tasks)
+        process.stdout.write(JSON.stringify({ body, status: response.status }))
+      `], appDir)
+      const netlifyResponse = JSON.parse(netlifyInvocation.stdout) as { body: string, status: number }
       expect(netlifyResponse.status).toBe(200)
-      expect(await netlifyResponse.text()).toContain("VITE_HUB_SERVER_ONLY:/workspace")
-      await Promise.all(netlifyTasks)
+      expect(netlifyResponse.body).toContain("VITE_HUB_SERVER_ONLY:/workspace")
 
       for (const alias of ["vitehub", "vite-hub"]) {
         const help = await run("pnpm", ["exec", alias, "--help"], appDir)

--- a/test/effect-ownership.test.ts
+++ b/test/effect-ownership.test.ts
@@ -1,0 +1,76 @@
+import { createRequire } from "node:module"
+import { existsSync } from "node:fs"
+import { readFile, readdir } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const effectVersion = "4.0.0-beta.99"
+
+async function readFiles(dir: string, predicate: (path: string) => boolean): Promise<string[]> {
+  if (!existsSync(dir)) return []
+  const files = (await readdir(dir, { recursive: true }))
+    .filter(path => predicate(path))
+  return Promise.all(files.map(path => readFile(join(dir, path), "utf8")))
+}
+
+async function effectOwners() {
+  const packagesDir = join(repoRoot, "packages")
+  const owners: string[] = []
+  for (const entry of await readdir(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const packageDir = join(packagesDir, entry.name)
+    const source = (await readFiles(join(packageDir, "src"), path => /\.[cm]?[jt]sx?$/.test(path))).join("\n")
+    if (/(?:from\s*|import\s*(?:\(\s*)?)["']effect(?:\/[^"']*)?["']/.test(source)) owners.push(packageDir)
+  }
+  return owners
+}
+
+function lockOwnerForV3References(lockfile: string) {
+  let owner = ""
+  const owners: string[] = []
+  for (const line of lockfile.split("\n")) {
+    const packageEntry = /^  (\S.*):$/.exec(line)
+    if (packageEntry) owner = packageEntry[1]!
+    if (/effect@3\.|effect:\s*[\^~]?3\./.test(line)) owners.push(owner)
+  }
+  return owners
+}
+
+describe("Effect ownership", () => {
+  it("pins every ViteHub Effect importer to the owned Effect 4 catalog", async () => {
+    const workspace = await readFile(join(repoRoot, "pnpm-workspace.yaml"), "utf8")
+    expect(workspace).toContain(`  effect:\n    effect: ${effectVersion}`)
+
+    const owners = await effectOwners()
+    expect(owners.length).toBeGreaterThan(0)
+    for (const packageDir of owners) {
+      const manifestPath = join(packageDir, "package.json")
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { dependencies?: Record<string, string> }
+      expect(manifest.dependencies?.effect, manifestPath).toBe("catalog:effect")
+
+      const effectPackage = createRequire(manifestPath).resolve("effect/package.json")
+      const resolved = JSON.parse(await readFile(effectPackage, "utf8")) as { version: string }
+      expect(resolved.version, packageDir).toBe(effectVersion)
+
+      const declarations = (await readFiles(join(packageDir, "dist"), path => path.endsWith(".d.ts"))).join("\n")
+      expect(declarations, packageDir).not.toMatch(/(?:from\s*|import\s*(?:\(\s*)?)["']effect(?:\/[^"']*)?["']/)
+
+      const bundles = (await readFiles(join(packageDir, "dist"), path => /\.[cm]?js$/.test(path))).join("\n")
+      expect(bundles, packageDir).not.toMatch(/effect@3\.|3\.17\.7/)
+    }
+  })
+
+  it("isolates the optional Effect 3 subtree to UploadThing", async () => {
+    const lockfile = await readFile(join(repoRoot, "pnpm-lock.yaml"), "utf8")
+    const owners = lockOwnerForV3References(lockfile)
+    expect(owners.length).toBeGreaterThan(0)
+    expect(owners.filter(owner => !(
+      /^effect@3\./.test(owner)
+      || owner.startsWith("'@effect/platform@")
+      || owner.startsWith("'@uploadthing/shared@")
+      || owner.startsWith("uploadthing@")
+    ))).toEqual([])
+  })
+})

--- a/test/local/deno-real-project.mjs
+++ b/test/local/deno-real-project.mjs
@@ -80,6 +80,7 @@ function renderWorkspaceYaml(overrides) {
   return [
     "allowBuilds:",
     "  esbuild: true",
+    "  msgpackr-extract: true",
     "catalog:",
     "  vite: npm:@voidzero-dev/vite-plus-core@latest",
     "  vitest: npm:@voidzero-dev/vite-plus-test@latest",

--- a/test/local/deno-real-project.mjs
+++ b/test/local/deno-real-project.mjs
@@ -80,7 +80,7 @@ function renderWorkspaceYaml(overrides) {
   return [
     "allowBuilds:",
     "  esbuild: true",
-    "  msgpackr-extract: true",
+    "  msgpackr-extract: false",
     "catalog:",
     "  vite: npm:@voidzero-dev/vite-plus-core@latest",
     "  vitest: npm:@voidzero-dev/vite-plus-test@latest",

--- a/test/local/netlify-real-project.mjs
+++ b/test/local/netlify-real-project.mjs
@@ -65,6 +65,7 @@ function renderWorkspaceYaml(overrides) {
     "  '@swc/core': true",
     "  cbor-extract: true",
     "  esbuild: true",
+    "  msgpackr-extract: true",
     "  node-liblzma: true",
     "catalog:",
     "  vite: npm:@voidzero-dev/vite-plus-core@latest",

--- a/test/local/netlify-real-project.mjs
+++ b/test/local/netlify-real-project.mjs
@@ -65,7 +65,7 @@ function renderWorkspaceYaml(overrides) {
     "  '@swc/core': true",
     "  cbor-extract: true",
     "  esbuild: true",
-    "  msgpackr-extract: true",
+    "  msgpackr-extract: false",
     "  node-liblzma: true",
     "catalog:",
     "  vite: npm:@voidzero-dev/vite-plus-core@latest",


### PR DESCRIPTION
Keeps the trusted-host command protocol as the existing compact Promise state machine and gives Effect the ownership boundary it can improve: one parent Scope owns the materialized root, each active command registers one finalizer in a child Scope, and parent close drains those children before releasing the root. Close during execution still returns exit 130, timeout returns 124, the 100ms SIGKILL fallback remains, and stdout, stderr, environment, cwd, and spawn-error behavior stay unchanged.

The shared resource Scope replaces the duplicated sandbox Scope implementation, so sandbox and trusted-host use one lifecycle mechanism. Effect owns child registration, finalizer ordering, concurrent close, and exactly-once root release; an explicit wrapper-owned closed flag guards the public session contract without reading non-contract `scope.state` internals. The Promise still owns the Node child-process event protocol.

Third-party cleanup promises enter through `tryWorkspacePromise`. Each infallible Scope finalizer catches its typed `WorkspaceEffectFailure`, records the original cause in an Effect `Ref`, and completes without `orDie` or defect promotion. Only after `Scope.close` does the Promise boundary read those causes and merge them with operation or root-release failures in the existing order. Cleanup-only failures retain their original identity; operation plus cleanup failures return `AggregateError([operation, cleanup])`; parent close preserves child plus root cleanup ordering as `AggregateError([child, root])`; no path exposes `WorkspaceEffectFailure` or `FiberFailure`. Actual Effect defects stay defects and retain their exact identity.

The production delta from #675 is +280/-127, or +153 net lines; tests add +415/-8. That increase pays for one shared sandbox/trusted-host owner, typed cleanup capture, child-before-root ordering, closed-scope admission, finalizer-registration and abort races, exactly-once concurrent close, ordered preservation of child operation, child cleanup, and root cleanup failures, and direct regression coverage for the typed-failure versus defect boundary.

## Hard dependency

This PR targets `refactor/effect-workspace-sandbox-scope` at `e9216213` and must not merge before #675.

Proof at head `0a3ad8c`: exact-head CI passes, including the full Workspace suite at 30 files and 449 tests with no type errors; focused Effect runtime, trusted-host, and sandbox tests pass 61/61; docs, consumer, provider verification, preview package, and Workers checks pass. The external Vercel preview is rate-limited; its repository `verify (vercel)` check passes.

EFFECT ADOPTION STATUS
  seam: Sandbox and trusted-host WorkspaceSession resource hierarchy, including trusted-host child command ownership
  public API: unchanged Promise/WorkspaceSession contract; close waits for active trusted-host commands
  boundary: packages/workspace/src/session/resource-scope.ts and packages/workspace/src/internal/effect-runtime.ts
  typed failures: WorkspaceEffectFailure is caught inside Scope finalizers, stored as original causes in Effect Ref, and unwrapped only from Cause.Fail after Scope.close; Cause.Die defects retain exact identity
  resources/fibers: one sequential parent Scope per session and one forked child Scope per active trusted-host command
  deleted: duplicated sandbox/trusted-host Scope plumbing, manual trusted-host active-process ownership, non-contract Scope state inspection, and recoverable-failure defect promotion
  retained: compact Promise child-process event and termination state machine; explicit public closed-state guard
  source pay-rent: +280/-127 production lines, +153 net; +415/-8 test lines
  todos: 0
  confidence: high

<!-- babysitter:blocker:v1 -->

> [!WARNING]
> **Babysitter is blocked:** prerequisite pull request #675 is still open, and this pull request explicitly must not merge before it.
>
> Merge #675 into its target branch; then this pull request can be revalidated and merged.

<!-- /babysitter:blocker:v1 -->

