### PR TITLE
fix(workflow): own OpenWorkflow backend lifecycle

### DIFF
--- a/packages/workflow/src/runtime/openworkflow.ts
+++ b/packages/workflow/src/runtime/openworkflow.ts
@@ -1,4 +1,5 @@
 import { runWorkflowHandler } from "./execute.ts"
+import { WorkflowError } from "../errors.ts"
 
 import type { RetryPolicy } from "openworkflow"
 import type { ResolvedWorkflowOptions, WorkflowDefinition, WorkflowDeferOptions, WorkflowProviderStep, WorkflowRun, WorkflowRunStatus, WorkflowRuntimeConfigValue, WorkflowRuntimeEnvDeclarationLike, WorkflowStepOptions } from "../types.ts"
@@ -24,7 +25,7 @@ interface OpenWorkflowRuntime {
   workflows: Map<string, OpenWorkflowRunnable>
 }
 
-const runtimes = new Map<string, Promise<OpenWorkflowRuntime>>()
+let runtimes = new Map<string, Promise<OpenWorkflowRuntime>>()
 
 function readEnv(name: string): string | undefined {
   const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
@@ -57,11 +58,11 @@ function normalizeSqlitePath(path: string): string {
   return path.startsWith("file:") ? path.slice("file:".length) : path
 }
 
-async function prepareSqlitePath(path: string): Promise<string> {
+async function prepareSqlitePath(path: string, importer: OpenWorkflowImporter): Promise<string> {
   if (path !== ":memory:") {
     const [{ mkdirSync }, { dirname }] = await Promise.all([
-      openWorkflowImporter<NodeFsModule>("node:fs"),
-      openWorkflowImporter<NodePathModule>("node:path"),
+      importer<NodeFsModule>("node:fs"),
+      importer<NodePathModule>("node:path"),
     ])
     mkdirSync(dirname(path), { recursive: true })
   }
@@ -112,16 +113,19 @@ function getRuntimeKey(config: ResolvedWorkflowOptions): string {
   return JSON.stringify(getOpenWorkflowConfig(config))
 }
 
-async function createOpenWorkflowRuntime(config: ResolvedWorkflowOptions): Promise<OpenWorkflowRuntime> {
+async function createOpenWorkflowRuntime(
+  config: ResolvedWorkflowOptions,
+  importer: OpenWorkflowImporter,
+): Promise<OpenWorkflowRuntime> {
   const options = getOpenWorkflowConfig(config)
   const [{ OpenWorkflow }, backendModule] = await Promise.all([
-    openWorkflowImporter<OpenWorkflowModule>("openworkflow"),
+    importer<OpenWorkflowModule>("openworkflow"),
     options.backend === "sqlite"
-      ? openWorkflowImporter<OpenWorkflowSqliteModule>("openworkflow/sqlite")
-      : openWorkflowImporter<OpenWorkflowPostgresModule>("openworkflow/postgres"),
+      ? importer<OpenWorkflowSqliteModule>("openworkflow/sqlite")
+      : importer<OpenWorkflowPostgresModule>("openworkflow/postgres"),
   ])
   const backend = options.backend === "sqlite"
-    ? (backendModule as OpenWorkflowSqliteModule).BackendSqlite.connect(await prepareSqlitePath(options.path), {
+    ? (backendModule as OpenWorkflowSqliteModule).BackendSqlite.connect(await prepareSqlitePath(options.path, importer), {
         namespaceId: options.namespaceId,
         ...(typeof options.runMigrations === "boolean" ? { runMigrations: options.runMigrations } : {}),
       })
@@ -139,13 +143,24 @@ async function createOpenWorkflowRuntime(config: ResolvedWorkflowOptions): Promi
 }
 
 export async function getOpenWorkflowRuntime(config: ResolvedWorkflowOptions): Promise<OpenWorkflowRuntime> {
+  const cache = runtimes
   const key = getRuntimeKey(config)
-  let runtime = runtimes.get(key)
+  let runtime = cache.get(key)
   if (!runtime) {
-    runtime = createOpenWorkflowRuntime(config)
-    runtimes.set(key, runtime)
+    runtime = createOpenWorkflowRuntime(config, openWorkflowImporter)
+    cache.set(key, runtime)
+    void runtime.catch(() => {
+      if (cache.get(key) === runtime) cache.delete(key)
+    })
   }
-  return await runtime
+  const resolved = await runtime
+  if (cache !== runtimes) {
+    throw new WorkflowError("OpenWorkflow runtime was reset while it was being acquired.", {
+      code: "OPENWORKFLOW_RUNTIME_RESET",
+      provider: "openworkflow",
+    })
+  }
+  return resolved
 }
 
 function toOpenWorkflowRetryPolicy(options: WorkflowStepOptions): Partial<RetryPolicy> | undefined {
@@ -276,14 +291,25 @@ export async function getOpenWorkflowRun<TPayload = unknown, TResult = unknown>(
 }
 
 export async function resetOpenWorkflowRuntime(): Promise<void> {
-  const settled = await Promise.allSettled(runtimes.values())
-  runtimes.clear()
+  const closing = runtimes
+  runtimes = new Map()
   openWorkflowImporter = defaultImporter
-  await Promise.all(settled.map(async (entry) => {
-    if (entry.status === "fulfilled") {
-      await entry.value.backend.stop()
-    }
-  }))
+  const settled = await Promise.allSettled(closing.values())
+  const fulfilled = settled.flatMap(entry => entry.status === "fulfilled"
+    ? [entry.value]
+    : [])
+  const stopped = await Promise.allSettled(fulfilled.map(runtime => Promise.resolve().then(() => runtime.backend.stop())))
+  const failures = stopped.flatMap(entry => entry.status === "rejected"
+    ? [new WorkflowError("OpenWorkflow backend cleanup failed.", {
+        cause: entry.reason,
+        code: "OPENWORKFLOW_BACKEND_CLOSE_FAILED",
+        provider: "openworkflow",
+      })]
+    : [])
+  if (failures.length === 1) throw failures[0]
+  if (failures.length > 1) {
+    throw new AggregateError(failures, "OpenWorkflow backend cleanup failed for multiple runtimes.")
+  }
 }
 
 export function setOpenWorkflowImporter(importer: OpenWorkflowImporter): void {

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -6,8 +6,9 @@ import { dirname, join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { WorkflowProviderStep } from "../src/types.ts"
+import { WorkflowError } from "../src/errors.ts"
 import { getCloudflareWorkflowBindingName } from "../src/integrations/cloudflare.ts"
-import { resetOpenWorkflowRuntime, setOpenWorkflowImporter } from "../src/runtime/openworkflow.ts"
+import { getOpenWorkflowRuntime, resetOpenWorkflowRuntime, setOpenWorkflowImporter } from "../src/runtime/openworkflow.ts"
 import { createOpenWorkflowWorker } from "../src/runtime/openworkflow-worker.ts"
 import { runCloudflareWorkflow } from "../src/runtime/cloudflare-runner.ts"
 import { cancelWorkflow, createWorkflow, deferWorkflow, getWorkflowRun, resumeWorkflowSignal, runWorkflow } from "../src/runtime/client.ts"
@@ -110,6 +111,8 @@ const openWorkflowMock = vi.hoisted(() => {
   }
 })
 
+type OpenWorkflowMockBackend = Awaited<ReturnType<typeof openWorkflowMock.connect>>
+
 vi.mock("openworkflow", () => ({
   OpenWorkflow: openWorkflowMock.OpenWorkflow,
 }))
@@ -126,9 +129,7 @@ vi.mock("openworkflow/sqlite", () => ({
   },
 }))
 
-beforeEach(async () => {
-  resetWorkflowRuntime()
-  await resetOpenWorkflowRuntime()
+function setOpenWorkflowMockImporter(): void {
   setOpenWorkflowImporter(async (specifier) => {
     if (specifier === "openworkflow") {
       return { OpenWorkflow: openWorkflowMock.OpenWorkflow } as never
@@ -141,6 +142,12 @@ beforeEach(async () => {
     }
     return await import(specifier) as never
   })
+}
+
+beforeEach(async () => {
+  resetWorkflowRuntime()
+  await resetOpenWorkflowRuntime()
+  setOpenWorkflowMockImporter()
   openWorkflowMock.connect.mockClear()
   openWorkflowMock.sqliteConnect.mockClear()
   openWorkflowMock.definitions.clear()
@@ -594,6 +601,129 @@ describe("workflow runtime", () => {
         status: "completed",
       })
     })
+  })
+
+  it("shares one OpenWorkflow acquisition and closes its backend once", async () => {
+    let resolveBackend: ((backend: OpenWorkflowMockBackend) => void) | undefined
+    const stop = vi.fn()
+    const backend = { getWorkflowRun: vi.fn(), stop }
+    openWorkflowMock.connect.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveBackend = resolve
+    }))
+    const config = {
+      postgres: { url: "postgres://localhost/shared" },
+      provider: "openworkflow" as const,
+    }
+
+    const first = getOpenWorkflowRuntime(config)
+    const second = getOpenWorkflowRuntime(config)
+    await vi.waitFor(() => expect(openWorkflowMock.connect).toHaveBeenCalledOnce())
+    resolveBackend?.(backend)
+
+    await expect(first).resolves.toBe(await second)
+    await resetOpenWorkflowRuntime()
+    await resetOpenWorkflowRuntime()
+    expect(stop).toHaveBeenCalledOnce()
+  })
+
+  it("evicts a rejected OpenWorkflow acquisition", async () => {
+    const failure = new Error("database unavailable")
+    const config = {
+      postgres: { url: "postgres://localhost/retry" },
+      provider: "openworkflow" as const,
+    }
+    openWorkflowMock.connect.mockRejectedValueOnce(failure)
+
+    await expect(getOpenWorkflowRuntime(config)).rejects.toBe(failure)
+    await expect(getOpenWorkflowRuntime(config)).resolves.toBeDefined()
+    expect(openWorkflowMock.connect).toHaveBeenCalledTimes(2)
+  })
+
+  it("preserves every OpenWorkflow cleanup failure in cache order", async () => {
+    const firstCause = new Error("first close failed")
+    const secondCause = new Error("second close failed")
+    const firstStop = vi.fn().mockRejectedValue(firstCause)
+    const secondStop = vi.fn().mockRejectedValue(secondCause)
+    const thirdStop = vi.fn()
+    openWorkflowMock.connect
+      .mockResolvedValueOnce({ getWorkflowRun: vi.fn(), stop: firstStop })
+      .mockResolvedValueOnce({ getWorkflowRun: vi.fn(), stop: secondStop })
+      .mockResolvedValueOnce({ getWorkflowRun: vi.fn(), stop: thirdStop })
+
+    await Promise.all(["first", "second", "third"].map(url => getOpenWorkflowRuntime({
+      postgres: { url: `postgres://localhost/${url}` },
+      provider: "openworkflow",
+    })))
+
+    const failure = await resetOpenWorkflowRuntime().catch(error => error) as AggregateError
+    expect(failure).toBeInstanceOf(AggregateError)
+    expect(failure.message).toBe("OpenWorkflow backend cleanup failed for multiple runtimes.")
+    expect(failure.errors).toEqual([
+      expect.objectContaining({ cause: firstCause, code: "OPENWORKFLOW_BACKEND_CLOSE_FAILED" }),
+      expect.objectContaining({ cause: secondCause, code: "OPENWORKFLOW_BACKEND_CLOSE_FAILED" }),
+    ])
+    expect(failure.errors.every(error => error instanceof WorkflowError)).toBe(true)
+    expect(firstStop).toHaveBeenCalledOnce()
+    expect(secondStop).toHaveBeenCalledOnce()
+    expect(thirdStop).toHaveBeenCalledOnce()
+
+    await expect(resetOpenWorkflowRuntime()).resolves.toBeUndefined()
+    expect(firstStop).toHaveBeenCalledOnce()
+    expect(secondStop).toHaveBeenCalledOnce()
+    expect(thirdStop).toHaveBeenCalledOnce()
+
+    const singleCause = new Error("single close failed")
+    const singleStop = vi.fn().mockRejectedValue(singleCause)
+    setOpenWorkflowMockImporter()
+    openWorkflowMock.connect.mockResolvedValueOnce({ getWorkflowRun: vi.fn(), stop: singleStop })
+    await getOpenWorkflowRuntime({
+      postgres: { url: "postgres://localhost/single" },
+      provider: "openworkflow",
+    })
+
+    const singleFailure = await resetOpenWorkflowRuntime().catch(error => error)
+    expect(singleFailure).toBeInstanceOf(WorkflowError)
+    expect(singleFailure).toMatchObject({
+      cause: singleCause,
+      code: "OPENWORKFLOW_BACKEND_CLOSE_FAILED",
+      provider: "openworkflow",
+    })
+    expect(singleStop).toHaveBeenCalledOnce()
+  })
+
+  it("separates OpenWorkflow acquisitions started across a reset", async () => {
+    let resolveOldBackend: ((backend: OpenWorkflowMockBackend) => void) | undefined
+    const oldStop = vi.fn()
+    const newStop = vi.fn()
+    openWorkflowMock.connect
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveOldBackend = resolve
+      }))
+      .mockResolvedValueOnce({ getWorkflowRun: vi.fn(), stop: newStop })
+    const config = {
+      postgres: { url: "postgres://localhost/reset-race" },
+      provider: "openworkflow" as const,
+    }
+
+    const oldRuntime = getOpenWorkflowRuntime(config)
+    await vi.waitFor(() => expect(openWorkflowMock.connect).toHaveBeenCalledOnce())
+    const resetting = resetOpenWorkflowRuntime()
+    setOpenWorkflowMockImporter()
+    const newRuntime = getOpenWorkflowRuntime(config)
+    await vi.waitFor(() => expect(openWorkflowMock.connect).toHaveBeenCalledTimes(2))
+    resolveOldBackend?.({ getWorkflowRun: vi.fn(), stop: oldStop })
+
+    await expect(oldRuntime).rejects.toMatchObject({
+      code: "OPENWORKFLOW_RUNTIME_RESET",
+      provider: "openworkflow",
+    })
+    await expect(resetting).resolves.toBeUndefined()
+    await expect(newRuntime).resolves.toBeDefined()
+    expect(oldStop).toHaveBeenCalledOnce()
+    expect(newStop).not.toHaveBeenCalled()
+
+    await resetOpenWorkflowRuntime()
+    expect(newStop).toHaveBeenCalledOnce()
   })
 
   it("reads OpenWorkflow Postgres connection options from runtime environment", async () => {


### PR DESCRIPTION
OpenWorkflow runtime caching now has one generation owner. Concurrent gets for the same storage config share one acquisition, rejected initialization is evicted, and reset atomically swaps the cache before waiting so new gets cannot join a generation being closed. A pending pre-reset get rejects with the stable `OPENWORKFLOW_RUNTIME_RESET` WorkflowError after its backend is closed, while post-reset gets use the new generation.

Reset closes every fulfilled backend exactly once and preserves cleanup failures in cache order: one failure rejects as `WorkflowError(OPENWORKFLOW_BACKEND_CLOSE_FAILED)`, while multiple failures reject as an AggregateError containing each WorkflowError and original cause. The importer is captured per acquisition so reset cannot mix importer generations. Public Promise declarations stay unchanged, and OpenWorkflow's durable SDK retry mapping is untouched.

Effect Scope is intentionally rejected under the migration report's pay-rent rule. The correct plain owner is +46/-20 production lines; Scope would leave the same Map, acquisition Promise, generation swap, rejection eviction, and reset/get admission checks, then add an interpreter and Cause mapper merely to replace `backend.stop()`. This PR is the retained-plain outcome, with no Effect dependency or lockfile change.

Proof: Workflow typecheck passes; the package build and publint pass; the focused runtime file passes all 53 tests and the complete Workflow suite passes all 92 tests across five files; the full workspace build, focused Oxlint, and repository Fallow pass; generated declarations and runtime output contain no Effect or FiberFailure leakage.

DEPENDENCY STATUS
  base: #676 at 5c0b0b7171cf6573b8e9fe95e0d37909b9ca7b6c
  merge: after #676, or retarget once #676 lands

EFFECT ADOPTION STATUS
  seam: cached OpenWorkflow backend lifecycle
  public API: Promise signatures unchanged; reset failures now use stable WorkflowError codes
  boundary: none; retained plain
  typed failures: OPENWORKFLOW_RUNTIME_RESET; OPENWORKFLOW_BACKEND_CLOSE_FAILED; AggregateError preserving ordered cleanup causes
  resources/fibers: one Map generation owner; reset swaps then closes the detached generation; no fibers
  deleted: sticky rejected acquisitions, unsnapshotted reset race, first-failure-only cleanup, live importer lookup during acquisition
  blocked: Scope cannot own cache identity, deduplication, generation, or reset admission and fails source pay-rent
  todos: 0
  confidence: high