### PR TITLE
fix(workflow): own OpenWorkflow worker shutdown

### DIFF
--- a/packages/workflow/src/runtime/openworkflow-worker.ts
+++ b/packages/workflow/src/runtime/openworkflow-worker.ts
@@ -1,5 +1,6 @@
 import { getOpenWorkflowRuntime, registerOpenWorkflowDefinition } from "./openworkflow.ts"
 import { getInlineWorkflowDefinitions, getWorkflowRuntimeConfig, getWorkflowRuntimeRegistry, setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry, takeInlineWorkflowDefinitionForModule } from "./state.ts"
+import { WorkflowError } from "../errors.ts"
 
 import type { ResolvedWorkflowOptions, WorkflowDefinition, WorkflowDefinitionRegistry } from "../types.ts"
 
@@ -12,15 +13,23 @@ export interface CreateOpenWorkflowWorkerOptions {
 }
 
 export interface StartOpenWorkflowWorkerOptions extends CreateOpenWorkflowWorkerOptions {
+  onError?: (error: WorkflowError) => Promise<void> | void
   signal?: AbortSignal
   signals?: boolean
 }
 
 function getProcess(): {
+  emitWarning?: (warning: Error) => void
   off?: (event: string, listener: () => void) => void
   on?: (event: string, listener: () => void) => void
 } | undefined {
-  return (globalThis as { process?: { off?: (event: string, listener: () => void) => void, on?: (event: string, listener: () => void) => void } }).process
+  return (globalThis as {
+    process?: {
+      emitWarning?: (warning: Error) => void
+      off?: (event: string, listener: () => void) => void
+      on?: (event: string, listener: () => void) => void
+    }
+  }).process
 }
 
 async function loadRegistryDefinitions(registry: WorkflowDefinitionRegistry) {
@@ -79,16 +88,81 @@ export async function startOpenWorkflowWorker(options: StartOpenWorkflowWorkerOp
   const worker = await createOpenWorkflowWorker(options)
   await worker.start()
 
-  const stop = () => {
-    void worker.stop()
+  const originalStop = worker.stop.bind(worker)
+  const proc = getProcess()
+  let abortListenerActive = false
+  let processListenersActive = false
+  let stopTask: Promise<void> | undefined
+
+  const removeListeners = () => {
+    if (abortListenerActive) {
+      abortListenerActive = false
+      options.signal?.removeEventListener("abort", requestStop)
+    }
+    if (processListenersActive) {
+      processListenersActive = false
+      proc?.off?.("SIGINT", requestStop)
+      proc?.off?.("SIGTERM", requestStop)
+    }
   }
 
-  options.signal?.addEventListener("abort", stop, { once: true })
-  const proc = getProcess()
-  if (options.signals !== false) {
-    proc?.on?.("SIGINT", stop)
-    proc?.on?.("SIGTERM", stop)
+  const stop = (): Promise<void> => {
+    removeListeners()
+    stopTask ??= Promise.resolve()
+      .then(() => originalStop())
+      .catch((cause) => {
+        throw new WorkflowError("OpenWorkflow worker stop failed.", {
+          cause,
+          code: "OPENWORKFLOW_WORKER_STOP_FAILED",
+          provider: "openworkflow",
+        })
+      })
+    return stopTask
   }
+
+  const reportUnhandledError = (error: WorkflowError): void => {
+    try {
+      if (proc?.emitWarning) proc.emitWarning(error)
+      else console.error(error)
+    }
+    catch {}
+  }
+
+  const reportError = (error: WorkflowError): void => {
+    if (!options.onError) {
+      reportUnhandledError(error)
+      return
+    }
+    try {
+      Promise.resolve(options.onError(error)).catch(() => {
+        reportUnhandledError(error)
+      })
+    }
+    catch {
+      reportUnhandledError(error)
+    }
+  }
+
+  function requestStop(): void {
+    stop().catch(reportError)
+  }
+
+  Object.defineProperty(worker, "stop", {
+    configurable: true,
+    value: stop,
+    writable: true,
+  })
+
+  if (options.signal) {
+    abortListenerActive = true
+    options.signal.addEventListener("abort", requestStop, { once: true })
+  }
+  if (options.signals !== false && proc?.on && proc.off) {
+    processListenersActive = true
+    proc.on("SIGINT", requestStop)
+    proc.on("SIGTERM", requestStop)
+  }
+  if (options.signal?.aborted) requestStop()
 
   return worker
 }

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -9,7 +9,7 @@ import type { WorkflowProviderStep } from "../src/types.ts"
 import { WorkflowError } from "../src/errors.ts"
 import { getCloudflareWorkflowBindingName } from "../src/integrations/cloudflare.ts"
 import { getOpenWorkflowRuntime, resetOpenWorkflowRuntime, setOpenWorkflowImporter } from "../src/runtime/openworkflow.ts"
-import { createOpenWorkflowWorker } from "../src/runtime/openworkflow-worker.ts"
+import { createOpenWorkflowWorker, startOpenWorkflowWorker } from "../src/runtime/openworkflow-worker.ts"
 import { runCloudflareWorkflow } from "../src/runtime/cloudflare-runner.ts"
 import { cancelWorkflow, createWorkflow, deferWorkflow, getWorkflowRun, resumeWorkflowSignal, runWorkflow } from "../src/runtime/client.ts"
 import { createWorkflowSteps } from "../src/runtime/execute.ts"
@@ -142,6 +142,23 @@ function setOpenWorkflowMockImporter(): void {
     }
     return await import(specifier) as never
   })
+}
+
+function interceptProcessSignals(): {
+  listeners: Map<string, () => void>
+  off: ReturnType<typeof vi.spyOn>
+  on: ReturnType<typeof vi.spyOn>
+} {
+  const listeners = new Map<string, () => void>()
+  const on = vi.spyOn(process, "on").mockImplementation(((event: string, listener: () => void) => {
+    listeners.set(event, listener)
+    return process
+  }) as typeof process.on)
+  const off = vi.spyOn(process, "off").mockImplementation(((event: string, listener: () => void) => {
+    if (listeners.get(event) === listener) listeners.delete(event)
+    return process
+  }) as typeof process.off)
+  return { listeners, off, on }
 }
 
 beforeEach(async () => {
@@ -856,6 +873,122 @@ describe("workflow runtime", () => {
     expect(openWorkflowMock.newWorker).toHaveBeenCalledWith({ concurrency: 3 })
     await worker.start()
     expect(worker.start).toHaveBeenCalled()
+  })
+
+  it("owns OpenWorkflow worker listeners until a cached public stop fails", async () => {
+    setWorkflowRuntimeConfig({
+      postgres: { url: "postgres://localhost/vitehub" },
+      provider: "openworkflow",
+    })
+    const controller = new AbortController()
+    const addEventListener = vi.spyOn(controller.signal, "addEventListener")
+    const removeEventListener = vi.spyOn(controller.signal, "removeEventListener")
+    const processSignals = interceptProcessSignals()
+    const cause = new Error("stop failed")
+    const stop = vi.fn(async () => { throw cause })
+    openWorkflowMock.newWorker.mockReturnValueOnce({
+      options: undefined,
+      start: vi.fn(async () => {}),
+      stop,
+    })
+
+    const worker = await startOpenWorkflowWorker({
+      signal: controller.signal,
+    })
+
+    expect(worker.start).toHaveBeenCalledOnce()
+    expect(addEventListener).toHaveBeenCalledWith("abort", expect.any(Function), { once: true })
+
+    const firstStop = worker.stop()
+    const secondStop = worker.stop()
+
+    expect(secondStop).toBe(firstStop)
+    await expect(firstStop).rejects.toMatchObject({
+      cause,
+      code: "OPENWORKFLOW_WORKER_STOP_FAILED",
+      provider: "openworkflow",
+    })
+    await expect(secondStop).rejects.toMatchObject({ cause })
+    expect(stop).toHaveBeenCalledOnce()
+    expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function))
+    expect(processSignals.off).toHaveBeenCalledTimes(2)
+
+    controller.abort()
+    expect(stop).toHaveBeenCalledOnce()
+  })
+
+  it("reports abort-triggered OpenWorkflow worker stop failures after removing listeners", async () => {
+    setWorkflowRuntimeConfig({
+      postgres: { url: "postgres://localhost/vitehub" },
+      provider: "openworkflow",
+    })
+    const cause = new Error("stop failed")
+    const stop = vi.fn(async () => { throw cause })
+    openWorkflowMock.newWorker.mockReturnValueOnce({
+      options: undefined,
+      start: vi.fn(async () => {}),
+      stop,
+    })
+    const controller = new AbortController()
+    const removeEventListener = vi.spyOn(controller.signal, "removeEventListener")
+    const processSignals = interceptProcessSignals()
+    const onError = vi.fn()
+
+    await startOpenWorkflowWorker({ onError, signal: controller.signal })
+    const sigint = processSignals.listeners.get("SIGINT")
+    const sigterm = processSignals.listeners.get("SIGTERM")
+
+    controller.abort()
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+        cause,
+        code: "OPENWORKFLOW_WORKER_STOP_FAILED",
+        provider: "openworkflow",
+      }))
+    })
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(WorkflowError)
+    expect(stop).toHaveBeenCalledOnce()
+    expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function))
+    expect(processSignals.off).toHaveBeenCalledWith("SIGINT", sigint)
+    expect(processSignals.off).toHaveBeenCalledWith("SIGTERM", sigterm)
+    expect(processSignals.on).toHaveBeenCalledTimes(2)
+  })
+
+  it("reports process-triggered OpenWorkflow worker stop failures without returning a promise to the host", async () => {
+    setWorkflowRuntimeConfig({
+      postgres: { url: "postgres://localhost/vitehub" },
+      provider: "openworkflow",
+    })
+    const cause = new Error("stop failed")
+    const stop = vi.fn(async () => { throw cause })
+    openWorkflowMock.newWorker.mockReturnValueOnce({
+      options: undefined,
+      start: vi.fn(async () => {}),
+      stop,
+    })
+    const processSignals = interceptProcessSignals()
+    const onError = vi.fn()
+
+    const worker = await startOpenWorkflowWorker({ onError })
+    const sigint = processSignals.listeners.get("SIGINT")
+    expect(sigint).toBeDefined()
+
+    const returned = sigint?.()
+
+    expect(returned).toBeUndefined()
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+        cause,
+        code: "OPENWORKFLOW_WORKER_STOP_FAILED",
+      }))
+    })
+    await expect(worker.stop()).rejects.toMatchObject({
+      cause,
+      code: "OPENWORKFLOW_WORKER_STOP_FAILED",
+    })
+    expect(stop).toHaveBeenCalledOnce()
+    expect(processSignals.off).toHaveBeenCalledTimes(2)
   })
 
   it("registers inline workflow definitions in OpenWorkflow workers", async () => {


### PR DESCRIPTION
Makes a successfully started OpenWorkflow worker own its AbortSignal and process-signal listeners. Public stop removes every listener before calling the SDK, concurrent and repeated stops share one cached result, and provider failures reject with `WorkflowError` code `OPENWORKFLOW_WORKER_STOP_FAILED`.

Abort and process callbacks stay synchronous because their hosts do not await returned Promises; stop failures are routed through the optional `onError` hook, with a process warning/console fallback, instead of becoming unhandled rejections. `createOpenWorkflowWorker` remains caller-owned and unchanged.

EFFECT ADOPTION STATUS: retained plain. Effect Scope would still require the same public stop cache, returned-worker method replacement, listener registration state, and synchronous host error bridge, so it adds an interpreter boundary without deleting ownership machinery.

Depends on #676, which already contains the canonical OpenWorkflow backend lifecycle from #684.

Validation: Workflow build, publint, typecheck, focused lint, and the full 95-test package suite pass.