### PR TITLE
feat(auth): add structured authentication error

### DIFF
--- a/docs/content/docs/concepts/auth-users-and-agent-invokers.md
+++ b/docs/content/docs/concepts/auth-users-and-agent-invokers.md
@@ -33,6 +33,8 @@ export default defineAgent({
 
 `authenticated()` is opt-in at the Agent or Entry Surface boundary. Merely defining Auth does not make every Agent Invocation require Auth.
 
+When a required Auth Session is missing, the bridge throws `AuthenticationRequiredError` with code `AUTHENTICATION_REQUIRED` and `statusCode: 401`, so Agent and HTTP entry surfaces can recognize the same failure without parsing its message.
+
 ## What Agent Invoker carries
 
 | Field | Meaning |

--- a/docs/content/docs/reference/errors-diagnostics.md
+++ b/docs/content/docs/reference/errors-diagnostics.md
@@ -16,7 +16,7 @@ Use the error family to choose the next proof path before changing implementatio
 | `CapabilityDeniedError` | Runtime Package | Runtime policy denied a capability operation. |
 | `ApprovalRequiredError` | Runtime Package | A policy decision requires an Approval Request before execution. |
 | `EnvError` | Env Package | Env Declaration resolution, validation, or diagnostics failed. |
-| `AuthenticationRequiredError` | Auth Package | A route or Agent Invoker bridge needs an authenticated application user. |
+| `AuthenticationRequiredError` | Auth Package | A route or Agent Invoker bridge needs an authenticated application user; inspect code `AUTHENTICATION_REQUIRED` and `statusCode: 401`. |
 | `EmailError` | Email Package | Message validation, missing Email Definition, delivery credentials, throttling, network, timeout, or provider delivery failed. |
 | `QueueError` | Queue Package | Queue dispatch, callback, or provider handling failed. |
 | `WorkspaceError` | Workspace Package | Workspace runtime, store, rule, or file-tree behavior failed. |
@@ -47,7 +47,7 @@ Use the error family to choose the next proof path before changing implementatio
 
 ## Local response
 
-Start with the owning package and the failing proof path. For packages that generate Provider Output, inspect that output before changing runtime code. Email emits no Provider Output; inspect `EmailError.code` and `driver`, then use `cause` only in protected server-side diagnostics.
+Start with the owning package and the failing proof path. For packages that generate Provider Output, inspect that output before changing runtime code. Authenticated Agent bridges expose `AuthenticationRequiredError.code` and `statusCode`; use safe `details` for boundary context and `cause` only in protected server-side diagnostics. Email emits no Provider Output; inspect `EmailError.code` and `driver` the same way.
 
 ```bash [Terminal]
 pnpm vitehub provision run --provider cloudflare --dry-run

--- a/docs/content/docs/server-primitives/auth.md
+++ b/docs/content/docs/server-primitives/auth.md
@@ -52,6 +52,7 @@ export default defineAuth({
 | `handleAuth`, `handleAuthRequest`, `createAuthHandler` from `@vite-hub/auth/server` | Mount or call the Auth handler manually. |
 | `requireAuth` from `@vite-hub/auth/server` | Guard server routes with an Auth Session. |
 | `authenticated` from `@vite-hub/auth/agent` | Map a Better Auth session into an Agent Invoker. |
+| `AuthenticationRequiredError` from `@vite-hub/auth/agent` | Handle missing authentication with a stable code and HTTP status. |
 | `hubAuth` from `@vite-hub/auth/vite` | Register Auth discovery, route exposure, and generated server aliases. |
 
 Create one Primary Auth Definition. ViteHub discovers `server/auth.ts` or `server.auth.ts`.
@@ -216,6 +217,23 @@ export default defineAuth({
 Auth identifies application users and sessions. Agents consume Agent Invokers, so Auth-to-Agent behavior should map trusted Auth state into an Agent Invoker instead of making Auth part of the Agent Definition.
 
 Read [Auth Users and Agent Invokers](/docs/concepts/auth-users-and-agent-invokers) for the mental model and [Official capabilities](/docs/capabilities/official-capabilities) for agent-facing access patterns.
+
+### Handle required authentication
+
+`authenticated()` throws `AuthenticationRequiredError` when it cannot resolve a required Auth Session. The error has code `AUTHENTICATION_REQUIRED`, preserves `statusCode: 401` for HTTP adapters, and serializes safe details without its cause or stack.
+
+```ts
+import { AuthenticationRequiredError } from '@vite-hub/auth/agent'
+
+const error = new AuthenticationRequiredError({
+  details: { surface: 'support-agent' },
+  message: 'Sign in to use this Agent.',
+})
+
+console.log(error.toJSON())
+```
+
+The string constructor remains available for custom messages. Invalid Auth Definitions and invalid `authenticated()` configuration are programmer errors, so they continue to throw `TypeError` rather than authentication failures.
 
 ## Next steps
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -174,3 +174,16 @@ export default defineAgent({
 ```
 
 By default, the Auth Package reads the same-app Better Auth session from the request and maps the Auth User to an Agent Invoker with `kind: "authUser"`. Customize `id`, `kind`, `label`, or `meta` for normal identity shaping, and use `source` or `map` when the Agent consumes JWTs, bearer tokens, OAuth/OIDC provider output, or product-specific identity.
+
+When authentication is required but unavailable, `authenticated()` throws `AuthenticationRequiredError` with code `AUTHENTICATION_REQUIRED` and `statusCode: 401`. The class keeps its existing string constructor and also accepts safe structured context.
+
+```ts
+import { AuthenticationRequiredError } from "@vite-hub/auth/agent"
+
+const error = new AuthenticationRequiredError({
+  details: { surface: "support-agent" },
+  message: "Sign in to use this Agent.",
+})
+```
+
+`error.toJSON()` includes `code`, `message`, and `details`, while omitting `cause` and stack data. Keep secrets out of `details`; use `cause` only for protected server-side diagnostics.

--- a/packages/auth/fixtures/published-types/agent-peer.d.ts
+++ b/packages/auth/fixtures/published-types/agent-peer.d.ts
@@ -1,0 +1,28 @@
+declare module "@vite-hub/agent" {
+  export interface AgentInvoker {
+    id: string
+    kind: string
+    label?: string
+    meta?: Record<string, unknown>
+  }
+
+  export interface AgentRuntimeConfig {}
+
+  export interface AgentInvokerResolveContext<
+    TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+    CALL_OPTIONS = unknown,
+  > {
+    callOptions?: CALL_OPTIONS
+    request?: Request
+    runtimeConfig?: TRuntimeConfig
+  }
+
+  export interface AgentInvokerOptions<
+    TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+    CALL_OPTIONS = unknown,
+  > {
+    resolve?: (context: AgentInvokerResolveContext<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<AgentInvoker | undefined>
+  }
+
+  export type MaybePromise<T> = Promise<T> | T
+}

--- a/packages/auth/fixtures/published-types/consumer.ts
+++ b/packages/auth/fixtures/published-types/consumer.ts
@@ -1,0 +1,18 @@
+import {
+  AuthenticationRequiredError,
+  type AuthenticationRequiredErrorOptions,
+} from "@vite-hub/auth/agent"
+
+import type { ViteHubErrorShape } from "@vite-hub/runtime"
+
+const options = {
+  details: { surface: "agent-invoker" },
+  message: "Sign in required.",
+} satisfies AuthenticationRequiredErrorOptions
+
+const error = new AuthenticationRequiredError(options)
+error.code satisfies "AUTHENTICATION_REQUIRED"
+error.statusCode satisfies 401
+error.toJSON() satisfies ViteHubErrorShape<"AUTHENTICATION_REQUIRED">
+
+new AuthenticationRequiredError("Sign in required.")

--- a/packages/auth/fixtures/published-types/package.json
+++ b/packages/auth/fixtures/published-types/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/auth/fixtures/published-types/tsconfig.json
+++ b/packages/auth/fixtures/published-types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "files": [
+    "agent-peer.d.ts",
+    "consumer.ts"
+  ]
+}

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -45,6 +45,7 @@
     "test": "vp run -t @vite-hub/auth#build && vp test"
   },
   "dependencies": {
+    "@vite-hub/runtime": "workspace:*",
     "better-auth": "catalog:auth"
   },
   "devDependencies": {

--- a/packages/auth/src/agent.ts
+++ b/packages/auth/src/agent.ts
@@ -1,5 +1,7 @@
 import { getAuth, getAuthForRequest } from "./server.ts"
 
+import { ViteHubError } from "@vite-hub/runtime"
+
 import type {
   AgentInvoker,
   AgentInvokerOptions,
@@ -7,6 +9,7 @@ import type {
   AgentRuntimeConfig,
   MaybePromise,
 } from "@vite-hub/agent"
+import type { ViteHubErrorDetails } from "@vite-hub/runtime"
 
 export interface AuthenticatedUser {
   email?: string | null
@@ -82,11 +85,26 @@ export interface AuthenticatedOptions<
   source?: AuthenticatedSource<TRuntimeConfig, CALL_OPTIONS, TUser, TSession>
 }
 
-export class AuthenticationRequiredError extends Error {
+export interface AuthenticationRequiredErrorOptions extends ErrorOptions {
+  details?: ViteHubErrorDetails
+  message?: string
+}
+
+export class AuthenticationRequiredError extends ViteHubError<"AUTHENTICATION_REQUIRED"> {
   declare readonly statusCode: 401
 
-  constructor(message = "[vitehub] Authentication required.") {
-    super(message)
+  constructor(options?: AuthenticationRequiredErrorOptions)
+  constructor(message?: string)
+  constructor(messageOrOptions: AuthenticationRequiredErrorOptions | string = {}) {
+    const options = typeof messageOrOptions === "string" ? {} : messageOrOptions
+    const message = typeof messageOrOptions === "string"
+      ? messageOrOptions
+      : messageOrOptions.message ?? "[vitehub] Authentication required."
+
+    super("AUTHENTICATION_REQUIRED", message, {
+      cause: options.cause,
+      details: options.details,
+    })
     this.name = "AuthenticationRequiredError"
     Object.defineProperty(this, "statusCode", {
       enumerable: true,

--- a/packages/auth/test/agent.test.ts
+++ b/packages/auth/test/agent.test.ts
@@ -171,6 +171,7 @@ describe("authenticated", () => {
     await expect(resolve(authenticated({
       source: () => undefined,
     }))).rejects.toMatchObject({
+      code: "AUTHENTICATION_REQUIRED",
       message: "[vitehub] Authentication required.",
       name: "AuthenticationRequiredError",
       statusCode: 401,
@@ -203,6 +204,7 @@ describe("authenticated", () => {
 
   it("exposes the auth error class", () => {
     expect(new AuthenticationRequiredError()).toMatchObject({
+      code: "AUTHENTICATION_REQUIRED",
       statusCode: 401,
     })
   })

--- a/packages/auth/test/errors.test.ts
+++ b/packages/auth/test/errors.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+
+import { ViteHubError } from "@vite-hub/runtime"
+
+import { AuthenticationRequiredError } from "../src/agent.ts"
+
+describe("AuthenticationRequiredError", () => {
+  it("preserves the existing class, message, and HTTP contract", () => {
+    const error = new AuthenticationRequiredError()
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(ViteHubError)
+    expect(error).toBeInstanceOf(AuthenticationRequiredError)
+    expect(error).toMatchObject({
+      code: "AUTHENTICATION_REQUIRED",
+      message: "[vitehub] Authentication required.",
+      name: "AuthenticationRequiredError",
+      statusCode: 401,
+    })
+    expect(new AuthenticationRequiredError("Sign in required.").message).toBe("Sign in required.")
+  })
+
+  it("serializes safe details without exposing its cause", () => {
+    const cause = new Error("Bearer secret-token")
+    const error = new AuthenticationRequiredError({
+      cause,
+      details: { surface: "agent-invoker" },
+      message: "Sign in required.",
+    })
+
+    expect(error.cause).toBe(cause)
+    expect(error.toJSON()).toEqual({
+      code: "AUTHENTICATION_REQUIRED",
+      details: { surface: "agent-invoker" },
+      message: "Sign in required.",
+    })
+    expect(JSON.stringify(error)).not.toContain("secret-token")
+  })
+})

--- a/packages/auth/test/published-types.test.ts
+++ b/packages/auth/test/published-types.test.ts
@@ -1,0 +1,34 @@
+import { execFile } from "node:child_process"
+import { copyFile, cp, mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { it } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const workspaceRoot = resolve(packageRoot, "../..")
+const fixtureRoot = join(packageRoot, "fixtures", "published-types")
+const tsc = resolve(workspaceRoot, "node_modules/typescript/bin/tsc")
+
+it("publishes the structured Authentication Required error contract", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-auth-types-"))
+
+  try {
+    await cp(fixtureRoot, root, { recursive: true })
+    for (const name of ["auth", "runtime"]) {
+      const source = join(workspaceRoot, "packages", name)
+      const installed = join(root, "node_modules", "@vite-hub", name)
+      await mkdir(installed, { recursive: true })
+      await copyFile(join(source, "package.json"), join(installed, "package.json"))
+      await cp(join(source, "dist"), join(installed, "dist"), { recursive: true })
+    }
+
+    await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", root])
+  }
+  finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})

--- a/packages/auth/test/types.test-d.ts
+++ b/packages/auth/test/types.test-d.ts
@@ -5,6 +5,8 @@ import { describe, expectTypeOf, it } from "vitest"
 
 import {
   authenticated,
+  AuthenticationRequiredError,
+  type AuthenticationRequiredErrorOptions,
   type AuthenticatedOptions,
   type AuthenticatedSessionData,
   type AuthenticatedUser,
@@ -134,6 +136,13 @@ describe("types", () => {
     expectTypeOf(invoker).toMatchTypeOf<AgentInvokerOptions>()
     expectTypeOf(typedInvoker).toMatchTypeOf<AgentInvokerOptions>()
     expectTypeOf({ kind: "authUser" }).toMatchTypeOf<AuthenticatedOptions>()
+
+    const authError = new AuthenticationRequiredError({
+      details: { surface: "agent-invoker" },
+      message: "Sign in required.",
+    } satisfies AuthenticationRequiredErrorOptions)
+    expectTypeOf(authError.code).toEqualTypeOf<"AUTHENTICATION_REQUIRED">()
+    expectTypeOf(authError.statusCode).toEqualTypeOf<401>()
   })
 
   it("exposes resolved database placement metadata", () => {

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -16,6 +16,9 @@
       ],
       "@vite-hub/internal/*": [
         "packages/internal/src/*.ts"
+      ],
+      "@vite-hub/runtime": [
+        "packages/runtime/src/index.ts"
       ]
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,9 @@ importers:
 
   packages/auth:
     dependencies:
+      '@vite-hub/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       better-auth:
         specifier: catalog:auth
         version: 1.6.23(@cloudflare/workers-types@4.20260509.1)(@opentelemetry/api@1.9.1)(@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0))(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1))(react@19.2.6)(vue@3.5.40(typescript@6.0.3))


### PR DESCRIPTION
Extends `AuthenticationRequiredError` from the shared `ViteHubError` foundation with the fixed code `AUTHENTICATION_REQUIRED`. Existing string construction, class identity, default messages, and `statusCode: 401` remain unchanged; the object form adds JSON-safe `details` and an optional protected `cause`, which serialization omits.

Auth Definition, discovery, and `authenticated()` configuration failures remain programmer errors (`TypeError` or plain `Error`). Runtime tests, declaration tests, and an installed-consumer fixture cover the public `@vite-hub/auth/agent` contract, while the package README, Auth guide, identity concept, and canonical errors reference document the boundary.

Validated with the Auth dependency build and publint, TypeScript, all 9 Auth test files (69 tests; rerun outside the sandbox for the localhost Vite case), the focused published-types proof, Fallow, Effect ownership, docs tests, root lint, and diff checks. This PR is stacked on #670 and targets `refactor/effect-error-contract`.