### PR TITLE
feat(blob): support served response headers

### DIFF
--- a/docs/content/docs/server-primitives/blob.md
+++ b/docs/content/docs/server-primitives/blob.md
@@ -77,7 +77,7 @@ export default defineConfig({
 | `blob: { stores: Record<string, BlobStoreConfig> }` | Defines named Blob Stores. `stores.default` is required. |
 | `blob: { serve: false }` | Disables Blob route generation. This is the default. |
 | `blob: { serve: true }` | Generates an opt-in Nitro route at `/api/_vitehub/blob/**` for serving the Default Blob Store. |
-| `blob: { serve: { route?, store?, publicBaseUrl? } }` | Generates an opt-in Nitro route. `route` defaults to `/api/_vitehub/blob`, `store` defaults to `default`, and `publicBaseUrl` changes generated public URLs. |
+| `blob: { serve: { route?, store?, publicBaseUrl?, headers? } }` | Generates an opt-in Nitro route. `route` defaults to `/api/_vitehub/blob`, `store` defaults to `default`, `publicBaseUrl` changes generated public URLs, and `headers` adds static response headers. |
 
 ## Provider options
 
@@ -330,10 +330,18 @@ export default defineConfig({
   blob: {
     driver: 's3',
     bucket: 'app-assets',
-    serve: { route: '/assets' },
+    serve: {
+      route: '/assets',
+      headers: {
+        'Cache-Control': 'public, max-age=300',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    },
   },
 })
 ```
+
+Use `serve.headers` for static cache and security policy. Blob metadata remains authoritative for content headers such as `Content-Type`, `Content-Length`, and `ETag`.
 
 The generated Nitro route maps `${route}/**` to the selected Blob Store and delegates streaming to `blob.store(storeName).serve(event, pathname)`. The default route is a safe framework default. It is not a recommendation that every app expose public assets under `/api`.
 

--- a/packages/blob/README.md
+++ b/packages/blob/README.md
@@ -56,13 +56,20 @@ At config time, the `fs` driver uses `BLOB_FS_BASE` when `blob.base` is omitted,
 
 Set `blob.serve` to generate a Nitro route for serving Blob-backed assets. `serve: true` uses `/api/_vitehub/blob` as a safe namespaced API route. Use `serve.route` for product-facing paths such as `/assets`.
 Objects from the served store receive an absolute URL when `serve.publicBaseUrl` is configured, or a route-relative URL otherwise.
+Use `serve.headers` for static cache and security headers. Blob metadata remains authoritative for content headers such as `Content-Type`, `Content-Length`, and `ETag`.
 
 ```ts
 // vite.config.ts
 export default defineConfig({
   blob: {
     driver: "fs",
-    serve: { route: "/assets" },
+    serve: {
+      route: "/assets",
+      headers: {
+        "Cache-Control": "public, max-age=300",
+        "X-Content-Type-Options": "nosniff",
+      },
+    },
   },
   plugins: [hubBlob()],
 })

--- a/packages/blob/src/config.ts
+++ b/packages/blob/src/config.ts
@@ -140,11 +140,30 @@ function resolveExplicitStore(
   }
 }
 
+function normalizeServeHeaders(value: unknown): Record<string, string> | undefined {
+  if (value === undefined) return
+  if (!isPlainObject(value)) throw new TypeError("`blob.serve.headers` must be a plain object.")
+
+  const entries = Object.entries(value)
+  for (const [name, headerValue] of entries) {
+    if (typeof headerValue !== "string") throw new TypeError("`blob.serve.headers` values must be strings.")
+    try {
+      new Headers({ [name]: headerValue })
+    }
+    catch {
+      throw new TypeError(`\`blob.serve.headers\` contains an invalid HTTP header: ${JSON.stringify(name)}.`)
+    }
+  }
+  return Object.fromEntries(entries) as Record<string, string>
+}
+
 function normalizeServeOptions(value: BlobServeOptions | undefined): ResolvedBlobModuleOptions["serve"] {
   if (value === undefined || value === false) return
   if (value === true) return { route: DEFAULT_BLOB_SERVE_ROUTE, store: "default" }
   if (!isPlainObject(value)) throw new TypeError("`blob.serve` must be true or a plain object.")
+  const headers = normalizeServeHeaders(value.headers)
   return {
+    ...(headers ? { headers } : {}),
     route: trimmed(value.route) || DEFAULT_BLOB_SERVE_ROUTE,
     store: trimmed(value.store) || "default",
     ...(trimmed(value.publicBaseUrl) ? { publicBaseUrl: trimmed(value.publicBaseUrl) } : {}),

--- a/packages/blob/src/types.ts
+++ b/packages/blob/src/types.ts
@@ -312,12 +312,14 @@ export type ResolvedBlobStoreConfig =
 export type BlobStoreName = "default" | (string & {})
 
 export type BlobServeOptions = boolean | {
+  headers?: Record<string, string>
   publicBaseUrl?: string
   route?: string
   store?: BlobStoreName
 }
 
 export interface BlobServeConfig {
+  headers?: Record<string, string>
   publicBaseUrl?: string
   route: string
   store: BlobStoreName

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -94,7 +94,7 @@ function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPa
   const headers = serve.headers && Object.keys(serve.headers).length > 0 ? serve.headers : undefined
   return [
     `import { blob } from '${importBase}'`,
-    `import { createError, defineEventHandler, getRouterParam${headers ? ", setResponseHeaders" : ""} } from 'h3'`,
+    `import { createError, defineEventHandler, getRouterParam${headers ? ", removeResponseHeader, setResponseHeaders" : ""} } from 'h3'`,
     "",
     `const storeName = ${JSON.stringify(serve.store)}`,
     ...(headers ? [`const responseHeaders = ${JSON.stringify(headers)}`] : []),
@@ -103,7 +103,17 @@ function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPa
     "  const pathname = getRouterParam(event, '_', { decode: false }) || ''",
     "  if (!pathname) throw createError({ statusCode: 404, statusMessage: 'Blob not found' })",
     ...(headers ? ["  setResponseHeaders(event, responseHeaders)"] : []),
-    "  return await blob.store(storeName).serve(event, pathname)",
+    ...(headers
+      ? [
+          "  try {",
+          "    return await blob.store(storeName).serve(event, pathname)",
+          "  }",
+          "  catch (error) {",
+          "    for (const name of Object.keys(responseHeaders)) removeResponseHeader(event, name)",
+          "    throw error",
+          "  }",
+        ]
+      : ["  return await blob.store(storeName).serve(event, pathname)"]),
     "})",
     "",
   ].join("\n")

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -91,15 +91,18 @@ function renderNitroBlobPlugin(blob: BlobViteRuntimeConfig["blob"], importBase =
 }
 
 function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPackageName): string {
+  const headers = serve.headers && Object.keys(serve.headers).length > 0 ? serve.headers : undefined
   return [
     `import { blob } from '${importBase}'`,
-    "import { createError, defineEventHandler, getRouterParam } from 'h3'",
+    `import { createError, defineEventHandler, getRouterParam${headers ? ", setResponseHeaders" : ""} } from 'h3'`,
     "",
     `const storeName = ${JSON.stringify(serve.store)}`,
+    ...(headers ? [`const responseHeaders = ${JSON.stringify(headers)}`] : []),
     "",
     "export default defineEventHandler(async (event) => {",
     "  const pathname = getRouterParam(event, '_', { decode: false }) || ''",
     "  if (!pathname) throw createError({ statusCode: 404, statusMessage: 'Blob not found' })",
+    ...(headers ? ["  setResponseHeaders(event, responseHeaders)"] : []),
     "  return await blob.store(storeName).serve(event, pathname)",
     "})",
     "",

--- a/packages/blob/test/config.test.ts
+++ b/packages/blob/test/config.test.ts
@@ -265,12 +265,20 @@ describe("blob config", () => {
       driver: "fs",
       base: ".data/assets",
       serve: {
+        headers: {
+          "Cache-Control": "public, max-age=300",
+          "X-Content-Type-Options": "nosniff",
+        },
         publicBaseUrl: "https://assets.example",
         route: "assets",
         store: "default",
       },
     })).toEqual({
       serve: {
+        headers: {
+          "Cache-Control": "public, max-age=300",
+          "X-Content-Type-Options": "nosniff",
+        },
         publicBaseUrl: "https://assets.example",
         route: "assets",
         store: "default",
@@ -284,6 +292,20 @@ describe("blob config", () => {
 
   it("rejects invalid serving config", () => {
     expect(() => normalizeBlobOptions({ serve: "yes" } as never)).toThrow("`blob.serve` must be true or a plain object.")
+  })
+
+  it("rejects invalid serving headers", () => {
+    expect(() => normalizeBlobOptions({
+      serve: { headers: ["Cache-Control"] },
+    } as never)).toThrow("`blob.serve.headers` must be a plain object.")
+
+    expect(() => normalizeBlobOptions({
+      serve: { headers: { "Cache-Control": 300 } },
+    } as never)).toThrow("`blob.serve.headers` values must be strings.")
+
+    expect(() => normalizeBlobOptions({
+      serve: { headers: { "Invalid Header": "value" } },
+    } as never)).toThrow("`blob.serve.headers` contains an invalid HTTP header: \"Invalid Header\".")
   })
 
   it("rejects serving from an unknown single Blob store", () => {

--- a/packages/blob/test/types.test-d.ts
+++ b/packages/blob/test/types.test-d.ts
@@ -37,6 +37,23 @@ describe("types", () => {
     expectTypeOf(config.blob).toMatchTypeOf<BlobModuleOptions | undefined>()
   })
 
+  it("accepts static headers for generated serving routes", () => {
+    const config = {
+      driver: "fs",
+      serve: {
+        headers: {
+          "Cache-Control": "public, max-age=300",
+          "X-Content-Type-Options": "nosniff",
+        },
+      },
+    } satisfies BlobModuleOptions
+
+    expectTypeOf(config.serve.headers).toEqualTypeOf<{
+      "Cache-Control": string
+      "X-Content-Type-Options": string
+    }>()
+  })
+
   it("allows MinIO to resolve common Docker env defaults", () => {
     const config: UserConfig = {
       blob: {

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -132,6 +132,10 @@ describe("hubBlob", () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-blob-serve-route-"))
     const plugin = hubBlob({
       serve: {
+        headers: {
+          "Cache-Control": "public, max-age=300",
+          "X-Content-Type-Options": "nosniff",
+        },
         route: "/assets",
         store: "media",
       },
@@ -153,8 +157,13 @@ describe("hubBlob", () => {
 
     const handler = await readFile(join(root, ".vitehub", "blob", "serve-route.ts"), "utf8")
     expect(handler).toContain("const storeName = \"media\"")
+    expect(handler).toContain("const responseHeaders = {\"Cache-Control\":\"public, max-age=300\",\"X-Content-Type-Options\":\"nosniff\"}")
     expect(handler).toContain("getRouterParam(event, '_', { decode: false })")
+    expect(handler).toContain("setResponseHeaders(event, responseHeaders)")
     expect(handler).toContain("blob.store(storeName).serve(event, pathname)")
+    expect(handler.indexOf("setResponseHeaders(event, responseHeaders)")).toBeLessThan(
+      handler.indexOf("blob.store(storeName).serve(event, pathname)"),
+    )
   })
 
   it("uses a configured package base in physical Nitro imports", async () => {

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -161,6 +161,8 @@ describe("hubBlob", () => {
     expect(handler).toContain("getRouterParam(event, '_', { decode: false })")
     expect(handler).toContain("setResponseHeaders(event, responseHeaders)")
     expect(handler).toContain("blob.store(storeName).serve(event, pathname)")
+    expect(handler).toContain("for (const name of Object.keys(responseHeaders)) removeResponseHeader(event, name)")
+    expect(handler).toContain("throw error")
     expect(handler.indexOf("setResponseHeaders(event, responseHeaders)")).toBeLessThan(
       handler.indexOf("blob.store(storeName).serve(event, pathname)"),
     )


### PR DESCRIPTION
Adds validated static `headers` to `blob.serve` and serializes them into the generated Nitro handler. The handler applies them before Blob storage writes its response metadata, so `Content-Type`, `Content-Length`, and `ETag` remain authoritative.

This lets applications configure cache and security headers on the established generated serving route instead of maintaining a parallel source handler.

Covered by Blob config, public type, generated-handler, build, package, README, and server-primitives documentation tests.