### PR TITLE
fix(auth): own session resolution failures

### DIFF
--- a/docs/content/docs/concepts/auth-users-and-agent-invokers.md
+++ b/docs/content/docs/concepts/auth-users-and-agent-invokers.md
@@ -35,7 +35,7 @@ export default defineAgent({
 
 When a required Auth Session is missing, the bridge throws `AuthenticationRequiredError` with code `AUTHENTICATION_REQUIRED` and `statusCode: 401`, so Agent and HTTP entry surfaces can recognize the same failure without parsing its message.
 
-When the default Better Auth request or session operation rejects, the bridge throws `AuthenticationProviderError` with code `AUTH_PROVIDER_OPERATION_FAILED`; application-owned `source` exceptions remain unchanged.
+When the default Better Auth session lookup fails or returns a malformed non-null response, the bridge throws `AuthSessionError` with code `AUTH_SESSION_FAILED` and `statusCode: 503`; application-owned `source` exceptions remain unchanged.
 
 ## What Agent Invoker carries
 

--- a/docs/content/docs/reference/errors-diagnostics.md
+++ b/docs/content/docs/reference/errors-diagnostics.md
@@ -17,7 +17,7 @@ Use the error family to choose the next proof path before changing implementatio
 | `ApprovalRequiredError` | Runtime Package | A policy decision requires an Approval Request before execution. |
 | `EnvError` | Env Package | Env Declaration or runtime resolution failed with an Env-owned code and JSON-safe context. |
 | `AuthenticationRequiredError` | Auth Package | A route or Agent Invoker bridge needs an authenticated application user; inspect code `AUTHENTICATION_REQUIRED` and `statusCode: 401`. |
-| `AuthenticationProviderError` | Auth Package | The default Better Auth request or session operation failed; inspect code `AUTH_PROVIDER_OPERATION_FAILED` and safe operation details. |
+| `AuthSessionError` | Auth Package | The default Better Auth session lookup failed or returned an invalid response; inspect code `AUTH_SESSION_FAILED` and `statusCode: 503`. |
 | `EmailError` | Email Package | Message validation, missing Email Definition, delivery credentials, throttling, network, timeout, or provider delivery failed. |
 | `QueueError` | Queue Package | Queue dispatch, callback, or provider handling failed. |
 | `WorkspaceError` | Workspace Package | Workspace runtime, store, rule, or file-tree behavior failed. |
@@ -48,7 +48,7 @@ Use the error family to choose the next proof path before changing implementatio
 
 ## Local response
 
-Start with the owning package and the failing proof path. For packages that generate Provider Output, inspect that output before changing runtime code. Authenticated Agent bridges expose `AuthenticationRequiredError.code` and `statusCode`; default Better Auth operational failures use `AuthenticationProviderError` and keep the provider cause in memory only. Email emits no Provider Output; inspect `EmailError.code` and `driver` the same way.
+Start with the owning package and the failing proof path. For packages that generate Provider Output, inspect that output before changing runtime code. Authenticated Agent bridges distinguish a missing session with `AuthenticationRequiredError` from a default provider lookup failure with `AuthSessionError`; use `cause` only in protected server-side diagnostics. Email emits no Provider Output; inspect `EmailError.code` and `driver` the same way.
 
 For Env, inspect `EnvError.code` first. `ENV_DECLARATION_INVALID` includes `details.path`, `ENV_REQUIRED_MISSING` includes the public source label and sometimes the declaration path, `ENV_RUNTIME_VALUE_INVALID` includes the public source label, and `ENV_SOURCE_FAILED` identifies a failed built-in Git or package metadata source through `details.source`. The serialized shape omits `cause`; never place secret values in `details`.
 

--- a/docs/content/docs/server-primitives/auth.md
+++ b/docs/content/docs/server-primitives/auth.md
@@ -53,7 +53,7 @@ export default defineAuth({
 | `requireAuth` from `@vite-hub/auth/server` | Guard server routes with an Auth Session. |
 | `authenticated` from `@vite-hub/auth/agent` | Map a Better Auth session into an Agent Invoker. |
 | `AuthenticationRequiredError` from `@vite-hub/auth/agent` | Handle missing authentication with a stable code and HTTP status. |
-| `AuthenticationProviderError` from `@vite-hub/auth/agent` | Inspect an operational failure from the default Better Auth session bridge. |
+| `AuthSessionError` from `@vite-hub/auth/agent` | Handle default Better Auth session lookup failures without exposing provider diagnostics. |
 | `hubAuth` from `@vite-hub/auth/vite` | Register Auth discovery, route exposure, and generated server aliases. |
 
 Create one Primary Auth Definition. ViteHub discovers `server/auth.ts` or `server.auth.ts`.
@@ -221,22 +221,17 @@ Read [Auth Users and Agent Invokers](/docs/concepts/auth-users-and-agent-invoker
 
 ### Handle required authentication
 
-`authenticated()` throws `AuthenticationRequiredError` when it cannot resolve a required Auth Session. The error has code `AUTHENTICATION_REQUIRED`, preserves `statusCode: 401` for HTTP adapters, and serializes safe details without its cause or stack.
+`authenticated()` throws `AuthenticationRequiredError` when no required Auth Session exists. The error has code `AUTHENTICATION_REQUIRED`, preserves `statusCode: 401` for HTTP adapters, and serializes its public message without its cause or stack.
 
 ```ts
 import { AuthenticationRequiredError } from '@vite-hub/auth/agent'
 
-const error = new AuthenticationRequiredError({
-  details: { surface: 'support-agent' },
-  message: 'Sign in to use this Agent.',
-})
+const error = new AuthenticationRequiredError('Sign in to use this Agent.')
 
 console.log(error.toJSON())
 ```
 
-The string constructor remains available for custom messages. Invalid Auth Definitions and invalid `authenticated()` configuration are programmer errors, so they continue to throw `TypeError` rather than authentication failures.
-
-The default Better Auth bridge wraps `getAuthForRequest()` and `getSession()` failures in `AuthenticationProviderError` with code `AUTH_PROVIDER_OPERATION_FAILED`. Its serialized details contain only `provider: 'better-auth'` and the failed operation; the original failure stays on the nonserialized `cause`. An application-owned `authenticated({ source })` remains its own seam, so its exceptions pass through unchanged.
+The string constructor remains available for custom messages. The default Better Auth boundary throws `AuthSessionError` with code `AUTH_SESSION_FAILED` and `statusCode: 503` when session lookup fails, its API is missing, or a non-null response is malformed. Custom `source`, `map`, and identity callbacks keep their original error identity. Invalid Auth Definitions and invalid `authenticated()` configuration are programmer errors, so they continue to throw `TypeError` rather than authentication failures.
 
 ## Next steps
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -175,17 +175,12 @@ export default defineAgent({
 
 By default, the Auth Package reads the same-app Better Auth session from the request and maps the Auth User to an Agent Invoker with `kind: "authUser"`. Customize `id`, `kind`, `label`, or `meta` for normal identity shaping, and use `source` or `map` when the Agent consumes JWTs, bearer tokens, OAuth/OIDC provider output, or product-specific identity.
 
-When authentication is required but unavailable, `authenticated()` throws `AuthenticationRequiredError` with code `AUTHENTICATION_REQUIRED` and `statusCode: 401`. The class keeps its existing string constructor and also accepts safe structured context.
+When authentication is required but unavailable, `authenticated()` throws `AuthenticationRequiredError` with code `AUTHENTICATION_REQUIRED` and `statusCode: 401`. The class keeps its existing string constructor and accepts a protected `cause` through its object form.
 
 ```ts
 import { AuthenticationRequiredError } from "@vite-hub/auth/agent"
 
-const error = new AuthenticationRequiredError({
-  details: { surface: "support-agent" },
-  message: "Sign in to use this Agent.",
-})
+const error = new AuthenticationRequiredError("Sign in to use this Agent.")
 ```
 
-`error.toJSON()` includes `code`, `message`, and `details`, while omitting `cause` and stack data. Keep secrets out of `details`; use `cause` only for protected server-side diagnostics.
-
-If the default Better Auth bridge fails while creating request-scoped Auth or reading its session, `authenticated()` throws `AuthenticationProviderError` with code `AUTH_PROVIDER_OPERATION_FAILED`. Its safe details identify Better Auth and the failed operation, while the original provider failure remains available only as the nonserialized `cause`. Exceptions from an application-owned `source` pass through unchanged.
+`error.toJSON()` includes `code` and `message`, while omitting `cause` and stack data. If the default Better Auth session lookup fails or returns an invalid non-null response, `authenticated()` throws `AuthSessionError` with code `AUTH_SESSION_FAILED` and `statusCode: 503`; raw provider diagnostics remain available only through `cause`.

--- a/packages/auth/fixtures/published-types/consumer.ts
+++ b/packages/auth/fixtures/published-types/consumer.ts
@@ -1,6 +1,6 @@
 import {
-  AuthenticationProviderError,
-  type AuthenticationProviderErrorOptions,
+  AuthSessionError,
+  type AuthSessionErrorOptions,
   AuthenticationRequiredError,
   type AuthenticationRequiredErrorOptions,
 } from "@vite-hub/auth/agent"
@@ -8,7 +8,7 @@ import {
 import type { ViteHubErrorShape } from "@vite-hub/runtime"
 
 const options = {
-  details: { surface: "agent-invoker" },
+  cause: new Error("protected diagnostic"),
   message: "Sign in required.",
 } satisfies AuthenticationRequiredErrorOptions
 
@@ -19,9 +19,10 @@ error.toJSON() satisfies ViteHubErrorShape<"AUTHENTICATION_REQUIRED">
 
 new AuthenticationRequiredError("Sign in required.")
 
-const providerOptions = {
-  operation: "get-session",
-} satisfies AuthenticationProviderErrorOptions
-const providerError = new AuthenticationProviderError(providerOptions)
-providerError.code satisfies "AUTH_PROVIDER_OPERATION_FAILED"
-providerError.toJSON() satisfies ViteHubErrorShape<"AUTH_PROVIDER_OPERATION_FAILED">
+const sessionOptions = {
+  cause: new Error("protected provider diagnostic"),
+} satisfies AuthSessionErrorOptions
+const sessionError = new AuthSessionError(sessionOptions)
+sessionError.code satisfies "AUTH_SESSION_FAILED"
+sessionError.statusCode satisfies 503
+sessionError.toJSON() satisfies ViteHubErrorShape<"AUTH_SESSION_FAILED">

--- a/packages/auth/src/agent.ts
+++ b/packages/auth/src/agent.ts
@@ -9,7 +9,6 @@ import type {
   AgentRuntimeConfig,
   MaybePromise,
 } from "@vite-hub/agent"
-import type { ViteHubErrorDetails } from "@vite-hub/runtime"
 
 export interface AuthenticatedUser {
   email?: string | null
@@ -86,7 +85,6 @@ export interface AuthenticatedOptions<
 }
 
 export interface AuthenticationRequiredErrorOptions extends ErrorOptions {
-  details?: ViteHubErrorDetails
   message?: string
 }
 
@@ -103,7 +101,6 @@ export class AuthenticationRequiredError extends ViteHubError<"AUTHENTICATION_RE
 
     super("AUTHENTICATION_REQUIRED", message, {
       cause: options.cause,
-      details: options.details,
     })
     this.name = "AuthenticationRequiredError"
     Object.defineProperty(this, "statusCode", {
@@ -113,25 +110,20 @@ export class AuthenticationRequiredError extends ViteHubError<"AUTHENTICATION_RE
   }
 }
 
-export type AuthenticationProviderOperation = "get-auth-for-request" | "get-session"
+export type AuthSessionErrorOptions = ErrorOptions
 
-export interface AuthenticationProviderErrorOptions extends ErrorOptions {
-  operation: AuthenticationProviderOperation
-}
+export class AuthSessionError extends ViteHubError<"AUTH_SESSION_FAILED"> {
+  declare readonly statusCode: 503
 
-export class AuthenticationProviderError extends ViteHubError<
-  "AUTH_PROVIDER_OPERATION_FAILED",
-  { operation: AuthenticationProviderOperation, provider: "better-auth" }
-> {
-  constructor(options: AuthenticationProviderErrorOptions) {
-    super("AUTH_PROVIDER_OPERATION_FAILED", "[vitehub] Authentication provider operation failed.", {
+  constructor(options: AuthSessionErrorOptions = {}) {
+    super("AUTH_SESSION_FAILED", "[vitehub] Authentication session resolution failed.", {
       cause: options.cause,
-      details: {
-        operation: options.operation,
-        provider: "better-auth",
-      },
     })
-    this.name = "AuthenticationProviderError"
+    this.name = "AuthSessionError"
+    Object.defineProperty(this, "statusCode", {
+      enumerable: true,
+      value: 503,
+    })
   }
 }
 
@@ -191,28 +183,49 @@ async function defaultAuthenticatedSource(
 ): Promise<AuthenticatedSession | null | undefined> {
   if (!context.request) return undefined
 
-  let auth: BetterAuthSessionApi
   try {
-    auth = getAuthForRequest(context.request) as BetterAuthSessionApi
-  }
-  catch (cause) {
-    throw new AuthenticationProviderError({ cause, operation: "get-auth-for-request" })
-  }
+    const auth = getAuthForRequest(context.request) as BetterAuthSessionApi
+    const getSession = auth.api?.getSession
+    if (!getSession) {
+      throw new AuthSessionError({
+        cause: new TypeError("Better Auth did not expose api.getSession()."),
+      })
+    }
 
-  let session: unknown
-  try {
-    session = await auth.api?.getSession?.({
+    const session = await getSession.call(auth.api, {
       headers: context.request.headers,
       query: {
         disableCookieCache: true,
         disableRefresh: true,
       },
     })
+    if (session == null) return session
+
+    const normalized = normalizeAuthenticatedSession(session)
+    if (!normalized) {
+      throw new AuthSessionError({
+        cause: new TypeError("Better Auth returned an invalid session response."),
+      })
+    }
+    return normalized
   }
-  catch (cause) {
-    throw new AuthenticationProviderError({ cause, operation: "get-session" })
+  catch (error) {
+    if (error instanceof AuthSessionError || error instanceof AuthenticationRequiredError || isAuthAbortError(error)) {
+      throw error
+    }
+    throw new AuthSessionError({ cause: error })
   }
-  return normalizeAuthenticatedSession(session)
+}
+
+function isAuthAbortError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false
+
+  try {
+    return "name" in error && error.name === "AbortError"
+  }
+  catch {
+    return false
+  }
 }
 
 function createAuthenticatedContext<

--- a/packages/auth/test/agent.test.ts
+++ b/packages/auth/test/agent.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { authenticated, AuthenticationProviderError, AuthenticationRequiredError } from "../src/agent.ts"
+import { authenticated, AuthSessionError, AuthenticationRequiredError } from "../src/agent.ts"
 
 import type { AgentInvokerOptions, AgentInvokerResolveContext } from "@vite-hub/agent"
 
@@ -57,13 +57,13 @@ async function resolve(options: AgentInvokerOptions, context = createContext()) 
 
 describe("authenticated", () => {
   beforeEach(() => {
+    serverMocks.getSession.mockReset()
     serverMocks.getAuthForRequest.mockReset()
     serverMocks.getAuthForRequest.mockReturnValue({
       api: {
         getSession: serverMocks.getSession,
       },
     })
-    serverMocks.getSession.mockReset()
   })
 
   it("reads Better Auth sessions authoritatively without refreshing cookies", async () => {
@@ -181,37 +181,62 @@ describe("authenticated", () => {
     })
   })
 
-  it.each([
-    ["get-auth-for-request", () => serverMocks.getAuthForRequest.mockImplementationOnce(() => { throw new Error("secret request failure") })],
-    ["get-session", () => serverMocks.getSession.mockRejectedValueOnce(new Error("secret session failure"))],
-  ] as const)("normalizes Better Auth %s failures", async (operation, reject) => {
+  it("maps default Better Auth failures without exposing provider diagnostics", async () => {
     const request = new Request("https://example.com/api/agent")
-    reject()
+    const providerError = new Error("Bearer secret-token")
+    serverMocks.getSession.mockRejectedValue(providerError)
 
-    const error = await resolve(authenticated(), createContext({ request })).catch(error => error)
+    const rejection = resolve(authenticated(), createContext({ request })).catch(error => error as AuthSessionError)
+    const error = await rejection
 
-    expect(error).toBeInstanceOf(AuthenticationProviderError)
+    expect(error).toBeInstanceOf(AuthSessionError)
     expect(error).toMatchObject({
-      code: "AUTH_PROVIDER_OPERATION_FAILED",
-      details: { operation, provider: "better-auth" },
-      message: "[vitehub] Authentication provider operation failed.",
-      name: "AuthenticationProviderError",
+      cause: providerError,
+      code: "AUTH_SESSION_FAILED",
+      message: "[vitehub] Authentication session resolution failed.",
+      statusCode: 503,
     })
-    expect(error.cause).toBeInstanceOf(Error)
-    expect(JSON.parse(JSON.stringify(error))).toEqual({
-      code: "AUTH_PROVIDER_OPERATION_FAILED",
-      details: { operation, provider: "better-auth" },
-      message: "[vitehub] Authentication provider operation failed.",
-    })
-    expect(JSON.stringify(error)).not.toContain("secret")
+    expect(JSON.stringify(error)).not.toContain("secret-token")
   })
 
-  it("preserves application source exceptions", async () => {
-    const error = new Error("application source failure")
+  it("distinguishes invalid Better Auth responses from missing sessions", async () => {
+    const request = new Request("https://example.com/api/agent")
+    serverMocks.getSession.mockResolvedValueOnce(null)
+    await expect(resolve(authenticated({ required: false }), createContext({ request }))).resolves.toBeUndefined()
 
+    serverMocks.getSession.mockResolvedValueOnce({ session: {}, user: {} })
+    await expect(resolve(authenticated(), createContext({ request }))).rejects.toMatchObject({
+      code: "AUTH_SESSION_FAILED",
+      name: "AuthSessionError",
+    })
+
+    serverMocks.getAuthForRequest.mockReturnValueOnce({ api: {} })
+    await expect(resolve(authenticated(), createContext({ request }))).rejects.toMatchObject({
+      code: "AUTH_SESSION_FAILED",
+      name: "AuthSessionError",
+    })
+  })
+
+  it("preserves exact abort and custom extension failures", async () => {
+    const request = new Request("https://example.com/api/agent")
+    const abort = new DOMException("cancelled", "AbortError")
+    serverMocks.getSession.mockRejectedValue(abort)
+    await expect(resolve(authenticated(), createContext({ request }))).rejects.toBe(abort)
+
+    const sourceError = new Error("custom source failed")
+    await expect(resolve(authenticated({ source: () => { throw sourceError } }))).rejects.toBe(sourceError)
+
+    const mapError = new Error("custom map failed")
     await expect(resolve(authenticated({
-      source: () => { throw error },
-    }))).rejects.toBe(error)
+      map: () => { throw mapError },
+      source: () => ({ session: {}, user: { id: "user_1" } }),
+    }))).rejects.toBe(mapError)
+
+    const valueError = new Error("custom value failed")
+    await expect(resolve(authenticated({
+      id: () => { throw valueError },
+      source: () => ({ session: {}, user: { id: "user_1" } }),
+    }))).rejects.toBe(valueError)
   })
 
   it("preserves normal Agent Invoker resolution when auth is optional", async () => {

--- a/packages/auth/test/errors.test.ts
+++ b/packages/auth/test/errors.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { ViteHubError } from "@vite-hub/runtime"
 
-import { AuthenticationRequiredError } from "../src/agent.ts"
+import { AuthSessionError, AuthenticationRequiredError } from "../src/agent.ts"
 
 describe("AuthenticationRequiredError", () => {
   it("preserves the existing class, message, and HTTP contract", () => {
@@ -20,19 +20,39 @@ describe("AuthenticationRequiredError", () => {
     expect(new AuthenticationRequiredError("Sign in required.").message).toBe("Sign in required.")
   })
 
-  it("serializes safe details without exposing its cause", () => {
+  it("preserves an explicit cause without serializing it", () => {
     const cause = new Error("Bearer secret-token")
     const error = new AuthenticationRequiredError({
       cause,
-      details: { surface: "agent-invoker" },
       message: "Sign in required.",
     })
 
     expect(error.cause).toBe(cause)
     expect(error.toJSON()).toEqual({
       code: "AUTHENTICATION_REQUIRED",
-      details: { surface: "agent-invoker" },
       message: "Sign in required.",
+    })
+    expect(JSON.stringify(error)).not.toContain("secret-token")
+  })
+})
+
+describe("AuthSessionError", () => {
+  it("owns a fixed safe session-resolution contract", () => {
+    const cause = new Error("Bearer secret-token")
+    const error = new AuthSessionError({ cause })
+
+    expect(error).toBeInstanceOf(ViteHubError)
+    expect(error).toBeInstanceOf(AuthSessionError)
+    expect(error).toMatchObject({
+      cause,
+      code: "AUTH_SESSION_FAILED",
+      message: "[vitehub] Authentication session resolution failed.",
+      name: "AuthSessionError",
+      statusCode: 503,
+    })
+    expect(error.toJSON()).toEqual({
+      code: "AUTH_SESSION_FAILED",
+      message: "[vitehub] Authentication session resolution failed.",
     })
     expect(JSON.stringify(error)).not.toContain("secret-token")
   })

--- a/packages/auth/test/published-types.test.ts
+++ b/packages/auth/test/published-types.test.ts
@@ -1,11 +1,11 @@
 import { execFile } from "node:child_process"
-import { copyFile, cp, mkdir, mkdtemp, rm, symlink } from "node:fs/promises"
+import { copyFile, cp, mkdir, mkdtemp, readFile, readdir, rm, symlink } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
 
-import { it } from "vitest"
+import { expect, it } from "vitest"
 
 const execFileAsync = promisify(execFile)
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
@@ -37,3 +37,18 @@ it("publishes the structured Authentication Required error contract", async () =
     await rm(root, { force: true, recursive: true })
   }
 }, 15_000)
+
+it("keeps Effect internals out of published Auth artifacts", async () => {
+  const dist = resolve(packageRoot, "dist")
+  const files = (await readdir(dist, { recursive: true }))
+    .filter(path => /\.(?:[cm]?js|d\.ts)$/.test(path))
+  const output = (await Promise.all(files.map(path => readFile(join(dist, path), "utf8")))).join("\n")
+  const manifest = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")) as Record<string, Record<string, string> | undefined>
+
+  expect(output).not.toMatch(/(?:from\s*|import\s*(?:\(\s*)?|require\s*\(\s*)["']effect(?:\/[^"']*)?["']/)
+  expect(output).not.toContain("FiberFailure")
+  expect(manifest.dependencies?.effect).toBeUndefined()
+  expect(manifest.devDependencies?.effect).toBeUndefined()
+  expect(manifest.optionalDependencies?.effect).toBeUndefined()
+  expect(manifest.peerDependencies?.effect).toBeUndefined()
+})

--- a/packages/auth/test/types.test-d.ts
+++ b/packages/auth/test/types.test-d.ts
@@ -5,9 +5,9 @@ import { describe, expectTypeOf, it } from "vitest"
 
 import {
   authenticated,
-  AuthenticationProviderError,
-  type AuthenticationProviderErrorOptions,
+  AuthSessionError,
   AuthenticationRequiredError,
+  type AuthSessionErrorOptions,
   type AuthenticationRequiredErrorOptions,
   type AuthenticatedOptions,
   type AuthenticatedSessionData,
@@ -140,20 +140,20 @@ describe("types", () => {
     expectTypeOf({ kind: "authUser" }).toMatchTypeOf<AuthenticatedOptions>()
 
     const authError = new AuthenticationRequiredError({
-      details: { surface: "agent-invoker" },
+      cause: new Error("protected diagnostic"),
       message: "Sign in required.",
     } satisfies AuthenticationRequiredErrorOptions)
     expectTypeOf(authError.code).toEqualTypeOf<"AUTHENTICATION_REQUIRED">()
     expectTypeOf(authError.statusCode).toEqualTypeOf<401>()
 
-    const providerError = new AuthenticationProviderError({
-      operation: "get-session",
-    } satisfies AuthenticationProviderErrorOptions)
-    expectTypeOf(providerError.code).toEqualTypeOf<"AUTH_PROVIDER_OPERATION_FAILED">()
-    expectTypeOf(providerError.details).toEqualTypeOf<{
-      operation: "get-auth-for-request" | "get-session"
-      provider: "better-auth"
-    } | undefined>()
+    const sessionError = new AuthSessionError({
+      cause: new Error("protected provider diagnostic"),
+    } satisfies AuthSessionErrorOptions)
+    expectTypeOf(sessionError.code).toEqualTypeOf<"AUTH_SESSION_FAILED">()
+    expectTypeOf(sessionError.statusCode).toEqualTypeOf<503>()
+
+    // @ts-expect-error AuthenticationRequiredError does not serialize arbitrary details.
+    new AuthenticationRequiredError({ details: { surface: "agent-invoker" } })
   })
 
   it("exposes resolved database placement metadata", () => {


### PR DESCRIPTION
## Summary

- add `AuthSessionError` with fixed code `AUTH_SESSION_FAILED`, safe message, `statusCode: 503`, and protected provider `cause`
- map only the default Better Auth session boundary, including missing API and malformed non-null responses
- preserve nullish unauthenticated sessions plus exact `AbortError`, existing Auth error, custom `source`, `map`, and value-callback identities
- remove the arbitrary `AuthenticationRequiredError.details` surface while preserving custom message and cause forms
- keep Effect and `FiberFailure` internals out of published Auth artifacts

## Public contract

`AuthenticationRequiredError` remains the 401 missing-session error. `AuthSessionError` is the distinct 503 default-provider failure, so consumers do not need to parse Better Auth or network messages to distinguish authentication absence from session-resolution failure.

## Validation

- `packages/auth: vp test --test-timeout 15000` — 9 files, 74 tests, no type errors
- `packages/auth: vp run typecheck`
- Auth build and publint
- `git diff --check`

Head verified at `a3ea3ac92c4cbe3c2f50ea191799f825a221db0b`.

EFFECT ADOPTION STATUS
  seam: Auth default Better Auth session resolution boundary
  public API: AuthSessionError is additive; arbitrary AuthenticationRequiredError details are intentionally removed
  boundary: authenticated default getSession Promise rejection and response validation
  typed failures: AUTH_SESSION_FAILED; AuthSessionError, AuthenticationRequiredError, AbortError, and custom extension identities preserved
  resources/fibers: no Effect resources or fibers
  deleted: raw provider rejection leakage, broad provider-operation error, and unrestricted authentication details
  todos: 0
  confidence: high