### PR TITLE
feat(schedule): harden public error contract

### DIFF
--- a/docs/content/docs/reference/errors-diagnostics.md
+++ b/docs/content/docs/reference/errors-diagnostics.md
@@ -45,6 +45,10 @@ Use the error family to choose the next proof path before changing implementatio
 | Trace Events | Runtime policy, approval, capability, lifecycle, and error records. |
 | Package tests | Contract failures owned by the primitive package. |
 
+### Schedule errors
+
+`ScheduleError` requires a stable `ScheduleErrorCode` when constructed. Its JSON form contains only `code`, `details`, `message`, `requestId`, and `retryable`; server-only fields such as `cause`, `stack`, and the `httpStatus` transport hint are not serialized. Validation failures describe the invalid field and value type without including the value itself.
+
 ## Local response
 
 Start with the owning package and the failing proof path. For packages that generate Provider Output, inspect that output before changing runtime code. Email emits no Provider Output; inspect `EmailError.code` and `driver`, then use `cause` only in protected server-side diagnostics.

--- a/packages/schedule/fixtures/published-types/consumer.ts
+++ b/packages/schedule/fixtures/published-types/consumer.ts
@@ -1,4 +1,16 @@
-import type { ScheduleDefinitionRegistry } from "@vite-hub/schedule"
+import { ScheduleError } from "@vite-hub/schedule"
+
+import type { ScheduleDefinitionRegistry, ScheduleErrorCode } from "@vite-hub/schedule"
 import registry from "#vitehub/schedule/registry"
 
 registry satisfies ScheduleDefinitionRegistry
+
+const code = "SCHEDULE_NOT_FOUND" satisfies ScheduleErrorCode
+const error = new ScheduleError("Runtime Schedule not found: daily", {
+  code,
+  details: { id: "daily" },
+  httpStatus: 404,
+})
+
+error.code satisfies ScheduleErrorCode
+error.toJSON().code satisfies ScheduleErrorCode

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@vite-hub/kv": "workspace:*",
+    "@vite-hub/runtime": "workspace:*",
     "cron-schedule": "catalog:workflow",
     "effect": "catalog:effect",
     "esbuild": "catalog:tooling"

