### PR TITLE
refactor(examples): simplify example pages

### DIFF
--- a/docs/app/pages/examples.vue
+++ b/docs/app/pages/examples.vue
@@ -9,54 +9,21 @@ useSeoMeta({
 </script>
 
 <template>
-  <main class="mx-auto w-full max-w-6xl px-4 pb-24 pt-16 sm:px-6 lg:px-8">
-    <header class="max-w-3xl border-b border-default pb-10">
+  <main class="mx-auto w-full max-w-5xl px-4 pb-24 pt-16 sm:px-6 lg:px-8">
+    <header class="max-w-3xl pb-12 sm:pb-16">
       <h1 class="text-[40px] font-semibold leading-[48px] text-highlighted">
         Examples
       </h1>
       <p class="mt-6 text-xl leading-8 text-muted">
-        Learn from applications built with ViteHub, or start from a template deliberately prepared for reuse.
+        See ViteHub in working applications, then inspect the code behind them.
       </p>
     </header>
 
-    <section class="grid border-b border-default md:grid-cols-2" aria-label="Catalog entry types">
-      <div class="border-default py-6 md:border-e md:pe-8">
-        <div class="flex items-center gap-2 text-sm font-medium text-highlighted">
-          <UIcon name="i-lucide-code-xml" class="size-4" />
-          Project
-        </div>
-        <p class="mt-2 leading-7 text-muted">
-          Open-source code you can inspect and learn from. Projects link to their source.
-        </p>
-      </div>
-      <div class="border-t border-default py-6 md:border-t-0 md:ps-8">
-        <div class="flex items-center gap-2 text-sm font-medium text-highlighted">
-          <UIcon name="i-lucide-copy" class="size-4" />
-          Template
-        </div>
-        <p class="mt-2 leading-7 text-muted">
-          Clone-ready code with a clear start path. Templates provide a direct use action.
-        </p>
-      </div>
-    </section>
-
-    <section class="mt-12" aria-labelledby="catalog-heading">
-      <div class="flex items-end justify-between gap-4 border-b border-default pb-4">
-        <div>
-          <p class="text-sm font-medium uppercase tracking-[0.14em] text-muted">
-            Catalog
-          </p>
-          <h2 id="catalog-heading" class="mt-2 text-2xl font-semibold text-highlighted">
-            Built with ViteHub
-          </h2>
-        </div>
-        <span class="font-mono text-sm text-muted">{{ examples.length.toString().padStart(2, "0") }}</span>
-      </div>
-
+    <section class="border-t border-default" aria-label="ViteHub examples">
       <article
         v-for="example in examples"
         :key="example.slug"
-        class="grid gap-8 border-b border-default py-8 lg:grid-cols-[minmax(0,1fr)_18rem]"
+        class="grid gap-8 border-b border-default py-10 md:grid-cols-[minmax(0,1fr)_12rem] md:items-center"
       >
         <div>
           <div class="flex flex-wrap items-center gap-2">
@@ -71,9 +38,9 @@ useSeoMeta({
               Publication pending
             </UBadge>
           </div>
-          <h3 class="mt-4 text-3xl font-semibold text-highlighted">
+          <h2 class="mt-4 text-3xl font-semibold text-highlighted">
             {{ example.name }}
-          </h3>
+          </h2>
           <p class="mt-3 max-w-2xl text-lg leading-8 text-muted">
             {{ example.description }}
           </p>
@@ -89,7 +56,7 @@ useSeoMeta({
           </div>
         </div>
 
-        <aside class="flex flex-col justify-between gap-5 border-s border-default ps-5">
+        <aside class="flex flex-col gap-3 md:border-s md:border-default md:ps-6">
           <p v-if="example.status === 'pending'" class="text-sm leading-6 text-muted">
             {{ example.publicationNote }}
           </p>


### PR DESCRIPTION
Simplifies the examples catalog so it leads directly from a concise introduction into the existing entries. Removes the redundant Project/Template explainer and Catalog/Built with ViteHub heading, then tightens the row layout and hierarchy at desktop and narrow widths.

Keeps the existing example data, publication state, primitive labels, notes, and source/template actions unchanged.