### PR TITLE
refactor: remove dead code

### DIFF
--- a/packages/agent/src/capability-cli.ts
+++ b/packages/agent/src/capability-cli.ts
@@ -7,7 +7,6 @@ import type {
   AgentCapabilityCliContribution,
   AgentCapabilityCliExecutionInput,
   AgentCapabilityCliExecutionResult,
-  AgentCapabilityCliOutputDefinition,
   AgentCapabilityCliOutputFormat,
   AgentCapabilityCliStandardSchemaV1,
   AgentCapabilityDefinition,
@@ -155,29 +154,6 @@ function firstExample(cliName: string, path: string[], command: AgentCapabilityC
 function toolInputExample(cliName: string, path: string[], command: AgentCapabilityCliCommand): string {
   const example = firstExample(cliName, path, command)
   return example.startsWith(`${cliName} `) ? example.slice(cliName.length + 1) : example
-}
-
-export function renderCapabilityCliInstructions<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  Name extends WorkspaceName,
->(
-  capabilityId: string,
-  cli: AgentCapabilityCliContribution<TRuntimeConfig, Name>,
-): string {
-  const leaves = commandLeaves(cli)
-  return [
-    `## Capability CLI: ${cli.name}`,
-    "",
-    cli.description || `Use the \`${cli.name}\` CLI for Capability "${capabilityId}".`,
-    "",
-    `Use \`${cli.name}\` commands for this capability instead of generic Bash or shell commands.`,
-    "",
-    "Available commands:",
-    ...leaves.map(({ command, path }) => {
-      const effects = command.effects?.length ? ` Effects: ${command.effects.join(", ")}.` : ""
-      return `- \`${firstExample(cli.name, path, command)}\` - ${command.description || path.join(" ")}.${effects}`
-    }),
-  ].join("\n")
 }
 
 function nodeHelp<TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(

--- a/packages/agent/src/chat/devtools.ts
+++ b/packages/agent/src/chat/devtools.ts
@@ -20,10 +20,7 @@ import type { DevToolsPluginOptions, DevToolsRpcServerFunctions, ViteDevToolsNod
 import type { Plugin } from "vite"
 import type {
   ChatDevtoolsClearInput,
-  ChatDevtoolsConversation,
-  ChatDevtoolsFileTreeItem,
   ChatDevtoolsMetadata,
-  ChatDevtoolsMaterializeSourceInput,
   ChatDevtoolsMessage,
   ChatDevtoolsMessageRole,
   ChatDevtoolsSendInput,
@@ -31,9 +28,7 @@ import type {
   ChatDevtoolsStateResult,
   ChatDevtoolsStreamEvent,
   ChatDevtoolsTool,
-  ChatDevtoolsToolDefinition,
   ChatDevtoolsToolStatus,
-  ChatDevtoolsWarning,
 } from "./devtools-shared.js"
 
 export {

--- a/packages/agent/src/chat/vite/devtools-bridge.ts
+++ b/packages/agent/src/chat/vite/devtools-bridge.ts
@@ -571,15 +571,6 @@ function createUserUIMessage(text: string): UIMessage {
   }
 }
 
-function createAssistantUIMessage(text: string, metadata: Record<string, unknown> = {}): UIMessage {
-  return {
-    id: randomId("devtools-assistant"),
-    metadata,
-    parts: [{ text, type: "text" }],
-    role: "assistant",
-  }
-}
-
 function uiMessageMetadata(message: UIMessage): Record<string, unknown> | undefined {
   return isRecord(message.metadata) ? message.metadata : undefined
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -49,7 +49,6 @@ import {
   applyCapabilityToolTransforms,
   applyOutputRenderers,
   createAgentInvocationExtensions,
-  defineCapability,
   normalizeCapabilities,
   resolveAgentCapabilities,
   resolveAgentCapabilityDefinitions,
@@ -95,78 +94,47 @@ import {
 import type {
   AgentAdapter,
   AgentAdapterFactory,
-  AgentAdapterMetadataContext,
   AgentAdapterRunContext,
-  AgentAdapterResult,
-  AgentCapabilitiesList,
   AgentCapabilitiesInput,
   AgentCapabilitiesResolver,
-  AgentCapabilitiesResolverContext,
   AgentChannelDefinition,
   AgentChannelInputs,
-  AgentChannelTriggerContext,
   AgentChannels,
-  AgentCapabilityHooks,
-  AgentCapabilityContext,
   AgentCapabilityDefinition,
-  AgentCapabilityInput,
   AgentCapabilityMode,
   AgentCapabilityTypeContract,
   AgentChannelDeliveryEffectHandler,
   AgentChannelDeliveryEffectIntent,
-  AgentChannelDeliveryEffectPayload,
   AgentChannelDeliveryFinishEffect,
-  AgentChannelDeliveryFinishEffectCallback,
   AgentChannelDeliveryFinishEffectResult,
   AgentChannelDeliveryFinishEffectContext,
-  AgentChannelDeliveryReactionInput,
-  AgentChannelDeliveryReactionPayload,
-  AgentChannelDeliveryReplyInput,
-  AgentChannelDeliveryReplyPayload,
-  AgentChannelDeliveryStatusInput,
-  AgentChannelDeliveryStatusPayload,
-  AgentChannelDeliveryStatusState,
-  AgentDeliveryArtifact,
-  AgentDeliveryArtifactPlacement,
   AgentDefinition,
   AgentDriverContribution,
   AgentDriverKind,
   AgentFinishEvent,
   AgentFinishHookEvent,
   AgentFinishExtensions,
-  AgentChatOptions,
-  AgentHostIdentity,
   AgentInput,
-  AgentInputHook,
   AgentInvocationContextStore,
   AgentInvocationContextValues,
   AgentHookObserverHooks,
   AgentInvoker,
   AgentInvokerOptions,
   AgentInvokerProfile,
-  AgentMessageChannelSettings,
-  AgentMessageConcurrency,
-  AgentMessageLockScope,
   AgentOutputDefinition,
   AgentModelResolver,
   AgentRegistry,
   AgentRegistryModule,
   AgentRunContext,
-  AgentRunHandler,
   AgentRunInput,
-  AgentRunInputContextValues,
   AgentRunMetadata,
   AgentRunResult,
-  AgentRuntimeBinding,
   AgentRuntimeConfig,
   AgentRuntimeContext,
   AgentSettings,
-  AgentUsageCost,
   AgentUsageRecord,
   AgentWorkflowRuntimeBinding,
-  AgentToolDefinition,
   MaybePromise,
-  PublishedAgentDeliveryArtifact,
   ResolvedAgentTriggerDefinition,
   ResolvedAgentRuntimeContext,
 } from "./types.ts"
@@ -175,7 +143,6 @@ import type { AgentTraceContext } from "./trace.ts"
 import type { ResolvedAgentTriggerInvocation, ResolvedAgentTriggerInvocationResult } from "./trigger-runtime.ts"
 import type {
   WorkspaceAgentDefinition,
-  WorkspaceAgentDefaults,
   WorkspaceAgentOptions,
 } from "./workspace-agent.ts"
 import type {
@@ -434,7 +401,6 @@ const baseAgentModel = Symbol.for("vitehub.baseAgentModel")
 const baseAgentDriverKind = Symbol.for("vitehub.baseAgentDriverKind")
 const baseAgentBoxRequirements = Symbol.for("vitehub.baseAgentBoxRequirements")
 const baseAgentCapabilitiesResolver = Symbol.for("vitehub.baseAgentCapabilitiesResolver")
-type NormalizedCapability = AgentCapabilityDefinition & { mode?: AgentCapabilityMode }
 type WorkspaceSourceNames<TWorkspace> =
   TWorkspace extends { sources: infer TSources }
     ? Extract<keyof NonNullable<TSources>, string>
@@ -798,7 +764,7 @@ function channelDeliveryEffectHandlers<TRuntimeConfig extends AgentRuntimeConfig
   return typeof handlers === "function" ? [handlers] : [...handlers]
 }
 
-function activeAgentChannel<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+function activeAgentChannel<TRuntimeConfig extends AgentRuntimeConfig>(
   channels: AgentChannels<TRuntimeConfig> | undefined,
   context: AgentInvocationContextStore,
   run?: AgentRunMetadata,

--- a/packages/agent/src/mcp.ts
+++ b/packages/agent/src/mcp.ts
@@ -1,4 +1,4 @@
-import type { MCPClientConfig, MCPTransport } from "@ai-sdk/mcp"
+import type { MCPClientConfig } from "@ai-sdk/mcp"
 import type { McpClientConfig } from "./mcp/types.ts"
 
 export type RemoteMcpServerTransport = "http" | "sse"

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -772,10 +772,6 @@ export async function resolveWorkspaceInstructionBindings(
   return Object.keys(resolved).length ? resolved : undefined
 }
 
-function cleanInstructions(content: string): string {
-  return content.trim().replace(/\n{3,}/g, "\n\n")
-}
-
 function localWorkspaceRoots<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
@@ -998,19 +994,6 @@ function readColocatedAgentInstructionsRaw<
   if (!fs || !path || !hasColocatedAgentInstructions(sourceRootDir)) return undefined
   const file = path.join(sourceRootDir!, colocatedAgentInstructionsPath)
   const content = fs.readFileSync(file, "utf8").trim()
-  if (content) return content
-}
-
-async function readColocatedAgentInstructions<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  Name extends WorkspaceName,
->(options: WorkspaceAgentOptions<TRuntimeConfig, Name>): Promise<string | undefined> {
-  const fs = getNodeBuiltin<typeof import("node:fs")>("node:fs")
-  const path = getNodeBuiltin<typeof import("node:path")>("node:path")
-  const sourceRootDir = workspaceDefinitionFromOptions(options).sourceRootDir
-  if (!fs || !path || !hasColocatedAgentInstructions(sourceRootDir)) return undefined
-  const file = path.join(sourceRootDir!, colocatedAgentInstructionsPath)
-  const content = (await resolveColocatedAgentInstructionDocument(fs.readFileSync(file, "utf8"), sourceRootDir)).trim()
   if (content) return content
 }
 

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -7,7 +7,6 @@ import type {
   AuthAccessConfiguration,
   AuthBetterAuthRuntimeOptions,
   AuthDefinition,
-  AuthDefinitionInput,
   AuthDefinitionResolver,
   AuthRequest,
   AuthRequestInput,

--- a/packages/box/test/crabbox.test.ts
+++ b/packages/box/test/crabbox.test.ts
@@ -763,17 +763,6 @@ async function temporaryRoot() {
   return root
 }
 
-async function rewriteTarEntryPath(path: string, name: string) {
-  const archive = await readFile(path);
-  archive.fill(0, 0, 100);
-  archive.write(name, 0, "utf8");
-  archive.fill(0x20, 148, 156);
-  let checksum = 0;
-  for (let index = 0; index < 512; index++) checksum += archive[index];
-  archive.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148, 8, "ascii");
-  await writeFile(path, archive);
-}
-
 async function fakeCrabbox(bin: string) {
   const command = join(bin, "crabbox")
   await writeFile(command,

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
 
-import { createKVRuntimeScheduleStore, createKVScheduleRunStore, createMemoryRuntimeScheduleStore, createMemoryScheduleRunStore, createScheduleRun, defineScheduleTarget, executeRuntimeSchedule, executeStaticSchedule, ScheduleError, schedules } from "../src/index.ts"
+import { createKVRuntimeScheduleStore, createKVScheduleRunStore, createMemoryScheduleRunStore, createScheduleRun, defineScheduleTarget, executeRuntimeSchedule, executeStaticSchedule, ScheduleError, schedules } from "../src/index.ts"
 import { loadScheduleDefinition, resetScheduleRuntime, setScheduleRunStore, setScheduleRuntimeRegistry } from "../src/runtime/state.ts"
 import type { KVStorage } from "@vite-hub/kv"
 

--- a/packages/workspace/src/build/workspace-config.ts
+++ b/packages/workspace/src/build/workspace-config.ts
@@ -1,16 +1,4 @@
-import { existsSync } from "node:fs"
-import { join } from "node:path"
-
 export const workspaceSuffixPattern = /\.workspace\.(?:c|m)?[jt]s$/i
 export const workspaceConfigPattern = /^config\.(?:c|m)?[jt]s$/i
 export const workspaceAgentPattern = /^agent\.(?:c|m)?[jt]s$/i
-export const declarationFilePattern = /\.d\.(?:c|m)?[jt]s$/i
 export const workspaceConfigFileNames = ["config.ts", "config.mts", "config.cts", "config.js", "config.mjs", "config.cjs"] as const
-
-export function hasWorkspaceDirectoryConfig(directory: string): boolean {
-  return workspaceConfigFileNames.some(file => existsSync(join(directory, file)))
-}
-
-export function isWorkspaceAssetFile(name: string): boolean {
-  return !workspaceConfigPattern.test(name) && !workspaceAgentPattern.test(name) && !declarationFilePattern.test(name)
-}

--- a/packages/workspace/src/providers/vercel/blob-store.ts
+++ b/packages/workspace/src/providers/vercel/blob-store.ts
@@ -308,11 +308,6 @@ class VercelBlobWorkspaceStore implements WorkspaceStore {
     return blobs
   }
 
-  async #readBytes(path: string): Promise<Uint8Array | undefined> {
-    const file = await this.readFile(path)
-    return file ? contentToBytes(file.content) : undefined
-  }
-
   async #readJson(pathname: string): Promise<unknown> {
     const file = await (await this.#client()).download(pathname).catch(() => null)
     return file ? JSON.parse(await file.text()) : undefined

--- a/packages/workspace/src/sources/materialization.ts
+++ b/packages/workspace/src/sources/materialization.ts
@@ -8,12 +8,9 @@ import { searchText } from "../core/search.ts"
 import type { ResolvedWorkspaceSource } from "./config.ts"
 import type { ResolvedSourcePath } from "./resolver.ts"
 import type {
-  ListOptions,
   ReadFileOptions,
   ReadFileResult,
   SourceContext,
-  WorkspaceEntry,
-  WorkspaceFile,
   WorkspaceSearchHit,
   WorkspaceSearchQuery,
   WorkspaceSourceItem,
@@ -71,11 +68,6 @@ function isSnapshotFresh(meta: SourceSnapshotMetadata | undefined, source: Resol
 
 async function readSourceSnapshotMetadata(store: WorkspaceStore, sourceKey: string) {
   return await store.getMeta?.(sourceSnapshotMetaKey(sourceKey)) as SourceSnapshotMetadata | undefined
-}
-
-export async function hasFreshSourceSnapshot(store: WorkspaceStore, source: ResolvedWorkspaceSource) {
-  const configHash = await sourceConfigHash(source)
-  return isSnapshotFresh(await readSourceSnapshotMetadata(store, source.key), source, configHash)
 }
 
 export async function hasCurrentSourceSnapshot(store: WorkspaceStore, source: ResolvedWorkspaceSource) {
@@ -520,33 +512,6 @@ export async function readResolvedSourceFile<TOptions extends ReadFileOptions | 
   return decodeFile(file.content, options)
 }
 
-export async function materializeSourceFile(
-  resolution: ResolvedSourcePath,
-  store: WorkspaceStore,
-  ctx: SourceContext,
-): Promise<WorkspaceFile> {
-  const existing = await store.readFile(resolution.workspacePath)
-  const storedMeta = await getStoredMaterializedMetadata(store, resolution)
-  if (existing && await shouldReuseMaterializedFile(resolution, storedMeta, ctx)) return existing
-
-  const item = await resolution.source.source.getItem(resolution.sourcePath, ctx)
-  const upstreamMeta = await resolution.source.source.getMeta?.(resolution.sourcePath, ctx)
-  const metadata = createLazyMaterializedMetadata(resolution, item, upstreamMeta)
-  const content = sourceItemContent(item)
-  const nextBase = {
-    path: resolution.workspacePath,
-    mediaType: item.mediaType,
-    metadata: { ...item.metadata, ...metadata },
-  }
-  const next: WorkspaceFile = {
-    ...nextBase,
-    content: content.content ?? await contentStreamToBytes(content.contentStream!),
-  }
-  await store.writeFile(resolution.workspacePath, next)
-  await store.setMeta?.(materializedMetaKey(resolution), metadata)
-  return next
-}
-
 async function writeMaterializedFile(
   store: WorkspaceStore,
   path: string,
@@ -604,100 +569,6 @@ export async function statVirtualSourcePath(
   }
 }
 
-export async function listVirtualSourceEntries(
-  source: ResolvedWorkspaceSource,
-  path: string,
-  options: ListOptions,
-  store: WorkspaceStore,
-  ctx: SourceContext,
-) {
-  const stored = await store.list(path, options)
-  const virtual = new Map<string, WorkspaceEntry>(stored.map(entry => [entry.path, entry]))
-  const keys = await source.source.getKeys(ctx)
-  const requestPath = path
-
-  for (const key of keys) {
-    const fullPath = toMountedSourcePath(source, key)
-    if (requestPath === source.mountPath && !key) continue
-
-    if (!requestPath) {
-      if (!fullPath.includes("/")) continue
-      const firstSegment = fullPath.split("/")[0]
-      if (!virtual.has(firstSegment)) virtual.set(firstSegment, { path: firstSegment, type: "directory" })
-      if (options.recursive) virtual.set(fullPath, virtual.get(fullPath) || { path: fullPath, type: "file" })
-      continue
-    }
-
-    if (requestPath === source.mountPath) {
-      if (!options.recursive) {
-        const relative = key
-        const child = relative.split("/")[0]
-        const childPath = child ? `${source.mountPath}/${child}` : source.mountPath
-        if (!childPath || childPath === source.mountPath) continue
-        if (!virtual.has(childPath)) {
-          virtual.set(childPath, {
-            path: childPath,
-            type: relative.includes("/") ? "directory" : "file",
-          })
-        }
-        continue
-      }
-
-      virtual.set(fullPath, virtual.get(fullPath) || { path: fullPath, type: "file" })
-      addVirtualParents(virtual, source.mountPath, fullPath)
-      continue
-    }
-
-    if (!fullPath.startsWith(`${requestPath}/`)) continue
-    if (!options.recursive) {
-      const remainder = fullPath.slice(requestPath.length + 1)
-      const child = remainder.split("/")[0]
-      const childPath = `${requestPath}/${child}`
-      if (!virtual.has(childPath)) {
-        virtual.set(childPath, {
-          path: childPath,
-          type: remainder.includes("/") ? "directory" : "file",
-        })
-      }
-      continue
-    }
-
-    virtual.set(fullPath, virtual.get(fullPath) || { path: fullPath, type: "file" })
-    addVirtualParents(virtual, requestPath, fullPath)
-  }
-
-  return [...virtual.values()].sort((left, right) => left.path.localeCompare(right.path))
-}
-
-export async function searchResolvedSource(
-  source: ResolvedWorkspaceSource,
-  query: WorkspaceSearchQuery,
-  store: WorkspaceStore,
-  ctx: SourceContext,
-): Promise<WorkspaceSearchHit[]> {
-  const limit = query.limit ?? 100
-  const materializedHits = await searchMaterializedStore(store, {
-    ...query,
-    paths: query.paths?.length ? query.paths : [source.mountPath],
-    limit,
-  })
-  if (materializedHits.length >= limit) return materializedHits.slice(0, limit)
-
-  if (source.source.search) {
-    const hits = await source.source.search({
-      ...query,
-      paths: toSourceSearchPaths(source, query.paths),
-      limit: limit - materializedHits.length,
-    }, ctx)
-    return dedupeSearchHits([...materializedHits, ...hits.map(hit => ({
-      ...hit,
-      path: hit.path.startsWith(source.mountPath) ? hit.path : toMountedSourcePath(source, hit.path),
-    }))]).slice(0, limit)
-  }
-
-  return materializedHits.slice(0, limit)
-}
-
 export async function searchMaterializedStore(store: WorkspaceStore, query: WorkspaceSearchQuery): Promise<WorkspaceSearchHit[]> {
   const limit = query.limit ?? 100
   const result: WorkspaceSearchHit[] = []
@@ -724,31 +595,6 @@ export async function searchMaterializedStore(store: WorkspaceStore, query: Work
   }
 
   return result.slice(0, limit)
-}
-
-function materializedMetaKey(resolution: ResolvedSourcePath) {
-  return `source:${resolution.sourceKey}:${resolution.workspacePath}:materialized`
-}
-
-async function getStoredMaterializedMetadata(store: WorkspaceStore, resolution: ResolvedSourcePath) {
-  return await store.getMeta?.(materializedMetaKey(resolution)) as LazyMaterializedMetadata | undefined
-}
-
-async function shouldReuseMaterializedFile(
-  resolution: ResolvedSourcePath,
-  metadata: LazyMaterializedMetadata | undefined,
-  ctx: SourceContext,
-): Promise<boolean> {
-  if (!metadata) return false
-  if (resolution.validate === false) return true
-
-  if (resolution.source.source.getMeta) {
-    const upstream = await resolution.source.source.getMeta(resolution.sourcePath, ctx)
-    if (!upstream) return isCacheFresh(metadata, resolution.cache)
-    return !hasSourceMetaChanged(metadata, upstream)
-  }
-
-  return isCacheFresh(metadata, resolution.cache)
 }
 
 function createLazyMaterializedMetadata(
@@ -782,13 +628,6 @@ function hasSourceMetaChanged(current: LazyMaterializedMetadata, upstreamMeta: R
     || current.ref !== next.ref
 }
 
-function isCacheFresh(metadata: LazyMaterializedMetadata, cache: ResolvedSourcePath["cache"]) {
-  if (!cache || typeof cache.maxAge !== "number") return false
-  const createdAt = Date.parse(metadata.validatedAt || metadata.materializedAt)
-  if (!createdAt) return false
-  return Date.now() - createdAt <= cache.maxAge * 1000
-}
-
 function normalizeSourcePath(source: ResolvedWorkspaceSource, workspacePath: string) {
   if (workspacePath === source.mountPath) return ""
   return source.mountPath && workspacePath.startsWith(`${source.mountPath}/`)
@@ -802,34 +641,4 @@ function readStringMeta(meta: Record<string, unknown> | undefined, key: string) 
 
 function readDigest(meta: Record<string, unknown> | undefined) {
   return readStringMeta(meta, "digest") || readStringMeta(meta, "sha")
-}
-
-function toSourceSearchPaths(source: ResolvedWorkspaceSource, paths: string[] | undefined) {
-  if (!paths?.length) return undefined
-  return paths
-    .filter(path => sourceMountContainsPath(source, path))
-    .map(path => normalizeSourcePath(source, path))
-}
-
-function toMountedSourcePath(source: ResolvedWorkspaceSource, key: string) {
-  return normalizeWorkspacePath(posix.join(source.mountPath, key))
-}
-
-function addVirtualParents(entries: Map<string, WorkspaceStat>, basePath: string, path: string) {
-  const relative = path.slice(basePath.length).replace(/^\/+/, "")
-  const parts = relative.split("/").filter(Boolean)
-  for (let index = 1; index < parts.length; index++) {
-    const directory = `${basePath}/${parts.slice(0, index).join("/")}`
-    if (!entries.has(directory)) entries.set(directory, { path: directory, type: "directory" })
-  }
-}
-
-function dedupeSearchHits(hits: WorkspaceSearchHit[]) {
-  const seen = new Set<string>()
-  return hits.filter((hit) => {
-    const key = `${hit.path}:${hit.line}:${hit.column}:${hit.text}`
-    if (seen.has(key)) return false
-    seen.add(key)
-    return true
-  })
 }

--- a/packages/workspace/src/sources/resolver.ts
+++ b/packages/workspace/src/sources/resolver.ts
@@ -1,7 +1,7 @@
 import { normalizeSafeWorkspacePath, normalizeWorkspacePath } from "../core/path.ts"
 import { normalizeWorkspaceSources, sourceMountContainsPath, type ResolvedWorkspaceSource } from "./config.ts"
 
-import type { WorkspaceDefinition, WorkspaceSearchQuery } from "../core/types.ts"
+import type { WorkspaceDefinition } from "../core/types.ts"
 
 export interface ResolvedStorePath {
   type: "store"
@@ -46,14 +46,6 @@ export function resolveWorkspacePath(definition: WorkspaceDefinition, path: stri
     workspacePath,
     readonly: false,
   }
-}
-
-export function resolveWorkspaceSearchPaths(definition: WorkspaceDefinition, query: WorkspaceSearchQuery): ResolvedWorkspacePath[] {
-  const rawPaths = query.paths?.length ? query.paths : [query.cwd || ""]
-  return rawPaths
-    .map(path => normalizeWorkspacePath(path))
-    .filter((path, index, list) => list.indexOf(path) === index)
-    .map(path => resolveWorkspacePath(definition, path))
 }
 
 function createSourceResolution(source: ResolvedWorkspaceSource, workspacePath: string, sourcePath: string): ResolvedSourcePath {


### PR DESCRIPTION
Removes superseded Workspace source materialization, listing, and search paths, along with unused Agent helpers, private methods, imports, and test utilities that no longer have consumers.

This keeps the current SourceView and Capability CLI paths as the single implementations and reduces the maintenance surface without changing the public package entrypoints.