### PR TITLE
feat(env): add structured error contract

### DIFF
--- a/docs/content/docs/reference/errors-diagnostics.md
+++ b/docs/content/docs/reference/errors-diagnostics.md
@@ -49,7 +49,7 @@ Use the error family to choose the next proof path before changing implementatio
 
 Start with the owning package and the failing proof path. For packages that generate Provider Output, inspect that output before changing runtime code. Authenticated Agent bridges expose `AuthenticationRequiredError.code` and `statusCode`; use safe `details` for boundary context and `cause` only in protected server-side diagnostics. Email emits no Provider Output; inspect `EmailError.code` and `driver` the same way.
 
-For Env, inspect `EnvError.code` first. `ENV_DECLARATION_INVALID` includes `details.path`, `ENV_REQUIRED_MISSING` includes the public source label and sometimes the declaration path, and `ENV_RUNTIME_VALUE_INVALID` includes the public source label. The serialized shape omits `cause`; never place secret values in `details`.
+For Env, inspect `EnvError.code` first. `ENV_DECLARATION_INVALID` includes `details.path`, `ENV_REQUIRED_MISSING` includes the public source label and sometimes the declaration path, `ENV_RUNTIME_VALUE_INVALID` includes the public source label, and `ENV_SOURCE_FAILED` identifies a failed built-in Git or package metadata source through `details.source`. The serialized shape omits `cause`; never place secret values in `details`.
 
 ```bash [Terminal]
 pnpm vitehub provision run --provider cloudflare --dry-run

--- a/docs/content/docs/reference/errors-diagnostics.md
+++ b/docs/content/docs/reference/errors-diagnostics.md
@@ -15,7 +15,7 @@ Use the error family to choose the next proof path before changing implementatio
 | `CapabilityNotFoundError` | Runtime Package | A Runtime Capability handle is missing. |
 | `CapabilityDeniedError` | Runtime Package | Runtime policy denied a capability operation. |
 | `ApprovalRequiredError` | Runtime Package | A policy decision requires an Approval Request before execution. |
-| `EnvError` | Env Package | Env Declaration resolution, validation, or diagnostics failed. |
+| `EnvError` | Env Package | Env Declaration or runtime resolution failed with an Env-owned code and JSON-safe context. |
 | `AuthenticationRequiredError` | Auth Package | A route or Agent Invoker bridge needs an authenticated application user; inspect code `AUTHENTICATION_REQUIRED` and `statusCode: 401`. |
 | `EmailError` | Email Package | Message validation, missing Email Definition, delivery credentials, throttling, network, timeout, or provider delivery failed. |
 | `QueueError` | Queue Package | Queue dispatch, callback, or provider handling failed. |
@@ -48,6 +48,8 @@ Use the error family to choose the next proof path before changing implementatio
 ## Local response
 
 Start with the owning package and the failing proof path. For packages that generate Provider Output, inspect that output before changing runtime code. Authenticated Agent bridges expose `AuthenticationRequiredError.code` and `statusCode`; use safe `details` for boundary context and `cause` only in protected server-side diagnostics. Email emits no Provider Output; inspect `EmailError.code` and `driver` the same way.
+
+For Env, inspect `EnvError.code` first. `ENV_DECLARATION_INVALID` includes `details.path`, `ENV_REQUIRED_MISSING` includes the public source label and sometimes the declaration path, and `ENV_RUNTIME_VALUE_INVALID` includes the public source label. The serialized shape omits `cause`; never place secret values in `details`.
 
 ```bash [Terminal]
 pnpm vitehub provision run --provider cloudflare --dry-run

--- a/docs/content/docs/server-primitives/env.md
+++ b/docs/content/docs/server-primitives/env.md
@@ -51,6 +51,7 @@ console.log(publicEnv.appName)
 | Import | Use |
 | --- | --- |
 | `env` from `@vite-hub/env` or `@vite-hub/env/vite` | Declare Env values and Env Sources. |
+| `EnvError` from `@vite-hub/env` | Throw or inspect a structured operational Env failure. |
 | `hubEnv` from `@vite-hub/env/vite` | Register the Vite Integration. |
 | `usePublicEnv` from `#vitehub/env/public` | Read generated Public Env from browser-safe code. |
 | `useServerEnv` from `#vitehub/env/server` | Read generated Server Env from server code. |
