### PR TITLE
fix(workspace): cancel source HTTP requests

### DIFF
--- a/packages/internal/src/http-request.ts
+++ b/packages/internal/src/http-request.ts
@@ -18,6 +18,7 @@ export interface StandardSchemaV1<T = unknown> {
 }
 
 export interface HttpRequestOptions {
+  abortSignal?: AbortSignal
   body?: unknown
   cookies?: Record<string, string>
   headers?: Record<string, string>
@@ -80,10 +81,12 @@ async function fetchWithRetry(definition: NormalizedHttpRequest): Promise<Respon
   const attempts = definition.method === "GET" || definition.method === "HEAD" ? 2 : 1
   let lastError: unknown
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    definition.abortSignal?.throwIfAborted()
     try {
       return await fetchOnce(definition)
     }
     catch (error) {
+      definition.abortSignal?.throwIfAborted()
       lastError = error
       if (attempt === attempts) break
     }
@@ -96,13 +99,16 @@ async function fetchOnce(definition: NormalizedHttpRequest): Promise<Response> {
   applyCookies(headers, definition.cookies)
   const body = serializeRequestBody(definition.body, headers)
   const controller = definition.timeout ? new AbortController() : undefined
+  const signal = controller && definition.abortSignal
+    ? AbortSignal.any([definition.abortSignal, controller.signal])
+    : controller?.signal || definition.abortSignal
   const timeout = controller ? setTimeout(() => controller.abort(), definition.timeout) : undefined
   try {
     const response = await fetch(urlWithQuery(definition).toString(), {
       body,
       headers,
       method: definition.method,
-      signal: controller?.signal,
+      signal,
     })
     if (!response.ok) {
       throw new Error(`[vitehub] HTTP request failed with status ${response.status}.`)

--- a/packages/internal/test/http-request.test.ts
+++ b/packages/internal/test/http-request.test.ts
@@ -38,4 +38,51 @@ describe("HTTP request", () => {
       url: "https://portal.example.com/inventory",
     })
   })
+
+  it("does not retry caller cancellation and preserves the abort reason", async () => {
+    const controller = new AbortController()
+    const reason = new Error("request cancelled")
+    const fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => await new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      if (!signal) return reject(new Error("missing fetch signal"))
+      if (signal.aborted) return reject(signal.reason)
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true })
+    }))
+    vi.stubGlobal("fetch", fetch)
+
+    const request = executeHttpRequest({
+      abortSignal: controller.signal,
+      url: "https://portal.example.com/inventory",
+    })
+    controller.abort(reason)
+
+    await expect(request).rejects.toBe(reason)
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it("does not start a request for an already aborted caller", async () => {
+    const controller = new AbortController()
+    const reason = new Error("already cancelled")
+    controller.abort(reason)
+    const fetch = vi.fn()
+    vi.stubGlobal("fetch", fetch)
+
+    await expect(executeHttpRequest({
+      abortSignal: controller.signal,
+      url: "https://portal.example.com/inventory",
+    })).rejects.toBe(reason)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("still retries non-cancellation GET failures", async () => {
+    const fetch = vi.fn()
+      .mockRejectedValueOnce(new Error("connection reset"))
+      .mockResolvedValueOnce(new Response("\"ok\""))
+    vi.stubGlobal("fetch", fetch)
+
+    await expect(executeHttpRequest({
+      url: "https://portal.example.com/inventory",
+    })).resolves.toMatchObject({ data: "ok" })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
 })

--- a/packages/workspace/src/sources/fetch.ts
+++ b/packages/workspace/src/sources/fetch.ts
@@ -151,6 +151,7 @@ function createFetchSource<TResponse = unknown, TOutput = TResponse>(options: Fe
       const request = await defaultFetchSourceRequest(options, method, ctx)
       const result = await executeHttpRequest({
         ...request,
+        abortSignal: ctx.abortSignal,
         method,
         url: requestBaseUrl(options.url),
       }, {
@@ -381,6 +382,7 @@ async function executeFetchSourceRequest(
   const request = await defaultFetchSourceRequest(options, method, ctx, { body, query })
   const result = await executeHttpRequest({
     ...request,
+    abortSignal: ctx.abortSignal,
     method,
     url: requestBaseUrl(options.url),
   }, {

--- a/packages/workspace/test/fetch-source.test.ts
+++ b/packages/workspace/test/fetch-source.test.ts
@@ -190,6 +190,36 @@ describe("fetch sources", () => {
     })
   })
 
+  it("cancels materialized fetch requests with the caller abort reason", async () => {
+    const controller = new AbortController()
+    const reason = new Error("materialization cancelled")
+    const request = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => await new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      if (!signal) return reject(new Error("missing fetch signal"))
+      if (signal.aborted) return reject(signal.reason)
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true })
+    }))
+    const view = createWorkspaceSourceView({
+      name: "fetch-abort",
+      sources: {
+        status: fetch({
+          url: "https://status.example.com/api/summary",
+          workspacePath: "status/summary.json",
+        }),
+      },
+    }, createMemoryWorkspaceStore())
+
+    const materialization = view.materializeSources({
+      abortSignal: controller.signal,
+      sources: ["status"],
+    })
+    while (!request.mock.calls.length) await Promise.resolve()
+    controller.abort(reason)
+
+    await expect(materialization).rejects.toBe(reason)
+    expect(request).toHaveBeenCalledOnce()
+  })
+
   it("hides stale materialized files from live fetch source listings", async () => {
     const store = createMemoryWorkspaceStore()
     await store.writeFile("status/old.json", {


### PR DESCRIPTION
Workspace materialization cancellation now reaches the shared HTTP request boundary so fetch can stop the underlying work.

Caller cancellation is composed with request timeouts, preserves the exact AbortSignal reason, and prevents GET/HEAD retry from starting another attempt after cancellation. Ordinary transport failures still retry as before.

This is an internal prerequisite rather than an Effect adoption: modeling interruption without passing the signal to fetch would leave the underlying request running.

Verification at head a22e5c64c957d9169a628d797c48349940aba037:

- internal HTTP request tests: 4/4
- Workspace fetch-source tests: 16/16 with no type errors
- affected package builds and publint: passed
- diff check: passed

The diff against the base is limited to four files: 9 production lines and 77 test lines.


## EFFECT ADOPTION STATUS

- Seam: Workspace HTTP cancellation propagation.
- Public API: unchanged; Promise and Web AbortSignal boundaries remain public.
- Boundary: internal HTTP request cancellation used by Workspace materialization.
- Typed failures: unchanged; exact AbortSignal reasons are preserved.
- Resources/fibers: no Effect runtime; fetch receives the composed caller and timeout signal.
- Deleted: underlying requests that outlive caller cancellation.
- Retained: ordinary GET/HEAD retry behavior for transport failures.
- TODOs: none; this prerequisite is merged.
- Confidence: high at merged head a22e5c64c957d9169a628d797c48349940aba037; all GitHub code checks are green.
