### PR TITLE
fix(shell): dispose background processes

### DIFF
--- a/packages/shell/src/runtime/session.ts
+++ b/packages/shell/src/runtime/session.ts
@@ -106,7 +106,7 @@ class RuntimeShellSession implements ShellSession {
     })
     let stopTask: Promise<ShellObservation> | undefined
     let trackedProcess: ShellProcess
-    const stop = () => stopTask ??= process.stop().finally(() => {
+    const stop = () => stopTask ??= Promise.resolve().then(() => process.stop()).finally(() => {
       this.#processes.delete(trackedProcess)
     })
     trackedProcess = { ...process, stop }

--- a/packages/shell/src/runtime/session.ts
+++ b/packages/shell/src/runtime/session.ts
@@ -155,11 +155,14 @@ class RuntimeShellSession implements ShellSession {
   dispose() {
     this.#disposed = true
     return this.#disposeTask ??= (async () => {
-      const starts = await Promise.allSettled(this.#starts)
+      const pendingStarts = [...this.#starts]
       this.#starts.clear()
       const processes = [...this.#processes.values()]
       this.#processes.clear()
-      const results = await Promise.allSettled(processes.map(process => process.stop()))
+      const [starts, results] = await Promise.all([
+        Promise.allSettled(pendingStarts),
+        Promise.allSettled(processes.map(process => process.stop())),
+      ])
       const failures = [...starts, ...results]
         .flatMap(result => result.status === "rejected" ? [result.reason] : [])
       if (failures.length > 0) throw new AggregateError(failures, shellSessionStopFailureMessage)

--- a/packages/shell/src/runtime/session.ts
+++ b/packages/shell/src/runtime/session.ts
@@ -38,11 +38,15 @@ function createPolicyObservation(command: string, cwd: string | undefined, messa
   }
 }
 
+const shellSessionDisposedMessage = "[vitehub] Shell session is disposed."
+const shellSessionStopFailureMessage = "[vitehub] Shell session failed to stop multiple background processes."
+
 class RuntimeShellSession implements ShellSession {
   readonly boundary
   readonly policy: ShellSessionPolicy
   #disposed = false
-  #processes = new Map<string, ShellProcess>()
+  #disposeTask: Promise<ShellObservation> | undefined
+  #processes = new Set<ShellProcess>()
   #shellCalls = 0
 
   constructor(
@@ -60,7 +64,7 @@ class RuntimeShellSession implements ShellSession {
 
   async exec(command: string, options: ShellRuntimeExecOptions = {}) {
     if (this.#disposed) {
-      return createPolicyObservation(command, options.cwd, "[vitehub] Shell session is disposed.")
+      return createPolicyObservation(command, options.cwd, shellSessionDisposedMessage)
     }
     if (typeof this.policy.maxShellCalls === "number" && this.#shellCalls >= this.policy.maxShellCalls) {
       return createPolicyObservation(
@@ -88,7 +92,7 @@ class RuntimeShellSession implements ShellSession {
   }
 
   async startProcess(command: string, options: ShellRuntimeExecOptions = {}) {
-    if (this.#disposed) throw new Error("[vitehub] Shell session is disposed.")
+    if (this.#disposed) throw new Error(shellSessionDisposedMessage)
     if (!this.provider.startProcess || !this.boundary.processes.background) {
       throw new Error("[vitehub] Shell provider does not support long-running processes.")
     }
@@ -100,18 +104,25 @@ class RuntimeShellSession implements ShellSession {
       env: { ...this.env, ...options.env },
       timeout: options.timeout ?? this.policy.timeout,
     })
-    const trackedProcess: ShellProcess = {
-      ...process,
-      stop: async () => {
-        try {
-          return await process.stop()
-        }
-        finally {
-          this.#processes.delete(process.id)
-        }
-      },
+    let stopTask: Promise<ShellObservation> | undefined
+    let trackedProcess: ShellProcess
+    const stop = () => stopTask ??= process.stop().finally(() => {
+      this.#processes.delete(trackedProcess)
+    })
+    trackedProcess = { ...process, stop }
+    if (this.#disposed) {
+      try {
+        await stop()
+      }
+      catch (error) {
+        throw new AggregateError(
+          [new Error(shellSessionDisposedMessage), error],
+          "[vitehub] Shell session was disposed while starting a background process, and stopping it failed.",
+        )
+      }
+      throw new Error(shellSessionDisposedMessage)
     }
-    this.#processes.set(process.id, trackedProcess)
+    this.#processes.add(trackedProcess)
     return trackedProcess
   }
 
@@ -119,14 +130,21 @@ class RuntimeShellSession implements ShellSession {
     return [...this.#processes.values()]
   }
 
-  async dispose() {
+  dispose() {
     this.#disposed = true
-    return {
-      event: "session_disposed",
-      exitCode: null,
-      stderr: "",
-      stdout: "",
-    } satisfies ShellObservation
+    return this.#disposeTask ??= (async () => {
+      const processes = [...this.#processes.values()]
+      this.#processes.clear()
+      const results = await Promise.allSettled(processes.map(process => process.stop()))
+      const failures = results.flatMap(result => result.status === "rejected" ? [result.reason] : [])
+      if (failures.length > 0) throw new AggregateError(failures, shellSessionStopFailureMessage)
+      return {
+        event: "session_disposed" as const,
+        exitCode: null,
+        stderr: "",
+        stdout: "",
+      }
+    })()
   }
 }
 

--- a/packages/shell/src/runtime/session.ts
+++ b/packages/shell/src/runtime/session.ts
@@ -47,6 +47,7 @@ class RuntimeShellSession implements ShellSession {
   #disposed = false
   #disposeTask: Promise<ShellObservation> | undefined
   #processes = new Set<ShellProcess>()
+  #starts = new Set<Promise<void>>()
   #shellCalls = 0
 
   constructor(
@@ -99,11 +100,29 @@ class RuntimeShellSession implements ShellSession {
     if (typeof this.policy.maxProcesses === "number" && this.#processes.size >= this.policy.maxProcesses) {
       throw new Error(`[vitehub] Shell session process budget exhausted after ${this.policy.maxProcesses} processes.`)
     }
-    const process = await this.provider.startProcess(command, {
-      ...options,
-      env: { ...this.env, ...options.env },
-      timeout: options.timeout ?? this.policy.timeout,
+    let resolveOwnership!: () => void
+    let rejectOwnership!: (reason: unknown) => void
+    const ownership = new Promise<void>((resolve, reject) => {
+      resolveOwnership = resolve
+      rejectOwnership = reject
     })
+    this.#starts.add(ownership)
+    void ownership.then(
+      () => this.#starts.delete(ownership),
+      () => this.#starts.delete(ownership),
+    )
+    let process: ShellProcess
+    try {
+      process = await this.provider.startProcess(command, {
+        ...options,
+        env: { ...this.env, ...options.env },
+        timeout: options.timeout ?? this.policy.timeout,
+      })
+    }
+    catch (error) {
+      resolveOwnership()
+      throw error
+    }
     let stopTask: Promise<ShellObservation> | undefined
     let trackedProcess: ShellProcess
     const stop = () => stopTask ??= Promise.resolve().then(() => process.stop()).finally(() => {
@@ -115,14 +134,17 @@ class RuntimeShellSession implements ShellSession {
         await stop()
       }
       catch (error) {
+        rejectOwnership(error)
         throw new AggregateError(
           [new Error(shellSessionDisposedMessage), error],
           "[vitehub] Shell session was disposed while starting a background process, and stopping it failed.",
         )
       }
+      resolveOwnership()
       throw new Error(shellSessionDisposedMessage)
     }
     this.#processes.add(trackedProcess)
+    resolveOwnership()
     return trackedProcess
   }
 
@@ -133,10 +155,13 @@ class RuntimeShellSession implements ShellSession {
   dispose() {
     this.#disposed = true
     return this.#disposeTask ??= (async () => {
+      const starts = await Promise.allSettled(this.#starts)
+      this.#starts.clear()
       const processes = [...this.#processes.values()]
       this.#processes.clear()
       const results = await Promise.allSettled(processes.map(process => process.stop()))
-      const failures = results.flatMap(result => result.status === "rejected" ? [result.reason] : [])
+      const failures = [...starts, ...results]
+        .flatMap(result => result.status === "rejected" ? [result.reason] : [])
       if (failures.length > 0) throw new AggregateError(failures, shellSessionStopFailureMessage)
       return {
         event: "session_disposed" as const,

--- a/packages/shell/test/runtime.test.ts
+++ b/packages/shell/test/runtime.test.ts
@@ -17,7 +17,6 @@ import { createCloudflareShellProvider } from "../src/providers/cloudflare.ts"
 import type {
   ShellExecutionProvider,
   ShellProcess,
-  ShellRuntimeExecOptions,
 } from "../src/index.ts"
 import type {
   ReadonlyShellWorkspace,
@@ -36,6 +35,48 @@ function createReadonlyRuntime(workspace: ReadonlyShellWorkspace) {
       fs: createReadonlyWorkspaceFs(workspace),
     }),
   })
+}
+
+function createBackgroundProvider(
+  startProcess: NonNullable<ShellExecutionProvider["startProcess"]>,
+): ShellExecutionProvider {
+  return {
+    boundary: {
+      cwd: true,
+      env: true,
+      filesystem: { writable: false },
+      network: false,
+      processes: {
+        background: true,
+        interactive: false,
+      },
+      streaming: false,
+      timeout: {
+        enforcedBy: "runtime",
+        supported: true,
+      },
+    },
+    async exec(command: string) {
+      return {
+        command,
+        event: "command_finished",
+        exitCode: 0,
+        stderr: "",
+        stdout: "",
+      }
+    },
+    startProcess,
+  }
+}
+
+function stoppedProcessObservation(command: string) {
+  return {
+    command,
+    event: "command_finished" as const,
+    exitCode: 0,
+    stderr: "",
+    stdout: "",
+  }
 }
 
 describe("@vite-hub/shell just-bash runtime", () => {
@@ -120,47 +161,17 @@ describe("@vite-hub/shell just-bash runtime", () => {
   })
 
   it("unregisters stopped long-running processes from session state", async () => {
-    const provider: ShellExecutionProvider = {
-      boundary: {
-        cwd: true,
-        env: true,
-        filesystem: { writable: false },
-        network: false,
-        processes: {
-          background: true,
-          interactive: false,
-        },
-        streaming: false,
-        timeout: {
-          enforcedBy: "runtime",
-          supported: true,
-        },
-      },
-      async exec(command: string, _options?: ShellRuntimeExecOptions) {
-        return {
-          command,
-          event: "command_finished",
-          exitCode: 0,
-          stderr: "",
-          stdout: "",
-        }
-      },
-      async startProcess(command: string): Promise<ShellProcess> {
-        return {
-          command,
-          id: command,
-          async stop() {
-            return {
-              command,
-              event: "command_finished",
-              exitCode: 0,
-              stderr: "",
-              stdout: "",
-            }
-          },
-        }
-      },
-    }
+    const stops = new Map<string, ReturnType<typeof vi.fn>>()
+    const startProcess = vi.fn(async (command: string): Promise<ShellProcess> => {
+      const stop = vi.fn(async () => stoppedProcessObservation(command))
+      stops.set(command, stop)
+      return {
+        command,
+        id: command,
+        stop,
+      }
+    })
+    const provider = createBackgroundProvider(startProcess)
     const session = createShellRuntime({ provider }).createSession({ policy: { maxProcesses: 1 } })
 
     const first = await session.startProcess("one")
@@ -168,8 +179,78 @@ describe("@vite-hub/shell just-bash runtime", () => {
     await expect(session.startProcess("two")).rejects.toThrow("process budget exhausted after 1 processes")
 
     await expect(first.stop()).resolves.toMatchObject({ exitCode: 0 })
+    await expect(first.stop()).resolves.toMatchObject({ exitCode: 0 })
+    expect(stops.get("one")).toHaveBeenCalledOnce()
     expect(await session.listProcesses()).toHaveLength(0)
+
     await expect(session.startProcess("two")).resolves.toMatchObject({ id: "two" })
+    await expect(session.dispose()).resolves.toMatchObject({ event: "session_disposed" })
+    await expect(session.dispose()).resolves.toMatchObject({ event: "session_disposed" })
+    expect(stops.get("two")).toHaveBeenCalledOnce()
+    expect(await session.listProcesses()).toHaveLength(0)
+    await expect(session.startProcess("three")).rejects.toThrow("Shell session is disposed")
+    expect(startProcess).toHaveBeenCalledTimes(2)
+    await expect(session.exec("pwd")).resolves.toMatchObject({ event: "policy_denied" })
+  })
+
+  it("stops every remaining process in deterministic order and aggregates failures", async () => {
+    const firstError = new Error("first stop failed")
+    const secondError = new Error("second stop failed")
+    const stopOrder: string[] = []
+    const stops = new Map<string, ReturnType<typeof vi.fn>>()
+    const provider = createBackgroundProvider(async (command: string): Promise<ShellProcess> => {
+      const stop = vi.fn(async () => {
+        stopOrder.push(command)
+        if (command === "one") throw firstError
+        if (command === "two") throw secondError
+        return stoppedProcessObservation(command)
+      })
+      stops.set(command, stop)
+      return {
+        command,
+        id: "shared-provider-id",
+        stop,
+      }
+    })
+    const session = createShellRuntime({ provider }).createSession()
+
+    await session.startProcess("one")
+    await session.startProcess("two")
+    await session.startProcess("three")
+    expect(await session.listProcesses()).toHaveLength(3)
+
+    const failure = await session.dispose().catch(error => error) as AggregateError
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect(failure.message).toBe("[vitehub] Shell session failed to stop multiple background processes.")
+    expect(failure.errors).toEqual([firstError, secondError])
+    expect(stopOrder).toEqual(["one", "two", "three"])
+    expect(await session.listProcesses()).toHaveLength(0)
+
+    await expect(session.dispose()).rejects.toBe(failure)
+    expect(stops.get("one")).toHaveBeenCalledOnce()
+    expect(stops.get("two")).toHaveBeenCalledOnce()
+    expect(stops.get("three")).toHaveBeenCalledOnce()
+  })
+
+  it("stops a process whose provider resolves after session disposal", async () => {
+    let resolveProcess: ((process: ShellProcess) => void) | undefined
+    const stop = vi.fn(async () => stoppedProcessObservation("late"))
+    const provider = createBackgroundProvider(() => new Promise((resolve) => {
+      resolveProcess = resolve
+    }))
+    const session = createShellRuntime({ provider }).createSession()
+    const starting = session.startProcess("late")
+
+    await expect(session.dispose()).resolves.toMatchObject({ event: "session_disposed" })
+    resolveProcess?.({
+      command: "late",
+      id: "late",
+      stop,
+    })
+
+    await expect(starting).rejects.toThrow("Shell session is disposed")
+    expect(stop).toHaveBeenCalledOnce()
+    expect(await session.listProcesses()).toHaveLength(0)
   })
 
   it("executes workspace inspection commands", async () => {

--- a/packages/shell/test/runtime.test.ts
+++ b/packages/shell/test/runtime.test.ts
@@ -262,13 +262,18 @@ describe("@vite-hub/shell just-bash runtime", () => {
       })
       return stoppedProcessObservation("late")
     })
-    const provider = createBackgroundProvider(() => new Promise((resolve) => {
-      resolveProcess = resolve
-    }))
+    const existingStop = vi.fn(async () => stoppedProcessObservation("existing"))
+    const provider = createBackgroundProvider(command => command === "existing"
+      ? Promise.resolve({ command, id: command, stop: existingStop })
+      : new Promise((resolve) => {
+          resolveProcess = resolve
+        }))
     const session = createShellRuntime({ provider }).createSession()
+    await session.startProcess("existing")
     const starting = session.startProcess("late")
 
     const disposing = session.dispose()
+    await vi.waitFor(() => expect(existingStop).toHaveBeenCalledOnce())
     resolveProcess?.({
       command: "late",
       id: "late",

--- a/packages/shell/test/runtime.test.ts
+++ b/packages/shell/test/runtime.test.ts
@@ -232,6 +232,27 @@ describe("@vite-hub/shell just-bash runtime", () => {
     expect(stops.get("three")).toHaveBeenCalledOnce()
   })
 
+  it("caches a synchronously thrown process stop failure", async () => {
+    const failure = new Error("synchronous stop failure")
+    const stop = vi.fn(() => { throw failure })
+    const provider = createBackgroundProvider(async (command: string): Promise<ShellProcess> => ({
+      command,
+      id: command,
+      stop,
+    }))
+    const session = createShellRuntime({ provider }).createSession()
+    const process = await session.startProcess("one")
+
+    const firstStop = process.stop()
+    const secondStop = process.stop()
+
+    expect(secondStop).toBe(firstStop)
+    await expect(firstStop).rejects.toBe(failure)
+    await expect(secondStop).rejects.toBe(failure)
+    expect(stop).toHaveBeenCalledOnce()
+    expect(await session.listProcesses()).toHaveLength(0)
+  })
+
   it("stops a process whose provider resolves after session disposal", async () => {
     let resolveProcess: ((process: ShellProcess) => void) | undefined
     const stop = vi.fn(async () => stoppedProcessObservation("late"))

--- a/packages/shell/test/runtime.test.ts
+++ b/packages/shell/test/runtime.test.ts
@@ -255,20 +255,36 @@ describe("@vite-hub/shell just-bash runtime", () => {
 
   it("stops a process whose provider resolves after session disposal", async () => {
     let resolveProcess: ((process: ShellProcess) => void) | undefined
-    const stop = vi.fn(async () => stoppedProcessObservation("late"))
+    let resolveStop: (() => void) | undefined
+    const stop = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveStop = resolve
+      })
+      return stoppedProcessObservation("late")
+    })
     const provider = createBackgroundProvider(() => new Promise((resolve) => {
       resolveProcess = resolve
     }))
     const session = createShellRuntime({ provider }).createSession()
     const starting = session.startProcess("late")
 
-    await expect(session.dispose()).resolves.toMatchObject({ event: "session_disposed" })
+    const disposing = session.dispose()
     resolveProcess?.({
       command: "late",
       id: "late",
       stop,
     })
 
+    await vi.waitFor(() => expect(stop).toHaveBeenCalledOnce())
+    let disposed = false
+    void disposing.then(() => {
+      disposed = true
+    })
+    await Promise.resolve()
+    expect(disposed).toBe(false)
+    resolveStop?.()
+
+    await expect(disposing).resolves.toMatchObject({ event: "session_disposed" })
     await expect(starting).rejects.toThrow("Shell session is disposed")
     expect(stop).toHaveBeenCalledOnce()
     expect(await session.listProcesses()).toHaveLength(0)


### PR DESCRIPTION
Shell Session now owns every background process until explicit stop or disposal. Provider stops are cached exactly once across synchronous throws and asynchronous rejections, explicit stop deregisters the process, and disposal atomically closes admission. It snapshots in-flight starts and registered processes, starts registered-process cleanup concurrently with pending provider startup, waits for late processes to stop before resolving, and returns every stop failure through AggregateError in deterministic registration order. Duplicate provider IDs remain independently owned, while the public Promise and observation contracts stay unchanged.

The two latest commits preserve that model while closing the remaining race: disposal now awaits provider starts already in flight, and registered stops are launched concurrently rather than serialized behind those starts. The Effect Scope prototype remains rejected under the migration report's pay-rent rule because it added +72/-17 lines to Session plus a 43-line interpreter boundary while retaining the process Map. The completed plain owner is production +71/-25 and deletes the ID-keyed Map for ownership Sets that handle pending starts and duplicate IDs without a second cleanup system.

Source accounting against #676: production +71/-25, tests +165/-42, total +236/-67.

At exact head d6783e376dca30e41c9adeed368666736c87e206, Shell build/publint, typecheck, focused Oxlint, and all 21 tests passed locally; all GitHub code and deployment checks later completed green. This pull request is now closed after dependency #676 merged and is not part of the active merge path.

DEPENDENCY STATUS
  base: #676 at d47c854576517a12fbfa75371b4328cf1bceb5f6
  merge: after #676, or retarget once #676 lands

EFFECT ADOPTION STATUS
  seam: Shell Session background-process lifetime
  public API: unchanged
  boundary: none; retained plain
  typed failures: AggregateError preserves every provider stop cause in registration order
  resources/fibers: process and pending-start ownership Sets; cached stop per process; cached dispose per session; no fibers
  deleted: ID-keyed process Map, marker-only disposal, repeated provider-stop execution, rejected Scope interpreter
  blocked: Effect Scope fails source pay-rent and duplicates ownership
  todos: 0
  confidence: high

<!-- babysitter:blocker:v1 -->

> [!WARNING]
> **Babysitter status:** this pull request is closed and no longer has an active merge path.
>
> If this Shell change is still required, recover it in a fresh branch from the surviving target and revalidate there.

<!-- /babysitter:blocker:v1 -->