@@ -160,6 +161,28 @@ export async function listIssues() {
   })
 }
 ```
+
+## Structured errors
+
+Env resolution failures use `EnvError` with stable codes and JSON-safe context. Built-in codes distinguish invalid declarations, missing required values, and invalid runtime values; application code can use its own stable code for an application-owned Env Source.
+
+```ts
+import { EnvError } from '@vite-hub/env'
+
+try {
+  await resolveVaultEnv()
+}
+catch (cause) {
+  throw new EnvError({
+    cause,
+    code: 'ENV_SOURCE_FAILED',
+    details: { source: 'vault:runtime' },
+    message: 'Runtime Env source failed.',
+  })
+}
+```
+
+Keep `details` free of secret values. `error.toJSON()` includes `code`, `message`, and `details`; it omits `cause`, which remains available only on the in-memory error. Invalid calls to declaration helpers remain `TypeError`, while `parseSchema()` continues to throw ordinary schema errors.
 
 ## Provider output
 

--- a/docs/content/docs/server-primitives/env.md
+++ b/docs/content/docs/server-primitives/env.md
@@ -164,7 +164,7 @@ export async function listIssues() {
 
 ## Structured errors
 
-Env resolution failures use `EnvError` with stable codes and JSON-safe context. Built-in codes distinguish invalid declarations, missing required values, and invalid runtime values; application code can use its own stable code for an application-owned Env Source.
+Env resolution failures use `EnvError` with stable codes and JSON-safe context. Built-in codes distinguish invalid declarations, missing required values, invalid runtime values, and failed Git or package metadata sources; application code can use its own stable code for an application-owned Env Source.
 
 ```ts
 import { EnvError } from '@vite-hub/env'
@@ -182,7 +182,7 @@ catch (cause) {
 }
 ```
 
-Keep `details` free of secret values. `error.toJSON()` includes `code`, `message`, and `details`; it omits `cause`, which remains available only on the in-memory error. Invalid calls to declaration helpers remain `TypeError`, while `parseSchema()` continues to throw ordinary schema errors.
+Keep `details` free of secret values. `ENV_SOURCE_FAILED` exposes only the public source label as `details.source`; the underlying failure remains in `cause`. `error.toJSON()` includes `code`, `message`, and `details`; it omits `cause`, which remains available only on the in-memory error. Invalid calls to declaration helpers remain `TypeError`, while `parseSchema()` continues to throw ordinary schema errors.
 
 ## Provider output
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -74,7 +74,7 @@ catch (cause) {
 }
 ```
 
-`code` is required and may be one of ViteHub's typed `EnvErrorCode` values or an app-owned stable string. Keep `details` JSON-safe and free of secret values; `toJSON()` includes the code, message, and details, while the in-memory `cause` is omitted from serialization. Invalid `env()` calls remain `TypeError`, and `parseSchema()` keeps the schema library's ordinary error boundary.
+`code` is required and may be one of ViteHub's typed `EnvErrorCode` values or an app-owned stable string. Built-in Git and package metadata failures use `ENV_SOURCE_FAILED` with the public source label in `details.source`. Keep `details` JSON-safe and free of secret values; `toJSON()` includes the code, message, and details, while the in-memory `cause` is omitted from serialization. Invalid `env()` calls remain `TypeError`, and `parseSchema()` keeps the schema library's ordinary error boundary.
 
 ## Vite Integration
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -54,6 +54,28 @@ export async function sync(event: unknown) {
 }
 ```
 
+## Structured errors
+
+Throw `EnvError` when application-owned Env resolution needs a stable failure that callers can inspect.
+
+```ts
+import { EnvError } from "@vite-hub/env"
+
+try {
+  await resolveVaultEnv()
+}
+catch (cause) {
+  throw new EnvError({
+    cause,
+    code: "ENV_SOURCE_FAILED",
+    details: { source: "vault:runtime" },
+    message: "Runtime Env source failed.",
+  })
+}
+```
+
+`code` is required and may be one of ViteHub's typed `EnvErrorCode` values or an app-owned stable string. Keep `details` JSON-safe and free of secret values; `toJSON()` includes the code, message, and details, while the in-memory `cause` is omitted from serialization. Invalid `env()` calls remain `TypeError`, and `parseSchema()` keeps the schema library's ordinary error boundary.
+
 ## Vite Integration
 
 Use `hubEnv()` in Vite to resolve public/build env, generate `#vitehub/env/public` and `#vitehub/env/server`, and keep environment declarations close to the app config. Runtime secrets are read from the host environment at request time and are wrapped in `SecretEnv` until explicitly unsealed.

