### PR TITLE
refactor(sandbox): prototype Effect attempt ownership (blocked)

### DIFF
--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -81,6 +81,7 @@
     "test": "vp run -t @vite-hub/sandbox#build && vp test"
   },
   "dependencies": {
+    "effect": "catalog:effect",
     "esbuild": "catalog:tooling",
     "h3": "catalog:unjs",
     "local-pkg": "catalog:tooling",

--- a/packages/sandbox/src/internal/shared/cloudflare-attempt.ts
+++ b/packages/sandbox/src/internal/shared/cloudflare-attempt.ts
@@ -1,0 +1,134 @@
+import { Cause, Data, Effect, Exit, Schedule } from 'effect'
+
+import { SandboxError } from '../../sandbox/errors'
+import { CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS } from './cloudflare-retry'
+
+class CloudflareAttemptFailure extends Data.TaggedError('CloudflareAttemptFailure')<{
+  readonly cause: unknown
+  readonly retryable: boolean
+}> {}
+
+interface CloudflareOperationOptions<T> {
+  isRetriable: (error: SandboxError) => boolean
+  mapError: (error: unknown) => SandboxError
+  operation: string
+  run: () => Promise<T>
+  timeout: number
+}
+
+interface CloudflareSandboxExecutionOptions<TResource, TResult> {
+  acquire: () => Promise<TResource>
+  isRetriable: (error: SandboxError) => boolean
+  mapError: (error: unknown) => SandboxError
+  release: (resource: TResource) => Promise<void>
+  use: (resource: TResource) => Promise<TResult>
+}
+
+const retrySchedule = Schedule.addDelay(
+  Schedule.recurs(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS.length),
+  ({ output }) => Effect.succeed(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS[output] ?? 0),
+)
+
+function interruptionError() {
+  const error = new Error('Cloudflare sandbox operation was interrupted.')
+  error.name = 'AbortError'
+  return error
+}
+
+function causeValues(cause: Cause.Cause<CloudflareAttemptFailure>): unknown[] {
+  return cause.reasons.map((reason) => {
+    if (Cause.isFailReason(reason)) return reason.error.cause
+    if (Cause.isDieReason(reason)) return reason.defect
+    return interruptionError()
+  })
+}
+
+function failureFromCause(cause: Cause.Cause<CloudflareAttemptFailure>) {
+  const failures = cause.reasons.filter(Cause.isFailReason).map(reason => reason.error)
+  if (failures.length === 1 && cause.reasons.length === 1) return failures[0]!
+  const causes = causeValues(cause)
+  return new CloudflareAttemptFailure({
+    cause: causes.length === 1
+      ? causes[0]
+      : new AggregateError(causes, 'Cloudflare sandbox operation failed for multiple reasons.'),
+    retryable: false,
+  })
+}
+
+function attempt<T>(run: () => Promise<T>, mapError: (error: unknown) => SandboxError, isRetriable: (error: SandboxError) => boolean) {
+  return Effect.tryPromise({
+    try: () => run(),
+    catch: (cause) => {
+      const error = mapError(cause)
+      return new CloudflareAttemptFailure({ cause: error, retryable: isRetriable(error) })
+    },
+  })
+}
+
+function withRetry<A>(effect: Effect.Effect<A, CloudflareAttemptFailure>) {
+  return Effect.retry(effect, {
+    schedule: retrySchedule,
+    while: failure => failure.retryable,
+  })
+}
+
+export function cloudflareOperationEffect<T>(options: CloudflareOperationOptions<T>) {
+  const operation = attempt(options.run, options.mapError, options.isRetriable).pipe(
+    Effect.timeoutOrElse({
+      duration: options.timeout,
+      orElse: () => Effect.fail(new CloudflareAttemptFailure({
+        cause: new SandboxError(`Cloudflare sandbox ${options.operation} timed out after ${options.timeout}ms.`, {
+          code: 'TIMEOUT',
+          details: { operation: options.operation, timeout: options.timeout },
+          provider: 'cloudflare',
+        }),
+        retryable: true,
+      })),
+    }),
+  )
+  return withRetry(operation)
+}
+
+const cloudflareSandboxExecutionAttempt = Effect.fn('Sandbox.Cloudflare.execute')(function* <TResource, TResult>(
+  options: CloudflareSandboxExecutionOptions<TResource, TResult>,
+) {
+  return yield* Effect.acquireUseRelease(
+    attempt(options.acquire, options.mapError, options.isRetriable),
+    resource => attempt(() => options.use(resource), options.mapError, options.isRetriable),
+    (resource, executionExit) => attempt(
+      () => options.release(resource),
+      options.mapError,
+      () => false,
+    ).pipe(Effect.catchTag('CloudflareAttemptFailure', (release) => {
+      if (Exit.isSuccess(executionExit)) return Effect.fail(release)
+      const execution = failureFromCause(executionExit.cause)
+      return Effect.fail(new CloudflareAttemptFailure({
+        cause: new AggregateError(
+          [execution.cause, release.cause],
+          'Cloudflare sandbox execution failed and cleanup also failed.',
+        ),
+        retryable: false,
+      }))
+    })),
+  )
+})
+
+export function cloudflareSandboxExecutionEffect<TResource, TResult>(options: CloudflareSandboxExecutionOptions<TResource, TResult>) {
+  return withRetry(cloudflareSandboxExecutionAttempt(options))
+}
+
+export async function runCloudflareEffect<T>(effect: Effect.Effect<T, CloudflareAttemptFailure>): Promise<T> {
+  const exit = await Effect.runPromiseExit(effect)
+  if (Exit.isSuccess(exit)) return exit.value
+  const causes = causeValues(exit.cause)
+  if (causes.length === 1) throw causes[0]
+  throw new AggregateError(causes, 'Cloudflare sandbox operation failed for multiple reasons.')
+}
+
+export function runCloudflareOperation<T>(options: CloudflareOperationOptions<T>): Promise<T> {
+  return runCloudflareEffect(cloudflareOperationEffect(options))
+}
+
+export function runCloudflareSandboxExecution<TResource, TResult>(options: CloudflareSandboxExecutionOptions<TResource, TResult>): Promise<TResult> {
+  return runCloudflareEffect(cloudflareSandboxExecutionEffect(options))
+}

--- a/packages/sandbox/src/runtime/runtime.ts
+++ b/packages/sandbox/src/runtime/runtime.ts
@@ -1,10 +1,10 @@
-import { CLOUDFLARE_RETRIABLE_STARTUP_ERROR_RE, CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS, collectCloudflareErrorMessages } from '../internal/shared/cloudflare-retry'
+import { runCloudflareSandboxExecution } from '../internal/shared/cloudflare-attempt'
+import { CLOUDFLARE_RETRIABLE_STARTUP_ERROR_RE, collectCloudflareErrorMessages } from '../internal/shared/cloudflare-retry'
 import {
   createResourceRuntime,
   type ProviderPort,
   type ResourceRuntimeContext,
 } from '../internal/shared/resource-runtime'
-import { sleep } from '../internal/shared/utils'
 import { SandboxError } from '../sandbox/errors'
 import { detectSandbox, isSandboxAvailable } from '../sandbox/providers/shared'
 import { validateSandboxConfig } from '../sandbox/validation'
@@ -97,55 +97,33 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
 
     return {
       name: context.name,
-      async run(payload, options = {}) {
-        const cloudflareSandboxId = provider.provider === 'cloudflare'
-          ? createCloudflareExecutionSandboxId(context.name, options.sandboxId || provider.sandboxId)
-          : undefined
-        const attempts = provider.provider === 'cloudflare'
-          ? CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS.length + 1
-          : 1
+      async run<TPayload = unknown, TResult = unknown>(payload: TPayload | undefined, options: SandboxExecutionOptions = {}): Promise<TResult> {
+        const execute = async (sandbox: SandboxClient) => await executeSandboxDefinition<TPayload, TResult>(
+          sandbox,
+          context.name,
+          context.definition.options,
+          context.definition.bundle,
+          payload,
+          options.context,
+        )
 
-        for (let attempt = 0; attempt < attempts; attempt++) {
-          let sandbox: SandboxClient | undefined
-
+        if (provider.provider !== 'cloudflare') {
+          const sandbox = await runtimeProvider.createSandboxClient(provider as SandboxProviderOptions)
           try {
-            const createdSandbox = await runtimeProvider.createSandboxClient(
-              cloudflareSandboxId
-                ? {
-                    ...provider,
-                    sandboxId: cloudflareSandboxId,
-                  } as SandboxProviderOptions
-                : provider as SandboxProviderOptions,
-            )
-            sandbox = createdSandbox
-            return await executeSandboxDefinition(
-              createdSandbox,
-              context.name,
-              context.definition.options,
-              context.definition.bundle,
-              payload,
-              options.context,
-            )
-          }
-          catch (error) {
-            const sandboxError = toSandboxError(error)
-            const shouldRetry = provider.provider === 'cloudflare'
-              && attempt < CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS.length
-              && isRetriableCloudflareSandboxError(sandboxError)
-
-            if (!shouldRetry)
-              throw sandboxError
-
-            await sleep(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS[attempt])
+            return await execute(sandbox)
           }
           finally {
-            await sandbox?.stop().catch(() => {})
+            await sandbox.stop().catch(() => {})
           }
         }
 
-        throw new SandboxError('Cloudflare sandbox retries exhausted.', {
-          code: 'SANDBOX_RUNTIME_ERROR',
-          provider: provider.provider,
+        const sandboxId = createCloudflareExecutionSandboxId(context.name, options.sandboxId || provider.sandboxId)
+        return await runCloudflareSandboxExecution({
+          acquire: async () => await runtimeProvider.createSandboxClient({ ...provider, sandboxId }),
+          isRetriable: isRetriableCloudflareSandboxError,
+          mapError: toSandboxError,
+          release: async sandbox => await sandbox.stop(),
+          use: execute,
         })
       },
     }

--- a/packages/sandbox/src/sandbox/adapters/cloudflare.ts
+++ b/packages/sandbox/src/sandbox/adapters/cloudflare.ts
@@ -9,8 +9,7 @@ import {
   CLOUDFLARE_READ_FILE_TIMEOUT_MS,
   CLOUDFLARE_STOP_TIMEOUT_MS,
   resolveExecRequestTimeout,
-  withCloudflareDeadline,
-  withCloudflareTransportRetry,
+  runCloudflareTransportOperation,
 } from './cloudflare/transport'
 
 import type { CloudflareSandboxNamespace, CloudflareSandboxSession, CloudflareSandboxSessionOptions, SandboxCodeContext, SandboxCodeContextOptions, SandboxCodeExecutionResult, SandboxExposedPort, SandboxExposePortOptions, SandboxGitCheckoutOptions, SandboxGitCheckoutResult, SandboxMountBucketOptions, SandboxRunCodeOptions } from '../types/cloudflare'
@@ -186,7 +185,7 @@ export class CloudflareSandboxAdapter extends BaseSandboxAdapter<'cloudflare'> {
 
   async exec(command: string, args: string[] = [], opts?: SandboxExecOptions): Promise<SandboxExecResult> {
     const cmd = args.length ? `${shellQuote(command)} ${args.map(shellQuote).join(' ')}` : shellQuote(command)
-    const result = await withCloudflareTransportRetry('exec', async () => await withCloudflareDeadline('exec', resolveExecRequestTimeout(opts?.timeout), async () => await this.native.exec(cmd, {
+    const result = await runCloudflareTransportOperation('exec', resolveExecRequestTimeout(opts?.timeout), async () => await this.native.exec(cmd, {
       timeout: opts?.timeout,
       env: opts?.env,
       cwd: opts?.cwd,
@@ -199,14 +198,14 @@ export class CloudflareSandboxAdapter extends BaseSandboxAdapter<'cloudflare'> {
               opts?.onStderr?.(data)
           }
         : undefined,
-    })))
+    }))
     return { ok: result.success, stdout: result.stdout, stderr: result.stderr, code: result.exitCode }
   }
 
   async writeFile(path: string, content: SandboxFileContent): Promise<void> {
     const body = typeof content === 'string' ? content : Buffer.from(content).toString('base64')
     const options = typeof content === 'string' ? undefined : { encoding: 'base64' }
-    const result = await withCloudflareTransportRetry('writeFile', async () => await withCloudflareDeadline('writeFile', CLOUDFLARE_CONTROL_PLANE_TIMEOUT_MS, async () => await this.native.writeFile(path, body, options)))
+    const result = await runCloudflareTransportOperation('writeFile', CLOUDFLARE_CONTROL_PLANE_TIMEOUT_MS, async () => await this.native.writeFile(path, body, options))
     if (!result.success)
       throw new SandboxError(`Failed to write file: ${path}`)
   }
@@ -214,7 +213,7 @@ export class CloudflareSandboxAdapter extends BaseSandboxAdapter<'cloudflare'> {
   async readFile(path: string, opts: SandboxReadFileOptions & { encoding: 'binary' }): Promise<Uint8Array>
   async readFile(path: string, opts?: SandboxReadFileOptions): Promise<string>
   async readFile(path: string, opts?: SandboxReadFileOptions): Promise<string | Uint8Array> {
-    const result = await withCloudflareTransportRetry('readFile', async () => await withCloudflareDeadline('readFile', CLOUDFLARE_READ_FILE_TIMEOUT_MS, async () => await this.native.readFile(path, opts?.encoding === 'binary' ? { encoding: 'base64' } : undefined)))
+    const result = await runCloudflareTransportOperation('readFile', CLOUDFLARE_READ_FILE_TIMEOUT_MS, async () => await this.native.readFile(path, opts?.encoding === 'binary' ? { encoding: 'base64' } : undefined))
     if (!result.success)
       throw new SandboxError(`Failed to read file: ${path}`)
     if (opts?.encoding === 'binary')
@@ -223,12 +222,12 @@ export class CloudflareSandboxAdapter extends BaseSandboxAdapter<'cloudflare'> {
   }
 
   async stop(): Promise<void> {
-    await withCloudflareTransportRetry('destroy', async () => await withCloudflareDeadline('destroy', CLOUDFLARE_STOP_TIMEOUT_MS, async () => await this.native.destroy()))
+    await runCloudflareTransportOperation('destroy', CLOUDFLARE_STOP_TIMEOUT_MS, async () => await this.native.destroy())
   }
 
   async mkdir(path: string, opts?: { recursive?: boolean }): Promise<void> {
     if (this.native.mkdir) {
-      const result = await withCloudflareTransportRetry('mkdir', async () => await withCloudflareDeadline('mkdir', CLOUDFLARE_CONTROL_PLANE_TIMEOUT_MS, async () => await this.native.mkdir!(path, opts)))
+      const result = await runCloudflareTransportOperation('mkdir', CLOUDFLARE_CONTROL_PLANE_TIMEOUT_MS, async () => await this.native.mkdir!(path, opts))
       if (!result.success)
         throw new SandboxError(`Failed to create directory: ${path}`)
       return

--- a/packages/sandbox/src/sandbox/adapters/cloudflare/transport.ts
+++ b/packages/sandbox/src/sandbox/adapters/cloudflare/transport.ts
@@ -1,6 +1,6 @@
-import { CLOUDFLARE_RETRIABLE_STARTUP_ERROR_RE, CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS } from '../../../internal/shared/cloudflare-retry'
+import { runCloudflareOperation } from '../../../internal/shared/cloudflare-attempt'
+import { CLOUDFLARE_RETRIABLE_STARTUP_ERROR_RE } from '../../../internal/shared/cloudflare-retry'
 import { SandboxError } from '../../errors'
-import { sleep } from '../_shared'
 
 export const CLOUDFLARE_CONTROL_PLANE_TIMEOUT_MS = 15_000
 export const CLOUDFLARE_READ_FILE_TIMEOUT_MS = 15_000
@@ -25,55 +25,13 @@ export function isRetriableCloudflareTransportError(error: unknown) {
   return CLOUDFLARE_RETRIABLE_STARTUP_ERROR_RE.test(message)
 }
 
-export async function withCloudflareDeadline<T>(operation: string, timeoutMs: number, run: () => Promise<T>) {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
-
-  try {
-    return await Promise.race([
-      run(),
-      new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          reject(new SandboxError(`Cloudflare sandbox ${operation} timed out after ${timeoutMs}ms.`, {
-            code: 'TIMEOUT',
-            details: { operation, timeout: timeoutMs },
-            provider: 'cloudflare',
-          }))
-        }, timeoutMs)
-      }),
-    ])
-  }
-  finally {
-    if (timeoutId)
-      clearTimeout(timeoutId)
-  }
-}
-
-export async function withCloudflareTransportRetry<T>(operation: string, run: () => Promise<T>) {
-  const attempts = CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS.length + 1
-
-  for (let attempt = 0; attempt < attempts; attempt++) {
-    try {
-      return await run()
-    }
-    catch (error) {
-      const sandboxError = error instanceof SandboxError
-        ? error
-        : createCloudflareTransportError(operation, error)
-
-      const shouldRetry = attempt < CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS.length
-        && isRetriableCloudflareTransportError(sandboxError)
-
-      if (!shouldRetry)
-        throw sandboxError
-
-      await sleep(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS[attempt])
-    }
-  }
-
-  throw new SandboxError(`Cloudflare sandbox ${operation} retries exhausted.`, {
-    code: 'SANDBOX_TRANSPORT_ERROR',
-    details: { operation },
-    provider: 'cloudflare',
+export function runCloudflareTransportOperation<T>(operation: string, timeout: number, run: () => Promise<T>) {
+  return runCloudflareOperation({
+    isRetriable: isRetriableCloudflareTransportError,
+    mapError: error => error instanceof SandboxError ? error : createCloudflareTransportError(operation, error),
+    operation,
+    run,
+    timeout,
   })
 }
 

--- a/packages/sandbox/test/cloudflare-attempt.test.ts
+++ b/packages/sandbox/test/cloudflare-attempt.test.ts
@@ -1,0 +1,182 @@
+import { Cause, Effect, Exit, Fiber } from 'effect'
+import { TestClock } from 'effect/testing'
+import { describe, expect, it } from 'vitest'
+
+import {
+  cloudflareOperationEffect,
+  cloudflareSandboxExecutionEffect,
+  runCloudflareOperation,
+  runCloudflareSandboxExecution,
+} from '../src/internal/shared/cloudflare-attempt'
+import { CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS } from '../src/internal/shared/cloudflare-retry'
+import { SandboxError } from '../src/sandbox/errors'
+
+const testClock = TestClock.layer({ warningDelay: '1 minute' })
+
+function testError(message: string) {
+  return new SandboxError(message, {
+    code: 'SANDBOX_TRANSPORT_ERROR',
+    provider: 'cloudflare',
+  })
+}
+
+const mapError = (error: unknown) => error instanceof SandboxError ? error : testError(String(error))
+const isRetriable = (error: SandboxError) => /container is starting/i.test(error.message)
+
+describe('Cloudflare attempt policy', () => {
+  it('uses the exact retry delays without real time', async () => {
+    let attempts = 0
+    const retriable = testError('container is starting')
+    const operation = cloudflareOperationEffect({
+      isRetriable,
+      mapError,
+      operation: 'exec',
+      run: async () => {
+        attempts += 1
+        if (attempts <= CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS.length) throw retriable
+        return 'ready'
+      },
+      timeout: 60_000,
+    })
+
+    const program = Effect.gen(function* () {
+      const fiber = yield* Effect.forkChild(operation)
+      yield* Effect.yieldNow
+      expect(attempts).toBe(1)
+
+      for (const [index, delay] of CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS.entries()) {
+        yield* TestClock.adjust(delay - 1)
+        expect(attempts).toBe(index + 1)
+        yield* TestClock.adjust(1)
+        expect(attempts).toBe(index + 2)
+      }
+
+      expect(yield* Fiber.join(fiber)).toBe('ready')
+    }).pipe(Effect.provide(testClock))
+
+    await Effect.runPromise(program)
+  })
+
+  it('applies a fresh deadline to every retry attempt', async () => {
+    let attempts = 0
+    const operation = cloudflareOperationEffect({
+      isRetriable,
+      mapError,
+      operation: 'readFile',
+      run: () => {
+        attempts += 1
+        return new Promise<never>(() => {})
+      },
+      timeout: 250,
+    })
+
+    const program = Effect.gen(function* () {
+      const fiber = yield* Effect.forkChild(Effect.exit(operation))
+      for (let attempt = 0; attempt <= CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS.length; attempt += 1) {
+        yield* TestClock.adjust(250)
+        if (attempt < CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS.length)
+          yield* TestClock.adjust(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS[attempt]!)
+      }
+
+      const exit = yield* Fiber.join(fiber)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        const failure = exit.cause.reasons.find(Cause.isFailReason)
+        expect(failure?.error.cause).toMatchObject({
+          code: 'TIMEOUT',
+          details: { operation: 'readFile', timeout: 250 },
+          provider: 'cloudflare',
+        })
+      }
+      expect(attempts).toBe(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS.length + 1)
+    }).pipe(Effect.provide(testClock))
+
+    await Effect.runPromise(program)
+  })
+
+  it('stops each acquired sandbox before retrying', async () => {
+    let acquisitions = 0
+    const events: string[] = []
+    const retriable = testError('container is starting')
+    let resolveFirstRelease!: () => void
+    const firstRelease = new Promise<void>((resolve) => {
+      resolveFirstRelease = resolve
+    })
+    const execution = cloudflareSandboxExecutionEffect({
+      acquire: async () => {
+        const id = ++acquisitions
+        events.push(`acquire:${id}`)
+        return { id }
+      },
+      isRetriable,
+      mapError,
+      release: async ({ id }) => {
+        events.push(`release:${id}`)
+        if (id === 1) resolveFirstRelease()
+      },
+      use: async ({ id }) => {
+        events.push(`use:${id}`)
+        if (id === 1) throw retriable
+        return 'done'
+      },
+    })
+
+    const program = Effect.gen(function* () {
+      const fiber = yield* Effect.forkChild(execution)
+      yield* Effect.promise(() => firstRelease)
+      expect(events).toEqual(['acquire:1', 'use:1', 'release:1'])
+      yield* TestClock.adjust(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS[0]!)
+      expect(yield* Fiber.join(fiber)).toBe('done')
+      expect(events).toEqual([
+        'acquire:1',
+        'use:1',
+        'release:1',
+        'acquire:2',
+        'use:2',
+        'release:2',
+      ])
+    }).pipe(Effect.provide(testClock))
+
+    await Effect.runPromise(program)
+  })
+
+  it('preserves execution and cleanup failures in order without retrying', async () => {
+    const executionError = testError('container is starting')
+    const cleanupError = testError('destroy failed')
+    let acquisitions = 0
+
+    const result = runCloudflareSandboxExecution({
+      acquire: async () => {
+        acquisitions += 1
+        return {}
+      },
+      isRetriable,
+      mapError,
+      release: async () => {
+        throw cleanupError
+      },
+      use: async () => {
+        throw executionError
+      },
+    })
+
+    await expect(result).rejects.toEqual(expect.objectContaining({
+      errors: [executionError, cleanupError],
+      message: 'Cloudflare sandbox execution failed and cleanup also failed.',
+    }))
+    expect(acquisitions).toBe(1)
+  })
+
+  it('rejects with the original Sandbox error rather than FiberFailure', async () => {
+    const error = testError('permission denied')
+    await expect(runCloudflareOperation({
+      isRetriable,
+      mapError,
+      operation: 'writeFile',
+      run: async () => {
+        throw error
+      },
+      timeout: 1_000,
+    })).rejects.toBe(error)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -997,6 +997,9 @@ importers:
 
   packages/sandbox:
     dependencies:
+      effect:
+        specifier: catalog:effect
+        version: 4.0.0-beta.99
       esbuild:
         specifier: catalog:tooling
         version: 0.28.1


### PR DESCRIPTION
> [!CAUTION]
> **BLOCKED — DO NOT MERGE.** This draft preserves the tested Effect experiment required by the migration process, but the experiment fails ViteHub's pay-rent rule.

## EFFECT ADOPTION STATUS

**RETAIN PLAIN TYPESCRIPT.**

The Effect version replaces both Cloudflare retry loops and proves the intended invariants: exact `[1s, 2s, 5s, 10s, 15s]` delays, one deadline per attempt, cleanup before retry, one stop per acquired client, ordered execution/cleanup causes, and raw Promise errors without `FiberFailure`.

An equivalent shared async TypeScript helper expresses the same runtime contract in 112 production lines. This Effect helper takes 134 production lines, so the complete slice is **+70 net lines with Effect versus +48 net lines in plain TypeScript**: 22 lines, or about 31%, worse on net source cost, plus a new runtime dependency and interpreter boundary.

The seam also has no outer cancellation signal to propagate into the Cloudflare SDK calls. Effect's interruption and uninterruptible release machinery therefore cannot materially strengthen the runtime contract here; deterministic `TestClock` coverage alone is insufficient pay rent for the added machinery.

## Validation

- Focused attempt-policy tests: 5/5 passed.
- Full `@vite-hub/sandbox` suite: 55/55 passed across 14 files.
- Sandbox typecheck passed again after the final dependency rebase.
- Sandbox build and declaration generation passed.
- Publint passed.
- Built public declarations contain no Effect or `FiberFailure` leakage.
- Frozen install passes on the rebased graph; the lockfile diff contains only the three-line `packages/sandbox` Effect importer entry.

This blocked experiment is rebased onto final #676 at `9ad2a81b3169869407e0099d765dc9de5ba5f22f`, which in turn is based on the repaired #670 Effect foundation. It should remain closed and unmerged unless the boundary gains real cancellation or another correctness property that plain TypeScript cannot express with the same clarity.
