### PR TITLE
fix(workspace): cancel source HTTP requests

### DIFF
--- a/packages/internal/src/http-request.ts
+++ b/packages/internal/src/http-request.ts
@@ -18,6 +18,7 @@ export interface StandardSchemaV1<T = unknown> {
 }
 
 export interface HttpRequestOptions {
+  abortSignal?: AbortSignal
   body?: unknown
   cookies?: Record<string, string>
   headers?: Record<string, string>
@@ -65,14 +66,22 @@ export async function executeHttpRequest<TOutput = unknown>(
 ): Promise<HttpRequestResult<TOutput>> {
   const normalized = normalizeHttpRequest(definition)
   const responseType = options.responseType || "json"
-  const response = await fetchWithRetry(normalized)
-  const decoded = await decodeResponse(response, responseType)
-  const data = options.schema ? await parseStandardSchema(options.schema, decoded, "HTTP response") : decoded
-  return {
-    data: data as TOutput,
-    mediaType: response.headers.get("content-type") || undefined,
-    status: response.status,
-    summary: redactedHttpRequestSummary(normalized, responseType),
+  try {
+    const response = await fetchWithRetry(normalized)
+    const decoded = await decodeResponse(response, responseType)
+    normalized.abortSignal?.throwIfAborted()
+    const data = options.schema ? await parseStandardSchema(options.schema, decoded, "HTTP response") : decoded
+    normalized.abortSignal?.throwIfAborted()
+    return {
+      data: data as TOutput,
+      mediaType: response.headers.get("content-type") || undefined,
+      status: response.status,
+      summary: redactedHttpRequestSummary(normalized, responseType),
+    }
+  }
+  catch (error) {
+    normalized.abortSignal?.throwIfAborted()
+    throw error
   }
 }
 
@@ -80,10 +89,12 @@ async function fetchWithRetry(definition: NormalizedHttpRequest): Promise<Respon
   const attempts = definition.method === "GET" || definition.method === "HEAD" ? 2 : 1
   let lastError: unknown
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    definition.abortSignal?.throwIfAborted()
     try {
       return await fetchOnce(definition)
     }
     catch (error) {
+      definition.abortSignal?.throwIfAborted()
       lastError = error
       if (attempt === attempts) break
     }
@@ -96,13 +107,16 @@ async function fetchOnce(definition: NormalizedHttpRequest): Promise<Response> {
   applyCookies(headers, definition.cookies)
   const body = serializeRequestBody(definition.body, headers)
   const controller = definition.timeout ? new AbortController() : undefined
+  const signal = controller && definition.abortSignal
+    ? AbortSignal.any([definition.abortSignal, controller.signal])
+    : controller?.signal || definition.abortSignal
   const timeout = controller ? setTimeout(() => controller.abort(), definition.timeout) : undefined
   try {
     const response = await fetch(urlWithQuery(definition).toString(), {
       body,
       headers,
       method: definition.method,
-      signal: controller?.signal,
+      signal,
     })
     if (!response.ok) {
       throw new Error(`[vitehub] HTTP request failed with status ${response.status}.`)

--- a/packages/internal/test/http-request.test.ts
+++ b/packages/internal/test/http-request.test.ts
@@ -38,4 +38,71 @@ describe("HTTP request", () => {
       url: "https://portal.example.com/inventory",
     })
   })
+
+  it("does not retry caller cancellation and preserves the abort reason", async () => {
+    const controller = new AbortController()
+    const reason = new Error("request cancelled")
+    const fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => await new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      if (!signal) return reject(new Error("missing fetch signal"))
+      if (signal.aborted) return reject(signal.reason)
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true })
+    }))
+    vi.stubGlobal("fetch", fetch)
+
+    const request = executeHttpRequest({
+      abortSignal: controller.signal,
+      timeout: 10_000,
+      url: "https://portal.example.com/inventory",
+    })
+    controller.abort(reason)
+
+    await expect(request).rejects.toBe(reason)
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it("preserves the abort reason while decoding the response", async () => {
+    const controller = new AbortController()
+    const reason = new Error("response cancelled")
+    const response = new Response()
+    const text = vi.spyOn(response, "text").mockImplementation(async () => await new Promise<string>((_resolve, reject) => {
+      controller.signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), { once: true })
+    }))
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response))
+
+    const request = executeHttpRequest({
+      abortSignal: controller.signal,
+      url: "https://portal.example.com/inventory",
+    })
+    while (!text.mock.calls.length) await Promise.resolve()
+    controller.abort(reason)
+
+    await expect(request).rejects.toBe(reason)
+  })
+
+  it("does not start a request for an already aborted caller", async () => {
+    const controller = new AbortController()
+    const reason = new Error("already cancelled")
+    controller.abort(reason)
+    const fetch = vi.fn()
+    vi.stubGlobal("fetch", fetch)
+
+    await expect(executeHttpRequest({
+      abortSignal: controller.signal,
+      url: "https://portal.example.com/inventory",
+    })).rejects.toBe(reason)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("still retries non-cancellation GET failures", async () => {
+    const fetch = vi.fn()
+      .mockRejectedValueOnce(new Error("connection reset"))
+      .mockResolvedValueOnce(new Response("\"ok\""))
+    vi.stubGlobal("fetch", fetch)
+
+    await expect(executeHttpRequest({
+      url: "https://portal.example.com/inventory",
+    })).resolves.toMatchObject({ data: "ok" })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/workspace/src/sources/fetch.ts
+++ b/packages/workspace/src/sources/fetch.ts
@@ -325,6 +325,7 @@ async function defaultFetchSourceRequest(
     ? await options.request(context)
     : options.request
   return {
+    abortSignal: ctx.abortSignal,
     body,
     cookies: {
       ...options.cookies,

--- a/packages/workspace/test/fetch-source.test.ts
+++ b/packages/workspace/test/fetch-source.test.ts
@@ -190,6 +190,36 @@ describe("fetch sources", () => {
     })
   })
 
+  it("cancels materialized fetch requests with the caller abort reason", async () => {
+    const controller = new AbortController()
+    const reason = new Error("materialization cancelled")
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => await new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      if (!signal) return reject(new Error("missing fetch signal"))
+      if (signal.aborted) return reject(signal.reason)
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true })
+    }))
+    const view = createWorkspaceSourceView({
+      name: "fetch-abort",
+      sources: {
+        status: fetch({
+          url: "https://status.example.com/api/summary",
+          workspacePath: "status/summary.json",
+        }),
+      },
+    }, createMemoryWorkspaceStore())
+
+    const materialization = view.materializeSources({
+      abortSignal: controller.signal,
+      sources: ["status"],
+    })
+    while (!fetchSpy.mock.calls.length) await Promise.resolve()
+    controller.abort(reason)
+
+    await expect(materialization).rejects.toBe(reason)
+    expect(fetchSpy).toHaveBeenCalledOnce()
+  })
+
   it("hides stale materialized files from live fetch source listings", async () => {
     const store = createMemoryWorkspaceStore()
     await store.writeFile("status/old.json", {


### PR DESCRIPTION
Propagates Workspace materialization cancellation into the shared HTTP request boundary, where `fetch` can actually stop the work. Caller cancellation is composed with request timeouts, preserves the caller's exact abort reason, and prevents the GET/HEAD retry path from starting another attempt after cancellation; ordinary transport failures still retry as before.

This is intentionally a plain TypeScript prerequisite rather than an Effect adoption: interruption would be false unless the underlying operation receives the signal. It keeps the later Effect migration honest while changing no successful-request API behavior.

**Hard dependency:** stacked on #680 and must be rebased after that PR lands.

```text
EFFECT ADOPTION STATUS
  seam: Workspace fetch-source request cancellation prerequisite; no Effect implementation added
  public API: unchanged; internal HttpRequestOptions gains an optional AbortSignal
  boundary: executeHttpRequest remains the single plain Promise interpreter and passes the composed signal to fetch
  typed failures: existing request failures remain unchanged; caller cancellation preserves the raw AbortSignal.reason identity
  resources/fibers: none
  deleted: none; retained the existing request interpreter and non-cancellation retry policy
  todos: 0
  confidence: high
  dependency: #680
```