--- a/packages/env/fixtures/published-types/consumer.ts
+++ b/packages/env/fixtures/published-types/consumer.ts
@@ -1,0 +1,23 @@
+import { EnvError } from "@vite-hub/env"
+
+import type { EnvErrorCode, EnvErrorOptions } from "@vite-hub/env"
+
+const code = "ENV_REQUIRED_MISSING" satisfies EnvErrorCode
+const options = {
+  code: "ENV_SOURCE_FAILED" as const,
+  details: { source: "vault:token" },
+  message: "Env source failed.",
+} satisfies EnvErrorOptions
+const error = new EnvError(options)
+
+error.code satisfies "ENV_SOURCE_FAILED"
+error.toJSON().details satisfies { source: string } | undefined
+
+new EnvError({ code, message: "Required Env is missing." })
+
+new EnvError({
+  code: "INVALID_DETAILS",
+  // @ts-expect-error Env error details must be JSON-safe.
+  details: { failedAt: new Date() },
+  message: "Invalid details.",
+})

--- a/packages/env/fixtures/published-types/consumer.ts
+++ b/packages/env/fixtures/published-types/consumer.ts
@@ -3,6 +3,7 @@ import { EnvError } from "@vite-hub/env"
 import type { EnvErrorCode, EnvErrorOptions } from "@vite-hub/env"
 
 const code = "ENV_REQUIRED_MISSING" satisfies EnvErrorCode
+"ENV_SOURCE_FAILED" satisfies EnvErrorCode
 const options = {
   code: "ENV_SOURCE_FAILED" as const,
   details: { source: "vault:token" },

--- a/packages/env/fixtures/published-types/package.json
+++ b/packages/env/fixtures/published-types/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/packages/env/fixtures/published-types/tsconfig.json
+++ b/packages/env/fixtures/published-types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "files": [
+    "consumer.ts"
+  ]
+}

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -62,6 +62,9 @@
     "typecheck": "tsc --noEmit -p ./tsconfig.json",
     "test": "vp run -t @vite-hub/env#build && vp test"
   },
+  "dependencies": {
+    "@vite-hub/runtime": "workspace:*"
+  },
   "devDependencies": {
     "@vite-hub/internal": "workspace:*",
     "publint": "catalog:tooling",

--- a/packages/env/src/core/errors.ts
+++ b/packages/env/src/core/errors.ts
@@ -6,6 +6,7 @@ export type EnvErrorCode =
   | "ENV_DECLARATION_INVALID"
   | "ENV_REQUIRED_MISSING"
   | "ENV_RUNTIME_VALUE_INVALID"
+  | "ENV_SOURCE_FAILED"
 
 export interface EnvErrorOptions<
   TCode extends string = string,
@@ -47,5 +48,14 @@ export function invalidRuntimeEnvValue(source: string, message: string): EnvErro
     code: "ENV_RUNTIME_VALUE_INVALID",
     details: { source },
     message,
+  })
+}
+
+export function envSourceFailed(source: string, cause: unknown): EnvError<"ENV_SOURCE_FAILED", { source: string }> {
+  return new EnvError({
+    cause,
+    code: "ENV_SOURCE_FAILED",
+    details: { source },
+    message: `Env source ${source} failed.`,
   })
 }

