### PR TITLE
feat(source): harden public error contract

### DIFF
--- a/docs/content/docs/reference/errors-diagnostics.md
+++ b/docs/content/docs/reference/errors-diagnostics.md
@@ -24,8 +24,8 @@ Use the error family to choose the next proof path before changing implementatio
 | `WorkspaceNotFoundError` | Workspace Package | The requested Workspace is not registered. |
 | `WorkspacePathError` | Workspace Package | A Workspace path is invalid or outside allowed shape. |
 | `SourceError` | Source Package | Source retrieval or Source Loader behavior failed. |
-| `SourceNotFoundError` | Source Package | The requested Source key or Source Path is missing. |
-| `SourcePathError` | Source Package | A Source Path is invalid. |
+| `SourceNotFoundError` | Source Package | The requested Source is not registered. |
+| `SourcePathError` | Source Package | A Source Path is invalid or escapes its Source root. |
 | `ScheduleError` | Schedule Package | Static or runtime schedule behavior failed. |
 | `SandboxError` | Sandbox Package | Sandbox Provider setup, execution, or output recovery failed. |
 | `NotSupportedError` | Sandbox shared runtime | A selected provider or operation is unsupported. |

--- a/docs/content/docs/server-primitives/source.md
+++ b/docs/content/docs/server-primitives/source.md
@@ -223,7 +223,7 @@ Workspace and other consuming packages can wrap Sources in discovered Definition
 
 ## Errors
 
-Built-in loaders throw `SourceError` with a stable `code` and safe `details`. Use `toJSON()` at a public boundary; it excludes causes, stacks, provider bodies, request URLs, credentials, absolute paths, and arbitrary SDK messages. The original provider failure remains available as `cause` for protected server-side diagnostics, and caller abort reasons keep their original identity.
+Built-in loaders throw `SourceError` with a stable `code` and code-specific safe `details`. Runtime construction rejects codes, providers, operations, status values, and path value types outside the public Source vocabulary, while dropping fields a code does not own. Use `toJSON()` at a public boundary; it excludes causes, stacks, provider bodies, request URLs, credentials, absolute paths, and arbitrary SDK messages. The original provider failure remains available as `cause` for protected server-side diagnostics, and caller abort reasons keep their original identity.
 
 Direct construction and subclasses use an object with a stable code:
 

--- a/docs/content/docs/server-primitives/source.md
+++ b/docs/content/docs/server-primitives/source.md
@@ -225,15 +225,18 @@ Workspace and other consuming packages can wrap Sources in discovered Definition
 
 Built-in loaders throw `SourceError` with a stable `code` and safe `details`. Use `toJSON()` at a public boundary; it excludes causes, stacks, provider bodies, request URLs, credentials, absolute paths, and arbitrary SDK messages. The original provider failure remains available as `cause` for protected server-side diagnostics, and caller abort reasons keep their original identity.
 
-Direct construction and subclasses must provide a stable code:
+Direct construction and subclasses use an object with a stable code:
 
 ```ts
-throw new SourceError('[vitehub] custom source request failed.', {
+throw new SourceError({
   code: 'SOURCE_PROVIDER_REQUEST_FAILED',
   details: { operation: 'read', provider: 'custom' },
   cause,
+  message: '[vitehub] custom source request failed.',
 })
 ```
+
+The positional `new SourceError(message, options)` form remains available for existing consumers.
 
 Custom Sources retain ownership of the values they throw. Map failures to `SourceError` inside a custom adapter when they may cross a public boundary; otherwise `useSource()` preserves the thrown value unchanged.
 

--- a/docs/content/docs/server-primitives/source.md
+++ b/docs/content/docs/server-primitives/source.md
@@ -221,6 +221,22 @@ The Source Package owns retrieval. The Workspace Package owns Mount placement, S
 
 Workspace and other consuming packages can wrap Sources in discovered Definitions, runtime registries, generated metadata, or Provider Output when they need placement, persistence, or deployment wiring.
 
+## Errors
+
+Built-in loaders throw `SourceError` with a stable `code` and safe `details`. Use `toJSON()` at a public boundary; it excludes causes, stacks, provider bodies, request URLs, credentials, absolute paths, and arbitrary SDK messages. The original provider failure remains available as `cause` for protected server-side diagnostics, and caller abort reasons keep their original identity.
+
+Direct construction and subclasses must provide a stable code:
+
+```ts
+throw new SourceError('[vitehub] custom source request failed.', {
+  code: 'SOURCE_PROVIDER_REQUEST_FAILED',
+  details: { operation: 'read', provider: 'custom' },
+  cause,
+})
+```
+
+Custom Sources retain ownership of the values they throw. Map failures to `SourceError` inside a custom adapter when they may cross a public boundary; otherwise `useSource()` preserves the thrown value unchanged.
+
 ## Production boundaries
 
 Treat Sources as read-only retrieval boundaries. Secrets for private origins should come from Server Env or trusted callbacks, not from model-authored input.

--- a/docs/content/docs/server-primitives/source.md
+++ b/docs/content/docs/server-primitives/source.md
@@ -223,7 +223,7 @@ Workspace and other consuming packages can wrap Sources in discovered Definition
 
 ## Errors
 
-Built-in loaders throw `SourceError` with a stable `code` and code-specific safe `details`. Runtime construction rejects codes, providers, operations, status values, and path value types outside the public Source vocabulary, while dropping fields a code does not own. Use `toJSON()` at a public boundary; it excludes causes, stacks, provider bodies, request URLs, credentials, absolute paths, and arbitrary SDK messages. The original provider failure remains available as `cause` for protected server-side diagnostics, and caller abort reasons keep their original identity.
+Built-in loaders throw `SourceError` with a stable `code`, code-specific safe `details`, and a public message derived from that safe context. Runtime construction rejects codes, providers, operations, status values, and path value types outside the public Source vocabulary, while dropping fields a code does not own. Use `toJSON()` at a public boundary; it excludes caller-supplied messages, causes, stacks, provider bodies, request URLs, credentials, absolute paths, and arbitrary SDK messages. The original provider failure remains available as `cause` for protected server-side diagnostics, and caller abort reasons keep their original identity.
 
 Direct construction and subclasses use an object with a stable code:
 
@@ -232,11 +232,10 @@ throw new SourceError({
   code: 'SOURCE_PROVIDER_REQUEST_FAILED',
   details: { operation: 'read', provider: 'custom' },
   cause,
-  message: '[vitehub] custom source request failed.',
 })
 ```
 
-The positional `new SourceError(message, options)` form remains available for existing consumers.
+The positional `new SourceError(message, options)` form remains accepted for existing consumers, but its message is no longer public; `SourceError` derives the serialized message from `code` and safe `details`. Keep raw diagnostics in `cause`.
 
 Custom Sources retain ownership of the values they throw. Map failures to `SourceError` inside a custom adapter when they may cross a public boundary; otherwise `useSource()` preserves the thrown value unchanged.
 

--- a/packages/source/README.md
+++ b/packages/source/README.md
@@ -38,12 +38,15 @@ Built-in loaders throw `SourceError` with a stable `code` and JSON-safe `details
 ```ts
 import { SourceError } from "@vite-hub/source"
 
-throw new SourceError("[vitehub] custom source request failed.", {
+throw new SourceError({
   code: "SOURCE_PROVIDER_REQUEST_FAILED",
   details: { operation: "read", provider: "custom" },
   cause,
+  message: "[vitehub] custom source request failed.",
 })
 ```
+
+The positional `new SourceError(message, options)` form remains available for existing consumers.
 
 `SourceNotFoundError` and `SourcePathError` preserve their specialized class identity for registry and path failures. Configuration mistakes such as a missing `file()` path remain `TypeError` because they are programmer errors rather than Source runtime failures.
 

--- a/packages/source/README.md
+++ b/packages/source/README.md
@@ -33,7 +33,7 @@ const first = await docs.read(keys[0]!)
 
 ## Errors
 
-Built-in loaders throw `SourceError` with a stable `code` and code-specific JSON-safe `details`. Runtime construction rejects codes, providers, operations, status values, and path value types outside the public Source vocabulary, while dropping fields a code does not own. `toJSON()` excludes the original `cause`, stack, credentials, request URLs, absolute paths, and provider response bodies; the protected server runtime can still inspect `error.cause` for diagnostics.
+Built-in loaders throw `SourceError` with a stable `code`, code-specific JSON-safe `details`, and a public message derived from that safe context. Runtime construction rejects codes, providers, operations, status values, and path value types outside the public Source vocabulary, while dropping fields a code does not own. `toJSON()` excludes caller-supplied messages, the original `cause`, stack, credentials, request URLs, absolute paths, and provider response bodies; the protected server runtime can still inspect `error.cause` for diagnostics.
 
 ```ts
 import { SourceError } from "@vite-hub/source"
@@ -42,11 +42,10 @@ throw new SourceError({
   code: "SOURCE_PROVIDER_REQUEST_FAILED",
   details: { operation: "read", provider: "custom" },
   cause,
-  message: "[vitehub] custom source request failed.",
 })
 ```
 
-The positional `new SourceError(message, options)` form remains available for existing consumers.
+The positional `new SourceError(message, options)` form remains accepted for existing consumers, but its message is no longer public; `SourceError` derives the serialized message from `code` and safe `details`. Keep raw diagnostics in `cause`.
 
 `SourceNotFoundError` and `SourcePathError` preserve their specialized class identity for registry and path failures. Configuration mistakes such as a missing `file()` path remain `TypeError` because they are programmer errors rather than Source runtime failures.
 

--- a/packages/source/README.md
+++ b/packages/source/README.md
@@ -33,7 +33,7 @@ const first = await docs.read(keys[0]!)
 
 ## Errors
 
-Built-in loaders throw `SourceError` with a stable `code` and JSON-safe `details`. `toJSON()` excludes the original `cause`, stack, credentials, request URLs, absolute paths, and provider response bodies; the protected server runtime can still inspect `error.cause` for diagnostics.
+Built-in loaders throw `SourceError` with a stable `code` and code-specific JSON-safe `details`. Runtime construction rejects codes, providers, operations, status values, and path value types outside the public Source vocabulary, while dropping fields a code does not own. `toJSON()` excludes the original `cause`, stack, credentials, request URLs, absolute paths, and provider response bodies; the protected server runtime can still inspect `error.cause` for diagnostics.
 
 ```ts
 import { SourceError } from "@vite-hub/source"

--- a/packages/source/README.md
+++ b/packages/source/README.md
@@ -31,6 +31,22 @@ const keys = await docs.keys()
 const first = await docs.read(keys[0]!)
 ```
 
+## Errors
+
+Built-in loaders throw `SourceError` with a stable `code` and JSON-safe `details`. `toJSON()` excludes the original `cause`, stack, credentials, request URLs, absolute paths, and provider response bodies; the protected server runtime can still inspect `error.cause` for diagnostics.
+
+```ts
+import { SourceError } from "@vite-hub/source"
+
+throw new SourceError("[vitehub] custom source request failed.", {
+  code: "SOURCE_PROVIDER_REQUEST_FAILED",
+  details: { operation: "read", provider: "custom" },
+  cause,
+})
+```
+
+`SourceNotFoundError` and `SourcePathError` preserve their specialized class identity for registry and path failures. Configuration mistakes such as a missing `file()` path remain `TypeError` because they are programmer errors rather than Source runtime failures.
+
 ## Used by
 
 [`@vite-hub/workspace`](../workspace/README.md) materializes Source output into workspace files. Use this package directly when you only need typed source loading and not a workspace file tree.

--- a/packages/source/fixtures/published-types/consumer.ts
+++ b/packages/source/fixtures/published-types/consumer.ts
@@ -17,6 +17,7 @@ error.toJSON().details?.key satisfies string | undefined
 "string" satisfies SourceValueType
 
 new SourceError("Missing source item", options)
