### PR TITLE
feat(queue): separate payload from enqueue options

### DIFF
--- a/docs/content/docs/server-primitives/queue.md
+++ b/docs/content/docs/server-primitives/queue.md
@@ -203,8 +203,7 @@ import { runQueue } from '@vite-hub/queue'
 export default defineEventHandler(async (event) => {
   const body = await readBody<{ email: string }>(event)
 
-  return runQueue('welcome-email', {
-    payload: { email: body.email },
+  return runQueue('welcome-email', { email: body.email }, {
     idempotencyKey: `welcome:${body.email}`,
   })
 })
@@ -218,18 +217,18 @@ await runQueue('welcome-email', { email: 'ava@example.com' })
 
 ## Queue Enqueue options
 
-Queue Enqueue accepts either a raw payload or an envelope with `payload` and options.
+Queue Enqueue accepts a payload followed by optional provider-neutral enqueue options.
 
 ```ts
-await runQueue('welcome-email', {
-  payload: { email: 'ava@example.com' },
+await runQueue('welcome-email', { email: 'ava@example.com' }, {
   delaySeconds: 60,
 })
 ```
 
+Move options from the previous envelope form into the third argument: `runQueue(name, { payload, ...options })` becomes `runQueue(name, payload, options)`. The lower-level `QueueClient.send()` API continues to accept an envelope for direct provider calls.
+
 | Option | Type | Cloudflare | Vercel | Description |
 | --- | --- | --- | --- | --- |
-| `payload` | `TPayload` | Yes | Yes | The payload delivered to the Queue Definition. Required when using the envelope form. |
 | `id` | `string` | Yes | Yes | ViteHub message id. If omitted, ViteHub generates one. |
 | `contentType` | `CloudflareQueueContentType` | Yes | No | Cloudflare message content type. Values: `bytes`, `json`, `text`, `v8`. |
 | `delaySeconds` | `number` | Yes | Yes | Provider-supported enqueue delay. |
@@ -262,7 +261,7 @@ Queue does not include an in-memory Queue Provider for local Queue Delivery. Tes
 
 ## Runtime Helpers
 
-### `runQueue(name, input)`
+### `runQueue(name, payload, options?)`
 
 Enqueues one Queue Job and returns the Queue Provider acceptance result.
 
@@ -279,7 +278,7 @@ type QueueSendResult = {
 }
 ```
 
-### `deferQueue(name, input)`
+### `deferQueue(name, payload, options?)`
 
 Schedules Queue Enqueue through the current request's `waitUntil` support and returns `void`.
 

--- a/packages/queue/src/enqueue.ts
+++ b/packages/queue/src/enqueue.ts
@@ -21,6 +21,21 @@ export function createQueueMessageId(prefix = "queue"): string {
   return `${prefix}_${Date.now().toString(36)}_${fallbackCounter.toString(36)}`
 }
 
+export function normalizeQueueEnqueuePayload<TPayload = unknown>(payload: TPayload, options: QueueEnqueueOptions = {}): NormalizedQueueEnqueueInput<TPayload> {
+  const { contentType, delaySeconds, id, idempotencyKey, region, retentionSeconds } = options
+  return {
+    id: typeof id === "string" && id.length > 0 ? id : createQueueMessageId(),
+    options: {
+      ...(contentType !== undefined ? { contentType } : {}),
+      ...(delaySeconds !== undefined ? { delaySeconds } : {}),
+      ...(idempotencyKey !== undefined ? { idempotencyKey } : {}),
+      ...(region !== undefined ? { region } : {}),
+      ...(retentionSeconds !== undefined ? { retentionSeconds } : {}),
+    },
+    payload,
+  }
+}
+
 function isQueueEnvelope<TPayload = unknown>(input: QueueEnqueueInput<TPayload>): input is QueueEnqueueEnvelope<TPayload> {
   if (typeof input !== "object" || input === null || Array.isArray(input) || !("payload" in input)) {
     return false
@@ -30,24 +45,9 @@ function isQueueEnvelope<TPayload = unknown>(input: QueueEnqueueInput<TPayload>)
 
 export function normalizeQueueEnqueueInput<TPayload = unknown>(input: QueueEnqueueInput<TPayload>): NormalizedQueueEnqueueInput<TPayload> {
   if (!isQueueEnvelope(input)) {
-    return {
-      id: createQueueMessageId(),
-      options: {},
-      payload: input,
-    }
+    return normalizeQueueEnqueuePayload(input)
   }
 
-  const { contentType, delaySeconds, id, idempotencyKey, payload, region, retentionSeconds } = input
-  const options: QueueEnqueueOptions = {
-    ...(contentType !== undefined ? { contentType } : {}),
-    ...(delaySeconds !== undefined ? { delaySeconds } : {}),
-    ...(idempotencyKey !== undefined ? { idempotencyKey } : {}),
-    ...(region !== undefined ? { region } : {}),
-    ...(retentionSeconds !== undefined ? { retentionSeconds } : {}),
-  }
-  return {
-    id: typeof id === "string" && id.length > 0 ? id : createQueueMessageId(),
-    options,
-    payload,
-  }
+  const { payload, ...options } = input
+  return normalizeQueueEnqueuePayload(payload, options)
 }

--- a/packages/queue/src/runtime/client.ts
+++ b/packages/queue/src/runtime/client.ts
@@ -1,14 +1,14 @@
 import { getCloudflareEnv, resolveWaitUntil } from "@vite-hub/internal/runtime/cloudflare-env"
 
 import { normalizeQueueOptions } from "../config.ts"
-import { normalizeQueueEnqueueInput } from "../enqueue.ts"
+import { normalizeQueueEnqueuePayload } from "../enqueue.ts"
 import { QueueError } from "../errors.ts"
 import { getCloudflareQueueBindingName } from "../integrations/cloudflare.ts"
 import { getVercelQueueTopicName } from "../integrations/vercel.ts"
 
 import { getQueueClientCache, getQueueRuntimeConfig, getQueueRuntimeEvent, loadQueueDefinition, runWithQueueRuntimeEvent } from "./state.ts"
 
-import type { CloudflareQueueClient, CloudflareQueueProviderOptions, QueueClient, QueueEnqueueInput, QueueProviderOptions, QueueSendResult, ResolvedQueueOptions, VercelQueueProviderOptions } from "../types.ts"
+import type { CloudflareQueueClient, CloudflareQueueProviderOptions, QueueClient, QueueEnqueueOptions, QueueProviderOptions, QueueSendResult, ResolvedQueueOptions, VercelQueueProviderOptions } from "../types.ts"
 
 function createQueueDefinitionNotFoundError(name: string): QueueError {
   return new QueueError(`Unknown queue definition: ${name}. Queue Runtime Registry is installed by generated Provider Output; direct Node scripts cannot discover Queue Definitions by themselves.`, {
@@ -120,13 +120,13 @@ export async function getQueue(name: string): Promise<QueueClient> {
   return await pending
 }
 
-export async function runQueue<TPayload = unknown>(name: string, input: QueueEnqueueInput<TPayload>): Promise<QueueSendResult> {
+export async function runQueue<TPayload = unknown>(name: string, payload: TPayload, options: QueueEnqueueOptions = {}): Promise<QueueSendResult> {
   const definition = await loadQueueDefinition(name)
   if (!definition) {
     throw createQueueDefinitionNotFoundError(name)
   }
 
-  const normalized = normalizeQueueEnqueueInput(input)
+  const normalized = normalizeQueueEnqueuePayload(payload, options)
   const queue = await getQueue(name)
   return await queue.send({
     ...normalized.options,
@@ -135,9 +135,9 @@ export async function runQueue<TPayload = unknown>(name: string, input: QueueEnq
   })
 }
 
-export function deferQueue<TPayload = unknown>(name: string, input: QueueEnqueueInput<TPayload>): void {
+export function deferQueue<TPayload = unknown>(name: string, payload: TPayload, options: QueueEnqueueOptions = {}): void {
   const request = getQueueRuntimeEvent()
-  const task = () => runWithQueueRuntimeEvent(request, () => runQueue(name, input))
+  const task = () => runWithQueueRuntimeEvent(request, () => runQueue(name, payload, options))
   const handleError = async (error: unknown) => {
     console.error(`[vitehub] Deferred queue dispatch failed for "${name}"`, error)
     try {

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -149,19 +149,14 @@ export interface QueueDefinition<TPayload = unknown, TResult = unknown> {
 export interface QueueEnqueueOptions {
   contentType?: CloudflareQueueContentType
   delaySeconds?: number
+  id?: string
   idempotencyKey?: string
   region?: string
   retentionSeconds?: number
 }
 
-export type QueueEnqueueEnvelope<TPayload = unknown> = {
+export type QueueEnqueueEnvelope<TPayload = unknown> = QueueEnqueueOptions & {
   payload: TPayload
-  contentType?: CloudflareQueueContentType
-  delaySeconds?: number
-  id?: string
-  idempotencyKey?: string
-  region?: string
-  retentionSeconds?: number
 }
 
 export type QueueEnqueueInput<TPayload = unknown> = TPayload | QueueEnqueueEnvelope<TPayload>

--- a/packages/queue/test/runtime.test.ts
+++ b/packages/queue/test/runtime.test.ts
@@ -123,6 +123,29 @@ describe("cloudflare queue runtime", () => {
     expect(vercelQueueMock.send).not.toHaveBeenCalled()
   })
 
+  it("keeps envelope-shaped payloads intact", async () => {
+    const send = vi.fn(async () => {})
+    const worker = createQueueCloudflareWorker({
+      app: async () => Response.json(await runQueue("welcome", { payload: "value" })),
+      registry: {
+        welcome: async () => ({
+          default: {
+            handler: async () => {},
+          },
+        }),
+      },
+    })
+
+    await worker.fetch(new Request("https://example.com/"), {
+      [getCloudflareQueueBindingName("welcome")]: {
+        send,
+        sendBatch: vi.fn(async () => {}),
+      },
+    }, { waitUntil: vi.fn() })
+
+    expect(send).toHaveBeenCalledWith({ payload: "value" }, expect.any(Object))
+  })
+
   it("uses nested Cloudflare waitUntil for deferred dispatch", async () => {
     const send = vi.fn(async () => {})
     const waitUntil = vi.fn()
@@ -147,13 +170,13 @@ describe("cloudflare queue runtime", () => {
         },
       },
     }, async () => {
-      deferQueue("welcome", { email: "ava@example.com" })
+      deferQueue("welcome", { payload: "value" }, { delaySeconds: 60 })
       await Promise.resolve()
     })
 
     expect(waitUntil).toHaveBeenCalledTimes(1)
     await waitUntil.mock.calls[0]?.[0]
-    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith({ payload: "value" }, expect.objectContaining({ delaySeconds: 60 }))
     expect(vercelQueueMock.send).not.toHaveBeenCalled()
   })
 

--- a/packages/queue/test/types.test-d.ts
+++ b/packages/queue/test/types.test-d.ts
@@ -2,6 +2,7 @@ import { expectTypeOf, it } from "vitest"
 import type { Plugin } from "vite"
 
 import { defineQueue } from "../src/definition.ts"
+import { deferQueue, runQueue } from "../src/runtime/client.ts"
 import { hubQueue } from "../src/vite.ts"
 
 it("returns a vite plugin", () => {
@@ -17,4 +18,10 @@ it("infers queue payload types", () => {
     metadata?: unknown
     payload: { email: string }
   }]>()
+})
+
+it("types Queue Enqueue payloads separately from options", () => {
+  expectTypeOf(runQueue("welcome", { payload: "value" })).toEqualTypeOf<Promise<{ messageId?: string, status: "queued" }>>()
+  expectTypeOf(runQueue("welcome", { email: "ava@example.com" }, { delaySeconds: 60 })).toEqualTypeOf<Promise<{ messageId?: string, status: "queued" }>>()
+  expectTypeOf(deferQueue("welcome", { payload: "value" }, { id: "message-1" })).toEqualTypeOf<void>()
 })


### PR DESCRIPTION
Changes the top-level Queue API to `runQueue(name, payload, options?)` and `deferQueue(name, payload, options?)`, so domain payloads are never inferred as enqueue-option envelopes from their object keys. A payload such as `{ payload: "value" }` now reaches the Queue Definition intact, while provider-neutral options remain available as the third argument.

This is a breaking change for top-level envelope calls: migrate `runQueue(name, { payload, ...options })` to `runQueue(name, payload, options)`. The lower-level `QueueClient.send()` envelope remains compatible for direct provider usage, including Cloudflare-only options.

## Hard dependency

Depends on #689 and is intentionally based on `agent/queue-nitro-integration`. Do not merge this PR independently; after #689 lands, rebase this branch onto `main` before merging.

<!-- babysitter:blocker:v1 -->

> [!WARNING]
> **Babysitter is blocked:** dependency pull request #689 is still open, and #704 is intentionally based on its unmerged Queue runtime foundation.
>
> Merge #689 into `main`; then #704 can be rebased onto `main`, reviewed at the resulting exact head, and merged.

<!-- /babysitter:blocker:v1 -->