--- a/packages/env/src/core/errors.ts
+++ b/packages/env/src/core/errors.ts
@@ -1,6 +1,51 @@
-export class EnvError extends Error {
-  constructor(message: string) {
-    super(`[vitehub] ${message}`)
+import { ViteHubError } from "@vite-hub/runtime"
+
+import type { ViteHubErrorDetails, ViteHubErrorOptions } from "@vite-hub/runtime"
+
+export type EnvErrorCode =
+  | "ENV_DECLARATION_INVALID"
+  | "ENV_REQUIRED_MISSING"
+  | "ENV_RUNTIME_VALUE_INVALID"
+
+export interface EnvErrorOptions<
+  TCode extends string = string,
+  TDetails extends ViteHubErrorDetails = ViteHubErrorDetails,
+> extends Pick<ViteHubErrorOptions<TDetails>, "cause" | "details"> {
+  code: TCode
+  message: string
+}
+
+export class EnvError<
+  TCode extends string = string,
+  TDetails extends ViteHubErrorDetails = ViteHubErrorDetails,
+> extends ViteHubError<TCode, TDetails> {
+  constructor(options: EnvErrorOptions<TCode, TDetails>) {
+    const { code, message, ...errorOptions } = options
+    super(code, message, errorOptions)
     this.name = "EnvError"
   }
+}
+
+export function invalidEnvDeclaration(path: string, message: string): EnvError<"ENV_DECLARATION_INVALID", { path: string }> {
+  return new EnvError({
+    code: "ENV_DECLARATION_INVALID",
+    details: { path },
+    message,
+  })
+}
+
+export function missingRequiredEnv(source: string, message: string, path?: string): EnvError<"ENV_REQUIRED_MISSING", { path?: string, source: string }> {
+  return new EnvError({
+    code: "ENV_REQUIRED_MISSING",
+    details: { ...(path ? { path } : {}), source },
+    message,
+  })
+}
+
+export function invalidRuntimeEnvValue(source: string, message: string): EnvError<"ENV_RUNTIME_VALUE_INVALID", { source: string }> {
+  return new EnvError({
+    code: "ENV_RUNTIME_VALUE_INVALID",
+    details: { source },
+    message,
+  })
 }

--- a/packages/env/src/core/resolve.ts
+++ b/packages/env/src/core/resolve.ts
@@ -5,7 +5,7 @@ import { promisify } from "node:util"
 
 import { parseSchema } from "../schema.ts"
 import { defaultStringSchema, isDefaultStringEnvVariable } from "./declarations.ts"
-import { EnvError } from "./errors.ts"
+import { invalidEnvDeclaration, missingRequiredEnv } from "./errors.ts"
 
 import type {
   EnvBuildConfigOptions,
@@ -32,17 +32,20 @@ export function validateEnvConfigShape(config: EnvViteConfigOptions | undefined,
   const viteConfig = config as EnvViteConfigOptions
   for (const key of Object.keys(viteConfig)) {
     if (key !== "define" && key !== "public" && key !== "server") {
-      throw new EnvError(`Invalid declaration at env.${key}. Vite env config only supports env.public, env.define, and env.server.`)
+      const path = `env.${key}`
+      throw invalidEnvDeclaration(path, `Invalid declaration at ${path}. Vite env config only supports env.public, env.define, and env.server.`)
     }
   }
 
   for (const [key, declaration] of Object.entries(viteConfig.public || {})) {
     assertEnvVariableDeclaration(`env.public.${key}`, declaration)
     if (declaration.mode !== "build") {
-      throw new EnvError(`env.public.${key} must use mode: "build" in Vite config.`)
+      const path = `env.public.${key}`
+      throw invalidEnvDeclaration(path, `${path} must use mode: "build" in Vite config.`)
     }
     if (declaration.secret) {
-      throw new EnvError(`env.public.${key} cannot be marked secret.`)
+      const path = `env.public.${key}`
+      throw invalidEnvDeclaration(path, `${path} cannot be marked secret.`)
     }
   }
 
@@ -130,7 +133,8 @@ export async function resolveEnvEntries(
     const valueForSchema = defaulted ? declaration.default : resolvedSource.value
     if (typeof valueForSchema === "undefined") {
       if (declaration.required) {
-        throw new EnvError(`Missing ${input.section}.${key} from ${source.label}.`)
+        const path = `${input.section}.${key}`
+        throw missingRequiredEnv(source.label, `Missing ${path} from ${source.label}.`, path)
       }
       entries.push({
         key,
@@ -197,7 +201,7 @@ async function resolveBuildConfigValue(
     const valueForSchema = defaulted ? declaration.default : resolvedSource.value
     if (typeof valueForSchema === "undefined") {
       if (declaration.required) {
-        throw new EnvError(`Missing ${path} from ${source.label}.`)
+        throw missingRequiredEnv(source.label, `Missing ${path} from ${source.label}.`, path)
       }
       return {
         diagnostics: [{
@@ -236,7 +240,7 @@ async function resolveBuildConfigValue(
   }
 
   if (!isPlainRecord(declaration)) {
-    throw new EnvError(`Invalid build declaration at ${path}. Use env(), a serializable static value, or a nested object.`)
+    throw invalidEnvDeclaration(path, `Invalid build declaration at ${path}. Use env(), a serializable static value, or a nested object.`)
   }
 
   const value: Record<string, unknown> = {}
@@ -255,7 +259,7 @@ function buildRegistry(declarations: EnvRuntimeConfigOptions | undefined, path: 
     return {}
   }
   if (!isPlainRecord(declarations)) {
-    throw new EnvError(`Invalid runtime declaration at ${path}. Use env(), a serializable static value, or a nested object.`)
+    throw invalidEnvDeclaration(path, `Invalid runtime declaration at ${path}. Use env(), a serializable static value, or a nested object.`)
   }
   return Object.fromEntries(Object.entries(declarations).map(([key, value]) => {
     const valuePath = `${path}.${key}`
@@ -264,22 +268,22 @@ function buildRegistry(declarations: EnvRuntimeConfigOptions | undefined, path: 
         return [key, { kind: "literal", value }]
       }
       if (!isPlainRecord(value)) {
-        throw new EnvError(`Invalid runtime declaration at ${valuePath}. Use env(), a serializable static value, or a nested object.`)
+        throw invalidEnvDeclaration(valuePath, `Invalid runtime declaration at ${valuePath}. Use env(), a serializable static value, or a nested object.`)
       }
       return [key, buildRegistry(value as EnvRuntimeConfigOptions, valuePath, prefix)]
     }
     if (value.mode !== "runtime") {
-      throw new EnvError(`Runtime declaration ${valuePath} must use mode: "runtime".`)
+      throw invalidEnvDeclaration(valuePath, `Runtime declaration ${valuePath} must use mode: "runtime".`)
     }
     const source = resolveEnvSource(value, valuePath, prefix)
     if (source.kind !== "env") {
-      throw new EnvError(`Runtime declaration ${valuePath} must use env.source() in v1.`)
+      throw invalidEnvDeclaration(valuePath, `Runtime declaration ${valuePath} must use env.source() in v1.`)
     }
     if (!isDefaultStringEnvVariable(value)) {
-      throw new EnvError(`Runtime declaration ${valuePath} uses a custom schema, but runtime schemas cannot be serialized in v1.`)
+      throw invalidEnvDeclaration(valuePath, `Runtime declaration ${valuePath} uses a custom schema, but runtime schemas cannot be serialized in v1.`)
     }
     if (value.type && value.type !== "string") {
-      throw new EnvError(`Runtime declaration ${valuePath} uses type ${JSON.stringify(value.type)}, but runtime values are strings in v1.`)
+      throw invalidEnvDeclaration(valuePath, `Runtime declaration ${valuePath} uses type ${JSON.stringify(value.type)}, but runtime values are strings in v1.`)
     }
     return [key, {
       default: typeof value.default === "undefined"
@@ -348,16 +352,16 @@ async function resolveSourceValue(source: EnvSource, context: EnvSourceContext):
 function validateBuildDeclarations(declarations: EnvBuildConfigOptions | undefined, path: string): void {
   if (typeof declarations === "undefined") return
   if (!isPlainRecord(declarations)) {
-    throw new EnvError(`Invalid declaration at ${path}. Use env(), a serializable static value, or a nested object.`)
+    throw invalidEnvDeclaration(path, `Invalid declaration at ${path}. Use env(), a serializable static value, or a nested object.`)
   }
   for (const [key, declaration] of Object.entries(declarations)) {
     const valuePath = `${path}.${key}`
     if (isEnvVariableDeclaration(declaration)) {
       if (declaration.mode !== "build") {
-        throw new EnvError(`${valuePath} must use mode: "build".`)
+        throw invalidEnvDeclaration(valuePath, `${valuePath} must use mode: "build".`)
       }
       if (declaration.secret) {
-        throw new EnvError(`${valuePath} cannot be marked secret because Vite define values are bundled.`)
+        throw invalidEnvDeclaration(valuePath, `${valuePath} cannot be marked secret because Vite define values are bundled.`)
       }
       continue
     }
@@ -368,7 +372,7 @@ function validateBuildDeclarations(declarations: EnvBuildConfigOptions | undefin
 
 function assertEnvVariableDeclaration(path: string, declaration: unknown): asserts declaration is EnvVariableDeclaration {
   if (!isEnvVariableDeclaration(declaration)) {
-    throw new EnvError(`Invalid declaration at ${path}. Use env().`)
+    throw invalidEnvDeclaration(path, `Invalid declaration at ${path}. Use env().`)
   }
 }
 

--- a/packages/env/src/core/resolve.ts
+++ b/packages/env/src/core/resolve.ts
@@ -5,7 +5,7 @@ import { promisify } from "node:util"
 
 import { parseSchema } from "../schema.ts"
 import { defaultStringSchema, isDefaultStringEnvVariable } from "./declarations.ts"
-import { invalidEnvDeclaration, missingRequiredEnv } from "./errors.ts"
+import { envSourceFailed, invalidEnvDeclaration, missingRequiredEnv } from "./errors.ts"
 
 import type {
   EnvBuildConfigOptions,
@@ -333,19 +333,28 @@ async function resolveSourceValue(source: EnvSource, context: EnvSourceContext):
       }
       return { label: source.label, value: undefined }
     case "git-branch":
-      return { label: source.label, value: await context.git.branch() }
+      return { label: source.label, value: await resolveBuiltInSource(source.label, () => context.git.branch()) }
     case "git-commit":
-      return { label: source.label, value: await context.git.commit({ short: source.short }) }
+      return { label: source.label, value: await resolveBuiltInSource(source.label, () => context.git.commit({ short: source.short })) }
     case "git-ref":
-      return { label: source.label, value: await context.git.ref() }
+      return { label: source.label, value: await resolveBuiltInSource(source.label, () => context.git.ref()) }
     case "git-sha":
-      return { label: source.label, value: await context.git.sha({ short: source.short }) }
+      return { label: source.label, value: await resolveBuiltInSource(source.label, () => context.git.sha({ short: source.short })) }
     case "git-tag":
-      return { label: source.label, value: await context.git.tag() }
+      return { label: source.label, value: await resolveBuiltInSource(source.label, () => context.git.tag()) }
     case "build-timestamp":
       return { label: source.label, value: context.build.timestamp() }
     case "package-json":
-      return { label: source.label, value: readPath(await context.packageJson(), source.path) }
+      return { label: source.label, value: readPath(await resolveBuiltInSource(source.label, () => context.packageJson()), source.path) }
+  }
+}
+
+async function resolveBuiltInSource<T>(source: string, resolveSource: () => T | Promise<T>): Promise<T> {
+  try {
+    return await resolveSource()
+  }
+  catch (cause) {
+    throw envSourceFailed(source, cause)
   }
 }
 

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,9 +1,11 @@
 export { env } from "./core/declarations.ts"
+export { EnvError } from "./core/errors.ts"
 export { openWorkflowEnv } from "./presets.ts"
 export { parseSchema } from "./schema.ts"
 export { SecretEnv } from "./secret.ts"
 export { resolveServerEnv } from "./server.ts"
 export type { StandardSchemaV1 } from "./schema.ts"
+export type { EnvErrorCode, EnvErrorOptions } from "./core/errors.ts"
 export type {
   EnvConfigOptions,
   EnvDiagnosticEntry,

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -52,7 +52,9 @@ function runtimeEnv(event?: unknown): RuntimeEnv {
 
 function readRuntimeSource(entry: RuntimeEnvEntry, env: RuntimeEnv): { found: boolean, value?: unknown } {
   for (const name of entry.source.names || [entry.source.name]) {
-    if (name in env) return { found: true, value: env[name] }
+    if (Object.hasOwn(env, name) && typeof env[name] !== "undefined") {
+      return { found: true, value: env[name] }
+    }
   }
   return { found: false }
 }

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -1,5 +1,6 @@
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 
+import { invalidRuntimeEnvValue, missingRequiredEnv } from "./core/errors.ts"
 import { SecretEnv } from "./secret.ts"
 
 import type { EnvRuntimeRegistry } from "./types.ts"
@@ -65,12 +66,12 @@ function resolveRegistryValue(value: unknown, env: RuntimeEnv): unknown {
     const resolved = readRuntimeSource(value, env) ?? value.default
     if (typeof resolved === "undefined") {
       if (value.required) {
-        throw new Error(`Missing Runtime Env from ${value.source.label}.`)
+        throw missingRequiredEnv(value.source.label, `Missing Runtime Env from ${value.source.label}.`)
       }
       return undefined
     }
     if (typeof resolved !== "string") {
-      throw new Error(`Runtime Env from ${value.source.label} must resolve to a string.`)
+      throw invalidRuntimeEnvValue(value.source.label, `Runtime Env from ${value.source.label} must resolve to a string.`)
     }
     return value.secret ? new SecretEnv(resolved) : resolved
   }

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -50,11 +50,11 @@ function runtimeEnv(event?: unknown): RuntimeEnv {
   }
 }
 
-function readRuntimeSource(entry: RuntimeEnvEntry, env: RuntimeEnv): string | undefined {
+function readRuntimeSource(entry: RuntimeEnvEntry, env: RuntimeEnv): { found: boolean, value?: unknown } {
   for (const name of entry.source.names || [entry.source.name]) {
-    const value = env[name]
-    if (typeof value === "string") return value
+    if (name in env) return { found: true, value: env[name] }
   }
+  return { found: false }
 }
 
 function resolveRegistryValue(value: unknown, env: RuntimeEnv): unknown {
@@ -63,7 +63,8 @@ function resolveRegistryValue(value: unknown, env: RuntimeEnv): unknown {
   }
 
   if (isRuntimeEnvEntry(value)) {
-    const resolved = readRuntimeSource(value, env) ?? value.default
+    const source = readRuntimeSource(value, env)
+    const resolved = source.found ? source.value : value.default
     if (typeof resolved === "undefined") {
       if (value.required) {
         throw missingRequiredEnv(value.source.label, `Missing Runtime Env from ${value.source.label}.`)

--- a/packages/env/test/errors.test.ts
+++ b/packages/env/test/errors.test.ts
@@ -64,6 +64,14 @@ describe("EnvError", () => {
       code: "ENV_RUNTIME_VALUE_INVALID",
       details: { source: "env:TOKEN" },
     }))
+
+    expect(resolveServerEnv({
+      token: {
+        required: true,
+        secret: false,
+        source: { kind: "env", label: "env:TOKEN", name: "TOKEN", names: ["TOKEN", "TOKEN_FALLBACK"], serializable: true },
+      },
+    }, { env: { TOKEN: undefined, TOKEN_FALLBACK: "fallback" } })).toEqual({ token: "fallback" })
   })
 
   it("keeps declaration misuse and schema helpers outside the Env error family", () => {

--- a/packages/env/test/errors.test.ts
+++ b/packages/env/test/errors.test.ts
@@ -2,7 +2,7 @@ import { ViteHubError } from "@vite-hub/runtime"
 import { describe, expect, it } from "vitest"
 
 import { env, EnvError, resolveServerEnv } from "../src/index.ts"
-import { validateEnvConfigShape } from "../src/core/resolve.ts"
+import { createSourceContext, resolveEnvEntries, validateEnvConfigShape } from "../src/core/resolve.ts"
 import { parseSchema } from "../src/schema.ts"
 
 describe("EnvError", () => {
@@ -66,5 +66,48 @@ describe("EnvError", () => {
       expect(error).toBeInstanceOf(Error)
       expect(error).not.toBeInstanceOf(EnvError)
     }
+  })
+
+  it("normalizes built-in Git and package metadata source failures", async () => {
+    const context = createSourceContext({ env: {}, mode: "build", rootDir: "/app" })
+    const input = {
+      context,
+      exposure: "build public" as const,
+      section: "env.public" as const,
+      timing: "build",
+    }
+    const gitCause = new Error("git credential leaked")
+    context.git.branch = async () => {
+      throw gitCause
+    }
+
+    const gitError = await resolveEnvEntries({
+      branch: env({ mode: "build", source: env.gitBranch() }),
+    }, input).then(() => undefined, error => error)
+
+    expect(gitError).toMatchObject({
+      cause: gitCause,
+      code: "ENV_SOURCE_FAILED",
+      details: { source: "git:branch" },
+      message: "Env source git:branch failed.",
+    })
+    expect(JSON.stringify(gitError)).not.toContain("git credential leaked")
+
+    const packageCause = new Error("private package metadata leaked")
+    context.packageJson = async () => {
+      throw packageCause
+    }
+
+    const packageError = await resolveEnvEntries({
+      name: env({ mode: "build", source: env.packageJson("name") }),
+    }, input).then(() => undefined, error => error)
+
+    expect(packageError).toMatchObject({
+      cause: packageCause,
+      code: "ENV_SOURCE_FAILED",
+      details: { source: "package.json:name" },
+      message: "Env source package.json:name failed.",
+    })
+    expect(JSON.stringify(packageError)).not.toContain("private package metadata leaked")
   })
 })

--- a/packages/env/test/errors.test.ts
+++ b/packages/env/test/errors.test.ts
@@ -53,6 +53,17 @@ describe("EnvError", () => {
       code: "ENV_RUNTIME_VALUE_INVALID",
       details: { source: "env:PORT" },
     }))
+
+    expect(() => resolveServerEnv({
+      token: {
+        required: true,
+        secret: true,
+        source: { kind: "env", label: "env:TOKEN", name: "TOKEN", names: ["TOKEN"], serializable: true },
+      },
+    }, { env: { TOKEN: {} } })).toThrow(expect.objectContaining({
+      code: "ENV_RUNTIME_VALUE_INVALID",
+      details: { source: "env:TOKEN" },
+    }))
   })
 
   it("keeps declaration misuse and schema helpers outside the Env error family", () => {

--- a/packages/env/test/errors.test.ts
+++ b/packages/env/test/errors.test.ts
@@ -1,0 +1,70 @@
+import { ViteHubError } from "@vite-hub/runtime"
+import { describe, expect, it } from "vitest"
+
+import { env, EnvError, resolveServerEnv } from "../src/index.ts"
+import { validateEnvConfigShape } from "../src/core/resolve.ts"
+import { parseSchema } from "../src/schema.ts"
+
+describe("EnvError", () => {
+  it("keeps structured details public and the cause in memory", () => {
+    const cause = new Error("secret provider failure")
+    const error = new EnvError({
+      cause,
+      code: "ENV_SOURCE_FAILED",
+      details: { source: "vault:token" },
+      message: "Env source failed.",
+    })
+
+    expect(error).toBeInstanceOf(ViteHubError)
+    expect(error.cause).toBe(cause)
+    expect(error.toJSON()).toEqual({
+      code: "ENV_SOURCE_FAILED",
+      details: { source: "vault:token" },
+      message: "Env source failed.",
+    })
+    expect(JSON.stringify(error)).not.toContain("secret provider failure")
+  })
+
+  it("classifies invalid declarations and missing runtime values", () => {
+    expect(() => validateEnvConfigShape({ unknown: env() } as never, "vite")).toThrow(expect.objectContaining({
+      code: "ENV_DECLARATION_INVALID",
+      details: { path: "env.unknown" },
+    }))
+
+    expect(() => resolveServerEnv({
+      token: {
+        required: true,
+        secret: true,
+        source: { kind: "env", label: "env:TOKEN", name: "TOKEN", names: ["TOKEN"], serializable: true },
+      },
+    }, { env: {} })).toThrow(expect.objectContaining({
+      code: "ENV_REQUIRED_MISSING",
+      details: { source: "env:TOKEN" },
+    }))
+
+    expect(() => resolveServerEnv({
+      port: {
+        default: 3000,
+        required: false,
+        secret: false,
+        source: { kind: "env", label: "env:PORT", name: "PORT", names: ["PORT"], serializable: true },
+      },
+    }, { env: {} })).toThrow(expect.objectContaining({
+      code: "ENV_RUNTIME_VALUE_INVALID",
+      details: { source: "env:PORT" },
+    }))
+  })
+
+  it("keeps declaration misuse and schema helpers outside the Env error family", () => {
+    expect.assertions(3)
+    expect(() => env({ optional: true, required: true })).toThrow(TypeError)
+
+    try {
+      parseSchema({ safeParse: () => ({ error: "invalid", success: false }) }, "value", "env.value")
+    }
+    catch (error) {
+      expect(error).toBeInstanceOf(Error)
+      expect(error).not.toBeInstanceOf(EnvError)
+    }
+  })
+})

--- a/packages/env/test/published-types.test.ts
+++ b/packages/env/test/published-types.test.ts
@@ -1,0 +1,33 @@
+import { execFile } from "node:child_process"
+import { copyFile, cp, mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { it } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const runtimeRoot = resolve(packageRoot, "../runtime")
+const fixtureRoot = join(packageRoot, "fixtures", "published-types")
+const tsc = resolve(packageRoot, "../../node_modules/typescript/bin/tsc")
+
+it("publishes the Env error contract", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-env-types-"))
+
+  try {
+    await cp(fixtureRoot, root, { recursive: true })
+    for (const [name, sourceRoot] of [["env", packageRoot], ["runtime", runtimeRoot]] as const) {
+      const installedPackageRoot = join(root, "node_modules", "@vite-hub", name)
+      await mkdir(installedPackageRoot, { recursive: true })
+      await copyFile(join(sourceRoot, "package.json"), join(installedPackageRoot, "package.json"))
+      await cp(join(sourceRoot, "dist"), join(installedPackageRoot, "dist"), { recursive: true })
+    }
+
+    await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", root])
+  }
+  finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})

--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -7,6 +7,9 @@
     "paths": {
       "@vite-hub/internal/*": [
         "packages/internal/src/*.ts"
+      ],
+      "@vite-hub/runtime": [
+        "packages/runtime/src/index.ts"
       ]
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -802,6 +802,9 @@ importers:
 
   packages/env:
     dependencies:
+      '@vite-hub/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
         version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@26.1.1)(@vitejs/devtools@0.1.19)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'


### PR DESCRIPTION
Depends on #670. This gives `@vite-hub/env` the shared structured-error contract: `EnvError` extends `ViteHubError`, uses object construction, and classifies invalid declarations, missing required values, invalid runtime values, and failed built-in Git or package metadata sources with stable Env-owned codes and JSON-safe details. Source failures retain the original failure as `cause` while exposing only the public source label. Declaration API misuse remains `TypeError`, schema helpers keep their ordinary error boundary, and serialization omits `cause`.

This intentionally leaves #693's Vite import-generation changes untouched so the two slices can review independently. The package README, Env guide, and shared errors reference document the contract, with runtime behavior, public exports, packed declarations, the full Env suite, publint, typecheck, lint, and scoped Fallow covering the package boundary.