--- a/packages/schedule/src/errors.ts
+++ b/packages/schedule/src/errors.ts
@@ -1,20 +1,65 @@
-interface ScheduleErrorOptions {
-  cause?: unknown
-  code?: string
-  details?: unknown
+import { ViteHubError } from "@vite-hub/runtime"
+
+import type { ViteHubErrorDetails, ViteHubErrorOptions } from "@vite-hub/runtime"
+
+export type ScheduleErrorCode =
+  | "SCHEDULE_ALREADY_EXISTS"
+  | "SCHEDULE_DISABLED"
+  | "SCHEDULE_INVALID_CRON"
+  | "SCHEDULE_INVALID_ENABLED"
+  | "SCHEDULE_INVALID_ID"
+  | "SCHEDULE_INVALID_INPUT"
+  | "SCHEDULE_INVALID_SCHEDULED_AT"
+  | "SCHEDULE_INVALID_TARGET"
+  | "SCHEDULE_INVALID_TIME_ZONE"
+  | "SCHEDULE_NOT_DUE"
+  | "SCHEDULE_NOT_FOUND"
+  | "SCHEDULE_RUN_NOT_FOUND"
+  | "SCHEDULE_TARGET_NOT_ELIGIBLE"
+  | "SCHEDULE_TARGET_NOT_FOUND"
+
+export interface ScheduleErrorOptions<TCode extends ScheduleErrorCode = ScheduleErrorCode> extends ViteHubErrorOptions {
+  code: TCode
   httpStatus?: number
 }
 
-export class ScheduleError extends Error {
-  code?: string
-  details?: unknown
-  httpStatus?: number
+export type ScheduleErrorField =
+  | "cron"
+  | "enabled"
+  | "id"
+  | "input"
+  | "options"
+  | "scheduledAt"
+  | "target"
+  | "timeZone"
 
-  constructor(message: string, options: ScheduleErrorOptions = {}) {
-    super(message, { cause: options.cause })
+export function invalidScheduleValueDetails(field: ScheduleErrorField, value: unknown): ViteHubErrorDetails {
+  const valueType = value === null
+    ? "null"
+    : Array.isArray(value)
+      ? "array"
+      : value instanceof Date
+        ? "date"
+        : typeof value
+  return { field, valueType }
+}
+
+export function assertRuntimeScheduleId(id: unknown): asserts id is string {
+  if (typeof id !== "string" || !id.trim()) {
+    throw new ScheduleError("Runtime Schedule id must be a non-empty string.", {
+      code: "SCHEDULE_INVALID_ID",
+      details: invalidScheduleValueDetails("id", id),
+      httpStatus: 400,
+    })
+  }
+}
+
+export class ScheduleError<TCode extends ScheduleErrorCode = ScheduleErrorCode> extends ViteHubError<TCode> {
+  readonly httpStatus?: number
+
+  constructor(message: string, options: ScheduleErrorOptions<TCode>) {
+    super(options.code, message, options)
     this.name = "ScheduleError"
-    this.code = options.code
-    this.details = options.details
     this.httpStatus = options.httpStatus
   }
 }

--- a/packages/schedule/src/index.ts
+++ b/packages/schedule/src/index.ts
@@ -17,6 +17,12 @@ export {
 } from "./runtime/state.ts"
 
 export type {
+  ScheduleErrorCode,
+  ScheduleErrorField,
+  ScheduleErrorOptions,
+} from "./errors.ts"
+
+export type {
   KVScheduleStoreOptions,
   ScheduleKVStorage,
 } from "./runtime/store.ts"

--- a/packages/schedule/src/runtime/client.ts
+++ b/packages/schedule/src/runtime/client.ts
@@ -1,7 +1,7 @@
 import { randomId } from "@vite-hub/internal/runtime/random"
 import { isIanaTimeZone } from "@vite-hub/internal/runtime/time-zone"
 
-import { ScheduleError } from "../errors.ts"
+import { assertRuntimeScheduleId, invalidScheduleValueDetails, ScheduleError } from "../errors.ts"
 import { executeRuntimeSchedule } from "./execute.ts"
 import { getRuntimeScheduleStore, getScheduleRunStore, loadScheduleDefinition } from "./state.ts"
 
@@ -71,7 +71,7 @@ export function validateRuntimeScheduleCron(cron: unknown): void {
   if (typeof cron !== "string" || cron.trim() !== cron || cron.length === 0) {
     throw new ScheduleError("Runtime Schedule cron must be a five-field cron expression.", {
       code: "SCHEDULE_INVALID_CRON",
-      details: { cron },
+      details: invalidScheduleValueDetails("cron", cron),
       httpStatus: 400,
     })
   }
@@ -80,7 +80,7 @@ export function validateRuntimeScheduleCron(cron: unknown): void {
   if (fields.length !== 5) {
     throw new ScheduleError("Runtime Schedule cron must be a five-field cron expression.", {
       code: "SCHEDULE_INVALID_CRON",
-      details: { cron },
+      details: invalidScheduleValueDetails("cron", cron),
       httpStatus: 400,
     })
   }
@@ -96,9 +96,9 @@ export function validateRuntimeScheduleCron(cron: unknown): void {
     })
   }
   catch {
-    throw new ScheduleError(`Invalid Runtime Schedule cron expression: ${cron}`, {
+    throw new ScheduleError("Runtime Schedule cron must be a valid five-field cron expression.", {
       code: "SCHEDULE_INVALID_CRON",
-      details: { cron },
+      details: invalidScheduleValueDetails("cron", cron),
       httpStatus: 400,
     })
   }
@@ -108,7 +108,7 @@ function validateRuntimeScheduleTimeZone(timeZone: unknown): void {
   if (!isIanaTimeZone(timeZone)) {
     throw new ScheduleError("Runtime Schedule timeZone must be a valid IANA time zone.", {
       code: "SCHEDULE_INVALID_TIME_ZONE",
-      details: { timeZone },
+      details: invalidScheduleValueDetails("timeZone", timeZone),
       httpStatus: 400,
     })
   }
@@ -118,7 +118,7 @@ async function assertRuntimeTarget(target: unknown): Promise<void> {
   if (typeof target !== "string" || !target.trim()) {
     throw new ScheduleError("Runtime Schedule target must be a non-empty string.", {
       code: "SCHEDULE_INVALID_TARGET",
-      details: { target },
+      details: invalidScheduleValueDetails("target", target),
       httpStatus: 400,
     })
   }
@@ -145,7 +145,7 @@ function assertRuntimeScheduleInputObject(input: unknown, operation: "create" | 
   if (typeof input !== "object" || input === null || Array.isArray(input)) {
     throw new ScheduleError(`Runtime Schedule ${operation} input must be an object.`, {
       code: "SCHEDULE_INVALID_INPUT",
-      details: { input },
+      details: invalidScheduleValueDetails("input", input),
       httpStatus: 400,
     })
   }
@@ -154,9 +154,9 @@ function assertRuntimeScheduleInputObject(input: unknown, operation: "create" | 
 function assertRuntimeScheduleInputKeys(input: Record<string, unknown>, allowed: Set<string>, operation: "create" | "update"): void {
   const unknownKey = Object.keys(input).find(key => !allowed.has(key))
   if (unknownKey) {
-    throw new ScheduleError(`Runtime Schedule ${operation} does not support "${unknownKey}".`, {
+    throw new ScheduleError(`Runtime Schedule ${operation} contains an unsupported field.`, {
       code: "SCHEDULE_INVALID_INPUT",
-      details: { key: unknownKey },
+      details: invalidScheduleValueDetails("input", input),
       httpStatus: 400,
     })
   }
@@ -167,17 +167,13 @@ async function validateCreateInput(input: RuntimeScheduleCreateInput): Promise<v
   assertRuntimeScheduleInputKeys(input, runtimeScheduleCreateInputKeys, "create")
   await assertRuntimeTarget(input.target)
   validateRuntimeScheduleCron(input.cron)
-  if (input.id !== undefined && (typeof input.id !== "string" || !input.id.trim())) {
-    throw new ScheduleError("Runtime Schedule id must be a non-empty string when provided.", {
-      code: "SCHEDULE_INVALID_ID",
-      details: { id: input.id },
-      httpStatus: 400,
-    })
+  if (input.id !== undefined) {
+    assertRuntimeScheduleId(input.id)
   }
   if (input.enabled !== undefined && typeof input.enabled !== "boolean") {
     throw new ScheduleError("Runtime Schedule enabled must be a boolean when provided.", {
       code: "SCHEDULE_INVALID_ENABLED",
-      details: { enabled: input.enabled },
+      details: invalidScheduleValueDetails("enabled", input.enabled),
       httpStatus: 400,
     })
   }
@@ -198,7 +194,7 @@ async function validateUpdateInput(input: RuntimeScheduleUpdateInput): Promise<v
   if (input.enabled !== undefined && typeof input.enabled !== "boolean") {
     throw new ScheduleError("Runtime Schedule enabled must be a boolean when provided.", {
       code: "SCHEDULE_INVALID_ENABLED",
-      details: { enabled: input.enabled },
+      details: invalidScheduleValueDetails("enabled", input.enabled),
       httpStatus: 400,
     })
   }
@@ -208,6 +204,7 @@ async function validateUpdateInput(input: RuntimeScheduleUpdateInput): Promise<v
 }
 
 async function updateRuntimeSchedule<TTarget extends ScheduleTargetName, TInput>(id: string, input: RuntimeScheduleUpdateInput<TTarget, TInput>): Promise<RuntimeScheduleRecord<TInput>> {
+  assertRuntimeScheduleId(id)
   await validateUpdateInput(input)
   const updated = await getRuntimeScheduleStore().update(id, {
     ...input,

--- a/packages/schedule/src/runtime/driver.ts
+++ b/packages/schedule/src/runtime/driver.ts
@@ -395,7 +395,7 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
               if (!isRuntimeScheduleDue(staticSchedule.record, input.scheduledAt)) {
                 throw new ScheduleError(`Static Schedule is not due: ${staticSchedule.name}`, {
                   code: "SCHEDULE_NOT_DUE",
-                  details: { id: input.scheduleId, scheduledAt: input.scheduledAt },
+                  details: { id: input.scheduleId, scheduledAt: input.scheduledAt.toISOString() },
                   httpStatus: 409,
                 })
               }

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -1,6 +1,6 @@
 import { randomId } from "@vite-hub/internal/runtime/random"
 
-import { ScheduleError } from "../errors.ts"
+import { assertRuntimeScheduleId, invalidScheduleValueDetails, ScheduleError } from "../errors.ts"
 import { isRuntimeScheduleDue } from "./due.ts"
 import { getRuntimeScheduleStore, getScheduleRunStore, loadScheduleDefinition } from "./state.ts"
 import { createLocalWaitUntil } from "./wait-until.ts"
@@ -45,7 +45,7 @@ function assertRuntimeExecuteOptionsObject(options: unknown): asserts options is
   if (typeof options !== "object" || options === null || Array.isArray(options)) {
     throw new ScheduleError("Runtime Schedule execute options must be a schedule id or options object.", {
       code: "SCHEDULE_INVALID_INPUT",
-      details: { options },
+      details: invalidScheduleValueDetails("options", options),
       httpStatus: 400,
     })
   }
@@ -63,7 +63,7 @@ function validateScheduledAt(scheduledAt: Date): Date {
   if (!(scheduledAt instanceof Date) || Number.isNaN(scheduledAt.getTime())) {
     throw new ScheduleError("Schedule Run scheduledAt must be a valid Date.", {
       code: "SCHEDULE_INVALID_SCHEDULED_AT",
-      details: { scheduledAt },
+      details: invalidScheduleValueDetails("scheduledAt", scheduledAt),
       httpStatus: 400,
     })
   }
@@ -258,6 +258,7 @@ async function loadRequiredRuntimeSchedule(id: string, store: RuntimeScheduleSto
 export async function executeRuntimeSchedule(options: ExecuteRuntimeScheduleOptions | string): Promise<ScheduleRunRecord> {
   const runtimeOptions = typeof options === "string" ? { id: options } : options
   assertRuntimeExecuteOptionsObject(runtimeOptions)
+  assertRuntimeScheduleId(runtimeOptions.id)
   const id = runtimeOptions.id
   const scheduledAt = validateScheduledAt(runtimeOptions.scheduledAt ?? new Date())
   const runtimeScheduleStore = runtimeOptions.runtimeScheduleStore
@@ -278,7 +279,7 @@ export async function executeRuntimeSchedule(options: ExecuteRuntimeScheduleOpti
   if (runtimeOptions.requireDue && !isRuntimeScheduleDue(schedule, scheduledAt)) {
     throw new ScheduleError(`Runtime Schedule is not due: ${id}`, {
       code: "SCHEDULE_NOT_DUE",
-      details: { id, scheduledAt },
+      details: { id, scheduledAt: scheduledAt.toISOString() },
       httpStatus: 409,
     })
   }

--- a/packages/schedule/src/runtime/store.ts
+++ b/packages/schedule/src/runtime/store.ts
@@ -1,4 +1,4 @@
-import { ScheduleError } from "../errors.ts"
+import { assertRuntimeScheduleId, ScheduleError } from "../errors.ts"
 
 import type { RuntimeScheduleRecord, RuntimeScheduleStore, RuntimeScheduleUpdateInput, ScheduleRunAttemptRecord, ScheduleRunRecord, ScheduleRunStore } from "../types.ts"
 
@@ -139,6 +139,7 @@ export function createMemoryRuntimeScheduleStore(): RuntimeScheduleStore {
 
   return {
     create(record) {
+      assertRuntimeScheduleId(record.id)
       if (records.has(record.id)) {
         throw new ScheduleError(`Runtime Schedule already exists: ${record.id}`, {
           code: "SCHEDULE_ALREADY_EXISTS",
@@ -185,6 +186,7 @@ export function createKVRuntimeScheduleStore(options: KVScheduleStoreOptions = {
 
   return {
     async create(record) {
+      assertRuntimeScheduleId(record.id)
       const store = await getKVStore()
       const key = runtimeScheduleKey(prefix, record.id)
       return await withKVKeyLock(key, async () => {

--- a/packages/schedule/test/errors.test.ts
+++ b/packages/schedule/test/errors.test.ts
@@ -1,0 +1,106 @@
+import { ViteHubError } from "@vite-hub/runtime"
+import { describe, expect, it } from "vitest"
+
+import { createMemoryRuntimeScheduleStore, ScheduleError, schedules, validateRuntimeScheduleCron } from "../src/index.ts"
+
+describe("ScheduleError", () => {
+  it("preserves its public identity and serializes only stable ViteHub fields", () => {
+    const error = new ScheduleError("Runtime Schedule not found: daily", {
+      cause: new Error("private-provider-cause"),
+      code: "SCHEDULE_NOT_FOUND",
+      details: { id: "daily" },
+      httpStatus: 404,
+      requestId: "request-1",
+      retryable: false,
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(ViteHubError)
+    expect(error).toBeInstanceOf(ScheduleError)
+    expect(error.name).toBe("ScheduleError")
+    expect(error.httpStatus).toBe(404)
+    expect(error.toJSON()).toEqual({
+      code: "SCHEDULE_NOT_FOUND",
+      details: { id: "daily" },
+      message: "Runtime Schedule not found: daily",
+      requestId: "request-1",
+      retryable: false,
+    })
+
+    const json = JSON.stringify(error)
+    expect(json).not.toContain("private-provider-cause")
+    expect(json).not.toContain("cause")
+    expect(json).not.toContain("httpStatus")
+    expect(json).not.toContain("stack")
+  })
+
+  it("redacts invalid cron values from messages, details, and JSON", () => {
+    const secret = "private-cron-value"
+
+    let error: unknown
+    try {
+      validateRuntimeScheduleCron(secret)
+    }
+    catch (cause) {
+      error = cause
+    }
+
+    expect(error).toBeInstanceOf(ScheduleError)
+    expect(error).toMatchObject({
+      code: "SCHEDULE_INVALID_CRON",
+      details: { field: "cron", valueType: "string" },
+    })
+    expect(JSON.stringify(error)).not.toContain(secret)
+  })
+
+  it("redacts unsupported input keys and values", async () => {
+    const secretKey = "privateSecretField"
+    const secretValue = "private-secret-value"
+    const error = await schedules.create({
+      cron: "0 9 * * *",
+      [secretKey]: secretValue,
+      target: "report",
+    } as never).then(() => undefined, cause => cause)
+
+    expect(error).toBeInstanceOf(ScheduleError)
+    expect(error).toMatchObject({
+      code: "SCHEDULE_INVALID_INPUT",
+      details: { field: "input", valueType: "object" },
+    })
+    const json = JSON.stringify(error)
+    expect(json).not.toContain(secretKey)
+    expect(json).not.toContain(secretValue)
+  })
+
+  it("redacts invalid schedule ids before storage access", async () => {
+    const secret = { token: "private-id-value" }
+    const error = await schedules.run(secret as never).then(() => undefined, cause => cause)
+
+    expect(error).toBeInstanceOf(ScheduleError)
+    expect(error).toMatchObject({
+      code: "SCHEDULE_INVALID_ID",
+      details: { field: "id", valueType: "object" },
+    })
+    expect(JSON.stringify(error)).not.toContain(secret.token)
+  })
+
+  it("redacts invalid ids passed directly to a public store", () => {
+    const secret = { token: "private-store-id-value" }
+    const store = createMemoryRuntimeScheduleStore()
+
+    let error: unknown
+    try {
+      store.create({ id: secret } as never)
+    }
+    catch (cause) {
+      error = cause
+    }
+
+    expect(error).toBeInstanceOf(ScheduleError)
+    expect(error).toMatchObject({
+      code: "SCHEDULE_INVALID_ID",
+      details: { field: "id", valueType: "object" },
+    })
+    expect(JSON.stringify(error)).not.toContain(secret.token)
+  })
+})

--- a/packages/schedule/test/published-types.test.ts
+++ b/packages/schedule/test/published-types.test.ts
@@ -9,6 +9,7 @@ import { expect, it } from "vitest"
 
 const execFileAsync = promisify(execFile)
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const runtimePackageRoot = resolve(packageRoot, "../runtime")
 const fixtureRoot = join(packageRoot, "fixtures", "published-types")
 const tsc = resolve(packageRoot, "../../node_modules/typescript/bin/tsc")
 
@@ -38,9 +39,13 @@ it("publishes virtual Schedule registry declarations", async () => {
   try {
     await cp(fixtureRoot, root, { recursive: true })
     const installedPackageRoot = join(root, "node_modules", "@vite-hub", "schedule")
+    const installedRuntimePackageRoot = join(root, "node_modules", "@vite-hub", "runtime")
     await mkdir(installedPackageRoot, { recursive: true })
+    await mkdir(installedRuntimePackageRoot, { recursive: true })
     await copyFile(join(packageRoot, "package.json"), join(installedPackageRoot, "package.json"))
+    await copyFile(join(runtimePackageRoot, "package.json"), join(installedRuntimePackageRoot, "package.json"))
     await cp(join(packageRoot, "dist"), join(installedPackageRoot, "dist"), { recursive: true })
+    await cp(join(runtimePackageRoot, "dist"), join(installedRuntimePackageRoot, "dist"), { recursive: true })
 
     await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", root])
     await expectPublicDeclarationsToExcludeEffect()

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -231,13 +231,13 @@ describe("Runtime Schedule helper", () => {
 
     await expect(schedules.create({ cron: "0 9 * * *", target: "report", timezone: "UTC" } as never)).rejects.toMatchObject({
       code: "SCHEDULE_INVALID_INPUT",
-      message: "Runtime Schedule create does not support \"timezone\".",
+      message: "Runtime Schedule create contains an unsupported field.",
     })
 
     await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
     await expect(schedules.update("schedule-1", { timezone: "UTC" } as never)).rejects.toMatchObject({
       code: "SCHEDULE_INVALID_INPUT",
-      message: "Runtime Schedule update does not support \"timezone\".",
+      message: "Runtime Schedule update contains an unsupported field.",
     })
   })
 

--- a/packages/schedule/tsconfig.json
+++ b/packages/schedule/tsconfig.json
@@ -8,6 +8,9 @@
       "@vite-hub/kv": [
         "packages/kv/src/index.ts"
       ],
+      "@vite-hub/runtime": [
+        "packages/runtime/src/index.ts"
+      ],
       "@vite-hub/internal/*": [
         "packages/internal/src/*.ts"
       ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,6 +1061,9 @@ importers:
       '@vite-hub/kv':
         specifier: workspace:*
         version: link:../kv
+      '@vite-hub/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       cron-schedule:
         specifier: catalog:workflow
         version: 6.0.0


### PR DESCRIPTION
Schedule errors now use the shared ViteHub error contract from #670 while preserving the existing ScheduleError class identity, error names, httpStatus transport hint, and Promise APIs. The exported code surface is the existing 14-code union; no catch-all code was added.

This intentionally tightens the public ScheduleError constructor so a stable code is required. ViteHub-owned invalid cron, time zone, target, ID, enabled, input, execute options, and scheduledAt failures expose only the field name and value type. Unsupported keys and invalid values are no longer echoed in messages or JSON. Valid persisted IDs and target names remain useful in known-error details, and Date details are serialized as ISO strings.

ScheduleError.toJSON() contains only code, details, message, requestId, and retryable. Cause, stack, httpStatus, handler input, provider bodies, URLs, and arbitrary invalid values are excluded. Raw handler and provider failures, AbortSignal reasons, lifecycle AggregateError ordering, and internal provider causes are unchanged.

This PR depends on #676 and is stacked on exact head 86172fca7ea45a7cc02e48771fd3680dc0af36a3, including its integrated #684 backend lifecycle and #685 worker shutdown commits. Published declaration coverage installs only built Schedule and Runtime packages and proves that the public error contract resolves without exposing Effect types. The errors reference documents the constructor and safe JSON boundary.

Source accounting: production source +87/-36, tests and published fixture +126/-3, documentation +4/-0, dependency/config/lock +7/-0.

Publication status: every GitHub CI, consumer, docs, provider verification, package preview, and Workers build job passes. The only failed check is the external Vercel deployment, which reports the project deployment quota and does not indicate a code failure.

EFFECT ADOPTION STATUS
- Seam: ScheduleError public contract
- Public API: intentional constructor tightening; class identity and Promise APIs preserved
- Boundary: ScheduleError.toJSON()
- Typed failures: existing ScheduleErrorCode union
- Resources and fibers: unchanged; owned by #676
- Removed: arbitrary invalid detail serialization and message echo
- Remaining TODOs: 0
- Confidence: high