+new SourceError({ code: "SOURCE_NOT_FOUND" })
 
 class ConsumerSourceError extends SourceError<"SOURCE_ITEM_NOT_FOUND"> {
   constructor() {

--- a/packages/source/fixtures/published-types/consumer.ts
+++ b/packages/source/fixtures/published-types/consumer.ts
@@ -7,13 +7,21 @@ const options: SourceErrorOptions<"SOURCE_ITEM_NOT_FOUND"> = {
   details: { key: "README.md", source: "docs" },
 }
 
-const error = new SourceError("Missing source item", options)
+const error = new SourceError({
+  ...options,
+  message: "Missing source item",
+})
 error.code satisfies SourceErrorCode
 error.toJSON().details?.key satisfies string | undefined
 
+new SourceError("Missing source item", options)
+
 class ConsumerSourceError extends SourceError<"SOURCE_ITEM_NOT_FOUND"> {
   constructor() {
-    super("Missing source item", options)
+    super({
+      ...options,
+      message: "Missing source item",
+    })
   }
 }
 

--- a/packages/source/fixtures/published-types/consumer.ts
+++ b/packages/source/fixtures/published-types/consumer.ts
@@ -1,0 +1,21 @@
+import { SourceError, SourceNotFoundError } from "@vite-hub/source"
+
+import type { SourceErrorCode, SourceErrorOptions } from "@vite-hub/source"
+
+const options: SourceErrorOptions<"SOURCE_ITEM_NOT_FOUND"> = {
+  code: "SOURCE_ITEM_NOT_FOUND",
+  details: { key: "README.md", source: "docs" },
+}
+
+const error = new SourceError("Missing source item", options)
+error.code satisfies SourceErrorCode
+error.toJSON().details?.key satisfies string | undefined
+
+class ConsumerSourceError extends SourceError<"SOURCE_ITEM_NOT_FOUND"> {
+  constructor() {
+    super("Missing source item", options)
+  }
+}
+
+new ConsumerSourceError()
+new SourceNotFoundError("docs")

--- a/packages/source/fixtures/published-types/consumer.ts
+++ b/packages/source/fixtures/published-types/consumer.ts
@@ -1,6 +1,6 @@
 import { SourceError, SourceNotFoundError } from "@vite-hub/source"
 
-import type { SourceErrorCode, SourceErrorOptions } from "@vite-hub/source"
+import type { SourceErrorCode, SourceErrorOptions, SourceProviderOperation, SourceValueType } from "@vite-hub/source"
 
 const options: SourceErrorOptions<"SOURCE_ITEM_NOT_FOUND"> = {
   code: "SOURCE_ITEM_NOT_FOUND",
@@ -13,6 +13,8 @@ const error = new SourceError({
 })
 error.code satisfies SourceErrorCode
 error.toJSON().details?.key satisfies string | undefined
+"read-item" satisfies SourceProviderOperation
+"string" satisfies SourceValueType
 
 new SourceError("Missing source item", options)
 
@@ -27,3 +29,17 @@ class ConsumerSourceError extends SourceError<"SOURCE_ITEM_NOT_FOUND"> {
 
 new ConsumerSourceError()
 new SourceNotFoundError("docs")
+
+new SourceError({
+  code: "SOURCE_PROVIDER_REQUEST_FAILED",
+  // @ts-expect-error Provider operations use the closed Source vocabulary.
+  details: { operation: "refresh-token", provider: "github" },
+  message: "Provider failed.",
+})
+
+new SourceError({
+  code: "SOURCE_ITEM_NOT_FOUND",
+  // @ts-expect-error Built-in details do not accept arbitrary fields.
+  details: { key: "README.md", token: "secret-token" },
+  message: "Missing source item",
+})

--- a/packages/source/fixtures/published-types/package.json
+++ b/packages/source/fixtures/published-types/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/source/fixtures/published-types/package.json
+++ b/packages/source/fixtures/published-types/package.json
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "@vite-hub/source": "0.0.1"
+  },
   "private": true,
   "type": "module"
 }

--- a/packages/source/fixtures/published-types/tsconfig.json
+++ b/packages/source/fixtures/published-types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "files": [
+    "consumer.ts"
+  ]
+}

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "catalog:ai",
+    "@vite-hub/runtime": "workspace:*",
     "mrmime": "catalog:workspace",
     "ocache": "catalog:unjs",
     "pathe": "catalog:unjs",

--- a/packages/source/src/core/errors.ts
+++ b/packages/source/src/core/errors.ts
@@ -30,8 +30,16 @@ export interface SourceErrorOptions<TCode extends SourceErrorCode = SourceErrorC
 }
 
 export class SourceError<TCode extends SourceErrorCode = SourceErrorCode> extends ViteHubError<TCode, SourceErrorDetails<TCode>> {
-  constructor(message: string, options: SourceErrorOptions<TCode>) {
-    super(options.code, message, options)
+  constructor(options: SourceErrorOptions<TCode> & { message: string })
+  constructor(message: string, options: SourceErrorOptions<TCode>)
+  constructor(
+    input: string | (SourceErrorOptions<TCode> & { message: string }),
+    legacyOptions?: SourceErrorOptions<TCode>,
+  ) {
+    const { code, message, ...options } = typeof input === "string"
+      ? { ...legacyOptions!, message: input }
+      : input
+    super(code, message, options)
     this.name = "SourceError"
   }
 }
@@ -39,9 +47,10 @@ export class SourceError<TCode extends SourceErrorCode = SourceErrorCode> extend
 export class SourceNotFoundError extends SourceError<"SOURCE_NOT_FOUND"> {
   constructor(name: string) {
     const source = normalizePublicSourceIdentifier(name)
-    super(source ? `[vitehub] Source "${source}" is not registered.` : "[vitehub] Source is not registered.", {
+    super({
       code: "SOURCE_NOT_FOUND",
       details: source ? { source } : undefined,
+      message: source ? `[vitehub] Source "${source}" is not registered.` : "[vitehub] Source is not registered.",
     })
     this.name = "SourceNotFoundError"
   }
@@ -49,9 +58,10 @@ export class SourceNotFoundError extends SourceError<"SOURCE_NOT_FOUND"> {
 
 export class SourcePathError extends SourceError<"SOURCE_PATH_INVALID"> {
   constructor(path: unknown) {
-    super("[vitehub] Source path escapes the source root.", {
+    super({
       code: "SOURCE_PATH_INVALID",
       details: { field: "path", valueType: sourceValueType(path) },
+      message: "[vitehub] Source path escapes the source root.",
     })
     this.name = "SourcePathError"
   }
@@ -59,25 +69,28 @@ export class SourcePathError extends SourceError<"SOURCE_PATH_INVALID"> {
 
 export function sourceContentMissingError(source: string, key: string): SourceError<"SOURCE_CONTENT_MISSING"> {
   const details = sourceItemDetails(source, key)
-  return new SourceError(sourceContentMissingMessage(details), {
+  return new SourceError({
     code: "SOURCE_CONTENT_MISSING",
     details,
+    message: sourceContentMissingMessage(details),
   })
 }
 
 export function sourceItemIsDirectoryError(source: string, key: string): SourceError<"SOURCE_ITEM_IS_DIRECTORY"> {
   const details = sourceItemDetails(source, key)
-  return new SourceError(sourceItemIsDirectoryMessage(details), {
+  return new SourceError({
     code: "SOURCE_ITEM_IS_DIRECTORY",
     details,
+    message: sourceItemIsDirectoryMessage(details),
   })
 }
 
 export function sourceItemNotFoundError(source: string, key: string): SourceError<"SOURCE_ITEM_NOT_FOUND"> {
   const details = sourceItemDetails(source, key)
-  return new SourceError(sourceItemNotFoundMessage(details), {
+  return new SourceError({
     code: "SOURCE_ITEM_NOT_FOUND",
     details,
+    message: sourceItemNotFoundMessage(details),
   })
 }
 
@@ -86,7 +99,7 @@ export function sourceProviderRequestError(
   operation: string,
   options: { cause?: unknown, status?: number } = {},
 ): SourceError<"SOURCE_PROVIDER_REQUEST_FAILED"> {
-  return new SourceError(`[vitehub] ${provider} source request failed during ${operation}.`, {
+  return new SourceError({
     cause: options.cause,
     code: "SOURCE_PROVIDER_REQUEST_FAILED",
     details: {
@@ -94,6 +107,7 @@ export function sourceProviderRequestError(
       provider,
       ...(options.status === undefined ? {} : { status: options.status }),
     },
+    message: `[vitehub] ${provider} source request failed during ${operation}.`,
   })
 }
 
@@ -103,7 +117,7 @@ export function sourceProviderResponseInvalidError(
   options: { cause?: unknown, key?: string } = {},
 ): SourceError<"SOURCE_PROVIDER_RESPONSE_INVALID"> {
   const key = normalizePublicSourceIdentifier(options.key)
-  return new SourceError(`[vitehub] ${provider} source returned an invalid response during ${operation}.`, {
+  return new SourceError({
     cause: options.cause,
     code: "SOURCE_PROVIDER_RESPONSE_INVALID",
     details: {
@@ -111,6 +125,7 @@ export function sourceProviderResponseInvalidError(
       provider,
       ...(key === undefined ? {} : { key }),
     },
+    message: `[vitehub] ${provider} source returned an invalid response during ${operation}.`,
   })
 }
 

--- a/packages/source/src/core/errors.ts
+++ b/packages/source/src/core/errors.ts
@@ -1,20 +1,163 @@
-export class SourceError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options)
+import { ViteHubError } from "@vite-hub/runtime"
+
+import type { ViteHubErrorDetails, ViteHubErrorOptions } from "@vite-hub/runtime"
+
+export type SourceErrorCode =
+  | "SOURCE_CONTENT_MISSING"
+  | "SOURCE_ITEM_IS_DIRECTORY"
+  | "SOURCE_ITEM_NOT_FOUND"
+  | "SOURCE_NOT_FOUND"
+  | "SOURCE_PATH_INVALID"
+  | "SOURCE_PROVIDER_REQUEST_FAILED"
+  | "SOURCE_PROVIDER_RESPONSE_INVALID"
+
+export type SourceProvider = "custom" | "filesystem" | "github" | "mcp"
+
+type SourceErrorDetailMap = {
+  SOURCE_CONTENT_MISSING: { readonly key?: string, readonly source?: string }
+  SOURCE_ITEM_IS_DIRECTORY: { readonly key?: string, readonly source?: string }
+  SOURCE_ITEM_NOT_FOUND: { readonly key?: string, readonly source?: string }
+  SOURCE_NOT_FOUND: { readonly source?: string }
+  SOURCE_PATH_INVALID: { readonly field: "path", readonly valueType: string }
+  SOURCE_PROVIDER_REQUEST_FAILED: { readonly operation: string, readonly provider: SourceProvider, readonly status?: number }
+  SOURCE_PROVIDER_RESPONSE_INVALID: { readonly key?: string, readonly operation: string, readonly provider: SourceProvider }
+}
+
+export type SourceErrorDetails<TCode extends SourceErrorCode = SourceErrorCode> = SourceErrorDetailMap[TCode] & ViteHubErrorDetails
+
+export interface SourceErrorOptions<TCode extends SourceErrorCode = SourceErrorCode> extends ViteHubErrorOptions<SourceErrorDetails<TCode>> {
+  code: TCode
+}
+
+export class SourceError<TCode extends SourceErrorCode = SourceErrorCode> extends ViteHubError<TCode, SourceErrorDetails<TCode>> {
+  constructor(message: string, options: SourceErrorOptions<TCode>) {
+    super(options.code, message, options)
     this.name = "SourceError"
   }
 }
 
-export class SourceNotFoundError extends SourceError {
+export class SourceNotFoundError extends SourceError<"SOURCE_NOT_FOUND"> {
   constructor(name: string) {
-    super(`[vitehub] Source "${name}" is not registered.`)
+    const source = normalizePublicSourceIdentifier(name)
+    super(source ? `[vitehub] Source "${source}" is not registered.` : "[vitehub] Source is not registered.", {
+      code: "SOURCE_NOT_FOUND",
+      details: source ? { source } : undefined,
+    })
     this.name = "SourceNotFoundError"
   }
 }
 
-export class SourcePathError extends SourceError {
-  constructor(path: string) {
-    super(`[vitehub] Source path escapes the source root: ${JSON.stringify(path)}.`)
+export class SourcePathError extends SourceError<"SOURCE_PATH_INVALID"> {
+  constructor(path: unknown) {
+    super("[vitehub] Source path escapes the source root.", {
+      code: "SOURCE_PATH_INVALID",
+      details: { field: "path", valueType: sourceValueType(path) },
+    })
     this.name = "SourcePathError"
   }
+}
+
+export function sourceContentMissingError(source: string, key: string): SourceError<"SOURCE_CONTENT_MISSING"> {
+  const details = sourceItemDetails(source, key)
+  return new SourceError(sourceContentMissingMessage(details), {
+    code: "SOURCE_CONTENT_MISSING",
+    details,
+  })
+}
+
+export function sourceItemIsDirectoryError(source: string, key: string): SourceError<"SOURCE_ITEM_IS_DIRECTORY"> {
+  const details = sourceItemDetails(source, key)
+  return new SourceError(sourceItemIsDirectoryMessage(details), {
+    code: "SOURCE_ITEM_IS_DIRECTORY",
+    details,
+  })
+}
+
+export function sourceItemNotFoundError(source: string, key: string): SourceError<"SOURCE_ITEM_NOT_FOUND"> {
+  const details = sourceItemDetails(source, key)
+  return new SourceError(sourceItemNotFoundMessage(details), {
+    code: "SOURCE_ITEM_NOT_FOUND",
+    details,
+  })
+}
+
+export function sourceProviderRequestError(
+  provider: SourceProvider,
+  operation: string,
+  options: { cause?: unknown, status?: number } = {},
+): SourceError<"SOURCE_PROVIDER_REQUEST_FAILED"> {
+  return new SourceError(`[vitehub] ${provider} source request failed during ${operation}.`, {
+    cause: options.cause,
+    code: "SOURCE_PROVIDER_REQUEST_FAILED",
+    details: {
+      operation,
+      provider,
+      ...(options.status === undefined ? {} : { status: options.status }),
+    },
+  })
+}
+
+export function sourceProviderResponseInvalidError(
+  provider: SourceProvider,
+  operation: string,
+  options: { cause?: unknown, key?: string } = {},
+): SourceError<"SOURCE_PROVIDER_RESPONSE_INVALID"> {
+  const key = normalizePublicSourceIdentifier(options.key)
+  return new SourceError(`[vitehub] ${provider} source returned an invalid response during ${operation}.`, {
+    cause: options.cause,
+    code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+    details: {
+      operation,
+      provider,
+      ...(key === undefined ? {} : { key }),
+    },
+  })
+}
+
+function sourceValueType(value: unknown): string {
+  if (value === null) return "null"
+  if (Array.isArray(value)) return "array"
+  if (value instanceof Date) return "date"
+  return typeof value
+}
+
+function normalizePublicSourceIdentifier(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value || value.trim() !== value) return
+  const normalized = value.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "")
+  if (normalized !== value) return
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(value) || /^[a-z]:\//i.test(value)) return
+  if ([...value].some(character => character.codePointAt(0)! <= 31 || character.codePointAt(0) === 127)) return
+  const parts = value.split("/")
+  if (parts.some(part => part === "." || part === "..")) return
+  return value
+}
+
+function sourceItemDetails(source: string, key: string) {
+  const safeSource = normalizePublicSourceIdentifier(source)
+  const safeKey = normalizePublicSourceIdentifier(key)
+  return {
+    ...(safeKey === undefined ? {} : { key: safeKey }),
+    ...(safeSource === undefined ? {} : { source: safeSource }),
+  }
+}
+
+function sourceContentMissingMessage(details: { key?: string, source?: string }): string {
+  const owner = details.source || "Source"
+  return details.key
+    ? `[vitehub] ${owner} did not include content for ${JSON.stringify(details.key)}.`
+    : `[vitehub] ${owner} did not include readable content.`
+}
+
+function sourceItemIsDirectoryMessage(details: { key?: string, source?: string }): string {
+  const owner = details.source || "Source"
+  return details.key
+    ? `[vitehub] ${owner} expected ${JSON.stringify(details.key)} to be a file, but it is a directory.`
+    : `[vitehub] ${owner} returned a directory instead of a file.`
+}
+
+function sourceItemNotFoundMessage(details: { key?: string, source?: string }): string {
+  const owner = details.source || "Source"
+  return details.key
+    ? `[vitehub] ${owner} could not find ${JSON.stringify(details.key)}.`
+    : `[vitehub] ${owner} could not find the requested item.`
 }

--- a/packages/source/src/core/errors.ts
+++ b/packages/source/src/core/errors.ts
@@ -166,7 +166,7 @@ function sourceValueType(value: unknown): SourceValueType {
 }
 
 function normalizePublicSourceIdentifier(value: unknown): string | undefined {
-  if (typeof value !== "string" || !value || value.trim() !== value) return
+  if (typeof value !== "string" || !value || value.length > 4096 || value.trim() !== value) return
   const normalized = value.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "")
   if (normalized !== value) return
   if (/^[a-z][a-z\d+.-]*:\/\//i.test(value) || /^[a-z]:\//i.test(value)) return

--- a/packages/source/src/core/errors.ts
+++ b/packages/source/src/core/errors.ts
@@ -1,6 +1,6 @@
 import { ViteHubError } from "@vite-hub/runtime"
 
-import type { ViteHubErrorDetails, ViteHubErrorOptions } from "@vite-hub/runtime"
+import type { ViteHubErrorOptions } from "@vite-hub/runtime"
 
 export type SourceErrorCode =
   | "SOURCE_CONTENT_MISSING"
@@ -13,17 +13,47 @@ export type SourceErrorCode =
 
 export type SourceProvider = "custom" | "filesystem" | "github" | "mcp"
 
+export type SourceProviderOperation =
+  | "close"
+  | "connect"
+  | "list"
+  | "list-resources"
+  | "metadata"
+  | "read"
+  | "read-archive"
+  | "read-item"
+  | "read-metadata"
+  | "read-resource"
+  | "resolve"
+  | "resolve-ref"
+  | "resolve-repository"
+  | "resolve-root"
+  | "validate-ref"
+
+export type SourceValueType =
+  | "array"
+  | "bigint"
+  | "boolean"
+  | "date"
+  | "function"
+  | "null"
+  | "number"
+  | "object"
+  | "string"
+  | "symbol"
+  | "undefined"
+
 type SourceErrorDetailMap = {
   SOURCE_CONTENT_MISSING: { readonly key?: string, readonly source?: string }
   SOURCE_ITEM_IS_DIRECTORY: { readonly key?: string, readonly source?: string }
   SOURCE_ITEM_NOT_FOUND: { readonly key?: string, readonly source?: string }
   SOURCE_NOT_FOUND: { readonly source?: string }
-  SOURCE_PATH_INVALID: { readonly field: "path", readonly valueType: string }
-  SOURCE_PROVIDER_REQUEST_FAILED: { readonly operation: string, readonly provider: SourceProvider, readonly status?: number }
-  SOURCE_PROVIDER_RESPONSE_INVALID: { readonly key?: string, readonly operation: string, readonly provider: SourceProvider }
+  SOURCE_PATH_INVALID: { readonly field: "path", readonly valueType: SourceValueType }
+  SOURCE_PROVIDER_REQUEST_FAILED: { readonly operation: SourceProviderOperation, readonly provider: SourceProvider, readonly status?: number }
+  SOURCE_PROVIDER_RESPONSE_INVALID: { readonly key?: string, readonly operation: SourceProviderOperation, readonly provider: SourceProvider }
 }
 
-export type SourceErrorDetails<TCode extends SourceErrorCode = SourceErrorCode> = SourceErrorDetailMap[TCode] & ViteHubErrorDetails
+export type SourceErrorDetails<TCode extends SourceErrorCode = SourceErrorCode> = SourceErrorDetailMap[TCode]
 
 export interface SourceErrorOptions<TCode extends SourceErrorCode = SourceErrorCode> extends ViteHubErrorOptions<SourceErrorDetails<TCode>> {
   code: TCode
@@ -36,10 +66,17 @@ export class SourceError<TCode extends SourceErrorCode = SourceErrorCode> extend
     input: string | (SourceErrorOptions<TCode> & { message: string }),
     legacyOptions?: SourceErrorOptions<TCode>,
   ) {
-    const { code, message, ...options } = typeof input === "string"
+    const { code: inputCode, message, ...options } = typeof input === "string"
       ? { ...legacyOptions!, message: input }
       : input
-    super(code, message, options)
+    const code = parseSourceErrorCode(inputCode) as TCode
+    const details = parseSourceErrorDetails(code, options.details) as SourceErrorDetails<TCode> | undefined
+    super(code, message, {
+      cause: options.cause,
+      ...(details === undefined ? {} : { details }),
+      requestId: options.requestId,
+      retryable: options.retryable,
+    })
     this.name = "SourceError"
   }
 }
@@ -96,7 +133,7 @@ export function sourceItemNotFoundError(source: string, key: string): SourceErro
 
 export function sourceProviderRequestError(
   provider: SourceProvider,
-  operation: string,
+  operation: SourceProviderOperation,
   options: { cause?: unknown, status?: number } = {},
 ): SourceError<"SOURCE_PROVIDER_REQUEST_FAILED"> {
   return new SourceError({
@@ -113,7 +150,7 @@ export function sourceProviderRequestError(
 
 export function sourceProviderResponseInvalidError(
   provider: SourceProvider,
-  operation: string,
+  operation: SourceProviderOperation,
   options: { cause?: unknown, key?: string } = {},
 ): SourceError<"SOURCE_PROVIDER_RESPONSE_INVALID"> {
   const key = normalizePublicSourceIdentifier(options.key)
@@ -129,7 +166,7 @@ export function sourceProviderResponseInvalidError(
   })
 }
 
-function sourceValueType(value: unknown): string {
+function sourceValueType(value: unknown): SourceValueType {
   if (value === null) return "null"
   if (Array.isArray(value)) return "array"
   if (value instanceof Date) return "date"
@@ -147,12 +184,130 @@ function normalizePublicSourceIdentifier(value: unknown): string | undefined {
   return value
 }
 
-function sourceItemDetails(source: string, key: string) {
+function sourceItemDetails(source: unknown, key: unknown) {
   const safeSource = normalizePublicSourceIdentifier(source)
   const safeKey = normalizePublicSourceIdentifier(key)
   return {
     ...(safeKey === undefined ? {} : { key: safeKey }),
     ...(safeSource === undefined ? {} : { source: safeSource }),
+  }
+}
+
+function parseSourceErrorCode(value: unknown): SourceErrorCode {
+  switch (value) {
+    case "SOURCE_CONTENT_MISSING":
+    case "SOURCE_ITEM_IS_DIRECTORY":
+    case "SOURCE_ITEM_NOT_FOUND":
+    case "SOURCE_NOT_FOUND":
+    case "SOURCE_PATH_INVALID":
+    case "SOURCE_PROVIDER_REQUEST_FAILED":
+    case "SOURCE_PROVIDER_RESPONSE_INVALID":
+      return value
+    default:
+      throw new TypeError("[vitehub] Invalid Source error code.")
+  }
+}
+
+function parseSourceErrorDetails(
+  code: SourceErrorCode,
+  value: unknown,
+): SourceErrorDetails | undefined {
+  if (value === undefined) return
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError("[vitehub] Invalid Source error details.")
+  }
+
+  try {
+    const details = value as Record<string, unknown>
+    switch (code) {
+      case "SOURCE_CONTENT_MISSING":
+      case "SOURCE_ITEM_IS_DIRECTORY":
+      case "SOURCE_ITEM_NOT_FOUND":
+        return sourceItemDetails(details.source, details.key)
+      case "SOURCE_NOT_FOUND": {
+        const source = normalizePublicSourceIdentifier(details.source)
+        return source === undefined ? {} : { source }
+      }
+      case "SOURCE_PATH_INVALID":
+        if (details.field !== "path") throw new TypeError()
+        return { field: "path", valueType: parseSourceValueType(details.valueType) }
+      case "SOURCE_PROVIDER_REQUEST_FAILED": {
+        const status = details.status
+        if (status !== undefined && (!Number.isInteger(status) || (status as number) < 100 || (status as number) > 599)) {
+          throw new TypeError()
+        }
+        return {
+          operation: parseSourceProviderOperation(details.operation),
+          provider: parseSourceProvider(details.provider),
+          ...(status === undefined ? {} : { status: status as number }),
+        }
+      }
+      case "SOURCE_PROVIDER_RESPONSE_INVALID": {
+        const key = normalizePublicSourceIdentifier(details.key)
+        return {
+          ...(key === undefined ? {} : { key }),
+          operation: parseSourceProviderOperation(details.operation),
+          provider: parseSourceProvider(details.provider),
+        }
+      }
+    }
+  }
+  catch {
+    throw new TypeError("[vitehub] Invalid Source error details.")
+  }
+}
+
+function parseSourceProvider(value: unknown): SourceProvider {
+  switch (value) {
+    case "custom":
+    case "filesystem":
+    case "github":
+    case "mcp":
+      return value
+    default:
+      throw new TypeError()
+  }
+}
+
+function parseSourceProviderOperation(value: unknown): SourceProviderOperation {
+  switch (value) {
+    case "close":
+    case "connect":
+    case "list":
+    case "list-resources":
+    case "metadata":
+    case "read":
+    case "read-archive":
+    case "read-item":
+    case "read-metadata":
+    case "read-resource":
+    case "resolve":
+    case "resolve-ref":
+    case "resolve-repository":
+    case "resolve-root":
+    case "validate-ref":
+      return value
+    default:
+      throw new TypeError()
+  }
+}
+
+function parseSourceValueType(value: unknown): SourceValueType {
+  switch (value) {
+    case "array":
+    case "bigint":
+    case "boolean":
+    case "date":
+    case "function":
+    case "null":
+    case "number":
+    case "object":
+    case "string":
+    case "symbol":
+    case "undefined":
+      return value
+    default:
+      throw new TypeError()
   }
 }
 

--- a/packages/source/src/core/errors.ts
+++ b/packages/source/src/core/errors.ts
@@ -57,21 +57,20 @@ export type SourceErrorDetails<TCode extends SourceErrorCode = SourceErrorCode> 
 
 export interface SourceErrorOptions<TCode extends SourceErrorCode = SourceErrorCode> extends ViteHubErrorOptions<SourceErrorDetails<TCode>> {
   code: TCode
+  message?: string
 }
 
 export class SourceError<TCode extends SourceErrorCode = SourceErrorCode> extends ViteHubError<TCode, SourceErrorDetails<TCode>> {
-  constructor(options: SourceErrorOptions<TCode> & { message: string })
+  constructor(options: SourceErrorOptions<TCode>)
   constructor(message: string, options: SourceErrorOptions<TCode>)
   constructor(
-    input: string | (SourceErrorOptions<TCode> & { message: string }),
+    input: string | SourceErrorOptions<TCode>,
     legacyOptions?: SourceErrorOptions<TCode>,
   ) {
-    const { code: inputCode, message, ...options } = typeof input === "string"
-      ? { ...legacyOptions!, message: input }
-      : input
-    const code = parseSourceErrorCode(inputCode) as TCode
+    const options = typeof input === "string" ? legacyOptions! : input
+    const code = parseSourceErrorCode(options.code) as TCode
     const details = parseSourceErrorDetails(code, options.details) as SourceErrorDetails<TCode> | undefined
-    super(code, message, {
+    super(code, sourceErrorMessage(code, details), {
       cause: options.cause,
       ...(details === undefined ? {} : { details }),
       requestId: options.requestId,
@@ -87,7 +86,6 @@ export class SourceNotFoundError extends SourceError<"SOURCE_NOT_FOUND"> {
     super({
       code: "SOURCE_NOT_FOUND",
       details: source ? { source } : undefined,
-      message: source ? `[vitehub] Source "${source}" is not registered.` : "[vitehub] Source is not registered.",
     })
     this.name = "SourceNotFoundError"
   }
@@ -98,7 +96,6 @@ export class SourcePathError extends SourceError<"SOURCE_PATH_INVALID"> {
     super({
       code: "SOURCE_PATH_INVALID",
       details: { field: "path", valueType: sourceValueType(path) },
-      message: "[vitehub] Source path escapes the source root.",
     })
     this.name = "SourcePathError"
   }
@@ -109,7 +106,6 @@ export function sourceContentMissingError(source: string, key: string): SourceEr
   return new SourceError({
     code: "SOURCE_CONTENT_MISSING",
     details,
-    message: sourceContentMissingMessage(details),
   })
 }
 
@@ -118,7 +114,6 @@ export function sourceItemIsDirectoryError(source: string, key: string): SourceE
   return new SourceError({
     code: "SOURCE_ITEM_IS_DIRECTORY",
     details,
-    message: sourceItemIsDirectoryMessage(details),
   })
 }
 
@@ -127,7 +122,6 @@ export function sourceItemNotFoundError(source: string, key: string): SourceErro
   return new SourceError({
     code: "SOURCE_ITEM_NOT_FOUND",
     details,
-    message: sourceItemNotFoundMessage(details),
   })
 }
 
@@ -144,7 +138,6 @@ export function sourceProviderRequestError(
       provider,
       ...(options.status === undefined ? {} : { status: options.status }),
     },
-    message: `[vitehub] ${provider} source request failed during ${operation}.`,
   })
 }
 
@@ -162,7 +155,6 @@ export function sourceProviderResponseInvalidError(
       provider,
       ...(key === undefined ? {} : { key }),
     },
-    message: `[vitehub] ${provider} source returned an invalid response during ${operation}.`,
   })
 }
 
@@ -308,6 +300,35 @@ function parseSourceValueType(value: unknown): SourceValueType {
       return value
     default:
       throw new TypeError()
+  }
+}
+
+function sourceErrorMessage(code: SourceErrorCode, details: SourceErrorDetails | undefined): string {
+  switch (code) {
+    case "SOURCE_CONTENT_MISSING":
+      return sourceContentMissingMessage((details as SourceErrorDetails<"SOURCE_CONTENT_MISSING"> | undefined) ?? {})
+    case "SOURCE_ITEM_IS_DIRECTORY":
+      return sourceItemIsDirectoryMessage((details as SourceErrorDetails<"SOURCE_ITEM_IS_DIRECTORY"> | undefined) ?? {})
+    case "SOURCE_ITEM_NOT_FOUND":
+      return sourceItemNotFoundMessage((details as SourceErrorDetails<"SOURCE_ITEM_NOT_FOUND"> | undefined) ?? {})
+    case "SOURCE_NOT_FOUND": {
+      const source = (details as SourceErrorDetails<"SOURCE_NOT_FOUND"> | undefined)?.source
+      return source ? `[vitehub] Source "${source}" is not registered.` : "[vitehub] Source is not registered."
+    }
+    case "SOURCE_PATH_INVALID":
+      return "[vitehub] Source path escapes the source root."
+    case "SOURCE_PROVIDER_REQUEST_FAILED": {
+      const providerDetails = details as SourceErrorDetails<"SOURCE_PROVIDER_REQUEST_FAILED"> | undefined
+      return providerDetails
+        ? `[vitehub] ${providerDetails.provider} source request failed during ${providerDetails.operation}.`
+        : "[vitehub] Source provider request failed."
+    }
+    case "SOURCE_PROVIDER_RESPONSE_INVALID": {
+      const providerDetails = details as SourceErrorDetails<"SOURCE_PROVIDER_RESPONSE_INVALID"> | undefined
+      return providerDetails
+        ? `[vitehub] ${providerDetails.provider} source returned an invalid response during ${providerDetails.operation}.`
+        : "[vitehub] Source provider returned an invalid response."
+    }
   }
 }
 

--- a/packages/source/src/core/registry.ts
+++ b/packages/source/src/core/registry.ts
@@ -1,4 +1,4 @@
-import { SourceNotFoundError, SourceError } from "./errors.ts"
+import { SourceNotFoundError, sourceContentMissingError } from "./errors.ts"
 import { decodeSourceContent, normalizeSafeSourcePath, normalizeSourcePath } from "./path.ts"
 
 import type {
@@ -50,10 +50,6 @@ function createSourceContext(name: string, context: Partial<SourceContext> = {})
   }
 }
 
-function createMissingContentError(key: string) {
-  return new SourceError(`[vitehub] Source item ${JSON.stringify(key)} does not provide readable content.`)
-}
-
 function isNestedUnder(path: string, prefix: string) {
   return !prefix || path === prefix || path.startsWith(`${prefix}/`)
 }
@@ -103,7 +99,7 @@ export function useSource<TName extends SourceName>(
       options?: TOptions,
     ): Promise<ReadSourceResult<TOptions>> {
       const item = await get(key)
-      if (typeof item.content === "undefined") throw createMissingContentError(key)
+      if (typeof item.content === "undefined") throw sourceContentMissingError(name, key)
       return decodeSourceContent(item.content, options)
     },
     async meta(key) {

--- a/packages/source/src/index.ts
+++ b/packages/source/src/index.ts
@@ -17,6 +17,8 @@ export type {
   SourceErrorDetails,
   SourceErrorOptions,
   SourceProvider,
+  SourceProviderOperation,
+  SourceValueType,
 } from "./core/errors.ts"
 export {
   custom,

--- a/packages/source/src/index.ts
+++ b/packages/source/src/index.ts
@@ -12,6 +12,12 @@ export {
   SourcePathError,
   SourceError,
 } from "./core/errors.ts"
+export type {
+  SourceErrorCode,
+  SourceErrorDetails,
+  SourceErrorOptions,
+  SourceProvider,
+} from "./core/errors.ts"
 export {
   custom,
   file,

--- a/packages/source/src/sources/file.ts
+++ b/packages/source/src/sources/file.ts
@@ -1,6 +1,6 @@
 import { lookup } from "mrmime"
 
-import { SourceError, SourcePathError } from "../core/errors.ts"
+import { SourcePathError, sourceItemNotFoundError, sourceProviderRequestError } from "../core/errors.ts"
 import { normalizeSafeSourcePath, normalizeSourcePath } from "../core/path.ts"
 
 import type { Source, SourceContent, SourceContext } from "../core/types.ts"
@@ -39,19 +39,39 @@ function resolveSourceRoot(ctx: SourceContext) {
   return ctx.sourceRootDir || ctx.rootDir
 }
 
-async function readSourceFile<TKey extends string>(options: FileSourceOptions<TKey>, ctx: SourceContext) {
+async function readSourceFile<TKey extends string>(options: FileSourceOptions<TKey>, ctx: SourceContext, key: TKey) {
   if (!("path" in options) || !options.path) {
     throw new TypeError("[vitehub] file requires path when content is not provided.")
   }
   const { readFile } = await import("node:fs/promises")
-  return new Uint8Array(await readFile(await resolveSafeSourceFilePath(options.path, ctx)))
+  const target = await resolveSafeSourceFilePath(options.path, key, ctx)
+  try {
+    return new Uint8Array(await readFile(target))
+  }
+  catch (cause) {
+    if (isFileNotFoundError(cause)) throw sourceItemNotFoundError("file", key)
+    throw sourceProviderRequestError("filesystem", "read", { cause })
+  }
 }
 
-async function resolveSafeSourceFilePath(path: string, ctx: SourceContext) {
+async function resolveSafeSourceFilePath(path: string, key: string, ctx: SourceContext) {
   const { realpath } = await import("node:fs/promises")
   const { relative, resolve, sep } = await import("node:path")
-  const root = await realpath(resolve(resolveSourceRoot(ctx)))
-  const target = await realpath(resolve(root, normalizeSafeSourcePath(path)))
+  let root: string
+  try {
+    root = await realpath(resolve(resolveSourceRoot(ctx)))
+  }
+  catch (cause) {
+    throw sourceProviderRequestError("filesystem", "resolve-root", { cause })
+  }
+  let target: string
+  try {
+    target = await realpath(resolve(root, normalizeSafeSourcePath(path)))
+  }
+  catch (cause) {
+    if (isFileNotFoundError(cause)) throw sourceItemNotFoundError("file", key)
+    throw sourceProviderRequestError("filesystem", "resolve", { cause })
+  }
   const rel = relative(root, target)
 
   if (rel === ".." || rel.startsWith(`..${sep}`)) {
@@ -59,6 +79,10 @@ async function resolveSafeSourceFilePath(path: string, ctx: SourceContext) {
   }
 
   return target
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"
 }
 
 export function file<const TKey extends string = string>(input: FileSourceInput<TKey>): Source<TKey> {
@@ -74,17 +98,25 @@ export function file<const TKey extends string = string>(input: FileSourceInput<
       if (requestedKey !== key) return
       if (!("path" in options) || !options.path) return
       const { stat } = await import("node:fs/promises")
-      const info = await stat(await resolveSafeSourceFilePath(options.path, ctx))
+      const target = await resolveSafeSourceFilePath(options.path, key, ctx)
+      let info
+      try {
+        info = await stat(target)
+      }
+      catch (cause) {
+        if (isFileNotFoundError(cause)) throw sourceItemNotFoundError("file", key)
+        throw sourceProviderRequestError("filesystem", "metadata", { cause })
+      }
       return {
         digest: `${info.size}:${info.mtimeMs}`,
       }
     },
     async getItem(requestedKey: TKey, ctx: SourceContext) {
       if (requestedKey !== key) {
-        throw new SourceError(`[vitehub] file could not find ${JSON.stringify(requestedKey)}.`)
+        throw sourceItemNotFoundError("file", requestedKey)
       }
       const content = typeof options.content === "undefined"
-        ? await readSourceFile(options, ctx)
+        ? await readSourceFile(options, ctx, key)
         : options.content
       return {
         key,

--- a/packages/source/src/sources/file.ts
+++ b/packages/source/src/sources/file.ts
@@ -71,6 +71,7 @@ async function resolveSafeSourceFilePath(path: string, key: string, ctx: SourceC
     target = await realpath(resolve(root, normalizeSafeSourcePath(path)))
   }
   catch (cause) {
+    if (cause instanceof SourceError) throw cause
     if (isFileNotFoundError(cause)) throw sourceItemNotFoundError("file", key)
     throw sourceProviderRequestError("filesystem", "resolve", { cause })
   }

--- a/packages/source/src/sources/file.ts
+++ b/packages/source/src/sources/file.ts
@@ -1,6 +1,6 @@
 import { lookup } from "mrmime"
 
-import { SourcePathError, sourceItemNotFoundError, sourceProviderRequestError } from "../core/errors.ts"
+import { SourceError, SourcePathError, sourceItemIsDirectoryError, sourceItemNotFoundError, sourceProviderRequestError } from "../core/errors.ts"
 import { normalizeSafeSourcePath, normalizeSourcePath } from "../core/path.ts"
 
 import type { Source, SourceContent, SourceContext } from "../core/types.ts"
@@ -43,12 +43,14 @@ async function readSourceFile<TKey extends string>(options: FileSourceOptions<TK
   if (!("path" in options) || !options.path) {
     throw new TypeError("[vitehub] file requires path when content is not provided.")
   }
-  const { readFile } = await import("node:fs/promises")
+  const { readFile, stat } = await import("node:fs/promises")
   const target = await resolveSafeSourceFilePath(options.path, key, ctx)
   try {
+    if ((await stat(target)).isDirectory()) throw sourceItemIsDirectoryError("file", key)
     return new Uint8Array(await readFile(target))
   }
   catch (cause) {
+    if (cause instanceof SourceError) throw cause
     if (isFileNotFoundError(cause)) throw sourceItemNotFoundError("file", key)
     throw sourceProviderRequestError("filesystem", "read", { cause })
   }

--- a/packages/source/src/sources/github/client.ts
+++ b/packages/source/src/sources/github/client.ts
@@ -3,6 +3,7 @@ import { sourceProviderRequestError, sourceProviderResponseInvalidError } from "
 import type { SourceProviderOperation } from "../../core/errors.ts"
 
 export async function requestGitHubJson<T>(input: {
+  decode: (value: unknown) => T
   operation: SourceProviderOperation
   signal?: AbortSignal
   token?: string
@@ -23,7 +24,8 @@ export async function requestGitHubJson<T>(input: {
   }
 
   try {
-    return await response.json() as T
+    const value = await response.json()
+    return input.decode(value)
   }
   catch (cause) {
     if (input.signal?.aborted) throw input.signal.reason

--- a/packages/source/src/sources/github/client.ts
+++ b/packages/source/src/sources/github/client.ts
@@ -1,13 +1,12 @@
-import { SourceError } from "../../core/errors.ts"
+import { sourceProviderRequestError, sourceProviderResponseInvalidError } from "../../core/errors.ts"
 
 export async function requestGitHubJson<T>(input: {
-  ref: string
-  repo: string
+  operation: string
   signal?: AbortSignal
   token?: string
   url: string
 }): Promise<T> {
-  const response = await fetch(input.url, {
+  const response = await requestGitHub(input.operation, input.signal, () => fetch(input.url, {
     headers: {
       accept: "application/vnd.github+json",
       ...(input.token ? { authorization: `Bearer ${input.token}` } : {}),
@@ -15,16 +14,19 @@ export async function requestGitHubJson<T>(input: {
       "x-github-api-version": "2022-11-28",
     },
     signal: input.signal,
-  })
+  }))
 
   if (!response.ok) {
-    if (response.status === 404) {
-      throw new SourceError(`[vitehub] github(${JSON.stringify(input.repo)}) could not access the repository or ref ${JSON.stringify(input.ref)}. Check that the repo exists, the ref exists, and auth can access it.`)
-    }
-    throw new SourceError(`[vitehub] github(${JSON.stringify(input.repo)}) request failed with ${response.status} for ${input.url}.`)
+    throw sourceProviderRequestError("github", input.operation, { status: response.status })
   }
 
-  return await response.json() as T
+  try {
+    return await response.json() as T
+  }
+  catch (cause) {
+    if (input.signal?.aborted) throw input.signal.reason
+    throw sourceProviderResponseInvalidError("github", input.operation, { cause })
+  }
 }
 
 export async function fetchGitHubArchive(input: {
@@ -33,20 +35,34 @@ export async function fetchGitHubArchive(input: {
   signal?: AbortSignal
   token?: string
 }) {
-  const response = await fetch(`https://codeload.github.com/${input.repo}/tar.gz/${encodeURIComponent(input.ref)}`, {
+  const operation = "read-archive"
+  const response = await requestGitHub(operation, input.signal, () => fetch(`https://codeload.github.com/${input.repo}/tar.gz/${encodeURIComponent(input.ref)}`, {
     headers: {
       ...(input.token ? { authorization: `Bearer ${input.token}` } : {}),
       "user-agent": "vitehub-source",
     },
     signal: input.signal,
-  })
+  }))
 
   if (!response.ok) {
-    if (response.status === 404) {
-      throw new SourceError(`[vitehub] github(${JSON.stringify(input.repo)}) could not access the repository or ref ${JSON.stringify(input.ref)}. Check that the repo exists and the ref exists.`)
-    }
-    throw new SourceError(`[vitehub] github(${JSON.stringify(input.repo)}) archive request failed with ${response.status}.`)
+    throw sourceProviderRequestError("github", operation, { status: response.status })
   }
 
-  return new Uint8Array(await response.arrayBuffer())
+  try {
+    return new Uint8Array(await response.arrayBuffer())
+  }
+  catch (cause) {
+    if (input.signal?.aborted) throw input.signal.reason
+    throw sourceProviderResponseInvalidError("github", operation, { cause })
+  }
+}
+
+async function requestGitHub(operation: string, signal: AbortSignal | undefined, request: () => Promise<Response>): Promise<Response> {
+  try {
+    return await request()
+  }
+  catch (cause) {
+    if (signal?.aborted) throw signal.reason
+    throw sourceProviderRequestError("github", operation, { cause })
+  }
 }

--- a/packages/source/src/sources/github/client.ts
+++ b/packages/source/src/sources/github/client.ts
@@ -1,7 +1,9 @@
 import { sourceProviderRequestError, sourceProviderResponseInvalidError } from "../../core/errors.ts"
 
+import type { SourceProviderOperation } from "../../core/errors.ts"
+
 export async function requestGitHubJson<T>(input: {
-  operation: string
+  operation: SourceProviderOperation
   signal?: AbortSignal
   token?: string
   url: string
@@ -57,7 +59,7 @@ export async function fetchGitHubArchive(input: {
   }
 }
 
-async function requestGitHub(operation: string, signal: AbortSignal | undefined, request: () => Promise<Response>): Promise<Response> {
+async function requestGitHub(operation: SourceProviderOperation, signal: AbortSignal | undefined, request: () => Promise<Response>): Promise<Response> {
   try {
     return await request()
   }

--- a/packages/source/src/sources/github/git.ts
+++ b/packages/source/src/sources/github/git.ts
@@ -197,6 +197,10 @@ export async function loadGitArchiveFiles<TKey extends string>(
     const sha = Buffer.from(await executeGit(["-C", dir, "rev-parse", "FETCH_HEAD"], options)).toString("utf8").trim()
     return await readGitArchiveFiles(dir, { ...input, sha }, executeGit, options)
   }
+  catch (error) {
+    if (input.signal?.aborted) throw input.signal.reason
+    throw error
+  }
   finally {
     await rm(dir, { force: true, recursive: true })
   }

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -1,7 +1,12 @@
 import { Buffer } from "node:buffer"
 import { defineCachedFunction } from "ocache"
 
-import { SourceError } from "../../core/errors.ts"
+import {
+  SourceError,
+  sourceContentMissingError,
+  sourceItemIsDirectoryError,
+  sourceItemNotFoundError,
+} from "../../core/errors.ts"
 import { matchesAny, normalizeSourcePath } from "../../core/path.ts"
 import { parseGitHubArchive } from "./archive.ts"
 import { createGitHubCacheKey, normalizeGitHubCache } from "./cache.ts"
@@ -76,16 +81,14 @@ export function github<const TKey extends string = string>(options: GitHubSource
 
     try {
       const repo = await requestGitHubJson<GitHubRepositoryResponse>({
-        ref: "default",
-        repo: options.repo,
+        operation: "resolve-repository",
         signal,
         token,
         url: `https://api.github.com/repos/${options.repo}`,
       })
       const defaultBranch = repo.default_branch || "main"
       const commit = await requestGitHubJson<GitHubCommitResponse>({
-        ref: defaultBranch,
-        repo: options.repo,
+        operation: "resolve-ref",
         signal,
         token,
         url: `https://api.github.com/repos/${options.repo}/commits/${encodeURIComponent(defaultBranch)}`,
@@ -99,7 +102,10 @@ export function github<const TKey extends string = string>(options: GitHubSource
   }
 
   function shouldResolveMainFallback(error: unknown) {
-    return error instanceof SourceError && error.message.includes(" request failed with 403 ")
+    return error instanceof SourceError
+      && error.code === "SOURCE_PROVIDER_REQUEST_FAILED"
+      && error.details?.provider === "github"
+      && error.details.status === 403
   }
 
   const resolvedRefs = new Map<string, Promise<string>>()
@@ -125,8 +131,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
   async function validateConfiguredRef(token = auth, signal?: AbortSignal): Promise<void> {
     if (!configuredRef) return
     await requestGitHubJson<GitHubCommitResponse>({
-      ref: configuredRef,
-      repo: options.repo,
+      operation: "validate-ref",
       signal,
       token,
       url: `https://api.github.com/repos/${options.repo}/commits/${encodeURIComponent(configuredRef)}`,
@@ -200,8 +205,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
     let file: GitHubContentResponse | GitHubContentResponse[] | undefined
     try {
       file = await requestGitHubJson<GitHubContentResponse | GitHubContentResponse[]>({
-        ref,
-        repo: options.repo,
+        operation: "read-metadata",
         signal,
         token,
         url: contentsUrl(repoPath, ref),
@@ -245,28 +249,30 @@ export function github<const TKey extends string = string>(options: GitHubSource
       )
 
   function isGitHubAccessError(error: unknown) {
-    return error instanceof SourceError && error.message.includes(" could not access the repository or ref ")
+    return error instanceof SourceError
+      && error.code === "SOURCE_PROVIDER_REQUEST_FAILED"
+      && error.details?.provider === "github"
+      && error.details.status === 404
   }
 
   async function loadFile(key: TKey, token = auth, signal?: AbortSignal): Promise<GitHubFile<TKey>> {
     const normalizedKey = normalizeSourcePath(key) as TKey
     if (!normalizedKey || !shouldInclude(normalizedKey)) {
-      throw new SourceError(`[vitehub] github(${JSON.stringify(options.repo)}) could not find ${JSON.stringify(key)}.`)
+      throw sourceItemNotFoundError("github", key)
     }
     const ref = await getRef(token, signal)
     const repoPath = repoPathForKey(normalizedKey)
     const file = await requestGitHubJson<GitHubContentResponse | GitHubContentResponse[]>({
-      ref,
-      repo: options.repo,
+      operation: "read-item",
       signal,
       token,
       url: contentsUrl(repoPath, ref),
     })
     if (Array.isArray(file) || file.type === "dir") {
-      throw new SourceError(`[vitehub] github(${JSON.stringify(options.repo)}) expected ${JSON.stringify(key)} to be a file, but it is a directory.`)
+      throw sourceItemIsDirectoryError("github", key)
     }
     if (file.encoding !== "base64" || typeof file.content !== "string") {
-      throw new SourceError(`[vitehub] github(${JSON.stringify(options.repo)}) did not include file content for ${JSON.stringify(key)}.`)
+      throw sourceContentMissingError("github", key)
     }
     return {
       content: new Uint8Array(Buffer.from(file.content.replace(/\s/g, ""), "base64")),
@@ -281,14 +287,14 @@ export function github<const TKey extends string = string>(options: GitHubSource
     if (ctx?.abortSignal) return await loadFile(key, token, ctx.abortSignal)
     const file = (await getFiles(token)).find(file => file.key === key)
     if (!file) {
-      throw new SourceError(`[vitehub] github(${JSON.stringify(options.repo)}) could not find ${JSON.stringify(key)}.`)
+      throw sourceItemNotFoundError("github", key)
     }
     return file
   }
 
   function fetchContent(key: TKey, file: GitHubFile<TKey>) {
     if (file.content) return Promise.resolve(file.content)
-    throw new SourceError(`[vitehub] github(${JSON.stringify(options.repo)}) did not include archive content for ${JSON.stringify(key)}.`)
+    throw sourceContentMissingError("github", key)
   }
 
   function cacheKey(kind: string, token: string, key = "") {

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -262,12 +262,22 @@ export function github<const TKey extends string = string>(options: GitHubSource
     }
     const ref = await getRef(token, signal)
     const repoPath = repoPathForKey(normalizedKey)
-    const file = await requestGitHubJson<GitHubContentResponse | GitHubContentResponse[]>({
-      operation: "read-item",
-      signal,
-      token,
-      url: contentsUrl(repoPath, ref),
-    })
+    let file: GitHubContentResponse | GitHubContentResponse[]
+    try {
+      file = await requestGitHubJson<GitHubContentResponse | GitHubContentResponse[]>({
+        operation: "read-item",
+        signal,
+        token,
+        url: contentsUrl(repoPath, ref),
+      })
+    }
+    catch (error) {
+      if (isGitHubAccessError(error)) {
+        await validateConfiguredRef(token, signal)
+        throw sourceItemNotFoundError("github", key)
+      }
+      throw error
+    }
     if (Array.isArray(file) || file.type === "dir") {
       throw sourceItemIsDirectoryError("github", key)
     }

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -21,6 +21,47 @@ function normalizeGitHubRoot(path = "") {
   return normalizeSourcePath(path).split("/").filter(part => part && part !== ".").join("/")
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readRequiredString(value: Record<string, unknown>, field: string): string {
+  const result = value[field]
+  if (typeof result !== "string" || !result) throw new TypeError(`GitHub response has an invalid ${field}.`)
+  return result
+}
+
+function decodeRepositoryResponse(value: unknown): GitHubRepositoryResponse {
+  if (!isRecord(value)) throw new TypeError("GitHub repository response must be an object.")
+  return { default_branch: readRequiredString(value, "default_branch") }
+}
+
+function decodeCommitResponse(value: unknown): GitHubCommitResponse {
+  if (!isRecord(value)) throw new TypeError("GitHub commit response must be an object.")
+  return { sha: readRequiredString(value, "sha") }
+}
+
+function decodeContentEntry(value: unknown): GitHubContentResponse {
+  if (!isRecord(value)) throw new TypeError("GitHub content response must be an object.")
+  const type = readRequiredString(value, "type")
+  for (const field of ["content", "encoding", "path", "sha"] as const) {
+    if (value[field] !== undefined && typeof value[field] !== "string") {
+      throw new TypeError(`GitHub content response has an invalid ${field}.`)
+    }
+  }
+  return {
+    ...(value.content === undefined ? {} : { content: value.content as string }),
+    ...(value.encoding === undefined ? {} : { encoding: value.encoding as string }),
+    ...(value.path === undefined ? {} : { path: value.path as string }),
+    ...(value.sha === undefined ? {} : { sha: value.sha as string }),
+    type,
+  }
+}
+
+function decodeContentResponse(value: unknown): GitHubContentResponse | GitHubContentResponse[] {
+  return Array.isArray(value) ? value.map(decodeContentEntry) : decodeContentEntry(value)
+}
+
 function dedupeProviderPromise<TResult>(
   promises: Map<string, Promise<TResult>>,
   key: string,
@@ -82,13 +123,15 @@ export function github<const TKey extends string = string>(options: GitHubSource
 
     try {
       const repo = await requestGitHubJson<GitHubRepositoryResponse>({
+        decode: decodeRepositoryResponse,
         operation: "resolve-repository",
         signal,
         token,
         url: `https://api.github.com/repos/${options.repo}`,
       })
-      const defaultBranch = repo.default_branch || "main"
+      const defaultBranch = repo.default_branch
       const commit = await requestGitHubJson<GitHubCommitResponse>({
+        decode: decodeCommitResponse,
         operation: "resolve-ref",
         signal,
         token,
@@ -132,6 +175,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
   async function validateConfiguredRef(token = auth, signal?: AbortSignal): Promise<void> {
     if (!configuredRef) return
     await requestGitHubJson<GitHubCommitResponse>({
+      decode: decodeCommitResponse,
       operation: "validate-ref",
       signal,
       token,
@@ -213,6 +257,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
     let file: GitHubContentResponse | GitHubContentResponse[] | undefined
     try {
       file = await requestGitHubJson<GitHubContentResponse | GitHubContentResponse[]>({
+        decode: decodeContentResponse,
         operation: "read-metadata",
         signal,
         token,
@@ -273,6 +318,7 @@ export function github<const TKey extends string = string>(options: GitHubSource
     let file: GitHubContentResponse | GitHubContentResponse[]
     try {
       file = await requestGitHubJson<GitHubContentResponse | GitHubContentResponse[]>({
+        decode: decodeContentResponse,
         operation: "read-item",
         signal,
         token,

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -6,6 +6,7 @@ import {
   sourceContentMissingError,
   sourceItemIsDirectoryError,
   sourceItemNotFoundError,
+  sourceProviderResponseInvalidError,
 } from "../../core/errors.ts"
 import { matchesAny, normalizeSourcePath } from "../../core/path.ts"
 import { parseGitHubArchive } from "./archive.ts"
@@ -141,7 +142,14 @@ export function github<const TKey extends string = string>(options: GitHubSource
   async function loadArchiveFiles(token = auth, signal?: AbortSignal, resolvedRef?: string) {
     const ref = resolvedRef ?? await getRef(token, signal)
     const archive = await fetchGitHubArchive({ ref, repo: options.repo, signal, token })
-    return parseGitHubArchive(archive)
+    let entries: ReturnType<typeof parseGitHubArchive>
+    try {
+      entries = parseGitHubArchive(archive)
+    }
+    catch (cause) {
+      throw sourceProviderResponseInvalidError("github", "read-archive", { cause })
+    }
+    return entries
       .map((entry): GitHubFile<TKey> | undefined => {
         const key = keyForRepoPath(entry.path)
         if (!key || !shouldInclude(key)) return undefined

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -62,6 +62,14 @@ function decodeContentResponse(value: unknown): GitHubContentResponse | GitHubCo
   return Array.isArray(value) ? value.map(decodeContentEntry) : decodeContentEntry(value)
 }
 
+function decodeBase64Content(value: string) {
+  const normalized = value.replace(/\s/g, "")
+  if (!/^(?:[A-Za-z\d+/]{4})*(?:[A-Za-z\d+/]{2}(?:==)?|[A-Za-z\d+/]{3}=?|)$/.test(normalized)) {
+    throw new TypeError("GitHub content response has invalid base64 content.")
+  }
+  return new Uint8Array(Buffer.from(normalized, "base64"))
+}
+
 function dedupeProviderPromise<TResult>(
   promises: Map<string, Promise<TResult>>,
   key: string,
@@ -338,8 +346,15 @@ export function github<const TKey extends string = string>(options: GitHubSource
     if (file.encoding !== "base64" || typeof file.content !== "string") {
       throw sourceContentMissingError("github", key)
     }
+    let content: Uint8Array
+    try {
+      content = decodeBase64Content(file.content)
+    }
+    catch (cause) {
+      throw sourceProviderResponseInvalidError("github", "read-item", { cause })
+    }
     return {
-      content: new Uint8Array(Buffer.from(file.content.replace(/\s/g, ""), "base64")),
+      content,
       key: normalizedKey,
       path: normalizedKey,
       ref,

--- a/packages/source/src/sources/glob.ts
+++ b/packages/source/src/sources/glob.ts
@@ -1,6 +1,6 @@
 import { glob as tinyglobby } from "tinyglobby"
 
-import { SourceError } from "../core/errors.ts"
+import { SourcePathError, sourceItemNotFoundError, sourceProviderRequestError } from "../core/errors.ts"
 import { matchesAny, normalizeSafeSourcePath, normalizeSourcePath } from "../core/path.ts"
 
 import type { Source, SourceContext, SourceItem } from "../core/types.ts"
@@ -26,13 +26,19 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
   async function loadKeys(ctx: SourceContext) {
     const cwd = await resolveCwd(resolveSourceRoot(ctx), options.cwd)
     const ignore = normalizePatterns(options.ignore)
-    const files = await tinyglobby(options.include, {
-      cwd,
-      dot: options.dot ?? false,
-      followSymbolicLinks: options.followSymlinks ?? false,
-      ignore: ["**/.git/**", "**/node_modules/**", ...ignore],
-      onlyFiles: true,
-    })
+    let files: string[]
+    try {
+      files = await tinyglobby(options.include, {
+        cwd,
+        dot: options.dot ?? false,
+        followSymbolicLinks: options.followSymlinks ?? false,
+        ignore: ["**/.git/**", "**/node_modules/**", ...ignore],
+        onlyFiles: true,
+      })
+    }
+    catch (cause) {
+      throw sourceProviderRequestError("filesystem", "list", { cause })
+    }
     return files
       .map(file => normalizeSourcePath(file))
       .filter(file => matchesAny(file, options.include) && !matchesAny(file, ignore))
@@ -70,10 +76,10 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
     const keys = await getKnownKeys(ctx)
     if (keys.includes(key)) return
     if (options.keyCache !== false) {
-      throw new SourceError(`[vitehub] glob could not find ${JSON.stringify(key)}.`)
+      throw sourceItemNotFoundError("glob", key)
     }
     if ((await refreshKeys(ctx)).includes(key)) return
-    throw new SourceError(`[vitehub] glob could not find ${JSON.stringify(key)}.`)
+    throw sourceItemNotFoundError("glob", key)
   }
 
   const source: Source<TKey> = {
@@ -90,7 +96,7 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
       const { stat } = await import("node:fs/promises")
       const { resolve } = await import("node:path")
       const cwd = await resolveCwd(resolveSourceRoot(ctx), options.cwd)
-      const info = await stat(resolve(cwd, key))
+      const info = await runFileOperation("metadata", key, () => stat(resolve(cwd, key)))
       return {
         digest: `${info.size}:${info.mtimeMs}`,
       }
@@ -101,8 +107,8 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
       const { resolve } = await import("node:path")
       const cwd = await resolveCwd(resolveSourceRoot(ctx), options.cwd)
       const prefix = normalizeSafeSourcePath(options.prefix || "", { allowEmpty: true })
-      const bytes = await readFile(resolve(cwd, key))
-      const info = await stat(resolve(cwd, key))
+      const bytes = await runFileOperation("read", key, () => readFile(resolve(cwd, key)))
+      const info = await runFileOperation("metadata", key, () => stat(resolve(cwd, key)))
       return {
         key,
         path: normalizeSourcePath(prefix ? `${prefix}/${key}` : key),
@@ -125,12 +131,36 @@ function resolveSourceRoot(ctx: SourceContext) {
 async function resolveCwd(rootDir: string, cwd = "."): Promise<string> {
   const { realpath } = await import("node:fs/promises")
   const { isAbsolute, relative, resolve } = await import("node:path")
-  const resolvedRoot = await realpath(resolve(rootDir))
+  let resolvedRoot: string
+  try {
+    resolvedRoot = await realpath(resolve(rootDir))
+  }
+  catch (cause) {
+    throw sourceProviderRequestError("filesystem", "resolve-root", { cause })
+  }
   const resolvedCwdPath = isAbsolute(cwd) ? resolve(cwd) : resolve(resolvedRoot, cwd)
-  const resolvedCwd = await realpath(resolvedCwdPath)
+  let resolvedCwd: string
+  try {
+    resolvedCwd = await realpath(resolvedCwdPath)
+  }
+  catch (cause) {
+    throw sourceProviderRequestError("filesystem", "resolve", { cause })
+  }
   const rel = relative(resolvedRoot, resolvedCwd)
   if (rel && (rel.startsWith("..") || isAbsolute(rel))) {
-    throw new SourceError(`[vitehub] glob cwd escapes the source root: ${JSON.stringify(cwd)}.`)
+    throw new SourcePathError(cwd)
   }
   return resolvedCwd
+}
+
+async function runFileOperation<TResult>(operation: string, key: string, run: () => Promise<TResult>): Promise<TResult> {
+  try {
+    return await run()
+  }
+  catch (cause) {
+    if (typeof cause === "object" && cause !== null && "code" in cause && cause.code === "ENOENT") {
+      throw sourceItemNotFoundError("glob", key)
+    }
+    throw sourceProviderRequestError("filesystem", operation, { cause })
+  }
 }

--- a/packages/source/src/sources/glob.ts
+++ b/packages/source/src/sources/glob.ts
@@ -3,6 +3,7 @@ import { glob as tinyglobby } from "tinyglobby"
 import { SourcePathError, sourceItemNotFoundError, sourceProviderRequestError } from "../core/errors.ts"
 import { matchesAny, normalizeSafeSourcePath, normalizeSourcePath } from "../core/path.ts"
 
+import type { SourceProviderOperation } from "../core/errors.ts"
 import type { Source, SourceContext, SourceItem } from "../core/types.ts"
 
 export interface GlobSourceOptions {
@@ -153,7 +154,7 @@ async function resolveCwd(rootDir: string, cwd = "."): Promise<string> {
   return resolvedCwd
 }
 
-async function runFileOperation<TResult>(operation: string, key: string, run: () => Promise<TResult>): Promise<TResult> {
+async function runFileOperation<TResult>(operation: SourceProviderOperation, key: string, run: () => Promise<TResult>): Promise<TResult> {
   try {
     return await run()
   }

--- a/packages/source/src/sources/mcp-resources.ts
+++ b/packages/source/src/sources/mcp-resources.ts
@@ -254,8 +254,12 @@ async function createEntries<TKey extends string>(
 }
 
 function decodeBase64(value: string) {
-  if (typeof Buffer !== "undefined") return new Uint8Array(Buffer.from(value, "base64"))
-  const binary = atob(value)
+  const normalized = value.replace(/\s/g, "")
+  if (!/^(?:[A-Za-z\d+/]{4})*(?:[A-Za-z\d+/]{2}(?:==)?|[A-Za-z\d+/]{3}=?|)$/.test(normalized)) {
+    throw new TypeError("[vitehub] MCP resource blob is not valid base64.")
+  }
+  if (typeof Buffer !== "undefined") return new Uint8Array(Buffer.from(normalized, "base64"))
+  const binary = atob(normalized)
   const bytes = new Uint8Array(binary.length)
   for (let index = 0; index < binary.length; index++) {
     bytes[index] = binary.charCodeAt(index)
@@ -263,10 +267,17 @@ function decodeBase64(value: string) {
   return bytes
 }
 
-function contentToSourceContent(content: McpResourceContent): SourceContent {
+function contentToSourceContent(content: McpResourceContent, key: string): SourceContent {
   if ("text" in content && typeof content.text === "string") return content.text
-  if ("blob" in content && typeof content.blob === "string") return decodeBase64(content.blob)
-  return ""
+  if ("blob" in content && typeof content.blob === "string") {
+    try {
+      return decodeBase64(content.blob)
+    }
+    catch {
+      throw sourceProviderResponseInvalidError("mcp", "read-resource", { cause: content, key })
+    }
+  }
+  throw sourceProviderResponseInvalidError("mcp", "read-resource", { cause: content, key })
 }
 
 function createResourceItem<TKey extends string>(
@@ -278,11 +289,12 @@ function createResourceItem<TKey extends string>(
   if (!content) {
     throw sourceProviderResponseInvalidError("mcp", "read-resource", { key })
   }
+  const sourceContents = contents.map(item => contentToSourceContent(item, key))
   const multipleContents = contents.length > 1
   return {
     key,
     path: key,
-    content: multipleContents ? JSON.stringify(contents, null, 2) : contentToSourceContent(content),
+    content: multipleContents ? JSON.stringify(contents, null, 2) : sourceContents[contents.indexOf(content)]!,
     mediaType: multipleContents ? "application/json" : content.mimeType || resource.mimeType,
     metadata: {
       description: resource.description,

--- a/packages/source/src/sources/mcp-resources.ts
+++ b/packages/source/src/sources/mcp-resources.ts
@@ -6,6 +6,7 @@ import {
 } from "../core/errors.ts"
 import { matchesAny, normalizeSafeSourcePath, normalizeSourcePath } from "../core/path.ts"
 
+import type { SourceProviderOperation } from "../core/errors.ts"
 import type { Source, SourceCacheOptions, SourceContent, SourceContext } from "../core/types.ts"
 import type { Client as SdkMcpClient } from "@modelcontextprotocol/sdk/client/index.js"
 import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js"
@@ -401,7 +402,7 @@ export function mcpResources<const TKey extends string = string>(options: McpRes
 }
 
 async function runMcpProviderOperation<TResult>(
-  operation: string,
+  operation: SourceProviderOperation,
   request: McpResourcesRequestOptions | undefined,
   signal: AbortSignal | undefined,
   run: () => Promise<TResult> | TResult,

--- a/packages/source/src/sources/mcp-resources.ts
+++ b/packages/source/src/sources/mcp-resources.ts
@@ -206,6 +206,12 @@ async function listAllResources(client: McpResourcesClient, request: McpResource
       signal,
       () => client.listResources(cursor ? { cursor } : undefined, request),
     )
+    if (!page || typeof page !== "object" || !Array.isArray(page.resources)) {
+      throw sourceProviderResponseInvalidError("mcp", "list-resources", { cause: page })
+    }
+    if (page.nextCursor !== undefined && typeof page.nextCursor !== "string") {
+      throw sourceProviderResponseInvalidError("mcp", "list-resources", { cause: page })
+    }
     resources.push(...page.resources)
     cursor = page.nextCursor
   } while (cursor)
@@ -224,6 +230,9 @@ async function readResourceContents(
     signal,
     () => client.readResource({ uri: resource.uri }, request),
   )
+  if (!response || typeof response !== "object" || !Array.isArray(response.contents)) {
+    throw sourceProviderResponseInvalidError("mcp", "read-resource", { cause: response })
+  }
   return response.contents
 }
 

--- a/packages/source/src/sources/mcp-resources.ts
+++ b/packages/source/src/sources/mcp-resources.ts
@@ -79,6 +79,28 @@ function isMcpTransport(value: unknown): value is Transport {
     && typeof (value as { start?: unknown }).start === "function"
 }
 
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string"
+}
+
+function isMcpResourceDescriptor(value: unknown): value is McpResourceDescriptor {
+  if (!value || typeof value !== "object") return false
+  const resource = value as Record<string, unknown>
+  return typeof resource.uri === "string"
+    && isOptionalString(resource.name)
+    && isOptionalString(resource.title)
+    && isOptionalString(resource.description)
+    && isOptionalString(resource.mimeType)
+    && (resource.size === undefined || typeof resource.size === "number")
+}
+
+function isMcpResourceContent(value: unknown): value is McpResourceContent {
+  if (!value || typeof value !== "object") return false
+  const content = value as Record<string, unknown>
+  return typeof content.uri === "string"
+    && isOptionalString(content.mimeType)
+}
+
 async function createMcpTransport(config: McpResourcesTransportConfig): Promise<Transport> {
   if (isMcpTransport(config)) return config
   const { type = "http", url, ...options } = config
@@ -206,7 +228,7 @@ async function listAllResources(client: McpResourcesClient, request: McpResource
       signal,
       () => client.listResources(cursor ? { cursor } : undefined, request),
     )
-    if (!page || typeof page !== "object" || !Array.isArray(page.resources)) {
+    if (!page || typeof page !== "object" || !Array.isArray(page.resources) || !page.resources.every(isMcpResourceDescriptor)) {
       throw sourceProviderResponseInvalidError("mcp", "list-resources", { cause: page })
     }
     if (page.nextCursor !== undefined && typeof page.nextCursor !== "string") {
@@ -230,7 +252,7 @@ async function readResourceContents(
     signal,
     () => client.readResource({ uri: resource.uri }, request),
   )
-  if (!response || typeof response !== "object" || !Array.isArray(response.contents)) {
+  if (!response || typeof response !== "object" || !Array.isArray(response.contents) || !response.contents.every(isMcpResourceContent)) {
     throw sourceProviderResponseInvalidError("mcp", "read-resource", { cause: response })
   }
   return response.contents

--- a/packages/source/src/sources/mcp-resources.ts
+++ b/packages/source/src/sources/mcp-resources.ts
@@ -1,4 +1,9 @@
-import { SourceError } from "../core/errors.ts"
+import {
+  SourceError,
+  sourceItemNotFoundError,
+  sourceProviderRequestError,
+  sourceProviderResponseInvalidError,
+} from "../core/errors.ts"
 import { matchesAny, normalizeSafeSourcePath, normalizeSourcePath } from "../core/path.ts"
 
 import type { Source, SourceCacheOptions, SourceContent, SourceContext } from "../core/types.ts"
@@ -84,26 +89,30 @@ async function createMcpTransport(config: McpResourcesTransportConfig): Promise<
   return new StreamableHTTPClientTransport(new URL(url), options)
 }
 
-async function createMcpClient(config: McpResourcesClientConfig): Promise<McpResourcesClient> {
-  const [{ Client }, transport] = await Promise.all([
-    import("@modelcontextprotocol/sdk/client/index.js"),
-    createMcpTransport(config.transport),
-  ])
-  const client = new Client({
-    name: "vitehub-source",
-    version: "0.0.1",
+async function createMcpClient(config: McpResourcesClientConfig, signal?: AbortSignal): Promise<McpResourcesClient> {
+  return await runMcpProviderOperation("connect", undefined, signal, async () => {
+    const [{ Client }, transport] = await Promise.all([
+      import("@modelcontextprotocol/sdk/client/index.js"),
+      createMcpTransport(config.transport),
+    ])
+    const client = new Client({
+      name: "vitehub-source",
+      version: "0.0.1",
+    })
+    await client.connect(transport)
+    return client
   })
-  await client.connect(transport)
-  return client
 }
 
 async function resolveMcpClient(server: McpResourcesServer, ctx: SourceContext) {
-  const resolved = typeof server === "function" ? await server(ctx) : server
+  const resolved = typeof server === "function"
+    ? await runMcpProviderOperation("resolve", undefined, ctx.abortSignal, () => server(ctx))
+    : server
   if (isMcpResourcesClient(resolved)) {
     return { client: resolved, ownsClient: false }
   }
   if (isMcpResourcesClientConfig(resolved)) {
-    return { client: await createMcpClient(resolved), ownsClient: true }
+    return { client: await createMcpClient(resolved, ctx.abortSignal), ownsClient: true }
   }
   throw new TypeError("[vitehub] mcpResources({ server }) must resolve to an MCP client or MCP client config.")
 }
@@ -114,7 +123,9 @@ async function withMcpClient<T>(server: McpResourcesServer, ctx: SourceContext, 
     return await callback(client)
   }
   finally {
-    if (ownsClient) await client.close?.()
+    if (ownsClient && client.close) {
+      await runMcpProviderOperation("close", undefined, ctx.abortSignal, () => client.close!())
+    }
   }
 }
 
@@ -184,11 +195,16 @@ function shouldInclude(path: string, options: Pick<McpResourcesSourceOptions, "i
   return true
 }
 
-async function listAllResources(client: McpResourcesClient, request: McpResourcesRequestOptions | undefined) {
+async function listAllResources(client: McpResourcesClient, request: McpResourcesRequestOptions | undefined, signal?: AbortSignal) {
   const resources: McpResourceDescriptor[] = []
   let cursor: string | undefined
   do {
-    const page = await client.listResources(cursor ? { cursor } : undefined, request)
+    const page = await runMcpProviderOperation(
+      "list-resources",
+      request,
+      signal,
+      () => client.listResources(cursor ? { cursor } : undefined, request),
+    )
     resources.push(...page.resources)
     cursor = page.nextCursor
   } while (cursor)
@@ -199,14 +215,22 @@ async function readResourceContents(
   client: McpResourcesClient,
   resource: McpResourceDescriptor,
   request: McpResourcesRequestOptions | undefined,
+  signal?: AbortSignal,
 ) {
-  return (await client.readResource({ uri: resource.uri }, request)).contents
+  const response = await runMcpProviderOperation(
+    "read-resource",
+    request,
+    signal,
+    () => client.readResource({ uri: resource.uri }, request),
+  )
+  return response.contents
 }
 
 async function createEntries<TKey extends string>(
   resources: McpResourceDescriptor[],
   options: McpResourcesSourceOptions<TKey>,
   client?: McpResourcesClient,
+  signal?: AbortSignal,
 ) {
   const entries: ResourceEntry<TKey>[] = []
   const seen = new Map<string, string>()
@@ -214,14 +238,14 @@ async function createEntries<TKey extends string>(
     let contents: McpResourceContent[] | undefined
     let resolvedResource = resource
     if (client && resourcePathNeedsContentMimeType(resource, options)) {
-      contents = await readResourceContents(client, resource, options.request)
+      contents = await readResourceContents(client, resource, options.request, signal)
       resolvedResource = resourceWithContentMimeType(resource, contents)
     }
     const key = resourceKey(resolvedResource, options)
     if (!shouldInclude(key, options)) continue
     const existingUri = seen.get(key)
     if (existingUri) {
-      throw new SourceError(`[vitehub] mcpResources produced duplicate path ${JSON.stringify(key)} for ${JSON.stringify(existingUri)} and ${JSON.stringify(resource.uri)}.`)
+      throw sourceProviderResponseInvalidError("mcp", "list-resources", { key })
     }
     seen.set(key, resource.uri)
     entries.push({ contents, key, resource: resolvedResource })
@@ -252,7 +276,7 @@ function createResourceItem<TKey extends string>(
 ) {
   const content = contents.find(item => item.uri === resource.uri) || contents[0]
   if (!content) {
-    throw new SourceError(`[vitehub] mcpResources could not read resource ${JSON.stringify(resource.uri)}.`)
+    throw sourceProviderResponseInvalidError("mcp", "read-resource", { key })
   }
   const multipleContents = contents.length > 1
   return {
@@ -278,15 +302,15 @@ export function mcpResources<const TKey extends string = string>(options: McpRes
 
   async function getEntries(ctx: SourceContext) {
     return await withMcpClient(options.server, ctx, async (client) => {
-      return await createEntries(await listAllResources(client, options.request), options, client)
+      return await createEntries(await listAllResources(client, options.request, ctx.abortSignal), options, client, ctx.abortSignal)
     })
   }
 
   async function getItems(ctx: SourceContext) {
     return await withMcpClient(options.server, ctx, async (client) => {
-      const entries = await createEntries(await listAllResources(client, options.request), options, client)
+      const entries = await createEntries(await listAllResources(client, options.request, ctx.abortSignal), options, client, ctx.abortSignal)
       return await Promise.all(entries.map(async ({ contents, key, resource }) => {
-        const result = contents ?? await readResourceContents(client, resource, options.request)
+        const result = contents ?? await readResourceContents(client, resource, options.request, ctx.abortSignal)
         return createResourceItem(key, resource, result)
       }))
     })
@@ -324,11 +348,16 @@ export function mcpResources<const TKey extends string = string>(options: McpRes
     },
     async getItem(key, ctx) {
       return await withMcpClient(options.server, ctx, async (client) => {
-        const entry = (await createEntries(await listAllResources(client, options.request), options, client)).find(entry => entry.key === key)
+        const entry = (await createEntries(
+          await listAllResources(client, options.request, ctx.abortSignal),
+          options,
+          client,
+          ctx.abortSignal,
+        )).find(entry => entry.key === key)
         if (!entry) {
-          throw new SourceError(`[vitehub] mcpResources could not find ${JSON.stringify(key)}.`)
+          throw sourceItemNotFoundError("mcpResources", key)
         }
-        const result = entry.contents ?? await readResourceContents(client, entry.resource, options.request)
+        const result = entry.contents ?? await readResourceContents(client, entry.resource, options.request, ctx.abortSignal)
         return createResourceItem(key, entry.resource, result)
       })
     },
@@ -356,5 +385,22 @@ export function mcpResources<const TKey extends string = string>(options: McpRes
       }
       return results
     },
+  }
+}
+
+async function runMcpProviderOperation<TResult>(
+  operation: string,
+  request: McpResourcesRequestOptions | undefined,
+  signal: AbortSignal | undefined,
+  run: () => Promise<TResult> | TResult,
+): Promise<TResult> {
+  try {
+    return await run()
+  }
+  catch (cause) {
+    if (signal?.aborted) throw signal.reason
+    if (request?.signal?.aborted) throw request.signal.reason
+    if (cause instanceof SourceError) throw cause
+    throw sourceProviderRequestError("mcp", operation, { cause })
   }
 }

--- a/packages/source/test/errors.test.ts
+++ b/packages/source/test/errors.test.ts
@@ -113,4 +113,17 @@ describe("@vite-hub/source public errors", () => {
     })
     expect(JSON.stringify([source, path])).not.toMatch(/secret-token|provider\.example|\/Users\/private|\.env/)
   })
+
+  it("omits overlong identifiers before constructing public errors", () => {
+    const error = new SourceError({
+      code: "SOURCE_ITEM_NOT_FOUND",
+      details: { key: "a".repeat(20_000), source: "docs" },
+    })
+
+    expect(error.toJSON()).toEqual({
+      code: "SOURCE_ITEM_NOT_FOUND",
+      details: { source: "docs" },
+      message: "[vitehub] docs could not find the requested item.",
+    })
+  })
 })

--- a/packages/source/test/errors.test.ts
+++ b/packages/source/test/errors.test.ts
@@ -39,6 +39,46 @@ describe("@vite-hub/source public errors", () => {
     })
   })
 
+  it("rejects unknown codes in both constructor forms", () => {
+    expect(() => new SourceError({
+      code: "Bearer secret-token at https://provider.example/private" as never,
+      message: "Provider failed.",
+    })).toThrow(new TypeError("[vitehub] Invalid Source error code."))
+    expect(() => new SourceError("Provider failed.", {
+      code: "Bearer secret-token at https://provider.example/private" as never,
+    })).toThrow(new TypeError("[vitehub] Invalid Source error code."))
+  })
+
+  it("allows only observed provider details at runtime", () => {
+    const error = new SourceError({
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: {
+        operation: "read-item",
+        provider: "github",
+        token: "secret-token",
+      } as never,
+      message: "Provider failed.",
+    })
+
+    expect(error.toJSON()).toEqual({
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "read-item", provider: "github" },
+      message: "Provider failed.",
+    })
+    for (const [code, details] of [
+      ["SOURCE_PROVIDER_REQUEST_FAILED", { operation: "Bearer secret-token at https://provider.example/private", provider: "github" }],
+      ["SOURCE_PROVIDER_REQUEST_FAILED", { operation: "read-item", provider: "private-provider" }],
+      ["SOURCE_PROVIDER_REQUEST_FAILED", { operation: "read-item", provider: "github", status: 99 }],
+      ["SOURCE_PATH_INVALID", { field: "path", valueType: "private-value-type" }],
+    ] as const) {
+      expect(() => new SourceError({
+        code: code as never,
+        details: details as never,
+        message: "Provider failed.",
+      })).toThrow(new TypeError("[vitehub] Invalid Source error details."))
+    }
+  })
+
   it("omits unsafe source names and paths from serialized errors", () => {
     const source = new SourceNotFoundError("https://user:secret-token@provider.example/private")
     const path = new SourcePathError("/Users/private/project/.env")

--- a/packages/source/test/errors.test.ts
+++ b/packages/source/test/errors.test.ts
@@ -27,16 +27,35 @@ describe("@vite-hub/source public errors", () => {
   })
 
   it("retains positional construction compatibility", () => {
-    const error = new SourceError("Missing source item", {
+    const cause = new Error("Bearer secret-token")
+    const error = new SourceError("Bearer secret-token", {
+      cause,
       code: "SOURCE_ITEM_NOT_FOUND",
       details: { key: "README.md", source: "docs" },
     })
 
+    expect(error.cause).toBe(cause)
     expect(error.toJSON()).toEqual({
       code: "SOURCE_ITEM_NOT_FOUND",
       details: { key: "README.md", source: "docs" },
-      message: "Missing source item",
+      message: "[vitehub] docs could not find \"README.md\".",
     })
+    expect(JSON.stringify(error)).not.toContain("secret-token")
+  })
+
+  it("derives object-constructor messages from safe code-owned context", () => {
+    const error = new SourceError({
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "read", provider: "custom" },
+      message: "Bearer secret-token at https://provider.example/private",
+    })
+
+    expect(error.toJSON()).toEqual({
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "read", provider: "custom" },
+      message: "[vitehub] custom source request failed during read.",
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|provider\.example/)
   })
 
   it("rejects unknown codes in both constructor forms", () => {
@@ -63,7 +82,7 @@ describe("@vite-hub/source public errors", () => {
     expect(error.toJSON()).toEqual({
       code: "SOURCE_PROVIDER_REQUEST_FAILED",
       details: { operation: "read-item", provider: "github" },
-      message: "Provider failed.",
+      message: "[vitehub] github source request failed during read-item.",
     })
     for (const [code, details] of [
       ["SOURCE_PROVIDER_REQUEST_FAILED", { operation: "Bearer secret-token at https://provider.example/private", provider: "github" }],

--- a/packages/source/test/errors.test.ts
+++ b/packages/source/test/errors.test.ts
@@ -1,0 +1,43 @@
+import { ViteHubError } from "@vite-hub/runtime"
+import { describe, expect, it } from "vitest"
+
+import { SourceError, SourceNotFoundError, SourcePathError } from "../src/index.ts"
+
+describe("@vite-hub/source public errors", () => {
+  it("serializes stable fields without internal causes or stacks", () => {
+    const cause = new Error("authorization=Bearer secret-token at https://provider.example/private")
+    const error = new SourceError("[vitehub] github source request failed during read-item.", {
+      cause,
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "read-item", provider: "github", status: 503 },
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(ViteHubError)
+    expect(error.cause).toBe(cause)
+    expect(error.toJSON()).toEqual({
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "read-item", provider: "github", status: 503 },
+      message: "[vitehub] github source request failed during read-item.",
+    })
+    expect(JSON.stringify(error)).not.toContain("secret-token")
+    expect(JSON.stringify(error)).not.toContain("provider.example")
+    expect(JSON.stringify(error)).not.toContain("stack")
+  })
+
+  it("omits unsafe source names and paths from serialized errors", () => {
+    const source = new SourceNotFoundError("https://user:secret-token@provider.example/private")
+    const path = new SourcePathError("/Users/private/project/.env")
+
+    expect(source.toJSON()).toEqual({
+      code: "SOURCE_NOT_FOUND",
+      message: "[vitehub] Source is not registered.",
+    })
+    expect(path.toJSON()).toEqual({
+      code: "SOURCE_PATH_INVALID",
+      details: { field: "path", valueType: "string" },
+      message: "[vitehub] Source path escapes the source root.",
+    })
+    expect(JSON.stringify([source, path])).not.toMatch(/secret-token|provider\.example|\/Users\/private|\.env/)
+  })
+})

--- a/packages/source/test/errors.test.ts
+++ b/packages/source/test/errors.test.ts
@@ -6,10 +6,11 @@ import { SourceError, SourceNotFoundError, SourcePathError } from "../src/index.
 describe("@vite-hub/source public errors", () => {
   it("serializes stable fields without internal causes or stacks", () => {
     const cause = new Error("authorization=Bearer secret-token at https://provider.example/private")
-    const error = new SourceError("[vitehub] github source request failed during read-item.", {
+    const error = new SourceError({
       cause,
       code: "SOURCE_PROVIDER_REQUEST_FAILED",
       details: { operation: "read-item", provider: "github", status: 503 },
+      message: "[vitehub] github source request failed during read-item.",
     })
 
     expect(error).toBeInstanceOf(Error)
@@ -23,6 +24,19 @@ describe("@vite-hub/source public errors", () => {
     expect(JSON.stringify(error)).not.toContain("secret-token")
     expect(JSON.stringify(error)).not.toContain("provider.example")
     expect(JSON.stringify(error)).not.toContain("stack")
+  })
+
+  it("retains positional construction compatibility", () => {
+    const error = new SourceError("Missing source item", {
+      code: "SOURCE_ITEM_NOT_FOUND",
+      details: { key: "README.md", source: "docs" },
+    })
+
+    expect(error.toJSON()).toEqual({
+      code: "SOURCE_ITEM_NOT_FOUND",
+      details: { key: "README.md", source: "docs" },
+      message: "Missing source item",
+    })
   })
 
   it("omits unsafe source names and paths from serialized errors", () => {

--- a/packages/source/test/published-types.test.ts
+++ b/packages/source/test/published-types.test.ts
@@ -36,7 +36,7 @@ it("publishes the Source error contract to installed consumers", async () => {
   finally {
     await rm(root, { force: true, recursive: true })
   }
-})
+}, 15_000)
 
 it("keeps Effect out of Source declarations and runtime bundles", async () => {
   const files = await listFiles(join(packageRoot, "dist"))

--- a/packages/source/test/published-types.test.ts
+++ b/packages/source/test/published-types.test.ts
@@ -12,6 +12,8 @@ const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const repositoryRoot = resolve(packageRoot, "../..")
 const fixtureRoot = join(packageRoot, "fixtures", "published-types")
 const tsc = resolve(repositoryRoot, "node_modules/typescript/bin/tsc")
+const processTimeout = 15_000
+const testTimeout = 45_000
 
 it("publishes the Source error contract to installed consumers", async () => {
   const root = await mkdtemp(join(tmpdir(), "vitehub-source-types-"))
@@ -29,7 +31,7 @@ it("publishes the Source error contract to installed consumers", async () => {
   finally {
     await rm(root, { force: true, recursive: true })
   }
-}, 15_000)
+}, testTimeout)
 
 it("keeps Effect out of Source declarations and runtime bundles", async () => {
   const files = await listFiles(join(packageRoot, "dist"))
@@ -52,7 +54,11 @@ it("keeps Effect out of Source declarations and runtime bundles", async () => {
 
 async function run(command: string, args: string[], cwd: string) {
   try {
-    return await execFileAsync(command, args, { cwd })
+    return await execFileAsync(command, args, {
+      cwd,
+      killSignal: "SIGKILL",
+      timeout: processTimeout,
+    })
   }
   catch (error) {
     const output = error as Error & { stderr?: string, stdout?: string }

--- a/packages/source/test/published-types.test.ts
+++ b/packages/source/test/published-types.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process"
-import { copyFile, cp, mkdir, mkdtemp, readdir, readFile, realpath, rm, symlink } from "node:fs/promises"
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, extname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -18,20 +18,13 @@ it("publishes the Source error contract to installed consumers", async () => {
 
   try {
     await cp(fixtureRoot, root, { recursive: true })
-    await installBuiltPackage(root, "source")
-    await installBuiltPackage(root, "runtime")
-    const sdkRoot = await realpath(join(packageRoot, "node_modules", "@modelcontextprotocol", "sdk"))
-    const sdkInstallRoot = join(root, "node_modules", "@modelcontextprotocol", "sdk")
-    await mkdir(dirname(sdkInstallRoot), { recursive: true })
-    await symlink(sdkRoot, sdkInstallRoot, "dir")
+    const packDir = join(root, "packs")
+    await mkdir(packDir)
+    const specs = await packWorkspacePackages(packDir, ["@vite-hub/runtime", "@vite-hub/source"])
+    await writeFile(join(root, "pnpm-workspace.yaml"), workspaceConfig(specs), "utf8")
+    await run("vp", ["exec", "pnpm", "install", "--prefer-offline", "--ignore-scripts", "--strict-peer-dependencies"], root)
 
-    try {
-      await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", root])
-    }
-    catch (error) {
-      const output = error as { stderr?: string, stdout?: string }
-      throw new Error([output.stdout, output.stderr].filter(Boolean).join("\n"), { cause: error })
-    }
+    await run(process.execPath, [tsc, "--noEmit", "-p", root], root)
   }
   finally {
     await rm(root, { force: true, recursive: true })
@@ -57,12 +50,35 @@ it("keeps Effect out of Source declarations and runtime bundles", async () => {
   expect(pkg.dependencies?.effect).toBeUndefined()
 })
 
-async function installBuiltPackage(root: string, name: "runtime" | "source") {
-  const sourceRoot = resolve(repositoryRoot, "packages", name)
-  const installedRoot = join(root, "node_modules", "@vite-hub", name)
-  await mkdir(installedRoot, { recursive: true })
-  await copyFile(join(sourceRoot, "package.json"), join(installedRoot, "package.json"))
-  await cp(join(sourceRoot, "dist"), join(installedRoot, "dist"), { recursive: true })
+async function run(command: string, args: string[], cwd: string) {
+  try {
+    return await execFileAsync(command, args, { cwd })
+  }
+  catch (error) {
+    const output = error as Error & { stderr?: string, stdout?: string }
+    throw new Error([output.message, output.stdout, output.stderr].filter(Boolean).join("\n"), { cause: error })
+  }
+}
+
+async function packWorkspacePackages(packDir: string, packageNames: string[]) {
+  const specs: Record<string, string> = {}
+  for (const packageName of packageNames) {
+    const packagePath = join(repositoryRoot, "packages", packageName.slice("@vite-hub/".length))
+    const manifest = JSON.parse(await readFile(join(packagePath, "package.json"), "utf8")) as { version: string }
+    await run("vp", ["exec", "pnpm", "--filter", packageName, "pack", "--pack-destination", packDir], repositoryRoot)
+    specs[packageName] = `file:${join(packDir, `${packageName.replace(/^@/, "").replaceAll("/", "-")}-${manifest.version}.tgz`)}`
+  }
+  return specs
+}
+
+function workspaceConfig(specs: Record<string, string>) {
+  return [
+    "packages:",
+    "  - .",
+    "overrides:",
+    ...Object.entries(specs).map(([name, spec]) => `  ${JSON.stringify(name)}: ${JSON.stringify(spec)}`),
+    "",
+  ].join("\n")
 }
 
 async function listFiles(root: string): Promise<string[]> {

--- a/packages/source/test/published-types.test.ts
+++ b/packages/source/test/published-types.test.ts
@@ -1,0 +1,74 @@
+import { execFile } from "node:child_process"
+import { copyFile, cp, mkdir, mkdtemp, readdir, readFile, realpath, rm, symlink } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, extname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { expect, it } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const repositoryRoot = resolve(packageRoot, "../..")
+const fixtureRoot = join(packageRoot, "fixtures", "published-types")
+const tsc = resolve(repositoryRoot, "node_modules/typescript/bin/tsc")
+
+it("publishes the Source error contract to installed consumers", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-source-types-"))
+
+  try {
+    await cp(fixtureRoot, root, { recursive: true })
+    await installBuiltPackage(root, "source")
+    await installBuiltPackage(root, "runtime")
+    const sdkRoot = await realpath(join(packageRoot, "node_modules", "@modelcontextprotocol", "sdk"))
+    const sdkInstallRoot = join(root, "node_modules", "@modelcontextprotocol", "sdk")
+    await mkdir(dirname(sdkInstallRoot), { recursive: true })
+    await symlink(sdkRoot, sdkInstallRoot, "dir")
+
+    try {
+      await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", root])
+    }
+    catch (error) {
+      const output = error as { stderr?: string, stdout?: string }
+      throw new Error([output.stdout, output.stderr].filter(Boolean).join("\n"), { cause: error })
+    }
+  }
+  finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})
+
+it("keeps Effect out of Source declarations and runtime bundles", async () => {
+  const files = await listFiles(join(packageRoot, "dist"))
+  const declarations = files.filter(file => file.endsWith(".d.ts"))
+  const runtimeFiles = files.filter(file => extname(file) === ".js")
+  const effectReference = /(?:from\s+|import\s*\()(["'])effect(?:\/[^"']*)?\1/
+
+  expect(declarations.length).toBeGreaterThan(0)
+  expect(runtimeFiles.length).toBeGreaterThan(0)
+
+  for (const file of [...declarations, ...runtimeFiles]) {
+    expect(await readFile(file, "utf8"), file).not.toMatch(effectReference)
+  }
+
+  const pkg = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")) as {
+    dependencies?: Record<string, string>
+  }
+  expect(pkg.dependencies?.effect).toBeUndefined()
+})
+
+async function installBuiltPackage(root: string, name: "runtime" | "source") {
+  const sourceRoot = resolve(repositoryRoot, "packages", name)
+  const installedRoot = join(root, "node_modules", "@vite-hub", name)
+  await mkdir(installedRoot, { recursive: true })
+  await copyFile(join(sourceRoot, "package.json"), join(installedRoot, "package.json"))
+  await cp(join(sourceRoot, "dist"), join(installedRoot, "dist"), { recursive: true })
+}
+
+async function listFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true })
+  return (await Promise.all(entries.map(async (entry) => {
+    const path = join(root, entry.name)
+    return entry.isDirectory() ? await listFiles(path) : [path]
+  }))).flat()
+}

--- a/packages/source/test/registry.test.ts
+++ b/packages/source/test/registry.test.ts
@@ -65,4 +65,21 @@ describe("@vite-hub/source registry", () => {
 
     expect(receivedSignal).toBe(controller.signal)
   })
+
+  it("preserves errors thrown by custom Sources", async () => {
+    const failure = new Error("custom source failure")
+    registerSources({
+      custom: custom({
+        name: "custom",
+        async getKeys() {
+          throw failure
+        },
+        async getItem(key) {
+          return { key }
+        },
+      }),
+    })
+
+    await expect(useSource("custom").keys()).rejects.toBe(failure)
+  })
 })

--- a/packages/source/test/sources/file-glob-markdown.test.ts
+++ b/packages/source/test/sources/file-glob-markdown.test.ts
@@ -42,6 +42,17 @@ describe("@vite-hub/source local file sources", () => {
     })
   })
 
+  it("reports directories through the public item contract", async () => {
+    const root = await createRoot()
+    await mkdir(join(root, "docs"), { recursive: true })
+    const docs = file("docs")
+
+    await expect(docs.getItem("docs", { rootDir: root })).rejects.toMatchObject({
+      code: "SOURCE_ITEM_IS_DIRECTORY",
+      details: { key: "docs", source: "file" },
+    })
+  })
+
   it("loads file, markdown, and glob providers", async () => {
     const root = await createRoot()
     await mkdir(join(root, "docs"), { recursive: true })

--- a/packages/source/test/sources/file-glob-markdown.test.ts
+++ b/packages/source/test/sources/file-glob-markdown.test.ts
@@ -136,9 +136,9 @@ describe("@vite-hub/source local file sources", () => {
       "README.md",
     ])
     await expect(glob({ cwd: outside, include: "**/*.md" }).getKeys({ rootDir: root }))
-      .rejects.toThrow("glob cwd escapes the source root")
+      .rejects.toThrow("Source path escapes the source root")
     await expect(glob({ cwd: "workspace/outside", include: "**/*.md" }).getKeys({ rootDir: root }))
-      .rejects.toThrow("glob cwd escapes the source root")
+      .rejects.toThrow("Source path escapes the source root")
   })
 
   it("rejects file provider symlinks that escape the source root", async () => {
@@ -152,5 +152,19 @@ describe("@vite-hub/source local file sources", () => {
 
     await expect(readme.getItem("linked.md", { rootDir: root })).rejects.toThrow("Source path escapes the source root")
     await expect(readme.getMeta?.("linked.md", { rootDir: root })).rejects.toThrow("Source path escapes the source root")
+  })
+
+  it("does not serialize unsafe requested file keys", async () => {
+    const readme = file({ content: "# Docs\n", workspacePath: "README.md" })
+    const error = await readme.getItem(
+      "https://user:secret-token@provider.example/private" as "README.md",
+      { rootDir: process.cwd() },
+    ).catch(error => error)
+
+    expect(error).toMatchObject({
+      code: "SOURCE_ITEM_NOT_FOUND",
+      details: { source: "file" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|provider\.example|https:/)
   })
 })

--- a/packages/source/test/sources/file-glob-markdown.test.ts
+++ b/packages/source/test/sources/file-glob-markdown.test.ts
@@ -53,6 +53,17 @@ describe("@vite-hub/source local file sources", () => {
     })
   })
 
+  it("preserves invalid backing paths as Source path errors", async () => {
+    const source = file({ path: "../secret", workspacePath: "safe.txt" })
+
+    await expect(source.getItem("safe.txt", { rootDir: await createRoot() })).rejects.toMatchObject({
+      code: "SOURCE_PATH_INVALID",
+    })
+    await expect(source.getMeta?.("safe.txt", { rootDir: await createRoot() })).rejects.toMatchObject({
+      code: "SOURCE_PATH_INVALID",
+    })
+  })
+
   it("loads file, markdown, and glob providers", async () => {
     const root = await createRoot()
     await mkdir(join(root, "docs"), { recursive: true })

--- a/packages/source/test/sources/github-git.test.ts
+++ b/packages/source/test/sources/github-git.test.ts
@@ -127,12 +127,13 @@ describe("@vite-hub/source GitHub git materialization", () => {
   })
 
   it("propagates aborts and removes the temporary checkout", async () => {
+    const reason = new Error("caller stopped sparse checkout")
     const controller = new AbortController()
     let checkoutDir: string | undefined
     const runGit: NonNullable<Parameters<typeof loadGitArchiveFiles>[1]> = async (args) => {
       checkoutDir = args.at(-1)
-      controller.abort()
-      throw controller.signal.reason
+      controller.abort(reason)
+      throw new Error("git abort wrapper")
     }
 
     await expect(loadGitArchiveFiles({
@@ -142,7 +143,7 @@ describe("@vite-hub/source GitHub git materialization", () => {
       shouldInclude: () => true,
       signal: controller.signal,
       sparsePatterns: ["docs/**"],
-    }, runGit)).rejects.toMatchObject({ name: "AbortError" })
+    }, runGit)).rejects.toBe(reason)
 
     if (!checkoutDir) throw new Error("Expected git init to receive the temporary checkout path.")
     await expect(access(checkoutDir)).rejects.toMatchObject({ code: "ENOENT" })

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -454,6 +454,47 @@ describe("@vite-hub/source GitHub source", () => {
     expect(JSON.stringify(error)).not.toMatch(/secret-token|api\.github\.com|private\/repo/)
   })
 
+  it("maps malformed GitHub repository bodies inside the provider boundary", async () => {
+    const providerBody = { default_branch: { secret: "repository-token" } }
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(providerBody)))
+    const docs = github({ repo: "private/repo" })
+
+    const error = await docs.getKeys({ rootDir: process.cwd() }).catch(error => error)
+
+    expect(error).toBeInstanceOf(SourceError)
+    expect(error).toMatchObject({
+      cause: expect.any(TypeError),
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: { operation: "resolve-repository", provider: "github" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/repository-token|private\/repo|cause|stack/)
+  })
+
+  it("maps malformed GitHub content bodies inside the provider boundary", async () => {
+    const providerBody = {
+      content: { secret: "content-token" },
+      encoding: "base64",
+      path: "README.md",
+      sha: "sha-readme",
+      type: "file",
+    }
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(providerBody)))
+    const docs = github({ ref: "main", repo: "private/repo" })
+
+    const error = await docs.getItem("README.md", {
+      abortSignal: new AbortController().signal,
+      rootDir: process.cwd(),
+    }).catch(error => error)
+
+    expect(error).toBeInstanceOf(SourceError)
+    expect(error).toMatchObject({
+      cause: expect.any(TypeError),
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: { operation: "read-item", provider: "github" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/content-token|private\/repo|cause|stack/)
+  })
+
   it("maps corrupt GitHub archives without serializing parser failures", async () => {
     const causeText = "secret-token from https://codeload.github.com/private/repo"
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(causeText, { status: 200 })))

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -454,6 +454,22 @@ describe("@vite-hub/source GitHub source", () => {
     expect(JSON.stringify(error)).not.toMatch(/secret-token|api\.github\.com|private\/repo/)
   })
 
+  it("maps corrupt GitHub archives without serializing parser failures", async () => {
+    const causeText = "secret-token from https://codeload.github.com/private/repo"
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(causeText, { status: 200 })))
+    const docs = github({ auth: () => "secret-token", ref: "main", repo: "private/repo" })
+
+    const error = await docs.getKeys({ rootDir: process.cwd() }).catch(error => error)
+
+    expect(error).toBeInstanceOf(SourceError)
+    expect(error).toMatchObject({
+      cause: expect.any(Error),
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: { operation: "read-archive", provider: "github" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|codeload\.github\.com|private\/repo|stack/)
+  })
+
   it("preserves raw GitHub abort reasons", async () => {
     const reason = new Error("caller stopped GitHub read")
     const controller = new AbortController()

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -1,7 +1,7 @@
 import { createMemoryStorage, setStorage } from "ocache"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { clearSources, github, registerSources, useSource } from "../../src/index.ts"
+import { clearSources, github, registerSources, SourceError, useSource } from "../../src/index.ts"
 import { createTarGz, jsonResponse, stubGitHubSource } from "./fixtures/github.ts"
 
 const loadGitArchiveFiles = vi.hoisted(() => vi.fn())
@@ -307,8 +307,10 @@ describe("@vite-hub/source GitHub source", () => {
 
     const docs = github({ ref: "missing-ref", repo: "acme/app", root: "docs" })
 
-    await expect(docs.getMeta?.("README.md", { rootDir: process.cwd() }))
-      .rejects.toThrow("could not access the repository or ref")
+    await expect(docs.getMeta?.("README.md", { rootDir: process.cwd() })).rejects.toMatchObject({
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "validate-ref", provider: "github", status: 404 },
+    })
   })
 
   it("returns missing GitHub metadata from the abort-signal contents path after validating the ref", async () => {
@@ -345,7 +347,80 @@ describe("@vite-hub/source GitHub source", () => {
     await expect(docs.getMeta?.("README.md", {
       abortSignal: new AbortController().signal,
       rootDir: process.cwd(),
-    })).rejects.toThrow("could not access the repository or ref")
+    })).rejects.toMatchObject({
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "validate-ref", provider: "github", status: 404 },
+    })
+  })
+
+  it("redacts GitHub transport failures while retaining the internal cause", async () => {
+    const cause = new Error("Bearer secret-token failed at https://api.github.com/repos/private/repo")
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(cause))
+    const docs = github({ auth: () => "secret-token", ref: "main", repo: "private/repo" })
+
+    const error = await docs.getItem("README.md", {
+      abortSignal: new AbortController().signal,
+      rootDir: process.cwd(),
+    }).catch(error => error)
+
+    expect(error).toBeInstanceOf(SourceError)
+    expect(error).toMatchObject({
+      cause,
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "read-item", provider: "github" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|api\.github\.com|private\/repo/)
+  })
+
+  it("serializes GitHub status failures without response bodies or request URLs", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(
+      "secret-token from https://api.github.com/repos/private/repo",
+      { status: 503 },
+    )))
+    const docs = github({ auth: () => "secret-token", ref: "main", repo: "private/repo" })
+
+    const error = await docs.getItem("README.md", {
+      abortSignal: new AbortController().signal,
+      rootDir: process.cwd(),
+    }).catch(error => error)
+
+    expect(error).toMatchObject({
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "read-item", provider: "github", status: 503 },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|api\.github\.com|private\/repo/)
+  })
+
+  it("maps invalid GitHub responses without serializing provider content", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(
+      "secret-token from https://api.github.com/repos/private/repo",
+      { status: 200 },
+    )))
+    const docs = github({ auth: () => "secret-token", ref: "main", repo: "private/repo" })
+
+    const error = await docs.getItem("README.md", {
+      abortSignal: new AbortController().signal,
+      rootDir: process.cwd(),
+    }).catch(error => error)
+
+    expect(error).toMatchObject({
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: { operation: "read-item", provider: "github" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|api\.github\.com|private\/repo/)
+  })
+
+  it("preserves raw GitHub abort reasons", async () => {
+    const reason = new Error("caller stopped GitHub read")
+    const controller = new AbortController()
+    controller.abort(reason)
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("provider abort wrapper")))
+    const docs = github({ ref: "main", repo: "acme/app" })
+
+    await expect(docs.getItem("README.md", {
+      abortSignal: controller.signal,
+      rootDir: process.cwd(),
+    })).rejects.toBe(reason)
   })
 
   it("reads non-ASCII paths from GitHub archive PAX headers", async () => {

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -495,6 +495,28 @@ describe("@vite-hub/source GitHub source", () => {
     expect(JSON.stringify(error)).not.toMatch(/content-token|private\/repo|cause|stack/)
   })
 
+  it("maps malformed GitHub base64 content inside the provider boundary", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({
+      content: "%%% secret-token",
+      encoding: "base64",
+      path: "README.md",
+      sha: "sha-readme",
+      type: "file",
+    })))
+    const docs = github({ ref: "main", repo: "private/repo" })
+
+    const error = await docs.getItem("README.md", {
+      abortSignal: new AbortController().signal,
+      rootDir: process.cwd(),
+    }).catch(error => error)
+
+    expect(error).toMatchObject({
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: { operation: "read-item", provider: "github" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|private\/repo|cause|stack/)
+  })
+
   it("maps corrupt GitHub archives without serializing parser failures", async () => {
     const causeText = "secret-token from https://codeload.github.com/private/repo"
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(causeText, { status: 200 })))

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -353,6 +353,50 @@ describe("@vite-hub/source GitHub source", () => {
     })
   })
 
+  it("returns missing GitHub items from the contents path after validating the ref", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url)
+      if (requestUrl.endsWith("/commits/main")) return jsonResponse({ sha: "latest-commit-sha" })
+      if (requestUrl.includes("/contents/docs/missing.md")) return new Response("not found", { status: 404 })
+      throw new Error(`Unexpected GitHub request: ${requestUrl}`)
+    }))
+
+    const docs = github({ ref: "main", repo: "acme/app", root: "docs" })
+
+    await expect(docs.getItem("missing.md", {
+      abortSignal: new AbortController().signal,
+      rootDir: process.cwd(),
+    })).rejects.toMatchObject({
+      code: "SOURCE_ITEM_NOT_FOUND",
+      details: { key: "missing.md", source: "github" },
+    })
+
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => String(url))).toEqual([
+      "https://api.github.com/repos/acme/app/contents/docs/missing.md?ref=main",
+      "https://api.github.com/repos/acme/app/commits/main",
+    ])
+  })
+
+  it("does not hide invalid GitHub refs as missing items", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
+      const requestUrl = String(url)
+      if (requestUrl.includes("/contents/docs/README.md") || requestUrl.endsWith("/commits/missing-ref")) {
+        return new Response("not found", { status: 404 })
+      }
+      throw new Error(`Unexpected GitHub request: ${requestUrl}`)
+    }))
+
+    const docs = github({ ref: "missing-ref", repo: "acme/app", root: "docs" })
+
+    await expect(docs.getItem("README.md", {
+      abortSignal: new AbortController().signal,
+      rootDir: process.cwd(),
+    })).rejects.toMatchObject({
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "validate-ref", provider: "github", status: 404 },
+    })
+  })
+
   it("redacts GitHub transport failures while retaining the internal cause", async () => {
     const cause = new Error("Bearer secret-token failed at https://api.github.com/repos/private/repo")
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(cause))

--- a/packages/source/test/sources/glob-cache.test.ts
+++ b/packages/source/test/sources/glob-cache.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { glob as tinyglobby } from "tinyglobby"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { glob } from "../../src/index.ts"
+import { SourceError, glob } from "../../src/index.ts"
 
 vi.mock("tinyglobby", () => ({
   glob: vi.fn(async () => ["docs/README.md"]),
@@ -67,7 +67,14 @@ describe("@vite-hub/source glob source cache", () => {
     const docs = glob({ include: "**/*.md" })
     const ctx = { rootDir: root }
 
-    await expect(docs.getKeys(ctx)).rejects.toThrow("transient failure")
+    const error = await docs.getKeys(ctx).catch(error => error)
+    expect(error).toBeInstanceOf(SourceError)
+    expect(error).toMatchObject({
+      cause: expect.objectContaining({ message: "transient failure" }),
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "list", provider: "filesystem" },
+    })
+    expect(JSON.stringify(error)).not.toContain("transient failure")
     await expect(docs.getKeys(ctx)).resolves.toEqual(["docs/README.md"])
     expect(tinyglobby).toHaveBeenCalledTimes(2)
   })

--- a/packages/source/test/sources/mcp-resources.test.ts
+++ b/packages/source/test/sources/mcp-resources.test.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises"
 
 import { describe, expect, it, vi } from "vitest"
 
-import { mcpResources } from "../../src/index.ts"
+import { mcpResources, SourceError } from "../../src/index.ts"
 
 import type { McpResourcesClient } from "../../src/index.ts"
 
@@ -79,6 +79,56 @@ describe("mcpResources", () => {
       mimeType: "application/json",
       uri: "resource://nuxt-com/blog-posts",
     })
+  })
+
+  it("redacts MCP provider failures while retaining the internal cause", async () => {
+    const cause = new Error("Bearer secret-token failed at https://mcp.example/private")
+    const client = createClient()
+    client.listResources = vi.fn().mockRejectedValue(cause)
+    const source = mcpResources({ server: client })
+
+    const error = await source.getKeys({ rootDir: "/tmp" }).catch(error => error)
+
+    expect(error).toBeInstanceOf(SourceError)
+    expect(error).toMatchObject({
+      cause,
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { operation: "list-resources", provider: "mcp" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|mcp\.example|private/)
+  })
+
+  it("preserves raw MCP abort reasons", async () => {
+    const reason = new Error("caller stopped MCP read")
+    const controller = new AbortController()
+    controller.abort(reason)
+    const client = createClient()
+    client.listResources = vi.fn().mockRejectedValue(new Error("provider abort wrapper"))
+    const source = mcpResources({ server: client })
+
+    await expect(source.getKeys({
+      abortSignal: controller.signal,
+      rootDir: "/tmp",
+    })).rejects.toBe(reason)
+  })
+
+  it("does not serialize duplicate MCP resource URIs", async () => {
+    const client = createClient()
+    client.listResources = vi.fn().mockResolvedValue({
+      resources: [
+        { mimeType: "text/plain", name: "one", uri: "https://user:secret-token@mcp.example/same.txt" },
+        { mimeType: "text/plain", name: "two", uri: "https://mcp.example/same.txt" },
+      ],
+    })
+    const source = mcpResources({ path: () => "safe/same.txt", server: client })
+
+    const error = await source.getKeys({ rootDir: "/tmp" }).catch(error => error)
+
+    expect(error).toMatchObject({
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: { key: "safe/same.txt", operation: "list-resources", provider: "mcp" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|mcp\.example|https:/)
   })
 
   it("filters resources and supports custom paths", async () => {

--- a/packages/source/test/sources/mcp-resources.test.ts
+++ b/packages/source/test/sources/mcp-resources.test.ts
@@ -131,6 +131,64 @@ describe("mcpResources", () => {
     expect(JSON.stringify(error)).not.toMatch(/secret-token|mcp\.example|https:/)
   })
 
+  it("rejects MCP contents without text or blob without serializing the provider payload", async () => {
+    const invalidContent = {
+      secret: "secret-token from https://mcp.example/private",
+      uri: "resource://nuxt-com/documentation-pages",
+    }
+    const client = createClient()
+    client.listResources = vi.fn().mockResolvedValue({
+      resources: [{
+        mimeType: "text/plain",
+        name: "documentation-pages.txt",
+        uri: invalidContent.uri,
+      }],
+    })
+    client.readResource = vi.fn().mockResolvedValue({ contents: [invalidContent] } as never)
+    const source = mcpResources({ server: client })
+
+    const error = await source.getItem("nuxt-com/documentation-pages.txt", { rootDir: "/tmp" }).catch(error => error)
+
+    expect(error).toBeInstanceOf(SourceError)
+    expect(error).toMatchObject({
+      cause: invalidContent,
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: {
+        key: "nuxt-com/documentation-pages.txt",
+        operation: "read-resource",
+        provider: "mcp",
+      },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|mcp\.example|private/)
+  })
+
+  it("rejects malformed MCP base64 blobs as invalid provider responses", async () => {
+    const invalidContent = {
+      blob: "%%% secret-token",
+      mimeType: "application/octet-stream",
+      uri: "resource://nuxt-com/archive.bin",
+    }
+    const client = createClient()
+    client.listResources = vi.fn().mockResolvedValue({
+      resources: [{
+        mimeType: "application/octet-stream",
+        name: "archive.bin",
+        uri: invalidContent.uri,
+      }],
+    })
+    client.readResource = vi.fn().mockResolvedValue({ contents: [invalidContent] } as never)
+    const source = mcpResources({ server: client })
+
+    const error = await source.getItem("nuxt-com/archive.bin", { rootDir: "/tmp" }).catch(error => error)
+
+    expect(error).toMatchObject({
+      cause: invalidContent,
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: { key: "nuxt-com/archive.bin", operation: "read-resource", provider: "mcp" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|mcp\.example|private/)
+  })
+
   it("filters resources and supports custom paths", async () => {
     const source = mcpResources({
       exclude: "**/blog-posts.json",

--- a/packages/source/test/sources/mcp-resources.test.ts
+++ b/packages/source/test/sources/mcp-resources.test.ts
@@ -114,6 +114,19 @@ describe("mcpResources", () => {
     expect(JSON.stringify(error)).not.toMatch(/secret-token|mcp\.example|private/)
   })
 
+  it("rejects malformed MCP resource descriptors as invalid provider responses", async () => {
+    const providerPage = { resources: [null] }
+    const client = createClient()
+    client.listResources = vi.fn().mockResolvedValue(providerPage as never)
+    const source = mcpResources({ server: client })
+
+    await expect(source.getKeys({ rootDir: "/tmp" })).rejects.toMatchObject({
+      cause: providerPage,
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: { operation: "list-resources", provider: "mcp" },
+    })
+  })
+
   it("rejects malformed MCP read payloads as invalid provider responses", async () => {
     const providerResponse = { secret: "secret-token from https://mcp.example/private" }
     const client = createClient()
@@ -128,6 +141,19 @@ describe("mcpResources", () => {
       details: { operation: "read-resource", provider: "mcp" },
     })
     expect(JSON.stringify(error)).not.toMatch(/secret-token|mcp\.example|private/)
+  })
+
+  it("rejects malformed MCP content entries as invalid provider responses", async () => {
+    const providerResponse = { contents: [null] }
+    const client = createClient()
+    client.readResource = vi.fn().mockResolvedValue(providerResponse as never)
+    const source = mcpResources({ server: client })
+
+    await expect(source.getItem("nuxt-com/documentation-pages.json", { rootDir: "/tmp" })).rejects.toMatchObject({
+      cause: providerResponse,
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: { operation: "read-resource", provider: "mcp" },
+    })
   })
 
   it("preserves raw MCP abort reasons", async () => {

--- a/packages/source/test/sources/mcp-resources.test.ts
+++ b/packages/source/test/sources/mcp-resources.test.ts
@@ -98,6 +98,38 @@ describe("mcpResources", () => {
     expect(JSON.stringify(error)).not.toMatch(/secret-token|mcp\.example|private/)
   })
 
+  it("rejects malformed MCP list pages as invalid provider responses", async () => {
+    const providerPage = { secret: "secret-token from https://mcp.example/private" }
+    const client = createClient()
+    client.listResources = vi.fn().mockResolvedValue(providerPage as never)
+    const source = mcpResources({ server: client })
+
+    const error = await source.getKeys({ rootDir: "/tmp" }).catch(error => error)
+
+    expect(error).toMatchObject({
+      cause: providerPage,
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: { operation: "list-resources", provider: "mcp" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|mcp\.example|private/)
+  })
+
+  it("rejects malformed MCP read payloads as invalid provider responses", async () => {
+    const providerResponse = { secret: "secret-token from https://mcp.example/private" }
+    const client = createClient()
+    client.readResource = vi.fn().mockResolvedValue(providerResponse as never)
+    const source = mcpResources({ server: client })
+
+    const error = await source.getItem("nuxt-com/documentation-pages.json", { rootDir: "/tmp" }).catch(error => error)
+
+    expect(error).toMatchObject({
+      cause: providerResponse,
+      code: "SOURCE_PROVIDER_RESPONSE_INVALID",
+      details: { operation: "read-resource", provider: "mcp" },
+    })
+    expect(JSON.stringify(error)).not.toMatch(/secret-token|mcp\.example|private/)
+  })
+
   it("preserves raw MCP abort reasons", async () => {
     const reason = new Error("caller stopped MCP read")
     const controller = new AbortController()

--- a/packages/source/tsconfig.json
+++ b/packages/source/tsconfig.json
@@ -2,7 +2,13 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
-    "rootDir": ".."
+    "rootDir": "..",
+    "baseUrl": "../..",
+    "paths": {
+      "@vite-hub/runtime": [
+        "packages/runtime/src/index.ts"
+      ]
+    }
   },
   "include": [
     "src/**/*.ts",

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -1407,8 +1407,10 @@ describe("sources, loaders, and publishers", () => {
       auth: "github-token",
     })
 
-    await expect(githubSource.getKeys({ rootDir: "", workspace: "github-error" }))
-      .rejects.toThrow("could not access the repository or ref \"main\"")
+    await expect(githubSource.getKeys({ rootDir: "", workspace: "github-error" })).rejects.toMatchObject({
+      code: "SOURCE_PROVIDER_REQUEST_FAILED",
+      details: { provider: "github", status: 404 },
+    })
   })
 
   it("loads glob/file/custom sources and writes publish artifacts", async () => {

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -140,6 +140,9 @@ function stubGitHubSource(files: Record<string, string>, options: StubGitHubSour
     return jsonResponse({
       content: Buffer.from(files[path] || "").toString("base64"),
       encoding: "base64",
+      path,
+      sha: `sha-${path}`,
+      type: "file",
     })
   }))
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1126,6 +1126,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: catalog:ai
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@vite-hub/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       mrmime:
         specifier: catalog:workspace
         version: 2.0.1


### PR DESCRIPTION
Extends `SourceError` from the shared ViteHub error foundation while preserving `SourceNotFoundError` and `SourcePathError` identity. Built-in filesystem, GitHub, glob, and MCP adapters expose stable Source codes and code-specific JSON-safe details; provider causes stay available to protected server diagnostics but are excluded from serialization.

Provider boundaries preserve caller abort reasons and custom Source failures by identity. GitHub contents reads distinguish a valid ref with a missing item from an invalid configured ref, sparse Git aborts return the exact caller reason, and malformed GitHub repository, commit, content, archive, MCP, or base64 payloads return `SOURCE_PROVIDER_RESPONSE_INVALID` while retaining provider values only as internal causes.

The public constructor supports both `new SourceError({ code, ... })` and the existing `new SourceError(message, { code, ... })` form. Runtime construction exhaustively validates the seven Source codes, four providers, fifteen observed operations, HTTP status range, and path value types. It rebuilds details from the selected code's schema and derives the public message from that safe context, so JavaScript casts cannot add arbitrary serialized fields or publish caller-controlled messages. The positional message remains accepted only for compatibility; raw diagnostics belong in the non-serialized `cause`.

This intentionally breaks old message-first calls that omitted `code` and any consumer that treated a caller-supplied Source message as public output. Migrate `new SourceError(message, { cause })` to either supported form with a required stable code, keep raw diagnostics in `cause`, and branch on `code` plus safe `details` rather than message text. `SourceNotFoundError(name)` and `SourcePathError(path)` remain unchanged.

## Validation

At exact head 9536fc7c237748d747a1e281d2fe53b3e026256b, the strict GitHub response decoder remains closed over the real repository, commit, and contents shapes. The branch is reconciled with live foundation head b9b334b70b2ccf049b39b5507783a05aafb2c667, and the installed-consumer fixture bounds child processes while allowing a separate test envelope. The Workspace GitHub fixture supplies the real contents fields path, sha, and type.

- Full Source package suite: 80 tests passed, including the installed-consumer contract; targeted Oxlint and `git diff --check` are clean.
- Focused malformed GitHub repository/content and cached archive cases: 3 tests passed.
- The preceding `1ccb530c` remote run passed Fallow, Knip, lint, typecheck, root contracts, consumer, docs, every provider verification job, preview publication, and Workers. Its full suite exposed the two stale Workspace fixture cases now repaired at this head.
- At exact head 9536fc7c237748d747a1e281d2fe53b3e026256b, GitHub aggregate CI, consumer, docs, package preview, provider verification, Continuous Releases, and Workers checks are green; the separate Vercel deployment is blocked only by its account build-rate quota.

The exact feature diff from historical foundation ancestor `4686a24760b3aa8b5404cde0b0bdebc0a7bebd85` is +667/-113 production lines, +548/-14 tests, +65/-0 installed-consumer fixtures, +38/-2 documentation, and +11/-1 package/config/lock metadata, for +1329/-130 overall. The added code pays for the Source-owned error vocabulary and derived messages, provider and response mappers, runtime detail reconstruction, identifier normalization, abort/custom-error identity, GitHub missing-ref discrimination, malformed provider-response validation, MCP payload validation, cached archive integration, and strict installed-package declaration proof.

## Hard dependency

This draft targets foundation PR #670, now contains live head `9331ce1c421ea0240c4c835e2b97332f43396c7e`, and must not merge before that prerequisite. Once #670 merges, revalidate this Source head against the merged foundation before merging.

EFFECT ADOPTION STATUS
  seam: Source public errors and filesystem, GitHub, glob, MCP, registry, and custom-provider failure boundaries
  public API: SourceError requires a stable built-in code in either object or positional form; SourceNotFoundError and SourcePathError signatures remain stable
  boundary: packages/source/src/core/errors.ts and the built-in adapter Promise boundaries
  typed failures: stable SourceErrorCode with code-specific details and derived public messages; code, provider, operation, status, and value-type vocabularies are enforced at runtime; internal causes are non-serialized; abort and custom error identities are preserved
  resources/fibers: none; Source has no long-lived resources or concurrent workflow that earns Effect
  deleted: raw and caller-controlled public message exposure, arbitrary runtime codes/details/operations, ambiguous message-only errors, empty malformed MCP content, GitHub missing-item/ref conflation, and sparse-Git abort wrappers
  retained: compact Promise provider adapters, Source registry shape, both required-code constructor forms, protected causes, and existing read/list/search behavior
  source pay-rent: +667/-113 production; +548/-14 tests; +65/-0 fixtures; +38/-2 docs; +11/-1 metadata; +1329/-130 total
  todos: 0
  confidence: high

<!-- babysitter:blocker:v1 -->

> [!WARNING]
> **Babysitter is blocked:** prerequisite pull request #670 is still open at live head `fb7e412794d5028afdeca35dda5194b3bcf199d3`, and this pull request explicitly must not merge before it.
>
> Merge #670 into its target branch; then this pull request can be revalidated and merged.

<!-- /babysitter:blocker:v1 -->