### PR TITLE
fix(agent): redact public error responses

### DIFF
--- a/docs/content/docs/development/troubleshooting.md
+++ b/docs/content/docs/development/troubleshooting.md
@@ -59,7 +59,7 @@ If the proof is timing out before it reaches the interesting failure, increase t
 pnpm vitehub agent eval server/agents/support.eval.ts --output .vitehub/evals/support.json
 ```
 
-When the Agent Dev Loop reports `Agent Invocation Stream timed out after <ms>`, first decide whether the invocation is expected to run longer than the default timeout. If so, rerun with `vitehub agent dev --timeout <ms>`. If the timeout is surprising, inspect the Agent Driver boundary and any Workspace or harness session setup before changing prompts.
+When the Agent Dev Loop reports `Agent Invocation Stream failed.`, first decide whether the invocation is expected to run longer than the configured timeout. If so, rerun with `vitehub agent dev --timeout <ms>`. Public stream errors intentionally omit internal failure messages, so inspect protected server diagnostics to distinguish a timeout from an Agent Driver, Workspace, or harness session failure before changing prompts.
 
 ## When to escalate
 

--- a/docs/content/docs/reference/errors-diagnostics.md
+++ b/docs/content/docs/reference/errors-diagnostics.md
@@ -32,7 +32,9 @@ Use the error family to choose the next proof path before changing implementatio
 | Rate Limit policy or driver error | Rate Limit Package | A policy is invalid, the selected driver cannot satisfy its guarantees, a Definition is unknown, or a provider binding is unavailable. |
 | `RateLimitRejectedError` | Agent Package | Rate Limit Capability rejected an Agent Invocation. |
 | `LlmGateRejectedError` | Agent Package | LLM Gate Capability rejected before the main Agent Invocation. |
-| `Agent Invocation Stream timed out after <ms>.` | Agent Package | The dev-loop stream aborted a long or stalled Agent Invocation after its timeout. |
+| `Agent Invocation Stream failed.` | Agent Package | The public dev-loop stream failed; inspect protected server diagnostics for the internal cause. |
+
+Agent HTTP failures use `{ code, error, details?, requestId? }`. Invocation Stream `error` events keep their existing `type` and `error` fields and may add `code`, `details`, and `requestId`. ViteHub exposes only allowlisted capability identifiers and retry metadata at these public boundaries; unowned failures use `INTERNAL` and omit internal messages, causes, stacks, and headers.
 
 ## Diagnostics sources
 

--- a/packages/agent/src/chat/devtools-stream.ts
+++ b/packages/agent/src/chat/devtools-stream.ts
@@ -48,10 +48,10 @@ export function createChatDevtoolsStreamResponse(run: (emit: (event: ChatDevtool
             controller.close()
           }
         })
-        .catch((cause) => {
+        .catch(() => {
           if (closed || abortController.signal.aborted) return
           emit(controller, {
-            message: cause instanceof Error ? cause.message : "Chat DevTools stream failed.",
+            message: "Chat DevTools stream failed.",
             type: "error",
           })
           if (!closed) {

--- a/packages/agent/src/chat/devtools.ts
+++ b/packages/agent/src/chat/devtools.ts
@@ -731,8 +731,8 @@ async function postChatDevtoolsBridge(ctx: ViteDevToolsNodeContext, route: strin
   return await response.json() as ChatDevtoolsStateResult
 }
 
-function toChatDevtoolsErrorMessage(cause: unknown): string {
-  return cause instanceof Error ? cause.message : String(cause)
+function toChatDevtoolsErrorMessage(_cause: unknown): string {
+  return "Chat DevTools stream failed."
 }
 
 async function writeChatDevtoolsStream(

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -326,8 +326,8 @@ function createChatDevtoolsAgentEntry(
   }
 }
 
-function metadataErrorMessage(cause: unknown): string {
-  return cause instanceof Error ? cause.message : "Chat DevTools metadata inspection failed."
+function metadataErrorMessage(_cause: unknown): string {
+  return "Chat DevTools metadata inspection failed."
 }
 
 function materializedSourceKeys(metadata: ChatDevtoolsMetadata | undefined): string[] {
@@ -926,7 +926,7 @@ async function writeResponse(res: ServerResponse, response: Response): Promise<v
 
 function errorResponse(error: unknown): Response {
   if (error instanceof Response) return error
-  return new Response(error instanceof Error ? error.message : "Chat DevTools bridge failed.", {
+  return Response.json({ code: "INTERNAL", error: "Agent request failed." }, {
     status: 500,
   })
 }

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -28,6 +28,7 @@ import { discoverAgentDefinitions } from "../../discovery.ts"
 import { workspaceAgentOwnsWorkspaceDefinition, workspaceAgentWithSourceRoot } from "../../workspace-agent.ts"
 import { loadAiSdk } from "../../internal/ai-sdk-runtime.ts"
 import { decodeColocatedAgentSkills, withColocatedAgentSkills } from "../../internal/colocated-agent-skills.ts"
+import { toHttpErrorResponse } from "../../http-error.ts"
 import { readColocatedAgentSkills } from "../../vite/colocated-agent-skills.ts"
 
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http"
@@ -926,9 +927,7 @@ async function writeResponse(res: ServerResponse, response: Response): Promise<v
 
 function errorResponse(error: unknown): Response {
   if (error instanceof Response) return error
-  return Response.json({ code: "INTERNAL", error: "Agent request failed." }, {
-    status: 500,
-  })
+  return toHttpErrorResponse(error, 500)!
 }
 
 export function registerChatDevtoolsBridge(server: ViteDevServer): void {

--- a/packages/agent/src/http-error.ts
+++ b/packages/agent/src/http-error.ts
@@ -1,10 +1,23 @@
 import { LlmGateRejectedError } from "./capabilities/llm-gate.ts"
-import { agentErrorPublicMessage } from "./agent-error.ts"
+import { RateLimitRejectedError } from "./capabilities/rate-limit.ts"
+import { toAgentPublicError } from "./public-error.ts"
 
 function readStatusCode(error: unknown): number | undefined {
-  if (error instanceof LlmGateRejectedError) return (error as unknown as { statusCode: number }).statusCode
+  try {
+    if (error instanceof RateLimitRejectedError) return 429
+    if (error instanceof LlmGateRejectedError) return 403
+  }
+  catch {
+    return
+  }
   if (typeof error !== "object" || error === null) return
-  const statusCode = (error as { statusCode?: unknown }).statusCode
+  let statusCode: unknown
+  try {
+    statusCode = (error as { statusCode?: unknown }).statusCode
+  }
+  catch {
+    return
+  }
   return typeof statusCode === "number" && statusCode >= 400 && statusCode <= 599
     ? statusCode
     : undefined
@@ -15,23 +28,35 @@ export function getHttpErrorStatusCode(error: unknown): number | undefined {
 }
 
 export function getHttpErrorMessage(error: unknown): string {
-  return agentErrorPublicMessage(error, "Agent request failed.")
+  return toAgentPublicError(error, "http").error
 }
 
-function readHeaders(error: unknown): Headers | Record<string, string> | undefined {
-  if (typeof error !== "object" || error === null) return
-  const headers = (error as { headers?: unknown }).headers
-  if (headers instanceof Headers) return headers
-  if (!headers || typeof headers !== "object" || Array.isArray(headers)) return
-  const entries = Object.entries(headers).filter((entry): entry is [string, string] => typeof entry[1] === "string")
-  return entries.length ? Object.fromEntries(entries) : undefined
+function rateLimitHeaders(error: unknown): Record<string, string> | undefined {
+  try {
+    if (!(error instanceof RateLimitRejectedError)) return
+  }
+  catch {
+    return
+  }
+  let value: unknown
+  try {
+    value = error.retryAfter
+  }
+  catch {
+    return
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return
+  return {
+    "retry-after": String(value),
+    "x-retry-after": String(value),
+  }
 }
 
-export function toHttpErrorResponse(error: unknown): Response | undefined {
-  const statusCode = getHttpErrorStatusCode(error)
+export function toHttpErrorResponse(error: unknown, fallbackStatus?: number): Response | undefined {
+  const statusCode = getHttpErrorStatusCode(error) || fallbackStatus
   if (!statusCode) return
-  return Response.json({ error: getHttpErrorMessage(error) }, {
-    headers: readHeaders(error),
+  return Response.json(toAgentPublicError(error, "http"), {
+    headers: rateLimitHeaders(error),
     status: statusCode,
   })
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -964,7 +964,7 @@ export {
   createAgentInvocationStreamResponse,
   readAgentInvocationStream,
 } from "./invocation-stream.ts"
-export type { AgentInvocationStreamEvent } from "./invocation-stream.ts"
+export type { AgentInvocationStreamErrorEvent, AgentInvocationStreamEvent } from "./invocation-stream.ts"
 
 export type {
   AgentRunEvent,

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -1,15 +1,24 @@
-import { formatAgentError } from "./agent-error.ts"
+import { toAgentPublicError } from "./public-error.ts"
 import type { StreamEvent } from "./messages.ts"
+import type { AgentPublicErrorCode, AgentPublicErrorDetails } from "./public-error.ts"
 import type { AgentChannelDeliveryEffectIntent, AgentRunMetadata } from "./types.ts"
 
 export const agentInvocationStreamRoute = "/__vitehub/agent/invocation-stream"
 export const agentInvocationStreamHeader = "x-vitehub-agent-dev-loop"
 export const agentInvocationStreamHeaderValue = "1"
 
+export interface AgentInvocationStreamErrorEvent {
+  code?: AgentPublicErrorCode | (string & {})
+  details?: AgentPublicErrorDetails
+  error: string
+  requestId?: string
+  type: "error"
+}
+
 export type AgentInvocationStreamEvent =
   | StreamEvent
   | { channelId?: string, effect: AgentChannelDeliveryEffectIntent, run?: AgentRunMetadata, type: "delivery-preview" }
-  | { error: string, type: "error" }
+  | AgentInvocationStreamErrorEvent
   | { data?: Record<string, unknown>, durationMs?: number, id: string, label?: string, phase: "workspace.prepare" | (string & {}), status: "completed" | "failed" | "started" | "updating", type: "progress" }
   | { agent: string, metadata?: Record<string, unknown>, run?: unknown, trigger?: string, type: "start" }
   | { type: "done" }
@@ -72,13 +81,17 @@ export function createAgentInvocationStreamResponse(
     }
   }
 
-  function fail(controller: ReadableStreamDefaultController<Uint8Array>, cause: unknown): void {
+  function fail(
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    cause: unknown,
+    context: "invocation" | "serialization" = "serialization",
+  ): void {
     if (closed) return
     clearTimeoutSignal()
     abort(cause)
     try {
       write(controller, {
-        error: cause instanceof Error ? cause.message : "Agent Invocation Stream event could not be serialized.",
+        ...toAgentPublicError(cause, context),
         type: "error",
       })
       closeFailed(controller)
@@ -114,7 +127,7 @@ export function createAgentInvocationStreamResponse(
     start(controller) {
       if (options.timeout && options.timeout > 0) {
         timeout = setTimeout(() => {
-          fail(controller, new Error(`Agent Invocation Stream timed out after ${options.timeout}ms.`))
+          fail(controller, new Error(`Agent Invocation Stream timed out after ${options.timeout}ms.`), "invocation")
         }, options.timeout)
       }
       run(event => emit(controller, event), abortController.signal)
@@ -126,7 +139,7 @@ export function createAgentInvocationStreamResponse(
           if (closed || abortController.signal.aborted) return
           clearTimeoutSignal()
           emit(controller, {
-            error: cause instanceof Error ? cause.message : formatAgentError(cause, "Agent Invocation Stream failed."),
+            ...toAgentPublicError(cause, "invocation"),
             type: "error",
           })
           if (emit(controller, { type: "done" })) close(controller)

--- a/packages/agent/src/public-error.ts
+++ b/packages/agent/src/public-error.ts
@@ -1,0 +1,135 @@
+import {
+  ApprovalRequiredError,
+  CapabilityDeniedError,
+  CapabilityNotFoundError,
+} from "@vite-hub/runtime"
+
+import { LlmGateRejectedError } from "./capabilities/llm-gate.ts"
+import { RateLimitRejectedError } from "./capabilities/rate-limit.ts"
+
+export type AgentPublicErrorCode =
+  | "APPROVAL_REQUIRED"
+  | "CAPABILITY_DENIED"
+  | "CAPABILITY_NOT_FOUND"
+  | "INTERNAL"
+  | "LLM_GATE_REJECTED"
+  | "RATE_LIMIT_REJECTED"
+
+export interface AgentPublicErrorDetails {
+  capability?: string
+  category?: string
+  retryAfter?: number
+}
+
+export interface AgentPublicError {
+  code: AgentPublicErrorCode
+  details?: AgentPublicErrorDetails
+  error: string
+  requestId?: string
+}
+
+export type AgentPublicErrorContext = "http" | "invocation" | "serialization"
+
+const internalMessages: Record<AgentPublicErrorContext, string> = {
+  http: "Agent request failed.",
+  invocation: "Agent Invocation Stream failed.",
+  serialization: "Agent Invocation Stream event could not be serialized.",
+}
+
+function readProperty(value: object, key: string): unknown {
+  try {
+    return (value as Record<string, unknown>)[key]
+  }
+  catch {
+    return undefined
+  }
+}
+
+function isInstance<T>(value: unknown, constructor: { prototype: T }): value is T {
+  if (typeof value !== "object" || value === null) return false
+  try {
+    return Object.prototype.isPrototypeOf.call(constructor.prototype, value)
+  }
+  catch {
+    return false
+  }
+}
+
+function publicIdentifier(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0 || value.length > 128) return
+  return /^[A-Za-z0-9@][A-Za-z0-9@._:/-]*$/.test(value) ? value : undefined
+}
+
+function retryAfter(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined
+}
+
+function capabilityDetails(error: object): AgentPublicErrorDetails | undefined {
+  const details = readProperty(error, "details")
+  const capability = publicIdentifier(readProperty(error, "capabilityId"))
+    || (details && typeof details === "object" ? publicIdentifier(readProperty(details, "capability")) : undefined)
+  return capability ? { capability } : undefined
+}
+
+function requestId(error: ApprovalRequiredError): string | undefined {
+  return publicIdentifier(readProperty(error, "requestId"))
+}
+
+export function toAgentPublicError(error: unknown, context: AgentPublicErrorContext): AgentPublicError {
+  if (isInstance(error, RateLimitRejectedError)) {
+    const details = capabilityDetails(error)
+    const safeRetryAfter = retryAfter(readProperty(error, "retryAfter"))
+    return {
+      code: "RATE_LIMIT_REJECTED",
+      ...(details ? { details: { ...details, ...(safeRetryAfter === undefined ? {} : { retryAfter: safeRetryAfter }) } } : {}),
+      error: "Rate limit exceeded. Try again later.",
+    }
+  }
+
+  if (isInstance(error, LlmGateRejectedError)) {
+    const details = capabilityDetails(error)
+    const decision = readProperty(error, "decision")
+    const category = decision && typeof decision === "object"
+      ? publicIdentifier(readProperty(decision, "category"))
+      : undefined
+    return {
+      code: "LLM_GATE_REJECTED",
+      ...(details ? { details: { ...details, ...(category === undefined ? {} : { category }) } } : {}),
+      error: "Agent request was rejected.",
+    }
+  }
+
+  if (isInstance(error, CapabilityNotFoundError)) {
+    const details = capabilityDetails(error)
+    return {
+      code: "CAPABILITY_NOT_FOUND",
+      ...(details ? { details } : {}),
+      error: "Capability was not found.",
+    }
+  }
+
+  if (isInstance(error, CapabilityDeniedError)) {
+    const details = capabilityDetails(error)
+    return {
+      code: "CAPABILITY_DENIED",
+      ...(details ? { details } : {}),
+      error: "Capability access was denied.",
+    }
+  }
+
+  if (isInstance(error, ApprovalRequiredError)) {
+    const details = capabilityDetails(error)
+    const safeRequestId = requestId(error)
+    return {
+      code: "APPROVAL_REQUIRED",
+      ...(details ? { details } : {}),
+      error: "Capability approval is required.",
+      ...(safeRequestId === undefined ? {} : { requestId: safeRequestId }),
+    }
+  }
+
+  return {
+    code: "INTERNAL",
+    error: internalMessages[context],
+  }
+}

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2006,8 +2006,8 @@ function metadataSelectionKey(selection: AgentChatDevtoolsInvokerSelection = {})
   return `${invoker}:${JSON.stringify(selection.meta || {})}`
 }
 
-function metadataErrorMessage(cause: unknown): string {
-  return cause instanceof Error ? cause.message : "Chat DevTools metadata inspection failed."
+function metadataErrorMessage(_cause: unknown): string {
+  return "Chat DevTools metadata inspection failed."
 }
 
 async function startAgentDevtoolsMetadataResolution(
@@ -2420,7 +2420,7 @@ function chatDevtoolsErrorResponse(error: unknown): Response {
   if (error instanceof Response) return error
   const response = toHttpErrorResponse(error)
   if (response) return response
-  return createJsonErrorResponse(500, error instanceof Error ? error.message : "Chat DevTools bridge failed.")
+  return toHttpErrorResponse(error, 500)!
 }
 
 function withChatDevtoolsCors(response: Response): Response {
@@ -2684,10 +2684,7 @@ async function toAgentChatFetchResponse(result: unknown): Promise<Response> {
 function agentChatFetchErrorResponse(error: unknown): Response {
   const response = toHttpErrorResponse(error)
   if (response) return response
-  if (error instanceof TypeError) {
-    return createJsonErrorResponse(400, error.message)
-  }
-  return createJsonErrorResponse(500, error instanceof Error ? error.message : "Agent chat request failed.")
+  return toHttpErrorResponse(error, error instanceof TypeError ? 400 : 500)!
 }
 
 export function createChannelChatRouteHandler(

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -16,6 +16,7 @@ import { isResolvedAgentTriggerHandledInvocation, resolveAgentTriggerInvocation,
 import { createAgentRuntimeContext } from "../runtime/context.ts"
 import { workspaceAgentOwnsWorkspaceDefinition, workspaceAgentWithSourceRoot, workspaceModeFromOptions, workspaceNameFromOptions } from "../workspace-agent.ts"
 import { decodeColocatedAgentSkills, withColocatedAgentSkills } from "../internal/colocated-agent-skills.ts"
+import { toHttpErrorResponse } from "../http-error.ts"
 import { readColocatedAgentSkills } from "./colocated-agent-skills.ts"
 
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http"
@@ -814,9 +815,7 @@ function isAbortError(error: unknown): error is Error {
 
 function errorResponse(error: unknown): Response {
   if (error instanceof Response) return error
-  return Response.json({ code: "INTERNAL", error: "Agent request failed." }, {
-    status: 500,
-  })
+  return toHttpErrorResponse(error, 500)!
 }
 
 export async function registerAgentInvocationStreamEndpoint(server: ViteDevServer): Promise<void> {

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -814,7 +814,7 @@ function isAbortError(error: unknown): error is Error {
 
 function errorResponse(error: unknown): Response {
   if (error instanceof Response) return error
-  return new Response(error instanceof Error ? error.message : "Agent Invocation Stream endpoint failed.", {
+  return Response.json({ code: "INTERNAL", error: "Agent request failed." }, {
     status: 500,
   })
 }

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -963,7 +963,7 @@ describe("agent chat capability discovery", () => {
     })
 
     expect(response.statusCode).toBe(500)
-    expect(response.body).toContain("Agent Capability CLI \"inventory\" is not defined by this agent")
+    expect(JSON.parse(response.body)).toEqual({ code: "INTERNAL", error: "Agent request failed." })
   })
 
   it("preserves model driver context for Capability CLI dev runs", async () => {

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -720,7 +720,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const response = await invokeMiddleware(handlers[0]!, {
       agent: "review",
       payload: { prompt: "review" },
-      timeout: 100,
+      timeout: 1_000,
       trigger: "github.webhook",
     }, agentInvocationStreamRoute, {
       "content-type": "application/json",
@@ -731,17 +731,18 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
       .split("\n")
       .map(line => JSON.parse(line))
 
-    expect(events).toEqual([
+    expect(events.slice(0, 2)).toEqual([
       expect.objectContaining({ agent: "review", trigger: "github.webhook", type: "start" }),
       expect.objectContaining({ id: "workspace.prepare:review", phase: "workspace.prepare", status: "started", type: "progress" }),
-      expect.objectContaining({ durationMs: expect.any(Number), id: "workspace.prepare:review", phase: "workspace.prepare", status: "completed", type: "progress" }),
-      { error: "Agent Invocation Stream timed out after 100ms.", type: "error" },
+    ])
+    expect(events.slice(-2)).toEqual([
+      { code: "INTERNAL", error: "Agent Invocation Stream failed.", type: "error" },
       { type: "done" },
     ])
     expect(harnessCreateSessionOptions[0]?.abortSignal).toBeInstanceOf(AbortSignal)
-    expect(harnessCreateSessionOptions[0]?.timeout).toBe(100)
+    expect(harnessCreateSessionOptions[0]?.timeout).toBe(1_000)
     expect(harnessStreamInputs[0]?.abortSignal).toBeInstanceOf(AbortSignal)
-    expect(harnessStreamInputs[0]?.timeout).toBe(100)
+    expect(harnessStreamInputs[0]?.timeout).toBe(1_000)
     await waitFor(() => {
       expect(workspaceClose).toHaveBeenCalledOnce()
       expect(harnessSessionDestroy).toHaveBeenCalledOnce()

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
+import { LlmGateRejectedError } from "../src/capabilities/llm-gate.ts"
+import { RateLimitRejectedError } from "../src/capabilities/rate-limit.ts"
 import { createAgentInvocationStreamResponse, readAgentInvocationStream } from "../src/invocation-stream.ts"
 import { writeResponse } from "../src/vite/invocation-stream-endpoint.ts"
 
@@ -21,7 +23,7 @@ describe("Agent Invocation Stream", () => {
     ])
 
     expect(text.trim().split("\n").map(line => JSON.parse(line))).toEqual([
-      { error: "Agent Invocation Stream timed out after 10ms.", type: "error" },
+      { code: "INTERNAL", error: "Agent Invocation Stream failed.", type: "error" },
       { type: "done" },
     ])
     expect(aborted).toBe(true)
@@ -103,7 +105,11 @@ describe("Agent Invocation Stream", () => {
   })
 
   it("closes with an error when event serialization fails", async () => {
-    const response = createAgentInvocationStreamResponse(async (emit) => {
+    let abortReason: unknown
+    const response = createAgentInvocationStreamResponse(async (emit, signal) => {
+      signal.addEventListener("abort", () => {
+        abortReason = signal.reason
+      })
       emit({ data: 1n, type: "data" } as never)
     })
 
@@ -113,12 +119,14 @@ describe("Agent Invocation Stream", () => {
     }
 
     expect(events).toEqual([
-      { error: "Do not know how to serialize a BigInt", type: "error" },
+      { code: "INTERNAL", error: "Agent Invocation Stream event could not be serialized.", type: "error" },
       { type: "done" },
     ])
+    expect(abortReason).toBeInstanceOf(TypeError)
+    expect((abortReason as Error).message).toContain("BigInt")
   })
 
-  it("formats non-Error thrown values as stream errors", async () => {
+  it("redacts unowned thrown values as stream errors", async () => {
     const response = createAgentInvocationStreamResponse(async () => {
       throw { code: "delivery_preview_failed", status: 422 }
     })
@@ -129,8 +137,44 @@ describe("Agent Invocation Stream", () => {
     }
 
     expect(events).toEqual([
-      { error: `{"code":"delivery_preview_failed","status":422}`, type: "error" },
+      { code: "INTERNAL", error: "Agent Invocation Stream failed.", type: "error" },
       { type: "done" },
     ])
+  })
+
+  it("emits allowlisted rate-limit and gate failures without changing event order", async () => {
+    const failures = [
+      [new RateLimitRejectedError("rate-limit", { retryAfter: 30 } as never, "private provider response"), {
+        code: "RATE_LIMIT_REJECTED",
+        details: { capability: "rate-limit", retryAfter: 30 },
+        error: "Rate limit exceeded. Try again later.",
+        type: "error",
+      }],
+      [new LlmGateRejectedError("safety-gate", {
+        allowed: false,
+        category: "unsafe",
+        reason: "private prompt",
+      }, "private classification"), {
+        code: "LLM_GATE_REJECTED",
+        details: { capability: "safety-gate", category: "unsafe" },
+        error: "Agent request was rejected.",
+        type: "error",
+      }],
+    ] as const
+
+    for (const [failure, expected] of failures) {
+      const response = createAgentInvocationStreamResponse(async (emit) => {
+        emit({ label: "before", type: "data" } as never)
+        throw failure
+      })
+      const events = []
+      for await (const event of readAgentInvocationStream(response.body!)) events.push(event)
+
+      expect(events).toEqual([
+        { label: "before", type: "data" },
+        expected,
+        { type: "done" },
+      ])
+    }
   })
 })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1932,7 +1932,7 @@ describe("server helpers", () => {
     }), { agentIdentity: { name: "mini" }, capabilities: { schedule: { schedules } } })
 
     expect(response.status).toBe(500)
-    await expect(response.text()).resolves.toContain("requires the run channelId to match a configured Agent Channel")
+    await expect(response.json()).resolves.toEqual({ code: "INTERNAL", error: "Agent request failed." })
     expect(schedules.create).not.toHaveBeenCalled()
   })
 
@@ -1959,9 +1959,7 @@ describe("server helpers", () => {
     }), { agentName: "mini" })
 
     expect(response.status).toBe(500)
-    await expect(response.json()).resolves.toMatchObject({
-      message: expect.stringContaining('Capability "schedule" requires the schedule primitive to be configured.'),
-    })
+    await expect(response.json()).resolves.toEqual({ code: "INTERNAL", error: "Agent request failed." })
   })
 
   it("leaves custom text/event-stream chat Response bodies unchanged", async () => {
@@ -2283,7 +2281,8 @@ describe("server helpers", () => {
 
     expect(rejectedResponse.status).toBe(401)
     await expect(rejectedResponse.json()).resolves.toMatchObject({
-      error: "Agent chat route request was not admitted.",
+      code: "INTERNAL",
+      error: "Agent request failed.",
     })
     expect(authenticate).toHaveBeenCalledWith(expect.objectContaining({
       rawBody: expect.stringContaining("hello"),
@@ -2306,7 +2305,8 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toMatchObject({
-      error: "Agent chat payload requires a messages array.",
+      code: "INTERNAL",
+      error: "Agent request failed.",
     })
   })
 
@@ -2344,7 +2344,8 @@ describe("server helpers", () => {
 
       expect(response.status).toBe(400)
       await expect(response.json()).resolves.toMatchObject({
-        error: "Agent chat route identity must be derived server-side with defineAgent({ invoker }).",
+        code: "INTERNAL",
+        error: "Agent request failed.",
       })
     }
   })
@@ -2527,7 +2528,8 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toMatchObject({
-      error: "Agent chat route identity must be derived server-side with defineAgent({ invoker }).",
+      code: "INTERNAL",
+      error: "Agent request failed.",
     })
   })
 
@@ -3672,7 +3674,7 @@ describe("server helpers", () => {
     }), "custom-support")
 
     expect(response.status).toBe(401)
-    await expect(response.json()).resolves.toEqual({ error: "[vitehub] Webhook secret header \"x-test-secret\" is required." })
+    await expect(response.json()).resolves.toEqual({ code: "INTERNAL", error: "Agent request failed." })
     expect(adapter.handleWebhook).not.toHaveBeenCalled()
     expect(run).not.toHaveBeenCalled()
   })
@@ -3702,7 +3704,7 @@ describe("server helpers", () => {
     }), "custom-support")
 
     expect(response.status).toBe(401)
-    await expect(response.json()).resolves.toEqual({ error: "[vitehub] Webhook registration \"custom-support\" declares secretHeader \"x-test-secret\" but no secretToken is configured. Verification requires secretToken from Server Env; secretToken: false explicitly disables verification." })
+    await expect(response.json()).resolves.toEqual({ code: "INTERNAL", error: "Agent request failed." })
     expect(adapter.handleWebhook).not.toHaveBeenCalled()
     expect(run).not.toHaveBeenCalled()
   })
@@ -3732,7 +3734,7 @@ describe("server helpers", () => {
     }), "telegram")
 
     expect(response.status).toBe(401)
-    await expect(response.json()).resolves.toEqual({ error: "[vitehub] Webhook secret header \"x-telegram-bot-api-secret-token\" is required." })
+    await expect(response.json()).resolves.toEqual({ code: "INTERNAL", error: "Agent request failed." })
     expect(adapter.handleWebhook).not.toHaveBeenCalled()
     expect(run).not.toHaveBeenCalled()
   })
@@ -3760,7 +3762,7 @@ describe("server helpers", () => {
     }), "github")
 
     expect(response.status).toBe(401)
-    await expect(response.json()).resolves.toEqual({ error: "[vitehub] Webhook registration \"github\" declares secretHeader \"x-hub-signature-256\" but no secretToken is configured. Verification requires secretToken from Server Env; secretToken: false explicitly disables verification." })
+    await expect(response.json()).resolves.toEqual({ code: "INTERNAL", error: "Agent request failed." })
     expect(run).not.toHaveBeenCalled()
   })
 
@@ -3861,7 +3863,7 @@ describe("server helpers", () => {
     const rejected = await handler(request("sha256=wrong"))
 
     expect(rejected.status).toBe(401)
-    await expect(rejected.json()).resolves.toEqual({ error: "[vitehub] Webhook secret verification failed." })
+    await expect(rejected.json()).resolves.toEqual({ code: "INTERNAL", error: "Agent request failed." })
     expect(run).toHaveBeenCalledOnce()
 
     const unsigned = await handler(new Request("https://example.com/api/github/webhook", {
@@ -3875,7 +3877,7 @@ describe("server helpers", () => {
     }))
 
     expect(unsigned.status).toBe(401)
-    await expect(unsigned.json()).resolves.toEqual({ error: "[vitehub] Webhook secret header \"x-hub-signature-256\" is required." })
+    await expect(unsigned.json()).resolves.toEqual({ code: "INTERNAL", error: "Agent request failed." })
     expect(run).toHaveBeenCalledOnce()
   })
 
@@ -4163,7 +4165,7 @@ describe("server helpers", () => {
     const rejected = await handler(request("sha256=wrong"))
 
     expect(rejected.status).toBe(401)
-    await expect(rejected.json()).resolves.toEqual({ error: "[vitehub] Webhook secret verification failed." })
+    await expect(rejected.json()).resolves.toEqual({ code: "INTERNAL", error: "Agent request failed." })
     expect(run).not.toHaveBeenCalled()
   })
 

--- a/packages/agent/test/public-api.test.ts
+++ b/packages/agent/test/public-api.test.ts
@@ -38,6 +38,20 @@ it("keeps Effect out of published Agent declarations", async () => {
   expect(declarations.join("\n")).not.toMatch(effectImportPattern)
 })
 
+it("publishes additive Agent Invocation Stream error metadata", async () => {
+  const dist = new URL("../dist/", import.meta.url)
+  const declaration = (await Promise.all(
+    (await readdir(dist, { recursive: true }))
+      .filter(path => path.endsWith(".d.ts"))
+      .map(path => readFile(new URL(path, dist), "utf8")),
+  )).join("\n")
+
+  expect(declaration).toMatch(/interface AgentInvocationStreamErrorEvent/)
+  expect(declaration).toMatch(/code\?:/)
+  expect(declaration).toMatch(/details\?: AgentPublicErrorDetails/)
+  expect(declaration).toMatch(/requestId\?: string/)
+})
+
 it("keeps Effect out of provider and browser bundle graphs", async () => {
   for (const entry of ["cloudflare.js", "cloudflare/state.js", "messages.js", "output.js"]) {
     const bundle = await readBundleGraph(new URL(`../dist/${entry}`, import.meta.url))

--- a/packages/agent/test/public-error.test.ts
+++ b/packages/agent/test/public-error.test.ts
@@ -1,0 +1,123 @@
+import {
+  ApprovalRequiredError,
+  CapabilityDeniedError,
+  CapabilityNotFoundError,
+} from "@vite-hub/runtime"
+import { describe, expect, it } from "vitest"
+
+import { LlmGateRejectedError } from "../src/capabilities/llm-gate.ts"
+import { RateLimitRejectedError } from "../src/capabilities/rate-limit.ts"
+import { getHttpErrorStatusCode, toHttpErrorResponse } from "../src/http-error.ts"
+import { toAgentPublicError } from "../src/public-error.ts"
+
+const hostileMessages = [
+  "prompt=delete every repository",
+  "https://provider.example/private?token=secret",
+  "provider body: {\"apiKey\":\"secret\"}",
+  "command: rm -rf /workspace",
+  "Error: private failure\n    at /srv/private.ts:10:2",
+]
+
+describe("Agent public errors", () => {
+  it("maps owned failures to fixed messages and allowlisted details", () => {
+    expect(toAgentPublicError(new RateLimitRejectedError("rate-limit", {
+      retryAfter: 60,
+    } as never, hostileMessages[0]), "http")).toEqual({
+      code: "RATE_LIMIT_REJECTED",
+      details: { capability: "rate-limit", retryAfter: 60 },
+      error: "Rate limit exceeded. Try again later.",
+    })
+
+    expect(toAgentPublicError(new LlmGateRejectedError("safety-gate", {
+      allowed: false,
+      category: "unsafe",
+      reason: hostileMessages[1],
+    }, hostileMessages[2]), "invocation")).toEqual({
+      code: "LLM_GATE_REJECTED",
+      details: { capability: "safety-gate", category: "unsafe" },
+      error: "Agent request was rejected.",
+    })
+  })
+
+  it("keeps the safe runtime error contract without copying error messages", () => {
+    const cases = [
+      [new CapabilityNotFoundError("search"), {
+        code: "CAPABILITY_NOT_FOUND",
+        details: { capability: "search" },
+        error: "Capability was not found.",
+      }],
+      [new CapabilityDeniedError("shell", { safeReason: hostileMessages[0] }), {
+        code: "CAPABILITY_DENIED",
+        details: { capability: "shell" },
+        error: "Capability access was denied.",
+      }],
+      [new ApprovalRequiredError({ capability: "email", id: "approval_email_abcdefgh", state: "awaiting-approval" }), {
+        code: "APPROVAL_REQUIRED",
+        details: { capability: "email" },
+        error: "Capability approval is required.",
+        requestId: "approval_email_abcdefgh",
+      }],
+    ] as const
+
+    for (const [error, expected] of cases) {
+      expect(toAgentPublicError(error, "invocation")).toEqual(expected)
+    }
+  })
+
+  it("never serializes hostile messages, causes, stacks, headers, or unvalidated metadata", async () => {
+    for (const hostile of hostileMessages) {
+      const error = new RateLimitRejectedError("unsafe capability\nsecret", {
+        retryAfter: 15,
+      } as never, hostile)
+      Object.defineProperties(error, {
+        cause: { value: new AggregateError([new Error(hostile)], hostile) },
+        headers: { value: { authorization: hostile, "x-provider-body": hostile } },
+        stack: { value: hostile },
+      })
+
+      const mapped = toAgentPublicError(error, "http")
+      expect(mapped).toEqual({
+        code: "RATE_LIMIT_REJECTED",
+        error: "Rate limit exceeded. Try again later.",
+      })
+      expect(JSON.stringify(mapped)).not.toContain(hostile)
+
+      const response = toHttpErrorResponse(error)!
+      expect(response.status).toBe(429)
+      expect(response.headers.has("authorization")).toBe(false)
+      expect(response.headers.has("x-provider-body")).toBe(false)
+      expect(JSON.stringify(await response.json())).not.toContain(hostile)
+    }
+  })
+
+  it("uses an empty INTERNAL fallback for unowned failures", () => {
+    const cause = new AggregateError(hostileMessages.map(message => new Error(message)), hostileMessages[0])
+
+    expect(toAgentPublicError(cause, "http")).toEqual({
+      code: "INTERNAL",
+      error: "Agent request failed.",
+    })
+    expect(toAgentPublicError(cause, "invocation")).toEqual({
+      code: "INTERNAL",
+      error: "Agent Invocation Stream failed.",
+    })
+    expect(cause.errors).toHaveLength(hostileMessages.length)
+  })
+
+  it("treats hostile objects as unowned instead of executing their metadata", () => {
+    const hostile = new Proxy({}, {
+      get() {
+        throw new Error(hostileMessages[0])
+      },
+      getPrototypeOf() {
+        throw new Error(hostileMessages[1])
+      },
+    })
+
+    expect(toAgentPublicError(hostile, "http")).toEqual({
+      code: "INTERNAL",
+      error: "Agent request failed.",
+    })
+    expect(getHttpErrorStatusCode(hostile)).toBeUndefined()
+  })
+})

--- a/packages/agent/test/rate-limit.test.ts
+++ b/packages/agent/test/rate-limit.test.ts
@@ -258,7 +258,11 @@ describe("rateLimit capability", () => {
       expect(response?.status).toBe(429)
       expect(response?.headers.get("retry-after")).toBe("60")
       expect(response?.headers.get("x-retry-after")).toBe("60")
-      await expect(response?.json()).resolves.toEqual({ error: "Try again in 60s." })
+      await expect(response?.json()).resolves.toEqual({
+        code: "RATE_LIMIT_REJECTED",
+        details: { capability: "rate-limit", retryAfter: 60 },
+        error: "Rate limit exceeded. Try again later.",
+      })
     }
     finally {
       vi.useRealTimers()


### PR DESCRIPTION
Routes Agent HTTP and Invocation Stream failures through one allowlist-only public mapper. Rate limits expose `RATE_LIMIT_REJECTED` with `{ capability, retryAfter? }`; LLM gates expose `LLM_GATE_REJECTED` with `{ capability, category? }`; known Runtime capability errors keep stable ViteHub codes and only validated identifiers. Everything else becomes `INTERNAL` with no details.

This intentionally changes Agent JSON error bodies from `{ error: <caught message> }` to `{ code, error, details?, requestId? }`. Invocation Stream error events keep the existing `type` and `error` fields and add optional `code`, `details`, and `requestId`, so event order and existing consumers remain compatible. Status codes, safe rate-limit headers, raw AbortSignal reasons, internal causes, class identity, Promise/Response/Web APIs, and `error → done` ordering are preserved. Arbitrary provider messages, bodies, prompts, URLs, commands, stacks, causes, lifecycle aggregates, and headers no longer cross public HTTP/NDJSON boundaries.

Source accounting against #677: production +209/-41, tests +216/-28, docs +4/-2, total +429/-71.

## EFFECT ADOPTION STATUS

- seam: Agent HTTP and Invocation Stream public error mapping
- public API: intentional break: HTTP error bodies gain stable `code` and fixed safe messages; NDJSON fields are additive
- boundary: one plain allowlist mapper in `packages/agent/src/public-error.ts`
- typed failures: `RATE_LIMIT_REJECTED | LLM_GATE_REJECTED | CAPABILITY_NOT_FOUND | CAPABILITY_DENIED | APPROVAL_REQUIRED | INTERNAL`
- resources/fibers: none; pure serialization boundary
- deleted: duck-typed header forwarding and direct caught-message serialization across Agent HTTP/NDJSON boundaries
- blocked: Effect retained plain because this is a pure mapper and Effect would add ceremony without deleting lifecycle or concurrency machinery
- todos: 0
- confidence: high

Depends on #677.

At merged exact head 38ea16fb072c4e9ab67b5dda9eba1e8999d83f1f, Agent build/publint, typecheck, focused public-error/invocation-stream/rate-limit tests, and the relevant docs test pass. GitHub aggregate CI, consumer, docs, package preview, provider verification, Continuous Releases, Workers, and the Vercel deployment are green.

