### PR TITLE
fix(rate-limit): tolerate unavailable enterWith

### DIFF
--- a/packages/rate-limit/src/runtime/state.ts
+++ b/packages/rate-limit/src/runtime/state.ts
@@ -22,7 +22,10 @@ export function getRateLimitLimiterCache(): Map<string, Promise<RateLimiter>> {
 }
 
 export function enterRateLimitRuntimeEvent(event: unknown): void {
-  runtimeEventStorage.enterWith(event)
+  try {
+    runtimeEventStorage.enterWith(event)
+  }
+  catch {}
   setActiveCloudflareEnv(getCloudflareEnv(event))
 }
 

--- a/packages/rate-limit/test/cloudflare.test.ts
+++ b/packages/rate-limit/test/cloudflare.test.ts
@@ -1,10 +1,29 @@
+import { AsyncLocalStorage } from "node:async_hooks"
+
+import { clearActiveCloudflareEnv, getActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { describe, expect, it, vi } from "vitest"
 
 import { createRateLimiter } from "../src/index.ts"
 import { cloudflareRateLimitDriver, getCloudflareRateLimitBindingName } from "../src/drivers/cloudflare.ts"
-import { runWithRateLimitRuntimeEvent } from "../src/runtime.ts"
+import { enterRateLimitRuntimeEvent, runWithRateLimitRuntimeEvent } from "../src/runtime.ts"
 
 describe("Cloudflare Rate Limit driver", () => {
+  it("sets the Cloudflare environment when enterWith is unavailable", () => {
+    const env = { RATE_LIMITER: {} }
+    const enterWith = vi.spyOn(AsyncLocalStorage.prototype, "enterWith").mockImplementation(() => {
+      throw new Error("enterWith is unavailable")
+    })
+
+    try {
+      expect(() => enterRateLimitRuntimeEvent({ env })).not.toThrow()
+      expect(getActiveCloudflareEnv()).toBe(env)
+    }
+    finally {
+      enterWith.mockRestore()
+      clearActiveCloudflareEnv()
+    }
+  })
+
   it("resolves the named binding from ViteHub's Cloudflare event seam", async () => {
     const limit = vi.fn(async () => ({ success: false }))
     const name = "image-upload"


### PR DESCRIPTION
Allows `enterRateLimitRuntimeEvent` to continue when a runtime exposes `AsyncLocalStorage` but rejects `enterWith`. The Cloudflare environment is still installed, preserving binding access in affected Workers runtimes.

Adds regression coverage that forces `enterWith` to throw and verifies the environment remains available. The package suite and typecheck pass.